### PR TITLE
Issue #882 Can't set FormUrlEncoded header for ktor http client request

### DIFF
--- a/ktor-client/ktor-client-apache/jvm/src/io/ktor/client/engine/apache/ApacheRequestProducer.kt
+++ b/ktor-client/ktor-client-apache/jvm/src/io/ktor/client/engine/apache/ApacheRequestProducer.kt
@@ -125,19 +125,19 @@ internal class ApacheRequestProducer(
         builder.uri = url.toURI()
 
         val content = requestData.body
-        val length = headers[io.ktor.http.HttpHeaders.ContentLength] ?: content.contentLength?.toString()
-        val type = headers[io.ktor.http.HttpHeaders.ContentType] ?: content.contentType?.toString()
+        var length: String? = null; var type: String? = null
 
         mergeHeaders(headers, content) { key, value ->
-            if (HttpHeaders.CONTENT_LENGTH == key) return@mergeHeaders
-            if (HttpHeaders.CONTENT_TYPE == key) return@mergeHeaders
-
-            builder.addHeader(key, value)
+            when(key) {
+                HttpHeaders.CONTENT_LENGTH -> length = value
+                HttpHeaders.CONTENT_TYPE -> type = value
+                else -> builder.addHeader(key, value)
+            }
         }
 
         if (body !is OutgoingContent.NoContent && body !is OutgoingContent.ProtocolUpgrade) {
             builder.entity = BasicHttpEntity().apply {
-                if (length == null) isChunked = true else contentLength = length.toLong()
+                if (length == null) isChunked = true else contentLength = length!!.toLong()
                 setContentType(type)
             }
         }

--- a/ktor-client/ktor-client-core/common/src/io/ktor/client/engine/HttpClientEngine.kt
+++ b/ktor-client/ktor-client-core/common/src/io/ktor/client/engine/HttpClientEngine.kt
@@ -59,7 +59,9 @@ interface HttpClientEngine : CoroutineScope, Closeable {
                 body = content
             }.build()
 
-            validateHeaders(requestData)
+            if (!config.allowUnsafeHeaders) {
+                validateSafeHeaders(requestData)
+            }
             checkExtensions(requestData)
 
             val responseData = executeWithinCallContext(requestData)
@@ -133,7 +135,7 @@ fun <T : HttpClientEngineConfig> HttpClientEngineFactory<T>.config(nested: T.() 
 /**
  * Validates request headers and fails if there are unsafe headers supplied
  */
-private fun validateHeaders(request: HttpRequestData) {
+private fun validateSafeHeaders(request: HttpRequestData) {
     val requestHeaders = request.headers
     for (header in HttpHeaders.UnsafeHeadersList) {
         if (header in requestHeaders) {

--- a/ktor-client/ktor-client-core/common/src/io/ktor/client/engine/HttpClientEngineConfig.kt
+++ b/ktor-client/ktor-client-core/common/src/io/ktor/client/engine/HttpClientEngineConfig.kt
@@ -5,10 +5,8 @@
 package io.ktor.client.engine
 
 import io.ktor.client.*
-import io.ktor.client.response.*
 import io.ktor.http.*
 import io.ktor.util.*
-import kotlinx.coroutines.*
 
 /**
  * Base configuration for [HttpClientEngine].
@@ -26,6 +24,11 @@ open class HttpClientEngineConfig {
      */
     @KtorExperimentalAPI
     var pipelining: Boolean = false
+
+    /**
+     * Allow client using headers from [HttpHeaders.UnsafeHeadersList] in requests
+     */
+    var allowUnsafeHeaders: Boolean = false
 
     /**
      * Proxy address to use. Use system proxy by default.

--- a/ktor-client/ktor-client-core/common/src/io/ktor/client/engine/Utils.kt
+++ b/ktor-client/ktor-client-core/common/src/io/ktor/client/engine/Utils.kt
@@ -42,8 +42,13 @@ fun mergeHeaders(
         block(HttpHeaders.UserAgent, KTOR_DEFAULT_USER_AGENT)
     }
 
-    val type = content.contentType?.toString() ?: content.headers[HttpHeaders.ContentType]
-    val length = content.contentLength?.toString() ?: content.headers[HttpHeaders.ContentLength]
+    val type = content.contentType?.toString()
+        ?: content.headers[HttpHeaders.ContentType]
+        ?: requestHeaders[HttpHeaders.ContentType]
+
+    val length = content.contentLength?.toString()
+        ?: content.headers[HttpHeaders.ContentLength]
+        ?: requestHeaders[HttpHeaders.ContentLength]
 
     type?.let { block(HttpHeaders.ContentType, it) }
     length?.let { block(HttpHeaders.ContentLength, it) }

--- a/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/HeadersTest.kt
+++ b/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/HeadersTest.kt
@@ -74,7 +74,7 @@ class HeadersTest : ClientLoader() {
     }
 
     @Test
-    fun testSimpleContentTypePropagation() = clientTests(skipEngines = listOf("CIO")) {
+    fun testContentTypePropagation() = clientTests(skipEngines = listOf("CIO")) {
         test { client ->
             client.post<HttpResponse>("$TEST_SERVER/headers/mirror"){
                 contentType(ContentType.Application.Json)
@@ -135,7 +135,14 @@ class HeadersTest : ClientLoader() {
                 contentType(ContentType.Application.OctetStream)
                 body = TextContent("test", ContentType.Text.Plain)
             }.let {
-                assertEquals(ContentType.Application.OctetStream.toString(), it.headers[HttpHeaders.ContentType])
+                assertEquals(ContentType.Text.Plain.toString(), it.headers[HttpHeaders.ContentType])
+            }
+
+            client.post<HttpResponse>("$TEST_SERVER/headers/mirror"){
+                contentType(ContentType.Text.Plain)
+                body = ByteArrayContent("test".toByteArray())
+            }.let {
+                assertEquals(ContentType.Text.Plain.toString(), it.headers[HttpHeaders.ContentType])
             }
         }
     }

--- a/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/HeadersTest.kt
+++ b/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/HeadersTest.kt
@@ -8,6 +8,10 @@ import io.ktor.client.request.*
 import io.ktor.client.statement.*
 import io.ktor.client.tests.utils.*
 import io.ktor.http.*
+import io.ktor.http.content.*
+import io.ktor.utils.io.*
+import io.ktor.utils.io.charsets.*
+import io.ktor.utils.io.core.*
 import kotlin.test.*
 
 class HeadersTest : ClientLoader() {
@@ -65,6 +69,73 @@ class HeadersTest : ClientLoader() {
         test { client ->
             client.get("$TEST_SERVER/headers/host") {
                 header(HttpHeaders.Host, "CustomHost")
+            }
+        }
+    }
+
+    @Test
+    fun testSimpleContentTypePropagation() = clientTests(skipEngines = listOf("CIO")) {
+        test { client ->
+            client.post<HttpResponse>("$TEST_SERVER/headers/mirror"){
+                contentType(ContentType.Application.Json)
+                body = "{}"
+            }.let {
+                assertEquals(ContentType.Application.Json.toString(), it.headers[HttpHeaders.ContentType])
+            }
+
+            client.post<HttpResponse>("$TEST_SERVER/headers/mirror"){
+                contentType(ContentType.Application.OctetStream)
+                body = "test".toByteArray()
+            }.let {
+                assertEquals(ContentType.Application.OctetStream.toString(), it.headers[HttpHeaders.ContentType])
+            }
+
+            client.post<HttpResponse>("$TEST_SERVER/headers/mirror"){
+                contentType(ContentType.Text.Plain)
+                body = ByteReadChannel("test")
+            }.let {
+                assertEquals(ContentType.Text.Plain.toString(), it.headers[HttpHeaders.ContentType])
+            }
+        }
+    }
+
+    @Test
+    fun testDefaultContentType() = clientTests(skipEngines = listOf("CIO")) {
+        test { client ->
+            client.post<HttpResponse>("$TEST_SERVER/headers/mirror"){
+                body = "{}"
+            }.let {
+                val expectedType = ContentType.Text.Plain.withCharset(Charset.forName("UTF-8"))
+                assertEquals(expectedType.toString(), it.headers[HttpHeaders.ContentType])
+            }
+
+            client.post<HttpResponse>("$TEST_SERVER/headers/mirror"){
+                body = "test".toByteArray()
+            }.let {
+                assertEquals(ContentType.Application.OctetStream.toString(), it.headers[HttpHeaders.ContentType])
+            }
+
+            client.post<HttpResponse>("$TEST_SERVER/headers/mirror"){
+                body = ByteReadChannel("test")
+            }.let {
+                assertEquals(ContentType.Application.OctetStream.toString(), it.headers[HttpHeaders.ContentType])
+            }
+        }
+    }
+
+    @Test
+    fun testOverrideContentType() = clientTests(skipEngines = listOf("CIO")) {
+        config {
+            engine {
+                allowUnsafeHeaders = true
+            }
+        }
+        test { client ->
+            client.post<HttpResponse>("$TEST_SERVER/headers/mirror"){
+                contentType(ContentType.Application.OctetStream)
+                body = TextContent("test", ContentType.Text.Plain)
+            }.let {
+                assertEquals(ContentType.Application.OctetStream.toString(), it.headers[HttpHeaders.ContentType])
             }
         }
     }

--- a/ktor-client/ktor-client-tests/jvm/src/io/ktor/client/tests/utils/tests/Headers.kt
+++ b/ktor-client/ktor-client-tests/jvm/src/io/ktor/client/tests/utils/tests/Headers.kt
@@ -8,7 +8,6 @@ import io.ktor.application.*
 import io.ktor.http.*
 import io.ktor.response.*
 import io.ktor.routing.*
-import kotlin.test.*
 
 internal fun Application.headersTestServer() {
     routing {
@@ -35,6 +34,13 @@ internal fun Application.headersTestServer() {
                 if (header.first() != "CustomHost") {
                     call.respond(HttpStatusCode.BadRequest, "Invalid host header: ${header.first()}")
                     return@get
+                }
+
+                call.respond(HttpStatusCode.OK)
+            }
+            post("mirror") {
+                call.request.headers.forEach{ name, values ->
+                    values.forEach { call.response.header(name, it, false) }
                 }
 
                 call.respond(HttpStatusCode.OK)

--- a/ktor-server/ktor-server-core/jvm/src/io/ktor/response/ApplicationResponseProperties.kt
+++ b/ktor-server/ktor-server-core/jvm/src/io/ktor/response/ApplicationResponseProperties.kt
@@ -13,42 +13,42 @@ import java.time.temporal.*
 /**
  * Append HTTP response header with string [value]
  */
-fun ApplicationResponse.header(name: String, value: String): Unit = headers.append(name, value)
+fun ApplicationResponse.header(name: String, value: String, safeOnly: Boolean = true): Unit = headers.append(name, value, safeOnly)
 
 /**
  * Append HTTP response header with integer numeric [value]
  */
-fun ApplicationResponse.header(name: String, value: Int): Unit = headers.append(name, value.toString())
+fun ApplicationResponse.header(name: String, value: Int, safeOnly: Boolean = true): Unit = header(name, value.toString(), safeOnly)
 
 /**
  * Append HTTP response header with long integer numeric [value]
  */
-fun ApplicationResponse.header(name: String, value: Long): Unit = headers.append(name, value.toString())
+fun ApplicationResponse.header(name: String, value: Long, safeOnly: Boolean = true): Unit = header(name, value.toString(), safeOnly)
 
 /**
  * Append HTTP response header with temporal [date] (date, time and so on)
  */
-fun ApplicationResponse.header(name: String, date: Temporal): Unit = headers.append(name, date.toHttpDateString())
+fun ApplicationResponse.header(name: String, date: Temporal, safeOnly: Boolean = true): Unit = header(name, date.toHttpDateString(), safeOnly)
 
 /**
  * Append response `E-Tag` HTTP header [value]
  */
-fun ApplicationResponse.etag(value: String): Unit = header(HttpHeaders.ETag, value)
+fun ApplicationResponse.etag(value: String, safeOnly: Boolean = true): Unit = header(HttpHeaders.ETag, value, safeOnly)
 
 /**
  * Append response `Last-Modified` HTTP header value from [dateTime]
  */
-fun ApplicationResponse.lastModified(dateTime: ZonedDateTime): Unit = header(HttpHeaders.LastModified, dateTime)
+fun ApplicationResponse.lastModified(dateTime: ZonedDateTime, safeOnly: Boolean = true): Unit = header(HttpHeaders.LastModified, dateTime, safeOnly)
 
 /**
  * Append response `Cache-Control` HTTP header [value]
  */
-fun ApplicationResponse.cacheControl(value: CacheControl): Unit = header(HttpHeaders.CacheControl, value.toString())
+fun ApplicationResponse.cacheControl(value: CacheControl, safeOnly: Boolean = true): Unit = header(HttpHeaders.CacheControl, value.toString(), safeOnly)
 
 /**
  * Append response `Expires` HTTP header [value]
  */
-fun ApplicationResponse.expires(value: LocalDateTime): Unit = header(HttpHeaders.Expires, value)
+fun ApplicationResponse.expires(value: LocalDateTime, safeOnly: Boolean = true): Unit = header(HttpHeaders.Expires, value, safeOnly)
 
 /**
  * Append `Cache-Control` HTTP header [value]


### PR DESCRIPTION
**Subsystem**
Ktor client
Ktor server (more convenient method to set unsafe header).

**Motivation**
issue #882

**Solution**
1. Added processing content-related headers in default transformers feature of `HttpClient`.
2. Added flag `HttpClientEngineConfig. allowUnsafeHeaders` that allows clients forwarding unsafe headers to an engine, by default that ability is disabled. If there is a conflict between a header and `OutgoingContent` object, data from the content object will be preferred. 
This is a controversial decision and, actually, I am not sure it is a right way, but that flag may be useful in situations when user can not affect `OutgoingContent` that does not contain `Content-Type` or when it's hard to do. Another option might be to make some decorator that overrides `Content-Type` from `OutgoingContent` or something.

PS: I disabled engine `CIO` in my tests because it hangs for some reasons even if I remove all my changes. At the moment I am not familiar with that engine and would be grateful if you could help me whit this.