### PR TITLE
Cy/windows websocket

### DIFF
--- a/ktor-server/ktor-server-jetty/src/io/ktor/server/jetty/internal/EndPointChannels.kt
+++ b/ktor-server/ktor-server-jetty/src/io/ktor/server/jetty/internal/EndPointChannels.kt
@@ -101,15 +101,14 @@ internal fun CoroutineScope.endPointWriter(
     pool: ObjectPool<ByteBuffer> = JettyWebSocketPool
 ): ByteWriteChannel = reader(EndpointWriterCoroutineName + Dispatchers.Unconfined, autoFlush = true) {
     pool.useInstance { buffer: ByteBuffer ->
-        endPoint.use { endPoint ->
-            while (!channel.isClosedForRead) {
-                buffer.clear()
-                if (channel.readAvailable(buffer) == -1) break
+        while (!channel.isClosedForRead) {
+            buffer.clear()
+            if (channel.readAvailable(buffer) == -1) break
 
-                buffer.flip()
-                endPoint.write(buffer)
-            }
+            buffer.flip()
+            endPoint.write(buffer)
         }
+        endPoint.flush()
     }
 }.channel
 

--- a/ktor-server/ktor-server-jetty/src/io/ktor/server/jetty/internal/JettyUpgradeImpl.kt
+++ b/ktor-server/ktor-server-jetty/src/io/ktor/server/jetty/internal/JettyUpgradeImpl.kt
@@ -35,7 +35,7 @@ object JettyUpgradeImpl : ServletUpgrade {
             val job = upgrade.upgrade(inputChannel, outputChannel, engineContext, userContext)
 
             job.invokeOnCompletion {
-                connection.close()
+                connection.endPoint.idleTimeout = TimeUnit.SECONDS.toMillis(30L)
             }
 
             job.join()

--- a/ktor-server/ktor-server-netty/src/io/ktor/server/netty/cio/NettyResponsePipeline.kt
+++ b/ktor-server/ktor-server-netty/src/io/ktor/server/netty/cio/NettyResponsePipeline.kt
@@ -159,8 +159,8 @@ internal class NettyResponsePipeline(private val dst: ChannelHandlerContext,
 
     @Suppress("NOTHING_TO_INLINE")
     private suspend inline fun finishCall(call: NettyApplicationCall, lastMessage: Any?, lastFuture: ChannelFuture) {
-        val close = !call.request.keepAlive || call.response.isUpgradeResponse()
-        val doNotFlush = hasNextResponseMessage() && !close
+        val prepareForClose = !call.request.keepAlive || call.response.isUpgradeResponse()
+        val doNotFlush = hasNextResponseMessage() && !prepareForClose
 
         val f: ChannelFuture? = when {
             lastMessage == null && doNotFlush -> null
@@ -177,7 +177,7 @@ internal class NettyResponsePipeline(private val dst: ChannelHandlerContext,
 
         f?.suspendWriteAwait()
 
-        if (close) {
+        if (prepareForClose) {
             dst.flush()
             lastFuture.suspendWriteAwait()
             requestQueue.cancel()

--- a/ktor-server/ktor-server-netty/src/io/ktor/server/netty/cio/NettyResponsePipeline.kt
+++ b/ktor-server/ktor-server-netty/src/io/ktor/server/netty/cio/NettyResponsePipeline.kt
@@ -159,7 +159,7 @@ internal class NettyResponsePipeline(private val dst: ChannelHandlerContext,
 
     @Suppress("NOTHING_TO_INLINE")
     private suspend inline fun finishCall(call: NettyApplicationCall, lastMessage: Any?, lastFuture: ChannelFuture) {
-        val close = !call.request.keepAlive
+        val close = !call.request.keepAlive || call.response.isUpgradeResponse()
         val doNotFlush = hasNextResponseMessage() && !close
 
         val f: ChannelFuture? = when {
@@ -365,6 +365,8 @@ sealed class WriterEncapsulation {
     }
 
     object Raw : WriterEncapsulation() {
+        override val requiresContextClose: Boolean get() = false
+
         override fun transform(buf: ByteBuf, last: Boolean): Any {
             return buf
         }


### PR DESCRIPTION
Fix network errors on Windows: the main idea is to not close actual socket at server side as it usually should do a client (to avoid TIME_WAIT). In fact we probably need to do this for any requests but for now we can fix for websockets only as it caused errors