### PR TITLE
Fix doubling host

### DIFF
--- a/ktor-client/ktor-client-android/jvm/src/io/ktor/client/engine/android/AndroidClientEngine.kt
+++ b/ktor-client/ktor-client-android/jvm/src/io/ktor/client/engine/android/AndroidClientEngine.kt
@@ -32,17 +32,17 @@ class AndroidClientEngine(override val config: AndroidEngineConfig) : HttpClient
         )
     }
 
-    override val supportedCapabilities = setOf(HttpTimeout)
+    override val supportedCapabilities: Set<HttpTimeout.Feature> = setOf(HttpTimeout)
 
     override suspend fun execute(data: HttpRequestData): HttpResponseData {
         val callContext = callContext()
 
-        val requestTime: GMTDate = GMTDate()
+        val requestTime = GMTDate()
 
         val url: String = URLBuilder().takeFrom(data.url).buildString()
         val outgoingContent: OutgoingContent = data.body
-        val contentLength: Long? =
-            data.headers[HttpHeaders.ContentLength]?.toLong() ?: outgoingContent.contentLength
+        val contentLength: Long? = data.headers[HttpHeaders.ContentLength]?.toLong()
+            ?: outgoingContent.contentLength
 
         val connection: HttpURLConnection = getProxyAwareConnection(url).apply {
             connectTimeout = config.connectTimeout

--- a/ktor-client/ktor-client-cio/jvm/src/io/ktor/client/engine/cio/utils.kt
+++ b/ktor-client/ktor-client-cio/jvm/src/io/ktor/client/engine/cio/utils.kt
@@ -40,7 +40,14 @@ internal suspend fun HttpRequestData.write(
 
             builder.requestLine(method, urlString, HttpProtocolVersion.HTTP_1_1.toString())
             // this will only add the port to the host header if the port is non-standard for the protocol
-            builder.headerLine("Host", if (url.protocol.defaultPort == url.port) url.host else url.hostWithPort)
+            if (!headers.contains(HttpHeaders.Host)) {
+                val host = if (url.protocol.defaultPort == url.port) {
+                    url.host
+                } else {
+                    url.hostWithPort
+                }
+                builder.headerLine(HttpHeaders.Host, host)
+            }
 
             mergeHeaders(headers, body) { key, value ->
                 builder.headerLine(key, value)

--- a/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/HeadersTest.kt
+++ b/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/HeadersTest.kt
@@ -13,8 +13,7 @@ import kotlin.test.*
 class HeadersTest : ClientLoader() {
 
     @Test
-    fun headersReturnNullWhenMissing() = clientTests {
-        config {}
+    fun testHeadersReturnNullWhenMissing() = clientTests {
         test { client ->
             client.get<HttpResponse>("$TEST_SERVER/headers/").let {
                 assertEquals(HttpStatusCode.OK, it.status)
@@ -27,8 +26,7 @@ class HeadersTest : ClientLoader() {
     }
 
     @Test
-    fun headersMergeTest() = clientTests(listOf("Js")) {
-        config {}
+    fun testHeadersMerge() = clientTests(listOf("Js")) {
         test { client ->
             client.get<HttpResponse>("$TEST_SERVER/headers-merge/") {
                 accept(ContentType.Text.Html)
@@ -50,8 +48,7 @@ class HeadersTest : ClientLoader() {
     }
 
     @Test
-    fun testTest() = clientTests(listOf("Js")) {
-        config {}
+    fun testAcceptMerge() = clientTests(listOf("Js")) {
         test { client ->
             val lines = client.get<String>("$HTTP_PROXY_SERVER/headers-merge") {
                 accept(ContentType.Application.Xml)
@@ -60,6 +57,15 @@ class HeadersTest : ClientLoader() {
 
             val acceptHeaderLine = lines.first { it.startsWith("Accept:") }
             assertEquals("Accept: application/xml,application/json", acceptHeaderLine)
+        }
+    }
+
+    @Test
+    fun testSingleHostHeader() = clientTests(listOf("Js", "Android")) {
+        test { client ->
+            client.get("$TEST_SERVER/headers/host") {
+                header(HttpHeaders.Host, "CustomHost")
+            }
         }
     }
 }

--- a/ktor-client/ktor-client-tests/jvm/src/io/ktor/client/tests/utils/tests/Headers.kt
+++ b/ktor-client/ktor-client-tests/jvm/src/io/ktor/client/tests/utils/tests/Headers.kt
@@ -8,6 +8,7 @@ import io.ktor.application.*
 import io.ktor.http.*
 import io.ktor.response.*
 import io.ktor.routing.*
+import kotlin.test.*
 
 internal fun Application.headersTestServer() {
     routing {
@@ -17,6 +18,26 @@ internal fun Application.headersTestServer() {
                 call.response.header("X-Header-Double-Value", "foo")
                 call.response.header("X-Header-Double-Value", "bar")
                 call.respond(HttpStatusCode.OK, "OK")
+            }
+            get("host") {
+                val header = call.request.headers.getAll(HttpHeaders.Host)
+
+                if (header == null || header.isEmpty()) {
+                    call.respond(HttpStatusCode.BadRequest, "Header is or empty: ${header?.size}")
+                    return@get
+                }
+
+                if (header.size > 1) {
+                    call.respond(HttpStatusCode.BadRequest, "Too many host headers: ${header.joinToString()}")
+                    return@get
+                }
+
+                if (header.first() != "CustomHost") {
+                    call.respond(HttpStatusCode.BadRequest, "Invalid host header: ${header.first()}")
+                    return@get
+                }
+
+                call.respond(HttpStatusCode.OK)
             }
         }
 


### PR DESCRIPTION
Fix doubling `Host` header