### PR TITLE
set AuthScheme.OAuth to `Bearer` as defined in RFC6750

### DIFF
--- a/ktor-http/common/src/io/ktor/http/auth/AuthScheme.kt
+++ b/ktor-http/common/src/io/ktor/http/auth/AuthScheme.kt
@@ -40,11 +40,11 @@ object AuthScheme {
     const val Negotiate = "Negotiate"
 
     /**
-     * OAuth Authentication described in the RFC-6749:
+     * OAuth Authentication described in the RFC-6750:
      *
-     * see https://tools.ietf.org/html/rfc6749
+     * see https://tools.ietf.org/html/rfc6750#section-3
      */
-    const val OAuth = "OAuth"
+    const val OAuth = "Bearer"
 
     @Suppress("KDocMissingDocumentation", "unused")
     @Deprecated("Compatibility", level = DeprecationLevel.HIDDEN)


### PR DESCRIPTION
In RFC6750 the auth-scheme is defined as `Bearer` (not `OAuth`). See https://tools.ietf.org/html/rfc6750#section-3:

> All challenges defined by this specification MUST use the auth-scheme value "Bearer".

This is also commonly used by servers which respond with `Bearer` as well so this must match to be used by an (not yet implemented) `OAuthAuthProvider` (see https://github.com/ktorio/ktor/issues/1595).
