### PR TITLE
KTOR-792 - Fix priority of routing with query parameter selector

### DIFF
--- a/ktor-server/ktor-server-core/jvm/src/io/ktor/routing/RouteSelector.kt
+++ b/ktor-server/ktor-server-core/jvm/src/io/ktor/routing/RouteSelector.kt
@@ -29,6 +29,11 @@ data class RouteSelectorEvaluation(val succeeded: Boolean,
         const val qualityConstant = 1.0
 
         /**
+         * Quality of [RouteSelectorEvaluation] when a query parameter has matched
+         */
+        internal const val qualityQueryParameter = 1.0
+
+        /**
          * Quality of [RouteSelectorEvaluation] when a parameter has matched
          */
         const val qualityParameter = 0.8
@@ -146,11 +151,11 @@ data class ConstantParameterRouteSelector(val name: String, val value: String) :
  * Evaluates a route against a query parameter value and captures its value
  * @param name is a name of the query parameter
  */
-data class ParameterRouteSelector(val name: String) : RouteSelector(RouteSelectorEvaluation.qualityParameter) {
+data class ParameterRouteSelector(val name: String) : RouteSelector(RouteSelectorEvaluation.qualityQueryParameter) {
     override fun evaluate(context: RoutingResolveContext, segmentIndex: Int): RouteSelectorEvaluation {
         val param = context.call.parameters.getAll(name)
         if (param != null)
-            return RouteSelectorEvaluation(true, RouteSelectorEvaluation.qualityParameter, parametersOf(name, param))
+            return RouteSelectorEvaluation(true, RouteSelectorEvaluation.qualityQueryParameter, parametersOf(name, param))
         return RouteSelectorEvaluation.Failed
     }
 
@@ -161,11 +166,11 @@ data class ParameterRouteSelector(val name: String) : RouteSelector(RouteSelecto
  * Evaluates a route against an optional query parameter value and captures its value, if found
  * @param name is a name of the query parameter
  */
-data class OptionalParameterRouteSelector(val name: String) : RouteSelector(RouteSelectorEvaluation.qualityParameter) {
+data class OptionalParameterRouteSelector(val name: String) : RouteSelector(RouteSelectorEvaluation.qualityQueryParameter) {
     override fun evaluate(context: RoutingResolveContext, segmentIndex: Int): RouteSelectorEvaluation {
         val param = context.call.parameters.getAll(name)
         if (param != null)
-            return RouteSelectorEvaluation(true, RouteSelectorEvaluation.qualityParameter, parametersOf(name, param))
+            return RouteSelectorEvaluation(true, RouteSelectorEvaluation.qualityQueryParameter, parametersOf(name, param))
         return RouteSelectorEvaluation.Missing
     }
 

--- a/ktor-server/ktor-server-tests/jvm/test/io/ktor/tests/server/routing/RoutingProcessingTest.kt
+++ b/ktor-server/ktor-server-tests/jvm/test/io/ktor/tests/server/routing/RoutingProcessingTest.kt
@@ -92,7 +92,7 @@ class RoutingProcessingTest {
     }
 
     @Test
-    fun `routing on param route`() = withTestApplication {
+    fun testRoutingOnParamRoute() = withTestApplication {
         var selectedRoute = SelectedRoute.None
         application.routing {
             route("test") {
@@ -128,7 +128,7 @@ class RoutingProcessingTest {
     }
 
     @Test
-    fun `routing on optional param route`() = withTestApplication {
+    fun testRoutingOnOptionalParamRoute() = withTestApplication {
         var selectedRoute = SelectedRoute.None
         application.routing {
             route("test") {
@@ -164,11 +164,11 @@ class RoutingProcessingTest {
     }
 
     @Test
-    fun `routing on route with same quality should be based on order`() = withTestApplication {
-        // `header {}` and `param {}` use quality = 1.0
+    fun testRoutingOnRoutesWithSameQualityShouldBeBasedOnOrder() = withTestApplication {
+        // `accept {}` and `param {}` use quality = 1.0
         var selectedRoute = SelectedRoute.None
         application.routing {
-            route("param") {
+            route("paramFirst") {
                 param("param") {
                     handle {
                         selectedRoute = SelectedRoute.Param
@@ -181,7 +181,7 @@ class RoutingProcessingTest {
                     }
                 }
             }
-            route("header") {
+            route("headerFirst") {
                 accept(ContentType.Text.Plain) {
                     handle {
                         selectedRoute = SelectedRoute.Header
@@ -195,18 +195,18 @@ class RoutingProcessingTest {
                 }
             }
         }
-        on("making request to /param with `param` query parameter and accept header") {
+        on("making request to /paramFirst with `param` query parameter and accept header") {
             handleRequest {
-                uri = "/param?param=value"
+                uri = "/paramFirst?param=value"
                 addHeader(HttpHeaders.Accept, "text/plain")
             }
             it("should choose param routing") {
                 assertEquals(selectedRoute, SelectedRoute.Param)
             }
         }
-        on("making request to /header with `param` query parameter and accept header") {
+        on("making request to /headerFirst with `param` query parameter and accept header") {
             handleRequest {
-                uri = "/header?param=value"
+                uri = "/headerFirst?param=value"
                 addHeader(HttpHeaders.Accept, "text/plain")
             }
             it("should choose header routing") {

--- a/ktor-server/ktor-server-tests/jvm/test/io/ktor/tests/server/routing/RoutingProcessingTest.kt
+++ b/ktor-server/ktor-server-tests/jvm/test/io/ktor/tests/server/routing/RoutingProcessingTest.kt
@@ -14,9 +14,12 @@ import org.junit.Test
 import kotlin.test.*
 
 private enum class SelectedRoute { Get, Param, Header, None }
+private class Foo
 
 class RoutingProcessingTest {
-    @Test fun `routing on GET foo-bar`() = withTestApplication {
+
+    @Test
+    fun testRoutingOnGETFooBar() = withTestApplication {
         application.routing {
             get("/foo/bar") {
                 call.respond(HttpStatusCode.OK)
@@ -47,7 +50,8 @@ class RoutingProcessingTest {
         }
     }
 
-    @Test fun `routing on GET user with parameter`() = withTestApplication {
+    @Test
+    fun testRoutingOnGETUserWithParameter() = withTestApplication {
         var username = ""
         application.routing {
             route("user") {
@@ -72,7 +76,8 @@ class RoutingProcessingTest {
 
     }
 
-    @Test fun `routing on GET user with surrounded parameter`() = withTestApplication {
+    @Test
+    fun testRoutingOnGETUserWithSurroundedParameter() = withTestApplication {
         var username = ""
         application.routing {
             get("/user-{name}-get") {
@@ -215,7 +220,8 @@ class RoutingProcessingTest {
         }
     }
 
-    @Test fun `verify most specific selected`() = withTestApplication {
+    @Test
+    fun testMostSpecificSelected() = withTestApplication {
         var path = ""
         application.routing {
             get("{path...}") {
@@ -245,7 +251,8 @@ class RoutingProcessingTest {
         }
     }
 
-    @Test fun `routing on GET -user-username with interceptors`() = withTestApplication {
+    @Test
+    fun testRoutingOnGETUserUsernameWithInterceptors() = withTestApplication {
 
         var userIntercepted = false
         var wrappedWithInterceptor = false
@@ -278,7 +285,8 @@ class RoutingProcessingTest {
         }
     }
 
-    @Test fun `verify interception order when outer should be after`() = withTestApplication {
+    @Test
+    fun testInterceptionOrderWhenOuterShouldBeAfter() = withTestApplication {
         var userIntercepted = false
         var wrappedWithInterceptor = false
         var rootIntercepted = false
@@ -316,7 +324,8 @@ class RoutingProcessingTest {
         }
     }
 
-    @Test fun `verify interception order when outer should be before because of phase`() = withTestApplication {
+    @Test
+    fun testInterceptionOrderWhenOuterShouldBeBeforeBecauseOfPhase() = withTestApplication {
         var userIntercepted = false
         var wrappedWithInterceptor = false
         var rootIntercepted = false
@@ -354,7 +363,8 @@ class RoutingProcessingTest {
         }
     }
 
-    @Test fun `verify interception order when outer should be before because of order`() = withTestApplication {
+    @Test
+    fun testInterceptionOrderWhenOuterShouldBeBeforeBecauseOfOrder() = withTestApplication {
         var userIntercepted = false
         var wrappedWithInterceptor = false
         var rootIntercepted = false
@@ -392,8 +402,8 @@ class RoutingProcessingTest {
         }
     }
 
-    class Foo
-    @Test fun `intercept receive pipeline`() = withTestApplication {
+    @Test
+    fun testInterceptReceivePipeline() = withTestApplication {
 
         var userIntercepted = false
         var wrappedWithInterceptor = false
@@ -434,7 +444,8 @@ class RoutingProcessingTest {
 
     }
 
-    @Test fun `verify accept header processing`() = withTestApplication {
+    @Test
+    fun testAcceptHeaderProcessing() = withTestApplication {
         application.routing {
             route("/") {
                 accept(ContentType.Text.Plain) {
@@ -484,7 +495,7 @@ class RoutingProcessingTest {
     }
 
     @Test
-    fun `host and port routing processing`(): Unit = withTestApplication {
+    fun testHostAndPortRoutingProcessing(): Unit = withTestApplication {
         application.routing {
             route("/") {
                 host("my-host", 8080) {
@@ -580,7 +591,7 @@ class RoutingProcessingTest {
     }
 
     @Test
-    fun `local port route processing`(): Unit = withTestApplication {
+    fun testLocalPortRouteProcessing(): Unit = withTestApplication {
         application.routing {
             route("/") {
                 // TestApplicationRequest.local defaults to 80 in the absence of headers
@@ -619,7 +630,7 @@ class RoutingProcessingTest {
     }
 
     @Test
-    fun `routing with tracing`() = withTestApplication {
+    fun testRoutingWithTracing() = withTestApplication {
         var trace: RoutingResolveTrace? = null
         application.routing {
             trace {

--- a/ktor-server/ktor-server-tests/jvm/test/io/ktor/tests/server/routing/RoutingProcessingTest.kt
+++ b/ktor-server/ktor-server-tests/jvm/test/io/ktor/tests/server/routing/RoutingProcessingTest.kt
@@ -89,6 +89,77 @@ class RoutingProcessingTest {
 
     }
 
+    enum class SelectedRoute { Get, Param, None }
+    @Test fun `routing on param route`() = withTestApplication {
+        var selectedRoute = SelectedRoute.None
+        application.routing {
+            route("test") {
+                param("param") {
+                    handle {
+                        selectedRoute = SelectedRoute.Param
+                    }
+                }
+
+                get {
+                    selectedRoute = SelectedRoute.Get
+                }
+            }
+        }
+        on("making get request to /test with `param` query parameter") {
+            handleRequest {
+                uri = "/test?param=value"
+                method = HttpMethod.Get
+            }
+            it("should choose param routing") {
+                assertEquals(selectedRoute, SelectedRoute.Param)
+            }
+        }
+        on("making get request to /test without `param` query parameter") {
+            handleRequest {
+                uri = "/test"
+                method = HttpMethod.Get
+            }
+            it("should choose get routing") {
+                assertEquals(selectedRoute, SelectedRoute.Get)
+            }
+        }
+    }
+
+    @Test fun `routing on optional param route`() = withTestApplication {
+        var selectedRoute = SelectedRoute.None
+        application.routing {
+            route("test") {
+                optionalParam("param") {
+                    handle {
+                        selectedRoute = SelectedRoute.Param
+                    }
+                }
+
+                get {
+                    selectedRoute = SelectedRoute.Get
+                }
+            }
+        }
+        on("making get request to /test with `param` query parameter") {
+            handleRequest {
+                uri = "/test?param=value"
+                method = HttpMethod.Get
+            }
+            it("should choose param routing") {
+                assertEquals(selectedRoute, SelectedRoute.Param)
+            }
+        }
+        on("making get request to /test without `param` query parameter") {
+            handleRequest {
+                uri = "/test"
+                method = HttpMethod.Get
+            }
+            it("should choose get routing") {
+                assertEquals(selectedRoute, SelectedRoute.Get)
+            }
+        }
+    }
+
     @Test fun `verify most specific selected`() = withTestApplication {
         var path = ""
         application.routing {


### PR DESCRIPTION
**Subsystem**
Server

**Motivation**
[Routing: get matcher has higher priority than param matcher on the same level
](https://youtrack.jetbrains.com/issue/KTOR-792)

**Solution**
Original problem happens because `ParameterRouteSelector` uses the same priority (quality) as `PathSegmentParameterRouteSelector`, but they should not be the same

Example:

1. path: `/users/admin`
selectors:
* `/users/admin` - `qualityConstant` (1.0)
* `/users/{username}` - `qualityParameter` (0.8)
in this case chosen selector is `/users/admin` because it's more specific - everything works as expected

2. path: `/users?username=admin`
selectors:
* `users?[username]` - `qualityParameter` (0.8)
* `users:get` - `qualityConstant` (1.0)
Here selector `users:get` wins, but is should be the opposite. Route with parameter is more specific and should have higher priority.

To make fix without api changes I introduces `internal` constant `qualityQueryParameter = 1.0` and use it for routing with query parameter. Downside of it - now we have `qualityQueryParameter` and `qualityParameter` and this  can be confusing.
 
In the follow up PR I will make `qualityQueryParameter` public,  create new constant `qualityPathParameter` and deprecate `qualityParameter` in favour of the new one. This will introduce public API change and can't be done in patch release.

