### PR TITLE
HttpBenchmarkClient: Fix deprecated response.body() - moved to val

### DIFF
--- a/ktor-server/ktor-server-benchmarks/src/jmh/kotlin/io/ktor/server/benchmarks/HttpBenchmarkClient.kt
+++ b/ktor-server/ktor-server-benchmarks/src/jmh/kotlin/io/ktor/server/benchmarks/HttpBenchmarkClient.kt
@@ -68,7 +68,7 @@ class OkHttpBenchmarkClient : HttpBenchmarkClient {
     override fun load(url: String) {
         val request = Request.Builder().url(url).build()
         val response = httpClient!!.newCall(request).execute()
-        response.body()?.byteStream()?.use { stream ->
+        response.body?.byteStream()?.use { stream ->
             val buf = ByteArray(8192)
             while (stream.read(buf) != -1);
         }


### PR DESCRIPTION
**Subsystem**
HTTP Benchmark Client

**Motivation**
When checking out the current master branch and running `gradlew build`, the project fails with a compilation error: "Using 'body(): ResponseBody?' is an error. moved to val".

**Solution**
This changes the function invocation to a property access, which fixes the deprecation compilation error.