### PR TITLE
Prevent infinite request-response loop for client authentication (#1051)

### DIFF
--- a/ktor-client/ktor-client-features/ktor-client-auth/build.gradle.kts
+++ b/ktor-client/ktor-client-features/ktor-client-auth/build.gradle.kts
@@ -11,4 +11,12 @@ kotlin.sourceSets {
             api(project(":ktor-client:ktor-client-tests"))
         }
     }
+    jvmTest {
+        dependencies {
+            runtimeOnly(project(":ktor-client:ktor-client-apache"))
+            runtimeOnly(project(":ktor-client:ktor-client-cio"))
+            runtimeOnly(project(":ktor-client:ktor-client-android"))
+            runtimeOnly(project(":ktor-client:ktor-client-okhttp"))
+        }
+    }
 }

--- a/ktor-client/ktor-client-features/ktor-client-auth/common/src/io/ktor/client/features/auth/Auth.kt
+++ b/ktor-client/ktor-client-features/ktor-client-auth/common/src/io/ktor/client/features/auth/Auth.kt
@@ -35,7 +35,7 @@ class Auth(
                 }
             }
 
-            val circuitBreaker = AttributeKey<Int>("auth-request")
+            val circuitBreaker = AttributeKey<Unit>("auth-request")
             scope.feature(HttpSend)!!.intercept { origin, context ->
                 if (origin.response.status != HttpStatusCode.Unauthorized) return@intercept origin
                 if (origin.request.attributes.contains(circuitBreaker)) return@intercept origin
@@ -51,7 +51,7 @@ class Auth(
                     val request = HttpRequestBuilder()
                     request.takeFrom(context)
                     provider.addRequestHeaders(request)
-                    request.attributes.put(circuitBreaker, 0)
+                    request.attributes.put(circuitBreaker, Unit)
 
                     call = execute(request)
                 }

--- a/ktor-client/ktor-client-features/ktor-client-auth/common/test/io/ktor/client/features/auth/AuthTest.kt
+++ b/ktor-client/ktor-client-features/ktor-client-auth/common/test/io/ktor/client/features/auth/AuthTest.kt
@@ -63,4 +63,23 @@ class AuthTest : ClientLoader() {
             client.get<String>("$TEST_SERVER/auth/basic-fixed")
         }
     }
+
+    @Test
+    fun testUnauthorizedBasicAuth() = clientTests(listOf("Js")) {
+        config {
+            install(Auth) {
+                basic {
+                    username = "usr"
+                    password = "pw"
+                }
+            }
+        }
+
+        test { client ->
+            client.get<HttpStatement>("$TEST_SERVER/auth/unauthorized").execute { response ->
+                assertEquals(HttpStatusCode.Unauthorized, response.status)
+            }
+        }
+    }
+
 }

--- a/ktor-client/ktor-client-tests/jvm/src/io/ktor/client/tests/utils/tests/Auth.kt
+++ b/ktor-client/ktor-client-tests/jvm/src/io/ktor/client/tests/utils/tests/Auth.kt
@@ -78,6 +78,12 @@ internal fun Application.authTestServer() {
                     call.respondText("ok")
                 }
             }
+
+            get("unauthorized") {
+                // simulate a server which responds with 401 and another auth request on bad credentials
+                call.response.status(HttpStatusCode.Unauthorized)
+                call.response.header(HttpHeaders.WWWAuthenticate, "Basic realm=\"TestServer\", charset=UTF-8")
+            }
         }
     }
 }


### PR DESCRIPTION
**Subsystem**
ktor-client:ktor-client-features:ktor-client-auth

**Motivation**
Solves Issue #1051 

**Solution**
The while loop on the returned status code (Unauthorized) was not the only problem for the potential infinite request-response loop: The interceptor is triggering itself infinitely. Solution was to introduce a circuit breaker in the form of an attribute on the HTTP request. My hypothesis here was that these attributes are kind of a meta-data on the client side only and are not sent to the server as a payload. If this is not correct, please let me know.

The first commit enables JVM tests for the unit tests already present (they did not run before). Also, I added a test which provokes the SendCountExceedException as described in the issue. The second commit is the actual fix. The added test and all other tests are successful on my machine with this fix.

