### PR TITLE
Fix http-redirect conformance

### DIFF
--- a/ktor-client/ktor-client-core/common/src/io/ktor/client/features/HttpRedirect.kt
+++ b/ktor-client/ktor-client-core/common/src/io/ktor/client/features/HttpRedirect.kt
@@ -13,9 +13,7 @@ import io.ktor.util.*
 /**
  * [HttpClient] feature that handles http redirect
  */
-class HttpRedirect(config: Config) {
-    val maximumRedirects: Int = config.maximumRedirects
-    val rewritePostAsGet: Boolean = config.rewritePostAsGet
+class HttpRedirect(val maximumRedirects: Int, val rewritePostAsGet: Boolean) {
 
     class Config {
         /** RFC2068 recommends a maximum of five redirection */
@@ -29,7 +27,10 @@ class HttpRedirect(config: Config) {
     companion object Feature : HttpClientFeature<Config, HttpRedirect> {
         override val key: AttributeKey<HttpRedirect> = AttributeKey("HttpRedirect")
 
-        override fun prepare(block: Config.() -> Unit): HttpRedirect = HttpRedirect(Config().apply(block))
+        override fun prepare(block: Config.() -> Unit): HttpRedirect {
+            val config = Config().apply(block)
+            return HttpRedirect(config.maximumRedirects, config.rewritePostAsGet)
+        }
 
         override fun install(feature: HttpRedirect, scope: HttpClient) {
             scope.feature(HttpSend)!!.intercept { origin ->

--- a/ktor-client/ktor-client-core/common/src/io/ktor/client/features/HttpRedirect.kt
+++ b/ktor-client/ktor-client-core/common/src/io/ktor/client/features/HttpRedirect.kt
@@ -13,21 +13,29 @@ import io.ktor.util.*
 /**
  * [HttpClient] feature that handles http redirect
  */
-class HttpRedirect {
-    companion object Feature : HttpClientFeature<Unit, HttpRedirect> {
+class HttpRedirect(config: Config) {
+    val maximumRedirects: Int = config.maximumRedirects
+
+    class Config {
+        /* RFC2068 recommends a maximum of five redirection */
+        var maximumRedirects: Int = 5
+    }
+
+    companion object Feature : HttpClientFeature<Config, HttpRedirect> {
         override val key: AttributeKey<HttpRedirect> = AttributeKey("HttpRedirect")
 
-        override fun prepare(block: Unit.() -> Unit): HttpRedirect = HttpRedirect()
+        override fun prepare(block: Config.() -> Unit): HttpRedirect = HttpRedirect(Config().apply(block))
 
         override fun install(feature: HttpRedirect, scope: HttpClient) {
             scope.feature(HttpSend)!!.intercept { origin ->
-                handleCall(origin)
+                handleCall(feature, origin)
             }
         }
 
-        private suspend fun Sender.handleCall(origin: HttpClientCall): HttpClientCall {
+        private suspend fun Sender.handleCall(feature: HttpRedirect, origin: HttpClientCall): HttpClientCall {
             if (!origin.response.status.isRedirect()) return origin
 
+            var redirects = 0
             var call = origin
             while (true) {
                 val location = call.response.headers[HttpHeaders.Location]
@@ -40,8 +48,12 @@ class HttpRedirect {
 
                     location?.let { url.takeFrom(it) }
                 })
+                redirects++
 
                 if (!call.response.status.isRedirect()) return call
+
+                // TODO: Just return last call, return original (closed) call, or throw an exception?
+                if (redirects > feature.maximumRedirects) return call
             }
         }
     }

--- a/ktor-client/ktor-client-core/common/src/io/ktor/client/features/HttpRedirect.kt
+++ b/ktor-client/ktor-client-core/common/src/io/ktor/client/features/HttpRedirect.kt
@@ -21,10 +21,12 @@ class HttpRedirect(val maximumRedirects: Int, val rewritePostAsGet: Boolean) {
     class Config {
         /**
          * Maximum number of times this feature will follow a http redirect before failing.
+         * Must be less than or equal to the configured value of [HttpSend.maxSendCount] for any effect.
          *
          * RFC2068 recommends a maximum of five redirection.
          *
          * @see [HttpRedirect.maximumRedirects]
+         * @see [HttpSend.maxSendCount]
          */
         var maximumRedirects: Int = 5
 
@@ -82,7 +84,7 @@ class HttpRedirect(val maximumRedirects: Int, val rewritePostAsGet: Boolean) {
 
                 if (!call.response.status.isRedirect()) return call
 
-                if (redirects > feature.maximumRedirects) throw RedirectCountExceedException("Max redirect count ${feature.maximumRedirects} exceeded")
+                if (redirects >= feature.maximumRedirects) throw RedirectCountExceedException("Max redirect count ${feature.maximumRedirects} exceeded")
             }
         }
     }

--- a/ktor-client/ktor-client-tests/jvm/src/io/ktor/client/tests/utils/tests/Redirect.kt
+++ b/ktor-client/ktor-client-tests/jvm/src/io/ktor/client/tests/utils/tests/Redirect.kt
@@ -5,6 +5,7 @@
 package io.ktor.client.tests.utils.tests
 
 import io.ktor.application.*
+import io.ktor.http.*
 import io.ktor.response.*
 import io.ktor.routing.*
 
@@ -15,6 +16,9 @@ internal fun Application.redirectTest() {
                 call.respondRedirect("/redirect/get")
             }
             get("/get") {
+                call.respondText("OK")
+            }
+            post("/post") {
                 call.respondText("OK")
             }
             get("/infinity") {
@@ -44,6 +48,28 @@ internal fun Application.redirectTest() {
             }
             get("/directory/hostAbsoluteRedirect") {
                 call.respondRedirect("https://httpstat.us/200")
+            }
+            post("/post-expecting-get-301") {
+                call.response.headers.append(HttpHeaders.Location, "/redirect/get")
+                call.respond(HttpStatusCode.MovedPermanently)
+            }
+            post("/post-expecting-get-302") {
+                call.response.headers.append(HttpHeaders.Location, "/redirect/get")
+                call.respond(HttpStatusCode.Found)
+            }
+            post("/post-expecting-post") {
+                call.response.headers.append(HttpHeaders.Location, "/redirect/post")
+                call.respond(HttpStatusCode.TemporaryRedirect)
+            }
+
+            for(n in 1..10) {
+                get("/count/$n") {
+                    if(n > 1) {
+                        call.respondRedirect("/redirect/count/${n-1}")
+                    } else {
+                        call.respondRedirect("/redirect/get")
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
**Subsystem**
Client, HttpRedirect feature

**Motivation**
While MDN **incorrectly** states that rewriting redirected POST requests to use GET is against the specification, it is actually **allowed** in RFC7231, specifically for [301 Moved Permanently and 302 Found](https://tools.ietf.org/html/rfc7231#page-56).
Most notably chrome, and probably all major browsers, do this (i.e. when submitting a login form which then receives a 302 Found back to the authenticated page).

**Solution**
Updated the HttpRedirect feature with a configuration class which allows the user to explicitly allow the rewrites of POST to GET (defaults to false) as well as a maximum number of redirects to follow (default is [RFC2068's 5](https://tools.ietf.org/html/rfc2068#section-10.3)).

This now allows users to do the following:
```kotlin
install(HttpRedirect) {
    maximumRedirects = 23 // Follow up to 23 redirects
    rewritePostAsGet = true // Enable rewrite to GET
}
```

Something that needs to be discussed, in the event that the client is redirected more than the configured number of times, I was unsure as to what to actually do:
```kotlin
// TODO: Just return last call, return original (closed) call, or throw an exception?
if (redirects > feature.maximumRedirects) return call
```

