### PR TITLE
Add @SharedImmutable over a readonly private var to avoid exceptions

### DIFF
--- a/ktor-client/ktor-client-core/common/src/io/ktor/client/features/DefaultResponseValidation.kt
+++ b/ktor-client/ktor-client-core/common/src/io/ktor/client/features/DefaultResponseValidation.kt
@@ -9,7 +9,9 @@ import io.ktor.client.call.*
 import io.ktor.util.*
 import io.ktor.client.statement.*
 import kotlin.jvm.*
+import kotlin.native.concurrent.*
 
+@SharedImmutable
 private val ValidateMark = AttributeKey<Unit>("ValidateMark")
 
 /**


### PR DESCRIPTION
Add @SharedImmutable over a readonly private var to avoid exceptions when used in multithreading

**Subsystem**
Client core.

**Motivation**
Encountered when making a request on iOS from another thread.

**Solution**
SharedImmutable should prevent the exception thrown by Kotlin when this var gets accessed on another thread.
