### PR TITLE
Digest Authentication not working in Chrome due to not following RFC 2617

### DIFF
--- a/ktor-features/ktor-auth/src/io/ktor/auth/DigestAuth.kt
+++ b/ktor-features/ktor-auth/src/io/ktor/auth/DigestAuth.kt
@@ -153,6 +153,6 @@ fun DigestCredential.expectedDigest(method: HttpMethod, digester: MessageDigest,
     val start = hex(userNameRealmPasswordDigest)
     val end = hex(digest("${method.value.toUpperCase()}:$digestUri"))
 
-    val a = listOf(start, nonce, nonceCount, cnonce, qop, end).map { it ?: "" }.joinToString(":")
+    val a = (qop == null ? listOf(start, nonce, end) : listOf(start, nonce, nonceCount, cnonce, qop, end)).joinToString(":")
     return digest(a)
 }

--- a/ktor-features/ktor-auth/src/io/ktor/auth/DigestAuth.kt
+++ b/ktor-features/ktor-auth/src/io/ktor/auth/DigestAuth.kt
@@ -153,6 +153,6 @@ fun DigestCredential.expectedDigest(method: HttpMethod, digester: MessageDigest,
     val start = hex(userNameRealmPasswordDigest)
     val end = hex(digest("${method.value.toUpperCase()}:$digestUri"))
 
-    val a = (qop == null ? listOf(start, nonce, end) : listOf(start, nonce, nonceCount, cnonce, qop, end)).joinToString(":")
+    val a = (if (qop == null) listOf(start, nonce, end) else listOf(start, nonce, nonceCount, cnonce, qop, end)).joinToString(":")
     return digest(a)
 }


### PR DESCRIPTION
According to **RFC 2617 (Section 3.2.2.1)**, if `qop` is not present, it should follow the older **RFC 2069** and the response should be in form of:

`MD5(HA1:nonce:HA2)`

 instead of:

`MD5(HA1:nonce:nonceCount:cnonce:qop:HA2)`

The current implementation of Digest Authorization does not work in Chrome 65.0.3325.181 due to not following the RFC.