### PR TITLE
Problem: PartialContent crashes with empty If-Range header

### DIFF
--- a/ktor-server/ktor-server-core/jvm/src/io/ktor/features/PartialContent.kt
+++ b/ktor-server/ktor-server-core/jvm/src/io/ktor/features/PartialContent.kt
@@ -109,7 +109,7 @@ class PartialContent(private val maxRangeCount: Int) {
         val versions = conditionalHeadersFeature?.versionsFor(content) ?: content.defaultVersions
         val ifRange = call.request.header(HttpHeaders.IfRange)
 
-        return ifRange == null || versions.all { version ->
+        return ifRange.isNullOrBlank() || versions.all { version ->
             when (version) {
                 is EntityTagVersion -> version.etag in ifRange.parseMatchTag()
                 is LastModifiedVersion -> version.lastModified <= ifRange.fromHttpToGmtDate()

--- a/ktor-server/ktor-server-tests/jvm/test/io/ktor/tests/server/features/PartialContentTest.kt
+++ b/ktor-server/ktor-server-tests/jvm/test/io/ktor/tests/server/features/PartialContentTest.kt
@@ -224,6 +224,16 @@ class PartialContentTest {
     }
 
     @Test
+    fun testDontCrashWithEmptyIfRange(): Unit = withRangeApplication { file ->
+        handleRequest(HttpMethod.Get, localPath) {
+            addHeader("Range", "bytes=573-")
+            addHeader("If-Range", "")
+        }.let { result ->
+            assertNull(result.response.headers[HttpHeaders.ContentLength])
+        }
+    }
+
+    @Test
     fun testMultipleMergedRanges(): Unit = withRangeApplication { file ->
         // multiple ranges should be merged into one
         handleRequest(HttpMethod.Get, localPath) {


### PR DESCRIPTION
**Subsystem**
Server, ktor-server-core

**Motivation**
PartialContent crashes with empty If-Range header (trying to parse it)

**Solution**
Dont' crash, check if If-Range is blank
