### PR TITLE
Fix httpclient gzip decoding failed #1189 - gzip header check fix

### DIFF
--- a/ktor-utils/jvm/src/io/ktor/util/EncodersJvm.kt
+++ b/ktor-utils/jvm/src/io/ktor/util/EncodersJvm.kt
@@ -48,11 +48,32 @@ private fun CoroutineScope.inflate(
         val header = source.readPacket(GZIP_HEADER_SIZE)
         val magic = header.readShortLittleEndian()
         val format = header.readByte()
-        val padding = header.readBytes()
+        val flags = header.readByte().toInt()
+        // val time = header.readInt()
+        // val extraFlags = header.readByte()
+        // val osType = header.readByte()
+
+        /* flags bits:
+            bit 0   FTEXT
+            bit 1   FHCRC
+            bit 2   FEXTRA
+            bit 3   FNAME
+            bit 4   FCOMMENT
+            bit 5   reserved
+            bit 6   reserved
+            bit 7   reserved
+        */
+        if (flags and 0b0000_0100 != 0) { //FLG.FEXTRA
+            val extraLen = source.readShort().toInt()
+            val extra = source.readPacket(extraLen)
+        }
 
         check(magic == GZIP_MAGIC) { "GZIP magic invalid: $magic" }
         check(format.toInt() == Deflater.DEFLATED) { "Deflater method unsupported: $format." }
-        check(padding.contentEquals(GZIP_HEADER_PADDING)) { "Gzip padding invalid." }
+        //FLG.FNAME
+        check(flags and 0b0000_1000 == 0) { "Gzip file name not suported" }
+        //FLG.FCOMMENT
+        check(flags and 0b0001_0000 == 0) { "Gzip file comment not suported" }
     }
 
     try {

--- a/ktor-utils/jvm/src/io/ktor/util/EncodersJvm.kt
+++ b/ktor-utils/jvm/src/io/ktor/util/EncodersJvm.kt
@@ -14,7 +14,7 @@ import java.util.zip.*
 private const val GZIP_HEADER_SIZE: Int = 10
 
 // GZIP header flags bits
-private object FLG {
+private object GzipHeaderFlags {
     const val FTEXT = 1 shl 0 // Is ASCII
     const val FHCRC = 1 shl 1 // Has header CRC16
     const val EXTRA = 1 shl 2 // Extra fields present
@@ -72,18 +72,18 @@ private fun CoroutineScope.inflate(
         header.discard()
 
         // skip the extra header if present
-        if (flags and FLG.EXTRA != 0) {
+        if (flags and GzipHeaderFlags.EXTRA != 0) {
             val extraLen = source.readShort().toLong()
             source.discardExact(extraLen)
         }
 
         check(magic == GZIP_MAGIC) { "GZIP magic invalid: $magic" }
         check(format.toInt() == Deflater.DEFLATED) { "Deflater method unsupported: $format." }
-        check(!(flags has FLG.FNAME)) { "Gzip file name not supported" }
-        check(!(flags has FLG.FCOMMENT)) { "Gzip file comment not supported" }
+        check(!(flags has GzipHeaderFlags.FNAME)) { "Gzip file name not supported" }
+        check(!(flags has GzipHeaderFlags.FCOMMENT)) { "Gzip file comment not supported" }
 
         // skip the header CRC if present
-        if (flags has FLG.FHCRC) {
+        if (flags has GzipHeaderFlags.FHCRC) {
             source.discardExact(2)
         }
     }

--- a/ktor-utils/jvm/src/io/ktor/util/EncodersJvm.kt
+++ b/ktor-utils/jvm/src/io/ktor/util/EncodersJvm.kt
@@ -68,6 +68,8 @@ private fun CoroutineScope.inflate(
         // val extraFlags = header.readByte()
         // val osType = header.readByte()
 
+        // however we have to discard them to prevent a memory leak
+        header.discard()
 
         // skip the extra header if present
         if (flags and FLG.EXTRA != 0) {


### PR DESCRIPTION
**Subsystem**
ktor-utils

**Motivation**
Fix httpclient gzip decoding failed #1189

**Solution**
Changing the gzip header check to conform [specification](http://www.zlib.org/rfc-gzip.html)

