### PR TITLE
Fix uri field in digest auth header to include query params

### DIFF
--- a/ktor-client/ktor-client-features/ktor-client-auth/common/src/io/ktor/client/features/auth/providers/DigestAuthProvider.kt
+++ b/ktor-client/ktor-client-features/ktor-client-auth/common/src/io/ktor/client/features/auth/providers/DigestAuthProvider.kt
@@ -82,7 +82,7 @@ class DigestAuthProvider(
         val credential = makeDigest("$username:$realm:$password")
 
         val start = hex(credential)
-        val end = hex(makeDigest("$methodName:${url.encodedPath}"))
+        val end = hex(makeDigest("$methodName:${url.fullPath}"))
         val tokenSequence = if (actualQop == null) listOf(start, nonce, end) else listOf(start, nonce, nonceCount, clientNonce, actualQop, end)
         val token = makeDigest(tokenSequence.joinToString(":"))
 
@@ -93,7 +93,7 @@ class DigestAuthProvider(
             this["nonce"] = nonce
             this["cnonce"] = clientNonce
             this["response"] = hex(token)
-            this["uri"] = url.encodedPath
+            this["uri"] = url.fullPath
             actualQop?.let { this["qop"] = it }
             this["nc"] = nonceCount.toString()
         })

--- a/ktor-client/ktor-client-features/ktor-client-auth/common/test/io/ktor/client/features/auth/DigestProviderTest.kt
+++ b/ktor-client/ktor-client-features/ktor-client-auth/common/test/io/ktor/client/features/auth/DigestProviderTest.kt
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2014-2020 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.client.features.auth
+
+import io.ktor.client.features.auth.providers.*
+import io.ktor.client.request.*
+import io.ktor.http.*
+import io.ktor.http.auth.*
+import io.ktor.test.dispatcher.*
+import kotlin.test.*
+
+class DigestProviderTest {
+
+    private val path = "path"
+
+    private val paramName = "param"
+
+    private val paramValue = "value"
+
+    private val authAllFields =
+        "Digest algorithm=MD5, username=\"username\", realm=\"realm\", nonce=\"nonce\", qop=\"qop\", snonce=\"server-nonce\", cnonce=\"client-nonce\", uri=\"requested-uri\", request=\"client-digest\", message=\"message-digest\", opaque=\"opaque\""
+
+    private val authMissingQopAndOpaque =
+        "Digest algorithm=MD5, username=\"username\", realm=\"realm\", nonce=\"nonce\", snonce=\"server-nonce\", cnonce=\"client-nonce\", uri=\"requested-uri\", request=\"client-digest\", message=\"message-digest\""
+
+    private val digestAuthProvider = DigestAuthProvider("username", "password", "realm")
+
+    lateinit var requestBuilder: HttpRequestBuilder
+
+    @BeforeTest
+    fun setup() {
+        val params = ParametersBuilder(1)
+        params.append(paramName, paramValue)
+        requestBuilder =
+            HttpRequestBuilder { takeFrom(URLBuilder(encodedPath = path, parameters = params, trailingQuery = true)) }
+    }
+
+    @Test
+    fun addRequestHeadersSetsExpectedAuthHeaderFields() {
+        runIsApplicable(authAllFields)
+        testSuspend {
+            val authHeader = addRequestHeaders()
+
+            assertTrue(authHeader.contains("qop=qop"))
+            assertTrue(authHeader.contains("opaque=opaque"))
+            checkStandardFields(authHeader)
+        }
+    }
+
+    @Test
+    fun addRequestHeadersOmitsQopAndOpaqueWhenMissing() {
+        runIsApplicable(authMissingQopAndOpaque)
+        testSuspend {
+            val authHeader = addRequestHeaders()
+
+            assertFalse(authHeader.contains("opaque="))
+            assertFalse(authHeader.contains("qop="))
+            checkStandardFields(authHeader)
+        }
+    }
+
+    private fun runIsApplicable(headerValue: String) =
+        digestAuthProvider.isApplicable(parseAuthorizationHeader(headerValue)!!)
+
+    private suspend fun addRequestHeaders(): String {
+        digestAuthProvider.addRequestHeaders(requestBuilder)
+        return requestBuilder.headers[HttpHeaders.Authorization]!!
+    }
+
+    private fun checkStandardFields(authHeader: String) {
+        assertTrue(authHeader.contains("realm=realm"))
+        assertTrue(authHeader.contains("username=username"))
+        assertTrue(authHeader.contains("nonce=nonce"))
+        assertTrue(authHeader.contains("uri=\"/$path?$paramName=$paramValue\""))
+    }
+}


### PR DESCRIPTION
Subsystem
Client

Motivation
The problem is described in issue #1990 . When using digest auth, the uri field does not include the request parameters included in the original request. This breaks digest authentication.

Solution
Changing all places in DigestAuthProvider.addRequestHeaders which currently use url.encodedPath to use url.fullPath so that the uri field and token include the request parameters.