### PR TITLE
Cy/io fixes

### DIFF
--- a/ktor-io/common/src/io/ktor/utils/io/core/AbstractInput.kt
+++ b/ktor-io/common/src/io/ktor/utils/io/core/AbstractInput.kt
@@ -80,20 +80,7 @@ abstract class AbstractInput(
 
     private var tailRemaining: Long = remaining - headRemaining
         set(newValue) {
-            if (newValue < 0) {
-                error("tailRemaining is negative: $newValue")
-            }
-            if (newValue == 0L) {
-                val tail = _head.next?.remainingAll() ?: 0L
-                if (tail != 0L) {
-                    error("tailRemaining is set 0 while there is a tail of size $tail")
-                }
-            }
-            val tailSize = _head.next?.remainingAll() ?: 0L
-            if (newValue != tailSize) {
-                error("tailRemaining is set to a value that is not consistent with the actual tail: $newValue != $tailSize")
-            }
-
+            check(newValue >= 0) { "tailRemaining is negative: $newValue" }
             field = newValue
         }
 


### PR DESCRIPTION
**Subsystem**
Core

**Motivation**
When receiving a large response as a single packet, it takes surprisingly long time to handle it (for example, to convert to a string or even to discard it).

**Solution**
- Remove debug assertions that were accidentally kept and never actually failed (nobody reported as far as I know).
- Replace several tailrec functions with regular loops because JS backend doesn't support it so large packets are handled too slowly or even may crash with stack overflow error 
- Reduce Long usages so in node/js it will run faster due to less allocations
