### PR TITLE
Add an option to filter logged calls for ktor-client-logging.

### DIFF
--- a/binary-compatibility-validator/reference-public-api/ktor-client-logging.txt
+++ b/binary-compatibility-validator/reference-public-api/ktor-client-logging.txt
@@ -32,8 +32,11 @@ public final class io/ktor/client/features/logging/LoggerKt {
 public final class io/ktor/client/features/logging/Logging {
 	public static final field Companion Lio/ktor/client/features/logging/Logging$Companion;
 	public fun <init> (Lio/ktor/client/features/logging/Logger;Lio/ktor/client/features/logging/LogLevel;)V
+	public fun <init> (Lio/ktor/client/features/logging/Logger;Lio/ktor/client/features/logging/LogLevel;Ljava/util/List;)V
+	public final fun getFilters ()Ljava/util/List;
 	public final fun getLevel ()Lio/ktor/client/features/logging/LogLevel;
 	public final fun getLogger ()Lio/ktor/client/features/logging/Logger;
+	public final fun setFilters (Ljava/util/List;)V
 	public final fun setLevel (Lio/ktor/client/features/logging/LogLevel;)V
 }
 
@@ -47,6 +50,7 @@ public final class io/ktor/client/features/logging/Logging$Companion : io/ktor/c
 
 public final class io/ktor/client/features/logging/Logging$Config {
 	public fun <init> ()V
+	public final fun filter (Lkotlin/jvm/functions/Function1;)V
 	public final fun getLevel ()Lio/ktor/client/features/logging/LogLevel;
 	public final fun getLogger ()Lio/ktor/client/features/logging/Logger;
 	public final fun setLevel (Lio/ktor/client/features/logging/LogLevel;)V

--- a/ktor-client/ktor-client-features/ktor-client-logging/common/src/io/ktor/client/features/logging/Logging.kt
+++ b/ktor-client/ktor-client-features/ktor-client-logging/common/src/io/ktor/client/features/logging/Logging.kt
@@ -23,12 +23,17 @@ import kotlinx.coroutines.*
  */
 class Logging(
     val logger: Logger,
-    var level: LogLevel
+    var level: LogLevel,
+    var filters: List<(HttpRequestBuilder) -> Boolean>
 ) {
     /**
      * [Logging] feature configuration
      */
     class Config {
+        /**
+         * filters
+         */
+        internal var filters = mutableListOf<(HttpRequestBuilder) -> Boolean>()
         /**
          * [Logger] instance to use
          */
@@ -38,6 +43,12 @@ class Logging(
          * log [LogLevel]
          */
         var level: LogLevel = LogLevel.HEADERS
+        /**
+         * Log messages for calls matching a [predicate]
+         */
+        fun filter(predicate: (HttpRequestBuilder) -> Boolean) {
+            filters.add(predicate)
+        }
     }
 
     private suspend fun logRequest(request: HttpRequestBuilder): OutgoingContent? {
@@ -124,13 +135,17 @@ class Logging(
 
         override fun prepare(block: Config.() -> Unit): Logging {
             val config = Config().apply(block)
-            return Logging(config.logger, config.level)
+            return Logging(config.logger, config.level, config.filters)
         }
 
         override fun install(feature: Logging, scope: HttpClient) {
             scope.sendPipeline.intercept(HttpSendPipeline.Monitoring) {
                 val response = try {
-                    feature.logRequest(context)
+                    if (feature.filters.isEmpty() || feature.filters.any { it(context) }) {
+                        feature.logRequest(context)
+                    } else {
+                        null
+                    }
                 } catch (_: Throwable) {
                     null
                 } ?: subject

--- a/ktor-client/ktor-client-features/ktor-client-logging/common/src/io/ktor/client/features/logging/Logging.kt
+++ b/ktor-client/ktor-client-features/ktor-client-logging/common/src/io/ktor/client/features/logging/Logging.kt
@@ -27,6 +27,11 @@ class Logging(
     var filters: List<(HttpRequestBuilder) -> Boolean>
 ) {
     /**
+     * Constructor
+     */
+    constructor(logger: Logger, level: LogLevel) : this(logger, level, emptyList())
+
+    /**
      * [Logging] feature configuration
      */
     class Config {
@@ -43,6 +48,7 @@ class Logging(
          * log [LogLevel]
          */
         var level: LogLevel = LogLevel.HEADERS
+
         /**
          * Log messages for calls matching a [predicate]
          */

--- a/ktor-client/ktor-client-features/ktor-client-logging/common/test/io/ktor/client/features/logging/CommonLoggingTest.kt
+++ b/ktor-client/ktor-client-features/ktor-client-logging/common/test/io/ktor/client/features/logging/CommonLoggingTest.kt
@@ -129,6 +129,31 @@ class CommonLoggingTest {
             assertTrue { dump.contains("Hello") }
         }
     }
+
+    @Test
+    fun testFilterRequest() = testWithEngine(MockEngine) {
+        val testLogger = TestLogger()
+
+        config {
+            engine {
+                addHandler { respondOk() }
+            }
+            install(Logging) {
+                level = LogLevel.ALL
+                logger = testLogger
+                filter { it.url.encodedPath == "/filtered_path" }
+            }
+        }
+
+        test { client ->
+            client.get<String>(urlString = "http://somewhere/filtered_path")
+            client.get<String>(urlString = "http://somewhere/not_filtered_path")
+
+            val dump = testLogger.dump()
+            assertTrue { dump.contains("REQUEST: http://somewhere/filtered_path") }
+            assertFalse { dump.contains("REQUEST: http://somewhere/not_filtered_path") }
+        }
+    }
 }
 
 internal class CustomError(override val message: String) : Throwable()


### PR DESCRIPTION
**Subsystem**
Kotlin multiplatform library: ktor-client-logging:1.3.0

**Motivation**
Problem: not able to filter calls to be logged. All calls are being logged by default.
This is inspired by issue https://github.com/ktorio/ktor/issues/1618.

**Solution**
Added filters of type `(HttpRequestBuilder) -> Boolean` to `Logging` Config.

