### PR TITLE
Allow other handlers beside JettyKtorHandler

### DIFF
--- a/ktor-server/ktor-server-jetty/jvm/src/io/ktor/server/jetty/JettyApplicationEngineBase.kt
+++ b/ktor-server/ktor-server-jetty/jvm/src/io/ktor/server/jetty/JettyApplicationEngineBase.kt
@@ -40,13 +40,12 @@ open class JettyApplicationEngineBase @EngineAPI constructor(
      * Jetty server instance being configuring and starting
      */
     protected val server: Server = Server().apply {
-        configuration.configureServer(this)
         initializeServer(environment)
     }
 
     override fun start(wait: Boolean): JettyApplicationEngineBase {
+        configuration.configureServer(server)
         environment.start()
-
         server.start()
         cancellationDeferred = stopServerOnCancellation()
         if (wait) {


### PR DESCRIPTION
When additional jetty configuration is postponed to the startup routine, users may configure additional handlers to the chain beside the JettyKtorHandler assigned in JettyApplicationEngine.start().

This makes the embedded jetty scenario feasible while still providing support e.g. for legacy integrations from the Servlet world.

**Subsystem**
ktor-server-jetty

**Motivation**
See #1741, #270


