### PR TITLE
Fix for #490

### DIFF
--- a/ktor-server/ktor-server-core/src/io/ktor/content/StaticContentResolution.kt
+++ b/ktor-server/ktor-server-core/src/io/ktor/content/StaticContentResolution.kt
@@ -27,7 +27,7 @@ fun ApplicationCall.resolveResource(path: String,
         when (url.protocol) {
             "file" -> {
                 val file = File(decodeURLPart(url.path))
-                return if (file.exists()) LocalFileContent(file, mimeResolve(file.extension)) else null
+                return if (file.exists() && file.isFile) LocalFileContent(file, mimeResolve(file.extension)) else null
             }
             "jar" -> {
                 val zipFile = findContainingJarFile(url.toString())


### PR DESCRIPTION
Added a check in `ApplicationCall.resourceResource` to validate that we
are accessing a file and not a directory before attempting to open it.

Not sure if this can be unit-tested, if you have any idea how to achieve this I'll gladly add the test case(s).