### PR TITLE
Handling jwt exceptions for missing keyId and failure to decode token

### DIFF
--- a/ktor-features/ktor-auth-jwt/src/io/ktor/auth/jwt/JWTAuth.kt
+++ b/ktor-features/ktor-auth-jwt/src/io/ktor/auth/jwt/JWTAuth.kt
@@ -116,11 +116,11 @@ private fun getVerifierNullableIssuer(jwkProvider: JwkProvider, issuer: String?,
             null
         } catch (ex: JWTDecodeException) {
             null
-        } ?: return null
-    }
+        }
+    } ?: return null
 
     val algorithm = try {
-        jwk?.makeAlgorithm()
+        jwk.makeAlgorithm()
     } catch (ex: IllegalArgumentException) {
         null
     } ?: return null

--- a/ktor-features/ktor-auth-jwt/src/io/ktor/auth/jwt/JWTAuth.kt
+++ b/ktor-features/ktor-auth-jwt/src/io/ktor/auth/jwt/JWTAuth.kt
@@ -117,7 +117,6 @@ private fun getVerifierNullableIssuer(jwkProvider: JwkProvider, issuer: String?,
         } catch (ex: JWTDecodeException) {
             null
         } ?: return null
-
     }
 
     val algorithm = try {

--- a/ktor-features/ktor-auth-jwt/src/io/ktor/auth/jwt/JWTAuth.kt
+++ b/ktor-features/ktor-auth-jwt/src/io/ktor/auth/jwt/JWTAuth.kt
@@ -109,9 +109,9 @@ private suspend fun evaluate(token: HttpAuthHeader?, principal: Principal?, real
 }
 
 private fun getVerifierNullableIssuer(jwkProvider: JwkProvider, issuer: String?, token: HttpAuthHeader?, schemes: JWTAuthSchemes): JWTVerifier? {
-    val jwk = token.getBlob(schemes)?.let {
+    val jwk = token.getBlob(schemes)?.let { blob ->
         try {
-            jwkProvider.get(JWT.decode(it).keyId)
+            jwkProvider.get(JWT.decode(blob).keyId)
         } catch (ex: JwkException) {
             null
         } catch (ex: JWTDecodeException) {

--- a/ktor-features/ktor-auth-jwt/src/io/ktor/auth/jwt/JWTAuth.kt
+++ b/ktor-features/ktor-auth-jwt/src/io/ktor/auth/jwt/JWTAuth.kt
@@ -109,7 +109,16 @@ private suspend fun evaluate(token: HttpAuthHeader?, principal: Principal?, real
 }
 
 private fun getVerifierNullableIssuer(jwkProvider: JwkProvider, issuer: String?, token: HttpAuthHeader?, schemes: JWTAuthSchemes): JWTVerifier? {
-    val jwk = token.getBlob(schemes)?.let { jwkProvider.get(JWT.decode(it).keyId) }
+    val jwk = token.getBlob(schemes)?.let {
+        try {
+            jwkProvider.get(JWT.decode(it).keyId)
+        } catch (ex: JwkException) {
+            null
+        } catch (ex: JWTDecodeException) {
+            null
+        } ?: return null
+
+    }
 
     val algorithm = try {
         jwk?.makeAlgorithm()

--- a/ktor-features/ktor-auth-jwt/test/io/ktor/auth/jwt/JWTAuthTest.kt
+++ b/ktor-features/ktor-auth-jwt/test/io/ktor/auth/jwt/JWTAuthTest.kt
@@ -260,6 +260,32 @@ class JWTAuthTest {
     }
 
     @Test
+    fun testJwkKidMismatch() {
+        withApplication {
+            application.configureServerJwk(mock = true)
+
+            val token = "Bearer " + JWT.create()
+                .withAudience(audience)
+                .withIssuer(issuer)
+                .withKeyId("wrong")
+                .sign(jwkAlgorithm)
+
+            val response = handleRequestWithToken(token)
+            verifyResponseUnauthorized(response)
+        }
+    }
+
+    @Test
+    fun testJwkInvalidToken() {
+        withApplication {
+            application.configureServerJwk(mock = true)
+            val token = "Bearer wrong"
+            val response = handleRequestWithToken(token)
+            verifyResponseUnauthorized(response)
+        }
+    }
+
+    @Test
     fun verifyWithMock() {
         val token = getJwkToken(prefix = false)
         val provider = getJwkProviderMock()

--- a/ktor-features/ktor-auth-jwt/test/io/ktor/auth/jwt/JWTAuthTest.kt
+++ b/ktor-features/ktor-auth-jwt/test/io/ktor/auth/jwt/JWTAuthTest.kt
@@ -407,7 +407,6 @@ class JWTAuthTest {
         }
         return mock {
             on { get(kid) } doReturn jwk
-            on { get("wrong") } doThrow(SigningKeyNotFoundException("Key not found", null))
         }
     }
 
@@ -416,11 +415,9 @@ class JWTAuthTest {
             on { algorithm } doReturn jwkAlgorithm.name
             on { publicKey } doReturn keyPair.public
         }
-        return JwkProvider { tokenId ->
-            when (tokenId) {
-                kid -> jwk
-                else -> throw SigningKeyNotFoundException("Key not found", null)
-            }
+        return mock {
+            on { get(kid) } doReturn jwk
+            on { get("wrong") } doThrow(SigningKeyNotFoundException("Key not found", null))
         }
     }
 

--- a/ktor-features/ktor-auth-jwt/test/io/ktor/auth/jwt/JWTAuthTest.kt
+++ b/ktor-features/ktor-auth-jwt/test/io/ktor/auth/jwt/JWTAuthTest.kt
@@ -407,6 +407,7 @@ class JWTAuthTest {
         }
         return mock {
             on { get(kid) } doReturn jwk
+            on { get("wrong") } doThrow(SigningKeyNotFoundException("Key not found", null))
         }
     }
 
@@ -415,8 +416,11 @@ class JWTAuthTest {
             on { algorithm } doReturn jwkAlgorithm.name
             on { publicKey } doReturn keyPair.public
         }
-        return mock {
-            on { get(kid) } doReturn jwk
+        return JwkProvider { tokenId ->
+            when (tokenId) {
+                kid -> jwk
+                else -> throw SigningKeyNotFoundException("Key not found", null)
+            }
         }
     }
 


### PR DESCRIPTION
Found and fixed a little bug when kid not found in jwks and when invalid bearer token used on verification of jwt (throws and causes 500 instead of 401)