### PR TITLE
Remove org.eclipse.jetty.alpn:alpn-api from ktor-server-netty

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -27,7 +27,6 @@ atomicfu_version=0.14.1
 netty_version=4.1.44.Final
 netty_tcnative_version=2.0.27.Final
 jetty_version=9.4.24.v20191120
-jetty_alpn_api_version=1.1.3.v20160715
 
 # utility
 logback_version=1.2.3

--- a/ktor-server/ktor-server-netty/build.gradle
+++ b/ktor-server/ktor-server-netty/build.gradle
@@ -5,7 +5,6 @@ kotlin.sourceSets {
         api project(':ktor-server:ktor-server-host-common')
 
         api group: 'io.netty', name: 'netty-codec-http2', version: netty_version
-        api group: 'org.eclipse.jetty.alpn', name: 'alpn-api', version: jetty_alpn_api_version
 
         api group: 'io.netty', name: 'netty-transport-native-kqueue', version: netty_version
         api group: 'io.netty', name: 'netty-transport-native-epoll', version: netty_version


### PR DESCRIPTION
**Subsystem**
ktor-server-netty

**Motivation**
See https://github.com/ktorio/ktor/issues/1307 - this dependency appears to be unused, and is creating noise for us when running the gradle dependency check (flags up https://nvd.nist.gov/vuln/detail/CVE-2007-5615).

**Solution**
I've removed the dependency and run gradle build - all seems fine. I have 56 tests passing locally with no failures. 

Let me know if there's anything else I should do to verify that I haven't broken anything :)

