### PR TITLE
KTOR-391 KTOR-425 omit logging of malformed body

### DIFF
--- a/ktor-client/ktor-client-features/ktor-client-logging/common/src/io/ktor/client/features/logging/Logging.kt
+++ b/ktor-client/ktor-client-features/ktor-client-logging/common/src/io/ktor/client/features/logging/Logging.kt
@@ -225,8 +225,8 @@ public fun HttpClientConfig<*>.Logging(block: Logging.Config.() -> Unit = {}) {
     install(Logging, block)
 }
 
-private suspend inline fun ByteReadChannel.tryReadText(charset: Charset): String? = try {
+internal suspend inline fun ByteReadChannel.tryReadText(charset: Charset): String? = try {
     readRemaining().readText(charset = charset)
-} catch (e: MalformedInputException) {
+} catch (cause: MalformedInputException) {
     null
 }

--- a/ktor-client/ktor-client-features/ktor-client-logging/common/src/io/ktor/client/features/logging/Logging.kt
+++ b/ktor-client/ktor-client-features/ktor-client-logging/common/src/io/ktor/client/features/logging/Logging.kt
@@ -104,7 +104,7 @@ public class Logging(
     private suspend fun logResponseBody(contentType: ContentType?, content: ByteReadChannel): Unit = with(logger) {
         log("BODY Content-Type: $contentType")
         log("BODY START")
-        val message = content.readText(contentType?.charset() ?: Charsets.UTF_8)
+        val message = content.tryReadText(contentType?.charset() ?: Charsets.UTF_8) ?: "[response body omitted]"
         log(message)
         log("BODY END")
     }
@@ -137,7 +137,7 @@ public class Logging(
 
         val channel = ByteChannel()
         GlobalScope.launch(Dispatchers.Unconfined) {
-            val text = channel.readText(charset)
+            val text = channel.tryReadText(charset) ?: "[request body omitted]"
             logger.log("BODY START")
             logger.log(text)
             logger.log("BODY END")
@@ -225,5 +225,8 @@ public fun HttpClientConfig<*>.Logging(block: Logging.Config.() -> Unit = {}) {
     install(Logging, block)
 }
 
-private suspend inline fun ByteReadChannel.readText(charset: Charset): String =
+private suspend inline fun ByteReadChannel.tryReadText(charset: Charset): String? = try {
     readRemaining().readText(charset = charset)
+} catch (e: MalformedInputException) {
+    null
+}

--- a/ktor-client/ktor-client-features/ktor-client-logging/jvm/test/io/ktor/client/features/logging/LoggingTest.kt
+++ b/ktor-client/ktor-client-features/ktor-client-logging/jvm/test/io/ktor/client/features/logging/LoggingTest.kt
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2014-2020 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.client.features.logging
+import io.ktor.utils.io.*
+import io.ktor.utils.io.charsets.*
+import kotlin.test.*
+import kotlinx.coroutines.*
+
+class LoggingTest {
+
+    @Test
+    fun testByteReadChannelTryReadTextShouldThrowOnMalformed() = runBlocking {
+        val channel = ByteReadChannel(byteArrayOf(-77, 111))
+        val result = channel.tryReadText(Charsets.UTF_8)
+        assertNull(result)
+    }
+
+    @Test
+    fun testByteReadChannelTryReadTextShouldReturnText() = runBlocking {
+        val channel = ByteReadChannel("test")
+        val result = channel.tryReadText(Charsets.UTF_8)
+        assertEquals(result, "test")
+    }
+
+}

--- a/ktor-client/ktor-client-tests/jvm/src/io/ktor/client/tests/utils/tests/Logging.kt
+++ b/ktor-client/ktor-client-tests/jvm/src/io/ktor/client/tests/utils/tests/Logging.kt
@@ -26,6 +26,16 @@ internal fun Application.loggingTestServer() {
             get("301") {
                 call.respondRedirect("/logging")
             }
+
+            route("non-utf") {
+                post {
+                    call.respondBytes(
+                        bytes = byteArrayOf(-77, 111),
+                        contentType = ContentType.parse("application/octet-stream"),
+                        status = HttpStatusCode.Created
+                    )
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
**Subsystem**
Client/Server

**Motivation**
[KTOR-391](https://youtrack.jetbrains.com/issue/KTOR-391)
[KTOR-425](https://youtrack.jetbrains.com/issue/KTOR-425)

**Solution**
Avoid throwing of exception when parsing the malformed body

