### PR TITLE
#1277 introduce new command line argument 'profile'

### DIFF
--- a/ktor-server/ktor-server-host-common/jvm/src/io/ktor/server/engine/CommandLine.kt
+++ b/ktor-server/ktor-server-host-common/jvm/src/io/ktor/server/engine/CommandLine.kt
@@ -24,7 +24,8 @@ fun commandLineEnvironment(args: Array<String>): ApplicationEngineEnvironment {
             else -> File(it).toURI().toURL()
         }
     }
-    val configFile = argsMap["-config"]?.let { File(it) }
+    val profile = argsMap["-profile"]
+    val configFile = argsMap["-config"]?.let { File(it) } ?: profile?.let { File("application-${profile}.conf") }
     val commandLineMap = argsMap.filterKeys { it.startsWith("-P:") }.mapKeys { it.key.removePrefix("-P:") }
 
     val environmentConfig = ConfigFactory.systemProperties().withOnlyPath("ktor")

--- a/ktor-server/ktor-server-host-common/jvm/test-resources/application-test.conf
+++ b/ktor-server/ktor-server-host-common/jvm/test-resources/application-test.conf
@@ -1,0 +1,9 @@
+ktor {
+    deployment {
+        port = 4000
+    }
+
+    application {
+        class = <org.company.ApplicationClass>
+    }
+}

--- a/ktor-server/ktor-server-host-common/jvm/test/io/ktor/tests/hosts/CommandLineTest.kt
+++ b/ktor-server/ktor-server-host-common/jvm/test/io/ktor/tests/hosts/CommandLineTest.kt
@@ -84,6 +84,12 @@ class CommandLineTest {
         assertEquals("8080", port)
     }
 
+    @Test
+    fun configFileWithProfile() {
+        val port = commandLineEnvironment(arrayOf("-profile=test")).config.property("ktor.deployment.port").getString()
+        assertEquals("4000", port)
+    }
+
     private tailrec fun findContainingZipFileOrUri(uri: URI): Pair<File?, URI?> {
         if (uri.scheme == "file") {
             return Pair(File(uri.path.substringBefore("!")), null)


### PR DESCRIPTION
**Subsystem**
Server

**Motivation**

refs #1277
Introduce new command line argument 'profile', and we can switch configuration files easily according to the environment like using `java -jar xxx.jar -profile=prd`.

