### PR TITLE
Fix Netty upgrade to wait for all jobs completion

### DIFF
--- a/ktor-features/ktor-websockets/jvm/test/io/ktor/tests/websocket/WriterTest.kt
+++ b/ktor-features/ktor-websockets/jvm/test/io/ktor/tests/websocket/WriterTest.kt
@@ -48,7 +48,7 @@ class WriterTest {
             (it.toInt() and 0xff).toString(16).padStart(2, '0')
         }
 
-        (writer.outgoing as Job).join()
+        writer.flush()
 
         assertEquals(true, writer.outgoing.isClosedForSend)
         assertEquals("88, 02, 03, e8", bytesWritten)

--- a/ktor-http/ktor-http-cio/jvm/src/io/ktor/http/cio/websocket/Frame.kt
+++ b/ktor-http/ktor-http-cio/jvm/src/io/ktor/http/cio/websocket/Frame.kt
@@ -16,7 +16,7 @@ import java.nio.*
  * @property data - a frame content or fragment content
  * @property disposableHandle could be invoked when the frame is processed
  */
-actual sealed class Frame private actual constructor(
+actual sealed class Frame actual constructor(
     actual val fin: Boolean,
     actual val frameType: FrameType,
     actual val data: ByteArray,
@@ -59,10 +59,12 @@ actual sealed class Frame private actual constructor(
      */
     actual class Close actual constructor(data: ByteArray) : Frame(true, FrameType.CLOSE, data) {
 
-        actual constructor(reason: CloseReason) : this(buildPacket {
-            writeShort(reason.code)
-            writeText(reason.message)
-        })
+        actual constructor(reason: CloseReason) : this(
+            buildPacket {
+                writeShort(reason.code)
+                writeText(reason.message)
+            }
+        )
         actual constructor(packet: ByteReadPacket) : this(packet.readBytes())
         actual constructor() : this(Empty)
 
@@ -95,7 +97,7 @@ actual sealed class Frame private actual constructor(
         constructor(buffer: ByteBuffer) : this(buffer.moveToByteArray(), NonDisposableHandle)
     }
 
-    override fun toString() = "Frame $frameType (fin=$fin, buffer len = ${data.size})"
+    override fun toString(): String = "Frame $frameType (fin=$fin, buffer len = ${data.size})"
 
     /**
      * Creates a frame copy
@@ -128,6 +130,6 @@ actual sealed class Frame private actual constructor(
     }
 }
 
-@Suppress("CONFLICTING_OVERLOADS")
+@Suppress("CONFLICTING_OVERLOADS", "KDocMissingDocumentation", "unused")
 @Deprecated("Binary compatibility", level = DeprecationLevel.HIDDEN)
 fun Frame.Close.readReason(): CloseReason? = readReason()

--- a/ktor-http/ktor-http-cio/jvm/src/io/ktor/http/cio/websocket/RawWebSocket.kt
+++ b/ktor-http/ktor-http-cio/jvm/src/io/ktor/http/cio/websocket/RawWebSocket.kt
@@ -40,25 +40,10 @@ class RawWebSocket(
     }
 
     internal val writer: WebSocketWriter = WebSocketWriter(output, this.coroutineContext, masking, pool)
-    internal val reader: WebSocketReader = WebSocketReader(input, coroutineContext + Job(), maxFrameSize, pool)
+    internal val reader: WebSocketReader = WebSocketReader(input, this.coroutineContext, maxFrameSize, pool)
 
     init {
-        coroutineContext[Job]?.invokeOnCompletion {
-            reader.cancel()
-        }
-
-        reader.coroutineContext[Job]?.invokeOnCompletion { cause ->
-            if (cause == null) {
-                socketJob.complete()
-            } else {
-                socketJob.completeExceptionally(cause)
-            }
-        }
-
-        // this was extracted from WebSocketReader (was broken).
-        writer.outgoing.invokeOnClose {
-            socketJob.complete()
-        }
+        socketJob.complete()
     }
 
     override suspend fun flush(): Unit = writer.flush()

--- a/ktor-http/ktor-http-cio/jvm/src/io/ktor/http/cio/websocket/WebSocketWriter.kt
+++ b/ktor-http/ktor-http-cio/jvm/src/io/ktor/http/cio/websocket/WebSocketWriter.kt
@@ -9,6 +9,7 @@ import kotlinx.coroutines.*
 import kotlinx.coroutines.channels.*
 import io.ktor.utils.io.*
 import io.ktor.utils.io.pool.*
+import kotlinx.coroutines.CancellationException
 import java.nio.*
 import kotlin.coroutines.*
 
@@ -27,24 +28,24 @@ class WebSocketWriter(
     val pool: ObjectPool<ByteBuffer> = KtorDefaultPool
 ) : CoroutineScope {
 
-    private val writeLoopCompletion: CompletableJob = Job()
+    private val queue = Channel<Any>(capacity = 8)
 
-    @Suppress("RemoveExplicitTypeArguments") // workaround for new kotlin inference issue
-    private val queue = actor<Any>(context = CoroutineName("ws-writer"), capacity = 8, start = CoroutineStart.ATOMIC) {
-        pool.useInstance { writeLoop(it) }
-    }
+    private val serializer = Serializer()
 
     /**
      * Channel for sending Websocket's [Frame] that will be serialized and written to [writeChannel].
      */
     val outgoing: SendChannel<Frame> get() = queue
 
-    private val serializer = Serializer()
+    @Suppress("RemoveExplicitTypeArguments") // workaround for new kotlin inference issue
+    private val writeLoopJob = launch(context = CoroutineName("ws-writer"), start = CoroutineStart.ATOMIC) {
+        pool.useInstance { writeLoop(it) }
+    }
 
-    private suspend fun ActorScope<Any>.writeLoop(buffer: ByteBuffer) {
+    private suspend fun writeLoop(buffer: ByteBuffer) {
         buffer.clear()
         try {
-            loop@ for (message in this) {
+            loop@ for (message in queue) {
                 when (message) {
                     is Frame -> if (drainQueueAndSerialize(message, buffer)) break@loop
                     is FlushRequest -> message.complete() // we don't need writeChannel.flush() here as we do flush at end of every drainQueueAndSerialize
@@ -58,23 +59,33 @@ class WebSocketWriter(
         } finally {
             queue.close(CancellationException("WebSocket closed.", null))
             writeChannel.close()
-            writeLoopCompletion.complete()
         }
 
-        consumeEach { message ->
-            when (message) {
-                is Frame.Close -> {} // ignore
-                is Frame.Ping, is Frame.Pong -> {
-                } // ignore
-                is FlushRequest -> message.complete()
-                is Frame.Text, is Frame.Binary -> {
-                } // discard
-                else -> throw IllegalArgumentException("unknown message $message")
-            }
+        drainQueueAndDiscard()
+    }
+
+    private fun drainQueueAndDiscard() {
+        check(queue.isClosedForSend)
+
+        try {
+            do {
+                val message = queue.poll() ?: break
+                when (message) {
+                    is Frame.Close -> {
+                    } // ignore
+                    is Frame.Ping, is Frame.Pong -> {
+                    } // ignore
+                    is FlushRequest -> message.complete()
+                    is Frame.Text, is Frame.Binary -> {
+                    } // discard
+                    else -> throw IllegalArgumentException("unknown message $message")
+                }
+            } while (true)
+        } catch (_: CancellationException) {
         }
     }
 
-    private suspend fun ActorScope<Any>.drainQueueAndSerialize(firstMsg: Frame, buffer: ByteBuffer): Boolean {
+    private suspend fun drainQueueAndSerialize(firstMsg: Frame, buffer: ByteBuffer): Boolean {
         var flush: FlushRequest? = null
         serializer.enqueue(firstMsg)
         var closeSent = firstMsg is Frame.Close
@@ -82,7 +93,7 @@ class WebSocketWriter(
         // initially serializer has at least one message queued
         while (true) {
             while (flush == null && !closeSent && serializer.remainingCapacity > 0) {
-                val message = poll() ?: break
+                val message = queue.poll() ?: break
                 when (message) {
                     is FlushRequest -> flush = message
                     is Frame.Close -> {
@@ -142,7 +153,7 @@ class WebSocketWriter(
             queue.send(it)
         } catch (closed: ClosedSendChannelException) {
             it.complete()
-            writeLoopCompletion.join()
+            writeLoopJob.join()
         } catch (sendFailure: Throwable) {
             it.complete()
             throw sendFailure

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http1/NettyHttp1ApplicationResponse.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http1/NettyHttp1ApplicationResponse.kt
@@ -99,6 +99,7 @@ internal class NettyHttp1ApplicationResponse(call: NettyApplicationCall,
         }
 
         (call as NettyApplicationCall).responseWriteJob.join()
+        job.join()
 
         context.channel().close()
     }


### PR DESCRIPTION
**Subsystem**
ktor-server-netty

**Motivation**
Too early channel close caused Windows to mark the connection as aborted so test client is unable to read close frame.

**Solution**
Wait for all jobs completion before closing channel.

