### PR TITLE
allow many ContentTypes when use JsonFeature

### DIFF
--- a/ktor-client/ktor-client-features/ktor-client-json/common/src/io/ktor/client/features/json/JsonFeature.kt
+++ b/ktor-client/ktor-client-features/ktor-client-json/common/src/io/ktor/client/features/json/JsonFeature.kt
@@ -72,7 +72,8 @@ class JsonFeature(
 
             scope.responsePipeline.intercept(HttpResponsePipeline.Transform) { (info, body) ->
                 if (body !is ByteReadChannel) return@intercept
-                if (context.response.contentType()?.match(ContentType.Application.Json) != true) return@intercept
+                if (feature.allowedContentTypes.none { context.response.contentType()?.match(it) == true })
+                    return@intercept
                 proceedWith(HttpResponseContainer(info, feature.serializer.read(info, body.readRemaining())))
             }
         }


### PR DESCRIPTION
Hi, while I use the JsonFeature to ktor-client, I wanted to allow more ContentTypes (from other server, they send json data with not a 'application/json' one, like, 'application/x-json')

My recommendation is as follows.
At the request and response process side,(line 58 ~ 61 and 75 ~ 76 at my new code) beside comparing with only "application/json", by comparing with list of allowed content types with list operation, like ```forEach``` and ```none``` function, this would be accomplished easily.
And for the configuration part, I think by adding more config option, (I named allowedContentTypes), and set default value to the "application/json", changing other codes would not be required.

Thanks.
p.s. Sorry for poor writing, naming or else.