### PR TITLE
Netty http2 fixes (part 1)

### DIFF
--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyChannelInitializer.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyChannelInitializer.kt
@@ -15,6 +15,7 @@ import io.netty.handler.codec.http2.*
 import io.netty.handler.ssl.*
 import io.netty.handler.timeout.*
 import io.netty.util.concurrent.*
+import kotlinx.coroutines.*
 import java.nio.channels.*
 import java.security.*
 import java.security.cert.*
@@ -95,6 +96,9 @@ class NettyChannelInitializer(
             ApplicationProtocolNames.HTTP_2 -> {
                 val handler = NettyHttp2Handler(enginePipeline, environment.application, callEventGroup, userContext)
                 pipeline.addLast(Http2MultiplexCodecBuilder.forServer(handler).build())
+                pipeline.channel().closeFuture().addListener {
+                    handler.cancel()
+                }
             }
             ApplicationProtocolNames.HTTP_1_1 -> {
                 val requestQueue = NettyRequestQueue(requestQueueLimit, runningLimit)

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http2/NettyHttp2ApplicationRequest.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http2/NettyHttp2ApplicationRequest.kt
@@ -8,6 +8,7 @@ import io.ktor.application.*
 import io.ktor.http.*
 import io.ktor.request.*
 import io.ktor.server.netty.*
+import io.ktor.utils.io.*
 import io.netty.channel.*
 import io.netty.handler.codec.http.*
 import io.netty.handler.codec.http.HttpMethod
@@ -15,7 +16,6 @@ import io.netty.handler.codec.http.multipart.*
 import io.netty.handler.codec.http2.*
 import kotlinx.coroutines.*
 import kotlinx.coroutines.channels.*
-import io.ktor.utils.io.*
 import java.net.*
 import kotlin.coroutines.*
 
@@ -36,11 +36,13 @@ internal class NettyHttp2ApplicationRequest(
 
     override val headers: Headers by lazy {
         Headers.build {
-            nettyHeaders.forEach {
-                append(
-                    it.key.toString(),
-                    it.value.toString()
-                )
+            nettyHeaders.forEach { (name, value) ->
+                if (name.isNotEmpty() && name[0] != ':') {
+                    append(
+                        name.toString(),
+                        value.toString()
+                    )
+                }
             }
         }
     }

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http2/NettyHttp2Handler.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http2/NettyHttp2Handler.kt
@@ -26,7 +26,7 @@ internal class NettyHttp2Handler(
     private val callEventGroup: EventExecutorGroup,
     private val userCoroutineContext: CoroutineContext
 ) : ChannelInboundHandlerAdapter(), CoroutineScope {
-    private val handlerJob = CompletableDeferred<Nothing>()
+    private val handlerJob = SupervisorJob(userCoroutineContext[Job])
 
     override val coroutineContext: CoroutineContext
         get() = handlerJob
@@ -65,13 +65,7 @@ internal class NettyHttp2Handler(
 
     @Suppress("OverridingDeprecatedMember")
     override fun exceptionCaught(ctx: ChannelHandlerContext, cause: Throwable) {
-        handlerJob.completeExceptionally(cause)
         ctx.close()
-    }
-
-    override fun handlerRemoved(ctx: ChannelHandlerContext?) {
-        super.handlerRemoved(ctx)
-        handlerJob.cancel()
     }
 
     private fun startHttp2(context: ChannelHandlerContext, headers: Http2Headers) {
@@ -100,6 +94,9 @@ internal class NettyHttp2Handler(
         val codec = channel.parent().pipeline().get(Http2MultiplexCodec::class.java)!!
         val connection = codec.connection()
 
+        if (!connection.remote().allowPushTo()) {
+            return
+        }
 
         val rootContext = channel.parent().pipeline().lastContext()
 


### PR DESCRIPTION
**Subsystem**
ktor-server-netty

**Motivation**
Netty's HTTP/2 implementation is still broken.

**Solution**
Several fixes were applied.

**Known Problems**
Push promises still get rejected sometimes for some reason - to be fixed in later releases.

