### PR TITLE
Add Application/Problem Content type RFC 7808

### DIFF
--- a/ktor-http/common/src/io/ktor/http/ContentTypes.kt
+++ b/ktor-http/common/src/io/ktor/http/ContentTypes.kt
@@ -132,6 +132,8 @@ class ContentType private constructor(val contentType: String, val contentSubtyp
         val FormUrlEncoded = ContentType("application", "x-www-form-urlencoded")
         val Pdf = ContentType("application", "pdf")
         val Wasm = ContentType("application", "wasm")
+        val ProblemJson = ContentType("application","problem+json")
+        val ProblemXml = ContentType("application","problem+xml")
     }
 
     /**


### PR DESCRIPTION
**Subsystem**
Relevant to both Client/Server

**Motivation**
RFC 7808 provides a way to add more problem Details for HTTP APIs than just an HTTP status code.

See example here:
https://tools.ietf.org/html/rfc7807#section-3

**Solution**
Added both IETF content types.

