### PR TITLE
Mark top-level vals SharedImmutable or thread local

### DIFF
--- a/ktor-http/common/src/io/ktor/http/Codecs.kt
+++ b/ktor-http/common/src/io/ktor/http/Codecs.kt
@@ -6,14 +6,21 @@ package io.ktor.http
 import io.ktor.util.*
 import io.ktor.utils.io.charsets.*
 import io.ktor.utils.io.core.*
+import kotlin.native.concurrent.*
 
+@SharedImmutable
 private val URL_ALPHABET = (('a'..'z') + ('A'..'Z') + ('0'..'9')).map { it.toByte() }
+
+@SharedImmutable
 private val URL_ALPHABET_CHARS = (('a'..'z') + ('A'..'Z') + ('0'..'9'))
+
+@SharedImmutable
 private val HEX_ALPHABET = ('a'..'f') + ('A'..'F') + ('0'..'9')
 
 /**
  * https://tools.ietf.org/html/rfc3986#section-2
  */
+@SharedImmutable
 private val URL_PROTOCOL_PART = listOf(
     ':', '/', '?', '#', '[', ']', '@',  // general
     '!', '$', '&', '\'', '(', ')', '*', ',', ';', '=',  // sub-components
@@ -23,6 +30,7 @@ private val URL_PROTOCOL_PART = listOf(
 /**
  * from `pchar` in https://tools.ietf.org/html/rfc3986#section-2
  */
+@SharedImmutable
 private val VALID_PATH_PART = listOf(
     ':', '@',
     '!', '$', '&', '\'', '(', ')', '*', '+', ',', ';', '=',
@@ -32,6 +40,7 @@ private val VALID_PATH_PART = listOf(
  * Oauth specific percent encoding
  * https://tools.ietf.org/html/rfc5849#section-3.6
  */
+@SharedImmutable
 private val OAUTH_SYMBOLS = listOf('-', '.', '_', '~').map { it.toByte() }
 
 /**

--- a/ktor-http/common/src/io/ktor/http/Cookie.kt
+++ b/ktor-http/common/src/io/ktor/http/Cookie.kt
@@ -7,6 +7,7 @@ package io.ktor.http
 import io.ktor.util.*
 import io.ktor.util.date.*
 import kotlin.jvm.*
+import kotlin.native.concurrent.*
 
 /**
  * Represents a cookie with name, content and a set of settings such as expiration, visibility and security.
@@ -65,6 +66,7 @@ enum class CookieEncoding {
     BASE64_ENCODING
 }
 
+@SharedImmutable
 private val loweredPartNames = setOf("max-age", "expires", "domain", "path", "secure", "httponly", "\$x-enc")
 
 /**
@@ -93,6 +95,7 @@ fun parseServerSetCookieHeader(cookiesHeader: String): Cookie {
     )
 }
 
+@ThreadLocal
 private val clientCookieHeaderPattern = """(^|;)\s*([^()<>@;:/\\"\[\]\?=\{\}\s]+)\s*(=\s*("[^"]*"|[^;]*))?""".toRegex()
 
 /**
@@ -214,7 +217,9 @@ private fun String.assertCookieName() = when {
     else -> this
 }
 
+@SharedImmutable
 private val cookieCharsShouldBeEscaped = setOf(';', ',', '"')
+
 private fun Char.shouldEscapeInCookies() = isWhitespace() || this < ' ' || this in cookieCharsShouldBeEscaped
 
 @Suppress("NOTHING_TO_INLINE")

--- a/ktor-http/common/src/io/ktor/http/DateUtils.kt
+++ b/ktor-http/common/src/io/ktor/http/DateUtils.kt
@@ -6,7 +6,9 @@ package io.ktor.http
 
 import io.ktor.util.*
 import io.ktor.util.date.*
+import kotlin.native.concurrent.*
 
+@SharedImmutable
 private val HTTP_DATE_FORMATS = listOf(
     "***, dd MMM YYYY hh:mm:ss zzz",
     "****, dd-MMM-YYYY hh:mm:ss zzz",

--- a/ktor-http/common/src/io/ktor/http/FileContentType.kt
+++ b/ktor-http/common/src/io/ktor/http/FileContentType.kt
@@ -6,6 +6,7 @@ package io.ktor.http
 
 import io.ktor.util.*
 import io.ktor.utils.io.charsets.*
+import kotlin.native.concurrent.*
 
 /**
  * Default [ContentType] for [extension]
@@ -52,10 +53,12 @@ fun ContentType.fileExtensions(): List<String> = extensionsByContentType[this]
     ?: extensionsByContentType[this.withoutParameters()]
     ?: emptyList()
 
+@ThreadLocal
 private val contentTypesByExtensions: Map<String, List<ContentType>> by lazy {
     caseInsensitiveMap<List<ContentType>>().apply { putAll(mimes.asSequence().groupByPairs()) }
 }
 
+@ThreadLocal
 private val extensionsByContentType: Map<ContentType, List<String>> by lazy {
     mimes.asSequence().map { (first, second) -> second to first }.groupByPairs()
 }

--- a/ktor-http/common/src/io/ktor/http/IpParser.kt
+++ b/ktor-http/common/src/io/ktor/http/IpParser.kt
@@ -6,13 +6,18 @@ package io.ktor.http
 
 import io.ktor.http.parsing.*
 import io.ktor.http.parsing.regex.*
+import kotlin.native.concurrent.*
 
 /**
  * Check if [host] is IPv4 or IPv6 address.
  */
 fun hostIsIp(host: String): Boolean = IP_PARSER.match(host)
 
+@SharedImmutable
 private val IPv4address = digits then "." then digits then "." then digits then "." then digits
+
+@SharedImmutable
 private val IPv6address = "[" then atLeastOne(hex or ":") then "]"
 
+@SharedImmutable
 private val IP_PARSER = (IPv4address or IPv6address).buildRegexParser()

--- a/ktor-http/common/src/io/ktor/http/Mimes.kt
+++ b/ktor-http/common/src/io/ktor/http/Mimes.kt
@@ -4,6 +4,8 @@
 
 package io.ktor.http
 
+import kotlin.native.concurrent.*
+
 private val rawMimes: String
     get() = """
 .123,application/vnd.lotus-1-2-3
@@ -1223,4 +1225,5 @@ internal fun loadMimes(): List<Pair<String, ContentType>> {
     }.toList()
 }
 
+@ThreadLocal
 internal val mimes: List<Pair<String, ContentType>> by lazy { loadMimes() }

--- a/ktor-http/common/src/io/ktor/http/auth/HttpAuthHeader.kt
+++ b/ktor-http/common/src/io/ktor/http/auth/HttpAuthHeader.kt
@@ -7,12 +7,20 @@ package io.ktor.http.auth
 import io.ktor.http.*
 import io.ktor.util.*
 import io.ktor.utils.io.charsets.*
+import kotlin.native.concurrent.*
 
 private const val valuePatternPart = """("((\\.)|[^\\"])*")|[^\s,]*"""
 
+@ThreadLocal
 private val token68Pattern = "[a-zA-Z0-9\\-._~+/]+=*".toRegex()
+
+@ThreadLocal
 private val authSchemePattern = "\\S+".toRegex()
+
+@ThreadLocal
 private val parameterPattern = "\\s*,?\\s*($token68Pattern)\\s*=\\s*($valuePatternPart)\\s*,?\\s*".toRegex()
+
+@ThreadLocal
 private val escapeRegex: Regex = "\\\\.".toRegex()
 
 /**

--- a/ktor-http/ktor-http-cio/common/src/io/ktor/http/cio/HttpParser.kt
+++ b/ktor-http/ktor-http-cio/common/src/io/ktor/http/cio/HttpParser.kt
@@ -7,6 +7,7 @@ package io.ktor.http.cio
 import io.ktor.http.*
 import io.ktor.http.cio.internals.*
 import io.ktor.utils.io.*
+import kotlin.native.concurrent.*
 
 /**
  * An HTTP parser exception
@@ -163,8 +164,9 @@ private fun parseUri(text: CharSequence, range: MutableRange): CharSequence {
     return s
 }
 
-
+@SharedImmutable
 private val versions = AsciiCharTree.build(listOf("HTTP/1.0", "HTTP/1.1"))
+
 private fun parseVersion(text: CharSequence, range: MutableRange): CharSequence {
     skipSpaces(text, range)
 

--- a/ktor-http/ktor-http-cio/common/src/io/ktor/http/cio/internals/Chars.kt
+++ b/ktor-http/ktor-http-cio/common/src/io/ktor/http/cio/internals/Chars.kt
@@ -6,6 +6,7 @@ package io.ktor.http.cio.internals
 
 import io.ktor.http.*
 import io.ktor.utils.io.core.*
+import kotlin.native.concurrent.*
 
 internal const val HTAB: Char = '\u0009'
 
@@ -33,10 +34,11 @@ internal fun CharSequence.equalsLowerCase(start: Int = 0, end: Int = length, oth
 private inline fun Int.toLowerCase() =
     if (this in 'A'.toInt()..'Z'.toInt()) 'a'.toInt() + (this - 'A'.toInt()) else this
 
+@SharedImmutable
 internal val DefaultHttpMethods =
     AsciiCharTree.build(HttpMethod.DefaultMethods, { it.value.length }, { m, idx -> m.value[idx] })
 
-
+@SharedImmutable
 private val HexTable = (0..0xff).map { v ->
     when {
         v in 0x30..0x39 -> v - 0x30L
@@ -46,6 +48,7 @@ private val HexTable = (0..0xff).map { v ->
     }
 }.toTypedArray()
 
+@SharedImmutable
 internal val HexLetterTable = (0..0xf).map {
     if (it < 0xa) (0x30 + it).toByte() else ('a' + it - 0x0a).toInt().toByte()
 }.toTypedArray()

--- a/ktor-io/common/test/io/ktor/utils/io/tests/ReadBufferTest.kt
+++ b/ktor-io/common/test/io/ktor/utils/io/tests/ReadBufferTest.kt
@@ -2,8 +2,10 @@ package io.ktor.utils.io.tests
 
 import io.ktor.utils.io.core.*
 import io.ktor.utils.io.core.internal.*
+import kotlin.native.concurrent.*
 import kotlin.test.*
 
+@SharedImmutable
 private val SIZES = intArrayOf(0, 1, 2, 3, 10, 100, 4087, 4088, 4089, 4095, 4096, 4097, 8191, 8192, 8193, 65537)
 
 class ReadBufferTest {

--- a/ktor-io/posix/src/io/ktor/utils/io/errors/PosixErrors.kt
+++ b/ktor-io/posix/src/io/ktor/utils/io/errors/PosixErrors.kt
@@ -4,8 +4,10 @@ import kotlinx.cinterop.*
 import io.ktor.utils.io.core.*
 import io.ktor.utils.io.internal.utils.*
 import platform.posix.*
-import kotlin.native.concurrent.SharedImmutable
+import kotlin.native.concurrent.*
 
+@Suppress("unused")
+@SharedImmutable
 private val s: KX_SOCKET = 0.convert() // do not remove! This is required to hold star import for strerror_r
 
 @SharedImmutable

--- a/ktor-utils/common/src/io/ktor/util/Base64.kt
+++ b/ktor-utils/common/src/io/ktor/util/Base64.kt
@@ -7,11 +7,13 @@ package io.ktor.util
 import io.ktor.utils.io.charsets.*
 import io.ktor.utils.io.core.*
 import kotlin.experimental.*
+import kotlin.native.concurrent.*
 
 private const val BASE64_ALPHABET = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/"
 private const val BASE64_MASK: Byte = 0x3f
 private const val BASE64_PAD = '='
 
+@SharedImmutable
 private val BASE64_INVERSE_ALPHABET = IntArray(256) {
     BASE64_ALPHABET.indexOf(it.toChar())
 }

--- a/ktor-utils/common/src/io/ktor/util/Crypto.kt
+++ b/ktor-utils/common/src/io/ktor/util/Crypto.kt
@@ -9,7 +9,9 @@ package io.ktor.util
 
 import io.ktor.utils.io.charsets.*
 import io.ktor.utils.io.core.*
+import kotlin.native.concurrent.*
 
+@SharedImmutable
 private val digits = "0123456789abcdef".toCharArray()
 
 /**


### PR DESCRIPTION
**Subsystem**
Client

**Motivation**
We have native crashes in non-main thread due to top-level vals.

**Solution**
We need to find and mark all top-level vals with `@SharedImmutable` or `@ThreadLocal`.

