### PR TITLE
Server digest and OAuth fixes

### DIFF
--- a/binary-compatibility-validator/reference-public-api/ktor-http.txt
+++ b/binary-compatibility-validator/reference-public-api/ktor-http.txt
@@ -1012,6 +1012,7 @@ public final class io/ktor/http/auth/HttpAuthHeader$Parameterized : io/ktor/http
 	public fun render ()Ljava/lang/String;
 	public fun render (Lio/ktor/http/auth/HeaderValueEncoding;)Ljava/lang/String;
 	public final fun withParameter (Ljava/lang/String;Ljava/lang/String;)Lio/ktor/http/auth/HttpAuthHeader$Parameterized;
+	public final fun withReplacedParameter (Ljava/lang/String;Ljava/lang/String;)Lio/ktor/http/auth/HttpAuthHeader$Parameterized;
 }
 
 public final class io/ktor/http/auth/HttpAuthHeader$Parameters {

--- a/binary-compatibility-validator/reference-public-api/ktor-utils.txt
+++ b/binary-compatibility-validator/reference-public-api/ktor-utils.txt
@@ -2,6 +2,12 @@ public final class io/ktor/pipeline/CompatibilityKt {
 	public static final fun execute (Lio/ktor/util/pipeline/Pipeline;Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
+public final class io/ktor/util/AlwaysFailNonceManager : io/ktor/util/NonceManager {
+	public static final field INSTANCE Lio/ktor/util/AlwaysFailNonceManager;
+	public fun newNonce (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun verifyNonce (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
 public final class io/ktor/util/AttributeKey {
 	public fun <init> (Ljava/lang/String;)V
 	public final fun getName ()Ljava/lang/String;
@@ -126,6 +132,12 @@ public abstract interface class io/ktor/util/Digest {
 	public abstract fun reset ()V
 }
 
+public final class io/ktor/util/GenerateOnlyNonceManager : io/ktor/util/NonceManager {
+	public static final field INSTANCE Lio/ktor/util/GenerateOnlyNonceManager;
+	public fun newNonce (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun verifyNonce (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
 public final class io/ktor/util/Hash {
 	public static final field INSTANCE Lio/ktor/util/Hash;
 	public final fun combine ([Ljava/lang/Object;)I
@@ -174,6 +186,11 @@ public final class io/ktor/util/NioPathKt {
 	public static final fun normalizeAndRelativize (Ljava/nio/file/Path;)Ljava/nio/file/Path;
 }
 
+public abstract interface class io/ktor/util/NonceManager {
+	public abstract fun newNonce (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun verifyNonce (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
 public final class io/ktor/util/PathKt {
 	public static final fun combineSafe (Ljava/io/File;Ljava/lang/String;)Ljava/io/File;
 	public static final fun normalizeAndRelativize (Ljava/io/File;)Ljava/io/File;
@@ -186,6 +203,19 @@ public final class io/ktor/util/RangesKt {
 
 public final class io/ktor/util/ReflectionKt {
 	public static final fun findAllSupertypes (Ljava/lang/Class;)Ljava/util/List;
+}
+
+public final class io/ktor/util/StatelessHmacNonceManager : io/ktor/util/NonceManager {
+	public fun <init> (Ljavax/crypto/spec/SecretKeySpec;Ljava/lang/String;JLkotlin/jvm/functions/Function0;)V
+	public synthetic fun <init> (Ljavax/crypto/spec/SecretKeySpec;Ljava/lang/String;JLkotlin/jvm/functions/Function0;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> ([BLjava/lang/String;JLkotlin/jvm/functions/Function0;)V
+	public synthetic fun <init> ([BLjava/lang/String;JLkotlin/jvm/functions/Function0;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getAlgorithm ()Ljava/lang/String;
+	public final fun getKeySpec ()Ljavax/crypto/spec/SecretKeySpec;
+	public final fun getNonceGenerator ()Lkotlin/jvm/functions/Function0;
+	public final fun getTimeoutMillis ()J
+	public fun newNonce (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun verifyNonce (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public abstract interface class io/ktor/util/StringValues {

--- a/ktor-client/ktor-client-features/ktor-client-auth/jvm/test/DigestTest.kt
+++ b/ktor-client/ktor-client-features/ktor-client-auth/jvm/test/DigestTest.kt
@@ -18,14 +18,11 @@ class DigestTest : TestWithKtor() {
         install(Authentication) {
             digest("digest") {
                 val password = "Circle Of Life"
-                digester = MessageDigest.getInstance("MD5")
+                algorithmName = "MD5"
                 realm = "testrealm@host.com"
 
                 userNameRealmPasswordDigestProvider = { userName, realm ->
-                    when (userName) {
-                        "missing" -> null
-                        else -> digest(digester, "$userName:$realm:$password")
-                    }
+                    digest(MessageDigest.getInstance(algorithmName), "$userName:$realm:$password")
                 }
             }
 

--- a/ktor-features/ktor-auth/jvm/src/io/ktor/auth/DigestAuth.kt
+++ b/ktor-features/ktor-auth/jvm/src/io/ktor/auth/DigestAuth.kt
@@ -68,11 +68,13 @@ fun Authentication.Configuration.digest(name: String? = null, configure: DigestA
 
         val principal = credentials?.let {
             if ((it.algorithm ?: "MD5") == provider.algorithmName
-                    && it.realm == provider.realm
-                    && provider.nonceManager.verifyNonce(it.nonce)
-                    && it.verifier(call.request.local.method, MessageDigest.getInstance(provider.algorithmName),
+                && it.realm == provider.realm
+                && provider.nonceManager.verifyNonce(it.nonce)
+                && it.verifier(
+                    call.request.local.method, MessageDigest.getInstance(provider.algorithmName),
                     provider.userNameRealmPasswordDigestProvider
-                ))
+                )
+            )
                 UserIdPrincipal(it.userName)
             else
                 null
@@ -120,16 +122,18 @@ fun Authentication.Configuration.digest(name: String? = null, configure: DigestA
  * @property cnonce must be sent if [qop] is specified and must be `null` otherwise. Should be passed through unchanged.
  * @property qop quality of protection sign
  */
-data class DigestCredential(val realm: String,
-                            val userName: String,
-                            val digestUri: String,
-                            val nonce: String,
-                            val opaque: String?,
-                            val nonceCount: String?,
-                            val algorithm: String?,
-                            val response: String,
-                            val cnonce: String?,
-                            val qop: String?) : Credential
+data class DigestCredential(
+    val realm: String,
+    val userName: String,
+    val digestUri: String,
+    val nonce: String,
+    val opaque: String?,
+    val nonceCount: String?,
+    val algorithm: String?,
+    val response: String,
+    val cnonce: String?,
+    val qop: String?
+) : Credential
 
 /**
  * Retrieves [DigestCredential] from this call
@@ -150,22 +154,26 @@ private val digestAuthenticationChallengeKey: Any = "DigestAuth"
  * Converts [HttpAuthHeader] to [DigestCredential]
  */
 fun HttpAuthHeader.Parameterized.toDigestCredential(): DigestCredential = DigestCredential(
-        parameter("realm")!!,
-        parameter("username")!!,
-        parameter("uri")!!,
-        parameter("nonce")!!,
-        parameter("opaque"),
-        parameter("nc"),
-        parameter("algorithm"),
-        parameter("response")!!,
-        parameter("cnonce"),
-        parameter("qop")
+    parameter("realm")!!,
+    parameter("username")!!,
+    parameter("uri")!!,
+    parameter("nonce")!!,
+    parameter("opaque"),
+    parameter("nc"),
+    parameter("algorithm"),
+    parameter("response")!!,
+    parameter("cnonce"),
+    parameter("qop")
 )
 
 /**
  * Verifies credentials are valid for given [method] and [digester] and [userNameRealmPasswordDigest]
  */
-suspend fun DigestCredential.verifier(method: HttpMethod, digester: MessageDigest, userNameRealmPasswordDigest: suspend (String, String) -> ByteArray?): Boolean {
+suspend fun DigestCredential.verifier(
+    method: HttpMethod,
+    digester: MessageDigest,
+    userNameRealmPasswordDigest: suspend (String, String) -> ByteArray?
+): Boolean {
     val userNameRealmPasswordDigestResult = userNameRealmPasswordDigest(userName, realm)
     val validDigest = expectedDigest(method, digester, userNameRealmPasswordDigestResult ?: ByteArray(0))
 
@@ -182,7 +190,11 @@ suspend fun DigestCredential.verifier(method: HttpMethod, digester: MessageDiges
 /**
  * Calculates expected digest bytes for this [DigestCredential]
  */
-fun DigestCredential.expectedDigest(method: HttpMethod, digester: MessageDigest, userNameRealmPasswordDigest: ByteArray): ByteArray {
+fun DigestCredential.expectedDigest(
+    method: HttpMethod,
+    digester: MessageDigest,
+    userNameRealmPasswordDigest: ByteArray
+): ByteArray {
     fun digest(data: String): ByteArray {
         digester.reset()
         digester.update(data.toByteArray(Charsets.ISO_8859_1))

--- a/ktor-features/ktor-auth/jvm/src/io/ktor/auth/NonceManager.kt
+++ b/ktor-features/ktor-auth/jvm/src/io/ktor/auth/NonceManager.kt
@@ -1,0 +1,131 @@
+package io.ktor.auth
+
+import io.ktor.util.*
+import java.util.concurrent.*
+import javax.crypto.*
+import javax.crypto.spec.*
+
+/**
+ * Represents a nonce manager. It's responsibility is to produce nonce values
+ * and verify nonce values from untrusted sources that they are provided by this manager.
+ * This is usually required in web environment to mitigate CSRF attacks.
+ * Depending on it's underlying implementation it could be stateful or stateless.
+ * Note that there is usually some timeout for nonce values to reduce memory usage and to avoid replay attacks.
+ * Nonce length is unspecified.
+ */
+@KtorExperimentalAPI
+interface NonceManager {
+    /**
+     * Generate new nonce instance
+     */
+    suspend fun newNonce(): String
+
+    /**
+     * Verify [nonce] value
+     * @return `true` if [nonce] is valid
+     */
+    suspend fun verifyNonce(nonce: String): Boolean
+}
+
+/**
+ * This implementation does only generate nonce values but doesn't validate them. This is recommended for testing only.
+ */
+@KtorExperimentalAPI
+object GenerateOnlyNonceManager : NonceManager {
+    override suspend fun newNonce(): String {
+        return generateNonce()
+    }
+
+    override suspend fun verifyNonce(nonce: String): Boolean {
+        return true
+    }
+}
+
+@Deprecated("This should be removed with OAuth2StateProvider")
+internal object AlwaysFailNonceManager : NonceManager {
+    override suspend fun newNonce(): String {
+        throw UnsupportedOperationException("This manager should never be used")
+    }
+
+    override suspend fun verifyNonce(nonce: String): Boolean {
+        throw UnsupportedOperationException("This manager should never be used")
+    }
+}
+
+/**
+ * Stateless nonce manager implementation with HMAC verification and timeout.
+ * Every nonce provided by this manager consist of a random part, timestamp and HMAC.
+ * @property keySpec secret key spec for HMAC
+ * @property algorithm HMAC algorithm name, `HmacSHA256` by default
+ * @property timeoutMillis specifies the amount of time for a nonce to be considered valid
+ * @property nonceGenerator function that produces random values
+ */
+@KtorExperimentalAPI
+class StatelessNonceManager(
+    val keySpec: SecretKeySpec,
+    val algorithm: String = "HmacSHA256",
+    val timeoutMillis: Long = 60000,
+    val nonceGenerator: () -> String = { generateNonce() }
+) : NonceManager {
+    /**
+     * Helper constructor that makes a secret key from [key] ByteArray
+     */
+    constructor(
+        key: ByteArray,
+        algorithm: String = "HmacSHA256",
+        timeoutMillis: Long = 60000,
+        nonceGenerator: () -> String = { generateNonce() }
+    ) : this(
+        SecretKeySpec(
+            key,
+            algorithm
+        ), algorithm, timeoutMillis, nonceGenerator
+    )
+
+    /**
+     * MAC length in bytes
+     */
+    private val macLength = Mac.getInstance(algorithm).let { mac ->
+        mac.init(keySpec)
+        mac.macLength
+    }
+
+    override suspend fun newNonce(): String {
+        val random = nonceGenerator()
+        val time = System.nanoTime().toString(16).padStart(16, '0')
+
+        val mac = hex(Mac.getInstance(algorithm).apply {
+            init(keySpec)
+            update("$random:$time".toByteArray(Charsets.ISO_8859_1))
+        }.doFinal())
+
+        return "$random+$time+$mac"
+    }
+
+    override suspend fun verifyNonce(nonce: String): Boolean {
+        val parts = nonce.split('+')
+        if (parts.size != 3) return false
+        val (random, time, mac) = parts
+
+        if (random.length < 8) return false
+        if (mac.length != macLength * 2) return false
+        if (time.length != 16) return false
+
+        val nanoTime = time.toLong(16)
+        if (nanoTime + TimeUnit.MILLISECONDS.toNanos(timeoutMillis) < System.nanoTime()) return false
+
+        val computedMac = hex(Mac.getInstance(algorithm).apply {
+            init(keySpec)
+            update("$random:$time".toByteArray(Charsets.ISO_8859_1))
+        }.doFinal())
+
+        var validCount = 0
+        for (i in 0 until minOf(computedMac.length, mac.length)) {
+            if (computedMac[i] == mac[i]) {
+                validCount++
+            }
+        }
+
+        return validCount == macLength * 2
+    }
+}

--- a/ktor-features/ktor-auth/jvm/src/io/ktor/auth/OAuth1a.kt
+++ b/ktor-features/ktor-auth/jvm/src/io/ktor/auth/OAuth1a.kt
@@ -191,7 +191,8 @@ private suspend fun requestOAuth1aAccessToken(
 }
 
 @Suppress("KDocMissingDocumentation")
-@Deprecated("Use createObtainRequestTokenHeader instead",
+@Deprecated(
+    "Use createObtainRequestTokenHeader instead",
     ReplaceWith("createObtainRequestTokenHeader(callback, consumerKey, nonce, timestamp)"),
     level = DeprecationLevel.ERROR
 )
@@ -227,7 +228,8 @@ fun createObtainRequestTokenHeader(
 /**
  * Create an HTTP auth header for OAuth1a upgrade token request
  */
-@Deprecated("Use createUpgradeRequestTokenHeader instead",
+@Deprecated(
+    "Use createUpgradeRequestTokenHeader instead",
     ReplaceWith("createUpgradeRequestTokenHeader(consumerKey, token, nonce, timestamp)"),
     level = DeprecationLevel.ERROR
 )

--- a/ktor-features/ktor-auth/jvm/src/io/ktor/auth/OAuth2.kt
+++ b/ktor-features/ktor-auth/jvm/src/io/ktor/auth/OAuth2.kt
@@ -30,7 +30,9 @@ internal suspend fun PipelineContext<Unit, ApplicationCall>.oauth2(
         val token = call.oauth2HandleCallback()
         val callbackRedirectUrl = call.urlProvider(provider)
         if (token == null) {
+            @Suppress("DEPRECATION")
             val stateProvider = provider.stateProvider
+
             call.redirectAuthenticateOAuth2(provider, callbackRedirectUrl,
                     state = stateProvider.getState(call),
                     scopes = provider.defaultScopes,
@@ -42,7 +44,7 @@ internal suspend fun PipelineContext<Unit, ApplicationCall>.oauth2(
                     call.authentication.principal(accessToken)
                 } catch (cause: OAuth2Exception.InvalidGrant) {
                     Logger.trace("Redirected to OAuth2 server due to error invalid_grant: {}", cause.message)
-                    val stateProvider = provider.stateProvider
+                    val stateProvider = @Suppress("DEPRECATION") provider.stateProvider
                     call.redirectAuthenticateOAuth2(provider, callbackRedirectUrl,
                         state = stateProvider.getState(call),
                         scopes = provider.defaultScopes,
@@ -91,7 +93,7 @@ internal suspend fun oauth2RequestAccessToken(client: HttpClient,
             extraParameters,
             configure,
             settings.accessTokenRequiresBasicAuth,
-            settings.stateProvider
+            @Suppress("DEPRECATION") settings.stateProvider
     )
 }
 
@@ -133,6 +135,7 @@ private suspend fun oauth2RequestAccessToken(client: HttpClient,
                                              extraParameters: Map<String, String> = emptyMap(),
                                              configure: HttpRequestBuilder.() -> Unit = {},
                                              useBasicAuth: Boolean = false,
+                                             @Suppress("DEPRECATION")
                                              stateProvider: OAuth2StateProvider = DefaultOAuth2StateProvider,
                                              grantType: String = OAuthGrantTypes.AuthorizationCode): OAuthAccessTokenResponse.OAuth2 {
 
@@ -268,7 +271,7 @@ suspend fun verifyWithOAuth2(
                     OAuth2RequestParameters.Password to credential.password
             ),
             useBasicAuth = true,
-            stateProvider = settings.stateProvider,
+            stateProvider = @Suppress("DEPRECATION") settings.stateProvider,
             grantType = OAuthGrantTypes.Password
     )
 }

--- a/ktor-features/ktor-auth/jvm/src/io/ktor/auth/OAuth2.kt
+++ b/ktor-features/ktor-auth/jvm/src/io/ktor/auth/OAuth2.kt
@@ -21,9 +21,9 @@ import java.net.*
 private val Logger: Logger = LoggerFactory.getLogger("io.ktor.auth.oauth")
 
 internal suspend fun PipelineContext<Unit, ApplicationCall>.oauth2(
-        client: HttpClient, dispatcher: CoroutineDispatcher,
-        providerLookup: ApplicationCall.() -> OAuthServerSettings?,
-        urlProvider: ApplicationCall.(OAuthServerSettings) -> String
+    client: HttpClient, dispatcher: CoroutineDispatcher,
+    providerLookup: ApplicationCall.() -> OAuthServerSettings?,
+    urlProvider: ApplicationCall.(OAuthServerSettings) -> String
 ) {
     val provider = call.providerLookup()
     if (provider is OAuthServerSettings.OAuth2ServerSettings) {
@@ -33,10 +33,12 @@ internal suspend fun PipelineContext<Unit, ApplicationCall>.oauth2(
             @Suppress("DEPRECATION")
             val stateProvider = provider.stateProvider
 
-            call.redirectAuthenticateOAuth2(provider, callbackRedirectUrl,
-                    state = stateProvider.getState(call),
-                    scopes = provider.defaultScopes,
-                    interceptor = provider.authorizeUrlInterceptor)
+            call.redirectAuthenticateOAuth2(
+                provider, callbackRedirectUrl,
+                state = stateProvider.getState(call),
+                scopes = provider.defaultScopes,
+                interceptor = provider.authorizeUrlInterceptor
+            )
         } else {
             withContext(dispatcher) {
                 try {
@@ -45,10 +47,12 @@ internal suspend fun PipelineContext<Unit, ApplicationCall>.oauth2(
                 } catch (cause: OAuth2Exception.InvalidGrant) {
                     Logger.trace("Redirected to OAuth2 server due to error invalid_grant: {}", cause.message)
                     val stateProvider = @Suppress("DEPRECATION") provider.stateProvider
-                    call.redirectAuthenticateOAuth2(provider, callbackRedirectUrl,
+                    call.redirectAuthenticateOAuth2(
+                        provider, callbackRedirectUrl,
                         state = stateProvider.getState(call),
                         scopes = provider.defaultScopes,
-                        interceptor = provider.authorizeUrlInterceptor)
+                        interceptor = provider.authorizeUrlInterceptor
+                    )
                 }
             }
         }
@@ -65,45 +69,58 @@ internal fun ApplicationCall.oauth2HandleCallback(): OAuthCallback.TokenSingle? 
     }
 }
 
-internal suspend fun ApplicationCall.redirectAuthenticateOAuth2(settings: OAuthServerSettings.OAuth2ServerSettings, callbackRedirectUrl: String, state: String, extraParameters: List<Pair<String, String>> = emptyList(), scopes: List<String> = emptyList(), interceptor: URLBuilder.() -> Unit) {
-    redirectAuthenticateOAuth2(authenticateUrl = settings.authorizeUrl,
-            callbackRedirectUrl = callbackRedirectUrl,
-            clientId = settings.clientId,
-            state = state,
-            scopes = scopes,
-            parameters = extraParameters,
-            interceptor = interceptor)
-}
-
-internal suspend fun oauth2RequestAccessToken(client: HttpClient,
-                                              settings: OAuthServerSettings.OAuth2ServerSettings,
-                                              usedRedirectUrl: String,
-                                              callbackResponse: OAuthCallback.TokenSingle,
-                                              extraParameters: Map<String, String> = emptyMap(),
-                                              configure: HttpRequestBuilder.() -> Unit = {}): OAuthAccessTokenResponse.OAuth2 {
-    return oauth2RequestAccessToken(
-            client,
-            settings.requestMethod,
-            usedRedirectUrl,
-            settings.accessTokenUrl,
-            settings.clientId,
-            settings.clientSecret,
-            callbackResponse.state,
-            callbackResponse.token,
-            extraParameters,
-            configure,
-            settings.accessTokenRequiresBasicAuth,
-            @Suppress("DEPRECATION") settings.stateProvider
+internal suspend fun ApplicationCall.redirectAuthenticateOAuth2(
+    settings: OAuthServerSettings.OAuth2ServerSettings,
+    callbackRedirectUrl: String,
+    state: String,
+    extraParameters: List<Pair<String, String>> = emptyList(),
+    scopes: List<String> = emptyList(),
+    interceptor: URLBuilder.() -> Unit
+) {
+    redirectAuthenticateOAuth2(
+        authenticateUrl = settings.authorizeUrl,
+        callbackRedirectUrl = callbackRedirectUrl,
+        clientId = settings.clientId,
+        state = state,
+        scopes = scopes,
+        parameters = extraParameters,
+        interceptor = interceptor
     )
 }
 
-private suspend fun ApplicationCall.redirectAuthenticateOAuth2(authenticateUrl: String,
-                                                               callbackRedirectUrl: String,
-                                                               clientId: String,
-                                                               state: String,
-                                                               scopes: List<String> = emptyList(),
-                                                               parameters: List<Pair<String, String>> = emptyList(),
-                                                               interceptor: URLBuilder.() -> Unit = {}) {
+internal suspend fun oauth2RequestAccessToken(
+    client: HttpClient,
+    settings: OAuthServerSettings.OAuth2ServerSettings,
+    usedRedirectUrl: String,
+    callbackResponse: OAuthCallback.TokenSingle,
+    extraParameters: Map<String, String> = emptyMap(),
+    configure: HttpRequestBuilder.() -> Unit = {}
+): OAuthAccessTokenResponse.OAuth2 {
+    return oauth2RequestAccessToken(
+        client,
+        settings.requestMethod,
+        usedRedirectUrl,
+        settings.accessTokenUrl,
+        settings.clientId,
+        settings.clientSecret,
+        callbackResponse.state,
+        callbackResponse.token,
+        extraParameters,
+        configure,
+        settings.accessTokenRequiresBasicAuth,
+        @Suppress("DEPRECATION") settings.stateProvider
+    )
+}
+
+private suspend fun ApplicationCall.redirectAuthenticateOAuth2(
+    authenticateUrl: String,
+    callbackRedirectUrl: String,
+    clientId: String,
+    state: String,
+    scopes: List<String> = emptyList(),
+    parameters: List<Pair<String, String>> = emptyList(),
+    interceptor: URLBuilder.() -> Unit = {}
+) {
 
     val url = URLBuilder()
     url.takeFrom(URI(authenticateUrl))
@@ -124,20 +141,22 @@ private suspend fun ApplicationCall.redirectAuthenticateOAuth2(authenticateUrl: 
     return respondRedirect(url.buildString())
 }
 
-private suspend fun oauth2RequestAccessToken(client: HttpClient,
-                                             method: HttpMethod,
-                                             usedRedirectUrl: String?,
-                                             baseUrl: String,
-                                             clientId: String,
-                                             clientSecret: String,
-                                             state: String?,
-                                             code: String?,
-                                             extraParameters: Map<String, String> = emptyMap(),
-                                             configure: HttpRequestBuilder.() -> Unit = {},
-                                             useBasicAuth: Boolean = false,
-                                             @Suppress("DEPRECATION")
-                                             stateProvider: OAuth2StateProvider = DefaultOAuth2StateProvider,
-                                             grantType: String = OAuthGrantTypes.AuthorizationCode): OAuthAccessTokenResponse.OAuth2 {
+private suspend fun oauth2RequestAccessToken(
+    client: HttpClient,
+    method: HttpMethod,
+    usedRedirectUrl: String?,
+    baseUrl: String,
+    clientId: String,
+    clientSecret: String,
+    state: String?,
+    code: String?,
+    extraParameters: Map<String, String> = emptyMap(),
+    configure: HttpRequestBuilder.() -> Unit = {},
+    useBasicAuth: Boolean = false,
+    @Suppress("DEPRECATION")
+    stateProvider: OAuth2StateProvider = DefaultOAuth2StateProvider,
+    grantType: String = OAuthGrantTypes.AuthorizationCode
+): OAuthAccessTokenResponse.OAuth2 {
 
     if (state != null) {
         stateProvider.verifyState(state)
@@ -147,9 +166,9 @@ private suspend fun oauth2RequestAccessToken(client: HttpClient,
     request.url.takeFrom(URI(baseUrl))
 
     val urlParameters = ParametersBuilder().apply {
-        append(OAuth2RequestParameters.ClientId,  clientId)
-        append(OAuth2RequestParameters.ClientSecret,  clientSecret)
-        append(OAuth2RequestParameters.GrantType,  grantType)
+        append(OAuth2RequestParameters.ClientId, clientId)
+        append(OAuth2RequestParameters.ClientSecret, clientSecret)
+        append(OAuth2RequestParameters.GrantType, grantType)
         if (state != null) {
             append(OAuth2RequestParameters.State, state)
         }
@@ -166,17 +185,24 @@ private suspend fun oauth2RequestAccessToken(client: HttpClient,
 
     when (method) {
         HttpMethod.Get -> request.url.parameters.appendAll(urlParameters)
-        HttpMethod.Post -> request.body = TextContent(urlParameters.build().formUrlEncode(), ContentType.Application.FormUrlEncoded)
+        HttpMethod.Post -> request.body =
+            TextContent(urlParameters.build().formUrlEncode(), ContentType.Application.FormUrlEncoded)
         else -> throw UnsupportedOperationException("Method $method is not supported. Use GET or POST")
     }
 
     request.apply {
         this.method = method
-        header(HttpHeaders.Accept, listOf(ContentType.Application.FormUrlEncoded, ContentType.Application.Json).joinToString(","))
+        header(
+            HttpHeaders.Accept,
+            listOf(ContentType.Application.FormUrlEncoded, ContentType.Application.Json).joinToString(",")
+        )
         if (useBasicAuth) {
             header(
-                    HttpHeaders.Authorization,
-                    HttpAuthHeader.Single(AuthScheme.Basic, encodeBase64("$clientId:$clientSecret".toByteArray(Charsets.ISO_8859_1))).render()
+                HttpHeaders.Authorization,
+                HttpAuthHeader.Single(
+                    AuthScheme.Basic,
+                    encodeBase64("$clientId:$clientSecret".toByteArray(Charsets.ISO_8859_1))
+                ).render()
             )
         }
 
@@ -240,8 +266,14 @@ private fun decodeContent(content: String, contentType: ContentType): Parameters
     else -> {
         // some servers may respond with wrong content type so we have to try to guess
         when {
-            content.startsWith("{") && content.trim().endsWith("}") -> decodeContent(content.trim(), ContentType.Application.Json)
-            content.matches("([a-zA-Z\\d_-]+=[^=&]+&?)+".toRegex()) -> decodeContent(content, ContentType.Application.FormUrlEncoded) // TODO too risky, isn't it?
+            content.startsWith("{") && content.trim().endsWith("}") -> decodeContent(
+                content.trim(),
+                ContentType.Application.Json
+            )
+            content.matches("([a-zA-Z\\d_-]+=[^=&]+&?)+".toRegex()) -> decodeContent(
+                content,
+                ContentType.Application.FormUrlEncoded
+            ) // TODO too risky, isn't it?
             else -> throw IOException("unsupported content type $contentType")
         }
     }
@@ -258,21 +290,22 @@ suspend fun verifyWithOAuth2(
     client: HttpClient,
     settings: OAuthServerSettings.OAuth2ServerSettings
 ): OAuthAccessTokenResponse.OAuth2 {
-    return oauth2RequestAccessToken(client, HttpMethod.Post,
-            usedRedirectUrl = null,
-            baseUrl = settings.accessTokenUrl,
-            clientId = settings.clientId,
-            clientSecret = settings.clientSecret,
-            code = null,
-            state = null,
-            configure = {},
-            extraParameters = mapOf(
-                    OAuth2RequestParameters.UserName to credential.name,
-                    OAuth2RequestParameters.Password to credential.password
-            ),
-            useBasicAuth = true,
-            stateProvider = @Suppress("DEPRECATION") settings.stateProvider,
-            grantType = OAuthGrantTypes.Password
+    return oauth2RequestAccessToken(
+        client, HttpMethod.Post,
+        usedRedirectUrl = null,
+        baseUrl = settings.accessTokenUrl,
+        clientId = settings.clientId,
+        clientSecret = settings.clientSecret,
+        code = null,
+        state = null,
+        configure = {},
+        extraParameters = mapOf(
+            OAuth2RequestParameters.UserName to credential.name,
+            OAuth2RequestParameters.Password to credential.password
+        ),
+        useBasicAuth = true,
+        stateProvider = @Suppress("DEPRECATION") settings.stateProvider,
+        grantType = OAuthGrantTypes.Password
     )
 }
 

--- a/ktor-features/ktor-auth/jvm/src/io/ktor/auth/OAuthProcedure.kt
+++ b/ktor-features/ktor-auth/jvm/src/io/ktor/auth/OAuthProcedure.kt
@@ -70,10 +70,12 @@ internal fun OAuthAuthenticationProvider.oauth2() {
 
             if (cause != null) {
                 context.challenge(OAuthKey, cause) {
-                    call.redirectAuthenticateOAuth2(provider, callbackRedirectUrl,
+                    call.redirectAuthenticateOAuth2(
+                        provider, callbackRedirectUrl,
                         state = @Suppress("DEPRECATION") provider.stateProvider.getState(call),
                         scopes = provider.defaultScopes,
-                        interceptor = provider.authorizeUrlInterceptor)
+                        interceptor = provider.authorizeUrlInterceptor
+                    )
                     it.complete()
                 }
             }

--- a/ktor-features/ktor-auth/jvm/src/io/ktor/auth/OAuthProcedure.kt
+++ b/ktor-features/ktor-auth/jvm/src/io/ktor/auth/OAuthProcedure.kt
@@ -71,7 +71,7 @@ internal fun OAuthAuthenticationProvider.oauth2() {
             if (cause != null) {
                 context.challenge(OAuthKey, cause) {
                     call.redirectAuthenticateOAuth2(provider, callbackRedirectUrl,
-                        state = provider.stateProvider.getState(call),
+                        state = @Suppress("DEPRECATION") provider.stateProvider.getState(call),
                         scopes = provider.defaultScopes,
                         interceptor = provider.authorizeUrlInterceptor)
                     it.complete()

--- a/ktor-features/ktor-auth/jvm/test/io/ktor/tests/auth/AuthHeadersTest.kt
+++ b/ktor-features/ktor-auth/jvm/test/io/ktor/tests/auth/AuthHeadersTest.kt
@@ -20,4 +20,44 @@ class AuthHeadersTest {
             assertEquals(header.encoding, header.withParameter("a", "c").encoding)
         }
     }
+
+    @Test
+    fun testReplaceParameter() {
+        HttpAuthHeader.Parameterized("testScheme", linkedMapOf("a" to "2")).let { headerWithNoSuchEntires ->
+            headerWithNoSuchEntires.withReplacedParameter("X", "1").let { result ->
+                assertNotSame(headerWithNoSuchEntires, result)
+                assertEquals(2, result.parameters.size)
+                assertEquals("1", result.parameters.single { it.name == "X" }.value)
+                assertEquals("2", result.parameters.single { it.name == "a" }.value)
+            }
+        }
+        HttpAuthHeader.Parameterized("testScheme", linkedMapOf("a" to "2", "X" to "0"))
+            .let { headerWithSingleOccurrence ->
+                headerWithSingleOccurrence.withReplacedParameter("X", "1").let { result ->
+                    assertNotSame(headerWithSingleOccurrence, result)
+                    assertEquals(2, result.parameters.size)
+                    assertEquals("1", result.parameters.single { it.name == "X" }.value)
+                    assertEquals("2", result.parameters.single { it.name == "a" }.value)
+                }
+            }
+        HttpAuthHeader.Parameterized("testScheme", linkedMapOf("a" to "2", "X" to "0", "X" to "3"))
+            .let { headerWithMultipleOccurrences ->
+                headerWithMultipleOccurrences.withReplacedParameter("X", "1").let { result ->
+                    assertNotSame(headerWithMultipleOccurrences, result)
+                    assertEquals(2, result.parameters.size)
+                    assertEquals("1", result.parameters.single { it.name == "X" }.value)
+                    assertEquals("2", result.parameters.single { it.name == "a" }.value)
+                }
+            }
+        HttpAuthHeader.Parameterized("testScheme", linkedMapOf("a" to "2", "X" to "0", "m" to "2", "X" to "7"))
+            .let { inTheMiddleReplace ->
+                inTheMiddleReplace.withReplacedParameter("X", "1").let { result ->
+                    assertNotSame(inTheMiddleReplace, result)
+                    assertEquals(3, result.parameters.size)
+                    assertEquals("1", result.parameters.single { it.name == "X" }.value)
+                    assertEquals("2", result.parameters.single { it.name == "a" }.value)
+                    assertEquals(1, result.parameters.indexOfLast { it.name == "X" })
+                }
+            }
+    }
 }

--- a/ktor-features/ktor-auth/jvm/test/io/ktor/tests/auth/DigestTest.kt
+++ b/ktor-features/ktor-auth/jvm/test/io/ktor/tests/auth/DigestTest.kt
@@ -252,7 +252,7 @@ class DigestTest {
 
         withTestApplication {
             application.configureDigestServer(
-                nonceManager = StatelessNonceManager(
+                nonceManager = StatelessHmacNonceManager(
                     key,
                     nonceGenerator = { nonceValue })
             )

--- a/ktor-features/ktor-auth/jvm/test/io/ktor/tests/auth/DigestTest.kt
+++ b/ktor-features/ktor-auth/jvm/test/io/ktor/tests/auth/DigestTest.kt
@@ -18,11 +18,15 @@ class DigestTest {
     fun createExampleChallengeFromRFC() {
         withTestApplication {
             application.intercept(ApplicationCallPipeline.Features) {
-                call.respond(UnauthorizedResponse(HttpAuthHeader.digestAuthChallenge(
-                        realm = "testrealm@host.com",
-                        nonce = "dcd98b7102dd2f0e8b11d0f600bfb0c093",
-                        opaque = "5ccc069c403ebaf9f0171e9517f40e41"
-                )))
+                call.respond(
+                    UnauthorizedResponse(
+                        HttpAuthHeader.digestAuthChallenge(
+                            realm = "testrealm@host.com",
+                            nonce = "dcd98b7102dd2f0e8b11d0f600bfb0c093",
+                            opaque = "5ccc069c403ebaf9f0171e9517f40e41"
+                        )
+                    )
+                )
             }
 
             val response = handleRequest {
@@ -30,11 +34,13 @@ class DigestTest {
 
             assertTrue(response.requestHandled)
             assertEquals(HttpStatusCode.Unauthorized, response.response.status())
-            assertEquals("""Digest
+            assertEquals(
+                """Digest
                  realm="testrealm@host.com",
                  nonce="dcd98b7102dd2f0e8b11d0f600bfb0c093",
                  opaque="5ccc069c403ebaf9f0171e9517f40e41",
-                 algorithm="MD5" """.normalize(), response.response.headers[HttpHeaders.WWWAuthenticate])
+                 algorithm="MD5" """.normalize(), response.response.headers[HttpHeaders.WWWAuthenticate]
+            )
         }
     }
 
@@ -60,7 +66,8 @@ class DigestTest {
             handleRequest {
                 uri = "/"
 
-                addHeader(HttpHeaders.Authorization, """Digest username="Mufasa",
+                addHeader(
+                    HttpHeaders.Authorization, """Digest username="Mufasa",
                  realm="testrealm@host.com",
                  nonce="dcd98b7102dd2f0e8b11d0f600bfb0c093",
                  uri="/dir/index.html",
@@ -68,7 +75,8 @@ class DigestTest {
                  nc=00000001,
                  cnonce="0a4f113b",
                  response="6629fae49393a05397450978507c4ef1",
-                 opaque="5ccc069c403ebaf9f0171e9517f40e41"""".normalize())
+                 opaque="5ccc069c403ebaf9f0171e9517f40e41"""".normalize()
+                )
             }
 
             assertEquals(1, foundDigests.size)
@@ -103,7 +111,10 @@ class DigestTest {
         val userNameRealmPassword = "${digest.userName}:${digest.realm}:$p"
         val digester = MessageDigest.getInstance(digest.algorithm ?: "MD5")
 
-        assertEquals(digest.response, hex(digest.expectedDigest(HttpMethod.Get, digester, digest(digester, userNameRealmPassword))))
+        assertEquals(
+            digest.response,
+            hex(digest.expectedDigest(HttpMethod.Get, digester, digest(digester, userNameRealmPassword)))
+        )
         assertTrue(digest.verifier(HttpMethod.Get, digester) { user, realm -> digest(digester, "$user:$realm:$p") })
     }
 
@@ -137,7 +148,8 @@ class DigestTest {
             val response = handleRequest {
                 uri = "/"
 
-                addHeader(HttpHeaders.Authorization, """Digest username="Mufasa",
+                addHeader(
+                    HttpHeaders.Authorization, """Digest username="Mufasa",
                  realm="testrealm@host.com",
                  nonce="dcd98b7102dd2f0e8b11d0f600bfb0c093",
                  uri="/dir/index.html",
@@ -145,7 +157,8 @@ class DigestTest {
                  nc=00000001,
                  cnonce="0a4f113b",
                  response="6629fae49393a05397450978507c4ef1",
-                 opaque="5ccc069c403ebaf9f0171e9517f40e41"""".normalize())
+                 opaque="5ccc069c403ebaf9f0171e9517f40e41"""".normalize()
+                )
             }
 
             assertTrue(response.requestHandled)
@@ -162,7 +175,8 @@ class DigestTest {
             val response = handleRequest {
                 uri = "/"
 
-                addHeader(HttpHeaders.Authorization, """Digest username="Mufasa",
+                addHeader(
+                    HttpHeaders.Authorization, """Digest username="Mufasa",
                  realm="testrealm@host.com1",
                  nonce="dcd98b7102dd2f0e8b11d0f600bfb0c093",
                  uri="/dir/index.html",
@@ -170,7 +184,8 @@ class DigestTest {
                  nc=00000001,
                  cnonce="0a4f113b",
                  response="6629fae49393a05397450978507c4ef1",
-                 opaque="5ccc069c403ebaf9f0171e9517f40e41"""".normalize())
+                 opaque="5ccc069c403ebaf9f0171e9517f40e41"""".normalize()
+                )
             }
 
             assertTrue(response.requestHandled)
@@ -186,7 +201,8 @@ class DigestTest {
             val response = handleRequest {
                 uri = "/"
 
-                addHeader(HttpHeaders.Authorization, """Digest username="Mufasa",
+                addHeader(
+                    HttpHeaders.Authorization, """Digest username="Mufasa",
                  realm="testrealm@host.com",
                  nonce="dcd98b7102dd2f0e8b11d0f600bfb0c093",
                  uri="/dir/index.html",
@@ -194,7 +210,8 @@ class DigestTest {
                  nc=00000001,
                  cnonce="0a4f113b",
                  response="bad response goes here  507c4ef1",
-                 opaque="5ccc069c403ebaf9f0171e9517f40e41"""".normalize())
+                 opaque="5ccc069c403ebaf9f0171e9517f40e41"""".normalize()
+                )
             }
 
             assertTrue(response.requestHandled)
@@ -210,7 +227,8 @@ class DigestTest {
             val response = handleRequest {
                 uri = "/"
 
-                addHeader(HttpHeaders.Authorization, """Digest username="missing",
+                addHeader(
+                    HttpHeaders.Authorization, """Digest username="missing",
                  realm="testrealm@host.com",
                  nonce="dcd98b7102dd2f0e8b11d0f600bfb0c093",
                  uri="/dir/index.html",
@@ -218,7 +236,8 @@ class DigestTest {
                  nc=00000001,
                  cnonce="0a4f113b",
                  response="6629fae49393a05397450978507c4ef1",
-                 opaque="5ccc069c403ebaf9f0171e9517f40e41"""".normalize())
+                 opaque="5ccc069c403ebaf9f0171e9517f40e41"""".normalize()
+                )
             }
 
             assertTrue(response.requestHandled)
@@ -232,7 +251,11 @@ class DigestTest {
         val nonceValue = "test-nonce"
 
         withTestApplication {
-            application.configureDigestServer(nonceManager = StatelessNonceManager(key, nonceGenerator = { nonceValue }))
+            application.configureDigestServer(
+                nonceManager = StatelessNonceManager(
+                    key,
+                    nonceGenerator = { nonceValue })
+            )
 
             val challenge = handleRequest(HttpMethod.Get, "/").let { call ->
                 assertEquals(HttpStatusCode.Unauthorized, call.response.status())
@@ -244,17 +267,19 @@ class DigestTest {
             assertNotNull(challenge, "Challenge is missing")
             assertNotNull(nonce, "Nonce is missing")
 
-            val authHeader = HttpAuthHeader.Parameterized(AuthScheme.Digest, linkedMapOf(
-                "username" to "Mufasa",
-                "realm" to "testrealm@host.com",
-                "nonce" to nonce,
-                "uri" to "/dir/index.html",
-                "qop" to "auth",
-                "nc" to "00000001",
-                "cnonce" to "0a4f113b",
-                "response" to "unknown yet",
-                "opaque" to "5ccc069c403ebaf9f0171e9517f40e41"
-            ), HeaderValueEncoding.QUOTED_ALWAYS)
+            val authHeader = HttpAuthHeader.Parameterized(
+                AuthScheme.Digest, linkedMapOf(
+                    "username" to "Mufasa",
+                    "realm" to "testrealm@host.com",
+                    "nonce" to nonce,
+                    "uri" to "/dir/index.html",
+                    "qop" to "auth",
+                    "nc" to "00000001",
+                    "cnonce" to "0a4f113b",
+                    "response" to "unknown yet",
+                    "opaque" to "5ccc069c403ebaf9f0171e9517f40e41"
+                ), HeaderValueEncoding.QUOTED_ALWAYS
+            )
 
 
             val userRealmPassDigest =

--- a/ktor-utils/common/src/io/ktor/util/NonceManager.kt
+++ b/ktor-utils/common/src/io/ktor/util/NonceManager.kt
@@ -1,0 +1,55 @@
+package io.ktor.util
+
+
+/**
+ * Represents a nonce manager. It's responsibility is to produce nonce values
+ * and verify nonce values from untrusted sources that they are provided by this manager.
+ * This is usually required in web environment to mitigate CSRF attacks.
+ * Depending on it's underlying implementation it could be stateful or stateless.
+ * Note that there is usually some timeout for nonce values to reduce memory usage and to avoid replay attacks.
+ * Nonce length is unspecified.
+ */
+@KtorExperimentalAPI
+interface NonceManager {
+    /**
+     * Generate new nonce instance
+     */
+    suspend fun newNonce(): String
+
+    /**
+     * Verify [nonce] value
+     * @return `true` if [nonce] is valid
+     */
+    suspend fun verifyNonce(nonce: String): Boolean
+}
+
+
+/**
+ * This implementation does only generate nonce values but doesn't validate them. This is recommended for testing only.
+ */
+@KtorExperimentalAPI
+object GenerateOnlyNonceManager : NonceManager {
+    override suspend fun newNonce(): String {
+        return generateNonce()
+    }
+
+    override suspend fun verifyNonce(nonce: String): Boolean {
+        return true
+    }
+}
+
+/**
+ * Stub implementation that always fails.
+ * Will be removed so no public signatures should rely on it
+ */
+@Deprecated("This should be removed with OAuth2StateProvider")
+@InternalAPI
+object AlwaysFailNonceManager : NonceManager {
+    override suspend fun newNonce(): String {
+        throw UnsupportedOperationException("This manager should never be used")
+    }
+
+    override suspend fun verifyNonce(nonce: String): Boolean {
+        throw UnsupportedOperationException("This manager should never be used")
+    }
+}

--- a/ktor-utils/jvm/src/io/ktor/util/StatelessHmacNonceManager.kt
+++ b/ktor-utils/jvm/src/io/ktor/util/StatelessHmacNonceManager.kt
@@ -1,56 +1,8 @@
-package io.ktor.auth
+package io.ktor.util
 
-import io.ktor.util.*
 import java.util.concurrent.*
 import javax.crypto.*
 import javax.crypto.spec.*
-
-/**
- * Represents a nonce manager. It's responsibility is to produce nonce values
- * and verify nonce values from untrusted sources that they are provided by this manager.
- * This is usually required in web environment to mitigate CSRF attacks.
- * Depending on it's underlying implementation it could be stateful or stateless.
- * Note that there is usually some timeout for nonce values to reduce memory usage and to avoid replay attacks.
- * Nonce length is unspecified.
- */
-@KtorExperimentalAPI
-interface NonceManager {
-    /**
-     * Generate new nonce instance
-     */
-    suspend fun newNonce(): String
-
-    /**
-     * Verify [nonce] value
-     * @return `true` if [nonce] is valid
-     */
-    suspend fun verifyNonce(nonce: String): Boolean
-}
-
-/**
- * This implementation does only generate nonce values but doesn't validate them. This is recommended for testing only.
- */
-@KtorExperimentalAPI
-object GenerateOnlyNonceManager : NonceManager {
-    override suspend fun newNonce(): String {
-        return generateNonce()
-    }
-
-    override suspend fun verifyNonce(nonce: String): Boolean {
-        return true
-    }
-}
-
-@Deprecated("This should be removed with OAuth2StateProvider")
-internal object AlwaysFailNonceManager : NonceManager {
-    override suspend fun newNonce(): String {
-        throw UnsupportedOperationException("This manager should never be used")
-    }
-
-    override suspend fun verifyNonce(nonce: String): Boolean {
-        throw UnsupportedOperationException("This manager should never be used")
-    }
-}
 
 /**
  * Stateless nonce manager implementation with HMAC verification and timeout.
@@ -61,7 +13,7 @@ internal object AlwaysFailNonceManager : NonceManager {
  * @property nonceGenerator function that produces random values
  */
 @KtorExperimentalAPI
-class StatelessNonceManager(
+class StatelessHmacNonceManager(
     val keySpec: SecretKeySpec,
     val algorithm: String = "HmacSHA256",
     val timeoutMillis: Long = 60000,

--- a/ktor-utils/jvm/test/io/ktor/tests/utils/StatelessHmacNonceManagerTest.kt
+++ b/ktor-utils/jvm/test/io/ktor/tests/utils/StatelessHmacNonceManagerTest.kt
@@ -1,0 +1,44 @@
+package io.ktor.tests.utils
+
+import io.ktor.util.*
+import kotlinx.coroutines.*
+import kotlin.test.*
+
+class StatelessHmacNonceManagerTest {
+    private val nonceValues = listOf("11111111", "22222222", "33333333")
+    private val nonceSequence = nonceValues.iterator()
+    private val key = "test-key".toByteArray()
+    private val manager = StatelessHmacNonceManager(key) { nonceSequence.next() }
+
+    @Test
+    fun smokeTest(): Unit = runBlocking {
+        val nonce = manager.newNonce()
+        assertTrue(manager.verifyNonce(nonce))
+    }
+
+    @Test
+    fun testContains(): Unit = runBlocking {
+        assertTrue(nonceValues[0] in manager.newNonce())
+        assertTrue(nonceValues[1] in manager.newNonce())
+        assertTrue(nonceValues[2] in manager.newNonce())
+    }
+
+    @Test
+    fun testIllegalValues(): Unit = runBlocking {
+        assertFalse(manager.verifyNonce(""))
+        assertFalse(manager.verifyNonce("+"))
+        assertFalse(manager.verifyNonce("++"))
+        assertFalse(manager.verifyNonce("+++"))
+        assertFalse(manager.verifyNonce("1"))
+        assertFalse(manager.verifyNonce("1777777777777777777777777777"))
+        assertFalse(manager.verifyNonce("1777777777+777777777777777777"))
+        assertFalse(manager.verifyNonce("1777777777+77777777+7777777777"))
+        assertFalse(manager.verifyNonce("1777777777+77777777+7777777777"))
+
+        val managerWithTheSameKey = StatelessHmacNonceManager(key) { "some-other-nonce" }
+        assertTrue(manager.verifyNonce(managerWithTheSameKey.newNonce()))
+
+        val managerWithAnotherKey = StatelessHmacNonceManager("some-other-key".toByteArray()) { nonceValues[0] }
+        assertFalse(manager.verifyNonce(managerWithAnotherKey.newNonce()))
+    }
+}


### PR DESCRIPTION
- Avoid concurrent digester usage in server digest auth implementation
- Deprecate `MessageDigest` in digest auth API
- Introduce `NonceManager` in replacement for `OAuth2StateProvider`
  - deprecate `OAuth2StateProvider` and add `NonceManager` support in OAuth2 with complete backward compatibility (old `OAuth2StateProvider` implementation will work as before)
  - add `NonceManager` support to server digest auth
- introduce `withReplacedParameter` helper function on `HttpAuthHeader` 

hint: review commit by commit
