### PR TITLE
Recover HttpRequestBuilder.takeFrom function (#1626).

### DIFF
--- a/binary-compatibility-validator/reference-public-api/ktor-client-core.txt
+++ b/binary-compatibility-validator/reference-public-api/ktor-client-core.txt
@@ -822,6 +822,7 @@ public final class io/ktor/client/request/HttpRequestBuilder : io/ktor/http/Http
 	public final fun setCapability (Lio/ktor/client/engine/HttpClientEngineCapability;Ljava/lang/Object;)V
 	public final fun setMethod (Lio/ktor/http/HttpMethod;)V
 	public final fun takeFrom (Lio/ktor/client/request/HttpRequestBuilder;)Lio/ktor/client/request/HttpRequestBuilder;
+	public final fun takeFromWithExecutionContext (Lio/ktor/client/request/HttpRequestBuilder;)Lio/ktor/client/request/HttpRequestBuilder;
 	public final fun url (Lkotlin/jvm/functions/Function2;)V
 }
 

--- a/ktor-client/ktor-client-core/common/src/io/ktor/client/engine/HttpClientEngine.kt
+++ b/ktor-client/ktor-client-core/common/src/io/ktor/client/engine/HttpClientEngine.kt
@@ -55,7 +55,7 @@ interface HttpClientEngine : CoroutineScope, Closeable {
     fun install(client: HttpClient) {
         client.sendPipeline.intercept(HttpSendPipeline.Engine) { content ->
             val requestData = HttpRequestBuilder().apply {
-                takeFrom(context)
+                takeFromWithExecutionContext(context)
                 body = content
             }.build()
 

--- a/ktor-client/ktor-client-core/common/src/io/ktor/client/features/HttpRedirect.kt
+++ b/ktor-client/ktor-client-core/common/src/io/ktor/client/features/HttpRedirect.kt
@@ -65,7 +65,7 @@ class HttpRedirect {
                 val location = call.response.headers[HttpHeaders.Location]
 
                 val requestBuilder = HttpRequestBuilder().apply {
-                    takeFrom(context)
+                    takeFromWithExecutionContext(context)
                     url.parameters.clear()
 
                     location?.let { url.takeFrom(it) }

--- a/ktor-client/ktor-client-core/common/src/io/ktor/client/request/HttpRequest.kt
+++ b/ktor-client/ktor-client-core/common/src/io/ktor/client/request/HttpRequest.kt
@@ -117,9 +117,15 @@ class HttpRequestBuilder : HttpMessageBuilder {
      * Mutates [this] copying all the data from another [builder] using it as base.
      */
     @InternalAPI
-    @Deprecated("For internal usage only")
-    fun takeFrom(builder: HttpRequestBuilder): HttpRequestBuilder {
+    fun takeFromWithExecutionContext(builder: HttpRequestBuilder): HttpRequestBuilder {
         executionContext = builder.executionContext
+        return takeFrom(builder)
+    }
+
+    /**
+     * Mutates [this] copying all the data but execution context from another [builder] using it as base.
+     */
+    fun takeFrom(builder: HttpRequestBuilder): HttpRequestBuilder {
         method = builder.method
         body = builder.body
         url.takeFrom(builder.url)

--- a/ktor-client/ktor-client-core/common/src/io/ktor/client/statement/HttpStatement.kt
+++ b/ktor-client/ktor-client-core/common/src/io/ktor/client/statement/HttpStatement.kt
@@ -14,7 +14,6 @@ import io.ktor.utils.io.*
 import io.ktor.utils.io.charsets.*
 import io.ktor.utils.io.core.*
 import kotlinx.coroutines.*
-import kotlin.reflect.*
 
 /**
  * Prepared statement for http client request.
@@ -100,7 +99,7 @@ class HttpStatement(
      */
     @PublishedApi
     internal suspend fun executeUnsafe(): HttpResponse {
-        val builder = HttpRequestBuilder().takeFrom(builder)
+        val builder = HttpRequestBuilder().takeFromWithExecutionContext(builder)
         @Suppress("DEPRECATION_ERROR")
         val call = client.execute(builder)
         return call.response

--- a/ktor-client/ktor-client-features/ktor-client-auth/common/src/io/ktor/client/features/auth/Auth.kt
+++ b/ktor-client/ktor-client-features/ktor-client-auth/common/src/io/ktor/client/features/auth/Auth.kt
@@ -49,7 +49,7 @@ class Auth(
                     candidateProviders.remove(provider)
 
                     val request = HttpRequestBuilder()
-                    request.takeFrom(context)
+                    request.takeFromWithExecutionContext(context)
                     provider.addRequestHeaders(request)
                     request.attributes.put(circuitBreaker, Unit)
 


### PR DESCRIPTION
**Subsystem**
Client, `HttpRequestBuilder`

**Motivation**
When we deprecated `takeFrom` we lost the support of important use case described in https://github.com/ktorio/ktor/issues/1626.

**Solution**
Make a separate `takeFromWithExecutionContext` method for internal usage and leave `takeFrom` to be used in client code.

