### PR TITLE
Client and server improvements

### DIFF
--- a/ktor-client/ktor-client-core/src/io/ktor/client/HttpClient.kt
+++ b/ktor-client/ktor-client-core/src/io/ktor/client/HttpClient.kt
@@ -5,6 +5,7 @@ import io.ktor.client.engine.*
 import io.ktor.client.features.*
 import io.ktor.client.request.*
 import io.ktor.client.response.*
+import io.ktor.http.*
 import io.ktor.util.*
 import kotlinx.coroutines.experimental.*
 import kotlinx.io.core.*
@@ -64,6 +65,8 @@ class HttpClient(
                 takeFrom(context)
                 body = content
             }.build()
+
+            validateHeaders(requestData)
 
             val (request, response) = engine.execute(call, requestData)
             call.request = request
@@ -131,6 +134,19 @@ class HttpClient(
             if (feature is Closeable) {
                 feature.close()
             }
+        }
+    }
+
+}
+
+/**
+ * Validates request headers and fails if there are unsafe headers supplied
+ */
+private fun validateHeaders(request: HttpRequestData) {
+    val requestHeaders = request.headers
+    for (header in HttpHeaders.UnsafeHeaders) {
+        if (header in requestHeaders) {
+            throw UnsafeHeaderException(header)
         }
     }
 }

--- a/ktor-client/ktor-client-core/src/io/ktor/client/engine/Utils.kt
+++ b/ktor-client/ktor-client-core/src/io/ktor/client/engine/Utils.kt
@@ -22,8 +22,8 @@ fun mergeHeaders(
         block(key, values.joinToString(";"))
     }
 
-    val type = requestHeaders[HttpHeaders.ContentType] ?: content.contentType?.toString()
-    val length = requestHeaders[HttpHeaders.ContentLength] ?: content.contentLength?.toString()
+    val type = content.contentType?.toString() ?: content.headers[HttpHeaders.ContentType]
+    val length = content.contentLength?.toString() ?: content.headers[HttpHeaders.ContentLength]
 
     type?.let { block(HttpHeaders.ContentType, it) }
     length?.let { block(HttpHeaders.ContentLength, it) }

--- a/ktor-http/ktor-http-cio/src/io/ktor/http/cio/HttpHeadersMap.kt
+++ b/ktor-http/ktor-http-cio/src/io/ktor/http/cio/HttpHeadersMap.kt
@@ -45,6 +45,18 @@ class HttpHeadersMap internal constructor(private val builder: CharBufferBuilder
         size++
     }
 
+    fun find(name: String, fromIndex: Int = 0): Int {
+        val nameHash = name.hashCodeLowerCase()
+        for (i in fromIndex until size) {
+            val offset = i * HEADER_SIZE
+            if (indexes[offset] == nameHash) {
+                return i
+            }
+        }
+
+        return -1
+    }
+
     operator fun get(name: String): CharSequence? {
         val nameHash = name.hashCodeLowerCase()
         for (i in 0 until size) {

--- a/ktor-http/src/io/ktor/http/HttpHeaders.kt
+++ b/ktor-http/src/io/ktor/http/HttpHeaders.kt
@@ -1,5 +1,7 @@
 package io.ktor.http
 
+import io.ktor.util.*
+
 @Suppress("unused")
 object HttpHeaders {
     // Permanently registered standard HTTP headers
@@ -104,5 +106,15 @@ object HttpHeaders {
     val XForwardedServer = "X-Forwarded-Server"
     val XForwardedProto = "X-Forwarded-Proto"
     val XForwardedFor = "X-Forwarded-For"
+
+    fun isUnsafe(header: String): Boolean = UnsafeHeaders.any { it.equals(header, ignoreCase = true) }
+
+    val UnsafeHeaders: Array<String> = arrayOf(
+            HttpHeaders.ContentLength,
+            HttpHeaders.ContentType,
+            HttpHeaders.TransferEncoding,
+            HttpHeaders.Upgrade
+    )
 }
 
+class UnsafeHeaderException(header: String) : IllegalArgumentException("Header $header is controlled by the engine and cannot be set explicitly")

--- a/ktor-http/src/io/ktor/http/HttpMessageProperties.kt
+++ b/ktor-http/src/io/ktor/http/HttpMessageProperties.kt
@@ -2,10 +2,14 @@ package io.ktor.http
 
 import kotlinx.io.charsets.*
 
-
 fun HttpMessageBuilder.contentType(type: ContentType) = headers.set(HttpHeaders.ContentType, type.toString())
+
+@Deprecated("Content-Length is controlled by underlying engine. Don't specify it explicitly.")
 fun HttpMessageBuilder.contentLength(length: Int) = headers.set(HttpHeaders.ContentLength, length.toString())
+
+@Deprecated("Use content with particular content type and charset instead")
 fun HttpMessageBuilder.charset(charset: Charset) = contentType()?.let { contentType(it.withCharset(charset)) }
+
 fun HttpMessageBuilder.maxAge(seconds: Int) = headers.append(HttpHeaders.CacheControl, "max-age:$seconds")
 fun HttpMessageBuilder.ifNoneMatch(value: String) = headers.set(HttpHeaders.IfNoneMatch, value)
 fun HttpMessageBuilder.userAgent(content: String) = headers.set(HttpHeaders.UserAgent, content)

--- a/ktor-server/ktor-server-cio/test/io/ktor/tests/server/cio/CIOHttpClientTest.kt
+++ b/ktor-server/ktor-server-cio/test/io/ktor/tests/server/cio/CIOHttpClientTest.kt
@@ -5,7 +5,9 @@ import io.ktor.client.call.*
 import io.ktor.client.engine.cio.*
 import io.ktor.client.request.*
 import io.ktor.client.response.*
+import io.ktor.client.utils.*
 import io.ktor.http.*
+import io.ktor.http.content.*
 import kotlinx.coroutines.experimental.*
 import org.junit.Test
 import java.io.*
@@ -151,8 +153,12 @@ class CIOHttpClientTest {
             method = HttpMethod.Post
             url.encodedPath = "/url"
             header("header", "value")
-            header("Transfer-Encoding", "chunked")
-            body = "request-body"
+            body = TextContent("request-body", ContentType.Text.Plain).wrapHeaders { hh ->
+                HeadersBuilder().apply {
+                    appendAll(hh)
+                    append(HttpHeaders.TransferEncoding, "chunked")
+                }.build()
+            }
         }.response
 
         try {

--- a/ktor-server/ktor-server-core/src/io/ktor/response/ResponseHeaders.kt
+++ b/ktor-server/ktor-server-core/src/io/ktor/response/ResponseHeaders.kt
@@ -13,7 +13,7 @@ abstract class ResponseHeaders {
     }
 
     fun append(name: String, value: String, safeOnly: Boolean = true) {
-        if (safeOnly && name.isUnsafe())
+        if (safeOnly && HttpHeaders.isUnsafe(name))
             throw UnsafeHeaderException(name)
         engineAppendHeader(name, value)
     }
@@ -23,13 +23,3 @@ abstract class ResponseHeaders {
     protected abstract fun getEngineHeaderValues(name: String): List<String>
 }
 
-private fun String.isUnsafe(): Boolean = unsafeHeaders.any { it.equals(this, ignoreCase = true) }
-
-private val unsafeHeaders = setOf(
-        HttpHeaders.ContentLength,
-        HttpHeaders.ContentType,
-        HttpHeaders.TransferEncoding,
-        HttpHeaders.Upgrade
-)
-
-class UnsafeHeaderException(header: String) : IllegalArgumentException("Header $header is controlled by the engine and cannot be set explicitly")

--- a/ktor-server/ktor-server-host-common/src/io/ktor/server/engine/BaseApplicationResponse.kt
+++ b/ktor-server/ktor-server-host-common/src/io/ktor/server/engine/BaseApplicationResponse.kt
@@ -139,7 +139,11 @@ abstract class BaseApplicationResponse(override val call: ApplicationCall) : App
         responseChannel().use {
             // Call user code to send data
 //            val before = totalBytesWritten
-            content.writeTo(this)
+            try {
+                content.writeTo(this)
+            } catch (closed: ClosedWriteChannelException) {
+                throw ChannelWriteException(exception = closed)
+            }
 
             // TODO currently we can't ensure length like that
             // because a joined channel doesn't increment totalBytesWritten

--- a/ktor-server/ktor-server-test-host/src/io/ktor/server/testing/EngineTestSuite.kt
+++ b/ktor-server/ktor-server-test-host/src/io/ktor/server/testing/EngineTestSuite.kt
@@ -161,8 +161,7 @@ abstract class EngineTestSuite<TEngine : ApplicationEngine, TConfiguration : App
 
         withUrl("/", {
             method = HttpMethod.Post
-            header(HttpHeaders.ContentType, ContentType.Application.FormUrlEncoded.toString())
-            body = parametersOf("a", "1").formUrlEncode()
+            body = TextContent(parametersOf("a", "1").formUrlEncode(), ContentType.Application.FormUrlEncoded)
         }) {
             assertEquals(200, status.value)
             assertEquals("a=1", readText())
@@ -558,8 +557,7 @@ abstract class EngineTestSuite<TEngine : ApplicationEngine, TConfiguration : App
 
         withUrl("/?urlp=1", {
             method = HttpMethod.Post
-            header(HttpHeaders.ContentType, ContentType.Application.FormUrlEncoded.toString())
-            body = ByteArrayContent("formp=2".toByteArray())
+            body = ByteArrayContent("formp=2".toByteArray(), ContentType.Application.FormUrlEncoded)
         }) {
             assertEquals(HttpStatusCode.OK.value, status.value)
             assertEquals("1,2", readText())
@@ -604,7 +602,7 @@ abstract class EngineTestSuite<TEngine : ApplicationEngine, TConfiguration : App
 
         withUrl("/", {
             method = HttpMethod.Post
-            header(HttpHeaders.ContentType, ContentType.Text.Plain.toString())
+//            header(HttpHeaders.ContentType, ContentType.Text.Plain.toString())
             body = ByteArrayContent("POST content".toByteArray())
         }) {
             assertEquals(200, status.value)
@@ -863,8 +861,7 @@ abstract class EngineTestSuite<TEngine : ApplicationEngine, TConfiguration : App
 
         withUrl("/", {
             method = HttpMethod.Post
-            header(HttpHeaders.ContentType, ContentType.Text.Plain.toString())
-            body = ByteArrayContent("Hello".toByteArray())
+            body = ByteArrayContent("Hello".toByteArray(), ContentType.Text.Plain)
         }) {
             assertEquals(200, status.value)
             assertEquals("Hello", readText())
@@ -1505,7 +1502,7 @@ abstract class EngineTestSuite<TEngine : ApplicationEngine, TConfiguration : App
                                 append(HttpHeaders.ContentLength, doubleSize)
                             }
 
-                        suspend override fun writeTo(channel: ByteWriteChannel) {
+                        override suspend fun writeTo(channel: ByteWriteChannel) {
                             channel.writeFully(data)
                             channel.close()
                         }

--- a/ktor-utils/src/io/ktor/util/StringValues.kt
+++ b/ktor-utils/src/io/ktor/util/StringValues.kt
@@ -149,6 +149,8 @@ open class StringValuesBuilder(val caseInsensitiveName: Boolean = false, size: I
     protected var built = false
 
     fun getAll(name: String): List<String>? = values[name]
+
+    operator fun contains(name: String): Boolean = name in values
     fun contains(name: String, value: String) = values[name]?.contains(value) ?: false
 
     fun names() = values.keys


### PR DESCRIPTION
- fix duplicate `Content-Length` header handling at CIO server
- prohibit setting unsafe headers for client request
- fix `testClosedConnection` to pass faster
- fix Bad Request processing at CIO server
- fix channel write error wrapping for `OutgoingContent.WriteChannelContent` 