### PR TITLE
Add support for image/tiff content-type

### DIFF
--- a/ktor-http/common/src/io/ktor/http/ContentTypes.kt
+++ b/ktor-http/common/src/io/ktor/http/ContentTypes.kt
@@ -161,6 +161,7 @@ class ContentType private constructor(val contentType: String, val contentSubtyp
         val PNG = ContentType("image", "png")
         val SVG = ContentType("image", "svg+xml")
         val XIcon = ContentType("image", "x-icon")
+        val TIFF = ContentType("image", "tiff")
     }
 
     /**


### PR DESCRIPTION
**Motivation**
I am currently working on a project that requires support for handling TIFF files. 

**Solution**
Added a tiff ContentType object consistently with RFC 3302 ( https://tools.ietf.org/html/rfc3302 ), filename extensions are already mapped here https://github.com/ktorio/ktor/blob/63c508918543774b857977ad033d602e04491dc4/ktor-http/common/src/io/ktor/http/Mimes.kt#L976 . 

