### PR TITLE
Add woff2 content type support

### DIFF
--- a/ktor-http/common/src/io/ktor/http/Mimes.kt
+++ b/ktor-http/common/src/io/ktor/http/Mimes.kt
@@ -1087,6 +1087,7 @@ N/A,application/andrew-inset
 .wmx,video/x-ms-wmx
 .wmz,application/x-ms-wmz
 .woff,application/x-font-woff
+.woff2,font/woff2
 .word,application/msword
 .wp5,application/wordperfect
 .wp5,application/wordperfect6.0


### PR DESCRIPTION
**Subsystem**
Server

**Motivation**
We want correct content-type instead of octet-stream when serves woff2 font static resource.
The content-type is 'font/woff2'.

- https://tools.ietf.org/html/rfc8081#section-4.4.6
- https://www.iana.org/assignments/media-types/media-types.xml#font

**Solution**
Insert woff2 entry into Mimes.kt#rawMimes.

```
.woff2,font/woff2
```

