### PR TITLE
Send empty body on GET request

### DIFF
--- a/ktor-client/ktor-client-features/ktor-client-json/common/src/io/ktor/client/features/json/JsonFeature.kt
+++ b/ktor-client/ktor-client-features/ktor-client-json/common/src/io/ktor/client/features/json/JsonFeature.kt
@@ -10,6 +10,7 @@ import io.ktor.client.request.*
 import io.ktor.client.response.*
 import io.ktor.client.utils.*
 import io.ktor.http.*
+import io.ktor.http.content.*
 import io.ktor.util.*
 import io.ktor.utils.io.*
 
@@ -97,7 +98,10 @@ class JsonFeature internal constructor(
                 context.headers.remove(HttpHeaders.ContentType)
 
                 val serializedContent = when (payload) {
-                    is EmptyContent -> feature.serializer.write(Unit, contentType)
+                    is EmptyContent -> {
+                        if (context.method == HttpMethod.Get) EmptyContent
+                        else feature.serializer.write(Unit, contentType)
+                    }
                     else -> feature.serializer.write(payload, contentType)
                 }
 


### PR DESCRIPTION
**Subsystem**
Client, JsonFeature

**Motivation**
As mentioned in https://github.com/ktorio/ktor/issues/1365, When sending a GET request without any body, the resulting request still contains body as {}. But iOS 13 does not allow body content for GET requests, so as a result the client fails with error.

**Solution**
Send `EmptyContent` on GET request.

