### PR TITLE
Remove 'development' word in comments of EngineMain

### DIFF
--- a/ktor-server/ktor-server-cio/jvm/src/io/ktor/server/cio/EngineMain.kt
+++ b/ktor-server/ktor-server-cio/jvm/src/io/ktor/server/cio/EngineMain.kt
@@ -9,11 +9,11 @@ import io.ktor.server.engine.*
 import java.util.concurrent.*
 
 /**
- * Default development engine with main function that starts CIO engine using application.conf
+ * Default engine with main function that starts CIO engine using application.conf
  */
 object EngineMain {
     /**
-     * CIO development engine entry point
+     * CIO engine entry point
      */
     @JvmStatic
     fun main(args: Array<String>) {

--- a/ktor-server/ktor-server-jetty/jvm/src/io/ktor/server/jetty/EngineMain.kt
+++ b/ktor-server/ktor-server-jetty/jvm/src/io/ktor/server/jetty/EngineMain.kt
@@ -8,11 +8,11 @@ import io.ktor.config.*
 import io.ktor.server.engine.*
 
 /**
- * Jetty development engine
+ * Jetty engine
  */
 object EngineMain {
     /**
-     * Main function for starting DevelopmentEngine with Jetty
+     * Main function for starting EngineMain with Jetty
      * Creates an embedded Jetty application with an environment built from command line arguments.
      */
     @JvmStatic

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/EngineMain.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/EngineMain.kt
@@ -8,11 +8,11 @@ import io.ktor.config.*
 import io.ktor.server.engine.*
 
 /**
- * Netty development engine
+ * Netty engine
  */
 object EngineMain {
     /**
-     * Main function for starting DevelopmentEngine with Netty
+     * Main function for starting EngineMain with Netty
      * Creates an embedded Netty application with an environment built from command line arguments.
      */
     @JvmStatic

--- a/ktor-server/ktor-server-tomcat/jvm/src/io/ktor/server/tomcat/EngineMain.kt
+++ b/ktor-server/ktor-server-tomcat/jvm/src/io/ktor/server/tomcat/EngineMain.kt
@@ -7,11 +7,11 @@ package io.ktor.server.tomcat
 import io.ktor.server.engine.*
 
 /**
- * Tomcat development engine
+ * Tomcat engine
  */
 object EngineMain {
     /**
-     * Main function for starting DevelopmentEngine with Tomcat
+     * Main function for starting EngineMain with Tomcat
      * Creates an embedded Tomcat application with an environment built from command line arguments.
      */
     @JvmStatic


### PR DESCRIPTION
Remove 'development' word in comments of EngineMain so not to confuse.