### PR TITLE
Update slf4j dependency in JVM HTTP Client Logging Feature

### DIFF
--- a/ktor-client/ktor-client-features/ktor-client-logging/ktor-client-logging-jvm/build.gradle.kts
+++ b/ktor-client/ktor-client-features/ktor-client-logging/ktor-client-logging-jvm/build.gradle.kts
@@ -2,7 +2,7 @@
 dependencies {
     expectedBy(project(":ktor-client:ktor-client-features:ktor-client-logging"))
 
-    implementation("org.slf4j:slf4j-simple:1.6.1")
+    implementation("org.slf4j:slf4j-api:1.7.25")
     compile(project(":ktor-client:ktor-client-core:ktor-client-core-jvm"))
 
     testCompile(project(":ktor-client:ktor-client-tests"))


### PR DESCRIPTION
Simple change to swap the slf4j implementation with the API.  I used the same slf4j-api version from jvm.gradle.