### PR TITLE
Introduce remoteAddress support

### DIFF
--- a/binary-compatibility-validator/reference-public-api/ktor-http-cio.txt
+++ b/binary-compatibility-validator/reference-public-api/ktor-http-cio.txt
@@ -138,7 +138,7 @@ public final class io/ktor/http/cio/PipelineKt {
 	public static final fun getHttpPipelineWriterCoroutine ()Lkotlinx/coroutines/CoroutineName;
 	public static final fun getRequestHandlerCoroutine ()Lkotlinx/coroutines/CoroutineName;
 	public static final synthetic fun lastHttpRequest (ZLio/ktor/http/cio/ConnectionOptions;)Z
-	public static final fun startConnectionPipeline (Lkotlinx/coroutines/CoroutineScope;Lio/ktor/utils/io/ByteReadChannel;Lio/ktor/utils/io/ByteWriteChannel;Lio/ktor/http/cio/internals/WeakTimeoutQueue;Lkotlin/jvm/functions/Function6;)Lkotlinx/coroutines/Job;
+	public static final fun startConnectionPipeline (Lkotlinx/coroutines/CoroutineScope;Ljava/net/SocketAddress;Lio/ktor/utils/io/ByteReadChannel;Lio/ktor/utils/io/ByteWriteChannel;Lio/ktor/http/cio/internals/WeakTimeoutQueue;Lkotlin/jvm/functions/Function7;)Lkotlinx/coroutines/Job;
 }
 
 public final class io/ktor/http/cio/Request : io/ktor/http/cio/HttpMessage {

--- a/binary-compatibility-validator/reference-public-api/ktor-http-cio.txt
+++ b/binary-compatibility-validator/reference-public-api/ktor-http-cio.txt
@@ -138,7 +138,7 @@ public final class io/ktor/http/cio/PipelineKt {
 	public static final fun getHttpPipelineWriterCoroutine ()Lkotlinx/coroutines/CoroutineName;
 	public static final fun getRequestHandlerCoroutine ()Lkotlinx/coroutines/CoroutineName;
 	public static final synthetic fun lastHttpRequest (ZLio/ktor/http/cio/ConnectionOptions;)Z
-	public static final fun startConnectionPipeline (Lkotlinx/coroutines/CoroutineScope;Ljava/net/SocketAddress;Lio/ktor/utils/io/ByteReadChannel;Lio/ktor/utils/io/ByteWriteChannel;Lio/ktor/http/cio/internals/WeakTimeoutQueue;Lkotlin/jvm/functions/Function7;)Lkotlinx/coroutines/Job;
+	public static final fun startConnectionPipeline (Lkotlinx/coroutines/CoroutineScope;Lio/ktor/utils/io/ByteReadChannel;Lio/ktor/utils/io/ByteWriteChannel;Lio/ktor/http/cio/internals/WeakTimeoutQueue;Lkotlin/jvm/functions/Function6;)Lkotlinx/coroutines/Job;
 }
 
 public final class io/ktor/http/cio/Request : io/ktor/http/cio/HttpMessage {
@@ -483,5 +483,25 @@ public final class io/ktor/http/cio/websocket/WebSocketWriter : kotlinx/coroutin
 	public final fun getPool ()Lio/ktor/utils/io/pool/ObjectPool;
 	public final fun send (Lio/ktor/http/cio/websocket/Frame;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun setMasking (Z)V
+}
+
+public final class io/ktor/server/cio/backend/ServerIncomingConnection {
+	public fun <init> (Lio/ktor/utils/io/ByteReadChannel;Lio/ktor/utils/io/ByteWriteChannel;Ljava/net/SocketAddress;)V
+	public final fun getInput ()Lio/ktor/utils/io/ByteReadChannel;
+	public final fun getOutput ()Lio/ktor/utils/io/ByteWriteChannel;
+	public final fun getRemoteAddress ()Ljava/net/SocketAddress;
+}
+
+public final class io/ktor/server/cio/backend/ServerPipelineKt {
+	public static final fun startServerConnectionPipeline (Lkotlinx/coroutines/CoroutineScope;Lio/ktor/server/cio/backend/ServerIncomingConnection;Lio/ktor/http/cio/internals/WeakTimeoutQueue;Lkotlin/jvm/functions/Function3;)Lkotlinx/coroutines/Job;
+}
+
+public final class io/ktor/server/cio/backend/ServerRequestScope : kotlinx/coroutines/CoroutineScope {
+	public fun getCoroutineContext ()Lkotlin/coroutines/CoroutineContext;
+	public final fun getInput ()Lio/ktor/utils/io/ByteReadChannel;
+	public final fun getOutput ()Lio/ktor/utils/io/ByteWriteChannel;
+	public final fun getRemoteAddress ()Ljava/net/SocketAddress;
+	public final fun getUpgraded ()Lkotlinx/coroutines/CompletableDeferred;
+	public final fun withContext (Lkotlin/coroutines/CoroutineContext;)Lio/ktor/server/cio/backend/ServerRequestScope;
 }
 

--- a/ktor-http/ktor-http-cio/jvm/src/io/ktor/http/cio/Pipeline.kt
+++ b/ktor-http/ktor-http-cio/jvm/src/io/ktor/http/cio/Pipeline.kt
@@ -4,16 +4,10 @@
 
 package io.ktor.http.cio
 
-import io.ktor.http.*
 import io.ktor.http.cio.internals.*
-import io.ktor.util.*
-import kotlinx.coroutines.*
-import kotlinx.coroutines.CancellationException
-import kotlinx.coroutines.channels.*
+import io.ktor.server.cio.backend.*
 import io.ktor.utils.io.*
-import java.io.*
-import java.net.*
-import kotlin.coroutines.*
+import kotlinx.coroutines.*
 
 @Deprecated("This is going to become private", level = DeprecationLevel.HIDDEN)
 @Suppress("KDocMissingDocumentation", "unused")
@@ -29,56 +23,21 @@ typealias HttpRequestHandler = suspend ServerRequestScope.(
 ) -> Unit
 
 /**
- * Represents a server incoming connection. Usually it is a TCP connection but potentially could be other transport.
- * @property input channel connected to incoming bytes end
- * @property output channel connected to outgoing bytes end
- * @property remoteAddress of the client (optional)
- */
-@KtorExperimentalAPI
-class ServerIncomingConnection(
-    val input: ByteReadChannel,
-    val output: ByteWriteChannel,
-    val remoteAddress: SocketAddress?
-)
-
-/**
- * Represents a request scope.
- * @property upgraded deferred should be completed on upgrade request
- * @property input channel connected to request body bytes stream
- * @property output channel connected to response body
- * @property remoteAddress of a client (if known)
- */
-@KtorExperimentalAPI
-class ServerRequestScope internal constructor(
-    override val coroutineContext: CoroutineContext,
-    val input: ByteReadChannel,
-    val output: ByteWriteChannel,
-    val remoteAddress: SocketAddress?,
-    val upgraded: CompletableDeferred<Boolean>?
-) : CoroutineScope {
-    /**
-     * Creates another request scope with same parameters except coroutine context
-     */
-    @KtorExperimentalAPI
-    fun withContext(coroutineContext: CoroutineContext): ServerRequestScope = ServerRequestScope(
-        this.coroutineContext + coroutineContext,
-        input, output, remoteAddress, upgraded
-    )
-}
-
-/**
  * HTTP pipeline coroutine name
  */
+@Deprecated("This is an implementation detail and will become internal in future releases.")
 val HttpPipelineCoroutine: CoroutineName = CoroutineName("http-pipeline")
 
 /**
  * HTTP pipeline writer coroutine name
  */
+@Deprecated("This is an implementation detail and will become internal in future releases.")
 val HttpPipelineWriterCoroutine: CoroutineName = CoroutineName("http-pipeline-writer")
 
 /**
  * HTTP request handler coroutine name
  */
+@Deprecated("This is an implementation detail and will become internal in future releases.")
 val RequestHandlerCoroutine: CoroutineName = CoroutineName("request-handler")
 
 /**
@@ -92,7 +51,10 @@ val RequestHandlerCoroutine: CoroutineName = CoroutineName("request-handler")
  *
  * @return pipeline job
  */
-@Deprecated("Use startServerConnectionPipeline instead.")
+@Deprecated(
+    "This is going to become internal. " +
+        "Start ktor server or raw cio server from ktor-server-cio module instead of constructing server from parts."
+)
 @UseExperimental(ObsoleteCoroutinesApi::class, ExperimentalCoroutinesApi::class)
 fun CoroutineScope.startConnectionPipeline(
     input: ByteReadChannel,
@@ -109,181 +71,3 @@ fun CoroutineScope.startConnectionPipeline(
     }
 }
 
-/**
- * Start connection HTTP pipeline invoking [handler] for every request.
- * Note that [handler] could be invoked multiple times concurrently due to HTTP pipeline nature
- *
- * @param connection incoming client connection info
- * @param timeout number of IDLE seconds after the connection will be closed
- * @param handler to be invoked for every incoming request
- *
- * @return pipeline job
- */
-@KtorExperimentalAPI
-@UseExperimental(ObsoleteCoroutinesApi::class, ExperimentalCoroutinesApi::class)
-fun CoroutineScope.startServerConnectionPipeline(
-    connection: ServerIncomingConnection,
-    timeout: WeakTimeoutQueue,
-    handler: HttpRequestHandler
-): Job = launch(HttpPipelineCoroutine) {
-    val outputsActor = actor<ByteReadChannel>(
-        context = HttpPipelineWriterCoroutine,
-        capacity = 3,
-        start = CoroutineStart.UNDISPATCHED
-    ) {
-        try {
-            val receiveChildOrNull = suspendLambda<CoroutineScope, ByteReadChannel?> {
-                @Suppress("DEPRECATION")
-                channel.receiveOrNull()
-            }
-            while (true) {
-                val child = timeout.withTimeout(receiveChildOrNull) ?: break
-                try {
-                    child.joinTo(connection.output, false)
-//                        child.copyTo(output)
-                    connection.output.flush()
-                } catch (t: Throwable) {
-                    if (child is ByteWriteChannel) {
-                        child.close(t)
-                    }
-                }
-            }
-        } catch (t: Throwable) {
-            connection.output.close(t)
-        } finally {
-            connection.output.close()
-        }
-    }
-
-    val requestContext = RequestHandlerCoroutine + Dispatchers.Unconfined
-
-    try {
-        while (true) {  // parse requests loop
-            val request = try {
-                parseRequest(connection.input) ?: break
-            } catch (io: IOException) {
-                throw io
-            } catch (cancelled: CancellationException) {
-                throw cancelled
-            } catch (parseFailed: Throwable) { // try to write 400 Bad Request
-                // TODO log parseFailed?
-                val bc = ByteChannel()
-                if (outputsActor.offer(bc)) {
-                    bc.writePacket(BadRequestPacket.copy())
-                    bc.close()
-                }
-                outputsActor.close()
-                break // end pipeline loop
-            }
-
-            val response = ByteChannel()
-
-            val transferEncoding = request.headers["Transfer-Encoding"]
-            val upgrade = request.headers["Upgrade"]
-            val contentType = request.headers["Content-Type"]
-            val http11 = request.version == "HTTP/1.1"
-
-            val connectionOptions: ConnectionOptions?
-            val contentLength: Long
-            val expectedHttpBody: Boolean
-            val expectedHttpUpgrade: Boolean
-
-            try {
-                outputsActor.send(response)
-            } catch (cause: Throwable) {
-                request.release()
-                throw cause
-            }
-
-            try {
-                val contentLengthIndex = request.headers.find("Content-Length")
-                connectionOptions = ConnectionOptions.parse(request.headers["Connection"])
-                if (contentLengthIndex != -1) {
-                    contentLength = request.headers.valueAt(contentLengthIndex).parseDecLong()
-                    if (request.headers.find("Content-Length", contentLengthIndex + 1) != -1) {
-                        throw ParserException("Duplicate Content-Length header")
-                    }
-                } else {
-                    contentLength = -1
-                }
-                expectedHttpBody = expectHttpBody(
-                    request.method, contentLength, transferEncoding, connectionOptions, contentType
-                )
-                expectedHttpUpgrade = !expectedHttpBody &&
-                    expectHttpUpgrade(request.method, upgrade, connectionOptions)
-            } catch (cause: Throwable) {
-                request.release()
-                response.writePacket(BadRequestPacket.copy())
-                response.close()
-                throw cause
-            }
-
-            val requestBody = if (expectedHttpBody || expectedHttpUpgrade)
-                ByteChannel(true)
-            else
-                ByteReadChannel.Empty
-
-            val upgraded = if (expectedHttpUpgrade) CompletableDeferred<Boolean>() else null
-
-            launch(requestContext, start = CoroutineStart.UNDISPATCHED) {
-                val handlerScope = ServerRequestScope(coroutineContext, requestBody, response, connection.remoteAddress, upgraded)
-
-                try {
-                    handler(handlerScope, request)
-                } catch (cause: Throwable) {
-                    response.close(cause)
-                    upgraded?.completeExceptionally(cause)
-                } finally {
-                    response.close()
-                    upgraded?.complete(false)
-                }
-            }
-
-            if (upgraded != null) {
-                if (upgraded.await()) { // suspend pipeline until we know if upgrade performed?
-                    outputsActor.close()
-                    connection.input.copyAndClose(requestBody as ByteChannel)
-                    break
-                } else if (!expectedHttpBody && requestBody is ByteChannel) { // not upgraded, for example 404
-                    requestBody.close()
-                }
-            }
-
-            if (expectedHttpBody && requestBody is ByteWriteChannel) {
-                try {
-                    parseHttpBody(contentLength, transferEncoding, connectionOptions, connection.input, requestBody)
-                } catch (cause: Throwable) {
-                    requestBody.close(cause)
-                    throw cause
-                } finally {
-                    requestBody.close()
-                }
-            }
-
-            if (isLastHttpRequest(http11, connectionOptions)) break
-        }
-    } catch (cause: IOException) { // already handled
-        coroutineContext.cancel()
-    } finally {
-        outputsActor.close()
-    }
-}
-
-private val BadRequestPacket =
-    RequestResponseBuilder().apply {
-        responseLine("HTTP/1.0", HttpStatusCode.BadRequest.value, "Bad Request")
-        headerLine("Connection", "close")
-        emptyLine()
-    }.build()
-
-private fun isLastHttpRequest(http11: Boolean, connectionOptions: ConnectionOptions?): Boolean {
-    return when {
-        connectionOptions == null -> !http11
-        connectionOptions.keepAlive -> false
-        connectionOptions.close -> true
-        else -> false
-    }
-}
-
-@Suppress("NOTHING_TO_INLINE")
-private inline fun <S, R> suspendLambda(noinline block: suspend S.() -> R): suspend S.() -> R = block

--- a/ktor-http/ktor-http-cio/jvm/src/io/ktor/http/cio/Pipeline.kt
+++ b/ktor-http/ktor-http-cio/jvm/src/io/ktor/http/cio/Pipeline.kt
@@ -60,9 +60,10 @@ class ServerRequestScope internal constructor(
      * Creates another request scope with same parameters except coroutine context
      */
     @KtorExperimentalAPI
-    fun withContext(coroutineContext: CoroutineContext): ServerRequestScope =
-        ServerRequestScope(this.coroutineContext + coroutineContext,
-            input, output, remoteAddress, upgraded)
+    fun withContext(coroutineContext: CoroutineContext): ServerRequestScope = ServerRequestScope(
+        this.coroutineContext + coroutineContext,
+        input, output, remoteAddress, upgraded
+    )
 }
 
 /**

--- a/ktor-http/ktor-http-cio/jvm/src/io/ktor/server/cio/backend/ServerIncomingConnection.kt
+++ b/ktor-http/ktor-http-cio/jvm/src/io/ktor/server/cio/backend/ServerIncomingConnection.kt
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2014-2020 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.server.cio.backend
+
+import io.ktor.util.*
+import io.ktor.utils.io.*
+import java.net.*
+
+/**
+ * Represents a server incoming connection. Usually it is a TCP connection but potentially could be other transport.
+ * @property input channel connected to incoming bytes end
+ * @property output channel connected to outgoing bytes end
+ * @property remoteAddress of the client (optional)
+ */
+@InternalAPI
+class ServerIncomingConnection(
+    val input: ByteReadChannel,
+    val output: ByteWriteChannel,
+    val remoteAddress: SocketAddress?
+)

--- a/ktor-http/ktor-http-cio/jvm/src/io/ktor/server/cio/backend/ServerPipeline.kt
+++ b/ktor-http/ktor-http-cio/jvm/src/io/ktor/server/cio/backend/ServerPipeline.kt
@@ -1,0 +1,210 @@
+/*
+ * Copyright 2014-2020 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.server.cio.backend
+
+import io.ktor.http.*
+import io.ktor.http.cio.*
+import io.ktor.http.cio.internals.*
+import io.ktor.util.*
+import io.ktor.utils.io.*
+import kotlinx.coroutines.*
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.channels.*
+import java.io.*
+
+/**
+ * Start connection HTTP pipeline invoking [handler] for every request.
+ * Note that [handler] could be invoked multiple times concurrently due to HTTP pipeline nature
+ *
+ * @param connection incoming client connection info
+ * @param timeout number of IDLE seconds after the connection will be closed
+ * @param handler to be invoked for every incoming request
+ *
+ * @return pipeline job
+ */
+@Suppress("DEPRECATION")
+@InternalAPI
+@UseExperimental(ObsoleteCoroutinesApi::class, ExperimentalCoroutinesApi::class)
+fun CoroutineScope.startServerConnectionPipeline(
+    connection: ServerIncomingConnection,
+    timeout: WeakTimeoutQueue,
+    handler: HttpRequestHandler
+): Job = launch(HttpPipelineCoroutine) {
+    val outputsActor = actor<ByteReadChannel>(
+        context = HttpPipelineWriterCoroutine,
+        capacity = 3,
+        start = CoroutineStart.UNDISPATCHED
+    ) {
+        try {
+            val receiveChildOrNull =
+                suspendLambda<CoroutineScope, ByteReadChannel?> {
+                    @Suppress("DEPRECATION")
+                    channel.receiveOrNull()
+                }
+            while (true) {
+                val child = timeout.withTimeout(receiveChildOrNull) ?: break
+                try {
+                    child.joinTo(connection.output, false)
+//                        child.copyTo(output)
+                    connection.output.flush()
+                } catch (t: Throwable) {
+                    if (child is ByteWriteChannel) {
+                        child.close(t)
+                    }
+                }
+            }
+        } catch (t: Throwable) {
+            connection.output.close(t)
+        } finally {
+            connection.output.close()
+        }
+    }
+
+    val requestContext = RequestHandlerCoroutine + Dispatchers.Unconfined
+
+    try {
+        while (true) {  // parse requests loop
+            val request = try {
+                parseRequest(connection.input) ?: break
+            } catch (io: IOException) {
+                throw io
+            } catch (cancelled: CancellationException) {
+                throw cancelled
+            } catch (parseFailed: Throwable) { // try to write 400 Bad Request
+                // TODO log parseFailed?
+                val bc = ByteChannel()
+                if (outputsActor.offer(bc)) {
+                    bc.writePacket(BadRequestPacket.copy())
+                    bc.close()
+                }
+                outputsActor.close()
+                break // end pipeline loop
+            }
+
+            val response = ByteChannel()
+
+            val transferEncoding = request.headers["Transfer-Encoding"]
+            val upgrade = request.headers["Upgrade"]
+            val contentType = request.headers["Content-Type"]
+            val http11 = request.version == "HTTP/1.1"
+
+            val connectionOptions: ConnectionOptions?
+            val contentLength: Long
+            val expectedHttpBody: Boolean
+            val expectedHttpUpgrade: Boolean
+
+            try {
+                outputsActor.send(response)
+            } catch (cause: Throwable) {
+                request.release()
+                throw cause
+            }
+
+            try {
+                val contentLengthIndex = request.headers.find("Content-Length")
+                connectionOptions =
+                    ConnectionOptions.parse(request.headers["Connection"])
+                if (contentLengthIndex != -1) {
+                    contentLength = request.headers.valueAt(contentLengthIndex).parseDecLong()
+                    if (request.headers.find("Content-Length", contentLengthIndex + 1) != -1) {
+                        throw ParserException("Duplicate Content-Length header")
+                    }
+                } else {
+                    contentLength = -1
+                }
+                expectedHttpBody = expectHttpBody(
+                    request.method, contentLength, transferEncoding, connectionOptions, contentType
+                )
+                expectedHttpUpgrade = !expectedHttpBody &&
+                        expectHttpUpgrade(
+                            request.method,
+                            upgrade,
+                            connectionOptions
+                        )
+            } catch (cause: Throwable) {
+                request.release()
+                response.writePacket(BadRequestPacket.copy())
+                response.close()
+                throw cause
+            }
+
+            val requestBody = if (expectedHttpBody || expectedHttpUpgrade)
+                ByteChannel(true)
+            else
+                ByteReadChannel.Empty
+
+            val upgraded = if (expectedHttpUpgrade) CompletableDeferred<Boolean>() else null
+
+            launch(requestContext, start = CoroutineStart.UNDISPATCHED) {
+                val handlerScope = ServerRequestScope(
+                    coroutineContext,
+                    requestBody, response, connection.remoteAddress, upgraded
+                )
+
+                try {
+                    handler(handlerScope, request)
+                } catch (cause: Throwable) {
+                    response.close(cause)
+                    upgraded?.completeExceptionally(cause)
+                } finally {
+                    response.close()
+                    upgraded?.complete(false)
+                }
+            }
+
+            if (upgraded != null) {
+                if (upgraded.await()) { // suspend pipeline until we know if upgrade performed?
+                    outputsActor.close()
+                    connection.input.copyAndClose(requestBody as ByteChannel)
+                    break
+                } else if (!expectedHttpBody && requestBody is ByteChannel) { // not upgraded, for example 404
+                    requestBody.close()
+                }
+            }
+
+            if (expectedHttpBody && requestBody is ByteWriteChannel) {
+                try {
+                    parseHttpBody(
+                        contentLength,
+                        transferEncoding,
+                        connectionOptions,
+                        connection.input,
+                        requestBody
+                    )
+                } catch (cause: Throwable) {
+                    requestBody.close(cause)
+                    throw cause
+                } finally {
+                    requestBody.close()
+                }
+            }
+
+            if (isLastHttpRequest(http11, connectionOptions)) break
+        }
+    } catch (cause: IOException) { // already handled
+        coroutineContext.cancel()
+    } finally {
+        outputsActor.close()
+    }
+}
+
+private val BadRequestPacket =
+    RequestResponseBuilder().apply {
+        responseLine("HTTP/1.0", HttpStatusCode.BadRequest.value, "Bad Request")
+        headerLine("Connection", "close")
+        emptyLine()
+    }.build()
+
+internal fun isLastHttpRequest(http11: Boolean, connectionOptions: ConnectionOptions?): Boolean {
+    return when {
+        connectionOptions == null -> !http11
+        connectionOptions.keepAlive -> false
+        connectionOptions.close -> true
+        else -> false
+    }
+}
+
+@Suppress("NOTHING_TO_INLINE")
+private inline fun <S, R> suspendLambda(noinline block: suspend S.() -> R): suspend S.() -> R = block

--- a/ktor-http/ktor-http-cio/jvm/src/io/ktor/server/cio/backend/ServerRequestScope.kt
+++ b/ktor-http/ktor-http-cio/jvm/src/io/ktor/server/cio/backend/ServerRequestScope.kt
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2014-2020 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.server.cio.backend
+
+import io.ktor.util.*
+import io.ktor.utils.io.*
+import kotlinx.coroutines.*
+import java.net.*
+import kotlin.coroutines.*
+
+/**
+ * Represents a request scope.
+ * @property upgraded deferred should be completed on upgrade request
+ * @property input channel connected to request body bytes stream
+ * @property output channel connected to response body
+ * @property remoteAddress of a client (if known)
+ */
+@KtorExperimentalAPI
+class ServerRequestScope internal constructor(
+    override val coroutineContext: CoroutineContext,
+    val input: ByteReadChannel,
+    val output: ByteWriteChannel,
+    val remoteAddress: SocketAddress?,
+    val upgraded: CompletableDeferred<Boolean>?
+) : CoroutineScope {
+    /**
+     * Creates another request scope with same parameters except coroutine context
+     */
+    @KtorExperimentalAPI
+    fun withContext(coroutineContext: CoroutineContext): ServerRequestScope =
+        ServerRequestScope(
+            this.coroutineContext + coroutineContext,
+            input, output, remoteAddress, upgraded
+        )
+}

--- a/ktor-http/ktor-http-cio/jvm/test/io/ktor/tests/http/cio/IntegrationTest.kt
+++ b/ktor-http/ktor-http-cio/jvm/test/io/ktor/tests/http/cio/IntegrationTest.kt
@@ -28,7 +28,7 @@ class IntegrationTest {
     @Before
     fun setUp() {
         val dispatcher = pool.asCoroutineDispatcher()
-        val (j, s) = testHttpServer(0, dispatcher, dispatcher) { _, request, input, output, _ ->
+        val (j, s) = testHttpServer(0, dispatcher, dispatcher) { request ->
             if (request.uri.toString() == "/do" && request.method == HttpMethod.Post) {
                 handler(request, input, output)
             } else {

--- a/ktor-http/ktor-http-cio/jvm/test/io/ktor/tests/http/cio/IntegrationTest.kt
+++ b/ktor-http/ktor-http-cio/jvm/test/io/ktor/tests/http/cio/IntegrationTest.kt
@@ -28,7 +28,7 @@ class IntegrationTest {
     @Before
     fun setUp() {
         val dispatcher = pool.asCoroutineDispatcher()
-        val (j, s) = testHttpServer(0, dispatcher, dispatcher) { request, input, output, _ ->
+        val (j, s) = testHttpServer(0, dispatcher, dispatcher) { _, request, input, output, _ ->
             if (request.uri.toString() == "/do" && request.method == HttpMethod.Post) {
                 handler(request, input, output)
             } else {

--- a/ktor-http/ktor-http-cio/jvm/test/io/ktor/tests/http/cio/TestHttpServer.kt
+++ b/ktor-http/ktor-http-cio/jvm/test/io/ktor/tests/http/cio/TestHttpServer.kt
@@ -113,15 +113,17 @@ private suspend fun client(
     val timeouts = WeakTimeoutQueue(TimeUnit.HOURS.toMillis(1000))
 
     CoroutineScope(ioCoroutineContext + Dispatchers.Unconfined).startConnectionPipeline(
+        socket.remoteAddress,
         incoming,
         outgoing,
         timeouts
-    ) { request: Request,
+    ) { remoteAddress: SocketAddress,
+        request: Request,
         _input: ByteReadChannel,
         _output: ByteWriteChannel,
         upgraded: CompletableDeferred<Boolean>? ->
         withContext(callDispatcher) {
-            handler(request, _input, _output, upgraded)
+            handler(remoteAddress, request, _input, _output, upgraded)
         }
     }.invokeOnCompletion {
         incoming.close()

--- a/ktor-http/ktor-http-cio/jvm/test/io/ktor/tests/http/cio/TestHttpServer.kt
+++ b/ktor-http/ktor-http-cio/jvm/test/io/ktor/tests/http/cio/TestHttpServer.kt
@@ -7,6 +7,7 @@ package io.ktor.tests.http.cio
 import io.ktor.http.cio.*
 import io.ktor.http.cio.internals.*
 import io.ktor.http.cio.internals.WeakTimeoutQueue
+import io.ktor.server.cio.backend.*
 import kotlinx.coroutines.*
 import io.ktor.utils.io.*
 import java.net.*
@@ -113,7 +114,11 @@ private suspend fun client(
     val timeouts = WeakTimeoutQueue(TimeUnit.HOURS.toMillis(1000))
 
     CoroutineScope(ioCoroutineContext + Dispatchers.Unconfined).startServerConnectionPipeline(
-        ServerIncomingConnection(incoming, outgoing, socket.remoteAddress),
+        ServerIncomingConnection(
+            incoming,
+            outgoing,
+            socket.remoteAddress
+        ),
         timeouts
     ) { request: Request ->
         val requestScope = this

--- a/ktor-server/ktor-server-benchmarks/src/jmh/kotlin/io/ktor/server/benchmarks/cio/CIOIntegrationBenchmark.kt
+++ b/ktor-server/ktor-server-benchmarks/src/jmh/kotlin/io/ktor/server/benchmarks/cio/CIOIntegrationBenchmark.kt
@@ -7,6 +7,7 @@ package io.ktor.server.benchmarks.cio
 import io.ktor.application.*
 import io.ktor.server.benchmarks.*
 import io.ktor.server.cio.*
+import io.ktor.server.cio.backend.*
 import io.ktor.server.engine.*
 
 class CIOIntegrationBenchmark : IntegrationBenchmark<CIOApplicationEngine>() {

--- a/ktor-server/ktor-server-benchmarks/src/jmh/kotlin/io/ktor/server/benchmarks/cio/CIOPlatformBenchmark.kt
+++ b/ktor-server/ktor-server-benchmarks/src/jmh/kotlin/io/ktor/server/benchmarks/cio/CIOPlatformBenchmark.kt
@@ -8,6 +8,7 @@ import io.ktor.http.*
 import io.ktor.http.cio.*
 import io.ktor.server.benchmarks.*
 import io.ktor.server.cio.*
+import io.ktor.server.cio.backend.*
 import io.netty.util.*
 import kotlinx.coroutines.*
 import io.ktor.utils.io.*

--- a/ktor-server/ktor-server-benchmarks/src/jmh/kotlin/io/ktor/server/benchmarks/cio/CIOPlatformBenchmark.kt
+++ b/ktor-server/ktor-server-benchmarks/src/jmh/kotlin/io/ktor/server/benchmarks/cio/CIOPlatformBenchmark.kt
@@ -30,7 +30,7 @@ class CIOPlatformBenchmark : PlatformBenchmark() {
     }.build()
 
     override fun runServer(port: Int) {
-        server = GlobalScope.httpServer(HttpServerSettings(port = port), handler =  { request: Request, input: ByteReadChannel, output: ByteWriteChannel, _: CompletableDeferred<Boolean>? ->
+        server = GlobalScope.httpServer(HttpServerSettings(port = port), handler =  { request: Request ->
             val uri = request.uri
             if (uri.length == 6 && uri.startsWith("/sayOK")) {
                 output.writePacket(sayOK.copy())

--- a/ktor-server/ktor-server-cio/jvm/src/io/ktor/server/cio/CIOApplicationCall.kt
+++ b/ktor-server/ktor-server-cio/jvm/src/io/ktor/server/cio/CIOApplicationCall.kt
@@ -9,6 +9,7 @@ import io.ktor.http.cio.*
 import io.ktor.server.engine.*
 import kotlinx.coroutines.*
 import io.ktor.utils.io.*
+import java.net.*
 import kotlin.coroutines.*
 
 internal class CIOApplicationCall(
@@ -18,10 +19,11 @@ internal class CIOApplicationCall(
     output: ByteWriteChannel,
     engineDispatcher: CoroutineContext,
     appDispatcher: CoroutineContext,
-    upgraded: CompletableDeferred<Boolean>?
-) : BaseApplicationCall(application) {
+    upgraded: CompletableDeferred<Boolean>?,
+    remoteAddress: SocketAddress?
+    ) : BaseApplicationCall(application) {
 
-    override val request = CIOApplicationRequest(this, input, _request)
+    override val request = CIOApplicationRequest(this, remoteAddress as? InetSocketAddress, input, _request)
     override val response = CIOApplicationResponse(this, output, input, engineDispatcher, appDispatcher, upgraded)
 
     internal fun release() {

--- a/ktor-server/ktor-server-cio/jvm/src/io/ktor/server/cio/CIOApplicationEngine.kt
+++ b/ktor-server/ktor-server-cio/jvm/src/io/ktor/server/cio/CIOApplicationEngine.kt
@@ -141,11 +141,12 @@ class CIOApplicationEngine(environment: ApplicationEngineEnvironment, configure:
             connectionIdleTimeoutSeconds = configuration.connectionIdleTimeoutSeconds.toLong()
         )
 
-        return scope.httpServer(settings) { request, input, output, upgraded ->
+        return scope.httpServer(settings) { remoteAddress, request, input, output, upgraded ->
             withContext(userDispatcher) {
                 val call = CIOApplicationCall(
                     application, request, input, output,
-                    engineDispatcher, userDispatcher, upgraded
+                    engineDispatcher, userDispatcher, upgraded,
+                    remoteAddress
                 )
                 try {
                     pipeline.execute(call)

--- a/ktor-server/ktor-server-cio/jvm/src/io/ktor/server/cio/CIOApplicationEngine.kt
+++ b/ktor-server/ktor-server-cio/jvm/src/io/ktor/server/cio/CIOApplicationEngine.kt
@@ -141,7 +141,7 @@ class CIOApplicationEngine(environment: ApplicationEngineEnvironment, configure:
             connectionIdleTimeoutSeconds = configuration.connectionIdleTimeoutSeconds.toLong()
         )
 
-        return scope.httpServer(settings) { remoteAddress, request, input, output, upgraded ->
+        return scope.httpServer(settings) { request ->
             withContext(userDispatcher) {
                 val call = CIOApplicationCall(
                     application, request, input, output,

--- a/ktor-server/ktor-server-cio/jvm/src/io/ktor/server/cio/CIOApplicationEngine.kt
+++ b/ktor-server/ktor-server-cio/jvm/src/io/ktor/server/cio/CIOApplicationEngine.kt
@@ -5,6 +5,7 @@
 package io.ktor.server.cio
 
 import io.ktor.application.*
+import io.ktor.server.cio.backend.*
 import io.ktor.server.engine.*
 import io.ktor.util.*
 import io.ktor.util.pipeline.*

--- a/ktor-server/ktor-server-cio/jvm/src/io/ktor/server/cio/CIOApplicationRequest.kt
+++ b/ktor-server/ktor-server-cio/jvm/src/io/ktor/server/cio/CIOApplicationRequest.kt
@@ -10,8 +10,11 @@ import io.ktor.http.cio.*
 import io.ktor.request.*
 import io.ktor.server.engine.*
 import io.ktor.utils.io.*
+import java.net.*
 
-internal class CIOApplicationRequest(call: ApplicationCall,
+internal class CIOApplicationRequest(
+                            call: ApplicationCall,
+                            private val remoteAddress: InetSocketAddress?,
                             private val input: ByteReadChannel,
                             private val request: Request
 ) : BaseApplicationRequest(call) {
@@ -48,7 +51,9 @@ internal class CIOApplicationRequest(call: ApplicationCall,
             get() = HttpMethod.parse(request.method.value)
 
         override val remoteHost: String
-            get() = "unknown" // TODO
+            get() = remoteAddress?.let {
+                it.hostName ?: it.address.hostAddress
+            } ?: "unknown"
     }
 
     internal fun release() {

--- a/ktor-server/ktor-server-cio/jvm/src/io/ktor/server/cio/HttpServer.kt
+++ b/ktor-server/ktor-server-cio/jvm/src/io/ktor/server/cio/HttpServer.kt
@@ -104,10 +104,11 @@ fun CoroutineScope.httpServer(
                     val client: Socket = server.accept()
 
                     val clientJob = connectionScope.startConnectionPipeline(
-                        input = client.openReadChannel(),
-                        output = client.openWriteChannel(),
-                        timeout = timeout,
-                        handler = handler
+                        client.remoteAddress,
+                        client.openReadChannel(),
+                        client.openWriteChannel(),
+                        timeout,
+                        handler
                     )
 
                     clientJob.invokeOnCompletion {

--- a/ktor-server/ktor-server-cio/jvm/src/io/ktor/server/cio/HttpServer.kt
+++ b/ktor-server/ktor-server-cio/jvm/src/io/ktor/server/cio/HttpServer.kt
@@ -5,17 +5,11 @@
 package io.ktor.server.cio
 
 import io.ktor.http.cio.*
-import io.ktor.http.cio.internals.WeakTimeoutQueue
-import io.ktor.network.selector.*
 import io.ktor.network.sockets.*
-import io.ktor.network.sockets.ServerSocket
-import io.ktor.network.sockets.Socket
-import io.ktor.server.engine.*
+import io.ktor.server.cio.backend.*
 import io.ktor.util.*
 import io.ktor.utils.io.*
 import kotlinx.coroutines.*
-import org.slf4j.*
-import java.nio.channels.*
 import kotlin.coroutines.*
 
 /**
@@ -67,7 +61,7 @@ fun httpServer(
 /**
  * Start an http server with [settings] invoking [handler] for every request
  */
-@Deprecated("Use handler function with single request parameter.")
+@Deprecated("Use handler function with single request parameter from package io.ktor.server.cio.backend.")
 fun CoroutineScope.httpServer(
     settings: HttpServerSettings,
     handler: suspend CoroutineScope.(
@@ -78,86 +72,4 @@ fun CoroutineScope.httpServer(
     return httpServer(settings) { request ->
         handler(this, request, input, output, upgraded)
     }
-}
-
-/**
- * Start an http server with [settings] invoking [handler] for every request
- */
-@UseExperimental(InternalAPI::class)
-fun CoroutineScope.httpServer(
-    settings: HttpServerSettings,
-    handler: HttpRequestHandler
-): HttpServer {
-    val socket = CompletableDeferred<ServerSocket>()
-
-    val serverLatch: CompletableJob = Job()
-    val serverJob = launch(
-        context = CoroutineName("server-root-${settings.port}"),
-        start = CoroutineStart.UNDISPATCHED
-    ) {
-        serverLatch.join()
-    }
-
-    val selector = ActorSelectorManager(coroutineContext)
-    val timeout = WeakTimeoutQueue(
-        settings.connectionIdleTimeoutSeconds * 1000L
-    )
-
-    val logger = LoggerFactory.getLogger(HttpServer::class.java)
-
-    val acceptJob = launch(serverJob + CoroutineName("accept-${settings.port}")) {
-        aSocket(selector).tcp().bind(settings.host, settings.port).use { server ->
-            socket.complete(server)
-
-            val connectionScope = CoroutineScope(
-                coroutineContext +
-                    SupervisorJob(serverJob) +
-                    DefaultUncaughtExceptionHandler(logger) +
-                    CoroutineName("request")
-            )
-
-            try {
-                while (true) {
-                    val client: Socket = server.accept()
-
-                    val connection = ServerIncomingConnection(
-                        client.openReadChannel(),
-                        client.openWriteChannel(),
-                        client.remoteAddress
-                    )
-                    val clientJob = connectionScope.startServerConnectionPipeline(
-                        connection,
-                        timeout,
-                        handler
-                    )
-
-                    clientJob.invokeOnCompletion {
-                        client.close()
-                    }
-                }
-            } catch (closed: ClosedChannelException) {
-                coroutineContext.cancel()
-            } finally {
-                server.close()
-                server.awaitClosed()
-                connectionScope.coroutineContext.cancel()
-            }
-        }
-    }
-
-    acceptJob.invokeOnCompletion { cause ->
-        cause?.let { socket.completeExceptionally(it) }
-        serverLatch.complete()
-        timeout.process()
-    }
-
-    @UseExperimental(InternalCoroutinesApi::class) // TODO it's attach child?
-    serverJob.invokeOnCompletion(onCancelling = true) {
-        timeout.cancel()
-    }
-    serverJob.invokeOnCompletion {
-        selector.close()
-    }
-
-    return HttpServer(serverJob, acceptJob, socket)
 }

--- a/ktor-server/ktor-server-cio/jvm/src/io/ktor/server/cio/backend/HttpServer.kt
+++ b/ktor-server/ktor-server-cio/jvm/src/io/ktor/server/cio/backend/HttpServer.kt
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2014-2020 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.server.cio.backend
+
+import io.ktor.http.cio.*
+import io.ktor.http.cio.internals.*
+import io.ktor.network.selector.*
+import io.ktor.network.sockets.*
+import io.ktor.server.cio.*
+import io.ktor.server.engine.*
+import io.ktor.util.*
+import kotlinx.coroutines.*
+import org.slf4j.*
+import java.nio.channels.*
+
+/**
+ * Start an http server with [settings] invoking [handler] for every request
+ */
+@UseExperimental(InternalAPI::class)
+fun CoroutineScope.httpServer(
+    settings: HttpServerSettings,
+    handler: HttpRequestHandler
+): HttpServer {
+    val socket = CompletableDeferred<ServerSocket>()
+
+    val serverLatch: CompletableJob = Job()
+    val serverJob = launch(
+        context = CoroutineName("server-root-${settings.port}"),
+        start = CoroutineStart.UNDISPATCHED
+    ) {
+        serverLatch.join()
+    }
+
+    val selector = ActorSelectorManager(coroutineContext)
+    val timeout = WeakTimeoutQueue(
+        settings.connectionIdleTimeoutSeconds * 1000L
+    )
+
+    val logger = LoggerFactory.getLogger(HttpServer::class.java)
+
+    val acceptJob = launch(serverJob + CoroutineName("accept-${settings.port}")) {
+        aSocket(selector).tcp().bind(settings.host, settings.port).use { server ->
+            socket.complete(server)
+
+            val connectionScope = CoroutineScope(
+                coroutineContext +
+                    SupervisorJob(serverJob) +
+                    DefaultUncaughtExceptionHandler(logger) +
+                    CoroutineName("request")
+            )
+
+            try {
+                while (true) {
+                    val client: Socket = server.accept()
+
+                    val connection = ServerIncomingConnection(
+                        client.openReadChannel(),
+                        client.openWriteChannel(),
+                        client.remoteAddress
+                    )
+                    val clientJob = connectionScope.startServerConnectionPipeline(
+                        connection,
+                        timeout,
+                        handler
+                    )
+
+                    clientJob.invokeOnCompletion {
+                        client.close()
+                    }
+                }
+            } catch (closed: ClosedChannelException) {
+                coroutineContext.cancel()
+            } finally {
+                server.close()
+                server.awaitClosed()
+                connectionScope.coroutineContext.cancel()
+            }
+        }
+    }
+
+    acceptJob.invokeOnCompletion { cause ->
+        cause?.let { socket.completeExceptionally(it) }
+        serverLatch.complete()
+        timeout.process()
+    }
+
+    @UseExperimental(InternalCoroutinesApi::class) // TODO it's attach child?
+    serverJob.invokeOnCompletion(onCancelling = true) {
+        timeout.cancel()
+    }
+    serverJob.invokeOnCompletion {
+        selector.close()
+    }
+
+    return HttpServer(serverJob, acceptJob, socket)
+}

--- a/ktor-server/ktor-server-cio/jvm/test/io/ktor/tests/server/cio/RAWExample.kt
+++ b/ktor-server/ktor-server-cio/jvm/test/io/ktor/tests/server/cio/RAWExample.kt
@@ -10,7 +10,6 @@ import io.ktor.server.cio.*
 import io.ktor.util.date.*
 import kotlinx.coroutines.*
 import io.ktor.utils.io.*
-import java.net.*
 
 @Volatile
 private var cachedDateText: String = GMTDate().toHttpDate()
@@ -37,11 +36,7 @@ fun main(args: Array<String>) {
         }
     }
 
-    val server = GlobalScope.httpServer(settings, handler = { _: SocketAddress,
-                                                              request: Request,
-                                                              _: ByteReadChannel,
-                                                              output: ByteWriteChannel,
-                                                              _: CompletableDeferred<Boolean>? ->
+    val server = GlobalScope.httpServer(settings, handler = { request ->
         try {
             if (request.uri.length == 1 && request.uri[0] == '/' && request.method == HttpMethod.Get) {
                 val response = RequestResponseBuilder()

--- a/ktor-server/ktor-server-cio/jvm/test/io/ktor/tests/server/cio/RAWExample.kt
+++ b/ktor-server/ktor-server-cio/jvm/test/io/ktor/tests/server/cio/RAWExample.kt
@@ -10,6 +10,7 @@ import io.ktor.server.cio.*
 import io.ktor.util.date.*
 import kotlinx.coroutines.*
 import io.ktor.utils.io.*
+import java.net.*
 
 @Volatile
 private var cachedDateText: String = GMTDate().toHttpDate()
@@ -36,7 +37,8 @@ fun main(args: Array<String>) {
         }
     }
 
-    val server = GlobalScope.httpServer(settings, handler = { request: Request,
+    val server = GlobalScope.httpServer(settings, handler = { _: SocketAddress,
+                                                              request: Request,
                                                               _: ByteReadChannel,
                                                               output: ByteWriteChannel,
                                                               _: CompletableDeferred<Boolean>? ->

--- a/ktor-server/ktor-server-cio/jvm/test/io/ktor/tests/server/cio/RAWExample.kt
+++ b/ktor-server/ktor-server-cio/jvm/test/io/ktor/tests/server/cio/RAWExample.kt
@@ -7,6 +7,7 @@ package io.ktor.tests.server.cio
 import io.ktor.http.*
 import io.ktor.http.cio.*
 import io.ktor.server.cio.*
+import io.ktor.server.cio.backend.*
 import io.ktor.util.date.*
 import kotlinx.coroutines.*
 import io.ktor.utils.io.*

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http1/NettyConnectionPoint.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http1/NettyConnectionPoint.kt
@@ -25,12 +25,16 @@ internal class NettyConnectionPoint(val request: HttpRequest, val context: Chann
 
     override val host: String
         get() = request.headers().get(HttpHeaders.Host)?.substringBefore(":")
-                ?: (context.channel().localAddress() as? InetSocketAddress)?.hostString
+                ?: (context.channel().localAddress() as? InetSocketAddress)?.let {
+                    it.hostName ?: it.address.hostAddress
+                }
                 ?: "localhost"
 
     override val port: Int
         get() = (context.channel().localAddress() as? InetSocketAddress)?.port ?: 80
 
     override val remoteHost: String
-        get() = (context.channel().remoteAddress() as? InetSocketAddress)?.hostString ?: "unknown"
+        get() = (context.channel().remoteAddress() as? InetSocketAddress)?.let {
+            it.hostName ?: it.address.hostAddress
+        } ?: "unknown"
 }

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http2/Http2LocalConnectionPoint.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http2/Http2LocalConnectionPoint.kt
@@ -8,7 +8,11 @@ import io.ktor.http.*
 import io.netty.handler.codec.http2.*
 import java.net.*
 
-internal class Http2LocalConnectionPoint(private val nettyHeaders: Http2Headers, private val address: InetSocketAddress?) : RequestConnectionPoint {
+internal class Http2LocalConnectionPoint(
+                    private val nettyHeaders: Http2Headers,
+                    private val localAddress: InetSocketAddress?,
+                    private val remoteAddress: InetSocketAddress?
+) : RequestConnectionPoint {
     override val method: HttpMethod = nettyHeaders.method()?.let { HttpMethod.parse(it.toString()) } ?: HttpMethod.Get
 
     override val scheme: String
@@ -25,9 +29,11 @@ internal class Http2LocalConnectionPoint(private val nettyHeaders: Http2Headers,
 
     override val port: Int
         get() = nettyHeaders.authority()?.toString()?.substringAfter(":")?.toInt()
-                ?: address?.port
+                ?: localAddress?.port
                 ?: 80
 
     override val remoteHost: String
-        get() = "unknown" // TODO
+        get() = remoteAddress?.let {
+            it.hostName ?: it.address.hostAddress
+        } ?: "unknown"
 }

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http2/NettyHttp2ApplicationRequest.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http2/NettyHttp2ApplicationRequest.kt
@@ -54,7 +54,11 @@ internal class NettyHttp2ApplicationRequest(
         http2frameLoop(contentByteChannel)
     }
 
-    override val local = Http2LocalConnectionPoint(nettyHeaders, context.channel().localAddress() as? InetSocketAddress)
+    override val local = Http2LocalConnectionPoint(
+        nettyHeaders,
+        context.channel().localAddress() as? InetSocketAddress,
+        context.channel().remoteAddress() as? InetSocketAddress
+    )
 
     override val cookies: RequestCookies
         get() = throw UnsupportedOperationException()

--- a/ktor-server/ktor-server-test-host/jvm/src/io/ktor/server/testing/EngineTestSuite.kt
+++ b/ktor-server/ktor-server-test-host/jvm/src/io/ktor/server/testing/EngineTestSuite.kt
@@ -1090,6 +1090,27 @@ abstract class EngineTestSuite<TEngine : ApplicationEngine, TConfiguration : App
     }
 
     @Test
+    fun testRemoteHost() {
+        createAndStartServer {
+            handle {
+                call.respondText {
+                    call.request.local.remoteHost
+                }
+            }
+        }
+
+        withUrl("/") {
+            readText().also { text ->
+                assertNotNull(
+                    listOf("localhost", "127.0.0.1", "::1", "0:0:0:0:0:0:0:1").find {
+                        it == text
+                    }
+                )
+            }
+        }
+    }
+
+    @Test
     fun testRequestParameters() {
         createAndStartServer {
             get("/*") {


### PR DESCRIPTION
**Subsystem**
ktor-server-cio, ktor-http-cio

**Motivation**
Some engines did not support remote address properly. A user opened PR #1531 addressing the issue. However, binary compatibility wasn't met so we were unable to apply it. 

**Solution**
Pick the author's commit and rework a bit CIO part:
- simplify RAW CIO server API so there is no need to write all request handler parameters
- introduce fallback functions so old code will compile (unless `HttpRequestHandler` type alias is used)
- only API changes, no behaviour changes

```kotlin
httpServer(...) { request -> 
  // input, output, remoteAddress, upgraded are available here on the receiver
}
```

instead of 
```kotlin
httpServer(...) { remoteAddress, request, input, output, upgraded ->
}
```

So changing parameters list will be easier in the future.

