### PR TITLE
Fix max-age directive on the Cache-Control header to use '=' instead of ':'.

### DIFF
--- a/ktor-http/common/src/io/ktor/http/HttpMessageProperties.kt
+++ b/ktor-http/common/src/io/ktor/http/HttpMessageProperties.kt
@@ -27,7 +27,7 @@ fun HttpMessageBuilder.charset(charset: Charset) = contentType()?.let { contentT
 /**
  * Append `Max-Age` header value.
  */
-fun HttpMessageBuilder.maxAge(seconds: Int): Unit = headers.append(HttpHeaders.CacheControl, "max-age:$seconds")
+fun HttpMessageBuilder.maxAge(seconds: Int): Unit = headers.append(HttpHeaders.CacheControl, "max-age=$seconds")
 
 /**
  * Set `If-None-Match` header value.


### PR DESCRIPTION
**Subsystem**
Client

**Motivation**
See https://github.com/ktorio/ktor/issues/1944
Using the ktor-client on Android with the OkHttp engine I noticed that using the `maxAge()` function to set the `Cache-Control` header had no effect on the caching strategy.
It was caused because using that function the `max-age` directive key and value are separated with ':' and the OkHttp client expected '=' as a separator.

According to the HTTP standard, the `max-age` directive of the `Cache-Control` header must use the '=' symbol instead of ':' to separate the directive key with the value.

**Solution**
The ':' separator has been replaced by '=' on the `max-age` directive key-value pair

