### PR TITLE
Add tailcard prefix support (#876, #526)

### DIFF
--- a/ktor-server/ktor-server-core/jvm/src/io/ktor/routing/RoutingBuilder.kt
+++ b/ktor-server/ktor-server-core/jvm/src/io/ktor/routing/RoutingBuilder.kt
@@ -6,6 +6,7 @@ import io.ktor.application.*
 import io.ktor.http.*
 import io.ktor.util.pipeline.*
 import io.ktor.request.*
+import java.lang.IllegalArgumentException
 
 /**
  * Builds a route to match specified [path]
@@ -246,7 +247,12 @@ object PathSegmentSelectorBuilder {
         val signature = value.substring(prefixIndex + 1, suffixIndex)
         return when {
             signature.endsWith("?") -> PathSegmentOptionalParameterRouteSelector(signature.dropLast(1), prefix, suffix)
-            signature.endsWith("...") -> PathSegmentTailcardRouteSelector(signature.dropLast(3))
+            signature.endsWith("...") -> {
+                if (suffix != null && suffix.isNotEmpty()) {
+                    throw IllegalArgumentException("Suffix after tailcard is not supported")
+                }
+                PathSegmentTailcardRouteSelector(signature.dropLast(3), prefix ?: "")
+            }
             else -> PathSegmentParameterRouteSelector(signature, prefix, suffix)
         }
     }

--- a/ktor-server/ktor-server-tests/jvm/test/io/ktor/tests/server/routing/RoutingResolveTest.kt
+++ b/ktor-server/ktor-server-tests/jvm/test/io/ktor/tests/server/routing/RoutingResolveTest.kt
@@ -573,4 +573,27 @@ class RoutingResolveTest {
         }
     }
 
+    @Test
+    fun testTailcardWithPrefix() {
+        val routing = routing()
+        val prefixChild = routing.route("prefix-{param...}") {
+            handle {}
+        }
+
+        resolve(routing, "/other").let { result ->
+            assertTrue(result is RoutingResolveResult.Failure)
+        }
+        resolve(routing, "/prefix-").let { result ->
+            assertTrue(result is RoutingResolveResult.Success)
+            assertSame(prefixChild, result.route)
+            assertEquals("", result.parameters["param"])
+        }
+        resolve(routing, "/prefix-value").let { result ->
+            assertTrue(result is RoutingResolveResult.Success)
+            assertSame(prefixChild, result.route)
+            assertEquals("value", result.parameters["param"])
+        }
+
+    }
+
 }


### PR DESCRIPTION
Currently the following tailcard `prefix-{param...}` route does actually handle all requests in spite of `prefix-`. This commit introduce prefix handling. Also it now cuts prefix from the first matched segment similar to `PathSegmentOptionalParameterRouteSelector` when capturing parameter values:
- `prefix-value` -> `param = ['value']`
- `prefix-a/b/c` -> `param = ['a', 'b', 'c']`

