### PR TITLE
improve kotlinxSerializer

### DIFF
--- a/ktor-client/ktor-client-features/ktor-client-json/build.gradle
+++ b/ktor-client/ktor-client-features/ktor-client-json/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.serialization_version = '0.6.1'
+    ext.serialization_version = '0.6.2'
     repositories {
         jcenter()
         maven { url "https://kotlin.bintray.com/kotlinx" }
@@ -12,8 +12,8 @@ apply plugin: 'kotlinx-serialization'
 description = "Ktor client JSON support"
 
 dependencies {
-    compile group: 'org.jetbrains.kotlinx', name: 'kotlinx-serialization-runtime-common', version: '0.6.1'
-    compile group: 'org.jetbrains.kotlinx', name: 'kotlinx-serialization-runtime-jsonparser', version: '0.6.1'
+    compile group: 'org.jetbrains.kotlinx', name: 'kotlinx-serialization-runtime-common', version: serialization_version
+    compile group: 'org.jetbrains.kotlinx', name: 'kotlinx-serialization-runtime-jsonparser', version: serialization_version
 
     compile project(':ktor-client:ktor-client-core')
 }

--- a/ktor-client/ktor-client-features/ktor-client-json/build.gradle
+++ b/ktor-client/ktor-client-features/ktor-client-json/build.gradle
@@ -1,7 +1,19 @@
+buildscript {
+    ext.serialization_version = '0.6.1'
+    repositories {
+        jcenter()
+        maven { url "https://kotlin.bintray.com/kotlinx" }
+    }
+    dependencies {
+        classpath "org.jetbrains.kotlinx:kotlinx-gradle-serialization-plugin:$serialization_version"
+    }
+}
+apply plugin: 'kotlinx-serialization'
 description = "Ktor client JSON support"
 
 dependencies {
-    compile group: 'org.jetbrains.kotlinx', name: 'kotlinx-serialization-runtime-jsonparser', version: '0.6.0'
+    compile group: 'org.jetbrains.kotlinx', name: 'kotlinx-serialization-runtime-common', version: '0.6.1'
+    compile group: 'org.jetbrains.kotlinx', name: 'kotlinx-serialization-runtime-jsonparser', version: '0.6.1'
 
     compile project(':ktor-client:ktor-client-core')
 }

--- a/ktor-client/ktor-client-features/ktor-client-json/ktor-client-json-ios/build.gradle
+++ b/ktor-client/ktor-client-features/ktor-client-json/ktor-client-json-ios/build.gradle
@@ -1,4 +1,4 @@
-
+apply plugin: 'kotlinx-serialization'
 dependencies {
     expectedBy project(':ktor-client:ktor-client-features:ktor-client-json')
     implementation project(':ktor-client:ktor-client-core:ktor-client-core-ios')

--- a/ktor-client/ktor-client-features/ktor-client-json/ktor-client-json-ios/src/io/ktor/client/features/json/serializer/SerialHelperIos.kt
+++ b/ktor-client/ktor-client-features/ktor-client-json/ktor-client-json-ios/src/io/ktor/client/features/json/serializer/SerialHelperIos.kt
@@ -1,0 +1,11 @@
+package io.ktor.client.features.json.serializer
+
+import io.ktor.client.call.TypeInfo
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.list
+import kotlinx.serialization.serializer
+import kotlinx.serialization.set
+import java.lang.reflect.ParameterizedType
+import java.lang.reflect.WildcardType
+
+internal actual fun serializerForPlatform(type: TypeInfo): KSerializer<*> = type.type.serializer()

--- a/ktor-client/ktor-client-features/ktor-client-json/ktor-client-json-ios/src/io/ktor/client/features/json/serializer/SerialHelperIos.kt
+++ b/ktor-client/ktor-client-features/ktor-client-json/ktor-client-json-ios/src/io/ktor/client/features/json/serializer/SerialHelperIos.kt
@@ -9,3 +9,5 @@ import java.lang.reflect.ParameterizedType
 import java.lang.reflect.WildcardType
 
 internal actual fun serializerForPlatform(type: TypeInfo): KSerializer<*> = type.type.serializer()
+
+internal actual fun serializerForObject(element: Any): KSerializer<Any>? = null

--- a/ktor-client/ktor-client-features/ktor-client-json/ktor-client-json-jvm/build.gradle
+++ b/ktor-client/ktor-client-features/ktor-client-json/ktor-client-json-jvm/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'kotlinx-serialization'
 dependencies {
     expectedBy project(':ktor-client:ktor-client-features:ktor-client-json')
 
-    compile group: 'org.jetbrains.kotlinx', name: 'kotlinx-serialization-runtime', version: '0.6.0'
+    compile group: 'org.jetbrains.kotlinx', name: 'kotlinx-serialization-runtime', version: serialization_version
 
     compile project(':ktor-client:ktor-client-core:ktor-client-core-jvm')
     compile project(":ktor-client:ktor-client-core")

--- a/ktor-client/ktor-client-features/ktor-client-json/ktor-client-json-jvm/build.gradle
+++ b/ktor-client/ktor-client-features/ktor-client-json/ktor-client-json-jvm/build.gradle
@@ -1,3 +1,4 @@
+apply plugin: 'kotlinx-serialization'
 dependencies {
     expectedBy project(':ktor-client:ktor-client-features:ktor-client-json')
 

--- a/ktor-client/ktor-client-features/ktor-client-json/ktor-client-json-jvm/src/io/ktor/client/features/json/serializer/SerialHelperJvm.kt
+++ b/ktor-client/ktor-client-features/ktor-client-json/ktor-client-json-jvm/src/io/ktor/client/features/json/serializer/SerialHelperJvm.kt
@@ -1,0 +1,56 @@
+package io.ktor.client.features.json.serializer
+
+import io.ktor.client.call.TypeInfo
+import kotlinx.serialization.*
+import kotlinx.serialization.internal.*
+import java.lang.reflect.ParameterizedType
+import java.lang.reflect.Type
+import java.lang.reflect.WildcardType
+import kotlin.reflect.KClass
+
+internal actual fun serializerForPlatform(type: TypeInfo): KSerializer<*> = serializerByTypeToken(type.reifiedType)
+
+@Suppress("UNCHECKED_CAST")
+fun serializerByTypeToken(type: Type): KSerializer<Any> = when (type) {
+    is Class<*> -> if (!type.isArray) {
+        serializerByClass(type.kotlin)
+    } else {
+        val componentType: Class<*> = type.componentType
+        val componentSerializer = kotlinx.serialization.serializerByTypeToken(componentType)
+        ReferenceArraySerializer(componentType.kotlin as KClass<Any>, componentSerializer) as KSerializer<Any>
+    }
+    is ParameterizedType -> {
+        val rootClass = (type.rawType as Class<*>)
+        val args = (type.actualTypeArguments).map { argument ->
+            when (argument) {
+                is WildcardType -> {
+                    argument.upperBounds.first().let { firstUpperBound ->
+                        when (firstUpperBound) {
+                            is Class<*> -> firstUpperBound
+                            else -> null
+                        }
+                    }
+                }
+                else -> null
+            } ?: argument
+        }
+        when {
+            List::class.java.isAssignableFrom(rootClass) -> ArrayListSerializer(serializerByTypeToken(args[0])) as KSerializer<Any>
+            Set::class.java.isAssignableFrom(rootClass) -> HashSetSerializer(serializerByTypeToken(args[0])) as KSerializer<Any>
+            Map::class.java.isAssignableFrom(rootClass) -> HashMapSerializer(
+                serializerByTypeToken(args[0]), serializerByTypeToken(args[1])
+            ) as KSerializer<Any>
+            Map.Entry::class.java.isAssignableFrom(rootClass) -> MapEntrySerializer(
+                serializerByTypeToken(args[0]), serializerByTypeToken(args[1])
+            ) as KSerializer<Any>
+
+            else -> {
+                throw IllegalStateException("ParameterizedType '${type.rawType}' is not implemented")
+                // Cannot access 'invokeSerializerGetter': it is internal in 'kotlinx.serialization'
+                //                    val varargs = args.map { kotlinx.serialization.serializerByTypeToken(it) }.toTypedArray()
+                //                    (rootClass.invokeSerializerGetter(*varargs) as? KSerializer<Any>) ?: serializerByClass<Any>(rootClass.kotlin)
+            }
+        }
+    }
+    else -> throw IllegalArgumentException("type should be instance of Class<?> or ParametrizedType")
+}

--- a/ktor-client/ktor-client-features/ktor-client-json/ktor-client-json-jvm/src/io/ktor/client/features/json/serializer/SerialHelperJvm.kt
+++ b/ktor-client/ktor-client-features/ktor-client-json/ktor-client-json-jvm/src/io/ktor/client/features/json/serializer/SerialHelperJvm.kt
@@ -3,54 +3,67 @@ package io.ktor.client.features.json.serializer
 import io.ktor.client.call.TypeInfo
 import kotlinx.serialization.*
 import kotlinx.serialization.internal.*
+import java.lang.reflect.GenericArrayType
 import java.lang.reflect.ParameterizedType
 import java.lang.reflect.Type
 import java.lang.reflect.WildcardType
 import kotlin.reflect.KClass
 
 internal actual fun serializerForPlatform(type: TypeInfo): KSerializer<*> = serializerByTypeToken(type.reifiedType)
+internal actual fun serializerForObject(element: Any): KSerializer<Any>? = serializerByTypeToken(element::class.java)
 
+//TODO: remove with release 0.6.3 of kotlinx-serialization
+// This method intended for static, format-agnostic resolving (e.g. in adapter factories) so context is not used here.
 @Suppress("UNCHECKED_CAST")
 fun serializerByTypeToken(type: Type): KSerializer<Any> = when (type) {
+    is GenericArrayType -> {
+        val eType = type.genericComponentType.let {
+            when (it) {
+                is WildcardType -> it.upperBounds.first()
+                else -> it
+            }
+        }
+        val serializer = serializerByTypeToken(eType)
+        val kclass = when (eType) {
+            is ParameterizedType -> (eType.rawType as Class<*>).kotlin
+            is KClass<*> -> eType
+            else -> throw IllegalStateException("unsupported type in GenericArray: ${eType::class}")
+        } as KClass<Any>
+        ReferenceArraySerializer<Any, Any>(kclass, serializer) as KSerializer<Any>
+    }
     is Class<*> -> if (!type.isArray) {
         serializerByClass(type.kotlin)
     } else {
-        val componentType: Class<*> = type.componentType
-        val componentSerializer = kotlinx.serialization.serializerByTypeToken(componentType)
-        ReferenceArraySerializer(componentType.kotlin as KClass<Any>, componentSerializer) as KSerializer<Any>
+        val eType: Class<*> = type.componentType
+        val s = serializerByTypeToken(eType)
+        val arraySerializer = ReferenceArraySerializer<Any, Any>(eType.kotlin as KClass<Any>, s)
+        arraySerializer as KSerializer<Any>
     }
     is ParameterizedType -> {
         val rootClass = (type.rawType as Class<*>)
-        val args = (type.actualTypeArguments).map { argument ->
-            when (argument) {
-                is WildcardType -> {
-                    argument.upperBounds.first().let { firstUpperBound ->
-                        when (firstUpperBound) {
-                            is Class<*> -> firstUpperBound
-                            else -> null
-                        }
-                    }
-                }
-                else -> null
-            } ?: argument
-        }
+        val args = (type.actualTypeArguments)
         when {
             List::class.java.isAssignableFrom(rootClass) -> ArrayListSerializer(serializerByTypeToken(args[0])) as KSerializer<Any>
             Set::class.java.isAssignableFrom(rootClass) -> HashSetSerializer(serializerByTypeToken(args[0])) as KSerializer<Any>
             Map::class.java.isAssignableFrom(rootClass) -> HashMapSerializer(
-                serializerByTypeToken(args[0]), serializerByTypeToken(args[1])
+                serializerByTypeToken(args[0]),
+                serializerByTypeToken(args[1])
             ) as KSerializer<Any>
             Map.Entry::class.java.isAssignableFrom(rootClass) -> MapEntrySerializer(
-                serializerByTypeToken(args[0]), serializerByTypeToken(args[1])
+                serializerByTypeToken(args[0]),
+                serializerByTypeToken(args[1])
             ) as KSerializer<Any>
 
             else -> {
-                throw IllegalStateException("ParameterizedType '${type.rawType}' is not implemented")
+                throw IllegalArgumentException("ParmaterizedTypes of $rootClass are not supported")
                 // Cannot access 'invokeSerializerGetter': it is internal in 'kotlinx.serialization'
-                //                    val varargs = args.map { kotlinx.serialization.serializerByTypeToken(it) }.toTypedArray()
-                //                    (rootClass.invokeSerializerGetter(*varargs) as? KSerializer<Any>) ?: serializerByClass<Any>(rootClass.kotlin)
+//                val varargs = args.map { serializerByTypeToken(it) }.toTypedArray()
+//                (rootClass.invokeSerializerGetter(*varargs) as? KSerializer<Any>) ?: serializerByClass<Any>(
+//                    rootClass.kotlin
+//                )
             }
         }
     }
-    else -> throw IllegalArgumentException("type should be instance of Class<?> or ParametrizedType")
+    is WildcardType -> serializerByTypeToken(type.upperBounds.first())
+    else -> throw IllegalArgumentException("typeToken should be an instance of Class<?>, GenericArray, ParametrizedType or WildcardType, but actual type is $type ${type::class}")
 }

--- a/ktor-client/ktor-client-features/ktor-client-json/ktor-client-json-jvm/test/io/ktor/client/features/json/test/JsonTest.kt
+++ b/ktor-client/ktor-client-features/ktor-client-json/ktor-client-json-jvm/test/io/ktor/client/features/json/test/JsonTest.kt
@@ -3,6 +3,7 @@ package io.ktor.client.features.json.test
 import io.ktor.application.*
 import io.ktor.client.engine.cio.*
 import io.ktor.client.features.json.*
+import io.ktor.client.features.json.serializer.*
 import io.ktor.client.request.*
 import io.ktor.client.tests.utils.*
 import io.ktor.features.*
@@ -13,8 +14,11 @@ import io.ktor.response.*
 import io.ktor.routing.*
 import io.ktor.server.engine.*
 import io.ktor.server.jetty.*
+import kotlinx.serialization.*
+import java.util.*
 import kotlin.test.*
 
+@Serializable
 data class Widget(
     val name: String,
     val value: Int,
@@ -23,6 +27,16 @@ data class Widget(
 
 class JsonTest : TestWithKtor() {
     val widget = Widget("Foo", 1000, listOf("bar", "baz", "qux"))
+    val usersArray = arrayOf(User("vasya", 10))
+    val usersList = listOf(User("vasya", 10))
+    val usersSet = setOf(User("vasya", 10))
+    val userMap = mapOf("baz" to User("vasya", 10))
+
+    @Serializable
+    data class Response<T>(val ok: Boolean, val result: T?)
+
+    @Serializable
+    data class User(val name: String, val age: Int)
 
     override val server: ApplicationEngine = embeddedServer(Jetty, serverPort) {
         install(ContentNegotiation) {
@@ -36,6 +50,18 @@ class JsonTest : TestWithKtor() {
             }
             get("/users") {
                 call.respond(Response(true, arrayOf(User("vasya", 10))))
+            }
+            get("/usersArray") {
+                call.respond(usersArray)
+            }
+            get("/usersList") {
+                call.respond(usersList)
+            }
+            get("/usersSet") {
+                call.respond(usersSet)
+            }
+            get("/userMap") {
+                call.respond(userMap)
             }
         }
     }
@@ -55,6 +81,93 @@ class JsonTest : TestWithKtor() {
         }
     }
 
-    data class Response<T>(val ok: Boolean, val result: T?)
-    data class User(val name: String, val age: Int)
+    @Test
+    fun testKotlinxSerialization() = clientTest(CIO) {
+        config {
+            install(JsonFeature) {
+                serializer = KotlinxSerializer().apply {
+                    serializer(Widget::class) {
+                        json.context?.getSerializerByClass(Widget::class)!!
+                    }
+                }
+            }
+        }
+
+        test { client ->
+            val result = client.post<Widget>(body = widget, port = serverPort) {
+                contentType(ContentType.Application.Json)
+            }
+
+            assertEquals(widget, result)
+        }
+    }
+
+    @Test
+    fun testKotlinxSerializationArray() = clientTest(CIO) {
+        config {
+            install(JsonFeature) {
+                serializer = KotlinxSerializer()
+            }
+        }
+
+        test { client ->
+            val result = client.get<Array<User>>(path = "/usersArray", body = widget, port = serverPort) {
+                contentType(ContentType.Application.Json)
+            }
+
+//            Arrays.deepEquals(usersArray, result)
+            assert(Arrays.deepEquals(usersArray, result))
+        }
+    }
+
+    @Test
+    fun testKotlinxSerializationList() = clientTest(CIO) {
+        config {
+            install(JsonFeature) {
+                serializer = KotlinxSerializer()
+            }
+        }
+
+        test { client ->
+            val result = client.get<List<User>>(path = "/usersList", body = widget, port = serverPort) {
+                contentType(ContentType.Application.Json)
+            }
+
+            assertEquals(usersList, result)
+        }
+    }
+
+    @Test
+    fun testKotlinxSerializationSet() = clientTest(CIO) {
+        config {
+            install(JsonFeature) {
+                serializer = KotlinxSerializer()
+            }
+        }
+
+        test { client ->
+            val result = client.get<Set<User>>(path = "/usersSet", body = widget, port = serverPort) {
+                contentType(ContentType.Application.Json)
+            }
+
+            assertEquals(usersSet, result)
+        }
+    }
+
+    @Test
+    fun testKotlinxSerializationMap() = clientTest(CIO) {
+        config {
+            install(JsonFeature) {
+                serializer = KotlinxSerializer()
+            }
+        }
+
+        test { client ->
+            val result = client.get<Map<String, User>>(path = "/userMap", body = widget, port = serverPort) {
+                contentType(ContentType.Application.Json)
+            }
+
+            assertEquals(userMap, result)
+        }
+    }
 }


### PR DESCRIPTION
this allows for serializing and deserializing of any types and classes without generic arguments

with expect / actual this reuses `serializerByTypeToken` on the jvm and uses a naive implementation on IOS because (afaik) there is no reified type available there, i cannot test this

it would be futureproofing to expose a TypeInfo to the write frunction (and the HttpRequestPipeline in general i guess)