### PR TITLE
Use comma to divide headers (Fix #1765).

### DIFF
--- a/ktor-client/ktor-client-core/common/src/io/ktor/client/engine/Utils.kt
+++ b/ktor-client/ktor-client-core/common/src/io/ktor/client/engine/Utils.kt
@@ -33,7 +33,8 @@ fun mergeHeaders(
         if (HttpHeaders.ContentLength == key) return@forEach // set later
         if (HttpHeaders.ContentType == key) return@forEach // set later
 
-        block(key, values.joinToString(";"))
+        // https://www.w3.org/Protocols/rfc2616/rfc2616-sec4.html#sec4.2
+        block(key, values.joinToString(","))
     }
 
     val missingAgent = requestHeaders[HttpHeaders.UserAgent] == null && content.headers[HttpHeaders.UserAgent] == null

--- a/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/HeadersTest.kt
+++ b/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/HeadersTest.kt
@@ -13,7 +13,7 @@ import kotlin.test.*
 class HeadersTest : ClientLoader() {
 
     @Test
-    fun headersReturnNullWhenMissing(): Unit = clientTests {
+    fun headersReturnNullWhenMissing() = clientTests {
         config {}
         test { client ->
             client.get<HttpResponse>("$TEST_SERVER/headers/").let {
@@ -23,6 +23,43 @@ class HeadersTest : ClientLoader() {
                 assertNull(it.headers["X-Nonexistent-Header"])
                 assertNull(it.headers.getAll("X-Nonexistent-Header"))
             }
+        }
+    }
+
+    @Test
+    fun headersMergeTest() = clientTests(listOf("Js")) {
+        config {}
+        test { client ->
+            client.get<HttpResponse>("$TEST_SERVER/headers-merge/") {
+                accept(ContentType.Text.Html)
+                accept(ContentType.Application.Json)
+            }.let {
+                assertEquals(HttpStatusCode.OK, it.status)
+                assertEquals("JSON", it.readText())
+                assertEquals("application/json; charset=UTF-8", it.headers[HttpHeaders.ContentType])
+            }
+
+            client.get<HttpResponse>("$TEST_SERVER/headers-merge/") {
+                accept(ContentType.Text.Html)
+                accept(ContentType.Application.Xml)
+            }.let {
+                assertEquals("XML", it.readText())
+                assertEquals("application/xml; charset=UTF-8", it.headers[HttpHeaders.ContentType])
+            }
+        }
+    }
+
+    @Test
+    fun testTest() = clientTests(listOf("Js")) {
+        config {}
+        test { client ->
+            val lines = client.get<String>("$HTTP_PROXY_SERVER/headers-merge") {
+                accept(ContentType.Application.Xml)
+                accept(ContentType.Application.Json)
+            }.split("\n")
+
+            val acceptHeaderLine = lines.first { it.startsWith("Accept:") }
+            assertEquals("Accept: application/xml,application/json", acceptHeaderLine)
         }
     }
 }

--- a/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/engine/UtilsTest.kt
+++ b/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/engine/UtilsTest.kt
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2014-2020 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.client.tests.engine
+
+import io.ktor.client.engine.*
+import io.ktor.client.utils.*
+import io.ktor.http.*
+import kotlin.test.*
+
+class UtilsTest {
+    @Test
+    fun testMergeHeaders() {
+        val headers = HeadersBuilder().apply {
+            append("Accept", "application/xml")
+            append("Accept", "application/json")
+        }
+
+        val result = mutableMapOf<String, String>()
+        mergeHeaders(headers.build(), EmptyContent) {
+                key, value -> result[key] = value
+        }
+
+        assertEquals("application/xml,application/json", result["Accept"])
+    }
+}

--- a/ktor-client/ktor-client-tests/jvm/src/io/ktor/client/tests/utils/tests/Headers.kt
+++ b/ktor-client/ktor-client-tests/jvm/src/io/ktor/client/tests/utils/tests/Headers.kt
@@ -19,5 +19,18 @@ internal fun Application.headersTestServer() {
                 call.respond(HttpStatusCode.OK, "OK")
             }
         }
+
+        route("/headers-merge") {
+            accept(ContentType.Application.Json) {
+                get("/") {
+                    call.respondText("JSON", ContentType.Application.Json, HttpStatusCode.OK)
+                }
+            }
+            accept(ContentType.Application.Xml) {
+                get("/") {
+                    call.respondText("XML", ContentType.Application.Xml, HttpStatusCode.OK)
+                }
+            }
+        }
     }
 }

--- a/ktor-server/ktor-server-test-host/jvm/src/io/ktor/server/testing/EngineTestSuite.kt
+++ b/ktor-server/ktor-server-test-host/jvm/src/io/ktor/server/testing/EngineTestSuite.kt
@@ -1894,7 +1894,7 @@ abstract class EngineTestSuite<TEngine : ApplicationEngine, TConfiguration : App
 
             get("/") {
                 assertEquals("foo", call.request.headers["X-Single-Value"])
-                assertEquals("foo;bar", call.request.headers["X-Double-Value"])
+                assertEquals("foo,bar", call.request.headers["X-Double-Value"])
 
                 assertNull(call.request.headers["X-Nonexistent-Header"])
                 assertNull(call.request.headers.getAll("X-Nonexistent-Header"))


### PR DESCRIPTION
**Subsystem**
Client Utils

**Motivation**
The issue described in https://github.com/ktorio/ktor/issues/1765 and [rfc2616](https://www.w3.org/Protocols/rfc2616/rfc2616-sec4.html#sec4.2).