### PR TITLE
Fix web socket conversation

### DIFF
--- a/ktor-server/ktor-server-core/jvm/src/io/ktor/features/StatusPages.kt
+++ b/ktor-server/ktor-server-core/jvm/src/io/ktor/features/StatusPages.kt
@@ -123,13 +123,13 @@ class StatusPages(config: Configuration) {
         override fun install(pipeline: ApplicationCallPipeline, configure: Configuration.() -> Unit): StatusPages {
             val configuration = Configuration().apply(configure)
             val feature = StatusPages(configuration)
-            pipeline.sendPipeline.intercept(ApplicationSendPipeline.After) { message ->
-                if (feature.statuses.isNotEmpty()) {
+            if (feature.statuses.isNotEmpty()) {
+                pipeline.sendPipeline.intercept(ApplicationSendPipeline.After) { message ->
                     feature.interceptResponse(this, message)
                 }
             }
-            pipeline.intercept(ApplicationCallPipeline.Monitoring) {
-                if (feature.exceptions.isNotEmpty()) {
+            if (feature.exceptions.isNotEmpty()) {
+                pipeline.intercept(ApplicationCallPipeline.Monitoring) {
                     feature.interceptCall(this)
                 }
             }


### PR DESCRIPTION
The old `handleWebSocketConversation` implementation was relying on the fact that the call pipeline is entirely executed and a client's conversation block was launched only after pipeline completion. However we actually can't rely on this behavior: `StatusPages` is a typical case (#889) : call pipeline is not completed because or async child jobs so it causes suspending _deadlock_ since client conversation block is not started at all if case when the server conversation block is waiting for client's frames. 