### PR TITLE
Fix NSUrlSession memory leak by finishing session

### DIFF
--- a/ktor-client/ktor-client-ios/darwin/src/io/ktor/client/engine/ios/IosClientEngine.kt
+++ b/ktor-client/ktor-client-ios/darwin/src/io/ktor/client/engine/ios/IosClientEngine.kt
@@ -118,6 +118,7 @@ internal class IosClientEngine(override val config: IosClientEngineConfig) : Htt
 
                 config.requestConfig(nativeRequest)
                 session.dataTaskWithRequest(nativeRequest).resume()
+                session.finishTasksAndInvalidate()
             }
         }
     }

--- a/ktor-client/ktor-client-ios/darwin/src/io/ktor/client/engine/ios/IosClientEngine.kt
+++ b/ktor-client/ktor-client-ios/darwin/src/io/ktor/client/engine/ios/IosClientEngine.kt
@@ -118,6 +118,7 @@ internal class IosClientEngine(override val config: IosClientEngineConfig) : Htt
 
                 config.requestConfig(nativeRequest)
                 session.dataTaskWithRequest(nativeRequest).resume()
+            }.invokeOnCompletion {
                 session.finishTasksAndInvalidate()
             }
         }


### PR DESCRIPTION
**Subsystem**
iOS client engine

**Motivation**
#1420 describes a memory leak in the iOS client. I have posted more details in that issue, but the gist of it is that when opening an `NSUrlSession` using `sessionWithConfiguration()`, the `delegate` is leaked until the app exits unless we call `invalidateAndCancel()` or `finishTasksAndInvalidate()` at some point. See the documentation for the `delegate` parameter [on developer.apple.com](https://developer.apple.com/documentation/foundation/nsurlsession/1411597-sessionwithconfiguration?language=objc) for more information.

In effect, this meant that the engine, the session, and the coroutine used for executing the request are all leaked until the app dies.

**Solution**
After adding the data task to `NSUrlSession`, we immediate call [`finishTasksAndInvalidate()`](https://developer.apple.com/documentation/foundation/nsurlsession/1407428-finishtasksandinvalidate?language=objc), which blocks creation of new tasks but allows the existing data task to complete. Once that data task completes, `NSUrlSession` will then break references to the delegate and callback objects, allowing those objects to become garbage collected.
