### PR TITLE
http-client UrlBuilder adds = to query parameters without value

### DIFF
--- a/ktor-http/common/src/io/ktor/http/HttpUrlEncoded.kt
+++ b/ktor-http/common/src/io/ktor/http/HttpUrlEncoded.kt
@@ -35,13 +35,17 @@ fun List<Pair<String, String?>>.formUrlEncode(): String = StringBuilder().apply 
  * Encode form parameters from a list of pairs to the specified [out] appendable
  */
 fun List<Pair<String, String?>>.formUrlEncodeTo(out: Appendable) {
-    filter { it.second != null }.joinTo(
+    joinTo(
         out, "&"
     ) {
         val key = it.first.encodeURLParameter(spaceToPlus = true)
-        val value = it.second.toString().encodeURLParameter(spaceToPlus = true)
-
-        "$key=$value"
+        if (it.second == null) {
+            key
+        }
+        else {
+            val value = it.second.toString().encodeURLParameter(spaceToPlus = true)
+            "$key=$value"
+        }
     }
 }
 
@@ -57,6 +61,6 @@ fun Parameters.formUrlEncode(): String = entries()
  */
 fun Parameters.formUrlEncodeTo(out: Appendable) {
     entries()
-        .flatMap { e -> e.value.map { e.key to it } }
+        .flatMap { e -> if (e.value.isEmpty()) listOf(e.key to null) else e.value.map { e.key to it } }
         .formUrlEncodeTo(out)
 }

--- a/ktor-http/common/src/io/ktor/http/Query.kt
+++ b/ktor-http/common/src/io/ktor/http/Query.kt
@@ -44,7 +44,7 @@ private fun ParametersBuilder.appendParam(query: String, nameIndex: Int, equalIn
 
         if (spaceEndIndex > spaceNameIndex) {
             val name = query.decodeURLQueryComponent(spaceNameIndex, spaceEndIndex)
-            append(name, "")
+            appendAll(name, emptyList())
         }
     } else {
         val spaceNameIndex = trimStart(nameIndex, equalIndex, query)

--- a/ktor-http/common/test/io/ktor/tests/http/QueryParametersTest.kt
+++ b/ktor-http/common/test/io/ktor/tests/http/QueryParametersTest.kt
@@ -57,9 +57,20 @@ class QueryParametersTest {
     @Test
     fun noValue() {
         assertQuery("id") {
-            append("id", "")
+            appendAll("id", emptyList())
         }
         assertQuery("id&optional") {
+            appendAll("id", emptyList())
+            appendAll("optional", emptyList())
+        }
+    }
+
+    @Test
+    fun emptyValue() {
+        assertQuery("id=") {
+            append("id", "")
+        }
+        assertQuery("id=&optional=") {
             append("id", "")
             append("optional", "")
         }

--- a/ktor-http/common/test/io/ktor/tests/http/URLBuilderTest.kt
+++ b/ktor-http/common/test/io/ktor/tests/http/URLBuilderTest.kt
@@ -84,4 +84,16 @@ internal class URLBuilderTest {
         url.takeFrom("/1")
         assertEquals("https://httpstat.us/1", url.buildString())
     }
+
+    @Test
+    fun queryParamsWithNoValue() {
+        val url = URLBuilder("https://httpstat.us/?novalue")
+        assertEquals("https://httpstat.us/?novalue", url.buildString())
+    }
+
+    @Test
+    fun queryParamsWithEmptyValue() {
+        val url = URLBuilder("https://httpstat.us/?empty=")
+        assertEquals("https://httpstat.us/?empty=", url.buildString())
+    }
 }


### PR DESCRIPTION
I noticed that you could add a key with an empty list to the `StringValues` class. I used this to convey that the key has no value and should not append the =. This means you can still get the = by setting the value to the empty string. An alternative solution would be to allow null values, and use that to convey no value. But that would require a major refactoring of the `StringValues` class and its  dependencies.

Fixes #818