### PR TITLE
Enable Jetty server to use arbitrary customized HTTP connectors.

### DIFF
--- a/ktor-server/ktor-server-jetty/jvm/src/io/ktor/server/jetty/JettyApplicationEngineBase.kt
+++ b/ktor-server/ktor-server-jetty/jvm/src/io/ktor/server/jetty/JettyApplicationEngineBase.kt
@@ -41,8 +41,8 @@ open class JettyApplicationEngineBase(
      * Jetty server instance being configuring and starting
      */
     protected val server: Server = Server().apply {
-        configuration.configureServer(this)
         initializeServer(environment)
+        configuration.configureServer(this)
     }
 
     override fun start(wait: Boolean): JettyApplicationEngineBase {

--- a/ktor-server/ktor-server-jetty/jvm/src/io/ktor/server/jetty/JettyApplicationEngineBase.kt
+++ b/ktor-server/ktor-server-jetty/jvm/src/io/ktor/server/jetty/JettyApplicationEngineBase.kt
@@ -41,8 +41,8 @@ open class JettyApplicationEngineBase(
      * Jetty server instance being configuring and starting
      */
     protected val server: Server = Server().apply {
-        initializeServer(environment)
         configuration.configureServer(this)
+        initializeServer(environment)
     }
 
     override fun start(wait: Boolean): JettyApplicationEngineBase {

--- a/ktor-server/ktor-server-jetty/jvm/src/io/ktor/server/jetty/ServerInitializer.kt
+++ b/ktor-server/ktor-server-jetty/jvm/src/io/ktor/server/jetty/ServerInitializer.kt
@@ -13,7 +13,7 @@ import org.eclipse.jetty.server.*
 import org.eclipse.jetty.util.ssl.*
 
 internal fun Server.initializeServer(environment: ApplicationEngineEnvironment) {
-    connectors = environment.connectors.map { ktorConnector ->
+    environment.connectors.map { ktorConnector ->
         val httpConfig = HttpConfiguration().apply {
             sendServerVersion = false
             sendDateHeader = false
@@ -68,5 +68,5 @@ internal fun Server.initializeServer(environment: ApplicationEngineEnvironment) 
             host = ktorConnector.host
             port = ktorConnector.port
         }
-    }.toTypedArray()
+    }.forEach { this.addConnector(it) }
 }


### PR DESCRIPTION
**Subsystem**
Server

**Motivation**
Enable Jetty server to use arbitrary customized HTTP connectors. #1182 .

**Solution**
exchange the order of `configuration.configureServer(this)` and `initializeServer(environment)`.
