### PR TITLE
Add some entries to AndroidEngineConfig

### DIFF
--- a/ktor-client/ktor-client-android/src/io/ktor/client/engine/android/AndroidClientEngine.kt
+++ b/ktor-client/ktor-client-android/src/io/ktor/client/engine/android/AndroidClientEngine.kt
@@ -43,7 +43,7 @@ class AndroidClientEngine(override val config: AndroidEngineConfig) : HttpClient
         val outgoingContent = this@execute.content
         val contentLength = headers[HttpHeaders.ContentLength]?.toLong() ?: outgoingContent.contentLength
 
-        val connection = (URL(url).openConnection() as HttpURLConnection).apply {
+        val connection = getProxyAwareConnection(url).apply {
             connectTimeout = config.connectTimeout
             readTimeout = config.socketTimeout
 
@@ -84,6 +84,12 @@ class AndroidClientEngine(override val config: AndroidEngineConfig) : HttpClient
             callContext,
             connection
         )
+    }
+
+    private fun getProxyAwareConnection(url: String): HttpURLConnection {
+        val u = URL(url)
+        val connection = config.proxy?.let { u.openConnection(it) } ?: u.openConnection()
+        return connection as HttpURLConnection
     }
 }
 

--- a/ktor-client/ktor-client-android/src/io/ktor/client/engine/android/AndroidClientEngine.kt
+++ b/ktor-client/ktor-client-android/src/io/ktor/client/engine/android/AndroidClientEngine.kt
@@ -13,6 +13,7 @@ import kotlinx.coroutines.io.*
 import kotlinx.coroutines.io.jvm.javaio.*
 import java.io.*
 import java.net.*
+import javax.net.ssl.*
 import kotlin.coroutines.*
 
 /**
@@ -46,6 +47,10 @@ class AndroidClientEngine(override val config: AndroidEngineConfig) : HttpClient
         val connection = getProxyAwareConnection(url).apply {
             connectTimeout = config.connectTimeout
             readTimeout = config.socketTimeout
+
+            if (this is HttpsURLConnection) {
+                config.sslManager(this)
+            }
 
             requestMethod = method.value
             useCaches = false

--- a/ktor-client/ktor-client-android/src/io/ktor/client/engine/android/AndroidEngineConfig.kt
+++ b/ktor-client/ktor-client-android/src/io/ktor/client/engine/android/AndroidEngineConfig.kt
@@ -2,6 +2,7 @@ package io.ktor.client.engine.android
 
 import io.ktor.client.engine.*
 import java.net.*
+import javax.net.ssl.*
 
 
 class AndroidEngineConfig : HttpClientEngineConfig() {
@@ -21,4 +22,9 @@ class AndroidEngineConfig : HttpClientEngineConfig() {
      * Proxy address to use - default <code>{@link #openConnection java.net.URL:URL.openConnection}</code>
      */
     var proxy: Proxy? = null
+
+    /**
+     * https connection manipulator. inherited methods are not permitted.
+     */
+    var sslManager: (HttpsURLConnection) -> Unit = {}
 }

--- a/ktor-client/ktor-client-android/src/io/ktor/client/engine/android/AndroidEngineConfig.kt
+++ b/ktor-client/ktor-client-android/src/io/ktor/client/engine/android/AndroidEngineConfig.kt
@@ -1,6 +1,7 @@
 package io.ktor.client.engine.android
 
 import io.ktor.client.engine.*
+import java.net.*
 
 
 class AndroidEngineConfig : HttpClientEngineConfig() {
@@ -16,4 +17,8 @@ class AndroidEngineConfig : HttpClientEngineConfig() {
      */
     var socketTimeout: Int = 100_000
 
+    /**
+     * Proxy address to use - default <code>{@link #openConnection java.net.URL:URL.openConnection}</code>
+     */
+    var proxy: Proxy? = null
 }

--- a/ktor-client/ktor-client-android/test/io/ktor/client/engine/android/AndroidHttpsTest.kt
+++ b/ktor-client/ktor-client-android/test/io/ktor/client/engine/android/AndroidHttpsTest.kt
@@ -1,0 +1,120 @@
+package io.ktor.client.engine.android
+
+import io.ktor.application.*
+import io.ktor.client.*
+import io.ktor.client.engine.*
+import io.ktor.client.request.*
+import io.ktor.client.response.*
+import io.ktor.client.tests.utils.*
+import io.ktor.http.*
+import io.ktor.network.tls.certificates.*
+import io.ktor.network.tls.extensions.*
+import io.ktor.response.*
+import io.ktor.routing.*
+import io.ktor.server.engine.*
+import io.ktor.server.netty.*
+import io.ktor.util.*
+import kotlinx.coroutines.*
+import org.junit.*
+import org.junit.Test
+import java.io.*
+import java.security.*
+import javax.net.ssl.*
+import kotlin.test.*
+
+class AndroidHttpsTest : TestWithKtor() {
+    override val server: ApplicationEngine = embeddedServer(Netty, applicationEngineEnvironment {
+        sslConnector(keyStore, "sha256ecdsa", { "changeit".toCharArray() }, { "changeit".toCharArray() }) {
+            port = serverPort
+            keyStorePath = keyStoreFile.absoluteFile
+
+            module {
+                routing {
+                    get("/") {
+                        call.respondText("Hello, world")
+                    }
+                }
+            }
+        }
+    })
+
+    companion object {
+        val keyStoreFile = File("build/temp.jks")
+        lateinit var keyStore: KeyStore
+        lateinit var sslContext: SSLContext
+        lateinit var x509TrustManager: X509TrustManager
+
+        @BeforeClass
+        @JvmStatic
+        fun setupAll() {
+            keyStore = buildKeyStore {
+                certificate("sha384ecdsa") {
+                    hash = HashAlgorithm.SHA384
+                    sign = SignatureAlgorithm.ECDSA
+                    keySizeInBits = 384
+                    password = "changeit"
+                }
+                certificate("sha256ecdsa") {
+                    hash = HashAlgorithm.SHA256
+                    sign = SignatureAlgorithm.ECDSA
+                    keySizeInBits = 256
+                    password = "changeit"
+                }
+                certificate("sha384rsa") {
+                    hash = HashAlgorithm.SHA384
+                    sign = SignatureAlgorithm.RSA
+                    keySizeInBits = 1024
+                    password = "changeit"
+                }
+                certificate("sha1rsa") {
+                    hash = HashAlgorithm.SHA1
+                    sign = SignatureAlgorithm.RSA
+                    keySizeInBits = 1024
+                    password = "changeit"
+                }
+            }
+
+            keyStore.saveToFile(keyStoreFile, "changeit")
+            val tmf = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm())
+            tmf.init(keyStore)
+            sslContext = SSLContext.getInstance("TLS")
+            sslContext.init(null, tmf.trustManagers, null)
+            x509TrustManager = tmf.trustManagers.first { it is X509TrustManager } as X509TrustManager
+        }
+    }
+
+    @Test
+    fun hello(): Unit = runBlocking {
+        HttpClient(Android.config {
+            sslManager = { conn ->
+                conn.sslSocketFactory = sslContext.socketFactory
+            }
+        }).use { client ->
+            val actual = client.get<String>("https://127.0.0.1:$serverPort/")
+            assertEquals("Hello, world", actual)
+        }
+    }
+
+    @Test
+    fun external(): Unit = runBlocking {
+        val client = HttpClient(Android)
+
+        val response = client.get<HttpResponse>("https://kotlinlang.org")
+        assertEquals(HttpStatusCode.OK, response.status)
+    }
+
+    @Test
+    fun customDomainsTest() = clientTest(Android) {
+        val domains = listOf(
+            "https://www.google.com",
+            "https://github.com",
+            "https://www.wikipedia.org"
+        )
+
+        test { client ->
+            domains.forEach { url ->
+                client.get<String>(url)
+            }
+        }
+    }
+}

--- a/ktor-client/ktor-client-android/test/io/ktor/client/engine/android/AndroidProxyTest.kt
+++ b/ktor-client/ktor-client-android/test/io/ktor/client/engine/android/AndroidProxyTest.kt
@@ -1,0 +1,43 @@
+package io.ktor.client.engine.android
+
+import io.ktor.application.*
+import io.ktor.client.engine.*
+import io.ktor.client.request.*
+import io.ktor.client.tests.utils.*
+import io.ktor.request.*
+import io.ktor.response.*
+import io.ktor.routing.*
+import io.ktor.server.engine.*
+import io.ktor.server.jetty.*
+import java.net.*
+import kotlin.test.*
+
+class AndroidProxyTest : TestWithKtor() {
+    private val factory: HttpClientEngineFactory<*> = Android
+
+    override val server = embeddedServer(Jetty, serverPort) {
+        routing {
+            post("/") {
+                assertEquals("Hello, server", call.receive())
+                call.respondText("Hello, client")
+            }
+        }
+    }
+
+    @Test
+    fun testProxyPost() = clientTest(factory) {
+        config {
+            engine {
+                if (this is AndroidEngineConfig) {
+                    proxy = Proxy(Proxy.Type.HTTP, InetSocketAddress("localhost", serverPort))
+                }
+            }
+        }
+        test { client ->
+            val text = client.post<String>("http://somewhere.else") {
+                body = "Hello, server"
+            }
+            assertEquals("Hello, client", text)
+        }
+    }
+}


### PR DESCRIPTION
First commit adds proxy configuration to `AndroidEngineConfig`. On Android platform `AndroidClientEngine` is the only choice and proxy feature is quite useful to inspect http traffic. So I request this feature.

Second commit permits `HttpsURLConnection` manipulation. Although I don't need it right now, I thought someone can need it. But it can be dangerous when an user calls inherited methods from `HttpConnection` etc. I have no refutation even if this commit is rejected.