### PR TITLE
Fix OkHttp WebSocket close reason completion (#1363).

### DIFF
--- a/ktor-client/ktor-client-okhttp/jvm/src/io/ktor/client/engine/okhttp/OkHttpWebsocketSession.kt
+++ b/ktor-client/ktor-client-okhttp/jvm/src/io/ktor/client/engine/okhttp/OkHttpWebsocketSession.kt
@@ -110,6 +110,7 @@ internal class OkHttpWebsocketSession(
     override fun onFailure(webSocket: WebSocket, t: Throwable, response: Response?) {
         super.onFailure(webSocket, t, response)
 
+        _closeReason.completeExceptionally(t)
         originResponse.completeExceptionally(t)
         _incoming.close(t)
         outgoing.close(t)

--- a/ktor-client/ktor-client-okhttp/jvm/test/io/ktor/client/engine/okhttp/OkHttpWebsocketSessionTest.kt
+++ b/ktor-client/ktor-client-okhttp/jvm/test/io/ktor/client/engine/okhttp/OkHttpWebsocketSessionTest.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2014-2020 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.client.engine.okhttp
+
+import kotlinx.coroutines.*
+import okhttp3.*
+import java.lang.RuntimeException
+import kotlin.test.*
+
+class OkHttpWebsocketSessionTest {
+    @Test
+    fun testOnFailure() {
+        val client = OkHttpClient()
+        val request = Request.Builder().url("ws://google.com").build()
+        val coroutineContext = Job()
+        val session = OkHttpWebsocketSession(client, request, coroutineContext)
+        val webSocket = client.newWebSocket(request, object : WebSocketListener() {})
+        val exception = RuntimeException()
+        session.onFailure(webSocket, exception, null)
+
+        val job = Job()
+        session.closeReason.invokeOnCompletion { cause ->
+            assertEquals(exception, cause)
+            job.complete()
+        }
+        runBlocking { job.join() }
+    }
+}


### PR DESCRIPTION
**Subsystem**
Client, OkHttp

**Motivation**
https://github.com/ktorio/ktor/issues/1363
OkHttp does not complete close reason in case of failure.

