### PR TITLE
Add OkHttpConfig#webSocketFactory

### DIFF
--- a/ktor-client/ktor-client-okhttp/jvm/src/io/ktor/client/engine/okhttp/OkHttpConfig.kt
+++ b/ktor-client/ktor-client-okhttp/jvm/src/io/ktor/client/engine/okhttp/OkHttpConfig.kt
@@ -29,6 +29,12 @@ class OkHttpConfig : HttpClientEngineConfig() {
     var clientCacheSize: Int = 10
 
     /**
+     * If provided, this [WebSocket.Factory] will be used to create [WebSocket] instances.
+     * Otherwise, [OkHttpClient] is used directly.
+     */
+    var webSocketFactory: WebSocket.Factory? = null
+
+    /**
      * Configure [OkHttpClient] using [OkHttpClient.Builder].
      */
     fun config(block: OkHttpClient.Builder.() -> Unit) {

--- a/ktor-client/ktor-client-okhttp/jvm/src/io/ktor/client/engine/okhttp/OkHttpEngine.kt
+++ b/ktor-client/ktor-client-okhttp/jvm/src/io/ktor/client/engine/okhttp/OkHttpEngine.kt
@@ -88,7 +88,12 @@ class OkHttpEngine(override val config: OkHttpConfig) : HttpClientEngineBase("kt
         callContext: CoroutineContext
     ): HttpResponseData {
         val requestTime = GMTDate()
-        val session = OkHttpWebsocketSession(engine, engineRequest, callContext).apply { start() }
+        val session = OkHttpWebsocketSession(
+            engine,
+            config.webSocketFactory ?: engine,
+            engineRequest,
+            callContext
+        ).apply { start() }
 
         val originResponse = session.originResponse.await()
         return buildResponseData(originResponse, requestTime, session, callContext)

--- a/ktor-client/ktor-client-okhttp/jvm/src/io/ktor/client/engine/okhttp/OkHttpWebsocketSession.kt
+++ b/ktor-client/ktor-client-okhttp/jvm/src/io/ktor/client/engine/okhttp/OkHttpWebsocketSession.kt
@@ -16,6 +16,7 @@ import kotlin.coroutines.*
 @OptIn(ObsoleteCoroutinesApi::class)
 internal class OkHttpWebsocketSession(
     private val engine: OkHttpClient,
+    private val webSocketFactory: WebSocket.Factory,
     engineRequest: Request,
     override val coroutineContext: CoroutineContext
 ) : DefaultWebSocketSession, WebSocketListener() {
@@ -50,7 +51,7 @@ internal class OkHttpWebsocketSession(
         get() = _closeReason
 
     override val outgoing: SendChannel<Frame> = actor {
-        val websocket: WebSocket = engine.newWebSocket(engineRequest, self.await())
+        val websocket: WebSocket = webSocketFactory.newWebSocket(engineRequest, self.await())
 
         try {
             for (frame in channel) {

--- a/ktor-client/ktor-client-okhttp/jvm/test/io/ktor/client/engine/okhttp/OkHttpWebsocketSessionTest.kt
+++ b/ktor-client/ktor-client-okhttp/jvm/test/io/ktor/client/engine/okhttp/OkHttpWebsocketSessionTest.kt
@@ -15,7 +15,7 @@ class OkHttpWebsocketSessionTest {
         val client = OkHttpClient()
         val request = Request.Builder().url("ws://google.com").build()
         val coroutineContext = Job()
-        val session = OkHttpWebsocketSession(client, request, coroutineContext)
+        val session = OkHttpWebsocketSession(client, client, request, coroutineContext)
         val webSocket = client.newWebSocket(request, object : WebSocketListener() {})
         val exception = RuntimeException()
         session.onFailure(webSocket, exception, null)


### PR DESCRIPTION
**Subsystem**
Client, OkHttp, WebSockets

**Motivation**
[KTOR-951](https://youtrack.jetbrains.com/issue/KTOR-951)  Allow OkHttpConfig to configure WebSocket.Factory 

Previously, OkHttpWebsocketSession used OkHttpClient directly to create WebSocket instances. This meant there was no way to provide a custom implementation of WebSocket interface.

**Solution**
This change allows users to provide their own WebSocket.Factory instance on OkHttpConfig.