### PR TITLE
Extend MockEngine to return Custom objects

### DIFF
--- a/ktor-client/ktor-client-mock/common/src/io/ktor/client/engine/mock/MockUtils.kt
+++ b/ktor-client/ktor-client-mock/common/src/io/ktor/client/engine/mock/MockUtils.kt
@@ -51,6 +51,13 @@ fun MockRequestHandleScope.respondOk(
     content: String = ""
 ): HttpResponseData = respond(content, HttpStatusCode.OK)
 
+/**
+ * Send ok response with any type of [content].
+ */
+fun MockRequestHandleScope.respondOk(
+    content: Any,
+): HttpResponseData = respond(content, HttpStatusCode.OK)
+
 
 /**
  * Send [HttpStatusCode.BadRequest] response.
@@ -81,6 +88,17 @@ fun MockRequestHandleScope.respond(
  */
 fun MockRequestHandleScope.respond(
     content: ByteReadChannel,
+    status: HttpStatusCode = HttpStatusCode.OK,
+    headers: Headers = headersOf()
+): HttpResponseData = HttpResponseData(
+    status, GMTDate(), headers, HttpProtocolVersion.HTTP_1_1, content, callContext
+)
+
+/**
+ * Send respond with specified [content] as any type, [status] and [headers].
+ */
+fun MockRequestHandleScope.respond(
+    content: Any,
     status: HttpStatusCode = HttpStatusCode.OK,
     headers: Headers = headersOf()
 ): HttpResponseData = HttpResponseData(


### PR DESCRIPTION
**Subsystem**
Client - Mock

**Motivation**
Fixes: #1776 

This ticket extends mock engine supported "responses". By enabling a custom object as a returned object we can do things like 

```kotlin
MockEngine {
       respondOk(content = Json.decodeFromString<User>("{\"name\":\"admin\"}"))
}

// or 
respondOk(content = User(name = "Admin")
```

**Solution**
`HttpResponseData` already accepts `Any` as a body. I've added another overload of `respond` and `respondOk` to be able to returned `Any`.

Fixes: #1776 
