### PR TITLE
Change exception type for long strings in readUtf8Line

### DIFF
--- a/ktor-io/api/ktor-io.api
+++ b/ktor-io/api/ktor-io.api
@@ -618,9 +618,13 @@ public final class io/ktor/utils/io/charsets/EncodingKt {
 	public static final fun encodeUTF8 (Ljava/nio/charset/CharsetEncoder;Lio/ktor/utils/io/core/ByteReadPacket;)Lio/ktor/utils/io/core/ByteReadPacket;
 }
 
-public final class io/ktor/utils/io/charsets/MalformedInputException : java/nio/charset/MalformedInputException {
+public class io/ktor/utils/io/charsets/MalformedInputException : java/nio/charset/MalformedInputException {
 	public fun <init> (Ljava/lang/String;)V
 	public fun getMessage ()Ljava/lang/String;
+}
+
+public final class io/ktor/utils/io/charsets/TooLongLineException : io/ktor/utils/io/charsets/MalformedInputException {
+	public fun <init> (Ljava/lang/String;)V
 }
 
 public final class io/ktor/utils/io/charsets/UTFKt {

--- a/ktor-io/common/src/io/ktor/utils/io/charsets/Encoding.kt
+++ b/ktor-io/common/src/io/ktor/utils/io/charsets/Encoding.kt
@@ -113,8 +113,10 @@ expect object Charsets {
     val ISO_8859_1: Charset
 }
 
-expect class MalformedInputException(message: String) : Throwable
+expect open class MalformedInputException(message: String) : Throwable
 
+
+class TooLongLineException(message: String) : MalformedInputException(message)
 
 // ----------------------------- INTERNALS -----------------------------------------------------------------------------
 

--- a/ktor-io/js/src/io/ktor/utils/io/charsets/CharsetJS.kt
+++ b/ktor-io/js/src/io/ktor/utils/io/charsets/CharsetJS.kt
@@ -204,8 +204,7 @@ private data class CharsetImpl(val name: String) : Charset(name) {
 }
 
 
-actual class MalformedInputException actual constructor(message: String) : Throwable(message)
-
+actual open class MalformedInputException actual constructor(message: String) : Throwable(message)
 
 private fun CharsetDecoder.decodeExactBytesSlow(input: Input, inputLength: Int): String {
     val decoder = TextDecoderFatal(charset.name, true)

--- a/ktor-io/jvm/src/io/ktor/utils/io/charsets/CharsetJVM.kt
+++ b/ktor-io/jvm/src/io/ktor/utils/io/charsets/CharsetJVM.kt
@@ -329,7 +329,7 @@ private fun CoderResult.throwExceptionWrapped() {
 actual typealias Charsets = kotlin.text.Charsets
 
 @Suppress("ACTUAL_WITHOUT_EXPECT")
-actual class MalformedInputException actual constructor(message: String) : java.nio.charset.MalformedInputException(0) {
+actual open class MalformedInputException actual constructor(message: String) : java.nio.charset.MalformedInputException(0) {
     private val _message = message
 
     override val message: String?

--- a/ktor-io/jvm/test/io/ktor/utils/io/charsets/ByteChannelTextTest.kt
+++ b/ktor-io/jvm/test/io/ktor/utils/io/charsets/ByteChannelTextTest.kt
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2014-2020 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.utils.io.charsets
+
+import io.ktor.utils.io.*
+import kotlinx.coroutines.*
+import org.junit.Test
+import kotlin.test.*
+
+class ByteChannelTextTest {
+
+    @Test
+    fun testReadUtf8LineThrowTooLongLine() = runBlocking<Unit> {
+        val line100 = (0..99).joinToString("")
+        val channel = ByteChannel()
+        channel.writeStringUtf8(line100)
+        channel.close()
+
+        assertFailsWith<TooLongLineException> {
+            channel.readUTF8Line(50)
+        }
+    }
+
+}

--- a/ktor-io/posix/src/io/ktor/utils/io/charsets/CharsetNative.kt
+++ b/ktor-io/posix/src/io/ktor/utils/io/charsets/CharsetNative.kt
@@ -390,4 +390,4 @@ actual object Charsets {
     internal val UTF_16: Charset = CharsetImpl(platformUtf16)
 }
 
-actual class MalformedInputException actual constructor(message: String) : Throwable(message)
+actual open class MalformedInputException actual constructor(message: String) : Throwable(message)


### PR DESCRIPTION
Change the exception type in `readLine` when a limit occurs, to distinguish the limit case from `MalformedInputException`

related: https://youtrack.jetbrains.com/issue/KTLIB-49