### PR TITLE
[SECURITY-FIX] Update to jackson version 2.9.8

### DIFF
--- a/ktor-features/ktor-jackson/build.gradle
+++ b/ktor-features/ktor-jackson/build.gradle
@@ -3,7 +3,7 @@ kotlin {
     sourceSets {
         jvmMain {
             dependencies {
-                api group: 'com.fasterxml.jackson.module', name: 'jackson-module-kotlin', version: '2.9.2'
+                api group: 'com.fasterxml.jackson.module', name: 'jackson-module-kotlin', version: '2.9.8'
             }
         }
     }


### PR DESCRIPTION
Security update for `jackson-databind`:
https://nvd.nist.gov/vuln/search/results?form_type=Basic&results_type=overview&query=+jackson-databind&search_type=all

Closes #952