### PR TITLE
Fix dropLeadingTopDirs to not hang at some cases

### DIFF
--- a/ktor-utils/jvm/src/io/ktor/util/Path.kt
+++ b/ktor-utils/jvm/src/io/ktor/util/Path.kt
@@ -44,29 +44,48 @@ private fun File.notRooted(): File {
     return File(path.drop(current.name.length).dropWhile { it == '\\' || it == '/' })
 }
 
-private fun File.dropLeadingTopDirs(): File {
+/**
+ * Discards all leading path separators, top dir (..) and current dir (.) references.
+ * The only exception is when the whole path is a current dir reference (.)
+ */
+internal fun dropLeadingTopDirs(path: String): Int {
     var startIndex = 0
-    val path = path!!
     val lastIndex = path.length - 1
 
-    while (startIndex < lastIndex) {
-        if (path[startIndex] == '.') {
-            val second = path[startIndex + 1]
-            if (second == '\\' || second == '/') {
-                startIndex += 2 // skip 2 characters: ./ or .\
-            } else if (second == '.') {
-                if (startIndex + 2 == path.length) {
-                    startIndex += 2 // skip the only 2 characters remaining: ..
-                } else if (path[startIndex + 2].let { it == '/' || it == '\\' }) {
-                    startIndex += 3 // skip 3 characters: ../ or ..\
-                }
-            } else {
+    while (startIndex <= lastIndex) {
+        val first = path[startIndex]
+        if (first.isPathSeparator()) {
+            startIndex++
+            continue
+        }
+        if (startIndex == lastIndex || first != '.') {
+            break
+        }
+
+        val second: Char = path[startIndex + 1]
+        if (second.isPathSeparator()) {
+            startIndex += 2 // skip 2 characters: ./ or .\
+        } else if (second == '.') {
+            if (startIndex + 2 == path.length) {
+                startIndex += 2 // skip the only 2 characters remaining: ..
+            } else if (path[startIndex + 2].isPathSeparator()) {
+                startIndex += 3 // skip 3 characters: ../ or ..\
+            } else { // we have a path component starting with two dots that shouldn't be discarded
                 break
             }
-        } else {
+        } else { // we have a path component starting with a single dot
             break
         }
     }
+
+    return startIndex
+}
+
+private fun Char.isPathSeparator(): Boolean = this == '\\' || this == '/'
+private fun Char.isPathSeparatorOrDot(): Boolean = this == '.' || isPathSeparator()
+
+private fun File.dropLeadingTopDirs(): File {
+    val startIndex = dropLeadingTopDirs(path ?: "")
 
     if (startIndex == 0) return this
     if (startIndex >= path.length) return File(".")

--- a/ktor-utils/jvm/test/io/ktor/tests/utils/DropLeadingTopDirsTest.kt
+++ b/ktor-utils/jvm/test/io/ktor/tests/utils/DropLeadingTopDirsTest.kt
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2014-2019 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.tests.utils
+
+import io.ktor.util.*
+import kotlin.test.*
+
+class DropLeadingTopDirsTest {
+    @Test
+    fun testEmptyPath() {
+        assertEquals(0, dropLeadingTopDirs(""))
+        assertEquals(0, dropLeadingTopDirs(" "))
+        assertEquals(1, dropLeadingTopDirs("/"))
+        assertEquals(1, dropLeadingTopDirs("\\"))
+    }
+
+    @Test
+    fun testSingleDot() {
+        assertEquals(0, dropLeadingTopDirs("."))
+        assertEquals(2, dropLeadingTopDirs("./"))
+        assertEquals(2, dropLeadingTopDirs(".\\"))
+    }
+
+    @Test
+    fun testSingleTopDir() {
+        assertEquals(2, dropLeadingTopDirs(".."))
+        assertEquals(3, dropLeadingTopDirs("../a"))
+        assertEquals(3, dropLeadingTopDirs("..\\a"))
+    }
+
+    @Test
+    fun testDoubleTopDir() {
+        assertEquals(5, dropLeadingTopDirs("../.."))
+        assertEquals(5, dropLeadingTopDirs("..\\.."))
+        assertEquals(6, dropLeadingTopDirs("../../"))
+        assertEquals(6, dropLeadingTopDirs("..\\..\\"))
+    }
+
+    @Test
+    fun testMultipleDots() {
+        assertEquals(0, dropLeadingTopDirs("."))
+        assertEquals(2, dropLeadingTopDirs(".."))
+        assertEquals(0, dropLeadingTopDirs("..."))
+        assertEquals(0, dropLeadingTopDirs("...."))
+        assertEquals(0, dropLeadingTopDirs("....."))
+    }
+
+    @Test
+    fun testPathElementStartingWithSingleDot() {
+        assertEquals(0, dropLeadingTopDirs(".a"))
+    }
+
+    @Test
+    fun testPathElementStartingWithTwoDots() {
+        assertEquals(0, dropLeadingTopDirs("..a"))
+    }
+}


### PR DESCRIPTION
**Subsystem**
Server

**Motivation**
Currently, dropLeadingTopDir that is used in several path resolution functions may hang at some inputs.

**Solution**
Fix bug, add tests

