### PR TITLE
Introduce HttpResponseConfig for client & enable to set custom default response charset rather than ISO-8859-1

### DIFF
--- a/ktor-client/ktor-client-core/src/io/ktor/client/call/HttpClientCall.kt
+++ b/ktor-client/ktor-client-core/src/io/ktor/client/call/HttpClientCall.kt
@@ -28,6 +28,11 @@ class HttpClientCall internal constructor(
         internal set
 
     /**
+     * Configuration for the [response].
+     */
+    val responseConfig: HttpResponseConfig = client.engineConfig.response
+
+    /**
      * Tries to receive the payload of the [response] as an specific [expectedType].
      * Returns [response] if [expectedType] is [HttpResponse].
      *

--- a/ktor-client/ktor-client-core/src/io/ktor/client/engine/HttpClientEngineConfig.kt
+++ b/ktor-client/ktor-client-core/src/io/ktor/client/engine/HttpClientEngineConfig.kt
@@ -1,5 +1,6 @@
 package io.ktor.client.engine
 
+import io.ktor.client.response.HttpResponseConfig
 import kotlinx.coroutines.experimental.*
 
 /**
@@ -15,4 +16,9 @@ open class HttpClientEngineConfig {
      * Enable http pipelining
      */
     var pipelining: Boolean = true
+
+    /**
+     * Configuration for http response.
+     */
+    val response: HttpResponseConfig = HttpResponseConfig()
 }

--- a/ktor-client/ktor-client-core/src/io/ktor/client/response/HttpResponse.kt
+++ b/ktor-client/ktor-client-core/src/io/ktor/client/response/HttpResponse.kt
@@ -55,13 +55,14 @@ interface HttpResponse : HttpMessage, Closeable {
 /**
  * Read the [HttpResponse.content] as a String. You can pass an optional [charset]
  * to specify a charset in the case no one is specified as part of the Content-Type response.
- * If no charset specified either as parameter or as part of the response, [Charsets.ISO_8859_1] will be used.
+ * If no charset specified either as parameter or as part of the response,
+ * [HttpResponseConfig.defaultCharset] will be used.
  *
  * Note that [charset] parameter will be ignored if the response already has a charset.
  *      So it just acts as a fallback, honoring the server preference.
  */
 suspend fun HttpResponse.readText(charset: Charset? = null): String {
     val packet = content.readRemaining(Long.MAX_VALUE)
-    val actualCharset = charset() ?: charset ?: Charset.forName("ISO_8859_1")
+    val actualCharset = charset() ?: charset ?: call.responseConfig.defaultCharset
     return packet.readText(charset = actualCharset)
 }

--- a/ktor-client/ktor-client-core/src/io/ktor/client/response/HttpResponseConfig.kt
+++ b/ktor-client/ktor-client-core/src/io/ktor/client/response/HttpResponseConfig.kt
@@ -1,0 +1,10 @@
+package io.ktor.client.response
+
+import kotlinx.io.charsets.Charset
+
+open class HttpResponseConfig {
+    /**
+     * Default [Charset] for response content if not specified, the initial value is ISO_8859_1.
+     */
+    var defaultCharset: Charset = Charset.forName("ISO_8859_1")
+}


### PR DESCRIPTION
Some HTTP servers maybe send a Content-Type header with MIME-type only( i.e. without charset), e.g. `text/plain`, `application/json`, etc. And if the real encoding of the response content is ISO-8859-1, the HTTP client now can handle the text/JSON correctly. But if the content is other encoding (e.g. UTF-8), the result of `HttpClient.get<String>` or `HttpClient.get<AComplexObject>` may contains messy code.

This change is for solving the above problem manually. Added a `HttpResponseConfig` property to the `HttpClientEngineConfig` and this enabled to set a custom default charset of response content rather than the hard coded ISO-8859-1.

e.g. To request a server URL which respond a json contains **UTF-8** strings with the Content-Type `application/json`, we can configure the HTTP client as followed:

``` kotlin
val httpClient = HttpClient() {
    install(JsonFeature) {
        serializer = JacksonSerializer  {
        }
    }
    engine {
        response.apply {
            defaultCharset = Charsets.UTF_8
        }
        // ...
    }
}
```