### PR TITLE
Apache should use existing approach when merging headers

### DIFF
--- a/ktor-client/ktor-client-apache/jvm/src/io/ktor/client/engine/apache/ApacheRequestProducer.kt
+++ b/ktor-client/ktor-client-apache/jvm/src/io/ktor/client/engine/apache/ApacheRequestProducer.kt
@@ -125,19 +125,20 @@ internal class ApacheRequestProducer(
         builder.uri = url.toURI()
 
         val content = requestData.body
-        val length = headers[io.ktor.http.HttpHeaders.ContentLength] ?: content.contentLength?.toString()
-        val type = headers[io.ktor.http.HttpHeaders.ContentType] ?: content.contentType?.toString()
+        var length = ""
+        var type = ""
 
         mergeHeaders(headers, content) { key, value ->
-            if (HttpHeaders.CONTENT_LENGTH == key) return@mergeHeaders
-            if (HttpHeaders.CONTENT_TYPE == key) return@mergeHeaders
-
-            builder.addHeader(key, value)
+            when(key) {
+                HttpHeaders.CONTENT_LENGTH -> length = value
+                HttpHeaders.CONTENT_TYPE -> type = value
+                else -> builder.addHeader(key, value)
+            }
         }
 
         if (body !is OutgoingContent.NoContent && body !is OutgoingContent.ProtocolUpgrade) {
             builder.entity = BasicHttpEntity().apply {
-                if (length == null) isChunked = true else contentLength = length.toLong()
+                if (length.isBlank()) isChunked = true else contentLength = length.toLong()
                 setContentType(type)
             }
         }

--- a/ktor-client/ktor-client-apache/jvm/test/io/ktor/client/engine/apache/RequestProducerTest.kt
+++ b/ktor-client/ktor-client-apache/jvm/test/io/ktor/client/engine/apache/RequestProducerTest.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2014-2020 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.client.engine.apache
+
+import io.ktor.client.request.*
+import io.ktor.http.*
+import io.ktor.http.HttpHeaders
+import io.ktor.http.content.*
+import io.ktor.util.*
+import kotlinx.coroutines.*
+import org.apache.http.*
+import org.junit.Test
+import kotlin.coroutines.*
+import kotlin.test.*
+
+class RequestProducerTest {
+
+    @Test
+    fun testHeadersMerge() {
+        val request = ApacheRequestProducer(
+            HttpRequestData(
+                Url("http://127.0.0.1/"),
+                HttpMethod.Post,
+                Headers.build {
+                    append(HttpHeaders.ContentType, ContentType.Text.Plain)
+                    append(HttpHeaders.ContentLength, "1")
+                },
+                TextContent("{}", ContentType.Application.Json),
+                Job(),
+                Attributes()
+            ),
+            ApacheEngineConfig(),
+            EmptyCoroutineContext
+        ).generateRequest() as HttpEntityEnclosingRequest
+
+        assertEquals(ContentType.Application.Json.toString(), request.entity.contentType.value)
+        assertEquals(2, request.entity.contentLength)
+    }
+}


### PR DESCRIPTION
**Subsystem**
Ktor client - Apache engine

**Motivation**
We should use existing approach when merging content-related headers and common ones, it will make engines safely replaceable.

**Solution**
Content-Type and Content-Length of OutgoingContent will be preferred now.
