### PR TITLE
Secure Cookie Expiration

### DIFF
--- a/ktor-server/ktor-server-core/jvm/src/io/ktor/response/ResponseCookies.kt
+++ b/ktor-server/ktor-server-core/jvm/src/io/ktor/response/ResponseCookies.kt
@@ -85,7 +85,7 @@ class ResponseCookies(
     /**
      * Append already expired cookie: useful to remove client cookies
      */
-    fun appendExpired(name: String, domain: String? = null, path: String? = null, secure: Boolean = false) {
-        append(name, "", domain = domain, path = path, expires = GMTDate.START, secure = secure)
+    fun appendExpired(name: String, domain: String? = null, path: String? = null, secure: Boolean = false, extensions: Map<String, String?> = emptyMap()) {
+        append(name, "", domain = domain, path = path, expires = GMTDate.START, secure = secure, extensions = extensions)
     }
 }

--- a/ktor-server/ktor-server-core/jvm/src/io/ktor/response/ResponseCookies.kt
+++ b/ktor-server/ktor-server-core/jvm/src/io/ktor/response/ResponseCookies.kt
@@ -85,7 +85,7 @@ class ResponseCookies(
     /**
      * Append already expired cookie: useful to remove client cookies
      */
-    fun appendExpired(name: String, domain: String? = null, path: String? = null) {
-        append(name, "", domain = domain, path = path, expires = GMTDate.START)
+    fun appendExpired(name: String, domain: String? = null, path: String? = null, secure: Boolean = false) {
+        append(name, "", domain = domain, path = path, expires = GMTDate.START, secure = secure)
     }
 }

--- a/ktor-server/ktor-server-core/jvm/src/io/ktor/sessions/SessionTransportCookie.kt
+++ b/ktor-server/ktor-server-core/jvm/src/io/ktor/sessions/SessionTransportCookie.kt
@@ -53,7 +53,7 @@ class SessionTransportCookie(
     }
 
     override fun clear(call: ApplicationCall) {
-        call.response.cookies.appendExpired(name, configuration.domain, configuration.path)
+        call.response.cookies.appendExpired(name, configuration.domain, configuration.path, configuration.secure)
     }
 
     override fun toString(): String {


### PR DESCRIPTION
**Subsystem**
Server, Sessions

**Motivation**
Attempted fix for #1738 

**Solution**
Add optional parameter to `ResponseCoookies::appendExpired` to set `Secure` cookie flag

