### PR TITLE
Fix for stress tests

### DIFF
--- a/ktor-server/ktor-server-cio/jvm/src/io/ktor/server/cio/CIOApplicationResponse.kt
+++ b/ktor-server/ktor-server-cio/jvm/src/io/ktor/server/cio/CIOApplicationResponse.kt
@@ -89,7 +89,7 @@ internal class CIOApplicationResponse(call: CIOApplicationCall,
         sendResponseMessage(contentReady = false)
 
         val upgradedJob = upgrade.upgrade(input, output, engineDispatcher, userDispatcher)
-        upgradedJob.invokeOnCompletion { output.close() }
+        upgradedJob.invokeOnCompletion { output.close(); input.cancel() }
         upgradedJob.join()
     }
 

--- a/ktor-server/ktor-server-jetty/jvm/src/io/ktor/server/jetty/internal/JettyUpgradeImpl.kt
+++ b/ktor-server/ktor-server-jetty/jvm/src/io/ktor/server/jetty/internal/JettyUpgradeImpl.kt
@@ -34,6 +34,17 @@ object JettyUpgradeImpl : ServletUpgrade {
         withContext(engineContext) {
             try {
                 coroutineScope {
+                    endPoint.connection.addListener(
+                        object : Connection.Listener {
+                            override fun onOpened(connection: Connection?) {
+                            }
+
+                            override fun onClosed(connection: Connection?) {
+                                cancel()
+                            }
+                        }
+                    )
+
                     val inputChannel = ByteChannel(autoFlush = true)
                     val reader = EndPointReader(endPoint, coroutineContext, inputChannel)
                     val writer = endPointWriter(endPoint)

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http1/NettyHttp1ApplicationResponse.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http1/NettyHttp1ApplicationResponse.kt
@@ -96,6 +96,7 @@ internal class NettyHttp1ApplicationResponse(call: NettyApplicationCall,
         job.invokeOnCompletion {
             upgradedWriteChannel.close()
             bodyHandler.close()
+            upgradedReadChannel.cancel()
         }
 
         (call as NettyApplicationCall).responseWriteJob.join()

--- a/ktor-server/ktor-server-test-host/jvm/src/io/ktor/server/testing/StressSuiteRunner.kt
+++ b/ktor-server/ktor-server-test-host/jvm/src/io/ktor/server/testing/StressSuiteRunner.kt
@@ -5,17 +5,30 @@
 package io.ktor.server.testing
 
 import org.junit.runner.*
+import org.junit.runner.manipulation.*
 import org.junit.runner.notification.*
 import org.junit.runners.*
 
-class StressSuiteRunner(klass: Class<*>) : Runner() {
+class StressSuiteRunner(klass: Class<*>) : Runner(), Filterable, Sortable {
     private val delegate = JUnit4(klass)
 
     override fun run(notifier: RunNotifier?) {
         if (System.getProperty("enable.stress.tests") != null) {
             delegate.run(notifier)
+        } else {
+            delegate.description.children?.forEach { child ->
+                notifier?.fireTestIgnored(child)
+            }
         }
     }
 
     override fun getDescription(): Description = delegate.description
+
+    override fun filter(filter: Filter?) {
+        delegate.filter(filter)
+    }
+
+    override fun sort(sorter: Sorter?) {
+        delegate.sort(sorter)
+    }
 }


### PR DESCRIPTION
**Subsystem**
ktor-server-cio, ktor-server-jetty, ktor-server-netty

**Motivation**
Currently, stress tests for upgrade requests are failing on both Linux and Windows. 

On Netty we were logging exceptions so that caused test failures. 
On Jetty, coroutines were hanging forever without proper cancellation. 
Also, test filtering in stress tests was not working properly.

**Solution**
Netty was broken at the point when the closed send exception stopped being cancellation. So now it is caught and wrapped to CancellationException.

On Jetty, there were no proper cancellation on upgrade job completion. So the reading job was hanging if the channel is full and nobody read from it anymore. 

Now we assume that if an upgrade job is completed, then nobody will use channels anymore so we close output and cancel input.

