### PR TITLE
fix webpack warning about ktor-client-core critical dependency

### DIFF
--- a/ktor-client/ktor-client-core/js/src/io/ktor/client/engine/js/compatibility/Utils.kt
+++ b/ktor-client/ktor-client-core/js/src/io/ktor/client/engine/js/compatibility/Utils.kt
@@ -25,7 +25,7 @@ internal suspend fun commonFetch(
     val promise: Promise<Response> = if (PlatformUtils.IS_BROWSER) {
         fetch(input, init)
     } else {
-        jsRequire("node-fetch")(input, init)
+        jsRequireNodeFetch()(input, init)
     }
 
     promise.then(
@@ -55,8 +55,8 @@ internal fun CoroutineScope.readBody(
     readBodyNode(response)
 }
 
-private fun jsRequire(moduleName: String): dynamic = try {
-    js("require(moduleName)")
+private fun jsRequireNodeFetch(): dynamic = try {
+    js("require('node-fetch')")
 } catch (cause: dynamic) {
-    throw Error("Error loading module '$moduleName': $cause")
+    throw Error("Error loading module 'node-fetch': $cause")
 }


### PR DESCRIPTION
**Subsystem**
ktor-client-core

**Motivation**
Solve webpack warning about a critical depencency (using require with an expression as a parameter).

```
WARNING in /Users/tiz/src/sandbox/ktor-client-test/build/js/packages_imported/ktor-ktor-client-core/1.3.2/ktor-ktor-client-core.js 16801:13-32
Critical dependency: the request of a dependency is an expression
 @ ./kotlin/ktor-client-test.js
 @ multi ./kotlin/ktor-client-test.js
```

**Solution**
Changed the require call to use the fixed 'node-fetch' string instead of a passed parameter.

This will cause builds to fail because of the missing 'node-fetch' dependency.

However, builds already fail because of missing dependencies. Users have to declare them in gradle build or add them to Webpack's externals so the build. See  #961 and #57

As of now I think this should be handled by documentation. There are some proposed solutions in  #961 and #57

In the future a separation of node and browser sources (to the necessary level) might be the best solution but that requires much more time to implement.

I've found the best way is to handle this by adding an externals.js into webpack.config.d with the following content:

```javascript
config.externals = [
    'text-encoding',
    'utf-8-validate',
    'abort-controller',
    'bufferutil',
    'fs',
    'node-fetch'
]
```



