### PR TITLE
Workaround variadic C function arguments

### DIFF
--- a/ktor-client/ktor-client-curl/posix/src/io/ktor/client/engine/curl/internal/CurlAdapters.kt
+++ b/ktor-client/ktor-client-curl/posix/src/io/ktor/client/engine/curl/internal/CurlAdapters.kt
@@ -25,12 +25,28 @@ internal fun CURLcode.verify() {
     }
 }
 
-internal fun EasyHandle.option(option: CURLoption, vararg variadicArguments: Any) {
-    curl_easy_setopt(this, option, *variadicArguments).verify()
+internal fun EasyHandle.option(option: CURLoption, singleArgument: Int) {
+    curl_easy_setopt(this, option, singleArgument).verify()
 }
 
-internal fun EasyHandle.getInfo(info: CURLINFO, vararg variadicArguments: Any) {
-    curl_easy_getinfo(this, info, *variadicArguments).verify()
+internal fun EasyHandle.option(option: CURLoption, singleArgument: Long) {
+    curl_easy_setopt(this, option, singleArgument).verify()
+}
+
+internal fun EasyHandle.option(option: CURLoption, singleArgument: CPointer<*>) {
+    curl_easy_setopt(this, option, singleArgument).verify()
+}
+
+internal fun EasyHandle.option(option: CURLoption, singleArgument: CValuesRef<*>) {
+    curl_easy_setopt(this, option, singleArgument).verify()
+}
+
+internal fun EasyHandle.option(option: CURLoption, singleArgument: String) {
+    curl_easy_setopt(this, option, singleArgument).verify()
+}
+
+internal fun EasyHandle.getInfo(info: CURLINFO, singleArgument: CPointer<*>) {
+    curl_easy_getinfo(this, info, singleArgument).verify()
 }
 
 internal fun HttpRequest.headersToCurl(): CPointer<curl_slist> {


### PR DESCRIPTION
Since variadic C function arguments is no longer supported in 1.3.30 we need to specify exact list. Passing `Any` arguments is restricted as well.

See [KT-30386](https://youtrack.jetbrains.com/issue/KT-30386) for more the explanation. 
