### PR TITLE
Add excludeSuffix()

### DIFF
--- a/ktor-server/ktor-server-core/api/ktor-server-core.api
+++ b/ktor-server/ktor-server-core/api/ktor-server-core.api
@@ -628,6 +628,7 @@ public final class io/ktor/features/HttpsRedirect$Configuration {
 	public fun <init> ()V
 	public final fun exclude (Lkotlin/jvm/functions/Function1;)V
 	public final fun excludePrefix (Ljava/lang/String;)V
+	public final fun excludeSuffix (Ljava/lang/String;)V
 	public final fun getExcludePredicates ()Ljava/util/List;
 	public final fun getPermanentRedirect ()Z
 	public final fun getSslPort ()I

--- a/ktor-server/ktor-server-core/jvm/src/io/ktor/features/HttpsRedirect.kt
+++ b/ktor-server/ktor-server-core/jvm/src/io/ktor/features/HttpsRedirect.kt
@@ -62,6 +62,16 @@ class HttpsRedirect(config: Configuration) {
         }
 
         /**
+         * Exclude calls with paths matching the [pathSuffix] from being redirected to https by this feature.
+        */
+        @KtorExperimentalAPI
+        fun excludeSuffix(pathSuffix: String) {
+            exclude { call ->
+                call.request.origin.uri.endsWith(pathSuffix)
+            }
+        }        
+        
+        /**
          * Exclude calls matching the [predicate] from being redirected to https by this feature.
          */
         @KtorExperimentalAPI

--- a/ktor-server/ktor-server-tests/jvm/test/io/ktor/tests/server/features/HttpsRedirectFeatureTest.kt
+++ b/ktor-server/ktor-server-tests/jvm/test/io/ktor/tests/server/features/HttpsRedirectFeatureTest.kt
@@ -85,7 +85,7 @@ class HttpsRedirectFeatureTest {
     }
 
     @Test
-    fun testRedirectHttpsExemption() {
+    fun testRedirectHttpsPrefixExemption() {
         withTestApplication {
             application.install(HttpsRedirect) {
                 excludePrefix("/exempted")
@@ -99,6 +99,26 @@ class HttpsRedirectFeatureTest {
             }
 
             handleRequest(HttpMethod.Get, "/exempted/path").let { call ->
+                assertEquals(HttpStatusCode.OK, call.response.status())
+            }
+        }
+    }
+
+    @Test
+    fun testRedirectHttpsSuffixExemption() {
+        withTestApplication {
+            application.install(HttpsRedirect) {
+                excludeSuffix("exempted")
+            }
+            application.intercept(ApplicationCallPipeline.Fallback) {
+                call.respond("ok")
+            }
+
+            handleRequest(HttpMethod.Get, "/exemptednot").let { call ->
+                assertEquals(HttpStatusCode.MovedPermanently, call.response.status())
+            }
+
+            handleRequest(HttpMethod.Get, "/path/exempted").let { call ->
                 assertEquals(HttpStatusCode.OK, call.response.status())
             }
         }


### PR DESCRIPTION
Add excludeSuffix() as a compliment to the existing excludePrefix() function

**Subsystem**
HttpsRedirect feature

**Motivation**
There is already a excludePrefix(). excludeSuffix() is a complimentary function.

**Solution**
Restrict inclusion by suffix.

