### PR TITLE
socketTimeout in EndpointConfig was read only

### DIFF
--- a/ktor-client/ktor-client-cio/common/src/io/ktor/client/engine/cio/CIOEngineConfig.kt
+++ b/ktor-client/ktor-client-cio/common/src/io/ktor/client/engine/cio/CIOEngineConfig.kt
@@ -71,7 +71,7 @@ class EndpointConfig {
     /**
      * Socket timeout in millis.
      */
-    val socketTimeout: Long = HttpTimeout.INFINITE_TIMEOUT_MS
+    var socketTimeout: Long = HttpTimeout.INFINITE_TIMEOUT_MS
 
     /**
      * Maximum number of connection attempts.


### PR DESCRIPTION
**Subsystem**
Client 

**Motivation**
I assume this is a typo. 

**Solution**
Make configuration option writable. 

