### PR TITLE
Switch conditional branch PlatformUtils.IS_NODE and PlatformUtils.IS_BROWSER

### DIFF
--- a/ktor-client/ktor-client-core/js/src/io/ktor/client/engine/js/compatibility/Utils.kt
+++ b/ktor-client/ktor-client-core/js/src/io/ktor/client/engine/js/compatibility/Utils.kt
@@ -22,10 +22,10 @@ internal suspend fun commonFetch(
         controller.abort()
     }
 
-    val promise: Promise<Response> = if (PlatformUtils.IS_NODE) {
-        jsRequire("node-fetch")(input, init)
-    } else {
+    val promise: Promise<Response> = if (PlatformUtils.IS_BROWSER) {
         fetch(input, init)
+    } else {
+        jsRequire("node-fetch")(input, init)
     }
 
     promise.then(
@@ -39,20 +39,20 @@ internal suspend fun commonFetch(
 }
 
 internal fun AbortController(): AbortController {
-    return if (PlatformUtils.IS_NODE) {
+    return if (PlatformUtils.IS_BROWSER) {
+        js("new AbortController()")
+    } else {
         val controller = js("require('abort-controller')")
         js("new controller()")
-    } else {
-        js("new AbortController()")
     }
 }
 
 internal fun CoroutineScope.readBody(
     response: Response
-): ByteReadChannel = if (PlatformUtils.IS_NODE) {
-    readBodyNode(response)
-} else {
+): ByteReadChannel = if (PlatformUtils.IS_BROWSER) {
     readBodyBrowser(response)
+} else {
+    readBodyNode(response)
 }
 
 

--- a/ktor-client/ktor-client-core/js/src/io/ktor/client/engine/js/compatibility/Utils.kt
+++ b/ktor-client/ktor-client-core/js/src/io/ktor/client/engine/js/compatibility/Utils.kt
@@ -55,7 +55,6 @@ internal fun CoroutineScope.readBody(
     readBodyNode(response)
 }
 
-
 private fun jsRequire(moduleName: String): dynamic = try {
     js("require(moduleName)")
 } catch (cause: dynamic) {


### PR DESCRIPTION
**Subsystem**
Js-Client

**Motivation**
Fixes #1674 .

**Solution**
`Response#body` returns `ReadableStream`. But, it does not have `on` method.
So I replaced `Response#arrayBuffer` method instead of `ReadableStream` methods on `CoroutineScope.readBodyNode`.

And I use `jsRequire`, always throws `"Error loading module 'node-fetch': Error: Cannot find module 'node-fetch'"`. So, I deleted the method.

The operation has been confirmed in my sample repository.