### PR TITLE
Fix OkHttp leaking threads.

### DIFF
--- a/ktor-client/ktor-client-tests/common/src/io/ktor/client/tests/utils/CommonClientTestUtils.kt
+++ b/ktor-client/ktor-client-tests/common/src/io/ktor/client/tests/utils/CommonClientTestUtils.kt
@@ -40,6 +40,8 @@ private fun testWithClient(
         client.config { builder.config(this as HttpClientConfig<HttpClientEngineConfig>) }
             .use { client -> builder.test(client) }
     }
+
+    client.engine.close()
 }
 
 /**

--- a/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/CommonHttpClientTest.kt
+++ b/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/CommonHttpClientTest.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2014-2020 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.client.tests
+
+import io.ktor.client.*
+import io.ktor.client.engine.mock.*
+import kotlinx.coroutines.*
+import kotlin.test.*
+
+class CommonHttpClientTest {
+    @Test
+    fun testHttpClientWithCustomEngineLifecycle() {
+        val engine = MockEngine { respondOk() }
+        val client = HttpClient(engine)
+        client.close()
+
+        // When the engine is provided by a user it should not be closed together with the client.
+        assertTrue { engine.isActive }
+    }
+
+    @Test
+    fun testHttpClientWithFactoryEngineLifecycle() {
+        val client = HttpClient(MockEngine) {
+            engine {
+                addHandler { respondOk() }
+            }
+        }
+        val engine = client.engine
+        client.close()
+
+        // When the engine is provided by Ktor factory is should be closed together with the client.
+        assertFalse { engine.isActive }
+    }
+}


### PR DESCRIPTION
**Subsystem**
`HttpClient`, `OkHttp` client infrastructure.

**Motivation**
The problem mentioned in https://github.com/ktorio/ktor/issues/1340.

**Solution**
The problem could be fixed by using a shared `OkHttp` client (aka prototype). Such an approach leads to the inability to clear resources fully closing all internal objects of the prototype. To allow it there is also separated `HttpClient` and `HttpClientEngine` closing.

