### PR TITLE
Fix followRedirects setting in JS client implementation

### DIFF
--- a/ktor-client/ktor-client-core/common/src/io/ktor/client/engine/HttpClientEngine.kt
+++ b/ktor-client/ktor-client-core/common/src/io/ktor/client/engine/HttpClientEngine.kt
@@ -57,6 +57,8 @@ interface HttpClientEngine : CoroutineScope, Closeable {
             val requestData = HttpRequestBuilder().apply {
                 takeFromWithExecutionContext(context)
                 body = content
+                if (!client.config.followRedirects)
+                    attributes.put(AttributeKey("redirect"), "manual")
             }.build()
 
             validateHeaders(requestData)

--- a/ktor-client/ktor-client-core/js/src/io/ktor/client/engine/js/JsClientEngine.kt
+++ b/ktor-client/ktor-client-core/js/src/io/ktor/client/engine/js/JsClientEngine.kt
@@ -4,6 +4,7 @@
 
 package io.ktor.client.engine.js
 
+import io.ktor.client.*
 import io.ktor.client.engine.*
 import io.ktor.client.features.*
 import io.ktor.client.engine.js.compatibility.*

--- a/ktor-client/ktor-client-core/js/src/io/ktor/client/engine/js/JsUtils.kt
+++ b/ktor-client/ktor-client-core/js/src/io/ktor/client/engine/js/JsUtils.kt
@@ -8,6 +8,7 @@ import io.ktor.client.engine.*
 import io.ktor.client.fetch.RequestInit
 import io.ktor.client.request.*
 import io.ktor.http.content.*
+import io.ktor.util.*
 import io.ktor.utils.io.*
 import io.ktor.utils.io.core.*
 import kotlinx.coroutines.*
@@ -35,8 +36,7 @@ internal suspend fun HttpRequestData.toRaw(callContext: CoroutineContext): Reque
     return buildObject {
         method = this@toRaw.method.value
         headers = jsHeaders
-        redirect = RequestRedirect.FOLLOW
-
+        redirect = attributes.getOrNull(AttributeKey<String>("redirect")) ?: RequestRedirect.FOLLOW
         bodyBytes?.let { body = Uint8Array(it.toTypedArray()) }
     }
 }

--- a/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/HttpRedirectTest.kt
+++ b/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/HttpRedirectTest.kt
@@ -117,4 +117,18 @@ class HttpRedirectTest : ClientLoader() {
             }
         }
     }
+
+    @Test
+    fun testRedirectResponse() = clientTests {
+        config {
+            followRedirects = false
+        }
+        test { client ->
+            client.get<HttpStatement>("$TEST_URL_BASE/").execute {
+                assertEquals(HttpStatusCode.Found, it.status)
+                assertNotNull(it.headers["Location"], "Location header not found.")
+                assertTrue(it.toString().endsWith("302 Found]"))
+            }
+        }
+    }
 }

--- a/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/HttpRedirectTest.kt
+++ b/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/HttpRedirectTest.kt
@@ -10,6 +10,7 @@ import io.ktor.client.request.*
 import io.ktor.client.statement.*
 import io.ktor.client.tests.utils.*
 import io.ktor.http.*
+import io.ktor.util.*
 import kotlin.test.*
 
 @Suppress("PublicApiImplicitType")
@@ -126,7 +127,7 @@ class HttpRedirectTest : ClientLoader() {
         test { client ->
             client.get<HttpStatement>("$TEST_URL_BASE/").execute {
                 assertEquals(HttpStatusCode.Found, it.status)
-                assertNotNull(it.headers["Location"], "Location header not found.")
+                assertNotNull(it.headers[HttpHeaders.Location], "Location header not found.")
                 assertTrue(it.toString().endsWith("302 Found]"))
             }
         }

--- a/ktor-utils/common/src/io/ktor/util/Attributes.kt
+++ b/ktor-utils/common/src/io/ktor/util/Attributes.kt
@@ -9,7 +9,7 @@ package io.ktor.util
  * @param T is type of the value stored in the attribute
  * @param name is a name of the attribute for diagnostic purposes
  */
-class AttributeKey<T>(val name: String) {
+data class AttributeKey<T>(val name: String) {
     override fun toString(): String = if (name.isEmpty())
         super.toString()
     else


### PR DESCRIPTION
**Subsystem**
Client, `ktor-client-core` (common and js) and `ktor-utils` (common)

**Motivation**
I want to resolve #1968 -- catch `HTTP 302 Found` and similiar redirect responses from backend and handle them manually in my frontend application.

**Solution**
I solved it by adding new attribute (`redirect`) that gets value from `config.followRedirects` and by using `attributes` container value passes to `HttpRequestData.toRaw`, that uses JS Fetch API.

Also, I changed AttributeKey signature from class to data class. I decided to do this because of need to have equals and hashCode methods for proper using AttributeKey as a mapping key. For example, now `AttributeKey("test") == AttributeKey("test")`, and so on.

Hope it gets merged soon, because I don't know other such powerful HTTP toolkits as ktor-client =)
