### PR TITLE
Introduce TestHttpClient shortcut in a test application

### DIFF
--- a/ktor-features/ktor-auth/jvm/test/io/ktor/tests/auth/OAuth1a.kt
+++ b/ktor-features/ktor-auth/jvm/test/io/ktor/tests/auth/OAuth1a.kt
@@ -404,10 +404,11 @@ private fun createOAuthServer(server: TestingOAuthServer): HttpClient {
 
         }
     }
-    val engine = TestApplicationEngine(environment)
-    engine.start()
-    return HttpClient(TestHttpClientEngine.config { app = engine }) {
-        expectSuccess = false
+    with(TestApplicationEngine(environment)) {
+        start()
+        return client.config {
+            expectSuccess = false
+        }
     }
 }
 

--- a/ktor-features/ktor-auth/jvm/test/io/ktor/tests/auth/OAuth2.kt
+++ b/ktor-features/ktor-auth/jvm/test/io/ktor/tests/auth/OAuth2.kt
@@ -596,10 +596,11 @@ private fun createOAuth2Server(server: OAuth2Server): HttpClient {
             }
         }
     }
-    val engine = TestApplicationEngine(environment)
-    engine.start()
-    return HttpClient(TestHttpClientEngine.config { app = engine }) {
-        expectSuccess = false
+    with(TestApplicationEngine(environment)) {
+        start()
+        return client.config {
+            expectSuccess = false
+        }
     }
 }
 

--- a/ktor-features/ktor-auth/jvm/test/io/ktor/tests/auth/SessionAuthTest.kt
+++ b/ktor-features/ktor-auth/jvm/test/io/ktor/tests/auth/SessionAuthTest.kt
@@ -63,7 +63,7 @@ class SessionAuthTest {
             runBlocking {
                 val cookieStorage = AcceptAllCookiesStorage()
 
-                HttpClient(TestHttpClientEngine.create { this.app = this@withTestApplication }) {
+                client.config {
                     expectSuccess = false
                     install(HttpCookies) {
                         storage = cookieStorage
@@ -129,7 +129,7 @@ class SessionAuthTest {
             runBlocking {
                 val cookieStorage = AcceptAllCookiesStorage()
 
-                HttpClient(TestHttpClientEngine.create { this.app = this@withTestApplication }) {
+                client.config {
                     expectSuccess = false
                     install(HttpCookies) {
                         storage = cookieStorage

--- a/ktor-features/ktor-locations/jvm/test/io/ktor/tests/locations/OAuthLocationsTest.kt
+++ b/ktor-features/ktor-locations/jvm/test/io/ktor/tests/locations/OAuthLocationsTest.kt
@@ -24,7 +24,7 @@ class OAuthLocationsTest {
         application.install(Locations)
         application.install(Authentication) {
             oauth {
-                client = HttpClient(TestHttpClientEngine.config { app = this@withTestApplication })
+                client = this@withTestApplication.client
                 providerLookup = {
                     OAuthServerSettings.OAuth2ServerSettings("a", "http://oauth-server/auth",
                             "http://oauth-server/token",
@@ -55,7 +55,7 @@ class OAuthLocationsTest {
         application.install(Locations)
         application.install(Authentication) {
             oauth {
-                client = HttpClient(TestHttpClientEngine.config { app = this@withTestApplication })
+                client = this@withTestApplication.client
                 providerLookup = {
                     OAuthServerSettings.OAuth2ServerSettings("a", "http://oauth-server/auth",
                             "http://oauth-server/token",

--- a/ktor-server/ktor-server-test-host/jvm/src/io/ktor/server/testing/client/TestHttpClientEngine.kt
+++ b/ktor-server/ktor-server-test-host/jvm/src/io/ktor/server/testing/client/TestHttpClientEngine.kt
@@ -26,7 +26,6 @@ class TestHttpClientEngine(override val config: TestHttpClientConfig) : HttpClie
 
     private val clientJob: CompletableJob = Job(app.coroutineContext[Job])
 
-    override val dispatcher: CoroutineDispatcher = Dispatchers.IO
     override val coroutineContext: CoroutineContext = dispatcher + clientJob
 
     override suspend fun execute(data: HttpRequestData): HttpResponseData {


### PR DESCRIPTION
**Subsystem**
server, client, tests

**Motivation**
Currently, creating a test client in a test application is not that easy and counterintuitive. Sometimes, it is important to do create a test client rather than use `handleRequest`. For example, if you need relatively complex features such as serialization that can't be installed into `handleRequest` function.

**Solution**
Introduce a function and a property capturing test application server engine and providing a connected test client engine.

