### PR TITLE
Fix behavior of Netty WebSocket closing, server initiates closing in accordance with RFC

### DIFF
--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http1/NettyHttp1ApplicationResponse.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http1/NettyHttp1ApplicationResponse.kt
@@ -99,6 +99,8 @@ internal class NettyHttp1ApplicationResponse(call: NettyApplicationCall,
         }
 
         (call as NettyApplicationCall).responseWriteJob.join()
+
+        context.channel().close()
     }
 
     private fun setChunked(message: HttpResponse) {


### PR DESCRIPTION
**Subsystem**
Server, Netty, WebSockets

**Motivation**
#1427, https://tools.ietf.org/html/rfc6455#section-5.5.1

According to RFC WebSockets TCP connection closing should be initialized from a server.

