### PR TITLE
Jackson: Do not convert to String before converting to JSON

### DIFF
--- a/ktor-features/ktor-jackson/jvm/src/io/ktor/jackson/JacksonConverter.kt
+++ b/ktor-features/ktor-jackson/jvm/src/io/ktor/jackson/JacksonConverter.kt
@@ -33,7 +33,19 @@ import io.ktor.utils.io.jvm.javaio.*
  */
 class JacksonConverter(private val objectmapper: ObjectMapper = jacksonObjectMapper()) : ContentConverter {
     override suspend fun convertForSend(context: PipelineContext<Any, ApplicationCall>, contentType: ContentType, value: Any): Any? {
-        return TextContent(objectmapper.writeValueAsString(value), contentType.withCharset(context.call.suitableCharset()))
+        val charset = context.call.suitableCharset()
+        return OutputStreamContent({
+            if(charset == Charsets.UTF_8) {
+                /*
+                Jackson internally does special casing on UTF-8, presumably for performance reasons. Thus we pass an
+                InputStream instead of a writer to let Jackson do it's thing.
+                 */
+                objectmapper.writeValue(this, value)
+            } else {
+                objectmapper.writeValue(this.writer(charset = charset), value)
+            }
+            }, contentType.withCharset(charset)
+        )
     }
 
     override suspend fun convertForReceive(context: PipelineContext<ApplicationReceiveRequest, ApplicationCall>): Any? {


### PR DESCRIPTION
**Subsystem**
ktor-jackson

**Motivation**
The existing implementation of the JacksonConverter used a TextContent, which meant that the ObjectMapper had to serialize the entire output value to a String before responding.

For large output objects, this causes significant allocation pressure. It can avoid by instead streaming the output. This change does that.

**Solution**

The change is fairly small, simply using different existing streaming methods on the ObjectMapper in combination with a OutputStreamContent.

There is an added test to verify that it got UTF-16 conversion right.