### PR TITLE
KTOR-792 - Follow up on #2041 with cleanup and API change

### DIFF
--- a/ktor-server/ktor-server-core/api/ktor-server-core.api
+++ b/ktor-server/ktor-server-core/api/ktor-server-core.api
@@ -1355,8 +1355,12 @@ public abstract class io/ktor/routing/RouteSelector {
 public final class io/ktor/routing/RouteSelectorEvaluation {
 	public static final field Companion Lio/ktor/routing/RouteSelectorEvaluation$Companion;
 	public static final field qualityConstant D
+	public static final field qualityMethodParameter D
 	public static final field qualityMissing D
 	public static final field qualityParameter D
+	public static final field qualityParameterWithPrefixOrSuffix D
+	public static final field qualityPathParameter D
+	public static final field qualityQueryParameter D
 	public static final field qualityTailcard D
 	public static final field qualityWildcard D
 	public fun <init> (ZDLio/ktor/http/Parameters;I)V

--- a/ktor-server/ktor-server-core/jvm/src/io/ktor/routing/RouteSelector.kt
+++ b/ktor-server/ktor-server-core/jvm/src/io/ktor/routing/RouteSelector.kt
@@ -33,22 +33,27 @@ public data class RouteSelectorEvaluation(
         /**
          * Quality of [RouteSelectorEvaluation] when a query parameter has matched
         */
-        public const val qualityQueryParameter = 1.0
+        public const val qualityQueryParameter: Double = 1.0
+
+        /**
+         * Quality of [RouteSelectorEvaluation] when a parameter with prefix or suffix has matched
+         */
+        public const val qualityParameterWithPrefixOrSuffix: Double = 0.9
 
         /**
          * Generic quality of [RouteSelectorEvaluation] to use as reference when some specific parameter has matched
          */
-        public const val qualityParameter = 0.8
+        public const val qualityParameter: Double = 0.8
 
         /**
          * Quality of [RouteSelectorEvaluation] when a path parameter has matched
          */
-        public const val qualityPathParameter = qualityParameter
+        public const val qualityPathParameter: Double = qualityParameter
 
         /**
          * Quality of [RouteSelectorEvaluation] when a HTTP method parameter has matched
          */
-        public const val qualityMethodParameter = qualityParameter
+        public const val qualityMethodParameter: Double= qualityParameter
 
         /**
          * Quality of [RouteSelectorEvaluation] when a wildcard has matched

--- a/ktor-server/ktor-server-core/jvm/src/io/ktor/routing/RouteSelector.kt
+++ b/ktor-server/ktor-server-core/jvm/src/io/ktor/routing/RouteSelector.kt
@@ -32,18 +32,23 @@ public data class RouteSelectorEvaluation(
 
         /**
          * Quality of [RouteSelectorEvaluation] when a query parameter has matched
-         */
-        internal const val qualityQueryParameter = 1.0
+        */
+        public const val qualityQueryParameter = 1.0
 
         /**
-         * Quality of [RouteSelectorEvaluation] when a parameter with prefix or suffix has matched
+         * Generic quality of [RouteSelectorEvaluation] to use as reference when some specific parameter has matched
          */
-        internal const val qualityParameterWithPrefixOrSuffix = 0.9
+        public const val qualityParameter = 0.8
 
         /**
-         * Quality of [RouteSelectorEvaluation] when a parameter has matched
+         * Quality of [RouteSelectorEvaluation] when a path parameter has matched
          */
-        public const val qualityParameter: Double = 0.8
+        public const val qualityPathParameter = qualityParameter
+
+        /**
+         * Quality of [RouteSelectorEvaluation] when a HTTP method parameter has matched
+         */
+        public const val qualityMethodParameter = qualityParameter
 
         /**
          * Quality of [RouteSelectorEvaluation] when a wildcard has matched

--- a/ktor-server/ktor-server-core/jvm/src/io/ktor/routing/RouteSelector.kt
+++ b/ktor-server/ktor-server-core/jvm/src/io/ktor/routing/RouteSelector.kt
@@ -227,7 +227,7 @@ public data class PathSegmentParameterRouteSelector(
     val name: String,
     val prefix: String? = null,
     val suffix: String? = null
-) : RouteSelector(RouteSelectorEvaluation.qualityParameter) {
+) : RouteSelector(RouteSelectorEvaluation.qualityPathParameter) {
     override fun evaluate(context: RoutingResolveContext, segmentIndex: Int): RouteSelectorEvaluation {
         return evaluatePathSegmentParameter(
             segments = context.segments,
@@ -252,7 +252,7 @@ public data class PathSegmentOptionalParameterRouteSelector(
     val name: String,
     val prefix: String? = null,
     val suffix: String? = null
-) : RouteSelector(RouteSelectorEvaluation.qualityParameter) {
+) : RouteSelector(RouteSelectorEvaluation.qualityPathParameter) {
     override fun evaluate(context: RoutingResolveContext, segmentIndex: Int): RouteSelectorEvaluation {
         return evaluatePathSegmentParameter(
             segments = context.segments,
@@ -368,7 +368,7 @@ public data class AndRouteSelector(val first: RouteSelector, val second: RouteSe
  * @param method is an instance of [HttpMethod]
  */
 public data class HttpMethodRouteSelector(val method: HttpMethod) :
-    RouteSelector(RouteSelectorEvaluation.qualityParameter) {
+    RouteSelector(RouteSelectorEvaluation.qualityMethodParameter) {
     override fun evaluate(context: RoutingResolveContext, segmentIndex: Int): RouteSelectorEvaluation {
         if (context.call.request.httpMethod == method)
             return RouteSelectorEvaluation.Constant
@@ -454,7 +454,7 @@ internal fun evaluatePathSegmentParameter(
     val values = parametersOf(name, suffixChecked)
     return RouteSelectorEvaluation(
         succeeded = true,
-        quality = if (prefix.isNullOrEmpty() && suffix.isNullOrEmpty()) RouteSelectorEvaluation.qualityParameter
+        quality = if (prefix.isNullOrEmpty() && suffix.isNullOrEmpty()) RouteSelectorEvaluation.qualityPathParameter
         else RouteSelectorEvaluation.qualityParameterWithPrefixOrSuffix,
         parameters = values,
         segmentIncrement = 1

--- a/ktor-server/ktor-server-core/jvm/src/io/ktor/routing/RouteSelector.kt
+++ b/ktor-server/ktor-server-core/jvm/src/io/ktor/routing/RouteSelector.kt
@@ -53,7 +53,7 @@ public data class RouteSelectorEvaluation(
         /**
          * Quality of [RouteSelectorEvaluation] when a HTTP method parameter has matched
          */
-        public const val qualityMethodParameter: Double= qualityParameter
+        public const val qualityMethodParameter: Double = qualityParameter
 
         /**
          * Quality of [RouteSelectorEvaluation] when a wildcard has matched


### PR DESCRIPTION
**Subsystem**
Server

**Motivation**
Cleanup #2041 with better naming but API change

**Solution**
Separate quality constants for different route selectors. Since this change adds new constants to public API, it can't go to patch release.
