### PR TITLE
Add optional contentType to formDsl

### DIFF
--- a/ktor-client/ktor-client-core/common/src/io/ktor/client/request/forms/formDsl.kt
+++ b/ktor-client/ktor-client-core/common/src/io/ktor/client/request/forms/formDsl.kt
@@ -80,15 +80,18 @@ inline fun FormBuilder.append(key: String, headers: Headers = Headers.Empty, bod
 }
 
 /**
- * Append a form part with the specified [key] and [filename] using [bodyBuilder] for it's body
+ * Append a form part with the specified [key], [filename] and optional [contentType] using [bodyBuilder] for it's body
  */
 @UseExperimental(ExperimentalContracts::class)
-fun FormBuilder.append(key: String, filename: String, bodyBuilder: BytePacketBuilder.() -> Unit) {
+fun FormBuilder.append(key: String, filename: String, contentType: ContentType? = null, bodyBuilder: BytePacketBuilder.() -> Unit) {
     contract {
         callsInPlace(bodyBuilder, InvocationKind.EXACTLY_ONCE)
     }
-    val filenameHeader: Headers = headersOf(
-        HttpHeaders.ContentDisposition, "filename=$filename"
-    )
-    append(key, filenameHeader, bodyBuilder)
+
+    val headersBuilder = HeadersBuilder()
+    headersBuilder[HttpHeaders.ContentDisposition] ="filename=$filename"
+    contentType?.run { headersBuilder[HttpHeaders.ContentType] = this.toString() }
+    val headers = headersBuilder.build()
+
+    append(key, headers, bodyBuilder)
 }


### PR DESCRIPTION
Fixes #766 

IMO it's enough to add `ContentType`, that covers like 99% of upload scenarios now. For all other scenarios we can use `append(key, headers,, bodyBuilder)`