### PR TITLE
MockEngine version which favors execution order and returns processed requests

### DIFF
--- a/ktor-client/ktor-client-mock/common/src/io/ktor/client/engine/mock/MockEngineExtended.kt
+++ b/ktor-client/ktor-client-mock/common/src/io/ktor/client/engine/mock/MockEngineExtended.kt
@@ -12,7 +12,6 @@ import kotlin.coroutines.*
  * Key differences with original implementation:
  *  - responses are added to the engine via enqueueResponse()
  *  - responses are given back in order they were added to the engine
- *  - the request url does not affect the order in which responses are returned
  *  - received requests are saved and can be retrieved via takeRequest()
  *  - stored responses and requests can be reset via reset() thus making the
  *      engine reusable throughout tests
@@ -62,5 +61,4 @@ class MockEngineExtended(
         override fun create(block: HttpClientEngineConfig.() -> Unit): MockEngineExtended =
             MockEngineExtended(HttpClientEngineConfig().apply(block))
     }
-
 }

--- a/ktor-client/ktor-client-mock/common/src/io/ktor/client/engine/mock/MockEngineExtended.kt
+++ b/ktor-client/ktor-client-mock/common/src/io/ktor/client/engine/mock/MockEngineExtended.kt
@@ -1,0 +1,66 @@
+package io.ktor.client.engine.mock
+
+import io.ktor.client.call.*
+import io.ktor.client.engine.*
+import io.ktor.client.request.*
+import kotlinx.coroutines.*
+import kotlin.coroutines.*
+
+/**
+ * Extended implementation of MockEngine.
+ *
+ * Key differences with original implementation:
+ *  - responses are added to the engine via enqueueResponse()
+ *  - responses are given back in order they were added to the engine
+ *  - the request url does not affect the order in which responses are returned
+ *  - received requests are saved and can be retrieved via takeRequest()
+ *  - stored responses and requests can be reset via reset() thus making the
+ *      engine reusable throughout tests
+ */
+class MockEngineExtended(
+    override val config: HttpClientEngineConfig
+) : HttpClientEngine {
+
+    private var invocationCount = 0
+
+    private val responses: MutableMap<Int, HttpClientCall.() -> MockHttpResponse> = mutableMapOf()
+
+    private val processedRequests: MutableList<MockHttpRequest> = mutableListOf()
+
+    fun enqueueResponses(vararg mockResponses: HttpClientCall.() -> MockHttpResponse) {
+        mockResponses.forEachIndexed { index, function ->
+            responses[index] = function
+        }
+    }
+
+    fun reset() {
+        responses.clear()
+        processedRequests.clear()
+        invocationCount = 0
+    }
+
+    fun takeRequest(order: Int = processedRequests.size - 1) = processedRequests[order]
+
+    override val dispatcher: CoroutineDispatcher = Dispatchers.Unconfined
+
+    override val coroutineContext: CoroutineContext = dispatcher + CompletableDeferred<Unit>()
+
+    override suspend fun execute(call: HttpClientCall, data: HttpRequestData): HttpEngineCall {
+        val request = data.toRequest(call)
+        if (invocationCount == responses.size) {
+            error("Unhandled ${request.url} on invocationCount=$invocationCount")
+        } else {
+            processedRequests.add(request)
+            val response = responses[invocationCount++]!!.invoke(call)
+            return HttpEngineCall(request, response)
+        }
+    }
+
+    override fun close() {}
+
+    companion object : HttpClientEngineFactory<HttpClientEngineConfig> {
+        override fun create(block: HttpClientEngineConfig.() -> Unit): MockEngineExtended =
+            MockEngineExtended(HttpClientEngineConfig().apply(block))
+    }
+
+}

--- a/ktor-client/ktor-client-mock/jvm/test/io/ktor/client/tests/mock/MockEngineExtendedTests.kt
+++ b/ktor-client/ktor-client-mock/jvm/test/io/ktor/client/tests/mock/MockEngineExtendedTests.kt
@@ -59,7 +59,6 @@ class MockEngineExtendedTests {
         assertEquals(secondCall.url.fullUrl, "https://127.0.0.02")
         assertEquals(secondCall.headers["header"], "second")
         assertEquals((secondCall.content as TextContent).text, "secured")
-
     }
 
     @Test
@@ -77,7 +76,6 @@ class MockEngineExtendedTests {
             }
         }
 
-        client.attributes
         assertEquals(exception.message, "Unhandled http://localhost/unhandled on invocationCount=1")
     }
 

--- a/ktor-client/ktor-client-mock/jvm/test/io/ktor/client/tests/mock/MockEngineExtendedTests.kt
+++ b/ktor-client/ktor-client-mock/jvm/test/io/ktor/client/tests/mock/MockEngineExtendedTests.kt
@@ -1,0 +1,117 @@
+package io.ktor.client.tests.mock
+
+import io.ktor.client.*
+import io.ktor.client.call.*
+import io.ktor.client.engine.mock.*
+import io.ktor.client.request.*
+import io.ktor.content.*
+import io.ktor.http.*
+import kotlinx.coroutines.io.*
+import kotlinx.coroutines.*
+import kotlin.test.*
+
+class MockEngineExtendedTests {
+
+    @Test
+    fun testExecutionOrder() = runBlocking {
+        val mockEngine = MockEngineExtended.create().apply {
+            enqueueResponses(
+                { respondOkText("first") },
+                { respondBadRequest() },
+                { respondOkText("third") })
+        }
+
+        val client = HttpClient(mockEngine) { expectSuccess = false }
+
+
+        assertEquals("first", client.get())
+        assertEquals("Bad Request", client.get())
+        assertEquals("third", client.get())
+    }
+
+    @Test
+    fun testReceivedRequest() = runBlocking {
+        val mockEngine = MockEngineExtended.create().apply {
+            enqueueResponses(
+                { respondOkText("first") },
+                { respondOkText("second") },
+                { respondOkText("third") })
+        }
+
+        val client = HttpClient(mockEngine)
+
+        client.call("http://127.0.0.1") {
+            header("header", "first")
+            body = "body"
+        }
+
+        client.call("https://127.0.0.02") {
+            header("header", "second")
+            body = "secured"
+        }
+
+        val firstCall = mockEngine.takeRequest(0)
+        val secondCall = mockEngine.takeRequest()
+
+        assertEquals(firstCall.url.fullUrl, "http://127.0.0.1")
+        assertEquals(firstCall.headers["header"], "first")
+        assertEquals((firstCall.content as TextContent).text, "body")
+        assertEquals(secondCall.url.fullUrl, "https://127.0.0.02")
+        assertEquals(secondCall.headers["header"], "second")
+        assertEquals((secondCall.content as TextContent).text, "secured")
+
+    }
+
+    @Test
+    fun testUnhandledRequest() = runBlocking {
+        val mockEngine = MockEngineExtended.create().apply {
+            enqueueResponses({ respondOkText("text") })
+        }
+
+        val client = HttpClient(mockEngine)
+
+        val exception = assertFails {
+            runBlocking {
+                client.get<String>("/")
+                client.get<String>("/unhandled")
+            }
+        }
+
+        client.attributes
+        assertEquals(exception.message, "Unhandled http://localhost/unhandled on invocationCount=1")
+    }
+
+    @Test
+    fun testReset() = runBlocking {
+        val mockEngine = MockEngineExtended.create()
+        val client = HttpClient(mockEngine)
+
+        mockEngine.enqueueResponses(
+            { respondOkText("first") },
+            { respondOkText("second") }
+        )
+        assertEquals("first", client.get("/first"))
+        assertEquals("first", mockEngine.takeRequest(0).url.encodedPath, "/first")
+
+        mockEngine.reset()
+
+        mockEngine.enqueueResponses({ respondOkText("third") })
+        assertEquals("third", client.get("/third"))
+        assertEquals("third", mockEngine.takeRequest(0).url.encodedPath, "/third")
+    }
+
+    private fun HttpClientCall.respondOkText(text: String) = MockHttpResponse(
+        this,
+        HttpStatusCode.OK,
+        ByteReadChannel(text.toByteArray()),
+        headersOf("header", "value")
+    )
+
+    private fun HttpClientCall.respondBadRequest() = MockHttpResponse(
+        this,
+        HttpStatusCode.BadRequest,
+        ByteReadChannel("Bad Request".toByteArray())
+    )
+
+    private val Url.fullUrl: String get() = "${protocol.name}://$host"
+}


### PR DESCRIPTION
Related issue - https://github.com/ktorio/ktor/issues/913