### PR TITLE
Optimize JS module import time

### DIFF
--- a/ktor-http/common/src/io/ktor/http/FileContentType.kt
+++ b/ktor-http/common/src/io/ktor/http/FileContentType.kt
@@ -52,11 +52,13 @@ fun ContentType.fileExtensions(): List<String> = extensionsByContentType[this]
     ?: extensionsByContentType[this.withoutParameters()]
     ?: emptyList()
 
-private val contentTypesByExtensions: Map<String, List<ContentType>> =
+private val contentTypesByExtensions: Map<String, List<ContentType>> by lazy {
     caseInsensitiveMap<List<ContentType>>().apply { putAll(mimes.asSequence().groupByPairs()) }
+}
 
-private val extensionsByContentType: Map<ContentType, List<String>> =
+private val extensionsByContentType: Map<ContentType, List<String>> by lazy {
     mimes.asSequence().map { (first, second) -> second to first }.groupByPairs()
+}
 
 internal fun List<ContentType>.selectDefault(): ContentType {
     val contentType = firstOrNull() ?: ContentType.Application.OctetStream

--- a/ktor-http/common/src/io/ktor/http/Mimes.kt
+++ b/ktor-http/common/src/io/ktor/http/Mimes.kt
@@ -1223,4 +1223,4 @@ internal fun loadMimes(): List<Pair<String, ContentType>> {
     }.toList()
 }
 
-internal val mimes: List<Pair<String, ContentType>> get() = loadMimes()
+internal val mimes: List<Pair<String, ContentType>> by lazy { loadMimes() }


### PR DESCRIPTION
**Subsystem**
Client

**Motivation**
It was doing a lot of unnecessary work when JS module were imported:

![Alt text](https://monosnap.com/image/DRtMHozfanYELUuPYkl89AwMgAYV7U)

**Solution**
Just make those properties lazy-initialized.