### PR TITLE
Fix ApplicationStopPreparing fired multiple times with test server engine

### DIFF
--- a/ktor-server/ktor-server-tests/jvm/test/io/ktor/tests/server/application/ApplicationEventTest.kt
+++ b/ktor-server/ktor-server-tests/jvm/test/io/ktor/tests/server/application/ApplicationEventTest.kt
@@ -1,0 +1,68 @@
+package io.ktor.tests.server.application
+
+import io.ktor.application.*
+import io.ktor.server.testing.*
+import org.junit.Test
+import kotlin.test.*
+
+class ApplicationEventTest {
+    @Test
+    fun `Checking the number of calls to ApplicationStopPreparing (use withTestApplication)`() {
+        var c = 0
+
+        withTestApplication {
+            environment.monitor.subscribe(ApplicationStopPreparing) {
+                c += 1
+            }
+        }
+        assertEquals(1, c)
+
+        withTestApplication {
+            environment.monitor.subscribe(ApplicationStopPreparing) {
+                c += 2
+            }
+        }
+        assertEquals(3, c)
+
+    }
+
+    @Test
+    fun `Checking the number of calls to ApplicationStopping (use withTestApplication)`() {
+        var c = 0
+
+        withTestApplication {
+            environment.monitor.subscribe(ApplicationStopping) {
+                c += 1
+            }
+        }
+        assertEquals(1, c)
+
+        withTestApplication {
+            environment.monitor.subscribe(ApplicationStopping) {
+                c += 2
+            }
+        }
+        assertEquals(3, c)
+
+    }
+
+    @Test
+    fun `Checking the number of calls to ApplicationStopPreparing (use withApplication)`() {
+        var c = 0
+
+        withApplication {
+            environment.monitor.subscribe(ApplicationStopPreparing) {
+                c += 1
+            }
+        }
+        assertEquals(1, c)
+
+        withApplication {
+            environment.monitor.subscribe(ApplicationStopPreparing) {
+                c += 2
+            }
+        }
+        assertEquals(3, c)
+
+    }
+}

--- a/ktor-server/ktor-server-tests/jvm/test/io/ktor/tests/server/application/ApplicationEventTest.kt
+++ b/ktor-server/ktor-server-tests/jvm/test/io/ktor/tests/server/application/ApplicationEventTest.kt
@@ -1,3 +1,7 @@
+/*
+ * Copyright 2014-2019 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
 package io.ktor.tests.server.application
 
 import io.ktor.application.*


### PR DESCRIPTION
**Subsystem**
Server, test engine

**Motivation**
Issue #1498 

**Solution**
Apply the same solution as we do for other server engines: we simply launch a coroutine that is always sleeping and resuming at cancellation and doing stop.

