### PR TITLE
Add a way to make daemon thread pool on jvm

### DIFF
--- a/ktor-client/ktor-client-android/jvm/src/io/ktor/client/engine/android/AndroidEngineConfig.kt
+++ b/ktor-client/ktor-client-android/jvm/src/io/ktor/client/engine/android/AndroidEngineConfig.kt
@@ -12,7 +12,7 @@ import javax.net.ssl.*
 /**
  * Configuration for [Android] client engine.
  */
-class AndroidEngineConfig : HttpClientEngineConfig() {
+class AndroidEngineConfig : HttpClientJvmEngineConfig() {
     /**
      * Max milliseconds to establish an HTTP connection - default 10 seconds.
      * A value of 0 represents infinite.

--- a/ktor-client/ktor-client-apache/jvm/src/io/ktor/client/engine/apache/ApacheEngine.kt
+++ b/ktor-client/ktor-client-apache/jvm/src/io/ktor/client/engine/apache/ApacheEngine.kt
@@ -33,7 +33,7 @@ internal class ApacheEngine(override val config: ApacheEngineConfig) : HttpClien
     private fun prepareClient(): CloseableHttpAsyncClient {
         val clientBuilder = HttpAsyncClients.custom()
         with(clientBuilder) {
-            setThreadFactory { Thread(it, "Ktor-client-apache").apply { isDaemon = true } }
+            setThreadFactory(KtorThreadFactory(config.daemon))
             disableAuthCaching()
             disableConnectionState()
             disableCookieManagement()

--- a/ktor-client/ktor-client-apache/jvm/src/io/ktor/client/engine/apache/ApacheEngineConfig.kt
+++ b/ktor-client/ktor-client-apache/jvm/src/io/ktor/client/engine/apache/ApacheEngineConfig.kt
@@ -12,7 +12,7 @@ import javax.net.ssl.*
 /**
  * Configuration for [Apache] implementation of [HttpClientEngineFactory].
  */
-class ApacheEngineConfig : HttpClientEngineConfig() {
+class ApacheEngineConfig : HttpClientJvmEngineConfig() {
     /**
      * Whether or not, it will follow `Location` headers. `false` by default.
      * It uses the default number of redirects defined by Apache's HttpClient that is 50.

--- a/ktor-client/ktor-client-cio/jvm/src/io/ktor/client/engine/cio/CIOEngineConfig.kt
+++ b/ktor-client/ktor-client-cio/jvm/src/io/ktor/client/engine/cio/CIOEngineConfig.kt
@@ -10,7 +10,7 @@ import io.ktor.network.tls.*
 /**
  * Configuration for [CIO] client engine.
  */
-class CIOEngineConfig : HttpClientEngineConfig() {
+class CIOEngineConfig : HttpClientJvmEngineConfig() {
     /**
      * [Endpoint] settings.
      */

--- a/ktor-client/ktor-client-core/common/src/io/ktor/client/engine/HttpClientEngineConfig.kt
+++ b/ktor-client/ktor-client-core/common/src/io/ktor/client/engine/HttpClientEngineConfig.kt
@@ -28,12 +28,6 @@ open class HttpClientEngineConfig {
         }
 
     /**
-     * Network threads count advice.
-     */
-    @KtorExperimentalAPI
-    var threadsCount: Int = 4
-
-    /**
      * Enable http pipelining advice.
      */
     @KtorExperimentalAPI

--- a/ktor-client/ktor-client-core/jvm/src/io/ktor/client/engine/HttpClientJvmEngine.kt
+++ b/ktor-client/ktor-client-core/jvm/src/io/ktor/client/engine/HttpClientJvmEngine.kt
@@ -18,9 +18,11 @@ abstract class HttpClientJvmEngine(engineName: String) : HttpClientEngine {
     abstract override val config: HttpClientJvmEngineConfig
 
     private val clientContext = SupervisorJob()
-    private val _dispatcher by lazy {
+    protected val executorService: ExecutorService by lazy {
         Executors.newFixedThreadPool(config.threadsCount, KtorThreadFactory(config.daemon))
-            .asCoroutineDispatcher()
+    }
+    private val _dispatcher by lazy {
+        executorService.asCoroutineDispatcher()
     }
 
     @UseExperimental(InternalCoroutinesApi::class)
@@ -45,7 +47,7 @@ abstract class HttpClientJvmEngine(engineName: String) : HttpClientEngine {
         }
     }
 
-    private class KtorThreadFactory(private val daemon: Boolean) : ThreadFactory {
+    protected class KtorThreadFactory(private val daemon: Boolean) : ThreadFactory {
         private val group = System.getSecurityManager()?.threadGroup ?: Thread.currentThread().threadGroup
         private val namePrefix = "ktor-${poolNumber.getAndIncrement()}-thread-"
         private val threadNumber = atomic(1)

--- a/ktor-client/ktor-client-core/jvm/src/io/ktor/client/engine/HttpClientJvmEngineConfig.kt
+++ b/ktor-client/ktor-client-core/jvm/src/io/ktor/client/engine/HttpClientJvmEngineConfig.kt
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2014-2019 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.client.engine
+
+import io.ktor.util.*
+
+abstract class HttpClientJvmEngineConfig() : HttpClientEngineConfig() {
+    /**
+     * Network threads count advice.
+     */
+    @KtorExperimentalAPI
+    var threadsCount: Int = 4
+
+    /**
+     * Use daemon thread pool
+     */
+    @KtorExperimentalAPI
+    var daemon: Boolean = false
+}

--- a/ktor-client/ktor-client-jetty/jvm/src/io/ktor/client/engine/jetty/JettyEngineConfig.kt
+++ b/ktor-client/ktor-client-jetty/jvm/src/io/ktor/client/engine/jetty/JettyEngineConfig.kt
@@ -11,7 +11,7 @@ import org.eclipse.jetty.util.ssl.*
 /**
  * Configuration for [Jetty] implementation of [HttpClientEngineFactory].
  */
-class JettyEngineConfig : HttpClientEngineConfig() {
+class JettyEngineConfig : HttpClientJvmEngineConfig() {
     /**
      * A Jetty's [SslContextFactory]. By default it trusts all the certificates.
      */

--- a/ktor-client/ktor-client-jetty/jvm/src/io/ktor/client/engine/jetty/JettyHttp2Engine.kt
+++ b/ktor-client/ktor-client-jetty/jvm/src/io/ktor/client/engine/jetty/JettyHttp2Engine.kt
@@ -18,6 +18,7 @@ internal class JettyHttp2Engine(
 
         executor = QueuedThreadPool().apply {
             name = "ktor-jetty-client-qtp"
+            isDaemon = config.daemon
         }
 
         start()

--- a/ktor-client/ktor-client-okhttp/jvm/src/io/ktor/client/engine/okhttp/OkHttpConfig.kt
+++ b/ktor-client/ktor-client-okhttp/jvm/src/io/ktor/client/engine/okhttp/OkHttpConfig.kt
@@ -10,7 +10,7 @@ import okhttp3.*
 /**
  * Configuration for [OkHttp] client engine.
  */
-class OkHttpConfig : HttpClientEngineConfig() {
+class OkHttpConfig : HttpClientJvmEngineConfig() {
 
     internal var config: OkHttpClient.Builder.() -> Unit = {}
 

--- a/ktor-client/ktor-client-okhttp/jvm/src/io/ktor/client/engine/okhttp/OkHttpEngine.kt
+++ b/ktor-client/ktor-client-okhttp/jvm/src/io/ktor/client/engine/okhttp/OkHttpEngine.kt
@@ -25,7 +25,11 @@ class OkHttpEngine(
 ) : HttpClientJvmEngine("ktor-okhttp") {
 
     private val engine: OkHttpClient = config.preconfigured
-        ?: OkHttpClient.Builder().apply(config.config).build()
+        ?: createClientBuilder().apply(config.config).build()
+
+    private fun createClientBuilder(): OkHttpClient.Builder = OkHttpClient.Builder().apply {
+        dispatcher(Dispatcher(executorService))
+    }
 
     override suspend fun execute(data: HttpRequestData): HttpResponseData {
         val callContext = createCallContext()


### PR DESCRIPTION
Closes #1170 

Need comments about keeping binary compatibility caused by extracting `threadsCount` from common sources (as it uses only on jvm it makes sense).