### PR TITLE
Fix missed preconfigured OkHttpClient in OkHttpEngine (#1646).

### DIFF
--- a/ktor-client/ktor-client-okhttp/jvm/src/io/ktor/client/engine/okhttp/OkHttpEngine.kt
+++ b/ktor-client/ktor-client-okhttp/jvm/src/io/ktor/client/engine/okhttp/OkHttpEngine.kt
@@ -121,7 +121,7 @@ class OkHttpEngine(override val config: OkHttpConfig) : HttpClientEngineBase("kt
     }
 
     private fun createOkHttpClient(timeoutExtension: HttpTimeout.HttpTimeoutCapabilityConfiguration?): OkHttpClient {
-        val builder = okHttpClientPrototype.newBuilder()
+        val builder = (config.preconfigured ?: okHttpClientPrototype).newBuilder()
 
         builder.apply(config.config)
         config.proxy?.let { builder.proxy(it) }


### PR DESCRIPTION
**Subsystem**
Client, OkHttp.

**Motivation**
The bug described in https://github.com/ktorio/ktor/issues/1646. Currently, we ignore preconfigured OkHttpClinet.

