### PR TITLE
Default Accept-Charset from ISO-8859-1 to UTF-8

### DIFF
--- a/ktor-core/src/org/jetbrains/ktor/content/IncomingContent.kt
+++ b/ktor-core/src/org/jetbrains/ktor/content/IncomingContent.kt
@@ -20,5 +20,5 @@ suspend fun IncomingContent.readText(): String {
     }
 
     readChannel().copyTo(buffer) // TODO provide buffer pool to copyTo function
-    return buffer.toByteArray().toString(request.contentCharset() ?: Charsets.ISO_8859_1)
+    return buffer.toByteArray().toString(request.contentCharset() ?: Charsets.UTF_8)
 }


### PR DESCRIPTION
Ktor responds with UTF-8 by [default](https://github.com/Kotlin/ktor/issues/80), then why not accepts default content charset as UTF-8 too?