### PR TITLE
Cy/websocket close to cancellation migration (wip)

### DIFF
--- a/binary-compatibility-validator/reference-public-api/ktor-client-core.txt
+++ b/binary-compatibility-validator/reference-public-api/ktor-client-core.txt
@@ -561,7 +561,6 @@ public final class io/ktor/client/features/websocket/ClientWebSocketSession$Defa
 
 public final class io/ktor/client/features/websocket/DefaultClientWebSocketSession : io/ktor/client/features/websocket/ClientWebSocketSession, io/ktor/http/cio/websocket/DefaultWebSocketSession {
 	public fun <init> (Lio/ktor/client/call/HttpClientCall;Lio/ktor/http/cio/websocket/DefaultWebSocketSession;)V
-	public fun close (Ljava/lang/Throwable;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun flush (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun getCall ()Lio/ktor/client/call/HttpClientCall;
 	public fun getCloseReason ()Lkotlinx/coroutines/Deferred;

--- a/binary-compatibility-validator/reference-public-api/ktor-http-cio.txt
+++ b/binary-compatibility-validator/reference-public-api/ktor-http-cio.txt
@@ -250,7 +250,6 @@ public final class io/ktor/http/cio/websocket/DefaultWebSocketSessionImpl : io/k
 	public static final field Companion Lio/ktor/http/cio/websocket/DefaultWebSocketSessionImpl$Companion;
 	public fun <init> (Lio/ktor/http/cio/websocket/WebSocketSession;JJLio/ktor/utils/io/pool/ObjectPool;)V
 	public synthetic fun <init> (Lio/ktor/http/cio/websocket/WebSocketSession;JJLio/ktor/utils/io/pool/ObjectPool;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public fun close (Ljava/lang/Throwable;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun flush (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun getCloseReason ()Lkotlinx/coroutines/Deferred;
 	public fun getCoroutineContext ()Lkotlin/coroutines/CoroutineContext;
@@ -392,7 +391,6 @@ public final class io/ktor/http/cio/websocket/PingPongKt {
 public final class io/ktor/http/cio/websocket/RawWebSocket : io/ktor/http/cio/websocket/WebSocketSession {
 	public fun <init> (Lio/ktor/utils/io/ByteReadChannel;Lio/ktor/utils/io/ByteWriteChannel;JZLkotlin/coroutines/CoroutineContext;Lio/ktor/utils/io/pool/ObjectPool;)V
 	public synthetic fun <init> (Lio/ktor/utils/io/ByteReadChannel;Lio/ktor/utils/io/ByteWriteChannel;JZLkotlin/coroutines/CoroutineContext;Lio/ktor/utils/io/pool/ObjectPool;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public fun close (Ljava/lang/Throwable;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun flush (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun getCoroutineContext ()Lkotlin/coroutines/CoroutineContext;
 	public fun getIncoming ()Lkotlinx/coroutines/channels/ReceiveChannel;
@@ -446,7 +444,6 @@ public final class io/ktor/http/cio/websocket/WebSocketReader$FrameTooBigExcepti
 }
 
 public abstract interface class io/ktor/http/cio/websocket/WebSocketSession : kotlinx/coroutines/CoroutineScope {
-	public abstract fun close (Ljava/lang/Throwable;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun flush (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun getIncoming ()Lkotlinx/coroutines/channels/ReceiveChannel;
 	public abstract fun getMasking ()Z
@@ -459,12 +456,14 @@ public abstract interface class io/ktor/http/cio/websocket/WebSocketSession : ko
 }
 
 public final class io/ktor/http/cio/websocket/WebSocketSession$DefaultImpls {
-	public static synthetic fun close$default (Lio/ktor/http/cio/websocket/WebSocketSession;Ljava/lang/Throwable;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public static fun send (Lio/ktor/http/cio/websocket/WebSocketSession;Lio/ktor/http/cio/websocket/Frame;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public final class io/ktor/http/cio/websocket/WebSocketSessionKt {
 	public static final fun close (Lio/ktor/http/cio/websocket/WebSocketSession;Lio/ktor/http/cio/websocket/CloseReason;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun close (Lio/ktor/http/cio/websocket/WebSocketSession;Ljava/lang/Throwable;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun close$default (Lio/ktor/http/cio/websocket/WebSocketSession;Lio/ktor/http/cio/websocket/CloseReason;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static final fun closeExceptionally (Lio/ktor/http/cio/websocket/WebSocketSession;Ljava/lang/Throwable;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static final fun send (Lio/ktor/http/cio/websocket/WebSocketSession;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static final fun send (Lio/ktor/http/cio/websocket/WebSocketSession;[BLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }

--- a/binary-compatibility-validator/reference-public-api/ktor-http-cio.txt
+++ b/binary-compatibility-validator/reference-public-api/ktor-http-cio.txt
@@ -215,6 +215,7 @@ public final class io/ktor/http/cio/websocket/CloseReason$Codes : java/lang/Enum
 	public static final field CANNOT_ACCEPT Lio/ktor/http/cio/websocket/CloseReason$Codes;
 	public static final field Companion Lio/ktor/http/cio/websocket/CloseReason$Codes$Companion;
 	public static final field GOING_AWAY Lio/ktor/http/cio/websocket/CloseReason$Codes;
+	public static final field INTERNAL_ERROR Lio/ktor/http/cio/websocket/CloseReason$Codes;
 	public static final field NORMAL Lio/ktor/http/cio/websocket/CloseReason$Codes;
 	public static final field NOT_CONSISTENT Lio/ktor/http/cio/websocket/CloseReason$Codes;
 	public static final field NO_EXTENSION Lio/ktor/http/cio/websocket/CloseReason$Codes;

--- a/gradle.properties
+++ b/gradle.properties
@@ -49,7 +49,8 @@ spring_dependency_management_version=1.0.8.RELEASE
 apache_version=4.1.4
 gson_version=2.8.5
 okhttp_version=3.14.2
-jackson_version=2.9.9
+jackson_version=2.9.9.3
+jackson_kotlin_version=2.9.9
 
 # js
 mocha_version=6.0.2

--- a/ktor-client/ktor-client-cio/jvm/src/io/ktor/client/features/websocket/buildersCio.kt
+++ b/ktor-client/ktor-client-cio/jvm/src/io/ktor/client/features/websocket/buildersCio.kt
@@ -7,6 +7,7 @@ package io.ktor.client.features.websocket
 import io.ktor.client.*
 import io.ktor.client.request.*
 import io.ktor.http.*
+import io.ktor.http.cio.websocket.*
 
 /**
  * Create raw [ClientWebSocketSession]: no ping-pong and other service messages are used.
@@ -37,7 +38,7 @@ suspend fun HttpClient.webSocketRaw(
     try {
         session.block()
     } catch (cause: Throwable) {
-        session.close(cause)
+        session.closeExceptionally(cause)
     } finally {
         session.close()
     }

--- a/ktor-client/ktor-client-core/common/src/io/ktor/client/features/websocket/builders.kt
+++ b/ktor-client/ktor-client-core/common/src/io/ktor/client/features/websocket/builders.kt
@@ -38,16 +38,15 @@ suspend fun HttpClient.webSocketSession(
  */
 suspend fun HttpClient.webSocket(
     request: HttpRequestBuilder.() -> Unit, block: suspend DefaultClientWebSocketSession.() -> Unit
-): Unit {
+) {
     val session = webSocketSession(request)
 
     try {
         session.block()
+        session.close()
     } catch (cause: Throwable) {
-        session.close(cause)
+        session.closeExceptionally(cause)
         throw cause
-    } finally {
-        session.close(null)
     }
 }
 
@@ -57,7 +56,7 @@ suspend fun HttpClient.webSocket(
 suspend fun HttpClient.webSocket(
     method: HttpMethod = HttpMethod.Get, host: String = "localhost", port: Int = DEFAULT_PORT, path: String = "/",
     request: HttpRequestBuilder.() -> Unit = {}, block: suspend DefaultClientWebSocketSession.() -> Unit
-): Unit {
+) {
     val session = webSocketSession(method, host, port, path) {
         url.protocol = URLProtocol.WS
         url.port = port
@@ -66,11 +65,10 @@ suspend fun HttpClient.webSocket(
 
     try {
         session.block()
+        session.close()
     } catch (cause: Throwable) {
-        session.close(cause)
+        session.closeExceptionally(cause)
         throw cause
-    } finally {
-        session.close(null)
     }
 }
 
@@ -80,7 +78,7 @@ suspend fun HttpClient.webSocket(
 suspend fun HttpClient.webSocket(
     urlString: String,
     request: HttpRequestBuilder.() -> Unit = {}, block: suspend DefaultClientWebSocketSession.() -> Unit
-): Unit {
+) {
     val session = webSocketSession(HttpMethod.Get) {
         url.protocol = URLProtocol.WS
         url.port = port
@@ -91,11 +89,10 @@ suspend fun HttpClient.webSocket(
 
     try {
         session.block()
+        session.close()
     } catch (cause: Throwable) {
-        session.close(cause)
+        session.closeExceptionally(cause)
         throw cause
-    } finally {
-        session.close(null)
     }
 }
 

--- a/ktor-client/ktor-client-core/js/src/io/ktor/client/features/websocket/JsWebSocketSession.kt
+++ b/ktor-client/ktor-client-core/js/src/io/ktor/client/features/websocket/JsWebSocketSession.kt
@@ -5,7 +5,6 @@
 package io.ktor.client.features.websocket
 
 import io.ktor.http.cio.websocket.*
-import io.ktor.util.*
 import kotlinx.coroutines.*
 import kotlinx.coroutines.channels.*
 import io.ktor.utils.io.core.*
@@ -78,6 +77,9 @@ internal class JsWebSocketSession(
                         val data = buildPacket { writeFully(it.data) }
                         websocket.close(data.readShort(), data.readText())
                     }
+                    FrameType.PING, FrameType.PONG -> {
+                        // ignore
+                    }
                 }
             }
         }
@@ -98,16 +100,5 @@ internal class JsWebSocketSession(
         _incoming.cancel()
         _outgoing.cancel()
         websocket.close()
-    }
-
-    @KtorExperimentalAPI
-    override suspend fun close(cause: Throwable?) {
-        val reason = cause?.let {
-            CloseReason(CloseReason.Codes.UNEXPECTED_CONDITION, cause.message ?: "")
-        } ?: CloseReason(CloseReason.Codes.NORMAL, "OK")
-
-        websocket.close(reason.code, reason.message)
-        _outgoing.close(cause)
-        _incoming.close(cause)
     }
 }

--- a/ktor-client/ktor-client-core/js/src/io/ktor/client/features/websocket/JsWebSocketSession.kt
+++ b/ktor-client/ktor-client-core/js/src/io/ktor/client/features/websocket/JsWebSocketSession.kt
@@ -86,7 +86,7 @@ internal class JsWebSocketSession(
             if (cause == null) {
                 websocket.close()
             } else {
-                websocket.close(CloseReason.Codes.UNEXPECTED_CONDITION.code, "Client failed")
+                websocket.close(CloseReason.Codes.INTERNAL_ERROR.code, "Client failed")
             }
         }
     }

--- a/ktor-client/ktor-client-core/js/src/io/ktor/client/features/websocket/JsWebSocketSession.kt
+++ b/ktor-client/ktor-client-core/js/src/io/ktor/client/features/websocket/JsWebSocketSession.kt
@@ -96,6 +96,10 @@ internal class JsWebSocketSession(
     override suspend fun flush() {
     }
 
+    @Deprecated(
+        "Use cancel() instead.",
+        ReplaceWith("cancel()", "kotlinx.coroutines.cancel")
+    )
     override fun terminate() {
         _incoming.cancel()
         _outgoing.cancel()

--- a/ktor-client/ktor-client-features/ktor-client-json/ktor-client-jackson/build.gradle.kts
+++ b/ktor-client/ktor-client-features/ktor-client-json/ktor-client-jackson/build.gradle.kts
@@ -1,10 +1,13 @@
 val jackson_version: String by project.extra
+val jackson_kotlin_version: String by project.extra
 
 kotlin.sourceSets {
     jvmMain {
         dependencies {
             api(project(":ktor-client:ktor-client-features:ktor-client-json"))
-            api("com.fasterxml.jackson.module:jackson-module-kotlin:$jackson_version")
+
+            api("com.fasterxml.jackson.core:jackson-databind:$jackson_version")
+            api("com.fasterxml.jackson.module:jackson-module-kotlin:$jackson_kotlin_version")
         }
     }
     jvmTest {

--- a/ktor-client/ktor-client-features/ktor-client-websockets/common/test/io/ktor/client/tests/features/WebSocketRemoteTest.kt
+++ b/ktor-client/ktor-client-features/ktor-client-websockets/common/test/io/ktor/client/tests/features/WebSocketRemoteTest.kt
@@ -9,6 +9,7 @@ import io.ktor.client.tests.utils.*
 import io.ktor.http.*
 import io.ktor.http.cio.websocket.*
 import io.ktor.utils.io.core.*
+import kotlinx.coroutines.*
 import kotlin.test.*
 
 class WebSocketRemoteTest : ClientLoader() {
@@ -89,7 +90,7 @@ class WebSocketRemoteTest : ClientLoader() {
                 url.port = DEFAULT_PORT
             }
 
-            session.terminate()
+            session.cancel()
         }
     }
 

--- a/ktor-client/ktor-client-okhttp/jvm/src/io/ktor/client/engine/okhttp/OkHttpWebsocketSession.kt
+++ b/ktor-client/ktor-client-okhttp/jvm/src/io/ktor/client/engine/okhttp/OkHttpWebsocketSession.kt
@@ -101,6 +101,10 @@ internal class OkHttpWebsocketSession(
     override suspend fun flush() {
     }
 
+    @Deprecated(
+        "Use cancel() instead.",
+        ReplaceWith("cancel()", "kotlinx.coroutines.cancel")
+    )
     override fun terminate() {
         coroutineContext.cancel()
     }

--- a/ktor-client/ktor-client-okhttp/jvm/src/io/ktor/client/engine/okhttp/OkHttpWebsocketSession.kt
+++ b/ktor-client/ktor-client-okhttp/jvm/src/io/ktor/client/engine/okhttp/OkHttpWebsocketSession.kt
@@ -87,7 +87,8 @@ internal class OkHttpWebsocketSession(
 
         _closeReason.complete(CloseReason(code.toShort(), reason))
         _incoming.close()
-        outgoing.close()
+        outgoing.close(CancellationException("WebSocket session closed with code " +
+            "${CloseReason.Codes.byCode(code.toShort())?.toString() ?: code}."))
     }
 
     override fun onFailure(webSocket: WebSocket, t: Throwable, response: Response?) {

--- a/ktor-client/ktor-client-okhttp/jvm/src/io/ktor/client/engine/okhttp/OkHttpWebsocketSession.kt
+++ b/ktor-client/ktor-client-okhttp/jvm/src/io/ktor/client/engine/okhttp/OkHttpWebsocketSession.kt
@@ -6,7 +6,6 @@ package io.ktor.client.engine.okhttp
 
 import io.ktor.client.features.websocket.*
 import io.ktor.http.cio.websocket.*
-import io.ktor.util.*
 import kotlinx.coroutines.*
 import kotlinx.coroutines.channels.*
 import okhttp3.*
@@ -104,11 +103,6 @@ internal class OkHttpWebsocketSession(
 
     override fun terminate() {
         coroutineContext.cancel()
-    }
-
-    @KtorExperimentalAPI
-    override suspend fun close(cause: Throwable?) {
-        outgoing.close(cause)
     }
 }
 

--- a/ktor-client/ktor-client-okhttp/jvm/src/io/ktor/client/engine/okhttp/OkHttpWebsocketSession.kt
+++ b/ktor-client/ktor-client-okhttp/jvm/src/io/ktor/client/engine/okhttp/OkHttpWebsocketSession.kt
@@ -63,7 +63,7 @@ internal class OkHttpWebsocketSession(
                 }
             }
         } finally {
-            websocket.close(CloseReason.Codes.UNEXPECTED_CONDITION.code.toInt(), "Client failure")
+            websocket.close(CloseReason.Codes.INTERNAL_ERROR.code.toInt(), "Client failure")
         }
     }
 

--- a/ktor-features/ktor-jackson/build.gradle
+++ b/ktor-features/ktor-jackson/build.gradle
@@ -3,7 +3,8 @@ kotlin {
     sourceSets {
         jvmMain {
             dependencies {
-                api group: 'com.fasterxml.jackson.module', name: 'jackson-module-kotlin', version: jackson_version
+                api group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: jackson_version
+                api group: 'com.fasterxml.jackson.module', name: 'jackson-module-kotlin', version: jackson_kotlin_version
             }
         }
     }

--- a/ktor-features/ktor-websockets/jvm/src/io/ktor/websocket/Routing.kt
+++ b/ktor-features/ktor-websockets/jvm/src/io/ktor/websocket/Routing.kt
@@ -130,10 +130,7 @@ private suspend fun WebSocketServerSession.proceedWebSocket(handler: suspend Def
     session.run {
         try {
             toServerSession(call).handler()
-            try {
-                session.close()
-            } catch (_: ClosedSendChannelException) {
-            }
+            session.close()
         } catch (cancelled: CancellationException) {
             throw cancelled
         } catch (io: ChannelIOException) {

--- a/ktor-features/ktor-websockets/jvm/test/io/ktor/tests/websocket/DefaultWebSocketTest.kt
+++ b/ktor-features/ktor-websockets/jvm/test/io/ktor/tests/websocket/DefaultWebSocketTest.kt
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2014-2019 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.tests.websocket
+
+import io.ktor.http.cio.websocket.*
+import io.ktor.utils.io.*
+import kotlinx.coroutines.*
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.channels.*
+import kotlinx.coroutines.debug.junit4.*
+import org.junit.Rule
+import kotlin.test.*
+
+class DefaultWebSocketTest {
+    @get:Rule
+    val timeout: CoroutinesTimeout = CoroutinesTimeout.seconds(2, true)
+
+    private lateinit var parent: CompletableJob
+    private lateinit var client2server: ByteChannel
+    private lateinit var server2client: ByteChannel
+
+    private lateinit var server: DefaultWebSocketSession
+
+    private lateinit var client: RawWebSocket
+
+    @BeforeTest
+    fun prepare() {
+        parent = Job()
+        client2server = ByteChannel()
+        server2client = ByteChannel()
+
+        server = DefaultWebSocketSession(
+            RawWebSocket(client2server, server2client, coroutineContext = parent), -1L, 1000L
+        )
+        client = RawWebSocket(server2client, client2server, coroutineContext = parent)
+    }
+
+    @AfterTest
+    fun cleanup() {
+        server.terminate()
+        client.terminate()
+        client2server.cancel()
+        server2client.cancel()
+        parent.cancel()
+    }
+
+    @Test
+    fun closeByClient(): Unit = runBlocking {
+        val reason = CloseReason(CloseReason.Codes.NORMAL, "test1")
+
+        client.close(reason)
+        assertEquals(reason, server.closeReason.await())
+
+        // server for sure received a close frame so it should reply with a duplicate close frame
+        // so we should be able to receive it at client side
+
+        val closed = client.incoming.receive() as Frame.Close
+        assertEquals(reason, closed.readReason())
+
+        ensureCompletion()
+    }
+
+    @Test
+    fun pingPong(): Unit = runBlocking {
+        val pingsMessages = (1..5).map { "ping $it" }
+
+        pingsMessages.forEach {
+            client.send(Frame.Ping(it.toByteArray()))
+        }
+        pingsMessages.forEach {
+            assertEquals(it, (client.incoming.receive() as Frame.Pong).readBytes().toString(Charsets.UTF_8))
+        }
+
+        client.close()
+        ensureCompletion()
+    }
+
+    private suspend fun ensureCompletion() {
+        parent.complete()
+        parent.join()
+
+        assertTrue("client -> server channel should be closed") { client2server.isClosedForRead }
+        assertTrue("client -> server channel should be closed") { client2server.isClosedForWrite }
+
+        assertTrue("server -> client channel should be closed") { server2client.isClosedForRead }
+        assertTrue("server -> client channel should be closed") { server2client.isClosedForWrite }
+
+        try {
+            server.incoming.consumeEach {
+                assertTrue("It should be no control frames") { !it.frameType.controlFrame }
+            }
+        } catch (_: CancellationException) {
+        }
+
+        try {
+            client.incoming.consumeEach {}
+        } catch (_: CancellationException) {
+        }
+
+        assertTrue("client incoming should be closed") { client.incoming.isClosedForReceive }
+        assertTrue("server incoming should be closed") { server.incoming.isClosedForReceive }
+
+        assertTrue("client outgoing should be closed") { client.outgoing.isClosedForSend }
+        assertTrue("server outgoing should be closed") { server.outgoing.isClosedForSend }
+    }
+}

--- a/ktor-features/ktor-websockets/jvm/test/io/ktor/tests/websocket/DefaultWebSocketTest.kt
+++ b/ktor-features/ktor-websockets/jvm/test/io/ktor/tests/websocket/DefaultWebSocketTest.kt
@@ -39,8 +39,8 @@ class DefaultWebSocketTest {
 
     @AfterTest
     fun cleanup() {
-        server.terminate()
-        client.terminate()
+        server.cancel()
+        client.cancel()
         client2server.cancel()
         server2client.cancel()
         parent.cancel()
@@ -74,6 +74,16 @@ class DefaultWebSocketTest {
         }
 
         client.close()
+        ensureCompletion()
+    }
+
+    @Test
+    fun testCancellation(): Unit = runBlocking {
+        server.cancel()
+
+        client.incoming.receiveOrNull()
+        client.close()
+
         ensureCompletion()
     }
 

--- a/ktor-features/ktor-websockets/jvm/test/io/ktor/tests/websocket/RawWebSocketTest.kt
+++ b/ktor-features/ktor-websockets/jvm/test/io/ktor/tests/websocket/RawWebSocketTest.kt
@@ -1,0 +1,207 @@
+/*
+ * Copyright 2014-2019 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.tests.websocket
+
+import io.ktor.http.cio.websocket.*
+import io.ktor.utils.io.*
+import kotlinx.coroutines.*
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.channels.*
+import kotlinx.coroutines.debug.junit4.*
+import org.junit.Rule
+import org.junit.rules.*
+import java.io.*
+import kotlin.reflect.*
+import kotlin.test.*
+
+class RawWebSocketTest {
+    @get:Rule
+    val timeout: CoroutinesTimeout = CoroutinesTimeout.seconds(2, true)
+
+    @get:Rule
+    val test: TestName = TestName()
+
+    @get:Rule
+    val errors = ErrorCollector()
+
+    private lateinit var parent: CompletableJob
+    private lateinit var client2server: ByteChannel
+    private lateinit var server2client: ByteChannel
+
+    private lateinit var server: RawWebSocket
+
+    private lateinit var client: RawWebSocket
+
+    private val exceptionHandler = CoroutineExceptionHandler { _, cause ->
+        if (cause !is CancellationException && cause !is PlannedIOException) {
+            errors.addError(cause)
+        }
+    }
+
+    @BeforeTest
+    fun prepare() {
+        parent = Job()
+        client2server = ByteChannel()
+        server2client = ByteChannel()
+
+        server = RawWebSocket(client2server, server2client, coroutineContext = parent + exceptionHandler)
+        client = RawWebSocket(server2client, client2server, coroutineContext = parent + exceptionHandler)
+    }
+
+    @AfterTest
+    fun cleanup() {
+        server.terminate()
+        client.terminate()
+        client2server.cancel()
+        server2client.cancel()
+        parent.cancel()
+    }
+
+    @Test
+    fun smokeTest(): Unit = runTest {
+        val text = "smoke"
+        client.send(Frame.Ping(text.toByteArray()))
+
+        val receivedPing = server.incoming.receive()
+        assertEquals(FrameType.PING, receivedPing.frameType)
+        assertEquals(text, receivedPing.readBytes().toString(Charsets.ISO_8859_1))
+
+        server.send(Frame.Pong(text.toByteArray()))
+        val receivedPong = client.incoming.receive()
+        assertEquals(FrameType.PONG, receivedPong.frameType)
+        assertEquals(text, receivedPong.readBytes().toString(Charsets.ISO_8859_1))
+
+        client.terminate()
+        server.terminate()
+
+        ensureCompletion()
+    }
+
+    @Test
+    fun testServerIncomingDisconnected(): Unit = runTest {
+        client2server.close()
+        assertNull(server.incoming.receiveOrNull())
+        server.outgoing.send(Frame.Close())
+
+        client.incoming.receiveOrNull() as Frame.Close
+        client.cancel()
+
+        ensureCompletion()
+    }
+
+    @Test
+    fun testServerIncomingConnectionLoss(): Unit = runTest {
+        client2server.close(PlannedIOException())
+        ensureCompletion(allowedExceptionsFromIncoming = listOf(IOException::class))
+    }
+
+    @Test
+    fun testCloseSequenceInitiatedByClient(): Unit = runTest {
+        val text = "content"
+
+        client.send(Frame.Text(text))
+        val textFrame = server.incoming.receive() as Frame.Text
+        assertEquals(text, textFrame.readText())
+
+        client.close()
+
+        val closed = server.incoming.receive() as Frame.Close
+        assertEquals(CloseReason(CloseReason.Codes.NORMAL, ""), closed.readReason())
+
+        server.close(closed.readReason()!!)
+
+        ensureCompletion()
+    }
+
+    @Test
+    fun testSendToClosed(): Unit = runTest {
+        cancelAtIncomingEnd(server)
+        client.close()
+        ensureCompletion()
+
+        assertFailsWith<CancellationException> {
+            server.outgoing.send(Frame.Close())
+        }
+        assertFailsWith<ClosedSendChannelException> {
+            client.outgoing.send(Frame.Close())
+        }
+
+        Unit
+    }
+
+    @Test
+    fun testCloseSequenceInitiatedByClientNoMessages(): Unit = runTest {
+        cancelAtIncomingEnd(server)
+        client.close()
+        ensureCompletion()
+    }
+
+    @Test
+    fun testParentCancellation(): Unit = runTest {
+        parent.cancel()
+        ensureCompletion()
+    }
+
+    @Test
+    fun testServerTerminate(): Unit = runTest {
+        cancelAtIncomingEnd(client)
+        server.terminate()
+        ensureCompletion()
+    }
+
+    private suspend fun ensureCompletion(allowedExceptionsFromIncoming: List<KClass<out Throwable>> = emptyList()) {
+        parent.complete()
+        parent.join()
+
+        assertTrue("client -> server channel should be closed") { client2server.isClosedForRead }
+        assertTrue("client -> server channel should be closed") { client2server.isClosedForWrite }
+
+        assertTrue("server -> client channel should be closed") { server2client.isClosedForRead }
+        assertTrue("server -> client channel should be closed") { server2client.isClosedForWrite }
+
+        try {
+            server.incoming.consumeEach {}
+        } catch (_: CancellationException) {
+        } catch (other: Throwable) {
+            other.assertOnOf(allowedExceptionsFromIncoming)
+        }
+
+        try {
+            client.incoming.consumeEach {}
+        } catch (_: CancellationException) {
+        } catch (other: Throwable) {
+            other.assertOnOf(allowedExceptionsFromIncoming)
+        }
+
+        assertTrue("client incoming should be closed") { client.incoming.isClosedForReceive }
+        assertTrue("server incoming should be closed") { server.incoming.isClosedForReceive }
+
+        assertTrue("client outgoing should be closed") { client.outgoing.isClosedForSend }
+        assertTrue("server outgoing should be closed") { server.outgoing.isClosedForSend }
+    }
+
+    private fun Throwable.assertOnOf(
+        exceptions: Collection<KClass<out Throwable>>
+    ) {
+        if (exceptions.none { it.isInstance(this) }) {
+            throw this
+        }
+    }
+
+    private fun CoroutineScope.cancelAtIncomingEnd(side: WebSocketSession) {
+        launch {
+            side.incoming.consumeEach {}
+            side.cancel()
+        }
+    }
+
+    private fun runTest(block: suspend CoroutineScope.() -> Unit) {
+        runBlocking(CoroutineName("test-${test.methodName}")) {
+            block()
+        }
+    }
+
+    private class PlannedIOException : IOException("Connection loss.")
+}

--- a/ktor-features/ktor-websockets/jvm/test/io/ktor/tests/websocket/RawWebSocketTest.kt
+++ b/ktor-features/ktor-websockets/jvm/test/io/ktor/tests/websocket/RawWebSocketTest.kt
@@ -52,8 +52,8 @@ class RawWebSocketTest {
 
     @AfterTest
     fun cleanup() {
-        server.terminate()
-        client.terminate()
+        server.cancel()
+        client.cancel()
         client2server.cancel()
         server2client.cancel()
         parent.cancel()
@@ -73,8 +73,8 @@ class RawWebSocketTest {
         assertEquals(FrameType.PONG, receivedPong.frameType)
         assertEquals(text, receivedPong.readBytes().toString(Charsets.ISO_8859_1))
 
-        client.terminate()
-        server.terminate()
+        client.cancel()
+        server.cancel()
 
         ensureCompletion()
     }
@@ -147,7 +147,7 @@ class RawWebSocketTest {
     @Test
     fun testServerTerminate(): Unit = runTest {
         cancelAtIncomingEnd(client)
-        server.terminate()
+        server.cancel()
         ensureCompletion()
     }
 

--- a/ktor-features/ktor-websockets/jvm/test/io/ktor/tests/websocket/WebSocketEngineSuite.kt
+++ b/ktor-features/ktor-websockets/jvm/test/io/ktor/tests/websocket/WebSocketEngineSuite.kt
@@ -61,30 +61,7 @@ abstract class WebSocketEngineSuite<TEngine : ApplicationEngine, TConfiguration 
         }
 
         socket {
-            // send upgrade request
-            outputStream.apply {
-                write(
-                    """
-                GET / HTTP/1.1
-                Host: localhost:$port
-                Upgrade: websocket
-                Connection: Upgrade
-                Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==
-                Origin: http://localhost:$port
-                Sec-WebSocket-Protocol: chat
-                Sec-WebSocket-Version: 13
-                """.trimIndent().replace("\n", "\r\n").toByteArray()
-                )
-                write("\r\n\r\n".toByteArray())
-                flush()
-            }
-
-            val status = inputStream.parseStatus()
-            assertEquals(HttpStatusCode.SwitchingProtocols.value, status.value)
-
-            val headers = inputStream.parseHeaders()
-            assertEquals("Upgrade", headers[HttpHeaders.Connection])
-            assertEquals("websocket", headers[HttpHeaders.Upgrade])
+            negotiateHttpWebSocket()
 
             outputStream.apply {
                 // text message with content "Hello"
@@ -120,28 +97,7 @@ abstract class WebSocketEngineSuite<TEngine : ApplicationEngine, TConfiguration 
         }
 
         socket {
-            // send upgrade request
-            outputStream.apply {
-                write(
-                    """
-                GET / HTTP/1.1
-                Host: localhost:$port
-                Upgrade: websocket
-                Connection: Upgrade
-                Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==
-                Origin: http://localhost:$port
-                Sec-WebSocket-Protocol: chat
-                Sec-WebSocket-Version: 13
-                """.trimIndent().replace("\n", "\r\n").toByteArray()
-                )
-                write("\r\n\r\n".toByteArray())
-                flush()
-            }
-
-            assertEquals(HttpStatusCode.SwitchingProtocols.value, inputStream.parseStatus().value)
-
-            val headers = inputStream.parseHeaders()
-            assertTrue { headers.contains(HttpHeaders.Upgrade) }
+            negotiateHttpWebSocket()
 
             for (i in 1..5) {
                 val frame = inputStream.readFrame()
@@ -197,30 +153,7 @@ abstract class WebSocketEngineSuite<TEngine : ApplicationEngine, TConfiguration 
         }
 
         socket {
-            // send upgrade request
-            outputStream.apply {
-                write(
-                    """
-                GET / HTTP/1.1
-                Host: localhost:$port
-                Upgrade: websocket
-                Connection: Upgrade
-                Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==
-                Origin: http://localhost:$port
-                Sec-WebSocket-Protocol: chat
-                Sec-WebSocket-Version: 13
-                """.trimIndent().replace("\n", "\r\n").toByteArray()
-                )
-                write("\r\n\r\n".toByteArray())
-                flush()
-            }
-
-            val status = inputStream.parseStatus()
-            assertEquals(HttpStatusCode.SwitchingProtocols.value, status.value)
-
-            val headers = inputStream.parseHeaders()
-            assertEquals("Upgrade", headers[HttpHeaders.Connection])
-            assertEquals("websocket", headers[HttpHeaders.Upgrade])
+            negotiateHttpWebSocket()
 
             outputStream.apply {
                 for (i in 1..count) {
@@ -260,30 +193,7 @@ abstract class WebSocketEngineSuite<TEngine : ApplicationEngine, TConfiguration 
         }
 
         socket {
-            // send upgrade request
-            outputStream.apply {
-                write(
-                    """
-                GET / HTTP/1.1
-                Host: localhost:$port
-                Upgrade: websocket
-                Connection: Upgrade
-                Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==
-                Origin: http://localhost:$port
-                Sec-WebSocket-Protocol: chat
-                Sec-WebSocket-Version: 13
-                """.trimIndent().replace("\n", "\r\n").toByteArray()
-                )
-                write("\r\n\r\n".toByteArray())
-                flush()
-            }
-
-            val status = inputStream.parseStatus()
-            assertEquals(HttpStatusCode.SwitchingProtocols.value, status.value)
-
-            val headers = inputStream.parseHeaders()
-            assertEquals("Upgrade", headers[HttpHeaders.Connection])
-            assertEquals("websocket", headers[HttpHeaders.Upgrade])
+            negotiateHttpWebSocket()
 
             getInputStream().apply {
                 for (i in 1..count) {
@@ -329,30 +239,7 @@ abstract class WebSocketEngineSuite<TEngine : ApplicationEngine, TConfiguration 
         }
 
         socket {
-            // send upgrade request
-            outputStream.apply {
-                write(
-                    """
-                GET / HTTP/1.1
-                Host: localhost:$port
-                Upgrade: websocket
-                Connection: Upgrade
-                Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==
-                Origin: http://localhost:$port
-                Sec-WebSocket-Protocol: chat
-                Sec-WebSocket-Version: 13
-                """.trimIndent().replace("\n", "\r\n").toByteArray()
-                )
-                write("\r\n\r\n".toByteArray())
-                flush()
-            }
-
-            val status = inputStream.parseStatus()
-            assertEquals(HttpStatusCode.SwitchingProtocols.value, status.value)
-
-            val headers = inputStream.parseHeaders()
-            assertEquals("Upgrade", headers[HttpHeaders.Connection])
-            assertEquals("websocket", headers[HttpHeaders.Upgrade])
+            negotiateHttpWebSocket()
 
             getOutputStream().apply {
                 write(sendBuffer.array(), 0, sendBuffer.remaining())
@@ -413,30 +300,7 @@ abstract class WebSocketEngineSuite<TEngine : ApplicationEngine, TConfiguration 
         }
 
         socket {
-            // send upgrade request
-            outputStream.apply {
-                write(
-                    """
-                GET / HTTP/1.1
-                Host: localhost:$port
-                Upgrade: websocket
-                Connection: Upgrade
-                Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==
-                Origin: http://localhost:$port
-                Sec-WebSocket-Protocol: chat
-                Sec-WebSocket-Version: 13
-                """.trimIndent().replace("\n", "\r\n").toByteArray()
-                )
-                write("\r\n\r\n".toByteArray())
-                flush()
-            }
-
-            val status = inputStream.parseStatus()
-            assertEquals(HttpStatusCode.SwitchingProtocols.value, status.value)
-
-            val headers = inputStream.parseHeaders()
-            assertEquals("Upgrade", headers[HttpHeaders.Connection])
-            assertEquals("websocket", headers[HttpHeaders.Upgrade])
+            negotiateHttpWebSocket()
 
             val sendBuffer = ByteBuffer.allocate(64)
             outputStream.apply {
@@ -478,30 +342,7 @@ abstract class WebSocketEngineSuite<TEngine : ApplicationEngine, TConfiguration 
         }
 
         socket {
-            // send upgrade request
-            outputStream.apply {
-                write(
-                    """
-                GET / HTTP/1.1
-                Host: localhost:$port
-                Upgrade: websocket
-                Connection: Upgrade
-                Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==
-                Origin: http://localhost:$port
-                Sec-WebSocket-Protocol: chat
-                Sec-WebSocket-Version: 13
-                """.trimIndent().replace("\n", "\r\n").toByteArray()
-                )
-                write("\r\n\r\n".toByteArray())
-                flush()
-            }
-
-            val status = inputStream.parseStatus()
-            assertEquals(HttpStatusCode.SwitchingProtocols.value, status.value)
-
-            val headers = inputStream.parseHeaders()
-            assertEquals("Upgrade", headers[HttpHeaders.Connection])
-            assertEquals("websocket", headers[HttpHeaders.Upgrade])
+            negotiateHttpWebSocket()
 
             // it should be close frame immediately
             assertCloseFrame(CloseReason.Codes.TRY_AGAIN_LATER.code, replyCloseFrame = false)
@@ -521,6 +362,77 @@ abstract class WebSocketEngineSuite<TEngine : ApplicationEngine, TConfiguration 
                 flush()
             }
         }
+    }
+
+    @Test
+    fun testClientClosingFirst() {
+        val deferred = CompletableDeferred<Unit>()
+
+        createAndStartServer {
+            webSocket("/") {
+                try {
+                    assertNull(incoming.receiveOrNull(), "Incoming channel should be closed")
+                    assertFailsWith<CancellationException>("Outgoing channel should be closed properly") {
+                        repeat(10) {
+                            // we need this loop because the outgoing is not closed immediately
+                            outgoing.send(Frame.Text("Should not be sent."))
+                            delay(100)
+                        }
+                    }
+                } catch (failed: Throwable) {
+                    deferred.completeExceptionally(failed)
+                } finally {
+                    deferred.complete(Unit)
+                }
+            }
+        }
+
+        socket {
+            negotiateHttpWebSocket()
+
+            val serializer = Serializer()
+            val buffer = ByteBuffer.allocate(8192)
+            serializer.enqueue(Frame.Close(CloseReason(CloseReason.Codes.GOING_AWAY, "Completed.")))
+            serializer.serialize(buffer)
+
+            getOutputStream().write(buffer.array(), buffer.arrayOffset(), buffer.position())
+            getOutputStream().flush()
+
+            val reply = getInputStream().readFrame() as Frame.Close
+            val reason = reply.readReason()
+            assertNotNull(reason)
+
+            runBlocking {
+                deferred.await()
+            }
+        }
+    }
+
+    private fun Socket.negotiateHttpWebSocket() {
+        // send upgrade request
+        outputStream.apply {
+            write(
+                """
+                    GET / HTTP/1.1
+                    Host: localhost:$port
+                    Upgrade: websocket
+                    Connection: Upgrade
+                    Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==
+                    Origin: http://localhost:$port
+                    Sec-WebSocket-Protocol: chat
+                    Sec-WebSocket-Version: 13
+                    """.trimIndent().replace("\n", "\r\n").toByteArray()
+            )
+            write("\r\n\r\n".toByteArray())
+            flush()
+        }
+
+        val status = inputStream.parseStatus()
+        assertEquals(HttpStatusCode.SwitchingProtocols.value, status.value)
+
+        val headers = inputStream.parseHeaders()
+        assertEquals("Upgrade", headers[HttpHeaders.Connection])
+        assertEquals("websocket", headers[HttpHeaders.Upgrade])
     }
 
     private fun Socket.assertCloseFrame(

--- a/ktor-features/ktor-websockets/jvm/test/io/ktor/tests/websocket/WebSocketTest.kt
+++ b/ktor-features/ktor-websockets/jvm/test/io/ktor/tests/websocket/WebSocketTest.kt
@@ -39,7 +39,7 @@ class WebSocketTest {
                         if (!frame.frameType.controlFrame) {
                             send(frame.copy())
                             flush()
-                            terminate()
+                            cancel()
                         }
                     }
                 }
@@ -103,7 +103,7 @@ class WebSocketTest {
                             assertEquals("Hello", frame.buffer.copy().array().toString(Charsets.UTF_8))
                             send(frame.copy())
                             flush()
-                            terminate()
+                            cancel()
                         }
                     }
                 }

--- a/ktor-http/ktor-http-cio/common/src/io/ktor/http/cio/websocket/CloseReason.kt
+++ b/ktor-http/ktor-http-cio/common/src/io/ktor/http/cio/websocket/CloseReason.kt
@@ -4,6 +4,8 @@
 
 package io.ktor.http.cio.websocket
 
+import kotlin.jvm.*
+
 /**
  * Websocket close reason
  * @property code - close reason code as per RFC 6455, recommended to be one of [CloseReason.Codes]
@@ -37,12 +39,20 @@ data class CloseReason(val code: Short, val message: String) {
         VIOLATED_POLICY(1008),
         TOO_BIG(1009),
         NO_EXTENSION(1010),
-        UNEXPECTED_CONDITION(1011),
+        INTERNAL_ERROR(1011),
         SERVICE_RESTART(1012),
         TRY_AGAIN_LATER(1013);
 
         companion object {
             private val byCodeMap = values().associateBy { it.code }
+
+            @Deprecated("Use INTERNAL_ERROR instead.",
+                ReplaceWith("INTERNAL_ERROR",
+                    "io.ktor.http.cio.websocket.CloseReason.Codes.INTERNAL_ERROR")
+            )
+            @JvmField
+            @Suppress("UNUSED")
+            val UNEXPECTED_CONDITION: Codes = INTERNAL_ERROR
 
             /**
              * Get enum value by close reason code

--- a/ktor-http/ktor-http-cio/common/src/io/ktor/http/cio/websocket/WebSocketSession.kt
+++ b/ktor-http/ktor-http-cio/common/src/io/ktor/http/cio/websocket/WebSocketSession.kt
@@ -66,14 +66,15 @@ suspend fun WebSocketSession.send(content: String): Unit = send(Frame.Text(conte
 suspend fun WebSocketSession.send(content: ByteArray): Unit = send(Frame.Binary(true, content))
 
 /**
- * Send a close frame with the specified [reason]. May suspend if outgoing channel is full or
- * may throw an exception if it is already closed. The specified [reason] could be ignored if there was already
- * close frame sent (for example in reply to a peer close frame).
+ * Send a close frame with the specified [reason]. May suspend if outgoing channel is full.
+ * The specified [reason] could be ignored if there was already
+ * close frame sent (for example in reply to a peer close frame). It also may do nothing when a session or an outgoing
+ * channel is already closed due to any reason.
  */
-suspend fun WebSocketSession.close(reason: CloseReason) {
-    send(Frame.Close(reason))
+suspend fun WebSocketSession.close(reason: CloseReason = CloseReason(CloseReason.Codes.NORMAL, "")) {
     try {
+        send(Frame.Close(reason))
         flush()
-    } catch (ignore: ClosedSendChannelException) {
+    } catch (_: Throwable) {
     }
 }

--- a/ktor-http/ktor-http-cio/common/src/io/ktor/http/cio/websocket/WebSocketSession.kt
+++ b/ktor-http/ktor-http-cio/common/src/io/ktor/http/cio/websocket/WebSocketSession.kt
@@ -42,6 +42,10 @@ expect interface WebSocketSession : CoroutineScope {
     /**
      * Initiate connection termination immediately. Termination may complete asynchronously.
      */
+    @Deprecated(
+        "Use cancel() instead.",
+        ReplaceWith("cancel()", "kotlinx.coroutines.cancel")
+    )
     fun terminate()
 }
 

--- a/ktor-http/ktor-http-cio/js/src/io/ktor/http/cio/websocket/WebSocketSession.kt
+++ b/ktor-http/ktor-http-cio/js/src/io/ktor/http/cio/websocket/WebSocketSession.kt
@@ -44,9 +44,4 @@ actual interface WebSocketSession : CoroutineScope {
      * Initiate connection termination immediately. Termination may complete asynchronously.
      */
     actual fun terminate()
-
-    /**
-     * Close session with the specified [cause] or with no reason if `null`
-     */
-    actual suspend fun close(cause: Throwable?)
 }

--- a/ktor-http/ktor-http-cio/js/src/io/ktor/http/cio/websocket/WebSocketSession.kt
+++ b/ktor-http/ktor-http-cio/js/src/io/ktor/http/cio/websocket/WebSocketSession.kt
@@ -43,5 +43,9 @@ actual interface WebSocketSession : CoroutineScope {
     /**
      * Initiate connection termination immediately. Termination may complete asynchronously.
      */
+    @Deprecated(
+        "Use cancel() instead.",
+        ReplaceWith("cancel()", "kotlinx.coroutines.cancel")
+    )
     actual fun terminate()
 }

--- a/ktor-http/ktor-http-cio/jvm/src/io/ktor/http/cio/websocket/DefaultWebSocketSessionImpl.kt
+++ b/ktor-http/ktor-http-cio/jvm/src/io/ktor/http/cio/websocket/DefaultWebSocketSessionImpl.kt
@@ -78,9 +78,13 @@ class DefaultWebSocketSessionImpl(
         raw.flush()
     }
 
+    @Deprecated(
+        "Use cancel() instead.",
+        ReplaceWith("cancel()", "kotlinx.coroutines.cancel")
+    )
     override fun terminate() {
         context.cancel()
-        raw.terminate()
+        raw.cancel()
     }
 
     @UseExperimental(ExperimentalCoroutinesApi::class, ObsoleteCoroutinesApi::class)

--- a/ktor-http/ktor-http-cio/jvm/src/io/ktor/http/cio/websocket/DefaultWebSocketSessionImpl.kt
+++ b/ktor-http/ktor-http-cio/jvm/src/io/ktor/http/cio/websocket/DefaultWebSocketSessionImpl.kt
@@ -158,10 +158,10 @@ class DefaultWebSocketSessionImpl(
         } catch (ignore: CancellationException) {
         } catch (ignore: ChannelIOException) {
         } catch (cause: Throwable) {
-            outgoingToBeProcessed.close()
+            outgoingToBeProcessed.cancel(CancellationException("Failed to send frame", cause))
             raw.close(cause)
         } finally {
-            outgoingToBeProcessed.close()
+            outgoingToBeProcessed.cancel()
             raw.close()
         }
     }

--- a/ktor-http/ktor-http-cio/jvm/src/io/ktor/http/cio/websocket/PingPong.kt
+++ b/ktor-http/ktor-http-cio/jvm/src/io/ktor/http/cio/websocket/PingPong.kt
@@ -89,7 +89,7 @@ fun CoroutineScope.pinger(
                     // we were unable to send ping or hadn't get valid pong message in time
                     // so we are triggering close sequence (if already started then the following close frame could be ignored)
 
-                    val closeFrame = Frame.Close(CloseReason(CloseReason.Codes.UNEXPECTED_CONDITION, "Ping timeout"))
+                    val closeFrame = Frame.Close(CloseReason(CloseReason.Codes.INTERNAL_ERROR, "Ping timeout"))
                     outgoing.send(closeFrame)
                     break
                 }

--- a/ktor-http/ktor-http-cio/jvm/src/io/ktor/http/cio/websocket/RawWebSocket.kt
+++ b/ktor-http/ktor-http-cio/jvm/src/io/ktor/http/cio/websocket/RawWebSocket.kt
@@ -54,13 +54,6 @@ class RawWebSocket(
         outgoing.close()
         socketJob.complete()
     }
-
-    override suspend fun close(cause: Throwable?) {
-        if (cause != null) {
-            socketJob.completeExceptionally(cause)
-            outgoing.close(cause)
-        } else terminate()
-    }
 }
 
 @Suppress("KDocMissingDocumentation")

--- a/ktor-http/ktor-http-cio/jvm/src/io/ktor/http/cio/websocket/RawWebSocket.kt
+++ b/ktor-http/ktor-http-cio/jvm/src/io/ktor/http/cio/websocket/RawWebSocket.kt
@@ -46,6 +46,11 @@ class RawWebSocket(
         coroutineContext[Job]?.invokeOnCompletion {
             reader.cancel()
         }
+
+        // this was extracted from WebSocketReader (was broken).
+        writer.outgoing.invokeOnClose {
+            socketJob.complete()
+        }
     }
 
     override suspend fun flush(): Unit = writer.flush()

--- a/ktor-http/ktor-http-cio/jvm/src/io/ktor/http/cio/websocket/RawWebSocket.kt
+++ b/ktor-http/ktor-http-cio/jvm/src/io/ktor/http/cio/websocket/RawWebSocket.kt
@@ -55,6 +55,10 @@ class RawWebSocket(
 
     override suspend fun flush(): Unit = writer.flush()
 
+    @Deprecated(
+        "Use cancel() instead.",
+        ReplaceWith("cancel()", "kotlinx.coroutines.cancel")
+    )
     override fun terminate() {
         outgoing.close()
         socketJob.complete()
@@ -69,6 +73,6 @@ suspend fun RawWebSocket.start(handler: suspend WebSocketSession.() -> Unit) {
         handler()
         writer.flush()
     } finally {
-        terminate()
+        cancel()
     }
 }

--- a/ktor-http/ktor-http-cio/jvm/src/io/ktor/http/cio/websocket/WebSocketReader.kt
+++ b/ktor-http/ktor-http-cio/jvm/src/io/ktor/http/cio/websocket/WebSocketReader.kt
@@ -9,6 +9,7 @@ import kotlinx.coroutines.*
 import kotlinx.coroutines.channels.*
 import io.ktor.utils.io.*
 import io.ktor.utils.io.pool.*
+import kotlinx.coroutines.CompletionHandler
 import java.nio.*
 import java.nio.channels.*
 import java.util.concurrent.CancellationException
@@ -39,7 +40,6 @@ class WebSocketReader(
             readLoop(buffer)
         } catch (expected: ClosedChannelException) {
         } catch (expected: CancellationException) {
-            queue.cancel()
         } catch (io: ChannelIOException) {
             queue.cancel()
         } catch (cause: Throwable) {
@@ -54,7 +54,7 @@ class WebSocketReader(
     /**
      * Channel receiving Websocket's [Frame] objects read from [byteChannel].
      */
-    val incoming: ReceiveChannel<Frame> get() = queue.also { readerJob.start() }
+    val incoming: ReceiveChannel<Frame> get() = queue
 
     private suspend fun readLoop(buffer: ByteBuffer) {
         buffer.clear()

--- a/ktor-http/ktor-http-cio/jvm/src/io/ktor/http/cio/websocket/WebSocketReader.kt
+++ b/ktor-http/ktor-http-cio/jvm/src/io/ktor/http/cio/websocket/WebSocketReader.kt
@@ -33,7 +33,7 @@ class WebSocketReader(
 
     private val queue = Channel<Frame>(8)
 
-    private val readerJob = launch(CoroutineName("ws-reader"), start = CoroutineStart.LAZY) {
+    private val readerJob = launch(CoroutineName("ws-reader")) {
         val buffer = pool.borrow()
         try {
             readLoop(buffer)

--- a/ktor-http/ktor-http-cio/jvm/src/io/ktor/http/cio/websocket/WebSocketSessionJvm.kt
+++ b/ktor-http/ktor-http-cio/jvm/src/io/ktor/http/cio/websocket/WebSocketSessionJvm.kt
@@ -55,10 +55,4 @@ actual interface WebSocketSession : CoroutineScope {
      * Initiate connection termination immediately. Termination may complete asynchronously.
      */
     actual fun terminate()
-
-    /**
-     * Close session with the specified [cause] or with no reason if `null`
-     */
-    @Suppress("ACTUAL_FUNCTION_WITH_DEFAULT_ARGUMENTS")
-    actual suspend fun close(cause: Throwable? = null)
 }

--- a/ktor-http/ktor-http-cio/jvm/src/io/ktor/http/cio/websocket/WebSocketSessionJvm.kt
+++ b/ktor-http/ktor-http-cio/jvm/src/io/ktor/http/cio/websocket/WebSocketSessionJvm.kt
@@ -54,5 +54,9 @@ actual interface WebSocketSession : CoroutineScope {
     /**
      * Initiate connection termination immediately. Termination may complete asynchronously.
      */
+    @Deprecated(
+        "Use cancel() instead.",
+        ReplaceWith("cancel()", "kotlinx.coroutines.cancel")
+    )
     actual fun terminate()
 }

--- a/ktor-http/ktor-http-cio/jvm/src/io/ktor/http/cio/websocket/WebSocketWriter.kt
+++ b/ktor-http/ktor-http-cio/jvm/src/io/ktor/http/cio/websocket/WebSocketWriter.kt
@@ -28,7 +28,7 @@ class WebSocketWriter(
 ) : CoroutineScope {
 
     @Suppress("RemoveExplicitTypeArguments") // workaround for new kotlin inference issue
-    private val queue = actor<Any>(capacity = 8) {
+    private val queue = actor<Any>(context = CoroutineName("ws-writer"), capacity = 8) {
         pool.useInstance { writeLoop(it) }
     }
 
@@ -52,9 +52,6 @@ class WebSocketWriter(
         } catch (t: Throwable) {
             queue.close(t)
         } finally {
-            (coroutineContext[Job] as? CompletableJob)?.apply {
-                complete()
-            }
             queue.close(CancellationException("WebSocket closed.", null))
             writeChannel.close()
         }

--- a/ktor-http/ktor-http-cio/jvm/src/io/ktor/http/cio/websocket/WebSocketWriter.kt
+++ b/ktor-http/ktor-http-cio/jvm/src/io/ktor/http/cio/websocket/WebSocketWriter.kt
@@ -49,11 +49,13 @@ class WebSocketWriter(
                     else -> throw IllegalArgumentException("unknown message $message")
                 }
             }
+        } catch (t: Throwable) {
+            queue.close(t)
         } finally {
             (coroutineContext[Job] as? CompletableJob)?.apply {
                 complete()
             }
-            close()
+            queue.close(CancellationException("WebSocket closed.", null))
             writeChannel.close()
         }
 
@@ -83,7 +85,7 @@ class WebSocketWriter(
                     is FlushRequest -> flush = message
                     is Frame.Close -> {
                         serializer.enqueue(message)
-                        close()
+                        queue.close()
                         closeSent = true
                         break@poll
                     }
@@ -143,6 +145,7 @@ class WebSocketWriter(
     /**
      * Closes the message queue
      */
+    @Deprecated("Will be removed")
     fun close() {
         queue.close()
     }

--- a/ktor-http/ktor-http-cio/jvm/src/io/ktor/http/cio/websocket/WebSocketWriter.kt
+++ b/ktor-http/ktor-http-cio/jvm/src/io/ktor/http/cio/websocket/WebSocketWriter.kt
@@ -28,7 +28,7 @@ class WebSocketWriter(
 ) : CoroutineScope {
 
     @Suppress("RemoveExplicitTypeArguments") // workaround for new kotlin inference issue
-    private val queue = actor<Any>(capacity = 8, start = CoroutineStart.LAZY) {
+    private val queue = actor<Any>(capacity = 8) {
         pool.useInstance { writeLoop(it) }
     }
 

--- a/ktor-http/ktor-http-cio/jvm/src/io/ktor/http/cio/websocket/WebSocketWriter.kt
+++ b/ktor-http/ktor-http-cio/jvm/src/io/ktor/http/cio/websocket/WebSocketWriter.kt
@@ -79,19 +79,21 @@ class WebSocketWriter(
 
         // initially serializer has at least one message queued
         while (true) {
-            poll@ while (flush == null && !closeSent && serializer.remainingCapacity > 0) {
+            while (flush == null && !closeSent && serializer.remainingCapacity > 0) {
                 val message = poll() ?: break
                 when (message) {
                     is FlushRequest -> flush = message
                     is Frame.Close -> {
                         serializer.enqueue(message)
-                        queue.close()
                         closeSent = true
-                        break@poll
                     }
                     is Frame -> serializer.enqueue(message)
                     else -> throw IllegalArgumentException("unknown message $message")
                 }
+            }
+
+            if (closeSent) {
+                queue.close()
             }
 
             if (!serializer.hasOutstandingBytes && buffer.position() == 0) break

--- a/ktor-http/ktor-http-cio/posix/src/io/ktor/http/cio/websocket/WebSocketSession.kt
+++ b/ktor-http/ktor-http-cio/posix/src/io/ktor/http/cio/websocket/WebSocketSession.kt
@@ -45,9 +45,4 @@ actual interface WebSocketSession : CoroutineScope {
      * Initiate connection termination immediately. Termination may complete asynchronously.
      */
     actual fun terminate()
-
-    /**
-     * Close session with the specified [cause] or with no reason if `null`
-     */
-    actual suspend fun close(cause: Throwable?)
 }

--- a/ktor-http/ktor-http-cio/posix/src/io/ktor/http/cio/websocket/WebSocketSession.kt
+++ b/ktor-http/ktor-http-cio/posix/src/io/ktor/http/cio/websocket/WebSocketSession.kt
@@ -44,5 +44,9 @@ actual interface WebSocketSession : CoroutineScope {
     /**
      * Initiate connection termination immediately. Termination may complete asynchronously.
      */
+    @Deprecated(
+        "Use cancel() instead.",
+        ReplaceWith("cancel()", "kotlinx.coroutines.cancel")
+    )
     actual fun terminate()
 }

--- a/ktor-server/ktor-server-test-host/jvm/src/io/ktor/server/testing/TestApplicationEngine.kt
+++ b/ktor-server/ktor-server-test-host/jvm/src/io/ktor/server/testing/TestApplicationEngine.kt
@@ -232,7 +232,7 @@ class TestApplicationEngine(
                 call.callback(reader.incoming, writer.outgoing)
             } finally {
                 writer.flush()
-                writer.close()
+                writer.outgoing.close()
                 job.cancelAndJoin()
             }
         }

--- a/ktor-utils/jvm/resources/META-INF/proguard/ktor.pro
+++ b/ktor-utils/jvm/resources/META-INF/proguard/ktor.pro
@@ -1,0 +1,12 @@
+# Most of volatile fields are updated with AtomicFU and should not be mangled/removed
+-keepclassmembers class io.ktor.** {
+    volatile <fields>;
+}
+
+-keepclassmembernames class io.ktor.** {
+    volatile <fields>;
+}
+
+# client engines are loaded using ServiceLoader so we need to keep them
+-keep io.ktor.client.engine.** implements io.ktor.client.HttpClientEngineContainer
+


### PR DESCRIPTION
**Subsystem**
Server+client, ktor-websockets

**Motivation**
Currently, we are always closing an outgoing WebSocket channel at the receive side that causes `ClosedSendChannelException` at a send attempt that leads to a lot of logged errors with coroutines `1.3.0+`.

**Solution**
Instead, we should only close an outgoing channel when a WS handler does WebSocket close with `CloseReason`. Otherwise, we need to do a cancellation, just the same as `actor` coroutines do. Unfortunately, due to missing channel resources cleanup in kx.coroutines, we can't just cancel a channel. However, we still can close it with a proper cancellation exception to emulate `cancel()` since the only difference between `cancel()` and `close(CancellationException(...))` is that the first discards all messages, that is not desired.

