### PR TITLE
JWT: Support multiple schemes in addition to Bearer

### DIFF
--- a/ktor-features/ktor-auth-jwt/src/io/ktor/auth/jwt/JWTAuth.kt
+++ b/ktor-features/ktor-auth-jwt/src/io/ktor/auth/jwt/JWTAuth.kt
@@ -60,7 +60,7 @@ class JWTAuthenticationProvider(name: String?) : AuthenticationProvider(name) {
     }
 }
 
-class JWTAuthSchemes(val defaultScheme: String, vararg val additionalSchemes: String) {
+internal class JWTAuthSchemes(val defaultScheme: String, vararg val additionalSchemes: String) {
     val schemes = (arrayOf(defaultScheme) + additionalSchemes).toSet()
     val schemesLowerCase = schemes.map { it.toLowerCase() }.toSet()
 

--- a/ktor-features/ktor-auth-jwt/src/io/ktor/auth/jwt/JWTAuth.kt
+++ b/ktor-features/ktor-auth-jwt/src/io/ktor/auth/jwt/JWTAuth.kt
@@ -26,9 +26,10 @@ class JWTAuthenticationProvider(name: String?) : AuthenticationProvider(name) {
     internal var verifier: ((HttpAuthHeader?) -> JWTVerifier?) = { null }
 
     /**
-     * @param [supported] list of supported authentication schemes for JWT (by default only "Bearer")
+     * @param [schemes] list of supported authentication schemes for JWT (by default only "Bearer")
      */
     fun authSchemes(vararg schemes: String = arrayOf("Bearer")) {
+        require(schemes.isNotEmpty()) { "At least one scheme should be provided" }
         supportedAuthSchemes = schemes.toSet()
     }
 

--- a/ktor-features/ktor-auth-jwt/test/io/ktor/auth/jwt/JWTAuthTest.kt
+++ b/ktor-features/ktor-auth-jwt/test/io/ktor/auth/jwt/JWTAuthTest.kt
@@ -64,6 +64,23 @@ class JWTAuthTest {
     }
 
     @Test
+    fun testJwtSuccessWithCustomSchemeWithDifferentCases() {
+        withApplication {
+            application.configureServerJwt {
+                authSchemes("Bearer", "tokEN")
+            }
+
+            val token = getToken(scheme = "TOKen")
+
+            val response = handleRequestWithToken(token)
+
+            assertTrue(response.requestHandled)
+            assertEquals(HttpStatusCode.OK, response.response.status())
+            assertNotNull(response.response.content)
+        }
+    }
+
+    @Test
     fun testJwtAlgorithmMismatch() {
         withApplication {
             application.configureServerJwt()


### PR DESCRIPTION
This should fix #397 required for supporting realworld with ktor https://github.com/gothinkster/node-express-realworld-example-app/blob/ba04b70c31af81ca7935096740a6e083563b3a4a/routes/auth.js#L5