### PR TITLE
HTTP headers validation

### DIFF
--- a/binary-compatibility-validator/reference-public-api/ktor-http.txt
+++ b/binary-compatibility-validator/reference-public-api/ktor-http.txt
@@ -427,6 +427,8 @@ public final class io/ktor/http/HttpHeaderValueParserKt {
 
 public final class io/ktor/http/HttpHeaders {
 	public static final field INSTANCE Lio/ktor/http/HttpHeaders;
+	public final fun checkHeaderName (Ljava/lang/String;)V
+	public final fun checkHeaderValue (Ljava/lang/String;)V
 	public final fun getALPN ()Ljava/lang/String;
 	public final fun getAccept ()Ljava/lang/String;
 	public final fun getAcceptCharset ()Ljava/lang/String;
@@ -511,6 +513,7 @@ public final class io/ktor/http/HttpHeaders {
 	public final fun getTrailer ()Ljava/lang/String;
 	public final fun getTransferEncoding ()Ljava/lang/String;
 	public final fun getUnsafeHeaders ()[Ljava/lang/String;
+	public final fun getUnsafeHeadersList ()Ljava/util/List;
 	public final fun getUpgrade ()Ljava/lang/String;
 	public final fun getUserAgent ()Ljava/lang/String;
 	public final fun getVary ()Ljava/lang/String;
@@ -701,6 +704,18 @@ public final class io/ktor/http/HttpUrlEncodedKt {
 	public static final fun formUrlEncodeTo (Ljava/util/List;Ljava/lang/Appendable;)V
 	public static final fun parseUrlEncodedParameters (Ljava/lang/String;Ljava/nio/charset/Charset;I)Lio/ktor/http/Parameters;
 	public static synthetic fun parseUrlEncodedParameters$default (Ljava/lang/String;Ljava/nio/charset/Charset;IILjava/lang/Object;)Lio/ktor/http/Parameters;
+}
+
+public final class io/ktor/http/IllegalHeaderNameException : java/lang/IllegalArgumentException {
+	public fun <init> (Ljava/lang/String;I)V
+	public final fun getHeaderName ()Ljava/lang/String;
+	public final fun getPosition ()I
+}
+
+public final class io/ktor/http/IllegalHeaderValueException : java/lang/IllegalArgumentException {
+	public fun <init> (Ljava/lang/String;I)V
+	public final fun getHeaderValue ()Ljava/lang/String;
+	public final fun getPosition ()I
 }
 
 public final class io/ktor/http/IpParserKt {

--- a/binary-compatibility-validator/reference-public-api/ktor-utils.txt
+++ b/binary-compatibility-validator/reference-public-api/ktor-utils.txt
@@ -293,6 +293,8 @@ public class io/ktor/util/StringValuesBuilder {
 	public final fun removeKeysWithNoEntries ()V
 	public final fun set (Ljava/lang/String;Ljava/lang/String;)V
 	protected final fun setBuilt (Z)V
+	protected fun validateName (Ljava/lang/String;)V
+	protected fun validateValue (Ljava/lang/String;)V
 }
 
 public class io/ktor/util/StringValuesImpl : io/ktor/util/StringValues {

--- a/ktor-client/ktor-client-core/common/src/io/ktor/client/engine/HttpClientEngine.kt
+++ b/ktor-client/ktor-client-core/common/src/io/ktor/client/engine/HttpClientEngine.kt
@@ -91,7 +91,7 @@ fun <T : HttpClientEngineConfig> HttpClientEngineFactory<T>.config(nested: T.() 
  */
 private fun validateHeaders(request: HttpRequestData) {
     val requestHeaders = request.headers
-    for (header in HttpHeaders.UnsafeHeaders) {
+    for (header in HttpHeaders.UnsafeHeadersList) {
         if (header in requestHeaders) {
             throw UnsafeHeaderException(header)
         }

--- a/ktor-http/common/src/io/ktor/http/Headers.kt
+++ b/ktor-http/common/src/io/ktor/http/Headers.kt
@@ -32,6 +32,16 @@ class HeadersBuilder(size: Int = 8) : StringValuesBuilder(true, size) {
         built = true
         return HeadersImpl(values)
     }
+
+    override fun validateName(name: String) {
+        super.validateName(name)
+        HttpHeaders.checkHeaderName(name)
+    }
+
+    override fun validateValue(value: String) {
+        super.validateValue(value)
+        HttpHeaders.checkHeaderValue(value)
+    }
 }
 
 @Suppress("KDocMissingDocumentation")

--- a/ktor-http/common/src/io/ktor/http/HttpHeaders.kt
+++ b/ktor-http/common/src/io/ktor/http/HttpHeaders.kt
@@ -4,6 +4,8 @@
 
 package io.ktor.http
 
+import io.ktor.util.*
+
 @Suppress("unused", "KDocMissingDocumentation", "PublicApiImplicitType", "MayBeConstant")
 object HttpHeaders {
     // Permanently registered standard HTTP headers
@@ -114,17 +116,77 @@ object HttpHeaders {
     val XTotalCount = "X-Total-Count"
 
     /**
-     * Check if [header] is unsafe. Header is unsafe if listed in [UnsafeHeaders]
+     * Check if [header] is unsafe. Header is unsafe if listed in [UnsafeHeadersList]
      */
-    fun isUnsafe(header: String): Boolean = UnsafeHeaders.any { it.equals(header, ignoreCase = true) }
+    fun isUnsafe(header: String): Boolean = UnsafeHeadersArray.any { it.equals(header, ignoreCase = true) }
 
-    val UnsafeHeaders: Array<String> = arrayOf(ContentLength, ContentType, TransferEncoding, Upgrade)
+    private val UnsafeHeadersArray: Array<String> = arrayOf(ContentLength, ContentType, TransferEncoding, Upgrade)
+
+    @Deprecated("Use UnsafeHeadersList instead.", replaceWith = ReplaceWith("HttpHeaders.UnsafeHeadersList"))
+    val UnsafeHeaders: Array<String> get() = UnsafeHeadersArray.copyOf()
+
+    /**
+     * A list of header names that are not safe to use unless it is low-level engine implementation.
+     */
+    val UnsafeHeadersList: List<String> = UnsafeHeadersArray.asList()
+
+    /**
+     * Validates header [name] throwing [IllegalHeaderNameException] when the name is not valid.
+     */
+    @KtorExperimentalAPI
+    fun checkHeaderName(name: String) {
+        name.forEachIndexed { index, ch ->
+            if (ch <= ' ' || isDelimiter(ch)) {
+                throw IllegalHeaderNameException(name, index)
+            }
+        }
+    }
+
+    /**
+     * Validates header [value] throwing [IllegalHeaderValueException] when the value is not valid.
+     */
+    @KtorExperimentalAPI
+    fun checkHeaderValue(value: String) {
+        value.forEachIndexed { index, ch ->
+            if (ch == ' ' || ch == '\u0009') return@forEachIndexed
+            if (ch < ' ') {
+                throw IllegalHeaderValueException(value, index)
+            }
+        }
+    }
 }
 
 /**
- * Thrown when an attempt to set unsafe header detected. A header is unsafe if listed in [HttpHeaders.UnsafeHeaders].
+ * Thrown when an attempt to set unsafe header detected. A header is unsafe if listed in [HttpHeaders.UnsafeHeadersList].
  */
 class UnsafeHeaderException(header: String) : IllegalArgumentException(
     "Header $header is controlled by the engine and " +
         "cannot be set explicitly"
 )
+
+/**
+ * Thrown when an illegal header name was used.
+ * A header name should only consist from visible characters
+ * without delimiters "double quote" and the following characters: `(),/:;<=>?@[\]{}`.
+ * @property headerName that was tried to use
+ * @property position at which validation failed
+ */
+@KtorExperimentalAPI
+class IllegalHeaderNameException(val headerName: String, val position: Int) : IllegalArgumentException(
+    "Header name '$headerName' contains illegal character '${headerName[position]}'" +
+        " (code ${(headerName[position].toInt() and 0xff)})"
+)
+
+/**
+ * Thrown when an illegal header value was used.
+ * A header value should only consist from visible characters, spaces and/or HTAB (0x09).
+ * @property headerValue that was tried to use
+ * @property position at which validation failed
+ */
+@KtorExperimentalAPI
+class IllegalHeaderValueException(val headerValue: String, val position: Int) : IllegalArgumentException(
+    "Header value '$headerValue' contains illegal character '${headerValue[position]}'" +
+        " (code ${(headerValue[position].toInt() and 0xff)})"
+)
+
+private fun isDelimiter(ch: Char): Boolean = ch in "\"(),/:;<=>?@[\\]{}"

--- a/ktor-http/common/test/io/ktor/tests/http/HeadersTest.kt
+++ b/ktor-http/common/test/io/ktor/tests/http/HeadersTest.kt
@@ -191,4 +191,23 @@ class HeadersTest {
         assertEquals(value, headersOf("hello", listOf(value))["HELLO"])
         assertEquals(value, headersOf("hello" to listOf(value))["HELLO"])
     }
+
+    @Test
+    fun headerNamesValidation() {
+        val illegalCharacters = "\u0000\u0009\r\n\"(),/:;<=>?@[\\]{}"
+        HeadersBuilder().apply {
+            append("valid", "ok")
+
+            illegalCharacters.forEach { ch ->
+                val key = "not${ch}valid"
+                assertFails {
+                    append(key, "ok")
+                }
+                assertFails {
+                    set(key, "ok2")
+                }
+                assertNull(get(key))
+            }
+        }
+    }
 }

--- a/ktor-http/ktor-http-cio/common/src/io/ktor/http/cio/internals/Chars.kt
+++ b/ktor-http/ktor-http-cio/common/src/io/ktor/http/cio/internals/Chars.kt
@@ -7,6 +7,8 @@ package io.ktor.http.cio.internals
 import io.ktor.http.*
 import io.ktor.utils.io.core.*
 
+internal const val HTAB: Char = '\u0009'
+
 internal fun CharSequence.hashCodeLowerCase(start: Int = 0, end: Int = length): Int {
     var hashCode = 0
     for (pos in start until end) {

--- a/ktor-http/ktor-http-cio/common/src/io/ktor/http/cio/internals/Tokenizer.kt
+++ b/ktor-http/ktor-http-cio/common/src/io/ktor/http/cio/internals/Tokenizer.kt
@@ -4,13 +4,25 @@
 
 package io.ktor.http.cio.internals
 
-import io.ktor.http.cio.*
-
 internal fun nextToken(text: CharSequence, range: MutableRange): CharSequence {
     val spaceOrEnd = findSpaceOrEnd(text, range)
     val s = text.subSequence(range.start, spaceOrEnd)
     range.start = spaceOrEnd
     return s
+}
+
+internal fun skipSpHTab(
+    text: CharArrayBuilder,
+    start: Int,
+    end: Int
+): Int {
+    var index = start
+    while (index < end) {
+        val ch = text[index]
+        if (ch != ' ' && ch != HTAB) break
+        index++
+    }
+    return index
 }
 
 internal fun skipSpaces(text: CharSequence, range: MutableRange) {
@@ -22,27 +34,6 @@ internal fun skipSpaces(text: CharSequence, range: MutableRange) {
 
     while (idx < end) {
         if (text[idx] != ' ') break
-        idx++
-    }
-
-    range.start = idx
-}
-
-internal fun skipSpacesAndColon(text: CharSequence, range: MutableRange) {
-    var idx = range.start
-    val end = range.end
-    var colons = 0
-
-    while (idx < end) {
-        val ch = text[idx]
-        if (ch == ':') {
-            if (++colons > 1) {
-                throw ParserException("Multiple colons in header")
-            }
-        } else if (ch != ' ') {
-            break
-        }
-
         idx++
     }
 
@@ -62,19 +53,4 @@ internal fun findSpaceOrEnd(text: CharSequence, range: MutableRange): Int {
     }
 
     return idx
-}
-
-internal fun findLetterBeforeColon(text: CharSequence, range: MutableRange): Int {
-    var index = range.start
-    var lastCharIndex = index
-    val end = range.end
-
-    while (index < end) {
-        val ch = text[index]
-        if (ch == ':') return lastCharIndex
-        if (ch != ' ') lastCharIndex = index
-        index++
-    }
-
-    return -1
 }

--- a/ktor-http/ktor-http-cio/common/test/io/ktor/tests/http/cio/HttpParserTest.kt
+++ b/ktor-http/ktor-http-cio/common/test/io/ktor/tests/http/cio/HttpParserTest.kt
@@ -1,0 +1,139 @@
+/*
+ * Copyright 2014-2019 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.tests.http.cio
+
+import io.ktor.http.cio.*
+import io.ktor.http.cio.internals.*
+import io.ktor.utils.io.*
+import kotlinx.coroutines.*
+import kotlinx.coroutines.intrinsics.*
+import kotlin.coroutines.*
+import kotlin.test.*
+
+class HttpParserTest {
+    private var failure: Throwable? = null
+
+    @Test
+    fun parseHeadersSmokeTest(): Unit = test {
+        val encodedHeaders = """
+            name: value
+            name2:${HTAB}p1${HTAB}p2 p3${HTAB}
+        """.trimIndent() + "\r\n\r\n"
+        val channel = ByteReadChannel(encodedHeaders)
+        val headers = parseHeaders(channel)
+
+        try {
+            assertEquals(2, headers.size)
+            assertEquals("value", headers["name"].toString())
+            assertEquals("p1${HTAB}p2 p3", headers["name2"].toString())
+        } finally {
+            headers.release()
+        }
+    }
+
+    @Test
+    fun parseHeadersNoLeadingSpace(): Unit = test {
+        val encodedHeaders = """
+            name:value
+        """.trimIndent() + "\r\n\r\n"
+        val channel = ByteReadChannel(encodedHeaders)
+        val headers = parseHeaders(channel)
+
+        try {
+            assertEquals(1, headers.size)
+            assertEquals("value", headers["name"].toString())
+        } finally {
+            headers.release()
+        }
+    }
+
+    @Test
+    fun parseHeadersNoLeadingSpaceWithTrailingSpaces(): Unit = test {
+        val encodedHeaders = """
+            name:value
+        """.trimIndent() + "    \r\n\r\n"
+        val channel = ByteReadChannel(encodedHeaders)
+        val headers = parseHeaders(channel)
+
+        try {
+            assertEquals(1, headers.size)
+            assertEquals("value", headers["name"].toString())
+        } finally {
+            headers.release()
+        }
+    }
+
+    @Test
+    fun parseHeadersSpaceAfterHeaderNameShouldBeProhibited(): Unit = test {
+        val encodedHeaders = """
+            name :value
+        """.trimIndent() + "\r\n\r\n"
+        val channel = ByteReadChannel(encodedHeaders)
+
+        assertFailsWith<ParserException> {
+            parseHeaders(channel).release()
+        }
+    }
+
+    @Test
+    fun parseHeadersSpacesInHeaderNameShouldBeProhibited(): Unit = test {
+        val encodedHeaders = """
+            name and more: value
+        """.trimIndent() + "\r\n\r\n"
+        val channel = ByteReadChannel(encodedHeaders)
+
+        assertFailsWith<ParserException> {
+            parseHeaders(channel).release()
+        }
+    }
+
+    @Test
+    fun parseHeadersSpacesInHeaderNameShouldBeProhibitedFixed(): Unit = test {
+        val encodedHeaders = """
+            name-and-more: value
+        """.trimIndent() + "\r\n\r\n"
+        val channel = ByteReadChannel(encodedHeaders)
+
+        parseHeaders(channel).release()
+    }
+
+    @Test
+    fun parseHeadersDelimitersInHeaderNameShouldBeProhibited(): Unit = test {
+        val encodedHeaders = """
+            name,: value
+        """.trimIndent() + "\r\n\r\n"
+        val channel = ByteReadChannel(encodedHeaders)
+
+        assertFailsWith<ParserException> {
+            parseHeaders(channel).release()
+        }
+    }
+
+    @Test
+    fun parseHeadersFoldingShouldBeProhibited(): Unit = test {
+        val encodedHeaders = "A:\r\n folding\r\n\r\n"
+        val channel = ByteReadChannel(encodedHeaders)
+
+        assertFailsWith<ParserException> {
+            parseHeaders(channel).release()
+        }
+    }
+
+    @UseExperimental(InternalCoroutinesApi::class)
+    private fun test(block: suspend () -> Unit) {
+        var completed = false
+        val cont = Continuation<Unit>(EmptyCoroutineContext) {
+            completed = true
+            failure = it.exceptionOrNull()
+        }
+
+        block.startCoroutineCancellable(cont)
+        if (!completed) {
+            fail("Suspended unexpectedly.")
+        }
+
+        failure?.let { throw it }
+    }
+}

--- a/ktor-http/ktor-http-cio/jvm/src/io/ktor/http/cio/Multipart.kt
+++ b/ktor-http/ktor-http-cio/jvm/src/io/ktor/http/cio/Multipart.kt
@@ -122,7 +122,7 @@ suspend fun parsePartHeaders(input: ByteReadChannel): HttpHeadersMap {
     val builder = CharArrayBuilder()
 
     try {
-        return parseHeaders(input, builder, MutableRange(0, 0))
+        return parseHeaders(input, builder)
             ?: throw EOFException("Failed to parse multipart headers: unexpected end of stream")
     } catch (t: Throwable) {
         builder.release()

--- a/ktor-http/ktor-http-cio/jvm/test/io/ktor/tests/http/cio/HeadersTest.kt
+++ b/ktor-http/ktor-http-cio/jvm/test/io/ktor/tests/http/cio/HeadersTest.kt
@@ -47,16 +47,15 @@ class HeadersTest {
     }
 
     @Test
-    fun extraSpacesLeading() = runBlocking {
+    fun extraSpacesLeading(): Unit = runBlocking<Unit> {
         ch.writeStringUtf8(" Host:  localhost\r\n\r\n")
-        val hh = parseHeaders(ch, builder)!!
-
-        assertEquals("localhost", hh["Host"]?.toString())
-        hh.release()
+        assertFailsWith<ParserException> {
+            parseHeaders(ch, builder)!!.release()
+        }
     }
 
     @Test
-    fun extraSpacesMiddle() = runBlocking {
+    fun extraSpacesMiddle(): Unit = runBlocking {
         ch.writeStringUtf8("Host:  localhost\r\n\r\n")
         val hh = parseHeaders(ch, builder)!!
 
@@ -65,21 +64,19 @@ class HeadersTest {
     }
 
     @Test
-    fun extraSpacesMiddleBeforeColon() = runBlocking {
+    fun extraSpacesMiddleBeforeColon(): Unit = runBlocking<Unit> {
         ch.writeStringUtf8("Host : localhost\r\n\r\n")
-        val hh = parseHeaders(ch, builder)!!
-
-        assertEquals("localhost", hh["Host"]?.toString())
-        hh.release()
+        assertFailsWith<ParserException> {
+            parseHeaders(ch, builder)!!.release()
+        }
     }
 
     @Test
-    fun extraSpacesMiddleBeforeColonNoAfter() = runBlocking {
+    fun extraSpacesMiddleBeforeColonNoAfter(): Unit = runBlocking<Unit> {
         ch.writeStringUtf8("Host :localhost\r\n\r\n")
-        val hh = parseHeaders(ch, builder)!!
-
-        assertEquals("localhost", hh["Host"]?.toString())
-        hh.release()
+        assertFailsWith<ParserException> {
+            parseHeaders(ch, builder)!!.release()
+        }
     }
 
     @Test
@@ -87,7 +84,7 @@ class HeadersTest {
         ch.writeStringUtf8("Host:  localhost \r\n\r\n")
         val hh = parseHeaders(ch, builder)!!
 
-        assertEquals("localhost ", hh["Host"]?.toString())
+        assertEquals("localhost", hh["Host"]?.toString())
         hh.release()
     }
 

--- a/ktor-server/ktor-server-core/jvm/src/io/ktor/response/ResponseHeaders.kt
+++ b/ktor-server/ktor-server-core/jvm/src/io/ktor/response/ResponseHeaders.kt
@@ -41,6 +41,8 @@ abstract class ResponseHeaders {
     fun append(name: String, value: String, safeOnly: Boolean = true) {
         if (safeOnly && HttpHeaders.isUnsafe(name))
             throw UnsafeHeaderException(name)
+        HttpHeaders.checkHeaderName(name)
+        HttpHeaders.checkHeaderValue(value)
         engineAppendHeader(name, value)
     }
 

--- a/ktor-server/ktor-server-tests/jvm/test/io/ktor/tests/server/features/CallIdTest.kt
+++ b/ktor-server/ktor-server-tests/jvm/test/io/ktor/tests/server/features/CallIdTest.kt
@@ -186,7 +186,7 @@ class CallIdTest {
         }
 
         // invalid call id
-        handleRequest(HttpMethod.Get, "/") { addHeader(HttpHeaders.XRequestId, "\u0000")}.let { call ->
+        handleRequest(HttpMethod.Get, "/") { addHeader(HttpHeaders.XRequestId, "\u1000")}.let { call ->
             assertTrue { call.requestHandled }
             assertEquals("null", call.response.content)
         }
@@ -195,7 +195,7 @@ class CallIdTest {
     @Test
     fun testDefaultVerifierForGenerate(): Unit = withTestApplication {
         application.install(CallId) {
-            generate { if (it.request.uri == "/valid") CALL_ID_DEFAULT_DICTIONARY else "\u0000" }
+            generate { if (it.request.uri == "/valid") CALL_ID_DEFAULT_DICTIONARY else "\u1000" }
         }
         handle {
             call.respond(call.callId.toString())


### PR DESCRIPTION
**Subsystem**
ktor utils, server, client

**Motivation**
Currently, header name and values requirements are not strict enough since we only prohibit setting so-called "unsafe" headers while we allow setting illegal headers. Setting illegal header names or values may cause HTTP protocol violations, software incompatibility, security issues and other negative consequences.

**Solution**
- restrict CIO HTTP parser so illegal names and values causing the request to be aborted
- restrict API to not allow setting illegal headers via `HeadersBuilder` and server's `ResponseHeaders`

