### PR TITLE
Fix UTF#decodeUTF8Line() wrong behavior in case ByteBuffer has an offset.

### DIFF
--- a/ktor-io/jvm/src/io/ktor/utils/io/charsets/UTF.kt
+++ b/ktor-io/jvm/src/io/ktor/utils/io/charsets/UTF.kt
@@ -154,7 +154,7 @@ private fun ByteBuffer.decodeUTF8_array(out: CharArray, offset: Int, length: Int
                 // 2 bytes, always valid
 
                 if (srcPos >= srcEnd) {
-                    position(srcPos - 1)
+                    position(srcPos - 1 - arrayOffset())
                     return decodeUtf8Result(outPos - offset, 2)
                 }
 
@@ -164,7 +164,7 @@ private fun ByteBuffer.decodeUTF8_array(out: CharArray, offset: Int, length: Int
             vi and 0xf0 == 0xe0 -> {
                 // 3 bytes
                 if (srcEnd - srcPos < 2) {
-                    position(srcPos - 1)
+                    position(srcPos - 1 - arrayOffset())
                     return decodeUtf8Result(outPos - offset, 3)
                 }
 
@@ -184,7 +184,7 @@ private fun ByteBuffer.decodeUTF8_array(out: CharArray, offset: Int, length: Int
                 // 4 bytes
 
                 if (srcEnd - srcPos < 3) {
-                    position(srcPos - 1)
+                    position(srcPos - 1 - arrayOffset())
                     return decodeUtf8Result(outPos - offset, 4)
                 }
 
@@ -204,7 +204,7 @@ private fun ByteBuffer.decodeUTF8_array(out: CharArray, offset: Int, length: Int
                     out[outPos++] = high.toChar()
                     out[outPos++] = low.toChar()
                 } else {
-                    position(srcPos - 4)
+                    position(srcPos - 4 - arrayOffset())
                     return decodeUtf8Result(outPos - offset, 0)
                 }
             }
@@ -212,7 +212,7 @@ private fun ByteBuffer.decodeUTF8_array(out: CharArray, offset: Int, length: Int
         }
     }
 
-    position(srcPos)
+    position(srcPos - arrayOffset() + 1)
 
     return decodeUtf8Result(outPos - offset, 0)
 }
@@ -332,7 +332,7 @@ private inline fun ByteBuffer.decodeUTF8_array(
             v >= 0 -> {
                 val ch = v.toChar()
                 if (!predicate(ch)) {
-                    position(srcPos - 1)
+                    position(srcPos - 1 - arrayOffset())
                     return decodeUtf8Result(outPos - offset, -1)
                 }
                 out[outPos++] = ch
@@ -341,7 +341,7 @@ private inline fun ByteBuffer.decodeUTF8_array(
                 // 2 bytes, always valid
 
                 if (srcPos >= srcEnd) {
-                    position(srcPos - 1)
+                    position(srcPos - 1 - arrayOffset())
                     return decodeUtf8Result(outPos - offset, 2)
                 }
 
@@ -349,7 +349,7 @@ private inline fun ByteBuffer.decodeUTF8_array(
                 val ch = ((vi and 0x1f shl 6) or (second and 0x3f)).toChar()
 
                 if (!predicate(ch)) {
-                    position(srcPos - 2)
+                    position(srcPos - 2 - arrayOffset())
                     return decodeUtf8Result(outPos - offset, -1)
                 }
 
@@ -358,7 +358,7 @@ private inline fun ByteBuffer.decodeUTF8_array(
             vi and 0xf0 == 0xe0 -> {
                 // 3 bytes
                 if (srcEnd - srcPos < 2) {
-                    position(srcPos - 1)
+                    position(srcPos - 1 - arrayOffset())
                     return decodeUtf8Result(outPos - offset, 3)
                 }
 
@@ -372,7 +372,7 @@ private inline fun ByteBuffer.decodeUTF8_array(
                     val ch = vv.toChar()
 
                     if (!predicate(ch)) {
-                        position(srcPos - 4)
+                        position(srcPos - 4 - arrayOffset())
                         return decodeUtf8Result(outPos - offset, -1)
                     }
 
@@ -385,7 +385,7 @@ private inline fun ByteBuffer.decodeUTF8_array(
                 // 4 bytes
 
                 if (srcEnd - srcPos < 3) {
-                    position(srcPos - 1)
+                    position(srcPos - 1 - arrayOffset())
                     return decodeUtf8Result(outPos - offset, 4)
                 }
 
@@ -403,14 +403,14 @@ private inline fun ByteBuffer.decodeUTF8_array(
                     val low = lowSurrogate(vv).toChar()
 
                     if (!predicate(high) || !predicate(low)) {
-                        position(srcPos - 4)
+                        position(srcPos - 4 - arrayOffset())
                         return decodeUtf8Result(outPos - offset, -1)
                     }
 
                     out[outPos++] = high
                     out[outPos++] = low
                 } else {
-                    position(srcPos - 4)
+                    position(srcPos - 4 - arrayOffset())
                     return decodeUtf8Result(outPos - offset, 0)
                 }
             }
@@ -418,7 +418,7 @@ private inline fun ByteBuffer.decodeUTF8_array(
         }
     }
 
-    position(srcPos)
+    position(srcPos - arrayOffset() + 1)
 
     return decodeUtf8Result(outPos - offset, 0)
 }

--- a/ktor-io/jvm/test/io/ktor/utils/io/charsets/UTFTest.kt
+++ b/ktor-io/jvm/test/io/ktor/utils/io/charsets/UTFTest.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2014-2020 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.utils.io.charsets
+
+import org.junit.Test
+import java.nio.*
+import kotlin.test.*
+
+class UTFTest {
+    @Test
+    fun testDecodeUTF8LineOnBufferWithOffset() {
+        val buffer = "HELLO\nWORLD\r\n1\r\n2\n".allocateBufferWithOffset(4)
+        println("Has array: ${buffer.hasArray()}")
+
+        buffer.assertEqualsDecodedUTF8Line("HELLO", 6)
+        buffer.assertEqualsDecodedUTF8Line("WORLD", 13)
+        buffer.assertEqualsDecodedUTF8Line("1", 16)
+        buffer.assertEqualsDecodedUTF8Line("2", 18)
+    }
+
+    private fun ByteBuffer.assertEqualsDecodedUTF8Line(expectedResult: String, expectedPosition: Int) {
+        val out = CharArray(expectedResult.length + 64)
+        decodeUTF8Line(out)
+
+        assertEquals(expectedResult, String(out).substring(0, expectedResult.length))
+        assertEquals(expectedPosition, position())
+    }
+
+    private fun String.allocateBufferWithOffset(offset: Int): ByteBuffer {
+        val buffer: ByteBuffer = ByteBuffer.allocate(offset + length)
+        repeat(offset) { buffer.put(0) }
+
+        val result = buffer.slice()
+        toByteArray().forEach { buffer.put(it) }
+
+        return result
+    }
+}


### PR DESCRIPTION
**Subsystem**
`ktor-io`

**Motivation**
The problem was mentioned in #1323. In case when `ByteBuffer` has an offset (particularly on Android when we call `ByteBuffer.allocateDirect(SIZE)`) function `decodeUTF8Line()` works incorrectly.

**Solution**
Fix position movements in `decodeUTF8Line()` function.

