### PR TITLE
Introduce support for json structures and improve diagnostics

### DIFF
--- a/ktor-client/ktor-client-features/ktor-client-json/common/test/CollectionsSerializationTest.kt
+++ b/ktor-client/ktor-client-features/ktor-client-json/common/test/CollectionsSerializationTest.kt
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2014-2019 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.client.features.json
+
+import io.ktor.client.features.json.serializer.*
+import io.ktor.http.*
+import io.ktor.http.content.*
+import kotlinx.serialization.json.*
+import kotlin.test.*
+
+class CollectionsSerializationTest {
+    private val testSerializer = KotlinxSerializer()
+
+    @Test
+    fun testJsonElements() {
+        testSerializer.testWrite(json {
+            "a" to "1"
+            "b" to json {
+                "c" to 3
+            }
+            "x" to JsonNull
+        }).let { result ->
+            assertEquals("""{"a":"1","b":{"c":3},"x":null}""", result)
+        }
+
+        testSerializer.testWrite(json {
+            "a" to "1"
+            "b" to jsonArray {
+                +"c"
+                +JsonPrimitive(2)
+            }
+        }).let { result ->
+            assertEquals("""{"a":"1","b":["c",2]}""", result)
+        }
+    }
+
+    @Test
+    fun testMapsElements() {
+        testSerializer.testWrite(mapOf(
+            "a" to "1",
+            "b" to "2"
+        )).let { result ->
+            assertEquals("""{"a":"1","b":"2"}""", result)
+        }
+
+        testSerializer.testWrite(mapOf(
+            "a" to "1",
+            "b" to null
+        )).let { result ->
+            assertEquals("""{"a":"1","b":null}""", result)
+        }
+
+        testSerializer.testWrite(mapOf(
+            "a" to "1",
+            null to "2"
+        )).let { result ->
+            assertEquals("""{"a":"1",null:"2"}""", result)
+        }
+
+        // this is not yet supported
+        assertFails {
+            testSerializer.testWrite(mapOf(
+                "a" to "1",
+                "b" to 2
+            ))
+        }
+    }
+
+    private fun JsonSerializer.testWrite(data: Any): String =
+        (write(data, ContentType.Application.Json) as? TextContent)?.text ?: error("Failed to get serialized $data")
+}

--- a/ktor-client/ktor-client-features/ktor-client-json/ktor-client-serialization/common/src/io/ktor/client/features/json/serializer/KotlinxSerializer.kt
+++ b/ktor-client/ktor-client-features/ktor-client-json/ktor-client-serialization/common/src/io/ktor/client/features/json/serializer/KotlinxSerializer.kt
@@ -10,6 +10,7 @@ import io.ktor.http.*
 import io.ktor.http.content.*
 import io.ktor.utils.io.core.*
 import kotlinx.serialization.*
+import kotlinx.serialization.internal.*
 import kotlinx.serialization.json.*
 import kotlin.reflect.*
 
@@ -79,6 +80,7 @@ class KotlinxSerializer(
 @Suppress("UNCHECKED_CAST")
 @UseExperimental(ImplicitReflectionSerializer::class)
 private fun buildSerializer(value: Any): KSerializer<*> = when (value) {
+    is JsonElement -> JsonElementSerializer
     is List<*> -> value.elementSerializer().list
     is Array<*> -> value.firstOrNull()?.let { buildSerializer(it) } ?: String.serializer().list
     is Set<*> -> value.elementSerializer().set
@@ -92,5 +94,25 @@ private fun buildSerializer(value: Any): KSerializer<*> = when (value) {
 }
 
 @UseExperimental(ImplicitReflectionSerializer::class)
-private fun Collection<*>.elementSerializer(): KSerializer<*> =
-    firstOrNull()?.let { buildSerializer(it) } ?: String.serializer()
+private fun Collection<*>.elementSerializer(): KSerializer<*> {
+    val serializers = filterNotNull().map { buildSerializer(it) }.distinctBy { it.descriptor.name }
+
+    if (serializers.size > 1) {
+        error("Different serializers selected: ${serializers.map { it.descriptor.name }}")
+    }
+
+    val selected = serializers.singleOrNull() ?: String.serializer()
+
+    if (selected.descriptor.isNullable) {
+        return selected
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    selected as KSerializer<Any>
+
+    if (any { it == null }) {
+        return selected.nullable
+    }
+
+    return selected
+}

--- a/ktor-features/ktor-serialization/jvm/src/io/ktor/serialization/SerializationConverter.kt
+++ b/ktor-features/ktor-serialization/jvm/src/io/ktor/serialization/SerializationConverter.kt
@@ -89,9 +89,6 @@ val DefaultJsonConfiguration: JsonConfiguration = JsonConfiguration.Stable.copy(
 
 @UseExperimental(ImplicitReflectionSerializer::class, ExperimentalStdlibApi::class)
 private fun serializerByTypeInfo(type: KType): KSerializer<*> {
-    if (type.arguments.isEmpty()) {
-        return type.jvmErasure.serializer()
-    }
     val classifierClass = type.classifier as? KClass<*>
     if (classifierClass != null && classifierClass.java.isArray) {
         return arraySerializer(type)
@@ -114,6 +111,9 @@ private fun arraySerializer(type: KType): KSerializer<*> {
 
 @UseExperimental(ImplicitReflectionSerializer::class)
 private fun serializerForSending(value: Any): KSerializer<*> {
+    if (value is JsonElement) {
+        return JsonElementSerializer
+    }
     if (value is List<*>) {
         return ArrayListSerializer(value.elementSerializer())
     }
@@ -143,6 +143,26 @@ private fun serializerForSending(value: Any): KSerializer<*> {
 }
 
 @UseExperimental(ImplicitReflectionSerializer::class)
-private fun Collection<*>.elementSerializer() = firstOrNull { it != null }?.let { first ->
-    serializerByTypeInfo(first.javaClass.kotlin.starProjectedType)
-} ?: String::class.serializer()
+private fun Collection<*>.elementSerializer(): KSerializer<*> {
+    val serializers = mapNotNull { value ->
+        value?.let { serializerForSending(it) }
+    }.distinctBy { it.descriptor.name }
+
+    if (serializers.size > 1) {
+        error("Multiple different serializers selected: ${serializers.map { it.descriptor.name }}")
+    }
+
+    val selected: KSerializer<*> = serializers.singleOrNull() ?: String.serializer()
+    if (selected.descriptor.isNullable) {
+        return selected
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    selected as KSerializer<Any>
+
+    if (any { it == null }) {
+        return selected.nullable
+    }
+
+    return selected
+}

--- a/ktor-features/ktor-serialization/jvm/test/io/ktor/tests/serialization/SerializationTest.kt
+++ b/ktor-features/ktor-serialization/jvm/test/io/ktor/tests/serialization/SerializationTest.kt
@@ -12,7 +12,7 @@ import io.ktor.response.*
 import io.ktor.routing.*
 import io.ktor.serialization.*
 import io.ktor.server.testing.*
-import kotlinx.serialization.Serializable
+import kotlinx.serialization.*
 import kotlinx.serialization.json.*
 import kotlin.test.*
 
@@ -20,7 +20,7 @@ class SerializationTest {
 
     @Test
     @Ignore
-    fun testMap() = withTestApplication {
+    fun testMap(): Unit = withTestApplication {
         val uc = "\u0422"
 
         application.install(ContentNegotiation) {
@@ -242,7 +242,7 @@ class SerializationTest {
     }
 
     @Test
-    fun testEntity() = withTestApplication {
+    fun testEntity(): Unit = withTestApplication {
         val uc = "\u0422"
         application.install(ContentNegotiation) {
             register(ContentType.Application.Json, SerializationConverter())
@@ -360,6 +360,62 @@ class SerializationTest {
         }
     }
 
+    @Test
+    fun testJsonElements(): Unit = withTestApplication {
+        application.install(ContentNegotiation) {
+            serialization()
+        }
+        application.routing {
+            get("/map") {
+                call.respond(json {
+                    "a" to "1"
+                    "b" to json {
+                        "c" to 3
+                    }
+                    "x" to JsonNull
+                })
+            }
+            get("/array") {
+                call.respond(json {
+                    "a" to "1"
+                    "b" to jsonArray {
+                        +"c"
+                        +JsonPrimitive(2)
+                    }
+                })
+            }
+        }
+
+        handleRequest(HttpMethod.Get, "/map").let {
+            assertEquals(HttpStatusCode.OK, it.response.status())
+            assertEquals("""{"a":"1","b":{"c":3},"x":null}""", it.response.content)
+        }
+        handleRequest(HttpMethod.Get, "/array").let {
+            assertEquals(HttpStatusCode.OK, it.response.status())
+            assertEquals("""{"a":"1","b":["c",2]}""", it.response.content)
+        }
+    }
+
+    @Test
+    fun testMapsElements(): Unit = withTestApplication {
+        application.install(ContentNegotiation) {
+            serialization()
+        }
+        application.routing {
+            get("/map") {
+                call.respond(mapOf(
+                    "a" to "1",
+                    null to "2",
+                    "b" to null
+                ))
+            }
+        }
+
+        handleRequest(HttpMethod.Get, "/map").let {
+            assertEquals(HttpStatusCode.OK, it.response.status())
+            assertEquals("""{"a":"1",null:"2","b":null}""", it.response.content)
+        }
+    }
 }
 
 @Serializable


### PR DESCRIPTION
**Subsystem**
client and server

**Motivation**
Currently we do not support `json {}` structures from kotlinx.serialization. See #1519 

**Solution**
- Use `JsonElementSerializer` when applicable
- Improve diagnostics to produce an error when non-uniform collections are serialized

