### PR TITLE
Allow configuring Logger instance for CallLogging

### DIFF
--- a/ktor-server/ktor-server-core/src/io/ktor/features/CallLogging.kt
+++ b/ktor-server/ktor-server-core/src/io/ktor/features/CallLogging.kt
@@ -36,6 +36,11 @@ class CallLogging private constructor(
         var level: Level = Level.TRACE
 
         /**
+         * Customize [Logger], will default to [ApplicationEnvironment.log]
+         */
+        var logger: Logger? = null
+
+        /**
          * Log messages for calls matching a [predicate]
          */
         fun filter(predicate: (ApplicationCall) -> Boolean) {
@@ -99,7 +104,8 @@ class CallLogging private constructor(
             val loggingPhase = PipelinePhase("Logging")
             val configuration = Configuration().apply(configure)
             val feature = CallLogging(
-                pipeline.log, pipeline.environment.monitor,
+                configuration.logger ?: pipeline.log,
+                pipeline.environment.monitor,
                 configuration.level,
                 configuration.filters.toList(),
                 configuration.mdcEntries.toList()

--- a/ktor-server/ktor-server-tests/test/io/ktor/tests/server/features/CallLoggingTest.kt
+++ b/ktor-server/ktor-server-tests/test/io/ktor/tests/server/features/CallLoggingTest.kt
@@ -217,4 +217,31 @@ class CallLoggingTest {
         }
     }
 
+    @Test
+    fun `can configure custom logger`() {
+        val customMessages = ArrayList<String>()
+        val customLogger: Logger = object : Logger by LoggerFactory.getLogger("ktor.test.custom") {
+            override fun trace(message: String?) {
+                if (message != null) {
+                    customMessages.add("CUSTOM TRACE: $message")
+                }
+            }
+        }
+        val environment = createTestEnvironment {
+            module {
+                install(CallLogging) {
+                    this.logger = customLogger
+                }
+            }
+        }
+        var hash: String? = null
+
+        withApplication(environment) {
+            hash = application.toString()
+        }
+
+        assertTrue(customMessages.isNotEmpty())
+        assertTrue(customMessages.all { it.startsWith("CUSTOM TRACE:") && it.contains(hash!!) })
+        assertTrue(messages.isEmpty())
+    }
 }


### PR DESCRIPTION
This will make is possible to use `CallLogging` feature with a customized logger, e.g.

```kotlin
install(CallLogging) {
    logger = LoggerFactory.getLogger("access.log")
}
```

Edit force-push: realised test was in error, updated with fix