### PR TITLE
Prevent Empty Cookie addition

### DIFF
--- a/ktor-client/ktor-client-core/common/src/io/ktor/client/features/cookies/HttpCookies.kt
+++ b/ktor-client/ktor-client-core/common/src/io/ktor/client/features/cookies/HttpCookies.kt
@@ -71,7 +71,9 @@ class HttpCookies(
                 val cookies = feature.get(context.url.clone().build())
 
                 with(context) {
-                    headers[HttpHeaders.Cookie] = renderClientCookies(cookies)
+                    if (cookies.isNotEmpty()) {
+                        headers[HttpHeaders.Cookie] = renderClientCookies(cookies)
+                    }
                 }
             }
 


### PR DESCRIPTION
**Subsystem**
Client.

**Motivation**
Some systems may behave differently if an empty cookie is sent, rather than omitting the Cookie header.

**Solution**
The header is only added if the Cookies list is not empty.

