### PR TITLE
Fix onClosing() web socket handler in OKHttp client (#1262).

### DIFF
--- a/ktor-client/ktor-client-okhttp/jvm/src/io/ktor/client/engine/okhttp/OkHttpWebsocketSession.kt
+++ b/ktor-client/ktor-client-okhttp/jvm/src/io/ktor/client/engine/okhttp/OkHttpWebsocketSession.kt
@@ -97,7 +97,9 @@ internal class OkHttpWebsocketSession(
         super.onClosing(webSocket, code, reason)
 
         _closeReason.complete(CloseReason(code.toShort(), reason))
-        outgoing.sendBlocking(Frame.Close(CloseReason(code.toShort(), reason)))
+        if (!outgoing.isClosedForSend) {
+            outgoing.sendBlocking(Frame.Close(CloseReason(code.toShort(), reason)))
+        }
         _incoming.close()
     }
 

--- a/ktor-client/ktor-client-okhttp/jvm/src/io/ktor/client/engine/okhttp/OkHttpWebsocketSession.kt
+++ b/ktor-client/ktor-client-okhttp/jvm/src/io/ktor/client/engine/okhttp/OkHttpWebsocketSession.kt
@@ -93,6 +93,14 @@ internal class OkHttpWebsocketSession(
             "${CloseReason.Codes.byCode(code.toShort())?.toString() ?: code}."))
     }
 
+    override fun onClosing(webSocket: WebSocket, code: Int, reason: String) {
+        super.onClosing(webSocket, code, reason)
+
+        _closeReason.complete(CloseReason(code.toShort(), reason))
+        outgoing.sendBlocking(Frame.Close(CloseReason(code.toShort(), reason)))
+        _incoming.close()
+    }
+
     override fun onFailure(webSocket: WebSocket, t: Throwable, response: Response?) {
         super.onFailure(webSocket, t, response)
 

--- a/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/WebSocketTest.kt
+++ b/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/WebSocketTest.kt
@@ -36,7 +36,7 @@ class WebSocketTest : ClientLoader() {
         }
 
         test { client ->
-            withTimeout(1000) {
+            withTimeout(2000) {
                 client.webSocket("$TEST_WEBSOCKET_SERVER/websockets/close") {
                     send(Frame.Text("End"))
                     val closeReason = closeReason.await()!!

--- a/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/WebSocketTest.kt
+++ b/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/WebSocketTest.kt
@@ -7,6 +7,7 @@ package io.ktor.client.tests
 import io.ktor.client.features.websocket.*
 import io.ktor.client.tests.utils.*
 import io.ktor.http.cio.websocket.*
+import kotlinx.coroutines.*
 import kotlin.test.*
 
 class WebSocketTest : ClientLoader() {
@@ -24,6 +25,24 @@ class WebSocketTest : ClientLoader() {
                 val actual = incoming.receive()
                 assertTrue(actual is Frame.Text)
                 assertEquals("Hello, world", actual.readText())
+            }
+        }
+    }
+
+    @Test
+    fun testClose() = clientTests(listOf("Apache", "Android")) {
+        config {
+            install(WebSockets)
+        }
+
+        test { client ->
+            withTimeout(1000) {
+                client.webSocket("$TEST_WEBSOCKET_SERVER/websockets/close") {
+                    send(Frame.Text("End"))
+                    val closeReason = closeReason.await()!!
+                    assertEquals("End", closeReason.message)
+                    assertEquals(1000, closeReason.code)
+                }
             }
         }
     }

--- a/ktor-client/ktor-client-tests/jvm/src/io/ktor/client/tests/utils/tests/WebSockets.kt
+++ b/ktor-client/ktor-client-tests/jvm/src/io/ktor/client/tests/utils/tests/WebSockets.kt
@@ -14,6 +14,15 @@ fun Application.webSockets() {
                     send(Frame.Text(fin = true, data = data))
                 }
             }
+
+            webSocket("close") {
+                for (packet in incoming) {
+                    val data = packet.data
+                    if (String(data) == "End") {
+                        close(CloseReason(1000, "End"))
+                    }
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
**Subsystem**
OkHttp client.

**Motivation**
The initial problem is mentioned in https://github.com/ktorio/ktor/issues/1262.

**Solution**
Add `onClosing()` handler to `OkHttpWebsocketSession.kt`.

