### PR TITLE
Client: Support relative redirects by making #takeFrom() resolve relative urls.

### DIFF
--- a/ktor-client/ktor-client-tests/jvm/src/io/ktor/client/tests/HttpRedirectTest.kt
+++ b/ktor-client/ktor-client-tests/jvm/src/io/ktor/client/tests/HttpRedirectTest.kt
@@ -39,6 +39,12 @@ abstract class HttpRedirectTest(private val factory: HttpClientEngineFactory<*>)
 
                 call.respondText("OK")
             }
+            get("/directory/redirectFile") {
+                call.respondRedirect("targetFile")
+            }
+            get("/directory/targetFile") {
+                call.respondText("targetFile")
+            }
         }
     }
 
@@ -114,6 +120,15 @@ abstract class HttpRedirectTest(private val factory: HttpClientEngineFactory<*>)
         test { client ->
             client.get<HttpResponse>("https://httpstat.us/301").use { response ->
                 assertEquals(response.status, HttpStatusCode.OK)
+            }
+        }
+    }
+
+    @Test
+    fun redirectRelative() = clientTest(factory) {
+        test { client ->
+            client.get<HttpResponse>(path = "/directory/redirectFile", port = serverPort).use {
+                assertEquals("targetFile", it.readText())
             }
         }
     }

--- a/ktor-http/common/src/io/ktor/http/URLParser.kt
+++ b/ktor-http/common/src/io/ktor/http/URLParser.kt
@@ -62,11 +62,33 @@ internal fun URLBuilder.takeFromUnsafe(urlString: String): URLBuilder {
     }
 
     // Path
-    encodedPath = "/"
-    if (startIndex >= endIndex) return this
+    if (startIndex >= endIndex) {
+        encodedPath = "/"
+        return this
+    }
+
+    encodedPath = if (slashCount == 0) {
+        // Relative path
+        val lastSlashIndex = encodedPath.lastIndexOf('/')
+
+        if (lastSlashIndex != encodedPath.length-1) {
+            // Current path does not end in slash, get rid of last path segment.
+            if (lastSlashIndex != -1) {
+                encodedPath.substring(0, lastSlashIndex+1)
+            } else {
+                "/"
+            }
+        } else {
+            // keep the whole path
+            encodedPath
+        }
+    } else {
+        // overwrite the path
+        ""
+    }
     val pathEnd = urlString.indexOfAny("?#".toCharArray(), startIndex).takeIf { it > 0 } ?: endIndex
     val rawPath = urlString.substring(startIndex, pathEnd)
-    encodedPath = rawPath.encodeURLPath()
+    encodedPath += rawPath.encodeURLPath()
     startIndex = pathEnd
 
     // Query

--- a/ktor-http/common/test/io/ktor/tests/http/URLBuilderTest.kt
+++ b/ktor-http/common/test/io/ktor/tests/http/URLBuilderTest.kt
@@ -84,4 +84,28 @@ internal class URLBuilderTest {
         url.takeFrom("/1")
         assertEquals("https://httpstat.us/1", url.buildString())
     }
+
+    @Test
+    fun rewritePathDirectoryWithRelative() {
+        val url = URLBuilder("https://example.org/first/directory/")
+
+        url.takeFrom("relative")
+        assertEquals("https://example.org/first/directory/relative", url.buildString())
+    }
+
+    @Test
+    fun rewritePathFileWithRelative() {
+        val url = URLBuilder("https://example.org/first/file.html")
+
+        url.takeFrom("relative")
+        assertEquals("https://example.org/first/relative", url.buildString())
+    }
+
+    @Test
+    fun rewritePathFileWithDot() {
+        val url = URLBuilder("https://example.org/first/file.html")
+
+        url.takeFrom("./")
+        assertEquals("https://example.org/first/./", url.buildString())
+    }
 }


### PR DESCRIPTION
Currently the HttpRedirect feature of the client cannot handle relative redirects.
I discovered this when requesting a Wikipedia URL like `https://en.wikipedia.org/api/rest_v1/page/summary/Amazon_Inc` which returns: `location: Amazon_(company)`

I created a simple fix directly in `URLBuilder.takeFrom`, which imo makes sense that it also supports resolving relative URLs? (It simply makes sure the old path is not overwritten by the new one, if the new one is relative - but as before it won't normalize paths like `../newpath`)
