### PR TITLE
Fixed typo in AndroidEngineConfig docs

### DIFF
--- a/ktor-client/ktor-client-android/jvm/src/io/ktor/client/engine/android/AndroidEngineConfig.kt
+++ b/ktor-client/ktor-client-android/jvm/src/io/ktor/client/engine/android/AndroidEngineConfig.kt
@@ -14,13 +14,13 @@ import javax.net.ssl.*
  */
 class AndroidEngineConfig : HttpClientEngineConfig() {
     /**
-     * Max milliseconds to establish an HTTP connection - default 10 seconds.
+     * Max milliseconds to establish an HTTP connection - default 100 seconds.
      * A value of 0 represents infinite.
      */
     var connectTimeout: Int = 100_000
 
     /**
-     * Max milliseconds between TCP packets - default 10 seconds.
+     * Max milliseconds between TCP packets - default 100 seconds.
      * A value of 0 represents infinite.
      */
     var socketTimeout: Int = 100_000


### PR DESCRIPTION
**Subsystem**
ktor-client-android

**Solution**
Fixed typo in AndroidEngineConfig docs. 100_000 ms == 100 seconds (not 10)

