### PR TITLE
KTOR-949 fix reusing HttpRequestBuilder for different network clients

### DIFF
--- a/ktor-client/ktor-client-core/common/src/io/ktor/client/request/HttpRequest.kt
+++ b/ktor-client/ktor-client-core/common/src/io/ktor/client/request/HttpRequest.kt
@@ -85,7 +85,7 @@ public class HttpRequestBuilder : HttpMessageBuilder {
      * A deferred used to control the execution of this request.
      */
     @KtorExperimentalAPI
-    public var executionContext: Job = Job()
+    public var executionContext: Job = SupervisorJob()
         .also { it.makeShared() }
         internal set(value) {
             value.makeShared()

--- a/ktor-client/ktor-client-okhttp/jvm/test/io/ktor/client/engine/okhttp/RequestTests.kt
+++ b/ktor-client/ktor-client-okhttp/jvm/test/io/ktor/client/engine/okhttp/RequestTests.kt
@@ -4,12 +4,32 @@
 
 package io.ktor.client.engine.okhttp
 
+import io.ktor.application.*
+import io.ktor.client.*
 import io.ktor.client.request.*
 import io.ktor.client.tests.utils.*
+import io.ktor.http.*
+import io.ktor.network.sockets.*
+import io.ktor.response.*
+import io.ktor.routing.*
+import io.ktor.server.cio.*
+import io.ktor.server.engine.*
+import kotlinx.coroutines.*
 import okhttp3.*
+import java.time.*
 import kotlin.test.*
 
-class RequestTests {
+class RequestTests : TestWithKtor() {
+
+    override val server = embeddedServer(CIO, serverPort) {
+        routing {
+            get("/delay") {
+                val delay = call.parameters["delay"]!!.toLong()
+                delay(delay)
+                call.respondText("OK")
+            }
+        }
+    }
 
     class LoggingInterceptor : Interceptor {
         override fun intercept(chain: Interceptor.Chain): Response {
@@ -30,6 +50,34 @@ class RequestTests {
 
         test { client ->
             client.get<String>("https://google.com")
+        }
+    }
+
+    @Test
+    fun testReusingRequestBuilderOnMultipleClients() {
+        val rb = HttpRequestBuilder()
+        rb.url.takeFrom("http://0.0.0.0:$serverPort/delay?delay=500")
+
+        val clientFail = HttpClient(OkHttp) {
+            engine {
+                config {
+                    readTimeout(Duration.ofMillis(100)) // SocketTimeoutException
+                }
+            }
+        }
+        val clientSuccess = HttpClient(OkHttp) {
+            engine {
+                config {
+                    readTimeout(Duration.ofMillis(1000)) // success
+                }
+            }
+        }
+
+        runBlocking {
+            assertFailsWith<SocketTimeoutException> { clientFail.get<HttpResponseData>(rb) }
+
+            val response = clientSuccess.get<String>(rb)
+            assertEquals("OK", response)
         }
     }
 }

--- a/ktor-client/ktor-client-okhttp/jvm/test/io/ktor/client/engine/okhttp/RequestTests.kt
+++ b/ktor-client/ktor-client-okhttp/jvm/test/io/ktor/client/engine/okhttp/RequestTests.kt
@@ -55,8 +55,8 @@ class RequestTests : TestWithKtor() {
 
     @Test
     fun testReusingRequestBuilderOnMultipleClients() {
-        val rb = HttpRequestBuilder()
-        rb.url.takeFrom("http://0.0.0.0:$serverPort/delay?delay=500")
+        val requestBuilder = HttpRequestBuilder()
+        requestBuilder.url.takeFrom("$testUrl/delay?delay=500")
 
         val clientFail = HttpClient(OkHttp) {
             engine {
@@ -74,9 +74,9 @@ class RequestTests : TestWithKtor() {
         }
 
         runBlocking {
-            assertFailsWith<SocketTimeoutException> { clientFail.get<HttpResponseData>(rb) }
+            assertFailsWith<SocketTimeoutException> { clientFail.get<HttpResponseData>(requestBuilder) }
 
-            val response = clientSuccess.get<String>(rb)
+            val response = clientSuccess.get<String>(requestBuilder)
             assertEquals("OK", response)
         }
     }

--- a/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/ExceptionsTest.kt
+++ b/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/ExceptionsTest.kt
@@ -4,6 +4,8 @@
 
 package io.ktor.client.tests
 
+import io.ktor.client.*
+import io.ktor.client.engine.mock.*
 import io.ktor.client.features.*
 import io.ktor.client.request.*
 import io.ktor.client.statement.*
@@ -12,7 +14,8 @@ import io.ktor.http.*
 import io.ktor.test.dispatcher.*
 import io.ktor.util.*
 import kotlin.test.*
-
+import kotlin.coroutines.*
+import kotlinx.coroutines.*
 
 class ExceptionsTest : ClientLoader() {
 

--- a/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/ExceptionsTest.kt
+++ b/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/ExceptionsTest.kt
@@ -40,7 +40,7 @@ class ExceptionsTest : ClientLoader() {
     }
 
     @Test
-    fun testErrorOnResponseCoroutine() = clientTests {
+    fun testErrorOnResponseCoroutine() = clientTests(listOf("Curl")) {
         config {
             test { client ->
                 val requestBuilder = HttpRequestBuilder()

--- a/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/ExceptionsTest.kt
+++ b/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/ExceptionsTest.kt
@@ -41,25 +41,23 @@ class ExceptionsTest : ClientLoader() {
 
     @Test
     fun testErrorOnResponseCoroutine() = clientTests(listOf("Curl")) {
-        config {
-            test { client ->
-                val requestBuilder = HttpRequestBuilder()
-                requestBuilder.url.takeFrom("$TEST_SERVER/download/infinite")
+        test { client ->
+            val requestBuilder = HttpRequestBuilder()
+            requestBuilder.url.takeFrom("$TEST_SERVER/download/infinite")
 
-                assertFailsWith<IllegalStateException> {
-                    client.get<HttpStatement>(requestBuilder).execute { response ->
-                        try {
-                            CoroutineScope(response.coroutineContext)
-                                .launch { throw IllegalStateException("failed on receive") }
-                                .join()
-                        } catch (e: Exception) {
-                        }
-                        response.content.toByteArray()
+            assertFailsWith<IllegalStateException> {
+                client.get<HttpStatement>(requestBuilder).execute { response ->
+                    try {
+                        CoroutineScope(response.coroutineContext)
+                            .launch { throw IllegalStateException("failed on receive") }
+                            .join()
+                    } catch (e: Exception) {
                     }
+                    response.content.toByteArray()
                 }
-
-                assertTrue(requestBuilder.executionContext[Job]!!.isActive)
             }
+
+            assertTrue(requestBuilder.executionContext[Job]!!.isActive)
         }
     }
 }

--- a/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/ExceptionsTest.kt
+++ b/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/ExceptionsTest.kt
@@ -5,6 +5,7 @@
 package io.ktor.client.tests
 
 import io.ktor.client.*
+import io.ktor.client.call.*
 import io.ktor.client.engine.mock.*
 import io.ktor.client.features.*
 import io.ktor.client.request.*
@@ -40,7 +41,7 @@ class ExceptionsTest : ClientLoader() {
     }
 
     @Test
-    fun testErrorOnResponseCoroutine() = clientTests(listOf("Curl")) {
+    fun testErrorOnResponseCoroutine() = clientTests(listOf("Curl", "CIO")) {
         test { client ->
             val requestBuilder = HttpRequestBuilder()
             requestBuilder.url.takeFrom("$TEST_SERVER/download/infinite")
@@ -53,7 +54,7 @@ class ExceptionsTest : ClientLoader() {
                             .join()
                     } catch (e: Exception) {
                     }
-                    response.content.toByteArray()
+                    response.receive<String>()
                 }
             }
 

--- a/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/ExceptionsTest.kt
+++ b/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/ExceptionsTest.kt
@@ -52,7 +52,7 @@ class ExceptionsTest : ClientLoader() {
                         CoroutineScope(response.coroutineContext)
                             .launch { throw IllegalStateException("failed on receive") }
                             .join()
-                    } catch (e: Exception) {
+                    } catch (cause: Exception) {
                     }
                     response.receive<String>()
                 }

--- a/ktor-client/ktor-client-tests/jvm/src/io/ktor/client/tests/utils/TestWithKtor.kt
+++ b/ktor-client/ktor-client-tests/jvm/src/io/ktor/client/tests/utils/TestWithKtor.kt
@@ -16,6 +16,7 @@ import java.util.concurrent.*
 @Suppress("KDocMissingDocumentation")
 public abstract class TestWithKtor {
     protected val serverPort: Int = ServerSocket(0).use { it.localPort }
+    protected val testUrl: String = "http://localhost:$serverPort"
 
     @get:Rule
     public open val timeout: CoroutinesTimeout = CoroutinesTimeout.seconds(5 * 60)

--- a/ktor-client/ktor-client-tests/jvm/src/io/ktor/client/tests/utils/tests/Download.kt
+++ b/ktor-client/ktor-client-tests/jvm/src/io/ktor/client/tests/utils/tests/Download.kt
@@ -9,6 +9,7 @@ import io.ktor.http.*
 import io.ktor.http.content.*
 import io.ktor.response.*
 import io.ktor.routing.*
+import kotlinx.coroutines.*
 
 private val content: String = buildString {
     repeat(1875) {
@@ -21,6 +22,14 @@ internal fun Application.downloadTest() {
         route("download") {
             get("8175") {
                 call.respond(TextContent(content, ContentType.Text.Plain))
+            }
+            get("infinite") {
+                call.respondOutputStream {
+                    while (true) {
+                        write(1)
+                        delay(1)
+                    }
+                }
             }
         }
     }

--- a/ktor-client/ktor-client-tests/jvm/src/io/ktor/client/tests/utils/tests/Download.kt
+++ b/ktor-client/ktor-client-tests/jvm/src/io/ktor/client/tests/utils/tests/Download.kt
@@ -26,7 +26,7 @@ internal fun Application.downloadTest() {
             get("infinite") {
                 call.respondOutputStream {
                     while (true) {
-                        write(1)
+                        write("test".toByteArray())
                         delay(1)
                     }
                 }

--- a/ktor-io/jvm/test/io/ktor/utils/io/ByteBufferChannelTest.kt
+++ b/ktor-io/jvm/test/io/ktor/utils/io/ByteBufferChannelTest.kt
@@ -16,4 +16,16 @@ class ByteBufferChannelTest {
 
         assertFailsWith<IOException> { runBlocking { channel.readByte() } }
     }
+
+    @Test
+    fun readRemainingThrowsOnClosed() = runBlocking {
+        val channel = ByteBufferChannel(false)
+        channel.writeFully(byteArrayOf(1, 2, 3, 4, 5))
+        channel.close(IllegalStateException("closed"))
+
+        assertFailsWith<IllegalStateException>("closed") {
+            channel.readRemaining()
+        }
+        Unit
+    }
 }


### PR DESCRIPTION
**Subsystem**
Client

**Motivation**
[OkHttp Can't reuse same HttpRequestBuilder for different network clients](https://youtrack.jetbrains.com/issue/KTOR-949)

**Solution**
When first client respond with timeout, it also cancels `executionContext` of a builder. Second client doesn't receive request because job is cancelled. `SupervisorJob` fix this issue.

