### PR TITLE
Add a bearer auth feature for http-client

### DIFF
--- a/ktor-client/ktor-client-features/ktor-client-auth/common/src/io/ktor/client/features/auth/Auth.kt
+++ b/ktor-client/ktor-client-features/ktor-client-auth/common/src/io/ktor/client/features/auth/Auth.kt
@@ -51,8 +51,7 @@ class Auth(
                     val provider = candidateProviders.find { it.isApplicable(authHeader) } ?: return@intercept call
                     when(provider) {
                         is BearerAuthProvider -> {
-                            val token = provider.refreshToken()
-                            if (token == null) return@intercept call
+                            provider.refreshToken() ?: return@intercept call
                         }
                     }
                     candidateProviders.remove(provider)

--- a/ktor-client/ktor-client-features/ktor-client-auth/common/src/io/ktor/client/features/auth/Auth.kt
+++ b/ktor-client/ktor-client-features/ktor-client-auth/common/src/io/ktor/client/features/auth/Auth.kt
@@ -6,6 +6,7 @@ package io.ktor.client.features.auth
 
 import io.ktor.client.*
 import io.ktor.client.features.*
+import io.ktor.client.features.auth.providers.*
 import io.ktor.client.request.*
 import io.ktor.http.*
 import io.ktor.http.auth.*
@@ -39,15 +40,22 @@ class Auth(
             scope.feature(HttpSend)!!.intercept { origin, context ->
                 if (origin.response.status != HttpStatusCode.Unauthorized) return@intercept origin
                 if (origin.request.attributes.contains(circuitBreaker)) return@intercept origin
-
                 var call = origin
-                val candidateProviders = HashSet(feature.providers).apply { removeAll(feature.alwaysSend) }
+                val candidateProviders = HashSet(feature.providers).apply {
+                    removeAll(feature.alwaysSend - feature.providers.find { it is BearerAuthProvider })
+                }
                 while (call.response.status == HttpStatusCode.Unauthorized) {
-                    val headerValue = call.response.headers[HttpHeaders.WWWAuthenticate] ?: return@intercept call
+                    val headerValue = call.response.headers[HttpHeaders.WWWAuthenticate]
+                    if (headerValue.isNullOrEmpty()) return@intercept call
                     val authHeader = parseAuthorizationHeader(headerValue) ?: return@intercept call
                     val provider = candidateProviders.find { it.isApplicable(authHeader) } ?: return@intercept call
+                    when(provider) {
+                        is BearerAuthProvider -> {
+                            val token = provider.refreshToken()
+                            if (token == null) return@intercept call
+                        }
+                    }
                     candidateProviders.remove(provider)
-
                     val request = HttpRequestBuilder()
                     request.takeFromWithExecutionContext(context)
                     provider.addRequestHeaders(request)
@@ -58,6 +66,7 @@ class Auth(
                 return@intercept call
             }
         }
+
     }
 }
 

--- a/ktor-client/ktor-client-features/ktor-client-auth/common/src/io/ktor/client/features/auth/providers/BearerAuthProvider.kt
+++ b/ktor-client/ktor-client-features/ktor-client-auth/common/src/io/ktor/client/features/auth/providers/BearerAuthProvider.kt
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2014-2020 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.client.features.auth.providers
+
+import io.ktor.client.features.auth.*
+import io.ktor.client.request.*
+import io.ktor.http.*
+import io.ktor.http.auth.*
+
+/**
+ * Add [BasicAuthProvider] to client [Auth] providers.
+ */
+fun Auth.bearer(block: BearerAuthConfig.() -> Unit) {
+    with(BearerAuthConfig().apply(block)) {
+        providers.add(BearerAuthProvider(refreshTokenFun, loadTokensFun, true, realm))
+    }
+}
+
+data class Tokens(
+    val accessToken: String,
+    val refreshToken: String,
+    val type: String
+)
+
+/**
+ * [DigestAuthProvider] configuration.
+ */
+@Suppress("KDocMissingDocumentation")
+class BearerAuthConfig {
+    var refreshTokenFun: suspend () -> Tokens? = { null }
+    var loadTokensFun: suspend () -> Tokens? = { null }
+    var realm: String? = null
+}
+
+/**
+ * Client digest [AuthProvider].
+ */
+@Suppress("KDocMissingDocumentation")
+class BearerAuthProvider(
+    val refreshTokenFun: suspend () -> Tokens?,
+    val loadTokensFun: suspend () -> Tokens?,
+    override val sendWithoutRequest: Boolean = true,
+    private val realm: String?
+) : AuthProvider {
+
+    private var cachedTokens: Tokens? = null
+
+    /**
+     * Check if current provider is applicable to the request.
+     */
+    override fun isApplicable(auth: HttpAuthHeader): Boolean {
+        if (auth.authScheme != AuthScheme.Bearer) return false
+        if (realm != null) {
+            if (auth !is HttpAuthHeader.Parameterized) return false
+            return auth.parameter("realm") == realm
+        }
+        return true
+    }
+
+    /**
+     * Add authentication method headers and creds.
+     */
+    override suspend fun addRequestHeaders(request: HttpRequestBuilder) {
+        val token = cachedTokens ?: loadTokensFun()
+        request.headers {
+            token?.let {
+                val tokenValue = "${it.type} ${it.accessToken}"
+                if(contains(HttpHeaders.Authorization)) {
+                    remove(HttpHeaders.Authorization)
+                }
+                append(HttpHeaders.Authorization, tokenValue)
+            }
+        }
+    }
+
+    suspend fun refreshToken(): Tokens? {
+        cachedTokens = refreshTokenFun()
+        return cachedTokens
+    }
+
+
+}

--- a/ktor-client/ktor-client-features/ktor-client-auth/common/test/io/ktor/client/features/auth/AuthTest.kt
+++ b/ktor-client/ktor-client-features/ktor-client-auth/common/test/io/ktor/client/features/auth/AuthTest.kt
@@ -87,8 +87,8 @@ class AuthTest : ClientLoader() {
         config {
             install(Auth) {
                 bearer {
-                    refreshTokenFun = { null }
-                    loadBearerTokenFun = { null }
+                    refreshTokensFun = { null }
+                    loadTokensFun = { null }
                 }
             }
         }
@@ -105,8 +105,8 @@ class AuthTest : ClientLoader() {
         config {
             install(Auth) {
                 bearer {
-                    refreshTokenFun = { BearerToken("invalid", "refresh") }
-                    loadBearerTokenFun = { BearerToken("invalid", "refresh") }
+                    refreshTokensFun = { BearerTokens("invalid", "refresh") }
+                    loadTokensFun = { BearerTokens("invalid", "refresh") }
                 }
             }
         }
@@ -125,8 +125,8 @@ class AuthTest : ClientLoader() {
         config {
             install(Auth) {
                 bearer {
-                    refreshTokenFun = { null }
-                    loadBearerTokenFun = { BearerToken("valid", "refresh") }
+                    refreshTokensFun = { null }
+                    loadTokensFun = { BearerTokens("valid", "refresh") }
                 }
             }
         }
@@ -144,8 +144,8 @@ class AuthTest : ClientLoader() {
         config {
             install(Auth) {
                 bearer {
-                    refreshTokenFun = { BearerToken("valid", "refresh") }
-                    loadBearerTokenFun = { BearerToken("invalid", "refresh") }
+                    refreshTokensFun = { BearerTokens("valid", "refresh") }
+                    loadTokensFun = { BearerTokens("invalid", "refresh") }
                     realm = "TestServer"
                 }
             }

--- a/ktor-client/ktor-client-features/ktor-client-auth/common/test/io/ktor/client/features/auth/AuthTest.kt
+++ b/ktor-client/ktor-client-features/ktor-client-auth/common/test/io/ktor/client/features/auth/AuthTest.kt
@@ -88,7 +88,7 @@ class AuthTest : ClientLoader() {
             install(Auth) {
                 bearer {
                     refreshTokenFun = { null }
-                    loadTokensFun = { null }
+                    loadBearerTokenFun = { null }
                 }
             }
         }
@@ -105,8 +105,8 @@ class AuthTest : ClientLoader() {
         config {
             install(Auth) {
                 bearer {
-                    refreshTokenFun = { Tokens("invalid", "refresh", "Bearer") }
-                    loadTokensFun = { Tokens("invalid", "refresh", "Bearer") }
+                    refreshTokenFun = { BearerToken("invalid", "refresh") }
+                    loadBearerTokenFun = { BearerToken("invalid", "refresh") }
                 }
             }
         }
@@ -126,7 +126,7 @@ class AuthTest : ClientLoader() {
             install(Auth) {
                 bearer {
                     refreshTokenFun = { null }
-                    loadTokensFun = { Tokens("valid", "refresh", "Bearer") }
+                    loadBearerTokenFun = { BearerToken("valid", "refresh") }
                 }
             }
         }
@@ -144,8 +144,8 @@ class AuthTest : ClientLoader() {
         config {
             install(Auth) {
                 bearer {
-                    refreshTokenFun = { Tokens("valid", "refresh", "Bearer") }
-                    loadTokensFun = { Tokens("invalid", "refresh", "Bearer") }
+                    refreshTokenFun = { BearerToken("valid", "refresh") }
+                    loadBearerTokenFun = { BearerToken("invalid", "refresh") }
                     realm = "TestServer"
                 }
             }

--- a/ktor-client/ktor-client-tests/jvm/src/io/ktor/client/tests/utils/tests/Auth.kt
+++ b/ktor-client/ktor-client-tests/jvm/src/io/ktor/client/tests/utils/tests/Auth.kt
@@ -84,6 +84,18 @@ internal fun Application.authTestServer() {
                 call.response.status(HttpStatusCode.Unauthorized)
                 call.response.header(HttpHeaders.WWWAuthenticate, "Basic realm=\"TestServer\", charset=UTF-8")
             }
+
+            route("bearer") {
+                get("test-refresh") {
+                    val token = call.request.headers["Authorization"]
+                    if (token.isNullOrEmpty() || token.contains("invalid")) {
+                        call.response.status(HttpStatusCode.Unauthorized)
+                        call.response.header(HttpHeaders.WWWAuthenticate, "Bearer realm=\"TestServer\"")
+                    } else {
+                        call.response.status(HttpStatusCode.OK)
+                    }
+                }
+            }
         }
     }
 }

--- a/ktor-http/common/src/io/ktor/http/auth/AuthScheme.kt
+++ b/ktor-http/common/src/io/ktor/http/auth/AuthScheme.kt
@@ -46,6 +46,13 @@ object AuthScheme {
      */
     const val OAuth = "OAuth"
 
+    /**
+     * Bearer Authentication described in the RFC-6749:
+     *
+     * see https://tools.ietf.org/html/rfc6750
+     */
+    const val Bearer = "Bearer"
+
     @Suppress("KDocMissingDocumentation", "unused")
     @Deprecated("Compatibility", level = DeprecationLevel.HIDDEN)
     fun getBasic(): String = Basic
@@ -57,4 +64,8 @@ object AuthScheme {
     @Suppress("KDocMissingDocumentation", "unused")
     @Deprecated("Compatibility", level = DeprecationLevel.HIDDEN)
     fun getNegotiate(): String = Negotiate
+
+    @Suppress("KDocMissingDocumentation", "unused")
+    @Deprecated("Compatibility", level = DeprecationLevel.HIDDEN)
+    fun getBearer(): String = Bearer
 }


### PR DESCRIPTION
**Subsystem**
Http-Client

**Motivation**
Add support of Bearer tokens to the client-side. (Issue #1967 )

**Solution**
Added a BearerAuthProvider with an ability to load and refresh tokens.
