### PR TITLE
[KTOR-940] CIO TLSConfigBuilder JVM allow null as password

### DIFF
--- a/ktor-network/ktor-network-tls/api/ktor-network-tls.api
+++ b/ktor-network/ktor-network-tls/api/ktor-network-tls.api
@@ -210,6 +210,8 @@ public final class io/ktor/network/tls/TLSConfigBuilderKt {
 	public static final synthetic fun addKeyStore (Lio/ktor/network/tls/TLSConfigBuilder;Ljava/security/KeyStore;[C)V
 	public static final fun addKeyStore (Lio/ktor/network/tls/TLSConfigBuilder;Ljava/security/KeyStore;[CLjava/lang/String;)V
 	public static synthetic fun addKeyStore$default (Lio/ktor/network/tls/TLSConfigBuilder;Ljava/security/KeyStore;[CLjava/lang/String;ILjava/lang/Object;)V
+	public static final fun addKeyStoreNullablePassword (Lio/ktor/network/tls/TLSConfigBuilder;Ljava/security/KeyStore;[CLjava/lang/String;)V
+	public static synthetic fun addKeyStoreNullablePassword$default (Lio/ktor/network/tls/TLSConfigBuilder;Ljava/security/KeyStore;[CLjava/lang/String;ILjava/lang/Object;)V
 	public static final fun takeFrom (Lio/ktor/network/tls/TLSConfigBuilder;Lio/ktor/network/tls/TLSConfigBuilder;)V
 }
 

--- a/ktor-network/ktor-network-tls/jvm/src/io/ktor/network/tls/TLSConfigBuilder.kt
+++ b/ktor-network/ktor-network-tls/jvm/src/io/ktor/network/tls/TLSConfigBuilder.kt
@@ -94,6 +94,15 @@ public fun TLSConfigBuilder.addKeyStore(store: KeyStore, password: CharArray) {
  * or all certificates, if [alias] is null.
  */
 public fun TLSConfigBuilder.addKeyStore(store: KeyStore, password: CharArray, alias: String? = null) {
+    addKeyStore(store, password as CharArray?, alias)
+}
+
+/**
+ * Add client certificates from [store] by using the certificate with specific [alias]
+ * or all certificates, if [alias] is null.
+ */
+@JvmName("addKeyStoreNullablePassword")
+public fun TLSConfigBuilder.addKeyStore(store: KeyStore, password: CharArray?, alias: String? = null) {
     val keyManagerAlgorithm = KeyManagerFactory.getDefaultAlgorithm()!!
     val keyManagerFactory = KeyManagerFactory.getInstance(keyManagerAlgorithm)!!
 

--- a/ktor-network/ktor-network-tls/jvm/src/io/ktor/network/tls/TLSConfigBuilder.kt
+++ b/ktor-network/ktor-network-tls/jvm/src/io/ktor/network/tls/TLSConfigBuilder.kt
@@ -86,14 +86,18 @@ public fun TLSConfigBuilder.addCertificateChain(chain: Array<X509Certificate>, k
 @Deprecated("Binary compatibility", level = DeprecationLevel.HIDDEN)
 @Suppress("unused") // Keep for binary compatibility
 public fun TLSConfigBuilder.addKeyStore(store: KeyStore, password: CharArray) {
-    addKeyStore(store, password)
+    addKeyStore(store, password as CharArray?)
 }
 
 /**
  * Add client certificates from [store] by using the certificate with specific [alias]
  * or all certificates, if [alias] is null.
  */
-@Deprecated("Please use the nullable overload", ReplaceWith("addKeyStore(store, password as CharArray?, alias)"), level = DeprecationLevel.WARNING)
+@Deprecated(
+    "Please use the nullable overload",
+    ReplaceWith("addKeyStore(store, password as CharArray?, alias)"),
+    level = DeprecationLevel.WARNING
+)
 public fun TLSConfigBuilder.addKeyStore(store: KeyStore, password: CharArray, alias: String? = null) {
     addKeyStore(store, password as CharArray?, alias)
 }

--- a/ktor-network/ktor-network-tls/jvm/src/io/ktor/network/tls/TLSConfigBuilder.kt
+++ b/ktor-network/ktor-network-tls/jvm/src/io/ktor/network/tls/TLSConfigBuilder.kt
@@ -93,6 +93,7 @@ public fun TLSConfigBuilder.addKeyStore(store: KeyStore, password: CharArray) {
  * Add client certificates from [store] by using the certificate with specific [alias]
  * or all certificates, if [alias] is null.
  */
+@Deprecated("Please use the nullable overload", ReplaceWith("addKeyStore(store, password as CharArray?, alias)"), level = DeprecationLevel.WARNING)
 public fun TLSConfigBuilder.addKeyStore(store: KeyStore, password: CharArray, alias: String? = null) {
     addKeyStore(store, password as CharArray?, alias)
 }

--- a/ktor-network/ktor-network-tls/jvm/test/io/ktor/network/tls/tests/TLSConfigBuilderTest.kt
+++ b/ktor-network/ktor-network-tls/jvm/test/io/ktor/network/tls/tests/TLSConfigBuilderTest.kt
@@ -7,9 +7,108 @@ package io.ktor.network.tls.tests
 import io.ktor.network.tls.*
 import io.ktor.network.tls.certificates.*
 import io.ktor.network.tls.extensions.*
+import io.ktor.util.*
+import java.io.*
+import java.security.*
+import java.security.cert.Certificate
+import java.util.*
 import kotlin.test.*
 
 internal class TLSConfigBuilderTest {
+    /**
+     * Implemented a new KeyStoreSpi, because the JavaKeyStore does not allow setting null as password.
+     *
+     * Some other KeyStoreSpis, like the KeyStoreSpi from IT Solution GmbH/trustWare CSP+ v1.1.0.7 needs null as passwords
+     * because they act as a middleware and en-/decrypt the keys with other passwords, like a PIN.
+     *
+     * This NON-ENCRYPTED in-memory KeyStore should used for testing only!
+     */
+    private class InMemoryKeyStoreSPI : KeyStoreSpi() {
+        sealed class Entry(val date: Date = Date()) {
+            abstract var certificates: Array<Certificate>
+
+            class KeyEntry(val password: CharArray?, val key: Key, override var certificates: Array<Certificate>) :
+                Entry()
+
+            class CertificateEntry(override var certificates: Array<Certificate>) : Entry()
+        }
+
+        private val certificates: MutableMap<String, Entry> = mutableMapOf()
+
+        override fun engineGetKey(alias: String, password: CharArray?): Key? =
+            (certificates[alias] as? Entry.KeyEntry?)?.let { entry ->
+                return if (entry.password.contentEquals(password)) {
+                    entry.key
+                } else {
+                    null
+                }
+            }
+
+        override fun engineGetCertificateChain(alias: String): Array<Certificate>? =
+            certificates[alias]?.certificates
+
+        override fun engineGetCertificate(alias: String): Certificate? =
+            engineGetCertificateChain(alias)?.firstOrNull()
+
+        override fun engineGetCreationDate(alias: String): Date? {
+            return certificates[alias]?.date
+        }
+
+        override fun engineSetKeyEntry(
+            alias: String,
+            key: Key,
+            password: CharArray?,
+            chain: Array<Certificate>
+        ) {
+            certificates[alias] = Entry.KeyEntry(password, key, chain)
+        }
+
+        override fun engineSetKeyEntry(alias: String, key: ByteArray, chain: Array<Certificate>) {
+            error("Not supported")
+        }
+
+        override fun engineSetCertificateEntry(alias: String, cert: Certificate) {
+            certificates[alias]?.certificates = arrayOf(cert)
+        }
+
+        override fun engineDeleteEntry(alias: String) {
+            certificates.remove(alias)
+        }
+
+        override fun engineAliases() = certificates.keys.iterator().enumeration
+
+        private val Iterator<String>.enumeration: Enumeration<String>
+            get() = object : Enumeration<String> {
+                override fun hasMoreElements() = this@enumeration.hasNext()
+                override fun nextElement() = this@enumeration.next()
+            }
+
+        override fun engineContainsAlias(alias: String) = certificates.containsKey(alias)
+
+        override fun engineSize() = certificates.size
+
+        override fun engineIsKeyEntry(alias: String): Boolean {
+            return certificates[alias] is Entry.KeyEntry
+        }
+
+        override fun engineIsCertificateEntry(alias: String): Boolean {
+            return certificates[alias] is Entry.CertificateEntry
+        }
+
+        override fun engineGetCertificateAlias(cert: Certificate): String {
+            return certificates.filterValues { entry ->
+                entry.certificates.first() == cert
+            }.keys.first()
+        }
+
+        override fun engineStore(stream: OutputStream?, password: CharArray?) {
+            error("Not supported")
+        }
+
+        override fun engineLoad(stream: InputStream?, password: CharArray?) {
+            check(stream == null)
+        }
+    }
     private val keyStore = buildKeyStore {
         certificate("first") {
             hash = HashAlgorithm.SHA256
@@ -21,6 +120,29 @@ internal class TLSConfigBuilderTest {
             sign = SignatureAlgorithm.RSA
             password = ""
         }
+    }
+
+    @Test
+    fun useNullAsPassword() {
+        val customProvider = object : Provider("InMemorySPI", "", "") {
+            override fun getService(type: String?, algorithm: String?) =
+                object: Service(this,  this.name, "", InMemoryKeyStoreSPI::class.simpleName, emptyList(), mapOf()) {
+                    override fun newInstance(constructorParameter: Any?) = InMemoryKeyStoreSPI()
+                }
+        }
+
+        val ks = generateCertificate(File.createTempFile("tmp", "jks"))
+        val key = ks.getKey("myKey", "changeit".toCharArray())
+        val cert = ks.getCertificate("myKey")
+
+        val keyStore = KeyStore.getInstance("InMemorySPI", customProvider).apply {
+            load(null, null)
+            setKeyEntry("myKey", key, null, arrayOf(cert))
+        }
+        val tlsConfig = TLSConfigBuilder().apply {
+            addKeyStore(keyStore, null)
+        }
+        assertEquals(1, tlsConfig.certificates.size)
     }
 
     @Test


### PR DESCRIPTION
**Subsystem**
CIO JVM TLSConfigBuilder

Fixing [KTOR-940](https://youtrack.jetbrains.com/issue/KTOR-940)
**Motivation**
It is legal (and possible with Apache HttpClientEngine) to use a keystore without a password. One valid and secure use-case is using a pki/smartcard middleware which is loaded as a keystore, and enforces itself the password/the smartcard pin.

**Solution**
Made password nullable

