### PR TITLE
Fixed issue #827: WebSocket masking cannot be enabled

### DIFF
--- a/ktor-client/ktor-client-features/ktor-client-websocket/jvm/src/io/ktor/client/features/websocket/ClientSessions.kt
+++ b/ktor-client/ktor-client-features/ktor-client-websocket/jvm/src/io/ktor/client/features/websocket/ClientSessions.kt
@@ -20,5 +20,7 @@ class DefaultClientWebSocketSession(
     override val call: HttpClientCall,
     delegate: DefaultWebSocketSession
 ) : ClientWebSocketSession, DefaultWebSocketSession by delegate {
-    override var masking: Boolean = true
+    init {
+        masking = true
+    }
 }


### PR DESCRIPTION
The bug is caused by the use of overriding to set the masking property to true, which has no effect on the actual session delegate. 
An init {} block should be used to initialise the "masking" property to true. This also preserves the delegation mechanism to work properly. Changing the masking value of the wrapper class will also be propagated to the underlying delegate.