### PR TITLE
Fix: [GMTDate] .toJvmDate() uses current date instead of given date.

### DIFF
--- a/ktor-utils/jvm/src/io/ktor/util/date/DateJvm.kt
+++ b/ktor-utils/jvm/src/io/ktor/util/date/DateJvm.kt
@@ -58,4 +58,4 @@ private fun Calendar.toDate(timestamp: Long?): GMTDate {
 /**
  * Convert to [Date]
  */
-fun GMTDate.toJvmDate(): Date = Calendar.getInstance(GMT_TIMEZONE, Locale.ROOT)!!.time!!
+fun GMTDate.toJvmDate(): Date = Date(timestamp)

--- a/ktor-utils/jvm/test/io/ktor/tests/utils/DateJvmTest.kt
+++ b/ktor-utils/jvm/test/io/ktor/tests/utils/DateJvmTest.kt
@@ -1,0 +1,46 @@
+package io.ktor.tests.utils
+
+import io.ktor.util.date.*
+import java.text.SimpleDateFormat
+import java.time.OffsetDateTime
+import java.time.ZoneOffset
+import java.util.*
+import kotlin.test.*
+
+class DateJvmTest {
+    @Test
+    fun testJvmDate() {
+        val dateRaw = GMTDate(1346524199000)
+        val date = dateRaw.toJvmDate()
+
+        assertEquals(dateRaw.timestamp, date.time)
+    }
+
+    @Test
+    fun testJvmDateWithOffSetDateTime() {
+        val dateRaw = GMTDate(20, 20, 20, 20, Month.FEBRUARY, 20)
+        val date: OffsetDateTime = OffsetDateTime.of(dateRaw.year, dateRaw.month.ordinal+1, dateRaw.dayOfMonth-2, dateRaw.hours, dateRaw.minutes, dateRaw.seconds, 0, ZoneOffset.UTC)
+
+        assertEquals(dateRaw.toJvmDate(), date.toInstant().toGMTDate().toJvmDate())
+    }
+
+    @Test
+    fun testJvmDateWithZoneOffset() {
+        val gmtDate: GMTDate = GMTDate(0, 0, 12, 1, Month.JANUARY, 2019)
+        val convertedDate = gmtDate.toJvmDate().toInstant().atZone(ZoneOffset.systemDefault())
+        assertEquals(convertedDate.toGMTDate(), gmtDate)
+    }
+
+    @Test
+    fun testJvmDateWithSimpleDateFormat() {
+        val dateFormat: SimpleDateFormat = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss")
+        dateFormat.timeZone = TimeZone.getTimeZone(ZoneOffset.systemDefault())
+        val date = dateFormat.parse("2019-01-01T12:00:00").toInstant()
+
+        val gmtDate: GMTDate = GMTDate(0, 0, 12, 1, Month.JANUARY, 2019)
+        val format: Long = dateFormat.timeZone.getOffset(gmtDate.timestamp).toLong()
+        val convertedDate = gmtDate.toJvmDate().toInstant().minusMillis(format)
+
+        assertEquals(date, convertedDate)
+    }
+}


### PR DESCRIPTION
Solves https://github.com/ktorio/ktor/issues/984