### PR TITLE
Conditional headers processing improvements

### DIFF
--- a/binary-compatibility-validator/reference-public-api/ktor-http.txt
+++ b/binary-compatibility-validator/reference-public-api/ktor-http.txt
@@ -1075,16 +1075,29 @@ public final class io/ktor/http/content/CachingOptionsKt {
 }
 
 public final class io/ktor/http/content/EntityTagVersion : io/ktor/http/content/Version {
-	public fun <init> (Ljava/lang/String;)V
+	public static final field Companion Lio/ktor/http/content/EntityTagVersion$Companion;
+	public synthetic fun <init> (Ljava/lang/String;)V
+	public fun <init> (Ljava/lang/String;Z)V
 	public fun appendHeadersTo (Lio/ktor/http/HeadersBuilder;)V
 	public fun check (Lio/ktor/http/Headers;)Lio/ktor/http/content/VersionCheckResult;
 	public final fun component1 ()Ljava/lang/String;
-	public final fun copy (Ljava/lang/String;)Lio/ktor/http/content/EntityTagVersion;
-	public static synthetic fun copy$default (Lio/ktor/http/content/EntityTagVersion;Ljava/lang/String;ILjava/lang/Object;)Lio/ktor/http/content/EntityTagVersion;
+	public final fun component2 ()Z
+	public final fun copy (Ljava/lang/String;Z)Lio/ktor/http/content/EntityTagVersion;
+	public static synthetic fun copy$default (Lio/ktor/http/content/EntityTagVersion;Ljava/lang/String;ZILjava/lang/Object;)Lio/ktor/http/content/EntityTagVersion;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getEtag ()Ljava/lang/String;
+	public final fun getWeak ()Z
 	public fun hashCode ()I
+	public final fun match (Lio/ktor/http/content/EntityTagVersion;)Z
+	public final fun match (Ljava/util/List;)Lio/ktor/http/content/VersionCheckResult;
+	public final fun noneMatch (Ljava/util/List;)Lio/ktor/http/content/VersionCheckResult;
 	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/ktor/http/content/EntityTagVersion$Companion {
+	public final fun getSTAR ()Lio/ktor/http/content/EntityTagVersion;
+	public final fun parse (Ljava/lang/String;)Ljava/util/List;
+	public final fun parseSingle (Ljava/lang/String;)Lio/ktor/http/content/EntityTagVersion;
 }
 
 public final class io/ktor/http/content/LastModifiedVersion : io/ktor/http/content/Version {
@@ -1098,6 +1111,8 @@ public final class io/ktor/http/content/LastModifiedVersion : io/ktor/http/conte
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getLastModified ()Lio/ktor/util/date/GMTDate;
 	public fun hashCode ()I
+	public final fun ifModifiedSince (Ljava/util/List;)Z
+	public final fun ifUnmodifiedSince (Ljava/util/List;)Z
 	public fun toString ()Ljava/lang/String;
 }
 
@@ -1225,6 +1240,7 @@ public final class io/ktor/http/content/VersionCheckResult : java/lang/Enum {
 }
 
 public final class io/ktor/http/content/VersionsKt {
+	public static final fun EntityTagVersion (Ljava/lang/String;)Lio/ktor/http/content/EntityTagVersion;
 	public static final fun getVersionListProperty ()Lio/ktor/util/AttributeKey;
 	public static final fun getVersions (Lio/ktor/http/content/OutgoingContent;)Ljava/util/List;
 	public static final fun setVersions (Lio/ktor/http/content/OutgoingContent;Ljava/util/List;)V

--- a/ktor-features/ktor-freemarker/jvm/test/io/ktor/tests/freemarker/FreeMarkerTest.kt
+++ b/ktor-features/ktor-freemarker/jvm/test/io/ktor/tests/freemarker/FreeMarkerTest.kt
@@ -38,7 +38,7 @@ class FreeMarkerTest {
                 }
                 val contentTypeText = assertNotNull(response.headers[HttpHeaders.ContentType])
                 assertEquals(ContentType.Text.Html.withCharset(Charsets.UTF_8), ContentType.parse(contentTypeText))
-                assertEquals("e", response.headers[HttpHeaders.ETag])
+                assertEquals("\"e\"", response.headers[HttpHeaders.ETag])
             }
         }
     }
@@ -91,7 +91,7 @@ class FreeMarkerTest {
                 }
                 val contentTypeText = assertNotNull(response.headers[HttpHeaders.ContentType])
                 assertEquals(ContentType.Text.Html.withCharset(Charsets.UTF_8), ContentType.parse(contentTypeText))
-                assertEquals("e", response.headers[HttpHeaders.ETag])
+                assertEquals("\"e\"", response.headers[HttpHeaders.ETag])
             }
         }
     }

--- a/ktor-features/ktor-mustache/jvm/test/io/ktor/mustache/MustacheTest.kt
+++ b/ktor-features/ktor-mustache/jvm/test/io/ktor/mustache/MustacheTest.kt
@@ -69,7 +69,7 @@ class MustacheTest {
                 }
             }
 
-            assertEquals("e", handleRequest(HttpMethod.Get, "/").response.headers[HttpHeaders.ETag])
+            assertEquals("\"e\"", handleRequest(HttpMethod.Get, "/").response.headers[HttpHeaders.ETag])
         }
     }
 

--- a/ktor-features/ktor-thymeleaf/jvm/test/it/ktor/thymeleaf/ThymeleafTest.kt
+++ b/ktor-features/ktor-thymeleaf/jvm/test/it/ktor/thymeleaf/ThymeleafTest.kt
@@ -51,7 +51,7 @@ class ThymeleafTest {
                 })
                 val contentTypeText = assertNotNull(response.headers[HttpHeaders.ContentType])
                 assertEquals(ContentType.Text.Html.withCharset(Charsets.UTF_8), ContentType.parse(contentTypeText))
-                assertEquals("e", response.headers[HttpHeaders.ETag])
+                assertEquals("\"e\"", response.headers[HttpHeaders.ETag])
             }
         }
     }
@@ -81,7 +81,7 @@ class ThymeleafTest {
                 })
                 val contentTypeText = assertNotNull(response.headers[HttpHeaders.ContentType])
                 assertEquals(ContentType.Text.Html.withCharset(Charsets.UTF_8), ContentType.parse(contentTypeText))
-                assertEquals("e", response.headers[HttpHeaders.ETag])
+                assertEquals("\"e\"", response.headers[HttpHeaders.ETag])
             }
         }
     }

--- a/ktor-features/ktor-velocity/jvm/test/io/ktor/tests/velocity/VelocityTest.kt
+++ b/ktor-features/ktor-velocity/jvm/test/io/ktor/tests/velocity/VelocityTest.kt
@@ -39,7 +39,7 @@ class VelocityTest {
                 }
                 val contentTypeText = assertNotNull(response.headers[HttpHeaders.ContentType])
                 assertEquals(ContentType.Text.Html.withCharset(Charsets.UTF_8), ContentType.parse(contentTypeText))
-                assertEquals("e", response.headers[HttpHeaders.ETag])
+                assertEquals("\"e\"", response.headers[HttpHeaders.ETag])
             }
         }
     }
@@ -69,7 +69,7 @@ class VelocityTest {
                 }
                 val contentTypeText = assertNotNull(response.headers[HttpHeaders.ContentType])
                 assertEquals(ContentType.Text.Html.withCharset(Charsets.UTF_8), ContentType.parse(contentTypeText))
-                assertEquals("e", response.headers[HttpHeaders.ETag])
+                assertEquals("\"e\"", response.headers[HttpHeaders.ETag])
             }
         }
     }

--- a/ktor-server/ktor-server-tests/jvm/test/io/ktor/tests/server/features/ConditionalHeadersTests.kt
+++ b/ktor-server/ktor-server-tests/jvm/test/io/ktor/tests/server/features/ConditionalHeadersTests.kt
@@ -38,28 +38,28 @@ class ETagsTest {
     }
 
     @Test
-    fun testNoConditions() = withConditionalApplication {
+    fun testNoConditions(): Unit = withConditionalApplication {
         val result = handleRequest {}
         assertTrue(result.requestHandled)
         assertEquals(HttpStatusCode.OK, result.response.status())
         assertEquals("response", result.response.content)
-        assertEquals("tag1", result.response.headers[HttpHeaders.ETag])
+        assertEquals("\"tag1\"", result.response.headers[HttpHeaders.ETag])
     }
 
 
     @Test
-    fun testIfMatchConditionAccepted() = withConditionalApplication {
+    fun testIfMatchConditionAccepted(): Unit = withConditionalApplication {
         val result = handleRequest {
             addHeader(HttpHeaders.IfMatch, "tag1")
         }
         assertTrue(result.requestHandled)
         assertEquals(HttpStatusCode.OK, result.response.status())
         assertEquals("response", result.response.content)
-        assertEquals("tag1", result.response.headers[HttpHeaders.ETag])
+        assertEquals("\"tag1\"", result.response.headers[HttpHeaders.ETag])
     }
 
     @Test
-    fun testIfMatchConditionFailed() = withConditionalApplication {
+    fun testIfMatchConditionFailed(): Unit = withConditionalApplication {
         val result = handleRequest {
             addHeader(HttpHeaders.IfMatch, "tag2")
         }
@@ -68,7 +68,7 @@ class ETagsTest {
     }
 
     @Test
-    fun testIfNoneMatchConditionAccepted() = withConditionalApplication {
+    fun testIfNoneMatchConditionAccepted(): Unit = withConditionalApplication {
         val result = handleRequest {
             addHeader(HttpHeaders.IfNoneMatch, "tag1")
         }
@@ -77,7 +77,7 @@ class ETagsTest {
     }
 
     @Test
-    fun testIfNoneMatchWeakConditionAccepted() = withConditionalApplication {
+    fun testIfNoneMatchWeakConditionAccepted(): Unit = withConditionalApplication {
         val result = handleRequest {
             addHeader(HttpHeaders.IfNoneMatch, "W/tag1")
         }
@@ -86,29 +86,29 @@ class ETagsTest {
     }
 
     @Test
-    fun testIfNoneMatchConditionFailed() = withConditionalApplication {
+    fun testIfNoneMatchConditionFailed(): Unit = withConditionalApplication {
         val result = handleRequest {
             addHeader(HttpHeaders.IfNoneMatch, "tag2")
         }
         assertTrue(result.requestHandled)
         assertEquals(HttpStatusCode.OK, result.response.status())
         assertEquals("response", result.response.content)
-        assertEquals("tag1", result.response.headers[HttpHeaders.ETag])
+        assertEquals("\"tag1\"", result.response.headers[HttpHeaders.ETag])
     }
 
     @Test
-    fun testIfMatchStar() = withConditionalApplication {
+    fun testIfMatchStar(): Unit = withConditionalApplication {
         val result = handleRequest {
             addHeader(HttpHeaders.IfMatch, "*")
         }
         assertTrue(result.requestHandled)
         assertEquals(HttpStatusCode.OK, result.response.status())
         assertEquals("response", result.response.content)
-        assertEquals("tag1", result.response.headers[HttpHeaders.ETag])
+        assertEquals("\"tag1\"", result.response.headers[HttpHeaders.ETag])
     }
 
     @Test
-    fun testIfNoneMatchStar() = withConditionalApplication {
+    fun testIfNoneMatchStar(): Unit = withConditionalApplication {
         val result = handleRequest {
             addHeader(HttpHeaders.IfNoneMatch, "*")
         }
@@ -120,7 +120,7 @@ class ETagsTest {
     }
 
     @Test
-    fun testIfNoneMatchListConditionFailed() = withConditionalApplication {
+    fun testIfNoneMatchListConditionFailed(): Unit = withConditionalApplication {
         val result = handleRequest {
             addHeader(HttpHeaders.IfNoneMatch, "tag0,tag1,tag3")
         }
@@ -129,29 +129,29 @@ class ETagsTest {
     }
 
     @Test
-    fun testIfNoneMatchListConditionSuccess() = withConditionalApplication {
+    fun testIfNoneMatchListConditionSuccess(): Unit = withConditionalApplication {
         val result = handleRequest {
             addHeader(HttpHeaders.IfNoneMatch, "tag2")
         }
         assertTrue(result.requestHandled)
         assertEquals(HttpStatusCode.OK, result.response.status())
         assertEquals("response", result.response.content)
-        assertEquals("tag1", result.response.headers[HttpHeaders.ETag])
+        assertEquals("\"tag1\"", result.response.headers[HttpHeaders.ETag])
     }
 
     @Test
-    fun testIfMatchListConditionAccepted() = withConditionalApplication {
+    fun testIfMatchListConditionAccepted(): Unit = withConditionalApplication {
         val result = handleRequest {
             addHeader(HttpHeaders.IfMatch, "tag0,tag1,tag3")
         }
         assertTrue(result.requestHandled)
         assertEquals(HttpStatusCode.OK, result.response.status())
         assertEquals("response", result.response.content)
-        assertEquals("tag1", result.response.headers[HttpHeaders.ETag])
+        assertEquals("\"tag1\"", result.response.headers[HttpHeaders.ETag])
     }
 
     @Test
-    fun testIfMatchListConditionFailed() = withConditionalApplication {
+    fun testIfMatchListConditionFailed(): Unit = withConditionalApplication {
         val result = handleRequest {
             addHeader(HttpHeaders.IfMatch, "tag0,tag2,tag3")
         }
@@ -166,7 +166,8 @@ class LastModifiedTest(@Suppress("UNUSED_PARAMETER") name: String, zone: ZoneId)
     companion object {
         @JvmStatic
         @Parameterized.Parameters(name = "{0}")
-        fun zones(): List<Array<Any>> = listOf(arrayOf<Any>("GMT", ZoneId.of("GMT")), arrayOf<Any>("SomeLocal", ZoneId.of("GMT+1")))
+        fun zones(): List<Array<Any>> =
+            listOf(arrayOf<Any>("GMT", ZoneId.of("GMT")), arrayOf<Any>("SomeLocal", ZoneId.of("GMT+1")))
     }
 
     private val date = ZonedDateTime.now(zone)!!
@@ -185,7 +186,7 @@ class LastModifiedTest(@Suppress("UNUSED_PARAMETER") name: String, zone: ZoneId)
     }
 
     @Test
-    fun testNoHeaders() = withConditionalApplication {
+    fun testNoHeaders(): Unit = withConditionalApplication {
         handleRequest(HttpMethod.Get, "/").let { result ->
             assertEquals(HttpStatusCode.OK, result.response.status())
             assertEquals("response", result.response.content)
@@ -193,8 +194,13 @@ class LastModifiedTest(@Suppress("UNUSED_PARAMETER") name: String, zone: ZoneId)
     }
 
     @Test
-    fun testIfModifiedSinceEq() = withConditionalApplication {
-        handleRequest(HttpMethod.Get, "/", { addHeader(HttpHeaders.IfModifiedSince, date.toHttpDateString()) }).let { result ->
+    fun testIfModifiedSinceEq(): Unit = withConditionalApplication {
+        handleRequest(HttpMethod.Get, "/") {
+            addHeader(
+                HttpHeaders.IfModifiedSince,
+                date.toHttpDateString()
+            )
+        }.let { result ->
             assertEquals(HttpStatusCode.NotModified, result.response.status())
             assertNull(result.response.content)
         }
@@ -212,7 +218,12 @@ class LastModifiedTest(@Suppress("UNUSED_PARAMETER") name: String, zone: ZoneId)
                 }
             }
 
-            handleRequest(HttpMethod.Get, "/", { addHeader(HttpHeaders.IfModifiedSince, date.toHttpDateString()) }).let { result ->
+            handleRequest(HttpMethod.Get, "/") {
+                addHeader(
+                    HttpHeaders.IfModifiedSince,
+                    date.toHttpDateString()
+                )
+            }.let { result ->
                 assertEquals(HttpStatusCode.NotModified, result.response.status())
                 assertNull(result.response.content)
             }
@@ -220,72 +231,287 @@ class LastModifiedTest(@Suppress("UNUSED_PARAMETER") name: String, zone: ZoneId)
     }
 
     @Test
-    fun testIfModifiedSinceLess() = withConditionalApplication {
-        handleRequest(HttpMethod.Get, "/", { addHeader(HttpHeaders.IfModifiedSince, date.minusDays(1).toHttpDateString()) }).let { result ->
+    fun testIfModifiedSinceLess(): Unit = withConditionalApplication {
+        handleRequest(HttpMethod.Get, "/") {
+            addHeader(
+                HttpHeaders.IfModifiedSince,
+                date.minusDays(1).toHttpDateString()
+            )
+        }.let { result ->
             assertEquals(HttpStatusCode.OK, result.response.status())
             assertEquals("response", result.response.content)
         }
     }
 
     @Test
-    fun testIfModifiedSinceGt() = withConditionalApplication {
-        handleRequest(HttpMethod.Get, "/", { addHeader(HttpHeaders.IfModifiedSince, date.plusDays(1).toHttpDateString()) }).let { result ->
+    fun testIfModifiedSinceGt(): Unit = withConditionalApplication {
+        handleRequest(HttpMethod.Get, "/") {
+            addHeader(
+                HttpHeaders.IfModifiedSince,
+                date.plusDays(1).toHttpDateString()
+            )
+        }.let { result ->
             assertEquals(HttpStatusCode.NotModified, result.response.status())
             assertNull(result.response.content)
-        }
-    }
-
-    // this test is disabled since non-GMT timezones are strictly prohibited by the specification
-    fun testIfModifiedSinceTimeZoned() = withConditionalApplication {
-        val expectedDate = date.toHttpDateString()
-        val customFormat = httpDateFormat.withZone(ZoneId.of("Europe/Moscow"))!!
-
-        handleRequest(HttpMethod.Get, "/", { addHeader(HttpHeaders.IfModifiedSince, customFormat.format(date).replace("MT", "MSK")) }).let { result ->
-            assertEquals(HttpStatusCode.NotModified, result.response.status())
-            assertNull(result.response.content)
-        }
-
-        handleRequest(HttpMethod.Get, "/", { addHeader(HttpHeaders.IfModifiedSince, customFormat.format(date.plusDays(1)).replace("MT", "MSK")) }).let { result ->
-            assertEquals(HttpStatusCode.NotModified, result.response.status())
-            assertNull(result.response.content)
-        }
-
-        handleRequest(HttpMethod.Get, "/", { addHeader(HttpHeaders.IfModifiedSince, customFormat.format(date.minusDays(1)).replace("MT", "MSK")) }).let { result ->
-            assertEquals(HttpStatusCode.OK, result.response.status())
-            assertEquals("response", result.response.content)
-            assertEquals(expectedDate, result.response.headers[HttpHeaders.LastModified])
         }
     }
 
     @Test
-    fun testIfUnModifiedSinceEq() = withConditionalApplication {
-        handleRequest(HttpMethod.Get, "/", { addHeader(HttpHeaders.IfUnmodifiedSince, date.toHttpDateString()) }).let { result ->
+    fun testIfUnModifiedSinceEq(): Unit = withConditionalApplication {
+        handleRequest(HttpMethod.Get, "/") {
+            addHeader(
+                HttpHeaders.IfUnmodifiedSince,
+                date.toHttpDateString()
+            )
+        }.let { result ->
             assertEquals(HttpStatusCode.OK, result.response.status())
             assertEquals("response", result.response.content)
         }
     }
 
     @Test
-    fun testIfUnModifiedSinceLess() = withConditionalApplication {
-        handleRequest(HttpMethod.Get, "/", { addHeader(HttpHeaders.IfUnmodifiedSince, date.minusDays(1).toHttpDateString()) }).let { result ->
+    fun testIfUnModifiedSinceLess(): Unit = withConditionalApplication {
+        handleRequest(HttpMethod.Get, "/") {
+            addHeader(
+                HttpHeaders.IfUnmodifiedSince,
+                date.minusDays(1).toHttpDateString()
+            )
+        }.let { result ->
             assertEquals(HttpStatusCode.PreconditionFailed, result.response.status())
             assertNull(result.response.content)
         }
     }
 
     @Test
-    fun testIfUnModifiedSinceGt() = withConditionalApplication {
-        handleRequest(HttpMethod.Get, "/", { addHeader(HttpHeaders.IfUnmodifiedSince, date.plusDays(1).toHttpDateString()) }).let { result ->
+    fun testIfUnModifiedSinceGt(): Unit = withConditionalApplication {
+        handleRequest(HttpMethod.Get, "/") {
+            addHeader(
+                HttpHeaders.IfUnmodifiedSince,
+                date.plusDays(1).toHttpDateString()
+            )
+        }.let { result ->
             assertEquals(HttpStatusCode.OK, result.response.status())
             assertEquals("response", result.response.content)
+        }
+    }
+
+    @Test
+    fun testIfUnmodifiedSinceIllegal(): Unit = withConditionalApplication {
+        handleRequest(HttpMethod.Get, "/") {
+            addHeader(
+                HttpHeaders.IfUnmodifiedSince,
+                "zzz"
+            )
+        }.let { result ->
+            assertEquals(HttpStatusCode.OK, result.response.status())
+            assertEquals("response", result.response.content)
+        }
+
+        handleRequest(HttpMethod.Get, "/") {
+            addHeader(
+                HttpHeaders.IfUnmodifiedSince,
+                "zzz"
+            )
+            addHeader(
+                HttpHeaders.IfUnmodifiedSince,
+                date.toHttpDateString()
+            )
+        }.let { result ->
+            assertEquals(HttpStatusCode.OK, result.response.status())
+            assertEquals("response", result.response.content)
+        }
+
+        handleRequest(HttpMethod.Get, "/") {
+            addHeader(
+                HttpHeaders.IfUnmodifiedSince,
+                "zzz"
+            )
+            addHeader(
+                HttpHeaders.IfUnmodifiedSince,
+                date.plusDays(1).toHttpDateString()
+            )
+        }.let { result ->
+            assertEquals(HttpStatusCode.OK, result.response.status())
+            assertEquals("response", result.response.content)
+        }
+
+        handleRequest(HttpMethod.Get, "/") {
+            addHeader(
+                HttpHeaders.IfUnmodifiedSince,
+                "zzz"
+            )
+            addHeader(
+                HttpHeaders.IfUnmodifiedSince,
+                date.plusDays(-1).toHttpDateString()
+            )
+        }.let { result ->
+            assertEquals(HttpStatusCode.PreconditionFailed, result.response.status())
+            assertEquals(null, result.response.content)
+        }
+    }
+
+    @Test
+    fun testIfUnmodifiedSinceMultiple(): Unit = withConditionalApplication {
+        handleRequest(HttpMethod.Get, "/") {
+            addHeader(
+                HttpHeaders.IfUnmodifiedSince,
+                ""
+            )
+        }.let { result ->
+            assertEquals(HttpStatusCode.OK, result.response.status())
+            assertEquals("response", result.response.content)
+        }
+
+        handleRequest(HttpMethod.Get, "/") {
+            addHeader(
+                HttpHeaders.IfUnmodifiedSince,
+                date.plusDays(1).toHttpDateString()
+            )
+            addHeader(
+                HttpHeaders.IfUnmodifiedSince,
+                date.plusDays(2).toHttpDateString()
+            )
+        }.let { result ->
+            assertEquals(HttpStatusCode.OK, result.response.status())
+            assertEquals("response", result.response.content)
+        }
+
+        handleRequest(HttpMethod.Get, "/") {
+            addHeader(
+                HttpHeaders.IfUnmodifiedSince,
+                date.plusDays(-1).toHttpDateString()
+            )
+            addHeader(
+                HttpHeaders.IfUnmodifiedSince,
+                date.plusDays(2).toHttpDateString()
+            )
+        }.let { result ->
+            assertEquals(HttpStatusCode.PreconditionFailed, result.response.status())
+            assertNull(result.response.content)
+        }
+    }
+
+    @Test
+    fun testIfModifiedSinceMultiple(): Unit = withConditionalApplication {
+        handleRequest(HttpMethod.Get, "/") {
+            addHeader(
+                HttpHeaders.IfModifiedSince,
+                ""
+            )
+        }.let { result ->
+            assertEquals(HttpStatusCode.OK, result.response.status())
+            assertEquals("response", result.response.content)
+        }
+
+        handleRequest(HttpMethod.Get, "/") {
+            addHeader(
+                HttpHeaders.IfModifiedSince,
+                date.plusDays(-1).toHttpDateString()
+            )
+            addHeader(
+                HttpHeaders.IfModifiedSince,
+                date.plusDays(2).toHttpDateString()
+            )
+        }.let { result ->
+            assertEquals(HttpStatusCode.OK, result.response.status())
+            assertEquals("response", result.response.content)
+        }
+
+        handleRequest(HttpMethod.Get, "/") {
+            addHeader(
+                HttpHeaders.IfModifiedSince,
+                date.plusDays(1).toHttpDateString()
+            )
+            addHeader(
+                HttpHeaders.IfModifiedSince,
+                date.plusDays(2).toHttpDateString()
+            )
+        }.let { result ->
+            assertEquals(HttpStatusCode.NotModified, result.response.status())
+            assertNull(result.response.content)
+        }
+    }
+
+    @Test
+    fun testBoth(): Unit = withConditionalApplication {
+        handleRequest(HttpMethod.Get, "/") {
+            addHeader(
+                HttpHeaders.IfModifiedSince,
+                ""
+            )
+            addHeader(
+                HttpHeaders.IfUnmodifiedSince,
+                ""
+            )
+        }.let { result ->
+            assertEquals(HttpStatusCode.OK, result.response.status())
+            assertEquals("response", result.response.content)
+        }
+
+        handleRequest(HttpMethod.Get, "/") {
+            addHeader(
+                HttpHeaders.IfModifiedSince,
+                date.plusDays(-1).toHttpDateString()
+            )
+            addHeader(
+                HttpHeaders.IfUnmodifiedSince,
+                date.plusDays(1).toHttpDateString()
+            )
+        }.let { result ->
+            assertEquals(HttpStatusCode.OK, result.response.status())
+            assertEquals("response", result.response.content)
+        }
+
+        handleRequest(HttpMethod.Get, "/") {
+            addHeader(
+                HttpHeaders.IfModifiedSince,
+                date.plusDays(-1).toHttpDateString()
+            )
+            addHeader(
+                HttpHeaders.IfUnmodifiedSince,
+                date.plusDays(-1).toHttpDateString()
+            )
+        }.let { result ->
+            assertEquals(HttpStatusCode.PreconditionFailed, result.response.status())
+            assertEquals(null, result.response.content)
+        }
+
+        handleRequest(HttpMethod.Get, "/") {
+            addHeader(
+                HttpHeaders.IfModifiedSince,
+                date.plusDays(1).toHttpDateString()
+            )
+            addHeader(
+                HttpHeaders.IfUnmodifiedSince,
+                date.plusDays(1).toHttpDateString()
+            )
+        }.let { result ->
+            assertEquals(HttpStatusCode.NotModified, result.response.status())
+            assertEquals(null, result.response.content)
+        }
+
+        handleRequest(HttpMethod.Get, "/") {
+            addHeader(
+                HttpHeaders.IfModifiedSince,
+                date.plusDays(1).toHttpDateString()
+            )
+            addHeader(
+                HttpHeaders.IfUnmodifiedSince,
+                date.plusDays(-1).toHttpDateString()
+            )
+        }.let { result ->
+            // both conditions are not met but actually it is not clear which one should win
+            // so we declare the order
+            assertEquals(HttpStatusCode.NotModified, result.response.status())
+            assertEquals(null, result.response.content)
         }
     }
 }
 
 
 class LastModifiedVersionTest {
-    private fun temporaryDefaultTimezone(timeZone : TimeZone, block : () -> Unit) {
-        val originalTimeZone : TimeZone = TimeZone.getDefault()
+    private fun temporaryDefaultTimezone(timeZone: TimeZone, block: () -> Unit) {
+        val originalTimeZone: TimeZone = TimeZone.getDefault()
         TimeZone.setDefault(timeZone)
         try {
             block()
@@ -294,15 +520,18 @@ class LastModifiedVersionTest {
         }
     }
 
-    private fun checkLastModifiedHeaderIsIndependentOfLocalTimezone(constructLastModifiedVersion : (Date) -> LastModifiedVersion) {
+    private fun checkLastModifiedHeaderIsIndependentOfLocalTimezone(constructLastModifiedVersion: (Date) -> LastModifiedVersion) {
         // setup: any non-zero-offset-Timezone will do
         temporaryDefaultTimezone(TimeZone.getTimeZone("GMT+08:00")) {
 
             // guard: local default timezone needs to be different from GMT for the problem to manifest
-            assertTrue(TimeZone.getDefault().rawOffset != 0, "invalid test setup - local timezone is GMT: ${TimeZone.getDefault()}")
+            assertTrue(
+                TimeZone.getDefault().rawOffset != 0,
+                "invalid test setup - local timezone is GMT: ${TimeZone.getDefault()}"
+            )
 
             // setup: last modified for file
-            val expectedLastModified : Date = SimpleDateFormat("yyyy-MM-dd HH:mm:ss z").parse("2018-03-04 15:12:23 GMT")
+            val expectedLastModified: Date = SimpleDateFormat("yyyy-MM-dd HH:mm:ss z").parse("2018-03-04 15:12:23 GMT")
 
             // setup: object to test
             val lastModifiedVersion = constructLastModifiedVersion(expectedLastModified)
@@ -320,26 +549,26 @@ class LastModifiedVersionTest {
 
     @Test
     fun lastModifiedHeaderFromDateIsIndependentOfLocalTimezone() {
-        checkLastModifiedHeaderIsIndependentOfLocalTimezone { input : Date ->
+        checkLastModifiedHeaderIsIndependentOfLocalTimezone { input: Date ->
             LastModifiedVersion(input)
         }
     }
 
     @Test
     fun lastModifiedHeaderFromLocalDateTimeIsIndependentOfLocalTimezone() {
-        checkLastModifiedHeaderIsIndependentOfLocalTimezone { input : Date ->
+        checkLastModifiedHeaderIsIndependentOfLocalTimezone { input: Date ->
             LastModifiedVersion(ZonedDateTime.ofInstant(input.toInstant(), ZoneId.systemDefault()))
         }
     }
 
     @get:Rule
-    val temporaryFolder = TemporaryFolder()
+    val temporaryFolder: TemporaryFolder = TemporaryFolder()
 
     @Test
     fun lastModifiedHeaderFromFileTimeIsIndependentOfLocalTimezone() {
-        checkLastModifiedHeaderIsIndependentOfLocalTimezone { input : Date ->
+        checkLastModifiedHeaderIsIndependentOfLocalTimezone { input: Date ->
             // setup: create file
-            val file : File = temporaryFolder.newFile("foo.txt").apply {
+            val file: File = temporaryFolder.newFile("foo.txt").apply {
                 setLastModified(input.time)
             }
 

--- a/ktor-server/ktor-server-tests/jvm/test/io/ktor/tests/server/features/PartialContentTest.kt
+++ b/ktor-server/ktor-server-tests/jvm/test/io/ktor/tests/server/features/PartialContentTest.kt
@@ -237,6 +237,16 @@ class PartialContentTest {
         }
     }
 
+    @Test
+    fun testDontCrashWithEmptyIfRange(): Unit = withRangeApplication { file ->
+        handleRequest(HttpMethod.Get, localPath) {
+            addHeader("Range", "bytes=573-")
+            addHeader("If-Range", "")
+        }.let { result ->
+            assertNull(result.response.headers[HttpHeaders.ContentLength])
+        }
+    }
+
     private fun assertMultipart(result: TestApplicationCall, block: (List<String>) -> Unit) {
         assertTrue(result.requestHandled)
         assertEquals(HttpStatusCode.PartialContent, result.response.status())

--- a/ktor-server/ktor-server-tests/jvm/test/io/ktor/tests/server/features/PartialContentTest.kt
+++ b/ktor-server/ktor-server-tests/jvm/test/io/ktor/tests/server/features/PartialContentTest.kt
@@ -11,6 +11,7 @@ import io.ktor.http.*
 import io.ktor.response.*
 import io.ktor.routing.*
 import io.ktor.server.testing.*
+import io.ktor.util.date.*
 import org.junit.Test
 import java.io.*
 import java.util.*
@@ -22,8 +23,9 @@ class PartialContentTest {
         .first(File::exists)
 
     private val localPath = "features/StaticContentTest.kt"
+    private val fileEtag = "etag-99"
 
-    private fun withRangeApplication(maxRangeCount: Int? = null, test: TestApplicationEngine.(File) -> Unit) =
+    private fun withRangeApplication(maxRangeCount: Int? = null, test: TestApplicationEngine.(File) -> Unit): Unit =
         withTestApplication {
             application.install(ConditionalHeaders)
             application.install(CachingHeaders)
@@ -36,7 +38,9 @@ class PartialContentTest {
                     handle {
                         val file = basedir.resolve(localPath)
                         if (file.isFile) {
-                            call.respond(LocalFileContent(file))
+                            call.respond(LocalFileContent(file).apply {
+                                versions += EntityTagVersion(fileEtag)
+                            })
                         }
                     }
                 }
@@ -240,10 +244,72 @@ class PartialContentTest {
     @Test
     fun testDontCrashWithEmptyIfRange(): Unit = withRangeApplication { file ->
         handleRequest(HttpMethod.Get, localPath) {
-            addHeader("Range", "bytes=573-")
-            addHeader("If-Range", "")
+            addHeader(HttpHeaders.Range, "bytes=1-2")
+            addHeader(HttpHeaders.IfRange, "")
         }.let { result ->
-            assertNull(result.response.headers[HttpHeaders.ContentLength])
+            assertEquals(HttpStatusCode.PartialContent, result.response.status())
+            assertEquals("bytes 1-2/${file.length()}", result.response.headers[HttpHeaders.ContentRange])
+        }
+    }
+
+    @Test
+    fun testIfRangeETag(): Unit = withRangeApplication { file ->
+        handleRequest(HttpMethod.Get, localPath) {
+            addHeader(HttpHeaders.Range, "bytes=1-2")
+            addHeader(HttpHeaders.IfRange, "\"$fileEtag\"")
+        }.let { result ->
+            assertEquals(HttpStatusCode.PartialContent, result.response.status())
+            assertEquals("bytes 1-2/${file.length()}", result.response.headers[HttpHeaders.ContentRange])
+        }
+
+        handleRequest(HttpMethod.Get, localPath) {
+            addHeader(HttpHeaders.Range, "bytes=1-2")
+            addHeader(HttpHeaders.IfRange, "\"wrong-$fileEtag\"")
+        }.let { result ->
+            assertEquals(HttpStatusCode.OK, result.response.status())
+            assertEquals(null, result.response.headers[HttpHeaders.ContentRange])
+        }
+    }
+
+    @Test
+    fun testIfRangeDate(): Unit = withRangeApplication { file ->
+        val fileDate = GMTDate(file.lastModified())
+
+        handleRequest(HttpMethod.Get, localPath) {
+            addHeader(HttpHeaders.Range, "bytes=1-2")
+            addHeader(HttpHeaders.IfRange, fileDate.toHttpDate())
+        }.let { result ->
+            assertEquals(HttpStatusCode.PartialContent, result.response.status())
+            assertEquals("bytes 1-2/${file.length()}", result.response.headers[HttpHeaders.ContentRange])
+        }
+
+        handleRequest(HttpMethod.Get, localPath) {
+            addHeader(HttpHeaders.Range, "bytes=1-2")
+            addHeader(HttpHeaders.IfRange, fileDate.plus(10000).toHttpDate())
+        }.let { result ->
+            assertEquals(HttpStatusCode.PartialContent, result.response.status())
+            assertEquals("bytes 1-2/${file.length()}", result.response.headers[HttpHeaders.ContentRange])
+        }
+
+        handleRequest(HttpMethod.Get, localPath) {
+            addHeader(HttpHeaders.Range, "bytes=1-2")
+            addHeader(HttpHeaders.IfRange, fileDate.minus(100000).toHttpDate())
+        }.let { result ->
+            assertEquals(HttpStatusCode.OK, result.response.status())
+            assertEquals(null, result.response.headers[HttpHeaders.ContentRange])
+        }
+    }
+
+    @Test
+    fun testIfRangeWrongDate(): Unit = withRangeApplication { file ->
+        val fileDate = GMTDate(file.lastModified())
+
+        handleRequest(HttpMethod.Get, localPath) {
+            addHeader(HttpHeaders.Range, "bytes=1-2")
+            addHeader(HttpHeaders.IfRange, fileDate.toHttpDate().drop(15))
+        }.let { result ->
+            assertEquals(HttpStatusCode.OK, result.response.status())
+            assertEquals(null, result.response.headers[HttpHeaders.ContentRange])
         }
     }
 


### PR DESCRIPTION
**Subsystem**
Server, `PartialContent`, `ConditionalHeaders`

**Motivation**
This is done as a followup for #1377 .

Currently, we are failing if conditional date headers (`If-Modified-Since`, `If-Unmodified-Since` and `If-Range`) have empty or broken values. However, according to RFC's such values need to be ignored or should lead to the particular condition evaluation result.

Also, many headers could be potentially repeatable so we need to support it. E-Tag could be repeated and/or have a concatenated value of multiple entity-tags. So we should consider all values during evaluation. Unlike entity-tags related headers, date header could not be concatenated because HTTP date contains commas inside so such headers are always repeated.

The other dangerous point is that `If-Range` could have an entity-tag or a date.

**Solution**
Fix all missing features, add more tests to cover multi-values and broken value cases.

**Known issues**
Currently, there is no way to provide a custom entity-tag comparison. We lived for long without it so let's keep TODO for this.