### PR TITLE
KTOR-1092 Improve curl error handling

### DIFF
--- a/ktor-client/ktor-client-curl/posix/src/io/ktor/client/engine/curl/internal/CurlMultiApiHandler.kt
+++ b/ktor-client/ktor-client-curl/posix/src/io/ktor/client/engine/curl/internal/CurlMultiApiHandler.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2014-2020 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package io.ktor.client.engine.curl.internal
@@ -217,10 +217,12 @@ internal class CurlMultiApiHandler : Closeable {
                         )
                     }
 
+                    val errorMessage = curl_easy_strerror(result)?.toKStringFromUtf8()
+
                     return CurlFail(
                         request,
                         @Suppress("DEPRECATION")
-                        CurlIllegalStateException("Connection failed for request: $request")
+                        CurlIllegalStateException("Connection failed for request: $request. Reason: $errorMessage")
                     )
                 }
 


### PR DESCRIPTION
**Subsystem**
ktor-client-curl

**Motivation**
[KTOR-1092](https://youtrack.jetbrains.com/issue/KTOR-1092)
When curl fails to do a request, no addition information provided, there is no even any meaninful message describing the issue

**Solution**
Use libcurl's [curl_easy_strerror](https://curl.haxx.se/libcurl/c/curl_easy_strerror.html) function to get an error message.

**Problems**
- Not sure how do I test it since error messages may vary
- Not clear, if the function provides localized messages or english only


