### PR TITLE
Reduce complexity of Pipeline implementation

### DIFF
--- a/ktor-utils/common/test/io/ktor/tests/utils/PipelinePhasesTest.kt
+++ b/ktor-utils/common/test/io/ktor/tests/utils/PipelinePhasesTest.kt
@@ -30,6 +30,15 @@ class PipelinePhasesTest {
     }
 
     @Test
+    fun testNaturalOrderMerge3() {
+        val phases1 = Pipeline<String, Unit>(a, c)
+        val phases2 = Pipeline<String, Unit>(a)
+        phases2.addPhase(b)
+        phases1.merge(phases2)
+        assertEquals(listOf(a, c, b), phases1.items)
+    }
+
+    @Test
     fun testInsertAfterMerge() {
         val phases1 = Pipeline<String, Unit>(a)
         val phases2 = Pipeline<String, Unit>(c)
@@ -39,11 +48,29 @@ class PipelinePhasesTest {
     }
 
     @Test
+    fun testInsertAfterMerge2() {
+        val phases1 = Pipeline<String, Unit>(a, c)
+        val phases2 = Pipeline<String, Unit>(a)
+        phases2.insertPhaseAfter(a, b)
+        phases1.merge(phases2)
+        assertEquals(listOf(a, b, c), phases1.items)
+    }
+
+    @Test
     fun testInsertBeforeMerge() {
         val phases1 = Pipeline<String, Unit>(c, a)
         val phases2 = Pipeline<String, Unit>(c)
         phases2.insertPhaseBefore(c, b)
         phases1.merge(phases2)
         assertEquals(listOf(b, c, a), phases1.items)
+    }
+
+    @Test
+    fun testInsertBeforeMerge2() {
+        val phases1 = Pipeline<String, Unit>(a)
+        val phases2 = Pipeline<String, Unit>(c)
+        phases2.insertPhaseBefore(c, b)
+        phases1.merge(phases2)
+        assertEquals(listOf(a, b, c), phases1.items)
     }
 }


### PR DESCRIPTION
**Subsystem**
`ktor-utils`

**Motivation**
In order to develop a clean solution for #985, I wanted to extend the `Pipeline` class with a new feature. However, the complexity of the `Pipeline` class blocked me from doing this.

**Solution**
I propose a re-implementation of the class. Goals of the re-implementation are:
* reduce size
* reduce complexity due to shared variable accesses
* make the code easier to understand and reason about, hence making it better to maintain
* keep the public interface as is
* the new implementation should not imply a major performance regression

**Caveats**
Some tests in `PipelineContractsTest` had to be removed because of the different nature of internal interceptors handling. If these tests were meant as an absolute requirement, the PR has to be rejected. On the other hand, I added further tests to increase code coverage.

**Side note**
The diff for `Pipeline.kt` is probably not so helpful for reviewing, since it is a complete rework of the code. However, note the removal of the `Volatile` annotation. I removed it since it is JVM specific but the class is part of the common source code. Should it be re-added to the `cachedInterceptors` variable?

