### PR TITLE
Fix empty multipart payload processing

### DIFF
--- a/ktor-http/ktor-http-cio/build.gradle
+++ b/ktor-http/ktor-http-cio/build.gradle
@@ -10,4 +10,8 @@ kotlin.sourceSets {
     jvmMain.dependencies {
         api project(':ktor-network')
     }
+
+    jvmTest.dependencies {
+        implementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:$coroutines_version")
+    }
 }

--- a/ktor-http/ktor-http-cio/jvm/src/io/ktor/http/cio/Multipart.kt
+++ b/ktor-http/ktor-http-cio/jvm/src/io/ktor/http/cio/Multipart.kt
@@ -199,9 +199,12 @@ public suspend fun boundary(boundaryPrefixed: ByteBuffer, input: ByteReadChannel
 
 /**
  * Skip multipart boundary
+ * @return `true` if end channel encountered
  */
 private suspend fun skipBoundary(boundaryPrefixed: ByteBuffer, input: ByteReadChannel): Boolean {
-    input.skipDelimiter(boundaryPrefixed)
+    if (!input.skipDelimiterOrEof(boundaryPrefixed)) {
+        return true
+    }
 
     var result = false
     @Suppress("DEPRECATION")
@@ -554,4 +557,106 @@ public fun parseBoundary(contentType: CharSequence): ByteBuffer {
     }
 
     return boundaryBytes
+}
+
+/**
+ * Tries to skip the specified [delimiter] or fails if encounters bytes differs from the required.
+ * @return `true` if the delimiter was found and skipped or `false` when EOF.
+ */
+internal suspend fun ByteReadChannel.skipDelimiterOrEof(delimiter: ByteBuffer): Boolean {
+    require(delimiter.hasRemaining())
+    require(delimiter.remaining() <= DEFAULT_BUFFER_SIZE) {
+        "Delimiter of ${delimiter.remaining()} bytes is too long: at most $DEFAULT_BUFFER_SIZE bytes could be checked"
+    }
+
+    var found = false
+
+    lookAhead {
+        found = tryEnsureDelimiter(delimiter) == delimiter.remaining()
+    }
+
+    if (found) {
+        return true
+    }
+
+    return trySkipDelimiterSuspend(delimiter)
+}
+
+private suspend fun ByteReadChannel.trySkipDelimiterSuspend(delimiter: ByteBuffer): Boolean {
+    var result = true
+
+    lookAheadSuspend {
+        if (!awaitAtLeast(delimiter.remaining()) && !awaitAtLeast(1)) {
+            result = false
+            return@lookAheadSuspend
+        }
+        if (tryEnsureDelimiter(delimiter) != delimiter.remaining()) throw IOException("Broken delimiter occurred")
+    }
+
+    return result
+}
+
+@Suppress("DEPRECATION")
+private fun LookAheadSession.tryEnsureDelimiter(delimiter: ByteBuffer): Int {
+    val found = startsWithDelimiter(delimiter)
+    if (found == -1) throw IOException("Failed to skip delimiter: actual bytes differ from delimiter bytes")
+    if (found < delimiter.remaining()) return found
+
+    consumed(delimiter.remaining())
+    return delimiter.remaining()
+}
+
+@Suppress("LoopToCallChain")
+private fun ByteBuffer.startsWith(prefix: ByteBuffer, prefixSkip: Int = 0): Boolean {
+    val size = minOf(remaining(), prefix.remaining() - prefixSkip)
+    if (size <= 0) return false
+
+    val position = position()
+    val prefixPosition = prefix.position() + prefixSkip
+
+    for (i in 0 until size) {
+        if (get(position + i) != prefix.get(prefixPosition + i)) return false
+    }
+
+    return true
+}
+
+/**
+ * @return Number of bytes of the delimiter found (possibly 0 if no bytes available yet) or -1 if it doesn't start
+ */
+@Suppress("DEPRECATION")
+private fun LookAheadSession.startsWithDelimiter(delimiter: ByteBuffer): Int {
+    val buffer = request(0, 1) ?: return 0
+    val index = buffer.indexOfPartial(delimiter)
+    if (index != 0) return -1
+
+    val found = minOf(buffer.remaining() - index, delimiter.remaining())
+    val notKnown = delimiter.remaining() - found
+
+    if (notKnown > 0) {
+        val next = request(index + found, notKnown) ?: return found
+        if (!next.startsWith(delimiter, found)) return -1
+    }
+
+    return delimiter.remaining()
+}
+
+@Suppress("LoopToCallChain")
+private fun ByteBuffer.indexOfPartial(sub: ByteBuffer): Int {
+    val subPosition = sub.position()
+    val subSize = sub.remaining()
+    val first = sub[subPosition]
+    val limit = limit()
+
+    outer@for (idx in position() until limit) {
+        if (get(idx) == first) {
+            for (j in 1 until subSize) {
+                if (idx + j == limit) break
+                if (get(idx + j) != sub.get(subPosition + j)) continue@outer
+            }
+            return idx - position()
+        }
+    }
+
+    return -1
 }

--- a/ktor-http/ktor-http-cio/jvm/test/io/ktor/tests/http/cio/TrySkipDelimiterTest.kt
+++ b/ktor-http/ktor-http-cio/jvm/test/io/ktor/tests/http/cio/TrySkipDelimiterTest.kt
@@ -1,0 +1,148 @@
+/*
+ * Copyright 2014-2020 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.tests.http.cio
+
+import io.ktor.http.cio.*
+import io.ktor.utils.io.*
+import kotlinx.coroutines.*
+import kotlinx.coroutines.test.*
+import java.nio.*
+import kotlin.test.*
+
+class TrySkipDelimiterTest {
+    private val ch = ByteChannel()
+
+    @Test
+    fun testSmoke(): Unit = runBlockingTest {
+        ch.writeFully(byteArrayOf(1, 2, 3))
+        ch.close()
+
+        val delimiter = ByteBuffer.wrap(byteArrayOf(1, 2))
+        assertTrue(ch.skipDelimiterOrEof(delimiter))
+        assertEquals(3, ch.readByte())
+        assertTrue(ch.isClosedForRead)
+    }
+
+    @Test
+    fun testSmokeWithOffsetShift(): Unit = runBlockingTest {
+        ch.writeFully(byteArrayOf(9, 1, 2, 3))
+        ch.close()
+
+        val delimiter = ByteBuffer.wrap(byteArrayOf(1, 2))
+        ch.discard(1)
+        assertTrue(ch.skipDelimiterOrEof(delimiter))
+        assertEquals(3, ch.readByte())
+        assertTrue(ch.isClosedForRead)
+    }
+
+    @Test
+    fun testEmpty(): Unit = runBlockingTest {
+        ch.close()
+
+        val delimiter = ByteBuffer.wrap(byteArrayOf(1, 2))
+        assertFalse(ch.skipDelimiterOrEof(delimiter))
+    }
+
+    @Test
+    fun testFull(): Unit = runBlockingTest {
+        ch.writeFully(byteArrayOf(1, 2))
+        ch.close()
+
+        val delimiter = ByteBuffer.wrap(byteArrayOf(1, 2))
+        assertTrue(ch.skipDelimiterOrEof(delimiter))
+        assertTrue(ch.isClosedForRead)
+    }
+
+    @Test
+    fun testIncomplete(): Unit = runBlockingTest {
+        ch.writeFully(byteArrayOf(1, 2))
+        ch.close()
+
+        val delimiter = ByteBuffer.wrap(byteArrayOf(1, 2, 3))
+        assertFails {
+            ch.skipDelimiterOrEof(delimiter)
+        }
+    }
+
+    @Test
+    fun testOtherBytes(): Unit = runBlockingTest {
+        ch.writeFully(byteArrayOf(7, 8))
+        ch.close()
+
+        val delimiter = ByteBuffer.wrap(byteArrayOf(1, 2))
+
+        assertFails {
+            ch.skipDelimiterOrEof(delimiter)
+        }
+
+        // content shouldn't be consumed
+        assertEquals(7, ch.readByte())
+        assertEquals(8, ch.readByte())
+        assertTrue(ch.isClosedForRead)
+    }
+
+    @Test
+    fun testTimeSplit(): Unit = runBlockingTest {
+        val writer = launch(CoroutineName("writer"), start = CoroutineStart.LAZY) {
+            ch.writeByte(2)
+            ch.close()
+        }
+
+        ch.writeByte(1)
+        ch.flush()
+        writer.start()
+
+        val delimiter = ByteBuffer.wrap(byteArrayOf(1, 2))
+
+        assertTrue(ch.skipDelimiterOrEof(delimiter))
+
+        assertTrue(ch.isClosedForRead)
+    }
+
+    @Test
+    fun testTimeSplitNonClosed(): Unit = runBlockingTest {
+        val writer = launch(CoroutineName("writer"), start = CoroutineStart.LAZY) {
+            ch.writeByte(2)
+            ch.flush()
+        }
+
+        ch.writeByte(1)
+        ch.flush()
+        writer.start()
+
+        val delimiter = ByteBuffer.wrap(byteArrayOf(1, 2))
+
+        assertTrue(ch.skipDelimiterOrEof(delimiter))
+        assertFalse(ch.isClosedForRead)
+        ch.cancel()
+    }
+
+    @Test
+    fun testTimeSplitWrongBytes(): Unit = runBlockingTest {
+        val writer = launch(CoroutineName("writer"), start = CoroutineStart.LAZY) {
+            ch.writeByte(33)
+            ch.flush()
+        }
+
+        ch.writeByte(1)
+        ch.flush()
+        writer.start()
+
+        val delimiter = ByteBuffer.wrap(byteArrayOf(1, 2))
+
+        assertFails {
+            ch.skipDelimiterOrEof(delimiter)
+        }
+
+        assertEquals(2, ch.availableForRead)
+    }
+
+    @Test
+    fun testSkipTooLongDelimiter(): Unit = runBlockingTest {
+        assertFails {
+            ch.skipDelimiterOrEof(ByteBuffer.allocate(DEFAULT_BUFFER_SIZE * 2))
+        }
+    }
+}

--- a/ktor-io/jvm/test/io/ktor/utils/io/SkipDelimiterTest.kt
+++ b/ktor-io/jvm/test/io/ktor/utils/io/SkipDelimiterTest.kt
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2014-2020 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.utils.io
+
+import java.nio.*
+import kotlin.test.*
+
+class SkipDelimiterTest : ByteChannelTestBase() {
+    @Test
+    fun testSmoke(): Unit = runTest {
+        ch.writeFully(byteArrayOf(1, 2, 3))
+        ch.close()
+
+        val delimiter = ByteBuffer.wrap(byteArrayOf(1, 2))
+        ch.skipDelimiter(delimiter)
+        assertEquals(3, ch.readByte())
+        assertTrue(ch.isClosedForRead)
+    }
+
+    @Test
+    fun testSmokeWithOffsetShift(): Unit = runTest {
+        ch.writeFully(byteArrayOf(9, 1, 2, 3))
+        ch.close()
+
+        val delimiter = ByteBuffer.wrap(byteArrayOf(1, 2))
+        ch.discard(1)
+        ch.skipDelimiter(delimiter)
+        assertEquals(3, ch.readByte())
+        assertTrue(ch.isClosedForRead)
+    }
+
+    @Test
+    fun testEmpty(): Unit = runTest {
+        ch.close()
+
+        val delimiter = ByteBuffer.wrap(byteArrayOf(1, 2))
+        assertFails {
+            ch.skipDelimiter(delimiter)
+        }
+    }
+
+    @Test
+    fun testFull(): Unit = runTest {
+        ch.writeFully(byteArrayOf(1, 2))
+        ch.close()
+
+        val delimiter = ByteBuffer.wrap(byteArrayOf(1, 2))
+        ch.skipDelimiter(delimiter)
+        assertTrue(ch.isClosedForRead)
+    }
+
+    @Test
+    fun testIncomplete(): Unit = runTest {
+        ch.writeFully(byteArrayOf(1, 2))
+        ch.close()
+
+        val delimiter = ByteBuffer.wrap(byteArrayOf(1, 2, 3))
+        assertFails {
+            ch.skipDelimiter(delimiter)
+        }
+    }
+
+    @Test
+    fun testOtherBytes(): Unit = runTest {
+        ch.writeFully(byteArrayOf(7, 8))
+        ch.close()
+
+        val delimiter = ByteBuffer.wrap(byteArrayOf(1, 2))
+
+        assertFails {
+            ch.skipDelimiter(delimiter)
+        }
+
+        // content shouldn't be consumed
+        assertEquals(7, ch.readByte())
+        assertEquals(8, ch.readByte())
+        assertTrue(ch.isClosedForRead)
+    }
+}


### PR DESCRIPTION
**Subsystem**
Both client and server

**Motivation**
[#KTOR-767](https://youtrack.jetbrains.com/issue/KTOR-767) (same as #482 )

I personally don't see if an empty payload is exactly conforming the specification but for sure we need to handle it safely since browsers generate such requests.

**Solution**
Don't demand a delimiter but try to skip and succeed if EOF detected. 

**Note**
For review purpose, the reformat/"explicit public" commit will be added later.
