### PR TITLE
Reduce required JDK version for DefaultHeaders feature

### DIFF
--- a/binary-compatibility-validator/reference-public-api/ktor-utils.txt
+++ b/binary-compatibility-validator/reference-public-api/ktor-utils.txt
@@ -479,6 +479,7 @@ public final class io/ktor/util/date/DateJvmKt {
 	public static final fun GMTDate (IIIILio/ktor/util/date/Month;I)Lio/ktor/util/date/GMTDate;
 	public static final fun GMTDate (Ljava/lang/Long;)Lio/ktor/util/date/GMTDate;
 	public static synthetic fun GMTDate$default (Ljava/lang/Long;ILjava/lang/Object;)Lio/ktor/util/date/GMTDate;
+	public static final fun toDate (Ljava/util/Calendar;Ljava/lang/Long;)Lio/ktor/util/date/GMTDate;
 	public static final fun toJvmDate (Lio/ktor/util/date/GMTDate;)Ljava/util/Date;
 }
 

--- a/ktor-server/ktor-server-tests/jvm/test/io/ktor/tests/server/features/DefaultHeadersTest.kt
+++ b/ktor-server/ktor-server-tests/jvm/test/io/ktor/tests/server/features/DefaultHeadersTest.kt
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2014-2019 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.tests.server.features
+
+import io.ktor.application.*
+import io.ktor.features.*
+import io.ktor.http.*
+import io.ktor.response.*
+import io.ktor.server.testing.*
+import kotlin.test.*
+
+class DefaultHeadersTest {
+    @Test
+    fun testDate(): Unit = withTestApplication {
+        var now = 1569882841014
+        application.install(DefaultHeaders) {
+            clock = { now }
+        }
+
+        application.intercept(ApplicationCallPipeline.Call) {
+            call.respondText("OK")
+        }
+
+        handleRequest(HttpMethod.Get, "/").let { call ->
+            assertEquals("Mon, 30 Sep 2019 22:34:01 GMT", call.response.headers[HttpHeaders.Date])
+        }
+
+        now += 999
+
+        handleRequest(HttpMethod.Get, "/").let { call ->
+            assertEquals("Mon, 30 Sep 2019 22:34:01 GMT", call.response.headers[HttpHeaders.Date])
+        }
+
+        now++
+
+        handleRequest(HttpMethod.Get, "/").let { call ->
+            assertEquals("Mon, 30 Sep 2019 22:34:02 GMT", call.response.headers[HttpHeaders.Date])
+        }
+    }
+
+    @Test
+    fun testCustomHeader(): Unit = withTestApplication {
+        application.install(DefaultHeaders) {
+            header("X-Test", "123")
+        }
+
+        handleRequest(HttpMethod.Get, "/").let { call ->
+            assertEquals("123", call.response.headers["X-Test"])
+        }
+    }
+
+    @Test
+    fun testDefaultServerHeader(): Unit = withTestApplication {
+        application.install(DefaultHeaders) {
+        }
+
+        handleRequest(HttpMethod.Get, "/").let { call ->
+            assertTrue { "ktor" in call.response.headers[HttpHeaders.Server]!! }
+        }
+    }
+
+    @Test
+    fun testCustomServerHeader(): Unit = withTestApplication {
+        application.install(DefaultHeaders) {
+            header(HttpHeaders.Server, "MyServer")
+        }
+
+        handleRequest(HttpMethod.Get, "/").let { call ->
+            assertEquals("MyServer", call.response.headers[HttpHeaders.Server])
+        }
+    }
+}

--- a/ktor-utils/jvm/src/io/ktor/util/date/DateJvm.kt
+++ b/ktor-utils/jvm/src/io/ktor/util/date/DateJvm.kt
@@ -4,6 +4,7 @@
 
 package io.ktor.util.date
 
+import io.ktor.util.*
 import java.util.*
 
 private val GMT_TIMEZONE = TimeZone.getTimeZone("GMT")
@@ -31,8 +32,8 @@ actual fun GMTDate(
     set(Calendar.MILLISECOND, 0)
 }.toDate(timestamp = null)
 
-
-private fun Calendar.toDate(timestamp: Long?): GMTDate {
+@InternalAPI
+fun Calendar.toDate(timestamp: Long?): GMTDate {
     timestamp?.let { timeInMillis = it }
 
     val seconds = get(Calendar.SECOND)


### PR DESCRIPTION
**Subsystem**
Server, [DefaultHeaders](https://ktor.io/servers/features/default-headers.html)

**Motivation**
Currently, [DefaultHeaders](https://ktor.io/servers/features/default-headers.html) feature requires JDK8 due to java.time dependency. However, the only we need is GMT time formatting.

#1369 java.lang.NoClassDefFoundError: Failed resolution of: Ljava/time/ZoneId;

**Solution**
Migrate to ktor's `GMTDate` with `Calendar` instantiation optimization.
