### PR TITLE
Add Monitoring phase to HttpSendPipeline

### DIFF
--- a/binary-compatibility-validator/reference-public-api/ktor-client-core.txt
+++ b/binary-compatibility-validator/reference-public-api/ktor-client-core.txt
@@ -815,6 +815,7 @@ public final class io/ktor/client/request/HttpSendPipeline : io/ktor/util/pipeli
 public final class io/ktor/client/request/HttpSendPipeline$Phases {
 	public final fun getBefore ()Lio/ktor/util/pipeline/PipelinePhase;
 	public final fun getEngine ()Lio/ktor/util/pipeline/PipelinePhase;
+	public final fun getMonitoring ()Lio/ktor/util/pipeline/PipelinePhase;
 	public final fun getReceive ()Lio/ktor/util/pipeline/PipelinePhase;
 	public final fun getState ()Lio/ktor/util/pipeline/PipelinePhase;
 }

--- a/ktor-client/ktor-client-core/common/src/io/ktor/client/request/HttpRequestPipeline.kt
+++ b/ktor-client/ktor-client-core/common/src/io/ktor/client/request/HttpRequestPipeline.kt
@@ -47,7 +47,7 @@ class HttpRequestPipeline : Pipeline<Any, HttpRequestBuilder>(Before, State, Tra
 /**
  * [HttpClient] Pipeline used for sending [HttpRequest] to remote server.
  */
-class HttpSendPipeline : Pipeline<Any, HttpRequestBuilder>(Before, State, Engine, Receive) {
+class HttpSendPipeline : Pipeline<Any, HttpRequestBuilder>(Before, State, Monitoring, Engine, Receive) {
 
     companion object Phases {
         /**
@@ -59,6 +59,11 @@ class HttpSendPipeline : Pipeline<Any, HttpRequestBuilder>(Before, State, Engine
          * Use this phase to modify request with shared state.
          */
         val State = PipelinePhase("State")
+
+        /**
+         * Use this phase for logging and other actions that don't modify request or shared data.
+         */
+        val Monitoring = PipelinePhase("Monitoring")
 
         /**
          * Send request to remote server.

--- a/ktor-client/ktor-client-features/ktor-client-logging/common/src/io/ktor/client/features/logging/Logging.kt
+++ b/ktor-client/ktor-client-features/ktor-client-logging/common/src/io/ktor/client/features/logging/Logging.kt
@@ -135,7 +135,7 @@ class Logging(
         }
 
         override fun install(feature: Logging, scope: HttpClient) {
-            scope.sendPipeline.intercept(HttpSendPipeline.Before) {
+            scope.sendPipeline.intercept(HttpSendPipeline.Monitoring) {
                 try {
                     feature.logRequest(context)
                 } catch (_: Throwable) {


### PR DESCRIPTION
**Subsystem**
Client, Pipeline and Logging

**Motivation**
Some client features like Logging need access to the final request that will be sent using engine (see https://github.com/ktorio/ktor/issues/1506). So far we have only `State` phase that modifies the request and `Engine` phase that actually sends the request.

**Solution**
 To support Logging we need to add the correspondent `Logging` phase that has access to request but don't modify it.

