### PR TITLE
Introduce Local Port Routing Builder

### DIFF
--- a/ktor-server/ktor-server-core/jvm/src/io/ktor/routing/LocalPortRoutingBuilder.kt
+++ b/ktor-server/ktor-server-core/jvm/src/io/ktor/routing/LocalPortRoutingBuilder.kt
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2014-2019 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.routing
+
+import io.ktor.http.parametersOf
+import io.ktor.util.*
+
+/**
+ * Create a route to match the port on which the call was received.
+ *
+ * The selector checks the [io.ktor.request.ApplicationRequest.local] request port,
+ * _ignoring_ HTTP headers such as "Host" or "X-Forwarded-Host".
+ * This is useful for securing routes under separate ports.
+ *
+ * For multi-tenant applications, you may want to use [io.ktor.routing.port],
+ * which takes HTTP headers into consideration.
+ *
+ * @param port the port to match against
+ *
+ * @throws IllegalArgumentException if the port is outside the range of acceptable, non-ephemeral ports
+ */
+@KtorExperimentalAPI
+fun Route.localPort(port: Int, build: Route.() -> Unit): Route {
+    require(port in 1..49151) { "Port $port must be a positive number within the range of non-ephemeral ports" }
+
+    val selector = LocalPortRouteSelector(port)
+    return createChild(selector).apply(build)
+}
+
+/**
+ * Evaluate a route against the port on which the call was received.
+ *
+ * @param port the port to match against
+ */
+@KtorExperimentalAPI
+data class LocalPortRouteSelector(val port: Int) : RouteSelector(RouteSelectorEvaluation.qualityConstant) {
+    override fun evaluate(context: RoutingResolveContext, segmentIndex: Int) =
+        if (context.call.request.local.port == port) {
+            val parameters = parametersOf(LocalPortParameter, port.toString())
+            RouteSelectorEvaluation(true, RouteSelectorEvaluation.qualityConstant, parameters)
+        } else {
+            RouteSelectorEvaluation.Failed
+        }
+
+    companion object {
+        /**
+         * Parameter name for [RoutingApplicationCall.parameters] for request host
+         */
+        @KtorExperimentalAPI
+        const val LocalPortParameter: String = "\$LocalPort"
+    }
+}

--- a/ktor-server/ktor-server-core/jvm/src/io/ktor/routing/LocalPortRoutingBuilder.kt
+++ b/ktor-server/ktor-server-core/jvm/src/io/ktor/routing/LocalPortRoutingBuilder.kt
@@ -19,11 +19,11 @@ import io.ktor.util.*
  *
  * @param port the port to match against
  *
- * @throws IllegalArgumentException if the port is outside the range of acceptable, non-ephemeral ports
+ * @throws IllegalArgumentException if the port is outside the range of TCP/UDP ports
  */
 @KtorExperimentalAPI
 fun Route.localPort(port: Int, build: Route.() -> Unit): Route {
-    require(port in 1..49151) { "Port $port must be a positive number within the range of non-ephemeral ports" }
+    require(port in 1..65535) { "Port $port must be a positive number between 1 and 65,535" }
 
     val selector = LocalPortRouteSelector(port)
     return createChild(selector).apply(build)

--- a/ktor-server/ktor-server-tests/jvm/test/io/ktor/tests/server/routing/RoutingProcessingTest.kt
+++ b/ktor-server/ktor-server-tests/jvm/test/io/ktor/tests/server/routing/RoutingProcessingTest.kt
@@ -448,6 +448,45 @@ class RoutingProcessingTest {
     }
 
     @Test
+    fun `local port route processing`(): Unit = withTestApplication {
+        application.routing {
+            route("/") {
+                // TestApplicationRequest.local defaults to 80 in the absence of headers
+                // so connections paths to port 80 in tests should work, whereas other ports shouldn't
+                localPort(80) {
+                    get("http") {
+                        call.respond("received")
+                    }
+                }
+                localPort(443) {
+                    get("https") {
+                        fail("shouldn't be received")
+                    }
+                }
+            }
+        }
+
+        // accepts calls to the specified port
+        handleRequest(HttpMethod.Get, "/http").apply {
+            assertEquals("received", response.content)
+        }
+
+        // ignores calls to different ports
+        handleRequest(HttpMethod.Get, "/https").apply {
+            assertNull(response.content)
+        }
+
+        // I tried to write a test to confirm that it ignores the HTTP Host header,
+        // but I couldn't get it to work without adding headers, because
+        // [io.ktor.server.testing.TestApplicationRequest.local] is hard-coded to
+        // extract the value of those headers.
+        // (even though, according to docs, it shouldn't; this should be done by `origin`)
+
+        // I also tried to create a test listening to multiple ports, but I couldn't get it
+        // to work because of the same reason above.
+    }
+
+    @Test
     fun `routing with tracing`() = withTestApplication {
         var trace: RoutingResolveTrace? = null
         application.routing {


### PR DESCRIPTION
**Subsystem**
ktor-server

**Motivation**
I'm building an application that has some functions that should be exposed on a separate port (e.g. metrics). The existing (experimental) [`HostRouteSelector`](https://api.ktor.io/1.2.4/io.ktor.routing/-host-route-selector/index.html) (introduced in #835) is geared towards multi-tenant/VirtualHost-style configurations, allowing a client to send a `Host` header to get information that perhaps shouldn't be exposed to them.

**Solution**
I suggest a simple `RouteSelector` based on the `local: RequestConnectionPoint` port, whose documentation says (emphasis mine):
> Contains http request and connection details such as a host name used to connect, port, scheme and so on. ***No proxy headers could affect it.***

Sadly, some implementations don't abide by this rule. Particularly noteworthy is the [`TestApplicationRequest`](https://api.ktor.io/1.2.4/io.ktor.server.testing/-test-application-request/index.html), which extracts the port from headers. I think that it should be changed to enable setting the port in the request builder, but this could be left for another PR.