### PR TITLE
Fix SessionTransportTransformers application order

### DIFF
--- a/ktor-server/ktor-server-core/jvm/src/io/ktor/sessions/SessionTransportTransformer.kt
+++ b/ktor-server/ktor-server-core/jvm/src/io/ktor/sessions/SessionTransportTransformer.kt
@@ -31,14 +31,8 @@ interface SessionTransportTransformer {
  * @return A string representing the original session contents.
  */
 fun List<SessionTransportTransformer>.transformRead(cookieValue: String?): String? {
-    var value = cookieValue
-    for (t in this) {
-        if (value == null) {
-            break
-        }
-        value = t.transformRead(value)
-    }
-    return value
+    val value = cookieValue ?: return null
+    return this.asReversed().fold(value) { v, t -> t.transformRead(v) ?: return null }
 }
 
 /**

--- a/ktor-server/ktor-server-core/jvm/test/io/ktor/tests/sessions/SessionTransportTransformerKtTest.kt
+++ b/ktor-server/ktor-server-core/jvm/test/io/ktor/tests/sessions/SessionTransportTransformerKtTest.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2014-2019 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.tests.sessions
+
+import io.ktor.sessions.SessionTransportTransformer
+import io.ktor.sessions.transformRead
+import io.ktor.sessions.transformWrite
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class SessionTransportTransformerKtTest {
+    @Test
+    fun allTransformersShouldBeAppliedOnWrite() {
+        assertEquals("0;1;2", listOf(Appending("1"), Appending("2")).transformWrite("0"))
+    }
+
+    @Test
+    fun allTransformersShouldBeAppliedOnReadInReverseOrder() {
+        assertEquals("0", listOf(Appending("1"), Appending("2")).transformRead("0;1;2"))
+    }
+
+    private class Appending(val value: String) : SessionTransportTransformer {
+        companion object {
+            const val separator = ';'
+        }
+
+        override fun transformRead(transportValue: String): String? {
+            return transportValue
+                .substringBeforeLast(separator)
+                .takeIf { transportValue.substringAfterLast(separator) == value }
+        }
+
+        override fun transformWrite(transportValue: String): String {
+            return "$transportValue$separator$value"
+        }
+    }
+}


### PR DESCRIPTION
I've found that if you add 2 different transformers, session reading breaks because of incorrect transformations order. Here is simple fix with tests.