### PR TITLE
 Jackson uses `line.separator` by default causing issues in windows

### DIFF
--- a/ktor-features/ktor-jackson/src/io/ktor/jackson/JacksonConverter.kt
+++ b/ktor-features/ktor-jackson/src/io/ktor/jackson/JacksonConverter.kt
@@ -1,5 +1,6 @@
 package io.ktor.jackson
 
+import com.fasterxml.jackson.core.util.*
 import com.fasterxml.jackson.databind.*
 import com.fasterxml.jackson.module.kotlin.*
 import io.ktor.application.*
@@ -42,6 +43,12 @@ class JacksonConverter(private val objectmapper: ObjectMapper = jacksonObjectMap
 
 fun ContentNegotiation.Configuration.jackson(block: ObjectMapper.() -> Unit) {
     val mapper = jacksonObjectMapper()
+    mapper.apply {
+        setDefaultPrettyPrinter(DefaultPrettyPrinter().apply {
+            indentArraysWith(DefaultPrettyPrinter.FixedSpaceIndenter.instance)
+            indentObjectsWith(DefaultIndenter("  ", "\n"))
+        })
+    }
     mapper.apply(block)
     val converter = JacksonConverter(mapper)
     register(ContentType.Application.Json, converter)

--- a/ktor-features/ktor-jackson/test/io/ktor/tests/jackson/JacksonTest.kt
+++ b/ktor-features/ktor-jackson/test/io/ktor/tests/jackson/JacksonTest.kt
@@ -1,5 +1,6 @@
 package io.ktor.tests.jackson
 
+import com.fasterxml.jackson.databind.*
 import io.ktor.application.*
 import io.ktor.features.*
 import io.ktor.http.*
@@ -95,7 +96,29 @@ class JacksonTest {
         }
 
     }
+
+    @Test
+    fun testPrettyPrinter() = withTestApplication {
+        application.install(ContentNegotiation) {
+            jackson {
+                configure(SerializationFeature.INDENT_OUTPUT, true)
+            }
+        }
+
+        application.routing {
+            get("/") {
+                call.respond(mapOf("a" to 1, "b" to 2))
+            }
+        }
+
+        handleRequest(HttpMethod.Get, "/") {
+            addHeader(HttpHeaders.Accept, "application/json")
+        }.response.let { response ->
+            assertEquals("{\n  \"a\" : 1,\n  \"b\" : 2\n}", response.content)
+        }
+    }
 }
+
 
 data class MyEntity(val id: Int, val name: String, val children: List<ChildEntity>)
 data class ChildEntity(val item: String, val quantity: Int)


### PR DESCRIPTION
Proposal: for a web server I think it is better to provide consistency by default. So this proposal overrides the Jackson default to use `LF`(`\n`) instead of platform dependant.