### PR TITLE
Add exclude engine functionality into ClientLoader.kt.

### DIFF
--- a/ktor-client/ktor-client-curl/posix/src/io/ktor/client/engine/curl/Curl.kt
+++ b/ktor-client/ktor-client-curl/posix/src/io/ktor/client/engine/curl/Curl.kt
@@ -37,4 +37,6 @@ object Curl : HttpClientEngineFactory<HttpClientEngineConfig> {
 
         return CurlClientEngine(CurlClientEngineConfig().apply(block))
     }
+
+    override fun toString() = "Curl"
 }

--- a/ktor-client/ktor-client-features/ktor-client-auth/common/test/io/ktor/client/features/auth/AuthTest.kt
+++ b/ktor-client/ktor-client-features/ktor-client-auth/common/test/io/ktor/client/features/auth/AuthTest.kt
@@ -13,7 +13,7 @@ import kotlin.test.*
 
 class AuthTest : ClientLoader() {
     @Test
-    fun testDigestAuth() = clientTests(listOf("js")) {
+    fun testDigestAuth() = clientTests(listOf("Js")) {
         config {
             install(Auth) {
                 digest {
@@ -31,7 +31,7 @@ class AuthTest : ClientLoader() {
     }
 
     @Test
-    fun testBasicAuth() = clientTests(listOf("js")) {
+    fun testBasicAuth() = clientTests(listOf("Js")) {
         config {
             install(Auth) {
                 basic {

--- a/ktor-client/ktor-client-ios/darwin/src/io/ktor/client/engine/ios/Ios.kt
+++ b/ktor-client/ktor-client-ios/darwin/src/io/ktor/client/engine/ios/Ios.kt
@@ -21,4 +21,6 @@ object Ios : HttpClientEngineFactory<IosClientEngineConfig> {
 
     override fun create(block: IosClientEngineConfig.() -> Unit): HttpClientEngine =
         IosClientEngine(IosClientEngineConfig().apply(block))
+
+    override fun toString() = "Ios"
 }

--- a/ktor-client/ktor-client-tests/common/src/io/ktor/client/tests/utils/ClientLoader.kt
+++ b/ktor-client/ktor-client-tests/common/src/io/ktor/client/tests/utils/ClientLoader.kt
@@ -14,7 +14,7 @@ expect abstract class ClientLoader() {
      * Perform test against all clients from dependencies.
      */
     fun clientTests(
-        skipPlatforms: List<String> = emptyList(),
+        skipEngines: List<String> = emptyList(),
         block: suspend TestClientBuilder<HttpClientEngineConfig>.() -> Unit
     )
 

--- a/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/ContentTest.kt
+++ b/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/ContentTest.kt
@@ -27,7 +27,7 @@ class ContentTest : ClientLoader() {
     )
 
     @Test
-    fun testGetFormData() = clientTests(listOf("js")) {
+    fun testGetFormData() = clientTests(listOf("Js")) {
         test { client ->
             val form = parametersOf(
                 "user" to listOf("myuser"),
@@ -43,7 +43,7 @@ class ContentTest : ClientLoader() {
     }
 
     @Test
-    fun testByteArray() = clientTests(listOf("js")) {
+    fun testByteArray() = clientTests(listOf("Js")) {
         test { client ->
             testSize.forEach { size ->
                 val content = makeArray(size)
@@ -55,7 +55,7 @@ class ContentTest : ClientLoader() {
     }
 
     @Test
-    fun testByteReadChannel() = clientTests(listOf("js")) {
+    fun testByteReadChannel() = clientTests(listOf("Js")) {
         test { client ->
             testSize.forEach { size ->
                 val content = makeArray(size)
@@ -66,7 +66,7 @@ class ContentTest : ClientLoader() {
     }
 
     @Test
-    fun testString() = clientTests(listOf("js")) {
+    fun testString() = clientTests(listOf("Js")) {
         test { client ->
             testSize.forEach { size ->
                 val content = makeString(size)
@@ -79,7 +79,7 @@ class ContentTest : ClientLoader() {
     }
 
     @Test
-    fun testTextContent() = clientTests(listOf("js")) {
+    fun testTextContent() = clientTests(listOf("Js")) {
         test { client ->
             testSize.forEach { size ->
                 val content = makeString(size)
@@ -91,7 +91,7 @@ class ContentTest : ClientLoader() {
     }
 
     @Test
-    fun testByteArrayContent() = clientTests(listOf("js")) {
+    fun testByteArrayContent() = clientTests(listOf("Js")) {
         test { client ->
             testSize.forEach { size ->
                 val content = makeArray(size)
@@ -103,7 +103,7 @@ class ContentTest : ClientLoader() {
     }
 
     @Test
-    fun testPostFormData() = clientTests(listOf("js")) {
+    fun testPostFormData() = clientTests(listOf("Js")) {
         test { client ->
             val form = parametersOf(
                 "user" to listOf("myuser"),
@@ -116,7 +116,7 @@ class ContentTest : ClientLoader() {
     }
 
     @Test
-    fun testMultipartFormData() = clientTests(listOf("js")) {
+    fun testMultipartFormData() = clientTests(listOf("Js")) {
         val data = {
             formData {
                 append("name", "hello")
@@ -147,7 +147,7 @@ class ContentTest : ClientLoader() {
     }
 
     @Test
-    fun testFormDataWithContentLength() = clientTests(listOf("js")) {
+    fun testFormDataWithContentLength() = clientTests(listOf("Js")) {
         test { client ->
             client.submitForm<Unit> {
                 url("$TEST_SERVER/content/file-upload")
@@ -201,7 +201,7 @@ class ContentTest : ClientLoader() {
     }
 
     @Test
-    fun testDownloadStreamChannelWithCancel() = clientTests(listOf("js")) {
+    fun testDownloadStreamChannelWithCancel() = clientTests(listOf("Js")) {
         test { client ->
             val content = client.get<ByteReadChannel>("$TEST_SERVER/content/stream")
             content.cancel()
@@ -209,7 +209,7 @@ class ContentTest : ClientLoader() {
     }
 
     @Test
-    fun testDownloadStreamResponseWithClose() = clientTests(listOf("js")) {
+    fun testDownloadStreamResponseWithClose() = clientTests(listOf("Js")) {
         test { client ->
             client.get<HttpStatement>("$TEST_SERVER/content/stream").execute {
             }
@@ -217,7 +217,7 @@ class ContentTest : ClientLoader() {
     }
 
     @Test
-    fun testDownloadStreamResponseWithCancel() = clientTests(listOf("js")) {
+    fun testDownloadStreamResponseWithCancel() = clientTests(listOf("Js")) {
         test { client ->
             client.get<HttpStatement>("$TEST_SERVER/content/stream").execute {
                 it.cancel()
@@ -226,7 +226,7 @@ class ContentTest : ClientLoader() {
     }
 
     @Test
-    fun testDownloadStreamArrayWithTimeout() = clientTests(listOf("js")) {
+    fun testDownloadStreamArrayWithTimeout() = clientTests(listOf("Js")) {
         test { client ->
             val result: ByteArray? = withTimeoutOrNull(100) {
                 client.get<ByteArray>("$TEST_SERVER/content/stream")

--- a/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/HttpRedirectTest.kt
+++ b/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/HttpRedirectTest.kt
@@ -43,7 +43,7 @@ class HttpRedirectTest : ClientLoader() {
     }
 
     @Test
-    fun testRedirectWithCookies() = clientTests(listOf("js")) {
+    fun testRedirectWithCookies() = clientTests(listOf("Js")) {
         config {
             install(HttpCookies)
             install(HttpRedirect)
@@ -99,7 +99,7 @@ class HttpRedirectTest : ClientLoader() {
     }
 
     @Test
-    fun testRedirectHostAbsolute() = clientTests(listOf("js")) {
+    fun testRedirectHostAbsolute() = clientTests(listOf("Js")) {
         test { client ->
             client.get<HttpStatement>("$TEST_URL_BASE/directory/hostAbsoluteRedirect").execute {
                 assertEquals("200 OK", it.readText())

--- a/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/HttpStatementTest.kt
+++ b/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/HttpStatementTest.kt
@@ -15,7 +15,7 @@ import kotlin.test.*
 class HttpStatementTest : ClientLoader() {
 
     @Test
-    fun testExecute() = clientTests {
+    fun testExecute() = clientTests(listOf("Js")) {
         test { client ->
             client.request<HttpStatement>("$TEST_SERVER/content/stream").execute {
                 val expected = buildPacket {

--- a/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/PostTest.kt
+++ b/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/PostTest.kt
@@ -14,21 +14,21 @@ import kotlin.test.*
 
 class PostTest : ClientLoader() {
     @Test
-    fun testPostString() = clientTests(listOf("js")) {
+    fun testPostString() = clientTests(listOf("Js")) {
         test { client ->
             client.postHelper(makeString(777))
         }
     }
 
     @Test
-    fun testHugePost() = clientTests(listOf("js")) {
+    fun testHugePost() = clientTests(listOf("Js")) {
         test { client ->
             client.postHelper(makeString(32 * 1024 * 1024))
         }
     }
 
     @Test
-    fun testWithPause() = clientTests(listOf("js")) {
+    fun testWithPause() = clientTests(listOf("Js")) {
         test { client ->
             val content = makeString(16 * 1024 * 1024)
 

--- a/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/ProxyTest.kt
+++ b/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/ProxyTest.kt
@@ -13,7 +13,7 @@ import kotlin.test.*
 class ProxyTest : ClientLoader() {
 
     @Test
-    fun testHttpProxy() = clientTests(listOf("js")) {
+    fun testHttpProxy() = clientTests(listOf("Js")) {
         config {
             engine {
                 proxy = ProxyBuilder.http(HTTP_PROXY_SERVER)

--- a/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/features/CacheTest.kt
+++ b/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/features/CacheTest.kt
@@ -60,7 +60,7 @@ class CacheTest : ClientLoader() {
     }
 
     @Test
-    fun testETagCache() = clientTests(listOf("js")) {
+    fun testETagCache() = clientTests(listOf("Js")) {
         var storage: HttpCache.Config? = null
         config {
             install(HttpCache) {
@@ -82,7 +82,7 @@ class CacheTest : ClientLoader() {
     }
 
     @Test
-    fun testLastModified() = clientTests(listOf("js")) {
+    fun testLastModified() = clientTests(listOf("Js")) {
         var storage: HttpCache.Config? = null
         config {
             install(HttpCache) {
@@ -104,7 +104,7 @@ class CacheTest : ClientLoader() {
     }
 
     @Test
-    fun testVary() = clientTests(listOf("js")) {
+    fun testVary() = clientTests(listOf("Js")) {
         var storage: HttpCache.Config? = null
         config {
             install(HttpCache) {

--- a/ktor-client/ktor-client-tests/js/src/io/ktor/client/tests/utils/ClientLoader.kt
+++ b/ktor-client/ktor-client-tests/js/src/io/ktor/client/tests/utils/ClientLoader.kt
@@ -16,11 +16,14 @@ actual abstract class ClientLoader {
      * Perform test against all clients from dependencies.
      */
     actual fun clientTests(
-        skipPlatforms: List<String>,
+        skipEngines: List<String>,
         block: suspend TestClientBuilder<HttpClientEngineConfig>.() -> Unit
-    ): dynamic = if ("js" in skipPlatforms) GlobalScope.async {}.asPromise() else testWithEngine(Js) {
-        withTimeout(30 * 1000) {
-            block()
+    ): dynamic = {
+        val skipEnginesLowerCase = skipEngines.map { it.toLowerCase() }
+        if (skipEnginesLowerCase.contains("js")) GlobalScope.async {}.asPromise() else testWithEngine(Js) {
+            withTimeout(30 * 1000) {
+                block()
+            }
         }
     }
 

--- a/ktor-client/ktor-client-tests/jvm/src/io/ktor/client/tests/utils/ClientLoader.kt
+++ b/ktor-client/ktor-client-tests/jvm/src/io/ktor/client/tests/utils/ClientLoader.kt
@@ -29,10 +29,10 @@ actual abstract class ClientLoader {
      * Perform test against all clients from dependencies.
      */
     actual fun clientTests(
-        skipPlatforms: List<String>,
+        skipEngines: List<String>,
         block: suspend TestClientBuilder<HttpClientEngineConfig>.() -> Unit
     ) {
-        if ("jvm" in skipPlatforms) return
+        if (skipEngines.map { it.toLowerCase() }.contains(engine.toString().toLowerCase())) return
         testWithEngine(engine.factory, block)
     }
 

--- a/ktor-client/ktor-client-tests/posix/src/io/ktor/client/tests/utils/ClientLoader.kt
+++ b/ktor-client/ktor-client-tests/posix/src/io/ktor/client/tests/utils/ClientLoader.kt
@@ -15,18 +15,19 @@ actual abstract class ClientLoader {
      * Perform test against all clients from dependencies.
      */
     actual fun clientTests(
-        skipPlatforms: List<String>,
+        skipEngines: List<String>,
         block: suspend TestClientBuilder<HttpClientEngineConfig>.() -> Unit
     ) {
-        if ("native" in skipPlatforms) return
-
-        engines.forEach {
-            testWithEngine(it) {
-                withTimeout(3000) {
-                    block()
+        val skipEnginesLowerCase = skipEngines.map { it.toLowerCase() }
+        engines
+            .filter { !skipEnginesLowerCase.contains(it.toString().toLowerCase()) }
+            .forEach {
+                testWithEngine(it) {
+                    withTimeout(3000) {
+                        block()
+                    }
                 }
             }
-        }
     }
 
     actual fun dumpCoroutines() {


### PR DESCRIPTION
**Subsystem**
Client Tests

**Motivation**
We need to add an ability to exclude engines by names, not platforms.

