### PR TITLE
Cy/server default exceptions

### DIFF
--- a/ktor-server/ktor-server-core/jvm/src/io/ktor/features/ContentNegotiation.kt
+++ b/ktor-server/ktor-server-core/jvm/src/io/ktor/features/ContentNegotiation.kt
@@ -113,8 +113,16 @@ class ContentNegotiation(val registrations: List<ConverterRegistration>,
             pipeline.sendPipeline.intercept(ApplicationSendPipeline.Render) { subject ->
                 if (subject is OutgoingContent) return@intercept
 
-                val acceptHeader = parseHeaderValue(call.request.header(HttpHeaders.Accept))
-                    .map { ContentTypeWithQuality(ContentType.parse(it.value), it.quality) }
+                val acceptHeaderContent = call.request.header(HttpHeaders.Accept)
+                val acceptHeader = try {
+                    parseHeaderValue(acceptHeaderContent)
+                        .map { ContentTypeWithQuality(ContentType.parse(it.value), it.quality) }
+                } catch (parseFailure: BadContentTypeFormatException) {
+                    throw BadRequestException(
+                        "Illegal Accept header format: $acceptHeaderContent",
+                        parseFailure
+                    )
+                }
 
                 val acceptItems = feature.acceptContributors.fold(acceptHeader) { acc, e ->
                     e(call, acc)
@@ -146,7 +154,14 @@ class ContentNegotiation(val registrations: List<ConverterRegistration>,
                 // skip if a byte channel has been requested so there is nothing to negotiate
                 if (subject.type == ByteReadChannel::class) return@intercept
 
-                val requestContentType = call.request.contentType().withoutParameters()
+                val requestContentType = try {
+                    call.request.contentType().withoutParameters()
+                } catch (parseFailure: BadContentTypeFormatException) {
+                    throw BadRequestException(
+                        "Illegal Content-Type header format: ${call.request.headers[HttpHeaders.ContentType]}",
+                        parseFailure
+                    )
+                }
                 val suitableConverter =
                     feature.registrations.firstOrNull { converter -> requestContentType.match(converter.contentType) }
                         ?: throw UnsupportedMediaTypeException(requestContentType)

--- a/ktor-server/ktor-server-core/jvm/src/io/ktor/response/ApplicationResponseFunctions.kt
+++ b/ktor-server/ktor-server-core/jvm/src/io/ktor/response/ApplicationResponseFunctions.kt
@@ -133,7 +133,13 @@ fun ApplicationCall.defaultTextContentType(contentType: ContentType?): ContentTy
     val result = when (contentType) {
         null -> {
             val headersContentType = response.headers[HttpHeaders.ContentType]
-            headersContentType?.let { ContentType.parse(headersContentType) } ?: ContentType.Text.Plain
+            headersContentType?.let {
+                try {
+                    ContentType.parse(headersContentType)
+                } catch (_: BadContentTypeFormatException) {
+                    null
+                }
+            } ?: ContentType.Text.Plain
         }
         else -> contentType
     }

--- a/ktor-server/ktor-server-host-common/jvm/src/io/ktor/server/engine/DefaultEnginePipeline.kt
+++ b/ktor-server/ktor-server-host-common/jvm/src/io/ktor/server/engine/DefaultEnginePipeline.kt
@@ -21,7 +21,7 @@ import java.util.concurrent.*
  * Default engine pipeline for all engines. Use it only if you are writing your own application engine implementation.
  */
 @EngineAPI
-fun  defaultEnginePipeline(environment: ApplicationEnvironment): EnginePipeline {
+fun defaultEnginePipeline(environment: ApplicationEnvironment): EnginePipeline {
     val pipeline = EnginePipeline()
 
     environment.config.propertyOrNull("ktor.deployment.shutdown.url")?.getString()?.let { url ->
@@ -101,6 +101,9 @@ private fun ApplicationEnvironment.logFailure(call: ApplicationCall, cause: Thro
             is CancellationException -> log.info("$status: $logString, cancelled")
             is ClosedChannelException -> log.info("$status: $logString, channel closed")
             is ChannelIOException -> log.info("$status: $logString, channel failed")
+            is BadRequestException -> log.debug("$status: $logString", cause)
+            is NotFoundException -> log.debug("$status: $logString", cause)
+            is UnsupportedMediaTypeException -> log.debug("$status: $logString, cause)")
             else -> log.error("$status: $logString", cause)
         }
     } catch (oom: OutOfMemoryError) {

--- a/ktor-server/ktor-server-host-common/jvm/src/io/ktor/server/engine/DefaultTransform.kt
+++ b/ktor-server/ktor-server-host-common/jvm/src/io/ktor/server/engine/DefaultTransform.kt
@@ -5,6 +5,7 @@
 package io.ktor.server.engine
 
 import io.ktor.application.*
+import io.ktor.features.*
 import io.ktor.http.*
 import io.ktor.http.cio.*
 import io.ktor.http.content.*
@@ -47,9 +48,12 @@ fun ApplicationReceivePipeline.installDefaultTransformations() {
             ByteArray::class -> channel.toByteArray()
             InputStream::class -> channel.toInputStream()
             MultiPartData::class -> multiPartData(channel)
-            String::class -> channel.readText(charset = call.request.contentCharset() ?: Charsets.ISO_8859_1)
+            String::class -> channel.readText(
+                charset = withContentType(call) { call.request.contentCharset() }
+                    ?: Charsets.ISO_8859_1
+            )
             Parameters::class -> {
-                val contentType = call.request.contentType()
+                val contentType = withContentType(call) { call.request.contentType() }
                 when {
                     contentType.match(ContentType.Application.FormUrlEncoded) -> {
                         val string = channel.readText(charset = call.request.contentCharset() ?: Charsets.ISO_8859_1)
@@ -76,6 +80,15 @@ fun ApplicationReceivePipeline.installDefaultTransformations() {
         if (transformed != null)
             proceedWith(ApplicationReceiveRequest(query.typeInfo, transformed, query.type in ReusableTypes))
     }
+}
+
+private inline fun <R> withContentType(call: ApplicationCall, block: () -> R): R = try {
+    block()
+} catch (parseFailure: BadContentTypeFormatException) {
+    throw BadRequestException(
+        "Illegal Content-Type header format: ${call.request.headers[HttpHeaders.ContentType]}",
+        parseFailure
+    )
 }
 
 private fun PipelineContext<*, ApplicationCall>.multiPartData(rc: ByteReadChannel): MultiPartData {

--- a/ktor-server/ktor-server-tests/jvm/test/io/ktor/tests/server/http/ApplicationRequestContentTest.kt
+++ b/ktor-server/ktor-server-tests/jvm/test/io/ktor/tests/server/http/ApplicationRequestContentTest.kt
@@ -29,6 +29,24 @@ class ApplicationRequestContentTest {
     }
 
     @Test
+    fun testSimpleStringContentWithBadContentType() {
+        withTestApplication {
+            application.intercept(ApplicationCallPipeline.Call) {
+                assertFailsWith<BadRequestException> {
+                    call.receiveText()
+                }.let { throw it }
+            }
+
+            handleRequest(HttpMethod.Get, "") {
+                addHeader(HttpHeaders.ContentType, "...la..la..la")
+                setBody("any")
+            }.let { call ->
+                assertEquals(HttpStatusCode.BadRequest, call.response.status())
+            }
+        }
+    }
+
+    @Test
     fun testStringValues() {
         withTestApplication {
             val values = parametersOf("a", "1")
@@ -42,6 +60,24 @@ class ApplicationRequestContentTest {
                 addHeader(HttpHeaders.ContentType, "application/x-www-form-urlencoded")
                 val value = values.formUrlEncode()
                 setBody(value)
+            }
+        }
+    }
+
+    @Test
+    fun testIllegalContentType() {
+        withTestApplication {
+            application.intercept(ApplicationCallPipeline.Call) {
+                assertFailsWith<BadRequestException> {
+                    call.receiveParameters()
+                }.let { throw it }
+            }
+
+            handleRequest(HttpMethod.Post, "") {
+                addHeader(HttpHeaders.ContentType, "...la..la..la")
+                setBody("don't care")
+            }.let { call ->
+                assertEquals(HttpStatusCode.BadRequest, call.response.status())
             }
         }
     }

--- a/ktor-server/ktor-server-tests/jvm/test/io/ktor/tests/server/routing/RoutingProcessingTest.kt
+++ b/ktor-server/ktor-server-tests/jvm/test/io/ktor/tests/server/routing/RoutingProcessingTest.kt
@@ -349,6 +349,12 @@ class RoutingProcessingTest {
         }.let { call ->
             assertFalse { call.requestHandled }
         }
+
+        handleRequest(HttpMethod.Get, "/") {
+            addHeader(HttpHeaders.Accept, "...lla..laa..la")
+        }.let { call ->
+            assertEquals(HttpStatusCode.BadRequest, call.response.status())
+        }
     }
 
     @Test


### PR DESCRIPTION
**Subsystem**
ktor-server-core

**Motivation**
When an http request contains an illegal Content-Type or Accept header value, ktor is producing a `BadContentTypeFormatException` that is reported as 500 and logged as regular exceptions. So log may contain a lot of such errors that is too noisy.

**Solution**
The better behaviour is to produce Bad Request (400) response and log error with debug level. This is much more convenient.
