### PR TITLE
Fix module function lookup with default args (regression fix)

### DIFF
--- a/ktor-server/ktor-server-host-common/jvm/src/io/ktor/server/engine/ApplicationEngineEnvironmentReloading.kt
+++ b/ktor-server/ktor-server-host-common/jvm/src/io/ktor/server/engine/ApplicationEngineEnvironmentReloading.kt
@@ -454,7 +454,8 @@ class ApplicationEngineEnvironmentReloading(
                 }
             }
 
-            return parameters.all { isApplication(it) || isApplicationEnvironment(it) || it.kind == KParameter.Kind.INSTANCE }
+            return parameters.all { isApplication(it) || isApplicationEnvironment(it)
+                || it.kind == KParameter.Kind.INSTANCE || it.isOptional }
         }
 
         private fun Class<*>.takeIfNotFacade(): KClass<*>? {

--- a/ktor-server/ktor-server-host-common/jvm/test/io/ktor/tests/hosts/ApplicationEngineEnvironmentReloadingTests.kt
+++ b/ktor-server/ktor-server-host-common/jvm/test/io/ktor/tests/hosts/ApplicationEngineEnvironmentReloadingTests.kt
@@ -252,6 +252,55 @@ class ApplicationEngineEnvironmentReloadingTests {
         environment.stop()
     }
 
+    @Test fun `top level module function with default arg`() {
+        val environment = applicationEngineEnvironment {
+            config = HoconApplicationConfig(ConfigFactory.parseMap(
+                mapOf(
+                    "ktor.deployment.environment" to "test",
+                    "ktor.application.modules" to listOf(ApplicationEngineEnvironmentReloadingTests::class.jvmName + "Kt.topLevelWithDefaultArg")
+                )))
+
+        }
+        environment.start()
+        val application = environment.application
+        assertNotNull(application)
+        assertEquals("topLevelWithDefaultArg", application.attributes[TestKey])
+        environment.stop()
+    }
+
+    @Test fun `static module function with default arg`() {
+        val environment = applicationEngineEnvironment {
+            config = HoconApplicationConfig(ConfigFactory.parseMap(
+                mapOf(
+                    "ktor.deployment.environment" to "test",
+                    "ktor.application.modules" to listOf(Companion::class.jvmName + ".functionWithDefaultArg")
+                )))
+
+        }
+        environment.start()
+        val application = environment.application
+        assertNotNull(application)
+        assertEquals("functionWithDefaultArg", application.attributes[TestKey])
+        environment.stop()
+    }
+
+    @Test fun `top level module function with jvm overloads`() {
+        val environment = applicationEngineEnvironment {
+            config = HoconApplicationConfig(ConfigFactory.parseMap(
+                mapOf(
+                    "ktor.deployment.environment" to "test",
+                    "ktor.application.modules" to listOf(ApplicationEngineEnvironmentReloadingTests::class.jvmName + "Kt.topLevelWithJvmOverloads")
+                )))
+
+        }
+        environment.start()
+        val application = environment.application
+        assertNotNull(application)
+        assertEquals("topLevelWithJvmOverloads", application.attributes[TestKey])
+        environment.stop()
+    }
+
+
     object NoArgModuleFunction {
         var result = 0
 
@@ -329,6 +378,11 @@ class ApplicationEngineEnvironmentReloadingTests {
         fun companionObjectJvmStaticFunction(app: Application) {
             app.attributes.put(TestKey, "companionObjectJvmStaticFunction")
         }
+
+        @JvmStatic
+        fun Application.functionWithDefaultArg(test: Boolean = false) {
+            attributes.put(TestKey, "functionWithDefaultArg")
+        }
     }
 }
 
@@ -343,4 +397,13 @@ fun topLevelFunction(app: Application) {
 @Suppress("unused")
 fun topLevelFunction() {
     error("Shouldn't be invoked")
+}
+
+fun Application.topLevelWithDefaultArg(testing: Boolean = false) {
+    attributes.put(ApplicationEngineEnvironmentReloadingTests.TestKey, "topLevelWithDefaultArg")
+}
+
+@JvmOverloads
+fun Application.topLevelWithJvmOverloads(testing: Boolean = false) {
+    attributes.put(ApplicationEngineEnvironmentReloadingTests.TestKey, "topLevelWithJvmOverloads")
 }


### PR DESCRIPTION
Using module functions with default arguments is broken as per 10ae206e196bf944016a3c35a28fb914c8cdfbd5 (#1082)

This is critical since already existing code may stop working.