### PR TITLE
Add SO_BROADCAST option to UDP sockets

### DIFF
--- a/ktor-network/jvm/src/io/ktor/network/sockets/JavaSocketOptions.kt
+++ b/ktor-network/jvm/src/io/ktor/network/sockets/JavaSocketOptions.kt
@@ -9,7 +9,6 @@ import java.lang.reflect.*
 import java.nio.channels.*
 
 private const val SO_REUSEPORT = "SO_REUSEPORT"
-private const val SO_BROADCAST = "SO_BROADCAST"
 
 // we invoke JDK7 specific api using reflection
 // all used API is public so it still works on JDK9+

--- a/ktor-network/jvm/src/io/ktor/network/sockets/JavaSocketOptions.kt
+++ b/ktor-network/jvm/src/io/ktor/network/sockets/JavaSocketOptions.kt
@@ -9,6 +9,7 @@ import java.lang.reflect.*
 import java.nio.channels.*
 
 private const val SO_REUSEPORT = "SO_REUSEPORT"
+private const val SO_BROADCAST = "SO_BROADCAST"
 
 // we invoke JDK7 specific api using reflection
 // all used API is public so it still works on JDK9+
@@ -149,6 +150,10 @@ internal fun SelectableChannel.assignOptions(options: SocketOptions) {
 
         if (options.reusePort) {
             SocketOptionsPlatformCapabilities.setReusePort(this)
+        }
+
+        if (options is SocketOptions.UDPSocketOptions) {
+            socket.broadcast = options.broadcast
         }
 
         if (options is SocketOptions.PeerSocketOptions) {

--- a/ktor-network/jvm/src/io/ktor/network/sockets/SocketOptions.kt
+++ b/ktor-network/jvm/src/io/ktor/network/sockets/SocketOptions.kt
@@ -117,6 +117,18 @@ sealed class SocketOptions(
      */
     class UDPSocketOptions internal constructor(customOptions: MutableMap<Any, Any?>) :
         PeerSocketOptions(customOptions) {
+        /**
+         * SO_BROADCAST socket option
+         */
+        var broadcast: Boolean = false
+
+        override fun copyCommon(from: SocketOptions) {
+            super.copyCommon(from)
+            if (from is UDPSocketOptions) {
+                broadcast = from.broadcast
+            }
+        }
+
         override fun copy(): UDPSocketOptions {
             return UDPSocketOptions(HashMap(customOptions)).apply {
                 copyCommon(this@UDPSocketOptions)


### PR DESCRIPTION
**Subsystem**
ktor-network

**Motivation**
ktor-network provides a coroutine-compatible implementation of Sockets and Channels but is pretty bare-bones at the moment.  Broadcast UDP sockets are useful when advertising or discovering services on a network.  Without setting `SO_BROADCAST` on the socket, broadcast messages are not properly sent.

**Solution**
Add a `broadcast` option to `UDPSocketOptions` to configure a UDP socket in broadcast mode.

**Example**
```kotlin
val socket = aSocket(ActorSelectorManager(Dispatchers.IO))
  .udp()
  .bind(InetSocketAddress("192.168.0.100", 0)) {
    reuseAddress = true
    broadcast = true
  }
socket.send(
  Datagram(
    ByteReadPacket(ByteBuffer()),
    InetSocketAddress("192.168.0.255", 1234)
  )
)
```

