### PR TITLE
Add a list of exempted path prefixes for https redirection.

### DIFF
--- a/binary-compatibility-validator/reference-public-api/ktor-server-core.txt
+++ b/binary-compatibility-validator/reference-public-api/ktor-server-core.txt
@@ -620,14 +620,17 @@ public final class io/ktor/features/HSTS$Feature : io/ktor/application/Applicati
 public final class io/ktor/features/HttpsRedirect {
 	public static final field Feature Lio/ktor/features/HttpsRedirect$Feature;
 	public fun <init> (Lio/ktor/features/HttpsRedirect$Configuration;)V
+	public final fun getExemptions ()Ljava/util/List;
 	public final fun getPermanent ()Z
 	public final fun getRedirectPort ()I
 }
 
 public final class io/ktor/features/HttpsRedirect$Configuration {
 	public fun <init> ()V
+	public final fun getExemptions ()Ljava/util/List;
 	public final fun getPermanentRedirect ()Z
 	public final fun getSslPort ()I
+	public final fun setExemptions (Ljava/util/List;)V
 	public final fun setPermanentRedirect (Z)V
 	public final fun setSslPort (I)V
 }

--- a/ktor-server/ktor-server-core/jvm/src/io/ktor/features/HttpsRedirect.kt
+++ b/ktor-server/ktor-server-core/jvm/src/io/ktor/features/HttpsRedirect.kt
@@ -30,11 +30,6 @@ class HttpsRedirect(config: Configuration) {
     val exemptions: List<String> = config.exemptions
 
     /**
-     * Check if the uri is exempted. If it starts with one of the exemptions, it will not be redirected to https.
-     */
-    fun exempted(uri: String): Boolean = exemptions.any { uri.startsWith(it) }
-
-    /**
      * Redirect feature configuration
      */
     class Configuration {
@@ -63,7 +58,8 @@ class HttpsRedirect(config: Configuration) {
         override fun install(pipeline: ApplicationCallPipeline, configure: Configuration.() -> Unit): HttpsRedirect {
             val feature = HttpsRedirect(Configuration().apply(configure))
             pipeline.intercept(ApplicationCallPipeline.Features) {
-                if (call.request.origin.scheme == "http" && !feature.exempted(call.request.origin.uri)) {
+                if (call.request.origin.scheme == "http" &&
+                        !feature.exemptions.any { call.request.origin.uri.startsWith(it) }) { 
                     val redirectUrl = call.url { protocol = URLProtocol.HTTPS; port = feature.redirectPort }
                     call.respondRedirect(redirectUrl, feature.permanent)
                     finish()

--- a/ktor-server/ktor-server-tests/jvm/test/io/ktor/tests/server/features/HttpsRedirectFeatureTest.kt
+++ b/ktor-server/ktor-server-tests/jvm/test/io/ktor/tests/server/features/HttpsRedirectFeatureTest.kt
@@ -83,4 +83,24 @@ class HttpsRedirectFeatureTest {
             }
         }
     }
+
+    @Test
+    fun testRedirectHttpsExemption() {
+        withTestApplication {
+            application.install(HttpsRedirect) {
+                exemptions = listOf("/exempted")
+            }
+            application.intercept(ApplicationCallPipeline.Fallback) {
+                call.respond("ok")
+            }
+
+            handleRequest(HttpMethod.Get, "/nonexempted").let { call ->
+                assertEquals(HttpStatusCode.MovedPermanently, call.response.status())
+            }
+
+            handleRequest(HttpMethod.Get, "/exempted/path").let { call ->
+                assertEquals(HttpStatusCode.OK, call.response.status())
+            }
+        }
+    }
 }


### PR DESCRIPTION
**Subsystem**
Server, HttpsRedirect feature.

**Motivation**
When using  the `HttpsRedirect` feature in some contexts it is necessary to exempt certain path prefixes from redirection. A specific example is Google App Engine cron jobs which use an http:// url to trigger scheduled tasks. Currently these fail with a 301 status if `HttpsRedirect` is used.

**Solution**
Add a configuration option to `HttpsRedirect` that specifies an list of uri prefixes to be exempted from redirection.
