### PR TITLE
OAuth2: Added option to pass params in URL

### DIFF
--- a/ktor-features/ktor-auth/api/ktor-auth.api
+++ b/ktor-features/ktor-auth/api/ktor-auth.api
@@ -436,8 +436,8 @@ public final class io/ktor/auth/OAuthServerSettings$OAuth1aServerSettings : io/k
 }
 
 public final class io/ktor/auth/OAuthServerSettings$OAuth2ServerSettings : io/ktor/auth/OAuthServerSettings {
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lio/ktor/http/HttpMethod;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;ZLio/ktor/util/NonceManager;Lkotlin/jvm/functions/Function1;)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lio/ktor/http/HttpMethod;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;ZLio/ktor/util/NonceManager;Lkotlin/jvm/functions/Function1;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lio/ktor/http/HttpMethod;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;ZLio/ktor/util/NonceManager;Lkotlin/jvm/functions/Function1;Z)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lio/ktor/http/HttpMethod;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;ZLio/ktor/util/NonceManager;Lkotlin/jvm/functions/Function1;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getAccessTokenRequiresBasicAuth ()Z
 	public final fun getAccessTokenUrl ()Ljava/lang/String;
 	public final fun getAuthorizeUrl ()Ljava/lang/String;
@@ -446,6 +446,7 @@ public final class io/ktor/auth/OAuthServerSettings$OAuth2ServerSettings : io/kt
 	public final fun getClientSecret ()Ljava/lang/String;
 	public final fun getDefaultScopes ()Ljava/util/List;
 	public final fun getNonceManager ()Lio/ktor/util/NonceManager;
+	public final fun getPassParamsInURL ()Z
 	public final fun getRequestMethod ()Lio/ktor/http/HttpMethod;
 }
 

--- a/ktor-features/ktor-auth/jvm/src/io/ktor/auth/OAuth.kt
+++ b/ktor-features/ktor-auth/jvm/src/io/ktor/auth/OAuth.kt
@@ -91,7 +91,7 @@ sealed class OAuthServerSettings(val name: String, val version: OAuthVersion) {
      * @property clientSecret client secret parameter (provided by OAuth server vendor)
      * @property defaultScopes OAuth scopes used by default
      * @property accessTokenRequiresBasicAuth to send BASIC auth header when an access token is requested
-     *
+     * @property passParamsInURL whether to pass request parameters in POST requests in URL instead of body.
      * @property nonceManager to be used to produce and verify nonce values
      * @property authorizeUrlInterceptor an interceptor function to customize authorization URL
      */
@@ -108,7 +108,8 @@ sealed class OAuthServerSettings(val name: String, val version: OAuthVersion) {
 
         val nonceManager: NonceManager = GenerateOnlyNonceManager,
 
-        val authorizeUrlInterceptor: URLBuilder.() -> Unit = {}
+        val authorizeUrlInterceptor: URLBuilder.() -> Unit = {},
+        val passParamsInURL: Boolean = false
     ) : OAuthServerSettings(name, OAuthVersion.V20)
 }
 


### PR DESCRIPTION
This allows to use GitLab OAuth2 provider.
Fixes #1846 

**Subsystem**
:ktor-features:ktor-auth

**Motivation**
This allows to use GitLab OAuth2 provider.

**Solution**
Added option to pass token retrieval params in URL instead of body in POST requests.
