### PR TITLE
Improve missing server session log message (KTOR-776)

### DIFF
--- a/ktor-server/ktor-server-core/jvm/src/io/ktor/sessions/SessionTrackerById.kt
+++ b/ktor-server/ktor-server-core/jvm/src/io/ktor/sessions/SessionTrackerById.kt
@@ -32,11 +32,15 @@ public class SessionTrackerById<S : Any>(
         call.attributes.put(SessionIdKey, sessionId)
         try {
             return storage.read(sessionId) { channel ->
-                val text = channel.readUTF8Line() ?: throw IllegalStateException("Failed to read stored session from $channel")
+                val text = channel.readUTF8Line()
+                    ?: throw IllegalStateException("Failed to read stored session from $channel")
                 serializer.deserialize(text)
             }
         } catch (notFound: NoSuchElementException) {
-            call.application.log.debug("Failed to lookup session: $notFound")
+            call.application.log.debug(
+                "Failed to lookup session: ${notFound.message ?: notFound.toString()}. " +
+                    "The session id is wrong or outdated."
+            )
         }
 
         // we remove the wrong session identifier if no related session found


### PR DESCRIPTION
NoSuchElementException prefix printed by Exception.toString() is too confusing
and makes impression that something is broken while it should simply explain why
there is no session in spite of that there is a session id.

**Subsystem**
ktor-server-core

