### PR TITLE
Add constructor for custom mapping with Jackson

### DIFF
--- a/ktor-client/ktor-client-features/ktor-client-json/ktor-client-jackson/jvm/src/io/ktor/client/features/json/JacksonSerializer.kt
+++ b/ktor-client/ktor-client-features/ktor-client-json/ktor-client-jackson/jvm/src/io/ktor/client/features/json/JacksonSerializer.kt
@@ -11,9 +11,17 @@ import io.ktor.http.*
 import io.ktor.http.content.*
 import kotlinx.io.core.*
 
-class JacksonSerializer(block: ObjectMapper.() -> Unit = {}) : JsonSerializer {
+class JacksonSerializer : JsonSerializer {
 
-    private val backend = jacksonObjectMapper().apply(block)
+    private val backend: ObjectMapper
+
+    constructor(block: ObjectMapper.() -> Unit={}) {
+        backend = jacksonObjectMapper().apply(block)
+    }
+
+    constructor(mapper: ObjectMapper) {
+        backend = mapper
+    }
 
     override fun write(data: Any, contentType: ContentType): OutgoingContent =
         TextContent(backend.writeValueAsString(data), contentType)

--- a/ktor-client/ktor-client-features/ktor-client-json/ktor-client-jackson/jvm/src/io/ktor/client/features/json/JacksonSerializer.kt
+++ b/ktor-client/ktor-client-features/ktor-client-json/ktor-client-jackson/jvm/src/io/ktor/client/features/json/JacksonSerializer.kt
@@ -11,17 +11,8 @@ import io.ktor.http.*
 import io.ktor.http.content.*
 import kotlinx.io.core.*
 
-class JacksonSerializer : JsonSerializer {
-
-    private val backend: ObjectMapper
-
-    constructor(block: ObjectMapper.() -> Unit={}) {
-        backend = jacksonObjectMapper().apply(block)
-    }
-
-    constructor(mapper: ObjectMapper) {
-        backend = mapper
-    }
+class JacksonSerializer(private val backend: ObjectMapper) : JsonSerializer {
+    constructor(block: ObjectMapper.() -> Unit = {}) : this(jacksonObjectMapper().apply(block))
 
     override fun write(data: Any, contentType: ContentType): OutgoingContent =
         TextContent(backend.writeValueAsString(data), contentType)


### PR DESCRIPTION
**Subsystem**
ktor-client:ktor-client-features:ktor-client-json:ktor-client-jackson

**Motivation**
Pr adds custom jackson mapper, now people can do
```kotlin
val client = HttpClient(HttpClientEngine) {
    install(JsonFeature) {
        serializer = JacksonSerializer(ObjectMapper())
    }
}
```
refs #1208 
Link for docs pr https://github.com/ktorio/ktorio.github.io/pull/204
**Solution**
I deleted one primary constructor and added to constructor in body of class with argument of previous constructor and constructor with objectMapper parameter to init backend value.

