### PR TITLE
Add json syntax exception handling to gson content negotiation converter

### DIFF
--- a/ktor-features/ktor-gson/jvm/src/io/ktor/gson/GsonSupport.kt
+++ b/ktor-features/ktor-gson/jvm/src/io/ktor/gson/GsonSupport.kt
@@ -5,7 +5,6 @@
 package io.ktor.gson
 
 import com.google.gson.*
-import com.google.gson.stream.*
 import io.ktor.application.*
 import io.ktor.features.*
 import io.ktor.features.ContentTransformationException
@@ -41,9 +40,9 @@ class GsonConverter(private val gson: Gson = Gson()) : ContentConverter {
             throw ExcludedTypeGsonException(type)
         }
 
-        return try{
+        return try {
             gson.fromJson(reader, type.javaObjectType) ?: throw UnsupportedNullValuesException()
-        }catch (e: JsonSyntaxException) {
+        } catch (e: JsonSyntaxException) {
             throw BadRequestException("Invalid Json")
         }
     }

--- a/ktor-features/ktor-gson/jvm/src/io/ktor/gson/GsonSupport.kt
+++ b/ktor-features/ktor-gson/jvm/src/io/ktor/gson/GsonSupport.kt
@@ -5,6 +5,7 @@
 package io.ktor.gson
 
 import com.google.gson.*
+import com.google.gson.stream.*
 import io.ktor.application.*
 import io.ktor.features.*
 import io.ktor.features.ContentTransformationException
@@ -40,7 +41,11 @@ class GsonConverter(private val gson: Gson = Gson()) : ContentConverter {
             throw ExcludedTypeGsonException(type)
         }
 
-        return gson.fromJson(reader, type.javaObjectType) ?: throw UnsupportedNullValuesException()
+        return try{
+            gson.fromJson(reader, type.javaObjectType) ?: throw UnsupportedNullValuesException()
+        }catch (e: JsonSyntaxException) {
+            throw BadRequestException("Invalid Json")
+        }
     }
 }
 

--- a/ktor-features/ktor-gson/jvm/test/io/ktor/tests/gson/GsonTest.kt
+++ b/ktor-features/ktor-gson/jvm/test/io/ktor/tests/gson/GsonTest.kt
@@ -203,6 +203,28 @@ class GsonTest {
         }
     }
 
+
+    @Test
+    fun testReceiveMalformedJson(): Unit = withTestApplication {
+        application.install(ContentNegotiation) {
+            gson()
+        }
+
+        application.routing {
+            post("/") {
+                val result = call.receive<Map<String, String>>().toString()
+                call.respondText(result)
+            }
+        }
+
+        handleRequest(HttpMethod.Post, "/") {
+            addHeader(HttpHeaders.ContentType, "application/json")
+            setBody("{")
+        }.let {
+            assertEquals(HttpStatusCode.BadRequest, it.response.status())
+        }
+    }
+
 }
 
 data class MyEntity(val id: Int, val name: String, val children: List<ChildEntity>)


### PR DESCRIPTION
**Subsystem**
Server - Features - ktor-gson

**Motivation**
Make gson converter return a 400 status code for bad json rather than a 500. More detail here: https://github.com/ktorio/ktor/issues/1874

**Solution**
Catch the "JsonSyntaxException" and throw a "BadRequestException"

