### PR TITLE
Bump Netty version per CVE-2019-20444, CVE-2019-20445, and CVE-2020-7…

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -24,7 +24,7 @@ coroutines_version=1.3.3
 atomicfu_version=0.14.1
 
 # server
-netty_version=4.1.43.Final
+netty_version=4.1.44.Final
 netty_tcnative_version=2.0.27.Final
 jetty_version=9.4.24.v20191120
 jetty_alpn_api_version=1.1.3.v20160715


### PR DESCRIPTION
…238 for request smuggling vulernabilities.

**Subsystem**
Server, specifically ktor-netty-server

**Motivation**
The current version of Netty Codec is vulnerable to request smuggling per CVE-2019-20444, CVE-2019-20445, and CVE-2020-7. I didn't open an issue since it felt a little forced to classify this as a Ktor bug with the provided templates. I can do so if necessary.

**Solution**
Bumped the patch version of Netty from 4.1.43.Final to 4.1.44.Final 

