### PR TITLE
Cy/jetty websocket close

### DIFF
--- a/ktor-http/ktor-http-cio/jvm/src/io/ktor/http/cio/websocket/PingPong.kt
+++ b/ktor-http/ktor-http-cio/jvm/src/io/ktor/http/cio/websocket/PingPong.kt
@@ -64,7 +64,7 @@ fun CoroutineScope.pinger(
         try {
             while (!isClosedForReceive) {
                 // drop pongs during period delay as they are irrelevant
-                // here timeout is expected so ignore it
+                // here we expect a timeout, so ignore it
                 withTimeoutOrNull(periodMillis) {
                     while (true) {
                         receive() // timeout causes loop to break on receive
@@ -86,7 +86,7 @@ fun CoroutineScope.pinger(
 
                 if (rc == null) {
                     // timeout
-                    // we were unable to send ping or hadn't get valid pong message in time
+                    // we were unable to send the ping or hadn't got a valid pong message in time,
                     // so we are triggering close sequence (if already started then the following close frame could be ignored)
 
                     val closeFrame = Frame.Close(CloseReason(CloseReason.Codes.INTERNAL_ERROR, "Ping timeout"))
@@ -116,12 +116,15 @@ private suspend fun SendChannel<Frame.Ping>.sendPing(
 ) = with(buffer) {
     clear()
     encoder.reset()
-
-    encoder.encode(CharBuffer.wrap(content), this, true).apply {
-        if (this.isError) throwException()
-        else if (this.isOverflow) throwException()
-    }
+    encoder.encodeOrFail(this, content)
     flip()
 
     send(Frame.Ping(this))
+}
+
+private fun CharsetEncoder.encodeOrFail(buffer: ByteBuffer, content: String) {
+    encode(CharBuffer.wrap(content), buffer, true).apply {
+        if (isError) throwException()
+        else if (isOverflow) throwException()
+    }
 }

--- a/ktor-server/ktor-server-jetty/jvm/src/io/ktor/server/jetty/internal/EndPointChannels.kt
+++ b/ktor-server/ktor-server-jetty/jvm/src/io/ktor/server/jetty/internal/EndPointChannels.kt
@@ -62,8 +62,6 @@ internal class EndPointReader(
         }
     }
 
-    override fun onIdleExpired() = false
-
     override fun onFillable() {
         val handler = currentHandler.getAndSet(null) ?: return
         buffer.flip()


### PR DESCRIPTION
**Subsystem**
ktor-server-jetty, ktor-websockets (server)

**Motivation**
Currently, Jetty may close a connection before writing close frame so a peer may accidentally get unexpected EOF error.

The other issue is that Jetty sometimes produce CloseChannelException error that should be silently handled. 

In ktor-websockets, it is a typical pattern to do close + flush that may accidentally fail because a close frame causes the outgoing queue closure so the following flush request may fail and unable to wait for.

**Solution**
See commits with messages.

