### PR TITLE
Fix for ktor-client digest authentication

### DIFF
--- a/ktor-client/ktor-client-features/ktor-client-auth/common/src/io/ktor/client/features/auth/providers/DigestAuthProvider.kt
+++ b/ktor-client/ktor-client-features/ktor-client-auth/common/src/io/ktor/client/features/auth/providers/DigestAuthProvider.kt
@@ -83,7 +83,7 @@ class DigestAuthProvider(
 
         val start = hex(credential)
         val end = hex(makeDigest("$methodName:${url.encodedPath}"))
-        val tokenSequence = if (actualQop == null) listOf(start, nonce, end) else listOf(start, nonce, nonceCount, clientNonce)
+        val tokenSequence = if (actualQop == null) listOf(start, nonce, end) else listOf(start, nonce, nonceCount, clientNonce, actualQop, end)
         val token = makeDigest(tokenSequence.joinToString(":"))
 
         val auth = HttpAuthHeader.Parameterized(AuthScheme.Digest, linkedMapOf<String, String>().apply {

--- a/ktor-client/ktor-client-features/ktor-client-auth/common/src/io/ktor/client/features/auth/providers/DigestAuthProvider.kt
+++ b/ktor-client/ktor-client-features/ktor-client-auth/common/src/io/ktor/client/features/auth/providers/DigestAuthProvider.kt
@@ -94,6 +94,8 @@ class DigestAuthProvider(
             this["cnonce"] = clientNonce
             this["response"] = hex(token)
             this["uri"] = url.encodedPath
+            actualQop?.let { this["qop"] }
+            this["nc"] = nonceCount.toString()
         })
 
         request.headers {


### PR DESCRIPTION
**Subsystem**

Client Digest Authentication

**Motivation**

#1385 describes a problem with ktor client's digest authentication. This PR proposes an implementation that makes ktor client's digest authentication compatible with [RFC 2617](https://tools.ietf.org/html/rfc2617#section-3.2.2.1)

**Solution**

Adjusts the computation of the digest response and the fields in the authentication header:
* adds the qop and the A2 hash to the digest response 
* adds the qop and the nonce count to the authentication header
