### PR TITLE
KTOR-835 Respond 500 in engines on not caught errors

### DIFF
--- a/ktor-server/ktor-server-cio/jvm/src/io/ktor/server/cio/CIOApplicationEngine.kt
+++ b/ktor-server/ktor-server-cio/jvm/src/io/ktor/server/cio/CIOApplicationEngine.kt
@@ -154,6 +154,8 @@ public class CIOApplicationEngine(environment: ApplicationEngineEnvironment, con
 
                 try {
                     pipeline.execute(call)
+                } catch (error: Exception) {
+                    handleFailure(call, error)
                 } finally {
                     call.release()
                 }

--- a/ktor-server/ktor-server-core/api/ktor-server-core.api
+++ b/ktor-server/ktor-server-core/api/ktor-server-core.api
@@ -298,6 +298,7 @@ public final class io/ktor/features/CallLogging$Feature : io/ktor/application/Ap
 
 public final class io/ktor/features/CallLogging$Internals {
 	public static final field INSTANCE Lio/ktor/features/CallLogging$Internals;
+	public final fun withMDCBlock (Lio/ktor/application/ApplicationCall;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun withMDCBlock (Lio/ktor/util/pipeline/PipelineContext;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 

--- a/ktor-server/ktor-server-core/jvm/src/io/ktor/features/CallLogging.kt
+++ b/ktor-server/ktor-server-core/jvm/src/io/ktor/features/CallLogging.kt
@@ -150,6 +150,11 @@ public class CallLogging private constructor(
     @InternalAPI
     public object Internals {
         @InternalAPI
+        public suspend fun <C : PipelineContext<*, ApplicationCall>> C.withMDCBlock(block: suspend C.() -> Unit) {
+            withMDCBlock(call) { block.invoke(this) }
+        }
+
+        @InternalAPI
         public suspend fun withMDCBlock(call: ApplicationCall, block: suspend () -> Unit) {
             withMDC(call, block)
         }

--- a/ktor-server/ktor-server-host-common/api/ktor-server-host-common.api
+++ b/ktor-server/ktor-server-host-common/api/ktor-server-host-common.api
@@ -185,6 +185,8 @@ public final class io/ktor/server/engine/ConnectorType$Companion {
 public final class io/ktor/server/engine/DefaultEnginePipelineKt {
 	public static final fun defaultEnginePipeline (Lio/ktor/application/ApplicationEnvironment;)Lio/ktor/server/engine/EnginePipeline;
 	public static final fun defaultExceptionStatusCode (Ljava/lang/Throwable;)Lio/ktor/http/HttpStatusCode;
+	public static final fun handleFailure (Lio/ktor/application/ApplicationCall;Ljava/lang/Throwable;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun logError (Lio/ktor/application/ApplicationCall;Ljava/lang/Throwable;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public final class io/ktor/server/engine/DefaultTransformKt {

--- a/ktor-server/ktor-server-host-common/jvm/src/io/ktor/server/engine/DefaultEnginePipeline.kt
+++ b/ktor-server/ktor-server-host-common/jvm/src/io/ktor/server/engine/DefaultEnginePipeline.kt
@@ -53,13 +53,13 @@ public fun defaultEnginePipeline(environment: ApplicationEnvironment): EnginePip
     return pipeline
 }
 
-@InternalAPI
+@EngineAPI
 public suspend fun handleFailure(call: ApplicationCall, error: Throwable) {
     logError(call, error)
     tryRespondError(call, defaultExceptionStatusCode(error) ?: HttpStatusCode.InternalServerError)
 }
 
-@InternalAPI
+@EngineAPI
 public suspend fun logError(call: ApplicationCall, error: Throwable) {
     with(CallLogging.Internals) {
         withMDCBlock(call) {

--- a/ktor-server/ktor-server-host-common/jvm/src/io/ktor/server/engine/DefaultEnginePipeline.kt
+++ b/ktor-server/ktor-server-host-common/jvm/src/io/ktor/server/engine/DefaultEnginePipeline.kt
@@ -36,17 +36,12 @@ public fun defaultEnginePipeline(environment: ApplicationEnvironment): EnginePip
             call.application.execute(call)
         } catch (error: ChannelIOException) {
             with(CallLogging.Internals) {
-                withMDCBlock {
+                withMDCBlock(call) {
                     call.application.environment.logFailure(call, error)
                 }
             }
         } catch (error: Throwable) {
-            with(CallLogging.Internals) {
-                withMDCBlock {
-                    call.application.environment.logFailure(call, error)
-                    handleFailure(error)
-                }
-            }
+            handleFailure(call, error)
         } finally {
             try {
                 call.request.receiveChannel().discard()
@@ -56,6 +51,21 @@ public fun defaultEnginePipeline(environment: ApplicationEnvironment): EnginePip
     }
 
     return pipeline
+}
+
+@InternalAPI
+public suspend fun handleFailure(call: ApplicationCall, error: Throwable) {
+    logError(call, error)
+    tryRespondError(call, defaultExceptionStatusCode(error) ?: HttpStatusCode.InternalServerError)
+}
+
+@InternalAPI
+public suspend fun logError(call: ApplicationCall, error: Throwable) {
+    with(CallLogging.Internals) {
+        withMDCBlock(call) {
+            call.application.environment.logFailure(call, error)
+        }
+    }
 }
 
 /**
@@ -72,11 +82,7 @@ public fun defaultExceptionStatusCode(cause: Throwable): HttpStatusCode? {
     }
 }
 
-private suspend fun PipelineContext<Unit, ApplicationCall>.handleFailure(cause: Throwable) {
-    tryRespondError(defaultExceptionStatusCode(cause) ?: HttpStatusCode.InternalServerError)
-}
-
-private suspend fun PipelineContext<Unit, ApplicationCall>.tryRespondError(statusCode: HttpStatusCode) {
+private suspend fun tryRespondError(call: ApplicationCall, statusCode: HttpStatusCode) {
     try {
         if (call.response.status() == null) {
             call.respond(statusCode)

--- a/ktor-server/ktor-server-jetty/jvm/src/io/ktor/server/jetty/JettyKtorHandler.kt
+++ b/ktor-server/ktor-server-jetty/jvm/src/io/ktor/server/jetty/JettyKtorHandler.kt
@@ -98,7 +98,8 @@ internal class JettyKtorHandler(
                 } catch (cancelled: CancellationException) {
                     response.sendErrorIfNotCommitted(HttpServletResponse.SC_GONE)
                 } catch (channelFailed: ChannelIOException) {
-                } catch (t: Throwable) {
+                } catch (error: Throwable) {
+                    logError(call, error)
                     if (!response.isCommitted) {
                         call.respond(HttpStatusCode.InternalServerError)
                     }

--- a/ktor-server/ktor-server-jetty/jvm/test/io/ktor/tests/server/jetty/JettyServletApplicationEngine.kt
+++ b/ktor-server/ktor-server-jetty/jvm/test/io/ktor/tests/server/jetty/JettyServletApplicationEngine.kt
@@ -31,6 +31,7 @@ internal class JettyServletApplicationEngine(
         server.handler = ServletContextHandler().apply {
             classLoader = environment.classLoader
             setAttribute(ServletApplicationEngine.ApplicationEngineEnvironmentAttributeKey, environment)
+            setAttribute(ServletApplicationEngine.ApplicationEnginePipelineAttributeKey, pipeline)
 
             insertHandler(ServletHandler().apply {
                 val holder = ServletHolder(

--- a/ktor-server/ktor-server-jetty/ktor-server-jetty-test-http2/jvm/test/io/ktor/tests/server/jetty/http2/JettyHttp2ServletContainer.kt
+++ b/ktor-server/ktor-server-jetty/ktor-server-jetty-test-http2/jvm/test/io/ktor/tests/server/jetty/http2/JettyHttp2ServletContainer.kt
@@ -34,6 +34,7 @@ internal class JettyServletApplicationEngine(
         server.handler = ServletContextHandler().apply {
             classLoader = environment.classLoader
             setAttribute(ServletApplicationEngine.ApplicationEngineEnvironmentAttributeKey, environment)
+            setAttribute(ServletApplicationEngine.ApplicationEnginePipelineAttributeKey, pipeline)
 
             insertHandler(ServletHandler().apply {
                 val holder = ServletHolder(

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyApplicationCallHandler.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyApplicationCallHandler.kt
@@ -5,6 +5,8 @@
 package io.ktor.server.netty
 
 import io.ktor.application.*
+import io.ktor.features.*
+import io.ktor.features.CallLogging.Internals.withMDCBlock
 import io.ktor.http.*
 import io.ktor.server.engine.*
 import io.ktor.server.netty.http1.*
@@ -41,7 +43,11 @@ internal class NettyApplicationCallHandler(
                     call.response.sendResponse(chunked = false, ByteReadChannel.Empty)
                     call.finish()
                 }
-                else -> enginePipeline.execute(call)
+                else -> try {
+                    enginePipeline.execute(call)
+                } catch (error: Exception) {
+                    handleFailure(call, error)
+                }
             }
         }
     }

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyApplicationCallHandler.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyApplicationCallHandler.kt
@@ -5,8 +5,6 @@
 package io.ktor.server.netty
 
 import io.ktor.application.*
-import io.ktor.features.*
-import io.ktor.features.CallLogging.Internals.withMDCBlock
 import io.ktor.http.*
 import io.ktor.server.engine.*
 import io.ktor.server.netty.http1.*

--- a/ktor-server/ktor-server-servlet/api/ktor-server-servlet.api
+++ b/ktor-server/ktor-server-servlet/api/ktor-server-servlet.api
@@ -55,6 +55,7 @@ public final class io/ktor/server/servlet/KtorServletKt {
 
 public class io/ktor/server/servlet/ServletApplicationEngine : io/ktor/server/servlet/KtorServlet {
 	public static final field ApplicationEngineEnvironmentAttributeKey Ljava/lang/String;
+	public static final field ApplicationEnginePipelineAttributeKey Ljava/lang/String;
 	public static final field Companion Lio/ktor/server/servlet/ServletApplicationEngine$Companion;
 	public fun <init> ()V
 	public fun destroy ()V

--- a/ktor-server/ktor-server-servlet/jvm/src/io/ktor/server/servlet/KtorServlet.kt
+++ b/ktor-server/ktor-server-servlet/jvm/src/io/ktor/server/servlet/KtorServlet.kt
@@ -119,6 +119,9 @@ public abstract class KtorServlet : HttpServlet(), CoroutineScope {
 
             try {
                 enginePipeline.execute(call)
+            } catch (cause: Throwable) {
+                logError(call, cause)
+                response.sendErrorIfNotCommitted("")
             } finally {
                 try {
                     asyncContext.complete()

--- a/ktor-server/ktor-server-servlet/jvm/src/io/ktor/server/servlet/ServletApplicationEngine.kt
+++ b/ktor-server/ktor-server-servlet/jvm/src/io/ktor/server/servlet/ServletApplicationEngine.kt
@@ -64,6 +64,8 @@ public open class ServletApplicationEngine : KtorServlet() {
     override val logger: Logger get() = environment.log
 
     override val enginePipeline: EnginePipeline by lazy {
+        servletContext.getAttribute(ApplicationEnginePipelineAttributeKey)?.let { return@lazy it as EnginePipeline }
+
         defaultEnginePipeline(environment).also {
             BaseApplicationResponse.setupSendPipeline(it.sendPipeline)
         }
@@ -91,11 +93,18 @@ public open class ServletApplicationEngine : KtorServlet() {
 
     public companion object {
         /**
-         * An application engine instance key. It is not recommended to use unless you are writing
+         * An application engine environment instance key. It is not recommended to use unless you are writing
          * your own servlet application engine implementation
          */
         @EngineAPI
         public const val ApplicationEngineEnvironmentAttributeKey: String = "_ktor_application_engine_environment_instance"
+
+        /**
+         * An application engine pipeline instance key. It is not recommended to use unless you are writing
+         * your own servlet application engine implementation
+         */
+        @EngineAPI
+        public const val ApplicationEnginePipelineAttributeKey: String = "_ktor_application_engine_pipeline_instance"
 
         private val jettyUpgrade by lazy {
             try {

--- a/ktor-server/ktor-server-test-host/api/ktor-server-test-host.api
+++ b/ktor-server/ktor-server-test-host/api/ktor-server-test-host.api
@@ -35,6 +35,7 @@ public abstract class io/ktor/server/testing/EngineTestBase : kotlinx/coroutines
 	public final fun setUpBase ()V
 	public static final fun setupAll ()V
 	protected final fun socket (Lkotlin/jvm/functions/Function1;)V
+	protected final fun startServer (Lio/ktor/server/engine/ApplicationEngine;)Ljava/util/List;
 	public final fun tearDownBase ()V
 	protected final fun withUrl (Ljava/lang/String;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function3;)V
 	public static synthetic fun withUrl$default (Lio/ktor/server/testing/EngineTestBase;Ljava/lang/String;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function3;ILjava/lang/Object;)V

--- a/ktor-server/ktor-server-test-host/jvm/src/io/ktor/server/testing/EngineTestBase.kt
+++ b/ktor-server/ktor-server-test-host/jvm/src/io/ktor/server/testing/EngineTestBase.kt
@@ -131,7 +131,7 @@ public abstract class EngineTestBase<TEngine : ApplicationEngine, TConfiguration
     }
 
     protected open fun createServer(
-        log: Logger?,
+        log: Logger? = null,
         parent: CoroutineContext = EmptyCoroutineContext,
         module: Application.() -> Unit
     ): TEngine {
@@ -211,7 +211,7 @@ public abstract class EngineTestBase<TEngine : ApplicationEngine, TConfiguration
         throw MultipleFailureException(lastFailures)
     }
 
-    private fun startServer(server: TEngine): List<Throwable> {
+    protected fun startServer(server: TEngine): List<Throwable> {
         this.server = server
 
         // we start it on the global scope because we don't want it to fail the whole test

--- a/ktor-server/ktor-server-test-suites/jvm/src/io/ktor/server/testing/suites/SustainabilityTestSuite.kt
+++ b/ktor-server/ktor-server-test-suites/jvm/src/io/ktor/server/testing/suites/SustainabilityTestSuite.kt
@@ -544,6 +544,7 @@ public abstract class SustainabilityTestSuite<TEngine : ApplicationEngine, TConf
             }
         }
         ApplicationCallPipeline().items
+            .filter { it != ApplicationCallPipeline.ApplicationPhase.Fallback } // fallback will reply with 404 and not 500
             .forEach { phase ->
                 val server = createServer(log = logger) {
                     intercept(phase) {
@@ -558,9 +559,9 @@ public abstract class SustainabilityTestSuite<TEngine : ApplicationEngine, TConf
                 }
                 startServer(server)
 
-                withUrl(if (phase == ApplicationCallPipeline.ApplicationPhase.Fallback) "/url" else "/") {
+                withUrl("/") {
                     assertEquals(HttpStatusCode.InternalServerError, status, "Failed in phase $phase")
-                    assertEquals(exceptions.size, 1)
+                    assertEquals(exceptions.size, 1, "Failed in phase $phase")
                     assertEquals(exceptions[0].message, "Failed in phase $phase")
                     exceptions.clear()
                 }
@@ -598,7 +599,7 @@ public abstract class SustainabilityTestSuite<TEngine : ApplicationEngine, TConf
                     { method = HttpMethod.Post; body = "body" }
                 ) {
                     assertEquals(HttpStatusCode.InternalServerError, status, "Failed in phase $phase")
-                    assertEquals(exceptions.size, 1)
+                    assertEquals(exceptions.size, 1, "Failed in phase $phase")
                     assertEquals(exceptions[0].message, "Failed in phase $phase")
                     exceptions.clear()
                 }
@@ -639,7 +640,7 @@ public abstract class SustainabilityTestSuite<TEngine : ApplicationEngine, TConf
                 withUrl("/", { intercepted = false }) {
                     val text = receive<String>()
                     assertEquals(HttpStatusCode.InternalServerError, status, "Failed in phase $phase")
-                    assertEquals(exceptions.size, 1)
+                    assertEquals(exceptions.size, 1, "Failed in phase $phase")
                     assertEquals(exceptions[0].message, "Failed in phase $phase")
                     exceptions.clear()
                 }
@@ -672,7 +673,7 @@ public abstract class SustainabilityTestSuite<TEngine : ApplicationEngine, TConf
 
         withUrl("/req") {
             assertEquals(HttpStatusCode.InternalServerError, status, "Failed in engine pipeline")
-            assertEquals(exceptions.size, 1)
+            assertEquals(exceptions.size, 1, "Failed in phase $phase")
             assertEquals(exceptions[0].message, "Failed in engine pipeline")
             exceptions.clear()
         }


### PR DESCRIPTION
**Subsystem**
Server

**Motivation**
[Implement proper unhandled exception handling strategy](https://youtrack.jetbrains.com/issue/KTOR-835)

**Solution**
Every engine now handles exception in the pipeline with a simple `try/catch` block. In case of failure, they log the error and respond with 500 status code.

