### PR TITLE
Handle callContext correctly in Mock client engine.

### DIFF
--- a/binary-compatibility-validator/reference-public-api/ktor-client-mock.txt
+++ b/binary-compatibility-validator/reference-public-api/ktor-client-mock.txt
@@ -12,29 +12,33 @@ public final class io/ktor/client/engine/mock/MockEngine : io/ktor/client/engine
 
 public final class io/ktor/client/engine/mock/MockEngine$Companion : io/ktor/client/engine/HttpClientEngineFactory {
 	public fun create (Lkotlin/jvm/functions/Function1;)Lio/ktor/client/engine/HttpClientEngine;
-	public final fun invoke (Lkotlin/jvm/functions/Function2;)Lio/ktor/client/engine/mock/MockEngine;
+	public final fun invoke (Lkotlin/jvm/functions/Function3;)Lio/ktor/client/engine/mock/MockEngine;
 }
 
 public final class io/ktor/client/engine/mock/MockEngineConfig : io/ktor/client/engine/HttpClientEngineConfig {
 	public fun <init> ()V
-	public final fun addHandler (Lkotlin/jvm/functions/Function2;)V
+	public final fun addHandler (Lkotlin/jvm/functions/Function3;)V
 	public final fun getRequestHandlers ()Ljava/util/List;
 	public final fun getReuseHandlers ()Z
 	public final fun setReuseHandlers (Z)V
 }
 
+public final class io/ktor/client/engine/mock/MockRequestHandleScope {
+	public fun <init> (Lkotlin/coroutines/CoroutineContext;)V
+}
+
 public final class io/ktor/client/engine/mock/MockUtilsKt {
-	public static final fun respond (Lio/ktor/utils/io/ByteReadChannel;Lio/ktor/http/HttpStatusCode;Lio/ktor/http/Headers;)Lio/ktor/client/request/HttpResponseData;
-	public static final fun respond (Ljava/lang/String;Lio/ktor/http/HttpStatusCode;Lio/ktor/http/Headers;)Lio/ktor/client/request/HttpResponseData;
-	public static final fun respond ([BLio/ktor/http/HttpStatusCode;Lio/ktor/http/Headers;)Lio/ktor/client/request/HttpResponseData;
-	public static synthetic fun respond$default (Lio/ktor/utils/io/ByteReadChannel;Lio/ktor/http/HttpStatusCode;Lio/ktor/http/Headers;ILjava/lang/Object;)Lio/ktor/client/request/HttpResponseData;
-	public static synthetic fun respond$default (Ljava/lang/String;Lio/ktor/http/HttpStatusCode;Lio/ktor/http/Headers;ILjava/lang/Object;)Lio/ktor/client/request/HttpResponseData;
-	public static synthetic fun respond$default ([BLio/ktor/http/HttpStatusCode;Lio/ktor/http/Headers;ILjava/lang/Object;)Lio/ktor/client/request/HttpResponseData;
-	public static final fun respondBadRequest ()Lio/ktor/client/request/HttpResponseData;
-	public static final fun respondError (Lio/ktor/http/HttpStatusCode;Ljava/lang/String;Lio/ktor/http/Headers;)Lio/ktor/client/request/HttpResponseData;
-	public static synthetic fun respondError$default (Lio/ktor/http/HttpStatusCode;Ljava/lang/String;Lio/ktor/http/Headers;ILjava/lang/Object;)Lio/ktor/client/request/HttpResponseData;
-	public static final fun respondOk (Ljava/lang/String;)Lio/ktor/client/request/HttpResponseData;
-	public static synthetic fun respondOk$default (Ljava/lang/String;ILjava/lang/Object;)Lio/ktor/client/request/HttpResponseData;
+	public static final fun respond (Lio/ktor/client/engine/mock/MockRequestHandleScope;Lio/ktor/utils/io/ByteReadChannel;Lio/ktor/http/HttpStatusCode;Lio/ktor/http/Headers;)Lio/ktor/client/request/HttpResponseData;
+	public static final fun respond (Lio/ktor/client/engine/mock/MockRequestHandleScope;Ljava/lang/String;Lio/ktor/http/HttpStatusCode;Lio/ktor/http/Headers;)Lio/ktor/client/request/HttpResponseData;
+	public static final fun respond (Lio/ktor/client/engine/mock/MockRequestHandleScope;[BLio/ktor/http/HttpStatusCode;Lio/ktor/http/Headers;)Lio/ktor/client/request/HttpResponseData;
+	public static synthetic fun respond$default (Lio/ktor/client/engine/mock/MockRequestHandleScope;Lio/ktor/utils/io/ByteReadChannel;Lio/ktor/http/HttpStatusCode;Lio/ktor/http/Headers;ILjava/lang/Object;)Lio/ktor/client/request/HttpResponseData;
+	public static synthetic fun respond$default (Lio/ktor/client/engine/mock/MockRequestHandleScope;Ljava/lang/String;Lio/ktor/http/HttpStatusCode;Lio/ktor/http/Headers;ILjava/lang/Object;)Lio/ktor/client/request/HttpResponseData;
+	public static synthetic fun respond$default (Lio/ktor/client/engine/mock/MockRequestHandleScope;[BLio/ktor/http/HttpStatusCode;Lio/ktor/http/Headers;ILjava/lang/Object;)Lio/ktor/client/request/HttpResponseData;
+	public static final fun respondBadRequest (Lio/ktor/client/engine/mock/MockRequestHandleScope;)Lio/ktor/client/request/HttpResponseData;
+	public static final fun respondError (Lio/ktor/client/engine/mock/MockRequestHandleScope;Lio/ktor/http/HttpStatusCode;Ljava/lang/String;Lio/ktor/http/Headers;)Lio/ktor/client/request/HttpResponseData;
+	public static synthetic fun respondError$default (Lio/ktor/client/engine/mock/MockRequestHandleScope;Lio/ktor/http/HttpStatusCode;Ljava/lang/String;Lio/ktor/http/Headers;ILjava/lang/Object;)Lio/ktor/client/request/HttpResponseData;
+	public static final fun respondOk (Lio/ktor/client/engine/mock/MockRequestHandleScope;Ljava/lang/String;)Lio/ktor/client/request/HttpResponseData;
+	public static synthetic fun respondOk$default (Lio/ktor/client/engine/mock/MockRequestHandleScope;Ljava/lang/String;ILjava/lang/Object;)Lio/ktor/client/request/HttpResponseData;
 	public static final fun toByteArray (Lio/ktor/http/content/OutgoingContent;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static final fun toByteReadPacket (Lio/ktor/http/content/OutgoingContent;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }

--- a/ktor-client/ktor-client-mock/common/src/io/ktor/client/engine/mock/MockEngineConfig.kt
+++ b/ktor-client/ktor-client-mock/common/src/io/ktor/client/engine/mock/MockEngineConfig.kt
@@ -8,11 +8,17 @@ import io.ktor.client.call.*
 import io.ktor.client.engine.*
 import io.ktor.client.request.*
 import io.ktor.client.statement.*
+import kotlin.coroutines.*
 
 /**
  * Single [HttpClientCall] to [HttpResponse] mapper.
  */
-typealias MockRequestHandler = suspend (request: HttpRequestData) -> HttpResponseData
+typealias MockRequestHandler = suspend MockRequestHandleScope.(request: HttpRequestData) -> HttpResponseData
+
+/**
+ * Scope for [MockRequestHandler].
+ */
+class MockRequestHandleScope(internal val callContext: CoroutineContext)
 
 /**
  * [HttpClientEngineConfig] for [MockEngine].

--- a/ktor-client/ktor-client-mock/common/src/io/ktor/client/engine/mock/MockUtils.kt
+++ b/ktor-client/ktor-client-mock/common/src/io/ktor/client/engine/mock/MockUtils.kt
@@ -9,11 +9,9 @@ import io.ktor.http.*
 import io.ktor.http.content.*
 import io.ktor.util.*
 import io.ktor.util.date.*
-import kotlinx.coroutines.*
 import io.ktor.utils.io.*
 import io.ktor.utils.io.charsets.*
 import io.ktor.utils.io.core.*
-import kotlin.coroutines.*
 
 @Suppress("KDocMissingDocumentation")
 @KtorExperimentalAPI
@@ -40,7 +38,7 @@ suspend fun OutgoingContent.toByteReadPacket(): ByteReadPacket = when (this) {
 /**
  * Send error response.
  */
-fun respondError(
+fun MockRequestHandleScope.respondError(
     status: HttpStatusCode,
     content: String = status.description,
     headers: Headers = headersOf()
@@ -49,7 +47,7 @@ fun respondError(
 /**
  * Send ok response.
  */
-fun respondOk(
+fun MockRequestHandleScope.respondOk(
     content: String = ""
 ): HttpResponseData = respond(content, HttpStatusCode.OK)
 
@@ -57,12 +55,12 @@ fun respondOk(
 /**
  * Send [HttpStatusCode.BadRequest] response.
  */
-fun respondBadRequest() = respond("Bad Request", HttpStatusCode.BadRequest)
+fun MockRequestHandleScope.respondBadRequest() = respond("Bad Request", HttpStatusCode.BadRequest)
 
 /**
  * Send response with specified string [content], [status] and [headers].
  */
-fun respond(
+fun MockRequestHandleScope.respond(
     content: String,
     status: HttpStatusCode = HttpStatusCode.OK,
     headers: Headers = headersOf()
@@ -72,7 +70,7 @@ fun respond(
 /**
  * Send response with specified bytes [content], [status] and [headers].
  */
-fun respond(
+fun MockRequestHandleScope.respond(
     content: ByteArray,
     status: HttpStatusCode = HttpStatusCode.OK,
     headers: Headers = headersOf()
@@ -81,12 +79,10 @@ fun respond(
 /**
  * Send response with specified [ByteReadChannel] [content], [status] and [headers].
  */
-fun respond(
+fun MockRequestHandleScope.respond(
     content: ByteReadChannel,
     status: HttpStatusCode = HttpStatusCode.OK,
     headers: Headers = headersOf()
 ): HttpResponseData = HttpResponseData(
-    status, GMTDate(), headers, HttpProtocolVersion.HTTP_1_1, content, createMockCallContext()
+    status, GMTDate(), headers, HttpProtocolVersion.HTTP_1_1, content, callContext
 )
-
-private fun createMockCallContext(): CoroutineContext = Dispatchers.Default + Job()


### PR DESCRIPTION
**Subsystem**
Mock client

**Motivation**
Call context is not handled correctly in the Mock engine and as a result, we get hanging tests.

**Solution**
Pass call context to the `HttpResponseData`.

