### PR TITLE
add OAuthProvider

### DIFF
--- a/ktor-client/ktor-client-features/ktor-client-auth/common/src/io/ktor/client/features/auth/Auth.kt
+++ b/ktor-client/ktor-client-features/ktor-client-auth/common/src/io/ktor/client/features/auth/Auth.kt
@@ -31,7 +31,7 @@ class Auth(
         override fun install(feature: Auth, scope: HttpClient) {
             scope.requestPipeline.intercept(HttpRequestPipeline.State) {
                 for (provider in feature.alwaysSend) {
-                    provider.addRequestHeaders(context)
+                    provider.authenticate(context)
                 }
             }
 
@@ -48,7 +48,7 @@ class Auth(
 
                     // let the provider prepare a new request by passing a copy of the original request to it
                     // `takeFromWithExecutionContext()` does not add the latest headers to the new request so use `call.request`
-                    provider.addRequestHeaders(HttpRequestBuilder().takeFrom(call.request))
+                    provider.authenticate(HttpRequestBuilder().takeFrom(call.request))
                         // only retry the request when the provider returns it (no circuitBreaker needed)
                         ?.let { call = execute(it) }
                 }

--- a/ktor-client/ktor-client-features/ktor-client-auth/common/src/io/ktor/client/features/auth/AuthProvider.kt
+++ b/ktor-client/ktor-client-features/ktor-client-auth/common/src/io/ktor/client/features/auth/AuthProvider.kt
@@ -23,7 +23,7 @@ interface AuthProvider {
     fun isApplicable(auth: HttpAuthHeader): Boolean
 
     /**
-     * Add authentication method headers and creds.
+     * Add authentication method headers and creds and return the updated request.
      */
-    suspend fun addRequestHeaders(request: HttpRequestBuilder)
+    suspend fun addRequestHeaders(request: HttpRequestBuilder) : HttpRequestBuilder?
 }

--- a/ktor-client/ktor-client-features/ktor-client-auth/common/src/io/ktor/client/features/auth/AuthProvider.kt
+++ b/ktor-client/ktor-client-features/ktor-client-auth/common/src/io/ktor/client/features/auth/AuthProvider.kt
@@ -25,5 +25,5 @@ interface AuthProvider {
     /**
      * Add authentication method headers and creds and return the updated request.
      */
-    suspend fun addRequestHeaders(request: HttpRequestBuilder) : HttpRequestBuilder?
+    suspend fun authenticate(request: HttpRequestBuilder) : HttpRequestBuilder?
 }

--- a/ktor-client/ktor-client-features/ktor-client-auth/common/src/io/ktor/client/features/auth/providers/BasicAuthProvider.kt
+++ b/ktor-client/ktor-client-features/ktor-client-auth/common/src/io/ktor/client/features/auth/providers/BasicAuthProvider.kt
@@ -68,7 +68,7 @@ class BasicAuthProvider(
         return true
     }
 
-    override suspend fun addRequestHeaders(request: HttpRequestBuilder): HttpRequestBuilder? {
+    override suspend fun authenticate(request: HttpRequestBuilder): HttpRequestBuilder? {
         // do not retry the request if the same authorization was already tried
         val authorization = constructBasicAuthValue()
         return if (authorization == request.headers[HttpHeaders.Authorization]) {

--- a/ktor-client/ktor-client-features/ktor-client-auth/common/src/io/ktor/client/features/auth/providers/BasicAuthProvider.kt
+++ b/ktor-client/ktor-client-features/ktor-client-auth/common/src/io/ktor/client/features/auth/providers/BasicAuthProvider.kt
@@ -68,8 +68,15 @@ class BasicAuthProvider(
         return true
     }
 
-    override suspend fun addRequestHeaders(request: HttpRequestBuilder) {
-        request.headers[HttpHeaders.Authorization] = constructBasicAuthValue()
+    override suspend fun addRequestHeaders(request: HttpRequestBuilder): HttpRequestBuilder? {
+        // do not retry the request if the same authorization was already tried
+        val authorization = constructBasicAuthValue()
+        return if (authorization == request.headers[HttpHeaders.Authorization]) {
+            null
+
+        } else {
+            request.apply { headers[HttpHeaders.Authorization] = authorization }
+        }
     }
 
     internal fun constructBasicAuthValue(): String {

--- a/ktor-client/ktor-client-features/ktor-client-auth/common/src/io/ktor/client/features/auth/providers/DigestAuthProvider.kt
+++ b/ktor-client/ktor-client-features/ktor-client-auth/common/src/io/ktor/client/features/auth/providers/DigestAuthProvider.kt
@@ -70,7 +70,7 @@ class DigestAuthProvider(
         return true
     }
 
-    override suspend fun addRequestHeaders(request: HttpRequestBuilder): HttpRequestBuilder? {
+    override suspend fun authenticate(request: HttpRequestBuilder): HttpRequestBuilder? {
         val nonceCount = requestCounter.incrementAndGet()
         val methodName = request.method.value.toUpperCase()
         val url = URLBuilder().takeFrom(request.url).build()

--- a/ktor-client/ktor-client-features/ktor-client-auth/common/src/io/ktor/client/features/auth/providers/oauth/OAuthProvider.kt
+++ b/ktor-client/ktor-client-features/ktor-client-auth/common/src/io/ktor/client/features/auth/providers/oauth/OAuthProvider.kt
@@ -72,7 +72,7 @@ class OAuthProvider(
         return true
     }
 
-    override suspend fun addRequestHeaders(request: HttpRequestBuilder): HttpRequestBuilder? {
+    override suspend fun authenticate(request: HttpRequestBuilder): HttpRequestBuilder? {
         /**
          * Use [REQUEST_TRIES_HEADER] to store [tryCount].
          * Cannot use [AttributeKey] because those are not copied by [HttpRequestBuilder.takeFrom].
@@ -95,7 +95,7 @@ class OAuthProvider(
              * If so, the token did not work and should be invalidated.
              *
              * But still return the request (and not null) in this case
-             * so [addRequestHeaders] is called again and we can try a new token
+             * so [authenticate] is called again and we can try a new token
              * (which should be requested by the [TokenProvider] after the old token has been invalidated).
              */
             tokenProvider.invalidateToken(token)

--- a/ktor-client/ktor-client-features/ktor-client-auth/common/src/io/ktor/client/features/auth/providers/oauth/OAuthProvider.kt
+++ b/ktor-client/ktor-client-features/ktor-client-auth/common/src/io/ktor/client/features/auth/providers/oauth/OAuthProvider.kt
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2014-2019 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.client.features.auth.providers.oauth
+
+import io.ktor.client.features.auth.*
+import io.ktor.client.request.*
+import io.ktor.http.*
+import io.ktor.http.auth.*
+
+const val DEFAULT_MAX_REQUEST_TRIES = 3 // original request, refreshToken, username/password
+const val REQUEST_TRIES_HEADER = "NumRequestTries"
+
+// `AuthScheme.OAuth` is currently wrong, so we use our own (see https://github.com/ktorio/ktor/pull/1733)
+val AuthScheme.Bearer: String
+    get() = "Bearer"
+
+/**
+ * Add [OAuthProvider] to client [Auth] providers.
+ *
+ * This provider is structured like the other ones in [io.ktor.client.features.auth.providers]
+ * but *requires* a [TokenProvider] (which is therefore enforced as a parameter in [Auth.oauth]
+ * and not found in [OAuthConfig].
+ */
+fun Auth.oauth(tokenProvider: TokenProvider, block: OAuthConfig.() -> Unit) {
+    with(OAuthConfig().apply(block)) {
+        providers.add(OAuthProvider(tokenProvider, maxTries, realm, sendWithoutRequest))
+    }
+}
+
+/**
+ * [OAuthProvider] configuration.
+ */
+class OAuthConfig {
+
+    /**
+     * Number of tries before the request is no longer retried.
+     * `0` means that the request is only send once and this provider will not add an Authorization-header.
+     */
+    var maxTries: Int = DEFAULT_MAX_REQUEST_TRIES
+
+    /**
+     * Optional: current provider realm
+     */
+    var realm: String? = null
+
+    /**
+     * Send credentials in without waiting for [HttpStatusCode.Unauthorized].
+     */
+    var sendWithoutRequest: Boolean = false
+}
+
+/**
+ * Client basic authentication provider.
+ */
+class OAuthProvider(
+    private val tokenProvider: TokenProvider,
+    private var maxTries: Int,
+    private val realm: String? = null,
+    override val sendWithoutRequest: Boolean = false
+) : AuthProvider {
+
+    override fun isApplicable(auth: HttpAuthHeader): Boolean {
+        if (auth.authScheme != AuthScheme.Bearer) return false
+
+        if (realm != null) {
+            if (auth !is HttpAuthHeader.Parameterized) return false
+            return auth.parameter("realm") == realm
+        }
+
+        return true
+    }
+
+    override suspend fun addRequestHeaders(request: HttpRequestBuilder): HttpRequestBuilder? {
+        /**
+         * Use [REQUEST_TRIES_HEADER] to store [tryCount].
+         * Cannot use [AttributeKey] because those are not copied by [HttpRequestBuilder.takeFrom].
+         */
+        var tryCount =
+            try {
+                request.headers[REQUEST_TRIES_HEADER]?.toInt() ?: 0
+            } catch (e: NumberFormatException) {
+                0
+            }
+
+        if (++tryCount > maxTries) return null
+
+        val token = tokenProvider.getToken() ?: return null
+        val authorization = "${AuthScheme.Bearer} $token"
+
+        return if (authorization == request.headers[HttpHeaders.Authorization]) {
+            /**
+             * Check, if this exact token has already been added to the request but we've still received a 401.
+             * If so, the token did not work and should be invalidated.
+             *
+             * But still return the request (and not null) in this case
+             * so [addRequestHeaders] is called again and we can try a new token
+             * (which should be requested by the [TokenProvider] after the old token has been invalidated).
+             */
+            tokenProvider.invalidateToken(token)
+            request
+
+        } else {
+            // add Authorization-header
+            request.apply { headers[HttpHeaders.Authorization] = authorization }
+
+        }.apply {
+            // store retryCount in a header
+            headers[REQUEST_TRIES_HEADER] = tryCount.toString()
+        }
+    }
+}

--- a/ktor-client/ktor-client-features/ktor-client-auth/common/src/io/ktor/client/features/auth/providers/oauth/OAuthProvider.kt
+++ b/ktor-client/ktor-client-features/ktor-client-auth/common/src/io/ktor/client/features/auth/providers/oauth/OAuthProvider.kt
@@ -25,7 +25,7 @@ val AuthScheme.Bearer: String
  */
 fun Auth.oauth(tokenProvider: TokenProvider, block: OAuthConfig.() -> Unit) {
     with(OAuthConfig().apply(block)) {
-        providers.add(OAuthProvider(tokenProvider, maxTries, realm, sendWithoutRequest))
+        providers.add(OAuthProvider(tokenProvider, maxTries, realm))
     }
 }
 
@@ -44,11 +44,6 @@ class OAuthConfig {
      * Optional: current provider realm
      */
     var realm: String? = null
-
-    /**
-     * Send credentials in without waiting for [HttpStatusCode.Unauthorized].
-     */
-    var sendWithoutRequest: Boolean = false
 }
 
 /**
@@ -57,9 +52,11 @@ class OAuthConfig {
 class OAuthProvider(
     private val tokenProvider: TokenProvider,
     private var maxTries: Int,
-    private val realm: String? = null,
-    override val sendWithoutRequest: Boolean = false
+    private val realm: String? = null
 ) : AuthProvider {
+
+    // set to `false` so this provider is not ignored by [Auth] and retries are possible
+    override val sendWithoutRequest = false
 
     override fun isApplicable(auth: HttpAuthHeader): Boolean {
         if (auth.authScheme != AuthScheme.Bearer) return false

--- a/ktor-client/ktor-client-features/ktor-client-auth/common/src/io/ktor/client/features/auth/providers/oauth/TokenProvider.kt
+++ b/ktor-client/ktor-client-features/ktor-client-auth/common/src/io/ktor/client/features/auth/providers/oauth/TokenProvider.kt
@@ -1,0 +1,12 @@
+/*
+ * Copyright 2014-2019 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.client.features.auth.providers.oauth
+
+interface TokenProvider {
+
+    suspend fun getToken(): String?
+
+    suspend fun invalidateToken(token: String)
+}


### PR DESCRIPTION
**Subsystem**
client, auth-feature

**Motivation**
There is no `AuthProvider` for OAuth. This is needed in many cases.

refs #1595 (and hopefully closes it as well)

**Solution**
I've modified `Auth` to let the `AuthProvider` decide, if the request should be retried or not. This is indicated by `AuthProvider.addRequestHeaders()` now *returning* a request or not. This is just like OkHttp handles this and many people might be used to. This is why, this was also renamed to `authenticate()`.

To let the `AuthProvider` get original request as a `HttpRequestBuilder`, I needed to use `HttpRequestBuilder().takeFrom(call.request)` because `takeFromWithExecutionContext()` does not add a header which was just added by the `AuthProvider` (not sure why).

I'm not sure how to add this provider to the test cases. Plus, all tests in `AuthTest` fail on my machine (using jvm as the target).

The documentation at https://github.com/ktorio/ktorio.github.io/blob/master/clients/http-client/features/auth.md should be updated as well when this new provider is added.

---

### Usage

To use it, you need to pass a `TokenProvider` to `Auth.oauth()`. This is prepared to be used in a multiplatform project where it can be implemented by platform-dependent versions (e.g. for android you can use the systems `AccountManager`:

**common**
Use expect/actual to use different approaches for each platform.
```kotlin
expect class MultiplatformTokenProvider : TokenProvider {

    override suspend fun getToken(): String?

    override suspend fun invalidateToken(token: String)
}
```

**android**
On android, we can still use suspended functions so we can simply delegate the calls to the `AccountManager` which can then be queried in a suspended function as well.
```kotlin
actual class MultiplatformTokenProvider(
    val getTokenFromAccountManager: suspend () -> String?,
    val invalidateTokenInAccountManager: suspend (String) -> Unit
) : TokenProvider {

    actual override suspend fun getToken(): String? = getTokenFromAccountManager()

    actual override suspend fun invalidateToken(token: String) = invalidateTokenInAccountManager(token)
}
```

**ios**
On iOS we cannot use suspended functions and need to use a `Continuation` which will be passed to copies of the original interface-functions (I did not tried this out yet but should be possible).
```kotlin
actual open class MultiplatformTokenProvider : TokenProvider {

    actual override suspend fun getToken(): String? {
        return suspendCancellableCoroutine { continuation ->
            getToken(continuation)
        }
    }

    actual override suspend fun invalidateToken(token: String) {
        return suspendCancellableCoroutine { continuation ->
            invalidateToken(token, continuation)
        }
    }

    open fun getToken(continuation: CancellableContinuation<String?>) {
        TODO("Not yet implemented")
    }

    open fun invalidateToken(token: String, continuation: CancellableContinuation<Unit>) {
        TODO("Not yet implemented")
    }

}
```