### PR TITLE
Server session ID handling

### DIFF
--- a/ktor-server/ktor-server-core/jvm/src/io/ktor/sessions/SessionTrackerById.kt
+++ b/ktor-server/ktor-server-core/jvm/src/io/ktor/sessions/SessionTrackerById.kt
@@ -36,7 +36,7 @@ class SessionTrackerById<S : Any>(
                 serializer.deserialize(text)
             }
         } catch (notFound: NoSuchElementException) {
-            call.application.log.debug("Failed to lookup session: $notFound")
+            call.application.log.debug("Failed to lookup session: ${notFound.message ?: notFound.toString()}")
         }
 
         // we remove the wrong session identifier if no related session found

--- a/ktor-server/ktor-server-core/jvm/src/io/ktor/sessions/Sessions.kt
+++ b/ktor-server/ktor-server-core/jvm/src/io/ktor/sessions/Sessions.kt
@@ -203,7 +203,8 @@ private data class SessionData(val sessions: Sessions,
 private suspend fun <S : Any> SessionProvider<S>.receiveSessionData(call: ApplicationCall): SessionProviderData<S> {
     val receivedValue = transport.receive(call)
     val unwrapped = tracker.load(call, receivedValue)
-    return SessionProviderData(unwrapped, unwrapped != null, this)
+    val incoming = receivedValue != null || unwrapped != null
+    return SessionProviderData(unwrapped, incoming, this)
 }
 
 private suspend fun <S : Any> SessionProviderData<S>.sendSessionData(call: ApplicationCall) {


### PR DESCRIPTION
**Subsystem**
ktor-server-core

**Motivation**
This PR corrects the wrong behaviour in the case when a client sends a wrong session ID through cookies. This could happen if a session is expired or after the server restart with in-memory session storage.

Logging related issue: [YT #776](https://youtrack.jetbrains.com/issue/KTOR-776)
Cookie handling: [YT #1007](https://youtrack.jetbrains.com/issue/KTOR-1007)

**Solution**
- Remove the exception name that caused confusion
- Remove wrong session ids by sending cookie expiration so a client stops sending wrong IDs

