### PR TITLE
Fix CIO headers and chunked parsers

### DIFF
--- a/binary-compatibility-validator/reference-public-api/ktor-http-cio.txt
+++ b/binary-compatibility-validator/reference-public-api/ktor-http-cio.txt
@@ -19,8 +19,10 @@ public final class io/ktor/http/cio/CIOMultipartDataBase : io/ktor/http/content/
 }
 
 public final class io/ktor/http/cio/ChunkedTransferEncodingKt {
+	public static final fun decodeChunked (Lio/ktor/utils/io/ByteReadChannel;Lio/ktor/utils/io/ByteWriteChannel;JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static final fun decodeChunked (Lio/ktor/utils/io/ByteReadChannel;Lio/ktor/utils/io/ByteWriteChannel;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static final fun decodeChunked (Lkotlinx/coroutines/CoroutineScope;Lio/ktor/utils/io/ByteReadChannel;)Lio/ktor/utils/io/WriterJob;
+	public static final fun decodeChunked (Lkotlinx/coroutines/CoroutineScope;Lio/ktor/utils/io/ByteReadChannel;J)Lio/ktor/utils/io/WriterJob;
 	public static final fun encodeChunked (Lio/ktor/utils/io/ByteWriteChannel;Lio/ktor/utils/io/ByteReadChannel;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static final fun encodeChunked (Lio/ktor/utils/io/ByteWriteChannel;Lkotlin/coroutines/CoroutineContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }

--- a/ktor-http/ktor-http-cio/common/src/io/ktor/http/cio/HttpBody.kt
+++ b/ktor-http/ktor-http-cio/common/src/io/ktor/http/cio/HttpBody.kt
@@ -68,6 +68,10 @@ fun expectHttpBody(request: Request): Boolean = expectHttpBody(
 /**
  * Parse HTTP request or response body using [contentLength], [transferEncoding] and [connectionOptions]
  * writing it to [out]. Usually doesn't fail but closing [out] channel with error.
+ *
+ * @param contentLength from the corresponding header or -1
+ * @param transferEncoding header or `null`
+ * @param
  */
 @KtorExperimentalAPI
 suspend fun parseHttpBody(
@@ -79,12 +83,11 @@ suspend fun parseHttpBody(
 ) {
     if (transferEncoding != null) {
         when {
-            transferEncoding.equalsLowerCase(other = "chunked") -> return decodeChunked(input, out)
+            transferEncoding.equalsLowerCase(other = "chunked") -> return decodeChunked(input, out, contentLength)
             transferEncoding.equalsLowerCase(other = "identity") -> {
                 // do nothing special
             }
             else -> out.close(IllegalStateException("Unsupported transfer-encoding $transferEncoding"))
-            // TODO: combined transfer encodings
         }
     }
 

--- a/ktor-http/ktor-http-cio/common/src/io/ktor/http/cio/HttpParser.kt
+++ b/ktor-http/ktor-http-cio/common/src/io/ktor/http/cio/HttpParser.kt
@@ -105,8 +105,10 @@ internal suspend fun parseHeaders(
             }
 
             range.end = builder.length
+            val rangeLength = range.end - range.start
 
-            if (range.start == range.end) break
+            if (rangeLength == 0) break
+            if (rangeLength >= HTTP_LINE_LIMIT) error("Header line length limit exceeded")
 
             val nameStart = range.start
             val nameEnd = parseHeaderName(builder, range)

--- a/ktor-http/ktor-http-cio/jvm/test/io/ktor/tests/http/cio/ChunkedTest.kt
+++ b/ktor-http/ktor-http-cio/jvm/test/io/ktor/tests/http/cio/ChunkedTest.kt
@@ -191,4 +191,8 @@ class ChunkedTest {
 
         assertEquals(first, second)
     }
+
+    private suspend fun decodeChunked(input: ByteReadChannel, out: ByteWriteChannel) {
+        return decodeChunked(input, out, -1L)
+    }
 }

--- a/ktor-http/ktor-http-cio/jvm/test/io/ktor/tests/http/cio/MultipartTest.kt
+++ b/ktor-http/ktor-http-cio/jvm/test/io/ktor/tests/http/cio/MultipartTest.kt
@@ -244,7 +244,7 @@ class MultipartTest {
 
         val ch = ByteReadChannel(body.toByteArray())
         val request = parseRequest(ch)!!
-        val decoded = GlobalScope.decodeChunked(ch)
+        val decoded = GlobalScope.decodeChunked(ch, -1L)
         val mp = GlobalScope.parseMultipart(decoded.channel, request.headers)
 
         val allEvents = ArrayList<MultipartEvent>()


### PR DESCRIPTION
**Subsystem**
ktor-server-cio, ktor-client-cio

**Motivation**
1. If a header is too long, then CIO parser simply cut it into two that is not correct.
2. If both content length and chunked encoding specified, then we discard content length. This is correct according to RFC. However, this may lead to undesired consequences. 
Both may cause potential security issues, especially with a proxy server.

**Solution**
1. Terminate request processing when a header body is too long
2. Terminate request processing AND connection when the specified content length and decoded chunked content length do not match. Note that this violates RFC however it looks like we have no choice. 

