### PR TITLE
Closes #KTOR-366

### DIFF
--- a/ktor-network/ktor-network-tls/build.gradle.kts
+++ b/ktor-network/ktor-network-tls/build.gradle.kts
@@ -1,3 +1,5 @@
+val netty_version: String by project.extra
+
 kotlin.sourceSets {
     val commonMain by getting {
         dependencies {
@@ -8,6 +10,7 @@ kotlin.sourceSets {
     val jvmTest by getting {
         dependencies {
             api(project(":ktor-network:ktor-network-tls:ktor-network-tls-certificates"))
+            api("io.netty:netty-handler:$netty_version")
         }
     }
 }

--- a/ktor-network/ktor-network-tls/jvm/src/io/ktor/network/tls/CertificateInfo.kt
+++ b/ktor-network/ktor-network-tls/jvm/src/io/ktor/network/tls/CertificateInfo.kt
@@ -5,10 +5,10 @@
 package io.ktor.network.tls
 
 import io.ktor.network.tls.extensions.*
-import java.security.*
+import javax.security.auth.x500.*
 
 internal class CertificateInfo(
     val types: ByteArray,
     val hashAndSign: Array<HashAndSign>,
-    val authorities: Set<Principal>
+    val authorities: Set<X500Principal>
 )

--- a/ktor-network/ktor-network-tls/jvm/src/io/ktor/network/tls/TLSClientHandshake.kt
+++ b/ktor-network/ktor-network-tls/jvm/src/io/ktor/network/tls/TLSClientHandshake.kt
@@ -312,7 +312,7 @@ internal class TLSClientHandshake(
                 it[0] = 0x03
                 it[1] = 0x03
             }
-            SecretExchangeType.ECDHE -> KeyAgreement.getInstance("ECDH")!!.run {
+            ECDHE -> KeyAgreement.getInstance("ECDH")!!.run {
                 if (encryptionInfo == null) throw TLSException("ECDHE_ECDSA: Encryption info should be provided")
                 init(encryptionInfo.clientPrivate)
                 doPhase(encryptionInfo.serverPublic, true)
@@ -357,7 +357,7 @@ internal class TLSClientHandshake(
 
             if (hasHashAndSignInCommon) return@find false
 
-            info.authorities.isEmpty() || candidate.certificateChain.any { it.issuerDN in info.authorities }
+            info.authorities.isEmpty() || candidate.certificateChain.map { X500Principal(it.issuerDN.name) }.any { it in info.authorities }
         }
 
         sendHandshakeRecord(TLSHandshakeType.Certificate) {
@@ -488,7 +488,7 @@ internal fun readClientCertificateRequest(packet: ByteReadPacket): CertificateIn
     }
 
     val authoritiesSize = packet.readShort().toInt() and 0xFFFF
-    val authorities = mutableSetOf<Principal>()
+    val authorities = mutableSetOf<X500Principal>()
 
     var position = 0
     while (position < authoritiesSize) {

--- a/ktor-network/ktor-network-tls/jvm/src/io/ktor/network/tls/TLSClientHandshake.kt
+++ b/ktor-network/ktor-network-tls/jvm/src/io/ktor/network/tls/TLSClientHandshake.kt
@@ -299,7 +299,7 @@ internal class TLSClientHandshake(
         )
         preSecret.fill(0)
 
-        certificateInfo?.let { sendClientCertificateVerify(it, chain!!) }
+        chain?.let { sendClientCertificateVerify(certificateInfo, it) }
 
         sendChangeCipherSpec()
         sendClientFinished(masterSecret)
@@ -391,7 +391,9 @@ internal class TLSClientHandshake(
     }
 
     private suspend fun sendChangeCipherSpec() {
-        output.send(TLSRecord(TLSRecordType.ChangeCipherSpec, packet = buildPacket { writeByte(1) }))
+        if (!output.isClosedForSend) {
+            output.send(TLSRecord(TLSRecordType.ChangeCipherSpec, packet = buildPacket { writeByte(1) }))
+        }
     }
 
     private suspend fun sendClientFinished(masterKey: SecretKeySpec) {
@@ -433,7 +435,9 @@ internal class TLSClientHandshake(
 
         digest.update(recordBody)
         val element = TLSRecord(TLSRecordType.Handshake, packet = recordBody)
-        output.send(element)
+        if (!output.isClosedForSend) {
+            output.send(element)
+        }
     }
 }
 

--- a/ktor-network/ktor-network-tls/jvm/test/io/ktor/network/tls/tests/ConnectionTests.kt
+++ b/ktor-network/ktor-network-tls/jvm/test/io/ktor/network/tls/tests/ConnectionTests.kt
@@ -8,12 +8,21 @@ import io.ktor.network.selector.*
 import io.ktor.network.sockets.*
 import io.ktor.network.tls.*
 import io.ktor.network.tls.certificates.*
+import io.ktor.utils.io.*
+import io.netty.bootstrap.*
+import io.netty.channel.*
+import io.netty.channel.nio.*
+import io.netty.channel.socket.*
+import io.netty.channel.socket.nio.*
+import io.netty.handler.ssl.*
 import kotlinx.coroutines.*
 import kotlinx.coroutines.debug.junit4.*
-import io.ktor.utils.io.*
 import org.junit.*
 import java.io.*
 import java.net.*
+import java.net.ServerSocket
+import java.security.*
+import java.security.cert.*
 import javax.net.ssl.*
 
 class ConnectionTests {
@@ -65,5 +74,63 @@ class ConnectionTests {
         val output = socket.openWriteChannel(autoFlush = true)
         output.close()
         socket.close()
+    }
+
+    @Test
+    fun test() {
+        val keyStoreFile = File("build/temp.jks")
+        val keyStore = generateCertificate(keyStoreFile, algorithm = "SHA256withRSA", keySizeInBits = 4096)
+        val chain1 = keyStore.getCertificateChain("mykey").toList() as List<X509Certificate>
+        val certs = chain1.toList().toTypedArray()
+        val password = "changeit".toCharArray()
+        val pk = keyStore.getKey("mykey", password) as PrivateKey
+        val trustManagerFactory = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm()) .also { it.init(keyStore) }
+        val workerGroup: EventLoopGroup = NioEventLoopGroup()
+        try {
+            val b = ServerBootstrap()
+            b.group(workerGroup)
+                .channel(NioServerSocketChannel::class.java)
+                .childHandler(object : ChannelInitializer<SocketChannel>() {
+                    override fun initChannel(ch: SocketChannel) {
+                        val sslContext = SslContextBuilder.forServer(pk, *certs).trustManager(trustManagerFactory).build()
+                        val sslEngine = sslContext.newEngine(ch.alloc()).apply {
+                            useClientMode = false
+                            needClientAuth = true
+                        }
+                        ch.pipeline().addLast(SslHandler(sslEngine))
+                    }
+                })
+            val port = firstFreePort()
+            b.bind(port).sync()
+
+            runBlocking {
+                val socket = aSocket(ActorSelectorManager(Dispatchers.IO)).tcp()
+                    .connect(InetSocketAddress("127.0.0.1", port))
+                    .tls(Dispatchers.IO) {
+                        addKeyStore(keyStore, password)
+                        trustManager = trustManagerFactory
+                            .trustManagers
+                            .filterIsInstance<X509TrustManager>()
+                            .first()
+                    }
+
+                val output = socket.openWriteChannel(autoFlush = true)
+                output.close()
+                socket.close()
+            }
+        } finally {
+            workerGroup.shutdownGracefully()
+        }
+    }
+
+    private fun firstFreePort(): Int {
+        while(true) {
+            try {
+                val socket = ServerSocket(0, 1)
+                val port = socket.localPort
+                socket.close()
+                return port
+            } catch (ignore: IOException) { }
+        }
     }
 }

--- a/ktor-network/ktor-network-tls/jvm/test/io/ktor/network/tls/tests/ConnectionTests.kt
+++ b/ktor-network/ktor-network-tls/jvm/test/io/ktor/network/tls/tests/ConnectionTests.kt
@@ -77,7 +77,7 @@ class ConnectionTests {
     }
 
     @Test
-    fun test() {
+    fun clientCertificatesAuthTest() {
         val keyStoreFile = File("build/temp.jks")
         val keyStore = generateCertificate(keyStoreFile, algorithm = "SHA256withRSA", keySizeInBits = 4096)
         val chain1 = keyStore.getCertificateChain("mykey").toList() as List<X509Certificate>


### PR DESCRIPTION
Subsystem
Client, ktor-network-tls

Motivation
Fix for [KTOR-366](https://youtrack.jetbrains.com/issue/KTOR-366)

Solution
Corrected the search of a Principal in the collection of principals. I.e. comparing X500Principal against other implementation of Principal interface always returns false. And since io.ktor.network.tls.CertificateInfo is an internal class I believe it is ok to make sure authorities are always X500Principals and then convert any other principal to X500Principal before comparison. That way the comparison will always be correct.
