### PR TITLE
Retain empty url path (ktorio#958)

### DIFF
--- a/ktor-http/common/src/io/ktor/http/URLUtils.kt
+++ b/ktor-http/common/src/io/ktor/http/URLUtils.kt
@@ -86,7 +86,7 @@ internal fun Appendable.appendUrlFullPath(
     queryParameters: Parameters,
     trailingQuery: Boolean
 ) {
-    if (!encodedPath.startsWith("/")) {
+    if (encodedPath.isNotBlank() && !encodedPath.startsWith("/")) {
         append('/')
     }
 

--- a/ktor-http/jvm/src/io/ktor/http/URLUtilsJvm.kt
+++ b/ktor-http/jvm/src/io/ktor/http/URLUtilsJvm.kt
@@ -31,12 +31,7 @@ fun URLBuilder.takeFrom(uri: URI) {
     }
 
     uri.host?.let { host = it }
-    uri.rawPath?.let {
-        encodedPath = when (it) {
-            "" -> "/"
-            else -> it
-        }
-    }
+    encodedPath = uri.rawPath
     uri.query?.let { parameters.appendAll(parseQueryString(it)) }
     if (uri.query?.isEmpty() == true) {
         trailingQuery = true

--- a/ktor-http/jvm/test/io/ktor/tests/http/URLBuilderTest.kt
+++ b/ktor-http/jvm/test/io/ktor/tests/http/URLBuilderTest.kt
@@ -44,6 +44,22 @@ class URLBuilderTestJvm {
     }
 
     @Test
+    fun testEmptyPath() {
+        val urlStr1 = "http://localhost"
+        val urlStr2 = "http://localhost?param1=foo"
+
+        val url1 = URLBuilder().apply {
+            takeFrom(URI.create(urlStr1))
+        }
+        val url2 = URLBuilder().apply {
+            takeFrom(URI.create(urlStr2))
+        }
+
+        assertEquals(urlStr1, url1.buildString())
+        assertEquals(urlStr2, url2.buildString())
+    }
+
+    @Test
     fun testCustom() {
         val url = URLBuilder().apply {
             takeFrom(URI.create("custom://localhost:8080/path"))


### PR DESCRIPTION
Fixes #958 .

Before this change, `URLBuilder` convert "http://localhost" into "http://localhost/" (automatically append root path `/`).
But described in [RFC 3986 section-3.3](https://tools.ietf.org/html/rfc3986#section-3.3), empty path is allowed in URI string.

>path          = path-abempty    ; begins with "/" or is empty
                    / path-absolute   ; begins with "/" but not "//"
                    / path-noscheme   ; begins with a non-colon segment
                    / path-rootless   ; begins with a segment
                    / path-empty      ; zero characters
