### PR TITLE
 Introduce support for server double receive

### DIFF
--- a/ktor-server/ktor-server-core/jvm/src/io/ktor/features/ContentNegotiation.kt
+++ b/ktor-server/ktor-server-core/jvm/src/io/ktor/features/ContentNegotiation.kt
@@ -153,7 +153,7 @@ class ContentNegotiation(val registrations: List<ConverterRegistration>,
                 val converted = suitableConverter.converter.convertForReceive(this)
                     ?: throw UnsupportedMediaTypeException(requestContentType)
 
-                proceedWith(ApplicationReceiveRequest(receive.type, converted))
+                proceedWith(ApplicationReceiveRequest(receive.type, converted, true))
             }
             return feature
         }

--- a/ktor-server/ktor-server-core/jvm/src/io/ktor/features/DoubleReceive.kt
+++ b/ktor-server/ktor-server-core/jvm/src/io/ktor/features/DoubleReceive.kt
@@ -1,0 +1,145 @@
+/*
+ * Copyright 2014-2019 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.features
+
+import io.ktor.application.*
+import io.ktor.features.DoubleReceive.*
+import io.ktor.request.*
+import io.ktor.util.*
+import kotlinx.coroutines.io.*
+import kotlin.reflect.*
+
+/**
+ * This feature provides ability to invoke [ApplicationCall.receive] several times.
+ * Please note that not every type could be received twice. For example, even with this feature installed you can't
+ * receive a channel twice (unless [Configuration.receiveEntireContent] is enabled).
+ * Types that always can be received twice or more: `ByteArray`, `String` and `Parameters`.
+ * Also some of content transformation features (such as [ContentNegotiation]) could support it as well.
+ * If not specified, a transformation result is not considered as reusable. So a transformation feature may
+ * mark a result as reusable by proceeding with a [ApplicationReceiveRequest] instance having
+ * [ApplicationReceiveRequest.reusableValue] `= true`.
+ * So installing [DoubleReceive] with [ContentNegotiation] provides ability to receive a user type that will be
+ * deserialized at first receive and then the same instance will be returned for every further receive invocation.
+ * When the same receive type requested as the firstly received, the receive pipeline and content transformation are
+ * not triggered (except when [Configuration.receiveEntireContent] = `true`).
+ */
+@KtorExperimentalAPI
+class DoubleReceive internal constructor(private val config: Configuration) {
+    /**
+     * [DoubleReceive] Feature configuration.
+     */
+    class Configuration {
+
+        /**
+         * When enabled, for every request the whole content will be received and stored as a byte array.
+         * This is useful when completely different types need to be received.
+         * You also can receive streams and channels.
+         * Note that enabling this causes the whole receive pipeline to be executed for every further receive pipeline.
+         */
+        var receiveEntireContent: Boolean = false
+    }
+
+    /**
+     * [DoubleReceive] feature's installation object.
+     */
+    companion object Feature : ApplicationFeature<Application, Configuration, DoubleReceive> {
+        override val key: AttributeKey<DoubleReceive> = AttributeKey("DoubleReceive")
+
+        override fun install(pipeline: Application, configure: Configuration.() -> Unit): DoubleReceive {
+            val feature = DoubleReceive(Configuration().apply(configure))
+
+            pipeline.receivePipeline.intercept(ApplicationReceivePipeline.Before) { request ->
+                val type = request.type
+                require(type != CachedTransformationResult::class) { "CachedTransformationResult can't be received" }
+
+                val cachedResult = call.attributes.getOrNull(LastReceiveCachedResult)
+                when {
+                    cachedResult == null -> call.attributes.put(LastReceiveCachedResult, RequestAlreadyConsumedResult)
+                    cachedResult === RequestAlreadyConsumedResult -> throw RequestAlreadyConsumedException()
+                    cachedResult is CachedTransformationResult.Failure<*> -> throw RequestReceiveAlreadyFailedException(
+                        cachedResult.cause
+                    )
+                    cachedResult is CachedTransformationResult.Success<*> && cachedResult.type == type -> {
+                        proceedWith(ApplicationReceiveRequest(request.type, cachedResult.value, false))
+                        return@intercept
+                    }
+                }
+
+                var byteArray = (cachedResult as? CachedTransformationResult.Success<*>)?.value as? ByteArray
+                val requestValue = request.value
+
+                if (byteArray == null && feature.config.receiveEntireContent && requestValue is ByteReadChannel) {
+                    byteArray = requestValue.toByteArray()
+                    call.attributes.put(
+                        LastReceiveCachedResult,
+                        CachedTransformationResult.Success(ByteArray::class, byteArray)
+                    )
+                }
+
+                val incomingContent = byteArray?.let { ByteReadChannel(it) } ?: cachedResult ?: request.value
+                val finishedRequest = try {
+                    proceedWith(ApplicationReceiveRequest(type, incomingContent, false))
+                } catch (cause: Throwable) {
+                    call.attributes.put(LastReceiveCachedResult, CachedTransformationResult.Failure(type, cause))
+                    throw cause
+                }
+
+                val transformed = finishedRequest.value
+
+                when {
+                    transformed is CachedTransformationResult.Success<*> -> throw RequestAlreadyConsumedException()
+                    !type.isInstance(transformed) -> throw CannotTransformContentToTypeException(type)
+                }
+
+                if (finishedRequest.reusableValue && (cachedResult == null || cachedResult !is CachedTransformationResult.Success)) {
+                    @Suppress("UNCHECKED_CAST")
+                    call.attributes.put(
+                        LastReceiveCachedResult,
+                        CachedTransformationResult.Success(type as KClass<Any>, finishedRequest.value)
+                    )
+                }
+            }
+
+            return feature
+        }
+    }
+}
+
+/**
+ * Represents a cached transformation result from a previous [ApplicationCall.receive] invocation.
+ * @property type requested by the corresponding [ApplicationCall.receive] invocation
+ */
+@KtorExperimentalAPI
+sealed class CachedTransformationResult<T : Any>(val type: KClass<T>) {
+    /**
+     * Holds a transformation result [value] after a successful transformation.
+     * @property value
+     */
+    class Success<T : Any>(type: KClass<T>, val value: T) : CachedTransformationResult<T>(type)
+
+    /**
+     * Holds a transformation failure [cause]
+     * @property cause describes transformation failure
+     */
+    open class Failure<T : Any>(type: KClass<T>, val cause: Throwable) : CachedTransformationResult<T>(type)
+}
+
+/**
+ * Thrown when a request receive was failed during the previous [ApplicationCall.receive] invocation so this
+ * receive attempt is simply replaying the previous exception cause.
+ */
+@KtorExperimentalAPI
+class RequestReceiveAlreadyFailedException internal constructor(cause: Throwable) :
+    Exception("Request body consumption was failed", cause, false, true)
+
+private val LastReceiveCachedResult = AttributeKey<CachedTransformationResult<*>>("LastReceiveRequest")
+
+/**
+ * It is assigned to a call when request pipeline is running or completed with no reusable value.
+ * For example, if a stream is received, one is unable to receive any values after that. However, when received
+ * a text, this instance will be replaced with the corresponding cached receive request.
+ */
+private val RequestAlreadyConsumedResult =
+    CachedTransformationResult.Failure(Any::class, RequestAlreadyConsumedException())

--- a/ktor-server/ktor-server-tests/jvm/test/io/ktor/tests/server/features/ContentNegotiationTest.kt
+++ b/ktor-server/ktor-server-tests/jvm/test/io/ktor/tests/server/features/ContentNegotiationTest.kt
@@ -446,4 +446,29 @@ class ContentNegotiationTest {
             assertEquals(ContentType.Text.Plain, call.response.contentType().withoutParameters())
         }
     }
+
+    @Test
+    fun testDoubleReceive(): Unit = withTestApplication {
+        with(application) {
+            install(DoubleReceive)
+            install(ContentNegotiation) {
+                register(ContentType.Text.Plain, textContentConverter)
+            }
+        }
+
+        application.routing {
+            get("/") {
+                call.respondText(call.receive<Wrapper>().value + "-" + call.receive<Wrapper>().value)
+            }
+        }
+
+        handleRequest(HttpMethod.Get, "/?format=text") {
+            addHeader(HttpHeaders.Accept, "text/plain")
+            addHeader(HttpHeaders.ContentType, "text/plain")
+            setBody("[content]")
+        }.let { call ->
+            assertEquals("[content]-[content]", call.response.content)
+            assertEquals(ContentType.Text.Plain, call.response.contentType().withoutParameters())
+        }
+    }
 }

--- a/ktor-utils/jvm/src/io/ktor/util/internal/LockFreeLinkedList.kt
+++ b/ktor-utils/jvm/src/io/ktor/util/internal/LockFreeLinkedList.kt
@@ -751,6 +751,7 @@ internal fun Any.unwrap(): Node = (this as? Removed)?.ref ?: this as Node
  *
  * @suppress **This is unstable API and it is subject to change.**
  */
+@InternalAPI
 public open class LockFreeLinkedListHead : LockFreeLinkedListNode() {
     public val isEmpty: Boolean get() = next === this
 


### PR DESCRIPTION
**Subsystem**
Server, core + content negotiation

**Motivation**
It is quite a usual mistake that one does `call.receive` several times. Currently, there is no double receive diagnostics at all. So sometimes double receive leads to an empty result or unexpected errors. This is definitely not user-friendly behaviour. The other problem is that sometimes it is very unlikely that there is no way to receive a post form content twice. For example, the form auth provider consumes the whole form content so one is unable to receive it again in spite of that it is the first receive invocation from the user's point of view.

**Solution**
The suggested solution is to provide a feature that supports double receive. Without the feature installed, any extra receive invocation should produce an exception.

This feature provides the following:
- receiving the same content twice produces the same result for simple types such as `String`, `ByteArray`, `Parameters` and deserialized values;
- receiving a non-repeatable content such as channels, streams, `Multipart` and so on causes `RequestAlreadyConsumedException` error;
- a second receive invocation after a failed request leads to a repeated exception thrown;
- bonus: receiving a text, stream or something after a `ByteArray` received successfully should work since the byte array content is already cached.

I believe it is non-breaking change since double receive did never work properly anyway. 