### PR TITLE
Several minor fixes

### DIFF
--- a/binary-compatibility-validator/reference-public-api/ktor-utils.txt
+++ b/binary-compatibility-validator/reference-public-api/ktor-utils.txt
@@ -379,6 +379,8 @@ public class io/ktor/util/StringValuesSingleImpl : io/ktor/util/StringValues {
 public final class io/ktor/util/TextKt {
 	public static final fun chomp (Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function0;)Lkotlin/Pair;
 	public static final fun escapeHTML (Ljava/lang/String;)Ljava/lang/String;
+	public static final fun toLowerCasePreservingASCIIRules (Ljava/lang/String;)Ljava/lang/String;
+	public static final fun toUpperCasePreservingASCIIRules (Ljava/lang/String;)Ljava/lang/String;
 }
 
 public final class io/ktor/util/cio/ByteBufferPool : io/ktor/utils/io/pool/DefaultPool {

--- a/ktor-client/ktor-client-core/common/src/io/ktor/client/call/HttpClientCall.kt
+++ b/ktor-client/ktor-client-core/common/src/io/ktor/client/call/HttpClientCall.kt
@@ -58,10 +58,10 @@ open class HttpClientCall internal constructor(
         internal set
 
     /**
-     * Tries to receive the payload of the [response] as an specific [expectedType].
-     * Returns [response] if [expectedType] is [HttpResponse].
+     * Tries to receive the payload of the [response] as a specific expected type provided in [info].
+     * Returns [response] if [info] corresponds to [HttpResponse].
      *
-     * @throws NoTransformationFoundException If no transformation is found for the [expectedType].
+     * @throws NoTransformationFoundException If no transformation is found for the type [info].
      * @throws DoubleReceiveException If already called [receive].
      */
     suspend fun receive(info: TypeInfo): Any {
@@ -127,6 +127,7 @@ data class HttpEngineCall(val request: HttpRequest, val response: HttpResponse)
         "io.ktor.client.statement.*"
     )
 )
+@Suppress("RedundantSuspendModifier", "unused", "UNUSED_PARAMETER")
 suspend fun HttpClient.call(block: suspend HttpRequestBuilder.() -> Unit = {}): HttpClientCall =
     error("Unbound [HttpClientCall] is deprecated. Consider using [request<HttpResponse>(block)] in instead.")
 
@@ -158,7 +159,7 @@ class DoubleReceiveException(call: HttpClientCall) : IllegalStateException() {
  * Exception representing fail of the response pipeline
  * [cause] contains origin pipeline exception
  */
-@Suppress("KDocMissingDocumentation")
+@Suppress("KDocMissingDocumentation", "unused")
 class ReceivePipelineException(
     val request: HttpClientCall,
     val info: TypeInfo,

--- a/ktor-client/ktor-client-core/common/src/io/ktor/client/call/utils.kt
+++ b/ktor-client/ktor-client-core/common/src/io/ktor/client/call/utils.kt
@@ -14,7 +14,7 @@ import io.ktor.http.content.*
 class UnsupportedContentTypeException(content: OutgoingContent) :
     IllegalStateException("Failed to write body: ${content::class}")
 
-@Suppress("KDocMissingDocumentation")
+@Suppress("KDocMissingDocumentation", "UNUSED")
 class UnsupportedUpgradeProtocolException(
     url: Url
 ) : IllegalArgumentException("Unsupported upgrade protocol exception: $url")
@@ -28,6 +28,7 @@ class UnsupportedUpgradeProtocolException(
     level = DeprecationLevel.ERROR,
     replaceWith = ReplaceWith("this.request<HttpResponse>(builder)", "io.ktor.client.statement.*")
 )
+@Suppress("UNUSED", "UNUSED_PARAMETER", "RedundantSuspendModifier")
 suspend fun HttpClient.call(builder: HttpRequestBuilder): HttpClientCall =
     error("Unbound [HttpClientCall] is deprecated. Consider using [request<HttpResponse>(builder)] instead.")
 
@@ -42,6 +43,7 @@ suspend fun HttpClient.call(builder: HttpRequestBuilder): HttpClientCall =
         "this.request<HttpResponse>(urlString, block)", "io.ktor.client.statement.*"
     )
 )
+@Suppress("UNUSED", "UNUSED_PARAMETER", "RedundantSuspendModifier")
 suspend fun HttpClient.call(
     urlString: String,
     block: suspend HttpRequestBuilder.() -> Unit = {}
@@ -58,6 +60,7 @@ suspend fun HttpClient.call(
     level = DeprecationLevel.ERROR,
     replaceWith = ReplaceWith("this.request<HttpResponse>(url, block)", "io.ktor.client.statement.*")
 )
+@Suppress("UNUSED", "UNUSED_PARAMETER", "RedundantSuspendModifier")
 suspend fun HttpClient.call(
     url: Url,
     block: suspend HttpRequestBuilder.() -> Unit = {}

--- a/ktor-client/ktor-client-core/common/src/io/ktor/client/features/HttpPlainText.kt
+++ b/ktor-client/ktor-client-core/common/src/io/ktor/client/features/HttpPlainText.kt
@@ -26,7 +26,7 @@ class HttpPlainText internal constructor(
     charsets: Set<Charset>,
     charsetQuality: Map<Charset, Float>,
     sendCharset: Charset?,
-    internal val responseCharsetFallback: Charset
+    private val responseCharsetFallback: Charset
 ) {
     private val requestCharset: Charset
     private val acceptCharsetHeader: String
@@ -99,6 +99,7 @@ class HttpPlainText internal constructor(
         /**
          * Default [Charset] to use.
          */
+        @Suppress("unused")
         @Deprecated(
             "Use [register] method instead.",
             replaceWith = ReplaceWith("register()"),
@@ -109,7 +110,7 @@ class HttpPlainText internal constructor(
 
     @Suppress("KDocMissingDocumentation")
     companion object Feature : HttpClientFeature<Config, HttpPlainText> {
-        override val key = AttributeKey<HttpPlainText>("HttpPlainText")
+        override val key: AttributeKey<HttpPlainText> = AttributeKey("HttpPlainText")
 
         override fun prepare(block: Config.() -> Unit): HttpPlainText {
             val config = Config().apply(block)
@@ -161,6 +162,7 @@ class HttpPlainText internal constructor(
     /**
      * Deprecated
      */
+    @Suppress("unused", "UNUSED_PARAMETER")
     @Deprecated(
         "Use [Config.register] method instead.",
         replaceWith = ReplaceWith("register()"),
@@ -183,6 +185,7 @@ class HttpPlainText internal constructor(
  * }
  * ```
  */
+@Suppress("FunctionName")
 fun HttpClientConfig<*>.Charsets(block: HttpPlainText.Config.() -> Unit) {
     install(HttpPlainText, block)
 }

--- a/ktor-client/ktor-client-core/common/src/io/ktor/client/features/cookies/CookiesStorage.kt
+++ b/ktor-client/ktor-client-core/common/src/io/ktor/client/features/cookies/CookiesStorage.kt
@@ -5,6 +5,7 @@
 package io.ktor.client.features.cookies
 
 import io.ktor.http.*
+import io.ktor.util.*
 import io.ktor.utils.io.core.*
 
 /**
@@ -30,13 +31,13 @@ suspend fun CookiesStorage.addCookie(urlString: String, cookie: Cookie) {
 }
 
 internal fun Cookie.matches(requestUrl: Url): Boolean {
-    val domain = domain?.toLowerCase()?.trimStart('.') ?: error("Domain field should have the default value")
+    val domain = domain?.toLowerCasePreservingASCIIRules()?.trimStart('.') ?: error("Domain field should have the default value")
     val path = with(path) {
         val current = path ?: error("Path field should have the default value")
         if (current.endsWith('/')) current else "$path/"
     }
 
-    val host = requestUrl.host.toLowerCase()
+    val host = requestUrl.host.toLowerCasePreservingASCIIRules()
     val requestPath = let {
         val pathInRequest = requestUrl.encodedPath
         if (pathInRequest.endsWith('/')) pathInRequest else "$pathInRequest/"

--- a/ktor-client/ktor-client-core/common/src/io/ktor/client/request/forms/formDsl.kt
+++ b/ktor-client/ktor-client-core/common/src/io/ktor/client/request/forms/formDsl.kt
@@ -123,12 +123,14 @@ class FormBuilder internal constructor() {
     /**
      * Append a pair [key]:[value] with optional [headers].
      */
+    @Suppress("UNUSED_PARAMETER")
     @Deprecated(
         "Input is not reusable. Please use [InputProvider] instead.",
         level = DeprecationLevel.ERROR,
         replaceWith = ReplaceWith("appendInput(key, headers) { /* create fresh input here */ }")
     )
     fun append(key: String, value: Input, headers: Headers = Headers.Empty) {
+        error("Input is not reusable. Please use [InputProvider] instead.")
     }
 
     /**
@@ -160,6 +162,7 @@ inline fun FormBuilder.append(
 /**
  * Reusable [Input] form entry.
  *
+ * @property size estimate for data produced by the block or `null` if no size estimation known
  * @param block: content generator
  */
 @KtorExperimentalAPI

--- a/ktor-client/ktor-client-core/common/src/io/ktor/client/response/Migration.kt
+++ b/ktor-client/ktor-client-core/common/src/io/ktor/client/response/Migration.kt
@@ -2,6 +2,8 @@
  * Copyright 2014-2019 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
+@file:Suppress("KDocMissingDocumentation")
+
 package io.ktor.client.response
 
 import io.ktor.http.*
@@ -22,7 +24,7 @@ class HttpResponse : CoroutineScope, HttpMessage {
         get() = error("Unbound streaming [HttpResponse] is deprecated. Consider using [HttpStatement] instead.")
 }
 
-@Suppress("DEPRECATION_ERROR")
+@Suppress("DEPRECATION_ERROR", "unused", "UNUSED_PARAMETER", "RedundantSuspendModifier")
 @Deprecated(
     "Unbound streaming [HttpResponse] is deprecated. Consider using [HttpStatement] instead.",
     level = DeprecationLevel.ERROR
@@ -38,7 +40,7 @@ suspend fun HttpResponse.readText(charset: Charset? = null): String {
     "Unbound streaming [HttpResponse] is deprecated. Consider using [HttpStatement] instead.",
     level = DeprecationLevel.ERROR
 )
-@Suppress("DEPRECATION_ERROR")
+@Suppress("DEPRECATION_ERROR", "unused", "UNUSED_PARAMETER", "RedundantSuspendModifier")
 suspend fun HttpResponse.readBytes(count: Int): ByteArray {
     error("Unbound streaming [HttpResponse] is deprecated. Consider using [HttpStatement] instead.")
 }
@@ -51,7 +53,7 @@ suspend fun HttpResponse.readBytes(count: Int): ByteArray {
     "Unbound streaming [HttpResponse] is deprecated. Consider using [HttpStatement] instead.",
     level = DeprecationLevel.ERROR
 )
-@Suppress("DEPRECATION_ERROR")
+@Suppress("DEPRECATION_ERROR", "unused", "UNUSED_PARAMETER", "RedundantSuspendModifier")
 suspend fun HttpResponse.readBytes(): ByteArray {
     error("Unbound streaming [HttpResponse] is deprecated. Consider using [HttpStatement] instead.")
 }
@@ -63,7 +65,7 @@ suspend fun HttpResponse.readBytes(): ByteArray {
     "Unbound streaming [HttpResponse] is deprecated. Consider using [HttpStatement] instead.",
     level = DeprecationLevel.ERROR
 )
-@Suppress("DEPRECATION_ERROR")
+@Suppress("DEPRECATION_ERROR", "unused", "UNUSED_PARAMETER", "RedundantSuspendModifier")
 suspend fun HttpResponse.discardRemaining() {
     error("Unbound streaming [HttpResponse] is deprecated. Consider using [HttpStatement] instead.")
 }

--- a/ktor-client/ktor-client-core/common/src/io/ktor/client/statement/HttpResponse.kt
+++ b/ktor-client/ktor-client-core/common/src/io/ktor/client/statement/HttpResponse.kt
@@ -57,14 +57,17 @@ abstract class HttpResponse : HttpMessage, CoroutineScope {
  */
 val HttpResponse.request: HttpRequest get() = call.request
 
+@Suppress("unused", "KDocMissingDocumentation")
 @Deprecated("Close is obsolete for [HttpResponse]", replaceWith = ReplaceWith("this"))
 fun HttpResponse.close() {
 }
 
+@Suppress("UNUSED_PARAMETER", "KDocMissingDocumentation", "unused")
 @Deprecated("Use is obsolete for [HttpResponse]", replaceWith = ReplaceWith("this.also(block)"))
 fun HttpResponse.use(block: () -> Unit) {
 }
 
+@Suppress("unused", "KDocMissingDocumentation")
 @Deprecated("[response] is obsolete for [HttpResponse]", replaceWith = ReplaceWith("this"))
 val HttpResponse.response: HttpResponse
     get() = this

--- a/ktor-client/ktor-client-core/common/src/io/ktor/client/statement/HttpStatement.kt
+++ b/ktor-client/ktor-client-core/common/src/io/ktor/client/statement/HttpStatement.kt
@@ -125,7 +125,7 @@ class HttpStatement(
     level = DeprecationLevel.ERROR,
     replaceWith = ReplaceWith("this.execute<T>(block)")
 )
-@Suppress("KDocMissingDocumentation")
+@Suppress("unused", "KDocMissingDocumentation", "UNUSED_PARAMETER")
 fun <T> HttpStatement.use(block: suspend (response: HttpResponse) -> T) {
 }
 
@@ -134,7 +134,7 @@ fun <T> HttpStatement.use(block: suspend (response: HttpResponse) -> T) {
     "Unbound [HttpResponse] is deprecated. Consider using [execute()] instead.",
     level = DeprecationLevel.ERROR, replaceWith = ReplaceWith("this.execute()")
 )
-@Suppress("KDocMissingDocumentation")
+@Suppress("KDocMissingDocumentation", "unused")
 val HttpStatement.response: HttpResponse
     get() = error("Unbound [HttpClientCall] is deprecated. Consider using [HttpResponse] instead.")
 
@@ -142,7 +142,7 @@ val HttpStatement.response: HttpResponse
  * Read the [HttpResponse.content] as a String. You can pass an optional [charset]
  * to specify a charset in the case no one is specified as part of the Content-Type response.
  * If no charset specified either as parameter or as part of the response,
- * [HttpResponseConfig.defaultCharset] will be used.
+ * [io.ktor.client.features.HttpPlainText] settings will be used.
  *
  * Note that [fallbackCharset] parameter will be ignored if the response already has a charset.
  *      So it just acts as a fallback, honoring the server preference.

--- a/ktor-client/ktor-client-core/jvm/src/io/ktor/client/call/utilsJvm.kt
+++ b/ktor-client/ktor-client-core/jvm/src/io/ktor/client/call/utilsJvm.kt
@@ -17,5 +17,6 @@ import java.net.*
     level = DeprecationLevel.ERROR,
     replaceWith = ReplaceWith("this.request<HttpResponse>(url, block)", "io.ktor.client.statement.*")
 )
+@Suppress("RedundantSuspendModifier", "unused", "UNUSED_PARAMETER")
 suspend fun HttpClient.call(url: URL, block: HttpRequestBuilder.() -> Unit = {}): HttpClientCall =
     error("Unbound [HttpClientCall] is deprecated. Consider using [request<HttpResponse>(url, block)] instead.")

--- a/ktor-client/ktor-client-features/ktor-client-encoding/common/src/ContentEncoding.kt
+++ b/ktor-client/ktor-client-features/ktor-client-encoding/common/src/ContentEncoding.kt
@@ -99,7 +99,7 @@ class ContentEncoding(
          */
         fun customEncoder(encoder: ContentEncoder, quality: Float? = null) {
             val name = encoder.name
-            encoders[name] = encoder
+            encoders[name.toLowerCase()] = encoder
 
             if (quality == null) {
                 qualityValues.remove(name)

--- a/ktor-client/ktor-client-features/ktor-client-json/ktor-client-serialization/common/src/io/ktor/client/features/json/serializer/KotlinxSerializer.kt
+++ b/ktor-client/ktor-client-features/ktor-client-json/ktor-client-serialization/common/src/io/ktor/client/features/json/serializer/KotlinxSerializer.kt
@@ -36,11 +36,13 @@ class KotlinxSerializer(
     }
 
     /** Set the mapping from [T] to [mapper]. */
+    @Suppress("UNUSED_PARAMETER", "unused")
     @Deprecated("[register] is obsolete with 1.3.50 `typeOf` feature", level = DeprecationLevel.WARNING)
     inline fun <reified T : Any> register(mapper: KSerializer<T>) {
     }
 
     /** Set the mapping from [List<T>] to [mapper]. */
+    @Suppress("UNUSED_PARAMETER", "unused")
     @Deprecated("[register] is obsolete with 1.3.50 `typeOf` feature", level = DeprecationLevel.WARNING)
     inline fun <reified T : Any> registerList(mapper: KSerializer<T>) {
     }
@@ -48,6 +50,7 @@ class KotlinxSerializer(
     /**
      * Set the mapping from [T] to it's [KSerializer]. This method only works for non-parameterized types.
      */
+    @Suppress("unused")
     @Deprecated("[register] is obsolete with 1.3.50 `typeOf` feature", level = DeprecationLevel.WARNING)
     inline fun <reified T : Any> register() {
     }
@@ -56,10 +59,12 @@ class KotlinxSerializer(
      * Set the mapping from [List<T>] to it's [KSerializer]. This method only works for non-parameterized types.
      */
     @Deprecated("[register] is obsolete with 1.3.50 `typeOf` feature", level = DeprecationLevel.WARNING)
+    @Suppress("unused")
     inline fun <reified T : Any> registerList() {
     }
 
     override fun write(data: Any, contentType: ContentType): OutgoingContent {
+        @Suppress("UNCHECKED_CAST")
         val content = json.stringify(buildSerializer(data) as KSerializer<Any>, data)
         return TextContent(content, contentType)
     }
@@ -71,6 +76,7 @@ class KotlinxSerializer(
     }
 }
 
+@Suppress("UNCHECKED_CAST")
 @UseExperimental(ImplicitReflectionSerializer::class)
 private fun buildSerializer(value: Any): KSerializer<*> = when (value) {
     is List<*> -> value.elementSerializer().list

--- a/ktor-client/ktor-client-jetty/jvm/src/io/ktor/client/engine/jetty/JettyEngineConfig.kt
+++ b/ktor-client/ktor-client-jetty/jvm/src/io/ktor/client/engine/jetty/JettyEngineConfig.kt
@@ -15,5 +15,5 @@ class JettyEngineConfig : HttpClientEngineConfig() {
     /**
      * A Jetty's [SslContextFactory]. By default it trusts all the certificates.
      */
-    var sslContextFactory: SslContextFactory = SslContextFactory()
+    var sslContextFactory: SslContextFactory = SslContextFactory.Client()
 }

--- a/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/HttpBinTest.kt
+++ b/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/HttpBinTest.kt
@@ -8,10 +8,8 @@ import io.ktor.client.*
 import io.ktor.client.features.json.*
 import io.ktor.client.features.json.serializer.*
 import io.ktor.client.request.*
-import io.ktor.client.response.*
 import io.ktor.client.statement.*
 import io.ktor.client.tests.utils.*
-import io.ktor.utils.io.core.*
 import kotlinx.serialization.*
 import kotlinx.serialization.json.*
 import kotlin.test.*
@@ -79,6 +77,7 @@ class HttpBinTest : ClientLoader() {
         }
     }
 
+    @UseExperimental(UnstableDefault::class)
     private fun HttpClientConfig<*>.testConfiguration() {
         install(JsonFeature) {
             serializer = KotlinxSerializer(Json.nonstrict)

--- a/ktor-client/ktor-client-tests/jvm/test/io/ktor/client/tests/cio/SemaphoreTest.kt
+++ b/ktor-client/ktor-client-tests/jvm/test/io/ktor/client/tests/cio/SemaphoreTest.kt
@@ -13,7 +13,7 @@ import kotlin.test.*
 internal const val TEST_SIZE = 100
 internal const val FAIL_TIMEOUT = 100L
 
-@Suppress("KDocMissingDocumentation")
+@Suppress("KDocMissingDocumentation", "DEPRECATION")
 class SemaphoreTest {
 
     @Test

--- a/ktor-features/ktor-auth/jvm/src/io/ktor/auth/DigestAuth.kt
+++ b/ktor-features/ktor-auth/jvm/src/io/ktor/auth/DigestAuth.kt
@@ -246,7 +246,7 @@ fun DigestCredential.expectedDigest(
     val start = hex(userNameRealmPasswordDigest)
 
     // H(A2) in the RFC
-    val end = hex(digest("${method.value.toUpperCase()}:$digestUri"))
+    val end = hex(digest("${method.value.toUpperCasePreservingASCIIRules()}:$digestUri"))
 
     val hashParameters = when (qop) {
         null -> listOf(start, nonce, end)

--- a/ktor-features/ktor-auth/jvm/src/io/ktor/auth/OAuth1a.kt
+++ b/ktor-features/ktor-auth/jvm/src/io/ktor/auth/OAuth1a.kt
@@ -249,7 +249,7 @@ fun signatureBaseString(
     method: HttpMethod,
     baseUrl: String,
     parameters: List<HeaderValueParam>
-): String = listOf(method.value.toUpperCase(), baseUrl, parametersString(header.parameters + parameters))
+): String = listOf(method.value.toUpperCasePreservingASCIIRules(), baseUrl, parametersString(header.parameters + parameters))
     .joinToString("&") { it.encodeURLParameter() }
 
 private fun String.hmacSha1(key: String): String {

--- a/ktor-http/common/src/io/ktor/http/CacheControl.kt
+++ b/ktor-http/common/src/io/ktor/http/CacheControl.kt
@@ -14,26 +14,26 @@ sealed class CacheControl(val visibility: Visibility?) {
     /**
      * Controls caching by proxies
      */
-    enum class Visibility {
+    enum class Visibility(internal val headerValue: String) {
         /**
          * Specifies that the response is cacheable by clients and shared (proxy) caches.
          */
-        Public,
+        Public("public"),
 
         /**
          * Specifies that the response is cacheable only on the client and not by shared (proxy server) caches.
          */
-        Private
+        Private("private")
     }
 
     /**
      * Represents a no-cache cache control value
      */
     class NoCache(visibility: Visibility?) : CacheControl(visibility) {
-        override fun toString() = if (visibility == null) {
+        override fun toString(): String = if (visibility == null) {
             "no-cache"
         } else {
-            "no-cache, ${visibility.name.toLowerCase()}"
+            "no-cache, ${visibility.headerValue}"
         }
     }
 
@@ -41,10 +41,10 @@ sealed class CacheControl(val visibility: Visibility?) {
      * Represents a no-store cache control value
      */
     class NoStore(visibility: Visibility?) : CacheControl(visibility) {
-        override fun toString() = if (visibility == null) {
+        override fun toString(): String = if (visibility == null) {
             "no-store"
         } else {
-            "no-store, ${visibility.name.toLowerCase()}"
+            "no-store, ${visibility.headerValue}"
         }
     }
 
@@ -75,7 +75,7 @@ sealed class CacheControl(val visibility: Visibility?) {
                 parts.add("proxy-revalidate")
             }
             if (visibility != null) {
-                parts.add(visibility.name.toLowerCase())
+                parts.add(visibility.headerValue)
             }
 
             return parts.joinToString(", ")

--- a/ktor-http/common/src/io/ktor/http/Codecs.kt
+++ b/ktor-http/common/src/io/ktor/http/Codecs.kt
@@ -222,9 +222,11 @@ private fun CharSequence.decodeImpl(
  */
 class URLDecodeException(message: String) : Exception(message)
 
-private fun Byte.percentEncode(): String {
-    val code = (toInt() and 0xff).toString(radix = 16).toUpperCase()
-    return "%${code.padStart(length = 2, padChar = '0')}"
+private fun Byte.percentEncode(): String= buildString(3) {
+    val code = toInt() and 0xff
+    append('%')
+    append(hexDigitToChar(code shr 4))
+    append(hexDigitToChar(code and 0x0f))
 }
 
 private fun charToHexDigit(c2: Char) = when (c2) {
@@ -232,6 +234,11 @@ private fun charToHexDigit(c2: Char) = when (c2) {
     in 'A'..'F' -> c2 - 'A' + 10
     in 'a'..'f' -> c2 - 'a' + 10
     else -> -1
+}
+
+private fun hexDigitToChar(digit: Int): Char = when (digit) {
+    in 0..9 -> '0' + digit
+    else -> 'A' + digit - 10
 }
 
 private fun ByteReadPacket.forEach(block: (Byte) -> Unit) {

--- a/ktor-http/common/src/io/ktor/http/Cookie.kt
+++ b/ktor-http/common/src/io/ktor/http/Cookie.kt
@@ -77,7 +77,7 @@ fun parseServerSetCookieHeader(cookiesHeader: String): Cookie {
     val asMap = parseClientCookiesHeader(cookiesHeader, false)
     val first = asMap.entries.first { !it.key.startsWith("$") }
     val encoding = asMap["\$x-enc"]?.let { CookieEncoding.valueOf(it) } ?: CookieEncoding.URI_ENCODING
-    val loweredMap = asMap.mapKeys { it.key.toLowerCase() }
+    val loweredMap = asMap.mapKeys { it.key.toLowerCasePreservingASCIIRules() }
 
     return Cookie(
         name = first.key,
@@ -90,7 +90,7 @@ fun parseServerSetCookieHeader(cookiesHeader: String): Cookie {
         secure = "secure" in loweredMap,
         httpOnly = "httponly" in loweredMap,
         extensions = asMap.filterKeys {
-            it.toLowerCase() !in loweredPartNames && it != first.key
+            it.toLowerCasePreservingASCIIRules() !in loweredPartNames && it != first.key
         }
     )
 }

--- a/ktor-http/common/src/io/ktor/http/FileContentType.kt
+++ b/ktor-http/common/src/io/ktor/http/FileContentType.kt
@@ -34,7 +34,7 @@ fun ContentType.Companion.fromFilePath(path: String): List<ContentType> {
  * Recommended content type by file name extension
  */
 fun ContentType.Companion.fromFileExtension(ext: String): List<ContentType> {
-    var current = ext.removePrefix(".")
+    var current = ext.removePrefix(".").toLowerCasePreservingASCIIRules()
     while (current.isNotEmpty()) {
         val type = contentTypesByExtensions[current]
         if (type != null) {

--- a/ktor-http/common/src/io/ktor/http/Mimes.kt
+++ b/ktor-http/common/src/io/ktor/http/Mimes.kt
@@ -4,6 +4,7 @@
 
 package io.ktor.http
 
+import io.ktor.util.*
 import kotlin.native.concurrent.*
 
 private val rawMimes: String
@@ -1221,7 +1222,7 @@ internal fun loadMimes(): List<Pair<String, ContentType>> {
         val extension = line.substring(0, index)
         val mime = line.substring(index + 1)
 
-        extension.removePrefix(".").toLowerCase() to mime.toContentType()
+        extension.removePrefix(".").toLowerCasePreservingASCIIRules() to mime.toContentType()
     }.toList()
 }
 

--- a/ktor-http/common/src/io/ktor/http/Ranges.kt
+++ b/ktor-http/common/src/io/ktor/http/Ranges.kt
@@ -9,22 +9,18 @@ import kotlin.math.*
 
 /**
  * Possible content range units: bytes and none
+ * @property unitToken Lower-case unit name
  */
-enum class RangeUnits {
+enum class RangeUnits(val unitToken: String) {
     /**
      * Range unit `bytes`
      */
-    Bytes,
+    Bytes("bytes"),
 
     /**
      * Range unit `none`
      */
-    None;
-
-    /**
-     * Lower-case unit name
-     */
-    val unitToken: String = name.toLowerCase()
+    None("none");
 }
 
 /**

--- a/ktor-http/common/src/io/ktor/http/URLProtocol.kt
+++ b/ktor-http/common/src/io/ktor/http/URLProtocol.kt
@@ -51,7 +51,7 @@ data class URLProtocol(val name: String, val defaultPort: Int) {
         /**
          * Create an instance by [name] or use already existing instance
          */
-        fun createOrDefault(name: String): URLProtocol = name.toLowerCase().let {
+        fun createOrDefault(name: String): URLProtocol = name.toLowerCasePreservingASCIIRules().let {
             byName[it] ?: URLProtocol(it, DEFAULT_PORT)
         }
     }

--- a/ktor-http/ktor-http-cio/common/src/io/ktor/http/cio/internals/Chars.kt
+++ b/ktor-http/ktor-http-cio/common/src/io/ktor/http/cio/internals/Chars.kt
@@ -24,7 +24,7 @@ internal fun CharSequence.equalsLowerCase(start: Int = 0, end: Int = length, oth
     if (end - start != other.length) return false
 
     for (pos in start until end) {
-        if (get(pos).toInt().toLowerCase() != other.get(pos - start).toInt().toLowerCase()) return false
+        if (get(pos).toInt().toLowerCase() != other[pos - start].toInt().toLowerCase()) return false
     }
 
     return true
@@ -95,7 +95,7 @@ private fun CharSequence.parseDecLongWithCheck(): Long {
     return result
 }
 
-internal fun IoBuffer.writeIntHex(value: Int) {
+internal fun Buffer.writeIntHex(value: Int) {
     require(value > 0) { "Does only work for positive numbers" } // zero is not included!
     var current = value
     val table = HexLetterTable

--- a/ktor-http/ktor-http-cio/common/src/io/ktor/http/cio/internals/Chars.kt
+++ b/ktor-http/ktor-http-cio/common/src/io/ktor/http/cio/internals/Chars.kt
@@ -46,12 +46,12 @@ private val HexTable = (0..0xff).map { v ->
         v >= 'A'.toLong() && v <= 'F'.toLong() -> v - 'A'.toLong() + 10
         else -> -1L
     }
-}.toTypedArray()
+}.toLongArray()
 
 @SharedImmutable
-internal val HexLetterTable = (0..0xf).map {
+internal val HexLetterTable: ByteArray = (0..0xf).map {
     if (it < 0xa) (0x30 + it).toByte() else ('a' + it - 0x0a).toInt().toByte()
-}.toTypedArray()
+}.toByteArray()
 
 internal fun CharSequence.parseHexLong(): Long {
     var result = 0L

--- a/ktor-http/ktor-http-cio/jvm/src/io/ktor/http/cio/RequestResponseBuilder.kt
+++ b/ktor-http/ktor-http-cio/jvm/src/io/ktor/http/cio/RequestResponseBuilder.kt
@@ -18,11 +18,11 @@ class RequestResponseBuilder {
      * Append response status line
      */
     fun responseLine(version: CharSequence, status: Int, statusText: CharSequence) {
-        packet.writeStringUtf8(version)
+        packet.writeText(version)
         packet.writeByte(SP)
-        packet.writeStringUtf8(status.toString())
+        packet.writeText(status.toString())
         packet.writeByte(SP)
-        packet.writeStringUtf8(statusText)
+        packet.writeText(statusText)
         packet.writeByte(CR)
         packet.writeByte(LF)
     }
@@ -31,11 +31,11 @@ class RequestResponseBuilder {
      * Append request line
      */
     fun requestLine(method: HttpMethod, uri: CharSequence, version: CharSequence) {
-        packet.writeStringUtf8(method.value)
+        packet.writeText(method.value)
         packet.writeByte(SP)
-        packet.writeStringUtf8(uri)
+        packet.writeText(uri)
         packet.writeByte(SP)
-        packet.writeStringUtf8(version)
+        packet.writeText(version)
         packet.writeByte(CR)
         packet.writeByte(LF)
     }

--- a/ktor-io/common/src/io/ktor/utils/io/core/AbstractOutput.kt
+++ b/ktor-io/common/src/io/ktor/utils/io/core/AbstractOutput.kt
@@ -406,7 +406,7 @@ internal constructor(
         writeText(s)
     }
 
-    @Deprecated("Use writeText instead", ReplaceWith("writeText(s)"))
+    @Deprecated("Use writeText instead", ReplaceWith("this.writeText(cs)"))
     fun writeStringUtf8(cs: CharSequence) {
         writeText(cs)
     }

--- a/ktor-io/js/src/io/ktor/utils/io/charsets/CharsetJS.kt
+++ b/ktor-io/js/src/io/ktor/utils/io/charsets/CharsetJS.kt
@@ -12,7 +12,7 @@ actual abstract class Charset(internal val _name: String) {
         actual fun forName(name: String): Charset {
             if (name == "UTF-8" || name == "utf-8" || name == "UTF8" || name == "utf8") return Charsets.UTF_8
             if (name == "ISO-8859-1" || name == "iso-8859-1"
-                || name.toLowerCase().replace('_', '-') == "iso-8859-1"
+                || name.replace('_', '-').let { it == "iso-8859-1" || it.toLowerCase() == "iso-8859-1" }
                 || name == "latin1"
             ) {
                 return Charsets.ISO_8859_1

--- a/ktor-network/ktor-network-tls/jvm/src/io/ktor/network/tls/Render.kt
+++ b/ktor-network/ktor-network-tls/jvm/src/io/ktor/network/tls/Render.kt
@@ -154,7 +154,7 @@ private fun buildServerNameExtension(name: String): ByteReadPacket = buildPacket
     writeShort((name.length + 2 + 1).toShort()) // list length
     writeByte(0) // type: host_name
     writeShort(name.length.toShort()) // name length
-    writeStringUtf8(name)
+    writeText(name)
 }
 
 private const val MAX_CURVES_QUANTITY: Int = Short.MAX_VALUE / 2 - 1

--- a/ktor-network/ktor-network-tls/ktor-network-tls-certificates/jvm/src/io/ktor/network/tls/certificates/Certificates.kt
+++ b/ktor-network/ktor-network-tls/ktor-network-tls-certificates/jvm/src/io/ktor/network/tls/certificates/Certificates.kt
@@ -264,7 +264,7 @@ private fun BytePacketBuilder.writeDerGeneralizedTime(date: Date) {
 
 private fun BytePacketBuilder.writeDerUTF8String(s: String, type: Int = 0x0c) {
     val sub = buildPacket {
-        writeStringUtf8(s)
+        writeText(s)
     }
 
     writeDerType(0, type, true)

--- a/ktor-server/ktor-server-core/jvm/src/io/ktor/features/CORS.kt
+++ b/ktor-server/ktor-server-core/jvm/src/io/ktor/features/CORS.kt
@@ -49,7 +49,7 @@ class CORS(configuration: Configuration) {
     /**
      * Set of all allowed headers
      */
-    val allHeadersSet: Set<String> = allHeaders.map { it.toLowerCase() }.toSet()
+    val allHeadersSet: Set<String> = allHeaders.map { it.toLowerCasePreservingASCIIRules() }.toSet()
 
     private val allowNonSimpleContentTypes: Boolean = configuration.allowNonSimpleContentTypes
 
@@ -176,7 +176,7 @@ class CORS(configuration: Configuration) {
     private fun ApplicationCall.corsCheckRequestHeaders(): Boolean {
         val requestHeaders =
             request.headers.getAll(HttpHeaders.AccessControlRequestHeaders)?.flatMap { it.split(",") }?.map {
-                it.trim().toLowerCase()
+                it.trim().toLowerCasePreservingASCIIRules()
             } ?: emptyList()
 
         return requestHeaders.none { it !in allHeadersSet }
@@ -465,6 +465,9 @@ class CORS(configuration: Configuration) {
      * Feature object for installation
      */
     companion object Feature : ApplicationFeature<ApplicationCallPipeline, Configuration, CORS> {
+        /**
+         * The default CORS max age value
+         */
         const val CORS_DEFAULT_MAX_AGE: Long = 24L * 3600 // 1 day
 
         override val key: AttributeKey<CORS> = AttributeKey("CORS")

--- a/ktor-server/ktor-server-core/jvm/src/io/ktor/sessions/SessionSerializerReflection.kt
+++ b/ktor-server/ktor-server-core/jvm/src/io/ktor/sessions/SessionSerializerReflection.kt
@@ -18,6 +18,7 @@ import kotlin.reflect.jvm.*
 /**
  * Creates the the default [SessionSerializer] for type [T]
  */
+@Suppress("DEPRECATION", "UNUSED")
 @Deprecated("Use defaultSessionSerializer instead.", ReplaceWith("defaultSessionSerializer<T>()"))
 inline fun <reified T : Any> autoSerializerOf(): SessionSerializerReflection<T> = autoSerializerOf(T::class)
 
@@ -83,7 +84,7 @@ class SessionSerializerReflection<T : Any>(val type: KClass<T>) : SessionSeriali
 
     private fun findConstructor(bundle: StringValues): KFunction<T> =
         type.constructors
-            .filter { it.parameters.all { it.name != null && it.name!! in bundle } }
+            .filter { it.parameters.all { parameter -> parameter.name != null && parameter.name!! in bundle } }
             .maxBy { it.parameters.size }
             ?: throw IllegalArgumentException("Couldn't instantiate type $type for parameters ${bundle.names()}")
 
@@ -242,7 +243,7 @@ class SessionSerializerReflection<T : Any>(val type: KClass<T>) : SessionSeriali
         filter { type.toJavaClass().isAssignableFrom(it.java) }
 
     private fun <T : Any> List<KClass<T>>.firstHasNoArgConstructor() =
-        firstOrNull { it.constructors.any { it.parameters.isEmpty() } }
+        firstOrNull { clazz -> clazz.constructors.any { it.parameters.isEmpty() } }
 
     private fun <T : Any> KClass<T>.callNoArgConstructor() = constructors.first { it.parameters.isEmpty() }.call()
 

--- a/ktor-server/ktor-server-core/jvm/src/io/ktor/util/Paths.kt
+++ b/ktor-server/ktor-server-core/jvm/src/io/ktor/util/Paths.kt
@@ -39,7 +39,7 @@ private fun List<String>.filterComponentsImpl(startIndex: Int): List<String> {
 }
 
 private fun MutableList<String>.processAndReplaceComponent(component: String) {
-    if (component.isEmpty() || component == "." || component == "~" || component.toUpperCase() in ReservedWords) return
+    if (component.isEmpty() || component == "." || component == "~" || component.toUpperCasePreservingASCIIRules() in ReservedWords) return
     if (component == "..") {
         if (isNotEmpty()) {
             removeAt(lastIndex)
@@ -76,7 +76,7 @@ private fun String.shouldBeReplaced(): Boolean {
         return true
     }
 
-    if (first in FirstReservedLetters && (this in ReservedWords || this.toUpperCase() in ReservedWords)) {
+    if (first in FirstReservedLetters && (this in ReservedWords || this.toUpperCasePreservingASCIIRules() in ReservedWords)) {
         return true
     }
 

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http2/NettyHttp2ApplicationResponse.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http2/NettyHttp2ApplicationResponse.kt
@@ -8,6 +8,7 @@ import io.ktor.http.content.*
 import io.ktor.http.*
 import io.ktor.response.*
 import io.ktor.server.netty.*
+import io.ktor.util.*
 import io.netty.channel.*
 import io.netty.handler.codec.http2.*
 import kotlin.coroutines.*
@@ -44,7 +45,7 @@ internal class NettyHttp2ApplicationResponse(call: NettyApplicationCall,
 
     override val headers = object : ResponseHeaders() {
         override fun engineAppendHeader(name: String, value: String) {
-            responseHeaders.add(name.toLowerCase(), value)
+            responseHeaders.add(name.toLowerCasePreservingASCIIRules(), value)
         }
 
         override fun get(name: String): String? = responseHeaders[name]?.toString()

--- a/ktor-server/ktor-server-servlet/jvm/src/io/ktor/server/servlet/ServletApplicationEngine.kt
+++ b/ktor-server/ktor-server-servlet/jvm/src/io/ktor/server/servlet/ServletApplicationEngine.kt
@@ -8,6 +8,7 @@ import com.typesafe.config.*
 import io.ktor.application.*
 import io.ktor.config.*
 import io.ktor.server.engine.*
+import io.ktor.util.*
 import org.slf4j.*
 import javax.servlet.*
 import javax.servlet.annotation.*
@@ -69,7 +70,7 @@ open class ServletApplicationEngine : KtorServlet() {
     }
 
     override val upgrade: ServletUpgrade by lazy {
-        if ("jetty" in servletContext.serverInfo?.toLowerCase() ?: "") {
+        if ("jetty" in servletContext.serverInfo?.toLowerCasePreservingASCIIRules() ?: "") {
             jettyUpgrade ?: DefaultServletUpgrade
         } else DefaultServletUpgrade
     }

--- a/ktor-utils/common/src/io/ktor/util/Base64.kt
+++ b/ktor-utils/common/src/io/ktor/util/Base64.kt
@@ -23,7 +23,7 @@ private val BASE64_INVERSE_ALPHABET = IntArray(256) {
  */
 @InternalAPI
 fun String.encodeBase64(): String = buildPacket {
-    writeStringUtf8(this@encodeBase64)
+    writeText(this@encodeBase64)
 }.encodeBase64()
 
 /**
@@ -69,7 +69,7 @@ fun String.decodeBase64String(): String = String(decodeBase64Bytes(), charset = 
  */
 @InternalAPI
 fun String.decodeBase64Bytes(): ByteArray = buildPacket {
-    writeStringUtf8(dropLastWhile { it == BASE64_PAD })
+    writeText(dropLastWhile { it == BASE64_PAD })
 }.decodeBase64Bytes().readBytes()
 
 /**

--- a/ktor-utils/common/src/io/ktor/util/Crypto.kt
+++ b/ktor-utils/common/src/io/ktor/util/Crypto.kt
@@ -60,7 +60,7 @@ expect fun generateNonce(): String
 @InternalAPI
 fun generateNonce(size: Int): ByteArray = buildPacket {
     while (this.size < size) {
-        writeStringUtf8(generateNonce())
+        writeText(generateNonce())
     }
 }.readBytes(size)
 

--- a/ktor-utils/common/src/io/ktor/util/Text.kt
+++ b/ktor-utils/common/src/io/ktor/util/Text.kt
@@ -39,6 +39,66 @@ inline fun String.chomp(separator: String, onMissingDelimiter: () -> Pair<String
     }
 }
 
+/**
+ * Does the same as the regular [toLowerCase] except that locale-specific rules are not applied to ASCII characters
+ * so latin characters are converted by the original english rules.
+ */
+@InternalAPI
+fun String.toLowerCasePreservingASCIIRules(): String {
+    val firstIndex = indexOfFirst {
+        toLowerCasePreservingASCII(it) != it
+    }
+
+    if (firstIndex == -1) {
+        return this
+    }
+
+    val original = this
+    return buildString(length) {
+        append(original, 0, firstIndex)
+
+        for (index in firstIndex .. original.lastIndex) {
+            append(toLowerCasePreservingASCII(original[index]))
+        }
+    }
+}
+
+/**
+ * Does the same as the regular [toUpperCase] except that locale-specific rules are not applied to ASCII characters
+ * so latin characters are converted by the original english rules.
+ */
+@InternalAPI
+fun String.toUpperCasePreservingASCIIRules(): String {
+    val firstIndex = indexOfFirst {
+        toUpperCasePreservingASCII(it) != it
+    }
+
+    if (firstIndex == -1) {
+        return this
+    }
+
+    val original = this
+    return buildString(length) {
+        append(original, 0, firstIndex)
+
+        for (index in firstIndex .. original.lastIndex) {
+            append(toUpperCasePreservingASCII(original[index]))
+        }
+    }
+}
+
+private fun toLowerCasePreservingASCII(ch: Char): Char = when (ch) {
+    in 'A' .. 'Z' -> ch + 32
+    in '\u0000' .. '\u007f' -> ch
+    else -> ch.toLowerCase()
+}
+
+private fun toUpperCasePreservingASCII(ch: Char): Char = when (ch) {
+    in 'a' .. 'z' -> ch - 32
+    in '\u0000' .. '\u007f' -> ch
+    else -> ch.toLowerCase()
+}
+
 internal fun String.caseInsensitive(): CaseInsensitiveString = CaseInsensitiveString(this)
 
 internal class CaseInsensitiveString(val content: String) {


### PR DESCRIPTION
**Subsystem**
Client and server

**Motivation**
There are a lot of warnings. 
Several places when we do upper/lowercase transformation using locale rules that may potentially break HTTP-related logic. 

**Solution**
- Cleanup warnings
- Avoid using toLowerCase/toUppwerCase, introduce internal utility function that preserves ASCII characters rules
- Avoid accidentally boxed precomputed lookup tables


