### PR TITLE
Make JVM MetricSet registration optional

### DIFF
--- a/ktor-features/ktor-metrics/api/ktor-metrics.api
+++ b/ktor-features/ktor-metrics/api/ktor-metrics.api
@@ -9,8 +9,10 @@ public final class io/ktor/metrics/dropwizard/DropwizardMetrics {
 public final class io/ktor/metrics/dropwizard/DropwizardMetrics$Configuration {
 	public fun <init> ()V
 	public final fun getBaseName ()Ljava/lang/String;
+	public final fun getRegisterJvmMetricSets ()Z
 	public final fun getRegistry ()Lcom/codahale/metrics/MetricRegistry;
 	public final fun setBaseName (Ljava/lang/String;)V
+	public final fun setRegisterJvmMetricSets (Z)V
 	public final fun setRegistry (Lcom/codahale/metrics/MetricRegistry;)V
 }
 

--- a/ktor-features/ktor-metrics/jvm/test/io/ktor/metrics/dropwizard/DropwizardMetricsTests.kt
+++ b/ktor-features/ktor-metrics/jvm/test/io/ktor/metrics/dropwizard/DropwizardMetricsTests.kt
@@ -57,4 +57,16 @@ class DropwizardMetricsTests {
 
         assertEquals(1, testRegistry.meter("/uri/(method:GET).200").count)
     }
+
+    @Test
+    fun `jvm metrics are not registered when disabled in config`(): Unit = withTestApplication {
+        val testRegistry = MetricRegistry()
+
+        application.install(DropwizardMetrics) {
+            registry = testRegistry
+            registerJvmMetricSets = false
+        }
+
+        assertEquals(setOf("ktor.calls.active", "ktor.calls.duration", "ktor.calls.exceptions"), testRegistry.names)
+    }
 }


### PR DESCRIPTION
**Subsystem**
ktor-metrics

**Motivation**
I was unpleasantly surprised to see that the `DropwizardMetrics` feature registered various MetricSets from `metrics-jvm`. Having them added for me in the Ktor feature means I cannot control the naming or configuration of those metrics, nor can I opt out entirely. It is easy to add those MetricSets outside of Ktor, so it's not like it's saving the user some huge burden by bundling that here. Ultimately, I don't think it's appropriate for Ktor to register metrics that aren't at all related to the core problem of measuring _Ktor specific_ things. 

**Solution**
Add a boolean to the feature's config that makes it possible to opt out. The default setting preserves the old behavior.

