### PR TITLE
Pass providers algorithm name to the auth challenge

### DIFF
--- a/ktor-features/ktor-auth/jvm/src/io/ktor/auth/DigestAuth.kt
+++ b/ktor-features/ktor-auth/jvm/src/io/ktor/auth/DigestAuth.kt
@@ -143,6 +143,7 @@ fun Authentication.Configuration.digest(
                         UnauthorizedResponse(
                             HttpAuthHeader.digestAuthChallenge(
                                 provider.realm,
+                                algorithm = provider.algorithmName,
                                 nonce = provider.nonceManager.newNonce()
                             )
                         )


### PR DESCRIPTION
Added provider´s algorithm name to the HttpAuthHeader.digestAuthChallenge method so it requests the algorithm user sets instead of the default MD5 all the time.