### PR TITLE
 Added `TestApplicationEngine.cookiesSession` to keep cookies between test requests

### DIFF
--- a/ktor-server/ktor-server-core/src/io/ktor/sessions/Sessions.kt
+++ b/ktor-server/ktor-server-core/src/io/ktor/sessions/Sessions.kt
@@ -82,6 +82,18 @@ inline fun <reified T> CurrentSession.set(value: T?) = set(findName(T::class), v
 inline fun <reified T> CurrentSession.get(): T? = get(findName(T::class)) as T?
 inline fun <reified T> CurrentSession.clear() = clear(findName(T::class))
 
+inline fun <reified T> CurrentSession.getOrSet(name: String = findName(T::class), generator: () -> T): T {
+    val result = get<T>()
+
+    if (result != null) {
+        return result
+    }
+
+    return generator().apply {
+        set(name, this)
+    }
+}
+
 private data class SessionData(val sessions: Sessions,
                                val providerData: Map<String, SessionProviderData>) : CurrentSession {
 

--- a/ktor-server/ktor-server-test-host/src/io/ktor/server/testing/TestApplicationEngine.kt
+++ b/ktor-server/ktor-server-test-host/src/io/ktor/server/testing/TestApplicationEngine.kt
@@ -142,12 +142,12 @@ fun TestApplicationEngine.cookiesSession(callback: () -> Unit) {
 
     hookRequests(
         processRequest = { setup ->
-            val cookieValue = trackedCookies.map { (it.name).encodeURLParameter() + "=" + (it.value).encodeURLParameter() }.joinToString("; ")
-            addHeader("Cookie", cookieValue)
+            val cookieValue = trackedCookies.joinToString("; ") { (it.name).encodeURLParameter() + "=" + (it.value).encodeURLParameter() }
+            addHeader(HttpHeaders.Cookie, cookieValue)
             setup() // setup after setting the cookie so the user can override cookies
         },
         processResponse = {
-            trackedCookies = response.headers.values("Set-Cookie").map { parseServerSetCookieHeader(it) }
+            trackedCookies = response.headers.values(HttpHeaders.SetCookie).map { parseServerSetCookieHeader(it) }
         }
     ) {
         callback()

--- a/ktor-server/ktor-server-test-host/src/io/ktor/server/testing/TestApplicationEngine.kt
+++ b/ktor-server/ktor-server-test-host/src/io/ktor/server/testing/TestApplicationEngine.kt
@@ -137,13 +137,19 @@ class TestApplicationEngine(
         TestApplicationCall(application, readResponse).apply { setup(request) }
 }
 
+/**
+ * Keep cookies between requests inside the [callback].
+ *
+ * This processes [HttpHeaders.SetCookie] from the responses and produce [HttpHeaders.Cookie] in subsequent requests.
+ */
 fun TestApplicationEngine.cookiesSession(callback: () -> Unit) {
     var trackedCookies: List<Cookie> = listOf()
 
     hookRequests(
         processRequest = { setup ->
-            val cookieValue = trackedCookies.joinToString("; ") { (it.name).encodeURLParameter() + "=" + (it.value).encodeURLParameter() }
-            addHeader(HttpHeaders.Cookie, cookieValue)
+            addHeader(HttpHeaders.Cookie, trackedCookies.joinToString("; ") {
+                (it.name).encodeURLParameter() + "=" + (it.value).encodeURLParameter()
+            })
             setup() // setup after setting the cookie so the user can override cookies
         },
         processResponse = {


### PR DESCRIPTION
* Added `TestApplicationEngine.cookiesSession` feature to keep cookie
* Added a `TestApplicationEngine.hookRequests` mechanism to hook requests in a scope
* Added a CurrentSession.getOrSet convenience method.