### PR TITLE
#1751 uri support

### DIFF
--- a/ktor-client/ktor-client-core/jvm/src/io/ktor/client/request/HttpRequestJvm.kt
+++ b/ktor-client/ktor-client-core/jvm/src/io/ktor/client/request/HttpRequestJvm.kt
@@ -9,7 +9,7 @@ import io.ktor.http.*
 /**
  * Sets the [HttpRequestBuilder.url] from [url].
  */
-fun HttpRequestBuilder.url(url: java.net.URL): Unit = this.url.takeFrom(url)
+fun HttpRequestBuilder.url(url: java.net.URL): URLBuilder = this.url.takeFrom(url)
 
 /**
  * Constructs a [HttpRequestBuilder] from [url].

--- a/ktor-http/jvm/src/io/ktor/http/URLUtilsJvm.kt
+++ b/ktor-http/jvm/src/io/ktor/http/URLUtilsJvm.kt
@@ -9,7 +9,7 @@ import java.net.*
 /**
  * Take URI components from [uri]
  */
-fun URLBuilder.takeFrom(uri: URI) {
+fun URLBuilder.takeFrom(uri: URI): URLBuilder {
     uri.scheme?.let {
         protocol = URLProtocol.createOrDefault(it)
         port = protocol.defaultPort
@@ -38,6 +38,7 @@ fun URLBuilder.takeFrom(uri: URI) {
     }
 
     uri.fragment?.let { fragment = it }
+    return this
 }
 
 /**

--- a/ktor-http/jvm/src/io/ktor/http/URLUtilsJvm.kt
+++ b/ktor-http/jvm/src/io/ktor/http/URLUtilsJvm.kt
@@ -50,3 +50,10 @@ fun URLBuilder.takeFrom(url: URL) = takeFrom(url.toURI())
  * Convert [Url] to [URI]
  */
 fun Url.toURI(): URI = URI(toString())
+
+/**
+ * Helper method that concisely creates a [Url] from a [URI]
+ *
+ * Creates [Url] from [URI]
+ */
+fun Url.Companion.from(uri: URI): Url = URLBuilder().takeFrom(uri).build()

--- a/ktor-http/jvm/src/io/ktor/http/URLUtilsJvm.kt
+++ b/ktor-http/jvm/src/io/ktor/http/URLUtilsJvm.kt
@@ -56,4 +56,5 @@ fun Url.toURI(): URI = URI(toString())
  *
  * Creates [Url] from [URI]
  */
-fun Url.Companion.from(uri: URI): Url = URLBuilder().takeFrom(uri).build()
+@Suppress("FunctionName")
+fun Url(uri: URI): Url = URLBuilder().takeFrom(uri).build()


### PR DESCRIPTION
**Subsystem**
JVM/Http

**Motivation**
closes #1751 

**Solution**
 change URLBuilder.takeFrom(uri: URI) and made return URLBuilder to be able to chain calls
Added a static extension to concisely create a Url object from a java.net.URI object

