### PR TITLE
Fix client call hanging in case of exception and OkHttp close method.

### DIFF
--- a/ktor-client/ktor-client-okhttp/jvm/src/io/ktor/client/engine/okhttp/OkHttpEngine.kt
+++ b/ktor-client/ktor-client-okhttp/jvm/src/io/ktor/client/engine/okhttp/OkHttpEngine.kt
@@ -54,7 +54,7 @@ class OkHttpEngine(
         clientTask.complete()
 
         clientTask.invokeOnCompletion {
-            launch(dispatcher) {
+            GlobalScope.launch(dispatcher) {
                 engine.dispatcher().executorService().shutdown()
                 engine.connectionPool().evictAll()
                 engine.cache()?.close()

--- a/ktor-client/ktor-client-okhttp/jvm/test/io/ktor/client/engine/okhttp/OkHttpEngineTests.kt
+++ b/ktor-client/ktor-client-okhttp/jvm/test/io/ktor/client/engine/okhttp/OkHttpEngineTests.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2014-2019 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.client.engine.okhttp
+
+import kotlinx.coroutines.*
+import okhttp3.*
+import kotlin.test.*
+
+class OkHttpEngineTests {
+    @Test
+    fun closeTest() {
+        val okHttpClient = OkHttpClient()
+        val engine = OkHttpEngine(OkHttpConfig().apply { preconfigured = okHttpClient })
+        engine.close()
+
+        runBlocking {
+            withTimeout(1000) {
+                while (!okHttpClient.dispatcher().executorService().isShutdown) {
+                    yield()
+                }
+
+                assertTrue("OkHttp dispatcher is still working.") { okHttpClient.dispatcher().executorService().isShutdown }
+                assertEquals(0, okHttpClient.connectionPool().connectionCount())
+                okHttpClient.cache()?.let { assertTrue("OkHttp client cache is not closed.") { it.isClosed } }
+            }
+        }
+    }
+}

--- a/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/HttpClientCallTest.kt
+++ b/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/HttpClientCallTest.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2014-2019 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.client.tests
+
+import io.ktor.client.call.*
+import io.ktor.client.engine.mock.*
+import io.ktor.client.response.*
+import io.ktor.client.tests.utils.*
+import io.ktor.http.*
+import kotlinx.coroutines.*
+import kotlin.test.*
+
+class HttpClientCallTest : ClientLoader() {
+    @Test
+    fun receiveWithExceptionTest() = clientTest(MockEngine) {
+        config {
+            engine {
+                addHandler {
+                    respondOk("content")
+                }
+            }
+        }
+
+        test { client ->
+            client.responsePipeline.intercept(HttpResponsePipeline.Receive) { error("TestException") }
+            val call = client.call("http://localhost") { method = HttpMethod.Get }
+            val cause = assertFails { call.receive<String>() }
+            assertTrue { cause.message!!.contains("TestException") }
+
+            withTimeout(1000) {
+                call.coroutineContext[Job]!!.join()
+            }
+
+            assertTrue { call.coroutineContext[Job]!!.isCompleted }
+        }
+    }
+}

--- a/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/HttpClientCallTest.kt
+++ b/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/HttpClientCallTest.kt
@@ -12,7 +12,7 @@ import io.ktor.http.*
 import kotlinx.coroutines.*
 import kotlin.test.*
 
-class HttpClientCallTest : ClientLoader() {
+class HttpClientCallTest {
     @Test
     fun receiveWithExceptionTest() = clientTest(MockEngine) {
         config {


### PR DESCRIPTION
**Subsystem**
Client, OkHttp and HttpClientCall.

**Motivation**
Bugs, tests in this PR demonstrates issues.

**Solution**
Wrap receive into try-catch and close it in case of exception. Launch OkHttp close functionality on `GlobalScope`.

