### PR TITLE
Fix Apache client engine freeze at request initiation

### DIFF
--- a/ktor-client/ktor-client-apache/jvm/src/io/ktor/client/engine/apache/ApacheHttpRequest.kt
+++ b/ktor-client/ktor-client-apache/jvm/src/io/ktor/client/engine/apache/ApacheHttpRequest.kt
@@ -10,7 +10,6 @@ import io.ktor.util.date.*
 import kotlinx.coroutines.*
 import org.apache.http.concurrent.*
 import org.apache.http.impl.nio.client.*
-import org.apache.http.protocol.*
 import kotlin.coroutines.*
 
 internal suspend fun CloseableHttpAsyncClient.sendRequest(
@@ -19,7 +18,7 @@ internal suspend fun CloseableHttpAsyncClient.sendRequest(
 ): HttpResponseData = suspendCancellableCoroutine { continuation ->
     val requestTime = GMTDate()
 
-    val consumer = ApacheResponseConsumer(callContext) { rawResponse, body ->
+    val consumer = ApacheResponseConsumerDispatching(callContext) { rawResponse, body ->
         val statusLine = rawResponse.statusLine
 
         val status = HttpStatusCode(statusLine.statusCode, statusLine.reasonPhrase)

--- a/ktor-client/ktor-client-apache/jvm/src/io/ktor/client/engine/apache/ApacheResponseConsumerDispatching.kt
+++ b/ktor-client/ktor-client-apache/jvm/src/io/ktor/client/engine/apache/ApacheResponseConsumerDispatching.kt
@@ -1,0 +1,143 @@
+/*
+ * Copyright 2014-2019 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.client.engine.apache
+
+import io.ktor.utils.io.*
+import kotlinx.atomicfu.*
+import kotlinx.coroutines.*
+import org.apache.http.*
+import org.apache.http.nio.*
+import org.apache.http.nio.protocol.*
+import org.apache.http.protocol.*
+import java.nio.*
+import java.util.concurrent.*
+import kotlin.coroutines.*
+
+internal class ApacheResponseConsumerDispatching(
+    callContext: CoroutineContext,
+    private val block: (HttpResponse, ByteReadChannel) -> Unit
+) : HttpAsyncResponseConsumer<Unit>, CoroutineScope {
+    private val queue = ArrayBlockingQueue<Runnable>(10)
+
+    private val interestController = atomic<IOControl?>(null)
+
+    override val coroutineContext: CoroutineContext = callContext + Dispatcher()
+
+    private val out = ByteChannel(true)
+
+    private var decoderWaiter: CancellableContinuation<ContentDecoder?>? = null
+
+    private val job = launch(start = CoroutineStart.UNDISPATCHED) {
+        try {
+            var rc = 0
+            do {
+                val decoder = waitForDecoder() ?: break
+
+                do {
+                    out.write { dst ->
+                        rc = decoder.read(dst)
+                    }
+                } while (rc > 0)
+            } while (rc >= 0)
+        } catch (cause: Throwable) {
+            out.close(cause)
+        } finally {
+            out.close()
+        }
+    }
+
+    private suspend fun waitForDecoder(): ContentDecoder? = suspendCancellableCoroutine {
+        decoderWaiter = it
+    }
+
+    override fun consumeContent(decoder: ContentDecoder, ioctrl: IOControl) {
+        do {
+            processLoop(Result.success(decoder))
+
+            when {
+                decoderWaiter != null -> {
+                }
+                job.isActive -> {
+                    ioctrl.suspendInput()
+                    this.interestController.value = ioctrl // this should be after suspendInput
+
+                    if (queue.isNotEmpty() && interestController.compareAndSet(ioctrl, null)) {
+                        ioctrl.requestInput()
+                    } else {
+                        return
+                    }
+                }
+                else -> {
+                    if (!decoder.isCompleted) {
+                        decoder.discardAll()
+                    }
+                }
+            }
+        } while (queue.isNotEmpty())
+    }
+
+    override fun failed(ex: Exception) {
+        job.cancel(CancellationException("Failed to execute request", ex))
+        processLoop(Result.failure(ex))
+    }
+
+    override fun cancel(): Boolean {
+        job.cancel()
+        return true
+    }
+
+    override fun close() {
+    }
+
+    @UseExperimental(InternalCoroutinesApi::class)
+    override fun getException(): Exception? {
+        return job.getCancellationException().cause as? Exception
+    }
+
+    override fun getResult() {
+    }
+
+    override fun isDone(): Boolean = job.isCompleted
+
+    override fun responseCompleted(context: HttpContext) {
+        processLoop(Result.success(null))
+    }
+
+    override fun responseReceived(response: HttpResponse) {
+        if (job.isActive) {
+            block(response, out)
+        }
+    }
+
+    private fun processLoop(result: Result<ContentDecoder?>) {
+        decoderWaiter?.let { continuation ->
+            this.decoderWaiter = null
+            continuation.resumeWith(result)
+        }
+
+        while (true) {
+            queue.poll()?.run() ?: break
+        }
+    }
+
+    private fun ContentDecoder.discardAll() {
+        val buffer = ByteBuffer.allocate(8192)
+        do {
+            buffer.clear()
+            if (read(buffer) <= 0) break
+        } while (true)
+    }
+
+    private inner class Dispatcher : CoroutineDispatcher() {
+        override fun dispatch(context: CoroutineContext, block: Runnable) {
+            queue.add(block)
+
+            interestController.updateAndGet { before ->
+                if (before == null) return
+                null
+            }?.requestInput()
+        }
+    }
+}

--- a/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/ContentTest.kt
+++ b/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/ContentTest.kt
@@ -79,6 +79,22 @@ class ContentTest : ClientLoader() {
     }
 
     @Test
+    fun testEmptyContent() = clientTests(listOf("js")) {
+        val size = 0
+        val content = makeString(size)
+        repeatCount = 200
+        test { client ->
+            val response = client.echo<String>(TextContent(content, ContentType.Text.Plain))
+
+            assertArrayEquals(
+                "Test fail with size: $size",
+                content.toByteArray(),
+                response.toByteArray()
+            )
+        }
+    }
+
+    @Test
     fun testTextContent() = clientTests(listOf("js")) {
         test { client ->
             testSize.forEach { size ->


### PR DESCRIPTION
**Subsystem**
ktor-client-apache

**Problem and solution**
When sending a request, it is likely that consumeContent callback will
be triggered before inDecoderThread invocation, especially on Windows.
Usually, it is not a problem since we do requestInput. However, if the response
is short or empty or it is the last chunk, then there will be no more callback invocations so there will be no
change for rendezvous. So to avoid this unfortunate case we introduce a decoder
reference that is populated in the callback in the case when no suspension yet
and then we pick it up in decoding loop initiation later.
