### PR TITLE
Cy/fixes2

### DIFF
--- a/gradle/experimental.gradle
+++ b/gradle/experimental.gradle
@@ -4,8 +4,6 @@ ext.experimentalAnnotations = [
     "io.ktor.util.KtorExperimentalAPI",
     "io.ktor.util.InternalAPI",
     "kotlinx.coroutines.ExperimentalCoroutinesApi",
-    "kotlinx.io.core.ExperimentalIoApi",
-    "kotlinx.io.core.internal.DangerousInternalIoApi",
     "io.ktor.utils.io.core.ExperimentalIoApi",
     "io.ktor.utils.io.core.internal.DangerousInternalIoApi",
     "kotlin.contracts.ExperimentalContracts"

--- a/gradle/pom.gradle
+++ b/gradle/pom.gradle
@@ -2,7 +2,7 @@ def pomConfig = {
     licenses {
         license {
             name "The Apache Software License, Version 2.0"
-            url "http://www.apache.org/licenses/LICENSE-2.0.txt"
+            url "https://www.apache.org/licenses/LICENSE-2.0.txt"
             distribution "repo"
         }
     }
@@ -11,7 +11,7 @@ def pomConfig = {
             id "JetBrains"
             name "JetBrains Team"
             organization "JetBrains"
-            organizationUrl "http://www.jetbrains.com"
+            organizationUrl "https://www.jetbrains.com"
         }
     }
 

--- a/ktor-io/common/src/io/ktor/utils/io/ReadSession.kt
+++ b/ktor-io/common/src/io/ktor/utils/io/ReadSession.kt
@@ -102,10 +102,13 @@ internal suspend fun ByteReadChannel.completeReadingFromBuffer(buffer: Buffer?, 
 
     if (readSession != null) {
         readSession.discard(bytesRead)
+        if (this is HasReadSession) {
+            endReadSession()
+        }
         return
     }
 
-    if (buffer is ChunkBuffer) {
+    if (buffer is ChunkBuffer && buffer !== ChunkBuffer.Empty) {
         buffer.release(ChunkBuffer.Pool)
         discard(bytesRead.toLong())
     }

--- a/ktor-io/common/src/io/ktor/utils/io/ReadSession.kt
+++ b/ktor-io/common/src/io/ktor/utils/io/ReadSession.kt
@@ -22,13 +22,17 @@ suspend inline fun ByteReadChannel.read(
     block: (source: Memory, start: Long, endExclusive: Long) -> Int
 ): Int {
     val buffer = requestBuffer(desiredSize) ?: Buffer.Empty
-    var bytesRead = 0
+
     try {
-        bytesRead = block(buffer.memory, buffer.readPosition.toLong(), buffer.readRemaining.toLong())
-        return bytesRead
-    } finally {
+        val bytesRead = block(buffer.memory, buffer.readPosition.toLong(), buffer.writePosition.toLong())
         completeReadingFromBuffer(buffer, bytesRead)
+        return bytesRead
+    } catch (cause: Throwable) {
+        completeReadingFromBuffer(buffer, 0)
+        throw cause
     }
+
+    // we don't use finally here because of KT-37279
 }
 
 @Deprecated("Use read { } instead.")
@@ -97,6 +101,7 @@ internal suspend fun ByteReadChannel.requestBuffer(desiredSize: Int): Buffer? {
 
 @PublishedApi
 internal suspend fun ByteReadChannel.completeReadingFromBuffer(buffer: Buffer?, bytesRead: Int) {
+    check(bytesRead >= 0) { "bytesRead shouldn't be negative: $bytesRead" }
     @Suppress("DEPRECATION")
     val readSession: SuspendableReadSession? = readSessionFor()
 

--- a/ktor-io/common/test/io/ktor/utils/io/ByteChannelSessionsTest.kt
+++ b/ktor-io/common/test/io/ktor/utils/io/ByteChannelSessionsTest.kt
@@ -1,0 +1,155 @@
+/*
+ * Copyright 2014-2020 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.utils.io
+
+import io.ktor.utils.io.bits.*
+import io.ktor.utils.io.core.*
+import kotlin.test.*
+
+class ByteChannelSessionsTest : ByteChannelTestBase() {
+    @Test
+    fun testSessionReadingSingleChunk(): Unit = runTest {
+        coroutines.schedule {
+            expect(2)
+            ch.writeStringUtf8("ABC")
+            ch.close()
+        }
+
+        expect(1)
+
+        val first = ch.read { _, start, endExclusive ->
+            assertEquals(3, endExclusive - start, "yo")
+            0
+        }
+
+        assertEquals(0, first)
+
+        expect(3)
+
+        assertEquals(1, ch.read { buffer, start, endExclusive ->
+            assertEquals(3, endExclusive - start)
+            assertEquals('A'.toByte(), buffer[start])
+            1
+        })
+
+        assertEquals(2, ch.read { buffer, start, endExclusive ->
+            assertEquals(2, endExclusive - start)
+            assertEquals('B'.toByte(), buffer[start])
+            assertEquals('C'.toByte(), buffer[start + 1])
+            2
+        })
+
+        assertTrue(ch.isClosedForRead, "Should be closed after all bytes read.")
+
+        assertEquals(0, ch.read { _, start, endExclusive ->
+            assertEquals(0, endExclusive - start)
+            0
+        })
+
+        finish(4)
+    }
+
+    @Test
+    fun testSessionReadingMultipleChunks(): Unit = runTest {
+        val text = buildString {
+            repeat(16384) { index ->
+                append("0123456789ABCDEF".let { it[index % it.length] })
+            }
+        }
+        coroutines.schedule {
+            ch.writeStringUtf8(text)
+            ch.close()
+        }
+
+        expect(1)
+
+        var bytesRead = 0
+        var completed = false
+
+        while (!completed) {
+            var size: Int = -1
+
+            val result = ch.read { source, start, endExclusive ->
+                check(start >= 0)
+                check(endExclusive >= start)
+                check(source.size32 >= (endExclusive - start))
+                check(endExclusive <= source.size)
+
+                val endIndex = endExclusive.minus(7)
+                    .coerceAtLeast(start + 10)
+                    .coerceAtMost(endExclusive)
+
+                var textOffset = bytesRead
+                for (index in start until endIndex) {
+                    assertEquals(
+                        text[textOffset].toByte(), source[index],
+                        "Expected character '${text[textOffset]}', " +
+                            "got '${source[index].toChar()}', index $bytesRead + $index"
+                    )
+                    textOffset++
+                }
+
+                size = (endIndex - start).toInt()
+                if (size < 0) {
+                    error(
+                        "Size is negative: $size, start = $start, endIndex = $endIndex, " +
+                            "endExclusive: $endExclusive"
+                    )
+                }
+                bytesRead += size
+
+                if (size == 0 && bytesRead == text.length) {
+                    completed = true
+                }
+
+                size
+            }
+
+            assertEquals(size, result)
+        }
+
+        assertTrue(ch.isClosedForRead, "Should be closed after all bytes read.")
+    }
+
+    @Test
+    fun testSessionReadingSessionMultipleChunks(): Unit = runTest {
+        val text = buildString {
+            repeat(16384) { index ->
+                append("0123456789ABCDEF".let { it[index % it.length] })
+            }
+        }
+        coroutines.schedule {
+            ch.writeStringUtf8(text)
+            ch.close()
+        }
+
+        expect(1)
+
+        var bytesRead = 0
+
+        @Suppress("DEPRECATION")
+        ch.readSuspendableSession {
+            while (true) {
+                val buffer = request(1)
+                if (buffer != null) {
+                    var count = 0
+                    (buffer as Buffer).forEach { byte ->
+                        assertEquals(text[bytesRead].toByte(), byte, "Broken character at index $bytesRead")
+                        count++
+                        bytesRead++
+                    }
+                    discard(count)
+                } else if (bytesRead < text.length) {
+                    await(1)
+                } else {
+                    break
+                }
+            }
+        }
+
+        yield()
+        assertTrue(ch.isClosedForRead, "Should be closed after all bytes read.")
+    }
+}

--- a/ktor-io/jvm/src/io/ktor/utils/io/ByteBufferChannel.kt
+++ b/ktor-io/jvm/src/io/ktor/utils/io/ByteBufferChannel.kt
@@ -1916,7 +1916,9 @@ internal open class ByteBufferChannel(
 
         state.let { s ->
             if (!s.capacity.tryReadExact(n)) throw IllegalStateException("Unable to consume $n bytes: not enough available bytes")
-            s.readBuffer.bytesRead(s.capacity, n)
+            if (n > 0) {
+                s.readBuffer.bytesRead(s.capacity, n)
+            }
         }
     }
 

--- a/ktor-io/jvm/src/io/ktor/utils/io/ByteBufferChannel.kt
+++ b/ktor-io/jvm/src/io/ktor/utils/io/ByteBufferChannel.kt
@@ -1684,6 +1684,7 @@ internal open class ByteBufferChannel(
         val state = state
         if (state is ReadWriteBufferState.Reading || state is ReadWriteBufferState.ReadingWriting) {
             restoreStateAfterRead()
+            tryTerminate()
         }
     }
 

--- a/ktor-io/jvm/src/io/ktor/utils/io/ByteChannel.kt
+++ b/ktor-io/jvm/src/io/ktor/utils/io/ByteChannel.kt
@@ -1,5 +1,6 @@
 package io.ktor.utils.io
 
+import io.ktor.utils.io.core.*
 import java.nio.*
 
 /**
@@ -23,6 +24,7 @@ actual fun ByteReadChannel(content: ByteArray, offset: Int, length: Int): ByteRe
  * Creates buffered channel for asynchronous reading and writing of sequences of bytes using [close] function to close
  * channel.
  */
+@ExperimentalIoApi
 fun ByteChannel(autoFlush: Boolean = false, exceptionMapper: (Throwable?) -> Throwable?): ByteChannel =
     object : ByteBufferChannel(autoFlush = autoFlush) {
 

--- a/ktor-io/jvm/src/io/ktor/utils/io/ConsumeEach.kt
+++ b/ktor-io/jvm/src/io/ktor/utils/io/ConsumeEach.kt
@@ -9,13 +9,14 @@ typealias ConsumeEachBufferVisitor = (buffer: ByteBuffer, last: Boolean) -> Bool
  */
 @Suppress("EXTENSION_SHADOWED_BY_MEMBER")
 suspend inline fun ByteReadChannel.consumeEachBufferRange(visitor: ConsumeEachBufferVisitor) {
-    var continueFlag = false
+    var continueFlag: Boolean
 
-    while (continueFlag) {
+    do {
+        continueFlag = false
         read { source, start, endExclusive ->
             val nioBuffer = source.slice(start, endExclusive - start).buffer
             continueFlag = visitor(nioBuffer, nioBuffer.remaining() == availableForRead && isClosedForWrite)
             nioBuffer.position()
         }
-    }
+    } while (continueFlag)
 }

--- a/ktor-io/jvm/src/io/ktor/utils/io/ConsumeEach.kt
+++ b/ktor-io/jvm/src/io/ktor/utils/io/ConsumeEach.kt
@@ -1,22 +1,41 @@
 package io.ktor.utils.io
 
+import io.ktor.utils.io.bits.*
 import java.nio.*
 
+/**
+ * Visitor function that is invoked for every available buffer (or chunk) of a channel.
+ * The last parameter shows that the buffer is known to be the last.
+ */
 typealias ConsumeEachBufferVisitor = (buffer: ByteBuffer, last: Boolean) -> Boolean
 
 /**
- * For every available bytes range invokes [visitor] function until it return false or end of stream encountered
+ * For every available bytes range invokes [visitor] function until it return false or end of stream encountered.
+ * The provided buffer should be never captured outside of the visitor block otherwise resource leaks, crashes and
+ * data corruptions may occur. The visitor block may be invoked multiple times, once or never.
  */
 @Suppress("EXTENSION_SHADOWED_BY_MEMBER")
 suspend inline fun ByteReadChannel.consumeEachBufferRange(visitor: ConsumeEachBufferVisitor) {
     var continueFlag: Boolean
+    var lastChunkReported = false
 
     do {
         continueFlag = false
         read { source, start, endExclusive ->
-            val nioBuffer = source.slice(start, endExclusive - start).buffer
-            continueFlag = visitor(nioBuffer, nioBuffer.remaining() == availableForRead && isClosedForWrite)
+            val nioBuffer = when {
+                endExclusive > start -> source.slice(start, endExclusive - start).buffer
+                else -> Memory.Empty.buffer
+            }
+
+            lastChunkReported = nioBuffer.remaining() == availableForRead && isClosedForWrite
+            continueFlag = visitor(nioBuffer, lastChunkReported)
+
             nioBuffer.position()
         }
+
+        if (lastChunkReported && isClosedForRead) {
+            break
+        }
+
     } while (continueFlag)
 }

--- a/ktor-io/jvm/test/io/ktor/utils/io/ConsumeEachBufferRangeTest.kt
+++ b/ktor-io/jvm/test/io/ktor/utils/io/ConsumeEachBufferRangeTest.kt
@@ -37,9 +37,9 @@ class ConsumeEachBufferRangeTest {
             val tmp = ByteArray(8192)
 
             flow<ByteBuffer> {
-                channel.consumeEachBufferRange { buffer, last ->
+                channel.consumeEachBufferRange { buffer, _ ->
                     emit(buffer)
-                    !last
+                    true
                 }
             }.collect { buffer ->
                 val size = buffer.remaining()

--- a/ktor-io/jvm/test/io/ktor/utils/io/ConsumeEachBufferRangeTest.kt
+++ b/ktor-io/jvm/test/io/ktor/utils/io/ConsumeEachBufferRangeTest.kt
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2014-2020 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.utils.io
+
+import kotlinx.coroutines.*
+import kotlinx.coroutines.debug.junit4.*
+import kotlinx.coroutines.flow.*
+import java.nio.*
+import kotlin.test.*
+import org.junit.Rule
+import java.io.*
+
+@Suppress("PublicApiImplicitType")
+class ConsumeEachBufferRangeTest {
+    private val content = ByteArray(16384) { it.toByte() }
+    private val channel = ByteChannel(autoFlush = true)
+
+    @get:Rule
+    val timeout = CoroutinesTimeout(10000, cancelOnTimeout = true)
+
+    @Test
+    fun test() {
+        runBlocking {
+            launch {
+                var pos = 0
+                while (pos < content.size) {
+                    val size = (content.size - pos).coerceAtMost(526)
+                    channel.writeFully(content, pos, size)
+                    pos += size
+                }
+                channel.close()
+            }
+
+            val data = ByteArrayOutputStream()
+            val tmp = ByteArray(8192)
+
+            flow<ByteBuffer> {
+                channel.consumeEachBufferRange { buffer, last ->
+                    emit(buffer)
+                    !last
+                }
+            }.collect { buffer ->
+                val size = buffer.remaining()
+                buffer.get(tmp, 0, size)
+                data.write(tmp, 0, size)
+            }
+
+            val result: ByteArray = data.toByteArray()
+            assertTrue(result.contentEquals(content))
+        }
+    }
+}

--- a/ktor-server/ktor-server-servlet/jvm/src/io/ktor/server/servlet/ServletApplicationRequest.kt
+++ b/ktor-server/ktor-server-servlet/jvm/src/io/ktor/server/servlet/ServletApplicationRequest.kt
@@ -19,11 +19,13 @@ abstract class ServletApplicationRequest(
 
     override val local: RequestConnectionPoint = ServletConnectionPoint(servletRequest)
 
-    override val queryParameters by lazy {
+    override val queryParameters: Parameters by lazy {
         servletRequest.queryString?.let { parseQueryString(it) } ?: Parameters.Empty
     }
 
     override val headers: Headers = ServletApplicationRequestHeaders(servletRequest)
+
+    @Suppress("LeakingThis") // this is safe because we don't access any content in the request
     override val cookies: RequestCookies = ServletApplicationRequestCookies(servletRequest, this)
 }
 

--- a/ktor-server/ktor-server-servlet/jvm/src/io/ktor/server/servlet/ServletApplicationRequestCookies.kt
+++ b/ktor-server/ktor-server-servlet/jvm/src/io/ktor/server/servlet/ServletApplicationRequestCookies.kt
@@ -10,7 +10,10 @@ import javax.servlet.http.*
 
 @Suppress("KDocMissingDocumentation")
 @EngineAPI
-class ServletApplicationRequestCookies(private val servletRequest: HttpServletRequest, request: ApplicationRequest) : RequestCookies(request) {
+class ServletApplicationRequestCookies(
+    private val servletRequest: HttpServletRequest,
+    request: ApplicationRequest
+) : RequestCookies(request) {
     override fun fetchCookies(): Map<String, String> {
         return servletRequest.cookies?.associateBy({ it.name }, { it.value }) ?: emptyMap()
     }

--- a/ktor-server/ktor-server-test-host/jvm/src/io/ktor/server/testing/TestApplicationRequest.kt
+++ b/ktor-server/ktor-server-test-host/jvm/src/io/ktor/server/testing/TestApplicationRequest.kt
@@ -14,8 +14,6 @@ import io.ktor.utils.io.*
 import io.ktor.utils.io.jvm.javaio.*
 import io.ktor.utils.io.charsets.*
 import io.ktor.utils.io.core.*
-import kotlinx.io.*
-import java.nio.channels.*
 
 /**
  * Represents a test application request
@@ -34,7 +32,7 @@ class TestApplicationRequest constructor(
 ) : BaseApplicationRequest(call), CoroutineScope by call {
     var protocol: String = "http"
 
-    override val local = object : RequestConnectionPoint {
+    override val local: RequestConnectionPoint = object : RequestConnectionPoint {
         override val uri: String
             get() = this@TestApplicationRequest.uri
 
@@ -63,9 +61,9 @@ class TestApplicationRequest constructor(
     @Volatile
     var bodyChannel: ByteReadChannel = if (closeRequest) ByteReadChannel.Empty else ByteChannel()
 
-    override val queryParameters by lazy(LazyThreadSafetyMode.NONE) { parseQueryString(queryString()) }
+    override val queryParameters: Parameters by lazy(LazyThreadSafetyMode.NONE) { parseQueryString(queryString()) }
 
-    override val cookies = RequestCookies(this)
+    override val cookies: RequestCookies = RequestCookies(this)
 
     private var headersMap: MutableMap<String, MutableList<String>>? = hashMapOf()
 
@@ -119,10 +117,17 @@ fun TestApplicationRequest.setBody(boundary: String, parts: List<PartData>) {
                     append("$key: ${values.joinToString(";")}\r\n")
                 }
                 append("\r\n")
-                when (it) {
-                    is PartData.FileItem -> it.provider().asStream().copyTo(channel.toOutputStream())
-                    is PartData.FormItem -> append(it.value)
-                }
+                append(when (it) {
+                    is PartData.FileItem -> {
+                        it.provider().asStream().copyTo(channel.toOutputStream())
+                        ""
+                    }
+                    is PartData.BinaryItem -> {
+                        it.provider().asStream().copyTo(channel.toOutputStream())
+                        ""
+                    }
+                    is PartData.FormItem -> it.value
+                })
                 append("\r\n")
             }
 

--- a/ktor-server/ktor-server-tests/jvm/test/io/ktor/tests/server/features/OriginConnectionPointTest.kt
+++ b/ktor-server/ktor-server-tests/jvm/test/io/ktor/tests/server/features/OriginConnectionPointTest.kt
@@ -10,7 +10,6 @@ import io.ktor.http.*
 import io.ktor.response.*
 import io.ktor.routing.*
 import io.ktor.server.testing.*
-import org.junit.Test
 import kotlin.test.*
 
 class OriginConnectionPointTest {
@@ -315,6 +314,51 @@ class OriginConnectionPointTest {
             handleRequest(HttpMethod.Get, "/") {
                 addHeader(HttpHeaders.Forwarded, "for=client;host=host,for=proxy;host=internal-host")
             }
+        }
+    }
+
+    @Test
+    fun testOriginWithNoFeatures(): Unit = withTestApplication {
+        application.routing {
+            get("/") {
+                with(call.request.origin) {
+                    assertEquals("host", host)
+                    assertEquals(80, port)
+                }
+
+                call.respond("OK")
+            }
+            get("/90") {
+                with(call.request.origin) {
+                    assertEquals("host", host)
+                    assertEquals(90, port)
+                }
+
+                call.respond("OK")
+            }
+            get("/no-header") {
+                with(call.request.origin) {
+                    assertEquals("localhost", host)
+                    assertEquals(80, port)
+                }
+
+                call.respond("OK")
+            }
+        }
+
+        handleRequest(HttpMethod.Get, "/") {
+            addHeader(HttpHeaders.Host, "host")
+        }
+
+        handleRequest(HttpMethod.Get, "/") {
+            addHeader(HttpHeaders.Host, "host:80")
+        }
+
+        handleRequest(HttpMethod.Get, "/90") {
+            addHeader(HttpHeaders.Host, "host:90")
+        }
+
+        handleRequest(HttpMethod.Get, "/no-header") {
         }
     }
 }

--- a/ktor-utils/common/src/io/ktor/util/pipeline/Pipeline.kt
+++ b/ktor-utils/common/src/io/ktor/util/pipeline/Pipeline.kt
@@ -14,7 +14,7 @@ open class Pipeline<TSubject : Any, TContext : Any>(vararg phases: PipelinePhase
     /**
      * Provides common place to store pipeline attributes
      */
-    val attributes = Attributes()
+    val attributes = Attributes(true)
 
     constructor(phase: PipelinePhase, interceptors: List<PipelineInterceptor<TSubject, TContext>>) : this(phase) {
         interceptors.forEach { intercept(phase, it) }


### PR DESCRIPTION
**Subsystem**
Server

**Motivation**
Several bugfixes including fix for `call.request.origin` that doesn't work properly in 1.3.1 and report IP address instead of hostname.


