### PR TITLE
add tvos and watchos targets to darwin.gradle

### DIFF
--- a/gradle/darwin.gradle
+++ b/gradle/darwin.gradle
@@ -12,6 +12,11 @@ kotlin {
             fromPreset(presets.iosArm32, 'iosArm32')
             fromPreset(presets.iosX64, 'iosX64')
             fromPreset(presets.macosX64, 'macosX64')
+            fromPreset(presets.tvosArm64, 'tvosArm64')
+            fromPreset(presets.tvosX64, 'tvosX64')
+            fromPreset(presets.watchosArm32, 'watchosArm32')
+            fromPreset(presets.watchosArm64, 'watchosArm64')
+            fromPreset(presets.watchosX86, 'watchosX86')
         }
     }
     sourceSets {
@@ -24,11 +29,11 @@ kotlin {
         darwinTest
 
         if (!project.ext.ideaActive) {
-            configure([iosArm32Main, iosArm64Main, iosX64Main, macosX64Main]) {
+            configure([iosArm32Main, iosArm64Main, iosX64Main, macosX64Main, tvosArm64Main, tvosX64Main, watchosArm32Main, watchosArm64Main, watchosX86Main]) {
                 dependsOn darwinMain
             }
 
-            configure([iosArm32Test, iosArm64Test, iosX64Test, macosX64Test]) {
+            configure([iosArm32Test, iosArm64Test, iosX64Test, macosX64Test, tvosArm64Test, tvosX64Test, watchosArm32Test, watchosArm64Test, watchosX86Test]]]) {
                 dependsOn darwinTest
             }
         }


### PR DESCRIPTION
**Subsystem**
Client

**Motivation**
As metioned in #1378 targets for both platforms were added to `posix.gradle` which makes artifacts like `ktor-client-core` already available for them. To actually use ktor on these platforms you need the platform specific artifacts like `ktor-client-ios` as well. However `darwin.gradle` which is used in the ios client was not updated.

**Solution**
This adds tvos and watchos targets to `darwin.gradle` which makes all artiacts that currently target only macOS and iOS available for them.

