### PR TITLE
KTOR-1034 Fix ConcurrentList clear

### DIFF
--- a/ktor-utils/common/src/io/ktor/util/collections/ConcurrentList.kt
+++ b/ktor-utils/common/src/io/ktor/util/collections/ConcurrentList.kt
@@ -14,7 +14,7 @@ private const val INITIAL_CAPACITY = 32
 
 @KtorExperimentalAPI
 public class ConcurrentList<T> : MutableList<T> {
-    private var data = SharedList<T>(INITIAL_CAPACITY)
+    private var data by shared(SharedList<T>(INITIAL_CAPACITY))
 
     override var size: Int by shared(0)
         private set

--- a/ktor-utils/common/test/io/ktor/util/ConcurrentListTest.kt
+++ b/ktor-utils/common/test/io/ktor/util/ConcurrentListTest.kt
@@ -37,4 +37,9 @@ class ConcurrentListTest {
             assertEquals(it, list[it])
         }
     }
+
+    @Test
+    fun testClearHasNoExceptions() {
+        ConcurrentList<Unit>().clear()
+    }
 }


### PR DESCRIPTION
Finish KTOR-1034 with fix of `clear` method