### PR TITLE
Fix missing qop in DigestAuthProvider (Issue #1974)

### DIFF
--- a/ktor-client/ktor-client-features/ktor-client-auth/common/src/io/ktor/client/features/auth/providers/DigestAuthProvider.kt
+++ b/ktor-client/ktor-client-features/ktor-client-auth/common/src/io/ktor/client/features/auth/providers/DigestAuthProvider.kt
@@ -94,7 +94,7 @@ class DigestAuthProvider(
             this["cnonce"] = clientNonce
             this["response"] = hex(token)
             this["uri"] = url.encodedPath
-            actualQop?.let { this["qop"] }
+            actualQop?.let { this["qop"] = it }
             this["nc"] = nonceCount.toString()
         })
 


### PR DESCRIPTION
**Subsystem**
Client

**Motivation**
The problem is described in issue #1974. When using digest auth, the qop field is never included in the authentication header. This breaks digest authentication.

**Solution**
Add missing `= it` so that the qop field is assigned to the correct value.

