### PR TITLE
Gson version should be consistent

### DIFF
--- a/ktor-features/ktor-gson/build.gradle
+++ b/ktor-features/ktor-gson/build.gradle
@@ -1,6 +1,6 @@
 description = ''
 dependencies {
-    compile group: 'com.google.code.gson', name: 'gson', version: '2.8.1'
+    compile group: 'com.google.code.gson', name: 'gson', version: gson_version
 
     compile project(":ktor-utils:ktor-utils-jvm")
 }


### PR DESCRIPTION
The version here is hardcoded and does not correspond to the version defined in the global `gradle.properties` [here](https://github.com/ktorio/ktor/blob/99aaf42a9210dbf25c500a980490d94ba3667435/gradle.properties#L38).

I suggest the feature should use the global version of gson, the same way [another client feature](https://github.com/ktorio/ktor/blob/99aaf42a9210dbf25c500a980490d94ba3667435/ktor-client/ktor-client-features/ktor-client-json/ktor-client-gson/build.gradle#L4) does.

Also, in the current state dependency resolution strategy `failOnVersionConflict` actually fails if the two features are used together.