### PR TITLE
Add an option to disable URL Encoding

### DIFF
--- a/ktor-http/api/ktor-http.api
+++ b/ktor-http/api/ktor-http.api
@@ -325,10 +325,10 @@ public final class io/ktor/http/EmptyParameters : io/ktor/http/Parameters {
 	public fun get (Ljava/lang/String;)Ljava/lang/String;
 	public fun getAll (Ljava/lang/String;)Ljava/util/List;
 	public fun getCaseInsensitiveName ()Z
+	public fun getUrlEncodingOption ()Lio/ktor/http/UrlEncodingOption;
 	public fun isEmpty ()Z
 	public fun names ()Ljava/util/Set;
 	public fun toString ()Ljava/lang/String;
-	public fun urlEncodingOption ()Lio/ktor/http/UrlEncodingOption;
 }
 
 public final class io/ktor/http/FileContentTypeJvmKt {
@@ -776,7 +776,7 @@ public final class io/ktor/http/LinkHeader$Rel {
 
 public abstract interface class io/ktor/http/Parameters : io/ktor/util/StringValues {
 	public static final field Companion Lio/ktor/http/Parameters$Companion;
-	public abstract fun urlEncodingOption ()Lio/ktor/http/UrlEncodingOption;
+	public abstract fun getUrlEncodingOption ()Lio/ktor/http/UrlEncodingOption;
 }
 
 public final class io/ktor/http/Parameters$Companion {
@@ -789,7 +789,7 @@ public final class io/ktor/http/Parameters$DefaultImpls {
 	public static fun contains (Lio/ktor/http/Parameters;Ljava/lang/String;Ljava/lang/String;)Z
 	public static fun forEach (Lio/ktor/http/Parameters;Lkotlin/jvm/functions/Function2;)V
 	public static fun get (Lio/ktor/http/Parameters;Ljava/lang/String;)Ljava/lang/String;
-	public static fun urlEncodingOption (Lio/ktor/http/Parameters;)Lio/ktor/http/UrlEncodingOption;
+	public static fun getUrlEncodingOption (Lio/ktor/http/Parameters;)Lio/ktor/http/UrlEncodingOption;
 }
 
 public final class io/ktor/http/ParametersBuilder : io/ktor/util/StringValuesBuilder {
@@ -808,8 +808,8 @@ public final class io/ktor/http/ParametersImpl : io/ktor/util/StringValuesImpl, 
 	public synthetic fun <init> (Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun <init> (Ljava/util/Map;Lio/ktor/http/UrlEncodingOption;)V
 	public synthetic fun <init> (Ljava/util/Map;Lio/ktor/http/UrlEncodingOption;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun getUrlEncodingOption ()Lio/ktor/http/UrlEncodingOption;
 	public fun toString ()Ljava/lang/String;
-	public fun urlEncodingOption ()Lio/ktor/http/UrlEncodingOption;
 }
 
 public final class io/ktor/http/ParametersKt {
@@ -822,8 +822,8 @@ public final class io/ktor/http/ParametersKt {
 
 public final class io/ktor/http/ParametersSingleImpl : io/ktor/util/StringValuesSingleImpl, io/ktor/http/Parameters {
 	public fun <init> (Ljava/lang/String;Ljava/util/List;)V
+	public fun getUrlEncodingOption ()Lio/ktor/http/UrlEncodingOption;
 	public fun toString ()Ljava/lang/String;
-	public fun urlEncodingOption ()Lio/ktor/http/UrlEncodingOption;
 }
 
 public final class io/ktor/http/QueryKt {

--- a/ktor-http/api/ktor-http.api
+++ b/ktor-http/api/ktor-http.api
@@ -794,7 +794,7 @@ public final class io/ktor/http/Parameters$DefaultImpls {
 
 public final class io/ktor/http/ParametersBuilder : io/ktor/util/StringValuesBuilder {
 	public fun <init> ()V
-	public fun <init> (I)V
+	public synthetic fun <init> (I)V
 	public synthetic fun <init> (IILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun <init> (ILio/ktor/http/UrlEncodingOption;)V
 	public synthetic fun <init> (ILio/ktor/http/UrlEncodingOption;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
@@ -804,7 +804,7 @@ public final class io/ktor/http/ParametersBuilder : io/ktor/util/StringValuesBui
 
 public final class io/ktor/http/ParametersImpl : io/ktor/util/StringValuesImpl, io/ktor/http/Parameters {
 	public fun <init> ()V
-	public fun <init> (Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/util/Map;)V
 	public synthetic fun <init> (Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun <init> (Ljava/util/Map;Lio/ktor/http/UrlEncodingOption;)V
 	public synthetic fun <init> (Ljava/util/Map;Lio/ktor/http/UrlEncodingOption;ILkotlin/jvm/internal/DefaultConstructorMarker;)V

--- a/ktor-http/api/ktor-http.api
+++ b/ktor-http/api/ktor-http.api
@@ -800,6 +800,7 @@ public final class io/ktor/http/ParametersBuilder : io/ktor/util/StringValuesBui
 	public synthetic fun <init> (ILio/ktor/http/UrlEncodingOption;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun build ()Lio/ktor/http/Parameters;
 	public synthetic fun build ()Lio/ktor/util/StringValues;
+	public final fun getUrlEncodingOption ()Lio/ktor/http/UrlEncodingOption;
 }
 
 public final class io/ktor/http/ParametersImpl : io/ktor/util/StringValuesImpl, io/ktor/http/Parameters {

--- a/ktor-http/api/ktor-http.api
+++ b/ktor-http/api/ktor-http.api
@@ -328,6 +328,7 @@ public final class io/ktor/http/EmptyParameters : io/ktor/http/Parameters {
 	public fun isEmpty ()Z
 	public fun names ()Ljava/util/Set;
 	public fun toString ()Ljava/lang/String;
+	public fun urlEncodingOption ()Lio/ktor/http/UrlEncodingOption;
 }
 
 public final class io/ktor/http/FileContentTypeJvmKt {
@@ -716,9 +717,13 @@ public final class io/ktor/http/HttpStatusCodeKt {
 
 public final class io/ktor/http/HttpUrlEncodedKt {
 	public static final fun formUrlEncode (Lio/ktor/http/Parameters;)Ljava/lang/String;
-	public static final fun formUrlEncode (Ljava/util/List;)Ljava/lang/String;
+	public static final synthetic fun formUrlEncode (Ljava/util/List;)Ljava/lang/String;
+	public static final fun formUrlEncode (Ljava/util/List;Lio/ktor/http/UrlEncodingOption;)Ljava/lang/String;
+	public static synthetic fun formUrlEncode$default (Ljava/util/List;Lio/ktor/http/UrlEncodingOption;ILjava/lang/Object;)Ljava/lang/String;
 	public static final fun formUrlEncodeTo (Lio/ktor/http/Parameters;Ljava/lang/Appendable;)V
-	public static final fun formUrlEncodeTo (Ljava/util/List;Ljava/lang/Appendable;)V
+	public static final synthetic fun formUrlEncodeTo (Ljava/util/List;Ljava/lang/Appendable;)V
+	public static final fun formUrlEncodeTo (Ljava/util/List;Ljava/lang/Appendable;Lio/ktor/http/UrlEncodingOption;)V
+	public static synthetic fun formUrlEncodeTo$default (Ljava/util/List;Ljava/lang/Appendable;Lio/ktor/http/UrlEncodingOption;ILjava/lang/Object;)V
 	public static final fun parseUrlEncodedParameters (Ljava/lang/String;Ljava/nio/charset/Charset;I)Lio/ktor/http/Parameters;
 	public static synthetic fun parseUrlEncodedParameters$default (Ljava/lang/String;Ljava/nio/charset/Charset;IILjava/lang/Object;)Lio/ktor/http/Parameters;
 }
@@ -771,6 +776,7 @@ public final class io/ktor/http/LinkHeader$Rel {
 
 public abstract interface class io/ktor/http/Parameters : io/ktor/util/StringValues {
 	public static final field Companion Lio/ktor/http/Parameters$Companion;
+	public abstract fun urlEncodingOption ()Lio/ktor/http/UrlEncodingOption;
 }
 
 public final class io/ktor/http/Parameters$Companion {
@@ -783,12 +789,15 @@ public final class io/ktor/http/Parameters$DefaultImpls {
 	public static fun contains (Lio/ktor/http/Parameters;Ljava/lang/String;Ljava/lang/String;)Z
 	public static fun forEach (Lio/ktor/http/Parameters;Lkotlin/jvm/functions/Function2;)V
 	public static fun get (Lio/ktor/http/Parameters;Ljava/lang/String;)Ljava/lang/String;
+	public static fun urlEncodingOption (Lio/ktor/http/Parameters;)Lio/ktor/http/UrlEncodingOption;
 }
 
 public final class io/ktor/http/ParametersBuilder : io/ktor/util/StringValuesBuilder {
 	public fun <init> ()V
 	public fun <init> (I)V
 	public synthetic fun <init> (IILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (ILio/ktor/http/UrlEncodingOption;)V
+	public synthetic fun <init> (ILio/ktor/http/UrlEncodingOption;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun build ()Lio/ktor/http/Parameters;
 	public synthetic fun build ()Lio/ktor/util/StringValues;
 }
@@ -797,7 +806,10 @@ public final class io/ktor/http/ParametersImpl : io/ktor/util/StringValuesImpl, 
 	public fun <init> ()V
 	public fun <init> (Ljava/util/Map;)V
 	public synthetic fun <init> (Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/util/Map;Lio/ktor/http/UrlEncodingOption;)V
+	public synthetic fun <init> (Ljava/util/Map;Lio/ktor/http/UrlEncodingOption;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun toString ()Ljava/lang/String;
+	public fun urlEncodingOption ()Lio/ktor/http/UrlEncodingOption;
 }
 
 public final class io/ktor/http/ParametersKt {
@@ -811,6 +823,7 @@ public final class io/ktor/http/ParametersKt {
 public final class io/ktor/http/ParametersSingleImpl : io/ktor/util/StringValuesSingleImpl, io/ktor/http/Parameters {
 	public fun <init> (Ljava/lang/String;Ljava/util/List;)V
 	public fun toString ()Ljava/lang/String;
+	public fun urlEncodingOption ()Lio/ktor/http/UrlEncodingOption;
 }
 
 public final class io/ktor/http/QueryKt {
@@ -999,6 +1012,15 @@ public final class io/ktor/http/Url {
 }
 
 public final class io/ktor/http/Url$Companion {
+}
+
+public final class io/ktor/http/UrlEncodingOption : java/lang/Enum {
+	public static final field DEFAULT Lio/ktor/http/UrlEncodingOption;
+	public static final field KEY_ONLY Lio/ktor/http/UrlEncodingOption;
+	public static final field NO_ENCODING Lio/ktor/http/UrlEncodingOption;
+	public static final field VALUE_ONLY Lio/ktor/http/UrlEncodingOption;
+	public static fun valueOf (Ljava/lang/String;)Lio/ktor/http/UrlEncodingOption;
+	public static fun values ()[Lio/ktor/http/UrlEncodingOption;
 }
 
 public final class io/ktor/http/auth/AuthScheme {

--- a/ktor-http/common/src/io/ktor/http/HttpUrlEncoded.kt
+++ b/ktor-http/common/src/io/ktor/http/HttpUrlEncoded.kt
@@ -12,7 +12,7 @@ import io.ktor.utils.io.charsets.*
  * Keys and values are encoded only when [encodeKey] and [encodeValue] are `true` respectively.
  */
 @KtorExperimentalAPI
-enum class UrlEncodingOption(internal val encodeKey: Boolean, internal val encodeValue: Boolean) {
+public enum class UrlEncodingOption(internal val encodeKey: Boolean, internal val encodeValue: Boolean) {
     DEFAULT(true, true),
     KEY_ONLY(true, false),
     VALUE_ONLY(false, true),
@@ -47,8 +47,9 @@ public fun String.parseUrlEncodedParameters(defaultEncoding: Charset = Charsets.
 public fun List<Pair<String, String?>>.formUrlEncode(): String = formUrlEncode(UrlEncodingOption.DEFAULT)
 
 /**
- * Encode form parameters from a list of pairs by using [option]
+ * Encode form parameters from a list of pairs
  */
+@KtorExperimentalAPI
 public fun List<Pair<String, String?>>.formUrlEncode(option: UrlEncodingOption = UrlEncodingOption.DEFAULT): String =
     buildString { formUrlEncodeTo(this, option) }
 
@@ -56,11 +57,13 @@ public fun List<Pair<String, String?>>.formUrlEncode(option: UrlEncodingOption =
  * Encode form parameters from a list of pairs to the specified [out] appendable
  */
 @Deprecated("Binary compatibility", level = DeprecationLevel.HIDDEN)
-public fun List<Pair<String, String?>>.formUrlEncodeTo(out: Appendable) = formUrlEncodeTo(out, UrlEncodingOption.DEFAULT)
+public fun List<Pair<String, String?>>.formUrlEncodeTo(out: Appendable): Unit =
+    formUrlEncodeTo(out, UrlEncodingOption.DEFAULT)
 
 /**
  * Encode form parameters from a list of pairs to the specified [out] appendable by using [option]
  */
+@KtorExperimentalAPI
 public fun List<Pair<String, String?>>.formUrlEncodeTo(
     out: Appendable,
     option: UrlEncodingOption = UrlEncodingOption.DEFAULT
@@ -82,7 +85,7 @@ public fun List<Pair<String, String?>>.formUrlEncodeTo(
  */
 public fun Parameters.formUrlEncode(): String = entries()
     .flatMap { e -> e.value.map { e.key to it } }
-    .formUrlEncode(urlEncodingOption())
+    .formUrlEncode(urlEncodingOption)
 
 /**
  * Encode form parameters to the specified [out] appendable
@@ -92,11 +95,19 @@ public fun Parameters.formUrlEncodeTo(out: Appendable) {
 }
 
 internal fun ParametersBuilder.formUrlEncodeTo(out: Appendable) {
-    entries().formUrlEncodeTo(out)
+    entries().formUrlEncodeTo(out, urlEncodingOption)
 }
 
-internal fun Set<Map.Entry<String, List<String>>>.formUrlEncodeTo(out: Appendable) {
+@Deprecated("Binary compatibility", level = DeprecationLevel.HIDDEN)
+internal fun Set<Map.Entry<String, List<String>>>.formUrlEncodeTo(out: Appendable) =
+    formUrlEncodeTo(out, UrlEncodingOption.DEFAULT)
+
+@KtorExperimentalAPI
+internal fun Set<Map.Entry<String, List<String>>>.formUrlEncodeTo(
+    out: Appendable,
+    option: UrlEncodingOption = UrlEncodingOption.DEFAULT
+) {
     flatMap { (key, value) ->
         if (value.isEmpty()) listOf(key to null) else value.map { key to it }
-    }.formUrlEncodeTo(out, urlEncodingOption)
+    }.formUrlEncodeTo(out, option)
 }

--- a/ktor-http/common/src/io/ktor/http/HttpUrlEncoded.kt
+++ b/ktor-http/common/src/io/ktor/http/HttpUrlEncoded.kt
@@ -43,11 +43,7 @@ public fun String.parseUrlEncodedParameters(defaultEncoding: Charset = Charsets.
 /**
  * Encode form parameters from a list of pairs
  */
-@Deprecated(
-    "Use formUrlEncode(option)",
-    ReplaceWith("formUrlEncode(UrlEncodingOption.DEFAULT)", "io.ktor.http.UrlEncodingOption"),
-    DeprecationLevel.HIDDEN
-)
+@Deprecated("Binary compatibility", level = DeprecationLevel.HIDDEN)
 public fun List<Pair<String, String?>>.formUrlEncode(): String = formUrlEncode(UrlEncodingOption.DEFAULT)
 
 /**
@@ -59,11 +55,7 @@ public fun List<Pair<String, String?>>.formUrlEncode(option: UrlEncodingOption =
 /**
  * Encode form parameters from a list of pairs to the specified [out] appendable
  */
-@Deprecated(
-    "Use formUrlEncodeTo(out, option)",
-    ReplaceWith("formUrlEncodeTo(out, UrlEncodingOption.DEFAULT)", "io.ktor.http.UrlEncodingOption"),
-    DeprecationLevel.HIDDEN
-)
+@Deprecated("Binary compatibility", level = DeprecationLevel.HIDDEN)
 public fun List<Pair<String, String?>>.formUrlEncodeTo(out: Appendable) = formUrlEncodeTo(out, UrlEncodingOption.DEFAULT)
 
 /**

--- a/ktor-http/common/src/io/ktor/http/HttpUrlEncoded.kt
+++ b/ktor-http/common/src/io/ktor/http/HttpUrlEncoded.kt
@@ -41,12 +41,30 @@ public fun String.parseUrlEncodedParameters(defaultEncoding: Charset = Charsets.
 }
 
 /**
+ * Encode form parameters from a list of pairs
+ */
+@Deprecated(
+    "Use formUrlEncode(option)",
+    ReplaceWith("formUrlEncode(UrlEncodingOption.DEFAULT)", "io.ktor.http.UrlEncodingOption"),
+    DeprecationLevel.HIDDEN
+)
+public fun List<Pair<String, String?>>.formUrlEncode(): String = formUrlEncode(UrlEncodingOption.DEFAULT)
+
+/**
  * Encode form parameters from a list of pairs by using [option]
  */
 public fun List<Pair<String, String?>>.formUrlEncode(option: UrlEncodingOption = UrlEncodingOption.DEFAULT): String =
-    StringBuilder().apply {
-        formUrlEncodeTo(this, option)
-    }.toString()
+    buildString { formUrlEncodeTo(this, option) }
+
+/**
+ * Encode form parameters from a list of pairs to the specified [out] appendable
+ */
+@Deprecated(
+    "Use formUrlEncodeTo(out, option)",
+    ReplaceWith("formUrlEncodeTo(out, UrlEncodingOption.DEFAULT)", "io.ktor.http.UrlEncodingOption"),
+    DeprecationLevel.HIDDEN
+)
+public fun List<Pair<String, String?>>.formUrlEncodeTo(out: Appendable) = formUrlEncodeTo(out, UrlEncodingOption.DEFAULT)
 
 /**
  * Encode form parameters from a list of pairs to the specified [out] appendable by using [option]

--- a/ktor-http/common/src/io/ktor/http/HttpUrlEncoded.kt
+++ b/ktor-http/common/src/io/ktor/http/HttpUrlEncoded.kt
@@ -98,5 +98,5 @@ internal fun ParametersBuilder.formUrlEncodeTo(out: Appendable) {
 internal fun Set<Map.Entry<String, List<String>>>.formUrlEncodeTo(out: Appendable) {
     flatMap { (key, value) ->
         if (value.isEmpty()) listOf(key to null) else value.map { key to it }
-    }.formUrlEncodeTo(out)
+    }.formUrlEncodeTo(out, urlEncodingOption)
 }

--- a/ktor-http/common/src/io/ktor/http/Parameters.kt
+++ b/ktor-http/common/src/io/ktor/http/Parameters.kt
@@ -34,13 +34,13 @@ public interface Parameters : StringValues {
 }
 
 @Suppress("KDocMissingDocumentation")
-class ParametersBuilder(
+public class ParametersBuilder(
     size: Int = 8,
-    private val urlEncodingOption: UrlEncodingOption = UrlEncodingOption.DEFAULT
+    public val urlEncodingOption: UrlEncodingOption = UrlEncodingOption.DEFAULT
 ) : StringValuesBuilder(true, size) {
 
     @Deprecated("Binary compatibility", level = DeprecationLevel.HIDDEN)
-    constructor(size: Int = 8) : this(size)
+    public constructor(size: Int = 8) : this(size, UrlEncodingOption.DEFAULT)
 
     override fun build(): Parameters {
         require(!built) { "ParametersBuilder can only build a single Parameters instance" }
@@ -94,7 +94,7 @@ public class ParametersImpl(
 ) : Parameters, StringValuesImpl(true, values) {
 
     @Deprecated("Binary compatibility", level = DeprecationLevel.HIDDEN)
-    constructor(values: Map<String, List<String>> = emptyMap()) : this(values)
+    public constructor(values: Map<String, List<String>> = emptyMap()) : this(values, UrlEncodingOption.DEFAULT)
 
     override fun toString(): String = "Parameters ${entries()}"
 }

--- a/ktor-http/common/src/io/ktor/http/Parameters.kt
+++ b/ktor-http/common/src/io/ktor/http/Parameters.kt
@@ -33,14 +33,17 @@ public interface Parameters : StringValues {
 }
 
 @Suppress("KDocMissingDocumentation")
-public class ParametersBuilder(
-    size: Int = 8,
-    private val urlEncodingOption: UrlEncodingOption = UrlEncodingOption.DEFAULT
-) : StringValuesBuilder(true, size) {
+public class ParametersBuilder(size: Int = 8) : StringValuesBuilder(true, size) {
+    private var urlEncodingOption: UrlEncodingOption = UrlEncodingOption.DEFAULT
+
+    constructor(size: Int = 8, urlEncodingOption: UrlEncodingOption = UrlEncodingOption.DEFAULT) : this(size) {
+        this.urlEncodingOption = urlEncodingOption
+    }
+
     override fun build(): Parameters {
         require(!built) { "ParametersBuilder can only build a single Parameters instance" }
         built = true
-        return ParametersImpl(values)
+        return ParametersImpl(values, urlEncodingOption)
     }
 }
 
@@ -83,11 +86,17 @@ public fun parametersOf(vararg pairs: Pair<String, List<String>>): Parameters = 
 
 @Suppress("KDocMissingDocumentation")
 @InternalAPI
-public class ParametersImpl(
-    values: Map<String, List<String>> = emptyMap(),
-    private val encodingOption: UrlEncodingOption = UrlEncodingOption.DEFAULT
-) : Parameters, StringValuesImpl(true, values) {
-    override fun urlEncodingOption() = encodingOption
+public class ParametersImpl(values: Map<String, List<String>> = emptyMap()) : Parameters, StringValuesImpl(true, values) {
+    private var urlEncodingOption: UrlEncodingOption = UrlEncodingOption.DEFAULT
+
+    constructor(
+        values: Map<String, List<String>> = emptyMap(),
+        urlEncodingOption: UrlEncodingOption = UrlEncodingOption.DEFAULT
+    ) : this(values) {
+        this.urlEncodingOption = urlEncodingOption
+    }
+
+    override fun urlEncodingOption() = urlEncodingOption
     override fun toString(): String = "Parameters ${entries()}"
 }
 

--- a/ktor-http/common/src/io/ktor/http/Parameters.kt
+++ b/ktor-http/common/src/io/ktor/http/Parameters.kt
@@ -14,7 +14,8 @@ public interface Parameters : StringValues {
      * Returns a [UrlEncodingOption] instance
      */
     @KtorExperimentalAPI
-    public fun urlEncodingOption(): UrlEncodingOption = UrlEncodingOption.DEFAULT
+    public val urlEncodingOption: UrlEncodingOption
+        get() = UrlEncodingOption.DEFAULT
 
     public companion object {
         /**
@@ -36,7 +37,7 @@ public interface Parameters : StringValues {
 public class ParametersBuilder(size: Int = 8) : StringValuesBuilder(true, size) {
     private var urlEncodingOption: UrlEncodingOption = UrlEncodingOption.DEFAULT
 
-    constructor(size: Int = 8, urlEncodingOption: UrlEncodingOption = UrlEncodingOption.DEFAULT) : this(size) {
+    constructor(size: Int = 8, urlEncodingOption: UrlEncodingOption) : this(size) {
         this.urlEncodingOption = urlEncodingOption
     }
 
@@ -87,13 +88,12 @@ public fun parametersOf(vararg pairs: Pair<String, List<String>>): Parameters = 
 @Suppress("KDocMissingDocumentation")
 @InternalAPI
 public class ParametersImpl(values: Map<String, List<String>> = emptyMap()) : Parameters, StringValuesImpl(true, values) {
-    private var urlEncodingOption: UrlEncodingOption = UrlEncodingOption.DEFAULT
+    private var option: UrlEncodingOption = super.urlEncodingOption
+    override val urlEncodingOption: UrlEncodingOption
+        get() = option
 
-    constructor(
-        values: Map<String, List<String>> = emptyMap(),
-        urlEncodingOption: UrlEncodingOption = UrlEncodingOption.DEFAULT
-    ) : this(values) {
-        this.urlEncodingOption = urlEncodingOption
+    constructor(values: Map<String, List<String>> = emptyMap(), urlEncodingOption: UrlEncodingOption) : this(values) {
+        this.option = urlEncodingOption
     }
 
     override fun urlEncodingOption() = urlEncodingOption

--- a/ktor-http/common/src/io/ktor/http/Parameters.kt
+++ b/ktor-http/common/src/io/ktor/http/Parameters.kt
@@ -10,6 +10,12 @@ import io.ktor.util.*
  * Represents HTTP parameters as a map from case-insensitive names to collection of [String] values
  */
 public interface Parameters : StringValues {
+    /**
+     * Returns a [UrlEncodingOption] instance
+     */
+    @KtorExperimentalAPI
+    public fun urlEncodingOption(): UrlEncodingOption = UrlEncodingOption.DEFAULT
+
     public companion object {
         /**
          * Empty [Parameters] instance
@@ -27,7 +33,10 @@ public interface Parameters : StringValues {
 }
 
 @Suppress("KDocMissingDocumentation")
-public class ParametersBuilder(size: Int = 8) : StringValuesBuilder(true, size) {
+public class ParametersBuilder(
+    size: Int = 8,
+    private val urlEncodingOption: UrlEncodingOption = UrlEncodingOption.DEFAULT
+) : StringValuesBuilder(true, size) {
     override fun build(): Parameters {
         require(!built) { "ParametersBuilder can only build a single Parameters instance" }
         built = true
@@ -74,8 +83,11 @@ public fun parametersOf(vararg pairs: Pair<String, List<String>>): Parameters = 
 
 @Suppress("KDocMissingDocumentation")
 @InternalAPI
-public class ParametersImpl(values: Map<String, List<String>> = emptyMap()) : Parameters,
-    StringValuesImpl(true, values) {
+public class ParametersImpl(
+    values: Map<String, List<String>> = emptyMap(),
+    private val encodingOption: UrlEncodingOption = UrlEncodingOption.DEFAULT
+) : Parameters, StringValuesImpl(true, values) {
+    override fun urlEncodingOption() = encodingOption
     override fun toString(): String = "Parameters ${entries()}"
 }
 

--- a/ktor-http/common/src/io/ktor/http/Parameters.kt
+++ b/ktor-http/common/src/io/ktor/http/Parameters.kt
@@ -34,12 +34,13 @@ public interface Parameters : StringValues {
 }
 
 @Suppress("KDocMissingDocumentation")
-public class ParametersBuilder(size: Int = 8) : StringValuesBuilder(true, size) {
-    private var urlEncodingOption: UrlEncodingOption = UrlEncodingOption.DEFAULT
+class ParametersBuilder(
+    size: Int = 8,
+    private val urlEncodingOption: UrlEncodingOption = UrlEncodingOption.DEFAULT
+) : StringValuesBuilder(true, size) {
 
-    constructor(size: Int = 8, urlEncodingOption: UrlEncodingOption) : this(size) {
-        this.urlEncodingOption = urlEncodingOption
-    }
+    @Deprecated("Binary compatibility", level = DeprecationLevel.HIDDEN)
+    constructor(size: Int = 8) : this(size)
 
     override fun build(): Parameters {
         require(!built) { "ParametersBuilder can only build a single Parameters instance" }
@@ -87,16 +88,14 @@ public fun parametersOf(vararg pairs: Pair<String, List<String>>): Parameters = 
 
 @Suppress("KDocMissingDocumentation")
 @InternalAPI
-public class ParametersImpl(values: Map<String, List<String>> = emptyMap()) : Parameters, StringValuesImpl(true, values) {
-    private var option: UrlEncodingOption = super.urlEncodingOption
-    override val urlEncodingOption: UrlEncodingOption
-        get() = option
+public class ParametersImpl(
+    values: Map<String, List<String>> = emptyMap(),
+    override val urlEncodingOption: UrlEncodingOption = UrlEncodingOption.DEFAULT
+) : Parameters, StringValuesImpl(true, values) {
 
-    constructor(values: Map<String, List<String>> = emptyMap(), urlEncodingOption: UrlEncodingOption) : this(values) {
-        this.option = urlEncodingOption
-    }
+    @Deprecated("Binary compatibility", level = DeprecationLevel.HIDDEN)
+    constructor(values: Map<String, List<String>> = emptyMap()) : this(values)
 
-    override fun urlEncodingOption() = urlEncodingOption
     override fun toString(): String = "Parameters ${entries()}"
 }
 

--- a/ktor-http/common/test/io/ktor/tests/http/ParametersBuilderTest.kt
+++ b/ktor-http/common/test/io/ktor/tests/http/ParametersBuilderTest.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2014-2019 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.tests.http
+
+import io.ktor.http.*
+import kotlin.test.*
+
+class ParametersBuilderTest {
+
+    private val original = "abc=def&efg=hij;klm=nop/qrs=tuv"
+    private val encoded = original.encodeURLParameter(false)
+
+    private fun assertEncodedQuery(option: UrlEncodingOption, expectedKey: String, expectedValue: String) {
+        val builder = ParametersBuilder(urlEncodingOption = option)
+        builder.append(original, original)
+        val encoded = builder.build().formUrlEncode()
+
+        assertEquals("$expectedKey=$expectedValue", encoded)
+    }
+
+    @Test
+    fun encodeKeyValueTest() {
+        assertEncodedQuery(UrlEncodingOption.DEFAULT, encoded, encoded)
+    }
+
+    @Test
+    fun encodeKeyOnlyTest() {
+        assertEncodedQuery(UrlEncodingOption.KEY_ONLY, encoded, original)
+    }
+
+    @Test
+    fun encodeValueOnlyTest() {
+        assertEncodedQuery(UrlEncodingOption.VALUE_ONLY, original, encoded)
+    }
+
+    @Test
+    fun noEncodingTest() {
+        assertEncodedQuery(UrlEncodingOption.NO_ENCODING, original, original)
+    }
+}

--- a/ktor-http/common/test/io/ktor/tests/http/ParametersBuilderTest.kt
+++ b/ktor-http/common/test/io/ktor/tests/http/ParametersBuilderTest.kt
@@ -12,12 +12,17 @@ class ParametersBuilderTest {
     private val original = "abc=def&efg=hij;klm=nop/qrs=tuv"
     private val encoded = original.encodeURLParameter(false)
 
-    private fun assertEncodedQuery(option: UrlEncodingOption, expectedKey: String, expectedValue: String) {
-        val builder = ParametersBuilder(urlEncodingOption = option)
+    private fun assertEncodedQuery(option: UrlEncodingOption?, expectedKey: String, expectedValue: String) {
+        val builder = option?.let { ParametersBuilder(urlEncodingOption = it) } ?: ParametersBuilder()
         builder.append(original, original)
         val encoded = builder.build().formUrlEncode()
 
         assertEquals("$expectedKey=$expectedValue", encoded)
+    }
+
+    @Test
+    fun encodeKeyValueDefaultConstructorTest() {
+        assertEncodedQuery(null, encoded, encoded)
     }
 
     @Test

--- a/ktor-http/common/test/io/ktor/tests/http/ParametersBuilderTest.kt
+++ b/ktor-http/common/test/io/ktor/tests/http/ParametersBuilderTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2014-2021 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package io.ktor.tests.http
@@ -10,13 +10,14 @@ import kotlin.test.*
 class ParametersBuilderTest {
 
     private val original = "abc=def&efg=hij;klm=nop/qrs=tu v"
-    private val encoded = original.encodeURLParameter(spaceToPlus = true)
+    private val encodedKey = original.encodeURLParameter(spaceToPlus = true)
+    private val encodedValue = original.encodeURLParameterValue()
 
     private fun assertEncodedQuery(option: UrlEncodingOption?, expectedKey: String, expectedValue: String) {
         // given that a builder is constructed with the UrlEncodingOption
-        val builder = option
-            ?.let { ParametersBuilder(urlEncodingOption = it) }
-            ?: ParametersBuilder()
+        val builder =
+            if (option == null) ParametersBuilder()
+            else ParametersBuilder(urlEncodingOption = option)
 
         // when the original string is added to the parameters as a key and value
         builder.append(original, original)
@@ -28,22 +29,22 @@ class ParametersBuilderTest {
 
     @Test
     fun defaultConstructorTest() {
-        assertEncodedQuery(null, encoded, encoded)
+        assertEncodedQuery(null, encodedKey, encodedValue)
     }
 
     @Test
     fun defaultEncodingTest() {
-        assertEncodedQuery(UrlEncodingOption.DEFAULT, encoded, encoded)
+        assertEncodedQuery(UrlEncodingOption.DEFAULT, encodedKey, encodedValue)
     }
 
     @Test
     fun keyOnlyEncodingTest() {
-        assertEncodedQuery(UrlEncodingOption.KEY_ONLY, encoded, original)
+        assertEncodedQuery(UrlEncodingOption.KEY_ONLY, encodedKey, original)
     }
 
     @Test
     fun valueOnlyEncodingTest() {
-        assertEncodedQuery(UrlEncodingOption.VALUE_ONLY, original, encoded)
+        assertEncodedQuery(UrlEncodingOption.VALUE_ONLY, original, encodedValue)
     }
 
     @Test

--- a/ktor-http/common/test/io/ktor/tests/http/ParametersBuilderTest.kt
+++ b/ktor-http/common/test/io/ktor/tests/http/ParametersBuilderTest.kt
@@ -9,34 +9,40 @@ import kotlin.test.*
 
 class ParametersBuilderTest {
 
-    private val original = "abc=def&efg=hij;klm=nop/qrs=tuv"
-    private val encoded = original.encodeURLParameter(false)
+    private val original = "abc=def&efg=hij;klm=nop/qrs=tu v"
+    private val encoded = original.encodeURLParameter(spaceToPlus = true)
 
     private fun assertEncodedQuery(option: UrlEncodingOption?, expectedKey: String, expectedValue: String) {
-        val builder = option?.let { ParametersBuilder(urlEncodingOption = it) } ?: ParametersBuilder()
+        // given that a builder is constructed with the UrlEncodingOption
+        val builder = option
+            ?.let { ParametersBuilder(urlEncodingOption = it) }
+            ?: ParametersBuilder()
+
+        // when the original string is added to the parameters as a key and value
         builder.append(original, original)
         val encoded = builder.build().formUrlEncode()
 
+        // then encoded string should be the expected key=value
         assertEquals("$expectedKey=$expectedValue", encoded)
     }
 
     @Test
-    fun encodeKeyValueDefaultConstructorTest() {
+    fun defaultConstructorTest() {
         assertEncodedQuery(null, encoded, encoded)
     }
 
     @Test
-    fun encodeKeyValueTest() {
+    fun defaultEncodingTest() {
         assertEncodedQuery(UrlEncodingOption.DEFAULT, encoded, encoded)
     }
 
     @Test
-    fun encodeKeyOnlyTest() {
+    fun keyOnlyEncodingTest() {
         assertEncodedQuery(UrlEncodingOption.KEY_ONLY, encoded, original)
     }
 
     @Test
-    fun encodeValueOnlyTest() {
+    fun valueOnlyEncodingTest() {
         assertEncodedQuery(UrlEncodingOption.VALUE_ONLY, original, encoded)
     }
 


### PR DESCRIPTION
**Subsystem**
ktor-http/common

**Motivation**
ktor-client cannot be used for URLs which are not supported by the URL Encoding format. It's because ktor-client always uses `URLBuidler` and there's no way to bypass the query encoding.

This PR adds an option to disable URL Encoding via `ParametersBuilder` (which can be passed to `URLBuidler`) without breaking changes.

(I mentioned in [this issue](https://github.com/ktorio/ktor/issues/1351) that `/api?k1=v1;k1=v1` (non-encoded `;`) is preventing us to use ktor-client. We needed to switch to another library just because of one character in the URL.)

**Solution**
`formUrlEncodeTo()` method is doing actual encoding. Added an option to bypass the encoding to `ParametersBuilder` and passed it to the method.

- Created `UrlEncodingOption` enum which provides encoding options (`DEFAULT`, `KEY_ONLY`, `VALUE_ONLY`, `NO_ENCODING`)
- Added the option to `ParametersBuilder` constructor
- Added the option to `Parameters` interface as a method and to `ParametersImpl` as a private property
- Changed `formUrlEncodeTo()` method to do URL Encoding only when it's enabled by the option
- The option added to methods and interfaces are defaulted to `DEFAULT` (i.e. keys and values are encoded) so as not to break existing code