### PR TITLE
Prevent ContentNegotiation from handling byte channel pipeline (#745)

### DIFF
--- a/ktor-features/ktor-websockets/test/io/ktor/tests/websocket/WebSocketWithContentNegotiationTest.kt
+++ b/ktor-features/ktor-websockets/test/io/ktor/tests/websocket/WebSocketWithContentNegotiationTest.kt
@@ -1,0 +1,45 @@
+package io.ktor.tests.websocket
+
+import io.ktor.application.*
+import io.ktor.features.*
+import io.ktor.http.*
+import io.ktor.http.cio.websocket.Frame
+import io.ktor.request.*
+import io.ktor.routing.*
+import io.ktor.server.testing.*
+import io.ktor.util.pipeline.*
+import io.ktor.websocket.*
+import kotlin.test.*
+
+class WebSocketWithContentNegotiationTest {
+
+    @Test
+    fun test(): Unit = withTestApplication {
+        application.install(WebSockets)
+        application.install(ContentNegotiation) {
+            val converter = object : ContentConverter {
+                override suspend fun convertForSend(
+                    context: PipelineContext<Any, ApplicationCall>,
+                    contentType: ContentType,
+                    value: Any
+                ): Any? = fail("convertForSend shouldn't be invoked")
+
+                override suspend fun convertForReceive(context: PipelineContext<ApplicationReceiveRequest, ApplicationCall>): Any? {
+                    fail("convertForReceive shouldn't be invoked")
+                }
+            }
+
+            register(ContentType.Any, converter)
+        }
+
+        application.routing {
+            webSocket("/") {
+                outgoing.send(Frame.Text("OK"))
+            }
+        }
+
+        handleWebSocketConversation("/", {}) { incoming, outgoing ->
+            incoming.receive()
+        }
+    }
+}

--- a/ktor-server/ktor-server-core/src/io/ktor/features/ContentNegotiation.kt
+++ b/ktor-server/ktor-server-core/src/io/ktor/features/ContentNegotiation.kt
@@ -88,7 +88,11 @@ class ContentNegotiation(val registrations: List<ConverterRegistration>) {
             }
 
             pipeline.receivePipeline.intercept(ApplicationReceivePipeline.Transform) { receive ->
+                // skip if already transformed
                 if (subject.value !is ByteReadChannel) return@intercept
+                // skip if a byte channel has been requested so there is nothing to negotiate
+                if (subject.type === ByteReadChannel::class) return@intercept
+
                 val contentType = call.request.contentType().withoutParameters()
                 val suitableConverter = feature.registrations.firstOrNull { it.contentType.match(contentType) }
                         ?: throw UnsupportedMediaTypeException(contentType)


### PR DESCRIPTION
Fix for ContentNegotiation bug. The reason why it did fail is that ContentNegotation shouldn't negotiate already transformed values. 