### PR TITLE
ktor-http: URLBuilder isolate port and the protocol's defaultPort

### DIFF
--- a/ktor-http/ktor-http-jvm/test/io/ktor/tests/http/URLBuilderJvmTest.kt
+++ b/ktor-http/ktor-http-jvm/test/io/ktor/tests/http/URLBuilderJvmTest.kt
@@ -5,7 +5,7 @@ import java.net.*
 import kotlin.test.*
 
 
-class URLBuilderTest {
+class URLBuilderJvmTest {
     private val urlString = "http://localhost:8080/path"
 
     @Test

--- a/ktor-http/src/io/ktor/http/URLProtocol.kt
+++ b/ktor-http/src/io/ktor/http/URLProtocol.kt
@@ -16,7 +16,7 @@ data class URLProtocol(val name: String, val defaultPort: Int) {
         val byName = listOf(HTTP, HTTPS, WS, WSS).associateBy { it.name }
 
         fun createOrDefault(name: String): URLProtocol = name.toLowerCase().let {
-            byName[it] ?: URLProtocol(it, -1)
+            byName[it] ?: URLProtocol(it, UNKNOWN_PORT)
         }
     }
 }

--- a/ktor-http/test/io/ktor/tests/http/URLBuilderTest.kt
+++ b/ktor-http/test/io/ktor/tests/http/URLBuilderTest.kt
@@ -1,0 +1,65 @@
+package io.ktor.tests.http
+
+import io.ktor.http.UNKNOWN_PORT
+import io.ktor.http.URLBuilder
+import io.ktor.http.URLProtocol
+import io.ktor.http.takeFrom
+import kotlin.test.*
+
+internal class URLBuilderTest {
+    @Test
+    fun portIsNotInStringIfItMatchesTheProtocolDefaultPort() {
+        URLBuilder().apply {
+            protocol = URLProtocol("custom", 12345)
+            port = 12345
+        }.buildString().let {
+            assertEquals("custom://localhost/", it)
+        }
+    }
+
+    @Test
+    fun settingTheProtocolDoesNotOverwriteAnExplicitPort() {
+        URLBuilder().apply {
+            port = 8080
+            protocol = URLProtocol.HTTPS
+        }.buildString().let { url ->
+            assertEquals("https://localhost:8080/", url)
+        }
+    }
+
+    @Test
+    fun protocolDefaultPortIsUsedIfAPortIsNotSpecified() {
+        URLBuilder().apply {
+            protocol = URLProtocol.HTTPS
+
+            assertEquals(UNKNOWN_PORT, port)
+        }.build().also { url ->
+            assertEquals(URLProtocol.HTTPS.defaultPort, url.port)
+        }
+    }
+
+    @Test
+    fun anExplicitPortIsUsedIfSpecified() {
+        URLBuilder().apply {
+            protocol = URLProtocol.HTTPS
+            port = 2048
+
+            assertEquals(2048, port)
+        }.build().also { url ->
+            assertEquals(2048, url.port)
+        }
+    }
+
+    @Test
+    fun takeFromACustomProtocolAndSettingTheDefaultPort() {
+        URLBuilder().apply {
+            takeFrom("custom://localhost/path")
+            protocol = URLProtocol("custom", 8080)
+
+            assertEquals(UNKNOWN_PORT, port)
+        }.buildString().also { url ->
+            // ensure that the built url does not specify the port when configuring the default port
+            assertEquals("custom://localhost/path", url)
+        }
+    }
+}

--- a/ktor-http/test/io/ktor/tests/http/UrlTest.kt
+++ b/ktor-http/test/io/ktor/tests/http/UrlTest.kt
@@ -1,6 +1,7 @@
 package io.ktor.tests.http
 
 import io.ktor.http.*
+import io.ktor.util.random
 import kotlin.test.*
 
 class UrlTest {
@@ -92,9 +93,11 @@ class UrlTest {
 
     @Test
     fun testEncoding() {
-        val urlBuilder = { URLBuilder("http://httpbin.org/response-headers").apply {
-            parameters.append("message", "foo%bar")
-        } }
+        val urlBuilder = {
+            URLBuilder("http://httpbin.org/response-headers").apply {
+                parameters.append("message", "foo%bar")
+            }
+        }
 
         val url = urlBuilder().build()
 
@@ -123,5 +126,22 @@ class UrlTest {
             assertEquals("", encodedPath)
             assertEquals("https://www.test.com/?test=ok&authtoken=testToken", url.toString())
         }
+    }
+
+    @Test
+    fun testPortRange() {
+        fun testPort(n: Int) {
+            assertEquals(n, Url(URLProtocol.HTTP, "localhost", n, "/", parametersOf(), "", null, null, false).port)
+        }
+
+        // smallest port value
+        testPort(0)
+        // largest port value 2^16
+        testPort(65535)
+
+        // Test a random port in the range
+        testPort(random(65535).coerceAtLeast(0))
+
+        assertFails { testPort(-2) }
     }
 }


### PR DESCRIPTION
See #561 for the original issue discussion

This modification removes the behavior on the [URLBuilder] to no longer set the `port` when explicitly specifying a `protocol`.

## Setting a `protocol` no longer changes `port`

### An explicit `port` is not overwritten when the `protocol` is set

#### Before

```kotlin
val url = URLBuilder().apply {
    port = 8080
    protocol = URLProtocol.HTTPS
}.build()
println(url.port) // 443
```

#### After

```kotlin
val url = URLBuilder().apply {
    port = 8080
    protocol = URLProtocol.HTTPS
}.build()
println(url.port) // 8080
```

## The `protocol.defaultPort` will be a fallback during the `build()`

### When `port` is never specified

#### Before

```kotlin
val url = URLBuilder().apply {
    protocol = URLProtocol.HTTPS
    println(port) // 443, changed by `protocol =`
}.build()
println(url.port) // 443
```

#### After

```kotlin
val url = URLBuilder().apply {
    protocol = URLProtocol.HTTPS
    println(port) // -1, no longer changed by `protocol =`
}.build()
println(url.port) // 443
```

### When `takeFrom()` does not find a port

#### Before

```kotlin
val url = URLBuilder().apply {
    takeFrom("http://localhost/path")
    protocol = URLProtocol("custom", 8080)

    println(port) // 8080, changed by `protocol =`
}.build()
println(url.protocol) // URLProtocol(name=custom, defaultPort=8080)
println(url.port) // 8080
```

#### After

```kotlin
val url = URLBuilder().apply {
    takeFrom("http://localhost/path")
    protocol = URLProtocol("custom", 8080)

    println(port) // -1, no port was specified in URL imported by `takeFrom` and not set by `protocol =`
}.build()
println(url.protocol) // URLProtocol(name=custom, defaultPort=8080)
println(url.port) // 8080
```