### PR TITLE
Cy/cio server localaddress

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,5 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
+  <component name="CommitMessageInspectionProfile">
+    <profile version="1.0">
+      <inspection_tool class="GrazieCommit" enabled="true" level="TYPO" enabled_by_default="true" />
+    </profile>
+  </component>
   <component name="VcsDirectoryMappings">
     <mapping directory="$PROJECT_DIR$" vcs="Git" />
   </component>

--- a/binary-compatibility-validator/reference-public-api/ktor-http-cio.txt
+++ b/binary-compatibility-validator/reference-public-api/ktor-http-cio.txt
@@ -483,8 +483,10 @@ public final class io/ktor/http/cio/websocket/WebSocketWriter : kotlinx/coroutin
 }
 
 public final class io/ktor/server/cio/backend/ServerIncomingConnection {
-	public fun <init> (Lio/ktor/utils/io/ByteReadChannel;Lio/ktor/utils/io/ByteWriteChannel;Ljava/net/SocketAddress;)V
+	public synthetic fun <init> (Lio/ktor/utils/io/ByteReadChannel;Lio/ktor/utils/io/ByteWriteChannel;Ljava/net/SocketAddress;)V
+	public fun <init> (Lio/ktor/utils/io/ByteReadChannel;Lio/ktor/utils/io/ByteWriteChannel;Ljava/net/SocketAddress;Ljava/net/SocketAddress;)V
 	public final fun getInput ()Lio/ktor/utils/io/ByteReadChannel;
+	public final fun getLocalAddress ()Ljava/net/SocketAddress;
 	public final fun getOutput ()Lio/ktor/utils/io/ByteWriteChannel;
 	public final fun getRemoteAddress ()Ljava/net/SocketAddress;
 }
@@ -496,6 +498,7 @@ public final class io/ktor/server/cio/backend/ServerPipelineKt {
 public final class io/ktor/server/cio/backend/ServerRequestScope : kotlinx/coroutines/CoroutineScope {
 	public fun getCoroutineContext ()Lkotlin/coroutines/CoroutineContext;
 	public final fun getInput ()Lio/ktor/utils/io/ByteReadChannel;
+	public final fun getLocalAddress ()Ljava/net/SocketAddress;
 	public final fun getOutput ()Lio/ktor/utils/io/ByteWriteChannel;
 	public final fun getRemoteAddress ()Ljava/net/SocketAddress;
 	public final fun getUpgraded ()Lkotlinx/coroutines/CompletableDeferred;

--- a/gradle/experimental.gradle
+++ b/gradle/experimental.gradle
@@ -1,5 +1,5 @@
 ext.experimentalAnnotations = [
-    "kotlin.Experimental",
+    "kotlin.RequiresOptIn",
     "kotlin.ExperimentalUnsignedTypes",
     "io.ktor.util.KtorExperimentalAPI",
     "io.ktor.util.InternalAPI",

--- a/ktor-client/ktor-client-apache/jvm/src/io/ktor/client/engine/apache/ApacheRequestProducer.kt
+++ b/ktor-client/ktor-client-apache/jvm/src/io/ktor/client/engine/apache/ApacheRequestProducer.kt
@@ -81,7 +81,7 @@ internal class ApacheRequestProducer(
         var buffer = currentBuffer.getAndSet(null) ?: requestChannel.poll()
 
         if (buffer == null) {
-            @UseExperimental(ExperimentalCoroutinesApi::class)
+            @OptIn(ExperimentalCoroutinesApi::class)
             if (requestChannel.isClosedForReceive) {
                 encoder.complete()
                 return

--- a/ktor-client/ktor-client-apache/jvm/test/io/ktor/client/engine/apache/ConsumerTest.kt
+++ b/ktor-client/ktor-client-apache/jvm/test/io/ktor/client/engine/apache/ConsumerTest.kt
@@ -39,7 +39,7 @@ class ConsumerTest : CoroutineScope {
     }
 
     @AfterTest
-    @UseExperimental(InternalCoroutinesApi::class)
+    @OptIn(InternalCoroutinesApi::class)
     fun cancel() {
         if (job.isCancelled) {
             throw job.getCancellationException()

--- a/ktor-client/ktor-client-cio/jvm/src/io/ktor/client/engine/cio/CIOEngine.kt
+++ b/ktor-client/ktor-client-cio/jvm/src/io/ktor/client/engine/cio/CIOEngine.kt
@@ -24,7 +24,7 @@ internal class CIOEngine(override val config: CIOEngineConfig) : HttpClientEngin
 
     private val endpoints = ConcurrentHashMap<String, Endpoint>()
 
-    @UseExperimental(InternalCoroutinesApi::class)
+    @OptIn(InternalCoroutinesApi::class)
     private val selectorManager by lazy { ActorSelectorManager(dispatcher) }
 
     private val connectionFactory = ConnectionFactory(selectorManager, config.maxConnectionsCount)

--- a/ktor-client/ktor-client-core/common/src/io/ktor/client/engine/Utils.kt
+++ b/ktor-client/ktor-client-core/common/src/io/ktor/client/engine/Utils.kt
@@ -68,7 +68,7 @@ internal class KtorCallContextElement(val callContext: CoroutineContext) : Corou
  * Attach [callJob] to user job using the following logic: when user job completes with exception, [callJob] completes
  * with exception too.
  */
-@UseExperimental(InternalCoroutinesApi::class)
+@OptIn(InternalCoroutinesApi::class)
 internal suspend inline fun attachToUserJob(callJob: Job) {
     val userJob = coroutineContext[Job] ?: return
 

--- a/ktor-client/ktor-client-core/common/src/io/ktor/client/features/websocket/WebSockets.kt
+++ b/ktor-client/ktor-client-core/common/src/io/ktor/client/features/websocket/WebSockets.kt
@@ -19,7 +19,7 @@ import io.ktor.util.*
  * @property maxFrameSize - max size of single websocket frame.
  */
 @KtorExperimentalAPI
-@UseExperimental(WebSocketInternalAPI::class)
+@OptIn(WebSocketInternalAPI::class)
 class WebSockets(
     val pingInterval: Long = -1L,
     val maxFrameSize: Long = Int.MAX_VALUE.toLong()

--- a/ktor-client/ktor-client-core/common/src/io/ktor/client/features/websocket/builders.kt
+++ b/ktor-client/ktor-client-core/common/src/io/ktor/client/features/websocket/builders.kt
@@ -13,7 +13,7 @@ import io.ktor.http.cio.websocket.*
 /**
  * Open [DefaultClientWebSocketSession].
  */
-@UseExperimental(WebSocketInternalAPI::class)
+@OptIn(WebSocketInternalAPI::class)
 suspend fun HttpClient.webSocketSession(block: HttpRequestBuilder.() -> Unit): DefaultClientWebSocketSession = request {
     url {
         protocol = URLProtocol.WS
@@ -25,7 +25,7 @@ suspend fun HttpClient.webSocketSession(block: HttpRequestBuilder.() -> Unit): D
 /**
  * Open [DefaultClientWebSocketSession].
  */
-@UseExperimental(WebSocketInternalAPI::class)
+@OptIn(WebSocketInternalAPI::class)
 suspend fun HttpClient.webSocketSession(
     method: HttpMethod = HttpMethod.Get, host: String = "localhost", port: Int = DEFAULT_PORT, path: String = "/",
     block: HttpRequestBuilder.() -> Unit = {}

--- a/ktor-client/ktor-client-core/common/src/io/ktor/client/request/forms/formDsl.kt
+++ b/ktor-client/ktor-client-core/common/src/io/ktor/client/request/forms/formDsl.kt
@@ -146,7 +146,7 @@ class FormBuilder internal constructor() {
 /**
  * Append a form part with the specified [key] using [bodyBuilder] for it's body.
  */
-@UseExperimental(ExperimentalContracts::class)
+@OptIn(ExperimentalContracts::class)
 inline fun FormBuilder.append(
     key: String,
     headers: Headers = Headers.Empty,
@@ -172,7 +172,7 @@ class InputProvider(val size: Long? = null, val block: () -> Input)
 /**
  * Append a form part with the specified [key], [filename] and optional [contentType] using [bodyBuilder] for it's body.
  */
-@UseExperimental(ExperimentalContracts::class)
+@OptIn(ExperimentalContracts::class)
 fun FormBuilder.append(
     key: String,
     filename: String,

--- a/ktor-client/ktor-client-core/common/src/io/ktor/client/statement/HttpStatement.kt
+++ b/ktor-client/ktor-client-core/common/src/io/ktor/client/statement/HttpStatement.kt
@@ -65,7 +65,7 @@ class HttpStatement(
      *
      * Note if T is a streaming type, you should manage how to close it manually.
      */
-    @UseExperimental(ExperimentalStdlibApi::class)
+    @OptIn(ExperimentalStdlibApi::class)
     suspend inline fun <reified T> receive(): T = when (T::class) {
         HttpStatement::class -> this as T
         HttpResponse::class -> execute() as T

--- a/ktor-client/ktor-client-core/js/src/io/ktor/client/call/TypeInfoJs.kt
+++ b/ktor-client/ktor-client-core/js/src/io/ktor/client/call/TypeInfoJs.kt
@@ -11,7 +11,7 @@ actual interface Type
 
 object JsType : Type
 
-@UseExperimental(ExperimentalStdlibApi::class)
+@OptIn(ExperimentalStdlibApi::class)
 actual inline fun <reified T> typeInfo(): TypeInfo = try {
     TypeInfo(T::class, JsType, typeOf<T>())
 } catch (_: dynamic) {

--- a/ktor-client/ktor-client-core/jvm/src/io/ktor/client/call/TypeInfoJvm.kt
+++ b/ktor-client/ktor-client-core/jvm/src/io/ktor/client/call/TypeInfoJvm.kt
@@ -12,7 +12,7 @@ actual typealias Type = java.lang.reflect.Type
 @PublishedApi
 internal open class TypeBase<T>
 
-@UseExperimental(ExperimentalStdlibApi::class)
+@OptIn(ExperimentalStdlibApi::class)
 actual inline fun <reified T> typeInfo(): TypeInfo {
     val base = object : TypeBase<T>() {}
     val superType = base::class.java.genericSuperclass!!

--- a/ktor-client/ktor-client-core/jvm/src/io/ktor/client/engine/HttpClientJvmEngine.kt
+++ b/ktor-client/ktor-client-core/jvm/src/io/ktor/client/engine/HttpClientJvmEngine.kt
@@ -24,11 +24,11 @@ abstract class HttpClientJvmEngine(engineName: String) : HttpClientEngine {
         }.asCoroutineDispatcher()
     }
 
-    @UseExperimental(InternalCoroutinesApi::class)
+    @OptIn(InternalCoroutinesApi::class)
     override val dispatcher: CoroutineDispatcher
         get() = _dispatcher
 
-    @UseExperimental(InternalCoroutinesApi::class)
+    @OptIn(InternalCoroutinesApi::class)
     override val coroutineContext: CoroutineContext by lazy {
         _dispatcher + clientContext + CoroutineName("$engineName-context")
     }
@@ -36,7 +36,7 @@ abstract class HttpClientJvmEngine(engineName: String) : HttpClientEngine {
     /**
      * Create [CoroutineContext] to execute call.
      */
-    @UseExperimental(InternalCoroutinesApi::class)
+    @OptIn(InternalCoroutinesApi::class)
     protected suspend fun createCallContext(): CoroutineContext {
         val callJob = Job(clientContext[Job])
         val callContext = coroutineContext + callJob

--- a/ktor-client/ktor-client-core/jvm/src/io/ktor/client/utils/CoroutineDispatcherUtils.kt
+++ b/ktor-client/ktor-client-core/jvm/src/io/ktor/client/utils/CoroutineDispatcherUtils.kt
@@ -11,7 +11,7 @@ import kotlinx.coroutines.scheduling.*
 /**
  * Creates [CoroutineDispatcher] based on thread pool of [threadCount] threads.
  */
-@UseExperimental(InternalCoroutinesApi::class)
+@OptIn(InternalCoroutinesApi::class)
 @InternalAPI
 fun Dispatchers.clientDispatcher(
     threadCount: Int,

--- a/ktor-client/ktor-client-core/posix/src/io/ktor/client/call/TypeInfoIos.kt
+++ b/ktor-client/ktor-client-core/posix/src/io/ktor/client/call/TypeInfoIos.kt
@@ -14,7 +14,7 @@ object IosType : Type
 @PublishedApi
 internal open class TypeBase<T>
 
-@UseExperimental(ExperimentalStdlibApi::class)
+@OptIn(ExperimentalStdlibApi::class)
 actual inline fun <reified T> typeInfo(): TypeInfo {
     val kClass = T::class
     return TypeInfo(kClass, IosType, typeOf<T>())

--- a/ktor-client/ktor-client-features/ktor-client-json/ktor-client-serialization/common/src/io/ktor/client/features/json/serializer/KotlinxSerializer.kt
+++ b/ktor-client/ktor-client-features/ktor-client-json/ktor-client-serialization/common/src/io/ktor/client/features/json/serializer/KotlinxSerializer.kt
@@ -20,7 +20,9 @@ import kotlin.reflect.*
 /**
  * A [JsonSerializer] implemented for kotlinx [Serializable] classes.
  */
-@UseExperimental(ImplicitReflectionSerializer::class, UnstableDefault::class)
+@OptIn(
+    ImplicitReflectionSerializer::class, UnstableDefault::class
+)
 class KotlinxSerializer(
     private val json: Json = Json.plain
 ) : JsonSerializer {
@@ -81,7 +83,7 @@ class KotlinxSerializer(
 }
 
 @Suppress("UNCHECKED_CAST")
-@UseExperimental(ImplicitReflectionSerializer::class)
+@OptIn(ImplicitReflectionSerializer::class)
 private fun buildSerializer(value: Any): KSerializer<*> = when (value) {
     is JsonElement -> JsonElementSerializer
     is List<*> -> value.elementSerializer().list
@@ -95,7 +97,7 @@ private fun buildSerializer(value: Any): KSerializer<*> = when (value) {
     else -> value::class.serializer()
 }
 
-@UseExperimental(ImplicitReflectionSerializer::class)
+@OptIn(ImplicitReflectionSerializer::class)
 private fun Collection<*>.elementSerializer(): KSerializer<*> {
     @Suppress("DEPRECATION_ERROR")
     val serializers = filterNotNull().map { buildSerializer(it) }.distinctBy { it.descriptor.name }

--- a/ktor-client/ktor-client-jetty/jvm/src/io/ktor/client/engine/jetty/JettyResponseListener.kt
+++ b/ktor-client/ktor-client-jetty/jvm/src/io/ktor/client/engine/jetty/JettyResponseListener.kt
@@ -101,7 +101,9 @@ internal class JettyResponseListener(
         return StatusWithHeaders(statusCode, headersBuilder.build())
     }
 
-    @UseExperimental(ExperimentalCoroutinesApi::class, ObsoleteCoroutinesApi::class)
+    @OptIn(
+        ExperimentalCoroutinesApi::class, ObsoleteCoroutinesApi::class
+    )
     private fun runResponseProcessing() = GlobalScope.launch(callContext) {
         while (!backendChannel.isClosedForReceive) {
             val (buffer, callback) = @Suppress("DEPRECATION") backendChannel.receiveOrNull() ?: break

--- a/ktor-client/ktor-client-okhttp/jvm/src/io/ktor/client/engine/okhttp/OkHttpWebsocketSession.kt
+++ b/ktor-client/ktor-client-okhttp/jvm/src/io/ktor/client/engine/okhttp/OkHttpWebsocketSession.kt
@@ -12,7 +12,7 @@ import okhttp3.*
 import okio.*
 import kotlin.coroutines.*
 
-@UseExperimental(ObsoleteCoroutinesApi::class)
+@OptIn(ObsoleteCoroutinesApi::class)
 internal class OkHttpWebsocketSession(
     private val engine: OkHttpClient,
     engineRequest: Request,

--- a/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/HttpBinTest.kt
+++ b/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/HttpBinTest.kt
@@ -77,7 +77,7 @@ class HttpBinTest : ClientLoader() {
         }
     }
 
-    @UseExperimental(UnstableDefault::class)
+    @OptIn(UnstableDefault::class)
     private fun HttpClientConfig<*>.testConfiguration() {
         install(JsonFeature) {
             serializer = KotlinxSerializer(Json.nonstrict)

--- a/ktor-features/ktor-locations/jvm/src/io/ktor/locations/BackwardCompatibleImpl.kt
+++ b/ktor-features/ktor-locations/jvm/src/io/ktor/locations/BackwardCompatibleImpl.kt
@@ -17,7 +17,7 @@ import kotlin.reflect.*
 import kotlin.reflect.full.*
 import kotlin.reflect.jvm.*
 
-@UseExperimental(KtorExperimentalLocationsAPI::class)
+@OptIn(KtorExperimentalLocationsAPI::class)
 internal abstract class LocationsImpl(
     protected val application: Application,
     protected val routeService: LocationRouteService
@@ -39,7 +39,7 @@ internal abstract class LocationsImpl(
     abstract fun href(location: Any, builder: URLBuilder)
 }
 
-@UseExperimental(KtorExperimentalLocationsAPI::class)
+@OptIn(KtorExperimentalLocationsAPI::class)
 internal class BackwardCompatibleImpl(
     application: Application,
     routeService: LocationRouteService

--- a/ktor-features/ktor-locations/jvm/src/io/ktor/locations/Location.kt
+++ b/ktor-features/ktor-locations/jvm/src/io/ktor/locations/Location.kt
@@ -3,7 +3,7 @@
  */
 
 @file:Suppress("unused")
-@file:UseExperimental(KtorExperimentalLocationsAPI::class)
+@file:OptIn(KtorExperimentalLocationsAPI::class)
 
 package io.ktor.locations
 
@@ -17,6 +17,11 @@ import kotlin.reflect.*
 /**
  * API marked with this annotation is experimental and is not guaranteed to be stable.
  */
+@Suppress("DEPRECATION")
+@RequiresOptIn(
+    level = RequiresOptIn.Level.WARNING,
+    message = "This locations API is experimental. It could be changed or removed in future releases."
+)
 @Experimental(level = Experimental.Level.WARNING)
 annotation class KtorExperimentalLocationsAPI
 

--- a/ktor-features/ktor-locations/jvm/src/io/ktor/locations/Locations.kt
+++ b/ktor-features/ktor-locations/jvm/src/io/ktor/locations/Locations.kt
@@ -24,7 +24,7 @@ open class Locations @KtorExperimentalLocationsAPI constructor(
     /**
      * Creates Locations service extracting path information from @Location annotation
      */
-    @UseExperimental(KtorExperimentalLocationsAPI::class)
+    @OptIn(KtorExperimentalLocationsAPI::class)
     constructor(application: Application) : this(application, LocationAttributeRouteService())
 
     private val implementation: LocationsImpl = BackwardCompatibleImpl(application, routeService)
@@ -80,7 +80,7 @@ open class Locations @KtorExperimentalLocationsAPI constructor(
         implementation.href(location, builder)
     }
 
-    @UseExperimental(KtorExperimentalLocationsAPI::class)
+    @OptIn(KtorExperimentalLocationsAPI::class)
     private fun createEntry(parent: Route, info: LocationInfo): Route {
         val hierarchyEntry = info.parent?.let { createEntry(parent, it) } ?: parent
         return hierarchyEntry.createRouteFromPath(info.path)
@@ -93,7 +93,7 @@ open class Locations @KtorExperimentalLocationsAPI constructor(
         val info = implementation.getOrCreateInfo(locationClass)
         val pathRoute = createEntry(parent, info)
 
-        @UseExperimental(KtorExperimentalLocationsAPI::class)
+        @OptIn(KtorExperimentalLocationsAPI::class)
         return info.queryParameters.fold(pathRoute) { entry, query ->
             val selector = if (query.isOptional)
                 OptionalParameterRouteSelector(query.name)
@@ -120,7 +120,7 @@ open class Locations @KtorExperimentalLocationsAPI constructor(
     companion object Feature : ApplicationFeature<Application, Configuration, Locations> {
         override val key: AttributeKey<Locations> = AttributeKey("Locations")
 
-        @UseExperimental(KtorExperimentalLocationsAPI::class)
+        @OptIn(KtorExperimentalLocationsAPI::class)
         override fun install(pipeline: Application, configure: Configuration.() -> Unit): Locations {
             val configuration = Configuration().apply(configure)
             val routeService = configuration.routeService ?: LocationAttributeRouteService()

--- a/ktor-features/ktor-locations/jvm/test/io/ktor/tests/locations/CustomLocationsTest.kt
+++ b/ktor-features/ktor-locations/jvm/test/io/ktor/tests/locations/CustomLocationsTest.kt
@@ -2,7 +2,7 @@
  * Copyright 2014-2019 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
-@file:UseExperimental(KtorExperimentalLocationsAPI::class)
+@OptIn(KtorExperimentalLocationsAPI::class)
 
 package io.ktor.tests.locations
 
@@ -43,7 +43,7 @@ class entity(val id: EntityID)
 
 data class EntityID(val typeId: Int, val entityId: Int)
 
-@UseExperimental(KtorExperimentalLocationsAPI::class)
+@OptIn(KtorExperimentalLocationsAPI::class)
 class CustomLocationsTest {
 
     @Test

--- a/ktor-features/ktor-locations/jvm/test/io/ktor/tests/locations/LocationsTest.kt
+++ b/ktor-features/ktor-locations/jvm/test/io/ktor/tests/locations/LocationsTest.kt
@@ -15,13 +15,13 @@ import org.junit.Test
 import java.math.*
 import kotlin.test.*
 
-@UseExperimental(KtorExperimentalLocationsAPI::class)
+@OptIn(KtorExperimentalLocationsAPI::class)
 private fun withLocationsApplication(test: TestApplicationEngine.() -> Unit) = withTestApplication {
     application.install(Locations)
     test()
 }
 
-@UseExperimental(KtorExperimentalLocationsAPI::class)
+@OptIn(KtorExperimentalLocationsAPI::class)
 class LocationsTest {
     @Location("/") class index
 

--- a/ktor-features/ktor-locations/jvm/test/io/ktor/tests/locations/OAuthLocationsTest.kt
+++ b/ktor-features/ktor-locations/jvm/test/io/ktor/tests/locations/OAuthLocationsTest.kt
@@ -17,7 +17,7 @@ import org.junit.Test
 import java.net.*
 import kotlin.test.*
 
-@UseExperimental(KtorExperimentalLocationsAPI::class)
+@OptIn(KtorExperimentalLocationsAPI::class)
 class OAuthLocationsTest {
     @Test
     fun testOAuthAtLocation() = withTestApplication {

--- a/ktor-features/ktor-serialization/jvm/src/io/ktor/serialization/SerializationConverter.kt
+++ b/ktor-features/ktor-serialization/jvm/src/io/ktor/serialization/SerializationConverter.kt
@@ -55,7 +55,7 @@ fun SerializationConverter(): SerializationConverter =
  * }
  * ```
  */
-@UseExperimental(ImplicitReflectionSerializer::class)
+@OptIn(ImplicitReflectionSerializer::class)
 class SerializationConverter private constructor(
     private val format: SerialFormat,
     private val defaultCharset: Charset = Charsets.UTF_8

--- a/ktor-features/ktor-serialization/jvm/src/io/ktor/serialization/SerializerLookup.kt
+++ b/ktor-features/ktor-serialization/jvm/src/io/ktor/serialization/SerializerLookup.kt
@@ -11,7 +11,9 @@ import kotlin.reflect.*
 import kotlin.reflect.full.*
 import kotlin.reflect.jvm.*
 
-@UseExperimental(ImplicitReflectionSerializer::class, ExperimentalStdlibApi::class)
+@OptIn(
+    ImplicitReflectionSerializer::class, ExperimentalStdlibApi::class
+)
 internal fun serializerByTypeInfo(type: KType): KSerializer<*> {
     val classifierClass = type.classifier as? KClass<*>
     if (classifierClass != null && classifierClass.java.isArray) {
@@ -34,7 +36,7 @@ private fun arraySerializer(type: KType): KSerializer<*> {
     )
 }
 
-@UseExperimental(ImplicitReflectionSerializer::class)
+@OptIn(ImplicitReflectionSerializer::class)
 internal fun serializerForSending(value: Any): KSerializer<*> {
     if (value is JsonElement) {
         return JsonElementSerializer
@@ -67,7 +69,7 @@ internal fun serializerForSending(value: Any): KSerializer<*> {
     return value::class.serializer()
 }
 
-@UseExperimental(ImplicitReflectionSerializer::class)
+@OptIn(ImplicitReflectionSerializer::class)
 private fun Collection<*>.elementSerializer(): KSerializer<*> {
     @Suppress("DEPRECATION_ERROR")
     val serializers = mapNotNull { value ->

--- a/ktor-features/ktor-server-sessions/jvm/src/io/ktor/sessions/Cache.kt
+++ b/ktor-features/ktor-server-sessions/jvm/src/io/ktor/sessions/Cache.kt
@@ -27,7 +27,7 @@ internal interface CacheReference<out K> {
     val key: K
 }
 
-@UseExperimental(ExperimentalCoroutinesApi::class)
+@OptIn(ExperimentalCoroutinesApi::class)
 internal class BaseCache<in K : Any, V : Any>(val calc: suspend (K) -> V) : Cache<K, V> {
     private val container = ConcurrentHashMap<K, Deferred<V>>()
 

--- a/ktor-features/ktor-websockets/jvm/src/io/ktor/websocket/Routing.kt
+++ b/ktor-features/ktor-websockets/jvm/src/io/ktor/websocket/Routing.kt
@@ -116,7 +116,7 @@ private fun Route.webSocketProtocol(protocol: String?, block: Route.() -> Unit) 
     }
 }
 
-@UseExperimental(WebSocketInternalAPI::class)
+@OptIn(WebSocketInternalAPI::class)
 private suspend fun WebSocketServerSession.proceedWebSocket(handler: suspend DefaultWebSocketServerSession.() -> Unit) {
     val webSockets = application.feature(WebSockets)
 
@@ -134,7 +134,7 @@ private suspend fun CoroutineScope.joinSession() {
     coroutineContext[Job]!!.join()
 }
 
-@UseExperimental(WebSocketInternalAPI::class)
+@OptIn(WebSocketInternalAPI::class)
 private suspend fun DefaultWebSocketSessionImpl.handleServerSession(
     call: ApplicationCall,
     handler: suspend DefaultWebSocketServerSession.() -> Unit

--- a/ktor-features/ktor-websockets/jvm/test/io/ktor/tests/websocket/ParserTest.kt
+++ b/ktor-features/ktor-websockets/jvm/test/io/ktor/tests/websocket/ParserTest.kt
@@ -10,7 +10,7 @@ import org.junit.Test
 import java.nio.*
 import kotlin.test.*
 
-@UseExperimental(WebSocketInternalAPI::class)
+@OptIn(WebSocketInternalAPI::class)
 class ParserTest {
     @Test
     fun testParserSimpleFrame() {

--- a/ktor-features/ktor-websockets/jvm/test/io/ktor/tests/websocket/WebSocketEngineSuite.kt
+++ b/ktor-features/ktor-websockets/jvm/test/io/ktor/tests/websocket/WebSocketEngineSuite.kt
@@ -30,7 +30,9 @@ import java.util.concurrent.CancellationException
 import kotlin.test.*
 import kotlin.test.Ignore
 
-@UseExperimental(WebSocketInternalAPI::class, ObsoleteCoroutinesApi::class)
+@OptIn(
+    WebSocketInternalAPI::class, ObsoleteCoroutinesApi::class
+)
 abstract class WebSocketEngineSuite<TEngine : ApplicationEngine, TConfiguration : ApplicationEngine.Configuration>(
     hostFactory: ApplicationEngineFactory<TEngine, TConfiguration>
 ) : EngineTestBase<TEngine, TConfiguration>(hostFactory) {

--- a/ktor-features/ktor-websockets/jvm/test/io/ktor/tests/websocket/WebSocketTest.kt
+++ b/ktor-features/ktor-websockets/jvm/test/io/ktor/tests/websocket/WebSocketTest.kt
@@ -24,7 +24,9 @@ import java.util.*
 import java.util.concurrent.CancellationException
 import kotlin.test.*
 
-@UseExperimental(WebSocketInternalAPI::class, ObsoleteCoroutinesApi::class)
+@OptIn(
+    WebSocketInternalAPI::class, ObsoleteCoroutinesApi::class
+)
 class WebSocketTest {
     @get:Rule
     val timeout = CoroutinesTimeout.seconds(30)

--- a/ktor-features/ktor-websockets/jvm/test/io/ktor/tests/websocket/WriterTest.kt
+++ b/ktor-features/ktor-websockets/jvm/test/io/ktor/tests/websocket/WriterTest.kt
@@ -12,7 +12,9 @@ import org.junit.Test
 import java.nio.ByteBuffer
 import kotlin.test.*
 
-@UseExperimental(WebSocketInternalAPI::class, ExperimentalCoroutinesApi::class)
+@OptIn(
+    WebSocketInternalAPI::class, ExperimentalCoroutinesApi::class
+)
 class WriterTest {
     @Test
     fun testWriteBigThenClose() = runBlocking {

--- a/ktor-http/ktor-http-cio/common/src/io/ktor/http/cio/websocket/DefaultWebSocketSession.kt
+++ b/ktor-http/ktor-http-cio/common/src/io/ktor/http/cio/websocket/DefaultWebSocketSession.kt
@@ -9,7 +9,7 @@ import kotlinx.coroutines.*
 /**
  * Create [DefaultWebSocketSession] from session.
  */
-@UseExperimental(WebSocketInternalAPI::class)
+@OptIn(WebSocketInternalAPI::class)
 expect fun DefaultWebSocketSession(
     session: WebSocketSession,
     pingInterval: Long,

--- a/ktor-http/ktor-http-cio/common/src/io/ktor/http/cio/websocket/WebSocketInternalAPI.kt
+++ b/ktor-http/ktor-http-cio/common/src/io/ktor/http/cio/websocket/WebSocketInternalAPI.kt
@@ -9,5 +9,11 @@ package io.ktor.http.cio.websocket
  * It is not recommended to use it as it may be changed in the future without notice or
  * it may be too low-level so could damage your data.
  */
-@Experimental(level = Experimental.Level.WARNING)
+@Suppress("DEPRECATION")
+@RequiresOptIn(
+    level = RequiresOptIn.Level.ERROR,
+    message = "This ktor WebSocket API is internal and should be never used outside. " +
+        "It is not guaranteed to work the same in future releases and may be changed or removed."
+)
+@Experimental(level = Experimental.Level.ERROR)
 annotation class WebSocketInternalAPI

--- a/ktor-http/ktor-http-cio/common/test/io/ktor/tests/http/cio/HttpParserTest.kt
+++ b/ktor-http/ktor-http-cio/common/test/io/ktor/tests/http/cio/HttpParserTest.kt
@@ -121,7 +121,7 @@ class HttpParserTest {
         }
     }
 
-    @UseExperimental(InternalCoroutinesApi::class)
+    @OptIn(InternalCoroutinesApi::class)
     private fun test(block: suspend () -> Unit) {
         var completed = false
         val cont = Continuation<Unit>(EmptyCoroutineContext) {

--- a/ktor-http/ktor-http-cio/jvm/src/io/ktor/http/cio/Multipart.kt
+++ b/ktor-http/ktor-http-cio/jvm/src/io/ktor/http/cio/Multipart.kt
@@ -45,7 +45,7 @@ sealed class MultipartEvent {
      * @property body a channel of part content
      */
     class MultipartPart(val headers: Deferred<HttpHeadersMap>, val body: ByteReadChannel) : MultipartEvent() {
-        @UseExperimental(ExperimentalCoroutinesApi::class)
+        @OptIn(ExperimentalCoroutinesApi::class)
         override fun release() {
             headers.invokeOnCompletion { t ->
                 if (t != null) {
@@ -155,7 +155,7 @@ suspend fun parsePartBody(
 /**
  * Skip multipart boundary
  */
-@UseExperimental(ExperimentalIoApi::class)
+@OptIn(ExperimentalIoApi::class)
 @KtorExperimentalAPI
 suspend fun boundary(boundaryPrefixed: ByteBuffer, input: ByteReadChannel): Boolean {
     input.skipDelimiter(boundaryPrefixed)
@@ -263,7 +263,7 @@ fun parseMultipart(
  * Starts a multipart parser coroutine producing multipart events
  */
 @KtorExperimentalAPI
-@UseExperimental(ExperimentalCoroutinesApi::class)
+@OptIn(ExperimentalCoroutinesApi::class)
 fun CoroutineScope.parseMultipart(
     boundaryPrefixed: ByteBuffer, input: ByteReadChannel, totalLength: Long?
 ): ReceiveChannel<MultipartEvent> = produce {

--- a/ktor-http/ktor-http-cio/jvm/src/io/ktor/http/cio/Pipeline.kt
+++ b/ktor-http/ktor-http-cio/jvm/src/io/ktor/http/cio/Pipeline.kt
@@ -65,7 +65,7 @@ fun CoroutineScope.startConnectionPipeline(
         input: ByteReadChannel, output: ByteWriteChannel, upgraded: CompletableDeferred<Boolean>?
     ) -> Unit
 ): Job {
-    val pipeline = ServerIncomingConnection(input, output, null)
+    val pipeline = ServerIncomingConnection(input, output, null, null)
     return startServerConnectionPipeline(pipeline, timeout) { request ->
         handler(this, request, input, output, upgraded)
     }

--- a/ktor-http/ktor-http-cio/jvm/src/io/ktor/http/cio/Pipeline.kt
+++ b/ktor-http/ktor-http-cio/jvm/src/io/ktor/http/cio/Pipeline.kt
@@ -55,7 +55,9 @@ val RequestHandlerCoroutine: CoroutineName = CoroutineName("request-handler")
     "This is going to become internal. " +
         "Start ktor server or raw cio server from ktor-server-cio module instead of constructing server from parts."
 )
-@UseExperimental(ObsoleteCoroutinesApi::class, ExperimentalCoroutinesApi::class)
+@OptIn(
+    ObsoleteCoroutinesApi::class, ExperimentalCoroutinesApi::class
+)
 fun CoroutineScope.startConnectionPipeline(
     input: ByteReadChannel,
     output: ByteWriteChannel,

--- a/ktor-http/ktor-http-cio/jvm/src/io/ktor/http/cio/internals/WeakTimeoutQueue.kt
+++ b/ktor-http/ktor-http-cio/jvm/src/io/ktor/http/cio/internals/WeakTimeoutQueue.kt
@@ -155,7 +155,7 @@ class WeakTimeoutQueue(
 
         init {
             context[Job]?.let { parent ->
-                @UseExperimental(InternalCoroutinesApi::class)
+                @OptIn(InternalCoroutinesApi::class)
                 parent.invokeOnCompletion(onCancelling = true) {
                     if (it != null) {
                         resumeWithException(it)

--- a/ktor-http/ktor-http-cio/jvm/src/io/ktor/http/cio/websocket/DefaultWebSocketSession.kt
+++ b/ktor-http/ktor-http-cio/jvm/src/io/ktor/http/cio/websocket/DefaultWebSocketSession.kt
@@ -9,7 +9,7 @@ import kotlinx.coroutines.*
 /**
  * Create [DefaultWebSocketSession] from session.
  */
-@UseExperimental(WebSocketInternalAPI::class)
+@OptIn(WebSocketInternalAPI::class)
 actual fun DefaultWebSocketSession(
     session: WebSocketSession,
     pingInterval: Long,

--- a/ktor-http/ktor-http-cio/jvm/src/io/ktor/http/cio/websocket/DefaultWebSocketSessionImpl.kt
+++ b/ktor-http/ktor-http-cio/jvm/src/io/ktor/http/cio/websocket/DefaultWebSocketSessionImpl.kt
@@ -88,7 +88,9 @@ class DefaultWebSocketSessionImpl(
         raw.cancel()
     }
 
-    @UseExperimental(ExperimentalCoroutinesApi::class, ObsoleteCoroutinesApi::class)
+    @OptIn(
+        ExperimentalCoroutinesApi::class, ObsoleteCoroutinesApi::class
+    )
     private fun runIncomingProcessor(ponger: SendChannel<Frame.Ping>): Job = launch(
         IncomingProcessorCoroutineName + Dispatchers.Unconfined
     ) {
@@ -142,7 +144,9 @@ class DefaultWebSocketSessionImpl(
         }
     }
 
-    @UseExperimental(ExperimentalCoroutinesApi::class, ObsoleteCoroutinesApi::class)
+    @OptIn(
+        ExperimentalCoroutinesApi::class, ObsoleteCoroutinesApi::class
+    )
     private fun runOutgoingProcessor(): Job = launch(
         OutgoingProcessorCoroutineName + Dispatchers.Unconfined, start = CoroutineStart.UNDISPATCHED
     ) {

--- a/ktor-http/ktor-http-cio/jvm/src/io/ktor/http/cio/websocket/PingPong.kt
+++ b/ktor-http/ktor-http-cio/jvm/src/io/ktor/http/cio/websocket/PingPong.kt
@@ -22,7 +22,9 @@ private val PingerCoroutineName = CoroutineName("ws-pinger")
  * Launch a ponger actor job on the [CoroutineScope] sending pongs to [outgoing] channel.
  * It is acting for every client's ping frame and replying with corresponding pong
  */
-@UseExperimental(ExperimentalCoroutinesApi::class, ObsoleteCoroutinesApi::class)
+@OptIn(
+    ExperimentalCoroutinesApi::class, ObsoleteCoroutinesApi::class
+)
 fun CoroutineScope.ponger(
     outgoing: SendChannel<Frame.Pong>,
     pool: ObjectPool<ByteBuffer> = KtorDefaultPool
@@ -44,7 +46,9 @@ fun CoroutineScope.ponger(
  * Launch pinger coroutine on [CoroutineScope] that is sending ping every specified [periodMillis] to [outgoing] channel,
  * waiting for and verifying client's pong frames. It is also handling [timeoutMillis] and sending timeout close frame
  */
-@UseExperimental(ExperimentalCoroutinesApi::class, ObsoleteCoroutinesApi::class)
+@OptIn(
+    ExperimentalCoroutinesApi::class, ObsoleteCoroutinesApi::class
+)
 fun CoroutineScope.pinger(
     outgoing: SendChannel<Frame>,
     periodMillis: Long,

--- a/ktor-http/ktor-http-cio/jvm/src/io/ktor/http/cio/websocket/RawWebSocket.kt
+++ b/ktor-http/ktor-http-cio/jvm/src/io/ktor/http/cio/websocket/RawWebSocket.kt
@@ -18,7 +18,7 @@ import kotlin.properties.*
 /**
  * Represents a RAW web socket session
  */
-@UseExperimental(WebSocketInternalAPI::class)
+@OptIn(WebSocketInternalAPI::class)
 class RawWebSocket(
     input: ByteReadChannel, output: ByteWriteChannel,
     maxFrameSize: Long = Int.MAX_VALUE.toLong(),
@@ -79,7 +79,7 @@ class RawWebSocket(
 }
 
 @Suppress("KDocMissingDocumentation")
-@UseExperimental(WebSocketInternalAPI::class)
+@OptIn(WebSocketInternalAPI::class)
 @InternalAPI
 suspend fun RawWebSocket.start(handler: suspend WebSocketSession.() -> Unit) {
     try {

--- a/ktor-http/ktor-http-cio/jvm/src/io/ktor/http/cio/websocket/WebSocketWriter.kt
+++ b/ktor-http/ktor-http-cio/jvm/src/io/ktor/http/cio/websocket/WebSocketWriter.kt
@@ -20,7 +20,9 @@ import kotlin.coroutines.*
  * @property pool: [ByteBuffer] pool to be used by this writer
  */
 @WebSocketInternalAPI
-@UseExperimental(ExperimentalCoroutinesApi::class, ObsoleteCoroutinesApi::class)
+@OptIn(
+    ExperimentalCoroutinesApi::class, ObsoleteCoroutinesApi::class
+)
 class WebSocketWriter(
     private val writeChannel: ByteWriteChannel,
     override val coroutineContext: CoroutineContext,

--- a/ktor-http/ktor-http-cio/jvm/src/io/ktor/server/cio/backend/ServerIncomingConnection.kt
+++ b/ktor-http/ktor-http-cio/jvm/src/io/ktor/server/cio/backend/ServerIncomingConnection.kt
@@ -21,4 +21,14 @@ class ServerIncomingConnection(
     val output: ByteWriteChannel,
     val remoteAddress: SocketAddress?,
     val localAddress: SocketAddress?
-)
+) {
+    @Deprecated(
+        "Specify localAddress as well.",
+        level = DeprecationLevel.HIDDEN
+    )
+    constructor(
+        input: ByteReadChannel,
+        output: ByteWriteChannel,
+        remoteAddress: SocketAddress?
+    ) : this(input, output, remoteAddress, null)
+}

--- a/ktor-http/ktor-http-cio/jvm/src/io/ktor/server/cio/backend/ServerIncomingConnection.kt
+++ b/ktor-http/ktor-http-cio/jvm/src/io/ktor/server/cio/backend/ServerIncomingConnection.kt
@@ -13,10 +13,12 @@ import java.net.*
  * @property input channel connected to incoming bytes end
  * @property output channel connected to outgoing bytes end
  * @property remoteAddress of the client (optional)
+ * @property localAddress on which the client was accepted (optional)
  */
 @InternalAPI
 class ServerIncomingConnection(
     val input: ByteReadChannel,
     val output: ByteWriteChannel,
-    val remoteAddress: SocketAddress?
+    val remoteAddress: SocketAddress?,
+    val localAddress: SocketAddress?
 )

--- a/ktor-http/ktor-http-cio/jvm/src/io/ktor/server/cio/backend/ServerPipeline.kt
+++ b/ktor-http/ktor-http-cio/jvm/src/io/ktor/server/cio/backend/ServerPipeline.kt
@@ -26,7 +26,9 @@ import java.io.*
  */
 @Suppress("DEPRECATION")
 @InternalAPI
-@UseExperimental(ObsoleteCoroutinesApi::class, ExperimentalCoroutinesApi::class)
+@OptIn(
+    ObsoleteCoroutinesApi::class, ExperimentalCoroutinesApi::class
+)
 fun CoroutineScope.startServerConnectionPipeline(
     connection: ServerIncomingConnection,
     timeout: WeakTimeoutQueue,

--- a/ktor-http/ktor-http-cio/jvm/src/io/ktor/server/cio/backend/ServerPipeline.kt
+++ b/ktor-http/ktor-http-cio/jvm/src/io/ktor/server/cio/backend/ServerPipeline.kt
@@ -140,7 +140,7 @@ fun CoroutineScope.startServerConnectionPipeline(
             launch(requestContext, start = CoroutineStart.UNDISPATCHED) {
                 val handlerScope = ServerRequestScope(
                     coroutineContext,
-                    requestBody, response, connection.remoteAddress, upgraded
+                    requestBody, response, connection.remoteAddress, connection.localAddress, upgraded
                 )
 
                 try {

--- a/ktor-http/ktor-http-cio/jvm/src/io/ktor/server/cio/backend/ServerRequestScope.kt
+++ b/ktor-http/ktor-http-cio/jvm/src/io/ktor/server/cio/backend/ServerRequestScope.kt
@@ -15,7 +15,8 @@ import kotlin.coroutines.*
  * @property upgraded deferred should be completed on upgrade request
  * @property input channel connected to request body bytes stream
  * @property output channel connected to response body
- * @property remoteAddress of a client (if known)
+ * @property remoteAddress of the client (if known)
+ * @property localAddress on which the client was accepted (if known)
  */
 @KtorExperimentalAPI
 class ServerRequestScope internal constructor(
@@ -23,6 +24,7 @@ class ServerRequestScope internal constructor(
     val input: ByteReadChannel,
     val output: ByteWriteChannel,
     val remoteAddress: SocketAddress?,
+    val localAddress: SocketAddress?,
     val upgraded: CompletableDeferred<Boolean>?
 ) : CoroutineScope {
     /**
@@ -32,6 +34,6 @@ class ServerRequestScope internal constructor(
     fun withContext(coroutineContext: CoroutineContext): ServerRequestScope =
         ServerRequestScope(
             this.coroutineContext + coroutineContext,
-            input, output, remoteAddress, upgraded
+            input, output, remoteAddress, localAddress, upgraded
         )
 }

--- a/ktor-http/ktor-http-cio/jvm/test/io/ktor/tests/http/cio/IntegrationTest.kt
+++ b/ktor-http/ktor-http-cio/jvm/test/io/ktor/tests/http/cio/IntegrationTest.kt
@@ -38,13 +38,13 @@ class IntegrationTest {
 
         s.invokeOnCompletion { t ->
             if (t != null) server.completeExceptionally(t)
-            else server.complete(@UseExperimental(ExperimentalCoroutinesApi::class) s.getCompleted())
+            else server.complete(@OptIn(ExperimentalCoroutinesApi::class) s.getCompleted())
         }
 
         j.invokeOnCompletion {
             s.invokeOnCompletion { t ->
                 if (t != null && !s.isCancelled) {
-                    @UseExperimental(ExperimentalCoroutinesApi::class)
+                    @OptIn(ExperimentalCoroutinesApi::class)
                     s.getCompleted().close()
                 }
             }
@@ -56,7 +56,7 @@ class IntegrationTest {
     }
 
     @After
-    @UseExperimental(ExperimentalCoroutinesApi::class)
+    @OptIn(ExperimentalCoroutinesApi::class)
     fun tearDown() {
         server.invokeOnCompletion { t ->
             if (t == null) {

--- a/ktor-http/ktor-http-cio/jvm/test/io/ktor/tests/http/cio/MultipartTest.kt
+++ b/ktor-http/ktor-http-cio/jvm/test/io/ktor/tests/http/cio/MultipartTest.kt
@@ -54,7 +54,7 @@ class MultipartTest {
         val mp = parseMultipart(ch, request.headers)
 
         val allEvents = ArrayList<MultipartEvent>()
-        @UseExperimental(ObsoleteCoroutinesApi::class)
+        @OptIn(ObsoleteCoroutinesApi::class)
         mp.consumeEach { allEvents.add(it) }
 
         assertEquals(6, allEvents.size)
@@ -121,7 +121,7 @@ class MultipartTest {
         val mp = parseMultipart(ch, request.headers)
 
         val allEvents = ArrayList<MultipartEvent>()
-        @UseExperimental(ObsoleteCoroutinesApi::class)
+        @OptIn(ObsoleteCoroutinesApi::class)
         mp.consumeEach { allEvents.add(it) }
 
         assertEquals(6, allEvents.size)
@@ -192,7 +192,7 @@ class MultipartTest {
         val mp = parseMultipart(ch, request.headers)
 
         val allEvents = ArrayList<MultipartEvent>()
-        @UseExperimental(ObsoleteCoroutinesApi::class)
+        @OptIn(ObsoleteCoroutinesApi::class)
         mp.consumeEach { allEvents.add(it) }
 
         val parts = allEvents.filterIsInstance<MultipartEvent.MultipartPart>()
@@ -248,7 +248,7 @@ class MultipartTest {
         val mp = GlobalScope.parseMultipart(decoded.channel, request.headers)
 
         val allEvents = ArrayList<MultipartEvent>()
-        @UseExperimental(ObsoleteCoroutinesApi::class)
+        @OptIn(ObsoleteCoroutinesApi::class)
         mp.consumeEach { allEvents.add(it) }
 
         assertEquals(6, allEvents.size)

--- a/ktor-http/ktor-http-cio/jvm/test/io/ktor/tests/http/cio/TestHttpServer.kt
+++ b/ktor-http/ktor-http-cio/jvm/test/io/ktor/tests/http/cio/TestHttpServer.kt
@@ -117,7 +117,8 @@ private suspend fun client(
         ServerIncomingConnection(
             incoming,
             outgoing,
-            socket.remoteAddress
+            socket.remoteAddress,
+            socket.localAddress
         ),
         timeouts
     ) { request: Request ->

--- a/ktor-http/ktor-http-cio/jvm/test/io/ktor/tests/http/cio/TestHttpServer.kt
+++ b/ktor-http/ktor-http-cio/jvm/test/io/ktor/tests/http/cio/TestHttpServer.kt
@@ -53,7 +53,7 @@ internal fun testHttpServer(
     j.invokeOnCompletion {
         deferred.invokeOnCompletion { t ->
             if (t == null) {
-                @UseExperimental(ExperimentalCoroutinesApi::class)
+                @OptIn(ExperimentalCoroutinesApi::class)
                 deferred.getCompleted().close()
             }
         }

--- a/ktor-io/common/src/io/ktor/utils/io/ByteChannelSequential.kt
+++ b/ktor-io/common/src/io/ktor/utils/io/ByteChannelSequential.kt
@@ -632,7 +632,7 @@ abstract class ByteChannelSequentialBase(
 
             return false
         }
-        @UseExperimental(DangerousInternalIoApi::class)
+        @OptIn(DangerousInternalIoApi::class)
         return decodeUTF8LineLoopSuspend(out, limit) { size ->
             afterRead()
             if (await(size)) readable

--- a/ktor-io/common/src/io/ktor/utils/io/core/Experimental.kt
+++ b/ktor-io/common/src/io/ktor/utils/io/core/Experimental.kt
@@ -3,5 +3,7 @@ package io.ktor.utils.io.core
 /**
  * API marked with this annotation is experimental and could be changed
  */
+@Suppress("DEPRECATION")
+@RequiresOptIn(level = RequiresOptIn.Level.WARNING)
 @Experimental(Experimental.Level.WARNING)
 annotation class ExperimentalIoApi

--- a/ktor-io/common/src/io/ktor/utils/io/core/internal/Unsafe.kt
+++ b/ktor-io/common/src/io/ktor/utils/io/core/internal/Unsafe.kt
@@ -1,3 +1,5 @@
+@file:Suppress("KDocMissingDocumentation")
+
 package io.ktor.utils.io.core.internal
 
 import io.ktor.utils.io.core.*
@@ -9,6 +11,8 @@ import kotlin.native.concurrent.*
  * Such API could be changed without notice including rename, removal and behaviour change.
  * Also using API marked with this annotation could cause data loss or any other damage.
  */
+@Suppress("DEPRECATION")
+@RequiresOptIn(level = RequiresOptIn.Level.ERROR)
 @Experimental(level = Experimental.Level.ERROR)
 annotation class DangerousInternalIoApi
 

--- a/ktor-io/js/src/io/ktor/utils/io/ByteChannelJS.kt
+++ b/ktor-io/js/src/io/ktor/utils/io/ByteChannelJS.kt
@@ -77,7 +77,7 @@ actual suspend fun ByteReadChannel.copyTo(dst: ByteWriteChannel, limit: Long): L
 internal class ByteChannelJS(initial: IoBuffer, autoFlush: Boolean) : ByteChannelSequentialBase(initial, autoFlush) {
     private var attachedJob: Job? = null
 
-    @UseExperimental(InternalCoroutinesApi::class)
+    @OptIn(InternalCoroutinesApi::class)
     override fun attachJob(job: Job) {
         attachedJob?.cancel()
         attachedJob = job

--- a/ktor-io/jvm/src/io/ktor/utils/io/ByteBufferChannel.kt
+++ b/ktor-io/jvm/src/io/ktor/utils/io/ByteBufferChannel.kt
@@ -62,7 +62,7 @@ internal open class ByteBufferChannel(
 
     internal fun getJoining(): JoiningState? = joining
 
-    @UseExperimental(InternalCoroutinesApi::class)
+    @OptIn(InternalCoroutinesApi::class)
     override fun attachJob(job: Job) {
         // TODO actually it looks like one-direction attachChild API
         attachedJob?.cancel()

--- a/ktor-io/jvm/src/io/ktor/utils/io/ByteChannelSequentialJVM.kt
+++ b/ktor-io/jvm/src/io/ktor/utils/io/ByteChannelSequentialJVM.kt
@@ -13,7 +13,7 @@ class ByteChannelSequentialJVM(initial: IoBuffer, autoFlush: Boolean)
     @Volatile
     private var attachedJob: Job? = null
 
-    @UseExperimental(InternalCoroutinesApi::class)
+    @OptIn(InternalCoroutinesApi::class)
     override fun attachJob(job: Job) {
         attachedJob?.cancel()
         attachedJob = job

--- a/ktor-io/jvm/src/io/ktor/utils/io/internal/CancellableReusableContinuation.kt
+++ b/ktor-io/jvm/src/io/ktor/utils/io/internal/CancellableReusableContinuation.kt
@@ -109,7 +109,7 @@ internal class CancellableReusableContinuation<T : Any> : Continuation<T> {
         private var handler: DisposableHandle? = null // not volatile as double removal is safe
 
         init {
-            @UseExperimental(InternalCoroutinesApi::class)
+            @OptIn(InternalCoroutinesApi::class)
             val h = job.invokeOnCompletion(onCancelling = true, handler = this)
 
             if (job.isActive) {

--- a/ktor-io/jvm/src/io/ktor/utils/io/jvm/javaio/Blocking.kt
+++ b/ktor-io/jvm/src/io/ktor/utils/io/jvm/javaio/Blocking.kt
@@ -269,7 +269,7 @@ private abstract class BlockingAdapter(val parent: Job? = null) {
 }
 
 private object UnsafeBlockingTrampoline : CoroutineDispatcher() {
-    @UseExperimental(ExperimentalCoroutinesApi::class)
+    @OptIn(ExperimentalCoroutinesApi::class)
     override fun isDispatchNeeded(context: CoroutineContext): Boolean = true
 
     override fun dispatch(context: CoroutineContext, block: Runnable) {

--- a/ktor-io/posix/src/io/ktor/utils/io/ByteChannelNative.kt
+++ b/ktor-io/posix/src/io/ktor/utils/io/ByteChannelNative.kt
@@ -61,7 +61,7 @@ internal class ByteChannelNative(
 ) : ByteChannelSequentialBase(initial, autoFlush, pool) {
     private var attachedJob: Job? = null
 
-    @UseExperimental(InternalCoroutinesApi::class)
+    @OptIn(InternalCoroutinesApi::class)
     override fun attachJob(job: Job) {
         attachedJob?.cancel()
         attachedJob = job

--- a/ktor-network/jvm/src/io/ktor/network/sockets/CIOReader.kt
+++ b/ktor-network/jvm/src/io/ktor/network/sockets/CIOReader.kt
@@ -62,7 +62,7 @@ internal fun CoroutineScope.attachForReadingImpl(
     }
 }
 
-@UseExperimental(ExperimentalIoApi::class)
+@OptIn(ExperimentalIoApi::class)
 internal fun CoroutineScope.attachForReadingDirectImpl(
     channel: ByteChannel,
     nioChannel: ReadableByteChannel,

--- a/ktor-network/jvm/src/io/ktor/network/sockets/CIOWriter.kt
+++ b/ktor-network/jvm/src/io/ktor/network/sockets/CIOWriter.kt
@@ -61,7 +61,7 @@ internal fun CoroutineScope.attachForWritingImpl(
     }
 }
 
-@UseExperimental(ExperimentalIoApi::class)
+@OptIn(ExperimentalIoApi::class)
 internal fun CoroutineScope.attachForWritingDirectImpl(
     channel: ByteChannel,
     nioChannel: WritableByteChannel,

--- a/ktor-network/jvm/src/io/ktor/network/sockets/DatagramSocketImpl.kt
+++ b/ktor-network/jvm/src/io/ktor/network/sockets/DatagramSocketImpl.kt
@@ -13,7 +13,9 @@ import java.net.*
 import java.nio.*
 import java.nio.channels.*
 
-@UseExperimental(ObsoleteCoroutinesApi::class, ExperimentalCoroutinesApi::class)
+@OptIn(
+    ObsoleteCoroutinesApi::class, ExperimentalCoroutinesApi::class
+)
 internal class DatagramSocketImpl(override val channel: DatagramChannel, selector: SelectorManager)
     : BoundDatagramSocket, ConnectedDatagramSocket, NIOSocketImpl<DatagramChannel>(channel, selector, DefaultDatagramByteBufferPool) {
 

--- a/ktor-network/jvm/src/io/ktor/network/sockets/NIOSocket.kt
+++ b/ktor-network/jvm/src/io/ktor/network/sockets/NIOSocket.kt
@@ -137,7 +137,7 @@ internal abstract class NIOSocketImpl<out S>(
     private val AtomicReference<out Job?>.completedOrNotStarted: Boolean
         get() = get().let { it == null || it.isCompleted }
 
-    @UseExperimental(InternalCoroutinesApi::class)
+    @OptIn(InternalCoroutinesApi::class)
     private val AtomicReference<out Job?>.exception: Throwable?
         get() = get()?.takeIf { it.isCancelled }
             ?.getCancellationException()?.cause // TODO it should be completable deferred or provide its own exception

--- a/ktor-network/jvm/src/io/ktor/network/sockets/SocketOptions.kt
+++ b/ktor-network/jvm/src/io/ktor/network/sockets/SocketOptions.kt
@@ -9,7 +9,7 @@ import io.ktor.network.util.*
 /**
  * Socket options builder
  */
-@UseExperimental(ExperimentalUnsignedTypes::class)
+@OptIn(ExperimentalUnsignedTypes::class)
 sealed class SocketOptions(
     @Suppress("KDocMissingDocumentation") protected val customOptions: MutableMap<Any, Any?>
 ) {

--- a/ktor-network/jvm/src/io/ktor/network/sockets/Sockets.kt
+++ b/ktor-network/jvm/src/io/ktor/network/sockets/Sockets.kt
@@ -39,7 +39,7 @@ val ASocket.isClosed: Boolean get() = socketContext.isCompleted
 suspend fun ASocket.awaitClosed(): Unit {
     socketContext.join()
 
-    @UseExperimental(InternalCoroutinesApi::class)
+    @OptIn(InternalCoroutinesApi::class)
     if (socketContext.isCancelled) throw socketContext.getCancellationException()
 }
 

--- a/ktor-network/jvm/src/io/ktor/network/sockets/TypeOfService.kt
+++ b/ktor-network/jvm/src/io/ktor/network/sockets/TypeOfService.kt
@@ -8,7 +8,7 @@ package io.ktor.network.sockets
  * An inline class to hold a IP ToS value
  * @property value an unsigned byte IP_TOS value
  */
-@UseExperimental(ExperimentalUnsignedTypes::class)
+@OptIn(ExperimentalUnsignedTypes::class)
 inline class TypeOfService(val value: UByte) {
     /**
      * Creates ToS by integer value discarding extra high bits

--- a/ktor-network/jvm/src/io/ktor/network/util/Coroutines.kt
+++ b/ktor-network/jvm/src/io/ktor/network/util/Coroutines.kt
@@ -20,7 +20,7 @@ private class TrackingContinuation<in T>(private val delegate: CancellableContin
         }
     }
 
-    @UseExperimental(InternalCoroutinesApi::class)
+    @OptIn(InternalCoroutinesApi::class)
     override fun tryResumeWithException(exception: Throwable): Any? {
         val token = delegate.tryResumeWithException(suspensionPoint)
         if (token != null) {

--- a/ktor-network/ktor-network-tls/jvm/src/io/ktor/network/tls/TLSClientHandshake.kt
+++ b/ktor-network/ktor-network-tls/jvm/src/io/ktor/network/tls/TLSClientHandshake.kt
@@ -50,7 +50,7 @@ internal class TLSClientHandshake(
         TLSCipher.fromSuite(serverHello.cipherSuite, keyMaterial)
     }
 
-    @UseExperimental(ExperimentalCoroutinesApi::class)
+    @OptIn(ExperimentalCoroutinesApi::class)
     val input: ReceiveChannel<TLSRecord> = produce(CoroutineName("cio-tls-parser")) {
         var useCipher = false
         try {
@@ -93,7 +93,7 @@ internal class TLSClientHandshake(
         }
     }
 
-    @UseExperimental(ObsoleteCoroutinesApi::class)
+    @OptIn(ObsoleteCoroutinesApi::class)
     val output: SendChannel<TLSRecord> = actor(CoroutineName("cio-tls-encoder")) {
         var useCipher = false
 
@@ -118,7 +118,7 @@ internal class TLSClientHandshake(
         }
     }
 
-    @UseExperimental(ExperimentalCoroutinesApi::class)
+    @OptIn(ExperimentalCoroutinesApi::class)
     private val handshakes = produce<TLSHandshake>(CoroutineName("cio-tls-handshake")) {
         while (true) {
             val record = input.receive()

--- a/ktor-network/ktor-network-tls/jvm/src/io/ktor/network/tls/TLSClientSession.kt
+++ b/ktor-network/ktor-network-tls/jvm/src/io/ktor/network/tls/TLSClientSession.kt
@@ -42,7 +42,7 @@ private class TLSSocket(
             appDataOutputLoop(this.channel)
         }
 
-    @UseExperimental(ObsoleteCoroutinesApi::class)
+    @OptIn(ObsoleteCoroutinesApi::class)
     private suspend fun appDataInputLoop(pipe: ByteWriteChannel) {
         try {
             input.consumeEach { record ->

--- a/ktor-server/ktor-server-benchmarks/src/jmh/kotlin/io/ktor/server/benchmarks/HttpBenchmarkAsyncClients.kt
+++ b/ktor-server/ktor-server-benchmarks/src/jmh/kotlin/io/ktor/server/benchmarks/HttpBenchmarkAsyncClients.kt
@@ -23,7 +23,7 @@ interface AsyncHttpBenchmarkClient {
     fun joinTask(control: Control)
 }
 
-@UseExperimental(InternalAPI::class)
+@OptIn(InternalAPI::class)
 class KtorBenchmarkClient(val engineFactory: HttpClientEngineFactory<*>) : AsyncHttpBenchmarkClient {
     private val loadLimit = Semaphore(1000)
     private var httpClient: HttpClient? = null

--- a/ktor-server/ktor-server-benchmarks/src/jmh/kotlin/io/ktor/server/benchmarks/PipelineBenchmark.kt
+++ b/ktor-server/ktor-server-benchmarks/src/jmh/kotlin/io/ktor/server/benchmarks/PipelineBenchmark.kt
@@ -25,7 +25,7 @@ class BaselinePipeline {
     }
 
     @Benchmark
-    @UseExperimental(InternalAPI::class)
+    @OptIn(InternalAPI::class)
     fun suspendCalls(): String {
         return runAndEnsureNoSuspensions {
             suspendFunctions.fold("") { a, b -> a + b() }
@@ -58,7 +58,7 @@ abstract class PipelineBenchmark {
     fun pipeline(): Pipeline<String, ApplicationCall> = Pipeline(callPhase)
     fun Pipeline<String, ApplicationCall>.intercept(block: PipelineInterceptor<String, ApplicationCall>) = intercept(callPhase, block)
 
-    @UseExperimental(InternalAPI::class)
+    @OptIn(InternalAPI::class)
     fun <T : Any> Pipeline<T, ApplicationCall>.executeBlocking(subject: T) = runAndEnsureNoSuspensions { execute(call, subject) }
 
     lateinit var pipeline: Pipeline<String, ApplicationCall>

--- a/ktor-server/ktor-server-benchmarks/src/jmh/kotlin/io/ktor/server/benchmarks/StringValuesBenchmark.kt
+++ b/ktor-server/ktor-server-benchmarks/src/jmh/kotlin/io/ktor/server/benchmarks/StringValuesBenchmark.kt
@@ -9,7 +9,7 @@ import io.ktor.util.*
 import org.openjdk.jmh.annotations.*
 
 @State(Scope.Benchmark)
-@UseExperimental(InternalAPI::class)
+@OptIn(InternalAPI::class)
 class StringValuesBenchmark {
     private val headers = valuesOf("A" to listOf("B"), "C" to listOf("D"))
 

--- a/ktor-server/ktor-server-benchmarks/src/jmh/kotlin/io/ktor/server/benchmarks/cio/CoroutineCancellationBenchmark.kt
+++ b/ktor-server/ktor-server-benchmarks/src/jmh/kotlin/io/ktor/server/benchmarks/cio/CoroutineCancellationBenchmark.kt
@@ -55,7 +55,7 @@ class CoroutineCancellationBenchmark {
     }
 
     @Benchmark
-    @UseExperimental(InternalCoroutinesApi::class)
+    @OptIn(InternalCoroutinesApi::class)
     fun customCancellationHandler(): Unit = runBlocking {
         var continuation: Continuation<Unit>? = null
 

--- a/ktor-server/ktor-server-cio/jvm/src/io/ktor/server/cio/CIOApplicationEngine.kt
+++ b/ktor-server/ktor-server-cio/jvm/src/io/ktor/server/cio/CIOApplicationEngine.kt
@@ -37,10 +37,10 @@ class CIOApplicationEngine(environment: ApplicationEngineEnvironment, configure:
         environment.connectors.size + 1 // number of selectors + 1
     )
 
-    @UseExperimental(InternalCoroutinesApi::class)
+    @OptIn(InternalCoroutinesApi::class)
     private val engineDispatcher = ExperimentalCoroutineDispatcher(corePoolSize)
 
-    @UseExperimental(InternalCoroutinesApi::class)
+    @OptIn(InternalCoroutinesApi::class)
     private val userDispatcher = DispatcherWithShutdown(engineDispatcher.blocking(configuration.callGroupSize))
 
     private val stopRequest: CompletableJob = Job()
@@ -104,7 +104,7 @@ class CIOApplicationEngine(environment: ApplicationEngineEnvironment, configure:
         try {
             shutdownServer(gracePeriodMillis, timeoutMillis)
         } finally {
-            @UseExperimental(InternalCoroutinesApi::class)
+            @OptIn(InternalCoroutinesApi::class)
             GlobalScope.launch(engineDispatcher) {
                 engineDispatcher.close()
             }

--- a/ktor-server/ktor-server-cio/jvm/src/io/ktor/server/cio/backend/HttpServer.kt
+++ b/ktor-server/ktor-server-cio/jvm/src/io/ktor/server/cio/backend/HttpServer.kt
@@ -58,7 +58,8 @@ fun CoroutineScope.httpServer(
                     val connection = ServerIncomingConnection(
                         client.openReadChannel(),
                         client.openWriteChannel(),
-                        client.remoteAddress
+                        client.remoteAddress,
+                        client.localAddress
                     )
                     val clientJob = connectionScope.startServerConnectionPipeline(
                         connection,

--- a/ktor-server/ktor-server-cio/jvm/src/io/ktor/server/cio/backend/HttpServer.kt
+++ b/ktor-server/ktor-server-cio/jvm/src/io/ktor/server/cio/backend/HttpServer.kt
@@ -18,7 +18,7 @@ import java.nio.channels.*
 /**
  * Start an http server with [settings] invoking [handler] for every request
  */
-@UseExperimental(InternalAPI::class)
+@OptIn(InternalAPI::class)
 fun CoroutineScope.httpServer(
     settings: HttpServerSettings,
     handler: HttpRequestHandler
@@ -87,7 +87,7 @@ fun CoroutineScope.httpServer(
         timeout.process()
     }
 
-    @UseExperimental(InternalCoroutinesApi::class) // TODO it's attach child?
+    @OptIn(InternalCoroutinesApi::class) // TODO it's attach child?
     serverJob.invokeOnCompletion(onCancelling = true) {
         timeout.cancel()
     }

--- a/ktor-server/ktor-server-core/jvm/src/io/ktor/features/Compression.kt
+++ b/ktor-server/ktor-server-core/jvm/src/io/ktor/features/Compression.kt
@@ -244,7 +244,7 @@ private fun ApplicationCall.isCompressionSuppressed() = Compression.SuppressionA
  * Represents a Compression encoder
  */
 @KtorExperimentalAPI
-@UseExperimental(ExperimentalCoroutinesApi::class)
+@OptIn(ExperimentalCoroutinesApi::class)
 interface CompressionEncoder {
     /**
      * May predict compressed length based on the [originalLength] or return `null` if it is impossible.

--- a/ktor-server/ktor-server-core/jvm/src/io/ktor/features/DoubleReceive.kt
+++ b/ktor-server/ktor-server-core/jvm/src/io/ktor/features/DoubleReceive.kt
@@ -44,7 +44,7 @@ class DoubleReceive internal constructor(private val config: Configuration) {
     /**
      * [DoubleReceive] feature's installation object.
      */
-    @UseExperimental(ExperimentalStdlibApi::class)
+    @OptIn(ExperimentalStdlibApi::class)
     companion object Feature : ApplicationFeature<Application, Configuration, DoubleReceive> {
         override val key: AttributeKey<DoubleReceive> = AttributeKey("DoubleReceive")
 
@@ -143,6 +143,6 @@ private val LastReceiveCachedResult = AttributeKey<CachedTransformationResult<*>
  * For example, if a stream is received, one is unable to receive any values after that. However, when received
  * a text, this instance will be replaced with the corresponding cached receive request.
  */
-@UseExperimental(ExperimentalStdlibApi::class)
+@OptIn(ExperimentalStdlibApi::class)
 private val RequestAlreadyConsumedResult =
     CachedTransformationResult.Failure(typeOf<Any>(), RequestAlreadyConsumedException())

--- a/ktor-server/ktor-server-core/jvm/src/io/ktor/request/ApplicationReceiveFunctions.kt
+++ b/ktor-server/ktor-server-core/jvm/src/io/ktor/request/ApplicationReceiveFunctions.kt
@@ -69,7 +69,7 @@ open class ApplicationReceivePipeline : Pipeline<ApplicationReceiveRequest, Appl
  * Receives content for this request.
  * @return instance of [T] received from this call, or `null` if content cannot be transformed to the requested type.
  */
-@UseExperimental(ExperimentalStdlibApi::class)
+@OptIn(ExperimentalStdlibApi::class)
 suspend inline fun <reified T : Any> ApplicationCall.receiveOrNull(): T? = receiveOrNull(typeOf<T>())
 
 /**
@@ -77,7 +77,7 @@ suspend inline fun <reified T : Any> ApplicationCall.receiveOrNull(): T? = recei
  * @return instance of [T] received from this call.
  * @throws ContentTransformationException when content cannot be transformed to the requested type.
  */
-@UseExperimental(ExperimentalStdlibApi::class)
+@OptIn(ExperimentalStdlibApi::class)
 suspend inline fun <reified T : Any> ApplicationCall.receive(): T = receive(typeOf<T>())
 
 /**

--- a/ktor-server/ktor-server-core/jvm/src/io/ktor/request/ApplicationReceiveFunctions.kt
+++ b/ktor-server/ktor-server-core/jvm/src/io/ktor/request/ApplicationReceiveFunctions.kt
@@ -126,7 +126,7 @@ suspend fun <T : Any> ApplicationCall.receive(type: KType): T {
  */
 suspend fun <T : Any> ApplicationCall.receiveOrNull(type: KType): T? {
     return try {
-        receive(type)
+        receive<T>(type)
     } catch (cause: ContentTransformationException) {
         application.log.debug("Conversion failed, null returned", cause)
         null
@@ -140,7 +140,7 @@ suspend fun <T : Any> ApplicationCall.receiveOrNull(type: KType): T? {
  */
 suspend fun <T : Any> ApplicationCall.receiveOrNull(type: KClass<T>): T? {
     return try {
-        receive(type)
+        receive<T>(type)
     } catch (cause: ContentTransformationException) {
         application.log.debug("Conversion failed, null returned", cause)
         null

--- a/ktor-server/ktor-server-core/jvm/src/io/ktor/util/Parameters.kt
+++ b/ktor-server/ktor-server-core/jvm/src/io/ktor/util/Parameters.kt
@@ -50,7 +50,7 @@ inline fun Parameters.getOrFail(name: String): String {
  * @throws ParameterConversionException when conversion from String to [R] fails
  */
 @KtorExperimentalAPI
-@UseExperimental(ExperimentalStdlibApi::class)
+@OptIn(ExperimentalStdlibApi::class)
 inline fun <reified R : Any> Parameters.getOrFail(name: String): R {
     return getOrFailImpl(name, R::class, typeOf<R>().toJavaType())
 }

--- a/ktor-server/ktor-server-host-common/jvm/src/io/ktor/server/engine/EngineAPI.kt
+++ b/ktor-server/ktor-server-host-common/jvm/src/io/ktor/server/engine/EngineAPI.kt
@@ -8,5 +8,10 @@ package io.ktor.server.engine
  * API marked with this annotation is not intended to be used by end users
  * unless a custom server engine implementation is required
  */
-@Experimental(Experimental.Level.WARNING)
+@Suppress("DEPRECATION")
+@RequiresOptIn(
+    level = RequiresOptIn.Level.ERROR,
+    message = "This is not general purpose API and should be only used in custom server engine implementations."
+)
+@Experimental(Experimental.Level.ERROR)
 annotation class EngineAPI

--- a/ktor-server/ktor-server-jetty/jvm/test/io/ktor/tests/server/jetty/JettyServletContainerEngineTest.kt
+++ b/ktor-server/ktor-server-jetty/jvm/test/io/ktor/tests/server/jetty/JettyServletContainerEngineTest.kt
@@ -39,7 +39,7 @@ private class Servlet(private val async: Boolean) :
     }
 }
 
-@UseExperimental(EngineAPI::class)
+@OptIn(EngineAPI::class)
 private class JettyServletApplicationEngine(
     environment: ApplicationEngineEnvironment,
     configure: JettyApplicationEngineBase.Configuration.() -> Unit,

--- a/ktor-server/ktor-server-jetty/jvm/test/io/ktor/tests/server/jetty/MultipleDispatchOnTimeout.kt
+++ b/ktor-server/ktor-server-jetty/jvm/test/io/ktor/tests/server/jetty/MultipleDispatchOnTimeout.kt
@@ -16,7 +16,7 @@ import java.util.concurrent.*
 import java.util.concurrent.atomic.*
 import kotlin.test.*
 
-@UseExperimental(EngineAPI::class)
+@OptIn(EngineAPI::class)
 @Suppress("BlockingMethodInNonBlockingContext")
 class MultipleDispatchOnTimeout {
 

--- a/ktor-server/ktor-server-jetty/ktor-server-jetty-test-http2/jvm/test/io/ktor/tests/server/jetty/http2/JettyServletContainerEngineTest.kt
+++ b/ktor-server/ktor-server-jetty/ktor-server-jetty-test-http2/jvm/test/io/ktor/tests/server/jetty/http2/JettyServletContainerEngineTest.kt
@@ -35,7 +35,7 @@ private class Servlet(private val async: Boolean) :
     }
 }
 
-@UseExperimental(EngineAPI::class)
+@OptIn(EngineAPI::class)
 private class JettyServletApplicationEngine(
     environment: ApplicationEngineEnvironment,
     configure: JettyApplicationEngineBase.Configuration.() -> Unit,

--- a/ktor-server/ktor-server-jetty/ktor-server-jetty-test-http2/jvm/test/io/ktor/tests/server/jetty/http2/MultipleDispatchOnTimeout.kt
+++ b/ktor-server/ktor-server-jetty/ktor-server-jetty-test-http2/jvm/test/io/ktor/tests/server/jetty/http2/MultipleDispatchOnTimeout.kt
@@ -16,7 +16,7 @@ import java.util.concurrent.*
 import java.util.concurrent.atomic.*
 import kotlin.test.*
 
-@UseExperimental(EngineAPI::class)
+@OptIn(EngineAPI::class)
 @Suppress("BlockingMethodInNonBlockingContext")
 class MultipleDispatchOnTimeout {
 

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/cio/NettyRequestQueue.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/cio/NettyRequestQueue.kt
@@ -41,7 +41,7 @@ internal class NettyRequestQueue(internal val readLimit: Int, internal val runni
         }
     }
 
-    @UseExperimental(ExperimentalCoroutinesApi::class)
+    @OptIn(ExperimentalCoroutinesApi::class)
     fun canRequestMoreEvents(): Boolean = incomingQueue.isEmpty
 
     internal class CallElement(val call: NettyApplicationCall) : LockFreeLinkedListNode() {

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/cio/NettyResponsePipeline.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/cio/NettyResponsePipeline.kt
@@ -87,7 +87,9 @@ internal class NettyResponsePipeline(private val dst: ChannelHandlerContext,
         }
     }
 
-    @UseExperimental(ExperimentalCoroutinesApi::class, ObsoleteCoroutinesApi::class)
+    @OptIn(
+        ExperimentalCoroutinesApi::class, ObsoleteCoroutinesApi::class
+    )
     private suspend fun fillSuspend() {
         if (running.isEmpty()) {
             @Suppress("DEPRECATION")
@@ -238,7 +240,7 @@ internal class NettyResponsePipeline(private val dst: ChannelHandlerContext,
         finishCall(call, encapsulation.endOfStream(true), future)
     }
 
-    @UseExperimental(ExperimentalIoApi::class)
+    @OptIn(ExperimentalIoApi::class)
     private suspend fun processBodyGeneral(call: NettyApplicationCall, response: NettyApplicationResponse, requestMessageFuture: ChannelFuture) {
         val channel = response.responseChannel
         val encapsulation = encapsulation
@@ -280,7 +282,7 @@ internal class NettyResponsePipeline(private val dst: ChannelHandlerContext,
         finishCall(call, encapsulation.endOfStream(false), lastFuture)
     }
 
-    @UseExperimental(ExperimentalIoApi::class)
+    @OptIn(ExperimentalIoApi::class)
     private suspend fun processBodyFlusher(call: NettyApplicationCall, response: NettyApplicationResponse, requestMessageFuture: ChannelFuture) {
         val channel = response.responseChannel
         val encapsulation = encapsulation

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/cio/RequestBodyHandler.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/cio/RequestBodyHandler.kt
@@ -26,7 +26,9 @@ internal class RequestBodyHandler(
 
     override val coroutineContext: CoroutineContext get() = handlerJob
 
-    @UseExperimental(ExperimentalCoroutinesApi::class, ObsoleteCoroutinesApi::class)
+    @OptIn(
+        ExperimentalCoroutinesApi::class, ObsoleteCoroutinesApi::class
+    )
     private val job = launch(context.executor().asCoroutineDispatcher(), start = CoroutineStart.LAZY) {
         var current: ByteWriteChannel? = null
         var upgraded = false
@@ -126,7 +128,7 @@ internal class RequestBodyHandler(
         }
     }
 
-    @UseExperimental(ExperimentalCoroutinesApi::class)
+    @OptIn(ExperimentalCoroutinesApi::class)
     private fun consumeAndReleaseQueue() {
         while (!queue.isEmpty) {
             val e = try {

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http2/HttpFrameAdapter.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http2/HttpFrameAdapter.kt
@@ -10,7 +10,9 @@ import kotlinx.coroutines.*
 import kotlinx.coroutines.channels.*
 import io.ktor.utils.io.*
 
-@UseExperimental(ExperimentalCoroutinesApi::class, ObsoleteCoroutinesApi::class)
+@OptIn(
+    ExperimentalCoroutinesApi::class, ObsoleteCoroutinesApi::class
+)
 internal suspend fun ReceiveChannel<Http2DataFrame>.http2frameLoop(bc: ByteWriteChannel) {
     try {
         while (!isClosedForReceive) {

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http2/NettyHttp2ApplicationRequest.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http2/NettyHttp2ApplicationRequest.kt
@@ -47,7 +47,7 @@ internal class NettyHttp2ApplicationRequest(
         }
     }
 
-    @UseExperimental(ObsoleteCoroutinesApi::class)
+    @OptIn(ObsoleteCoroutinesApi::class)
     val contentActor = actor<Http2DataFrame>(
         Dispatchers.Unconfined, kotlinx.coroutines.channels.Channel.UNLIMITED
     ) {

--- a/ktor-server/ktor-server-servlet/jvm/src/io/ktor/server/servlet/BlockingServlet.kt
+++ b/ktor-server/ktor-server-servlet/jvm/src/io/ktor/server/servlet/BlockingServlet.kt
@@ -80,7 +80,7 @@ internal class BlockingServletApplicationResponse(
 /**
  * Never do like this! Very special corner-case.
  */
-@UseExperimental(ExperimentalCoroutinesApi::class)
+@OptIn(ExperimentalCoroutinesApi::class)
 private object UnsafeBlockingTrampoline : CoroutineDispatcher() {
     override fun isDispatchNeeded(context: CoroutineContext): Boolean = true
 

--- a/ktor-server/ktor-server-servlet/jvm/src/io/ktor/server/servlet/KtorServlet.kt
+++ b/ktor-server/ktor-server-servlet/jvm/src/io/ktor/server/servlet/KtorServlet.kt
@@ -22,7 +22,7 @@ import kotlin.coroutines.*
  * A base class for servlet engine implementations
  */
 @EngineAPI
-@UseExperimental(InternalAPI::class)
+@OptIn(InternalAPI::class)
 abstract class KtorServlet : HttpServlet(), CoroutineScope {
     private val asyncDispatchers = lazy { AsyncDispatchers() }
 

--- a/ktor-server/ktor-server-servlet/jvm/src/io/ktor/server/servlet/ServletReader.kt
+++ b/ktor-server/ktor-server-servlet/jvm/src/io/ktor/server/servlet/ServletReader.kt
@@ -37,7 +37,9 @@ private class ServletReader(val input: ServletInputStream) : ReadListener {
                 return
             }
             @Suppress("DEPRECATION")
-            @UseExperimental(ExperimentalCoroutinesApi::class, ObsoleteCoroutinesApi::class)
+            @OptIn(
+                ExperimentalCoroutinesApi::class, ObsoleteCoroutinesApi::class
+            )
             events.receiveOrNull() ?: return
             loop(buffer)
 
@@ -66,7 +68,9 @@ private class ServletReader(val input: ServletInputStream) : ReadListener {
             } else {
                 channel.flush()
                 @Suppress("DEPRECATION")
-                @UseExperimental(ExperimentalCoroutinesApi::class, ObsoleteCoroutinesApi::class)
+                @OptIn(
+                    ExperimentalCoroutinesApi::class, ObsoleteCoroutinesApi::class
+                )
                 events.receiveOrNull() ?: break
             }
         }

--- a/ktor-server/ktor-server-test-host/jvm/src/io/ktor/server/testing/EngineTestBase.kt
+++ b/ktor-server/ktor-server-test-host/jvm/src/io/ktor/server/testing/EngineTestBase.kt
@@ -42,7 +42,7 @@ abstract class EngineTestBase<TEngine : ApplicationEngine, TConfiguration : Appl
 ) : CoroutineScope {
     private val testJob = Job()
 
-    @UseExperimental(ObsoleteCoroutinesApi::class)
+    @OptIn(ObsoleteCoroutinesApi::class)
     protected val testDispatcher by lazy { newFixedThreadPoolContext(32, "dispatcher-${test.methodName}") }
 
     protected val isUnderDebugger: Boolean =
@@ -230,7 +230,7 @@ abstract class EngineTestBase<TEngine : ApplicationEngine, TConfiguration : Appl
         return try {
             runBlocking {
                 starting.join()
-                @UseExperimental(ExperimentalCoroutinesApi::class)
+                @OptIn(ExperimentalCoroutinesApi::class)
                 starting.getCompletionExceptionOrNull()?.let { listOf(it) } ?: emptyList()
             }
         } catch (t: Throwable) { // InterruptedException?

--- a/ktor-server/ktor-server-test-host/jvm/src/io/ktor/server/testing/TestApplicationEngine.kt
+++ b/ktor-server/ktor-server-test-host/jvm/src/io/ktor/server/testing/TestApplicationEngine.kt
@@ -138,7 +138,7 @@ class TestApplicationEngine(
     /**
      * Make a test request
      */
-    @UseExperimental(InternalAPI::class)
+    @OptIn(InternalAPI::class)
     fun handleRequest(closeRequest: Boolean = true, setup: TestApplicationRequest.() -> Unit): TestApplicationCall {
         val call = createCall(readResponse = true, closeRequest = closeRequest, setup = { processRequest(setup) })
 
@@ -195,7 +195,7 @@ class TestApplicationEngine(
      * Make a test request that setup a websocket session and invoke [callback] function
      * that does conversation with server
      */
-    @UseExperimental(WebSocketInternalAPI::class)
+    @OptIn(WebSocketInternalAPI::class)
     fun handleWebSocketConversation(
         uri: String,
         setup: TestApplicationRequest.() -> Unit = {},

--- a/ktor-server/ktor-server-tests/jvm/test/io/ktor/tests/server/features/CallLoggingTest.kt
+++ b/ktor-server/ktor-server-tests/jvm/test/io/ktor/tests/server/features/CallLoggingTest.kt
@@ -18,7 +18,7 @@ import org.slf4j.*
 import org.slf4j.event.*
 import kotlin.test.*
 
-@UseExperimental(ObsoleteCoroutinesApi::class)
+@OptIn(ObsoleteCoroutinesApi::class)
 class CallLoggingTest {
 
     private lateinit var messages: MutableList<String>

--- a/ktor-server/ktor-server-tests/jvm/test/io/ktor/tests/server/sessions/SessionTest.kt
+++ b/ktor-server/ktor-server-tests/jvm/test/io/ktor/tests/server/sessions/SessionTest.kt
@@ -22,7 +22,7 @@ import kotlin.test.*
 import kotlin.time.*
 
 @Suppress("ReplaceSingleLineLet")
-@UseExperimental(ExperimentalTime::class)
+@OptIn(ExperimentalTime::class)
 class SessionTest {
     private val cookieName = "_S" + Random.nextInt(100)
 

--- a/ktor-server/ktor-server-tests/jvm/test/io/ktor/tests/server/testing/TestApplicationEngineTest.kt
+++ b/ktor-server/ktor-server-tests/jvm/test/io/ktor/tests/server/testing/TestApplicationEngineTest.kt
@@ -21,7 +21,9 @@ import kotlin.test.*
 class TestApplicationEngineTest {
     @Test
     fun testCustomDispatcher() {
-        @UseExperimental(ExperimentalCoroutinesApi::class, InternalCoroutinesApi::class)
+        @OptIn(
+            ExperimentalCoroutinesApi::class, InternalCoroutinesApi::class
+        )
         fun CoroutineDispatcher.withDelay(delay: Delay): CoroutineDispatcher =
             object : CoroutineDispatcher(), Delay by delay {
                 override fun isDispatchNeeded(context: CoroutineContext): Boolean =
@@ -45,7 +47,7 @@ class TestApplicationEngineTest {
                 }
             },
             configure = {
-                @UseExperimental(InternalCoroutinesApi::class)
+                @OptIn(InternalCoroutinesApi::class)
                 dispatcher = Dispatchers.Unconfined.withDelay(object : Delay {
                     override fun scheduleResumeAfterDelay(
                         timeMillis: Long,

--- a/ktor-utils/common/src/io/ktor/util/Annotations.kt
+++ b/ktor-utils/common/src/io/ktor/util/Annotations.kt
@@ -11,6 +11,11 @@ package io.ktor.util
  *
  * We are strongly recommend to not use such API.
  */
+@Suppress("DEPRECATION")
+@RequiresOptIn(
+    level = RequiresOptIn.Level.ERROR,
+    message = "This API is internal in ktor and should not be used. It could be removed or changed without notice."
+)
 @Experimental(level = Experimental.Level.ERROR)
 @Target(
     AnnotationTarget.CLASS,
@@ -25,6 +30,12 @@ annotation class InternalAPI
 /**
  * API marked with this annotation is experimental and is not guaranteed to be stable.
  */
+@Suppress("DEPRECATION")
+@RequiresOptIn(
+    level = RequiresOptIn.Level.WARNING,
+    message = "This API is experimental. " +
+        "It could be removed or changed in future releases or it's behaviour may be different."
+)
 @Experimental(level = Experimental.Level.WARNING)
 @Target(
     AnnotationTarget.CLASS,

--- a/ktor-utils/jvm/src/io/ktor/util/Deflater.kt
+++ b/ktor-utils/jvm/src/io/ktor/util/Deflater.kt
@@ -59,7 +59,7 @@ private suspend fun ByteWriteChannel.deflateWhile(deflater: Deflater, buffer: By
  * optionally doing CRC and writing GZIP header and trailer if [gzip] = `true`
  */
 @KtorExperimentalAPI
-@UseExperimental(ExperimentalCoroutinesApi::class)
+@OptIn(ExperimentalCoroutinesApi::class)
 fun ByteReadChannel.deflated(
     gzip: Boolean = true,
     pool: ObjectPool<ByteBuffer> = KtorDefaultPool,

--- a/ktor-utils/jvm/src/io/ktor/util/cio/FileChannels.kt
+++ b/ktor-utils/jvm/src/io/ktor/util/cio/FileChannels.kt
@@ -23,7 +23,7 @@ import kotlin.coroutines.*
  * a coroutine dispatcher that is properly configured for blocking IO.
  */
 @KtorExperimentalAPI
-@UseExperimental(ExperimentalIoApi::class)
+@OptIn(ExperimentalIoApi::class)
 fun File.readChannel(
     start: Long = 0,
     endInclusive: Long = -1,


### PR DESCRIPTION
**Subsystem**
experimental annotations: all
local address: ktor-server-cio, ktor-http-cio

**Motivation**
- Currently, CIO engine is always providing IPv6 zero address as local address that is not correct at all.
- Experimental annotations are now replaced with OptIn/RequiresOptIn

**Solution**
- Migrate to new annotations
- Provide actual server accepted client's local address instead of listening address (these are not the same)
- workaround new inference behaviour
