### PR TITLE
Ktor test client returns 404 if request not handled. Fixing NPE #1891

### DIFF
--- a/ktor-server/ktor-server-test-host/jvm/src/io/ktor/server/testing/client/TestHttpClientEngine.kt
+++ b/ktor-server/ktor-server-test-host/jvm/src/io/ktor/server/testing/client/TestHttpClientEngine.kt
@@ -31,15 +31,29 @@ class TestHttpClientEngine(override val config: TestHttpClientConfig) : HttpClie
     override val coroutineContext: CoroutineContext = dispatcher + clientJob
 
     override suspend fun execute(data: HttpRequestData): HttpResponseData {
-        val testServerCall = with(data) { runRequest(method, url.fullPath, headers, body).response }
+        val testServerCall = with(data) { runRequest(method, url.fullPath, headers, body) }
 
-        return HttpResponseData(
-            testServerCall.status()!!, GMTDate(),
-            testServerCall.headers.allValues(),
-            HttpProtocolVersion.HTTP_1_1,
-            ByteReadChannel(testServerCall.byteContent ?: byteArrayOf()),
-            callContext()
-        )
+        return if (testServerCall.requestHandled) {
+            with(testServerCall.response) {
+                HttpResponseData(
+                    status()!!, GMTDate(),
+                    headers.allValues(),
+                    HttpProtocolVersion.HTTP_1_1,
+                    ByteReadChannel(byteContent ?: byteArrayOf()),
+                    callContext()
+                )
+            }
+        } else {
+            HttpResponseData(
+                HttpStatusCode.NotFound, GMTDate(),
+                Headers.build {
+                    this[HttpHeaders.ContentLength] = "0"
+                },
+                HttpProtocolVersion.HTTP_1_1,
+                ByteReadChannel(byteArrayOf()),
+                callContext()
+            )
+        }
     }
 
     private fun runRequest(

--- a/ktor-server/ktor-server-tests/jvm/test/io/ktor/tests/server/testing/TestApplicationEngineTest.kt
+++ b/ktor-server/ktor-server-tests/jvm/test/io/ktor/tests/server/testing/TestApplicationEngineTest.kt
@@ -5,6 +5,8 @@
 package io.ktor.tests.server.testing
 
 import io.ktor.application.*
+import io.ktor.client.request.*
+import io.ktor.client.statement.*
 import io.ktor.features.*
 import io.ktor.http.*
 import io.ktor.response.*
@@ -194,6 +196,25 @@ class TestApplicationEngineTest {
                 doRequestAndCheckResponse("0")
                 doRequestAndCheckResponse("1")
                 doRequestAndCheckResponse("2")
+            }
+        }
+    }
+
+    @Test
+    fun accessNotExistingRouteTest() {
+        withTestApplication {
+            application.routing {
+                get("/exist") {
+                    call.respondText("Route exist")
+                }
+            }
+
+            runBlocking {
+                val notExistingResponse = client.get<HttpResponse>("/notExist")
+                assertEquals(HttpStatusCode.NotFound, notExistingResponse.status)
+
+                val existingResponse = client.get<HttpResponse>("/exist")
+                assertEquals(HttpStatusCode.OK, existingResponse.status)
             }
         }
     }


### PR DESCRIPTION
**Subsystem**
Test Ktor Client
ktor-server-test-host

**Motivation**
Fixing NPE #1891 
We should never throw NPE

**Solution**
We should emulate real client behavor with test client engine. So, if request not handled we should return 404 like real ktor.

