### PR TITLE
Make default auth validate functions fail to force users to implement them

### DIFF
--- a/ktor-features/ktor-auth-jwt/jvm/src/io/ktor/auth/jwt/JWTAuth.kt
+++ b/ktor-features/ktor-auth-jwt/jvm/src/io/ktor/auth/jwt/JWTAuth.kt
@@ -59,7 +59,11 @@ class JWTAuthenticationProvider internal constructor(config: Configuration) : Au
      * JWT auth provider configuration
      */
     class Configuration internal constructor(name: String?) : AuthenticationProvider.Configuration(name) {
-        internal var authenticationFunction: AuthenticationFunction<JWTCredential> = { null }
+        internal var authenticationFunction: AuthenticationFunction<JWTCredential> = {
+            throw NotImplementedError(
+                "JWT auth validate function is not specified. Use jwt { validate { ... } } to fix."
+            )
+        }
 
         internal var schemes = JWTAuthSchemes("Bearer")
 

--- a/ktor-features/ktor-auth-jwt/jvm/test/io/ktor/auth/jwt/JWTAuthTest.kt
+++ b/ktor-features/ktor-auth-jwt/jvm/test/io/ktor/auth/jwt/JWTAuthTest.kt
@@ -37,6 +37,24 @@ class JWTAuthTest {
     }
 
     @Test
+    fun testJwtNoAuthCustomChallengeNoToken() {
+        withApplication {
+            application.configureServerJwt {
+                challenge { _, _ ->
+                    call.respond(UnauthorizedResponse(HttpAuthHeader.basicAuthChallenge("custom1", Charsets.UTF_8)))
+                }
+            }
+
+            val response = handleRequest {
+                uri = "/"
+            }
+
+            verifyResponseUnauthorized(response)
+            assertEquals("Basic realm=custom1, charset=UTF-8", response.response.headers[HttpHeaders.WWWAuthenticate])
+        }
+    }
+
+    @Test
     fun testJwtSuccess() {
         withApplication {
             application.configureServerJwt()

--- a/ktor-features/ktor-auth/jvm/src/io/ktor/auth/BasicAuth.kt
+++ b/ktor-features/ktor-auth/jvm/src/io/ktor/auth/BasicAuth.kt
@@ -29,7 +29,11 @@ class BasicAuthenticationProvider internal constructor(
      * Basic auth configuration
      */
     class Configuration internal constructor(name: String?) : AuthenticationProvider.Configuration(name) {
-        internal var authenticationFunction: AuthenticationFunction<UserPasswordCredential> = { null }
+        internal var authenticationFunction: AuthenticationFunction<UserPasswordCredential> = {
+            throw NotImplementedError(
+                "Basic auth validate function is not specified. Use basic { validate { ... } } to fix."
+            )
+        }
 
         /**
          * Specifies realm to be passed in `WWW-Authenticate` header

--- a/ktor-features/ktor-auth/jvm/test/io/ktor/tests/auth/BasicAuthTest.kt
+++ b/ktor-features/ktor-auth/jvm/test/io/ktor/tests/auth/BasicAuthTest.kt
@@ -13,7 +13,6 @@ import io.ktor.response.*
 import io.ktor.routing.*
 import io.ktor.server.testing.*
 import io.ktor.util.*
-import org.junit.Test
 import java.nio.charset.*
 import kotlin.test.*
 
@@ -222,6 +221,24 @@ class BasicAuthTest {
                 assertEquals(HttpStatusCode.OK, call.response.status())
                 assertEquals("Secret info", call.response.content)
             }
+        }
+    }
+
+    @Test
+    fun testNonConfiguredAuth(): Unit = withTestApplication {
+        application.install(Authentication) {
+            basic {}
+        }
+
+        application.routing {
+            authenticate {
+                get("/") {
+                }
+            }
+        }
+
+        assertFailsWith<NotImplementedError> {
+            handleRequest(HttpMethod.Get, "/")
         }
     }
 

--- a/ktor-features/ktor-auth/jvm/test/io/ktor/tests/auth/BasicAuthTest.kt
+++ b/ktor-features/ktor-auth/jvm/test/io/ktor/tests/auth/BasicAuthTest.kt
@@ -238,7 +238,7 @@ class BasicAuthTest {
         }
 
         assertFailsWith<NotImplementedError> {
-            handleRequest(HttpMethod.Get, "/")
+            handleRequestWithBasic("/", "u", "a")
         }
     }
 


### PR DESCRIPTION
Make default auth validate functions fail to force users to implement them

**Subsystem**
Server, ktor-auth, ktor-auth-jwt

**Motivation**
Currently we simply always forbid access if the validation function is not specified. We should throw an exception in all auth providers by default to notice users not implementing the function that is always required. Also see #1515 

**Solution**
Simply replace the default function `{ null }` with `{ error(...descriptive message...) }`

