### PR TITLE
fix log channel is not closed for ByteArrayContent

### DIFF
--- a/ktor-client/ktor-client-features/ktor-client-logging/common/src/io/ktor/client/features/logging/ObservingUtils.kt
+++ b/ktor-client/ktor-client-features/ktor-client-logging/common/src/io/ktor/client/features/logging/ObservingUtils.kt
@@ -12,6 +12,7 @@ import kotlinx.coroutines.*
 internal suspend fun OutgoingContent.observe(log: ByteWriteChannel): OutgoingContent = when (this) {
     is OutgoingContent.ByteArrayContent -> {
         log.writeFully(bytes())
+        log.close()
         this
     }
     is OutgoingContent.ReadChannelContent -> {

--- a/ktor-io/common/src/io/ktor/utils/io/ByteWriteChannel.kt
+++ b/ktor-io/common/src/io/ktor/utils/io/ByteWriteChannel.kt
@@ -187,7 +187,7 @@ suspend fun ByteWriteChannel.writeStringUtf8(s: CharBuffer) {
 
 suspend fun ByteWriteChannel.writeStringUtf8(s: String) {
     val packet = buildPacket {
-        writeStringUtf8(s)
+        writeText(s)
     }
 
     return writePacket(packet)


### PR DESCRIPTION
fix log channel is not closed for ByteArrayContent and
add tests for OutgoingContent types handled in ObservingUtils.kt
replace deprecated call to `writeStringUtf8` with `writeText` in `ByteWriteChannel.kt`

**Subsystem**
Client

**Motivation**
Solving the problem stated in https://github.com/ktorio/ktor/issues/1729

**Solution**
The log channel was not closed for ByteArrayContent. Added closing and added tests for all the types of OutgoingContent that are used in ObservingUtils.kt

