### PR TITLE
Bump jwks-rsa to 0.4.0

### DIFF
--- a/ktor-features/ktor-auth-jwt/build.gradle
+++ b/ktor-features/ktor-auth-jwt/build.gradle
@@ -3,6 +3,6 @@ dependencies {
     compile project(':ktor-features:ktor-auth')
     compile group: 'com.googlecode.json-simple', name: 'json-simple', version: '1.1.1'
     compile group: 'com.auth0', name: 'java-jwt', version: '3.3.0'
-    compile group: 'com.auth0', name: 'jwks-rsa', version: '0.3.0'
+    compile group: 'com.auth0', name: 'jwks-rsa', version: '0.4.0'
     testCompile "com.nhaarman:mockito-kotlin:1.5.0"
 }


### PR DESCRIPTION
Suggested by @mkporwit:

> Can you guys bump the version of `com.auth0:jwks-rsa` that you pull in for `ktor-auth-jwt` from 0.3.0 to 0.4.0 please? It includes a JwkProviderBuilder that takes a URL for non-auth0-standard JWKS file locations. Microsoft keeps theirs at https://login.microsoftonline.com/common/discovery/v2.0/keys, and passing that in as a string was not being handled correctly by UrlJwkProvider. Thanks!