### PR TITLE
[SECURITY] Forbid the use of the sample key in production

### DIFF
--- a/ktor-server/ktor-server-core/jvm/src/io/ktor/sessions/SessionTransportTransformerMessageAuthentication.kt
+++ b/ktor-server/ktor-server-core/jvm/src/io/ktor/sessions/SessionTransportTransformerMessageAuthentication.kt
@@ -20,6 +20,12 @@ import javax.crypto.spec.*
 class SessionTransportTransformerMessageAuthentication(val keySpec: SecretKeySpec, val algorithm: String = "HmacSHA256") :
     SessionTransportTransformer {
     constructor(key: ByteArray, algorithm: String = "HmacSHA256") : this(SecretKeySpec(key, algorithm), algorithm)
+    
+    init {
+        if (key.contentEquals(hex("6819b57a326945c1968f45236581")) || key.contentEquals(hex("6819b57a326945c1968f45236589"))) {
+            throw IllegalArgumentException("The use of the key used in our sample documentation is forbidden.")
+        }
+    }
 
     override fun transformRead(transportValue: String): String? {
         val expectedSignature = transportValue.substringAfterLast('/', "")


### PR DESCRIPTION
If the Ktor documentation is going to provide an example with a default value, it's only responsible to forbid the use of that default value in the actual codebase.

**Subsystem**
Session

**Motivation**
Developers have a bad habit of copy and pasting sample code without understanding the security implications of their decisions. This will prevent this from happening with the default signing key used for signing sessions.

**Solution**
Black list the keys used in the sample documentation.
