### PR TITLE
Added ReadTimeoutHandler to Netty pipeline.

### DIFF
--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyApplicationEngine.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyApplicationEngine.kt
@@ -48,6 +48,11 @@ class NettyApplicationEngine(environment: ApplicationEngineEnvironment, configur
         var responseWriteTimeoutSeconds: Int = 10
 
         /**
+         * Timeout in seconds for reading requests from client.
+         */
+        var requestReadTimeoutSeconds: Int = 10
+
+        /**
          * User-provided function to configure Netty's [HttpServerCodec]
          */
         var httpServerCodec: () -> HttpServerCodec = ::HttpServerCodec
@@ -88,6 +93,7 @@ class NettyApplicationEngine(environment: ApplicationEngineEnvironment, configur
                     configuration.requestQueueLimit,
                     configuration.runningLimit,
                     configuration.responseWriteTimeoutSeconds,
+                    configuration.requestReadTimeoutSeconds,
                     configuration.httpServerCodec
                 )
             )

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyApplicationEngine.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyApplicationEngine.kt
@@ -48,9 +48,9 @@ class NettyApplicationEngine(environment: ApplicationEngineEnvironment, configur
         var responseWriteTimeoutSeconds: Int = 10
 
         /**
-         * Timeout in seconds for reading requests from client.
+         * Timeout in seconds for reading requests from client, "0" is inifinite.
          */
-        var requestReadTimeoutSeconds: Int = 10
+        var requestReadTimeoutSeconds: Int = 0
 
         /**
          * User-provided function to configure Netty's [HttpServerCodec]

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyApplicationEngine.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyApplicationEngine.kt
@@ -48,7 +48,7 @@ class NettyApplicationEngine(environment: ApplicationEngineEnvironment, configur
         var responseWriteTimeoutSeconds: Int = 10
 
         /**
-         * Timeout in seconds for reading requests from client, "0" is inifinite.
+         * Timeout in seconds for reading requests from client, "0" is infinite.
          */
         var requestReadTimeoutSeconds: Int = 0
 

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyChannelInitializer.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyChannelInitializer.kt
@@ -105,7 +105,9 @@ class NettyChannelInitializer(
 
                 with(pipeline) {
                     //                    addLast(LoggingHandler(LogLevel.WARN))
-                    addLast("readTimeout", ReadTimeoutHandler(requestReadTimeout))
+                    if(requestReadTimeout > 0) {
+                        addLast("readTimeout", ReadTimeoutHandler(requestReadTimeout))
+                    }
                     addLast("codec", httpServerCodec())
                     addLast("continue", HttpServerExpectContinueHandler())
                     addLast("timeout", WriteTimeoutHandler(responseWriteTimeout))

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyChannelInitializer.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyChannelInitializer.kt
@@ -30,6 +30,7 @@ class NettyChannelInitializer(
     private val requestQueueLimit: Int,
     private val runningLimit: Int,
     private val responseWriteTimeout: Int,
+    private val requestReadTimeout: Int,
     private val httpServerCodec: () -> HttpServerCodec
 ) : ChannelInitializer<SocketChannel>() {
     private var sslContext: SslContext? = null
@@ -104,6 +105,7 @@ class NettyChannelInitializer(
 
                 with(pipeline) {
                     //                    addLast(LoggingHandler(LogLevel.WARN))
+                    addLast("readTimeout", ReadTimeoutHandler(requestReadTimeout))
                     addLast("codec", httpServerCodec())
                     addLast("continue", HttpServerExpectContinueHandler())
                     addLast("timeout", WriteTimeoutHandler(responseWriteTimeout))


### PR DESCRIPTION
I encountered an issue with the Netty pipeline where it's possible to keep a connection open indefinitely when sending a request with a JSON body (parsed by Jackson) that doesn't complete, for example by using Telnet to send a request but never closing it (I have hit this issue in real world use too though).

When using ktor in an environment where it will only handle a single connection at a time, this causes it to entirely stop responding to new requests because the stream is kept open waiting for the partial request to complete. 

This PR adds a `ReadTimeoutHandler` to Netty which terminates the connection after a configurable timeout, as the pipeline already does for writes. I'm happy to make changes to the PR if I've done anything nasty  :)

Thanks! 