### PR TITLE
Add SO_BROADCAST option to UDP sockets

### DIFF
--- a/ktor-network/api/ktor-network.api
+++ b/ktor-network/api/ktor-network.api
@@ -263,6 +263,8 @@ public final class io/ktor/network/sockets/SocketOptions$TCPClientSocketOptions 
 public final class io/ktor/network/sockets/SocketOptions$UDPSocketOptions : io/ktor/network/sockets/SocketOptions$PeerSocketOptions {
 	public synthetic fun copy$ktor_network ()Lio/ktor/network/sockets/SocketOptions$PeerSocketOptions;
 	public synthetic fun copy$ktor_network ()Lio/ktor/network/sockets/SocketOptions;
+	public final fun getBroadcast ()Z
+	public final fun setBroadcast (Z)V
 }
 
 public final class io/ktor/network/sockets/SocketsKt {

--- a/ktor-network/common/src/io/ktor/network/sockets/SocketOptions.kt
+++ b/ktor-network/common/src/io/ktor/network/sockets/SocketOptions.kt
@@ -137,6 +137,19 @@ public sealed class SocketOptions(
     public class UDPSocketOptions internal constructor(
         customOptions: MutableMap<Any, Any?>
     ) : PeerSocketOptions(customOptions) {
+
+        /**
+         * SO_BROADCAST socket option
+         */
+        public var broadcast: Boolean = false
+
+        override fun copyCommon(from: SocketOptions) {
+            super.copyCommon(from)
+            if (from is UDPSocketOptions) {
+                broadcast = from.broadcast
+            }
+        }
+
         override fun copy(): UDPSocketOptions {
             return UDPSocketOptions(HashMap(customOptions)).apply {
                 copyCommon(this@UDPSocketOptions)

--- a/ktor-network/jvm/src/io/ktor/network/sockets/JavaSocketOptions.kt
+++ b/ktor-network/jvm/src/io/ktor/network/sockets/JavaSocketOptions.kt
@@ -152,6 +152,9 @@ internal fun SelectableChannel.assignOptions(options: SocketOptions) {
             SocketOptionsPlatformCapabilities.setReusePort(this)
         }
 
+        if (options is SocketOptions.UDPSocketOptions) {
+            socket.broadcast = options.broadcast
+        }
         if (options is SocketOptions.PeerSocketOptions) {
             options.receiveBufferSize.takeIf { it > 0 }?.let { socket.receiveBufferSize = it }
             options.sendBufferSize.takeIf { it > 0 }?.let { socket.sendBufferSize = it }

--- a/ktor-network/jvm/test/io/ktor/network/sockets/tests/UDPSocketTest.kt
+++ b/ktor-network/jvm/test/io/ktor/network/sockets/tests/UDPSocketTest.kt
@@ -13,7 +13,6 @@ import kotlinx.coroutines.*
 import kotlinx.coroutines.channels.*
 import kotlinx.coroutines.debug.junit4.*
 import org.junit.*
-import java.lang.IllegalStateException
 import java.net.*
 import kotlin.coroutines.*
 import kotlin.io.use
@@ -69,6 +68,41 @@ class UDPSocketTest : CoroutineScope {
             assertTrue(denied)
             socket.socketContext.join()
             assertTrue(socket.isClosed)
+        }
+    }
+
+    @Test
+    fun testBroadcastSuccessful() = runBlocking {
+        retryIgnoringBindException {
+            val serverSocket = CompletableDeferred<BoundDatagramSocket>()
+            val server = launch {
+                aSocket(selector)
+                    .udp()
+                    .bind(NetworkAddress("0.0.0.0", 56700))
+                    .use { socket ->
+                        serverSocket.complete(socket)
+                        val received = socket.receive()
+                        assertEquals("0123456789", received.packet.readText())
+                    }
+            }
+
+            serverSocket.await()
+
+            aSocket(selector)
+                .udp()
+                .bind {
+                    broadcast = true
+                }
+                .use { socket ->
+                    socket.send(
+                        Datagram(
+                            packet = buildPacket { writeText("0123456789") },
+                            address = NetworkAddress("255.255.255.255", 56700)
+                        )
+                    )
+                }
+
+            server.join()
         }
     }
 

--- a/ktor-network/jvm/test/io/ktor/network/sockets/tests/UDPSocketTest.kt
+++ b/ktor-network/jvm/test/io/ktor/network/sockets/tests/UDPSocketTest.kt
@@ -78,7 +78,7 @@ class UDPSocketTest : CoroutineScope {
             val server = launch {
                 aSocket(selector)
                     .udp()
-                    .bind(NetworkAddress("0.0.0.0", 56700))
+                    .bind(NetworkAddress("0.0.0.0", 0))
                     .use { socket ->
                         serverSocket.complete(socket)
                         val received = socket.receive()
@@ -86,7 +86,7 @@ class UDPSocketTest : CoroutineScope {
                     }
             }
 
-            serverSocket.await()
+            val serverSocketPort = serverSocket.await().localAddress.port
 
             aSocket(selector)
                 .udp()
@@ -97,7 +97,7 @@ class UDPSocketTest : CoroutineScope {
                     socket.send(
                         Datagram(
                             packet = buildPacket { writeText("0123456789") },
-                            address = NetworkAddress("255.255.255.255", 56700)
+                            address = NetworkAddress("255.255.255.255", serverSocketPort)
                         )
                     )
                 }


### PR DESCRIPTION
**Subsystem**
ktor-network

**Motivation**
ktor-network provides a coroutine-compatible implementation of Sockets and Channels but is pretty bare-bones at the moment. Broadcast UDP sockets are useful when advertising or discovering services on a network. Without setting `SO_BROADCAST` on the socket, broadcast messages are not properly sent.

**Solution**
Add a `broadcast` option to `UDPSocketOptions` to configure a UDP socket in broadcast mode.

See the following pull request by @ObsidianX for more details:
Closes https://github.com/ktorio/ktor/pull/1258