### PR TITLE
Mime types

### DIFF
--- a/ktor-http/common/src/io/ktor/http/Mimes.kt
+++ b/ktor-http/common/src/io/ktor/http/Mimes.kt
@@ -558,8 +558,8 @@ private val rawMimes: String
 .mp3,audio/mpeg
 .mp3,audio/mpeg3
 .mp4a,audio/mp4
-.mp4,application/mp4
 .mp4,video/mp4
+.mp4,application/mp4
 .mpa,audio/mpeg
 .mpc,application/vnd.mophun.certificate
 .mpc,application/x-project

--- a/ktor-http/common/src/io/ktor/http/Mimes.kt
+++ b/ktor-http/common/src/io/ktor/http/Mimes.kt
@@ -757,8 +757,8 @@ N/A,application/andrew-inset
 .pwn,application/vnd.3m.post-it-notes
 .pwz,application/vnd.ms-powerpoint
 .pya,audio/vnd.ms-playready.media.pya
-.pyc,applicaiton/x-bytecode.python
-.py,text/x-script.phyton
+.pyc,application/x-bytecode.python
+.py,text/x-script.python
 .pyv,video/vnd.ms-playready.media.pyv
 .qam,application/vnd.epson.quickanime
 .qbo,application/vnd.intu.qbo


### PR DESCRIPTION
**Subsystem**
Server/http

**Motivation**
Some mime type mapping were incorrect/had typo's (I bet there are more in the file). The mime type for .mp4 files was incorrectly set to application/mp4 instead of video/mp4 due to ordering within the file.

**Solution**
Corrected typo's and ordering

