### PR TITLE
option to include/ exclude query parameters in the constructed url

### DIFF
--- a/ktor-features/ktor-locations/jvm/src/io/ktor/locations/Locations.kt
+++ b/ktor-features/ktor-locations/jvm/src/io/ktor/locations/Locations.kt
@@ -217,10 +217,11 @@ open class Locations(private val application: Application, private val routeServ
      * Constructs the url for [location].
      *
      * The class of [location] instance **must** be annotated with [Location].
+     * @param shouldIncludeQuery Include or exclude query parameters in the constructed url.
      */
-    fun href(location: Any): String {
+    fun href(location: Any, shouldIncludeQuery: Boolean = true): String {
         val info = pathAndQuery(location)
-        return info.path + if (info.query.any())
+        return info.path + if (shouldIncludeQuery && info.query.any())
             "?" + info.query.formUrlEncode()
         else
             ""

--- a/ktor-features/ktor-locations/jvm/test/io/ktor/tests/locations/LocationsTest.kt
+++ b/ktor-features/ktor-locations/jvm/test/io/ktor/tests/locations/LocationsTest.kt
@@ -500,5 +500,10 @@ class LocationsTest {
             assertEquals(HttpStatusCode.BadRequest, call.response.status())
         }
     }
-}
 
+    @Location("/street") class someQuery(val streetNumber: Int, val optional: String? = null)
+    @Test fun `location construction with href can ignore query params`() = withLocationsApplication {
+        val href = application.locations.href(someQuery(4, "something"), shouldIncludeQuery = false)
+        assertEquals("/street", href, message = "check that query is ignored.")
+    }
+}


### PR DESCRIPTION
**Subsystem**
Locations API
**Motivation**
To construct the url based on location, query parameters are also included by default. There is no way to exclude the query parameters.
**Solution**
Added ability to specify whether to include the query params. By providing the default as true, this is not a breaking change.
