### PR TITLE
Eliminate byteOrder usage + fix

### DIFF
--- a/ktor-utils/jvm/src/io/ktor/util/EncodersJvm.kt
+++ b/ktor-utils/jvm/src/io/ktor/util/EncodersJvm.kt
@@ -36,7 +36,6 @@ private fun CoroutineScope.inflate(
     source: ByteReadChannel,
     gzip: Boolean = true
 ): ByteReadChannel = writer {
-    source.readByteOrder = ByteOrder.LITTLE_ENDIAN
     val readBuffer = KtorDefaultPool.borrow()
     val writeBuffer = KtorDefaultPool.borrow()
     val inflater = Inflater(true)


### PR DESCRIPTION
- Eliminate using mutable channel's byteOrder, using `reverseByteOrder` instead.
- Fix random gzip/deflate corruption on JDK11
