### PR TITLE
Fix server's outgoing content channel cancellation on any failure

### DIFF
--- a/ktor-server/ktor-server-host-common/jvm/src/io/ktor/server/engine/BaseApplicationResponse.kt
+++ b/ktor-server/ktor-server-host-common/jvm/src/io/ktor/server/engine/BaseApplicationResponse.kt
@@ -118,13 +118,17 @@ abstract class BaseApplicationResponse(override val call: ApplicationCall) : App
                 return respondWriteChannelContent(content)
             }
 
-            // Pipe is least efficient
+            // Pipe is the least efficient
             is OutgoingContent.ReadChannelContent -> {
                 // First call user code to acquire read channel, because it could fail
                 val readChannel = content.readFrom()
-                // If channel is fine, commit headers and pipe data
-                commitHeaders(content)
-                return respondFromChannel(readChannel)
+                try {
+                    // If channel is fine, commit headers and pipe data
+                    commitHeaders(content)
+                    return respondFromChannel(readChannel)
+                } finally {
+                    readChannel.cancel()
+                }
             }
 
             // Do nothing, but maintain `when` exhaustiveness

--- a/ktor-server/ktor-server-servlet/jvm/src/io/ktor/server/servlet/KtorServlet.kt
+++ b/ktor-server/ktor-server-servlet/jvm/src/io/ktor/server/servlet/KtorServlet.kt
@@ -13,6 +13,7 @@ import kotlinx.coroutines.*
 import org.slf4j.*
 import org.slf4j.event.*
 import java.util.concurrent.*
+import java.util.concurrent.CancellationException
 import javax.servlet.*
 import javax.servlet.http.*
 import kotlin.coroutines.*
@@ -81,6 +82,8 @@ abstract class KtorServlet : HttpServlet(), CoroutineScope {
             }
         } catch (ioError: ChannelIOException) {
             application.log.debug("I/O error", ioError)
+        } catch (cancelled: CancellationException) {
+            application.log.debug("Request cancelled", cancelled)
         } catch (ex: Throwable) {
             application.log.error("ServletApplicationEngine cannot service the request", ex)
             response.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR, ex.message)


### PR DESCRIPTION
**Subsystem**
ktor-server-host-common

**Motivation**
As described in #1589, when a response transferring is cancelled, we don't cancel content's channel so the file reading coroutine is not cancelled and get stuck. This leads to a file descriptor leakage.

**Solution**
Always cancel channel at the end of a content processing.

**Priority**
This is critical and the fix should be introduced in 1.3.1
