### PR TITLE
resovle config file in command line env

### DIFF
--- a/ktor-server/ktor-server-host-common/src/io/ktor/server/engine/CommandLine.kt
+++ b/ktor-server/ktor-server-host-common/src/io/ktor/server/engine/CommandLine.kt
@@ -24,7 +24,7 @@ fun commandLineEnvironment(args: Array<String>): ApplicationEngineEnvironment {
     val commandLineMap = argsMap.filterKeys { it.startsWith("-P:") }.mapKeys { it.key.removePrefix("-P:") }
 
     val environmentConfig = ConfigFactory.systemProperties().withOnlyPath("ktor")
-    val fileConfig = configFile?.let { ConfigFactory.parseFile(it) } ?: ConfigFactory.load()
+    val fileConfig = configFile?.let { ConfigFactory.parseFile(it).resolve() } ?: ConfigFactory.load()
     val argConfig = ConfigFactory.parseMap(commandLineMap, "Command-line options")
     val combinedConfig = argConfig.withFallback(fileConfig).withFallback(environmentConfig)
 

--- a/ktor-server/ktor-server-host-common/src/io/ktor/server/engine/CommandLine.kt
+++ b/ktor-server/ktor-server-host-common/src/io/ktor/server/engine/CommandLine.kt
@@ -24,9 +24,9 @@ fun commandLineEnvironment(args: Array<String>): ApplicationEngineEnvironment {
     val commandLineMap = argsMap.filterKeys { it.startsWith("-P:") }.mapKeys { it.key.removePrefix("-P:") }
 
     val environmentConfig = ConfigFactory.systemProperties().withOnlyPath("ktor")
-    val fileConfig = configFile?.let { ConfigFactory.parseFile(it).resolve() } ?: ConfigFactory.load()
+    val fileConfig = configFile?.let { ConfigFactory.parseFile(it) } ?: ConfigFactory.load()
     val argConfig = ConfigFactory.parseMap(commandLineMap, "Command-line options")
-    val combinedConfig = argConfig.withFallback(fileConfig).withFallback(environmentConfig)
+    val combinedConfig = argConfig.withFallback(fileConfig).withFallback(environmentConfig).resolve()
 
     val applicationIdPath = "ktor.application.id"
 

--- a/ktor-server/ktor-server-host-common/test-resources/applicationWithEnv.conf
+++ b/ktor-server/ktor-server-host-common/test-resources/applicationWithEnv.conf
@@ -1,0 +1,10 @@
+ktor {
+    deployment {
+        port = 8080
+        port = ${?PORT}
+    }
+
+    application {
+        class = <org.company.ApplicationClass>
+    }
+}

--- a/ktor-server/ktor-server-host-common/test/io/ktor/tests/hosts/CommandLineTest.kt
+++ b/ktor-server/ktor-server-host-common/test/io/ktor/tests/hosts/CommandLineTest.kt
@@ -72,6 +72,13 @@ class CommandLineTest {
         assertEquals(expectedUri, urlClassLoader.urLs.single().toURI())
     }
 
+    @Test
+    fun configFileWithEnvironmentVariables() {
+        val configPath = CommandLineTest::class.java.classLoader.getResource("applicationWithEnv.conf").toURI().path
+        val port = commandLineEnvironment(arrayOf("-config=$configPath")).config.property("ktor.deployment.port").getString()
+        assertEquals("8080", port)
+    }
+
     private tailrec fun findContainingZipFileOrUri(uri: URI): Pair<File?, URI?> {
         if (uri.scheme == "file") {
             return Pair(File(uri.path.substringBefore("!")), null)


### PR DESCRIPTION
fixes #374

It was hard to test that the resolution actually pulls in env vars. Without the `.resolve()` the test blows up, so I still think it's a worthwhile test, just not the most thorough. Open to suggestions.