### PR TITLE
add verify configuration that does not require an issuer, just the JwkProvider (#437)

### DIFF
--- a/ktor-features/ktor-auth-jwt/src/io/ktor/auth/jwt/JWTAuth.kt
+++ b/ktor-features/ktor-auth-jwt/src/io/ktor/auth/jwt/JWTAuth.kt
@@ -55,6 +55,13 @@ class JWTAuthenticationProvider(name: String?) : AuthenticationProvider(name) {
         this.verifier = { token -> getVerifier(jwkProvider, issuer, token, schemes) }
     }
 
+    /**
+     * @param [jwkProvider] provides the JSON Web Key
+     */
+    fun verifier(jwkProvider: JwkProvider) {
+        this.verifier = { token -> getVerifier(jwkProvider, token, schemes) }
+    }
+
     fun validate(body: suspend ApplicationCall.(JWTCredential) -> Principal?) {
         authenticationFunction = body
     }
@@ -101,7 +108,7 @@ private suspend fun evaluate(token: HttpAuthHeader?, principal: Principal?, real
     }
 }
 
-private fun getVerifier(jwkProvider: JwkProvider, issuer: String, token: HttpAuthHeader?, schemes: JWTAuthSchemes): JWTVerifier? {
+private fun getVerifierNullableIssuer(jwkProvider: JwkProvider, issuer: String?, token: HttpAuthHeader?, schemes: JWTAuthSchemes): JWTVerifier? {
     val jwk = token.getBlob(schemes)?.let { jwkProvider.get(JWT.decode(it).keyId) }
 
     val algorithm = try {
@@ -109,7 +116,18 @@ private fun getVerifier(jwkProvider: JwkProvider, issuer: String, token: HttpAut
     } catch (ex: IllegalArgumentException) {
         null
     } ?: return null
-    return JWT.require(algorithm).withIssuer(issuer).build()
+    return when(issuer) {
+        null -> JWT.require(algorithm).build()
+        else -> JWT.require(algorithm).withIssuer(issuer).build()
+    }
+}
+
+private fun getVerifier(jwkProvider: JwkProvider, issuer: String, token: HttpAuthHeader?, schemes: JWTAuthSchemes): JWTVerifier? {
+    return getVerifierNullableIssuer(jwkProvider, issuer, token, schemes)
+}
+
+private fun getVerifier(jwkProvider: JwkProvider, token: HttpAuthHeader?, schemes: JWTAuthSchemes): JWTVerifier? {
+    return getVerifierNullableIssuer(jwkProvider, null, token, schemes)
 }
 
 private suspend fun verifyAndValidate(call: ApplicationCall, jwtVerifier: JWTVerifier?, token: HttpAuthHeader?, schemes: JWTAuthSchemes, validate: suspend ApplicationCall.(JWTCredential) -> Principal?): Principal? {


### PR DESCRIPTION
defines a new verifier that does not need an issuer, to address scenarios where the issuer may vary for a single set of JWKS (like in AzureAD)