### PR TITLE
Avoid security constants in tests 

### DIFF
--- a/ktor-features/ktor-auth/jvm/test/io/ktor/tests/auth/UserHashedTableAuthTest.kt
+++ b/ktor-features/ktor-auth/jvm/test/io/ktor/tests/auth/UserHashedTableAuthTest.kt
@@ -1,27 +1,38 @@
 /*
- * Copyright 2014-2019 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2014-2020 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package io.ktor.tests.auth
 
 import io.ktor.application.*
 import io.ktor.auth.*
-import io.ktor.config.*
 import io.ktor.http.*
 import io.ktor.response.*
 import io.ktor.routing.*
 import io.ktor.server.testing.*
 import io.ktor.util.*
-import org.junit.Test
+import kotlin.random.*
 import kotlin.test.*
 
 class UserHashedTableAuthTest {
+    private val randomSaltPart = Random.nextInt(0, 0x10000)
+        .toString(radix = 16)
+        .padStart(4, '0')
+
+    // for test we don't care of hash stability so we append random part to the hash salt
+    // for production, you should keep salt part in secret and never use constant salt
+    // please see the documentation for explanation and read related articles for best practices
+    private val digestFunction = getDigestFunction("SHA-256") { "ktor-$randomSaltPart-${it.length}" }
 
     @Test
     fun testConfigInlined() {
-        testSingle(UserHashedTableAuth(table = mapOf(
-                "test" to "VltM4nfheqcJSyH887H+4NEOm2tDuKCl83p5axYXlF0=".decodeBase64Bytes() // sha256 for "test"
-        ), digester = getDigestFunction("SHA-256") { "ktor" }))
+        testSingle(
+            UserHashedTableAuth(
+                table = mapOf(
+                    "test" to digestFunction("test")
+                ), digester = digestFunction
+            )
+        )
     }
 
     private fun testSingle(hashedUserTable: UserHashedTableAuth) {
@@ -78,14 +89,18 @@ class UserHashedTableAuthTest {
         }
     }
 
-    private fun TestApplicationEngine.handlePost(uri: String, user: String? = null, password: String? = null): TestApplicationCall {
+    private fun TestApplicationEngine.handlePost(
+        uri: String,
+        user: String? = null,
+        password: String? = null
+    ): TestApplicationCall {
         return handleRequest(HttpMethod.Post, uri) {
             addHeader(HttpHeaders.ContentType, ContentType.Application.FormUrlEncoded.toString())
             setBody(
-                    Parameters.build {
-                        if (user != null) append("user", user)
-                        if (password != null) append("password", password)
-                    }.formUrlEncode()
+                Parameters.build {
+                    if (user != null) append("user", user)
+                    if (password != null) append("password", password)
+                }.formUrlEncode()
             )
         }
     }

--- a/ktor-server/ktor-server-tests/jvm/test/io/ktor/tests/server/sessions/SessionTest.kt
+++ b/ktor-server/ktor-server-tests/jvm/test/io/ktor/tests/server/sessions/SessionTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2014-2020 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package io.ktor.tests.server.sessions
@@ -112,6 +112,8 @@ class SessionTest {
             application.install(Sessions) {
                 cookie<TestUserSession>(cookieName) {
                     @Suppress("DEPRECATION_ERROR")
+                    // Stop using SessionTransportTransformerDigest
+                    // Never use it and see the deprecation message
                     transform(SessionTransportTransformerDigest())
                 }
             }
@@ -492,6 +494,8 @@ class SessionTest {
                 cookie<TestUserSession>(cookieName, sessionStorage) {
                     identity { (id++).toString() }
                     @Suppress("DEPRECATION_ERROR")
+                    // Stop using SessionTransportTransformerDigest
+                    // Never use it and see the deprecation message
                     transform(SessionTransportTransformerDigest(algorithm = "SHA-256"))
                 }
             }
@@ -545,6 +549,8 @@ class SessionTest {
                 cookie<EmptySession>("EMPTY")
                 header<TestUserSession>(cookieName, sessionStorage) {
                     @Suppress("DEPRECATION_ERROR")
+                    // Stop using SessionTransportTransformerDigest
+                    // Never use it and see the deprecation message
                     transform(SessionTransportTransformerDigest())
                 }
             }


### PR DESCRIPTION
**Subsystem**
ktor-auth (Server)

**Motivation**
[KTOR-1078](https://youtrack.jetbrains.com/issue/KTOR-1078)  Avoid security constants in tests 
In tests, we use security constant and unsafe/vulnurable features. 
This is fine for tests, but the problem is that users look into tests for usage samples and may accidentally copy-paste such code lines. But they are not suitable for production and using them lead to vulnurabilities. 

**Solution**
- Avoid constants when possible
- Comment code lines to warn users from blind copy-pasting

