### PR TITLE
Fix server auth feature and session cache issues

### DIFF
--- a/binary-compatibility-validator/reference-public-api/ktor-auth.txt
+++ b/binary-compatibility-validator/reference-public-api/ktor-auth.txt
@@ -30,6 +30,8 @@ public final class io/ktor/auth/AuthenticationContext {
 	public fun <init> (Lio/ktor/application/ApplicationCall;)V
 	public final fun challenge (Ljava/lang/Object;Lio/ktor/auth/AuthenticationFailedCause;Lkotlin/jvm/functions/Function3;)V
 	public final fun error (Ljava/lang/Object;Lio/ktor/auth/AuthenticationFailedCause;)V
+	public final fun getAllErrors ()Ljava/util/List;
+	public final fun getAllFailures ()Ljava/util/List;
 	public final fun getCall ()Lio/ktor/application/ApplicationCall;
 	public final fun getChallenge ()Lio/ktor/auth/AuthenticationProcedureChallenge;
 	public final fun getErrors ()Ljava/util/HashMap;

--- a/binary-compatibility-validator/reference-public-api/ktor-auth.txt
+++ b/binary-compatibility-validator/reference-public-api/ktor-auth.txt
@@ -47,7 +47,9 @@ public abstract class io/ktor/auth/AuthenticationFailedCause {
 
 public class io/ktor/auth/AuthenticationFailedCause$Error : io/ktor/auth/AuthenticationFailedCause {
 	public fun <init> (Ljava/lang/String;)V
+	public fun <init> ([Lkotlin/Unit;Ljava/lang/String;)V
 	public final fun getCause ()Ljava/lang/String;
+	public final fun getMessage ()Ljava/lang/String;
 }
 
 public final class io/ktor/auth/AuthenticationFailedCause$InvalidCredentials : io/ktor/auth/AuthenticationFailedCause {

--- a/binary-compatibility-validator/reference-public-api/ktor-auth.txt
+++ b/binary-compatibility-validator/reference-public-api/ktor-auth.txt
@@ -1,0 +1,550 @@
+public final class io/ktor/auth/Authentication {
+	public static final field Feature Lio/ktor/auth/Authentication$Feature;
+	public fun <init> ()V
+	public fun <init> (Lio/ktor/auth/Authentication$Configuration;)V
+	public fun <init> (Ljava/util/List;)V
+	public final fun configure (Lkotlin/jvm/functions/Function1;)V
+	public final fun interceptPipeline (Lio/ktor/application/ApplicationCallPipeline;Ljava/util/List;Z)V
+	public static synthetic fun interceptPipeline$default (Lio/ktor/auth/Authentication;Lio/ktor/application/ApplicationCallPipeline;Ljava/util/List;ZILjava/lang/Object;)V
+}
+
+public final class io/ktor/auth/Authentication$Configuration {
+	public fun <init> ()V
+	public fun <init> (Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun provider (Ljava/lang/String;Lkotlin/jvm/functions/Function1;)V
+	public static synthetic fun provider$default (Lio/ktor/auth/Authentication$Configuration;Ljava/lang/String;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+	public final fun register (Lio/ktor/auth/AuthenticationProvider;)V
+}
+
+public final class io/ktor/auth/Authentication$Feature : io/ktor/application/ApplicationFeature {
+	public final fun getAuthenticatePhase ()Lio/ktor/util/pipeline/PipelinePhase;
+	public final fun getChallengePhase ()Lio/ktor/util/pipeline/PipelinePhase;
+	public fun getKey ()Lio/ktor/util/AttributeKey;
+	public fun install (Lio/ktor/application/Application;Lkotlin/jvm/functions/Function1;)Lio/ktor/auth/Authentication;
+	public synthetic fun install (Lio/ktor/util/pipeline/Pipeline;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+}
+
+public final class io/ktor/auth/AuthenticationContext {
+	public static final field Companion Lio/ktor/auth/AuthenticationContext$Companion;
+	public fun <init> (Lio/ktor/application/ApplicationCall;)V
+	public final fun challenge (Ljava/lang/Object;Lio/ktor/auth/AuthenticationFailedCause;Lkotlin/jvm/functions/Function3;)V
+	public final fun error (Ljava/lang/Object;Lio/ktor/auth/AuthenticationFailedCause;)V
+	public final fun getCall ()Lio/ktor/application/ApplicationCall;
+	public final fun getChallenge ()Lio/ktor/auth/AuthenticationProcedureChallenge;
+	public final fun getErrors ()Ljava/util/HashMap;
+	public final fun getPrincipal ()Lio/ktor/auth/Principal;
+	public final synthetic fun principal ()Lio/ktor/auth/Principal;
+	public final fun principal (Lio/ktor/auth/Principal;)V
+	public final fun setPrincipal (Lio/ktor/auth/Principal;)V
+}
+
+public final class io/ktor/auth/AuthenticationContext$Companion {
+}
+
+public abstract class io/ktor/auth/AuthenticationFailedCause {
+}
+
+public class io/ktor/auth/AuthenticationFailedCause$Error : io/ktor/auth/AuthenticationFailedCause {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun getCause ()Ljava/lang/String;
+}
+
+public final class io/ktor/auth/AuthenticationFailedCause$InvalidCredentials : io/ktor/auth/AuthenticationFailedCause {
+	public static final field INSTANCE Lio/ktor/auth/AuthenticationFailedCause$InvalidCredentials;
+}
+
+public final class io/ktor/auth/AuthenticationFailedCause$NoCredentials : io/ktor/auth/AuthenticationFailedCause {
+	public static final field INSTANCE Lio/ktor/auth/AuthenticationFailedCause$NoCredentials;
+}
+
+public final class io/ktor/auth/AuthenticationKt {
+	public static final fun authenticate (Lio/ktor/routing/Route;[Ljava/lang/String;ZLkotlin/jvm/functions/Function1;)Lio/ktor/routing/Route;
+	public static synthetic fun authenticate$default (Lio/ktor/routing/Route;[Ljava/lang/String;ZLkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lio/ktor/routing/Route;
+	public static final fun authentication (Lio/ktor/application/Application;Lkotlin/jvm/functions/Function1;)V
+	public static final fun getAuthentication (Lio/ktor/application/ApplicationCall;)Lio/ktor/auth/AuthenticationContext;
+	public static final synthetic fun principal (Lio/ktor/application/ApplicationCall;)Lio/ktor/auth/Principal;
+}
+
+public final class io/ktor/auth/AuthenticationPipeline : io/ktor/util/pipeline/Pipeline {
+	public static final field Companion Lio/ktor/auth/AuthenticationPipeline$Companion;
+	public fun <init> ()V
+}
+
+public final class io/ktor/auth/AuthenticationPipeline$Companion {
+	public final fun getCheckAuthentication ()Lio/ktor/util/pipeline/PipelinePhase;
+	public final fun getRequestAuthentication ()Lio/ktor/util/pipeline/PipelinePhase;
+}
+
+public final class io/ktor/auth/AuthenticationProcedureChallenge {
+	public fun <init> ()V
+	public final fun complete ()V
+	public final fun getChallenges ()Ljava/util/List;
+	public final fun getCompleted ()Z
+	public final fun getErrorChallenges ()Ljava/util/List;
+	public fun toString ()Ljava/lang/String;
+}
+
+public class io/ktor/auth/AuthenticationProvider {
+	public fun <init> (Lio/ktor/auth/AuthenticationProvider$Configuration;)V
+	public fun <init> (Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getName ()Ljava/lang/String;
+	public final fun getPipeline ()Lio/ktor/auth/AuthenticationPipeline;
+	public final fun getSkipWhen ()Ljava/util/List;
+	public final fun skipWhen (Lkotlin/jvm/functions/Function1;)V
+}
+
+public class io/ktor/auth/AuthenticationProvider$Configuration {
+	protected fun <init> (Ljava/lang/String;)V
+	public final fun getName ()Ljava/lang/String;
+	public final fun getPipeline ()Lio/ktor/auth/AuthenticationPipeline;
+	public final fun skipWhen (Lkotlin/jvm/functions/Function1;)V
+}
+
+public final class io/ktor/auth/AuthenticationRouteSelector : io/ktor/routing/RouteSelector {
+	public fun <init> (Ljava/util/List;)V
+	public fun evaluate (Lio/ktor/routing/RoutingResolveContext;I)Lio/ktor/routing/RouteSelectorEvaluation;
+	public final fun getNames ()Ljava/util/List;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/ktor/auth/BasicAuthKt {
+	public static final fun basic (Lio/ktor/auth/Authentication$Configuration;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)V
+	public static synthetic fun basic$default (Lio/ktor/auth/Authentication$Configuration;Ljava/lang/String;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+	public static final fun basicAuthenticationCredentials (Lio/ktor/request/ApplicationRequest;Ljava/nio/charset/Charset;)Lio/ktor/auth/UserPasswordCredential;
+	public static synthetic fun basicAuthenticationCredentials$default (Lio/ktor/request/ApplicationRequest;Ljava/nio/charset/Charset;ILjava/lang/Object;)Lio/ktor/auth/UserPasswordCredential;
+}
+
+public final class io/ktor/auth/BasicAuthenticationProvider : io/ktor/auth/AuthenticationProvider {
+}
+
+public final class io/ktor/auth/BasicAuthenticationProvider$Configuration : io/ktor/auth/AuthenticationProvider$Configuration {
+	public final fun getCharset ()Ljava/nio/charset/Charset;
+	public final fun getRealm ()Ljava/lang/String;
+	public final fun setCharset (Ljava/nio/charset/Charset;)V
+	public final fun setRealm (Ljava/lang/String;)V
+	public final fun validate (Lkotlin/jvm/functions/Function3;)V
+}
+
+public abstract interface class io/ktor/auth/Credential {
+}
+
+public final class io/ktor/auth/DefaultOAuth2StateProvider : io/ktor/auth/OAuth2StateProvider {
+	public static final field INSTANCE Lio/ktor/auth/DefaultOAuth2StateProvider;
+	public fun getState (Lio/ktor/application/ApplicationCall;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun verifyState (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class io/ktor/auth/DigestAuthKt {
+	public static final fun digest (Lio/ktor/auth/Authentication$Configuration;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)V
+	public static synthetic fun digest$default (Lio/ktor/auth/Authentication$Configuration;Ljava/lang/String;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+	public static final fun digestAuthenticationCredentials (Lio/ktor/application/ApplicationCall;)Lio/ktor/auth/DigestCredential;
+	public static final fun expectedDigest (Lio/ktor/auth/DigestCredential;Lio/ktor/http/HttpMethod;Ljava/security/MessageDigest;[B)[B
+	public static final fun toDigestCredential (Lio/ktor/http/auth/HttpAuthHeader$Parameterized;)Lio/ktor/auth/DigestCredential;
+	public static final fun verifier (Lio/ktor/auth/DigestCredential;Lio/ktor/http/HttpMethod;Ljava/security/MessageDigest;Lkotlin/jvm/functions/Function3;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class io/ktor/auth/DigestAuthenticationProvider : io/ktor/auth/AuthenticationProvider {
+	public final fun getAlgorithmName ()Ljava/lang/String;
+	public final fun getRealm ()Ljava/lang/String;
+}
+
+public final class io/ktor/auth/DigestAuthenticationProvider$Configuration : io/ktor/auth/AuthenticationProvider$Configuration {
+	public final fun digestProvider (Lkotlin/jvm/functions/Function3;)V
+	public final fun getAlgorithmName ()Ljava/lang/String;
+	public final fun getNonceManager ()Lio/ktor/util/NonceManager;
+	public final fun getRealm ()Ljava/lang/String;
+	public final fun getUserNameRealmPasswordDigestProvider ()Lkotlin/jvm/functions/Function3;
+	public final fun setAlgorithmName (Ljava/lang/String;)V
+	public final fun setNonceManager (Lio/ktor/util/NonceManager;)V
+	public final fun setRealm (Ljava/lang/String;)V
+	public final fun setUserNameRealmPasswordDigestProvider (Lkotlin/jvm/functions/Function3;)V
+}
+
+public final class io/ktor/auth/DigestCredential : io/ktor/auth/Credential {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component10 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun component7 ()Ljava/lang/String;
+	public final fun component8 ()Ljava/lang/String;
+	public final fun component9 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lio/ktor/auth/DigestCredential;
+	public static synthetic fun copy$default (Lio/ktor/auth/DigestCredential;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lio/ktor/auth/DigestCredential;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAlgorithm ()Ljava/lang/String;
+	public final fun getCnonce ()Ljava/lang/String;
+	public final fun getDigestUri ()Ljava/lang/String;
+	public final fun getNonce ()Ljava/lang/String;
+	public final fun getNonceCount ()Ljava/lang/String;
+	public final fun getOpaque ()Ljava/lang/String;
+	public final fun getQop ()Ljava/lang/String;
+	public final fun getRealm ()Ljava/lang/String;
+	public final fun getResponse ()Ljava/lang/String;
+	public final fun getUserName ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/ktor/auth/ForbiddenResponse : io/ktor/http/content/OutgoingContent$NoContent {
+	public fun <init> (Lio/ktor/http/auth/HttpAuthHeader;)V
+	public fun <init> ([Lio/ktor/http/auth/HttpAuthHeader;)V
+	public final fun getChallenges ()[Lio/ktor/http/auth/HttpAuthHeader;
+	public fun getHeaders ()Lio/ktor/http/Headers;
+	public fun getStatus ()Lio/ktor/http/HttpStatusCode;
+}
+
+public abstract class io/ktor/auth/FormAuthChallenge {
+}
+
+public final class io/ktor/auth/FormAuthChallenge$Redirect : io/ktor/auth/FormAuthChallenge {
+	public fun <init> (Lkotlin/jvm/functions/Function2;)V
+	public final fun getUrl ()Lkotlin/jvm/functions/Function2;
+}
+
+public final class io/ktor/auth/FormAuthChallenge$Unauthorized : io/ktor/auth/FormAuthChallenge {
+	public static final field INSTANCE Lio/ktor/auth/FormAuthChallenge$Unauthorized;
+}
+
+public final class io/ktor/auth/FormAuthKt {
+	public static final fun form (Lio/ktor/auth/Authentication$Configuration;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)V
+	public static synthetic fun form$default (Lio/ktor/auth/Authentication$Configuration;Ljava/lang/String;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+}
+
+public final class io/ktor/auth/FormAuthenticationProvider : io/ktor/auth/AuthenticationProvider {
+}
+
+public final class io/ktor/auth/FormAuthenticationProvider$Configuration : io/ktor/auth/AuthenticationProvider$Configuration {
+	public final fun challenge (Lio/ktor/http/Url;)V
+	public final fun challenge (Ljava/lang/String;)V
+	public final fun challenge (Lkotlin/jvm/functions/Function3;)V
+	public final fun getChallenge ()Lio/ktor/auth/FormAuthChallenge;
+	public final fun getPasswordParamName ()Ljava/lang/String;
+	public final fun getUserParamName ()Ljava/lang/String;
+	public final fun setChallenge (Lio/ktor/auth/FormAuthChallenge;)V
+	public final fun setPasswordParamName (Ljava/lang/String;)V
+	public final fun setUserParamName (Ljava/lang/String;)V
+	public final fun validate (Lkotlin/jvm/functions/Function3;)V
+}
+
+public final class io/ktor/auth/HeadersKt {
+	public static final fun parseAuthorizationHeader (Lio/ktor/request/ApplicationRequest;)Lio/ktor/http/auth/HttpAuthHeader;
+}
+
+public abstract class io/ktor/auth/OAuth1aException : java/lang/Exception {
+	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+}
+
+public final class io/ktor/auth/OAuth1aException$MissingTokenException : io/ktor/auth/OAuth1aException {
+	public fun <init> ()V
+}
+
+public final class io/ktor/auth/OAuth1aException$UnknownException : io/ktor/auth/OAuth1aException {
+	public fun <init> (Ljava/lang/String;)V
+}
+
+public final class io/ktor/auth/OAuth1aKt {
+	public static final fun createObtainRequestTokenHeader (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/time/LocalDateTime;)Lio/ktor/http/auth/HttpAuthHeader$Parameterized;
+	public static synthetic fun createObtainRequestTokenHeader$default (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/time/LocalDateTime;ILjava/lang/Object;)Lio/ktor/http/auth/HttpAuthHeader$Parameterized;
+	public static final fun createUpgradeRequestTokenHeader (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/time/LocalDateTime;)Lio/ktor/http/auth/HttpAuthHeader$Parameterized;
+	public static synthetic fun createUpgradeRequestTokenHeader$default (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/time/LocalDateTime;ILjava/lang/Object;)Lio/ktor/http/auth/HttpAuthHeader$Parameterized;
+	public static final fun sign (Lio/ktor/http/auth/HttpAuthHeader$Parameterized;Lio/ktor/http/HttpMethod;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;)Lio/ktor/http/auth/HttpAuthHeader$Parameterized;
+	public static final fun signatureBaseString (Lio/ktor/http/auth/HttpAuthHeader$Parameterized;Lio/ktor/http/HttpMethod;Ljava/lang/String;Ljava/util/List;)Ljava/lang/String;
+}
+
+public abstract class io/ktor/auth/OAuth2Exception : java/lang/Exception {
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getErrorCode ()Ljava/lang/String;
+}
+
+public final class io/ktor/auth/OAuth2Exception$InvalidGrant : io/ktor/auth/OAuth2Exception {
+	public fun <init> (Ljava/lang/String;)V
+}
+
+public final class io/ktor/auth/OAuth2Exception$MissingAccessToken : io/ktor/auth/OAuth2Exception {
+	public fun <init> ()V
+}
+
+public final class io/ktor/auth/OAuth2Exception$UnknownException : io/ktor/auth/OAuth2Exception, kotlinx/coroutines/CopyableThrowable {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public fun createCopy ()Lio/ktor/auth/OAuth2Exception$UnknownException;
+	public synthetic fun createCopy ()Ljava/lang/Throwable;
+}
+
+public final class io/ktor/auth/OAuth2Exception$UnsupportedGrantType : io/ktor/auth/OAuth2Exception, kotlinx/coroutines/CopyableThrowable {
+	public fun <init> (Ljava/lang/String;)V
+	public fun createCopy ()Lio/ktor/auth/OAuth2Exception$UnsupportedGrantType;
+	public synthetic fun createCopy ()Ljava/lang/Throwable;
+	public final fun getGrantType ()Ljava/lang/String;
+}
+
+public final class io/ktor/auth/OAuth2Kt {
+	public static final fun verifyWithOAuth2 (Lio/ktor/auth/UserPasswordCredential;Lio/ktor/client/HttpClient;Lio/ktor/auth/OAuthServerSettings$OAuth2ServerSettings;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class io/ktor/auth/OAuth2RequestParameters {
+	public static final field ClientId Ljava/lang/String;
+	public static final field ClientSecret Ljava/lang/String;
+	public static final field Code Ljava/lang/String;
+	public static final field GrantType Ljava/lang/String;
+	public static final field INSTANCE Lio/ktor/auth/OAuth2RequestParameters;
+	public static final field Password Ljava/lang/String;
+	public static final field RedirectUri Ljava/lang/String;
+	public static final field ResponseType Ljava/lang/String;
+	public static final field Scope Ljava/lang/String;
+	public static final field State Ljava/lang/String;
+	public static final field UserName Ljava/lang/String;
+}
+
+public final class io/ktor/auth/OAuth2ResponseParameters {
+	public static final field AccessToken Ljava/lang/String;
+	public static final field Error Ljava/lang/String;
+	public static final field ErrorDescription Ljava/lang/String;
+	public static final field ExpiresIn Ljava/lang/String;
+	public static final field INSTANCE Lio/ktor/auth/OAuth2ResponseParameters;
+	public static final field RefreshToken Ljava/lang/String;
+	public static final field TokenType Ljava/lang/String;
+}
+
+public abstract interface class io/ktor/auth/OAuth2StateProvider {
+	public abstract fun getState (Lio/ktor/application/ApplicationCall;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun verifyState (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public abstract class io/ktor/auth/OAuthAccessTokenResponse : io/ktor/auth/Principal {
+}
+
+public final class io/ktor/auth/OAuthAccessTokenResponse$OAuth1a : io/ktor/auth/OAuthAccessTokenResponse {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Lio/ktor/http/Parameters;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Lio/ktor/http/Parameters;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Lio/ktor/http/Parameters;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Lio/ktor/http/Parameters;)Lio/ktor/auth/OAuthAccessTokenResponse$OAuth1a;
+	public static synthetic fun copy$default (Lio/ktor/auth/OAuthAccessTokenResponse$OAuth1a;Ljava/lang/String;Ljava/lang/String;Lio/ktor/http/Parameters;ILjava/lang/Object;)Lio/ktor/auth/OAuthAccessTokenResponse$OAuth1a;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getExtraParameters ()Lio/ktor/http/Parameters;
+	public final fun getToken ()Ljava/lang/String;
+	public final fun getTokenSecret ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/ktor/auth/OAuthAccessTokenResponse$OAuth2 : io/ktor/auth/OAuthAccessTokenResponse {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;JLjava/lang/String;Lio/ktor/http/Parameters;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;JLjava/lang/String;Lio/ktor/http/Parameters;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()J
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Lio/ktor/http/Parameters;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;JLjava/lang/String;Lio/ktor/http/Parameters;)Lio/ktor/auth/OAuthAccessTokenResponse$OAuth2;
+	public static synthetic fun copy$default (Lio/ktor/auth/OAuthAccessTokenResponse$OAuth2;Ljava/lang/String;Ljava/lang/String;JLjava/lang/String;Lio/ktor/http/Parameters;ILjava/lang/Object;)Lio/ktor/auth/OAuthAccessTokenResponse$OAuth2;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAccessToken ()Ljava/lang/String;
+	public final fun getExpiresIn ()J
+	public final fun getExtraParameters ()Lio/ktor/http/Parameters;
+	public final fun getRefreshToken ()Ljava/lang/String;
+	public final fun getTokenType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/ktor/auth/OAuthAuthenticationProvider : io/ktor/auth/AuthenticationProvider {
+}
+
+public final class io/ktor/auth/OAuthAuthenticationProvider$Configuration : io/ktor/auth/AuthenticationProvider$Configuration {
+	public field client Lio/ktor/client/HttpClient;
+	public field providerLookup Lkotlin/jvm/functions/Function1;
+	public field urlProvider Lkotlin/jvm/functions/Function2;
+	public final fun getClient ()Lio/ktor/client/HttpClient;
+	public final fun getProviderLookup ()Lkotlin/jvm/functions/Function1;
+	public final fun getUrlProvider ()Lkotlin/jvm/functions/Function2;
+	public final fun setClient (Lio/ktor/client/HttpClient;)V
+	public final fun setProviderLookup (Lkotlin/jvm/functions/Function1;)V
+	public final fun setUrlProvider (Lkotlin/jvm/functions/Function2;)V
+}
+
+public abstract class io/ktor/auth/OAuthCallback {
+}
+
+public final class io/ktor/auth/OAuthCallback$TokenPair : io/ktor/auth/OAuthCallback {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;)Lio/ktor/auth/OAuthCallback$TokenPair;
+	public static synthetic fun copy$default (Lio/ktor/auth/OAuthCallback$TokenPair;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lio/ktor/auth/OAuthCallback$TokenPair;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getToken ()Ljava/lang/String;
+	public final fun getTokenSecret ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/ktor/auth/OAuthCallback$TokenSingle : io/ktor/auth/OAuthCallback {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;)Lio/ktor/auth/OAuthCallback$TokenSingle;
+	public static synthetic fun copy$default (Lio/ktor/auth/OAuthCallback$TokenSingle;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lio/ktor/auth/OAuthCallback$TokenSingle;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getState ()Ljava/lang/String;
+	public final fun getToken ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/ktor/auth/OAuthGrantTypes {
+	public static final field AuthorizationCode Ljava/lang/String;
+	public static final field INSTANCE Lio/ktor/auth/OAuthGrantTypes;
+	public static final field Password Ljava/lang/String;
+}
+
+public final class io/ktor/auth/OAuthKt {
+	public static final fun oauth (Lio/ktor/util/pipeline/PipelineContext;Lio/ktor/client/HttpClient;Lkotlinx/coroutines/CoroutineDispatcher;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun oauthHandleCallback (Lio/ktor/util/pipeline/PipelineContext;Lio/ktor/client/HttpClient;Lkotlinx/coroutines/CoroutineDispatcher;Lio/ktor/auth/OAuthServerSettings;Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun oauthHandleCallback$default (Lio/ktor/util/pipeline/PipelineContext;Lio/ktor/client/HttpClient;Lkotlinx/coroutines/CoroutineDispatcher;Lio/ktor/auth/OAuthServerSettings;Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static final fun oauthRespondRedirect (Lio/ktor/util/pipeline/PipelineContext;Lio/ktor/client/HttpClient;Lkotlinx/coroutines/CoroutineDispatcher;Lio/ktor/auth/OAuthServerSettings;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class io/ktor/auth/OAuthProcedureKt {
+	public static final fun getOAuthKey ()Ljava/lang/Object;
+	public static final fun oauth (Lio/ktor/auth/Authentication$Configuration;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)V
+	public static synthetic fun oauth$default (Lio/ktor/auth/Authentication$Configuration;Ljava/lang/String;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+}
+
+public abstract class io/ktor/auth/OAuthServerSettings {
+	public synthetic fun <init> (Ljava/lang/String;Lio/ktor/auth/OAuthVersion;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getName ()Ljava/lang/String;
+	public final fun getVersion ()Lio/ktor/auth/OAuthVersion;
+}
+
+public final class io/ktor/auth/OAuthServerSettings$OAuth1aServerSettings : io/ktor/auth/OAuthServerSettings {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public final fun getAccessTokenUrl ()Ljava/lang/String;
+	public final fun getAuthorizeUrl ()Ljava/lang/String;
+	public final fun getConsumerKey ()Ljava/lang/String;
+	public final fun getConsumerSecret ()Ljava/lang/String;
+	public final fun getRequestTokenUrl ()Ljava/lang/String;
+}
+
+public final class io/ktor/auth/OAuthServerSettings$OAuth2ServerSettings : io/ktor/auth/OAuthServerSettings {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lio/ktor/http/HttpMethod;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;ZLio/ktor/util/NonceManager;Lkotlin/jvm/functions/Function1;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lio/ktor/http/HttpMethod;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;ZLio/ktor/util/NonceManager;Lkotlin/jvm/functions/Function1;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getAccessTokenRequiresBasicAuth ()Z
+	public final fun getAccessTokenUrl ()Ljava/lang/String;
+	public final fun getAuthorizeUrl ()Ljava/lang/String;
+	public final fun getAuthorizeUrlInterceptor ()Lkotlin/jvm/functions/Function1;
+	public final fun getClientId ()Ljava/lang/String;
+	public final fun getClientSecret ()Ljava/lang/String;
+	public final fun getDefaultScopes ()Ljava/util/List;
+	public final fun getNonceManager ()Lio/ktor/util/NonceManager;
+	public final fun getRequestMethod ()Lio/ktor/http/HttpMethod;
+}
+
+public final class io/ktor/auth/OAuthVersion : java/lang/Enum {
+	public static final field V10a Lio/ktor/auth/OAuthVersion;
+	public static final field V20 Lio/ktor/auth/OAuthVersion;
+	public static fun valueOf (Ljava/lang/String;)Lio/ktor/auth/OAuthVersion;
+	public static fun values ()[Lio/ktor/auth/OAuthVersion;
+}
+
+public abstract interface class io/ktor/auth/Principal {
+}
+
+public abstract class io/ktor/auth/SessionAuthChallenge {
+	public static final field Companion Lio/ktor/auth/SessionAuthChallenge$Companion;
+}
+
+public final class io/ktor/auth/SessionAuthChallenge$Companion {
+	public final fun getDefault ()Lio/ktor/auth/SessionAuthChallenge;
+}
+
+public final class io/ktor/auth/SessionAuthChallenge$Ignore : io/ktor/auth/SessionAuthChallenge {
+	public static final field INSTANCE Lio/ktor/auth/SessionAuthChallenge$Ignore;
+}
+
+public final class io/ktor/auth/SessionAuthChallenge$Redirect : io/ktor/auth/SessionAuthChallenge {
+	public fun <init> (Lkotlin/jvm/functions/Function2;)V
+	public final fun getUrl ()Lkotlin/jvm/functions/Function2;
+}
+
+public final class io/ktor/auth/SessionAuthChallenge$Unauthorized : io/ktor/auth/SessionAuthChallenge {
+	public static final field INSTANCE Lio/ktor/auth/SessionAuthChallenge$Unauthorized;
+}
+
+public final class io/ktor/auth/SessionAuthKt {
+	public static final field SessionAuthChallengeKey Ljava/lang/String;
+	public static final synthetic fun session (Lio/ktor/auth/Authentication$Configuration;Ljava/lang/String;)V
+	public static final synthetic fun session (Lio/ktor/auth/Authentication$Configuration;Ljava/lang/String;Lio/ktor/auth/SessionAuthChallenge;)V
+	public static final synthetic fun session (Lio/ktor/auth/Authentication$Configuration;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)V
+	public static synthetic fun session$default (Lio/ktor/auth/Authentication$Configuration;Ljava/lang/String;ILjava/lang/Object;)V
+	public static synthetic fun session$default (Lio/ktor/auth/Authentication$Configuration;Ljava/lang/String;Lio/ktor/auth/SessionAuthChallenge;ILjava/lang/Object;)V
+	public static synthetic fun session$default (Lio/ktor/auth/Authentication$Configuration;Ljava/lang/String;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+}
+
+public final class io/ktor/auth/SessionAuthenticationProvider : io/ktor/auth/AuthenticationProvider {
+	public static final field Companion Lio/ktor/auth/SessionAuthenticationProvider$Companion;
+	public synthetic fun <init> (Lio/ktor/auth/SessionAuthenticationProvider$Configuration;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getType ()Lkotlin/reflect/KClass;
+}
+
+public final class io/ktor/auth/SessionAuthenticationProvider$Companion {
+}
+
+public final class io/ktor/auth/SessionAuthenticationProvider$Configuration : io/ktor/auth/AuthenticationProvider$Configuration {
+	public fun <init> (Ljava/lang/String;Lkotlin/reflect/KClass;)V
+	public final fun buildProvider ()Lio/ktor/auth/SessionAuthenticationProvider;
+	public final fun challenge (Lio/ktor/http/Url;)V
+	public final fun challenge (Ljava/lang/String;)V
+	public final fun challenge (Lkotlin/jvm/functions/Function3;)V
+	public final fun getChallenge ()Lio/ktor/auth/SessionAuthChallenge;
+	public final fun setChallenge (Lio/ktor/auth/SessionAuthChallenge;)V
+	public final fun validate (Lkotlin/jvm/functions/Function3;)V
+}
+
+public final class io/ktor/auth/UnauthorizedResponse : io/ktor/http/content/OutgoingContent$NoContent {
+	public fun <init> ([Lio/ktor/http/auth/HttpAuthHeader;)V
+	public final fun getChallenges ()[Lio/ktor/http/auth/HttpAuthHeader;
+	public fun getHeaders ()Lio/ktor/http/Headers;
+	public fun getStatus ()Lio/ktor/http/HttpStatusCode;
+}
+
+public final class io/ktor/auth/UserHashedTableAuth {
+	public synthetic fun <init> (Lio/ktor/config/ApplicationConfig;)V
+	public synthetic fun <init> (Ljava/util/Map;)V
+	public fun <init> (Lkotlin/jvm/functions/Function1;Ljava/util/Map;)V
+	public final fun authenticate (Lio/ktor/auth/UserPasswordCredential;)Lio/ktor/auth/UserIdPrincipal;
+	public final fun getDigester ()Lkotlin/jvm/functions/Function1;
+	public final fun getTable ()Ljava/util/Map;
+}
+
+public final class io/ktor/auth/UserIdPrincipal : io/ktor/auth/Principal {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lio/ktor/auth/UserIdPrincipal;
+	public static synthetic fun copy$default (Lio/ktor/auth/UserIdPrincipal;Ljava/lang/String;ILjava/lang/Object;)Lio/ktor/auth/UserIdPrincipal;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getName ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/ktor/auth/UserPasswordCredential : io/ktor/auth/Credential {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;)Lio/ktor/auth/UserPasswordCredential;
+	public static synthetic fun copy$default (Lio/ktor/auth/UserPasswordCredential;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lio/ktor/auth/UserPasswordCredential;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getName ()Ljava/lang/String;
+	public final fun getPassword ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+

--- a/binary-compatibility-validator/reference-public-api/ktor-websockets.txt
+++ b/binary-compatibility-validator/reference-public-api/ktor-websockets.txt
@@ -1,0 +1,98 @@
+public final class io/ktor/http/cio/websocket/DurationsKt {
+	public static final fun WebSockets (Ljava/time/Duration;Ljava/time/Duration;JZ)Lio/ktor/websocket/WebSockets;
+	public static final fun getPingInterval (Lio/ktor/websocket/DefaultWebSocketServerSession;)Ljava/time/Duration;
+	public static final fun getPingInterval (Lio/ktor/websocket/WebSockets;)Ljava/time/Duration;
+	public static final fun getPingPeriod (Lio/ktor/websocket/WebSockets$WebSocketOptions;)Ljava/time/Duration;
+	public static final fun getTimeout (Lio/ktor/websocket/DefaultWebSocketServerSession;)Ljava/time/Duration;
+	public static final fun getTimeout (Lio/ktor/websocket/WebSockets$WebSocketOptions;)Ljava/time/Duration;
+	public static final fun getTimeout (Lio/ktor/websocket/WebSockets;)Ljava/time/Duration;
+	public static final fun pinger (Lkotlinx/coroutines/CoroutineScope;Lkotlinx/coroutines/channels/SendChannel;Ljava/time/Duration;Ljava/time/Duration;Lio/ktor/utils/io/pool/ObjectPool;)Lkotlinx/coroutines/channels/SendChannel;
+	public static synthetic fun pinger$default (Lkotlinx/coroutines/CoroutineScope;Lkotlinx/coroutines/channels/SendChannel;Ljava/time/Duration;Ljava/time/Duration;Lio/ktor/utils/io/pool/ObjectPool;ILjava/lang/Object;)Lkotlinx/coroutines/channels/SendChannel;
+	public static final fun setPingInterval (Lio/ktor/websocket/DefaultWebSocketServerSession;Ljava/time/Duration;)V
+	public static final fun setPingPeriod (Lio/ktor/websocket/WebSockets$WebSocketOptions;Ljava/time/Duration;)V
+	public static final fun setTimeout (Lio/ktor/websocket/DefaultWebSocketServerSession;Ljava/time/Duration;)V
+	public static final fun setTimeout (Lio/ktor/websocket/WebSockets$WebSocketOptions;Ljava/time/Duration;)V
+}
+
+public abstract interface class io/ktor/websocket/DefaultWebSocketServerSession : io/ktor/http/cio/websocket/DefaultWebSocketSession, io/ktor/websocket/WebSocketServerSession {
+}
+
+public final class io/ktor/websocket/DefaultWebSocketServerSession$DefaultImpls {
+	public static fun send (Lio/ktor/websocket/DefaultWebSocketServerSession;Lio/ktor/http/cio/websocket/Frame;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class io/ktor/websocket/KotlinDurationsKt {
+	public static final fun WebSockets-v29k7_A (Lkotlin/time/Duration;DJZ)Lio/ktor/websocket/WebSockets;
+	public static final fun pinger-1WGW0hc (Lkotlinx/coroutines/CoroutineScope;Lkotlinx/coroutines/channels/SendChannel;DDLio/ktor/utils/io/pool/ObjectPool;)Lkotlinx/coroutines/channels/SendChannel;
+	public static synthetic fun pinger-1WGW0hc$default (Lkotlinx/coroutines/CoroutineScope;Lkotlinx/coroutines/channels/SendChannel;DDLio/ktor/utils/io/pool/ObjectPool;ILjava/lang/Object;)Lkotlinx/coroutines/channels/SendChannel;
+}
+
+public final class io/ktor/websocket/RoutingKt {
+	public static final fun webSocket (Lio/ktor/routing/Route;Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function2;)V
+	public static final fun webSocket (Lio/ktor/routing/Route;Ljava/lang/String;Lkotlin/jvm/functions/Function2;)V
+	public static synthetic fun webSocket$default (Lio/ktor/routing/Route;Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function2;ILjava/lang/Object;)V
+	public static synthetic fun webSocket$default (Lio/ktor/routing/Route;Ljava/lang/String;Lkotlin/jvm/functions/Function2;ILjava/lang/Object;)V
+	public static final fun webSocketRaw (Lio/ktor/routing/Route;Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function2;)V
+	public static final fun webSocketRaw (Lio/ktor/routing/Route;Ljava/lang/String;Lkotlin/jvm/functions/Function2;)V
+	public static synthetic fun webSocketRaw$default (Lio/ktor/routing/Route;Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function2;ILjava/lang/Object;)V
+	public static synthetic fun webSocketRaw$default (Lio/ktor/routing/Route;Ljava/lang/String;Lkotlin/jvm/functions/Function2;ILjava/lang/Object;)V
+}
+
+public abstract interface class io/ktor/websocket/WebSocketServerSession : io/ktor/http/cio/websocket/WebSocketSession {
+	public abstract fun getCall ()Lio/ktor/application/ApplicationCall;
+}
+
+public final class io/ktor/websocket/WebSocketServerSession$DefaultImpls {
+	public static fun send (Lio/ktor/websocket/WebSocketServerSession;Lio/ktor/http/cio/websocket/Frame;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class io/ktor/websocket/WebSocketServerSessionKt {
+	public static final fun getApplication (Lio/ktor/websocket/WebSocketServerSession;)Lio/ktor/application/Application;
+}
+
+public final class io/ktor/websocket/WebSocketUpgrade : io/ktor/http/content/OutgoingContent$ProtocolUpgrade {
+	public static final field Companion Lio/ktor/websocket/WebSocketUpgrade$Companion;
+	public fun <init> (Lio/ktor/application/ApplicationCall;Ljava/lang/String;Lkotlin/jvm/functions/Function2;)V
+	public synthetic fun <init> (Lio/ktor/application/ApplicationCall;Ljava/lang/String;Lkotlin/jvm/functions/Function2;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getCall ()Lio/ktor/application/ApplicationCall;
+	public final fun getHandle ()Lkotlin/jvm/functions/Function2;
+	public fun getHeaders ()Lio/ktor/http/Headers;
+	public final fun getProtocol ()Ljava/lang/String;
+	public fun upgrade (Lio/ktor/utils/io/ByteReadChannel;Lio/ktor/utils/io/ByteWriteChannel;Lkotlin/coroutines/CoroutineContext;Lkotlin/coroutines/CoroutineContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class io/ktor/websocket/WebSocketUpgrade$Companion {
+}
+
+public final class io/ktor/websocket/WebSockets : kotlinx/coroutines/CoroutineScope {
+	public static final field Feature Lio/ktor/websocket/WebSockets$Feature;
+	public fun <init> (JJJZ)V
+	public fun getCoroutineContext ()Lkotlin/coroutines/CoroutineContext;
+	public final fun getMasking ()Z
+	public final fun getMaxFrameSize ()J
+	public final fun getPingIntervalMillis ()J
+	public final fun getTimeoutMillis ()J
+}
+
+public final class io/ktor/websocket/WebSockets$Feature : io/ktor/application/ApplicationFeature {
+	public fun getKey ()Lio/ktor/util/AttributeKey;
+	public fun install (Lio/ktor/application/Application;Lkotlin/jvm/functions/Function1;)Lio/ktor/websocket/WebSockets;
+	public synthetic fun install (Lio/ktor/util/pipeline/Pipeline;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+}
+
+public final class io/ktor/websocket/WebSockets$WebSocketOptions {
+	public fun <init> ()V
+	public final fun getMasking ()Z
+	public final fun getMaxFrameSize ()J
+	public final synthetic fun getPingPeriod ()Ljava/time/Duration;
+	public final fun getPingPeriodMillis ()J
+	public final synthetic fun getTimeout ()Ljava/time/Duration;
+	public final fun getTimeoutMillis ()J
+	public final fun setMasking (Z)V
+	public final fun setMaxFrameSize (J)V
+	public final synthetic fun setPingPeriod (Ljava/time/Duration;)V
+	public final fun setPingPeriodMillis (J)V
+	public final synthetic fun setTimeout (Ljava/time/Duration;)V
+	public final fun setTimeoutMillis (J)V
+}
+

--- a/gradle/compatibility.gradle
+++ b/gradle/compatibility.gradle
@@ -17,7 +17,9 @@ dependencies {
         project(":ktor-http"),
         project(":ktor-network"),
         project(":ktor-utils"),
-        project(":ktor-server:ktor-server-core")
+        project(":ktor-server:ktor-server-core"),
+        project(":ktor-features:ktor-auth"),
+        project(":ktor-features:ktor-websockets")
     ]
 
     while (!queue.isEmpty()) {

--- a/ktor-features/ktor-auth-jwt/build.gradle
+++ b/ktor-features/ktor-auth-jwt/build.gradle
@@ -4,8 +4,8 @@ kotlin.sourceSets {
     jvmMain.dependencies {
         api project(':ktor-features:ktor-auth')
         api group: 'com.googlecode.json-simple', name: 'json-simple', version: '1.1.1', transitive: false
-        api group: 'com.auth0', name: 'java-jwt', version: '3.4.1'
-        api group: 'com.auth0', name: 'jwks-rsa', version: '0.7.0'
+        api group: 'com.auth0', name: 'java-jwt', version: '3.9.0'
+        api group: 'com.auth0', name: 'jwks-rsa', version: '0.9.0'
     }
     jvmTest.dependencies {
         api 'com.nhaarman:mockito-kotlin:1.6.0'

--- a/ktor-features/ktor-auth-jwt/jvm/src/io/ktor/auth/jwt/JWTAuth.kt
+++ b/ktor-features/ktor-auth-jwt/jvm/src/io/ktor/auth/jwt/JWTAuth.kt
@@ -10,6 +10,7 @@ import com.auth0.jwt.algorithms.*
 import com.auth0.jwt.exceptions.*
 import com.auth0.jwt.impl.*
 import com.auth0.jwt.interfaces.*
+import com.auth0.jwt.interfaces.JWTVerifier
 import io.ktor.application.*
 import io.ktor.auth.*
 import io.ktor.http.auth.*

--- a/ktor-features/ktor-auth-jwt/jvm/test/io/ktor/auth/jwt/JWTAuthTest.kt
+++ b/ktor-features/ktor-auth-jwt/jvm/test/io/ktor/auth/jwt/JWTAuthTest.kt
@@ -55,6 +55,24 @@ class JWTAuthTest {
     }
 
     @Test
+    fun testJwtMultipleNoAuthCustomChallengeNoToken() {
+        withApplication {
+            application.configureServerJwt {
+                challenge { _, _ ->
+                    call.respond(UnauthorizedResponse(HttpAuthHeader.basicAuthChallenge("custom1", Charsets.UTF_8)))
+                }
+            }
+
+            val response = handleRequest {
+                uri = "/"
+            }
+
+            verifyResponseUnauthorized(response)
+            assertEquals("Basic realm=custom1, charset=UTF-8", response.response.headers[HttpHeaders.WWWAuthenticate])
+        }
+    }
+
+    @Test
     fun testJwtSuccess() {
         withApplication {
             application.configureServerJwt()

--- a/ktor-features/ktor-auth-jwt/jvm/test/io/ktor/auth/jwt/JWTAuthTest.kt
+++ b/ktor-features/ktor-auth-jwt/jvm/test/io/ktor/auth/jwt/JWTAuthTest.kt
@@ -10,12 +10,12 @@ import com.auth0.jwt.algorithms.*
 import com.nhaarman.mockito_kotlin.*
 import io.ktor.application.*
 import io.ktor.auth.*
+import io.ktor.auth.Principal
 import io.ktor.http.*
 import io.ktor.http.auth.*
 import io.ktor.response.*
 import io.ktor.routing.*
 import io.ktor.server.testing.*
-import org.junit.Test
 import java.security.*
 import java.security.interfaces.*
 import java.util.concurrent.*
@@ -69,6 +69,68 @@ class JWTAuthTest {
 
             verifyResponseUnauthorized(response)
             assertEquals("Basic realm=custom1, charset=UTF-8", response.response.headers[HttpHeaders.WWWAuthenticate])
+        }
+    }
+
+    @Test
+    fun testJwtWithMultipleConfigurations() {
+        val validated = mutableSetOf<String>()
+        var currentPrincipal: (JWTCredential) -> Principal? = { null }
+
+        withApplication {
+            application.install(Authentication) {
+                jwt(name = "first") {
+                    realm = "realm1"
+                    verifier(makeJwtVerifier())
+                    validate { validated.add("1"); currentPrincipal(it) }
+                    challenge { _, _ ->
+                        call.respond(UnauthorizedResponse(HttpAuthHeader.basicAuthChallenge("custom1", Charsets.UTF_8)))
+                    }
+                }
+                jwt(name = "second") {
+                    realm = "realm2"
+                    verifier(makeJwtVerifier())
+                    validate { validated.add("2"); currentPrincipal(it) }
+                    challenge { _, _ ->
+                        call.respond(UnauthorizedResponse(HttpAuthHeader.basicAuthChallenge("custom2", Charsets.UTF_8)))
+                    }
+                }
+            }
+
+            application.routing {
+                authenticate("first", "second") {
+                    get("/") {
+                        val principal = call.authentication.principal<JWTPrincipal>()!!
+                        call.respondText("Secret info, ${principal.payload.audience}")
+                    }
+                }
+            }
+
+            val token = getToken()
+            handleRequestWithToken(token).let { call ->
+                verifyResponseUnauthorized(call)
+                assertEquals(
+                    "Basic realm=custom1, charset=UTF-8",
+                    call.response.headers[HttpHeaders.WWWAuthenticate]
+                )
+            }
+            assertEquals(setOf("1", "2"), validated)
+
+            currentPrincipal = { JWTPrincipal(it.payload) }
+            validated.clear()
+
+            handleRequestWithToken(token).let { call ->
+                assertEquals(HttpStatusCode.OK, call.response.status())
+
+                assertEquals(
+                    "Secret info, [$audience]",
+                    call.response.content
+                )
+
+                assertNull(call.response.headers[HttpHeaders.WWWAuthenticate])
+            }
+
+            assertEquals(setOf("1"), validated)
         }
     }
 

--- a/ktor-features/ktor-auth/jvm/src/io/ktor/auth/AuthenticationContext.kt
+++ b/ktor-features/ktor-auth/jvm/src/io/ktor/auth/AuthenticationContext.kt
@@ -7,6 +7,7 @@ package io.ktor.auth
 import io.ktor.application.*
 import io.ktor.util.pipeline.*
 import io.ktor.util.*
+import kotlin.collections.HashMap
 import kotlin.properties.*
 
 /**
@@ -14,10 +15,12 @@ import kotlin.properties.*
  * @param call instance of [ApplicationCall] this context is for
  */
 class AuthenticationContext(val call: ApplicationCall) {
+    private val _errors = HashMap<Any, AuthenticationFailedCause>()
+
     /**
      * Retrieves authenticated principal, or returns null if no user was authenticated
      */
-    var principal by Delegates.vetoable<Principal?>(null) { _, old, _ ->
+    var principal: Principal? by Delegates.vetoable<Principal?>(null) { _, old, _ ->
         require(old == null) { "Principal can be only assigned once" }
         true
     }
@@ -25,19 +28,33 @@ class AuthenticationContext(val call: ApplicationCall) {
     /**
      * Stores authentication failures for keys provided by authentication mechanisms
      */
-    val errors = HashMap<Any, AuthenticationFailedCause>()
+    @Suppress("unused")
+    @Deprecated("Use allErrors, allFailures or error() function instead")
+    val errors: HashMap<Any, AuthenticationFailedCause> get() = _errors
 
     /**
-     * Appends an error to the [errors]
+     * All registered errors during auth procedure (only [AuthenticationFailedCause.Error]).
+     */
+    val allErrors: List<AuthenticationFailedCause.Error>
+        get() = _errors.values.filterIsInstance<AuthenticationFailedCause.Error>()
+
+    /**
+     * All authentication failures during auth procedure including missing or invalid credentials
+     */
+    val allFailures: List<AuthenticationFailedCause>
+        get() = _errors.values.toList()
+
+    /**
+     * Appends an error to the errors list. Overwrites if already registered for the same [key].
      */
     fun error(key: Any, cause: AuthenticationFailedCause) {
-        errors[key] = cause
+        _errors[key] = cause
     }
 
     /**
      * Gets an [AuthenticationProcedureChallenge] for this context
      */
-    val challenge = AuthenticationProcedureChallenge()
+    val challenge: AuthenticationProcedureChallenge = AuthenticationProcedureChallenge()
 
     /**
      * Sets an authenticated principal for this context.

--- a/ktor-features/ktor-auth/jvm/src/io/ktor/auth/AuthenticationFailedCause.kt
+++ b/ktor-features/ktor-auth/jvm/src/io/ktor/auth/AuthenticationFailedCause.kt
@@ -20,7 +20,17 @@ sealed class AuthenticationFailedCause {
 
     /**
      * Represents a case when authentication mechanism failed
-     * @param cause cause of authentication failure
+     * @param message describing the cause of the authentication failure
      */
-    open class Error(val cause: String) : AuthenticationFailedCause()
+    open class Error(val message: String) : AuthenticationFailedCause() {
+        @Suppress("UNUSED_PARAMETER")
+        @Deprecated("Use message instead of cause.")
+        constructor(vararg placeholder: Unit, cause: String) : this(message = cause)
+
+        /**
+         * Contains error message explaining the reason of auth failure.
+         */
+        @Deprecated("Use message instead.", ReplaceWith("message"))
+        val cause: String get() = message
+    }
 }

--- a/ktor-features/ktor-auth/jvm/test/io/ktor/tests/auth/AuthBuildersTest.kt
+++ b/ktor-features/ktor-auth/jvm/test/io/ktor/tests/auth/AuthBuildersTest.kt
@@ -447,11 +447,23 @@ class AuthBuildersTest {
 
     @Test
     fun testAuthProviderFailureNoChallenge(): Unit = withTestApplication<Unit> {
+        class CustomErrorCause : AuthenticationFailedCause.Error("custom error")
+
+        @Suppress("DEPRECATION", "unused")
+        class DeprecationTest : AuthenticationFailedCause.Error(cause = "deprecated") {
+            fun f(): String = cause
+        }
+
         application.apply {
             authentication {
                 provider("custom") {
                     pipeline.intercept(AuthenticationPipeline.CheckAuthentication) {
                         context.authentication.error(this, AuthenticationFailedCause.Error("test"))
+                    }
+                }
+                provider("custom-inheritance") {
+                    pipeline.intercept(AuthenticationPipeline.CheckAuthentication) {
+                        context.authentication.error(this, CustomErrorCause())
                     }
                 }
             }
@@ -466,6 +478,16 @@ class AuthBuildersTest {
                         call.respondText("OK")
                     }
                 }
+                authenticate("custom-inheritance") {
+                    get("/fail-inheritance") {
+                        fail("shouldn't reach here")
+                    }
+                }
+                authenticate("custom-inheritance", optional = true) {
+                    get("/pass-inheritance") {
+                        call.respondText("OK")
+                    }
+                }
             }
         }
 
@@ -474,6 +496,15 @@ class AuthBuildersTest {
         }
 
         handleRequest(HttpMethod.Get, "/pass").let { call ->
+            assertEquals(HttpStatusCode.OK.value, call.response.status()?.value)
+            assertEquals("OK", call.response.content)
+        }
+
+        handleRequest(HttpMethod.Get, "/fail-inheritance").let { call ->
+            assertEquals(HttpStatusCode.Unauthorized.value, call.response.status()?.value)
+        }
+
+        handleRequest(HttpMethod.Get, "/pass-inheritance").let { call ->
             assertEquals(HttpStatusCode.OK.value, call.response.status()?.value)
             assertEquals("OK", call.response.content)
         }

--- a/ktor-features/ktor-server-sessions/jvm/src/io/ktor/sessions/Cache.kt
+++ b/ktor-features/ktor-server-sessions/jvm/src/io/ktor/sessions/Cache.kt
@@ -38,8 +38,36 @@ internal class BaseCache<in K : Any, V : Any>(val calc: suspend (K) -> V) : Cach
 
     override fun peek(key: K): V? = container[key]?.let { if (!it.isActive) it.getCompleted() else null }
 
-    override fun invalidate(key: K): V? = container.remove(key)?.let { if (!it.isActive) it.getCompleted() else null }
-    override fun invalidate(key: K, value: V) = container[key]?.let { l -> !l.isActive && l.getCompleted() == value && container.remove(key, l) } ?: false
+    override fun invalidate(key: K): V? {
+        container.remove(key)?.let {
+            if (!it.isActive) {
+                try {
+                    it.getCompleted()
+                } catch (_: Throwable) {
+                    // we shouldn't re-throw a failure but simply return null
+                }
+            }
+        }
+
+        return null
+    }
+
+    override fun invalidate(key: K, value: V): Boolean {
+        container[key]?.let { l ->
+            if (!l.isActive) {
+                try {
+                    if (l.getCompleted() == value && container.remove(key, l)) {
+                        return true
+                    }
+                } catch (_: Throwable) {
+                    return false
+                }
+            }
+        }
+
+        return false
+    }
+
     override fun invalidateAll() {
         container.clear()
     }

--- a/ktor-server/ktor-server-core/jvm/src/io/ktor/sessions/SessionTrackerById.kt
+++ b/ktor-server/ktor-server-core/jvm/src/io/ktor/sessions/SessionTrackerById.kt
@@ -38,6 +38,10 @@ class SessionTrackerById<S : Any>(
         } catch (notFound: NoSuchElementException) {
             call.application.log.debug("Failed to lookup session: $notFound")
         }
+
+        // we remove the wrong session identifier if no related session found
+        call.attributes.put(SessionIdKey, sessionId)
+
         return null
     }
 

--- a/ktor-server/ktor-server-host-common/jvm/src/io/ktor/server/engine/DefaultUncaughtExceptionHandler.kt
+++ b/ktor-server/ktor-server-host-common/jvm/src/io/ktor/server/engine/DefaultUncaughtExceptionHandler.kt
@@ -27,6 +27,8 @@ class DefaultUncaughtExceptionHandler(
         if (exception is CancellationException) return
         if (exception is IOException) return
 
-        logger().error(exception)
+        val coroutineName = context[CoroutineName] ?: context.toString()
+
+        logger().error("Unhandled exception caught for $coroutineName", exception)
     }
 }


### PR DESCRIPTION
**Subsystem**
Server ktor-auth, ktor-auth-jwt

**Motivation**
There are the following issues:
- Sometimes an exception from session loader is accidentally re-thrown and cancelled a request handling job in spite of the fact that it is caught (#1591)
- If a session loader crashes, the session cache watchdog may crash (without possible restart).
- When there are multiple auth providers registered, only the first has a chance to handle request while extra providers will be never invoked if the first is failed with invalid credentials (#1586)
- There is minor confusion with auth failure property name

**Solution**
- Fix exceptions handling caused by async sub-coroutine that accidentally killed all parents. Such behaviour is not intended and an exception should be caught and logger in debug level
- Fix cache invalidate functions to not rethrow exceptions. The invalidate function caused watchdog crashes.
- Upgrade JWT/JWKS implementation libraries.
- Simplify server auth procedure and always process all challenges in the end (after all providers actually started).
- Enable binary compatibility validator for two more server modules because 3rd part libraries depend on them: ktor-auth and ktor-websockets

