### PR TITLE
Bump to Netty 4.1.48.Final

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -26,7 +26,7 @@ atomicfu_version=0.14.2
 validator_version=0.2.2
 
 # server
-netty_version=4.1.44.Final
+netty_version=4.1.48.Final
 netty_tcnative_version=2.0.27.Final
 jetty_version=9.4.24.v20191120
 jetty_alpn_api_version=1.1.3.v20160715


### PR DESCRIPTION
**Subsystem**
ktor-server-netty

**Motivation**
Fixes #1778 - mitigate https://nvd.nist.gov/vuln/detail/CVE-2020-11612

**Solution**
Upgrade netty version from `4.1.44.Final` -> `4.1.48.Final` (latest). Have verified that all the tests for project `ktor:ktor-server:ktor-server-netty` still pass.

