### PR TITLE
Fix CIO ActorSelectorManager to not spin due to cancelled keys

### DIFF
--- a/ktor-network/jvm/src/io/ktor/network/selector/ActorSelectorManager.kt
+++ b/ktor-network/jvm/src/io/ktor/network/selector/ActorSelectorManager.kt
@@ -81,6 +81,8 @@ class ActorSelectorManager(dispatcher: CoroutineContext) : SelectorManagerSuppor
                 selector.selectNow()
                 if (pending > 0) {
                     handleSelectedKeys(selector.selectedKeys(), selector.keys())
+                } else {
+                    cancelled = 0
                 }
             } else {
                 val received = mb.receiveOrNull() ?: break


### PR DESCRIPTION
**Subsystem**
ktor-client-cio, ktor-server-cio

**Description**
If there were cancelled keys encountered but no pending keys (other keys) then the selection loop may do spin too many times because only `handleSelectedKeys` clears the cancelled counter. The spinning causes high CPU load when it happens with low activity.

This is important since this is proven to happen in Circlet production from time to time and therefore should be included in 1.3.0.

**Solution**
The solution is to always zero the counter.

