### PR TITLE
Fix typo: it's -> its

### DIFF
--- a/ktor-utils/common/src/io/ktor/util/Annotations.kt
+++ b/ktor-utils/common/src/io/ktor/util/Annotations.kt
@@ -34,7 +34,7 @@ annotation class InternalAPI
 @RequiresOptIn(
     level = RequiresOptIn.Level.WARNING,
     message = "This API is experimental. " +
-        "It could be removed or changed in future releases or it's behaviour may be different."
+        "It could be removed or changed in future releases or its behaviour may be different."
 )
 @Experimental(level = Experimental.Level.WARNING)
 @Target(

--- a/ktor-utils/common/src/io/ktor/util/Annotations.kt
+++ b/ktor-utils/common/src/io/ktor/util/Annotations.kt
@@ -34,7 +34,7 @@ annotation class InternalAPI
 @RequiresOptIn(
     level = RequiresOptIn.Level.WARNING,
     message = "This API is experimental. " +
-        "It could be removed or changed in future releases or its behaviour may be different."
+        "It could be removed or changed in future releases, or its behaviour may be different."
 )
 @Experimental(level = Experimental.Level.WARNING)
 @Target(


### PR DESCRIPTION
Reminder for those struggling:
Possessive adjective: her, his, its (one word, see)
Being: she's, he's, it's (two words contracted)