### PR TITLE
Expose LocationInfo (#1657)

### DIFF
--- a/ktor-features/ktor-locations/jvm/src/io/ktor/locations/Locations.kt
+++ b/ktor-features/ktor-locations/jvm/src/io/ktor/locations/Locations.kt
@@ -27,10 +27,10 @@ open class Locations(private val application: Application, private val routeServ
     private val rootUri = ResolvedUriInfo("", emptyList())
     private val info = hashMapOf<KClass<*>, LocationInfo>()
 
-    private class LocationInfoProperty(val name: String, val getter: KProperty1.Getter<*, *>, val isOptional: Boolean)
+    class LocationInfoProperty(val name: String, val getter: KProperty1.Getter<*, *>, val isOptional: Boolean)
 
     private data class ResolvedUriInfo(val path: String, val query: List<Pair<String, String>>)
-    private data class LocationInfo(
+    data class LocationInfo(
         val klass: KClass<*>,
         val parent: LocationInfo?,
         val parentParameter: LocationInfoProperty?,
@@ -80,6 +80,11 @@ open class Locations(private val application: Application, private val routeServ
 
     @Suppress("UNUSED_PARAMETER")
     private fun getParameterNameFromAnnotation(parameter: KParameter): String = TODO()
+
+    /**
+     *  Returns an immutable list of currently defined [LocationInfo]'s.
+     */
+    fun getLocationInfos() = info.values.toList()
 
     private fun ResolvedUriInfo.combine(
         relativePath: String,


### PR DESCRIPTION
**Subsystem**
Server

**Motivation**
This PR exposes `LocationInfo` in `io.ktor.locations.Locations`. This'll allow, for example, the ability to get a defined class annotated with `@Location` from a URL path. See #1657 .

**Solution**
I exposed `io.ktor.locations.Locations.LocationInfo` and added a public function that returns an immutable list of the currently mapped `LocationInfo`'s.

```kotlin
fun getLocationInfos() = info.values.toList()
```