### PR TITLE
Fixes #1406

### DIFF
--- a/ktor-client/ktor-client-core/common/src/io/ktor/client/features/cache/HttpCacheEntry.kt
+++ b/ktor-client/ktor-client-core/common/src/io/ktor/client/features/cache/HttpCacheEntry.kt
@@ -87,9 +87,13 @@ internal fun HttpResponse.cacheExpires(): GMTDate {
 @KtorExperimentalAPI
 internal fun HttpCacheEntry.shouldValidate(): Boolean {
     val cacheControl = responseHeaders[HttpHeaders.CacheControl]?.let { parseHeaderValue(it) } ?: emptyList()
-    var result = GMTDate() > expires
-    result = result || CacheControl.MUST_REVALIDATE in cacheControl
-    result = result || CacheControl.NO_CACHE in cacheControl
-
-    return result
+    val isStale = GMTDate() > expires
+    // must-revalidate; re-validate once STALE, and MUST NOT return a cached response once stale.
+    //  This is how majority of clients implement the RFC
+    //  OkHttp Implements this the same: https://github.com/square/okhttp/issues/4043#issuecomment-403679369
+    // Disabled for now, as we don't currently return a cached object when there's a network failure; must-revalidate
+    // works the same as being stale on the request side. On response side, must-revalidate would not return a cached
+    // object if we are stale and couldn't refresh.
+    // isStale = isStale && CacheControl.MUST_REVALIDATE in cacheControl
+    return isStale || CacheControl.NO_CACHE in cacheControl
 }


### PR DESCRIPTION
Fixed must-revalidate on the request side for now as per details in #1406.

Note: Response interceptor should check cache on response error to see if we can serve the cached response - in the case of `must-revalidate` it can serve the cache as long as it's not stale, once stale and must-revalidate then it cache should be purged and return the response error

**Subsystem**
Client/Core

**Motivation**
See #1406 for how must-revalidate details

**Solution**
For now we disable `must-revalidate` on the request side, as it doesn't really do anything different to a stale response.

When error response recover is introduced - must-revalidate + max-age will act together to see if they can return a cached response in the case of a response failure. 
Normal cacheing would try and refresh once expired but return if it fails to refresh. Once you add `must-revalidate` a stale response can not be returned when getting a fresh response fails.
