### PR TITLE
Rename `XForwardedHeaderSupport` to `XForwardedHeadersSupport`

### DIFF
--- a/ktor-server/ktor-server-core/src/io/ktor/features/OriginConnectionPoint.kt
+++ b/ktor-server/ktor-server-core/src/io/ktor/features/OriginConnectionPoint.kt
@@ -27,9 +27,9 @@ class MutableOriginConnectionPoint(delegate: RequestConnectionPoint) : RequestCo
     override var remoteHost by AssignableWithDelegate { delegate.remoteHost }
 }
 
-object XForwardedHeadersSupport : ApplicationFeature<ApplicationCallPipeline, XForwardedHeadersSupport.Config, XForwardedHeadersSupport.Config> {
+object XForwardedHeaderSupport : ApplicationFeature<ApplicationCallPipeline, XForwardedHeaderSupport.Config, XForwardedHeaderSupport.Config> {
 
-    override val key = AttributeKey<Config>("XForwardedHeadersSupport")
+    override val key = AttributeKey<Config>("XForwardedHeaderSupport")
 
     override fun install(pipeline: ApplicationCallPipeline, configure: Config.() -> Unit): Config {
         val config = Config()
@@ -90,6 +90,9 @@ object XForwardedHeadersSupport : ApplicationFeature<ApplicationCallPipeline, XF
         val httpsFlagHeaders = arrayListOf("X-Forwarded-SSL", "Front-End-Https")
     }
 }
+
+@Deprecated("", replaceWith = ReplaceWith("XForwardedHeaderSupport"))
+typealias XForwardedHeadersSupport = XForwardedHeaderSupport
 
 /**
  * Forwarded header support. See RFC 7239 https://tools.ietf.org/html/rfc7239

--- a/ktor-server/ktor-server-test-host/src/io/ktor/server/testing/EngineTestSuite.kt
+++ b/ktor-server/ktor-server-test-host/src/io/ktor/server/testing/EngineTestSuite.kt
@@ -916,7 +916,7 @@ abstract class EngineTestSuite<TEngine : ApplicationEngine, TConfiguration : App
     @Test
     fun testProxyHeaders() {
         createAndStartServer {
-            install(XForwardedHeadersSupport)
+            install(XForwardedHeaderSupport)
             get("/") {
                 call.respond(call.url { })
             }

--- a/ktor-server/ktor-server-tests/test/io/ktor/tests/server/features/HSTSTest.kt
+++ b/ktor-server/ktor-server-tests/test/io/ktor/tests/server/features/HSTSTest.kt
@@ -105,7 +105,7 @@ class HSTSTest {
     }
 
     private fun Application.testApp(block: HSTS.Configuration.() -> Unit = {}) {
-        install(XForwardedHeadersSupport)
+        install(XForwardedHeaderSupport)
         install(HSTS) {
             maxAge = Duration.ofSeconds(10L)
             includeSubDomains = true

--- a/ktor-server/ktor-server-tests/test/io/ktor/tests/server/features/HttpsRedirectFeatureTest.kt
+++ b/ktor-server/ktor-server-tests/test/io/ktor/tests/server/features/HttpsRedirectFeatureTest.kt
@@ -31,7 +31,7 @@ class HttpsRedirectFeatureTest {
     @Test
     fun testRedirectHttps() {
         withTestApplication {
-            application.install(XForwardedHeadersSupport)
+            application.install(XForwardedHeaderSupport)
             application.install(HttpsRedirect)
             application.routing {
                 get("/") {

--- a/ktor-server/ktor-server-tests/test/io/ktor/tests/server/features/OriginConnectionPointTest.kt
+++ b/ktor-server/ktor-server-tests/test/io/ktor/tests/server/features/OriginConnectionPointTest.kt
@@ -13,7 +13,7 @@ class OriginConnectionPointTest {
     @Test
     fun testDirectRequest() {
         withTestApplication {
-            application.install(XForwardedHeadersSupport)
+            application.install(XForwardedHeaderSupport)
             application.routing {
                 get("/") {
                     with(call.request.local) {
@@ -41,7 +41,7 @@ class OriginConnectionPointTest {
     @Test
     fun testProxyXForwardedFor() {
         withTestApplication {
-            application.install(XForwardedHeadersSupport)
+            application.install(XForwardedHeaderSupport)
             application.routing {
                 get("/") {
                     with(call.request.origin) {
@@ -64,7 +64,7 @@ class OriginConnectionPointTest {
     @Test
     fun testProxyXForwardedHostNoPort() {
         withTestApplication {
-            application.install(XForwardedHeadersSupport)
+            application.install(XForwardedHeaderSupport)
             application.routing {
                 get("/") {
                     with(call.request.origin) {
@@ -87,7 +87,7 @@ class OriginConnectionPointTest {
     @Test
     fun testProxyXForwardedHostWithPort() {
         withTestApplication {
-            application.install(XForwardedHeadersSupport)
+            application.install(XForwardedHeaderSupport)
             application.routing {
                 get("/") {
                     with(call.request.origin) {
@@ -110,7 +110,7 @@ class OriginConnectionPointTest {
     @Test
     fun testProxyXForwardedScheme() {
         withTestApplication {
-            application.install(XForwardedHeadersSupport)
+            application.install(XForwardedHeaderSupport)
             application.routing {
                 get("/") {
                     with(call.request.origin) {
@@ -133,7 +133,7 @@ class OriginConnectionPointTest {
     @Test
     fun testProxyXForwardedSchemeWithPort() {
         withTestApplication {
-            application.install(XForwardedHeadersSupport)
+            application.install(XForwardedHeaderSupport)
             application.routing {
                 get("/") {
                     with(call.request.origin) {
@@ -157,7 +157,7 @@ class OriginConnectionPointTest {
     @Test
     fun testProxyXForwardedSchemeNoPort() {
         withTestApplication {
-            application.install(XForwardedHeadersSupport)
+            application.install(XForwardedHeaderSupport)
             application.routing {
                 get("/") {
                     with(call.request.origin) {
@@ -181,7 +181,7 @@ class OriginConnectionPointTest {
     @Test
     fun testProxyXForwardedHttpsFlagOn() {
         withTestApplication {
-            application.install(XForwardedHeadersSupport)
+            application.install(XForwardedHeaderSupport)
             application.routing {
                 get("/") {
                     with(call.request.origin) {

--- a/ktor-server/ktor-server-tests/test/io/ktor/tests/server/http/URLBuilderTest.kt
+++ b/ktor-server/ktor-server-tests/test/io/ktor/tests/server/http/URLBuilderTest.kt
@@ -173,7 +173,7 @@ class URLBuilderTest {
     @Test
     fun testWithProxy() {
         withTestApplication {
-            application.install(XForwardedHeadersSupport)
+            application.install(XForwardedHeaderSupport)
             application.intercept(ApplicationCallPipeline.Call) {
                 assertEquals("http://special-host:90/", call.url())
             }
@@ -187,7 +187,7 @@ class URLBuilderTest {
     @Test
     fun testWithProxyHttps() {
         withTestApplication {
-            application.install(XForwardedHeadersSupport)
+            application.install(XForwardedHeaderSupport)
             application.intercept(ApplicationCallPipeline.Call) {
                 assertEquals("https://special-host:90/", call.url())
             }
@@ -202,7 +202,7 @@ class URLBuilderTest {
     @Test
     fun testWithProxyHttpsDefaultPort() {
         withTestApplication {
-            application.install(XForwardedHeadersSupport)
+            application.install(XForwardedHeaderSupport)
             application.intercept(ApplicationCallPipeline.Call) {
                 assertEquals("https://special-host/", call.url())
             }
@@ -217,7 +217,7 @@ class URLBuilderTest {
     @Test
     fun testWithProxyHttpsWithPortEqualToDefault() {
         withTestApplication {
-            application.install(XForwardedHeadersSupport)
+            application.install(XForwardedHeaderSupport)
             application.intercept(ApplicationCallPipeline.Call) {
                 assertEquals("https://special-host/", call.url())
             }


### PR DESCRIPTION
To be consistent with `ForwardedHeaderSupport`.

The alternative is to rename `ForwardedHeaderSupport` to `ForwardedHeadersSupport`.

Documentation was wrong because of copy-pasting `ForwardedHeaderSupport` adding an `X`: https://github.com/ktorio/ktorio.github.io/commit/3985523155489d17c8ac623595629e2e1ef5c653

But would be nice if they are consistent.