### PR TITLE
Cy/cio non parallel fix

### DIFF
--- a/ktor-server/ktor-server-benchmarks/src-jmh/io/ktor/server/benchmarks/StringValuesBenchmark.kt
+++ b/ktor-server/ktor-server-benchmarks/src-jmh/io/ktor/server/benchmarks/StringValuesBenchmark.kt
@@ -5,6 +5,7 @@ import io.ktor.util.*
 import org.openjdk.jmh.annotations.*
 
 @State(Scope.Benchmark)
+@UseExperimental(InternalAPI::class)
 class StringValuesBenchmark {
     private val headers = valuesOf("A" to listOf("B"), "C" to listOf("D"))
 

--- a/ktor-utils/ktor-utils-jvm/src/io/ktor/util/cio/FileChannels.kt
+++ b/ktor-utils/ktor-utils-jvm/src/io/ktor/util/cio/FileChannels.kt
@@ -15,7 +15,7 @@ import kotlin.coroutines.*
 fun File.readChannel(
     start: Long = 0,
     endInclusive: Long = -1,
-    coroutineContext: CoroutineContext = Dispatchers.Unconfined
+    coroutineContext: CoroutineContext = Dispatchers.IO
 ): ByteReadChannel {
     val fileLength = length()
     val file = RandomAccessFile(this@readChannel, "r")


### PR DESCRIPTION
This is required to break unconfined loop in the copy pipe that blocks
selector's loop forever and cause the whole server to stuck