### PR TITLE
Cy/server cleanup

### DIFF
--- a/binary-compatibility-validator/reference-public-api/ktor-http.txt
+++ b/binary-compatibility-validator/reference-public-api/ktor-http.txt
@@ -249,7 +249,8 @@ public final class io/ktor/http/Cookie {
 	public final fun getExpires ()Lio/ktor/util/date/GMTDate;
 	public final fun getExtensions ()Ljava/util/Map;
 	public final fun getHttpOnly ()Z
-	public final fun getMaxAge ()I
+	public final synthetic fun getMaxAge ()I
+	public final fun getMaxAgeInt ()I
 	public final fun getName ()Ljava/lang/String;
 	public final fun getPath ()Ljava/lang/String;
 	public final fun getSecure ()Z

--- a/binary-compatibility-validator/reference-public-api/ktor-utils.txt
+++ b/binary-compatibility-validator/reference-public-api/ktor-utils.txt
@@ -451,6 +451,7 @@ public final class io/ktor/util/collections/ConcurrentMap : java/util/Map, kotli
 	public fun <init> (Lio/ktor/util/Lock;Ljava/util/Map;)V
 	public synthetic fun <init> (Lio/ktor/util/Lock;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun clear ()V
+	public final fun computeIfAbsent (Ljava/lang/Object;Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
 	public fun containsKey (Ljava/lang/Object;)Z
 	public fun containsValue (Ljava/lang/Object;)Z
 	public final fun entrySet ()Ljava/util/Set;

--- a/binary-compatibility-validator/reference-public-api/ktor-utils.txt
+++ b/binary-compatibility-validator/reference-public-api/ktor-utils.txt
@@ -89,6 +89,28 @@ public final class io/ktor/util/CaseInsensitiveMap : java/util/Map, kotlin/jvm/i
 	public final fun values ()Ljava/util/Collection;
 }
 
+public final class io/ktor/util/CaseInsensitiveSet : java/util/Set, kotlin/jvm/internal/markers/KMutableSet {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/Iterable;)V
+	public synthetic fun add (Ljava/lang/Object;)Z
+	public fun add (Ljava/lang/String;)Z
+	public fun addAll (Ljava/util/Collection;)Z
+	public fun clear ()V
+	public final fun contains (Ljava/lang/Object;)Z
+	public fun contains (Ljava/lang/String;)Z
+	public fun containsAll (Ljava/util/Collection;)Z
+	public fun getSize ()I
+	public fun isEmpty ()Z
+	public fun iterator ()Ljava/util/Iterator;
+	public final fun remove (Ljava/lang/Object;)Z
+	public fun remove (Ljava/lang/String;)Z
+	public fun removeAll (Ljava/util/Collection;)Z
+	public fun retainAll (Ljava/util/Collection;)Z
+	public final fun size ()I
+	public fun toArray ()[Ljava/lang/Object;
+	public fun toArray ([Ljava/lang/Object;)[Ljava/lang/Object;
+}
+
 public final class io/ktor/util/CharsetKt {
 	public static final fun isLowerCase (C)Z
 	public static final fun toCharArray (Ljava/lang/String;)[C

--- a/ktor-client/ktor-client-core/common/src/io/ktor/client/features/cache/storage/UnlimitedCacheStorage.kt
+++ b/ktor-client/ktor-client-core/common/src/io/ktor/client/features/cache/storage/UnlimitedCacheStorage.kt
@@ -12,7 +12,7 @@ internal class UnlimitedCacheStorage : HttpCacheStorage() {
     private val store = ConcurrentMap<Url, MutableSet<HttpCacheEntry>>()
 
     override fun store(url: Url, value: HttpCacheEntry) {
-        val data = store.getOrDefault(url) { ConcurrentSet() }
+        val data = store.computeIfAbsent(url) { ConcurrentSet() }
         if (!data.add(value)) {
             data.remove(value)
             data.add(value)
@@ -20,7 +20,7 @@ internal class UnlimitedCacheStorage : HttpCacheStorage() {
     }
 
     override fun find(url: Url, varyKeys: Map<String, String>): HttpCacheEntry? {
-        val data = store.getOrDefault(url) { ConcurrentSet() }
+        val data = store.computeIfAbsent(url) { ConcurrentSet() }
         return data.find { it.varyKeys == varyKeys }
     }
 

--- a/ktor-features/ktor-auth/jvm/src/io/ktor/auth/AuthenticationContext.kt
+++ b/ktor-features/ktor-auth/jvm/src/io/ktor/auth/AuthenticationContext.kt
@@ -7,7 +7,6 @@ package io.ktor.auth
 import io.ktor.application.*
 import io.ktor.util.pipeline.*
 import io.ktor.util.*
-import java.util.*
 import kotlin.properties.*
 
 /**

--- a/ktor-features/ktor-auth/jvm/src/io/ktor/auth/BasicAuth.kt
+++ b/ktor-features/ktor-auth/jvm/src/io/ktor/auth/BasicAuth.kt
@@ -9,7 +9,8 @@ import io.ktor.http.auth.*
 import io.ktor.request.*
 import io.ktor.response.*
 import io.ktor.util.*
-import java.nio.charset.*
+import io.ktor.utils.io.charsets.*
+import kotlin.text.Charsets
 
 /**
  * Represents a Basic authentication provider

--- a/ktor-features/ktor-websockets/jvm/src/io/ktor/websocket/Durations.kt
+++ b/ktor-features/ktor-websockets/jvm/src/io/ktor/websocket/Durations.kt
@@ -2,6 +2,8 @@
  * Copyright 2014-2019 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
+@file:Suppress("FunctionName")
+
 package io.ktor.http.cio.websocket
 
 import io.ktor.util.cio.*
@@ -42,3 +44,44 @@ fun CoroutineScope.pinger(
     timeout: Duration,
     pool: ObjectPool<ByteBuffer> = KtorDefaultPool
 ): SendChannel<Frame.Pong> = pinger(outgoing, period.toMillis(), timeout.toMillis(), pool)
+
+fun WebSockets(
+    pingInterval: Duration?,
+    timeout: Duration,
+    maxFrameSize: Long,
+    masking: Boolean
+): WebSockets = WebSockets(
+    pingInterval?.toMillis() ?: 0L,
+    timeout.toMillis(),
+    maxFrameSize,
+    masking
+)
+
+inline val WebSockets.pingInterval: Duration?
+    get() = when (pingIntervalMillis) {
+        0L -> null
+        else -> Duration.ofMillis(pingIntervalMillis)
+    }
+
+inline val WebSockets.timeout: Duration
+    get() = Duration.ofMillis(timeoutMillis)
+
+@Suppress("EXTENSION_SHADOWED_BY_MEMBER")
+inline var WebSockets.WebSocketOptions.pingPeriod: Duration?
+    get() = when (pingPeriodMillis) {
+        0L -> null
+        else -> Duration.ofMillis(pingPeriodMillis)
+    }
+    set(new) {
+        pingPeriodMillis = when (new) {
+            null -> 0
+            else -> new.toMillis()
+        }
+    }
+
+@Suppress("EXTENSION_SHADOWED_BY_MEMBER")
+inline var WebSockets.WebSocketOptions.timeout: Duration
+    get() = Duration.ofMillis(timeoutMillis)
+    set(new) {
+        timeoutMillis = new.toMillis()
+    }

--- a/ktor-features/ktor-websockets/jvm/src/io/ktor/websocket/Routing.kt
+++ b/ktor-features/ktor-websockets/jvm/src/io/ktor/websocket/Routing.kt
@@ -11,8 +11,6 @@ import io.ktor.response.*
 import io.ktor.routing.*
 import io.ktor.util.cio.*
 import kotlinx.coroutines.*
-import kotlinx.coroutines.channels.*
-import java.util.concurrent.CancellationException
 
 /**
  * Bind RAW websocket at the current route + [path] optionally checking for websocket [protocol] (ignored if `null`)

--- a/ktor-features/ktor-websockets/jvm/src/io/ktor/websocket/WebSockets.kt
+++ b/ktor-features/ktor-websockets/jvm/src/io/ktor/websocket/WebSockets.kt
@@ -5,6 +5,7 @@
 package io.ktor.websocket
 
 import io.ktor.application.*
+import io.ktor.http.cio.websocket.*
 import io.ktor.response.*
 import io.ktor.util.*
 import kotlinx.coroutines.*
@@ -24,14 +25,14 @@ import kotlin.coroutines.*
  * }
  * ```
  *
- * @param pingInterval duration between pings or `null` to disable pings
- * @param timeout write/ping timeout after that a connection will be closed
+ * @param pingIntervalMillis duration between pings or `null` to disable pings
+ * @param timeoutMillis write/ping timeout after that a connection will be closed
  * @param maxFrameSize maximum frame that could be received or sent
  * @param masking whether masking need to be enabled (useful for security)
  */
 class WebSockets(
-    val pingInterval: Duration?,
-    val timeout: Duration,
+    val pingIntervalMillis: Long,
+    val timeoutMillis: Long,
     val maxFrameSize: Long,
     val masking: Boolean
 ) : CoroutineScope {
@@ -39,6 +40,12 @@ class WebSockets(
 
     override val coroutineContext: CoroutineContext
         get() = parent
+
+    init {
+        require(pingIntervalMillis >= 0)
+        require(timeoutMillis >= 0)
+        require(maxFrameSize > 0)
+    }
 
     private fun shutdown() {
         parent.complete()
@@ -51,12 +58,34 @@ class WebSockets(
         /**
          * Duration between pings or `null` to disable pings
          */
-        var pingPeriod: Duration? = null
+        @Suppress("unused")
+        @Deprecated("Binary compatibility.", level = DeprecationLevel.HIDDEN)
+        var pingPeriod: Duration?
+            get() = pingPeriod
+            set(new) {
+                pingPeriod = new
+            }
+
+        /**
+         * Duration between pings or `0` to disable pings
+         */
+        var pingPeriodMillis: Long = 0
 
         /**
          * write/ping timeout after that a connection will be closed
          */
-        var timeout: Duration = Duration.ofSeconds(15)
+        @Suppress("unused")
+        @Deprecated("Binary compatibility.", level = DeprecationLevel.HIDDEN)
+        var timeout: Duration
+            get() = timeout
+            set(new) {
+                timeout = new
+            }
+
+        /**
+         * write/ping timeout after that a connection will be closed
+         */
+        var timeoutMillis: Long = 15000L
 
         /**
          * Maximum frame that could be received or sent

--- a/ktor-http/common/src/io/ktor/http/Cookie.kt
+++ b/ktor-http/common/src/io/ktor/http/Cookie.kt
@@ -6,6 +6,7 @@ package io.ktor.http
 
 import io.ktor.util.*
 import io.ktor.util.date.*
+import kotlin.jvm.*
 
 /**
  * Represents a cookie with name, content and a set of settings such as expiration, visibility and security.
@@ -26,6 +27,7 @@ data class Cookie(
     val name: String,
     val value: String,
     val encoding: CookieEncoding = CookieEncoding.URI_ENCODING,
+    @get:JvmName("getMaxAgeInt")
     val maxAge: Int = 0,
     val expires: GMTDate? = null,
     val domain: String? = null,
@@ -33,7 +35,11 @@ data class Cookie(
     val secure: Boolean = false,
     val httpOnly: Boolean = false,
     val extensions: Map<String, String?> = emptyMap()
-)
+) {
+    @Suppress("unused", "KDocMissingDocumentation")
+    @Deprecated("Binary compatibility.", level = DeprecationLevel.HIDDEN)
+    fun getMaxAge(): Int = maxAge
+}
 
 /**
  * Cooke encoding strategy

--- a/ktor-server/ktor-server-cio/jvm/src/io/ktor/server/cio/EngineMain.kt
+++ b/ktor-server/ktor-server-cio/jvm/src/io/ktor/server/cio/EngineMain.kt
@@ -6,7 +6,6 @@ package io.ktor.server.cio
 
 import io.ktor.config.*
 import io.ktor.server.engine.*
-import java.util.concurrent.*
 
 /**
  * Default engine with main function that starts CIO engine using application.conf
@@ -20,7 +19,7 @@ object EngineMain {
         val applicationEnvironment = commandLineEnvironment(args)
         val engine = CIOApplicationEngine(applicationEnvironment) { loadConfiguration(applicationEnvironment.config) }
         engine.addShutdownHook {
-            engine.stop(3, 5, TimeUnit.SECONDS)
+            engine.stop(3000, 5000)
         }
         engine.start(true)
     }

--- a/ktor-server/ktor-server-cio/jvm/src/io/ktor/server/cio/HttpServer.kt
+++ b/ktor-server/ktor-server-cio/jvm/src/io/ktor/server/cio/HttpServer.kt
@@ -14,9 +14,7 @@ import io.ktor.server.engine.*
 import io.ktor.util.*
 import kotlinx.coroutines.*
 import org.slf4j.*
-import java.net.*
 import java.nio.channels.*
-import java.util.concurrent.*
 import kotlin.coroutines.*
 
 /**
@@ -85,13 +83,13 @@ fun CoroutineScope.httpServer(
 
     val selector = ActorSelectorManager(coroutineContext)
     val timeout = WeakTimeoutQueue(
-        TimeUnit.SECONDS.toMillis(settings.connectionIdleTimeoutSeconds)
+        settings.connectionIdleTimeoutSeconds * 1000L
     )
 
     val logger = LoggerFactory.getLogger(HttpServer::class.java)
 
     val acceptJob = launch(serverJob + CoroutineName("accept-${settings.port}")) {
-        aSocket(selector).tcp().bind(InetSocketAddress(settings.host, settings.port)).use { server ->
+        aSocket(selector).tcp().bind(settings.host, settings.port).use { server ->
             socket.complete(server)
 
             val connectionScope = CoroutineScope(

--- a/ktor-server/ktor-server-cio/jvm/test/io/ktor/tests/server/cio/RAWExample.kt
+++ b/ktor-server/ktor-server-cio/jvm/test/io/ktor/tests/server/cio/RAWExample.kt
@@ -7,14 +7,12 @@ package io.ktor.tests.server.cio
 import io.ktor.http.*
 import io.ktor.http.cio.*
 import io.ktor.server.cio.*
+import io.ktor.util.date.*
 import kotlinx.coroutines.*
 import io.ktor.utils.io.*
-import java.time.*
-
-private val GreenwichMeanTime: ZoneId = ZoneId.of("GMT")
 
 @Volatile
-private var cachedDateText: String = ZonedDateTime.now(GreenwichMeanTime).toHttpDateString()
+private var cachedDateText: String = GMTDate().toHttpDate()
 
 private val HelloWorld = "Hello, World!".toByteArray()
 private val HelloWorldLength = HelloWorld.size.toString()
@@ -33,7 +31,7 @@ fun main(args: Array<String>) {
 
     GlobalScope.launch {
         while (isActive) {
-            cachedDateText = ZonedDateTime.now(GreenwichMeanTime).toHttpDateString()
+            cachedDateText = GMTDate().toHttpDate()
             delay(1000)
         }
     }

--- a/ktor-server/ktor-server-core/jvm/src/io/ktor/application/ApplicationEvents.kt
+++ b/ktor-server/ktor-server-core/jvm/src/io/ktor/application/ApplicationEvents.kt
@@ -4,15 +4,15 @@
 
 package io.ktor.application
 
+import io.ktor.util.*
 import io.ktor.util.internal.*
 import kotlinx.coroutines.*
-import java.util.concurrent.*
 
 /**
  * Provides events for [Application] lifecycle
  */
 class ApplicationEvents {
-    private val handlers = ConcurrentHashMap<EventDefinition<*>, LockFreeLinkedListHead>()
+    private val handlers = CopyOnWriteHashMap<EventDefinition<*>, LockFreeLinkedListHead>()
 
     /**
      * Subscribe [handler] to an event specified by [definition]

--- a/ktor-server/ktor-server-core/jvm/src/io/ktor/features/CachingHeaders.kt
+++ b/ktor-server/ktor-server-core/jvm/src/io/ktor/features/CachingHeaders.kt
@@ -10,7 +10,6 @@ import io.ktor.http.*
 import io.ktor.util.pipeline.*
 import io.ktor.response.*
 import io.ktor.util.*
-import java.util.*
 
 /**
  * Feature that set [CachingOptions] headers for every response.
@@ -65,10 +64,10 @@ class CachingHeaders(private val optionsProviders: List<(OutgoingContent) -> Cac
     /**
      * `ApplicationFeature` implementation for [ConditionalHeaders]
      */
-    companion object Feature : ApplicationFeature<ApplicationCallPipeline, CachingHeaders.Configuration, CachingHeaders> {
-        override val key = AttributeKey<CachingHeaders>("Conditional Headers")
-        override fun install(pipeline: ApplicationCallPipeline, configure: CachingHeaders.Configuration.() -> Unit): CachingHeaders {
-            val configuration = CachingHeaders.Configuration().apply(configure)
+    companion object Feature : ApplicationFeature<ApplicationCallPipeline, Configuration, CachingHeaders> {
+        override val key: AttributeKey<CachingHeaders> = AttributeKey("Conditional Headers")
+        override fun install(pipeline: ApplicationCallPipeline, configure: Configuration.() -> Unit): CachingHeaders {
+            val configuration = Configuration().apply(configure)
             val feature = CachingHeaders(configuration.optionsProviders)
 
             pipeline.sendPipeline.intercept(ApplicationSendPipeline.After) { message -> feature.interceptor(this, message) }

--- a/ktor-server/ktor-server-core/jvm/src/io/ktor/features/CallId.kt
+++ b/ktor-server/ktor-server-core/jvm/src/io/ktor/features/CallId.kt
@@ -10,8 +10,7 @@ import io.ktor.response.*
 import io.ktor.util.*
 import io.ktor.util.pipeline.*
 import org.slf4j.*
-import java.lang.IllegalArgumentException
-import java.util.*
+import kotlin.random.*
 import kotlin.reflect.jvm.*
 
 /**
@@ -172,7 +171,7 @@ class CallId private constructor(
     /**
      * Installable feature for [CallId]
      */
-    companion object Feature : ApplicationFeature<ApplicationCallPipeline, CallId.Configuration, CallId> {
+    companion object Feature : ApplicationFeature<ApplicationCallPipeline, Configuration, CallId> {
         /**
          * [ApplicationCallPipeline]'s phase which this feature will be installed to
          */
@@ -258,7 +257,7 @@ fun CallId.Configuration.generate(length: Int = 64, dictionary: String = CALL_ID
         "Dictionary should not contain duplicates, found: ${dictionary.duplicates()}"
     }
 
-    generate { Random().nextString(length, dictionaryCharacters) }
+    generate { Random.nextString(length, dictionaryCharacters) }
 }
 
 /**

--- a/ktor-server/ktor-server-core/jvm/src/io/ktor/features/ConditionalHeaders.kt
+++ b/ktor-server/ktor-server-core/jvm/src/io/ktor/features/ConditionalHeaders.kt
@@ -10,8 +10,6 @@ import io.ktor.http.*
 import io.ktor.util.pipeline.*
 import io.ktor.response.*
 import io.ktor.util.*
-import java.time.*
-import java.util.*
 
 /**
  * Feature to check modified/match conditional headers and avoid sending contents if it was not changed
@@ -147,7 +145,7 @@ fun Headers.parseVersions(): List<Version> {
     val versions = ArrayList<Version>(lastModifiedHeaders.size + etagHeaders.size)
 
     lastModifiedHeaders.mapTo(versions) {
-        LastModifiedVersion(ZonedDateTime.parse(it, httpDateFormat))
+        LastModifiedVersion(it.fromHttpToGmtDate())
     }
     etagHeaders.mapTo(versions) { EntityTagVersion(it) }
 

--- a/ktor-server/ktor-server-core/jvm/src/io/ktor/features/ContentNegotiation.kt
+++ b/ktor-server/ktor-server-core/jvm/src/io/ktor/features/ContentNegotiation.kt
@@ -12,7 +12,8 @@ import io.ktor.request.*
 import io.ktor.response.*
 import io.ktor.util.*
 import io.ktor.utils.io.*
-import java.nio.charset.Charset
+import io.ktor.utils.io.charsets.*
+import kotlin.text.Charsets
 
 /**
  * Functional type for accepted content types contributor

--- a/ktor-server/ktor-server-core/jvm/src/io/ktor/features/Errors.kt
+++ b/ktor-server/ktor-server-core/jvm/src/io/ktor/features/Errors.kt
@@ -6,7 +6,6 @@ package io.ktor.features
 
 import io.ktor.http.*
 import io.ktor.util.*
-import java.lang.Exception
 import kotlin.reflect.*
 import kotlin.reflect.full.*
 
@@ -54,6 +53,7 @@ abstract class ContentTransformationException(message: String) : Exception(messa
 
 internal class CannotTransformContentToTypeException(type: KType) :
     ContentTransformationException("Cannot transform this request's content to $type") {
+    @Suppress("unused")
     @Deprecated("Use KType instead", level = DeprecationLevel.HIDDEN)
     constructor(type: KClass<*>) : this(type.starProjectedType)
 }

--- a/ktor-server/ktor-server-core/jvm/src/io/ktor/features/HSTS.kt
+++ b/ktor-server/ktor-server-core/jvm/src/io/ktor/features/HSTS.kt
@@ -1,14 +1,12 @@
 /*
  * Copyright 2014-2019 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
-
 package io.ktor.features
 
 import io.ktor.application.*
 import io.ktor.http.*
 import io.ktor.response.*
 import io.ktor.util.*
-import java.time.*
 
 /**
  * HSTS feature that appends `Strict-Transport-Security` HTTP header to every response.
@@ -23,17 +21,32 @@ class HSTS(config: Configuration) {
         /**
          * Consents that the policy allows including the domain into web browser preloading list
          */
-        var preload = false
+        var preload: Boolean = false
 
         /**
          * Adds includeSubDomains directive, which applies this policy to this domain and any subdomains
          */
-        var includeSubDomains = true
+        var includeSubDomains: Boolean = true
 
         /**
          * Duration to tell the client to keep the host in a list of known HSTS hosts
          */
-        var maxAge: Duration = Duration.ofDays(365)
+        @Suppress("unused", "DEPRECATION")
+        @Deprecated("Use maxAgeInSeconds or maxAgeDuration instead.", level = DeprecationLevel.HIDDEN)
+        var maxAge: java.time.Duration
+            get() = maxAge
+            set(newDuration) {
+                maxAge = newDuration
+            }
+
+        /**
+         * Duration in seconds to tell the client to keep the host in a list of known HSTS hosts.
+         */
+        var maxAgeInSeconds: Long = DEFAULT_HSTS_MAX_AGE
+            set(newMaxAge) {
+                check(newMaxAge >= 0L) { "maxAgeInSeconds shouldn't be negative: $newMaxAge" }
+                field = newMaxAge
+            }
 
         /**
          * Any custom directives supported by specific user-agent
@@ -44,9 +57,10 @@ class HSTS(config: Configuration) {
     /**
      * Constructed `Strict-Transport-Security` header value
      */
+    @Suppress("MemberVisibilityCanBePrivate")
     val headerValue: String = buildString {
         append("max-age=")
-        append(config.maxAge.toMillis() / 1000L)
+        append(config.maxAgeInSeconds)
 
         if (config.includeSubDomains) {
             append("; includeSubDomains")
@@ -79,7 +93,9 @@ class HSTS(config: Configuration) {
      * Feature installation object
      */
     companion object Feature : ApplicationFeature<ApplicationCallPipeline, Configuration, HSTS> {
-        override val key = AttributeKey<HSTS>("HSTS")
+        const val DEFAULT_HSTS_MAX_AGE: Long = 365L * 24 * 3600 // 365 days
+
+        override val key: AttributeKey<HSTS> = AttributeKey("HSTS")
         override fun install(pipeline: ApplicationCallPipeline, configure: Configuration.() -> Unit): HSTS {
             val feature = HSTS(Configuration().apply(configure))
             pipeline.intercept(ApplicationCallPipeline.Features) { feature.intercept(call) }

--- a/ktor-server/ktor-server-core/jvm/src/io/ktor/features/HSTS.kt
+++ b/ktor-server/ktor-server-core/jvm/src/io/ktor/features/HSTS.kt
@@ -9,7 +9,6 @@ import io.ktor.http.*
 import io.ktor.response.*
 import io.ktor.util.*
 import java.time.*
-import java.util.*
 
 /**
  * HSTS feature that appends `Strict-Transport-Security` HTTP header to every response.

--- a/ktor-server/ktor-server-core/jvm/src/io/ktor/features/JavaTimeMigration.kt
+++ b/ktor-server/ktor-server-core/jvm/src/io/ktor/features/JavaTimeMigration.kt
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2014-2019 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.features
+
+import io.ktor.sessions.*
+import java.time.*
+
+@Suppress("unused", "EXTENSION_SHADOWED_BY_MEMBER")
+@Deprecated("Use maxAgeInSeconds or maxAgeDuration instead.")
+var CORS.Configuration.maxAge: Duration
+    get() = Duration.ofSeconds(maxAgeInSeconds)
+    set(newMaxAge) {
+        maxAgeInSeconds = newMaxAge.toMillis() / 1000
+    }
+
+@Suppress("unused", "EXTENSION_SHADOWED_BY_MEMBER")
+@Deprecated("Use maxAgeInSeconds or maxAgeDuration instead.")
+var HSTS.Configuration.maxAge: Duration
+    get() = Duration.ofSeconds(maxAgeInSeconds)
+    set(newMaxAge) {
+        maxAgeInSeconds = newMaxAge.toMillis() / 1000
+    }

--- a/ktor-server/ktor-server-core/jvm/src/io/ktor/features/KotlinTimeJvm.kt
+++ b/ktor-server/ktor-server-core/jvm/src/io/ktor/features/KotlinTimeJvm.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2014-2019 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.features
+
+import io.ktor.sessions.*
+import kotlin.math.*
+import kotlin.time.*
+
+/**
+ * Duration to tell the client to keep CORS options.
+ */
+@ExperimentalTime
+var CORS.Configuration.maxAgeDuration: Duration
+    get() = maxAgeInSeconds.seconds
+    set(newMaxAge) {
+        require(!newMaxAge.isNegative()) { "Only non-negative durations can be specified" }
+        maxAgeInSeconds = newMaxAge.inSeconds.roundToLong()
+    }
+
+@ExperimentalTime
+var HSTS.Configuration.maxAgeDuration: Duration
+    get() = maxAgeInSeconds.seconds
+    set(newMaxAge) {
+        require(!newMaxAge.isNegative()) { "Only non-negative durations can be specified" }
+        maxAgeInSeconds = newMaxAge.inSeconds.roundToLong()
+    }
+
+/**
+ * Cookie time to live duration or `null` for session cookies.
+ * Session cookies are client-driven. For example, a web browser usually removes session
+ * cookies at browser or window close unless the session is restored.
+ */
+@ExperimentalTime
+var CookieConfiguration.maxAge: Duration?
+    get() = maxAgeInSeconds.seconds
+    set(newMaxAge) {
+        require(newMaxAge == null || !newMaxAge.isNegative()) { "Only non-negative durations can be specified" }
+        maxAgeInSeconds = newMaxAge?.inSeconds?.roundToLong() ?: 0L
+    }

--- a/ktor-server/ktor-server-core/jvm/src/io/ktor/features/OriginConnectionPoint.kt
+++ b/ktor-server/ktor-server-core/jvm/src/io/ktor/features/OriginConnectionPoint.kt
@@ -8,7 +8,6 @@ import io.ktor.application.*
 import io.ktor.http.*
 import io.ktor.request.*
 import io.ktor.util.*
-import java.util.*
 import kotlin.reflect.*
 
 /**

--- a/ktor-server/ktor-server-core/jvm/src/io/ktor/http/HttpDate.kt
+++ b/ktor-server/ktor-server-core/jvm/src/io/ktor/http/HttpDate.kt
@@ -5,6 +5,7 @@
 package io.ktor.http
 
 import io.ktor.util.*
+import io.ktor.util.date.*
 import java.time.*
 import java.time.format.*
 import java.time.temporal.*
@@ -14,7 +15,7 @@ import java.util.*
  * Format epoch milliseconds as HTTP date (GMT)
  */
 @KtorExperimentalAPI
-fun Long.toHttpDateString(): String = Instant.ofEpochMilli(this).toHttpDateString()
+fun Long.toHttpDateString(): String = GMTDate(this).toHttpDate()
 
 /**
  * Format as HTTP date (GMT)

--- a/ktor-server/ktor-server-core/jvm/src/io/ktor/http/HttpDate.kt
+++ b/ktor-server/ktor-server-core/jvm/src/io/ktor/http/HttpDate.kt
@@ -9,7 +9,6 @@ import io.ktor.util.date.*
 import java.time.*
 import java.time.format.*
 import java.time.temporal.*
-import java.util.*
 
 /**
  * Format epoch milliseconds as HTTP date (GMT)
@@ -20,21 +19,21 @@ fun Long.toHttpDateString(): String = GMTDate(this).toHttpDate()
 /**
  * Format as HTTP date (GMT)
  */
-fun Temporal.toHttpDateString(): String = httpDateFormat.format(this)
+@Suppress("CONFLICTING_OVERLOADS", "unused")
+@Deprecated("Binary compatibility.", level = DeprecationLevel.HIDDEN)
+fun Temporal.toHttpDateString(): String = toHttpDateString()
 
 /**
  * Parse HTTP date to [ZonedDateTime]
  */
-@KtorExperimentalAPI
+@Suppress("CONFLICTING_OVERLOADS", "unused")
+@Deprecated("Binary compatibility.", level = DeprecationLevel.HIDDEN)
 fun String.fromHttpDateString(): ZonedDateTime = ZonedDateTime.parse(this, httpDateFormat)
-
-private val GreenwichMeanTime: ZoneId = ZoneId.of("GMT")
 
 /**
  * Default HTTP date format
  */
-@KtorExperimentalAPI
-val httpDateFormat: DateTimeFormatter = DateTimeFormatter
-    .ofPattern("EEE, dd MMM yyyy HH:mm:ss z")
-    .withLocale(Locale.US)
-    .withZone(GreenwichMeanTime)!!
+@Suppress("CONFLICTING_OVERLOADS", "REDECLARATION", "unused")
+@Deprecated("Binary compatibility.", level = DeprecationLevel.HIDDEN)
+val httpDateFormat: DateTimeFormatter
+    get() = httpDateFormat

--- a/ktor-server/ktor-server-core/jvm/src/io/ktor/http/HttpDateJvm.kt
+++ b/ktor-server/ktor-server-core/jvm/src/io/ktor/http/HttpDateJvm.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2014-2019 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.http
+
+import io.ktor.util.*
+import java.time.*
+import java.time.format.*
+import java.time.temporal.*
+import java.util.*
+
+/**
+ * Format as HTTP date (GMT)
+ */
+@Suppress("CONFLICTING_OVERLOADS", "REDECLARATION")
+fun Temporal.toHttpDateString(): String = httpDateFormat.format(this)
+
+/**
+ * Parse HTTP date to [ZonedDateTime]
+ */
+@KtorExperimentalAPI
+@Suppress("CONFLICTING_OVERLOADS", "REDECLARATION", "unused")
+fun String.fromHttpDateString(): ZonedDateTime = ZonedDateTime.parse(this, httpDateFormat)
+
+private val GreenwichMeanTime: ZoneId = ZoneId.of("GMT")
+
+/**
+ * Default HTTP date format
+ */
+@KtorExperimentalAPI
+@Suppress("CONFLICTING_OVERLOADS", "REDECLARATION")
+val httpDateFormat: DateTimeFormatter = DateTimeFormatter
+    .ofPattern("EEE, dd MMM yyyy HH:mm:ss z")
+    .withLocale(Locale.US)
+    .withZone(GreenwichMeanTime)!!

--- a/ktor-server/ktor-server-core/jvm/src/io/ktor/http/content/StaticContent.kt
+++ b/ktor-server/ktor-server-core/jvm/src/io/ktor/http/content/StaticContent.kt
@@ -10,7 +10,7 @@ import io.ktor.routing.*
 import io.ktor.util.*
 import java.io.*
 
-private val pathParameterName = "static-content-path-parameter"
+private const val pathParameterName = "static-content-path-parameter"
 
 private val staticRootFolderKey = AttributeKey<File>("BaseFolder")
 

--- a/ktor-server/ktor-server-core/jvm/src/io/ktor/request/RequestCookies.kt
+++ b/ktor-server/ktor-server-core/jvm/src/io/ktor/request/RequestCookies.kt
@@ -6,14 +6,14 @@ package io.ktor.request
 
 import io.ktor.http.*
 import io.ktor.util.*
-import java.util.concurrent.*
+import io.ktor.util.collections.*
 
 /**
  * Server request's cookies
  * @property request application request to fetch cookies from
  */
 open class RequestCookies(protected val request: ApplicationRequest) {
-    private val map = ConcurrentHashMap<Pair<CookieEncoding, String>, String>()
+    private val map = ConcurrentMap<Pair<CookieEncoding, String>, String>()
 
     /**
      * RAW cookie values, not decoded so could have percent encoded values, quotes, escape characters and so on.

--- a/ktor-server/ktor-server-core/jvm/src/io/ktor/request/RequestCookies.kt
+++ b/ktor-server/ktor-server-core/jvm/src/io/ktor/request/RequestCookies.kt
@@ -6,7 +6,6 @@ package io.ktor.request
 
 import io.ktor.http.*
 import io.ktor.util.*
-import java.util.*
 import java.util.concurrent.*
 
 /**

--- a/ktor-server/ktor-server-core/jvm/src/io/ktor/response/ResponseCookies.kt
+++ b/ktor-server/ktor-server-core/jvm/src/io/ktor/response/ResponseCookies.kt
@@ -35,11 +35,30 @@ class ResponseCookies(
     /**
      * Append a cookie using `Set-Cookie` HTTP response header from the specified parameters
      */
+    @Deprecated("Convert maxAge to Long")
     fun append(
         name: String,
         value: String,
         encoding: CookieEncoding = CookieEncoding.URI_ENCODING,
-        maxAge: Int = 0,
+        maxAge: Int,
+        expires: GMTDate? = null,
+        domain: String? = null,
+        path: String? = null,
+        secure: Boolean = false,
+        httpOnly: Boolean = false,
+        extensions: Map<String, String?> = emptyMap()
+    ) {
+        append(name, value, encoding, maxAge.toLong(), expires, domain, path, secure, httpOnly, extensions)
+    }
+
+    /**
+     * Append a cookie using `Set-Cookie` HTTP response header from the specified parameters
+     */
+    fun append(
+        name: String,
+        value: String,
+        encoding: CookieEncoding = CookieEncoding.URI_ENCODING,
+        maxAge: Long = 0,
         expires: GMTDate? = null,
         domain: String? = null,
         path: String? = null,
@@ -52,7 +71,7 @@ class ResponseCookies(
                 name,
                 value,
                 encoding,
-                maxAge,
+                maxAge.coerceAtMost(Int.MAX_VALUE.toLong()).toInt(),
                 expires,
                 domain,
                 path,

--- a/ktor-server/ktor-server-core/jvm/src/io/ktor/routing/Route.kt
+++ b/ktor-server/ktor-server-core/jvm/src/io/ktor/routing/Route.kt
@@ -6,7 +6,6 @@ package io.ktor.routing
 
 import io.ktor.application.*
 import io.ktor.util.pipeline.*
-import java.util.*
 
 /**
  * Describes a node in a routing tree
@@ -44,7 +43,7 @@ open class Route(val parent: Route?, val selector: RouteSelector) : ApplicationC
     /**
      * Allows using route instance for building additional routes
      */
-    operator fun invoke(body: Route.() -> Unit) = body()
+    operator fun invoke(body: Route.() -> Unit): Unit = body()
 
     /**
      * Installs a handler into this route which will be called when the route is selected for a call
@@ -87,7 +86,7 @@ open class Route(val parent: Route?, val selector: RouteSelector) : ApplicationC
 
             val handlers = handlers
             for (index in 0..handlers.lastIndex) {
-                pipeline.intercept(ApplicationCallPipeline.Call, handlers[index])
+                pipeline.intercept(Call, handlers[index])
             }
             cachedPipeline = pipeline
             pipeline

--- a/ktor-server/ktor-server-core/jvm/src/io/ktor/routing/RoutingResolveTrace.kt
+++ b/ktor-server/ktor-server-core/jvm/src/io/ktor/routing/RoutingResolveTrace.kt
@@ -5,7 +5,6 @@
 package io.ktor.routing
 
 import io.ktor.application.*
-import java.util.*
 
 /**
  * Represents a single entry in the [RoutingResolveTrace].
@@ -87,5 +86,29 @@ class RoutingResolveTrace(val call: ApplicationCall, val segments: List<String>)
     fun buildText(): String = buildString {
         appendln(this@RoutingResolveTrace.toString())
         routing?.buildText(this, 0)
+    }
+}
+
+private class Stack<E> {
+    private val tower = ArrayList<E>()
+
+    fun empty(): Boolean = tower.isEmpty()
+
+    fun push(element: E) {
+        tower.add(element)
+    }
+
+    fun pop(): E {
+        if (tower.isEmpty()) {
+            throw NoSuchElementException("Unable to pop an element from empty stack")
+        }
+        return tower.removeAt(tower.lastIndex)
+    }
+
+    fun peek(): E {
+        if (tower.isEmpty()) {
+            throw NoSuchElementException("Unable to peek an element into empty stack")
+        }
+        return tower.last()
     }
 }

--- a/ktor-server/ktor-server-core/jvm/src/io/ktor/sessions/JavaTimeMigration.kt
+++ b/ktor-server/ktor-server-core/jvm/src/io/ktor/sessions/JavaTimeMigration.kt
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2014-2019 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.sessions
+
+import java.time.*
+import java.time.temporal.*
+
+@Suppress("unused", "EXTENSION_SHADOWED_BY_MEMBER")
+@Deprecated("Use maxAgeInSeconds or maxAgeDuration instead.")
+var CookieConfiguration.duration: TemporalAmount?
+    get() = Duration.ofSeconds(maxAgeInSeconds)
+    set(newMaxAge) {
+        maxAgeInSeconds = when (newMaxAge) {
+            null -> 0
+            is Duration -> newMaxAge.toMillis() / 1000L
+            else -> newMaxAge[ChronoUnit.SECONDS]
+        }
+    }
+

--- a/ktor-server/ktor-server-core/jvm/src/io/ktor/sessions/SessionTransportCookie.kt
+++ b/ktor-server/ktor-server-core/jvm/src/io/ktor/sessions/SessionTransportCookie.kt
@@ -1,15 +1,13 @@
 /*
  * Copyright 2014-2019 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
-
 package io.ktor.sessions
 
 import io.ktor.application.*
 import io.ktor.http.*
 import io.ktor.util.date.*
-import java.time.*
-import java.time.temporal.*
-import java.util.concurrent.*
+
+const val DEFAULT_SESSION_MAX_AGE: Long = 7L * 24 * 3600 // 7 days
 
 /**
  * SessionTransport that adds a Set-Cookie header and reads Cookie header
@@ -32,14 +30,17 @@ class SessionTransportCookie(
 
     override fun send(call: ApplicationCall, value: String) {
         val now = GMTDate()
-        val maxAge = configuration.duration?.let { it[ChronoUnit.SECONDS].coerceAtMost(Int.MAX_VALUE.toLong()) }
-        val expires = maxAge?.let { now + TimeUnit.SECONDS.toMillis(maxAge) }
+        val maxAge = configuration.maxAgeInSeconds
+        val expires = when {
+            maxAge == 0L -> null
+            else -> now + maxAge * 1000L
+        }
 
         val cookie = Cookie(
             name,
             transformers.transformWrite(value),
             configuration.encoding,
-            maxAge?.toInt() ?: 0,
+            maxAge.coerceAtMost(Int.MAX_VALUE.toLong()).toInt(),
             expires,
             configuration.domain,
             configuration.path,
@@ -69,7 +70,24 @@ class CookieConfiguration {
      * Session cookies are client-driven. For example, a web browser usually removes session
      * cookies at browser or window close unless the session is restored.
      */
-    var duration: TemporalAmount? = Duration.ofDays(7)
+    @Suppress("DEPRECATION", "unused")
+    @Deprecated("Use maxAge or maxAgeInSeconds instead.", level = DeprecationLevel.HIDDEN)
+    var duration: java.time.temporal.TemporalAmount?
+        get() = duration
+        set(newDuration) {
+            duration = newDuration
+        }
+
+    /**
+     * Cookie time to live duration or 0 for session cookies.
+     * Session cookies are client-driven. For example, a web browser usually removes session
+     * cookies at browser or window close unless the session is restored.
+     */
+    var maxAgeInSeconds: Long = DEFAULT_SESSION_MAX_AGE
+        set(newMaxAge) {
+            require(newMaxAge >= 0) { "maxAgeInSeconds shouldn't be negative: $newMaxAge" }
+            field = newMaxAge
+        }
 
     /**
      * Cookie encoding

--- a/ktor-server/ktor-server-core/jvm/src/io/ktor/util/CopyOnWriteHashMap.kt
+++ b/ktor-server/ktor-server-core/jvm/src/io/ktor/util/CopyOnWriteHashMap.kt
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2014-2019 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.util
+
+import kotlinx.atomicfu.*
+
+/**
+ * This is an internal implementation for copy-on-write concurrent map.
+ * It is very limited since it is not intended as general purpose implementation.
+ */
+@InternalAPI
+class CopyOnWriteHashMap<K : Any, V : Any> {
+    private val current = atomic(emptyMap<K, V>())
+
+    /**
+     * @see MutableMap.put
+     */
+    fun put(key: K, value: V): V? {
+        do {
+            val old = current.value
+            if (old[key] === value) return value
+
+            val copy = HashMap(old)
+            val replaced = copy.put(key, value)
+            if (current.compareAndSet(old, copy)) return replaced
+        } while (true)
+    }
+
+    /**
+     * @see Map.get
+     */
+    operator fun get(key: K): V? = current.value[key]
+
+    /**
+     * Operator function for array access syntax
+     */
+    operator fun set(key: K, value: V) {
+        put(key, value)
+    }
+
+    /**
+     * @see MutableMap.remove
+     */
+    fun remove(key: K): V? {
+        do {
+            val old = current.value
+            if (old[key] == null) return null
+
+            val copy = HashMap(old)
+            val removed = copy.remove(key)
+            if (current.compareAndSet(old, copy)) return removed
+        } while (true)
+    }
+
+    /**
+     * @see MutableMap.computeIfAbsent
+     */
+    fun computeIfAbsent(key: K, producer: (key: K) -> V): V {
+        do {
+            val old = current.value
+            old[key]?.let { return it }
+
+            val copy = HashMap(old)
+            val newValue = producer(key)
+            copy[key] = newValue
+            if (current.compareAndSet(old, copy)) return newValue
+        } while (true)
+    }
+}

--- a/ktor-server/ktor-server-core/jvm/test/io/ktor/tests/http/FindContainingJarFileTest.kt
+++ b/ktor-server/ktor-server-core/jvm/test/io/ktor/tests/http/FindContainingJarFileTest.kt
@@ -5,7 +5,6 @@
 package io.ktor.tests.http
 
 import io.ktor.http.content.*
-import org.junit.Test
 import kotlin.test.*
 
 class FindContainingJarFileTest {

--- a/ktor-server/ktor-server-core/jvm/test/io/ktor/tests/http/MultipleRangeWriterTest.kt
+++ b/ktor-server/ktor-server-core/jvm/test/io/ktor/tests/http/MultipleRangeWriterTest.kt
@@ -8,7 +8,6 @@ import io.ktor.features.*
 import kotlinx.coroutines.*
 import io.ktor.utils.io.*
 import io.ktor.utils.io.jvm.javaio.*
-import org.junit.Test
 import kotlin.coroutines.*
 import kotlin.test.*
 

--- a/ktor-server/ktor-server-core/jvm/test/io/ktor/tests/utils/CopyOnWriteHashMapTest.kt
+++ b/ktor-server/ktor-server-core/jvm/test/io/ktor/tests/utils/CopyOnWriteHashMapTest.kt
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2014-2019 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.tests.utils
+
+import io.ktor.util.*
+import kotlin.test.*
+
+class CopyOnWriteHashMapTest {
+    private val map = CopyOnWriteHashMap<String, String>()
+
+    @Test
+    fun smoke() {
+        assertEquals(null, map["k1"])
+        map["k1"] = "v1"
+        assertEquals("v1", map["k1"])
+
+        assertEquals(null, map["k2"])
+        assertEquals(null, map.put("k2", "v2"))
+        assertEquals("v2", map.put("k2", "v3"))
+        assertEquals("v3", map.remove("k2"))
+
+        assertEquals("v31", map.computeIfAbsent("k3") { "v31" })
+        assertEquals("v31", map.computeIfAbsent("k3") { "v32" })
+    }
+
+    @Test
+    fun getEmpty() {
+        assertNull(map["k1"])
+    }
+
+    @Test
+    fun getExisting() {
+        map.put("k1", "v1")
+        assertEquals("v1", map["k1"])
+    }
+
+    @Test
+    fun putNewAndReplace() {
+        assertEquals(null, map.put("k1", "v1"))
+        assertEquals("v1", map.put("k1", "v2"))
+        assertEquals("v2", map.put("k1", "v3"))
+        assertEquals("v3", map["k1"])
+    }
+
+    @Test
+    fun putMany() {
+        repeat(100) {
+            assertNull(map.put("k-$it", "v-$it"))
+        }
+
+        repeat(100) {
+            assertEquals("v-$it", map["k-$it"])
+        }
+    }
+
+    @Test
+    fun testRemoveMissing() {
+        assertNull(map["k"])
+        assertNull(map.remove("k"))
+        assertNull(map["k"])
+    }
+
+    @Test
+    fun testRemoveExisting() {
+        map.put("k1", "v1")
+        assertEquals("v1", map.remove("k1"))
+        assertNull(map.remove("k1"))
+        assertNull(map["k1"])
+    }
+
+    @Test
+    fun testRemoveOnlySpecified() {
+        map.put("k1", "v1")
+        map.put("k2", "v2")
+
+        assertEquals("v1", map["k1"])
+        assertEquals("v2", map["k2"])
+        assertEquals("v1", map.remove("k1"))
+        assertEquals(null, map["k1"])
+        assertEquals("v2", map["k2"])
+    }
+
+    @Test
+    fun testComputeIfAbsentMissing() {
+        assertNull(map["k1"])
+        assertEquals("v1", map.computeIfAbsent("k1") { "v1" })
+        assertEquals("v1", map["k1"])
+    }
+
+    @Test
+    fun testComputeIfAbsentExisting() {
+        map.put("k1", "v0")
+        assertEquals("v0", map.computeIfAbsent("k1") { fail("shouldn't be invoked") })
+        assertEquals("v0", map["k1"])
+    }
+}

--- a/ktor-server/ktor-server-host-common/jvm/src/io/ktor/server/engine/ApplicationEngine.kt
+++ b/ktor-server/ktor-server-host-common/jvm/src/io/ktor/server/engine/ApplicationEngine.kt
@@ -5,7 +5,6 @@
 package io.ktor.server.engine
 
 import io.ktor.application.*
-import java.util.concurrent.*
 
 /**
  * Engine which runs an application
@@ -15,6 +14,7 @@ interface ApplicationEngine {
     /**
      * Configuration for the [ApplicationEngine]
      */
+    @Suppress("MemberVisibilityCanBePrivate")
     open class Configuration {
         /**
          * Provides currently available parallelism, e.g. number of available processors
@@ -24,17 +24,17 @@ interface ApplicationEngine {
         /**
          * Specifies size of the event group for accepting connections
          */
-        var connectionGroupSize = parallelism / 2 + 1
+        var connectionGroupSize: Int = parallelism / 2 + 1
 
         /**
          * Specifies size of the event group for processing connections, parsing messages and doing engine's internal work
          */
-        var workerGroupSize = parallelism / 2 + 1
+        var workerGroupSize: Int = parallelism / 2 + 1
 
         /**
          * Specifies size of the event group for running application code
          */
-        var callGroupSize = parallelism
+        var callGroupSize: Int = parallelism
     }
 
     /**
@@ -60,8 +60,19 @@ interface ApplicationEngine {
      *
      * @param gracePeriod the maximum amount of time for activity to cool down
      * @param timeout the maximum amount of time to wait until server stops gracefully
-     * @param timeUnit the [TimeUnit] for [gracePeriod] and [timeout]
+     * @param timeUnit the [java.util.concurrent.TimeUnit] for [gracePeriod] and [timeout]
      */
-    fun stop(gracePeriod: Long, timeout: Long, timeUnit: TimeUnit)
+    @Deprecated("Binary compatibility.", level = DeprecationLevel.HIDDEN)
+    fun stop(gracePeriod: Long, timeout: Long, timeUnit: java.util.concurrent.TimeUnit) {
+        stop(gracePeriod, timeout, timeUnit)
+    }
+
+    /**
+     * Stops this [ApplicationEngine]
+     *
+     * @param gracePeriodMillis the maximum amount of time for activity to cool down
+     * @param timeoutMillis the maximum amount of time to wait until server stops gracefully
+     */
+    fun stop(gracePeriodMillis: Long, timeoutMillis: Long)
 }
 

--- a/ktor-server/ktor-server-host-common/jvm/src/io/ktor/server/engine/ApplicationEngineJvm.kt
+++ b/ktor-server/ktor-server-host-common/jvm/src/io/ktor/server/engine/ApplicationEngineJvm.kt
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2014-2019 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.server.engine
+
+import java.util.concurrent.*
+
+/**
+ * Stops this [ApplicationEngine]
+ *
+ * @param gracePeriod the maximum amount of time for activity to cool down
+ * @param timeout the maximum amount of time to wait until server stops gracefully
+ * @param timeUnit the [TimeUnit] for [gracePeriod] and [timeout]
+ */
+@Suppress("EXTENSION_SHADOWED_BY_MEMBER")
+fun ApplicationEngine.stop(gracePeriod: Long, timeout: Long, timeUnit: TimeUnit) {
+    stop(timeUnit.toMillis(gracePeriod), timeUnit.toMillis(timeout))
+}

--- a/ktor-server/ktor-server-host-common/jvm/src/io/ktor/server/engine/DefaultEnginePipeline.kt
+++ b/ktor-server/ktor-server-host-common/jvm/src/io/ktor/server/engine/DefaultEnginePipeline.kt
@@ -13,9 +13,9 @@ import io.ktor.response.*
 import io.ktor.util.*
 import kotlinx.coroutines.*
 import io.ktor.utils.io.*
+import kotlinx.coroutines.CancellationException
 import java.nio.channels.*
 import java.util.concurrent.*
-import java.util.concurrent.CancellationException
 
 /**
  * Default engine pipeline for all engines. Use it only if you are writing your own application engine implementation.

--- a/ktor-server/ktor-server-host-common/jvm/src/io/ktor/server/engine/DefaultUncaughtExceptionHandler.kt
+++ b/ktor-server/ktor-server-host-common/jvm/src/io/ktor/server/engine/DefaultUncaughtExceptionHandler.kt
@@ -8,7 +8,6 @@ import io.ktor.util.*
 import kotlinx.coroutines.*
 import org.slf4j.*
 import java.io.*
-import java.util.concurrent.CancellationException
 import kotlin.coroutines.*
 
 /**

--- a/ktor-server/ktor-server-host-common/jvm/src/io/ktor/server/engine/EngineContextCancellationHelper.kt
+++ b/ktor-server/ktor-server-host-common/jvm/src/io/ktor/server/engine/EngineContextCancellationHelper.kt
@@ -6,7 +6,6 @@ package io.ktor.server.engine
 
 import io.ktor.util.*
 import kotlinx.coroutines.*
-import java.util.concurrent.*
 
 /**
  * Stop server on job cancellation. The returned deferred need to be completed or cancelled.
@@ -15,7 +14,7 @@ import java.util.concurrent.*
 @KtorExperimentalAPI
 fun ApplicationEngine.stopServerOnCancellation(): CompletableJob =
     environment.parentCoroutineContext[Job]?.launchOnCancellation {
-        stop(1, 5, TimeUnit.SECONDS)
+        stop(1000, 5000)
     } ?: Job()
 
 /**

--- a/ktor-server/ktor-server-jetty/jvm/src/io/ktor/server/jetty/JettyApplicationEngine.kt
+++ b/ktor-server/ktor-server-jetty/jvm/src/io/ktor/server/jetty/JettyApplicationEngine.kt
@@ -7,7 +7,6 @@ package io.ktor.server.jetty
 import io.ktor.server.engine.*
 import io.ktor.util.*
 import kotlinx.coroutines.*
-import java.util.concurrent.*
 
 /**
  * [ApplicationEngine] implementation for running in a standalone Jetty
@@ -24,10 +23,10 @@ class JettyApplicationEngine(
         return this
     }
 
-    override fun stop(gracePeriod: Long, timeout: Long, timeUnit: TimeUnit) {
+    override fun stop(gracePeriodMillis: Long, timeoutMillis: Long) {
         dispatcher.prepareShutdown()
         try {
-            super.stop(gracePeriod, timeout, timeUnit)
+            super.stop(gracePeriodMillis, timeoutMillis)
         } finally {
             dispatcher.completeShutdown()
         }

--- a/ktor-server/ktor-server-jetty/jvm/src/io/ktor/server/jetty/JettyApplicationEngineBase.kt
+++ b/ktor-server/ktor-server-jetty/jvm/src/io/ktor/server/jetty/JettyApplicationEngineBase.kt
@@ -57,10 +57,10 @@ open class JettyApplicationEngineBase(
         return this
     }
 
-    override fun stop(gracePeriod: Long, timeout: Long, timeUnit: TimeUnit) {
+    override fun stop(gracePeriodMillis: Long, timeoutMillis: Long) {
         cancellationDeferred?.complete()
         environment.monitor.raise(ApplicationStopPreparing, environment)
-        server.stopTimeout = timeUnit.toMillis(timeout)
+        server.stopTimeout = timeoutMillis
         server.stop()
         server.destroy()
         environment.stop()

--- a/ktor-server/ktor-server-test-host/jvm/src/io/ktor/server/testing/TestApplicationEngine.kt
+++ b/ktor-server/ktor-server-test-host/jvm/src/io/ktor/server/testing/TestApplicationEngine.kt
@@ -16,7 +16,6 @@ import kotlinx.coroutines.*
 import kotlinx.coroutines.channels.*
 import kotlinx.coroutines.future.*
 import io.ktor.utils.io.*
-import java.util.concurrent.*
 import kotlin.coroutines.*
 
 /**
@@ -74,9 +73,9 @@ class TestApplicationEngine(
     }
 
     override fun start(wait: Boolean): ApplicationEngine {
-        if (!testEngineJob.isActive) throw IllegalStateException("Test engine is already completed")
+        check(testEngineJob.isActive) { "Test engine is already completed" }
         testEngineJob.invokeOnCompletion {
-            stop(0, 0, TimeUnit.SECONDS)
+            stop(0, 0)
         }
         environment.start()
         return this

--- a/ktor-server/ktor-server-test-host/jvm/src/io/ktor/server/testing/TestApplicationEngine.kt
+++ b/ktor-server/ktor-server-test-host/jvm/src/io/ktor/server/testing/TestApplicationEngine.kt
@@ -82,7 +82,7 @@ class TestApplicationEngine(
         return this
     }
 
-    override fun stop(gracePeriod: Long, timeout: Long, timeUnit: TimeUnit) {
+    override fun stop(gracePeriodMillis: Long, timeoutMillis: Long) {
         try {
             environment.monitor.raise(ApplicationStopPreparing, environment)
             environment.stop()

--- a/ktor-server/ktor-server-test-host/jvm/src/io/ktor/server/testing/TestApplicationResponse.kt
+++ b/ktor-server/ktor-server-test-host/jvm/src/io/ktor/server/testing/TestApplicationResponse.kt
@@ -12,7 +12,6 @@ import io.ktor.server.engine.*
 import io.ktor.util.*
 import kotlinx.coroutines.*
 import io.ktor.utils.io.*
-import java.time.*
 import kotlin.coroutines.*
 
 /**
@@ -144,8 +143,8 @@ class TestApplicationResponse(
     /**
      * Wait for websocket session completion
      */
-    fun awaitWebSocket(duration: Duration): Unit = runBlocking {
-        withTimeout(duration.toMillis()) {
+    fun awaitWebSocket(durationMillis: Long): Unit = runBlocking {
+        withTimeout(durationMillis) {
             responseChannelDeferred.join()
             responseJob?.join()
             webSocketCompleted.join()
@@ -153,6 +152,10 @@ class TestApplicationResponse(
 
         Unit
     }
+
+    @Suppress("unused")
+    @Deprecated("Binary compatibility.", level = DeprecationLevel.HIDDEN)
+    fun awaitWebSocket(duration: java.time.Duration): Unit = awaitWebSocket(duration)
 
     /**
      * Websocket session's channel

--- a/ktor-server/ktor-server-test-host/jvm/src/io/ktor/server/testing/TestApplicationResponseJvm.kt
+++ b/ktor-server/ktor-server-test-host/jvm/src/io/ktor/server/testing/TestApplicationResponseJvm.kt
@@ -1,0 +1,15 @@
+/*
+ * Copyright 2014-2019 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.server.testing
+
+import java.time.*
+
+/**
+ * Wait for websocket session completion
+ */
+@Suppress("EXTENSION_SHADOWED_BY_MEMBER")
+fun TestApplicationResponse.awaitWebSocket(duration: Duration) {
+    awaitWebSocket(duration.toMillis())
+}

--- a/ktor-server/ktor-server-test-host/jvm/src/io/ktor/server/testing/TestEngine.kt
+++ b/ktor-server/ktor-server-test-host/jvm/src/io/ktor/server/testing/TestEngine.kt
@@ -9,7 +9,6 @@ import io.ktor.config.*
 import io.ktor.http.*
 import io.ktor.server.engine.*
 import org.slf4j.*
-import java.util.concurrent.*
 
 /**
  * Creates test application engine environment
@@ -49,7 +48,7 @@ fun <R> withApplication(
     try {
         return engine.test()
     } finally {
-        engine.stop(0L, 0L, TimeUnit.MILLISECONDS)
+        engine.stop(0L, 0L)
     }
 }
 

--- a/ktor-server/ktor-server-test-host/jvm/src/io/ktor/server/testing/client/TestHttpClientEngine.kt
+++ b/ktor-server/ktor-server-test-host/jvm/src/io/ktor/server/testing/client/TestHttpClientEngine.kt
@@ -14,7 +14,6 @@ import io.ktor.util.*
 import io.ktor.util.date.*
 import kotlinx.coroutines.*
 import io.ktor.utils.io.*
-import java.util.concurrent.*
 import kotlin.coroutines.*
 
 @Suppress("KDocMissingDocumentation")
@@ -65,7 +64,7 @@ class TestHttpClientEngine(override val config: TestHttpClientConfig) : HttpClie
     }
 
     override fun close() {
-        app.stop(0L, 0L, TimeUnit.MILLISECONDS)
+        app.stop(0L, 0L)
     }
 
     companion object : HttpClientEngineFactory<TestHttpClientConfig> {

--- a/ktor-server/ktor-server-tests/jvm/test/io/ktor/tests/server/features/CORSTest.kt
+++ b/ktor-server/ktor-server-tests/jvm/test/io/ktor/tests/server/features/CORSTest.kt
@@ -646,4 +646,28 @@ class CORSTest {
             }
         }
     }
+
+    @Test
+    fun testPreflightCustomMaxAge() {
+        withTestApplication {
+            application.install(CORS) {
+                anyHost()
+                maxAgeInSeconds = 100
+            }
+
+            application.routing {
+                get("/") {
+                    call.respond("OK")
+                }
+            }
+
+            handleRequest(HttpMethod.Options, "/") {
+                addHeader(HttpHeaders.Origin, "http://host")
+                addHeader(HttpHeaders.AccessControlRequestMethod, "GET")
+            }.let { call ->
+                assertEquals(HttpStatusCode.OK, call.response.status())
+                assertEquals("100", call.response.headers[HttpHeaders.AccessControlMaxAge])
+            }
+        }
+    }
 }

--- a/ktor-server/ktor-server-tests/jvm/test/io/ktor/tests/server/features/HSTSTest.kt
+++ b/ktor-server/ktor-server-tests/jvm/test/io/ktor/tests/server/features/HSTSTest.kt
@@ -10,8 +10,6 @@ import io.ktor.http.*
 import io.ktor.response.*
 import io.ktor.routing.*
 import io.ktor.server.testing.*
-import org.junit.Test
-import java.time.*
 import kotlin.test.*
 
 class HSTSTest {
@@ -111,7 +109,7 @@ class HSTSTest {
     private fun Application.testApp(block: HSTS.Configuration.() -> Unit = {}) {
         install(XForwardedHeaderSupport)
         install(HSTS) {
-            maxAge = Duration.ofSeconds(10L)
+            maxAgeInSeconds = 10
             includeSubDomains = true
             preload = true
             customDirectives["some"] = "va=lue"

--- a/ktor-server/ktor-server-tomcat/jvm/src/io/ktor/server/tomcat/TomcatApplicationEngine.kt
+++ b/ktor-server/ktor-server-tomcat/jvm/src/io/ktor/server/tomcat/TomcatApplicationEngine.kt
@@ -122,7 +122,7 @@ class TomcatApplicationEngine(environment: ApplicationEngineEnvironment, configu
         return this
     }
 
-    override fun stop(gracePeriod: Long, timeout: Long, timeUnit: TimeUnit) {
+    override fun stop(gracePeriodMillis: Long, timeoutMillis: Long) {
         if (stopped.compareAndSet(false, true)) {
             cancellationDeferred?.complete()
             environment.monitor.raise(ApplicationStopPreparing, environment)

--- a/ktor-utils/common/src/io/ktor/util/CaseInsensitiveSet.kt
+++ b/ktor-utils/common/src/io/ktor/util/CaseInsensitiveSet.kt
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2014-2019 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+package io.ktor.util
+
+@InternalAPI
+class CaseInsensitiveSet() : MutableSet<String> {
+    private val backingMap = CaseInsensitiveMap<Boolean>()
+
+    constructor(initial: Iterable<String>) : this() {
+        addAll(initial)
+    }
+
+    override fun add(element: String): Boolean {
+        if (element in backingMap) {
+            return false
+        }
+        backingMap[element] = true
+        return true
+    }
+
+    override val size: Int
+        get() = backingMap.size
+
+    override fun remove(element: String): Boolean {
+        return backingMap.remove(element) == true
+    }
+
+    override fun addAll(elements: Collection<String>): Boolean {
+        var added = false
+        for (element in elements) {
+            if (add(element)) {
+                added = true
+            }
+        }
+        return added
+    }
+
+    override fun clear() {
+        backingMap.clear()
+    }
+
+    override fun removeAll(elements: Collection<String>): Boolean {
+        return backingMap.keys.removeAll(elements)
+    }
+
+    override fun retainAll(elements: Collection<String>): Boolean {
+        return backingMap.keys.retainAll(elements)
+    }
+
+    override fun contains(element: String): Boolean {
+        return backingMap.contains(element)
+    }
+
+    override fun containsAll(elements: Collection<String>): Boolean {
+        return backingMap.keys.containsAll(elements)
+    }
+
+    override fun isEmpty(): Boolean {
+        return backingMap.isEmpty()
+    }
+
+    override fun iterator(): MutableIterator<String> = backingMap.keys.iterator()
+}

--- a/ktor-utils/common/src/io/ktor/util/collections/ConcurrentMap.kt
+++ b/ktor-utils/common/src/io/ktor/util/collections/ConcurrentMap.kt
@@ -54,9 +54,22 @@ class ConcurrentMap<Key, Value>(
     }
 
     /**
-     * Perform concurrent insert.
+     * Perform concurrent get and compute [block] if no associated value found in the map.
+     * @return an existing value or the result of [block]
      */
     fun getOrDefault(key: Key, block: () -> Value): Value = lock.use {
+        get(key)?.let { return it }
+
+        val result = block()
+        put(key, result)
+        return result
+    }
+
+    /**
+     * Perform concurrent get and compute [block] if no associated value found in the map and insert the new value.
+     * @return an existing value or the result of [block]
+     */
+    fun computeIfAbsent(key: Key, block: () -> Value): Value = lock.use {
         get(key)?.let { return it }
 
         val result = block()

--- a/ktor-utils/common/src/io/ktor/util/collections/ConcurrentMap.kt
+++ b/ktor-utils/common/src/io/ktor/util/collections/ConcurrentMap.kt
@@ -54,15 +54,14 @@ class ConcurrentMap<Key, Value>(
     }
 
     /**
-     * Perform concurrent get and compute [block] if no associated value found in the map.
-     * @return an existing value or the result of [block]
+     * Perform concurrent insert.
      */
+    @Deprecated(
+        "This is accidentally does insert instead of get. Use computeIfAbsent or getOrElse instead.",
+        level = DeprecationLevel.ERROR
+    )
     fun getOrDefault(key: Key, block: () -> Value): Value = lock.use {
-        get(key)?.let { return it }
-
-        val result = block()
-        put(key, result)
-        return result
+        return computeIfAbsent(key, block)
     }
 
     /**


### PR DESCRIPTION
**Subsystem**
server and common utils

**Motivation**
Android and potential K/N migration demand us to reduce java API usages.

**Solution**
- Reduce java.util.* imports, fix java-specific collections usages
- Reduce java.time usages, especially `Duration`

