### PR TITLE
Fix Apache Client Engine cancellation

### DIFF
--- a/ktor-client/ktor-client-apache/jvm/src/io/ktor/client/engine/apache/ApacheHttpRequest.kt
+++ b/ktor-client/ktor-client-apache/jvm/src/io/ktor/client/engine/apache/ApacheHttpRequest.kt
@@ -58,6 +58,13 @@ internal suspend fun CloseableHttpAsyncClient.sendRequest(
     }
 
     execute(request, consumer, callback).apply {
+        @OptIn(InternalCoroutinesApi::class)
+        callContext[Job]?.invokeOnCompletion(onCancelling = true) { cause ->
+            if (cause != null) {
+                cancel(true)
+            }
+        }
+
         // We need to cancel Apache future if it's not needed anymore.
         continuation.invokeOnCancellation {
             cancel(true)

--- a/ktor-client/ktor-client-apache/jvm/src/io/ktor/client/engine/apache/ApacheResponseConsumerDispatching.kt
+++ b/ktor-client/ktor-client-apache/jvm/src/io/ktor/client/engine/apache/ApacheResponseConsumerDispatching.kt
@@ -27,6 +27,7 @@ internal class ApacheResponseConsumerDispatching(
 
     override val coroutineContext: CoroutineContext = callContext + dispatcher
 
+    // this is not volatile because it is always accessed from the reactor thread except for the constructor
     private var decoderWaiter: CancellableContinuation<ContentDecoder?>? = null
 
     /**


### PR DESCRIPTION
**Subsystem**
ktor-client-apache

**Motivation**
The consumer job may get stuck at cancelling state because it's dispatcher is tied up to the reactor
so if there are no apache callbacks, then there is no chance to process dispatched queue and the job is unable to complete. Evidence: [TC build log](https://teamcity.jetbrains.com/viewLog.html?buildId=2802591&buildTypeId=KotlinTools_Ktor_BuildGradle&fromExperimentalUI=true)

**Solution**
Play dispatched continuation if it is cancelled immediately instead of enqueuing since the queue is processed only in the reactor thread.

