### PR TITLE
Fix hanging suspension in CIO endpoint

### DIFF
--- a/ktor-client/ktor-client-cio/jvm/src/io/ktor/client/engine/cio/CIOEngine.kt
+++ b/ktor-client/ktor-client-cio/jvm/src/io/ktor/client/engine/cio/CIOEngine.kt
@@ -39,9 +39,6 @@ internal class CIOEngine(
 
             val endpoint = selectEndpoint(data.url, proxy)
             val callContext = createCallContext()
-
-            launch(callContext) { throw java.lang.IllegalStateException("42") }
-
             try {
                 return endpoint.execute(data, callContext)
             } catch (cause: ClosedSendChannelException) {

--- a/ktor-client/ktor-client-cio/jvm/src/io/ktor/client/engine/cio/CIOEngine.kt
+++ b/ktor-client/ktor-client-cio/jvm/src/io/ktor/client/engine/cio/CIOEngine.kt
@@ -39,6 +39,9 @@ internal class CIOEngine(
 
             val endpoint = selectEndpoint(data.url, proxy)
             val callContext = createCallContext()
+
+            launch(callContext) { throw java.lang.IllegalStateException("42") }
+
             try {
                 return endpoint.execute(data, callContext)
             } catch (cause: ClosedSendChannelException) {

--- a/ktor-client/ktor-client-cio/jvm/src/io/ktor/client/engine/cio/Endpoint.kt
+++ b/ktor-client/ktor-client-cio/jvm/src/io/ktor/client/engine/cio/Endpoint.kt
@@ -44,7 +44,9 @@ internal class Endpoint(
 
                 try {
                     if (!config.pipelining || task.requiresDedicatedConnection()) {
-                        makeDedicatedRequest(task)
+                        makeDedicatedRequest(task).invokeOnCompletion {
+                            it?.let { task.response.resumeWithException(it) }
+                        }
                     } else {
                         makePipelineRequest(task)
                     }


### PR DESCRIPTION
**Subsystem**
Client, CIOEngine

**Motivation**
In CIOEngine `endpoint.execute(data, callContext)` hangs if `callContext` is cancelled.

**Solution**
Add `invokeOnCompletion` to a dedicated request task that checks if task completed with an exception and passes this exception to response continuation.

