### PR TITLE
Validate scheme and contents in authorization header

### DIFF
--- a/ktor-features/ktor-auth/test/io/ktor/tests/auth/BasicAuthTest.kt
+++ b/ktor-features/ktor-auth/test/io/ktor/tests/auth/BasicAuthTest.kt
@@ -88,6 +88,42 @@ class BasicAuthTest {
     }
 
     @Test
+    fun testBasicAuthDifferentScheme() {
+        withTestApplication {
+            application.configureServer()
+
+            val call = handleRequest {
+                uri = "/"
+                addHeader(HttpHeaders.Authorization, "Bearer some-token")
+            }
+
+            assertTrue(call.requestHandled)
+            assertEquals(HttpStatusCode.Unauthorized, call.response.status())
+            assertNotEquals("Secret info", call.response.content)
+
+            assertWWWAuthenticateHeaderExist(call)
+        }
+    }
+
+    @Test
+    fun testBasicAuthInvalidBase64() {
+        withTestApplication {
+            application.configureServer()
+
+            val call = handleRequest {
+                uri = "/"
+                addHeader(HttpHeaders.Authorization, "Basic +-test")
+            }
+
+            assertTrue(call.requestHandled)
+            assertEquals(HttpStatusCode.Unauthorized, call.response.status())
+            assertNotEquals("Secret info", call.response.content)
+
+            assertWWWAuthenticateHeaderExist(call)
+        }
+    }
+
+    @Test
     fun testBasicAuthFiltered() {
         withTestApplication {
             application.configureServer()


### PR DESCRIPTION
This change adds validation for the scheme and contents when trying to
parse the HTTP Basic credentials from the Authorization HTTP header.
This prevents the HTTP Basic protected routes from crashing when the
user sends an Authorization header with a scheme other than "Basic" or
when the user sends a malformed Base64 string.

See #414 for the responsible issue.