### PR TITLE
okhttp-client: pass contentLength for multipart form data to StreamRe…

### DIFF
--- a/ktor-client/ktor-client-okhttp/src/io/ktor/client/engine/okhttp/OkHttpEngine.kt
+++ b/ktor-client/ktor-client-okhttp/src/io/ktor/client/engine/okhttp/OkHttpEngine.kt
@@ -51,9 +51,9 @@ class OkHttpEngine(override val config: OkHttpConfig) : HttpClientJvmEngine("kto
 
 internal fun OutgoingContent.convertToOkHttpBody(callContext: CoroutineContext): RequestBody? = when (this) {
     is OutgoingContent.ByteArrayContent -> RequestBody.create(null, bytes())
-    is OutgoingContent.ReadChannelContent -> StreamRequestBody { readFrom() }
+    is OutgoingContent.ReadChannelContent -> StreamRequestBody(contentLength) { readFrom() }
     is OutgoingContent.WriteChannelContent -> {
-        StreamRequestBody { GlobalScope.writer(callContext) { writeTo(channel) }.channel }
+        StreamRequestBody(contentLength) { GlobalScope.writer(callContext) { writeTo(channel) }.channel }
     }
     is OutgoingContent.NoContent -> null
     else -> throw UnsupportedContentTypeException(this)

--- a/ktor-client/ktor-client-okhttp/src/io/ktor/client/engine/okhttp/StreamRequestBody.kt
+++ b/ktor-client/ktor-client-okhttp/src/io/ktor/client/engine/okhttp/StreamRequestBody.kt
@@ -5,7 +5,7 @@ import kotlinx.coroutines.io.jvm.javaio.*
 import okhttp3.*
 import okio.*
 
-internal class StreamRequestBody(private val block: () -> ByteReadChannel) : RequestBody() {
+internal class StreamRequestBody(private val contentLength: Long?, private val block: () -> ByteReadChannel) : RequestBody() {
     override fun contentType(): MediaType? = null
 
     override fun writeTo(sink: BufferedSink) {
@@ -13,4 +13,6 @@ internal class StreamRequestBody(private val block: () -> ByteReadChannel) : Req
             sink.writeAll(it)
         }
     }
+
+    override fun contentLength(): Long = contentLength ?: -1
 }


### PR DESCRIPTION
…questBody

The existing implementation caused okhttp to never send the correct `Content-Length` and instead sending `Transfer-Encoding: chunked`, even though one might have set the `contentLength` in a `OutgoingContent.WriteChannelContent` subclass.

Note: the MultiPartFormDataContent from ktor should also support calculating contentLength