### PR TITLE
Remove private modifier from Routing.interceptor

### DIFF
--- a/ktor-server/ktor-server-core/jvm/src/io/ktor/routing/Routing.kt
+++ b/ktor-server/ktor-server-core/jvm/src/io/ktor/routing/Routing.kt
@@ -27,7 +27,7 @@ class Routing(val application: Application) :
         tracers.add(block)
     }
 
-    private suspend fun interceptor(context: PipelineContext<Unit, ApplicationCall>) {
+    suspend fun interceptor(context: PipelineContext<Unit, ApplicationCall>) {
         val resolveContext = RoutingResolveContext(this, context.call, tracers)
         val resolveResult = resolveContext.resolve()
         if (resolveResult is RoutingResolveResult.Success) {


### PR DESCRIPTION
Move all inner logic of Routing to separated class to allow user use routing feature in detached mode.
Also make interceptor function public to use it independently of `install(Routing)`

Main motivation of that pull request is to allow user use dynamic routing