### PR TITLE
Add append method for form-data filename

### DIFF
--- a/ktor-client/ktor-client-core/src/io/ktor/client/request/forms/formDsl.kt
+++ b/ktor-client/ktor-client-core/src/io/ktor/client/request/forms/formDsl.kt
@@ -18,8 +18,8 @@ fun formData(vararg values: FormPart<*>): List<PartData> {
 
     values.forEach { (key, value, headers) ->
         val partHeaders = Headers.build {
-            appendAll(headers)
             append(HttpHeaders.ContentDisposition, "form-data;name=$key")
+            appendAll(headers)
         }
         val part = when (value) {
             is String -> PartData.FormItem(value, {}, partHeaders)

--- a/ktor-client/ktor-client-core/src/io/ktor/client/request/forms/formDsl.kt
+++ b/ktor-client/ktor-client-core/src/io/ktor/client/request/forms/formDsl.kt
@@ -53,5 +53,12 @@ class FormBuilder {
         append(FormPart(key, buildPacket { block() }, headers))
     }
 
+    fun append(key: String, filename: String, block: BytePacketBuilder.() -> Unit) {
+        val filenameHeader: Headers = headersOf(
+            HttpHeaders.ContentDisposition, "filename=$filename"
+        )
+        append(key, filenameHeader, block)
+    }
+
     internal fun build(): List<FormPart<*>> = parts
 }


### PR DESCRIPTION
The first commit fixes `Content-Disposition: name="fieldName";filename="filename.jpg";form-data` to `Content-Disposition: form-data;name="fieldName";filename="filename.jpg"`. The rationale is [this MDN documentation](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Disposition#As_a_header_for_a_multipart_body).

About the second commit, I think it's not bad to treat filename header specially.