### PR TITLE
Unwrap cancellation exception in client code (#1482).

### DIFF
--- a/binary-compatibility-validator/reference-public-api/ktor-client-core.txt
+++ b/binary-compatibility-validator/reference-public-api/ktor-client-core.txt
@@ -1155,6 +1155,10 @@ public final class io/ktor/client/utils/EmptyContent : io/ktor/http/content/Outg
 	public fun toString ()Ljava/lang/String;
 }
 
+public final class io/ktor/client/utils/ExceptionUtilsKt {
+	public static final fun unwrapCancellationException (Ljava/lang/Throwable;)Ljava/lang/Throwable;
+}
+
 public final class io/ktor/client/utils/HeadersKt {
 	public static final fun buildHeaders (Lkotlin/jvm/functions/Function1;)Lio/ktor/http/Headers;
 	public static synthetic fun buildHeaders$default (Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lio/ktor/http/Headers;

--- a/ktor-client/ktor-client-apache/jvm/src/io/ktor/client/engine/apache/ApacheHttpRequest.kt
+++ b/ktor-client/ktor-client-apache/jvm/src/io/ktor/client/engine/apache/ApacheHttpRequest.kt
@@ -45,8 +45,8 @@ internal suspend fun CloseableHttpAsyncClient.sendRequest(
                 else -> exception
             }
 
+            continuation.cancel(mappedCause)
             callContext.cancel(CancellationException("Failed to execute request", mappedCause))
-            continuation.cancel(exception)
         }
 
         override fun completed(result: Unit) {}

--- a/ktor-client/ktor-client-core/common/src/io/ktor/client/features/HttpCallValidator.kt
+++ b/ktor-client/ktor-client-core/common/src/io/ktor/client/features/HttpCallValidator.kt
@@ -7,8 +7,10 @@ package io.ktor.client.features
 import io.ktor.client.*
 import io.ktor.client.request.*
 import io.ktor.client.statement.*
+import io.ktor.client.utils.*
 import io.ktor.util.*
 import io.ktor.util.pipeline.*
+import io.ktor.utils.io.*
 
 /**
  * Response validator method.
@@ -86,8 +88,9 @@ class HttpCallValidator(
                 try {
                     proceedWith(it)
                 } catch (cause: Throwable) {
-                    feature.processException(cause)
-                    throw cause
+                    val unwrappedCause = cause.unwrapCancellationException()
+                    feature.processException(unwrappedCause)
+                    throw unwrappedCause
                 }
             }
 
@@ -96,8 +99,9 @@ class HttpCallValidator(
                     feature.validateResponse(context.response)
                     proceedWith(container)
                 } catch (cause: Throwable) {
-                    feature.processException(cause)
-                    throw cause
+                    val unwrappedCause = cause.unwrapCancellationException()
+                    feature.processException(unwrappedCause)
+                    throw unwrappedCause
                 }
             }
         }

--- a/ktor-client/ktor-client-core/common/src/io/ktor/client/utils/ExceptionUtils.kt
+++ b/ktor-client/ktor-client-core/common/src/io/ktor/client/utils/ExceptionUtils.kt
@@ -1,0 +1,14 @@
+/*
+ * Copyright 2014-2020 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.client.utils
+
+import io.ktor.util.*
+import io.ktor.utils.io.*
+
+/**
+ * If the exception contains cause that differs from [CancellationException] returns it otherwise returns itself.
+ */
+@InternalAPI
+expect fun Throwable.unwrapCancellationException(): Throwable

--- a/ktor-client/ktor-client-core/js/src/io/ktor/client/utils/ExceptionUtils.kt
+++ b/ktor-client/ktor-client-core/js/src/io/ktor/client/utils/ExceptionUtils.kt
@@ -1,0 +1,14 @@
+/*
+ * Copyright 2014-2020 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.client.utils
+
+import io.ktor.util.*
+import io.ktor.utils.io.*
+
+/**
+ * If the exception contains cause that differs from [CancellationException] returns it otherwise returns itself.
+ */
+@InternalAPI
+actual fun Throwable.unwrapCancellationException(): Throwable = this

--- a/ktor-client/ktor-client-core/jvm/src/io/ktor/client/utils/ExceptionUtils.kt
+++ b/ktor-client/ktor-client-core/jvm/src/io/ktor/client/utils/ExceptionUtils.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2014-2020 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.client.utils
+
+import io.ktor.util.*
+import io.ktor.utils.io.*
+
+/**
+ * If the exception contains cause that differs from [CancellationException] returns it otherwise returns itself.
+ */
+@InternalAPI
+actual fun Throwable.unwrapCancellationException(): Throwable {
+    var exception: Throwable? = this
+    while (exception is CancellationException) {
+        // If there is a cycle, we return the initial exception.
+        if (exception == exception.cause) {
+            return this
+        }
+        exception = exception.cause
+    }
+
+    return exception ?: this
+}

--- a/ktor-client/ktor-client-core/posix/src/io/ktor/client/utils/ExceptionUtils.kt
+++ b/ktor-client/ktor-client-core/posix/src/io/ktor/client/utils/ExceptionUtils.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2014-2020 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.client.utils
+
+import io.ktor.util.*
+import io.ktor.utils.io.*
+
+/**
+ * If the exception contains cause that differs from [CancellationException] returns it otherwise returns itself.
+ */
+@InternalAPI
+actual fun Throwable.unwrapCancellationException(): Throwable {
+    var exception: Throwable? = this
+    while (exception is CancellationException) {
+        // If there is a cycle, we return the initial exception.
+        if (exception == exception.cause) {
+            return this
+        }
+        exception = exception.cause
+    }
+
+    return exception ?: this
+}

--- a/ktor-client/ktor-client-tests/common/src/io/ktor/client/tests/utils/Assertions.kt
+++ b/ktor-client/ktor-client-tests/common/src/io/ktor/client/tests/utils/Assertions.kt
@@ -7,7 +7,13 @@ package io.ktor.client.tests.utils
 import io.ktor.util.*
 
 /**
- * Check that [block] completed with given type of root cause.
+ * Asserts that [block] completed with given type of root cause.
  */
 @InternalAPI
 expect inline fun <reified T : Throwable> assertFailsAndContainsCause(block: () -> Unit)
+
+/**
+ * Asserts that a [block] fails with a specific exception of type [T] being thrown.
+ */
+@InternalAPI
+expect inline fun <reified T : Throwable> assertFailsWith(block: () -> Unit)

--- a/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/HttpTimeoutTest.kt
+++ b/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/HttpTimeoutTest.kt
@@ -15,6 +15,7 @@ import io.ktor.utils.io.*
 import io.ktor.utils.io.core.*
 import kotlinx.coroutines.*
 import kotlin.test.*
+import io.ktor.client.tests.utils.assertFailsWith
 
 private const val TEST_URL = "$TEST_SERVER/timeout"
 
@@ -102,7 +103,7 @@ class HttpTimeoutTest : ClientLoader() {
         }
 
         test { client ->
-            assertFailsAndContainsCause<HttpRequestTimeoutException> {
+            assertFailsWith<HttpRequestTimeoutException> {
                 client.head<HttpResponse>("$TEST_URL/with-delay?delay=1000")
             }
         }
@@ -209,7 +210,7 @@ class HttpTimeoutTest : ClientLoader() {
                 method = HttpMethod.Get
                 parameter("delay", 500)
             }
-            assertFailsAndContainsCause<HttpRequestTimeoutException> {
+            assertFailsWith<HttpRequestTimeoutException> {
                 response.readUTF8Line()
             }
         }
@@ -228,7 +229,7 @@ class HttpTimeoutTest : ClientLoader() {
 
                 timeout { requestTimeoutMillis = 1000 }
             }
-            assertFailsAndContainsCause<HttpRequestTimeoutException> {
+            assertFailsWith<HttpRequestTimeoutException> {
                 response.readUTF8Line()
             }
         }
@@ -273,7 +274,7 @@ class HttpTimeoutTest : ClientLoader() {
         }
 
         test { client ->
-            assertFailsAndContainsCause<HttpRequestTimeoutException> {
+            assertFailsWith<HttpRequestTimeoutException> {
                 client.get<ByteArray>("$TEST_URL/with-stream") {
                     parameter("delay", 400)
                 }
@@ -288,7 +289,7 @@ class HttpTimeoutTest : ClientLoader() {
         }
 
         test { client ->
-            assertFailsAndContainsCause<HttpRequestTimeoutException> {
+            assertFailsWith<HttpRequestTimeoutException> {
                 client.get<ByteArray>("$TEST_URL/with-stream") {
                     parameter("delay", 400)
 
@@ -338,7 +339,7 @@ class HttpTimeoutTest : ClientLoader() {
         }
 
         test { client ->
-            assertFailsAndContainsCause<HttpRequestTimeoutException> {
+            assertFailsWith<HttpRequestTimeoutException> {
                 client.get<String>("$TEST_URL/with-redirect") {
                     parameter("delay", 1000)
                     parameter("count", 5)
@@ -354,7 +355,7 @@ class HttpTimeoutTest : ClientLoader() {
         }
 
         test { client ->
-            assertFailsAndContainsCause<HttpRequestTimeoutException> {
+            assertFailsWith<HttpRequestTimeoutException> {
                 client.get<String>("$TEST_URL/with-redirect") {
                     parameter("delay", 1000)
                     parameter("count", 5)
@@ -372,7 +373,7 @@ class HttpTimeoutTest : ClientLoader() {
         }
 
         test { client ->
-            assertFailsAndContainsCause<HttpRequestTimeoutException> {
+            assertFailsWith<HttpRequestTimeoutException> {
                 client.get<String>("$TEST_URL/with-redirect") {
                     parameter("delay", 500)
                     parameter("count", 5)
@@ -388,7 +389,7 @@ class HttpTimeoutTest : ClientLoader() {
         }
 
         test { client ->
-            assertFailsAndContainsCause<HttpRequestTimeoutException> {
+            assertFailsWith<HttpRequestTimeoutException> {
                 client.get<String>("$TEST_URL/with-redirect") {
                     parameter("delay", 500)
                     parameter("count", 5)
@@ -406,7 +407,7 @@ class HttpTimeoutTest : ClientLoader() {
         }
 
         test { client ->
-            assertFailsAndContainsCause<ConnectTimeoutException> {
+            assertFailsWith<ConnectTimeoutException> {
                 client.get<String>("http://www.google.com:81")
             }
         }
@@ -436,7 +437,7 @@ class HttpTimeoutTest : ClientLoader() {
         }
 
         test { client ->
-            assertFailsAndContainsCause<ConnectTimeoutException> {
+            assertFailsWith<ConnectTimeoutException> {
                 client.get<String>("http://www.google.com:81") {
                     timeout { connectTimeoutMillis = 1000 }
                 }
@@ -451,7 +452,7 @@ class HttpTimeoutTest : ClientLoader() {
         }
 
         test { client ->
-            assertFailsAndContainsCause<SocketTimeoutException> {
+            assertFailsWith<SocketTimeoutException> {
                 client.get<String>("$TEST_URL/with-stream") {
                     parameter("delay", 5000)
                 }
@@ -466,7 +467,7 @@ class HttpTimeoutTest : ClientLoader() {
         }
 
         test { client ->
-            assertFailsAndContainsCause<SocketTimeoutException> {
+            assertFailsWith<SocketTimeoutException> {
                 client.get<String>("$TEST_URL/with-stream") {
                     parameter("delay", 5000)
 
@@ -483,7 +484,7 @@ class HttpTimeoutTest : ClientLoader() {
         }
 
         test { client ->
-            assertFailsAndContainsCause<SocketTimeoutException> {
+            assertFailsWith<SocketTimeoutException> {
                 client.post("$TEST_URL/slow-read") { body = makeString(4 * 1024 * 1024) }
             }
         }
@@ -496,7 +497,7 @@ class HttpTimeoutTest : ClientLoader() {
         }
 
         test { client ->
-            assertFailsAndContainsCause<SocketTimeoutException> {
+            assertFailsWith<SocketTimeoutException> {
                 client.post("$TEST_URL/slow-read") {
                     body = makeString(4 * 1024 * 1024)
                     timeout { socketTimeoutMillis = 500 }

--- a/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/WebSocketTest.kt
+++ b/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/WebSocketTest.kt
@@ -46,4 +46,24 @@ class WebSocketTest : ClientLoader() {
             }
         }
     }
+
+    @Test
+    fun testCancel() = clientTests(listOf("Apache", "Android", "Js")) {
+        config {
+            install(WebSockets)
+
+            test { client ->
+                io.ktor.client.tests.utils.assertFailsWith<CancellationException> {
+                    withTimeout(1000) {
+                        client.webSocket("$TEST_WEBSOCKET_SERVER/websockets/echo") {
+                            repeat(10) {
+                                send(Frame.Text("Hello"))
+                                delay(250)
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
 }

--- a/ktor-client/ktor-client-tests/js/src/io/ktor/client/tests/utils/Assertions.kt
+++ b/ktor-client/ktor-client-tests/js/src/io/ktor/client/tests/utils/Assertions.kt
@@ -11,6 +11,14 @@ import io.ktor.util.*
  */
 @InternalAPI
 actual inline fun <reified T : Throwable> assertFailsAndContainsCause(block: () -> Unit) {
+    assertFailsWith<T>(block)
+}
+
+/**
+ * Asserts that a [block] fails with a specific exception of type [T] being thrown.
+ */
+@InternalAPI
+actual inline fun <reified T : Throwable> assertFailsWith(block: () -> Unit) {
     try {
         block()
         error("Expected ${T::class} exception, but it wasn't thrown")

--- a/ktor-client/ktor-client-tests/jvm/src/io/ktor/client/tests/utils/Assertions.kt
+++ b/ktor-client/ktor-client-tests/jvm/src/io/ktor/client/tests/utils/Assertions.kt
@@ -14,10 +14,18 @@ import kotlin.test.*
 actual inline fun <reified T : Throwable> assertFailsAndContainsCause(block: () -> Unit) {
     var cause = assertFails(block)
 
-    while(true) {
+    while (true) {
         if (cause is T) return
         cause = cause.cause ?: break
     }
 
     assertTrue("Expected root cause is ${T::class}, but got ${cause::class}") { cause is T }
+}
+
+/**
+ * Asserts that a [block] fails with a specific exception of type [T] being thrown.
+ */
+@InternalAPI
+actual inline fun <reified T : Throwable> assertFailsWith(block: () -> Unit) {
+    kotlin.test.assertFailsWith<T> { block() }
 }

--- a/ktor-client/ktor-client-tests/posix/src/io/ktor/client/tests/utils/Assertions.kt
+++ b/ktor-client/ktor-client-tests/posix/src/io/ktor/client/tests/utils/Assertions.kt
@@ -21,3 +21,11 @@ actual inline fun <reified T : Throwable> assertFailsAndContainsCause(block: () 
 
     assertTrue("Expected root cause is ${T::class}, but got ${cause::class}") { cause is T }
 }
+
+/**
+ * Asserts that a [block] fails with a specific exception of type [T] being thrown.
+ */
+@InternalAPI
+actual inline fun <reified T : Throwable> assertFailsWith(block: () -> Unit) {
+    kotlin.test.assertFailsWith<T> { block() }
+}

--- a/ktor-io/common/test/io/ktor/utils/io/ByteChannelSmokeTest.kt
+++ b/ktor-io/common/test/io/ktor/utils/io/ByteChannelSmokeTest.kt
@@ -1,6 +1,9 @@
 package io.ktor.utils.io
 
 import io.ktor.utils.io.core.*
+import io.ktor.utils.io.core.EOFException
+import io.ktor.utils.io.errors.*
+import kotlinx.coroutines.*
 import kotlin.math.*
 import kotlin.test.*
 
@@ -646,6 +649,13 @@ open class ByteChannelSmokeTest : ByteChannelTestBase() {
         assertEquals(4, ch.availableForRead)
         ch.discard(4)
         finish(5)
+    }
+
+    @Test
+    fun testCompleteExceptionallyJob() = runTest {
+        Job().also { ch.attachJob(it) }.completeExceptionally(IOException("Test exception"))
+
+        assertFailsWith<IOException> { ch.readByte() }
     }
 
     private fun assertEquals(expected: Float, actual: Float) {

--- a/ktor-io/js/src/io/ktor/utils/io/ByteChannelJS.kt
+++ b/ktor-io/js/src/io/ktor/utils/io/ByteChannelJS.kt
@@ -84,7 +84,7 @@ internal class ByteChannelJS(initial: IoBuffer, autoFlush: Boolean) : ByteChanne
         job.invokeOnCompletion(onCancelling = true) { cause ->
             attachedJob = null
             if (cause != null) {
-                cancel(CancellationException("Channel closed due to job failure: $cause"))
+                cancel(cause)
             }
         }
     }

--- a/ktor-io/jvm/src/io/ktor/utils/io/ByteBufferChannel.kt
+++ b/ktor-io/jvm/src/io/ktor/utils/io/ByteBufferChannel.kt
@@ -70,7 +70,7 @@ internal open class ByteBufferChannel(
         job.invokeOnCompletion(onCancelling = true) { cause ->
             attachedJob = null
             if (cause != null) {
-                cancel(CancellationException("Channel closed due to job failure").apply { initCause(cause) })
+                cancel(cause)
             }
         }
     }

--- a/ktor-io/jvm/src/io/ktor/utils/io/ByteChannelSequentialJVM.kt
+++ b/ktor-io/jvm/src/io/ktor/utils/io/ByteChannelSequentialJVM.kt
@@ -20,7 +20,7 @@ class ByteChannelSequentialJVM(initial: IoBuffer, autoFlush: Boolean)
         job.invokeOnCompletion(onCancelling = true) { cause ->
             attachedJob = null
             if (cause != null) {
-                cancel(CancellationException("Channel closed due to job failure").apply { initCause(cause) })
+                cancel(cause)
             }
         }
     }

--- a/ktor-io/jvm/test/io/ktor/utils/io/ByteBufferChannelTest.kt
+++ b/ktor-io/jvm/test/io/ktor/utils/io/ByteBufferChannelTest.kt
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2014-2020 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.utils.io
+
+import kotlinx.coroutines.*
+import java.io.*
+import kotlin.test.*
+
+class ByteBufferChannelTest {
+    @Test
+    fun testCompleteExceptionallyJob() {
+        val channel = ByteBufferChannel(false)
+        Job().also { channel.attachJob(it) }.completeExceptionally(IOException("Text exception"))
+
+        assertFailsWith<IOException> { runBlocking { channel.readByte() } }
+    }
+}


### PR DESCRIPTION
**Subsystem**
Client, `ktor-io`.

**Motivation**
The client throws `CancellationException` with the actual exception put into the cause. It is not convenient in many cases.

