### PR TITLE
KTOR-844 add responseText field to ResponseException and SavedCall

### DIFF
--- a/ktor-client/ktor-client-core/api/ktor-client-core.api
+++ b/ktor-client/ktor-client-core/api/ktor-client-core.api
@@ -59,11 +59,13 @@ public final class io/ktor/client/call/DoubleReceiveException : java/lang/Illega
 
 public class io/ktor/client/call/HttpClientCall : kotlinx/coroutines/CoroutineScope {
 	public static final field Companion Lio/ktor/client/call/HttpClientCall$Companion;
+	protected fun getAllowDoubleReceive ()Z
 	public final fun getAttributes ()Lio/ktor/util/Attributes;
 	public final fun getClient ()Lio/ktor/client/HttpClient;
 	public fun getCoroutineContext ()Lkotlin/coroutines/CoroutineContext;
 	public final fun getRequest ()Lio/ktor/client/request/HttpRequest;
 	public final fun getResponse ()Lio/ktor/client/statement/HttpResponse;
+	protected fun getResponseContent (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun receive (Lio/ktor/client/call/TypeInfo;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun toString ()Ljava/lang/String;
 }
@@ -261,6 +263,7 @@ public final class io/ktor/client/engine/UtilsKt {
 
 public final class io/ktor/client/features/ClientRequestException : io/ktor/client/features/ResponseException {
 	public fun <init> (Lio/ktor/client/statement/HttpResponse;)V
+	public fun <init> (Lio/ktor/client/statement/HttpResponse;Ljava/lang/String;)V
 	public fun getMessage ()Ljava/lang/String;
 }
 
@@ -460,11 +463,13 @@ public final class io/ktor/client/features/HttpTimeoutKt {
 
 public final class io/ktor/client/features/RedirectResponseException : io/ktor/client/features/ResponseException {
 	public fun <init> (Lio/ktor/client/statement/HttpResponse;)V
+	public fun <init> (Lio/ktor/client/statement/HttpResponse;Ljava/lang/String;)V
 	public fun getMessage ()Ljava/lang/String;
 }
 
 public class io/ktor/client/features/ResponseException : java/lang/IllegalStateException {
 	public fun <init> (Lio/ktor/client/statement/HttpResponse;)V
+	public fun <init> (Lio/ktor/client/statement/HttpResponse;Ljava/lang/String;)V
 	public final fun getResponse ()Lio/ktor/client/statement/HttpResponse;
 }
 
@@ -478,6 +483,7 @@ public abstract interface class io/ktor/client/features/Sender {
 
 public final class io/ktor/client/features/ServerResponseException : io/ktor/client/features/ResponseException {
 	public fun <init> (Lio/ktor/client/statement/HttpResponse;)V
+	public fun <init> (Lio/ktor/client/statement/HttpResponse;Ljava/lang/String;)V
 	public fun getMessage ()Ljava/lang/String;
 }
 

--- a/ktor-client/ktor-client-core/common/src/io/ktor/client/features/DefaultResponseValidation.kt
+++ b/ktor-client/ktor-client-core/common/src/io/ktor/client/features/DefaultResponseValidation.kt
@@ -6,8 +6,8 @@ package io.ktor.client.features
 
 import io.ktor.client.*
 import io.ktor.client.call.*
-import io.ktor.util.*
 import io.ktor.client.statement.*
+import io.ktor.util.*
 import io.ktor.utils.io.concurrent.*
 import kotlin.native.concurrent.*
 
@@ -32,33 +32,46 @@ public fun HttpClientConfig<*>.addDefaultResponseValidation() {
             }
 
             val exceptionResponse = exceptionCall.response
+            val exceptionResponseText = exceptionResponse.readText()
             when (statusCode) {
-                in 300..399 -> throw RedirectResponseException(exceptionResponse)
-                in 400..499 -> throw ClientRequestException(exceptionResponse)
-                in 500..599 -> throw ServerResponseException(exceptionResponse)
-                else -> throw ResponseException(exceptionResponse)
+                in 300..399 -> throw RedirectResponseException(exceptionResponse, exceptionResponseText)
+                in 400..499 -> throw ClientRequestException(exceptionResponse, exceptionResponseText)
+                in 500..599 -> throw ServerResponseException(exceptionResponse, exceptionResponseText)
+                else -> throw ResponseException(exceptionResponse, exceptionResponseText)
             }
         }
     }
 }
+
+internal const val NO_RESPONSE_TEXT: String = "<no response text provided>"
+internal const val DEPRECATED_EXCEPTION_CTOR: String = "Please, provide response text in constructor"
 
 /**
  * Base for default response exceptions.
  * @param [response]: origin response
  */
 public open class ResponseException(
-    response: HttpResponse
-) : IllegalStateException("Bad response: $response") {
+    response: HttpResponse,
+    cachedResponseText: String
+) : IllegalStateException("Bad response: $response. Text: \"$cachedResponseText\"") {
+    @Deprecated(level = DeprecationLevel.WARNING, message = DEPRECATED_EXCEPTION_CTOR)
+    public constructor(response: HttpResponse): this(response, NO_RESPONSE_TEXT)
+
     private val _response: HttpResponse? by threadLocal(response)
-    public val response: HttpResponse get() = _response ?: error("Failed to access response from a different native thread")
+    public val response: HttpResponse
+        get() = _response ?: error("Failed to access response from a different native thread")
 }
 
 /**
  * Unhandled redirect exception.
  */
 @Suppress("KDocMissingDocumentation")
-public class RedirectResponseException(response: HttpResponse) : ResponseException(response) {
-    override val message: String? = "Unhandled redirect: ${response.call.request.url}. Status: ${response.status}"
+public class RedirectResponseException(response: HttpResponse, cachedResponseText: String) :
+    ResponseException(response, cachedResponseText) {
+    @Deprecated(level = DeprecationLevel.WARNING, message = DEPRECATED_EXCEPTION_CTOR)
+    public constructor(response: HttpResponse): this(response, NO_RESPONSE_TEXT)
+
+    override val message: String? = "Unhandled redirect: ${response.call.request.url}. Status: ${response.status}. Text: \"$cachedResponseText\""
 }
 
 /**
@@ -66,9 +79,13 @@ public class RedirectResponseException(response: HttpResponse) : ResponseExcepti
  */
 @Suppress("KDocMissingDocumentation")
 public class ServerResponseException(
-    response: HttpResponse
-) : ResponseException(response) {
-    override val message: String? = "Server error(${response.call.request.url}: ${response.status}."
+    response: HttpResponse,
+    cachedResponseText: String
+) : ResponseException(response, cachedResponseText) {
+    @Deprecated(level = DeprecationLevel.WARNING, message = DEPRECATED_EXCEPTION_CTOR)
+    public constructor(response: HttpResponse): this(response, NO_RESPONSE_TEXT)
+
+    override val message: String? = "Server error(${response.call.request.url}: ${response.status}. Text: \"$cachedResponseText\""
 }
 
 /**
@@ -76,7 +93,11 @@ public class ServerResponseException(
  */
 @Suppress("KDocMissingDocumentation")
 public class ClientRequestException(
-    response: HttpResponse
-) : ResponseException(response) {
-    override val message: String? = "Client request(${response.call.request.url}) invalid: ${response.status}"
+    response: HttpResponse,
+    cachedResponseText: String
+) : ResponseException(response, cachedResponseText) {
+    @Deprecated(level = DeprecationLevel.WARNING, message = DEPRECATED_EXCEPTION_CTOR)
+    public constructor(response: HttpResponse): this(response, NO_RESPONSE_TEXT)
+
+    override val message: String? = "Client request(${response.call.request.url}) invalid: ${response.status}. Text: \"$cachedResponseText\""
 }

--- a/ktor-client/ktor-client-core/posix/test/ExceptionsTest.kt
+++ b/ktor-client/ktor-client-core/posix/test/ExceptionsTest.kt
@@ -52,4 +52,4 @@ private fun createResponseException(): ResponseException = ResponseException(obj
         get() = TODO("Not yet implemented")
 
     override fun toString(): String = "FakeCall"
-})
+}, cachedResponseText = "Fake text")

--- a/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/ExceptionsTest.kt
+++ b/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/ExceptionsTest.kt
@@ -14,6 +14,7 @@ import io.ktor.client.tests.utils.*
 import io.ktor.http.*
 import io.ktor.test.dispatcher.*
 import io.ktor.util.*
+import kotlin.reflect.*
 import kotlin.test.*
 import kotlin.coroutines.*
 import kotlinx.coroutines.*
@@ -37,6 +38,88 @@ class ExceptionsTest : ClientLoader() {
         } catch (exception: ResponseException) {
             val text = exception.response?.readText()
             assertEquals(HttpStatusCode.BadRequest.description, text)
+        }
+    }
+
+    @Test
+    fun testTextInResponseException() = testTextInException(
+        code = HttpStatusCode.BadRequest,
+        message = "Some request",
+        exceptionType = ResponseException::class
+    )
+
+    @Test
+    fun testTextInRedirectResponseException() =
+        testTextInException(
+            code = HttpStatusCode.PermanentRedirect,
+            message = "Some redirect",
+            exceptionType = RedirectResponseException::class
+        )
+
+    @Test
+    fun testTextInClientRequestException() =
+        testTextInException(
+            code = HttpStatusCode.Conflict,
+            message = "Some conflict",
+            exceptionType = ClientRequestException::class
+        )
+
+    @Test
+    fun testTextInServerRequestException() =
+        testTextInException(
+            code = HttpStatusCode.VariantAlsoNegotiates,
+            message = "Some variant",
+            exceptionType = ServerResponseException::class
+        )
+
+    @Test
+    fun testBinaryGarbageInExceptionMessage() = testTextInException(
+        code = HttpStatusCode.BadRequest,
+        message = """
+            .Q
+            build.gradle�Q�J�0��+B��NwŃ<�A����C7m��${'$'}]���n�v��������7o&��+��B�4�]���^�,����
+            9a�j�Ȯ�@��˰uZ��x��g(�'������g�r��|��+Z�b��K�X�)��L�<
+                                                    Ol�o�;7~B�Z!+
+            j�m�`=��'��xm9
+              ן�]�̇��%��ȓ��=�t ����M�)A�C�7H�|ƾ��rs��ʺ��}��8��!�M��O!�g�
+                             \"\"                                           ���a����7D\X6��E��
+                             "   {}';a
+            ?��������~u��ڿqa҂C3����o异>u~�����W���U�N���9��j1_L_�c��PS_��9�P϶�r�f.Q�2Cj�
+                                                                  build.gradlf.Qƻ�>"${'$'}�settings.gradlf.Q&&
+                                                                                                                 %
+        """.trimIndent(),
+        exceptionType = ResponseException::class
+    )
+
+
+    private fun testTextInException(
+        code: HttpStatusCode,
+        message: String,
+        exceptionType: KClass<out ResponseException>
+    ) = testSuspend {
+        if (PlatformUtils.IS_NATIVE) return@testSuspend
+
+        val client = HttpClient(MockEngine) {
+            engine {
+                addHandler {
+                    respondError(code, message)
+                }
+            }
+            followRedirects = false
+        }
+
+        try {
+            client.get<String>("www.google.com")
+        } catch (exception: ResponseException) {
+            assertTrue(
+                exceptionType.isInstance(exception),
+                "Exception must be of type ${exceptionType.simpleName} but is of type ${exception::class.simpleName}"
+            )
+            assertNotNull(exception.message, "Message must be specified")
+            assertTrue(
+                exception.message!!.endsWith("Text: \"$message\""),
+                "Exception message must contain response text"
+            )
         }
     }
 


### PR DESCRIPTION
**Subsystem**
Client (ktor-client-core), exceptions in validation

**Motivation**
This PR solves https://youtrack.jetbrains.com/issue/KTOR-844 issue.

**Solution**
- Read  `responseText` in `HttpResponseValidator` and provide the constructor of `ResponseException` and it's descendants (`ServerResponseException`, `ClientRequestException`, `RedirectResponseException`) with the cached response text.
- Put the text to the message.
