### PR TITLE
Cy/exceptions

### DIFF
--- a/ktor-server/ktor-server-host-common/jvm/src/io/ktor/server/engine/DefaultUncaughtExceptionHandler.kt
+++ b/ktor-server/ktor-server-host-common/jvm/src/io/ktor/server/engine/DefaultUncaughtExceptionHandler.kt
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2014-2019 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.server.engine
+
+import io.ktor.util.*
+import kotlinx.coroutines.*
+import org.slf4j.*
+import java.io.*
+import java.util.concurrent.CancellationException
+import kotlin.coroutines.*
+
+/**
+ * Handles all uncaught exceptions and logs errors with the specified [logger]
+ * ignoring [CancellationException] and [IOException].
+ */
+@EngineAPI
+class DefaultUncaughtExceptionHandler(
+    private val logger: () -> Logger
+) : CoroutineExceptionHandler {
+    constructor(logger: Logger) : this({ logger })
+
+    override val key: CoroutineContext.Key<*>
+        get() = CoroutineExceptionHandler.Key
+
+    override fun handleException(context: CoroutineContext, exception: Throwable) {
+        if (exception is CancellationException) return
+        if (exception is IOException) return
+
+        logger().error(exception)
+    }
+}

--- a/ktor-server/ktor-server-jetty/jvm/src/io/ktor/server/jetty/JettyKtorHandler.kt
+++ b/ktor-server/ktor-server-jetty/jvm/src/io/ktor/server/jetty/JettyKtorHandler.kt
@@ -13,7 +13,6 @@ import io.ktor.util.pipeline.*
 import kotlinx.coroutines.*
 import org.eclipse.jetty.server.*
 import org.eclipse.jetty.server.handler.*
-import java.io.*
 import java.util.concurrent.*
 import java.util.concurrent.CancellationException
 import java.util.concurrent.atomic.*
@@ -24,6 +23,8 @@ import kotlin.coroutines.*
 private val JettyCallHandlerCoroutineName = CoroutineName("jetty-call-handler")
 
 private val JettyKtorCounter = AtomicLong()
+
+private const val THREAD_KEEP_ALIVE_TIME = 1L
 
 internal class JettyKtorHandler(
     val environment: ApplicationEngineEnvironment,
@@ -36,7 +37,7 @@ internal class JettyKtorHandler(
     private val executor = ThreadPoolExecutor(
         configuration.callGroupSize,
         configuration.callGroupSize * 8,
-        1L,
+        THREAD_KEEP_ALIVE_TIME,
         TimeUnit.MINUTES,
         queue
     ) { r ->

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyApplicationCallHandler.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyApplicationCallHandler.kt
@@ -9,11 +9,15 @@ import io.ktor.util.pipeline.*
 import io.ktor.server.engine.*
 import io.netty.channel.*
 import kotlinx.coroutines.*
+import org.slf4j.*
 import kotlin.coroutines.*
 
 internal class NettyApplicationCallHandler(userCoroutineContext: CoroutineContext,
-                                           private val enginePipeline: EnginePipeline) : ChannelInboundHandlerAdapter(), CoroutineScope {
-    override val coroutineContext: CoroutineContext = userCoroutineContext
+                                           private val enginePipeline: EnginePipeline,
+                                           private val logger: Logger) : ChannelInboundHandlerAdapter(), CoroutineScope {
+    override val coroutineContext: CoroutineContext = userCoroutineContext +
+        CallHandlerCoroutineName +
+        DefaultUncaughtExceptionHandler(logger)
 
     override fun channelRead(ctx: ChannelHandlerContext, msg: Any) {
         when (msg) {

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http1/NettyHttp1Handler.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http1/NettyHttp1Handler.kt
@@ -90,7 +90,7 @@ internal class NettyHttp1Handler(
 
             ctx.pipeline().apply {
                 addLast(requestBodyHandler)
-                addLast(callEventGroup, NettyApplicationCallHandler(userContext, enginePipeline))
+                addLast(callEventGroup, NettyApplicationCallHandler(userContext, enginePipeline, environment.log))
             }
 
             responseWriter.ensureRunning()

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http2/NettyHttp2Handler.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http2/NettyHttp2Handler.kt
@@ -59,7 +59,7 @@ internal class NettyHttp2Handler(
         super.channelRegistered(ctx)
 
         ctx?.pipeline()?.apply {
-            addLast(callEventGroup, NettyApplicationCallHandler(userCoroutineContext, enginePipeline))
+            addLast(callEventGroup, NettyApplicationCallHandler(userCoroutineContext, enginePipeline, application.log))
         }
     }
 

--- a/ktor-server/ktor-server-servlet/jvm/src/io/ktor/server/servlet/KtorServlet.kt
+++ b/ktor-server/ktor-server-servlet/jvm/src/io/ktor/server/servlet/KtorServlet.kt
@@ -10,6 +10,8 @@ import io.ktor.util.*
 import io.ktor.util.cio.*
 import io.ktor.util.pipeline.*
 import kotlinx.coroutines.*
+import org.slf4j.*
+import org.slf4j.event.*
 import java.util.concurrent.*
 import javax.servlet.*
 import javax.servlet.http.*
@@ -34,12 +36,19 @@ abstract class KtorServlet : HttpServlet(), CoroutineScope {
     protected abstract val enginePipeline: EnginePipeline
 
     /**
+     * Application logger
+     */
+    protected open val logger: Logger get() = LoggerFactory.getLogger(servletName)
+
+    /**
      * Servlet upgrade implementation
      */
     protected abstract val upgrade: ServletUpgrade
 
     override val coroutineContext: CoroutineContext =
-        Dispatchers.Unconfined + SupervisorJob() + CoroutineName("servlet")
+        Dispatchers.Unconfined + SupervisorJob() +
+            CoroutineName("servlet") +
+            DefaultUncaughtExceptionHandler { logger }
 
     /**
      * Called by the servlet container when loading the servlet (on load)

--- a/ktor-server/ktor-server-servlet/jvm/src/io/ktor/server/servlet/ServletApplicationEngine.kt
+++ b/ktor-server/ktor-server-servlet/jvm/src/io/ktor/server/servlet/ServletApplicationEngine.kt
@@ -60,6 +60,8 @@ open class ServletApplicationEngine : KtorServlet() {
 
     override val application: Application get() = environment.application
 
+    override val logger: Logger get() = environment.log
+
     override val enginePipeline: EnginePipeline by lazy {
         defaultEnginePipeline(environment).also {
             BaseApplicationResponse.setupSendPipeline(it.sendPipeline)

--- a/ktor-server/ktor-server-tomcat/jvm/src/io/ktor/server/tomcat/TomcatApplicationEngine.kt
+++ b/ktor-server/ktor-server-tomcat/jvm/src/io/ktor/server/tomcat/TomcatApplicationEngine.kt
@@ -16,6 +16,7 @@ import org.apache.tomcat.jni.*
 import org.apache.tomcat.util.net.*
 import org.apache.tomcat.util.net.jsse.*
 import org.apache.tomcat.util.net.openssl.*
+import org.slf4j.*
 import java.nio.file.*
 import java.util.concurrent.*
 import javax.servlet.*
@@ -49,6 +50,8 @@ class TomcatApplicationEngine(environment: ApplicationEngineEnvironment, configu
             get() = this@TomcatApplicationEngine.application
         override val upgrade: ServletUpgrade
             get() = DefaultServletUpgrade
+        override val logger: Logger
+            get() = this@TomcatApplicationEngine.environment.log
     }
 
     private val server = Tomcat().apply {


### PR DESCRIPTION
**Subsystem**
Server

**Motivation**
Currently, we are losing unhandled exceptions in servers so they are handled by the default exception handler that is crashing an application on Android and does not log errors properly. 

**Solution**
Introduce `DefaultUnhandledExceptionHandler` that logs exceptions using the application environment logger (configurable) and apply everywhere in server engines.

