### PR TITLE
Allow passing ObjectMapper to serializer

### DIFF
--- a/ktor-client/ktor-client-features/ktor-client-json/ktor-client-jackson/jvm/src/io/ktor/client/features/json/JacksonSerializer.kt
+++ b/ktor-client/ktor-client-features/ktor-client-json/ktor-client-jackson/jvm/src/io/ktor/client/features/json/JacksonSerializer.kt
@@ -11,9 +11,9 @@ import io.ktor.http.*
 import io.ktor.http.content.*
 import io.ktor.utils.io.core.*
 
-class JacksonSerializer(block: ObjectMapper.() -> Unit = {}) : JsonSerializer {
+class JacksonSerializer(jackson: ObjectMapper = jacksonObjectMapper(), block: ObjectMapper.() -> Unit = {}) : JsonSerializer {
 
-    private val backend = jacksonObjectMapper().apply(block)
+    private val backend = jackson.apply(block)
 
     override fun write(data: Any, contentType: ContentType): OutgoingContent =
         TextContent(backend.writeValueAsString(data), contentType)


### PR DESCRIPTION
**Subsystem**
Client Jackson

**Motivation**
I have my own ObjectMapper instance which I would like to use as JsonSerializer.

**Solution**
Just allow passing it as argument with current implementation as default. This is also more in line with content converters for ktor server.

