### PR TITLE
Expose servlet request attributes as call attributes

### DIFF
--- a/ktor-server/ktor-server-servlet/jvm/src/io/ktor/server/servlet/ServletApplicationRequest.kt
+++ b/ktor-server/ktor-server-servlet/jvm/src/io/ktor/server/servlet/ServletApplicationRequest.kt
@@ -8,6 +8,7 @@ import io.ktor.application.*
 import io.ktor.http.*
 import io.ktor.request.*
 import io.ktor.server.engine.*
+import io.ktor.util.*
 import javax.servlet.http.*
 
 @Suppress("KDocMissingDocumentation")
@@ -17,6 +18,10 @@ abstract class ServletApplicationRequest(
     val servletRequest: HttpServletRequest
 ) : BaseApplicationRequest(call) {
 
+    companion object {
+        val servletRequestAttributes = AttributeKey<Map<String, Any>>("ServletRequestAttributes")
+    }
+
     override val local: RequestConnectionPoint = ServletConnectionPoint(servletRequest)
 
     override val queryParameters: Parameters by lazy {
@@ -24,6 +29,10 @@ abstract class ServletApplicationRequest(
     }
 
     override val headers: Headers = ServletApplicationRequestHeaders(servletRequest)
+
+    val attributes = servletRequest.attributeNames.toList().associateWith { servletRequest.getAttribute(it) }.also {
+        call.attributes.put(servletRequestAttributes, it)
+    }
 
     @Suppress("LeakingThis") // this is safe because we don't access any content in the request
     override val cookies: RequestCookies = ServletApplicationRequestCookies(servletRequest, this)


### PR DESCRIPTION
**Subsystem**
ktor-server-servlet

**Motivation**
[KTOR-424](https://youtrack.jetbrains.com/issue/KTOR-424) Get client certificate information from request 
This implements feature request #1767 by exposing servlet request attributes as call attributes

**Solution**
On instantiating a ServletApplicationRequest from a HttpServletRequest, the attributes in the servlet request are extracted and stored in the call attributes using a key that is exposed in a companion object to ServletApplicationRequest.

Note that the map with servlet attributes is also stored as a property on ServletApplicationRequest. This currently serves no purpose but has been done to be symmetrical to the headers. But one could certainly argue this is not useful

