### PR TITLE
Fix StatusPages to handle child job failures (#646)

### DIFF
--- a/ktor-server/ktor-server-core/src/io/ktor/features/StatusPages.kt
+++ b/ktor-server/ktor-server-core/src/io/ktor/features/StatusPages.kt
@@ -6,6 +6,7 @@ import io.ktor.http.*
 import io.ktor.util.pipeline.*
 import io.ktor.response.*
 import io.ktor.util.*
+import kotlinx.coroutines.*
 import java.util.*
 
 /**
@@ -83,7 +84,9 @@ class StatusPages(config: Configuration) {
         }
 
         try {
-            context.proceed()
+            coroutineScope {
+                context.proceed()
+            }
         } catch (exception: Throwable) {
             if (context.call.response.status() == null) {
                 val handler = findHandlerByType(exception.javaClass)


### PR DESCRIPTION
Run a nested `coroutineScope { }` block to gather all children's job completions and re-throw if failed. Otherwise job failure are propagated to an engine so status page feature has no chance to handle it