### PR TITLE
Cy/server fixes

### DIFF
--- a/ktor-features/ktor-serialization/jvm/src/io/ktor/serialization/SerializationConverter.kt
+++ b/ktor-features/ktor-serialization/jvm/src/io/ktor/serialization/SerializationConverter.kt
@@ -87,69 +87,29 @@ val DefaultJsonConfiguration: JsonConfiguration = JsonConfiguration.Stable.copy(
     useArrayPolymorphism = true
 )
 
-// NOTE: this should be removed once kotlinx.serialization get proper typeOf support
 @UseExperimental(ImplicitReflectionSerializer::class, ExperimentalStdlibApi::class)
 private fun serializerByTypeInfo(type: KType): KSerializer<*> {
     if (type.arguments.isEmpty()) {
         return type.jvmErasure.serializer()
     }
     val classifierClass = type.classifier as? KClass<*>
-    if (classifierClass != null) {
-        if (classifierClass.java.isArray) {
-            val elementType = type.arguments[0].type ?: error("Array<*> is not supported")
-            val elementSerializer = serializerByTypeInfo(elementType)
-
-            @Suppress("UNCHECKED_CAST")
-            return ReferenceArraySerializer(
-                elementType.jvmErasure as KClass<Any>,
-                elementSerializer as KSerializer<Any>
-            )
-        }
-
-        return when (classifierClass) {
-            List::class, ArrayList::class -> {
-                val elementSerializer = type.argumentSerializer(0, "List<*> is not supported")
-
-                ArrayListSerializer(elementSerializer)
-            }
-            Set::class, HashSet::class -> {
-                val elementSerializer = type.argumentSerializer(0, "Set<*> is not supported")
-
-                HashSetSerializer(elementSerializer)
-            }
-            LinkedHashSet::class -> {
-                val elementSerializer = type.argumentSerializer(0, "Set<*> is not supported")
-
-                LinkedHashSetSerializer(elementSerializer)
-            }
-            Map::class, HashMap::class -> {
-                val keySerializer = type.argumentSerializer(0, "Map<*, V> is not supported")
-                val valueSerializer = type.argumentSerializer(1, "Map<K, *> is not supported")
-
-                HashMapSerializer(keySerializer, valueSerializer)
-            }
-            LinkedHashMap::class -> {
-                val keySerializer = type.argumentSerializer(0, "Map<*, V> is not supported")
-                val valueSerializer = type.argumentSerializer(1, "Map<K, *> is not supported")
-
-                LinkedHashMapSerializer(keySerializer, valueSerializer)
-            }
-            Map.Entry::class -> {
-                val keySerializer = type.argumentSerializer(0, "Map.Entry<*, V> is not supported")
-                val valueSerializer = type.argumentSerializer(1, "Map.Entry<K, *> is not supported")
-
-                MapEntrySerializer(keySerializer, valueSerializer)
-            }
-            else -> error("Unsupported classifier $classifierClass of type $type")
-        }
+    if (classifierClass != null && classifierClass.java.isArray) {
+        return arraySerializer(type)
     }
 
-    error("Unsupported type $type")
+    return serializer(type)
 }
 
-private fun KType.argumentSerializer(position: Int, message: String): KSerializer<*> {
-    val type = arguments[position].type ?: error(message)
-    return serializerByTypeInfo(type)
+// NOTE: this should be removed once kotlinx.serialization serializer get support of arrays that is blocked by KT-32839
+private fun arraySerializer(type: KType): KSerializer<*> {
+    val elementType = type.arguments[0].type ?: error("Array<*> is not supported")
+    val elementSerializer = serializerByTypeInfo(elementType)
+
+    @Suppress("UNCHECKED_CAST")
+    return ReferenceArraySerializer(
+        elementType.jvmErasure as KClass<Any>,
+        elementSerializer as KSerializer<Any>
+    )
 }
 
 @UseExperimental(ImplicitReflectionSerializer::class)


### PR DESCRIPTION
**Subsystem**
server, ktor-serialization, `Compression`

**Motivation**
1. Since 1.2.3 we have initial `typeOf` support with ktor private serializer detection (there was no kotlinx.serialization built-in function like that). We need to avoid it.
2. Responses with the "identity" content-encoding lack `Content-Length` header and always switched to chunked transfer encoding in spite of the fact that no actual compression applied.

**Solution**
1. We need to avoid our implementation and use kotlinx.serialization instead. 
2. An encoder may predict content-length or say that it is impossible to predict (the default behaviour). The "identity" encoder always predict the length since we do not change the content.


