### PR TITLE
referencing private processors when storing old state

### DIFF
--- a/ktor-server/ktor-server-test-host/jvm/src/io/ktor/server/testing/TestApplicationEngine.kt
+++ b/ktor-server/ktor-server-test-host/jvm/src/io/ktor/server/testing/TestApplicationEngine.kt
@@ -103,8 +103,8 @@ class TestApplicationEngine(
         processResponse: TestApplicationCall.() -> Unit,
         block: () -> Unit
     ) {
-        val oldProcessRequest = processRequest
-        val oldProcessResponse = processResponse
+        val oldProcessRequest = this.processRequest
+        val oldProcessResponse = this.processResponse
         this.processRequest = {
             oldProcessRequest {
                 processRequest(it)


### PR DESCRIPTION
**Subsystem**
Server, ktor-server/ktor-server-test-host

**Motivation**
There is a clash in names between this.processRequest and function's argument processRequest and it resolved to function's argument (bug #1300)

**Solution**
`hookRequest` will restore the original set of processors

Kudos to @LoneEngineer

