### PR TITLE
Support Configurable Log Levels for Call Logging Feature

### DIFF
--- a/ktor-core/src/org/jetbrains/ktor/features/CallLogging.kt
+++ b/ktor-core/src/org/jetbrains/ktor/features/CallLogging.kt
@@ -54,7 +54,7 @@ class CallLogging(private val log: Logger, private val monitor: ApplicationMonit
             level == Level.INFO && log.isInfoEnabled -> log.info(message)
             level == Level.DEBUG && log.isDebugEnabled -> log.debug(message)
             level == Level.TRACE && log.isTraceEnabled -> log.trace(message)
-            else -> throw IllegalArgumentException("Call logging is not supported for levels higher than INFO.")
+            else -> throw IllegalArgumentException("Call logging is not supported for the $level log level.")
         }
     }
 

--- a/ktor-core/src/org/jetbrains/ktor/features/CallLogging.kt
+++ b/ktor-core/src/org/jetbrains/ktor/features/CallLogging.kt
@@ -8,8 +8,9 @@ import org.jetbrains.ktor.util.*
 import org.slf4j.*
 import org.slf4j.event.*
 
-class CallLogging(private val log: Logger, private val monitor: ApplicationMonitor, private val configuration: Configuration) {
-
+class CallLogging(private val log: Logger, private val monitor: ApplicationMonitor, configuration: Configuration) {
+    private val level = configuration.level
+    
     class Configuration {
         var level: Level = Level.TRACE
     }
@@ -51,13 +52,13 @@ class CallLogging(private val log: Logger, private val monitor: ApplicationMonit
     }
 
     private fun log(message: String) {
-        if (configuration.level == Level.INFO && log.isInfoEnabled) {
+        if (level == Level.INFO && log.isInfoEnabled) {
             log.info(message)
         }
-        else if (configuration.level == Level.DEBUG && log.isDebugEnabled) {
+        else if (level == Level.DEBUG && log.isDebugEnabled) {
             log.debug(message)
         }
-        else if (configuration.level == Level.TRACE && log.isTraceEnabled) {
+        else if (level == Level.TRACE && log.isTraceEnabled) {
             log.trace(message)
         }
     }

--- a/ktor-core/src/org/jetbrains/ktor/features/CallLogging.kt
+++ b/ktor-core/src/org/jetbrains/ktor/features/CallLogging.kt
@@ -8,9 +8,7 @@ import org.jetbrains.ktor.util.*
 import org.slf4j.*
 import org.slf4j.event.*
 
-class CallLogging(private val log: Logger, private val monitor: ApplicationMonitor, configuration: Configuration) {
-    private val level = configuration.level
-    
+class CallLogging(private val log: Logger, private val monitor: ApplicationMonitor, private val level: Level) {
     class Configuration {
         var level: Level = Level.TRACE
     }
@@ -40,7 +38,7 @@ class CallLogging(private val log: Logger, private val monitor: ApplicationMonit
         override fun install(pipeline: Application, configure: Configuration.() -> Unit): CallLogging {
             val loggingPhase = PipelinePhase("Logging")
             val configuration = Configuration().apply(configure)
-            val feature = CallLogging(pipeline.log, pipeline.environment.monitor, configuration)
+            val feature = CallLogging(pipeline.log, pipeline.environment.monitor, configuration.level)
             pipeline.insertPhaseBefore(ApplicationCallPipeline.Infrastructure, loggingPhase)
             pipeline.intercept(loggingPhase) {
                 proceed()

--- a/ktor-core/src/org/jetbrains/ktor/features/CallLogging.kt
+++ b/ktor-core/src/org/jetbrains/ktor/features/CallLogging.kt
@@ -39,9 +39,10 @@ class CallLogging(private val log: Logger, private val monitor: ApplicationMonit
             val loggingPhase = PipelinePhase("Logging")
             val configuration = Configuration().apply(configure)
             val level = when {
+                configuration.level == Level.TRACE && pipeline.log.isTraceEnabled -> Level.TRACE
                 configuration.level == Level.DEBUG && pipeline.log.isDebugEnabled -> Level.DEBUG
                 configuration.level == Level.INFO && pipeline.log.isInfoEnabled -> Level.INFO
-                else -> Level.TRACE
+                else -> throw IllegalArgumentException("The ${configuration.level} log level is not supported.")
             }
             val feature = CallLogging(pipeline.log, pipeline.environment.monitor, level)
             pipeline.insertPhaseBefore(ApplicationCallPipeline.Infrastructure, loggingPhase)

--- a/ktor-core/src/org/jetbrains/ktor/features/CallLogging.kt
+++ b/ktor-core/src/org/jetbrains/ktor/features/CallLogging.kt
@@ -51,12 +51,14 @@ class CallLogging(private val log: Logger, private val monitor: ApplicationMonit
     }
 
     private fun log(message: String) {
-        when (configuration.level) {
-            Level.ERROR -> if (log.isErrorEnabled) log.error(message)
-            Level.WARN -> if (log.isWarnEnabled) log.warn(message)
-            Level.INFO -> if (log.isInfoEnabled) log.info(message)
-            Level.DEBUG -> if (log.isDebugEnabled) log.debug(message)
-            Level.TRACE -> if (log.isTraceEnabled) log.trace(message)
+        if (configuration.level == Level.INFO && log.isInfoEnabled) {
+            log.info(message)
+        }
+        else if (configuration.level == Level.DEBUG && log.isDebugEnabled) {
+            log.debug(message)
+        }
+        else if (configuration.level == Level.TRACE && log.isTraceEnabled) {
+            log.trace(message)
         }
     }
 

--- a/ktor-core/src/org/jetbrains/ktor/features/CallLogging.kt
+++ b/ktor-core/src/org/jetbrains/ktor/features/CallLogging.kt
@@ -52,14 +52,11 @@ class CallLogging(private val log: Logger, private val monitor: ApplicationMonit
     }
 
     private fun log(message: String) {
-        if (level == Level.INFO && log.isInfoEnabled) {
-            log.info(message)
-        }
-        else if (level == Level.DEBUG && log.isDebugEnabled) {
-            log.debug(message)
-        }
-        else if (level == Level.TRACE && log.isTraceEnabled) {
-            log.trace(message)
+        when {
+            level == Level.INFO && log.isInfoEnabled -> log.info(message)
+            level == Level.DEBUG && log.isDebugEnabled -> log.debug(message)
+            level == Level.TRACE && log.isTraceEnabled -> log.trace(message)
+            else -> throw IllegalArgumentException("Call logging is not supported for levels higher than INFO.")
         }
     }
 

--- a/ktor-core/src/org/jetbrains/ktor/features/CallLogging.kt
+++ b/ktor-core/src/org/jetbrains/ktor/features/CallLogging.kt
@@ -38,8 +38,7 @@ class CallLogging(private val log: Logger, private val monitor: ApplicationMonit
         override val key: AttributeKey<CallLogging> = AttributeKey("Call Logging")
         override fun install(pipeline: Application, configure: Configuration.() -> Unit): CallLogging {
             val loggingPhase = PipelinePhase("Logging")
-            val configuration = Configuration()
-            configuration.apply(configure)
+            val configuration = Configuration().apply(configure)
             val feature = CallLogging(pipeline.log, pipeline.environment.monitor, configuration)
             pipeline.insertPhaseBefore(ApplicationCallPipeline.Infrastructure, loggingPhase)
             pipeline.intercept(loggingPhase) {


### PR DESCRIPTION
This PR allows the `CallLogging` feature to be configured to use any log level, while defaulting to the previous behaviour of logging at `trace`.