### PR TITLE
Improve server kotlinx.serialization support

### DIFF
--- a/ktor-features/ktor-serialization/jvm/test/io/ktor/tests/serialization/SerializationTest.kt
+++ b/ktor-features/ktor-serialization/jvm/test/io/ktor/tests/serialization/SerializationTest.kt
@@ -87,6 +87,26 @@ class SerializationTest {
     }
 
     @Test
+    fun testEntityListSend(): Unit = withTestApplication {
+        application.install(ContentNegotiation) {
+            register(ContentType.Application.Json, SerializationConverter())
+        }
+        application.routing {
+            get("/") {
+                call.respond(listOf(MyEntity(3, "third", emptyList())))
+            }
+        }
+
+        handleRequest(HttpMethod.Get, "/") {
+            addHeader("Accept", "application/json")
+        }.response.let { response ->
+            assertEquals(HttpStatusCode.OK, response.status())
+            assertNotNull(response.content)
+            assertEquals(listOf("""[{"id":3,"name":"third","children":[]}]"""), response.content!!.lines())
+        }
+    }
+
+    @Test
     fun testEntityArrayReceive(): Unit = withTestApplication {
         application.install(ContentNegotiation) {
             register(ContentType.Application.Json, SerializationConverter())
@@ -112,6 +132,26 @@ class SerializationTest {
     }
 
     @Test
+    fun testEntityArraySend(): Unit = withTestApplication {
+        application.install(ContentNegotiation) {
+            register(ContentType.Application.Json, SerializationConverter())
+        }
+        application.routing {
+            get("/") {
+                call.respond(arrayOf(MyEntity(1, "first", emptyList())))
+            }
+        }
+
+        handleRequest(HttpMethod.Get, "/") {
+            addHeader("Accept", "application/json")
+        }.response.let { response ->
+            assertEquals(HttpStatusCode.OK, response.status())
+            assertNotNull(response.content)
+            assertEquals(listOf("""[{"id":1,"name":"first","children":[]}]"""), response.content!!.lines())
+        }
+    }
+
+    @Test
     fun testEntitySetReceive(): Unit = withTestApplication {
         application.install(ContentNegotiation) {
             register(ContentType.Application.Json, SerializationConverter())
@@ -133,6 +173,71 @@ class SerializationTest {
             assertEquals(listOf("""[MyEntity(id=1, name=Hello, World!, children=[])]"""), response.content!!.lines())
             val contentTypeText = assertNotNull(response.headers[HttpHeaders.ContentType])
             assertEquals(ContentType.Text.Plain.withCharset(Charsets.UTF_8), ContentType.parse(contentTypeText))
+        }
+    }
+
+    @Test
+    fun testEntitySetSend(): Unit = withTestApplication {
+        application.install(ContentNegotiation) {
+            register(ContentType.Application.Json, SerializationConverter())
+        }
+        application.routing {
+            get("/") {
+                call.respond(setOf(MyEntity(2, "second", emptyList())))
+            }
+        }
+
+        handleRequest(HttpMethod.Get, "/") {
+            addHeader("Accept", "application/json")
+        }.response.let { response ->
+            assertEquals(HttpStatusCode.OK, response.status())
+            assertNotNull(response.content)
+            assertEquals(listOf("""[{"id":2,"name":"second","children":[]}]"""), response.content!!.lines())
+        }
+    }
+
+    @Test
+    fun testEntityMapReceive(): Unit = withTestApplication {
+        application.install(ContentNegotiation) {
+            register(ContentType.Application.Json, SerializationConverter())
+        }
+        application.routing {
+            post("/") {
+                val receivedList = call.receive<Map<Int, MyEntity>>()
+                call.respond(receivedList.toString())
+            }
+        }
+
+        handleRequest(HttpMethod.Post, "/") {
+            addHeader("Accept", "text/plain")
+            addHeader("Content-Type", "application/json")
+            setBody("""{"1":{"id":1,"name":"Hello, World!","children":[]}}""")
+        }.response.let { response ->
+            assertEquals(HttpStatusCode.OK, response.status())
+            assertNotNull(response.content)
+            assertEquals(listOf("""{1=MyEntity(id=1, name=Hello, World!, children=[])}"""), response.content!!.lines())
+            val contentTypeText = assertNotNull(response.headers[HttpHeaders.ContentType])
+            assertEquals(ContentType.Text.Plain.withCharset(Charsets.UTF_8), ContentType.parse(contentTypeText))
+        }
+    }
+
+    @Test
+    fun testEntityMapSend(): Unit = withTestApplication {
+        application.install(ContentNegotiation) {
+            register(ContentType.Application.Json, SerializationConverter())
+        }
+        application.routing {
+            get("/") {
+                call.respond(mapOf(3 to MyEntity(3, "third", emptyList())))
+            }
+        }
+
+        handleRequest(HttpMethod.Get, "/") {
+            addHeader("Accept", "application/json")
+        }.response.let { response ->
+            assertEquals(HttpStatusCode.OK, response.status())
+            assertNotNull(response.content)
+            assertEquals(listOf("""{"3":{"id":3,"name":"third","children":[]}}"""), response.content!!.lines())
         }
     }
 

--- a/ktor-features/ktor-serialization/jvm/test/io/ktor/tests/serialization/SerializationTest.kt
+++ b/ktor-features/ktor-serialization/jvm/test/io/ktor/tests/serialization/SerializationTest.kt
@@ -62,6 +62,81 @@ class SerializationTest {
     }
 
     @Test
+    fun testEntityListReceive(): Unit = withTestApplication {
+        application.install(ContentNegotiation) {
+            register(ContentType.Application.Json, SerializationConverter())
+        }
+        application.routing {
+            post("/") {
+                val receivedList = call.receive<List<MyEntity>>()
+                call.respond(receivedList.toString())
+            }
+        }
+
+        handleRequest(HttpMethod.Post, "/") {
+            addHeader("Accept", "text/plain")
+            addHeader("Content-Type", "application/json")
+            setBody("""[{"id":1,"name":"Hello, World!","children":[]}]""")
+        }.response.let { response ->
+            assertEquals(HttpStatusCode.OK, response.status())
+            assertNotNull(response.content)
+            assertEquals(listOf("""[MyEntity(id=1, name=Hello, World!, children=[])]"""), response.content!!.lines())
+            val contentTypeText = assertNotNull(response.headers[HttpHeaders.ContentType])
+            assertEquals(ContentType.Text.Plain.withCharset(Charsets.UTF_8), ContentType.parse(contentTypeText))
+        }
+    }
+
+    @Test
+    fun testEntityArrayReceive(): Unit = withTestApplication {
+        application.install(ContentNegotiation) {
+            register(ContentType.Application.Json, SerializationConverter())
+        }
+        application.routing {
+            post("/") {
+                val receivedList = call.receive<Array<MyEntity>>()
+                call.respond(receivedList.toList().toString())
+            }
+        }
+
+        handleRequest(HttpMethod.Post, "/") {
+            addHeader("Accept", "text/plain")
+            addHeader("Content-Type", "application/json")
+            setBody("""[{"id":1,"name":"Hello, World!","children":[]}]""")
+        }.response.let { response ->
+            assertEquals(HttpStatusCode.OK, response.status())
+            assertNotNull(response.content)
+            assertEquals(listOf("""[MyEntity(id=1, name=Hello, World!, children=[])]"""), response.content!!.lines())
+            val contentTypeText = assertNotNull(response.headers[HttpHeaders.ContentType])
+            assertEquals(ContentType.Text.Plain.withCharset(Charsets.UTF_8), ContentType.parse(contentTypeText))
+        }
+    }
+
+    @Test
+    fun testEntitySetReceive(): Unit = withTestApplication {
+        application.install(ContentNegotiation) {
+            register(ContentType.Application.Json, SerializationConverter())
+        }
+        application.routing {
+            post("/") {
+                val receivedList = call.receive<Set<MyEntity>>()
+                call.respond(receivedList.toString())
+            }
+        }
+
+        handleRequest(HttpMethod.Post, "/") {
+            addHeader("Accept", "text/plain")
+            addHeader("Content-Type", "application/json")
+            setBody("""[{"id":1,"name":"Hello, World!","children":[]}]""")
+        }.response.let { response ->
+            assertEquals(HttpStatusCode.OK, response.status())
+            assertNotNull(response.content)
+            assertEquals(listOf("""[MyEntity(id=1, name=Hello, World!, children=[])]"""), response.content!!.lines())
+            val contentTypeText = assertNotNull(response.headers[HttpHeaders.ContentType])
+            assertEquals(ContentType.Text.Plain.withCharset(Charsets.UTF_8), ContentType.parse(contentTypeText))
+        }
+    }
+
+    @Test
     fun testEntity() = withTestApplication {
         val uc = "\u0422"
         application.install(ContentNegotiation) {

--- a/ktor-features/ktor-serialization/jvm/test/io/ktor/tests/serialization/SerializationTest.kt
+++ b/ktor-features/ktor-serialization/jvm/test/io/ktor/tests/serialization/SerializationTest.kt
@@ -120,7 +120,7 @@ class SerializationTest {
     private data class TextPlainData(val x: Int)
 
     @Test
-    fun testGsonOnTextAny(): Unit = withTestApplication {
+    fun testOnTextAny(): Unit = withTestApplication {
         application.install(ContentNegotiation) {
             serialization()
             register(contentType = ContentType.Text.Any, converter = SerializationConverter())

--- a/ktor-server/ktor-server-core/jvm/src/io/ktor/features/ContentNegotiation.kt
+++ b/ktor-server/ktor-server-core/jvm/src/io/ktor/features/ContentNegotiation.kt
@@ -143,7 +143,7 @@ class ContentNegotiation(val registrations: List<ConverterRegistration>,
                 // skip if already transformed
                 if (subject.value !is ByteReadChannel) return@intercept
                 // skip if a byte channel has been requested so there is nothing to negotiate
-                if (subject.type === ByteReadChannel::class) return@intercept
+                if (subject.type == ByteReadChannel::class) return@intercept
 
                 val requestContentType = call.request.contentType().withoutParameters()
                 val suitableConverter =
@@ -153,7 +153,7 @@ class ContentNegotiation(val registrations: List<ConverterRegistration>,
                 val converted = suitableConverter.converter.convertForReceive(this)
                     ?: throw UnsupportedMediaTypeException(requestContentType)
 
-                proceedWith(ApplicationReceiveRequest(receive.type, converted, reusableValue = true))
+                proceedWith(ApplicationReceiveRequest(receive.typeInfo, converted, reusableValue = true))
             }
             return feature
         }

--- a/ktor-server/ktor-server-core/jvm/src/io/ktor/features/Errors.kt
+++ b/ktor-server/ktor-server-core/jvm/src/io/ktor/features/Errors.kt
@@ -8,6 +8,7 @@ import io.ktor.http.*
 import io.ktor.util.*
 import java.lang.Exception
 import kotlin.reflect.*
+import kotlin.reflect.full.*
 
 /**
  * Base exception to indicate that the request is not correct due to
@@ -51,8 +52,11 @@ class ParameterConversionException(val parameterName: String, val type: String, 
 @KtorExperimentalAPI
 abstract class ContentTransformationException(message: String) : Exception(message)
 
-internal class CannotTransformContentToTypeException(type: KClass<*>) :
-    ContentTransformationException("Cannot transform this request's content to $type")
+internal class CannotTransformContentToTypeException(type: KType) :
+    ContentTransformationException("Cannot transform this request's content to $type") {
+    @Deprecated("Use KType instead", level = DeprecationLevel.ERROR)
+    constructor(type: KClass<*>) : this(type.starProjectedType)
+}
 
 /**
  * Thrown when there is no conversion for a content type configured.

--- a/ktor-server/ktor-server-host-common/jvm/src/io/ktor/server/engine/DefaultTransform.kt
+++ b/ktor-server/ktor-server-host-common/jvm/src/io/ktor/server/engine/DefaultTransform.kt
@@ -73,7 +73,7 @@ fun ApplicationReceivePipeline.installDefaultTransformations() {
             else -> null
         }
         if (transformed != null)
-            proceedWith(ApplicationReceiveRequest(query.type, transformed, query.type in ReusableTypes))
+            proceedWith(ApplicationReceiveRequest(query.typeInfo, transformed, query.type in ReusableTypes))
     }
 }
 


### PR DESCRIPTION
**Subsystem**
Server, kotlinx.serialiation

**Motivation**
kotlinx.serialization server support for was slightly useless since it didn't provide any extra over gson/jackson.

**Solution**
The following things done:
- json serializer configuration made stable
- introduced server receive `typeOf` support
- `SerializerConverter` get initial `KType` support 


