### PR TITLE
ktor-client-core: Copy existing config in HttpClient#config

### DIFF
--- a/ktor-client/ktor-client-android/test/io/ktor/client/engine/android/CommonTests.kt
+++ b/ktor-client/ktor-client-android/test/io/ktor/client/engine/android/CommonTests.kt
@@ -20,3 +20,5 @@ class AndroidContentTest : ContentTest(Android)
 class AndroidRedirectTest : HttpRedirectTest(Android)
 
 class AndroidBuildersTest : BuildersTest(Android)
+
+class AndroidHttpClientTest : HttpClientTest(Android)

--- a/ktor-client/ktor-client-apache/test/io/ktor/client/engine/apache/CommonTests.kt
+++ b/ktor-client/ktor-client-apache/test/io/ktor/client/engine/apache/CommonTests.kt
@@ -27,3 +27,5 @@ class ApacheBuildersTest : BuildersTest(Apache)
 class ApacheFeaturesTest : FeaturesTest(Apache)
 
 class ApacheConnectionTest : ConnectionTest(Apache)
+
+class ApacheHttpClientTest : HttpClientTest(Apache)

--- a/ktor-client/ktor-client-cio/test/io/ktor/client/engine/cio/CommonTests.kt
+++ b/ktor-client/ktor-client-cio/test/io/ktor/client/engine/cio/CommonTests.kt
@@ -24,3 +24,5 @@ class CIOBuildersTest : BuildersTest(CIO)
 class CIOFeaturesTest : FeaturesTest(CIO)
 
 class CIOConnectionTest : ConnectionTest(CIO)
+
+class CIOHttpClientTest : HttpClientTest(CIO)

--- a/ktor-client/ktor-client-core/src/io/ktor/client/HttpClient.kt
+++ b/ktor-client/ktor-client-core/src/io/ktor/client/HttpClient.kt
@@ -118,7 +118,7 @@ class HttpClient(
      * and additionally configured by the [block] parameter.
      */
     fun config(block: HttpClientConfig<*>.() -> Unit): HttpClient = HttpClient(
-        engine, useDefaultTransformers, HttpClientConfig<HttpClientEngineConfig>().apply(block)
+        engine, useDefaultTransformers, config.clone().apply(block)
     )
 
     /**

--- a/ktor-client/ktor-client-okhttp/test/io/ktor/client/engine/okhttp/CommonTests.kt
+++ b/ktor-client/ktor-client-okhttp/test/io/ktor/client/engine/okhttp/CommonTests.kt
@@ -20,3 +20,5 @@ class OkHttpBuildersTest : BuildersTest(OkHttp)
 class OkHttpFeaturesTest : FeaturesTest(OkHttp)
 
 class OkHttpConnectionTest : ConnectionTest(OkHttp)
+
+class OkHttpHttpClientTest : HttpClientTest(OkHttp)

--- a/ktor-client/ktor-client-tests/src/io/ktor/client/tests/HttpClientTest.kt
+++ b/ktor-client/ktor-client-tests/src/io/ktor/client/tests/HttpClientTest.kt
@@ -1,0 +1,85 @@
+package io.ktor.client.tests
+
+import io.ktor.application.call
+import io.ktor.client.HttpClient
+import io.ktor.client.call.call
+import io.ktor.client.features.DefaultRequest
+import io.ktor.client.request.HttpRequestBuilder
+import io.ktor.client.request.port
+import io.ktor.client.tests.utils.TestWithKtor
+import io.ktor.http.HttpMethod
+import io.ktor.http.fullPath
+import io.ktor.response.respondText
+import io.ktor.routing.get
+import io.ktor.routing.routing
+import io.ktor.server.engine.ApplicationEngine
+import io.ktor.server.engine.embeddedServer
+import io.ktor.server.netty.Netty
+import io.ktor.util.AttributeKey
+import kotlinx.coroutines.experimental.runBlocking
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class HttpClientTest : TestWithKtor() {
+    override val server: ApplicationEngine = embeddedServer(Netty, serverPort) {
+        routing {
+            get("/empty") {
+                call.respondText("")
+            }
+            get("/hello") {
+                call.respondText("hello")
+            }
+        }
+    }
+
+    @Test
+    fun configCopiesOldFeaturesAndInterceptors() {
+        val customFeatureKey = AttributeKey<Boolean>("customFeature")
+        val anotherCustomFeatureKey = AttributeKey<Boolean>("anotherCustomFeature")
+
+        val originalClient = HttpClient(useDefaultTransformers = false) {
+            install(DefaultRequest) {
+                port = serverPort
+                url.path("empty")
+            }
+            install("customFeature") {
+                attributes.put(customFeatureKey, true)
+            }
+        }
+
+        // check everything was installed in original
+        val originalRequest = runBlocking {
+            originalClient.execute(HttpRequestBuilder())
+        }.request
+        assertEquals("/empty", originalRequest.url.fullPath)
+
+        assertTrue(originalClient.attributes.contains(customFeatureKey), "no custom feature installed")
+
+        // create a new client, copying the original, with:
+        // - a reconfigured DefaultRequest
+        // - a new custom feature
+        val newClient = originalClient.config {
+            install(DefaultRequest) {
+                port = serverPort
+                url.path("hello")
+            }
+            install("anotherCustomFeature") {
+                attributes.put(anotherCustomFeatureKey, true)
+            }
+        }
+
+        // check the custom feature remained installed
+        // and that we overrode the DefaultRequest
+        val newRequest = runBlocking {
+            newClient.execute(HttpRequestBuilder())
+        }.request
+        assertEquals("/hello", newRequest.url.fullPath)
+
+        assertTrue(newClient.attributes.contains(customFeatureKey), "no custom feature installed")
+
+        // check the new custom feature is there too
+        assertTrue(newClient.attributes.contains(anotherCustomFeatureKey), "no other custom feature installed")
+    }
+
+}

--- a/ktor-client/ktor-client-tests/src/io/ktor/client/tests/HttpClientTest.kt
+++ b/ktor-client/ktor-client-tests/src/io/ktor/client/tests/HttpClientTest.kt
@@ -3,6 +3,7 @@ package io.ktor.client.tests
 import io.ktor.application.call
 import io.ktor.client.HttpClient
 import io.ktor.client.call.call
+import io.ktor.client.engine.HttpClientEngineFactory
 import io.ktor.client.features.DefaultRequest
 import io.ktor.client.request.HttpRequestBuilder
 import io.ktor.client.request.port
@@ -21,7 +22,7 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
-class HttpClientTest : TestWithKtor() {
+open class HttpClientTest(private val factory: HttpClientEngineFactory<*>) : TestWithKtor() {
     override val server: ApplicationEngine = embeddedServer(Netty, serverPort) {
         routing {
             get("/empty") {
@@ -38,7 +39,7 @@ class HttpClientTest : TestWithKtor() {
         val customFeatureKey = AttributeKey<Boolean>("customFeature")
         val anotherCustomFeatureKey = AttributeKey<Boolean>("anotherCustomFeature")
 
-        val originalClient = HttpClient(useDefaultTransformers = false) {
+        val originalClient = HttpClient(factory, useDefaultTransformers = false) {
             install(DefaultRequest) {
                 port = serverPort
                 url.path("empty")


### PR DESCRIPTION
Copy the existing config in HttpClient#config, as the docs specify.
Prior to this all features and interceptors were lost.