### PR TITLE
Cy/fixes

### DIFF
--- a/ktor-client/ktor-client-core/src/io/ktor/client/features/HttpRedirect.kt
+++ b/ktor-client/ktor-client-core/src/io/ktor/client/features/HttpRedirect.kt
@@ -50,4 +50,12 @@ private fun HttpStatusCode.isRedirect(): Boolean = when (value) {
     else -> false
 }
 
+@Deprecated(
+    "Not thrown anymore. Use SendCountExceedException",
+    replaceWith = ReplaceWith(
+        "SendCountExceedException",
+        "io.ktor.client.features.SendCountExceedException"
+    )
+)
+@Suppress("KDocMissingDocumentation")
 class RedirectException(val request: HttpRequest, cause: String) : IllegalStateException(cause)

--- a/ktor-client/ktor-client-core/src/io/ktor/client/features/HttpSend.kt
+++ b/ktor-client/ktor-client-core/src/io/ktor/client/features/HttpSend.kt
@@ -6,21 +6,42 @@ import io.ktor.client.request.*
 import io.ktor.http.content.*
 import io.ktor.util.*
 
+/**
+ * HttpSend pipeline interceptor function
+ */
 typealias HttpSendInterceptor = suspend Sender.(HttpClientCall) -> HttpClientCall
 
+/**
+ * This interface represents a request send pipeline interceptor chain
+ */
+@KtorExperimentalAPI
 interface Sender {
+    /**
+     * Execute send pipeline. It could start pipeline execution or replace the call
+     */
     suspend fun execute(requestBuilder: HttpRequestBuilder): HttpClientCall
 }
 
+/**
+ * This is internal feature that is always installed.
+ * @property maxSendCount is a maximum number of requests that can be sent during a call
+ */
+@KtorExperimentalAPI
 class HttpSend(
     var maxSendCount: Int = 20
 ) {
     private val interceptors: MutableList<HttpSendInterceptor> = mutableListOf()
 
+    /**
+     * Install send pipeline starter interceptor
+     */
     fun intercept(block: HttpSendInterceptor) {
         interceptors += block
     }
 
+    /**
+     * Feature installation object
+     */
     companion object Feature : HttpClientFeature<HttpSend, HttpSend> {
         override val key: AttributeKey<HttpSend> = AttributeKey("HttpSend")
 
@@ -32,32 +53,44 @@ class HttpSend(
                 if (content !is OutgoingContent) return@intercept
                 context.body = content
 
-                var sent =  0
-                val sender = object : Sender {
-                    override suspend fun execute(requestBuilder: HttpRequestBuilder): HttpClientCall {
-                        if (sent >= feature.maxSendCount) throw SendCountExceed()
-                        sent++
-                        return scope.sendPipeline.execute(requestBuilder, requestBuilder.body) as HttpClientCall
-                    }
-                }
+                val sender = DefaultSender(feature.maxSendCount, scope)
 
                 var currentCall = sender.execute(context)
-                while (true) {
-                    loop@for (interceptor in feature.interceptors) {
+                var callChanged: Boolean
+
+                do {
+                    callChanged = false
+
+                    passInterceptors@for (interceptor in feature.interceptors) {
                         val transformed = interceptor(sender, currentCall)
-                        if (transformed === currentCall) continue@loop
+                        if (transformed === currentCall) continue@passInterceptors
 
                         currentCall = transformed
-                        break@loop
+                        callChanged = true
+                        break@passInterceptors
                     }
-
-                    break
-                }
+                } while (callChanged)
 
                 proceedWith(currentCall)
             }
         }
     }
+
+    private class DefaultSender(private val maxSendCount: Int, private val client: HttpClient) : Sender {
+        private var sentCount =  0
+
+        override suspend fun execute(requestBuilder: HttpRequestBuilder): HttpClientCall {
+            if (sentCount >= maxSendCount) throw SendCountExceedException("Max send count $maxSendCount exceeded")
+            sentCount++
+
+            return client.sendPipeline.execute(requestBuilder, requestBuilder.body) as HttpClientCall
+        }
+    }
 }
 
-class SendCountExceed : IllegalStateException()
+/**
+ * Thrown when too many actual requests were sent during a client call.
+ * It could be caused by infinite or too long redirect sequence.
+ * Maximum number of requests is limited by [HttpSend.maxSendCount]
+ */
+class SendCountExceedException(message: String) : IllegalStateException(message)

--- a/ktor-server/ktor-server-tests/test/io/ktor/tests/server/features/StaticContentTest.kt
+++ b/ktor-server/ktor-server-tests/test/io/ktor/tests/server/features/StaticContentTest.kt
@@ -50,11 +50,8 @@ class StaticContentTest {
             assertEquals(HttpStatusCode.OK, result.response.status())
         }
         // can't get up to containing folder
-        assertFailsWith<InvalidPathException> {
-            handleRequest(HttpMethod.Get, "/selected/../features/StaticContentTest.kt").let { result ->
-                assertTrue(result.requestHandled)
-                assertEquals(HttpStatusCode.OK, result.response.status())
-            }
+        handleRequest(HttpMethod.Get, "/selected/../features/StaticContentTest.kt").let { result ->
+            assertFalse(result.requestHandled)
         }
 
         // can serve select file from other dir
@@ -138,11 +135,9 @@ class StaticContentTest {
             }
         }
 
-        listOf("../pom.xml", "../../pom.xml", "/../pom.xml", "/../../pom.xml", "/./.././../pom.xml").forEach { path ->
-            assertFailsWith<InvalidPathException> {
-                handleRequest(HttpMethod.Get, path).let { result ->
-                    assertFalse(result.requestHandled, "Should be unhandled for path $path")
-                }
+        listOf("../build.gradle", "../../build.gradle", "/../build.gradle", "/../../build.gradle", "/./.././../build.gradle").forEach { path ->
+            handleRequest(HttpMethod.Get, path).let { result ->
+                assertFalse(result.requestHandled, "Should be unhandled for path $path")
             }
         }
     }
@@ -180,13 +175,13 @@ class StaticContentTest {
                 call.respond(LocalFileContent(basedir, "../../../../../../../../../../../../../etc/passwd"))
             }
             assertFailsWithSuspended<Exception> {
-                call.respond(LocalFileContent(basedir.toPath(), Paths.get("../pom.xml")))
+                call.respond(LocalFileContent(basedir.toPath(), Paths.get("../build.gradle")))
             }
             assertFailsWithSuspended<Exception> {
-                call.respond(LocalFileContent(basedir.toPath(), Paths.get("../../pom.xml")))
+                call.respond(LocalFileContent(basedir.toPath(), Paths.get("../../build.gradle")))
             }
             assertFailsWithSuspended<Exception> {
-                call.respond(LocalFileContent(basedir.toPath(), Paths.get("/../pom.xml")))
+                call.respond(LocalFileContent(basedir.toPath(), Paths.get("/../build.gradle")))
             }
         }
 
@@ -205,13 +200,13 @@ class StaticContentTest {
                 call.respond(LocalFileContent(basedir.toPath(), Paths.get("../../../../../../../../../../../../../etc/passwd")))
             }
             assertFailsWithSuspended<Exception> {
-                call.respond(LocalFileContent(basedir, "../pom.xml"))
+                call.respond(LocalFileContent(basedir, "../build.gradle"))
             }
             assertFailsWithSuspended<Exception> {
-                call.respond(LocalFileContent(basedir, "../../pom.xml"))
+                call.respond(LocalFileContent(basedir, "../../build.gradle"))
             }
             assertFailsWithSuspended<Exception> {
-                call.respond(LocalFileContent(basedir, "/../pom.xml"))
+                call.respond(LocalFileContent(basedir, "/../build.gradle"))
             }
         }
 

--- a/ktor-utils/ktor-utils-jvm/src/io/ktor/util/Path.kt
+++ b/ktor-utils/ktor-utils-jvm/src/io/ktor/util/Path.kt
@@ -8,10 +8,20 @@ import java.nio.file.*
  *
  * Extension is a substring of a [Path.fileName] after last dot
  */
-val Path.extension get() = fileName.toString().substringAfterLast(".")
+val Path.extension: String get() = fileName.toString().substringAfterLast(".")
 
+/**
+ * Append a [relativePath] safely that means that adding any extra `..` path elements will not let
+ * access anything out of the reference directory (unless you have symbolic or hard links or multiple mount points)
+ */
+@KtorExperimentalAPI
 fun File.combineSafe(relativePath: String): File = combineSafe(Paths.get(relativePath))
 
+/**
+ * Append a [relativePath] safely that means that adding any extra `..` path elements will not let
+ * access anything out of the reference directory (unless you have symbolic or hard links or multiple mount points)
+ */
+@KtorExperimentalAPI
 fun File.combineSafe(relativePath: Path): File {
     val normalized = relativePath.normalizeAndRelativize()
     if (normalized.startsWith("..")) {
@@ -22,6 +32,11 @@ fun File.combineSafe(relativePath: Path): File {
     return File(this, normalized.toString())
 }
 
+/**
+ * Append a [relativePath] safely that means that adding any extra `..` path elements will not let
+ * access anything out of the reference directory (unless you have symbolic or hard links or multiple mount points)
+ */
+@KtorExperimentalAPI
 fun Path.combineSafe(relativePath: Path): File {
     val normalized = relativePath.normalizeAndRelativize()
     if (normalized.startsWith("..")) {
@@ -32,11 +47,14 @@ fun Path.combineSafe(relativePath: Path): File {
     return resolve(normalized).toFile()
 }
 
+/**
+ * Remove all redundant `.` and `..` path elements. Leading `..` are also considered redundant.
+ */
+@KtorExperimentalAPI
 fun Path.normalizeAndRelativize(): Path =
     root?.relativize(this)?.normalize()?.dropLeadingTopDirs() ?: normalize().dropLeadingTopDirs()
 
 private fun Path.dropLeadingTopDirs(): Path {
-    return this
     val startIndex = indexOfFirst { it.toString() != ".." }
     if (startIndex == 0) return this
     return subpath(startIndex, nameCount)


### PR DESCRIPTION
`HttpSend` feature:
- eliminate unreachable code by extracting lambda content to a separate private function
- fix send loop: it should be restarting after call change by an interceptor but it was completing in any case
- cleanup, brief documentation

`normalizeAndRelativize`, `dropLeadingTopDirs`: 
- fixed unreachable code 
- fixed ambiguous undefined behaviour caused by JDK implementation change
