### PR TITLE
Add X-Total-Count HTTP header

### DIFF
--- a/binary-compatibility-validator/reference-public-api/ktor-http.txt
+++ b/binary-compatibility-validator/reference-public-api/ktor-http.txt
@@ -536,6 +536,7 @@ public final class io/ktor/http/HttpHeaders {
 	public final fun getXForwardedServer ()Ljava/lang/String;
 	public final fun getXHttpMethodOverride ()Ljava/lang/String;
 	public final fun getXRequestId ()Ljava/lang/String;
+	public final fun getXTotalCount ()Ljava/lang/String;
 	public final fun isUnsafe (Ljava/lang/String;)Z
 }
 

--- a/ktor-http/common/src/io/ktor/http/HttpHeaders.kt
+++ b/ktor-http/common/src/io/ktor/http/HttpHeaders.kt
@@ -111,6 +111,7 @@ object HttpHeaders {
 
     val XRequestId = "X-Request-ID"
     val XCorrelationId = "X-Correlation-ID"
+    val XTotalCount = "X-Total-Count"
 
     /**
      * Check if [header] is unsafe. Header is unsafe if listed in [UnsafeHeaders]


### PR DESCRIPTION
De-facto header used in many REST APIs to indicate the amount of items returned in list response (i.e. plain GET on a REST resources). Most useful in conjunction with paginated results where the number of returned item might be different than what was requested.

**Subsystem**
Server, related modules

**Motivation**
It's a fairly common header that is used in several popular REST APIs (a few can easily be found with a [Google search](google.com/search?q=x-total-count+header))

**Solution**
Adding that header to the framework's enum avoids custom solutions.
