### PR TITLE
Initial client-json support of json values (null, string, ...)

### DIFF
--- a/ktor-client/ktor-client-features/ktor-client-json/ktor-client-gson/src/io/ktor/client/features/json/GsonSerializer.kt
+++ b/ktor-client/ktor-client-features/ktor-client-json/ktor-client-gson/src/io/ktor/client/features/json/GsonSerializer.kt
@@ -11,9 +11,9 @@ class GsonSerializer(block: GsonBuilder.() -> Unit = {}) : JsonSerializer {
 
     private val backend: Gson = GsonBuilder().apply(block).create()
 
-    override fun write(data: Any): OutgoingContent = TextContent(backend.toJson(data), ContentType.Application.Json)
+    override fun write(data: Any?): OutgoingContent = TextContent(backend.toJson(data), ContentType.Application.Json)
 
-    override suspend fun read(type: TypeInfo, response: HttpResponse): Any {
+    override suspend fun read(type: TypeInfo, response: HttpResponse): Any? {
         val text= response.readText()
         return backend.fromJson(text, type.reifiedType)
     }

--- a/ktor-client/ktor-client-features/ktor-client-json/ktor-client-gson/test/io/ktor/client/features/json/test/GsonTest.kt
+++ b/ktor-client/ktor-client-features/ktor-client-json/ktor-client-gson/test/io/ktor/client/features/json/test/GsonTest.kt
@@ -47,11 +47,11 @@ class GsonTest : TestWithKtor() {
         }
 
         test { client ->
-            val result = client.post<Widget>(body = widget, port = serverPort) {
+            val result = client.post<JsonContent<Widget>>(body = JsonContent(widget), port = serverPort) {
                 contentType(ContentType.Application.Json)
             }
 
-            assertEquals(widget, result)
+            assertEquals(widget, result.value)
         }
     }
 

--- a/ktor-client/ktor-client-features/ktor-client-json/ktor-client-jackson/src/io/ktor/client/features/json/JacksonSerializer.kt
+++ b/ktor-client/ktor-client-features/ktor-client-json/ktor-client-jackson/src/io/ktor/client/features/json/JacksonSerializer.kt
@@ -11,9 +11,9 @@ class JacksonSerializer(block: ObjectMapper.() -> Unit = {}) : JsonSerializer {
 
     private val backend = jacksonObjectMapper().apply(block)
 
-    override fun write(data: Any) = TextContent(backend.writeValueAsString(data), ContentType.Application.Json)
+    override fun write(data: Any?) = TextContent(backend.writeValueAsString(data), ContentType.Application.Json)
 
-    override suspend fun read(type: TypeInfo, response: HttpResponse): Any {
+    override suspend fun read(type: TypeInfo, response: HttpResponse): Any? {
         return backend.readValue(response.readText(), backend.typeFactory.constructType(type.reifiedType))
     }
 }

--- a/ktor-client/ktor-client-features/ktor-client-json/ktor-client-jackson/test/io/ktor/client/features/json/JsonTest.kt
+++ b/ktor-client/ktor-client-features/ktor-client-json/ktor-client-jackson/test/io/ktor/client/features/json/JsonTest.kt
@@ -61,11 +61,11 @@ class JsonTest : TestWithKtor() {
         }
 
         test { client ->
-            val result = client.post<Widget>(body = widget, port = serverPort) {
+            val result = client.post<JsonContent<Widget>>(body = JsonContent(widget), port = serverPort) {
                 contentType(ContentType.Application.Json)
             }
 
-            assertEquals(widget, result)
+            assertEquals(widget, result.value)
         }
     }
 
@@ -82,14 +82,10 @@ class JsonTest : TestWithKtor() {
         }
 
         test { client ->
-            val response = client.post<Response<List<Jackson>>>(port = serverPort, path = "jackson",  body = Jackson(
-                "request",
-                "ignored"
-            )
-            )
-            {
+            val body = JsonContent(Jackson("request", "ignored"))
+            val response = client.post<JsonContent<Response<List<Jackson>>>>(port = serverPort, path = "jackson",  body = body) {
                 contentType(ContentType.Application.Json)
-            }
+            }.value
 
             assertTrue(response.ok)
             val list = response.result!!

--- a/ktor-client/ktor-client-features/ktor-client-json/ktor-client-json-jvm/src/io/ktor/client/features/json/DefaultJvm.kt
+++ b/ktor-client/ktor-client-features/ktor-client-json/ktor-client-json-jvm/src/io/ktor/client/features/json/DefaultJvm.kt
@@ -1,6 +1,9 @@
 package io.ktor.client.features.json
 
+import io.ktor.client.call.TypeInfo
+import java.lang.reflect.ParameterizedType
 import java.util.*
+import kotlin.reflect.full.isSubclassOf
 
 actual fun defaultSerializer(): JsonSerializer {
     val serializers = ServiceLoader.load(JsonSerializer::class.java).toList()
@@ -11,4 +14,11 @@ actual fun defaultSerializer(): JsonSerializer {
     )
 
     return serializers.maxBy { it::class.simpleName!! }!!
+}
+
+internal actual fun unwrapJsonContent(typeInfo: TypeInfo) : TypeInfo {
+    require(typeInfo.type.isSubclassOf(JsonContent::class)) { "typeInfo.type must be type ${JsonContent::class.simpleName}" }
+    val reifiedType = (typeInfo.reifiedType as ParameterizedType).actualTypeArguments.first()!!
+    val type = (reifiedType as Class<*>).kotlin
+    return TypeInfo(type, reifiedType)
 }

--- a/ktor-client/ktor-client-features/ktor-client-json/ktor-client-json-jvm/src/io/ktor/client/features/json/DefaultJvm.kt
+++ b/ktor-client/ktor-client-features/ktor-client-json/ktor-client-json-jvm/src/io/ktor/client/features/json/DefaultJvm.kt
@@ -2,6 +2,7 @@ package io.ktor.client.features.json
 
 import io.ktor.client.call.*
 import java.lang.reflect.*
+import java.lang.reflect.Type
 import java.util.*
 
 actual fun defaultSerializer(): JsonSerializer {
@@ -19,8 +20,10 @@ internal actual fun safeUnwrapJsonContent(typeInfo: TypeInfo): TypeInfo? {
     val parameterizedType = typeInfo.reifiedType as? ParameterizedType
     // JSonContent is final so we can avoid subclass check
     return if (parameterizedType?.rawType == JsonContent::class.java){
-        val reifiedType = parameterizedType.actualTypeArguments.first()!!
-        val type = (reifiedType as Class<*>).kotlin
-        TypeInfo(type, reifiedType)
+        val wrappedType: Type = parameterizedType.actualTypeArguments.first()!!
+        val backingClass = (wrappedType as? ParameterizedType)?.rawType ?: wrappedType
+        val backingClassObj = backingClass as? Class<*> ?: error("Wrapped type was unexpectedly $backingClass")
+        val type = backingClassObj.kotlin
+        TypeInfo(type, wrappedType)
     } else null
 }

--- a/ktor-client/ktor-client-features/ktor-client-json/ktor-client-json-jvm/src/io/ktor/client/features/json/DefaultJvm.kt
+++ b/ktor-client/ktor-client-features/ktor-client-json/ktor-client-json-jvm/src/io/ktor/client/features/json/DefaultJvm.kt
@@ -1,9 +1,8 @@
 package io.ktor.client.features.json
 
-import io.ktor.client.call.TypeInfo
-import java.lang.reflect.ParameterizedType
+import io.ktor.client.call.*
+import java.lang.reflect.*
 import java.util.*
-import kotlin.reflect.full.isSubclassOf
 
 actual fun defaultSerializer(): JsonSerializer {
     val serializers = ServiceLoader.load(JsonSerializer::class.java).toList()
@@ -16,9 +15,12 @@ actual fun defaultSerializer(): JsonSerializer {
     return serializers.maxBy { it::class.simpleName!! }!!
 }
 
-internal actual fun unwrapJsonContent(typeInfo: TypeInfo) : TypeInfo {
-    require(typeInfo.type.isSubclassOf(JsonContent::class)) { "typeInfo.type must be type ${JsonContent::class.simpleName}" }
-    val reifiedType = (typeInfo.reifiedType as ParameterizedType).actualTypeArguments.first()!!
-    val type = (reifiedType as Class<*>).kotlin
-    return TypeInfo(type, reifiedType)
+internal actual fun safeUnwrapJsonContent(typeInfo: TypeInfo): TypeInfo? {
+    val parameterizedType = typeInfo.reifiedType as? ParameterizedType
+    // JSonContent is final so we can avoid subclass check
+    return if (parameterizedType?.rawType == JsonContent::class.java){
+        val reifiedType = parameterizedType.actualTypeArguments.first()!!
+        val type = (reifiedType as Class<*>).kotlin
+        TypeInfo(type, reifiedType)
+    } else null
 }

--- a/ktor-client/ktor-client-features/ktor-client-json/ktor-client-json-jvm/test/io/ktor/client/features/json/test/JsonTest.kt
+++ b/ktor-client/ktor-client-features/ktor-client-json/ktor-client-json-jvm/test/io/ktor/client/features/json/test/JsonTest.kt
@@ -68,6 +68,9 @@ class JsonTest : TestWithKtor() {
     fun testSerializeNumber() = testJson(42)
 
     @Test
+    fun testSerializeGenericList() = testJson(listOf(""))
+
+    @Test
     fun testManuallySerializedJson() = clientTest(CIO) {
         config {
             install(JsonFeature)

--- a/ktor-client/ktor-client-features/ktor-client-json/ktor-client-json-jvm/test/io/ktor/client/features/json/test/JsonTest.kt
+++ b/ktor-client/ktor-client-features/ktor-client-json/ktor-client-json-jvm/test/io/ktor/client/features/json/test/JsonTest.kt
@@ -46,9 +46,7 @@ class JsonTest : TestWithKtor() {
         }
 
         test { client ->
-            val result = client.jsonPost<R>(body = jsonValue, port = serverPort) {
-                contentType(ContentType.Application.Json)
-            }
+            val result = client.jsonPost<R>(body = jsonValue, port = serverPort)
 
             assertEquals(jsonValue, result.value)
         }
@@ -82,6 +80,19 @@ class JsonTest : TestWithKtor() {
         }
     }
 
+    @Test
+    fun testReceiveJsonAsStringForManualDeserialization() = clientTest(CIO) {
+        config {
+            install(JsonFeature)
+        }
+
+        test { client ->
+            val result = client.jsonPost<String>(body = "Str", port = serverPort)
+
+            assertEquals("\"Str\"", result)
+        }
+    }
+
 }
 
 private suspend inline fun <reified T> HttpClient.jsonPost(
@@ -89,4 +100,7 @@ private suspend inline fun <reified T> HttpClient.jsonPost(
         path: String = "/",
         body: Any? = null,
         block: HttpRequestBuilder.() -> Unit = {}
-): T = post(scheme, host, port, path, JsonContent(body), block)
+): T = post(scheme, host, port, path, JsonContent(body)){
+    contentType(ContentType.Application.Json)
+    block()
+}

--- a/ktor-client/ktor-client-features/ktor-client-json/src/io/ktor/client/features/json/JsonFeature.kt
+++ b/ktor-client/ktor-client-features/ktor-client-json/src/io/ktor/client/features/json/JsonFeature.kt
@@ -24,7 +24,7 @@ expect fun defaultSerializer(): JsonSerializer
 /**
  * Platform support for unwrapping generic parameters of JsonContent
  */
-internal expect fun unwrapJsonContent(typeInfo: TypeInfo) : TypeInfo
+internal expect fun safeUnwrapJsonContent(typeInfo: TypeInfo) : TypeInfo?
 
 /**
  * [HttpClient] feature that serializes/de-serializes as JSON custom objects
@@ -72,8 +72,12 @@ class JsonFeature(val serializer: JsonSerializer) {
                         is String -> ResponseWithContent(context.response, response) // Undo HttpPlainText feature
                         else -> return@intercept
                     }
-                    val unwrappedInfo = unwrapJsonContent(info)
-                    proceedWith(HttpResponseContainer(unwrappedInfo, JsonContent(feature.serializer.read(unwrappedInfo, responseToParse))))
+                    val unwrappedInfo = safeUnwrapJsonContent(info)
+                    if (unwrappedInfo != null) {
+                        proceedWith(HttpResponseContainer(unwrappedInfo, JsonContent(feature.serializer.read(unwrappedInfo, responseToParse))))
+                    } else {
+                        return@intercept
+                    }
                 } else {
                     return@intercept
                 }

--- a/ktor-client/ktor-client-features/ktor-client-json/src/io/ktor/client/features/json/JsonSerializer.kt
+++ b/ktor-client/ktor-client-features/ktor-client-json/src/io/ktor/client/features/json/JsonSerializer.kt
@@ -5,7 +5,7 @@ import io.ktor.client.response.*
 import io.ktor.http.content.*
 
 interface JsonSerializer {
-    fun write(data: Any): OutgoingContent
+    fun write(data: Any?): OutgoingContent
 
-    suspend fun read(type: TypeInfo, response: HttpResponse): Any
+    suspend fun read(type: TypeInfo, response: HttpResponse): Any?
 }


### PR DESCRIPTION
Not tested on other platforms and serverside json support is still lacking.

First step at fixing #588 by wrapping object/value meant for json (de)serialization. This seems like the best solution without touching the core machinery.

Can you provide some feedback ?