### PR TITLE
Fix minor grammar mistakes in the README.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,10 +4,10 @@ Before contributing to ktor, it could be advisable
 to check [Slack](https://surveys.jetbrains.com/s3/kotlin-slack-sign-up) **#ktor** channel first 
 and discuss the problem with the communitity.
 
-If your contribution is a bugfix, try to [search](https://github.com/ktorio/ktor/issues), 
+If your contribution is a bugfix, try to [search](https://github.com/ktorio/ktor/issues)
 if there is already an open ticket and open a new one if not yet opened.
 
-Contributions are made using github [pull requests](https://help.github.com/en/articles/about-pull-requests). 
+Contributions are made using Github [pull requests](https://help.github.com/en/articles/about-pull-requests). 
 
 1. [Create](https://github.com/ktorio/ktor/compare) a new PR, your PR should request to merge to the **master** branch.
 2. Ensure that the description is clear, refer to an existing ticket/bug if applicable.
@@ -30,12 +30,12 @@ Every public API (including functions, classes, objects and so on) should be doc
 every parameter, property, return types and exceptions should be described properly. 
 
 Commit messages should be written in English only, should be clear and descriptive, 
-written in Present Tense and using Imperative Mood ("Fix" instead of "Fixes", "Improve" instead of "Improved").
+written in present tense and using imperative mood ("Fix" instead of "Fixes", "Improve" instead of "Improved").
 Add the related bug reference to a commit message (bug number after a hash character between round braces). 
 See [How to Write a Git Commit Message](https://chris.beams.io/posts/git-commit/)
 
-A questionable and new API should be marked with `@KtorExperimentalAPI` annotation. 
-Public API that is not intended to be used by end-users that couldn't be made private/internal due to technical reasons,
+A questionable and new API should be marked with the `@KtorExperimentalAPI` annotation. 
+A Public API that is not intended to be used by end-users that couldn't be made private/internal due to technical reasons,
 should be marked with `@InternalAPI` annotation. 
 
 # Code of conduct

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ fun main(args: Array<String>) {
 ```
 
 * Runs embedded web server on `localhost:8080`
-* Installs routing and responds with `Hello, world!` when receiving GET http request for root path
+* Installs routing and responds with `Hello, world!` when receiving a GET http request for the root path
 
 ## Principles
 
@@ -36,27 +36,27 @@ fun main(args: Array<String>) {
 Ktor Framework doesn't impose a lot of constraints on what technology a project is going to use – logging, 
 templating, messaging, persistent, serializing, dependency injection, etc. 
 Sometimes it may be required to implement a simple interface, but usually it is a matter of writing a 
-transforming or intercepting function. Features are installed into application using unified *interception* mechanism
+transforming or intercepting function. Features are installed into the application using a unified *interception* mechanism
 which allows building arbitrary pipelines. 
 
-Ktor Application can be hosted in any servlet container with Servlet 3.0+ API support such as Tomcat, or 
+Ktor Applications can be hosted in any servlet container with Servlet 3.0+ API support such as Tomcat, or 
 standalone using Netty or Jetty. Support for other hosts can be added through the unified hosting API.
 
-Ktor APIs are mostly functions calls with lambdas. Thanks to Kotlin DSL capabilities, code looks declarative. 
-Application composition is entirely developer's choice – with functions or classes, using dependency injection 
-framework or doing it all manually in main function. 
+Ktor APIs are mostly functions calls with lambdas. Thanks to Kotlin DSL capabilities, the code looks declarative. 
+Application composition is entirely up to the developer's choice – with functions or classes, using dependency injection 
+framework or doing it all manually in the main function. 
 
 #### Asynchronous
 
-Ktor pipeline machinery and API is utilising Kotlin coroutines to provide easy-to-use asynchronous 
+The Ktor pipeline machinery and API are utilising Kotlin coroutines to provide easy-to-use asynchronous 
 programming model without making it too cumbersome. All host implementations are using asynchronous I/O facilities
 to avoid thread blocking. 
 
 #### Testable
 
-Ktor application can be hosted in a special test environment, which emulates to some 
-extent web server without actually doing any networking. It provides easy way to test an application without mocking 
-too much stuff, and still achieve good performance while validating application calls. Integration tests with real 
+Ktor applications can be hosted in a special test environment, which emulates a web server to some 
+extent without actually doing any networking. It provides easy way to test an application without mocking 
+too much stuff, and still achieve good performance while validating application calls. Running integration tests with a real 
 embedded web server are of course possible, too.
 
 ## Documentation
@@ -77,4 +77,4 @@ If you find a security vulnerability in Ktor, we kindly request that instead of 
 
 ## Contributing
 
-Please see [the contribution guide](CONTRIBUTING.md) before contirbuting and [Code of conduct](CODE_OF_CONDUCT.md).
+Please see [the contribution guide](CONTRIBUTING.md) and the [Code of conduct](CODE_OF_CONDUCT.md) before contributing.


### PR DESCRIPTION
**Subsystem**
README and CONTRIBUTING files only 

**Motivation**
Minor updates to the English grammar.

**Solution**

Please note that I am not a native English speaker either and that some of my fixes might be incorrect. Some sentences were missing articles though, and there is at least one definite typo :).