### PR TITLE
Fix wrong command in README.md of binary-compatibility-validator module.

### DIFF
--- a/binary-compatibility-validator/README.md
+++ b/binary-compatibility-validator/README.md
@@ -6,5 +6,5 @@ This tool is slightly adapted copy of [original Kotlin compatibility validator](
 To update public API dumps use:
 
 ```bash
-./gradlew :binary-compatibility-validator:test -Poverwrite.output=true 
+./gradlew :binary-compatibility-validator:check -Poverwrite.output=true 
 ```


### PR DESCRIPTION
**Subsystem**
Binary compatibility validator, docs.

**Motivation**
The wrong command mentioned in docs.

**Solution**
Correct command, `s/test/check`.

