### PR TITLE
Fix for #492

### DIFF
--- a/ktor-server/ktor-server-core/src/io/ktor/content/StaticContentResolution.kt
+++ b/ktor-server/ktor-server-core/src/io/ktor/content/StaticContentResolution.kt
@@ -30,15 +30,15 @@ fun ApplicationCall.resolveResource(path: String,
                 return if (file.exists()) LocalFileContent(file, mimeResolve(file.extension)) else null
             }
             "jar" -> {
-                val zipFile = findContainingJarFile(url.toString())
-                return url.path.extension()?.let { extension ->
-                    JarFileContent(zipFile, normalizedResource, mimeResolve(extension))
+                return if (packagePath.endsWith("/")) {
+                    null
+                } else {
+                    val zipFile = findContainingJarFile(url.toString())
+                    JarFileContent(zipFile, normalizedResource, mimeResolve(url.path.extension()))
                 }
             }
             "jrt" -> {
-                return url.path.extension()?.let { extension ->
-                    URIFileContent(url, mimeResolve(extension))
-                }
+                return URIFileContent(url, mimeResolve(url.path.extension()))
             }
             else -> {}
         }
@@ -58,10 +58,10 @@ internal fun findContainingJarFile(url: String): File {
     throw IllegalArgumentException("Only local jars are supported (jar:file:)")
 }
 
-private fun String.extension(): String? {
+private fun String.extension(): String {
     val indexOfName = lastIndexOf('/').takeIf { it != 1 } ?: lastIndexOf('\\').takeIf { it != 1 } ?: 0
     val indexOfDot = indexOf('.', indexOfName)
-    return if (indexOfDot >= 0) substring(indexOfDot) else null
+    return if (indexOfDot >= 0) substring(indexOfDot) else ""
 }
 
 private fun String.appendPathPart(part: String): String {

--- a/ktor-server/ktor-server-core/src/io/ktor/content/StaticContentResolution.kt
+++ b/ktor-server/ktor-server-core/src/io/ktor/content/StaticContentResolution.kt
@@ -31,9 +31,15 @@ fun ApplicationCall.resolveResource(path: String,
             }
             "jar" -> {
                 val zipFile = findContainingJarFile(url.toString())
-                return JarFileContent(zipFile, normalizedResource, mimeResolve(url.path.extension()))
+                return url.path.extension()?.let { extension ->
+                    JarFileContent(zipFile, normalizedResource, mimeResolve(extension))
+                }
             }
-            "jrt" -> return URIFileContent(url, mimeResolve(url.path.extension()))
+            "jrt" -> {
+                return url.path.extension()?.let { extension ->
+                    URIFileContent(url, mimeResolve(extension))
+                }
+            }
             else -> {}
         }
     }
@@ -52,10 +58,10 @@ internal fun findContainingJarFile(url: String): File {
     throw IllegalArgumentException("Only local jars are supported (jar:file:)")
 }
 
-private fun String.extension(): String {
+private fun String.extension(): String? {
     val indexOfName = lastIndexOf('/').takeIf { it != 1 } ?: lastIndexOf('\\').takeIf { it != 1 } ?: 0
     val indexOfDot = indexOf('.', indexOfName)
-    return substring(indexOfDot)
+    return if (indexOfDot >= 0) substring(indexOfDot) else null
 }
 
 private fun String.appendPathPart(part: String): String {


### PR DESCRIPTION
Fixes #492 

Added range check before calling `substring` to extract the extension
of a file path.

As with #491, not sure if/how this can be unit-tested, if you have any idea how to achieve this I'll gladly add the test case(s).