### PR TITLE
Accumulate cookies instead of replacing in cookiesSession

### DIFF
--- a/ktor-server/ktor-server-test-host/jvm/src/io/ktor/server/testing/TestApplicationEngine.kt
+++ b/ktor-server/ktor-server-test-host/jvm/src/io/ktor/server/testing/TestApplicationEngine.kt
@@ -263,7 +263,7 @@ fun TestApplicationEngine.cookiesSession(callback: () -> Unit) {
             setup() // setup after setting the cookie so the user can override cookies
         },
         processResponse = {
-            trackedCookies = response.headers.values(HttpHeaders.SetCookie).map { parseServerSetCookieHeader(it) }
+            trackedCookies += response.headers.values(HttpHeaders.SetCookie).map { parseServerSetCookieHeader(it) }
         }
     ) {
         callback()


### PR DESCRIPTION
**Subsystem**
Server Testing

**Motivation**
Cookies in `cookiesSession { ... }` only persist for one request before being overwritten. In my case I needed to run multiple requests after storing a session cookie.

**Solution**
Instead of replacing the `trackedCookies` list, I instead append new cookies from responses. Perhaps this should be a `Set<Cookie>` instead?

