### PR TITLE
Cy/server serialization

### DIFF
--- a/binary-compatibility-validator/reference-public-api/ktor-http.txt
+++ b/binary-compatibility-validator/reference-public-api/ktor-http.txt
@@ -146,6 +146,7 @@ public final class io/ktor/http/ContentType$Application {
 	public static final field INSTANCE Lio/ktor/http/ContentType$Application;
 	public final fun getAny ()Lio/ktor/http/ContentType;
 	public final fun getAtom ()Lio/ktor/http/ContentType;
+	public final fun getCbor ()Lio/ktor/http/ContentType;
 	public final fun getFontWoff ()Lio/ktor/http/ContentType;
 	public final fun getFormUrlEncoded ()Lio/ktor/http/ContentType;
 	public final fun getGZip ()Lio/ktor/http/ContentType;
@@ -155,6 +156,7 @@ public final class io/ktor/http/ContentType$Application {
 	public final fun getPdf ()Lio/ktor/http/ContentType;
 	public final fun getProblemJson ()Lio/ktor/http/ContentType;
 	public final fun getProblemXml ()Lio/ktor/http/ContentType;
+	public final fun getProtoBuf ()Lio/ktor/http/ContentType;
 	public final fun getRss ()Lio/ktor/http/ContentType;
 	public final fun getWasm ()Lio/ktor/http/ContentType;
 	public final fun getXml ()Lio/ktor/http/ContentType;

--- a/ktor-features/ktor-serialization/jvm/src/io/ktor/serialization/CborSupport.kt
+++ b/ktor-features/ktor-serialization/jvm/src/io/ktor/serialization/CborSupport.kt
@@ -9,6 +9,11 @@ import io.ktor.http.*
 import kotlinx.serialization.cbor.*
 import kotlinx.serialization.modules.*
 
+/**
+ * Register `application/cbor` content type to [ContentNegotiation] feature using kotlinx.serialization.
+ * @param module is used for serialization (optional)
+ * @param encodeDefaults is true when property default values are serialized, false when skipped
+ */
 fun ContentNegotiation.Configuration.cbor(module: SerialModule = EmptyModule, encodeDefaults: Boolean = true) {
     serialization(
         ContentType.Application.Cbor,

--- a/ktor-features/ktor-serialization/jvm/src/io/ktor/serialization/CborSupport.kt
+++ b/ktor-features/ktor-serialization/jvm/src/io/ktor/serialization/CborSupport.kt
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2014-2020 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.serialization
+
+import io.ktor.features.*
+import io.ktor.http.*
+import kotlinx.serialization.cbor.*
+import kotlinx.serialization.modules.*
+
+fun ContentNegotiation.Configuration.cbor(module: SerialModule = EmptyModule, encodeDefaults: Boolean = true) {
+    serialization(
+        ContentType.Application.Cbor,
+        Cbor(context = module, encodeDefaults = encodeDefaults)
+    )
+}

--- a/ktor-features/ktor-serialization/jvm/src/io/ktor/serialization/ConverterSupport.kt
+++ b/ktor-features/ktor-serialization/jvm/src/io/ktor/serialization/ConverterSupport.kt
@@ -10,7 +10,7 @@ import kotlinx.serialization.*
 
 /**
  * Register kotlinx.serialization converter into [ContentNegotiation] feature
- * wit
+ * with the specified [contentType] and binary [format] (such as CBOR, ProtoBuf)
  */
 fun ContentNegotiation.Configuration.serialization(
     contentType: ContentType,
@@ -24,6 +24,7 @@ fun ContentNegotiation.Configuration.serialization(
 
 /**
  * Register kotlinx.serialization converter into [ContentNegotiation] feature
+ * with the specified [contentType] and string [format] (such as Json)
  */
 fun ContentNegotiation.Configuration.serialization(
     contentType: ContentType,

--- a/ktor-features/ktor-serialization/jvm/src/io/ktor/serialization/ConverterSupport.kt
+++ b/ktor-features/ktor-serialization/jvm/src/io/ktor/serialization/ConverterSupport.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2014-2020 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.serialization
+
+import io.ktor.features.*
+import io.ktor.http.*
+import kotlinx.serialization.*
+
+/**
+ * Register kotlinx.serialization converter into [ContentNegotiation] feature
+ * wit
+ */
+fun ContentNegotiation.Configuration.serialization(
+    contentType: ContentType,
+    format: BinaryFormat
+) {
+    register(
+        contentType,
+        SerializationConverter(format)
+    )
+}
+
+/**
+ * Register kotlinx.serialization converter into [ContentNegotiation] feature
+ */
+fun ContentNegotiation.Configuration.serialization(
+    contentType: ContentType,
+    format: StringFormat
+) {
+    register(
+        contentType,
+        SerializationConverter(format)
+    )
+}

--- a/ktor-features/ktor-serialization/jvm/src/io/ktor/serialization/JsonSupport.kt
+++ b/ktor-features/ktor-serialization/jvm/src/io/ktor/serialization/JsonSupport.kt
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2014-2020 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.serialization
+
+import io.ktor.features.*
+import io.ktor.http.*
+import kotlinx.serialization.*
+import kotlinx.serialization.json.*
+import kotlinx.serialization.modules.*
+
+/**
+ * The default json configuration used in [SerializationConverter]. The settings are:
+ * - defaults are serialized
+ * - mode is not strict so extra json fields are ignored
+ * - pretty printing is disabled
+ * - array polymorphism is enabled
+ * - keys and values are quoted, non-quoted are not allowed
+ *
+ * See [JsonConfiguration] for more details.
+ */
+val DefaultJsonConfiguration: JsonConfiguration = JsonConfiguration.Stable.copy(
+    encodeDefaults = true,
+    strictMode = false,
+    unquoted = false,
+    prettyPrint = false,
+    useArrayPolymorphism = true
+)
+
+fun ContentNegotiation.Configuration.json(
+    json: JsonConfiguration = DefaultJsonConfiguration,
+    module: SerialModule = EmptyModule,
+    contentType: ContentType = ContentType.Application.Json
+) {
+    json(Json(json, module), contentType)
+}
+
+fun ContentNegotiation.Configuration.json(
+    json: Json = Json(DefaultJsonConfiguration),
+    contentType: ContentType = ContentType.Application.Json
+) {
+    serialization(contentType, json as StringFormat)
+}
+
+/**
+ * Register kotlinx.serialization converter into [ContentNegotiation] feature
+ */
+@Suppress("unused")
+@Deprecated("Use json instead", ReplaceWith("json()"))
+fun ContentNegotiation.Configuration.serialization() {
+    json()
+}
+
+/**
+ * Register kotlinx.serialization converter into [ContentNegotiation] feature
+ */
+@Deprecated("Use json function instead.", ReplaceWith("json(contentType = contentType)"))
+fun ContentNegotiation.Configuration.serialization(
+    contentType: ContentType
+) {
+    json(contentType = contentType)
+}
+
+/**
+ * Register kotlinx.serialization converter into [ContentNegotiation] feature
+ */
+@Suppress("CONFLICTING_OVERLOADS") // conflict with hidden declaration
+@Deprecated("Use json function instead.", ReplaceWith("json(json, contentType)"))
+fun ContentNegotiation.Configuration.serialization(
+    contentType: ContentType,
+    json: Json
+) {
+    json(json, contentType)
+}
+

--- a/ktor-features/ktor-serialization/jvm/src/io/ktor/serialization/JsonSupport.kt
+++ b/ktor-features/ktor-serialization/jvm/src/io/ktor/serialization/JsonSupport.kt
@@ -28,6 +28,14 @@ val DefaultJsonConfiguration: JsonConfiguration = JsonConfiguration.Stable.copy(
     useArrayPolymorphism = true
 )
 
+/**
+ * Register `application/json` (or another specified [contentType]) content type
+ * to [ContentNegotiation] feature using kotlinx.serialization.
+ *
+ * @param json configuration with settings such as quoting, pretty print and so on (optional)
+ * @param module is used for serialization (optional)
+ * @param contentType to register with, application/json by default
+ */
 fun ContentNegotiation.Configuration.json(
     json: JsonConfiguration = DefaultJsonConfiguration,
     module: SerialModule = EmptyModule,
@@ -36,6 +44,13 @@ fun ContentNegotiation.Configuration.json(
     json(Json(json, module), contentType)
 }
 
+/**
+ * Register `application/json` (or another specified [contentType]) content type
+ * to [ContentNegotiation] feature using kotlinx.serialization.
+ *
+ * @param json format instance (optional)
+ * @param contentType to register with, application/json by default
+ */
 fun ContentNegotiation.Configuration.json(
     json: Json = Json(DefaultJsonConfiguration),
     contentType: ContentType = ContentType.Application.Json

--- a/ktor-features/ktor-serialization/jvm/src/io/ktor/serialization/ProtoBufSupport.kt
+++ b/ktor-features/ktor-serialization/jvm/src/io/ktor/serialization/ProtoBufSupport.kt
@@ -9,6 +9,10 @@ import io.ktor.http.*
 import kotlinx.serialization.modules.*
 import kotlinx.serialization.protobuf.*
 
+/**
+ * Register `application/protobuf` content type to [ContentNegotiation] feature using kotlinx.serialization.
+ * @param module is used for serialization (optional)
+ */
 fun ContentNegotiation.Configuration.protoBuf(module: SerialModule = EmptyModule) {
     serialization(
         ContentType.Application.ProtoBuf,

--- a/ktor-features/ktor-serialization/jvm/src/io/ktor/serialization/ProtoBufSupport.kt
+++ b/ktor-features/ktor-serialization/jvm/src/io/ktor/serialization/ProtoBufSupport.kt
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2014-2020 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.serialization
+
+import io.ktor.features.*
+import io.ktor.http.*
+import kotlinx.serialization.modules.*
+import kotlinx.serialization.protobuf.*
+
+fun ContentNegotiation.Configuration.protoBuf(module: SerialModule = EmptyModule) {
+    serialization(
+        ContentType.Application.ProtoBuf,
+        ProtoBuf(module)
+    )
+}

--- a/ktor-features/ktor-serialization/jvm/src/io/ktor/serialization/SerializationConverter.kt
+++ b/ktor-features/ktor-serialization/jvm/src/io/ktor/serialization/SerializationConverter.kt
@@ -36,13 +36,21 @@ class SerializationConverter private constructor(
     private val defaultCharset: Charset = Charsets.UTF_8
 ) : ContentConverter {
 
+    /**
+     * Creates a converter serializing with the specified binary [format].
+     */
     constructor(format: BinaryFormat) : this(format as SerialFormat)
 
+    /**
+     * Creates a converter serializing with the specified string [format] and
+     * [defaultCharset] (optional, usually it is UTF-8).
+     */
     constructor(
         format: StringFormat,
         defaultCharset: Charset = Charsets.UTF_8
     ) : this(format as SerialFormat, defaultCharset)
 
+    @Suppress("unused")
     @Deprecated("Binary compatibility.", level = DeprecationLevel.HIDDEN)
     constructor(json: Json = Json(DefaultJsonConfiguration)) : this(json as StringFormat)
 

--- a/ktor-features/ktor-serialization/jvm/src/io/ktor/serialization/SerializerLookup.kt
+++ b/ktor-features/ktor-serialization/jvm/src/io/ktor/serialization/SerializerLookup.kt
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2014-2020 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.serialization
+
+import kotlinx.serialization.*
+import kotlinx.serialization.internal.*
+import kotlinx.serialization.json.*
+import kotlin.reflect.*
+import kotlin.reflect.full.*
+import kotlin.reflect.jvm.*
+
+@UseExperimental(ImplicitReflectionSerializer::class, ExperimentalStdlibApi::class)
+internal fun serializerByTypeInfo(type: KType): KSerializer<*> {
+    val classifierClass = type.classifier as? KClass<*>
+    if (classifierClass != null && classifierClass.java.isArray) {
+        return arraySerializer(type)
+    }
+
+    return serializer(type)
+}
+
+// NOTE: this should be removed once kotlinx.serialization serializer get support of arrays that is blocked by KT-32839
+private fun arraySerializer(type: KType): KSerializer<*> {
+    val elementType = type.arguments[0].type ?: error("Array<*> is not supported")
+    val elementSerializer = serializerByTypeInfo(elementType)
+
+    @Suppress("UNCHECKED_CAST")
+    return ReferenceArraySerializer(
+        elementType.jvmErasure as KClass<Any>,
+        elementSerializer as KSerializer<Any>
+    )
+}
+
+@UseExperimental(ImplicitReflectionSerializer::class)
+internal fun serializerForSending(value: Any): KSerializer<*> {
+    if (value is JsonElement) {
+        return JsonElementSerializer
+    }
+    if (value is List<*>) {
+        return ArrayListSerializer(value.elementSerializer())
+    }
+    if (value is Set<*>) {
+        return HashSetSerializer(value.elementSerializer())
+    }
+    if (value is Map<*, *>) {
+        return HashMapSerializer(value.keys.elementSerializer(), value.values.elementSerializer())
+    }
+    if (value is Map.Entry<*, *>) {
+        return MapEntrySerializer(
+            serializerForSending(value.key ?: error("Map.Entry(null, ...) is not supported")),
+            serializerForSending(value.value ?: error("Map.Entry(..., null) is not supported)"))
+        )
+    }
+    if (value is Array<*>) {
+        val componentType = value.javaClass.componentType.kotlin.starProjectedType
+        val componentClass =
+            componentType.classifier as? KClass<*> ?: error("Unsupported component type $componentType")
+        @Suppress("UNCHECKED_CAST")
+        return ReferenceArraySerializer(
+            componentClass as KClass<Any>,
+            serializerByTypeInfo(componentType) as KSerializer<Any>
+        )
+    }
+    return value::class.serializer()
+}
+
+@UseExperimental(ImplicitReflectionSerializer::class)
+private fun Collection<*>.elementSerializer(): KSerializer<*> {
+    @Suppress("DEPRECATION_ERROR")
+    val serializers = mapNotNull { value ->
+        value?.let { serializerForSending(it) }
+    }.distinctBy { it.descriptor.name }
+
+    if (serializers.size > 1) {
+        @Suppress("DEPRECATION_ERROR")
+        error("Serializing collections of different element types is not yet supported. " +
+            "Selected serializers: ${serializers.map { it.descriptor.name }}"
+        )
+    }
+
+    val selected: KSerializer<*> = serializers.singleOrNull() ?: String.serializer()
+    if (selected.descriptor.isNullable) {
+        return selected
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    selected as KSerializer<Any>
+
+    if (any { it == null }) {
+        return selected.nullable
+    }
+
+    return selected
+}

--- a/ktor-features/ktor-serialization/jvm/test/io/ktor/tests/serialization/AbstractSerializationTest.kt
+++ b/ktor-features/ktor-serialization/jvm/test/io/ktor/tests/serialization/AbstractSerializationTest.kt
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2014-2020 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.tests.serialization
+
+import io.ktor.application.*
+import io.ktor.features.*
+import io.ktor.http.*
+import io.ktor.request.*
+import io.ktor.response.*
+import io.ktor.routing.*
+import io.ktor.server.testing.*
+import kotlinx.coroutines.*
+import kotlinx.serialization.*
+import kotlin.test.*
+
+abstract class AbstractSerializationTest {
+    protected val serializer = TestEntity.serializer()
+
+    protected abstract val testContentType: ContentType
+    protected abstract fun ContentNegotiation.Configuration.configureContentNegotiation()
+
+    protected abstract fun simpleSerialize(any: TestEntity): ByteArray
+    protected abstract fun simpleDeserialize(t: ByteArray): TestEntity
+
+    protected fun withTestSerializingApplication(block: suspend TestApplicationEngine.() -> Unit): Unit =
+        withTestApplication {
+            application.install(ContentNegotiation) {
+                configureContentNegotiation()
+            }
+
+            application.routing {
+                get("/dump") {
+                    call.respond(TestEntity(777))
+                }
+                put("/parse") {
+                    val entity = call.receive<TestEntity>()
+                    assertEquals(999, entity.x)
+                    call.respondText("OK")
+                }
+            }
+
+            runBlocking {
+                block()
+            }
+        }
+
+    @Test
+    fun testDumpNoAccept(): Unit = withTestSerializingApplication {
+        handleRequest(HttpMethod.Get, "/dump").let { call ->
+            assertEquals(HttpStatusCode.OK, call.response.status())
+            val bytes = call.response.byteContent
+            assertNotNull(bytes)
+            val entity = simpleDeserialize(bytes)
+            assertEquals(777, entity.x)
+        }
+    }
+
+    @Test
+    fun testDumpWithAccept(): Unit = withTestSerializingApplication {
+        handleRequest(HttpMethod.Get, "/dump") {
+            addHeader(HttpHeaders.Accept, testContentType.toString())
+        }.let { call ->
+            assertEquals(HttpStatusCode.OK, call.response.status())
+            val bytes = call.response.byteContent
+            assertNotNull(bytes)
+            val entity = simpleDeserialize(bytes)
+            assertEquals(777, entity.x)
+        }
+    }
+
+    @Test
+    fun testDumpWithMultipleAccept(): Unit = withTestSerializingApplication {
+        handleRequest(HttpMethod.Get, "/dump") {
+            addHeader(HttpHeaders.Accept, "$testContentType;q=1,text/plain;q=0.9")
+        }.let { call ->
+            assertEquals(HttpStatusCode.OK, call.response.status())
+            val bytes = call.response.byteContent
+            assertNotNull(bytes)
+            val entity = simpleDeserialize(bytes)
+            assertEquals(777, entity.x)
+        }
+    }
+
+    @Test
+    fun testParseWithContentType(): Unit = withTestSerializingApplication {
+        handleRequest(HttpMethod.Put, "/parse") {
+            addHeader(HttpHeaders.ContentType, testContentType.toString())
+            setBody(simpleSerialize(TestEntity(999)))
+        }.let { call ->
+            assertEquals(HttpStatusCode.OK, call.response.status())
+            assertEquals("OK", call.response.content)
+        }
+    }
+
+    @Serializable
+    data class TestEntity(val x: Int)
+}

--- a/ktor-features/ktor-serialization/jvm/test/io/ktor/tests/serialization/CborTest.kt
+++ b/ktor-features/ktor-serialization/jvm/test/io/ktor/tests/serialization/CborTest.kt
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2014-2020 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.tests.serialization
+
+import io.ktor.features.*
+import io.ktor.http.*
+import io.ktor.serialization.*
+import kotlinx.serialization.cbor.*
+
+class CborTest : AbstractSerializationTest() {
+    override val testContentType: ContentType = ContentType.Application.Cbor
+
+    override fun ContentNegotiation.Configuration.configureContentNegotiation() {
+        cbor()
+    }
+
+    override fun simpleDeserialize(t: ByteArray): TestEntity {
+        return Cbor.load(serializer, t)
+    }
+
+    override fun simpleSerialize(any: TestEntity): ByteArray {
+        return Cbor.dump(serializer, any)
+    }
+}

--- a/ktor-features/ktor-serialization/jvm/test/io/ktor/tests/serialization/JsonTest.kt
+++ b/ktor-features/ktor-serialization/jvm/test/io/ktor/tests/serialization/JsonTest.kt
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2014-2020 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.tests.serialization
+
+import io.ktor.features.*
+import io.ktor.http.*
+import io.ktor.serialization.*
+import kotlinx.serialization.json.*
+
+class JsonTest : AbstractSerializationTest() {
+    override val testContentType: ContentType = ContentType.Application.Json
+
+    override fun ContentNegotiation.Configuration.configureContentNegotiation() {
+        json()
+    }
+
+    override fun simpleDeserialize(t: ByteArray): TestEntity {
+        return Json(DefaultJsonConfiguration).parse(serializer, String(t))
+    }
+
+    override fun simpleSerialize(any: TestEntity): ByteArray {
+        return Json(DefaultJsonConfiguration).stringify(serializer, any).toByteArray()
+    }
+}

--- a/ktor-features/ktor-serialization/jvm/test/io/ktor/tests/serialization/ProtobufTest.kt
+++ b/ktor-features/ktor-serialization/jvm/test/io/ktor/tests/serialization/ProtobufTest.kt
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2014-2020 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.tests.serialization
+
+import io.ktor.features.*
+import io.ktor.http.*
+import io.ktor.serialization.*
+import kotlinx.serialization.protobuf.*
+
+class ProtobufTest : AbstractSerializationTest() {
+    override val testContentType: ContentType = ContentType.Application.ProtoBuf
+
+    override fun ContentNegotiation.Configuration.configureContentNegotiation() {
+        protoBuf()
+    }
+
+    override fun simpleDeserialize(t: ByteArray): TestEntity {
+        return ProtoBuf.load(serializer, t)
+    }
+
+    override fun simpleSerialize(any: TestEntity): ByteArray {
+        return ProtoBuf.dump(serializer, any)
+    }
+}

--- a/ktor-features/ktor-serialization/jvm/test/io/ktor/tests/serialization/SerializationTest.kt
+++ b/ktor-features/ktor-serialization/jvm/test/io/ktor/tests/serialization/SerializationTest.kt
@@ -302,7 +302,7 @@ class SerializationTest {
     @Test
     fun testOnTextAny(): Unit = withTestApplication {
         application.install(ContentNegotiation) {
-            serialization()
+            json()
             register(contentType = ContentType.Text.Any, converter = SerializationConverter())
         }
 
@@ -336,7 +336,7 @@ class SerializationTest {
     @Test
     fun testReceiveNullValue(): Unit = withTestApplication {
         application.install(ContentNegotiation) {
-            serialization()
+            json()
             register(contentType = ContentType.Text.Any, converter = SerializationConverter())
         }
 
@@ -363,7 +363,7 @@ class SerializationTest {
     @Test
     fun testJsonElements(): Unit = withTestApplication {
         application.install(ContentNegotiation) {
-            serialization()
+            json()
         }
         application.routing {
             get("/map") {
@@ -399,7 +399,7 @@ class SerializationTest {
     @Test
     fun testMapsElements(): Unit = withTestApplication {
         application.install(ContentNegotiation) {
-            serialization()
+            json()
         }
         application.routing {
             get("/map") {

--- a/ktor-http/common/src/io/ktor/http/ContentTypes.kt
+++ b/ktor-http/common/src/io/ktor/http/ContentTypes.kt
@@ -120,6 +120,7 @@ class ContentType private constructor(val contentType: String, val contentSubtyp
          */
         val Any = ContentType("application", "*")
         val Atom = ContentType("application", "atom+xml")
+        val Cbor = ContentType("application", "cbor")
         val Json = ContentType("application", "json")
         val JavaScript = ContentType("application", "javascript")
         val OctetStream = ContentType("application", "octet-stream")
@@ -131,6 +132,7 @@ class ContentType private constructor(val contentType: String, val contentSubtyp
         val GZip = ContentType("application", "gzip")
         val FormUrlEncoded = ContentType("application", "x-www-form-urlencoded")
         val Pdf = ContentType("application", "pdf")
+        val ProtoBuf = ContentType("application", "protobuf")
         val Wasm = ContentType("application", "wasm")
         val ProblemJson = ContentType("application", "problem+json")
         val ProblemXml = ContentType("application", "problem+xml")


### PR DESCRIPTION
**Subsystem**
server ktor-serialization

**Motivation**
This is inspired by PR #663 and issue #1624 . Briefly saying, people asking for ProtoBuf and even CBOR. 


**Solution**
The serialization converter is generalized to work with any binary or string format. Introduced DSL functions to easily configure defaults for json, protbuf and cbor, and with ability to specify any format instance. Tests changed accordingly. 

