### PR TITLE
finishTasksAndInvalidate after executing a request (#1341).

### DIFF
--- a/ktor-client/ktor-client-ios/darwin/src/io/ktor/client/engine/ios/IosClientEngine.kt
+++ b/ktor-client/ktor-client-ios/darwin/src/io/ktor/client/engine/ios/IosClientEngine.kt
@@ -123,6 +123,8 @@ internal class IosClientEngine(override val config: IosClientEngineConfig) : Htt
 
             config.requestConfig(nativeRequest)
             session.dataTaskWithRequest(nativeRequest).resume()
+        }.invokeOnCompletion {
+            session.finishTasksAndInvalidate()
         }
     }
 


### PR DESCRIPTION
**Subsystem**
iOS engine client

**Motivation**
Fixes #1341

**Solution**
Since a new session is used for each request, we can safely allow the session to be invalidated after the request has completed.