### PR TITLE
default to RS256 as algorithm if JWK does not optionally provide one (#434)

### DIFF
--- a/ktor-features/ktor-auth-jwt/src/io/ktor/auth/jwt/JWTAuth.kt
+++ b/ktor-features/ktor-auth-jwt/src/io/ktor/auth/jwt/JWTAuth.kt
@@ -138,7 +138,7 @@ private fun ApplicationRequest.parseAuthorizationHeaderOrNull() = try {
 private fun HttpAuthHeader.Companion.bearerAuthChallenge(realm: String, schemes: JWTAuthSchemes): HttpAuthHeader =
         HttpAuthHeader.Parameterized(schemes.defaultScheme, mapOf(HttpAuthHeader.Parameters.Realm to realm))
 
-private fun Jwk.makeAlgorithm(): Algorithm = when (algorithm) {
+internal fun Jwk.makeAlgorithm(): Algorithm = when (algorithm) {
     "RS256" -> Algorithm.RSA256(publicKey as RSAPublicKey, null)
     "RS384" -> Algorithm.RSA384(publicKey as RSAPublicKey, null)
     "RS512" -> Algorithm.RSA512(publicKey as RSAPublicKey, null)

--- a/ktor-features/ktor-auth-jwt/src/io/ktor/auth/jwt/JWTAuth.kt
+++ b/ktor-features/ktor-auth-jwt/src/io/ktor/auth/jwt/JWTAuth.kt
@@ -145,6 +145,7 @@ private fun Jwk.makeAlgorithm(): Algorithm = when (algorithm) {
     "ES256" -> Algorithm.ECDSA256(publicKey as ECPublicKey, null)
     "ES384" -> Algorithm.ECDSA384(publicKey as ECPublicKey, null)
     "ES512" -> Algorithm.ECDSA512(publicKey as ECPublicKey, null)
+    null -> Algorithm.RSA256(publicKey as RSAPublicKey, null)
     else -> throw IllegalArgumentException("Unsupported algorithm $algorithm")
 }
 


### PR DESCRIPTION
Per RFC7517, alg should be optional. Spring fixes this by defaulting to RS256 if no alg is given.