### PR TITLE
Fix a NumberFormatException

### DIFF
--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http2/Http2LocalConnectionPoint.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http2/Http2LocalConnectionPoint.kt
@@ -28,7 +28,7 @@ internal class Http2LocalConnectionPoint(
         get() = nettyHeaders.authority()?.toString() ?: "localhost"
 
     override val port: Int
-        get() = nettyHeaders.authority()?.toString()?.substringAfter(":")?.toInt()
+        get() = nettyHeaders.authority()?.toString()?.substringAfter(":")?.toIntOrNull()
                 ?: localAddress?.port
                 ?: 80
 


### PR DESCRIPTION
The default behavior of `substringAfter` is to return the original string if no match was found,
causing a `NumberFormatException` to be thrown with URLs such as `https://localhost`.

**Subsystem**
Server, Netty module

**Motivation**
During 1 of my tests I got the following stacktrace on any URL:
```
2020-07-22T08:20:49.440 [nioEventLoopGroup-4-1] ERROR Application - Unhandled: OPTIONS - /api/v2/login
java.lang.NumberFormatException: For input string: "localhost"
	at java.base/java.lang.NumberFormatException.forInputString(NumberFormatException.java:68) ~[na:na]
	at java.base/java.lang.Integer.parseInt(Integer.java:652) ~[na:na]
	at java.base/java.lang.Integer.parseInt(Integer.java:770) ~[na:na]
	at io.ktor.server.netty.http2.Http2LocalConnectionPoint.getPort(Http2LocalConnectionPoint.kt:31) ~[ktor-server-netty-1.3.2.jar:1.3.2]
	at io.ktor.features.CORS.isSameOrigin(CORS.kt:168) ~[ktor-server-core-1.3.2.jar:1.3.2]
	at io.ktor.features.CORS.intercept(CORS.kt:91) ~[ktor-server-core-1.3.2.jar:1.3.2]
	at io.ktor.features.CORS$Feature$install$1.invokeSuspend(CORS.kt:476) ~[ktor-server-core-1.3.2.jar:1.3.2]
	at io.ktor.features.CORS$Feature$install$1.invoke(CORS.kt) ~[ktor-server-core-1.3.2.jar:1.3.2]
	at io.ktor.util.pipeline.SuspendFunctionGun.loop(PipelineContext.kt:318) ~[ktor-utils-jvm-1.3.2.jar:1.3.2]
	at io.ktor.util.pipeline.SuspendFunctionGun.proceed(PipelineContext.kt:163) ~[ktor-utils-jvm-1.3.2.jar:1.3.2]
	at io.ktor.features.StatusPages$interceptCall$2.invokeSuspend(StatusPages.kt:101) ~[ktor-server-core-1.3.2.jar:1.3.2]
	at io.ktor.features.StatusPages$interceptCall$2.invoke(StatusPages.kt) ~[ktor-server-core-1.3.2.jar:1.3.2]
	at kotlinx.coroutines.intrinsics.UndispatchedKt.startUndispatchedOrReturn(Undispatched.kt:91) ~[kotlinx-coroutines-core-1.3.4.jar:na]
	at kotlinx.coroutines.CoroutineScopeKt.coroutineScope(CoroutineScope.kt:177) ~[kotlinx-coroutines-core-1.3.4.jar:na]
	at io.ktor.features.StatusPages.interceptCall(StatusPages.kt:100) ~[ktor-server-core-1.3.2.jar:1.3.2]
	at io.ktor.features.StatusPages$Feature$install$2.invokeSuspend(StatusPages.kt:140) ~[ktor-server-core-1.3.2.jar:1.3.2]
	at io.ktor.features.StatusPages$Feature$install$2.invoke(StatusPages.kt) ~[ktor-server-core-1.3.2.jar:1.3.2]
	at io.ktor.util.pipeline.SuspendFunctionGun.loop(PipelineContext.kt:318) ~[ktor-utils-jvm-1.3.2.jar:1.3.2]
	at io.ktor.util.pipeline.SuspendFunctionGun.proceed(PipelineContext.kt:163) ~[ktor-utils-jvm-1.3.2.jar:1.3.2]
	at io.ktor.features.CallLogging$Feature$install$1$invokeSuspend$$inlined$withMDC$1.invokeSuspend(CallLogging.kt:226) ~[ktor-server-core-1.3.2.jar:1.3.2]
	at io.ktor.features.CallLogging$Feature$install$1$invokeSuspend$$inlined$withMDC$1.invoke(CallLogging.kt) ~[ktor-server-core-1.3.2.jar:1.3.2]
	at kotlinx.coroutines.intrinsics.UndispatchedKt.startUndispatchedOrReturn(Undispatched.kt:91) ~[kotlinx-coroutines-core-1.3.4.jar:na]
	at kotlinx.coroutines.BuildersKt__Builders_commonKt.withContext(Builders.common.kt:154) ~[kotlinx-coroutines-core-1.3.4.jar:na]
	at kotlinx.coroutines.BuildersKt.withContext(Unknown Source) ~[kotlinx-coroutines-core-1.3.4.jar:na]
	at io.ktor.features.CallLogging$Feature$install$1.invokeSuspend(CallLogging.kt:230) ~[ktor-server-core-1.3.2.jar:1.3.2]
	at io.ktor.features.CallLogging$Feature$install$1.invoke(CallLogging.kt) ~[ktor-server-core-1.3.2.jar:1.3.2]
	at io.ktor.util.pipeline.SuspendFunctionGun.loop(PipelineContext.kt:318) ~[ktor-utils-jvm-1.3.2.jar:1.3.2]
	at io.ktor.util.pipeline.SuspendFunctionGun.proceed(PipelineContext.kt:163) ~[ktor-utils-jvm-1.3.2.jar:1.3.2]
	at io.ktor.util.pipeline.SuspendFunctionGun.execute(PipelineContext.kt:183) ~[ktor-utils-jvm-1.3.2.jar:1.3.2]
	at io.ktor.util.pipeline.Pipeline.execute(Pipeline.kt:27) ~[ktor-utils-jvm-1.3.2.jar:1.3.2]
	at io.ktor.server.engine.DefaultEnginePipelineKt$defaultEnginePipeline$2.invokeSuspend(DefaultEnginePipeline.kt:120) ~[ktor-server-host-common-1.3.2.jar:1.3.2]
	at io.ktor.server.engine.DefaultEnginePipelineKt$defaultEnginePipeline$2.invoke(DefaultEnginePipeline.kt) ~[ktor-server-host-common-1.3.2.jar:1.3.2]
	at io.ktor.util.pipeline.SuspendFunctionGun.loop(PipelineContext.kt:318) ~[ktor-utils-jvm-1.3.2.jar:1.3.2]
	at io.ktor.util.pipeline.SuspendFunctionGun.proceed(PipelineContext.kt:163) ~[ktor-utils-jvm-1.3.2.jar:1.3.2]
	at io.ktor.util.pipeline.SuspendFunctionGun.execute(PipelineContext.kt:183) ~[ktor-utils-jvm-1.3.2.jar:1.3.2]
	at io.ktor.util.pipeline.Pipeline.execute(Pipeline.kt:27) ~[ktor-utils-jvm-1.3.2.jar:1.3.2]
	at io.ktor.server.netty.NettyApplicationCallHandler$handleRequest$1.invokeSuspend(NettyApplicationCallHandler.kt:40) ~[ktor-server-netty-1.3.2.jar:1.3.2]
	at io.ktor.server.netty.NettyApplicationCallHandler$handleRequest$1.invoke(NettyApplicationCallHandler.kt) ~[ktor-server-netty-1.3.2.jar:1.3.2]
	at kotlinx.coroutines.intrinsics.UndispatchedKt.startCoroutineUndispatched(Undispatched.kt:55) ~[kotlinx-coroutines-core-1.3.4.jar:na]
	at kotlinx.coroutines.CoroutineStart.invoke(CoroutineStart.kt:111) ~[kotlinx-coroutines-core-1.3.4.jar:na]
	at kotlinx.coroutines.AbstractCoroutine.start(AbstractCoroutine.kt:158) ~[kotlinx-coroutines-core-1.3.4.jar:na]
	at kotlinx.coroutines.BuildersKt__Builders_commonKt.launch(Builders.common.kt:54) ~[kotlinx-coroutines-core-1.3.4.jar:na]
	at kotlinx.coroutines.BuildersKt.launch(Unknown Source) ~[kotlinx-coroutines-core-1.3.4.jar:na]
	at io.ktor.server.netty.NettyApplicationCallHandler.handleRequest(NettyApplicationCallHandler.kt:30) ~[ktor-server-netty-1.3.2.jar:1.3.2]
	at io.ktor.server.netty.NettyApplicationCallHandler.channelRead(NettyApplicationCallHandler.kt:24) ~[ktor-server-netty-1.3.2.jar:1.3.2]
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:377) ~[netty-transport-4.1.44.Final.jar:4.1.44.Final]
	at io.netty.channel.AbstractChannelHandlerContext.access$600(AbstractChannelHandlerContext.java:59) ~[netty-transport-4.1.44.Final.jar:4.1.44.Final]
	at io.netty.channel.AbstractChannelHandlerContext$7.run(AbstractChannelHandlerContext.java:368) ~[netty-transport-4.1.44.Final.jar:4.1.44.Final]
	at io.netty.util.concurrent.AbstractEventExecutor.safeExecute$$$capture(AbstractEventExecutor.java:164) ~[netty-common-4.1.44.Final.jar:4.1.44.Final]
	at io.netty.util.concurrent.AbstractEventExecutor.safeExecute(AbstractEventExecutor.java) ~[netty-common-4.1.44.Final.jar:4.1.44.Final]
	at io.netty.util.concurrent.SingleThreadEventExecutor.runAllTasks(SingleThreadEventExecutor.java:472) ~[netty-common-4.1.44.Final.jar:4.1.44.Final]
	at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:500) ~[netty-transport-4.1.44.Final.jar:4.1.44.Final]
	at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:989) ~[netty-common-4.1.44.Final.jar:4.1.44.Final]
	at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74) ~[netty-common-4.1.44.Final.jar:4.1.44.Final]
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30) ~[netty-common-4.1.44.Final.jar:4.1.44.Final]
	at java.base/java.lang.Thread.run(Thread.java:832) ~[na:na]
```

**Solution**
The solution is to parse the port number null-safe, so the alternatives already present are executed.
