### PR TITLE
Release @Deprecated annotation from getDigestFunction

### DIFF
--- a/ktor-utils/jvm/src/io/ktor/util/CryptoJvm.kt
+++ b/ktor-utils/jvm/src/io/ktor/util/CryptoJvm.kt
@@ -10,17 +10,22 @@ package io.ktor.util
 
 import kotlinx.coroutines.*
 import java.security.*
-import java.util.*
 
 /**
  * Create a digest function with the specified [algorithm] and [salt]
+ *
+ * CAUTION: salt must be different in each principal because of security reason
+ *
+ * @param algorithm digest algorithm name
+ * @param salt a function computing a salt for a particular hash input value
  */
-@Suppress("DeprecatedCallableAddReplaceWith")
-@Deprecated("Use getDigestFunction with non-constant salt.", level = DeprecationLevel.ERROR)
 fun getDigestFunction(algorithm: String, salt: String): (String) -> ByteArray = getDigestFunction(algorithm) { salt }
 
 /**
  * Create a digest function with the specified [algorithm] and [salt] provider.
+ *
+ * CAUTION: salt must be different in each principal because of security reason
+ *
  * @param algorithm digest algorithm name
  * @param salt a function computing a salt for a particular hash input value
  */


### PR DESCRIPTION
**Subsystem**
ktor-utils

**Motivation**

`getDigestFunction` method on CryptoJvm.kt with constant salt (String) is Deprecated after ktor 1.2.0. (fixed by this issue https://github.com/ktorio/ktor/issues/1061 ).
After 1.2.0, we must set salt as function ((value: String) -> String) like below code.

```
// Old style code (Before 1.2.0)
// fun getDigestFunction(algorithm: String, salt: String): (String) -> ByteArray
val userTable = UserHashedTableAuth(getDigestFunction("SHA-256", salt = "ktor"), mapOf(
    "test" to decodeBase64("VltM4nfheqcJSyH887H+4NEOm2tDuKCl83p5axYXlF0=") // sha256 for "test"
))

// New style code (After 1.2.0)
// fun getDigestFunction(algorithm: String, salt: (password: String) -> String): (String) -> ByteArray
val userTable = UserHashedTableAuth(getDigestFunction("SHA-256", salt = { password -> "ktor" }), mapOf(
    "test" to decodeBase64("VltM4nfheqcJSyH887H+4NEOm2tDuKCl83p5axYXlF0=") // sha256 for "test"
))
```

But according to (this article)[https://auth0.com/blog/adding-salt-to-hashing-a-better-way-to-store-passwords/#Generating-a-Good-Random-Salt], salt must be different by each principal.

> Following OWASP Guidelines, to properly implement credential-specific salts, we must:
> Generate a unique salt upon creation of each stored credential (not just per user or system-wide).


New style code (after 1.2.0) seems not to be effective for this requirement.
And old style code (before 1.2.0) should not be deprecated.


**Solution**

* Release @Deprecated annotation from old style `getDigestFunction` method
* Add caution comment about salt requirement

If my opinion is not good, feel free to close this PR.