### PR TITLE
HttpClient should render cookies with their respective encoding

### DIFF
--- a/ktor-client/ktor-client-core/common/src/io/ktor/client/features/cookies/HttpCookies.kt
+++ b/ktor-client/ktor-client-core/common/src/io/ktor/client/features/cookies/HttpCookies.kt
@@ -89,7 +89,7 @@ private fun renderClientCookies(cookies: List<Cookie>): String = buildString {
     cookies.forEach {
         append(it.name)
         append('=')
-        append(encodeCookieValue(it.value, CookieEncoding.DQUOTES))
+        append(encodeCookieValue(it.value, it.encoding))
         append(';')
     }
 }

--- a/ktor-client/ktor-client-tests/jvm/src/io/ktor/client/tests/utils/tests/Cookies.kt
+++ b/ktor-client/ktor-client-tests/jvm/src/io/ktor/client/tests/utils/tests/Cookies.kt
@@ -6,6 +6,7 @@ package io.ktor.client.tests.utils.tests
 
 import io.ktor.application.*
 import io.ktor.http.*
+import io.ktor.request.*
 import io.ktor.response.*
 import io.ktor.routing.*
 import kotlin.test.*
@@ -85,6 +86,9 @@ fun Application.cookiesTest() {
                     append(Cookie("fourth", "fourth cookie", domain = "127.0.0.1", path = "/"))
                 }
                 context.respond("Multiple done")
+            }
+            get("/encoded") {
+                context.respond(context.request.header(HttpHeaders.Cookie) ?: fail())
             }
         }
     }

--- a/ktor-client/ktor-client-tests/jvm/test/io/ktor/client/tests/features/CookiesTest.kt
+++ b/ktor-client/ktor-client-tests/jvm/test/io/ktor/client/tests/features/CookiesTest.kt
@@ -32,7 +32,7 @@ class CookiesTest {
             install(HttpCookies) {
                 default {
                     runBlocking {
-                        addCookie("//localhost", Cookie("first", "1,2,3,4"))
+                        addCookie("//localhost", Cookie("first", "1,2,3,4", encoding = CookieEncoding.DQUOTES))
                         addCookie("http://localhost", Cookie("second", "abc"))
                     }
                 }
@@ -57,7 +57,7 @@ class CookiesTest {
             install(HttpCookies) {
                 default {
                     runBlocking {
-                        addCookie("http://localhost", Cookie("myServer", "value:value"))
+                        addCookie("http://localhost", Cookie("myServer", "value:value", encoding = CookieEncoding.RAW))
                     }
                 }
             }


### PR DESCRIPTION
Subsystem
Client, HttpCookies feature.

Motivation
HttpCookies encodes all cookies with DQUOTES rather than respecting their own encoding

Solution
HttpCookies uses the cookies respective encoding

Continues work on #1393
Fixes #1222