### PR TITLE
Update HttpHeadersMap.kt header buffer limit

### DIFF
--- a/ktor-http/ktor-http-cio/common/src/io/ktor/http/cio/HttpHeadersMap.kt
+++ b/ktor-http/ktor-http-cio/common/src/io/ktor/http/cio/HttpHeadersMap.kt
@@ -10,7 +10,7 @@ import io.ktor.utils.io.pool.*
 import kotlin.native.concurrent.*
 
 
-private const val EXPECTED_HEADERS_QTY = 32
+private const val EXPECTED_HEADERS_QTY = 64
 /*
  * index array structure
  * [0] = name hash


### PR DESCRIPTION
**Subsystem**
CIO client

**Motivation**
Trello authentication api is returning more than that, so we clearly need this lifted. Also that's a cheap change, and does not prompt for a refactoring.

**Solution**
I just bumped header buffer size to 64k.

