### PR TITLE
Use 404 status code instead of null for unhandled test requests

### DIFF
--- a/ktor-server/ktor-server-test-host/jvm/src/io/ktor/server/testing/TestApplicationEngine.kt
+++ b/ktor-server/ktor-server-test-host/jvm/src/io/ktor/server/testing/TestApplicationEngine.kt
@@ -54,6 +54,9 @@ class TestApplicationEngine(
         {
             try {
                 call.application.execute(call)
+                if (call.response.status() == null) {
+                    call.respond(HttpStatusCode.NotFound)
+                }
             } catch (cause: Throwable) {
                 handleTestFailure(cause)
             }


### PR DESCRIPTION
There seems to be a discrepancy between how DefaultEngine and TestApplicationEngine handle unhandled requests:

If a call has not been assigned a status code, DefaultEnginePipeline adds 404 to the call, which makes sense, but TestApplicationEngine's pipeline doesn't modify these requests at all, leading `response.statusCode() == null` instead of `response.statusCode() == 404`, as is expected.

This can be worked around, but makes testing less clear, so it would be nice if there was some parity here.

Background: 
[DefaultEnginePipeline](https://github.com/ktorio/ktor/blob/68eef1948ce4c8c11dae794588f8d063afb67d0b/ktor-server/ktor-server-host-common/jvm/src/io/ktor/server/engine/DefaultEnginePipeline.kt#L35)
[TestApplicationEngine](https://github.com/ktorio/ktor/blob/68eef1948ce4c8c11dae794588f8d063afb67d0b/ktor-server/ktor-server-test-host/jvm/src/io/ktor/server/testing/TestApplicationEngine.kt#L56)