### PR TITLE
bug-fix: enhanced handling of statusCode for AndroidEngine

### DIFF
--- a/ktor-client/ktor-client-android/jvm/src/io/ktor/client/engine/android/AndroidClientEngine.kt
+++ b/ktor-client/ktor-client-android/jvm/src/io/ktor/client/engine/android/AndroidClientEngine.kt
@@ -82,7 +82,9 @@ class AndroidClientEngine(override val config: AndroidEngineConfig) : HttpClient
 
         connection.timeoutAwareConnect(data)
 
-        val statusCode = HttpStatusCode.fromValue(connection.responseCode)
+        val responseCode = connection.responseCode
+        val responseMessage = connection.responseMessage
+        val statusCode = responseMessage?.let { HttpStatusCode(responseCode, it) } ?: HttpStatusCode.fromValue(responseCode)
         val content: ByteReadChannel = connection.content(callContext, data)
         val headerFields: MutableMap<String?, MutableList<String>> = connection.headerFields
         val version: HttpProtocolVersion = HttpProtocolVersion.HTTP_1_1

--- a/ktor-client/ktor-client-android/jvm/src/io/ktor/client/engine/android/AndroidClientEngine.kt
+++ b/ktor-client/ktor-client-android/jvm/src/io/ktor/client/engine/android/AndroidClientEngine.kt
@@ -82,7 +82,7 @@ class AndroidClientEngine(override val config: AndroidEngineConfig) : HttpClient
 
         connection.timeoutAwareConnect(data)
 
-        val statusCode = HttpStatusCode(connection.responseCode, connection.responseMessage)
+        val statusCode = HttpStatusCode.fromValue(connection.responseCode)
         val content: ByteReadChannel = connection.content(callContext, data)
         val headerFields: MutableMap<String?, MutableList<String>> = connection.headerFields
         val version: HttpProtocolVersion = HttpProtocolVersion.HTTP_1_1


### PR DESCRIPTION
**Subsystem**
Client/Android Engine

**Motivation**
This pull request should solve the following issue: https://github.com/ktorio/ktor/issues/1812

**Solution**
Describe your solution.
The underlying http client of AndroidEngine can't extract the reasonPhrase when the server is not sending it. The reason phrase is actually optional, so it could be that some servers are sending and some dont. The http specification has also mentioned that it is optional:
> The reason-phrase element exists for the sole purpose of providing a
textual description associated with the numeric status code, mostly
out of deference to earlier Internet application protocols that were
more frequently used with interactive text clients. A client SHOULD
ignore the reason-phrase content.

See here for more information: https://tools.ietf.org/html/rfc7230#section-3.1.2

By switching over to HttpStatusCode#fromValue method AndroidEngine can create HttpStatusCode from the status code. It won't rely on the underlying http client for getting the reason phrase anymore but it will use the internal contants of HttpStatusCode to find a match based on the status code.