### PR TITLE
Fix feature Compression always set Transfer-Encoding as chunked

### DIFF
--- a/ktor-server/ktor-server-core/src/io/ktor/features/Compression.kt
+++ b/ktor-server/ktor-server-core/src/io/ktor/features/Compression.kt
@@ -116,6 +116,7 @@ class Compression(compression: Configuration) {
         }
 
         override val contentType: ContentType? get() = original.contentType
+        override val contentLength: Long? get() = original.contentLength
         override val status: HttpStatusCode? get() = original.status
         override fun <T : Any> getProperty(key: AttributeKey<T>) = original.getProperty(key)
         override fun <T : Any> setProperty(key: AttributeKey<T>, value: T?) = original.setProperty(key, value)
@@ -132,6 +133,7 @@ class Compression(compression: Configuration) {
         }
 
         override val contentType: ContentType? get() = original.contentType
+        override val contentLength: Long? get() = original.contentLength
         override val status: HttpStatusCode? get() = original.status
         override fun <T : Any> getProperty(key: AttributeKey<T>) = original.getProperty(key)
         override fun <T : Any> setProperty(key: AttributeKey<T>, value: T?) = original.setProperty(key, value)


### PR DESCRIPTION
Compression feature did not implement `contentLength` so each response will set `Transfer-Encoding=chunked` instead of correct `Content-Length`.