### PR TITLE
Client: Redirect URL resolution bug with relative paths

### DIFF
--- a/ktor-client/ktor-client-core/common/src/io/ktor/client/features/HttpRedirect.kt
+++ b/ktor-client/ktor-client-core/common/src/io/ktor/client/features/HttpRedirect.kt
@@ -59,13 +59,14 @@ class HttpRedirect {
             if (!origin.response.status.isRedirect()) return origin
 
             var call = origin
+            var requestBuilder = context
             val originProtocol = origin.request.url.protocol
             val originAuthority = origin.request.url.authority
             while (true) {
                 val location = call.response.headers[HttpHeaders.Location]
 
-                val requestBuilder = HttpRequestBuilder().apply {
-                    takeFromWithExecutionContext(context)
+                requestBuilder = HttpRequestBuilder().apply {
+                    takeFromWithExecutionContext(requestBuilder)
                     url.parameters.clear()
 
                     location?.let { url.takeFrom(it) }

--- a/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/HttpRedirectTest.kt
+++ b/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/HttpRedirectTest.kt
@@ -91,6 +91,15 @@ class HttpRedirectTest : ClientLoader() {
     }
 
     @Test
+    fun testMultipleRedirectRelative() = clientTests {
+        test { client ->
+            client.get<HttpStatement>("$TEST_URL_BASE/multipleRedirects/login").execute {
+                assertEquals("account details", it.readText())
+            }
+        }
+    }
+
+    @Test
     fun testRedirectAbsolute() = clientTests {
         test { client ->
             client.get<HttpStatement>("$TEST_URL_BASE/directory/absoluteRedirectFile").execute {

--- a/ktor-client/ktor-client-tests/jvm/src/io/ktor/client/tests/utils/tests/Redirect.kt
+++ b/ktor-client/ktor-client-tests/jvm/src/io/ktor/client/tests/utils/tests/Redirect.kt
@@ -46,6 +46,15 @@ internal fun Application.redirectTest() {
             get("/directory/hostAbsoluteRedirect") {
                 call.respondRedirect("$TEST_SERVER/redirect/get")
             }
+            get("/multipleRedirects/login") {
+                call.respondRedirect("/redirect/multipleRedirects/user/")
+            }
+            get("/multipleRedirects/user/") {
+                call.respondRedirect("account/details")
+            }
+            get("/multipleRedirects/user/account/details") {
+                call.respondText("account details")
+            }
         }
     }
 }


### PR DESCRIPTION
When a requested url responds with multiple redirects and the last redirect uses a relative path the relative path is resolved with the path of the initial request.

Example: 
initial request https://test.com/login/ location[/user/ ] -> https://test.com/user/ location[acccount/details] -> https://test.com/login/account/details

Expected:
initial request https://test.com/login/ location[/user/ ] -> https://test.com/user/ location[acccount/details] -> https://test.com/user/account/details

