### PR TITLE
Fixed serialization of empty body

### DIFF
--- a/ktor-client/ktor-client-features/ktor-client-json/common/src/io/ktor/client/features/json/JsonFeature.kt
+++ b/ktor-client/ktor-client-features/ktor-client-json/common/src/io/ktor/client/features/json/JsonFeature.kt
@@ -10,6 +10,7 @@ import io.ktor.client.request.*
 import io.ktor.client.statement.*
 import io.ktor.client.utils.*
 import io.ktor.http.*
+import io.ktor.http.content.*
 import io.ktor.util.*
 import io.ktor.utils.io.*
 import io.ktor.utils.io.core.*
@@ -109,7 +110,7 @@ class JsonFeature internal constructor(val config: Config) {
                 context.headers.remove(HttpHeaders.ContentType)
 
                 val serializedContent = when (payload) {
-                    is EmptyContent -> config.serializer.write(Unit, contentType)
+                    is EmptyContent -> EmptyContent
                     else -> config.serializer.write(payload, contentType)
                 }
 

--- a/ktor-client/ktor-client-features/ktor-client-json/common/src/io/ktor/client/features/json/JsonFeature.kt
+++ b/ktor-client/ktor-client-features/ktor-client-json/common/src/io/ktor/client/features/json/JsonFeature.kt
@@ -6,11 +6,11 @@ package io.ktor.client.features.json
 
 import io.ktor.client.*
 import io.ktor.client.features.*
+import io.ktor.client.features.json.JsonFeature.*
 import io.ktor.client.request.*
 import io.ktor.client.statement.*
 import io.ktor.client.utils.*
 import io.ktor.http.*
-import io.ktor.http.content.*
 import io.ktor.util.*
 import io.ktor.utils.io.*
 import io.ktor.utils.io.core.*
@@ -110,6 +110,7 @@ class JsonFeature internal constructor(val config: Config) {
                 context.headers.remove(HttpHeaders.ContentType)
 
                 val serializedContent = when (payload) {
+                    Unit -> EmptyContent
                     is EmptyContent -> EmptyContent
                     else -> config.serializer.write(payload, contentType)
                 }

--- a/ktor-client/ktor-client-features/ktor-client-json/common/test/KotlinxSerializerTest.kt
+++ b/ktor-client/ktor-client-features/ktor-client-json/common/test/KotlinxSerializerTest.kt
@@ -99,14 +99,15 @@ class KotlinxSerializerTest : ClientLoader() {
             val response = client.post<String>("$TEST_SERVER/echo-with-content-type") {
                 body = "Hello"
             }
-
             assertEquals("Hello", response)
 
             val textResponse = client.post<String>("$TEST_SERVER/echo") {
                 body = "Hello"
             }
-
             assertEquals("\"Hello\"", textResponse)
+
+            val emptyResponse = client.post<String>("$TEST_SERVER/echo")
+            assertEquals("", emptyResponse)
         }
     }
 

--- a/ktor-client/ktor-client-features/ktor-client-json/ktor-client-gson/jvm/src/io/ktor/client/features/json/GsonSerializer.kt
+++ b/ktor-client/ktor-client-features/ktor-client-json/ktor-client-gson/jvm/src/io/ktor/client/features/json/GsonSerializer.kt
@@ -17,12 +17,7 @@ class GsonSerializer(block: GsonBuilder.() -> Unit = {}) : JsonSerializer {
     private val backend: Gson = GsonBuilder().apply(block).create()
 
     override fun write(data: Any, contentType: ContentType): OutgoingContent =
-        // Unit would be converted to `{}`, which may cause problems with some backends.
-        // So, we convert Unit to the empty body.
-        if (data === Unit)
-            TextContent("", contentType)
-        else
-            TextContent(backend.toJson(data), contentType)
+        TextContent(backend.toJson(data), contentType)
 
     override fun read(type: TypeInfo, body: Input): Any {
         val text = body.readText()

--- a/ktor-client/ktor-client-features/ktor-client-json/ktor-client-gson/jvm/src/io/ktor/client/features/json/GsonSerializer.kt
+++ b/ktor-client/ktor-client-features/ktor-client-json/ktor-client-gson/jvm/src/io/ktor/client/features/json/GsonSerializer.kt
@@ -14,11 +14,15 @@ import io.ktor.utils.io.core.*
  * [JsonSerializer] using [Gson] as backend.
  */
 class GsonSerializer(block: GsonBuilder.() -> Unit = {}) : JsonSerializer {
-
     private val backend: Gson = GsonBuilder().apply(block).create()
 
     override fun write(data: Any, contentType: ContentType): OutgoingContent =
-        TextContent(backend.toJson(data), contentType)
+        // Unit would be converted to `{}`, which may cause problems with some backends.
+        // So, we convert Unit to the empty body.
+        if (data === Unit)
+            TextContent("", contentType)
+        else
+            TextContent(backend.toJson(data), contentType)
 
     override fun read(type: TypeInfo, body: Input): Any {
         val text = body.readText()

--- a/ktor-client/ktor-client-features/ktor-client-json/ktor-client-jackson/jvm/src/io/ktor/client/features/json/JacksonSerializer.kt
+++ b/ktor-client/ktor-client-features/ktor-client-json/ktor-client-jackson/jvm/src/io/ktor/client/features/json/JacksonSerializer.kt
@@ -15,12 +15,7 @@ class JacksonSerializer(jackson: ObjectMapper = jacksonObjectMapper(), block: Ob
     private val backend = jackson.apply(block)
 
     override fun write(data: Any, contentType: ContentType): OutgoingContent =
-        // Unit would be converted to `{}`, which may cause problems with some backends.
-        // So, we convert Unit to the empty body.
-        if (data === Unit)
-            TextContent("", contentType)
-        else
-            TextContent(backend.writeValueAsString(data), contentType)
+        TextContent(backend.writeValueAsString(data), contentType)
 
     override fun read(type: TypeInfo, body: Input): Any {
         return backend.readValue(body.readText(), backend.typeFactory.constructType(type.reifiedType))

--- a/ktor-client/ktor-client-features/ktor-client-json/ktor-client-json-tests/jvm/src/io/ktor/client/features/json/tests/JsonTest.kt
+++ b/ktor-client/ktor-client-features/ktor-client-json/ktor-client-json-tests/jvm/src/io/ktor/client/features/json/tests/JsonTest.kt
@@ -14,6 +14,7 @@ import io.ktor.client.features.json.*
 import io.ktor.client.request.*
 import io.ktor.client.statement.*
 import io.ktor.client.tests.utils.*
+import io.ktor.client.utils.*
 import io.ktor.features.*
 import io.ktor.gson.*
 import io.ktor.http.*
@@ -97,7 +98,9 @@ abstract class JsonTest : TestWithKtor() {
         config {
                 engine {
                     addHandler { request ->
-                        respond(request.body.toByteReadPacket().readText())
+                        respond(request.body.toByteReadPacket().readText(), headers = buildHeaders {
+                            append("X-ContentType", request.body.contentType.toString())
+                        })
                     }
                 }
                 defaultRequest {
@@ -109,6 +112,7 @@ abstract class JsonTest : TestWithKtor() {
         test { client ->
             val response: HttpResponse = client.get("https://test.com")
             assertEquals("", response.readText())
+            assertEquals("null", response.headers["X-ContentType"])
         }
     }
 


### PR DESCRIPTION
**Subsystem**
Client: JsonFeature/JsonSerializer

**Motivation**
When using `JsonFeature` the empty body (e.g. a `get()` request without a body) gets serialized to `{}` instead of an empty string. This causes problems with some backends which expect the body to be empty.

For more context, let's assume we define an HttpClient with JsonFeature and a default `Content-Type` header like this:

```
val client = HttpClient(...) {
    defaultRequest {
        contentType(ContentType.Application.Json)
    }
    install(JsonFeature) {
        // ...
    }
}
```

This gives us some more convenience because we don't need to add the Content-Type header to each `post()`/`put()` call. However, now every request where we don't assign a body (e.g. a simple `get("https://...")`) gets turned into a request containing `{}` in the body and having a `Content-Type: application/json` header.

This causes some backends to return an error because they expect an empty body for `get()` requests. Often, the backend isn't under our control, so we have to comply with the usual expection: No body in `get()` should mean no body in the resulting HTTP request.

**Solution**
With this PR, `JsonFeature` simply passes through `EmptyContent`. I think this really is the most sensible behavior, mapping the intent 1:1. It also removes the `Content-Type` header because there really is no content.

If someone wants to send an empty `{}` then that's still possible by explicitly setting e.g. `body = Unit` (or any serializable object without attributes). At least, now it's explicit.

If someone wants to send an empty body, but with `Content-Type` set (for obscure backend requirements), that's also still possible by customizing the serializer and using a special object as a marker.