### PR TITLE
Fix cookie expires-date parsing (implements RFC6265)

### DIFF
--- a/ktor-http/common/src/io/ktor/http/Cookie.kt
+++ b/ktor-http/common/src/io/ktor/http/Cookie.kt
@@ -76,7 +76,7 @@ fun parseServerSetCookieHeader(cookiesHeader: String): Cookie {
         value = decodeCookieValue(first.value, encoding),
         encoding = encoding,
         maxAge = loweredMap["max-age"]?.toInt() ?: 0,
-        expires = loweredMap["expires"]?.fromHttpToGmtDate(),
+        expires = loweredMap["expires"]?.fromCookieToGmtDate(),
         domain = loweredMap["domain"],
         path = loweredMap["path"],
         secure = "secure" in loweredMap,

--- a/ktor-http/common/src/io/ktor/http/CookieUtils.kt
+++ b/ktor-http/common/src/io/ktor/http/CookieUtils.kt
@@ -15,6 +15,8 @@ import io.ktor.util.date.*
 internal class StringLexer(val source: String) {
     var index = 0
 
+    val hasRemaining: Boolean get() = index < source.length
+
     /**
      * Check if the current character satisfies the predicate
      *
@@ -57,7 +59,98 @@ internal class StringLexer(val source: String) {
     }
 }
 
+internal fun Char.isDelimiter(): Boolean =
+    this == '\u0009'
+        || this in ('\u0020'..'\u002f')
+        || this in ('\u003b'..'\u0040')
+        || this in ('\u005b'..'\u0060')
+        || this in ('\u007b'..'\u007e')
+
+internal fun Char.isNonDelimiter(): Boolean =
+    this in ('\u0000'..'\u0008')
+        || this in ('\u000a'..'\u001f')
+        || this in ('0'..'9')
+        || this == ':'
+        || this in ('a'..'z')
+        || this in ('A'..'Z')
+        || this in ('\u007f'..'\u00ff')
+
+internal fun Char.isOctet(): Boolean =
+    this in ('\u0000'..'\u00ff')
+
+internal fun Char.isNonDigit(): Boolean =
+    this in ('\u0000'..'\u002f') || this in ('\u004a'..'\u00ff')
+
+internal inline fun Boolean.otherwise(block: () -> Unit) {
+    if (!this) block()
+}
+
+internal fun CookieDateBuilder.handleToken(token: String) {
+
+}
+
 class CookieDateParser {
 
-    fun parse(source: String): GMTDate = TODO()
+    fun parse(source: String): GMTDate {
+        val lexer = StringLexer(source)
+        val builder = CookieDateBuilder()
+
+        lexer.acceptWhile { it.isDelimiter() }
+
+        while (lexer.hasRemaining) {
+            if (lexer.test { it.isNonDelimiter() }) {
+                val token = lexer.capture { acceptWhile { it.isNonDelimiter() } }
+
+                builder.handleToken(token)
+
+                lexer.acceptWhile { it.isDelimiter() }
+            }
+        }
+
+        when (builder.year) {
+            in 70..99 -> builder.year = builder.year!! + 1900
+            in 0..69 -> builder.year = builder.year!! + 2000
+        }
+
+        if (builder.dayOfMonth == null)
+            throw InvalidDateStringException(source, 0, "Could not find day-of-month")
+
+        if (builder.month == null)
+            throw InvalidDateStringException(source, 0, "Could not find month")
+
+        if (builder.year == null)
+            throw InvalidDateStringException(source, 0, "Could not find year")
+
+        if (builder.hours == null || builder.minutes == null || builder.seconds == null)
+            throw InvalidDateStringException(source, 0, "Could not find time")
+
+        if (builder.dayOfMonth!! !in 1..31)
+            throw InvalidDateStringException(source, 0, "Invalid day of month: ${builder.dayOfMonth} not in [1,31]")
+
+        if (builder.year!! < 1601)
+            throw InvalidDateStringException(source, 0, "Invalid year: ${builder.year} < 1601")
+
+        if (builder.hours!! > 23)
+            throw InvalidDateStringException(source, 0, "Invalid hours: ${builder.hours} > 23")
+
+        if (builder.minutes!! > 59)
+            throw InvalidDateStringException(source, 0, "Invalid minutes: ${builder.minutes} > 59")
+
+        if (builder.seconds!! > 59)
+            throw InvalidDateStringException(source, 0, "Invalid seconds: ${builder.seconds} > 59")
+
+        return builder.build()
+    }
+}
+
+internal class CookieDateBuilder {
+    var seconds: Int? = null
+    var minutes: Int? = null
+    var hours: Int? = null
+
+    var dayOfMonth: Int? = null
+    var month: Month? = null
+    var year: Int? = null
+
+    fun build(): GMTDate = GMTDate(seconds!!, minutes!!, hours!!, dayOfMonth!!, month!!, year!!)
 }

--- a/ktor-http/common/src/io/ktor/http/CookieUtils.kt
+++ b/ktor-http/common/src/io/ktor/http/CookieUtils.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2014-2019 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.http
+
+import io.ktor.util.date.*
+
+internal class StringLexer(val source: String) {
+    var index = 0
+
+    fun test(predicate: (Char) -> Boolean): Boolean =
+        index < source.length && predicate(source[index])
+
+    fun accept(predicate: (Char) -> Boolean): Boolean =
+        test(predicate).also { if (it) index++ }
+
+    fun acceptWhile(predicate: (Char) -> Boolean): Boolean {
+        if (!test(predicate)) return false
+        while (test(predicate)) index++
+        return true
+    }
+
+    fun capture(block: StringLexer.() -> Unit): String {
+        val start = index
+        block()
+        return source.substring(start, index)
+    }
+}
+
+class CookieDateParser {
+
+    fun parse(source: String): GMTDate = TODO()
+}

--- a/ktor-http/common/src/io/ktor/http/CookieUtils.kt
+++ b/ktor-http/common/src/io/ktor/http/CookieUtils.kt
@@ -6,22 +6,51 @@ package io.ktor.http
 
 import io.ktor.util.date.*
 
+/**
+ * Lexer over a source string, allowing testing, accepting and capture of spans of characters given
+ * some predicates.
+ *
+ * @property source string to iterate over
+ */
 internal class StringLexer(val source: String) {
     var index = 0
 
+    /**
+     * Check if the current character satisfies the predicate
+     *
+     * @param predicate character test
+     */
     fun test(predicate: (Char) -> Boolean): Boolean =
         index < source.length && predicate(source[index])
 
+    /**
+     * Checks if the current character satisfies the predicate, consuming it is so
+     *
+     * @param predicate character test
+     */
     fun accept(predicate: (Char) -> Boolean): Boolean =
         test(predicate).also { if (it) index++ }
 
+    /**
+     * Keep accepting characters while they satisfy the predicate
+     *
+     * @param predicate character test
+     * @see [accept]
+     */
     fun acceptWhile(predicate: (Char) -> Boolean): Boolean {
         if (!test(predicate)) return false
         while (test(predicate)) index++
         return true
     }
 
-    fun capture(block: StringLexer.() -> Unit): String {
+    /**
+     * Run the block on this lexer taking note of the starting and ending index. Returning the span of the
+     * source which was traversed.
+     *
+     * @param block scope of traversal to be captured
+     * @return The traversed span of the source string
+     */
+    inline fun capture(block: StringLexer.() -> Unit): String {
         val start = index
         block()
         return source.substring(start, index)

--- a/ktor-http/common/src/io/ktor/http/CookieUtils.kt
+++ b/ktor-http/common/src/io/ktor/http/CookieUtils.kt
@@ -133,6 +133,9 @@ internal inline fun String.tryParseTime(success: (Int, Int, Int) -> Unit) {
         accept { it.isDigit() }
     }.toInt()
 
+    if (lexer.accept { it.isNonDigit() })
+        lexer.acceptWhile { it.isOctet() }
+
     success(hour, minute, second)
 }
 

--- a/ktor-http/common/src/io/ktor/http/DateUtils.kt
+++ b/ktor-http/common/src/io/ktor/http/DateUtils.kt
@@ -46,7 +46,7 @@ fun String.fromCookieToGmtDate(): GMTDate = with(trim()) {
     try {
         val parser = CookieDateParser()
         return parser.parse(this@with)
-    } catch (_: InvalidDateStringException) {
+    } catch (_: InvalidCookieDateException) {
     }
 
     return fromHttpToGmtDate()

--- a/ktor-http/common/src/io/ktor/http/DateUtils.kt
+++ b/ktor-http/common/src/io/ktor/http/DateUtils.kt
@@ -38,6 +38,21 @@ fun String.fromHttpToGmtDate(): GMTDate = with(trim()) {
 }
 
 /**
+ * Convert valid cookie date [String] to [GMTDate] trying first the RFC6265 standard, falling back on [fromHttpToGmtDate]
+ *
+ * @see [fromHttpToGmtDate]
+ */
+fun String.fromCookieToGmtDate(): GMTDate = with(trim()) {
+    try {
+        val parser = CookieDateParser()
+        return parser.parse(this@with)
+    } catch (_: InvalidDateStringException) {
+    }
+
+    return fromHttpToGmtDate()
+}
+
+/**
  * Convert [GMTDate] to valid http date [String]
  */
 fun GMTDate.toHttpDate(): String = buildString {

--- a/ktor-http/common/test/io/ktor/tests/http/CookieDateParserTest.kt
+++ b/ktor-http/common/test/io/ktor/tests/http/CookieDateParserTest.kt
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2014-2019 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.tests.http
+
+import io.ktor.http.*
+import io.ktor.util.date.*
+import kotlin.test.*
+
+class CookieDateParserTest {
+
+    @Test
+    fun testHttpGmtFormats() {
+
+        val eleven = GMTDate(1, 45, 12, 11, Month.APRIL, 2018)
+        val first = GMTDate(1, 45, 12, 1, Month.APRIL, 2018)
+
+        val dates = listOf(
+            "Wed, 11 Apr 2018 12:45:01 GMT" to eleven,
+            "Wedn, 11-Apr-2018 12:45:01 GMT" to eleven,
+            "Wed Apr 1 12:45:01 2018" to first,
+            "Wed, 11-Apr-2018 12:45:01 GMT" to eleven,
+            "Wed, 11-Apr-2018 12-45-01 GMT" to eleven,
+            "Wed, 11 Apr 2018 12:45:01 GMT" to eleven,
+            "Wed 11-Apr-2018 12:45:01 GMT" to eleven,
+            "Wed 11 Apr 2018 12:45:01 GMT" to eleven,
+            "Wed 11-Apr-2018 12-45-01 GMT" to eleven,
+            "Wed,11-Apr-2018 12:45:01 GMT" to eleven,
+            "Wed Apr 1 2018 12:45:01 GMT" to first
+        )
+
+        for (index in dates.indices) {
+            val parser = CookieDateParser()
+            val (dateString, expected) = dates[index]
+            val date = parser.parse(dateString)
+
+            assertEquals(expected, date)
+        }
+    }
+
+    @Test
+    fun testRfc6265Format() {
+        val eleventh = GMTDate(1, 45, 12, 11, Month.APRIL, 2018)
+
+        val dates = listOf(
+            // Time field is placement-independent
+            "12:45:01 11 Apr 2018" to eleventh,
+            "11 12:45:01 Apr 2018" to eleventh,
+            "11 Apr 12:45:01 2018" to eleventh,
+            "11 Apr 2018 12:45:01" to eleventh,
+
+            // Day-of-month field is placement-independent before year
+            "11 Apr 2018 12:45:01" to eleventh,
+            "Apr 11 2018 12:45:01" to eleventh,
+            "Apr 12:45:01 11 2018" to eleventh,
+
+            // Month is placement-independent
+            "Apr 11 2018 12:45:01" to eleventh,
+            "11 Apr 2018 12:45:01" to eleventh,
+            "11 2018 Apr 12:45:01" to eleventh,
+            "11 2018 12:45:01 Apr" to eleventh,
+
+            // Year is placement-independent after day-of-month
+            "Apr 11 2018 12:45:01" to eleventh,
+            "Apr 11 12:45:01 2018" to eleventh
+        )
+
+        for ((date, expected) in dates) {
+            val parser = CookieDateParser()
+            assertEquals(expected, parser.parse(date))
+        }
+    }
+
+    @Test
+    fun testBoundaryChecks() {
+        val incorrect = listOf(
+            "Wed, 0 Apr 2018 12:45:01", // Day of month < 1
+            "Wed, 32 Apr 2018 12:45:01", // Day of month > 31
+            "Wed, 1 Apr 1600 12:45:01", // Year < 1601
+            "Wed, 32 Apr 2018 24:45:01", // Hour > 24
+            "Wed, 32 Apr 2018 12:60:01", // Minute > 59
+            "Wed, 32 Apr 2018 12:45:60" // Second > 59
+        )
+
+        for (date in incorrect) {
+            val parser = CookieDateParser()
+            assertFailsWith(InvalidDateStringException::class) {
+                parser.parse(date)
+            }
+        }
+    }
+
+    @Test
+    fun testCorrectlyMutatesYear() {
+        val tests = mapOf(
+            // 70 <= year <= 99, increment by 1900
+            "Wed, 11 Apr 70 12:45:01 GMT" to GMTDate(1, 45, 12, 11, Month.APRIL, 1970),
+            "Wed, 11 Apr 99 12:45:01 GMT" to GMTDate(1, 45, 12, 11, Month.APRIL, 1999),
+
+            // 0 <= year <= 69, increment by 2000
+            "Wed, 11 Apr 0 12:45:01 GMT" to GMTDate(1, 45, 12, 11, Month.APRIL, 2000),
+            "Wed, 11 Apr 69 12:45:01 GMT" to GMTDate(1, 45, 12, 11, Month.APRIL, 2069)
+        )
+
+        for ((date, expected) in tests) {
+            val parser = CookieDateParser()
+            assertEquals(expected, parser.parse(date))
+        }
+    }
+}

--- a/ktor-http/common/test/io/ktor/tests/http/CookieDateParserTest.kt
+++ b/ktor-http/common/test/io/ktor/tests/http/CookieDateParserTest.kt
@@ -41,6 +41,7 @@ class CookieDateParserTest {
 
     @Test
     fun testRfc6265Format() {
+        val one = GMTDate(1, 1, 1, 1, Month.APRIL, 2018)
         val eleventh = GMTDate(1, 45, 12, 11, Month.APRIL, 2018)
 
         val dates = listOf(
@@ -63,7 +64,11 @@ class CookieDateParserTest {
 
             // Year is placement-independent after day-of-month
             "Apr 11 2018 12:45:01" to eleventh,
-            "Apr 11 12:45:01 2018" to eleventh
+            "Apr 11 12:45:01 2018" to eleventh,
+
+            // Day-of-month, hours, minutes and seconds can be 1 digit long,
+            // Year can be 2 digits long
+            "1 Apr 18 1:1:1" to one
         )
 
         for ((date, expected) in dates) {

--- a/ktor-http/common/test/io/ktor/tests/http/CookieDateParserTest.kt
+++ b/ktor-http/common/test/io/ktor/tests/http/CookieDateParserTest.kt
@@ -31,9 +31,8 @@ class CookieDateParserTest {
         )
 
         for (index in dates.indices) {
-            val parser = CookieDateParser()
             val (dateString, expected) = dates[index]
-            val date = parser.parse(dateString)
+            val date = dateString.fromHttpToGmtDate()
 
             assertEquals(expected, date)
         }
@@ -104,7 +103,7 @@ class CookieDateParserTest {
             "Wed, 11 Apr 99 12:45:01 GMT" to GMTDate(1, 45, 12, 11, Month.APRIL, 1999),
 
             // 0 <= year <= 69, increment by 2000
-            "Wed, 11 Apr 0 12:45:01 GMT" to GMTDate(1, 45, 12, 11, Month.APRIL, 2000),
+            "Wed, 11 Apr 00 12:45:01 GMT" to GMTDate(1, 45, 12, 11, Month.APRIL, 2000),
             "Wed, 11 Apr 69 12:45:01 GMT" to GMTDate(1, 45, 12, 11, Month.APRIL, 2069)
         )
 

--- a/ktor-http/common/test/io/ktor/tests/http/CookieDateParserTest.kt
+++ b/ktor-http/common/test/io/ktor/tests/http/CookieDateParserTest.kt
@@ -89,7 +89,7 @@ class CookieDateParserTest {
 
         for (date in incorrect) {
             val parser = CookieDateParser()
-            assertFailsWith(InvalidDateStringException::class) {
+            assertFailsWith(InvalidCookieDateException::class) {
                 parser.parse(date)
             }
         }


### PR DESCRIPTION
**Subsystem**
ktor-http

**Motivation**
Attempts to fix #1382 by implementing the algorithm described in RFC6265 for cookie Expires dates.

**Solution**
Adds a new function to DateUtils for parsing cookie-specific dates using the new RFC6265-conformant CookieDateParser. Should this fail it falls back on the current implementation.

