### PR TITLE
#1333 Set content-length for empty request payload for Apache Http Client

### DIFF
--- a/ktor-client/ktor-client-android/jvm/src/io/ktor/client/engine/android/AndroidClientEngine.kt
+++ b/ktor-client/ktor-client-android/jvm/src/io/ktor/client/engine/android/AndroidClientEngine.kt
@@ -66,7 +66,7 @@ class AndroidClientEngine(override val config: AndroidEngineConfig) : HttpClient
 
 
             if (outgoingContent is OutgoingContent.NoContent && data.method.supportsBody) {
-                setFixedLengthStreamingMode(0L)
+                setFixedLengthStreamingMode(0)
                 doOutput = true
             } else if (outgoingContent !is OutgoingContent.NoContent) {
                 if (!data.method.supportsBody) error(

--- a/ktor-client/ktor-client-apache/jvm/src/io/ktor/client/engine/apache/ApacheRequestProducer.kt
+++ b/ktor-client/ktor-client-apache/jvm/src/io/ktor/client/engine/apache/ApacheRequestProducer.kt
@@ -135,7 +135,7 @@ internal class ApacheRequestProducer(
             builder.addHeader(key, value)
         }
 
-        if (body is OutgoingContent.NoContent && method.isSupportingPayload) {
+        if (body is OutgoingContent.NoContent) {
             builder.entity = BasicHttpEntity().apply {
                 contentLength = 0
             }
@@ -202,10 +202,4 @@ private fun RequestConfig.Builder.setupTimeoutAttributes(requestData: HttpReques
         timeoutAttributes.connectTimeoutMillis?.let { setConnectTimeout(convertLongTimeoutToIntWithInfiniteAsZero(it)) }
         timeoutAttributes.socketTimeoutMillis?.let { setSocketTimeout(convertLongTimeoutToIntWithInfiniteAsZero(it)) }
     }
-}
-
-private val HttpMethod.isSupportingPayload get() = when(this.value) {
-    HttpMethod.Post.value -> true
-    HttpMethod.Put.value -> true
-    else -> false
 }

--- a/ktor-client/ktor-client-tests/jvm/src/io/ktor/client/tests/HttpClientTest.kt
+++ b/ktor-client/ktor-client-tests/jvm/src/io/ktor/client/tests/HttpClientTest.kt
@@ -47,16 +47,7 @@ abstract class HttpClientTest(private val factory: HttpClientEngineFactory<*>) :
         runBlocking {
             val client = HttpClient(factory)
             val statement = client.post<HttpStatement>("http://localhost:$serverPort/contentLengthRequestHeader")
-            assertEquals("0", statement.execute().readText(), "expect content-length to be set to 0")
-        }
-    }
-
-    @Test
-    fun testContentLengthSetToZeroForGet() {
-        runBlocking {
-            val client = HttpClient(factory)
-            val statement = client.get<HttpStatement>("http://localhost:$serverPort/contentLengthRequestHeader")
-            assertEquals("0", statement.execute().readText(), "expect content-length to be set to 0")
+            assertEquals("0", statement.execute().readText(), "expect proper content-length to be set")
         }
     }
 

--- a/ktor-client/ktor-client-tests/jvm/src/io/ktor/client/tests/HttpClientTest.kt
+++ b/ktor-client/ktor-client-tests/jvm/src/io/ktor/client/tests/HttpClientTest.kt
@@ -47,16 +47,16 @@ abstract class HttpClientTest(private val factory: HttpClientEngineFactory<*>) :
         runBlocking {
             val client = HttpClient(factory)
             val statement = client.post<HttpStatement>("http://localhost:$serverPort/contentLengthRequestHeader")
-            assertEquals("0", statement.execute().readText(), "Expected content-length to be set to 0.")
+            assertEquals("0", statement.execute().readText(), "expect content-length to be set to 0")
         }
     }
 
     @Test
-    fun testContentLengthNotSentForGetRequest() {
+    fun testContentLengthSetToZeroForGet() {
         runBlocking {
             val client = HttpClient(factory)
             val statement = client.get<HttpStatement>("http://localhost:$serverPort/contentLengthRequestHeader")
-            assertEquals("null", statement.execute().readText(), "Expected content-length not to be set.")
+            assertEquals("0", statement.execute().readText(), "expect content-length to be set to 0")
         }
     }
 

--- a/ktor-client/ktor-client-tests/jvm/src/io/ktor/client/tests/HttpClientTest.kt
+++ b/ktor-client/ktor-client-tests/jvm/src/io/ktor/client/tests/HttpClientTest.kt
@@ -33,6 +33,30 @@ abstract class HttpClientTest(private val factory: HttpClientEngineFactory<*>) :
             get("/hello") {
                 call.respondText("hello")
             }
+            post("/contentLengthRequestHeader") {
+                call.respondText(call.request.headers["content-length"] ?: "null")
+            }
+            get("/contentLengthRequestHeader") {
+                call.respondText(call.request.headers["content-length"] ?: "null")
+            }
+        }
+    }
+
+    @Test
+    fun testContentLengthSetToZeroForPostWithoutBodyBeingSet() {
+        runBlocking {
+            val client = HttpClient(factory)
+            val statement = client.post<HttpStatement>("http://localhost:$serverPort/contentLengthRequestHeader")
+            assertEquals("0", statement.execute().readText(), "Expected content-length to be set to 0.")
+        }
+    }
+
+    @Test
+    fun testContentLengthNotSentForGetRequest() {
+        runBlocking {
+            val client = HttpClient(factory)
+            val statement = client.get<HttpStatement>("http://localhost:$serverPort/contentLengthRequestHeader")
+            assertEquals("null", statement.execute().readText(), "Expected content-length not to be set.")
         }
     }
 


### PR DESCRIPTION


**Subsystem**
ktor-client

**Motivation**
When sending a POST/PUT without a payload, then some servers might reject the request with a `411 Length Required`. Other HTTP client implementations (CIO) are properly sending this header (`content-length = 0`), only the Apache client doesn't send the right header.

Refers to: #1333 (Apache HTTP Client does not send Content-Length header if body is empty content)

**Solution**
Simply check whether A) there is no request body and B) we are dealing with POST/PUT (which are the only HTTP methods which support a request body, so we don't want to do it for GET requests for example), and in that case hardcoded set the `content-length` header to `0`.