### PR TITLE
Fix IOOBE in coroutine debug probes

### DIFF
--- a/ktor-utils/common/src/io/ktor/util/StackFrames.kt
+++ b/ktor-utils/common/src/io/ktor/util/StackFrames.kt
@@ -4,7 +4,17 @@
 
 package io.ktor.util
 
+import kotlin.reflect.*
+
 internal expect class StackTraceElement
+
+@Suppress("FunctionName")
+internal expect fun createStackTraceElement(
+    kClass: KClass<*>,
+    methodName: String,
+    fileName: String,
+    lineNumber: Int
+): StackTraceElement
 
 internal expect interface CoroutineStackFrame {
     public val callerFrame: CoroutineStackFrame?

--- a/ktor-utils/common/src/io/ktor/util/pipeline/StackWalkingFailed.kt
+++ b/ktor-utils/common/src/io/ktor/util/pipeline/StackWalkingFailed.kt
@@ -1,0 +1,16 @@
+/*
+ * Copyright 2014-2020 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.util.pipeline
+
+internal object StackWalkingFailed {
+    fun failedToCaptureStackFrame() {
+        error(
+            "Failed to capture stack frame. This is usually happens when a coroutine is running so" +
+                " the frame stack is changing quickly " +
+                "and the coroutine debug agent is unable to capture it concurrently." +
+                " You may retry running your test to see this particular trace."
+        )
+    }
+}

--- a/ktor-utils/js/src/io/ktor/util/StackFramesJs.kt
+++ b/ktor-utils/js/src/io/ktor/util/StackFramesJs.kt
@@ -4,6 +4,8 @@
 
 package io.ktor.util
 
+import kotlin.reflect.*
+
 @Suppress("UNUSED")
 internal actual interface CoroutineStackFrame {
     public actual val callerFrame: CoroutineStackFrame?
@@ -12,3 +14,11 @@ internal actual interface CoroutineStackFrame {
 
 @Suppress("ACTUAL_WITHOUT_EXPECT")
 internal actual typealias StackTraceElement = Any
+
+@Suppress("FunctionName")
+internal actual fun createStackTraceElement(
+    kClass: KClass<*>,
+    methodName: String,
+    fileName: String,
+    lineNumber: Int
+): StackTraceElement = Any()

--- a/ktor-utils/jvm/src/io/ktor/util/StackFramesJvm.kt
+++ b/ktor-utils/jvm/src/io/ktor/util/StackFramesJvm.kt
@@ -4,8 +4,24 @@
 
 package io.ktor.util
 
+import kotlin.reflect.*
+
 @Suppress("ACTUAL_WITHOUT_EXPECT")
 internal actual typealias CoroutineStackFrame = kotlin.coroutines.jvm.internal.CoroutineStackFrame
 
 @Suppress("ACTUAL_WITHOUT_EXPECT")
 internal actual typealias StackTraceElement = java.lang.StackTraceElement
+
+@Suppress("FunctionName")
+internal actual fun createStackTraceElement(
+    kClass: KClass<*>,
+    methodName: String,
+    fileName: String,
+    lineNumber: Int
+): StackTraceElement {
+    return java.lang.StackTraceElement(
+        kClass.java.name,
+        methodName,
+        fileName, lineNumber
+    )
+}

--- a/ktor-utils/jvm/test/io/ktor/tests/utils/StackWalkingFailedTest.kt
+++ b/ktor-utils/jvm/test/io/ktor/tests/utils/StackWalkingFailedTest.kt
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2014-2020 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.tests.utils
+
+import io.ktor.util.pipeline.*
+import java.io.*
+import kotlin.test.*
+
+class StackWalkingFailedTest {
+    @Test
+    fun testInvocation() {
+        assertFails {
+            StackWalkingFailed.failedToCaptureStackFrame()
+        }
+    }
+
+    @Test
+    fun testStackTraceElement() {
+        val element = StackWalkingFailedFrame.getStackTraceElement()
+        assertNotNull(element)
+        val foundClass = Class.forName(element.className)
+        val foundMethod = foundClass.getMethod(element.methodName)
+        val fileName = element.fileName
+        assertNotNull(fileName)
+        assertEquals(element.methodName, foundMethod.name)
+
+        val file = File("common/src").walkTopDown()
+            .filter { it.name == fileName }
+            .asSequence()
+            .singleOrNull() ?: error("File with name $fileName is not found in sources")
+
+        val fileLines = file.readLines()
+
+        fileLines.firstOrNull { it.trimStart().startsWith("package ${foundClass.packageName}") }
+            ?: fail("The returned file $fileName name should have the correct package definition")
+
+        val pointedLine = fileLines.getOrElse(element.lineNumber - 1) {
+            fail("The returned line number ${element.lineNumber} doesn't exist in $fileName")
+        }
+
+        assertTrue(
+            "The returned line number ${element.lineNumber} doesn't point to " +
+                "the declaration of function ${element.methodName}"
+        ) {
+            element.methodName in pointedLine && "fun " in pointedLine
+        }
+    }
+
+    @Test
+    fun fillStackTraceElement() {
+        val element = StackWalkingFailedFrame.getStackTraceElement()!!
+        val container = Exception("Expected exception.")
+        container.stackTrace = arrayOf(element)
+
+        val out = StringWriter()
+        container.printStackTrace(PrintWriter(out, true))
+        val trace = out.toString()
+
+        assertTrue { container.message!! in trace }
+        assertTrue { StackWalkingFailed::class.java.name in trace }
+        assertTrue { StackWalkingFailed::failedToCaptureStackFrame.name in trace }
+
+        assertTrue { "${element.fileName}:${element.lineNumber}" in trace }
+    }
+}

--- a/ktor-utils/jvm/test/io/ktor/tests/utils/StackWalkingFailedTest.kt
+++ b/ktor-utils/jvm/test/io/ktor/tests/utils/StackWalkingFailedTest.kt
@@ -33,7 +33,7 @@ class StackWalkingFailedTest {
 
         val fileLines = file.readLines()
 
-        fileLines.firstOrNull { it.trimStart().startsWith("package ${foundClass.packageName}") }
+        fileLines.firstOrNull { it.trimStart().startsWith("package ${foundClass.getPackage().name}") }
             ?: fail("The returned file $fileName name should have the correct package definition")
 
         val pointedLine = fileLines.getOrElse(element.lineNumber - 1) {

--- a/ktor-utils/posix/src/io/ktor/util/StackFramesNative.kt
+++ b/ktor-utils/posix/src/io/ktor/util/StackFramesNative.kt
@@ -4,6 +4,8 @@
 
 package io.ktor.util
 
+import kotlin.reflect.*
+
 @Suppress("UNUSED")
 internal actual interface CoroutineStackFrame {
     public actual val callerFrame: CoroutineStackFrame?
@@ -12,3 +14,11 @@ internal actual interface CoroutineStackFrame {
 
 @Suppress("ACTUAL_WITHOUT_EXPECT")
 internal actual typealias StackTraceElement = Any
+
+@Suppress("FunctionName")
+internal actual fun createStackTraceElement(
+    kClass: KClass<*>,
+    methodName: String,
+    fileName: String,
+    lineNumber: Int
+): StackTraceElement = Any()


### PR DESCRIPTION
**Subsystem**
ktor-utils (Pipelines)

**Motivation**
Sometimes, debug probes do walk through stack frames when the analyzed coroutine is running concurrently. This causes IOOBE exceptions in tests from time to time and makes tests flaky.

**Solution**
Catch all crashes and fallback to `null` on any accident.

