### PR TITLE
Migrate to kotlinx.coroutines 1.0.0-RC1

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -6,14 +6,14 @@ version=0.9.4-SNAPSHOT
 kotlin.incremental.multiplatform=true
 
 # kotlin
-kotlin_version=1.3.0-rc-131
-kotlin_native_version=1.3.0-rc-131
+kotlin_version=1.3.0-rc-146
+kotlin_native_version=1.3.0-rc-146
 
 # kotlin libraries
-kotlinx_io_version=0.1.0-alpha-19-rc13
+kotlinx_io_version=0.1.0-alpha-25-rc13
 serialization_version=0.8.2-rc13
-coroutines_version=0.30.2-eap13
-atomic_fu_version=0.11.10-eap13
+coroutines_version=1.0.0-RC1
+atomic_fu_version=0.11.11
 
 # server
 netty_version=4.1.24.Final

--- a/ktor-server/ktor-server-tests/test/io/ktor/tests/server/features/CompressionTest.kt
+++ b/ktor-server/ktor-server-tests/test/io/ktor/tests/server/features/CompressionTest.kt
@@ -12,6 +12,7 @@ import kotlinx.coroutines.io.*
 import org.junit.Test
 import java.time.*
 import java.util.zip.*
+import kotlin.coroutines.*
 import kotlin.test.*
 
 class CompressionTest {
@@ -125,8 +126,15 @@ class CompressionTest {
             application.install(Compression) {
                 default()
                 encoder("special", object : CompressionEncoder {
-                    override fun compress(readChannel: ByteReadChannel) = readChannel
-                    override fun compress(writeChannel: ByteWriteChannel) = writeChannel
+                    override fun compress(
+                        readChannel: ByteReadChannel,
+                        coroutineContext: CoroutineContext
+                    ) = readChannel
+
+                    override fun compress(
+                        writeChannel: ByteWriteChannel,
+                        coroutineContext: CoroutineContext
+                    ) = writeChannel
                 })
             }
             application.routing {


### PR DESCRIPTION
- Upgrade Kotlin (1.3.0-rc-146) and kotlinx.io (to get migration fixes as well)
- Modify `CompressionEncoder` interface (breaking change), mark it as experimental