### PR TITLE
Fixes binary data in multipart tests `TestApplicationRequest.setBody`

### DIFF
--- a/ktor-server/ktor-server-test-host/src/io/ktor/server/testing/TestApplicationRequest.kt
+++ b/ktor-server/ktor-server-test-host/src/io/ktor/server/testing/TestApplicationRequest.kt
@@ -3,11 +3,13 @@ package io.ktor.server.testing
 import io.ktor.application.*
 import io.ktor.content.*
 import io.ktor.http.*
+import io.ktor.network.util.*
 import io.ktor.request.*
 import io.ktor.server.engine.*
 import io.ktor.util.*
 import kotlinx.coroutines.experimental.io.*
-import kotlinx.io.core.*
+import kotlinx.coroutines.experimental.io.jvm.javaio.*
+import java.nio.charset.*
 
 class TestApplicationRequest(
         call: ApplicationCall,
@@ -93,20 +95,28 @@ fun TestApplicationRequest.setBody(value: ByteArray) {
     bodyChannel = ByteReadChannel(value)
 }
 
-fun TestApplicationRequest.setBody(boundary: String, values: List<PartData>): Unit = setBody(buildPacket {
-    if (values.isEmpty()) return
+private suspend fun WriterScope.append(str: String, charset: Charset = Charsets.UTF_8) {
+    channel.writeFully(str.toByteArray(charset))
+}
 
-    append("\r\n\r\n")
-    values.forEach {
-        append("--$boundary\r\n")
-        it.headers.flattenForEach { key, value -> append("$key: $value\r\n") }
-        append("\r\n")
-        when (it) {
-            is PartData.FileItem -> writeFully(it.streamProvider().readBytes()) // Not optimized since this is for tests and have to fit in memory anyway
-            is PartData.FormItem -> append(it.value)
+fun TestApplicationRequest.setBody(boundary: String, values: List<PartData>): Unit {
+    bodyChannel = writer(ioCoroutineDispatcher) {
+        if (!values.isEmpty()) {
+            append("\r\n\r\n")
+            values.forEach {
+                append("--$boundary\r\n")
+                for ((key, value) in it.headers.flattenEntries()) {
+                    append("$key: $value\r\n")
+                }
+                append("\r\n")
+                when (it) {
+                    is PartData.FileItem -> it.streamProvider().copyTo(channel.toOutputStream())
+                    is PartData.FormItem -> append(it.value)
+                }
+                append("\r\n")
+            }
+
+            append("--$boundary--\r\n\r\n")
         }
-        append("\r\n")
-    }
-
-    append("--$boundary--\r\n\r\n")
-}.readBytes())
+    }.channel
+}

--- a/ktor-server/ktor-server-tests/test/io/ktor/tests/server/http/TestEngineMultipartTest.kt
+++ b/ktor-server/ktor-server-tests/test/io/ktor/tests/server/http/TestEngineMultipartTest.kt
@@ -33,7 +33,7 @@ class TestEngineMultipartTest {
 
     @Test
     fun testMultiPartsFileItemText() {
-        val string = "file content"
+        val string = "file content with unicode 🌀 : здороваться : 여보세요 : 你好 : ñç"
         testMultiPartsFileItemBase(
             filename = "file.txt",
             streamProvider = { string.toByteArray().inputStream() },

--- a/ktor-server/ktor-server-tests/test/io/ktor/tests/server/http/TestEngineMultipartTest.kt
+++ b/ktor-server/ktor-server-tests/test/io/ktor/tests/server/http/TestEngineMultipartTest.kt
@@ -5,6 +5,7 @@ import io.ktor.content.*
 import io.ktor.http.*
 import io.ktor.request.*
 import io.ktor.server.testing.*
+import io.ktor.util.*
 import org.junit.Test
 import kotlin.test.*
 
@@ -46,6 +47,8 @@ class TestEngineMultipartTest {
 
     @Test
     fun testMultiPartsFileItem() {
+        val bytes = ByteArray(256) { it.toByte() }
+
         testMultiParts({
             assertNotNull(it, "it should be multipart data")
             if (it != null) {
@@ -55,21 +58,21 @@ class TestEngineMultipartTest {
                 val file = parts[0] as PartData.FileItem
 
                 assertEquals("fileField", file.name)
-                assertEquals("file.txt", file.originalFileName)
-                assertEquals("file content", file.streamProvider().reader().readText())
+                assertEquals("file.bin", file.originalFileName)
+                assertEquals(hex(bytes), hex(file.streamProvider().readBytes()))
 
                 file.dispose()
             }
         }, setup = {
             addHeader(HttpHeaders.ContentType, contentType.toString())
             setBody(boundary, listOf(PartData.FileItem(
-                    streamProvider = { "file content".toByteArray().inputStream() },
+                    streamProvider = { bytes.inputStream() },
                     dispose = {},
                     partHeaders = headersOf(
                             HttpHeaders.ContentDisposition,
                             ContentDisposition.File
                                     .withParameter(ContentDisposition.Parameters.Name, "fileField")
-                                    .withParameter(ContentDisposition.Parameters.FileName, "file.txt")
+                                    .withParameter(ContentDisposition.Parameters.FileName, "file.bin")
                                     .toString()
                     )
             )))


### PR DESCRIPTION
The problem was that File input streams read as `ISO-8859-1`, but later the whole content was encoded as UTF-8.
This PR tries to handle it as a binary stream so no decoding+encoding is required, and calculates it with a writer and pipes the content, so if the input comes from a large File for testing, no need to read the whole content in memory.