### PR TITLE
added protocol specific conditions

### DIFF
--- a/ktor-http/common/src/io/ktor/http/URLBuilder.kt
+++ b/ktor-http/common/src/io/ktor/http/URLBuilder.kt
@@ -135,24 +135,42 @@ data class Url(
 
     override fun toString(): String = buildString {
         append(protocol.name)
-        append("://")
-        if (user != null) {
-            append(user)
-            if (password != null) {
-                append(':')
-                append(password)
-            }
-            append('@')
-        }
-        if (specifiedPort == DEFAULT_PORT) {
+        if(protocol.name == "file"){
+            append(":///")
             append(host)
-        } else {
-            append(hostWithPort)
         }
-        append(fullPath)
-        if (fragment.isNotEmpty()) {
-            append('#')
-            append(fragment)
+        else if(protocol.name == "mailto"){
+            append(":")
+            if (user != null) {
+                append(user)
+                if (password != null) {
+                    append(':')
+                    append(password)
+                }
+                append('@')
+            }
+            append(host)
+        }
+        else{
+            append("://")
+            if (user != null) {
+                append(user)
+                if (password != null) {
+                    append(':')
+                    append(password)
+                }
+                append('@')
+            }
+            if (specifiedPort == DEFAULT_PORT) {
+                append(host)
+            } else {
+                append(hostWithPort)
+            }
+            append(fullPath)
+            if (fragment.isNotEmpty()) {
+                append('#')
+                append(fragment)
+            }
         }
     }
 

--- a/ktor-http/common/src/io/ktor/http/URLParser.kt
+++ b/ktor-http/common/src/io/ktor/http/URLParser.kt
@@ -42,7 +42,14 @@ internal fun URLBuilder.takeFromUnsafe(urlString: String): URLBuilder {
     val slashCount = count(urlString, startIndex, endIndex, '/')
     startIndex += slashCount
 
-    if (slashCount >= 2) {
+    if(slashCount >= 2 && protocol.name == "file"){
+        host = urlString.substring(startIndex, endIndex)
+
+        startIndex = endIndex;
+
+    }
+
+    else if (slashCount >= 2) {
         loop@ while (true) {
             val delimiter = urlString.indexOfAny("@/\\?#".toCharArray(), startIndex).takeIf { it > 0 } ?: endIndex
 
@@ -64,6 +71,24 @@ internal fun URLBuilder.takeFromUnsafe(urlString: String): URLBuilder {
 
         }
     }
+
+    else if (slashCount == 0 && protocol.name == "mailto"){
+
+
+        val delimiter = urlString.indexOf("@", startIndex);
+        val passwordIndex = urlString.indexOfColonInHostPort(startIndex, delimiter)
+        if(delimiter < endIndex){
+            if (passwordIndex != -1) {
+                user = urlString.substring(startIndex, passwordIndex)
+                password = urlString.substring(passwordIndex + 1, delimiter)
+            } else {
+                user = urlString.substring(startIndex, delimiter)
+            }
+            host = urlString.substring(delimiter+1, endIndex);
+        }
+        startIndex = endIndex;
+    }
+
 
     // Path
     if (startIndex >= endIndex) {
@@ -119,7 +144,6 @@ internal fun URLBuilder.takeFromUnsafe(urlString: String): URLBuilder {
 
     return this
 }
-
 private fun URLBuilder.fillHost(urlString: String, startIndex: Int, endIndex: Int) {
     val colonIndex = urlString.indexOfColonInHostPort(startIndex, endIndex).takeIf { it > 0 } ?: endIndex
 


### PR DESCRIPTION
ktor-http client - UrlBuilder & UrlParser

This PR fixes string parser of url to cover all protocols, not just HTTP-like protocols. 
https://github.com/ktorio/ktor/issues/1204

There was no logic to handle cases for the protocols like 'file' or 'mailto' where there is no host or number of slashes differ from conventional http ones. So have added the code snippets which will handle when there is no slash or more than two when bulding Url object from the string. Added control flow to handle all cases in string parser for Url.
