### PR TITLE
Make CIO TCP half close behavior optional and disabled by default.

### DIFF
--- a/binary-compatibility-validator/reference-public-api/ktor-client-cio.txt
+++ b/binary-compatibility-validator/reference-public-api/ktor-client-cio.txt
@@ -36,11 +36,13 @@ public class io/ktor/client/engine/cio/ConnectException : java/lang/Exception {
 
 public final class io/ktor/client/engine/cio/EndpointConfig {
 	public fun <init> ()V
+	public final fun getAllowHalfClose ()Z
 	public final fun getConnectRetryAttempts ()I
 	public final fun getConnectTimeout ()J
 	public final fun getKeepAliveTime ()J
 	public final fun getMaxConnectionsPerRoute ()I
 	public final fun getPipelineMaxSize ()I
+	public final fun setAllowHalfClose (Z)V
 	public final fun setConnectRetryAttempts (I)V
 	public final fun setConnectTimeout (J)V
 	public final fun setKeepAliveTime (J)V

--- a/ktor-client/ktor-client-cio/jvm/src/io/ktor/client/engine/cio/CIOEngineConfig.kt
+++ b/ktor-client/ktor-client-cio/jvm/src/io/ktor/client/engine/cio/CIOEngineConfig.kt
@@ -71,4 +71,11 @@ class EndpointConfig {
      * Maximum number of connection attempts.
      */
     var connectRetryAttempts: Int = 5
+
+    /**
+     * Allow socket to close output channel immediately on writing completion (TCP connection half close).
+     */
+    var allowHalfClose: Boolean = false
+        @Deprecated("Half closed TCP connection is not supported by all servers, use it at your own risk.")
+        set
 }

--- a/ktor-client/ktor-client-cio/jvm/src/io/ktor/client/engine/cio/ConnectionPipeline.kt
+++ b/ktor-client/ktor-client-cio/jvm/src/io/ktor/client/engine/cio/ConnectionPipeline.kt
@@ -52,7 +52,7 @@ internal class ConnectionPipeline(
                     throw cause
                 }
 
-                task.request.write(networkOutput, task.context, overProxy)
+                task.request.write(networkOutput, task.context, overProxy, false)
                 networkOutput.flush()
             }
         } catch (_: ClosedChannelException) {

--- a/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/MultiPartFormDataTest.kt
+++ b/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/MultiPartFormDataTest.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2014-2019 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.client.tests
+
+import io.ktor.client.request.*
+import io.ktor.client.request.forms.*
+import io.ktor.client.statement.*
+import io.ktor.client.tests.utils.*
+import io.ktor.http.*
+import kotlinx.io.*
+import kotlinx.serialization.internal.*
+import kotlin.test.*
+
+/**
+ * Tests client request with multi-part form data.
+ */
+class MultiPartFormDataTest : ClientLoader() {
+
+    @Test
+    fun testMultiPartFormData() = clientTests {
+        test { client ->
+            val result = client.post<HttpStatement>("$TEST_SERVER/multipart") {
+                body = MultiPartFormDataContent(formData {
+                    append(
+                        "file",
+                        ByteArray(1024 * 1024),
+                        Headers.build {
+                            append(HttpHeaders.ContentDisposition, """form-data; name="file"; filename="test.png"""")
+                        }
+                    )
+                })
+            }.execute()
+
+            assertEquals(HttpStatusCode.OK, result.status)
+        }
+    }
+}

--- a/ktor-client/ktor-client-tests/jvm/src/io/ktor/client/tests/utils/ClientTestServer.kt
+++ b/ktor-client/ktor-client-tests/jvm/src/io/ktor/client/tests/utils/ClientTestServer.kt
@@ -27,6 +27,7 @@ internal fun Application.tests() {
     redirectTest()
     featuresTest()
     webSockets()
+    multiPartFormDataTest()
 
     routing {
         post("/echo") {

--- a/ktor-client/ktor-client-tests/jvm/src/io/ktor/client/tests/utils/TestServer.kt
+++ b/ktor-client/ktor-client-tests/jvm/src/io/ktor/client/tests/utils/TestServer.kt
@@ -8,6 +8,7 @@ import ch.qos.logback.classic.*
 import io.ktor.client.tests.utils.tests.*
 import io.ktor.server.engine.*
 import io.ktor.server.jetty.*
+import io.ktor.server.netty.*
 import org.slf4j.*
 import java.io.*
 import java.util.concurrent.*
@@ -19,7 +20,7 @@ internal fun startServer(): Closeable {
     val logger = LoggerFactory.getLogger(org.slf4j.Logger.ROOT_LOGGER_NAME) as ch.qos.logback.classic.Logger
     logger.level = Level.WARN
 
-    val server = embeddedServer(Jetty, DEFAULT_PORT) {
+    val server = embeddedServer(Netty, DEFAULT_PORT) {
         tests()
         benchmarks()
     }.start()

--- a/ktor-client/ktor-client-tests/jvm/src/io/ktor/client/tests/utils/tests/MultiPartFormData.kt
+++ b/ktor-client/ktor-client-tests/jvm/src/io/ktor/client/tests/utils/tests/MultiPartFormData.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2014-2019 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.client.tests.utils.tests
+
+import io.ktor.application.*
+import io.ktor.http.*
+import io.ktor.http.content.*
+import io.ktor.request.*
+import io.ktor.response.*
+import io.ktor.routing.*
+import io.ktor.utils.io.core.*
+
+private const val TEST_FILE_SIZE = 1024 * 1024
+
+internal fun Application.multiPartFormDataTest() {
+    routing {
+        route("/multipart") {
+            post("/") {
+                call.receiveMultipart().forEachPart {
+                    try {
+                        if (it is PartData.FileItem) {
+                            val array = ByteArray(TEST_FILE_SIZE)
+                            it.provider().readFully(array, 0, TEST_FILE_SIZE)
+                        }
+                    } finally {
+                        it.dispose()
+                    }
+                }
+                call.respond(HttpStatusCode.OK)
+            }
+        }
+    }
+}


### PR DESCRIPTION
**Subsystem**
Client, CIO

**Motivation**
In the case of using `WriteChannelContent` CIO client closes the output channel and so triggers TCP connection half-close. Although this behavior is correct from the protocol perspective it's not encouraged in some cases and is not supported by all servers (Netty for example).

There are several issues caused by current implementation: #1456 and #1462.

**Solution**
This change makes TCP half-close optional and disabled by default.

