### PR TITLE
HttpCookies feature cookie encoding retention

### DIFF
--- a/ktor-client/ktor-client-core/common/src/io/ktor/client/features/cookies/HttpCookies.kt
+++ b/ktor-client/ktor-client-core/common/src/io/ktor/client/features/cookies/HttpCookies.kt
@@ -82,7 +82,7 @@ private fun renderClientCookies(cookies: List<Cookie>): String = buildString {
     cookies.forEach {
         append(it.name)
         append('=')
-        append(encodeCookieValue(it.value, CookieEncoding.DQUOTES))
+        append(encodeCookieValue(it.value, it.encoding))
         append(';')
     }
 }


### PR DESCRIPTION
**Subsystem**
Client, HttpCookies feature.

**Motivation**
The HttpCookies feature attempted to encode all cookies using DQUOTES rather than respecting the cookies own encoding, which defaults to URI during parsing anyway.

**Solution**
HttpCookies feature now renders cookies using their own encoding.

