### PR TITLE
 Add freeze calls to iOS engine

### DIFF
--- a/ktor-client/ktor-client-ios/darwin/src/io/ktor/client/engine/ios/IosClientEngine.kt
+++ b/ktor-client/ktor-client-ios/darwin/src/io/ktor/client/engine/ios/IosClientEngine.kt
@@ -10,6 +10,7 @@ import io.ktor.client.request.*
 import io.ktor.http.*
 import kotlinx.coroutines.*
 import platform.Foundation.*
+import kotlin.native.concurrent.*
 
 internal class IosClientEngine(override val config: IosClientEngineConfig) : HttpClientEngineBase("ktor-ios") {
 
@@ -47,7 +48,7 @@ internal class IosClientEngine(override val config: IosClientEngineConfig) : Htt
         }
 
         val session = NSURLSession.sessionWithConfiguration(
-            configuration, responseReader, delegateQueue = NSOperationQueue.mainQueue()
+            configuration, responseReader.freeze(), delegateQueue = NSOperationQueue.mainQueue()
         )
 
         val task = session.dataTaskWithRequest(nativeRequest)

--- a/ktor-client/ktor-client-ios/darwin/src/io/ktor/client/engine/ios/ProxySupportCommon.kt
+++ b/ktor-client/ktor-client-ios/darwin/src/io/ktor/client/engine/ios/ProxySupportCommon.kt
@@ -7,6 +7,7 @@ package io.ktor.client.engine.ios
 import io.ktor.http.*
 import platform.CoreFoundation.*
 import platform.Foundation.*
+import kotlin.native.concurrent.*
 
 private const val HTTP_ENABLE_KEY = "HTTPEnable"
 private const val HTTP_PROXY_KEY = "HTTPProxy"
@@ -25,11 +26,11 @@ internal fun NSURLSessionConfiguration.setupProxy(config: IosClientEngineConfig)
 }
 
 internal fun NSURLSessionConfiguration.setupHttpProxy(url: Url) {
-    connectionProxyDictionary = mapOf(
+    connectionProxyDictionary = mapOf<Any?, Any?>(
         HTTP_ENABLE_KEY to 1,
         HTTP_PROXY_KEY to url.host,
         HTTP_PORT_KEY to url.port
-    )
+    ).freeze()
 }
 
 internal fun CFStringRef?.toNSString(): NSString = CFBridgingRelease(this) as NSString


### PR DESCRIPTION
**Subsystem**
`io.ktor:ktor-client-ios`

**Motivation**
This PR makes it possible to make network requests from `Dispatchers.Default` without getting `IncorrectDereferenceException`. See: https://kotlinlang.slack.com/archives/C0A974TJ9/p1600972836014600

**Solution**
Add some freeze calls to the iOS engine.