### PR TITLE
Introduce common request, connect and socket timeouts

### DIFF
--- a/binary-compatibility-validator/reference-public-api/ktor-client-android.txt
+++ b/binary-compatibility-validator/reference-public-api/ktor-client-android.txt
@@ -9,6 +9,7 @@ public final class io/ktor/client/engine/android/AndroidClientEngine : io/ktor/c
 	public synthetic fun getConfig ()Lio/ktor/client/engine/HttpClientEngineConfig;
 	public fun getConfig ()Lio/ktor/client/engine/android/AndroidEngineConfig;
 	public fun getDispatcher ()Lkotlinx/coroutines/CoroutineDispatcher;
+	public fun getSupportedCapabilities ()Ljava/util/Set;
 }
 
 public final class io/ktor/client/engine/android/AndroidEngineConfig : io/ktor/client/engine/HttpClientEngineConfig {

--- a/binary-compatibility-validator/reference-public-api/ktor-client-cio.txt
+++ b/binary-compatibility-validator/reference-public-api/ktor-client-cio.txt
@@ -42,6 +42,7 @@ public final class io/ktor/client/engine/cio/EndpointConfig {
 	public final fun getKeepAliveTime ()J
 	public final fun getMaxConnectionsPerRoute ()I
 	public final fun getPipelineMaxSize ()I
+	public final fun getSocketTimeout ()J
 	public final fun setAllowHalfClose (Z)V
 	public final fun setConnectRetryAttempts (I)V
 	public final fun setConnectTimeout (J)V

--- a/binary-compatibility-validator/reference-public-api/ktor-client-core.txt
+++ b/binary-compatibility-validator/reference-public-api/ktor-client-core.txt
@@ -13,6 +13,7 @@ public final class io/ktor/client/HttpClient : java/io/Closeable, kotlinx/corout
 	public final fun getRequestPipeline ()Lio/ktor/client/request/HttpRequestPipeline;
 	public final fun getResponsePipeline ()Lio/ktor/client/statement/HttpResponsePipeline;
 	public final fun getSendPipeline ()Lio/ktor/client/request/HttpSendPipeline;
+	public final fun isSupported (Lio/ktor/client/engine/HttpClientEngineCapability;)Z
 	public fun toString ()Ljava/lang/String;
 }
 
@@ -178,10 +179,12 @@ public abstract interface class io/ktor/client/engine/HttpClientEngine : java/io
 	public abstract fun execute (Lio/ktor/client/request/HttpRequestData;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun getConfig ()Lio/ktor/client/engine/HttpClientEngineConfig;
 	public abstract fun getDispatcher ()Lkotlinx/coroutines/CoroutineDispatcher;
+	public abstract fun getSupportedCapabilities ()Ljava/util/Set;
 	public abstract fun install (Lio/ktor/client/HttpClient;)V
 }
 
 public final class io/ktor/client/engine/HttpClientEngine$DefaultImpls {
+	public static fun getSupportedCapabilities (Lio/ktor/client/engine/HttpClientEngine;)Ljava/util/Set;
 	public static fun install (Lio/ktor/client/engine/HttpClientEngine;Lio/ktor/client/HttpClient;)V
 }
 
@@ -189,7 +192,15 @@ public abstract class io/ktor/client/engine/HttpClientEngineBase : io/ktor/clien
 	public fun <init> (Ljava/lang/String;)V
 	public fun close ()V
 	public fun getCoroutineContext ()Lkotlin/coroutines/CoroutineContext;
+	public fun getSupportedCapabilities ()Ljava/util/Set;
 	public fun install (Lio/ktor/client/HttpClient;)V
+}
+
+public abstract interface class io/ktor/client/engine/HttpClientEngineCapability {
+}
+
+public final class io/ktor/client/engine/HttpClientEngineCapabilityKt {
+	public static final fun getDEFAULT_CAPABILITIES ()Ljava/util/Set;
 }
 
 public class io/ktor/client/engine/HttpClientEngineConfig {
@@ -221,6 +232,7 @@ public abstract class io/ktor/client/engine/HttpClientJvmEngine : io/ktor/client
 	protected final fun createCallContext (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun getCoroutineContext ()Lkotlin/coroutines/CoroutineContext;
 	public fun getDispatcher ()Lkotlinx/coroutines/CoroutineDispatcher;
+	public fun getSupportedCapabilities ()Ljava/util/Set;
 	public fun install (Lio/ktor/client/HttpClient;)V
 }
 
@@ -320,6 +332,10 @@ public final class io/ktor/client/features/HttpClientFeatureKt {
 	public static final fun feature (Lio/ktor/client/HttpClient;Lio/ktor/client/features/HttpClientFeature;)Ljava/lang/Object;
 }
 
+public final class io/ktor/client/features/HttpConnectTimeoutException : java/net/ConnectException {
+	public fun <init> (Lio/ktor/client/request/HttpRequestData;)V
+}
+
 public final class io/ktor/client/features/HttpPlainText {
 	public static final field Feature Lio/ktor/client/features/HttpPlainText$Feature;
 	public final fun getDefaultCharset ()Ljava/nio/charset/Charset;
@@ -367,6 +383,10 @@ public final class io/ktor/client/features/HttpRedirect$Feature : io/ktor/client
 	public synthetic fun prepare (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
 }
 
+public final class io/ktor/client/features/HttpRequestTimeoutException : java/util/concurrent/CancellationException {
+	public fun <init> (Lio/ktor/client/request/HttpRequestBuilder;)V
+}
+
 public final class io/ktor/client/features/HttpSend {
 	public static final field Feature Lio/ktor/client/features/HttpSend$Feature;
 	public fun <init> ()V
@@ -374,6 +394,7 @@ public final class io/ktor/client/features/HttpSend {
 	public synthetic fun <init> (IILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getMaxSendCount ()I
 	public final fun intercept (Lkotlin/jvm/functions/Function3;)V
+	public final fun intercept (Lkotlin/jvm/functions/Function4;)V
 	public final fun setMaxSendCount (I)V
 }
 
@@ -383,6 +404,51 @@ public final class io/ktor/client/features/HttpSend$Feature : io/ktor/client/fea
 	public synthetic fun install (Ljava/lang/Object;Lio/ktor/client/HttpClient;)V
 	public fun prepare (Lkotlin/jvm/functions/Function1;)Lio/ktor/client/features/HttpSend;
 	public synthetic fun prepare (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+}
+
+public final class io/ktor/client/features/HttpSocketTimeoutException : java/net/SocketTimeoutException {
+	public fun <init> (Lio/ktor/client/request/HttpRequestData;)V
+}
+
+public final class io/ktor/client/features/HttpTimeout {
+	public static final field Feature Lio/ktor/client/features/HttpTimeout$Feature;
+	public static final field INFINITE_TIMEOUT_MS J
+	public fun <init> (Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;)V
+}
+
+public final class io/ktor/client/features/HttpTimeout$Feature : io/ktor/client/engine/HttpClientEngineCapability, io/ktor/client/features/HttpClientFeature {
+	public fun getKey ()Lio/ktor/util/AttributeKey;
+	public fun install (Lio/ktor/client/features/HttpTimeout;Lio/ktor/client/HttpClient;)V
+	public synthetic fun install (Ljava/lang/Object;Lio/ktor/client/HttpClient;)V
+	public fun prepare (Lkotlin/jvm/functions/Function1;)Lio/ktor/client/features/HttpTimeout;
+	public synthetic fun prepare (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+}
+
+public final class io/ktor/client/features/HttpTimeout$HttpTimeoutCapabilityConfiguration {
+	public static final field Companion Lio/ktor/client/features/HttpTimeout$HttpTimeoutCapabilityConfiguration$Companion;
+	public fun <init> (Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;)V
+	public synthetic fun <init> (Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getConnectTimeoutMillis ()Ljava/lang/Long;
+	public final fun getRequestTimeoutMillis ()Ljava/lang/Long;
+	public final fun getSocketTimeoutMillis ()Ljava/lang/Long;
+	public final fun setConnectTimeoutMillis (Ljava/lang/Long;)V
+	public final fun setRequestTimeoutMillis (Ljava/lang/Long;)V
+	public final fun setSocketTimeoutMillis (Ljava/lang/Long;)V
+}
+
+public final class io/ktor/client/features/HttpTimeout$HttpTimeoutCapabilityConfiguration$Companion {
+	public final fun getKey ()Lio/ktor/util/AttributeKey;
+}
+
+public final class io/ktor/client/features/HttpTimeoutJVMKt {
+	public static final fun mapEngineExceptions (Lkotlinx/coroutines/CoroutineScope;Lio/ktor/utils/io/ByteReadChannel;Lio/ktor/client/request/HttpRequestData;)Lio/ktor/utils/io/ByteReadChannel;
+	public static final fun mapEngineExceptions (Lkotlinx/coroutines/CoroutineScope;Lio/ktor/utils/io/ByteWriteChannel;Lio/ktor/client/request/HttpRequestData;)Lio/ktor/utils/io/ByteWriteChannel;
+}
+
+public final class io/ktor/client/features/HttpTimeoutKt {
+	public static final fun convertLongTimeoutToIntWithInfiniteAsZero (J)I
+	public static final fun convertLongTimeoutToLongWithInfiniteAsZero (J)J
+	public static final fun timeout (Lio/ktor/client/request/HttpRequestBuilder;Lkotlin/jvm/functions/Function1;)V
 }
 
 public final class io/ktor/client/features/RedirectResponseException : io/ktor/client/features/ResponseException {
@@ -755,12 +821,14 @@ public final class io/ktor/client/request/HttpRequestBuilder : io/ktor/http/Http
 	public final fun build ()Lio/ktor/client/request/HttpRequestData;
 	public final fun getAttributes ()Lio/ktor/util/Attributes;
 	public final fun getBody ()Ljava/lang/Object;
+	public final fun getCapabilityOrNull (Lio/ktor/client/engine/HttpClientEngineCapability;)Ljava/lang/Object;
 	public final fun getExecutionContext ()Lkotlinx/coroutines/Job;
 	public fun getHeaders ()Lio/ktor/http/HeadersBuilder;
 	public final fun getMethod ()Lio/ktor/http/HttpMethod;
 	public final fun getUrl ()Lio/ktor/http/URLBuilder;
 	public final fun setAttributes (Lkotlin/jvm/functions/Function1;)V
 	public final fun setBody (Ljava/lang/Object;)V
+	public final fun setCapability (Lio/ktor/client/engine/HttpClientEngineCapability;Ljava/lang/Object;)V
 	public final fun setMethod (Lio/ktor/http/HttpMethod;)V
 	public final fun takeFrom (Lio/ktor/client/request/HttpRequestBuilder;)Lio/ktor/client/request/HttpRequestBuilder;
 	public final fun url (Lkotlin/jvm/functions/Function2;)V
@@ -770,8 +838,10 @@ public final class io/ktor/client/request/HttpRequestBuilder$Companion {
 }
 
 public final class io/ktor/client/request/HttpRequestData {
+	public fun <init> (Lio/ktor/http/Url;Lio/ktor/http/HttpMethod;Lio/ktor/http/Headers;Lio/ktor/http/content/OutgoingContent;Lkotlinx/coroutines/Job;Lio/ktor/util/Attributes;)V
 	public final fun getAttributes ()Lio/ktor/util/Attributes;
 	public final fun getBody ()Lio/ktor/http/content/OutgoingContent;
+	public final fun getCapabilityOrNull (Lio/ktor/client/engine/HttpClientEngineCapability;)Ljava/lang/Object;
 	public final fun getExecutionContext ()Lkotlinx/coroutines/Job;
 	public final fun getHeaders ()Lio/ktor/http/Headers;
 	public final fun getMethod ()Lio/ktor/http/HttpMethod;

--- a/binary-compatibility-validator/reference-public-api/ktor-client-jetty.txt
+++ b/binary-compatibility-validator/reference-public-api/ktor-client-jetty.txt
@@ -5,7 +5,9 @@ public final class io/ktor/client/engine/jetty/Jetty : io/ktor/client/engine/Htt
 
 public final class io/ktor/client/engine/jetty/JettyEngineConfig : io/ktor/client/engine/HttpClientEngineConfig {
 	public fun <init> ()V
+	public final fun getClientCacheSize ()I
 	public final fun getSslContextFactory ()Lorg/eclipse/jetty/util/ssl/SslContextFactory;
+	public final fun setClientCacheSize (I)V
 	public final fun setSslContextFactory (Lorg/eclipse/jetty/util/ssl/SslContextFactory;)V
 }
 

--- a/binary-compatibility-validator/reference-public-api/ktor-client-mock.txt
+++ b/binary-compatibility-validator/reference-public-api/ktor-client-mock.txt
@@ -8,6 +8,7 @@ public final class io/ktor/client/engine/mock/MockEngine : io/ktor/client/engine
 	public fun getDispatcher ()Lkotlinx/coroutines/CoroutineDispatcher;
 	public final fun getRequestHistory ()Ljava/util/List;
 	public final fun getResponseHistory ()Ljava/util/List;
+	public fun getSupportedCapabilities ()Ljava/util/Set;
 }
 
 public final class io/ktor/client/engine/mock/MockEngine$Companion : io/ktor/client/engine/HttpClientEngineFactory {

--- a/binary-compatibility-validator/reference-public-api/ktor-client-okhttp.txt
+++ b/binary-compatibility-validator/reference-public-api/ktor-client-okhttp.txt
@@ -8,7 +8,9 @@ public final class io/ktor/client/engine/okhttp/OkHttpConfig : io/ktor/client/en
 	public final fun addInterceptor (Lokhttp3/Interceptor;)V
 	public final fun addNetworkInterceptor (Lokhttp3/Interceptor;)V
 	public final fun config (Lkotlin/jvm/functions/Function1;)V
+	public final fun getClientCacheSize ()I
 	public final fun getPreconfigured ()Lokhttp3/OkHttpClient;
+	public final fun setClientCacheSize (I)V
 	public final fun setPreconfigured (Lokhttp3/OkHttpClient;)V
 }
 
@@ -19,6 +21,7 @@ public final class io/ktor/client/engine/okhttp/OkHttpEngine : io/ktor/client/en
 	public synthetic fun getConfig ()Lio/ktor/client/engine/HttpClientEngineConfig;
 	public fun getConfig ()Lio/ktor/client/engine/okhttp/OkHttpConfig;
 	public fun getDispatcher ()Lkotlinx/coroutines/CoroutineDispatcher;
+	public fun getSupportedCapabilities ()Ljava/util/Set;
 }
 
 public final class io/ktor/client/engine/okhttp/OkHttpEngineContainer : io/ktor/client/HttpClientEngineContainer {

--- a/binary-compatibility-validator/reference-public-api/ktor-network.txt
+++ b/binary-compatibility-validator/reference-public-api/ktor-network.txt
@@ -240,9 +240,11 @@ public final class io/ktor/network/sockets/SocketOptions$TCPClientSocketOptions 
 	public final fun getKeepAlive ()Ljava/lang/Boolean;
 	public final fun getLingerSeconds ()I
 	public final fun getNoDelay ()Z
+	public final fun getSocketTimeout ()J
 	public final fun setKeepAlive (Ljava/lang/Boolean;)V
 	public final fun setLingerSeconds (I)V
 	public final fun setNoDelay (Z)V
+	public final fun setSocketTimeout (J)V
 }
 
 public final class io/ktor/network/sockets/SocketOptions$UDPSocketOptions : io/ktor/network/sockets/SocketOptions$PeerSocketOptions {

--- a/binary-compatibility-validator/reference-public-api/ktor-utils.txt
+++ b/binary-compatibility-validator/reference-public-api/ktor-utils.txt
@@ -64,6 +64,10 @@ public final class io/ktor/util/BytesKt {
 	public static final fun readShort ([BI)S
 }
 
+public final class io/ktor/util/CacheKt {
+	public static final fun createLRUCache (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;I)Ljava/util/Map;
+}
+
 public final class io/ktor/util/CaseInsensitiveMap : java/util/Map, kotlin/jvm/internal/markers/KMutableMap {
 	public fun <init> ()V
 	public fun clear ()V
@@ -390,6 +394,10 @@ public final class io/ktor/util/TextKt {
 	public static final fun escapeHTML (Ljava/lang/String;)Ljava/lang/String;
 	public static final fun toLowerCasePreservingASCIIRules (Ljava/lang/String;)Ljava/lang/String;
 	public static final fun toUpperCasePreservingASCIIRules (Ljava/lang/String;)Ljava/lang/String;
+}
+
+public final class io/ktor/util/ThrowableKt {
+	public static final fun getRootCause (Ljava/lang/Throwable;)Ljava/lang/Throwable;
 }
 
 public final class io/ktor/util/cio/ByteBufferPool : io/ktor/utils/io/pool/DefaultPool {

--- a/ktor-client/ktor-client-android/jvm/src/io/ktor/client/engine/android/AndroidURLConnectionUtils.kt
+++ b/ktor-client/ktor-client-android/jvm/src/io/ktor/client/engine/android/AndroidURLConnectionUtils.kt
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2014-2019 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.client.engine.android
+
+import io.ktor.client.features.*
+import io.ktor.client.request.*
+import io.ktor.util.cio.*
+import io.ktor.utils.io.*
+import io.ktor.utils.io.jvm.javaio.*
+import kotlinx.coroutines.*
+import java.io.*
+import java.net.*
+import kotlin.coroutines.*
+
+/**
+ * Setup [HttpURLConnection] timeout configuration using [HttpTimeout.HttpTimeoutCapabilityConfiguration] as a source.
+ */
+internal fun HttpURLConnection.setupTimeoutAttributes(requestData: HttpRequestData) {
+    requestData.getCapabilityOrNull(HttpTimeout)?.let { timeoutAttributes ->
+        timeoutAttributes.connectTimeoutMillis?.let { connectTimeout = convertLongTimeoutToIntWithInfiniteAsZero(it) }
+        timeoutAttributes.socketTimeoutMillis?.let { readTimeout = convertLongTimeoutToIntWithInfiniteAsZero(it) }
+        setupRequestTimeoutAttributes(timeoutAttributes)
+    }
+}
+
+/**
+ * Update [HttpURLConnection] timeout configuration to support request timeout. Required to support blocking
+ * [HttpURLConnection.connect] call.
+ */
+private fun HttpURLConnection.setupRequestTimeoutAttributes(
+    timeoutAttributes: HttpTimeout.HttpTimeoutCapabilityConfiguration
+) {
+    // Android performs blocking connect call, so we need to add an upper bound on the call time.
+    timeoutAttributes.requestTimeoutMillis?.let { requestTimeout ->
+        if (requestTimeout == HttpTimeout.INFINITE_TIMEOUT_MS) return@let
+        if (connectTimeout == 0 || connectTimeout > requestTimeout) {
+            connectTimeout = convertLongTimeoutToIntWithInfiniteAsZero(requestTimeout)
+        }
+    }
+}
+
+/**
+ * Call [HttpURLConnection.connect] catching [SocketTimeoutException] and returning [HttpSocketTimeoutException] instead
+ * of it. If request timeout happens earlier [HttpRequestTimeoutException] will be thrown.
+ */
+internal suspend fun HttpURLConnection.timeoutAwareConnect(request: HttpRequestData) {
+    try {
+        connect()
+    } catch (cause: Throwable) {
+        // Allow to throw request timeout cancellation exception instead of connect timeout exception if needed.
+        yield()
+        throw when (cause) {
+            is SocketTimeoutException -> HttpConnectTimeoutException(request)
+            else -> cause
+        }
+    }
+}
+
+/**
+ * Establish connection and return correspondent [ByteReadChannel].
+ */
+internal fun HttpURLConnection.content(callContext: CoroutineContext, request: HttpRequestData): ByteReadChannel = try {
+    inputStream?.buffered()
+} catch (_: IOException) {
+    errorStream?.buffered()
+}?.toByteReadChannel(
+    context = callContext,
+    pool = KtorDefaultPool
+)?.let { CoroutineScope(callContext).mapEngineExceptions(it, request) } ?: ByteReadChannel.Empty

--- a/ktor-client/ktor-client-apache/jvm/src/io/ktor/client/engine/apache/ApacheEngine.kt
+++ b/ktor-client/ktor-client-apache/jvm/src/io/ktor/client/engine/apache/ApacheEngine.kt
@@ -5,6 +5,7 @@
 package io.ktor.client.engine.apache
 
 import io.ktor.client.engine.*
+import io.ktor.client.features.*
 import io.ktor.client.request.*
 import io.ktor.client.utils.*
 import kotlinx.coroutines.*
@@ -25,13 +26,15 @@ internal class ApacheEngine(override val config: ApacheEngineConfig) : HttpClien
         )
     }
 
+    override val supportedCapabilities = setOf(HttpTimeout)
+
     private val engine: CloseableHttpAsyncClient = prepareClient().apply { start() }
 
     override suspend fun execute(data: HttpRequestData): HttpResponseData {
         val callContext = callContext()
 
         val apacheRequest = ApacheRequestProducer(data, config, callContext)
-        return engine.sendRequest(apacheRequest, callContext)
+        return engine.sendRequest(apacheRequest, callContext, data)
     }
 
     override fun close() {

--- a/ktor-client/ktor-client-apache/jvm/src/io/ktor/client/engine/apache/ApacheHttpRequest.kt
+++ b/ktor-client/ktor-client-apache/jvm/src/io/ktor/client/engine/apache/ApacheHttpRequest.kt
@@ -4,21 +4,24 @@
 
 package io.ktor.client.engine.apache
 
+import io.ktor.client.features.*
 import io.ktor.client.request.*
 import io.ktor.http.*
 import io.ktor.util.date.*
 import kotlinx.coroutines.*
 import org.apache.http.concurrent.*
 import org.apache.http.impl.nio.client.*
+import java.net.*
 import kotlin.coroutines.*
 
 internal suspend fun CloseableHttpAsyncClient.sendRequest(
     request: ApacheRequestProducer,
-    callContext: CoroutineContext
+    callContext: CoroutineContext,
+    requestData: HttpRequestData
 ): HttpResponseData = suspendCancellableCoroutine { continuation ->
     val requestTime = GMTDate()
 
-    val consumer = ApacheResponseConsumerDispatching(callContext) { rawResponse, body ->
+    val consumer = ApacheResponseConsumerDispatching(callContext, requestData) { rawResponse, body ->
         val statusLine = rawResponse.statusLine
 
         val status = HttpStatusCode(statusLine.statusCode, statusLine.reasonPhrase)
@@ -34,7 +37,15 @@ internal suspend fun CloseableHttpAsyncClient.sendRequest(
 
     val callback = object : FutureCallback<Unit> {
         override fun failed(exception: Exception) {
-            callContext.cancel()
+            val mappedCause = when {
+                exception is ConnectException && exception.isTimeoutException() -> HttpConnectTimeoutException(
+                    requestData
+                )
+                exception is SocketTimeoutException -> HttpSocketTimeoutException(requestData)
+                else -> exception
+            }
+
+            callContext.cancel(CancellationException("Failed to execute request", mappedCause))
             continuation.cancel(exception)
         }
 
@@ -46,5 +57,10 @@ internal suspend fun CloseableHttpAsyncClient.sendRequest(
         }
     }
 
-    execute(request, consumer, callback)
+    execute(request, consumer, callback).apply {
+        // We need to cancel Apache future if it's not needed anymore.
+        continuation.invokeOnCancellation {
+            cancel(true)
+        }
+    }
 }

--- a/ktor-client/ktor-client-apache/jvm/src/io/ktor/client/engine/apache/ApacheUtils.kt
+++ b/ktor-client/ktor-client-apache/jvm/src/io/ktor/client/engine/apache/ApacheUtils.kt
@@ -1,0 +1,12 @@
+/*
+ * Copyright 2014-2020 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.client.engine.apache
+
+import java.net.*
+
+/**
+ * Checks the message of the exception and identifies timeout exception by it.
+ */
+internal fun ConnectException.isTimeoutException() = message?.contains("Timeout connecting") ?: false

--- a/ktor-client/ktor-client-apache/jvm/test/io/ktor/client/engine/apache/ConsumerTest.kt
+++ b/ktor-client/ktor-client-apache/jvm/test/io/ktor/client/engine/apache/ConsumerTest.kt
@@ -56,7 +56,7 @@ class ConsumerTest : CoroutineScope {
 
     @Test
     fun testCreating() {
-        ApacheResponseConsumerDispatching(coroutineContext) { response, channel ->
+        ApacheResponseConsumerDispatching(coroutineContext, null) { response, channel ->
             this.receivedResponse = response
             this.channel = channel
         }.responseCompleted(BasicHttpContext())
@@ -64,7 +64,7 @@ class ConsumerTest : CoroutineScope {
 
     @Test
     fun smokeTest() {
-        val consumer = ApacheResponseConsumerDispatching(coroutineContext) { response, channel ->
+        val consumer = ApacheResponseConsumerDispatching(coroutineContext, null) { response, channel ->
             this.receivedResponse = response
             this.channel = channel
         }
@@ -87,7 +87,7 @@ class ConsumerTest : CoroutineScope {
 
     @Test
     fun emptyContent() {
-        val consumer = ApacheResponseConsumerDispatching(coroutineContext) { response, channel ->
+        val consumer = ApacheResponseConsumerDispatching(coroutineContext, null) { response, channel ->
             this.receivedResponse = response
             this.channel = channel
         }
@@ -110,7 +110,7 @@ class ConsumerTest : CoroutineScope {
         // for some response kinds (HEAD, status NoContent as so on) consumeContent is not called
         // so we have completed immediately after response received
 
-        val consumer = ApacheResponseConsumerDispatching(coroutineContext) { response, channel ->
+        val consumer = ApacheResponseConsumerDispatching(coroutineContext, null) { response, channel ->
             this.receivedResponse = response
             this.channel = channel
         }
@@ -126,7 +126,7 @@ class ConsumerTest : CoroutineScope {
 
     @Test
     fun consumeBeforeResponseReceived() {
-        val consumer = ApacheResponseConsumerDispatching(coroutineContext) { response, channel ->
+        val consumer = ApacheResponseConsumerDispatching(coroutineContext, null) { response, channel ->
             this.receivedResponse = response
             this.channel = channel
         }
@@ -153,7 +153,7 @@ class ConsumerTest : CoroutineScope {
 
     @Test
     fun suspendSmokeTest() {
-        val consumer = ApacheResponseConsumerDispatching(coroutineContext) { response, channel ->
+        val consumer = ApacheResponseConsumerDispatching(coroutineContext, null) { response, channel ->
             this.receivedResponse = response
             this.channel = channel
         }
@@ -198,7 +198,7 @@ class ConsumerTest : CoroutineScope {
 
     @Test
     fun integrationTest() {
-        val consumer = ApacheResponseConsumerDispatching(coroutineContext) { response, channel ->
+        val consumer = ApacheResponseConsumerDispatching(coroutineContext, null) { response, channel ->
             this.receivedResponse = response
             this.channel = channel
         }
@@ -258,7 +258,7 @@ class ConsumerTest : CoroutineScope {
                 consumerCrc.cancel()
                 consumer.consumeContent(decoder, ioControl)
             } else {
-                check(decoder.isCompleted) { "Decoder expected to be completed."}
+                check(decoder.isCompleted) { "Decoder expected to be completed." }
             }
 
             assertEquals(producerCrc.await(), consumerCrc.await())
@@ -267,7 +267,7 @@ class ConsumerTest : CoroutineScope {
 
     @Test
     fun lastChunkReadTest() {
-        val consumer = ApacheResponseConsumerDispatching(coroutineContext) { response, channel ->
+        val consumer = ApacheResponseConsumerDispatching(coroutineContext, null) { response, channel ->
             this.receivedResponse = response
             this.channel = channel
         }

--- a/ktor-client/ktor-client-cio/jvm/src/io/ktor/client/engine/cio/CIOEngine.kt
+++ b/ktor-client/ktor-client-cio/jvm/src/io/ktor/client/engine/cio/CIOEngine.kt
@@ -5,6 +5,7 @@
 package io.ktor.client.engine.cio
 
 import io.ktor.client.engine.*
+import io.ktor.client.features.*
 import io.ktor.client.request.*
 import io.ktor.client.utils.*
 import io.ktor.http.*
@@ -18,6 +19,8 @@ import java.util.concurrent.*
 internal class CIOEngine(override val config: CIOEngineConfig) : HttpClientEngineBase("ktor-cio") {
 
     override val dispatcher by lazy { Dispatchers.clientDispatcher(config.threadsCount, "ktor-cio-dispatcher") }
+
+    override val supportedCapabilities = setOf(HttpTimeout)
 
     private val endpoints = ConcurrentHashMap<String, Endpoint>()
 

--- a/ktor-client/ktor-client-cio/jvm/src/io/ktor/client/engine/cio/CIOEngineConfig.kt
+++ b/ktor-client/ktor-client-cio/jvm/src/io/ktor/client/engine/cio/CIOEngineConfig.kt
@@ -5,6 +5,7 @@
 package io.ktor.client.engine.cio
 
 import io.ktor.client.engine.*
+import io.ktor.client.features.*
 import io.ktor.network.tls.*
 
 /**
@@ -68,9 +69,14 @@ class EndpointConfig {
     var connectTimeout: Long = 5000
 
     /**
+     * Socket timeout in millis.
+     */
+    val socketTimeout: Long = HttpTimeout.INFINITE_TIMEOUT_MS
+
+    /**
      * Maximum number of connection attempts.
      */
-    var connectRetryAttempts: Int = 5
+    var connectRetryAttempts: Int = 1
 
     /**
      * Allow socket to close output channel immediately on writing completion (TCP connection half close).

--- a/ktor-client/ktor-client-cio/jvm/src/io/ktor/client/engine/cio/ConnectionFactory.kt
+++ b/ktor-client/ktor-client-cio/jvm/src/io/ktor/client/engine/cio/ConnectionFactory.kt
@@ -7,6 +7,7 @@ package io.ktor.client.engine.cio
 import io.ktor.network.selector.*
 import io.ktor.network.sockets.*
 import io.ktor.network.sockets.Socket
+import io.ktor.network.sockets.SocketOptions
 import kotlinx.coroutines.sync.*
 import java.net.*
 
@@ -16,10 +17,13 @@ internal class ConnectionFactory(
 ) {
     private val semaphore = Semaphore(maxConnectionsCount)
 
-    suspend fun connect(address: InetSocketAddress): Socket {
+    suspend fun connect(
+        address: InetSocketAddress,
+        configuration: SocketOptions.TCPClientSocketOptions.() -> Unit = {}
+    ): Socket {
         semaphore.acquire()
         return try {
-            aSocket(selector).tcpNoDelay().tcp().connect(address)
+            aSocket(selector).tcpNoDelay().tcp().connect(address, configuration)
         } catch (cause: Throwable) {
             // a failure or cancellation
             semaphore.release()

--- a/ktor-client/ktor-client-core/common/src/io/ktor/client/HttpClient.kt
+++ b/ktor-client/ktor-client-core/common/src/io/ktor/client/HttpClient.kt
@@ -125,6 +125,8 @@ class HttpClient(
         }
 
         with(userConfig) {
+            config.install(HttpRequestLifecycle)
+
             if (useDefaultTransformers) {
                 config.install(HttpPlainText)
                 config.install("DefaultTransformers") { defaultTransformers() }
@@ -160,6 +162,13 @@ class HttpClient(
     @InternalAPI
     suspend fun execute(builder: HttpRequestBuilder): HttpClientCall =
         requestPipeline.execute(builder, builder.body) as HttpClientCall
+
+    /**
+     * Check if the specified [capability] is supported by this client.
+     */
+    fun isSupported(capability: HttpClientEngineCapability<*>): Boolean {
+        return engine.supportedCapabilities.contains(capability)
+    }
 
     /**
      * Returns a new [HttpClient] copying this client configuration,

--- a/ktor-client/ktor-client-core/common/src/io/ktor/client/engine/HttpClientEngineCapability.kt
+++ b/ktor-client/ktor-client-core/common/src/io/ktor/client/engine/HttpClientEngineCapability.kt
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2014-2019 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.client.engine
+
+import io.ktor.client.features.*
+import io.ktor.util.*
+import kotlin.native.concurrent.*
+
+/**
+ * Key required to access capabilities.
+ */
+@KtorExperimentalAPI
+@SharedImmutable
+internal val ENGINE_CAPABILITIES_KEY = AttributeKey<MutableMap<HttpClientEngineCapability<*>, Any>>("EngineCapabilities")
+
+/**
+ * Default capabilities expected to be supported by engine.
+ */
+@KtorExperimentalAPI
+@SharedImmutable
+val DEFAULT_CAPABILITIES = setOf(HttpTimeout)
+
+/**
+ * Capability required by request to be supported by [HttpClientEngine] with [T] representing type of the capability
+ * configuration.
+ */
+interface HttpClientEngineCapability<T>

--- a/ktor-client/ktor-client-core/common/src/io/ktor/client/features/HttpRequestLifecycle.kt
+++ b/ktor-client/ktor-client-core/common/src/io/ktor/client/features/HttpRequestLifecycle.kt
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2014-2019 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.client.features
+
+import io.ktor.client.*
+import io.ktor.client.request.*
+import io.ktor.util.*
+import io.ktor.util.pipeline.*
+import kotlinx.coroutines.*
+
+/**
+ * Client HTTP feature that sets up [HttpRequestBuilder.executionContext] and completes it when the pipeline is fully
+ * processed.
+ */
+internal class HttpRequestLifecycle {
+    /**
+     * Companion object for feature installation.
+     */
+    companion object Feature : HttpClientFeature<Unit, HttpRequestLifecycle> {
+
+        override val key: AttributeKey<HttpRequestLifecycle> = AttributeKey("RequestLifecycle")
+
+        override fun prepare(block: Unit.() -> Unit): HttpRequestLifecycle = HttpRequestLifecycle()
+
+        override fun install(feature: HttpRequestLifecycle, scope: HttpClient) {
+            scope.requestPipeline.intercept(HttpRequestPipeline.Before) {
+                val executionContext = Job(context.executionContext)
+                attachToClientEngineJob(executionContext)
+
+                try {
+                    context.executionContext = executionContext
+                    proceed()
+                } catch (cause: Throwable) {
+                    executionContext.completeExceptionally(cause)
+                    throw cause
+                } finally {
+                    executionContext.complete()
+                }
+            }
+        }
+    }
+}
+
+/**
+ * Attach client engine job
+ */
+private fun PipelineContext<*, HttpRequestBuilder>.attachToClientEngineJob(clientEngineJob: Job) {
+    val handler = clientEngineJob.invokeOnCompletion { cause ->
+        if (cause != null) {
+            context.executionContext.cancel("Engine failed", cause)
+        } else {
+            (context.executionContext[Job] as CompletableJob).complete()
+        }
+    }
+
+    context.executionContext[Job]!!.invokeOnCompletion {
+        handler.dispose()
+    }
+}

--- a/ktor-client/ktor-client-core/common/src/io/ktor/client/features/HttpTimeout.kt
+++ b/ktor-client/ktor-client-core/common/src/io/ktor/client/features/HttpTimeout.kt
@@ -1,0 +1,177 @@
+/*
+ * Copyright 2014-2019 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.client.features
+
+import io.ktor.client.*
+import io.ktor.client.engine.*
+import io.ktor.client.request.*
+import io.ktor.util.*
+import io.ktor.utils.io.errors.*
+import kotlinx.coroutines.*
+import kotlin.native.concurrent.*
+
+/**
+ * Client HTTP timeout feature. There are no default values, so default timeouts will be taken from engine configuration
+ * or considered as infinite time if engine doesn't provide them.
+ */
+class HttpTimeout(
+    private val requestTimeoutMillis: Long?,
+    private val connectTimeoutMillis: Long?,
+    private val socketTimeoutMillis: Long?
+) {
+    /**
+     * [HttpTimeout] extension configuration that is used during installation.
+     */
+    class HttpTimeoutCapabilityConfiguration {
+        /**
+         * Creates a new instance of [HttpTimeoutCapabilityConfiguration].
+         */
+        @InternalAPI
+        constructor(
+            requestTimeoutMillis: Long? = null,
+            connectTimeoutMillis: Long? = null,
+            socketTimeoutMillis: Long? = null
+        ) {
+            this.requestTimeoutMillis = requestTimeoutMillis
+            this.connectTimeoutMillis = connectTimeoutMillis
+            this.socketTimeoutMillis = socketTimeoutMillis
+        }
+
+        /**
+         * Request timeout in milliseconds.
+         */
+        var requestTimeoutMillis: Long?
+            set(value) {
+                field = checkTimeoutValue(value)
+            }
+
+        /**
+         * Connect timeout in milliseconds.
+         */
+        var connectTimeoutMillis: Long?
+            set(value) {
+                field = checkTimeoutValue(value)
+            }
+
+        /**
+         * Socket timeout (read and write) in milliseconds.
+         */
+        var socketTimeoutMillis: Long?
+            set(value) {
+                field = checkTimeoutValue(value)
+            }
+
+        internal fun build(): HttpTimeout = HttpTimeout(requestTimeoutMillis, connectTimeoutMillis, socketTimeoutMillis)
+
+        private fun checkTimeoutValue(value: Long?): Long? {
+            require(value == null || value > 0) {
+                "Only positive timeout values are allowed, for infinite timeout use HttpTimeout.INFINITE_TIMEOUT_MS"
+            }
+            return value
+        }
+
+        companion object {
+            @SharedImmutable
+            val key = AttributeKey<HttpTimeoutCapabilityConfiguration>("TimeoutConfiguration")
+        }
+    }
+
+    /**
+     * Utils method that return true if at least one timeout is configured (has not null value).
+     */
+    private fun hasNotNullTimeouts() =
+        requestTimeoutMillis != null || connectTimeoutMillis != null || socketTimeoutMillis != null
+
+    /**
+     * Companion object for feature installation.
+     */
+    companion object Feature : HttpClientFeature<HttpTimeoutCapabilityConfiguration, HttpTimeout>,
+        HttpClientEngineCapability<HttpTimeoutCapabilityConfiguration> {
+
+        override val key: AttributeKey<HttpTimeout> = AttributeKey("TimeoutFeature")
+
+        /**
+         * Infinite timeout in milliseconds.
+         */
+        @SharedImmutable
+        const val INFINITE_TIMEOUT_MS = Long.MAX_VALUE
+
+        override fun prepare(block: HttpTimeoutCapabilityConfiguration.() -> Unit): HttpTimeout =
+            HttpTimeoutCapabilityConfiguration().apply(block).build()
+
+        override fun install(feature: HttpTimeout, scope: HttpClient) {
+            scope.requestPipeline.intercept(HttpRequestPipeline.Before) {
+                var configuration = context.getCapabilityOrNull(HttpTimeout)
+                if (configuration == null && feature.hasNotNullTimeouts()) {
+                    configuration = HttpTimeoutCapabilityConfiguration()
+                    context.setCapability(HttpTimeout, configuration)
+                }
+
+                configuration?.apply {
+                    connectTimeoutMillis = connectTimeoutMillis ?: feature.connectTimeoutMillis
+                    socketTimeoutMillis = socketTimeoutMillis ?: feature.socketTimeoutMillis
+                    requestTimeoutMillis = requestTimeoutMillis ?: feature.requestTimeoutMillis
+
+                    val requestTimeout = requestTimeoutMillis ?: feature.requestTimeoutMillis
+                    if (requestTimeout == null || requestTimeout == INFINITE_TIMEOUT_MS) return@apply
+
+                    val executionContext = context.executionContext
+                    val killer = scope.launch {
+                        delay(requestTimeout)
+                        executionContext.cancel(HttpRequestTimeoutException(context))
+                    }
+
+                    context.executionContext.invokeOnCompletion {
+                        killer.cancel()
+                    }
+                }
+            }
+        }
+    }
+}
+
+/**
+ * Adds timeout boundaries to the request. Requires [HttpTimeout] feature to be installed.
+ */
+fun HttpRequestBuilder.timeout(block: HttpTimeout.HttpTimeoutCapabilityConfiguration.() -> Unit) =
+    setCapability(HttpTimeout, HttpTimeout.HttpTimeoutCapabilityConfiguration().apply(block))
+
+/**
+ * This exception is thrown in case request timeout exceeded.
+ */
+class HttpRequestTimeoutException(request: HttpRequestBuilder) :
+    CancellationException(
+        "Request timeout has been expired [url=${request.url}, request_timeout=${request.getCapabilityOrNull(
+            HttpTimeout
+        )?.requestTimeoutMillis ?: "unknown"} ms]"
+    )
+
+/**
+ * This exception is thrown in case connect timeout exceeded.
+ */
+expect class HttpConnectTimeoutException(request: HttpRequestData) : IOException
+
+/**
+ * This exception is thrown in case socket timeout (read or write) exceeded.
+ */
+expect class HttpSocketTimeoutException(request: HttpRequestData) : IOException
+
+/**
+ * Convert long timeout in milliseconds to int value. To do that we need to consider [HttpTimeout.INFINITE_TIMEOUT_MS]
+ * as zero and convert timeout value to [Int].
+ */
+@InternalAPI
+fun convertLongTimeoutToIntWithInfiniteAsZero(timeout: Long): Int = when {
+    timeout == HttpTimeout.INFINITE_TIMEOUT_MS -> 0
+    timeout < Int.MIN_VALUE -> Int.MIN_VALUE
+    timeout > Int.MAX_VALUE -> Int.MAX_VALUE
+    else -> timeout.toInt()
+}
+
+@InternalAPI
+fun convertLongTimeoutToLongWithInfiniteAsZero(timeout: Long): Long = when (timeout) {
+    HttpTimeout.INFINITE_TIMEOUT_MS -> 0L
+    else -> timeout
+}

--- a/ktor-client/ktor-client-core/common/src/io/ktor/client/request/HttpRequest.kt
+++ b/ktor-client/ktor-client-core/common/src/io/ktor/client/request/HttpRequest.kt
@@ -6,6 +6,7 @@ package io.ktor.client.request
 
 import io.ktor.client.*
 import io.ktor.client.call.*
+import io.ktor.client.engine.*
 import io.ktor.client.utils.*
 import io.ktor.http.*
 import io.ktor.http.content.*
@@ -83,7 +84,8 @@ class HttpRequestBuilder : HttpMessageBuilder {
      * A deferred used to control the execution of this request.
      */
     @KtorExperimentalAPI
-    val executionContext: Job = Job()
+    var executionContext: Job = Job()
+        internal set
 
     /**
      * Call specific attributes.
@@ -114,7 +116,10 @@ class HttpRequestBuilder : HttpMessageBuilder {
     /**
      * Mutates [this] copying all the data from another [builder] using it as base.
      */
+    @InternalAPI
+    @Deprecated("For internal usage only")
     fun takeFrom(builder: HttpRequestBuilder): HttpRequestBuilder {
+        executionContext = builder.executionContext
         method = builder.method
         body = builder.body
         url.takeFrom(builder.url)
@@ -128,6 +133,24 @@ class HttpRequestBuilder : HttpMessageBuilder {
         return this
     }
 
+    /**
+     * Set capability configuration.
+     */
+    @KtorExperimentalAPI
+    fun <T : Any> setCapability(key: HttpClientEngineCapability<T>, capability: T) {
+        val capabilities = attributes.computeIfAbsent(ENGINE_CAPABILITIES_KEY) { mutableMapOf() }
+        capabilities[key] = capability
+    }
+
+    /**
+     * Retrieve capability by key.
+     */
+    @KtorExperimentalAPI
+    fun <T : Any> getCapabilityOrNull(key: HttpClientEngineCapability<T>): T? {
+        @Suppress("UNCHECKED_CAST")
+        return attributes.getOrNull(ENGINE_CAPABILITIES_KEY)?.get(key) as T?
+    }
+
     companion object
 }
 
@@ -135,7 +158,7 @@ class HttpRequestBuilder : HttpMessageBuilder {
  * Actual data of the [HttpRequest], including [url], [method], [headers], [body] and [executionContext].
  * Built by [HttpRequestBuilder].
  */
-class HttpRequestData internal constructor(
+class HttpRequestData @InternalAPI constructor(
     val url: Url,
     val method: HttpMethod,
     val headers: Headers,
@@ -143,6 +166,21 @@ class HttpRequestData internal constructor(
     val executionContext: Job,
     val attributes: Attributes
 ) {
+    /**
+     * Retrieve extension by it's key.
+     */
+    @KtorExperimentalAPI
+    fun <T> getCapabilityOrNull(key: HttpClientEngineCapability<T>): T? {
+        @Suppress("UNCHECKED_CAST")
+        return attributes.getOrNull(ENGINE_CAPABILITIES_KEY)?.get(key) as T?
+    }
+
+    /**
+     * All extension keys associated with this request.
+     */
+    internal val requiredCapabilities: Set<HttpClientEngineCapability<*>> =
+        attributes.getOrNull(ENGINE_CAPABILITIES_KEY)?.keys ?: emptySet()
+
     override fun toString(): String = "HttpRequestData(url=$url, method=$method)"
 }
 

--- a/ktor-client/ktor-client-core/js/src/io/ktor/client/engine/js/JsClientEngine.kt
+++ b/ktor-client/ktor-client-core/js/src/io/ktor/client/engine/js/JsClientEngine.kt
@@ -5,6 +5,7 @@
 package io.ktor.client.engine.js
 
 import io.ktor.client.engine.*
+import io.ktor.client.features.*
 import io.ktor.client.engine.js.compatibility.*
 import io.ktor.client.features.websocket.*
 import io.ktor.client.request.*
@@ -20,6 +21,8 @@ import kotlin.coroutines.*
 internal class JsClientEngine(override val config: HttpClientEngineConfig) : HttpClientEngineBase("ktor-js") {
 
     override val dispatcher = Dispatchers.Default
+
+    override val supportedCapabilities = setOf(HttpTimeout)
 
     init {
         check(config.proxy == null) { "Proxy unsupported in Js engine." }

--- a/ktor-client/ktor-client-core/js/src/io/ktor/client/features/HttpTimeoutJS.kt
+++ b/ktor-client/ktor-client-core/js/src/io/ktor/client/features/HttpTimeoutJS.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2014-2019 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.client.features
+
+import io.ktor.client.request.*
+import io.ktor.utils.io.errors.*
+
+/**
+ * HTTP connect timeout exception.
+ */
+@Suppress("ACTUAL_WITHOUT_EXPECT")
+actual class HttpConnectTimeoutException actual constructor(request: HttpRequestData) :
+    IOException(
+        "Connect timeout has been expired [url=${request.url}, connect_timeout=${request.getCapabilityOrNull(
+            HttpTimeout
+        )?.connectTimeoutMillis ?: "unknown"} ms]"
+    )
+
+/**
+ * HTTP socket timeout exception.
+ */
+@Suppress("ACTUAL_WITHOUT_EXPECT")
+actual class HttpSocketTimeoutException actual constructor(request: HttpRequestData) :
+    IOException(
+        "Socket timeout has been expired [url=${request.url}, socket_timeout=${request.getCapabilityOrNull(
+            HttpTimeout
+        )?.socketTimeoutMillis ?: "unknown"}] ms"
+    )

--- a/ktor-client/ktor-client-core/jvm/src/io/ktor/client/features/HttpTimeoutJVM.kt
+++ b/ktor-client/ktor-client-core/jvm/src/io/ktor/client/features/HttpTimeoutJVM.kt
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2014-2019 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.client.features
+
+import io.ktor.client.request.*
+import io.ktor.util.*
+import io.ktor.utils.io.*
+import kotlinx.coroutines.*
+import java.net.*
+
+@Suppress("ACTUAL_WITHOUT_EXPECT")
+actual class HttpConnectTimeoutException actual constructor(request: HttpRequestData) :
+    ConnectException(
+        "Connect timeout has been expired [url=${request.url}, connect_timeout=${request.getCapabilityOrNull(
+            HttpTimeout
+        )?.connectTimeoutMillis ?: "unknown"} ms]"
+    )
+
+@Suppress("ACTUAL_WITHOUT_EXPECT")
+actual class HttpSocketTimeoutException actual constructor(request: HttpRequestData) :
+    SocketTimeoutException(
+        "Socket timeout has been expired [url=${request.url}, socket_timeout=${request.getCapabilityOrNull(
+            HttpTimeout
+        )?.socketTimeoutMillis ?: "unknown"}] ms"
+    )
+
+/**
+ * Returns [ByteReadChannel] with [ByteChannel.close] handler that returns [HttpSocketTimeoutException] instead of
+ * [SocketTimeoutException].
+ */
+@InternalAPI
+fun CoroutineScope.mapEngineExceptions(input: ByteReadChannel, request: HttpRequestData): ByteReadChannel {
+    val replacementChannel = ByteChannelWithMappedExceptions(request)
+
+    writer(coroutineContext, replacementChannel) {
+        try {
+            input.joinTo(replacementChannel, closeOnEnd = true)
+        } catch (cause: Throwable) {
+            input.cancel(cause)
+        }
+    }
+
+    return replacementChannel
+}
+
+/**
+ * Returns [ByteWriteChannel] with [ByteChannel.close] handler that returns [HttpSocketTimeoutException] instead of
+ * [SocketTimeoutException].
+ */
+@InternalAPI
+fun CoroutineScope.mapEngineExceptions(input: ByteWriteChannel, request: HttpRequestData): ByteWriteChannel {
+    val replacementChannel = ByteChannelWithMappedExceptions(request)
+
+    writer(coroutineContext, replacementChannel) {
+        try {
+            replacementChannel.joinTo(input, closeOnEnd = true)
+        } catch (cause: Throwable) {
+            replacementChannel.close(cause)
+        }
+    }
+
+    return replacementChannel
+}
+
+/**
+ * Creates [ByteChannel] that maps close exceptions (close the channel with [HttpSocketTimeoutException] if asked to
+ * close it with [SocketTimeoutException]).
+ */
+private fun ByteChannelWithMappedExceptions(request: HttpRequestData) = ByteChannel { cause ->
+    when (cause?.rootCause) {
+        is SocketTimeoutException -> HttpSocketTimeoutException(request)
+        else -> cause
+    }
+}

--- a/ktor-client/ktor-client-core/posix/src/io/ktor/client/engine/Loader.kt
+++ b/ktor-client/ktor-client-core/posix/src/io/ktor/client/engine/Loader.kt
@@ -15,7 +15,7 @@ private typealias T = HttpClientEngineFactory<HttpClientEngineConfig>
  * Shared engines collection for.
  * Use [append] to enable engine auto discover in [HttpClient()].
  */
-object engines : Iterable<HttpClientEngineFactory<HttpClientEngineConfig>> {
+object engines : Iterable<T> {
     private val head = AtomicReference<Node?>(null)
 
     /**
@@ -46,7 +46,7 @@ object engines : Iterable<HttpClientEngineFactory<HttpClientEngineConfig>> {
     }
 
     private class Node(
-        val item: HttpClientEngineFactory<HttpClientEngineConfig>, val next: Node?
+        val item: T, val next: Node?
     ) {
         init {
             freeze()

--- a/ktor-client/ktor-client-core/posix/src/io/ktor/client/features/HttpTimeoutNative.kt
+++ b/ktor-client/ktor-client-core/posix/src/io/ktor/client/features/HttpTimeoutNative.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2014-2019 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.client.features
+
+import io.ktor.client.request.*
+import io.ktor.utils.io.errors.*
+
+/**
+ * HTTP connect timeout exception.
+ */
+@Suppress("ACTUAL_WITHOUT_EXPECT")
+actual class HttpConnectTimeoutException actual constructor(request: HttpRequestData) :
+    IOException(
+        "Connect timeout has been expired [url=${request.url}, connect_timeout=${request.getCapabilityOrNull(
+            HttpTimeout
+        )?.connectTimeoutMillis ?: "unknown"} ms]"
+    )
+
+/**
+ * HTTP socket timeout exception.
+ */
+@Suppress("ACTUAL_WITHOUT_EXPECT")
+actual class HttpSocketTimeoutException actual constructor(request: HttpRequestData) :
+    IOException(
+        "Socket timeout has been expired [url=${request.url}, socket_timeout=${request.getCapabilityOrNull(
+            HttpTimeout
+        )?.socketTimeoutMillis ?: "unknown"}] ms"
+    )

--- a/ktor-client/ktor-client-curl/posix/src/io/ktor/client/engine/curl/Curl.kt
+++ b/ktor-client/ktor-client-curl/posix/src/io/ktor/client/engine/curl/Curl.kt
@@ -24,7 +24,6 @@ private val initHook = Curl
  * with the the associated configuration [HttpClientEngineConfig].
  */
 object Curl : HttpClientEngineFactory<HttpClientEngineConfig> {
-
     init {
         engines.append(this)
     }

--- a/ktor-client/ktor-client-curl/posix/src/io/ktor/client/engine/curl/CurlClientEngine.kt
+++ b/ktor-client/ktor-client-curl/posix/src/io/ktor/client/engine/curl/CurlClientEngine.kt
@@ -6,6 +6,7 @@ package io.ktor.client.engine.curl
 
 import io.ktor.client.engine.*
 import io.ktor.client.engine.curl.internal.*
+import io.ktor.client.features.*
 import io.ktor.client.request.*
 import io.ktor.client.utils.*
 import io.ktor.http.*
@@ -19,6 +20,8 @@ internal class CurlClientEngine(
 ) : HttpClientEngineBase("ktor-curl") {
     override val dispatcher = Dispatchers.Unconfined
 
+    override val supportedCapabilities = setOf(HttpTimeout)
+
     private val curlProcessor = CurlProcessor(coroutineContext)
 
     override suspend fun execute(data: HttpRequestData): HttpResponseData {
@@ -27,7 +30,7 @@ internal class CurlClientEngine(
         val requestTime = GMTDate()
 
         val curlRequest = data.toCurlRequest(config)
-        val responseData = curlProcessor.executeRequest(curlRequest)
+        val responseData = curlProcessor.executeRequest(curlRequest, callContext)
 
         return with(responseData) {
             val headerBytes = ByteReadChannel(headersBytes).apply {

--- a/ktor-client/ktor-client-curl/posix/src/io/ktor/client/engine/curl/internal/CurlRaw.kt
+++ b/ktor-client/ktor-client-curl/posix/src/io/ktor/client/engine/curl/internal/CurlRaw.kt
@@ -6,6 +6,7 @@ package io.ktor.client.engine.curl.internal
 
 import io.ktor.client.call.*
 import io.ktor.client.engine.*
+import io.ktor.client.features.*
 import io.ktor.client.request.*
 import io.ktor.http.*
 import io.ktor.http.content.*
@@ -24,7 +25,9 @@ internal suspend fun HttpRequestData.toCurlRequest(config: HttpClientEngineConfi
     method = method.value,
     headers = headersToCurl(),
     proxy = config.proxy,
-    content = body.toCurlByteArray()
+    content = body.toCurlByteArray(),
+    connectTimeout = getCapabilityOrNull(HttpTimeout)?.connectTimeoutMillis,
+    requestData = HttpRequestData(url, method, headers, body, Job(), attributes)
 )
 
 internal class CurlRequestData(
@@ -32,7 +35,9 @@ internal class CurlRequestData(
     val method: String,
     val headers: CPointer<curl_slist>,
     val proxy: ProxyConfig?,
-    val content: ByteArray
+    val content: ByteArray,
+    val connectTimeout: Long?,
+    val requestData: HttpRequestData
 ) {
     override fun toString(): String =
         "CurlRequestData(url='$url', method='$method', content: ${content.size} bytes)"

--- a/ktor-client/ktor-client-features/ktor-client-auth/common/src/io/ktor/client/features/auth/Auth.kt
+++ b/ktor-client/ktor-client-features/ktor-client-auth/common/src/io/ktor/client/features/auth/Auth.kt
@@ -35,7 +35,7 @@ class Auth(
                 }
             }
 
-            scope.feature(HttpSend)!!.intercept { origin ->
+            scope.feature(HttpSend)!!.intercept { origin, context ->
                 var call = origin
 
                 val usedProviders = mutableSetOf<AuthProvider>()
@@ -47,7 +47,7 @@ class Auth(
                     if (provider in usedProviders || provider in feature.alwaysSend) return@intercept call
 
                     val request = HttpRequestBuilder()
-                    request.takeFrom(call.request)
+                    request.takeFrom(context)
                     provider.addRequestHeaders(request)
 
                     call = execute(request)

--- a/ktor-client/ktor-client-jetty/jvm/src/io/ktor/client/engine/jetty/JettyEngineConfig.kt
+++ b/ktor-client/ktor-client-jetty/jvm/src/io/ktor/client/engine/jetty/JettyEngineConfig.kt
@@ -16,4 +16,9 @@ class JettyEngineConfig : HttpClientEngineConfig() {
      * A Jetty's [SslContextFactory]. By default it trusts all the certificates.
      */
     var sslContextFactory: SslContextFactory = SslContextFactory.Client()
+
+    /**
+     * Size of the cache that keeps least recently used [JettyHttp2Engine] instances.
+     */
+    var clientCacheSize: Int = 10
 }

--- a/ktor-client/ktor-client-jetty/jvm/src/io/ktor/client/engine/jetty/JettyHttp2Engine.kt
+++ b/ktor-client/ktor-client-jetty/jvm/src/io/ktor/client/engine/jetty/JettyHttp2Engine.kt
@@ -5,8 +5,10 @@
 package io.ktor.client.engine.jetty
 
 import io.ktor.client.engine.*
+import io.ktor.client.features.*
 import io.ktor.client.request.*
 import io.ktor.client.utils.*
+import io.ktor.util.*
 import kotlinx.coroutines.*
 import org.eclipse.jetty.http2.client.*
 import org.eclipse.jetty.util.thread.*
@@ -20,27 +22,49 @@ internal class JettyHttp2Engine(override val config: JettyEngineConfig) : HttpCl
         )
     }
 
-    private val jettyClient = HTTP2Client().apply {
-        addBean(config.sslContextFactory)
-        check(config.proxy == null) { "Proxy unsupported in Jetty engine." }
+    override val supportedCapabilities = setOf(HttpTimeout)
 
-        executor = QueuedThreadPool().apply {
-            name = "ktor-jetty-client-qtp"
-        }
-
-        start()
-    }
+    /**
+     * Cache that keeps least recently used [HTTP2Client] instances. Set "0" to avoid caching.
+     */
+    private val clientCache = createLRUCache(::createJettyClient, HTTP2Client::stop, config.clientCacheSize)
 
     override suspend fun execute(data: HttpRequestData): HttpResponseData {
         val callContext = callContext()
+        val jettyClient =
+            clientCache[data.getCapabilityOrNull(HttpTimeout)]
+                ?: error("Http2Client can't be constructed because HttpTimeout feature is not installed")
 
         return data.executeRequest(jettyClient, config, callContext)
     }
 
     override fun close() {
         super.close()
+
         coroutineContext[Job]!!.invokeOnCompletion {
-            jettyClient.stop()
+            clientCache.forEach { (_, client) -> client.stop() }
         }
     }
+
+    private fun createJettyClient(timeoutExtension: HttpTimeout.HttpTimeoutCapabilityConfiguration?): HTTP2Client =
+        HTTP2Client().apply {
+            addBean(config.sslContextFactory)
+            check(config.proxy == null) { "Proxy unsupported in Jetty engine." }
+
+            executor = QueuedThreadPool().apply {
+                name = "ktor-jetty-client-qtp"
+            }
+
+            setupTimeoutAttributes(timeoutExtension)
+
+            start()
+        }
+}
+
+/**
+ * Update [HTTP2Client] to use connect and socket timeouts specified by [HttpTimeout] feature.
+ */
+private fun HTTP2Client.setupTimeoutAttributes(timeoutAttributes: HttpTimeout.HttpTimeoutCapabilityConfiguration?) {
+    timeoutAttributes?.connectTimeoutMillis?.let { connectTimeout = it }
+    timeoutAttributes?.socketTimeoutMillis?.let { idleTimeout = it }
 }

--- a/ktor-client/ktor-client-jetty/jvm/src/io/ktor/client/engine/jetty/JettyResponseListener.kt
+++ b/ktor-client/ktor-client-jetty/jvm/src/io/ktor/client/engine/jetty/JettyResponseListener.kt
@@ -46,6 +46,11 @@ internal class JettyResponseListener(
         return Ignore
     }
 
+    override fun onIdleTimeout(stream: Stream, cause: Throwable): Boolean {
+        channel.close(cause)
+        return true
+    }
+
     override fun onReset(stream: Stream, frame: ResetFrame) {
         val error = when (frame.error) {
             0 -> null

--- a/ktor-client/ktor-client-mock/common/src/io/ktor/client/engine/mock/MockEngine.kt
+++ b/ktor-client/ktor-client-mock/common/src/io/ktor/client/engine/mock/MockEngine.kt
@@ -5,6 +5,7 @@
 package io.ktor.client.engine.mock
 
 import io.ktor.client.engine.*
+import io.ktor.client.features.*
 import io.ktor.client.request.*
 import io.ktor.util.*
 import kotlinx.atomicfu.locks.*
@@ -15,6 +16,7 @@ import kotlinx.coroutines.*
  */
 class MockEngine(override val config: MockEngineConfig) : HttpClientEngineBase("ktor-mock") {
     override val dispatcher = Dispatchers.Unconfined
+    override val supportedCapabilities = setOf(HttpTimeout)
     private var invocationCount = 0
     private val mutex = Lock()
     private val _requestsHistory: MutableList<HttpRequestData> = mutableListOf()

--- a/ktor-client/ktor-client-okhttp/jvm/src/io/ktor/client/engine/okhttp/OkHttpConfig.kt
+++ b/ktor-client/ktor-client-okhttp/jvm/src/io/ktor/client/engine/okhttp/OkHttpConfig.kt
@@ -15,12 +15,18 @@ class OkHttpConfig : HttpClientEngineConfig() {
     internal var config: OkHttpClient.Builder.() -> Unit = {
         followRedirects(false)
         followSslRedirects(false)
+        retryOnConnectionFailure(false)
     }
 
     /**
      * Preconfigured [OkHttpClient] instance instead of configuring one.
      */
     var preconfigured: OkHttpClient? = null
+
+    /**
+     * Size of the cache that keeps least recently used [OkHttpClient] instances. Set "0" to avoid caching.
+     */
+    var clientCacheSize: Int = 10
 
     /**
      * Configure [OkHttpClient] using [OkHttpClient.Builder].

--- a/ktor-client/ktor-client-tests/common/src/io/ktor/client/tests/utils/Assertions.kt
+++ b/ktor-client/ktor-client-tests/common/src/io/ktor/client/tests/utils/Assertions.kt
@@ -1,0 +1,13 @@
+/*
+ * Copyright 2014-2019 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.client.tests.utils
+
+import io.ktor.util.*
+
+/**
+ * Check that [block] completed with given type of root cause.
+ */
+@InternalAPI
+expect inline fun <reified T : Throwable> assertFailsWithRootCause(block: () -> Unit)

--- a/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/HttpRedirectTest.kt
+++ b/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/HttpRedirectTest.kt
@@ -10,6 +10,7 @@ import io.ktor.client.request.*
 import io.ktor.client.statement.*
 import io.ktor.client.tests.utils.*
 import io.ktor.http.*
+import io.ktor.utils.io.core.*
 import kotlin.test.*
 
 class HttpRedirectTest : ClientLoader() {

--- a/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/HttpTimeoutTest.kt
+++ b/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/HttpTimeoutTest.kt
@@ -1,0 +1,553 @@
+/*
+ * Copyright 2014-2019 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.client.tests
+
+import io.ktor.client.call.*
+import io.ktor.client.features.*
+import io.ktor.client.request.*
+import io.ktor.client.statement.*
+import io.ktor.client.tests.utils.*
+import io.ktor.http.*
+import io.ktor.utils.io.*
+import io.ktor.utils.io.core.*
+import kotlinx.coroutines.*
+import kotlin.test.*
+
+private const val TEST_URL = "$TEST_SERVER/timeout"
+
+class HttpTimeoutTest : ClientLoader() {
+    @Test
+    fun testGet() = clientTests {
+        config {
+            install(HttpTimeout) { requestTimeoutMillis = 500 }
+        }
+
+        test { client ->
+            val response = client.get<String>("$TEST_URL/with-delay") {
+                parameter("delay", 10)
+            }
+            assertEquals("Text", response)
+        }
+    }
+
+    @Test
+    fun testGetWithExceptionAndTryAgain() = clientTests {
+        test { client ->
+            val requestBuilder = HttpRequestBuilder().apply {
+                method = HttpMethod.Get
+                url("$TEST_URL/404")
+                parameter("delay", 10)
+            }
+
+            val job = requestBuilder.executionContext
+            assertTrue { job.isActive }
+
+            assertFails { client.request<String>(requestBuilder) }
+            assertTrue { job.isActive }
+
+            requestBuilder.url("$TEST_URL/with-delay")
+
+            val response = client.request<String>(requestBuilder)
+
+            assertEquals("Text", response)
+            assertTrue { job.isActive }
+        }
+    }
+
+    @Test
+    fun testWithExternalTimeout() = clientTests(listOf("Android")) {
+        config {
+            install(HttpTimeout)
+        }
+
+        test { client ->
+            val requestBuilder = HttpRequestBuilder().apply {
+                method = HttpMethod.Get
+                url("$TEST_URL/with-delay")
+                parameter("delay", 60 * 1000)
+            }
+
+            val exception = assertFails {
+                withTimeout(500) {
+                    client.request<String>(requestBuilder)
+                }
+            }
+
+            assertTrue { exception is TimeoutCancellationException }
+            assertTrue { requestBuilder.executionContext.getActiveChildren().none() }
+        }
+    }
+
+    @Test
+    fun testHead() = clientTests {
+        config {
+            install(HttpTimeout)
+        }
+
+        test { client ->
+            val response = client.head<HttpResponse>("$TEST_URL/with-delay?delay=10")
+            assertEquals(HttpStatusCode.OK, response.status)
+        }
+    }
+
+    @Test
+    fun testHeadWithTimeout() = clientTests {
+        config {
+            install(HttpTimeout) {
+                requestTimeoutMillis = 500
+            }
+        }
+
+        test { client ->
+            assertFailsWithRootCause<HttpRequestTimeoutException> {
+                client.head<HttpResponse>("$TEST_URL/with-delay?delay=1000")
+            }
+        }
+    }
+
+    @Test
+    fun testGetWithCancellation() = clientTests {
+        config {
+            install(HttpTimeout) {
+                requestTimeoutMillis = 500
+            }
+
+            test { client ->
+                val requestBuilder = HttpRequestBuilder().apply {
+                    method = HttpMethod.Get
+                    url("$TEST_URL/with-stream")
+                    parameter("delay", 2000)
+                }
+
+                client.request<ByteReadChannel>(requestBuilder).cancel()
+
+                delay(2000) // Channel is closing asynchronously.
+                assertTrue { requestBuilder.executionContext.getActiveChildren().none() }
+            }
+        }
+    }
+
+    @Test
+    fun testGetRequestTimeout() = clientTests {
+        config {
+            install(HttpTimeout) { requestTimeoutMillis = 10 }
+        }
+
+        test { client ->
+            assertFails {
+                client.get<String>("$TEST_URL/with-delay") {
+                    parameter("delay", 5000)
+                }
+            }
+        }
+    }
+
+    @Test
+    fun testGetRequestTimeoutPerRequestAttributes() = clientTests {
+        config {
+            install(HttpTimeout)
+        }
+
+        test { client ->
+            assertFails {
+                client.get<String>("$TEST_URL/with-delay") {
+                    parameter("delay", 5000)
+
+                    timeout { requestTimeoutMillis = 10 }
+                }
+            }
+        }
+    }
+
+    @Test
+    fun testGetWithSeparateReceive() = clientTests {
+        config {
+            install(HttpTimeout) { requestTimeoutMillis = 500 }
+        }
+
+        test { client ->
+            val response = client.request<HttpResponse>("$TEST_URL/with-delay") {
+                method = HttpMethod.Get
+                parameter("delay", 10)
+            }
+            val result: String = response.receive()
+
+            assertEquals("Text", result)
+        }
+    }
+
+    @Test
+    fun testGetWithSeparateReceivePerRequestAttributes() = clientTests {
+        config {
+            install(HttpTimeout)
+        }
+
+        test { client ->
+            val response = client.request<HttpResponse>("$TEST_URL/with-delay") {
+                method = HttpMethod.Get
+                parameter("delay", 10)
+
+                timeout { requestTimeoutMillis = 500 }
+            }
+            val result: String = response.receive()
+
+            assertEquals("Text", result)
+        }
+    }
+
+    @Test
+    fun testGetRequestTimeoutWithSeparateReceive() = clientTests(listOf("Curl", "Ios", "Js")) {
+        config {
+            install(HttpTimeout) { requestTimeoutMillis = 1000 }
+        }
+
+        test { client ->
+            val response = client.request<ByteReadChannel>("$TEST_URL/with-stream") {
+                method = HttpMethod.Get
+                parameter("delay", 500)
+            }
+            assertFailsWithRootCause<HttpRequestTimeoutException> {
+                response.readUTF8Line()
+            }
+        }
+    }
+
+    @Test
+    fun testGetRequestTimeoutWithSeparateReceivePerRequestAttributes() = clientTests(listOf("Curl", "Ios", "Js")) {
+        config {
+            install(HttpTimeout)
+        }
+
+        test { client ->
+            val response = client.request<ByteReadChannel>("$TEST_URL/with-stream") {
+                method = HttpMethod.Get
+                parameter("delay", 500)
+
+                timeout { requestTimeoutMillis = 1000 }
+            }
+            assertFailsWithRootCause<HttpRequestTimeoutException> {
+                response.readUTF8Line()
+            }
+        }
+    }
+
+    @Test
+    fun testGetStream() = clientTests {
+        config {
+            install(HttpTimeout) { requestTimeoutMillis = 500 }
+        }
+
+        test { client ->
+            val response = client.get<ByteArray>("$TEST_URL/with-stream") {
+                parameter("delay", 10)
+            }
+
+            assertEquals("Text", String(response))
+        }
+    }
+
+    @Test
+    fun testGetStreamPerRequestAttributes() = clientTests {
+        config {
+            install(HttpTimeout)
+        }
+
+        test { client ->
+            val response = client.get<ByteArray>("$TEST_URL/with-stream") {
+                parameter("delay", 10)
+
+                timeout { requestTimeoutMillis = 500 }
+            }
+
+            assertEquals("Text", String(response))
+        }
+    }
+
+    @Test
+    fun testGetStreamRequestTimeout() = clientTests {
+        config {
+            install(HttpTimeout) { requestTimeoutMillis = 500 }
+        }
+
+        test { client ->
+            assertFailsWithRootCause<HttpRequestTimeoutException> {
+                client.get<ByteArray>("$TEST_URL/with-stream") {
+                    parameter("delay", 200)
+                }
+            }
+        }
+    }
+
+    @Test
+    fun testGetStreamRequestTimeoutPerRequestAttributes() = clientTests {
+        config {
+            install(HttpTimeout)
+        }
+
+        test { client ->
+            assertFailsWithRootCause<HttpRequestTimeoutException> {
+                client.get<ByteArray>("$TEST_URL/with-stream") {
+                    parameter("delay", 200)
+
+                    timeout { requestTimeoutMillis = 500 }
+                }
+            }
+        }
+    }
+
+    @Test
+    fun testRedirect() = clientTests {
+        config {
+            install(HttpTimeout) { requestTimeoutMillis = 500 }
+        }
+
+        test { client ->
+            val response = client.get<String>("$TEST_URL/with-redirect") {
+                parameter("delay", 10)
+                parameter("count", 2)
+            }
+
+            assertEquals("Text", response)
+        }
+    }
+
+    @Test
+    fun testRedirectPerRequestAttributes() = clientTests {
+        config {
+            install(HttpTimeout)
+        }
+
+        test { client ->
+            val response = client.get<String>("$TEST_URL/with-redirect") {
+                parameter("delay", 10)
+                parameter("count", 2)
+
+                timeout { requestTimeoutMillis = 500 }
+            }
+            assertEquals("Text", response)
+        }
+    }
+
+    @Test
+    fun testRedirectRequestTimeoutOnFirstStep() = clientTests {
+        config {
+            install(HttpTimeout) { requestTimeoutMillis = 10 }
+        }
+
+        test { client ->
+            assertFailsWithRootCause<HttpRequestTimeoutException> {
+                client.get<String>("$TEST_URL/with-redirect") {
+                    parameter("delay", 500)
+                    parameter("count", 5)
+                }
+            }
+        }
+    }
+
+    @Test
+    fun testRedirectRequestTimeoutOnFirstStepPerRequestAttributes() = clientTests {
+        config {
+            install(HttpTimeout)
+        }
+
+        test { client ->
+            assertFailsWithRootCause<HttpRequestTimeoutException> {
+                client.get<String>("$TEST_URL/with-redirect") {
+                    parameter("delay", 500)
+                    parameter("count", 5)
+
+                    timeout { requestTimeoutMillis = 10 }
+                }
+            }
+        }
+    }
+
+    @Test
+    fun testRedirectRequestTimeoutOnSecondStep() = clientTests {
+        config {
+            install(HttpTimeout) { requestTimeoutMillis = 200 }
+        }
+
+        test { client ->
+            assertFailsWithRootCause<HttpRequestTimeoutException> {
+                client.get<String>("$TEST_URL/with-redirect") {
+                    parameter("delay", 250)
+                    parameter("count", 5)
+                }
+            }
+        }
+    }
+
+    @Test
+    fun testRedirectRequestTimeoutOnSecondStepPerRequestAttributes() = clientTests {
+        config {
+            install(HttpTimeout)
+        }
+
+        test { client ->
+            assertFailsWithRootCause<HttpRequestTimeoutException> {
+                client.get<String>("$TEST_URL/with-redirect") {
+                    parameter("delay", 250)
+                    parameter("count", 5)
+
+                    timeout { requestTimeoutMillis = 200 }
+                }
+            }
+        }
+    }
+
+    @Test
+    fun testConnectTimeout() = clientTests(listOf("Js", "Ios")) {
+        config {
+            install(HttpTimeout) { connectTimeoutMillis = 1000 }
+        }
+
+        test { client ->
+            assertFailsWithRootCause<HttpConnectTimeoutException> {
+                client.get<String>("http://www.google.com:81")
+            }
+        }
+    }
+
+    @Test
+    fun testConnectionRefusedException() = clientTests(listOf("Js", "Ios")) {
+        config {
+            install(HttpTimeout) { connectTimeoutMillis = 1000 }
+        }
+
+        test { client ->
+            assertFails {
+                try {
+                    client.get<String>("http://localhost:11")
+                } catch (_: HttpConnectTimeoutException) {
+                    /* Ignore. */
+                }
+            }
+        }
+    }
+
+    @Test
+    fun testConnectTimeoutPerRequestAttributes() = clientTests(listOf("Js", "Ios")) {
+        config {
+            install(HttpTimeout)
+        }
+
+        test { client ->
+            assertFailsWithRootCause<HttpConnectTimeoutException> {
+                client.get<String>("http://www.google.com:81") {
+                    timeout { connectTimeoutMillis = 1000 }
+                }
+            }
+        }
+    }
+
+    @Test
+    fun testSocketTimeoutRead() = clientTests(listOf("Js", "Curl")) {
+        config {
+            install(HttpTimeout) { socketTimeoutMillis = 1000 }
+        }
+
+        test { client ->
+            assertFailsWithRootCause<HttpSocketTimeoutException> {
+                client.get<String>("$TEST_URL/with-stream") {
+                    parameter("delay", 5000)
+                }
+            }
+        }
+    }
+
+    @Test
+    fun testSocketTimeoutReadPerRequestAttributes() = clientTests(listOf("Js", "Curl")) {
+        config {
+            install(HttpTimeout)
+        }
+
+        test { client ->
+            assertFailsWithRootCause<HttpSocketTimeoutException> {
+                client.get<String>("$TEST_URL/with-stream") {
+                    parameter("delay", 5000)
+
+                    timeout { socketTimeoutMillis = 1000 }
+                }
+            }
+        }
+    }
+
+    @Test
+    fun testSocketTimeoutWriteFailOnWrite() = clientTests(listOf("Js", "Curl", "Android")) {
+        config {
+            install(HttpTimeout) { socketTimeoutMillis = 500 }
+        }
+
+        test { client ->
+            assertFailsWithRootCause<HttpSocketTimeoutException> {
+                client.post("$TEST_URL/slow-read") { body = makeString(4 * 1024 * 1024) }
+            }
+        }
+    }
+
+    @Test
+    fun testSocketTimeoutWriteFailOnWritePerRequestAttributes() = clientTests(listOf("Js", "Curl", "Android")) {
+        config {
+            install(HttpTimeout)
+        }
+
+        test { client ->
+            assertFailsWithRootCause<HttpSocketTimeoutException> {
+                client.post("$TEST_URL/slow-read") {
+                    body = makeString(4 * 1024 * 1024)
+                    timeout { socketTimeoutMillis = 500 }
+                }
+            }
+        }
+    }
+
+    @Test
+    fun testNonPositiveTimeout() {
+        assertFailsWith<IllegalArgumentException> {
+            HttpTimeout.HttpTimeoutCapabilityConfiguration(
+                requestTimeoutMillis = -1
+            )
+        }
+        assertFailsWith<IllegalArgumentException> {
+            HttpTimeout.HttpTimeoutCapabilityConfiguration(
+                requestTimeoutMillis = 0
+            )
+        }
+
+        assertFailsWith<IllegalArgumentException> {
+            HttpTimeout.HttpTimeoutCapabilityConfiguration(
+                socketTimeoutMillis = -1
+            )
+        }
+        assertFailsWith<IllegalArgumentException> {
+            HttpTimeout.HttpTimeoutCapabilityConfiguration(
+                socketTimeoutMillis = 0
+            )
+        }
+
+        assertFailsWith<IllegalArgumentException> {
+            HttpTimeout.HttpTimeoutCapabilityConfiguration(
+                connectTimeoutMillis = -1
+            )
+        }
+        assertFailsWith<IllegalArgumentException> {
+            HttpTimeout.HttpTimeoutCapabilityConfiguration(
+                connectTimeoutMillis = 0
+            )
+        }
+    }
+
+    @Test
+    fun testNotInstalledFeatures() = clientTests {
+        test { client ->
+            assertFailsWith<IllegalArgumentException> {
+                client.get<String>("https://www.google.com") {
+                    timeout { requestTimeoutMillis = 1000 }
+                }
+            }
+        }
+    }
+}

--- a/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/PostTest.kt
+++ b/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/PostTest.kt
@@ -5,6 +5,7 @@
 package io.ktor.client.tests
 
 import io.ktor.client.*
+import io.ktor.client.features.*
 import io.ktor.client.request.*
 import io.ktor.client.tests.utils.*
 import io.ktor.http.content.*

--- a/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/utils/JobUtils.kt
+++ b/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/utils/JobUtils.kt
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2014-2019 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.client.tests.utils
+
+import kotlinx.coroutines.*
+
+/**
+ * Utils function returning all active jobs in the hierarchy.
+ */
+internal fun Job.getActiveChildren(): Sequence<Job> = sequence {
+    for (child in children) {
+        if (child.isActive) {
+            yield(child)
+        }
+
+        yieldAll(child.getActiveChildren())
+    }
+}

--- a/ktor-client/ktor-client-tests/js/src/io/ktor/client/tests/utils/Assertions.kt
+++ b/ktor-client/ktor-client-tests/js/src/io/ktor/client/tests/utils/Assertions.kt
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2014-2019 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.client.tests.utils
+
+import io.ktor.util.*
+
+/**
+ * Check that [block] completed with given type of root cause.
+ */
+@InternalAPI
+actual inline fun <reified T : Throwable> assertFailsWithRootCause(block: () -> Unit) {
+    try {
+        block()
+        error("Expected ${T::class} exception, but it wasn't thrown")
+    } catch (cause: Throwable) {
+        if (cause !is T && cause.message?.contains(T::class.simpleName!!) == true) {
+            error("Expected ${T::class} exception, but $cause was thrown instead")
+        }
+    }
+}

--- a/ktor-client/ktor-client-tests/jvm/src/io/ktor/client/tests/utils/Assertions.kt
+++ b/ktor-client/ktor-client-tests/jvm/src/io/ktor/client/tests/utils/Assertions.kt
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2014-2019 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.client.tests.utils
+
+import io.ktor.util.*
+import kotlin.test.*
+
+/**
+ * Check that [block] completed with given type of root cause.
+ */
+@InternalAPI
+actual inline fun <reified T : Throwable> assertFailsWithRootCause(block: () -> Unit) {
+    var cause = assertFails(block)
+    while (cause.cause != null) {
+        cause = cause.cause!!
+    }
+
+    assertTrue("Expected root cause is ${T::class}, but got ${cause::class}") { cause is T }
+}

--- a/ktor-client/ktor-client-tests/jvm/src/io/ktor/client/tests/utils/ClientTestServer.kt
+++ b/ktor-client/ktor-client-tests/jvm/src/io/ktor/client/tests/utils/ClientTestServer.kt
@@ -29,6 +29,7 @@ internal fun Application.tests() {
     webSockets()
     multiPartFormDataTest()
     headersTestServer()
+    timeoutTest()
 
     routing {
         post("/echo") {

--- a/ktor-client/ktor-client-tests/jvm/src/io/ktor/client/tests/utils/tests/Timeout.kt
+++ b/ktor-client/ktor-client-tests/jvm/src/io/ktor/client/tests/utils/tests/Timeout.kt
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2014-2019 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.client.tests.utils.tests
+
+import io.ktor.application.*
+import io.ktor.http.*
+import io.ktor.http.content.*
+import io.ktor.response.*
+import io.ktor.routing.*
+import io.ktor.utils.io.*
+import kotlinx.coroutines.*
+
+internal fun Application.timeoutTest() {
+    routing {
+        route("/timeout") {
+            head("/with-delay") {
+                val delay = call.parameters["delay"]!!.toLong()
+                delay(delay)
+                call.respond(HttpStatusCode.OK)
+            }
+
+            get("/with-delay") {
+                val delay = call.parameters["delay"]!!.toLong()
+                delay(delay)
+                call.respondText { "Text" }
+            }
+
+            get("/with-stream") {
+                val delay = call.parameters["delay"]!!.toLong()
+                val response = "Text".toByteArray()
+                call.respond(object : OutgoingContent.WriteChannelContent() {
+                    override val contentType = ContentType.Application.OctetStream
+                    override suspend fun writeTo(channel: ByteWriteChannel) {
+                        for (offset in response.indices) {
+                            channel.writeFully(response, offset, 1)
+                            channel.flush()
+                            delay(delay)
+                        }
+                    }
+                })
+            }
+
+            get("/with-redirect") {
+                val delay = call.parameters["delay"]!!.toLong()
+                val count = call.parameters["count"]!!.toInt()
+                val url = if (count == 0) "/timeout/with-delay?delay=$delay"
+                else "/timeout/with-redirect?delay=$delay&count=${count - 1}"
+                delay(delay)
+                call.respondRedirect(url)
+            }
+
+            post("/slow-read") {
+                val buffer = ByteArray(1024 * 1024)
+                val input = call.request.receiveChannel()
+                var count = 0
+                while (true) {
+                    val read = input.readAvailable(buffer)
+                    if (read == -1) break
+                    count += read
+                    if (count >= 1024 * 1024) {
+                        count = 0
+                        delay(1000)
+                    }
+                }
+
+                call.respond(HttpStatusCode.OK)
+            }
+        }
+    }
+}

--- a/ktor-client/ktor-client-tests/posix/src/io/ktor/client/tests/utils/Assertions.kt
+++ b/ktor-client/ktor-client-tests/posix/src/io/ktor/client/tests/utils/Assertions.kt
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2014-2019 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.client.tests.utils
+
+import io.ktor.util.*
+import kotlin.test.*
+
+/**
+ * Check that [block] completed with given type of root cause.
+ */
+@InternalAPI
+actual inline fun <reified T : Throwable> assertFailsWithRootCause(block: () -> Unit) {
+    var cause = assertFails(block)
+    while (cause.cause != null) {
+        cause = cause.cause!!
+    }
+
+    assertTrue("Expected root cause is ${T::class}, but got ${cause::class}") { cause is T }
+}

--- a/ktor-io/common/src/io/ktor/utils/io/ByteChannelSequential.kt
+++ b/ktor-io/common/src/io/ktor/utils/io/ByteChannelSequential.kt
@@ -612,7 +612,14 @@ abstract class ByteChannelSequentialBase(
     }
 
     override suspend fun <A : Appendable> readUTF8LineTo(out: A, limit: Int): Boolean {
-        if (isClosedForRead) return false
+        if (isClosedForRead) {
+            val cause = closedCause
+            if (cause != null) {
+                throw cause
+            }
+
+            return false
+        }
         @UseExperimental(DangerousInternalIoApi::class)
         return decodeUTF8LineLoopSuspend(out, limit) { size ->
             afterRead()

--- a/ktor-io/common/test/io/ktor/utils/io/ByteChannelSmokeTest.kt
+++ b/ktor-io/common/test/io/ktor/utils/io/ByteChannelSmokeTest.kt
@@ -55,6 +55,20 @@ open class ByteChannelSmokeTest : ByteChannelTestBase() {
     }
 
     @Test
+    fun testReadLineFromExceptionallyClosedChannel() = runTest {
+        val bc = ByteChannel(true)
+        bc.writeStringUtf8("Test\n")
+        bc.flush()
+        bc.close(IllegalStateException("Something goes wrong"))
+
+        val exception = assertFailsWith<IllegalStateException> {
+            bc.readUTF8LineTo(StringBuilder(), 10)
+        }
+
+        assertEquals("Something goes wrong", exception.message)
+    }
+
+    @Test
     fun testBoolean() {
         runTest {
             ch.writeBoolean(true)

--- a/ktor-io/jvm/src/io/ktor/utils/io/ByteChannel.kt
+++ b/ktor-io/jvm/src/io/ktor/utils/io/ByteChannel.kt
@@ -17,5 +17,17 @@ actual fun ByteChannel(autoFlush: Boolean): ByteChannel = ByteBufferChannel(auto
  * Creates channel for reading from the specified byte array.
  */
 actual fun ByteReadChannel(content: ByteArray, offset: Int, length: Int): ByteReadChannel =
-        ByteBufferChannel(ByteBuffer.wrap(content, offset, length))
+    ByteBufferChannel(ByteBuffer.wrap(content, offset, length))
 
+/**
+ * Creates buffered channel for asynchronous reading and writing of sequences of bytes using [close] function to close
+ * channel.
+ */
+fun ByteChannel(autoFlush: Boolean = false, exceptionMapper: (Throwable?) -> Throwable?): ByteChannel =
+    object : ByteBufferChannel(autoFlush = autoFlush) {
+
+        override fun close(cause: Throwable?): Boolean {
+            val mappedException = exceptionMapper(cause)
+            return super.close(mappedException)
+        }
+    }

--- a/ktor-network/jvm/src/io/ktor/network/selector/SelectorManagerSupport.kt
+++ b/ktor-network/jvm/src/io/ktor/network/selector/SelectorManagerSupport.kt
@@ -38,7 +38,8 @@ abstract class SelectorManagerSupport internal constructor() : SelectorManager {
 //            val c = base.tracked()  // useful for debugging
 
             c.invokeOnCancellation {
-                selectable.dispose()
+                // TODO: We've got a race here (and exception erasure)!
+//                selectable.dispose()
             }
             selectable.suspensions.addSuspension(interest, c)
 

--- a/ktor-network/jvm/src/io/ktor/network/sockets/Builders.kt
+++ b/ktor-network/jvm/src/io/ktor/network/sockets/Builders.kt
@@ -103,7 +103,7 @@ class TcpSocketBuilder internal constructor(
         assignOptions(options)
         nonBlocking()
 
-        SocketImpl(this, socket()!!, selector).apply {
+        SocketImpl(this, socket()!!, selector, options).apply {
             connect(remoteAddress)
         }
     }

--- a/ktor-network/jvm/src/io/ktor/network/sockets/SocketImpl.kt
+++ b/ktor-network/jvm/src/io/ktor/network/sockets/SocketImpl.kt
@@ -11,8 +11,10 @@ import java.nio.channels.*
 internal class SocketImpl<out S : SocketChannel>(
     override val channel: S,
     private val socket: java.net.Socket,
-    selector: SelectorManager
-) : NIOSocketImpl<S>(channel, selector, pool = null), Socket {
+    selector: SelectorManager,
+    socketOptions: SocketOptions.TCPClientSocketOptions? = null
+) : NIOSocketImpl<S>(channel, selector, pool = null, socketOptions = socketOptions),
+    Socket {
     init {
         require(!channel.isBlocking) { "channel need to be configured as non-blocking" }
     }

--- a/ktor-network/jvm/src/io/ktor/network/sockets/SocketOptions.kt
+++ b/ktor-network/jvm/src/io/ktor/network/sockets/SocketOptions.kt
@@ -4,6 +4,8 @@
 
 package io.ktor.network.sockets
 
+import io.ktor.network.util.*
+
 /**
  * Socket options builder
  */
@@ -144,6 +146,11 @@ sealed class SocketOptions(
          * SO_KEEPALIVE option is to enable/disable TCP keep-alive
          */
         var keepAlive: Boolean? = null
+
+        /**
+         * Socket timeout (read and write).
+         */
+        var socketTimeout: Long = INFINITE_TIMEOUT_MS
 
         @Suppress("KDocMissingDocumentation")
         override fun copyCommon(from: SocketOptions) {

--- a/ktor-network/jvm/src/io/ktor/network/util/Utils.kt
+++ b/ktor-network/jvm/src/io/ktor/network/util/Utils.kt
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2014-2019 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.network.util
+
+import kotlinx.coroutines.*
+import java.net.*
+
+/**
+ * Infinite timeout in milliseconds.
+ */
+internal const val INFINITE_TIMEOUT_MS = Long.MAX_VALUE
+
+/**
+ * Wrap [block] into [withTimeout] wrapper and throws [SocketTimeoutException] if timeout exceeded.
+ */
+internal suspend fun CoroutineScope.withSocketTimeout(socketTimeout: Long, block: suspend CoroutineScope.() -> Unit) {
+    if (socketTimeout == INFINITE_TIMEOUT_MS) {
+        block()
+    } else {
+        async {
+            withTimeoutOrNull(socketTimeout, block) ?: throw SocketTimeoutException()
+        }.await()
+    }
+}

--- a/ktor-server/ktor-server-benchmarks/src/jmh/kotlin/io/ktor/server/benchmarks/RoutingBenchmark.kt
+++ b/ktor-server/ktor-server-benchmarks/src/jmh/kotlin/io/ktor/server/benchmarks/RoutingBenchmark.kt
@@ -10,6 +10,7 @@ import io.ktor.response.*
 import io.ktor.routing.*
 import io.ktor.server.testing.*
 import org.openjdk.jmh.annotations.*
+import java.util.concurrent.*
 
 @State(Scope.Benchmark)
 class RoutingBenchmark {

--- a/ktor-server/ktor-server-test-host/jvm/src/io/ktor/server/testing/client/TestHttpClientEngine.kt
+++ b/ktor-server/ktor-server-test-host/jvm/src/io/ktor/server/testing/client/TestHttpClientEngine.kt
@@ -7,13 +7,13 @@ package io.ktor.server.testing.client
 import io.ktor.client.call.*
 import io.ktor.client.engine.*
 import io.ktor.client.request.*
-import io.ktor.http.content.*
 import io.ktor.http.*
+import io.ktor.http.content.*
 import io.ktor.server.testing.*
 import io.ktor.util.*
 import io.ktor.util.date.*
-import kotlinx.coroutines.*
 import io.ktor.utils.io.*
+import kotlinx.coroutines.*
 import kotlin.coroutines.*
 
 @Suppress("KDocMissingDocumentation")
@@ -21,6 +21,8 @@ import kotlin.coroutines.*
 class TestHttpClientEngine(override val config: TestHttpClientConfig) : HttpClientEngineBase("ktor-test") {
 
     override val dispatcher = Dispatchers.IO
+
+    override val supportedCapabilities = emptySet<HttpClientEngineCapability<*>>()
 
     private val app: TestApplicationEngine = config.app
 

--- a/ktor-test-dispatcher/iosArm32/src/TestIosArm32.kt
+++ b/ktor-test-dispatcher/iosArm32/src/TestIosArm32.kt
@@ -7,6 +7,11 @@ import kotlin.coroutines.*
 import platform.Foundation.*
 
 /**
+ * Amount of time any task is processed and can't be rescheduled.
+ */
+private const val TIME_QUANTUM = 0.01
+
+/**
  * Test runner for native suspend tests.
  */
 actual fun testSuspend(
@@ -17,7 +22,7 @@ actual fun testSuspend(
 
     val task = launch { block() }
     while (!task.isCompleted) {
-        val date = NSDate().addTimeInterval(1.0) as NSDate
+        val date = NSDate().addTimeInterval(TIME_QUANTUM) as NSDate
         NSRunLoop.mainRunLoop.runUntilDate(date)
 
         loop.processNextEvent()

--- a/ktor-test-dispatcher/iosArm64/src/TestIosArm64.kt
+++ b/ktor-test-dispatcher/iosArm64/src/TestIosArm64.kt
@@ -7,6 +7,11 @@ import kotlin.coroutines.*
 import platform.Foundation.*
 
 /**
+ * Amount of time any task is processed and can't be rescheduled.
+ */
+private const val TIME_QUANTUM = 0.01
+
+/**
  * Test runner for native suspend tests.
  */
 actual fun testSuspend(
@@ -17,7 +22,7 @@ actual fun testSuspend(
 
     val task = launch { block() }
     while (!task.isCompleted) {
-        val date = NSDate().addTimeInterval(1.0) as NSDate
+        val date = NSDate().addTimeInterval(TIME_QUANTUM) as NSDate
         NSRunLoop.mainRunLoop.runUntilDate(date)
 
         loop.processNextEvent()

--- a/ktor-test-dispatcher/iosX64/src/TestIosX64.kt
+++ b/ktor-test-dispatcher/iosX64/src/TestIosX64.kt
@@ -7,6 +7,11 @@ import kotlin.coroutines.*
 import platform.Foundation.*
 
 /**
+ * Amount of time any task is processed and can't be rescheduled.
+ */
+private const val TIME_QUANTUM = 0.01
+
+/**
  * Test runner for native suspend tests.
  */
 actual fun testSuspend(
@@ -17,7 +22,7 @@ actual fun testSuspend(
 
     val task = launch { block() }
     while (!task.isCompleted) {
-        val date = NSDate().addTimeInterval(1.0) as NSDate
+        val date = NSDate().addTimeInterval(TIME_QUANTUM) as NSDate
         NSRunLoop.mainRunLoop.runUntilDate(date)
 
         loop.processNextEvent()

--- a/ktor-test-dispatcher/macosX64/src/TestMacosX64.kt
+++ b/ktor-test-dispatcher/macosX64/src/TestMacosX64.kt
@@ -7,6 +7,11 @@ import kotlin.coroutines.*
 import platform.Foundation.*
 
 /**
+ * Amount of time any task is processed and can't be rescheduled.
+ */
+private const val TIME_QUANTUM = 0.01
+
+/**
  * Test runner for native suspend tests.
  */
 actual fun testSuspend(
@@ -17,7 +22,7 @@ actual fun testSuspend(
 
     val task = launch { block() }
     while (!task.isCompleted) {
-        val date = NSDate().addTimeInterval(1.0) as NSDate
+        val date = NSDate().addTimeInterval(TIME_QUANTUM) as NSDate
         NSRunLoop.mainRunLoop.runUntilDate(date)
 
         loop.processNextEvent()

--- a/ktor-utils/common/src/io/ktor/util/Throwable.kt
+++ b/ktor-utils/common/src/io/ktor/util/Throwable.kt
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2014-2019 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.util
+
+/**
+ * Root cause of the [Throwable].
+ */
+@InternalAPI
+val Throwable.rootCause: Throwable?
+    get() {
+        var rootCause: Throwable? = this
+        while (rootCause?.cause != null) {
+            rootCause = rootCause.cause
+        }
+        return rootCause
+    }

--- a/ktor-utils/jvm/src/io/ktor/util/Cache.kt
+++ b/ktor-utils/jvm/src/io/ktor/util/Cache.kt
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2014-2019 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.util
+
+import java.util.*
+
+/**
+ * Initial capacity of [LinkedHashMap] used as [LRUCache].
+ */
+private const val CACHE_INITIAL_CAPACITY = 10
+
+/**
+ * Load factory of [LinkedHashMap] used as [LRUCache].
+ */
+private const val CACHE_LOAD_FACTOR = 0.75f
+
+/**
+ * Create a new instance of thread safe [LRUCache] and return it.
+ */
+@InternalAPI
+fun <K, V> createLRUCache(supplier: (K) -> V, close: (V) -> Unit, maxSize: Int): Map<K, V> =
+    Collections.synchronizedMap(LRUCache(supplier, close, maxSize))
+
+/**
+ * LRU cache based on [LinkedHashMap] with specified [maxSize] and [supplier].
+ */
+internal class LRUCache<K, V> internal constructor(
+    private val supplier: (K) -> V,
+    private val close: (V) -> Unit,
+    private val maxSize: Int
+) : LinkedHashMap<K, V>(CACHE_INITIAL_CAPACITY, CACHE_LOAD_FACTOR, true) {
+
+    override fun removeEldestEntry(eldest: Map.Entry<K, V>): Boolean {
+        return (size > maxSize).also {
+            if (it) {
+                close(eldest.value)
+            }
+        }
+    }
+
+    override fun get(key: K): V {
+        return if (maxSize == 0) {
+            supplier(key)
+        } else {
+            synchronized(this) {
+                super.get(key)?.let { return it }
+
+                supplier(key).let {
+                    put(key, it)
+                    it
+                }
+            }
+        }
+    }
+}

--- a/ktor-utils/jvm/test/io/ktor/tests/utils/CacheTest.kt
+++ b/ktor-utils/jvm/test/io/ktor/tests/utils/CacheTest.kt
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2014-2019 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.tests.utils
+
+import io.ktor.util.*
+import java.util.*
+import java.util.concurrent.atomic.*
+import kotlin.concurrent.*
+import kotlin.test.*
+
+class CacheTest {
+
+    @Test
+    fun testGet() {
+        val counter = AtomicInteger(0)
+        val cache = LRUCache<Int, Int>({ counter.incrementAndGet(); it }, {}, 2)
+
+        for (i in 0 until 10) {
+            assertEquals(i, cache[i])
+        }
+
+        assertEquals(10, counter.get())
+    }
+
+    @Test
+    fun testClose() {
+        val counter = AtomicInteger(0)
+        val lastRemoved = AtomicInteger(-1)
+        val cache = LRUCache<Int, Int>({ counter.incrementAndGet(); it }, { lastRemoved.set(it) }, 2)
+
+        for (i in 0 until 10) {
+            assertEquals(i, cache[i])
+            if (i < 2) {
+                assertEquals(-1, lastRemoved.get())
+            } else {
+                assertEquals(i - 2, lastRemoved.get())
+            }
+        }
+
+        assertEquals(10, counter.get())
+    }
+
+    @Test
+    fun testCloseMultithreaded() {
+        val created = AtomicInteger(0)
+        val closed = AtomicInteger(0)
+
+        val cache = LRUCache<Int, Int>({ created.incrementAndGet(); it }, { closed.incrementAndGet() }, 2)
+
+        (1..100).map {
+            thread {
+                val random = Random(it * 43L)
+                repeat(1000) {
+                    val key = random.nextInt(1000)
+                    assertEquals(key, cache[key])
+                }
+            }
+        }.forEach {
+            it.join()
+        }
+
+        assertEquals(created.get(), closed.get() + cache.size)
+    }
+
+    @Test
+    fun testWithoutCaching() {
+        val counter = AtomicInteger(0)
+        val lastRemoved = AtomicInteger(-1)
+        val cache = LRUCache<Int, Int>({ counter.incrementAndGet(); it }, { lastRemoved.set(it) }, 0)
+
+        for (i in 0 until 10) {
+            assertEquals(i, cache[i])
+            assertEquals(-1, lastRemoved.get())
+        }
+
+        assertEquals(10, counter.get())
+    }
+}


### PR DESCRIPTION
**Subsystem**
Client (all client modules)

**Motivation**
The idea is to add request timeout, connect timeout and socket timeout that could be specified in a unified way for all engines.

**Solution**
Request timeout is introduced using an approach with `executionContext` and `delay`, connect and socket timeout are specific for each client engine.
