### PR TITLE
Problem: partial content without the passed range doesn't have content length

### DIFF
--- a/ktor-server/ktor-server-core/jvm/src/io/ktor/features/PartialContent.kt
+++ b/ktor-server/ktor-server-core/jvm/src/io/ktor/features/PartialContent.kt
@@ -174,6 +174,10 @@ class PartialContent(private val maxRangeCount: Int) {
         override fun <T : Any> setProperty(key: AttributeKey<T>, value: T?) = original.setProperty(key, value)
 
         class Bypass(original: ReadChannelContent) : PartialOutgoingContent(original) {
+
+            override val contentLength: Long?
+                get() = original.contentLength
+
             override fun readFrom() = original.readFrom()
 
             override val headers by lazy(LazyThreadSafetyMode.NONE) {

--- a/ktor-server/ktor-server-tests/jvm/test/io/ktor/tests/server/features/PartialContentTest.kt
+++ b/ktor-server/ktor-server-tests/jvm/test/io/ktor/tests/server/features/PartialContentTest.kt
@@ -216,6 +216,14 @@ class PartialContentTest {
     }
 
     @Test
+    fun testBypassContentLength(): Unit = withRangeApplication { file ->
+        handleRequest(HttpMethod.Get, localPath) {
+        }.let { result ->
+            assertEquals(file.length(), result.response.headers[HttpHeaders.ContentLength]!!.toLong())
+        }
+    }
+
+    @Test
     fun testMultipleMergedRanges(): Unit = withRangeApplication { file ->
         // multiple ranges should be merged into one
         handleRequest(HttpMethod.Get, localPath) {


### PR DESCRIPTION
**Subsystem**
Server Core

**Motivation**
Partial content without the passed range doesn't have content length. But it should

**Solution**
override ContentLength in PartialContent.Bypass
