### PR TITLE
Fix NPE when executing a call within a coroutine with no job

### DIFF
--- a/ktor-client/ktor-client-core/common/src/io/ktor/client/engine/Utils.kt
+++ b/ktor-client/ktor-client-core/common/src/io/ktor/client/engine/Utils.kt
@@ -69,7 +69,7 @@ internal class KtorCallContextElement(val callContext: CoroutineContext) : Corou
  */
 @UseExperimental(InternalCoroutinesApi::class)
 internal suspend inline fun attachToUserJob(callJob: Job) {
-    val userJob = coroutineContext[Job]!!
+    val userJob = coroutineContext[Job] ?: return
 
     val cleanupHandler = userJob.invokeOnCompletion(onCancelling = true) { cause ->
         cause ?: return@invokeOnCompletion


### PR DESCRIPTION
**Subsystem**
ktor-client-core

**Motivation**
When running a client call within a coroutine with no job (suspend main fun or manually started), a client crashes with NPE. See #1542 

**Solution**
Simply ignore missing `Job` instance when attaching to a parent job

