### PR TITLE
Introduce standard ktor exceptions

### DIFF
--- a/.idea/dictionaries/cy.xml
+++ b/.idea/dictionaries/cy.xml
@@ -24,6 +24,7 @@
       <w>crypto</w>
       <w>datagrams</w>
       <w>deflater</w>
+      <w>deserialized</w>
       <w>dest</w>
       <w>digester</w>
       <w>disguisement</w>

--- a/ktor-features/ktor-locations/jvm/src/io/ktor/locations/Locations.kt
+++ b/ktor-features/ktor-locations/jvm/src/io/ktor/locations/Locations.kt
@@ -68,7 +68,7 @@ open class Locations(private val application: Application, private val routeServ
                 try {
                     conversionService.fromValues(values, type)
                 } catch (cause: Throwable) {
-                    throw ParameterConversionException(name, type.typeName, cause)
+                    throw ParameterConversionException(name, type.toString(), cause)
                 }
             }
         }

--- a/ktor-features/ktor-locations/jvm/src/io/ktor/locations/Locations.kt
+++ b/ktor-features/ktor-locations/jvm/src/io/ktor/locations/Locations.kt
@@ -59,10 +59,18 @@ open class Locations(private val application: Application, private val routeServ
         val values = parameters.getAll(name)
         return when (values) {
             null -> when {
-                !optional -> throw DataConversionException("Parameter '$name' was not found in the map")
+                !optional -> {
+                    throw MissingRequestParameterException(name)
+                }
                 else -> null
             }
-            else -> conversionService.fromValues(values, type)
+            else -> {
+                try {
+                    conversionService.fromValues(values, type)
+                } catch (cause: Throwable) {
+                    throw ParameterConversionException(name, type.typeName, cause)
+                }
+            }
         }
     }
 

--- a/ktor-features/ktor-locations/jvm/test/io/ktor/tests/locations/LocationsTest.kt
+++ b/ktor-features/ktor-locations/jvm/test/io/ktor/tests/locations/LocationsTest.kt
@@ -491,6 +491,11 @@ class LocationsTest {
         handleRequest(HttpMethod.Get, "/?text=abc&number=z&longNumber=2").let { call ->
             assertEquals(HttpStatusCode.BadRequest, call.response.status())
         }
+
+        // illegal value for numeric property
+        handleRequest(HttpMethod.Get, "/?text=abc&number=${Long.MAX_VALUE}&longNumber=2").let { call ->
+            assertEquals(HttpStatusCode.BadRequest, call.response.status())
+        }
     }
 }
 

--- a/ktor-features/ktor-locations/jvm/test/io/ktor/tests/locations/LocationsTest.kt
+++ b/ktor-features/ktor-locations/jvm/test/io/ktor/tests/locations/LocationsTest.kt
@@ -446,12 +446,9 @@ class LocationsTest {
         urlShouldBeHandled("/?e=A", "A")
         urlShouldBeHandled("/?e=B", "B")
 
-        val t = assertFailsWith<DataConversionException> {
-            handleRequest(HttpMethod.Get, "/?e=x")
+        handleRequest(HttpMethod.Get, "/?e=x").let { call ->
+            assertEquals(HttpStatusCode.BadRequest, call.response.status())
         }
-
-        assertTrue { "LocationEnum" in t.message!! || "LocationEnum" in t.cause?.message ?: "" }
-        assertTrue { "x" in t.message!! || "x" in t.cause?.message ?: "" }
     }
 
     @Location("/") class LocationWithBigNumbers(val bd: BigDecimal, val bi: BigInteger)
@@ -471,6 +468,29 @@ class LocationsTest {
 
         urlShouldBeHandled("/?bd=123456789012345678901234567890&bi=123456789012345678901234567890",
             "/?bd=123456789012345678901234567890&bi=123456789012345678901234567890")
+    }
+
+    @Test fun `location parameter mismatch should lead to bad request status`() = withLocationsApplication {
+        @Location("/") data class L(val text: String, val number: Int, val longNumber: Long)
+
+        application.routing {
+            get<L> { instance ->
+                call.respondText("text = ${instance.text}, number = ${instance.number}, longNumber = ${instance.longNumber}")
+            }
+        }
+
+        urlShouldBeHandled("/?text=abc&number=1&longNumber=2", "text = abc, number = 1, longNumber = 2")
+
+        // missing parameter text
+        handleRequest(HttpMethod.Get, "/?number=1&longNumber=2").let { call ->
+            // null because missing parameter leads to routing miss
+            assertEquals(null, call.response.status())
+        }
+
+        // illegal value for numeric property
+        handleRequest(HttpMethod.Get, "/?text=abc&number=z&longNumber=2").let { call ->
+            assertEquals(HttpStatusCode.BadRequest, call.response.status())
+        }
     }
 }
 

--- a/ktor-server/ktor-server-core/jvm/src/io/ktor/features/ContentNegotiation.kt
+++ b/ktor-server/ktor-server-core/jvm/src/io/ktor/features/ContentNegotiation.kt
@@ -48,7 +48,7 @@ class ContentNegotiation(val registrations: List<ConverterRegistration>) {
      * Implementation of an [ApplicationFeature] for the [ContentNegotiation]
      */
     companion object Feature : ApplicationFeature<ApplicationCallPipeline, Configuration, ContentNegotiation> {
-        override val key = AttributeKey<ContentNegotiation>("ContentNegotiation")
+        override val key: AttributeKey<ContentNegotiation> = AttributeKey("ContentNegotiation")
 
         override fun install(pipeline: ApplicationCallPipeline, configure: Configuration.() -> Unit): ContentNegotiation {
             val configuration = Configuration().apply(configure)
@@ -104,12 +104,6 @@ class ContentNegotiation(val registrations: List<ConverterRegistration>) {
         }
     }
 }
-
-/**
- * Thrown when there is no conversion for a content type configured
- */
-class UnsupportedMediaTypeException(contentType: ContentType) :
-        ContentTransformationException("Content type $contentType is not supported")
 
 /**
  * A custom content converted that could be registered in [ContentNegotiation] feature for any particular content type

--- a/ktor-server/ktor-server-core/jvm/src/io/ktor/features/Errors.kt
+++ b/ktor-server/ktor-server-core/jvm/src/io/ktor/features/Errors.kt
@@ -1,0 +1,58 @@
+package io.ktor.features
+
+import io.ktor.http.*
+import io.ktor.util.*
+import java.lang.Exception
+import kotlin.reflect.*
+
+/**
+ * Base exception to indicate that the request is not correct due to
+ * wrong/missing request parameters, body content or header values.
+ * Throwing this exception in a handler will lead to 400 Bad Request response
+ * unless a custom [io.ktor.features.StatusPages] handler registered.
+ */
+@KtorExperimentalAPI
+open class BadRequestException(message: String, cause: Throwable? = null) : Exception(message, cause)
+
+/**
+ * This exception means that the requested resource is not found.
+ * HTTP status 404 Not found will be replied when this exception is thrown and not caught.
+ * 404 status page could be configured by registering a custom [io.ktor.features.StatusPages] handler.
+ */
+@KtorExperimentalAPI
+class NotFoundException(message: String? = "Resource not found") : Exception(message)
+
+/**
+ * This exception is thrown when a required parameter with name [parameterName] is missing
+ * @property parameterName of missing request parameter
+ */
+@KtorExperimentalAPI
+class MissingRequestParameterException(val parameterName: String) :
+    BadRequestException("Request parameter $parameterName is missing")
+
+/**
+ * This exception is thrown when a required parameter with name [parameterName] couldn't be converted to the [type]
+ * @property parameterName of missing request parameter
+ * @property type this parameter is unable to convert to
+ */
+@KtorExperimentalAPI
+class ParameterConversionException(val parameterName: String, val type: String, cause: Throwable? = null) :
+    BadRequestException("Request parameter $parameterName couldn't be parsed/converted to $type", cause)
+
+/**
+ * Thrown when content cannot be transformed to the desired type.
+ * It is not defined which status code will be replied when an exception of this type is thrown and not caught.
+ * Depending on child type it could be 4xx or 5xx status code. By default it will be 500 Internal Server Error.
+ */
+@KtorExperimentalAPI
+abstract class ContentTransformationException(message: String) : Exception(message)
+
+internal class CannotTransformContentToTypeException(type: KClass<*>) :
+    ContentTransformationException("Cannot transform this request's content to $type")
+
+/**
+ * Thrown when there is no conversion for a content type configured.
+ * HTTP status 415 Unsupported Media Type will be replied when this exception is thrown and not caught.
+ */
+class UnsupportedMediaTypeException(contentType: ContentType) :
+    ContentTransformationException("Content type $contentType is not supported")

--- a/ktor-server/ktor-server-core/jvm/src/io/ktor/request/ApplicationReceiveFunctions.kt
+++ b/ktor-server/ktor-server-core/jvm/src/io/ktor/request/ApplicationReceiveFunctions.kt
@@ -1,6 +1,7 @@
 package io.ktor.request
 
 import io.ktor.application.*
+import io.ktor.features.*
 import io.ktor.http.content.*
 import io.ktor.http.*
 import io.ktor.util.pipeline.*
@@ -68,7 +69,7 @@ suspend fun <T : Any> ApplicationCall.receive(type: KClass<T>): T {
     val transformed = request.pipeline.execute(this, receiveRequest).value
 
     if (!type.isInstance(transformed))
-        throw CannotTransformToTypeException(type)
+        throw CannotTransformContentToTypeException(type)
 
     @Suppress("UNCHECKED_CAST")
     return transformed as T
@@ -131,7 +132,4 @@ suspend inline fun ApplicationCall.receiveParameters(): Parameters = receive()
 /**
  * Thrown when content cannot be transformed to the desired type.
  */
-abstract class ContentTransformationException(message: String) : Exception(message)
-
-private class CannotTransformToTypeException(type: KClass<*>)
-    : ContentTransformationException("Cannot transform this request's content to $type")
+typealias ContentTransformationException = io.ktor.features.ContentTransformationException

--- a/ktor-server/ktor-server-core/jvm/src/io/ktor/util/Parameters.kt
+++ b/ktor-server/ktor-server-core/jvm/src/io/ktor/util/Parameters.kt
@@ -1,0 +1,40 @@
+package io.ktor.util
+
+import io.ktor.features.*
+import io.ktor.http.*
+import java.lang.reflect.*
+import kotlin.reflect.*
+import kotlin.reflect.full.*
+import kotlin.reflect.jvm.*
+
+@KtorExperimentalAPI
+inline operator fun <reified R : Any> Parameters.getValue(thisRef: Any?, property: KProperty<*>): R {
+    return getOrFail<R>(property.name)
+}
+
+@KtorExperimentalAPI
+@Suppress("NOTHING_TO_INLINE")
+inline fun Parameters.getOrFail(name: String): String {
+    return get(name) ?: throw MissingRequestParameterException(name)
+}
+
+@KtorExperimentalAPI
+inline fun <reified R : Any> Parameters.getOrFail(name: String): R {
+    val o = object {
+        @Suppress("unused")
+        val reflectField: R? = null
+    }
+    val type = o.javaClass.declaredFields.first { it.name == "reflectField" }.genericType
+    return getOrFailImpl(name, R::class, type)
+}
+
+@PublishedApi
+internal fun <R : Any> Parameters.getOrFailImpl(name: String, type: KClass<R>, javaType: Type): R {
+    val values = getAll(name) ?: throw MissingRequestParameterException(name)
+    return try {
+        type.cast(DefaultConversionService.fromValues(values, javaType))
+    } catch (cause: Exception) {
+        throw ParameterConversionException(name, type.jvmName, cause)
+    }
+}
+

--- a/ktor-server/ktor-server-core/jvm/test/io/ktor/tests/http/ParametersTest.kt
+++ b/ktor-server/ktor-server-core/jvm/test/io/ktor/tests/http/ParametersTest.kt
@@ -1,0 +1,43 @@
+package io.ktor.tests.http
+
+import io.ktor.http.*
+import io.ktor.util.*
+import kotlin.test.*
+
+class ParametersTest {
+    private val parameters = parametersOf(
+        "single" to listOf("a"),
+        "another" to listOf("2"),
+        "multiple" to listOf("3", "4")
+    )
+
+    @Test
+    fun testSingleValues() {
+        val single: String by parameters
+        val another: Int by parameters
+
+        assertEquals("a", single)
+        assertEquals(2, another)
+    }
+
+    @Test
+    fun testMultipleAsStrings() {
+        val multiple: List<String> by parameters
+
+        assertEquals(listOf("3", "4"), multiple)
+    }
+
+    @Test
+    fun testMultipleAsIntegers() {
+        val multiple: List<Int> by parameters
+
+        assertEquals(listOf(3, 4), multiple)
+    }
+
+    @Test
+    fun testMultipleAsLongIntegers() {
+        val multiple: List<Long> by parameters
+
+        assertEquals(listOf(3L, 4L), multiple)
+    }
+}

--- a/ktor-server/ktor-server-host-common/jvm/src/io/ktor/server/engine/ApplicationEngine.kt
+++ b/ktor-server/ktor-server-host-common/jvm/src/io/ktor/server/engine/ApplicationEngine.kt
@@ -1,5 +1,6 @@
 package io.ktor.server.engine
 
+import io.ktor.application.*
 import java.util.concurrent.*
 
 /**
@@ -36,6 +37,11 @@ interface ApplicationEngine {
      * Environment with which this engine is running
      */
     val environment: ApplicationEngineEnvironment
+
+    /**
+     * Currently running application instance
+     */
+    val application: Application get() = environment.application
 
     /**
      * Starts this [ApplicationEngine]

--- a/ktor-server/ktor-server-host-common/jvm/src/io/ktor/server/engine/BaseApplicationEngine.kt
+++ b/ktor-server/ktor-server-host-common/jvm/src/io/ktor/server/engine/BaseApplicationEngine.kt
@@ -22,11 +22,6 @@ abstract class BaseApplicationEngine(
      */
     open class Configuration : ApplicationEngine.Configuration()
 
-    /**
-     * Currently running application instance
-     */
-    val application: Application get() = environment.application
-
     init {
         BaseApplicationResponse.setupSendPipeline(pipeline.sendPipeline)
         environment.monitor.subscribe(ApplicationStarting) {

--- a/ktor-server/ktor-server-host-common/jvm/src/io/ktor/server/engine/DefaultEnginePipeline.kt
+++ b/ktor-server/ktor-server-host-common/jvm/src/io/ktor/server/engine/DefaultEnginePipeline.kt
@@ -7,8 +7,10 @@ import io.ktor.http.*
 import io.ktor.util.pipeline.*
 import io.ktor.response.*
 import io.ktor.util.*
+import kotlinx.coroutines.*
 import kotlinx.coroutines.io.*
 import java.nio.channels.*
+import java.util.concurrent.*
 import java.util.concurrent.CancellationException
 
 /**
@@ -34,20 +36,35 @@ fun defaultEnginePipeline(environment: ApplicationEnvironment): EnginePipeline {
             call.application.environment.logFailure(call, error)
         } catch (error: Throwable) {
             call.application.environment.logFailure(call, error)
-            try {
-                call.respond(HttpStatusCode.InternalServerError)
-            } catch (ignore: BaseApplicationResponse.ResponseAlreadySentException) {
-            }
+            handleFailure(error)
         } finally {
             try {
                 call.request.receiveChannel().discard()
             } catch (ignore: Throwable) {
-            } finally {
             }
         }
     }
 
     return pipeline
+}
+
+private suspend fun PipelineContext<Unit, ApplicationCall>.handleFailure(cause: Throwable) {
+    tryRespondError(when (cause) {
+        is BadRequestException -> HttpStatusCode.BadRequest
+        is NotFoundException -> HttpStatusCode.NotFound
+        is UnsupportedMediaTypeException -> HttpStatusCode.UnsupportedMediaType
+        is TimeoutException, is TimeoutCancellationException -> HttpStatusCode.GatewayTimeout
+        else -> HttpStatusCode.InternalServerError
+    })
+}
+
+private suspend fun PipelineContext<Unit, ApplicationCall>.tryRespondError(statusCode: HttpStatusCode) {
+    try {
+        if (call.response.status() == null) {
+            call.respond(statusCode)
+        }
+    } catch (ignore: BaseApplicationResponse.ResponseAlreadySentException) {
+    }
 }
 
 private fun ApplicationEnvironment.logFailure(call: ApplicationCall, cause: Throwable) {

--- a/ktor-server/ktor-server-test-host/jvm/src/io/ktor/server/testing/TestApplicationEngine.kt
+++ b/ktor-server/ktor-server-test-host/jvm/src/io/ktor/server/testing/TestApplicationEngine.kt
@@ -1,8 +1,10 @@
 package io.ktor.server.testing
 
 import io.ktor.application.*
+import io.ktor.features.*
 import io.ktor.http.*
 import io.ktor.http.cio.websocket.*
+import io.ktor.response.*
 import io.ktor.server.engine.*
 import io.ktor.util.*
 import io.ktor.util.cio.*
@@ -41,7 +43,30 @@ class TestApplicationEngine(
 
     init {
         pipeline.intercept(EnginePipeline.Call) {
-            call.application.execute(call)
+            try {
+                call.application.execute(call)
+            } catch (cause: Throwable) {
+                handleTestFailure(cause)
+            }
+        }
+    }
+
+    private suspend fun PipelineContext<Unit, ApplicationCall>.handleTestFailure(cause: Throwable) {
+        tryRespondError(when (cause) {
+            is BadRequestException -> HttpStatusCode.BadRequest
+            is NotFoundException -> HttpStatusCode.NotFound
+            is UnsupportedMediaTypeException -> HttpStatusCode.UnsupportedMediaType
+            is TimeoutException, is TimeoutCancellationException -> HttpStatusCode.GatewayTimeout
+            else -> throw cause
+        })
+    }
+
+    private suspend fun PipelineContext<Unit, ApplicationCall>.tryRespondError(statusCode: HttpStatusCode) {
+        try {
+            if (call.response.status() == null) {
+                call.respond(statusCode)
+            }
+        } catch (ignore: BaseApplicationResponse.ResponseAlreadySentException) {
         }
     }
 

--- a/ktor-server/ktor-server-tests/jvm/test/io/ktor/tests/server/features/StatusPageTest.kt
+++ b/ktor-server/ktor-server-tests/jvm/test/io/ktor/tests/server/features/StatusPageTest.kt
@@ -6,6 +6,7 @@ import io.ktor.features.*
 import io.ktor.http.*
 import io.ktor.response.*
 import io.ktor.routing.*
+import io.ktor.server.engine.*
 import io.ktor.server.testing.*
 import kotlinx.coroutines.*
 import kotlinx.coroutines.io.*
@@ -319,6 +320,111 @@ class StatusPageTest {
 
         handleRequest(HttpMethod.Get, "/cancel").let {
             assertEquals("OK", it.response.content)
+        }
+    }
+
+    @Test
+    fun testDefaultKtorExceptionWithoutFeature(): Unit = withTestApplication {
+        application.routing {
+            get("/bad-request") {
+                throw BadRequestException("Planned failure")
+            }
+            get("/media-type-not-supported") {
+                throw UnsupportedMediaTypeException(ContentType.Text.Plain)
+            }
+            get("/not-found") {
+                throw NotFoundException()
+            }
+        }
+
+        handleRequest(HttpMethod.Get, "/bad-request").let { call ->
+            assertEquals(HttpStatusCode.BadRequest, call.response.status())
+        }
+        handleRequest(HttpMethod.Get, "/media-type-not-supported").let { call ->
+            assertEquals(HttpStatusCode.UnsupportedMediaType, call.response.status())
+        }
+        handleRequest(HttpMethod.Get, "/not-found").let { call ->
+            assertEquals(HttpStatusCode.NotFound, call.response.status())
+        }
+    }
+
+    @Test
+    fun testDefaultKtorExceptionWithFeatureHandlingExceptions(): Unit = withTestApplication {
+        application.install(StatusPages) {
+            exception<BadRequestException> {
+                call.respondText("BadRequestException")
+            }
+            exception<UnsupportedMediaTypeException> {
+                call.respondText("UnsupportedMediaTypeException")
+            }
+            exception<NotFoundException> {
+                call.respondText("NotFoundException")
+            }
+        }
+
+        application.routing {
+            get("/bad-request") {
+                throw BadRequestException("Planned failure")
+            }
+            get("/media-type-not-supported") {
+                throw UnsupportedMediaTypeException(ContentType.Text.Plain)
+            }
+            get("/not-found") {
+                throw NotFoundException()
+            }
+        }
+
+        handleRequest(HttpMethod.Get, "/bad-request").let { call ->
+            assertEquals(HttpStatusCode.OK, call.response.status())
+            assertEquals("BadRequestException", call.response.content)
+        }
+        handleRequest(HttpMethod.Get, "/media-type-not-supported").let { call ->
+            assertEquals(HttpStatusCode.OK, call.response.status())
+            assertEquals("UnsupportedMediaTypeException", call.response.content)
+        }
+        handleRequest(HttpMethod.Get, "/not-found").let { call ->
+            assertEquals(HttpStatusCode.OK, call.response.status())
+            assertEquals("NotFoundException", call.response.content)
+        }
+    }
+
+    @Test
+    fun testDefaultKtorExceptionWithFeatureCustomStatusPages(): Unit = withTestApplication {
+        application.install(StatusPages) {
+            status(HttpStatusCode.BadRequest) {
+                call.respondText("BadRequest")
+            }
+            status(HttpStatusCode.UnsupportedMediaType) {
+                call.respondText("UnsupportedMediaType")
+            }
+            status(HttpStatusCode.NotFound) {
+                call.respondText("NotFound")
+            }
+        }
+
+        application.routing {
+            get("/bad-request") {
+                throw BadRequestException("Planned failure")
+            }
+            get("/media-type-not-supported") {
+                throw UnsupportedMediaTypeException(ContentType.Text.Plain)
+            }
+            get("/not-found") {
+                throw NotFoundException()
+            }
+        }
+
+        handleRequest(HttpMethod.Get, "/bad-request").let { call ->
+            assertEquals(HttpStatusCode.OK, call.response.status())
+            assertEquals("BadRequest", call.response.content)
+        }
+        handleRequest(HttpMethod.Get, "/media-type-not-supported").let { call ->
+            assertEquals(HttpStatusCode.OK, call.response.status())
+            assertEquals("UnsupportedMediaType", call.response.content)
+        }
+        handleRequest(HttpMethod.Get, "/not-found").let { call ->
+            assertEquals(HttpStatusCode.OK, call.response.status())
+            assertEquals("NotFound", call.response.content)
         }
     }
 }

--- a/ktor-server/ktor-server-tests/jvm/test/io/ktor/tests/server/features/StatusPageTest.kt
+++ b/ktor-server/ktor-server-tests/jvm/test/io/ktor/tests/server/features/StatusPageTest.kt
@@ -68,9 +68,7 @@ class StatusPageTest {
     @Test
     fun testStatus404() {
         withTestApplication {
-            application.intercept(ApplicationCallPipeline.Fallback) {
-                call.respond(HttpStatusCode.NotFound)
-            }
+            installFallback()
 
             application.install(StatusPages) {
                 status(HttpStatusCode.NotFound) {
@@ -135,9 +133,7 @@ class StatusPageTest {
         class O
 
         withTestApplication {
-            application.intercept(ApplicationCallPipeline.Fallback) {
-                call.respond(HttpStatusCode.NotFound)
-            }
+            installFallback()
 
             application.install(StatusPages) {
                 status(HttpStatusCode.NotFound) {
@@ -238,9 +234,7 @@ class StatusPageTest {
                 }
             }
 
-            application.intercept(ApplicationCallPipeline.Fallback) {
-                call.respond(HttpStatusCode.NotFound)
-            }
+            installFallback()
 
             handleRequest(HttpMethod.Get, "/").let { call ->
                 assertEquals(HttpStatusCode.InternalServerError, call.response.status())
@@ -325,6 +319,14 @@ class StatusPageTest {
 
         handleRequest(HttpMethod.Get, "/cancel").let {
             assertEquals("OK", it.response.content)
+        }
+    }
+}
+
+private fun TestApplicationEngine.installFallback() {
+    application.intercept(ApplicationCallPipeline.Fallback) {
+        if (call.response.status() == null) {
+            call.respond(HttpStatusCode.NotFound)
         }
     }
 }


### PR DESCRIPTION
- Introduce standard ktor exceptions:
  - `BadRequestException`  (leads to `400 Bad Request`)
    - `MissingRequestParameterException`
    - `ParameterConversionException`
  - `NotFoundException` (leads to `404 Not Found`)
  - handle `TimeoutException` and `TimeoutCancellationException` (leads to `504 Gateway Timeout`)
  - `UnsupportedMediaTypeException` is handled without `ContentNegotiation` feature
- Locations feature supports these exceptions out of the box
- Introduce initial parameters delegation support, allows the following

```kotlin
get("/") {
    val name: String by call.request.queryParameters
    val page: Int by call.request.queryParameters
}
```

Open questions:
- There are `ParameterConversionException` (when request parameter conversion failed, e.g. `toInt()`) and `ContentTransformationException` (when request body fails) but the first one inherits `BadRequestException` while the second doesn't. Should it? Note that `UnsupportedMediaTypeException` does inherit `ContentTransformationException`.
- Should we handle timeout exceptions? `NotImplementedError`? (such exception is thrown by `kotlin.TODO()`
- Parameters delegation issues:
  - `DefaultConversionService` is always used, there is no way to capture application's service
  - operator function `getValue` doesn't support overloading so the leads to:
    - local variable type specification is required
    - relatively slow due to KClass reflection magic 
- test engine usually by-passed all exceptions from request handlers to test level however not these new kotlin exceptions are handled so they are not by-passed but converted to the corresponding status codes

  

