### PR TITLE
KTOR-307 update documentation of HttpResponse::content property

### DIFF
--- a/ktor-client/ktor-client-core/common/src/io/ktor/client/statement/HttpResponse.kt
+++ b/ktor-client/ktor-client-core/common/src/io/ktor/client/statement/HttpResponse.kt
@@ -45,7 +45,10 @@ public abstract class HttpResponse : HttpMessage, CoroutineScope {
     public abstract val responseTime: GMTDate
 
     /**
-     * [ByteReadChannel] with the payload of the response.
+     * Unmodified [ByteReadChannel] with the raw payload of the response.
+     *
+     * **Note:** this content doesn't go through any interceptors from [HttpResponsePipeline].
+     * If you need modified content, use [HttpResponse::receive<T>] function.
      */
     public abstract val content: ByteReadChannel
 

--- a/ktor-client/ktor-client-core/common/src/io/ktor/client/statement/HttpResponse.kt
+++ b/ktor-client/ktor-client-core/common/src/io/ktor/client/statement/HttpResponse.kt
@@ -48,7 +48,7 @@ public abstract class HttpResponse : HttpMessage, CoroutineScope {
      * Unmodified [ByteReadChannel] with the raw payload of the response.
      *
      * **Note:** this content doesn't go through any interceptors from [HttpResponsePipeline].
-     * If you need modified content, use [HttpResponse::receive<T>] function.
+     * If you need modified content, use [HttpResponse::receive<ByteReadChannel>] function.
      */
     public abstract val content: ByteReadChannel
 


### PR DESCRIPTION
Added note that this property is not touched by any interceptors from HttpResponsePipeline

**Subsystem**
Server

**Motivation**
Property `content` of `HttpResponse` is a raw response from the server, that is not modified by `HttpResponsePipeline`. It created confusions and questions, like [KTOR-307](https://youtrack.jetbrains.com/issue/KTOR-307)

**Solution**
Added note that this property is not touched by any interceptors from HttpResponsePipeline

