### PR TITLE
Fixes headersOf case insensitive issue

### DIFF
--- a/ktor-http/test/io/ktor/tests/http/HeadersTest.kt
+++ b/ktor-http/test/io/ktor/tests/http/HeadersTest.kt
@@ -180,4 +180,12 @@ class HeadersTest {
         assertEquals("file; k=\"v,v\"; k2=\"=\"", ContentDisposition.File.withParameter("k", "v,v").withParameter("k2", "=").toString())
         assertEquals("file; k=\"v,v\"; k2=v2", ContentDisposition.File.withParameter("k", "v,v").withParameter("k2", "v2").toString())
     }
+
+    @Test
+    fun `headersOf should be case insensitive`() {
+        val value = "world"
+        assertEquals(value, headersOf("hello", value)["HELLO"])
+        assertEquals(value, headersOf("hello", listOf(value))["HELLO"])
+        assertEquals(value, headersOf("hello" to listOf(value))["HELLO"])
+    }
 }

--- a/ktor-utils/src/io/ktor/util/StringValues.kt
+++ b/ktor-utils/src/io/ktor/util/StringValues.kt
@@ -98,7 +98,10 @@ open class StringValuesSingleImpl(override val caseInsensitiveName: Boolean, val
     override fun contains(name: String, value: String): Boolean = name.equals(this.name, caseInsensitiveName) && values.contains(value)
 }
 
-open class StringValuesImpl(override val caseInsensitiveName: Boolean = false, private val values: Map<String, List<String>> = emptyMap()) : StringValues {
+open class StringValuesImpl(override val caseInsensitiveName: Boolean = false, values: Map<String, List<String>> = emptyMap()) : StringValues {
+    protected val values: Map<String, List<String>> by lazy {
+        if (caseInsensitiveName) CaseInsensitiveMap<List<String>>().apply { putAll(values) } else values.toMap()
+    }
     override operator fun get(name: String) = listForKey(name)?.firstOrNull()
     override fun getAll(name: String): List<String>? = listForKey(name)
 


### PR DESCRIPTION
The `fun headersOf(vararg pairs: Pair<String, List<String>>): Headers` signature is not case-insensitve.