### PR TITLE
Stop application engine servers if ports could not be bound (#336)

### DIFF
--- a/ktor-server/ktor-server-jetty/jvm/src/io/ktor/server/jetty/JettyApplicationEngineBase.kt
+++ b/ktor-server/ktor-server-jetty/jvm/src/io/ktor/server/jetty/JettyApplicationEngineBase.kt
@@ -47,8 +47,12 @@ open class JettyApplicationEngineBase(
 
     override fun start(wait: Boolean): JettyApplicationEngineBase {
         environment.start()
-
-        server.start()
+        try {
+            server.start()
+        } catch (e: Exception) {
+            stop(1, 5, TimeUnit.SECONDS)
+            throw e
+        }
         cancellationDeferred = stopServerOnCancellation()
         if (wait) {
             server.join()

--- a/ktor-server/ktor-server-tomcat/jvm/src/io/ktor/server/tomcat/TomcatApplicationEngine.kt
+++ b/ktor-server/ktor-server-tomcat/jvm/src/io/ktor/server/tomcat/TomcatApplicationEngine.kt
@@ -17,6 +17,7 @@ import org.apache.tomcat.util.net.*
 import org.apache.tomcat.util.net.jsse.*
 import org.apache.tomcat.util.net.openssl.*
 import org.slf4j.*
+import java.net.*
 import java.nio.file.*
 import java.util.concurrent.*
 import javax.servlet.*
@@ -114,6 +115,12 @@ class TomcatApplicationEngine(environment: ApplicationEngineEnvironment, configu
     override fun start(wait: Boolean): TomcatApplicationEngine {
         environment.start()
         server.start()
+        server.service.findConnectors().forEach {
+            if (it.localPort == -1) {
+                stop(1, 5, TimeUnit.SECONDS)
+                throw BindException("Tomcat socket could not be bound to port ${it.port}.")
+            }
+        }
         cancellationDeferred = stopServerOnCancellation()
         if (wait) {
             server.server.await()


### PR DESCRIPTION
**Subsystem**
ktor-server-netty
ktor-server-jetty
ktor-server-tomcat

**Motivation**
Solves #336

**Solution**
If an exception is raised while binding engine sockets to ports, the server is stopped.
A similar behavior as described in the issue occurred for Jetty and Tomcat, hence analogous changes are applied there.