### PR TITLE
add direct access to payload in JWTCredential & JWTPrincipal

### DIFF
--- a/ktor-features/ktor-auth-jwt/api/ktor-auth-jwt.api
+++ b/ktor-features/ktor-auth-jwt/api/ktor-auth-jwt.api
@@ -26,60 +26,26 @@ public final class io/ktor/auth/jwt/JWTAuthenticationProvider$Configuration : io
 	public static synthetic fun verifier$default (Lio/ktor/auth/jwt/JWTAuthenticationProvider$Configuration;Ljava/lang/String;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
 }
 
-public final class io/ktor/auth/jwt/JWTCredential : io/ktor/auth/Credential, io/ktor/auth/jwt/JWTPayloadHolder {
+public final class io/ktor/auth/jwt/JWTCredential : io/ktor/auth/jwt/JWTPayloadHolder, io/ktor/auth/Credential {
 	public fun <init> (Lcom/auth0/jwt/interfaces/Payload;)V
-	public fun get (Ljava/lang/String;)Ljava/lang/String;
-	public fun getAudience ()Ljava/util/List;
-	public fun getClaim (Ljava/lang/String;Lkotlin/reflect/KClass;)Ljava/lang/Object;
-	public fun getExpiresAt ()Ljava/util/Date;
-	public fun getIssuedAt ()Ljava/util/Date;
-	public fun getIssuer ()Ljava/lang/String;
-	public fun getJwtId ()Ljava/lang/String;
-	public fun getListClaim (Ljava/lang/String;Lkotlin/reflect/KClass;)Ljava/util/List;
-	public fun getNotBefore ()Ljava/util/Date;
-	public fun getPayload ()Lcom/auth0/jwt/interfaces/Payload;
-	public fun getSubject ()Ljava/lang/String;
 }
 
-public abstract interface class io/ktor/auth/jwt/JWTPayloadHolder {
-	public abstract fun get (Ljava/lang/String;)Ljava/lang/String;
-	public abstract fun getAudience ()Ljava/util/List;
-	public abstract fun getClaim (Ljava/lang/String;Lkotlin/reflect/KClass;)Ljava/lang/Object;
-	public abstract fun getExpiresAt ()Ljava/util/Date;
-	public abstract fun getIssuedAt ()Ljava/util/Date;
-	public abstract fun getIssuer ()Ljava/lang/String;
-	public abstract fun getJwtId ()Ljava/lang/String;
-	public abstract fun getListClaim (Ljava/lang/String;Lkotlin/reflect/KClass;)Ljava/util/List;
-	public abstract fun getNotBefore ()Ljava/util/Date;
-	public abstract fun getPayload ()Lcom/auth0/jwt/interfaces/Payload;
-	public abstract fun getSubject ()Ljava/lang/String;
-}
-
-public final class io/ktor/auth/jwt/JWTPayloadHolder$DefaultImpls {
-	public static fun get (Lio/ktor/auth/jwt/JWTPayloadHolder;Ljava/lang/String;)Ljava/lang/String;
-	public static fun getAudience (Lio/ktor/auth/jwt/JWTPayloadHolder;)Ljava/util/List;
-	public static fun getClaim (Lio/ktor/auth/jwt/JWTPayloadHolder;Ljava/lang/String;Lkotlin/reflect/KClass;)Ljava/lang/Object;
-	public static fun getExpiresAt (Lio/ktor/auth/jwt/JWTPayloadHolder;)Ljava/util/Date;
-	public static fun getIssuedAt (Lio/ktor/auth/jwt/JWTPayloadHolder;)Ljava/util/Date;
-	public static fun getIssuer (Lio/ktor/auth/jwt/JWTPayloadHolder;)Ljava/lang/String;
-	public static fun getJwtId (Lio/ktor/auth/jwt/JWTPayloadHolder;)Ljava/lang/String;
-	public static fun getListClaim (Lio/ktor/auth/jwt/JWTPayloadHolder;Ljava/lang/String;Lkotlin/reflect/KClass;)Ljava/util/List;
-	public static fun getNotBefore (Lio/ktor/auth/jwt/JWTPayloadHolder;)Ljava/util/Date;
-	public static fun getSubject (Lio/ktor/auth/jwt/JWTPayloadHolder;)Ljava/lang/String;
-}
-
-public final class io/ktor/auth/jwt/JWTPrincipal : io/ktor/auth/Principal, io/ktor/auth/jwt/JWTPayloadHolder {
+public abstract class io/ktor/auth/jwt/JWTPayloadHolder {
 	public fun <init> (Lcom/auth0/jwt/interfaces/Payload;)V
-	public fun get (Ljava/lang/String;)Ljava/lang/String;
-	public fun getAudience ()Ljava/util/List;
-	public fun getClaim (Ljava/lang/String;Lkotlin/reflect/KClass;)Ljava/lang/Object;
-	public fun getExpiresAt ()Ljava/util/Date;
-	public fun getIssuedAt ()Ljava/util/Date;
-	public fun getIssuer ()Ljava/lang/String;
-	public fun getJwtId ()Ljava/lang/String;
-	public fun getListClaim (Ljava/lang/String;Lkotlin/reflect/KClass;)Ljava/util/List;
-	public fun getNotBefore ()Ljava/util/Date;
-	public fun getPayload ()Lcom/auth0/jwt/interfaces/Payload;
-	public fun getSubject ()Ljava/lang/String;
+	public final fun get (Ljava/lang/String;)Ljava/lang/String;
+	public final fun getAudience ()Ljava/util/List;
+	public final fun getClaim (Ljava/lang/String;Lkotlin/reflect/KClass;)Ljava/lang/Object;
+	public final fun getExpiresAt ()Ljava/util/Date;
+	public final fun getIssuedAt ()Ljava/util/Date;
+	public final fun getIssuer ()Ljava/lang/String;
+	public final fun getJwtId ()Ljava/lang/String;
+	public final fun getListClaim (Ljava/lang/String;Lkotlin/reflect/KClass;)Ljava/util/List;
+	public final fun getNotBefore ()Ljava/util/Date;
+	public final fun getPayload ()Lcom/auth0/jwt/interfaces/Payload;
+	public final fun getSubject ()Ljava/lang/String;
+}
+
+public final class io/ktor/auth/jwt/JWTPrincipal : io/ktor/auth/jwt/JWTPayloadHolder, io/ktor/auth/Principal {
+	public fun <init> (Lcom/auth0/jwt/interfaces/Payload;)V
 }
 

--- a/ktor-features/ktor-auth-jwt/api/ktor-auth-jwt.api
+++ b/ktor-features/ktor-auth-jwt/api/ktor-auth-jwt.api
@@ -26,13 +26,60 @@ public final class io/ktor/auth/jwt/JWTAuthenticationProvider$Configuration : io
 	public static synthetic fun verifier$default (Lio/ktor/auth/jwt/JWTAuthenticationProvider$Configuration;Ljava/lang/String;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
 }
 
-public final class io/ktor/auth/jwt/JWTCredential : io/ktor/auth/Credential {
+public final class io/ktor/auth/jwt/JWTCredential : io/ktor/auth/Credential, io/ktor/auth/jwt/JWTPayloadHolder {
 	public fun <init> (Lcom/auth0/jwt/interfaces/Payload;)V
-	public final fun getPayload ()Lcom/auth0/jwt/interfaces/Payload;
+	public fun get (Ljava/lang/String;)Ljava/lang/String;
+	public fun getAudience ()Ljava/util/List;
+	public fun getClaim (Ljava/lang/String;Lkotlin/reflect/KClass;)Ljava/lang/Object;
+	public fun getExpiresAt ()Ljava/util/Date;
+	public fun getIssuedAt ()Ljava/util/Date;
+	public fun getIssuer ()Ljava/lang/String;
+	public fun getJwtId ()Ljava/lang/String;
+	public fun getListClaim (Ljava/lang/String;Lkotlin/reflect/KClass;)Ljava/util/List;
+	public fun getNotBefore ()Ljava/util/Date;
+	public fun getPayload ()Lcom/auth0/jwt/interfaces/Payload;
+	public fun getSubject ()Ljava/lang/String;
 }
 
-public final class io/ktor/auth/jwt/JWTPrincipal : io/ktor/auth/Principal {
+public abstract interface class io/ktor/auth/jwt/JWTPayloadHolder {
+	public abstract fun get (Ljava/lang/String;)Ljava/lang/String;
+	public abstract fun getAudience ()Ljava/util/List;
+	public abstract fun getClaim (Ljava/lang/String;Lkotlin/reflect/KClass;)Ljava/lang/Object;
+	public abstract fun getExpiresAt ()Ljava/util/Date;
+	public abstract fun getIssuedAt ()Ljava/util/Date;
+	public abstract fun getIssuer ()Ljava/lang/String;
+	public abstract fun getJwtId ()Ljava/lang/String;
+	public abstract fun getListClaim (Ljava/lang/String;Lkotlin/reflect/KClass;)Ljava/util/List;
+	public abstract fun getNotBefore ()Ljava/util/Date;
+	public abstract fun getPayload ()Lcom/auth0/jwt/interfaces/Payload;
+	public abstract fun getSubject ()Ljava/lang/String;
+}
+
+public final class io/ktor/auth/jwt/JWTPayloadHolder$DefaultImpls {
+	public static fun get (Lio/ktor/auth/jwt/JWTPayloadHolder;Ljava/lang/String;)Ljava/lang/String;
+	public static fun getAudience (Lio/ktor/auth/jwt/JWTPayloadHolder;)Ljava/util/List;
+	public static fun getClaim (Lio/ktor/auth/jwt/JWTPayloadHolder;Ljava/lang/String;Lkotlin/reflect/KClass;)Ljava/lang/Object;
+	public static fun getExpiresAt (Lio/ktor/auth/jwt/JWTPayloadHolder;)Ljava/util/Date;
+	public static fun getIssuedAt (Lio/ktor/auth/jwt/JWTPayloadHolder;)Ljava/util/Date;
+	public static fun getIssuer (Lio/ktor/auth/jwt/JWTPayloadHolder;)Ljava/lang/String;
+	public static fun getJwtId (Lio/ktor/auth/jwt/JWTPayloadHolder;)Ljava/lang/String;
+	public static fun getListClaim (Lio/ktor/auth/jwt/JWTPayloadHolder;Ljava/lang/String;Lkotlin/reflect/KClass;)Ljava/util/List;
+	public static fun getNotBefore (Lio/ktor/auth/jwt/JWTPayloadHolder;)Ljava/util/Date;
+	public static fun getSubject (Lio/ktor/auth/jwt/JWTPayloadHolder;)Ljava/lang/String;
+}
+
+public final class io/ktor/auth/jwt/JWTPrincipal : io/ktor/auth/Principal, io/ktor/auth/jwt/JWTPayloadHolder {
 	public fun <init> (Lcom/auth0/jwt/interfaces/Payload;)V
-	public final fun getPayload ()Lcom/auth0/jwt/interfaces/Payload;
+	public fun get (Ljava/lang/String;)Ljava/lang/String;
+	public fun getAudience ()Ljava/util/List;
+	public fun getClaim (Ljava/lang/String;Lkotlin/reflect/KClass;)Ljava/lang/Object;
+	public fun getExpiresAt ()Ljava/util/Date;
+	public fun getIssuedAt ()Ljava/util/Date;
+	public fun getIssuer ()Ljava/lang/String;
+	public fun getJwtId ()Ljava/lang/String;
+	public fun getListClaim (Ljava/lang/String;Lkotlin/reflect/KClass;)Ljava/util/List;
+	public fun getNotBefore ()Ljava/util/Date;
+	public fun getPayload ()Lcom/auth0/jwt/interfaces/Payload;
+	public fun getSubject ()Ljava/lang/String;
 }
 

--- a/ktor-features/ktor-auth-jwt/jvm/src/io/ktor/auth/jwt/JWTAuth.kt
+++ b/ktor-features/ktor-auth-jwt/jvm/src/io/ktor/auth/jwt/JWTAuth.kt
@@ -27,18 +27,115 @@ private val JWTAuthKey: Any = "JWTAuth"
 private val JWTLogger: Logger = LoggerFactory.getLogger("io.ktor.auth.jwt")
 
 /**
+ * Shortcut functions for standard registered [JWT Claims](https://tools.ietf.org/html/rfc7519#section-4.1)
+ */
+public interface JWTPayloadHolder {
+    /**
+     * The JWT payload
+     */
+    public val payload: Payload
+
+    /**
+     * Get the value of the "iss" claim, or null if it's not available.
+     *
+     * The "iss" (issuer) claim identifies the principal that issued the
+     * JWT.  The processing of this claim is generally application specific.
+     * The "iss" value is a case-sensitive string containing a StringOrURI
+     * value.  Use of this claim is OPTIONAL.
+     */
+    public val issuer: String? get() = payload.issuer
+
+    /**
+     * Get the value of the "sub" claim, or null if it's not available.
+     *
+     * The "sub" (subject) claim identifies the principal that is the
+     * subject of the JWT.  The claims in a JWT are normally statements
+     * about the subject.  The subject value MUST either be scoped to be
+     * locally unique in the context of the issuer or be globally unique.
+     * The processing of this claim is generally application specific.  The
+     * "sub" value is a case-sensitive string containing a StringOrURI
+     * value.  Use of this claim is OPTIONAL.
+     */
+    public val subject: String? get() = payload.subject
+
+    /**
+     * Get the value of the "aud" claim, or an empty list if it's not available.
+     *
+     * The "aud" (audience) claim identifies the recipients that the JWT is
+     * intended for.  Each principal intended to process the JWT MUST
+     * identify itself with a value in the audience claim.  If the principal
+     * processing the claim does not identify itself with a value in the
+     * "aud" claim when this claim is present, then the JWT MUST be
+     * rejected.  In the general case, the "aud" value is an array of case-
+     * sensitive strings, each containing a StringOrURI value.  In the
+     * special case when the JWT has one audience, the "aud" value MAY be a
+     * single case-sensitive string containing a StringOrURI value.  The
+     * interpretation of audience values is generally application specific.
+     * Use of this claim is OPTIONAL.
+     */
+    public val audience: List<String> get() = payload.audience ?: emptyList()
+
+    /**
+     * Get the value of the "exp" claim, or null if it's not available.
+     *
+     * The "exp" (expiration time) claim identifies the expiration time on
+     * or after which the JWT MUST NOT be accepted for processing.  The
+     * processing of the "exp" claim requires that the current date/time
+     * MUST be before the expiration date/time listed in the "exp" claim.
+     * Implementers MAY provide for some small leeway, usually no more than
+     * a few minutes, to account for clock skew. Use of this claim is OPTIONAL.
+     */
+    public val expiresAt: Date? get() = payload.expiresAt
+
+    /**
+     * Get the value of the "nbf" claim, or null if it's not available.
+     *
+     * The "nbf" (not before) claim identifies the time before which the JWT
+     * MUST NOT be accepted for processing.  The processing of the "nbf"
+     * claim requires that the current date/time MUST be after or equal to
+     * the not-before date/time listed in the "nbf" claim.  Implementers MAY
+     * provide for some small leeway, usually no more than a few minutes, to
+     * account for clock skew. Use of this claim is OPTIONAL.
+     */
+    public val notBefore: Date? get() = payload.notBefore
+
+    /**
+     * Get the value of the "iat" claim, or null if it's not available.
+     *
+     * The "iat" (issued at) claim identifies the time at which the JWT was
+     * issued.  This claim can be used to determine the age of the JWT.
+     * Use of this claim is OPTIONAL.
+     */
+    public val issuedAt: Date? get() = payload.issuedAt
+
+    /**
+     * Get the value of the "jti" claim, or null if it's not available.
+     *
+     * The "jti" (JWT ID) claim provides a unique identifier for the JWT.
+     * The identifier value MUST be assigned in a manner that ensures that
+     * there is a negligible probability that the same value will be
+     * accidentally assigned to a different data object; if the application
+     * uses multiple issuers, collisions MUST be prevented among values
+     * produced by different issuers as well.  The "jti" claim can be used
+     * to prevent the JWT from being replayed.  The "jti" value is a case-
+     * sensitive string.  Use of this claim is OPTIONAL.
+     */
+    public val jwtId: String? get() = payload.id
+}
+
+/**
  * Represents a JWT credential consist of the specified [payload]
  * @param payload JWT
  * @see Payload
  */
-public class JWTCredential(public val payload: Payload) : Credential
+public class JWTCredential(public override val payload: Payload) : Credential, JWTPayloadHolder
 
 /**
  * Represents a JWT principal consist of the specified [payload]
  * @param payload JWT
  * @see Payload
  */
-public class JWTPrincipal(public val payload: Payload) : Principal
+public class JWTPrincipal(public override val payload: Payload) : Principal, JWTPayloadHolder
 
 /**
  * JWT verifier configuration function. It is applied on the verifier builder.

--- a/ktor-features/ktor-auth-jwt/jvm/src/io/ktor/auth/jwt/JWTAuth.kt
+++ b/ktor-features/ktor-auth-jwt/jvm/src/io/ktor/auth/jwt/JWTAuth.kt
@@ -21,6 +21,7 @@ import org.slf4j.*
 import java.security.interfaces.*
 import java.util.*
 import java.util.concurrent.*
+import kotlin.reflect.*
 
 private val JWTAuthKey: Any = "JWTAuth"
 
@@ -121,6 +122,44 @@ public interface JWTPayloadHolder {
      * sensitive string.  Use of this claim is OPTIONAL.
      */
     public val jwtId: String? get() = payload.id
+
+    /**
+     * Retrieve a non-RFC JWT string Claim by its name
+     *
+     * @param name The claim's key as it appears in the JSON object
+     * @return the Claim's value or null if not available or not a string
+     */
+    public operator fun get(name: String): String? {
+        return payload.getClaim(name).asString()
+    }
+
+    /**
+     * Retrieve a non-RFC JWT Claim by its name and attempt to decode as the supplied type
+     *
+     * @param name The claim's key as it appears in the JSON object
+     * @return the Claim's value or null if not available or unable to deserialise
+     */
+    public fun <T : Any> getClaim(name: String, clazz: KClass<T>): T? {
+        return try {
+            payload.getClaim(name).`as`(clazz.javaObjectType)
+        } catch (ex: JWTDecodeException) {
+            null
+        }
+    }
+
+    /**
+     * Retrieve a non-RFC JWT Claim by its name and attempt to decode as a list of the supplied type
+     *
+     * @param name The claim's key as it appears in the JSON object
+     * @return the Claim's value or an empty list if not available or unable to deserialise
+     */
+    public fun <T : Any> getListClaim(name: String, clazz: KClass<T>): List<T> {
+        return try {
+            payload.getClaim(name).asList(clazz.javaObjectType)
+        } catch (ex: JWTDecodeException) {
+            emptyList()
+        }
+    }
 }
 
 /**

--- a/ktor-features/ktor-auth-jwt/jvm/src/io/ktor/auth/jwt/JWTAuth.kt
+++ b/ktor-features/ktor-auth-jwt/jvm/src/io/ktor/auth/jwt/JWTAuth.kt
@@ -30,11 +30,12 @@ private val JWTLogger: Logger = LoggerFactory.getLogger("io.ktor.auth.jwt")
 /**
  * Shortcut functions for standard registered [JWT Claims](https://tools.ietf.org/html/rfc7519#section-4.1)
  */
-public interface JWTPayloadHolder {
+public abstract class JWTPayloadHolder(
     /**
      * The JWT payload
      */
     public val payload: Payload
+) {
 
     /**
      * Get the value of the "iss" claim, or null if it's not available.
@@ -167,14 +168,14 @@ public interface JWTPayloadHolder {
  * @param payload JWT
  * @see Payload
  */
-public class JWTCredential(public override val payload: Payload) : Credential, JWTPayloadHolder
+public class JWTCredential(payload: Payload) : Credential, JWTPayloadHolder(payload)
 
 /**
  * Represents a JWT principal consist of the specified [payload]
  * @param payload JWT
  * @see Payload
  */
-public class JWTPrincipal(public override val payload: Payload) : Principal, JWTPayloadHolder
+public class JWTPrincipal(payload: Payload) : Principal, JWTPayloadHolder(payload)
 
 /**
  * JWT verifier configuration function. It is applied on the verifier builder.

--- a/ktor-features/ktor-auth-jwt/jvm/test/io/ktor/auth/jwt/JWTAuthTest.kt
+++ b/ktor-features/ktor-auth-jwt/jvm/test/io/ktor/auth/jwt/JWTAuthTest.kt
@@ -101,7 +101,7 @@ class JWTAuthTest {
                 authenticate("first", "second") {
                     get("/") {
                         val principal = call.authentication.principal<JWTPrincipal>()!!
-                        call.respondText("Secret info, ${principal.payload.audience}")
+                        call.respondText("Secret info, ${principal.audience}")
                     }
                 }
             }
@@ -497,7 +497,7 @@ class JWTAuthTest {
             }
             validate { credential ->
                 when {
-                    credential.payload.audience.contains(audience) -> JWTPrincipal(credential.payload)
+                    credential.audience.contains(audience) -> JWTPrincipal(credential.payload)
                     else -> null
                 }
             }
@@ -527,7 +527,7 @@ class JWTAuthTest {
             verifier(if (mock) getJwkProviderMock() else makeJwkProvider())
             validate { credential ->
                 when {
-                    credential.payload.audience.contains(audience) -> JWTPrincipal(credential.payload)
+                    credential.audience.contains(audience) -> JWTPrincipal(credential.payload)
                     else -> null
                 }
             }
@@ -548,7 +548,7 @@ class JWTAuthTest {
             }
             validate { credential ->
                 when {
-                    credential.payload.audience.contains(audience) -> JWTPrincipal(credential.payload)
+                    credential.audience.contains(audience) -> JWTPrincipal(credential.payload)
                     else -> null
                 }
             }
@@ -562,7 +562,7 @@ class JWTAuthTest {
                 verifier(issuer, audience, algorithm)
                 validate { credential ->
                     when {
-                        credential.payload.audience.contains(audience) -> JWTPrincipal(credential.payload)
+                        credential.audience.contains(audience) -> JWTPrincipal(credential.payload)
                         else -> null
                     }
                 }


### PR DESCRIPTION
**Subsystem**
JWT Auth

**Motivation**
When interacting with `JWTCredential` & `JWTPrincipal`, to access the decoded JWT token, it's a bit clunky to need to do `credential.payload.<foo>` (or its variable based workarounds) - the classes are just wrappers to apply the Ktor interfaces

**Solution**
This PR simply adds an implementation of auth0-jwt's `Payload` interface by delegation.
It doesn't provide _much_ benefit, but the more fields accessed the more evident it becomes.

Before (snippet from the docs)
```
validate { credential ->
    if (credential.payload.audience.contains(jwtAudience)) JWTPrincipal(credential.payload) else null
}
```

After
```
validate { credential ->
    if (credential.audience.contains(jwtAudience)) JWTPrincipal(credential.payload) else null
}
```

