### PR TITLE
Add support for additional params to locations.href

### DIFF
--- a/ktor-features/ktor-locations/jvm/src/io/ktor/locations/Locations.kt
+++ b/ktor-features/ktor-locations/jvm/src/io/ktor/locations/Locations.kt
@@ -226,6 +226,20 @@ open class Locations(private val application: Application, private val routeServ
             ""
     }
 
+    /**
+     * Constructs the url for [location] with additional query parameters.
+     *
+     * The class of [location] instance **must** be annotated with [Location].
+     */
+    fun href(location: Any, queryParameters: List<Pair<String, String>>): String {
+        val info = pathAndQuery(location)
+        val query = info.query + queryParameters
+        return info.path + if (query.any())
+            "?" + query.formUrlEncode()
+        else
+            ""
+    }
+
     internal fun href(location: Any, builder: URLBuilder) {
         val info = pathAndQuery(location)
         builder.encodedPath = info.path

--- a/ktor-features/ktor-locations/jvm/test/io/ktor/tests/locations/LocationsTest.kt
+++ b/ktor-features/ktor-locations/jvm/test/io/ktor/tests/locations/LocationsTest.kt
@@ -500,5 +500,17 @@ class LocationsTest {
             assertEquals(HttpStatusCode.BadRequest, call.response.status())
         }
     }
+
+    @Location("/query") class query(val q: String)
+
+
+    @Test fun `href with extra query parameters`() = withLocationsApplication {
+
+        var href = application.locations.href(query(q = "testQuery"), listOf(Pair("q2", "abc"), Pair("q3", "123")))
+        assertEquals("/query?q=testQuery&q2=abc&q3=123", href)
+
+        href = application.locations.href(query(q = "testQuery"), listOf(Pair("q", "abc"), Pair("q3", "123")))
+        assertEquals("/query?q=testQuery&q=abc&q3=123", href) // parameter q gets added twice
+    }
 }
 


### PR DESCRIPTION
**Subsystem**
`ktor-locations`

**Motivation**
In the http API of the application I'm working on you can specify additional query parameters which I can't provide in the class annotated with `@Location`.
For example, you can add a `formatting` parameter to the query strings, but this can also be specified using the `Accept` header, hence I don't want to specify a (wrong) default in the location class.


**Solution**
I added an extra function `href` which gets a list of pairs with query parameters, which will be added to the url.
I wasn't able to do this by creating an extension method, hence this PR.

Is this something you want to add? If not, please let me know so I can look for another solution.
If you like this I will open a PR for the docs (https://github.com/ktorio/ktorio.github.io/blob/master/servers/features/locations.md#building-urls)