### PR TITLE
Cy/server get body

### DIFF
--- a/ktor-http/ktor-http-cio/common/src/io/ktor/http/cio/HttpBody.kt
+++ b/ktor-http/ktor-http-cio/common/src/io/ktor/http/cio/HttpBody.kt
@@ -43,11 +43,12 @@ fun expectHttpBody(
     connectionOptions: ConnectionOptions?,
     contentType: CharSequence?
 ): Boolean {
-    if (method == HttpMethod.Get || method == HttpMethod.Head || method == HttpMethod.Options) return false
-
-    if (transferEncoding != null || connectionOptions?.close == true) return true
+    if (transferEncoding != null) return true
     if (contentLength != -1L) return contentLength > 0L
     if (contentType != null) return true
+
+    if (method == HttpMethod.Get || method == HttpMethod.Head || method == HttpMethod.Options) return false
+    if (connectionOptions?.close == true) return true
 
     return false
 }

--- a/ktor-http/ktor-http-cio/jvm/test/io/ktor/tests/http/cio/HeadersTest.kt
+++ b/ktor-http/ktor-http-cio/jvm/test/io/ktor/tests/http/cio/HeadersTest.kt
@@ -148,7 +148,7 @@ class HeadersTest {
         val request = parseRequest(ch)!!
 
         try {
-            assertFalse { expectHttpBody(request) }
+            assertTrue { expectHttpBody(request) }
         } finally {
             request.release()
         }

--- a/ktor-server/ktor-server-test-host/jvm/src/io/ktor/server/testing/EngineTestSuite.kt
+++ b/ktor-server/ktor-server-test-host/jvm/src/io/ktor/server/testing/EngineTestSuite.kt
@@ -1827,6 +1827,24 @@ abstract class EngineTestSuite<TEngine : ApplicationEngine, TConfiguration : App
         }
     }
 
+    @Test
+    fun testGetWithBody() {
+        createAndStartServer {
+            application.install(Compression)
+
+            get("/") {
+                call.respondText(call.receive())
+            }
+        }
+
+        val text = "text body"
+
+        withUrl("/", { body = text; }) {
+            val actual = readText()
+            assertEquals(text, actual)
+        }
+    }
+
     private fun String.urlPath() = replace("\\", "/")
     private class ExpectedException(message: String) : RuntimeException(message)
 


### PR DESCRIPTION
**Subsystem**
server CIO, server netty

**Motivation**
Currently, we do not support GET requests with a body (it works only with Jetty/Tomcat). This leads to issues like #1302 

**Solution**
Actually, GET requests with a body are allowed by the HTTP spec so we need to support it as well in spite of the fact that we ignored it for years. 


