### PR TITLE
Fix documentation inaccuracy in stop()

### DIFF
--- a/ktor-server/ktor-server-host-common/src/io/ktor/server/engine/ApplicationEngine.kt
+++ b/ktor-server/ktor-server-host-common/src/io/ktor/server/engine/ApplicationEngine.kt
@@ -48,9 +48,9 @@ interface ApplicationEngine {
     /**
      * Stops this [ApplicationEngine]
      *
-     * @param gracePeriod the maximum amount of time in milliseconds to allow for activity to cool down
+     * @param gracePeriod the maximum amount of time for activity to cool down
      * @param timeout the maximum amount of time to wait until server stops gracefully
-     * @param timeUnit the [TimeUnit] for [timeout]
+     * @param timeUnit the [TimeUnit] for [gracePeriod] and [timeout]
      */
     fun stop(gracePeriod: Long, timeout: Long, timeUnit: TimeUnit)
 }


### PR DESCRIPTION
Fix error in documentation which wrongly claims that the gradePeriod is in millis. In reality both the gradeperiod and the timeout is applied to the timeUnit specified as the third argument.
If one specifies `stop(1_000, 20, TimeUnit.SECONDS)`an `java.lang.IllegalArgumentException: timeout: 20 (expected >= quietPeriod (1000))` is thrown.