### PR TITLE
KTOR-715 Provide access token request interceptor

### DIFF
--- a/ktor-features/ktor-auth/api/ktor-auth.api
+++ b/ktor-features/ktor-auth/api/ktor-auth.api
@@ -410,6 +410,7 @@ public final class io/ktor/auth/OAuthGrantTypes {
 public final class io/ktor/auth/OAuthKt {
 	public static final fun oauth (Lio/ktor/util/pipeline/PipelineContext;Lio/ktor/client/HttpClient;Lkotlinx/coroutines/CoroutineDispatcher;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static final fun oauthHandleCallback (Lio/ktor/util/pipeline/PipelineContext;Lio/ktor/client/HttpClient;Lkotlinx/coroutines/CoroutineDispatcher;Lio/ktor/auth/OAuthServerSettings;Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun oauthHandleCallback (Lio/ktor/util/pipeline/PipelineContext;Lio/ktor/client/HttpClient;Lkotlinx/coroutines/CoroutineDispatcher;Lio/ktor/auth/OAuthServerSettings;Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun oauthHandleCallback$default (Lio/ktor/util/pipeline/PipelineContext;Lio/ktor/client/HttpClient;Lkotlinx/coroutines/CoroutineDispatcher;Lio/ktor/auth/OAuthServerSettings;Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public static final fun oauthRespondRedirect (Lio/ktor/util/pipeline/PipelineContext;Lio/ktor/client/HttpClient;Lkotlinx/coroutines/CoroutineDispatcher;Lio/ktor/auth/OAuthServerSettings;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
@@ -427,7 +428,10 @@ public abstract class io/ktor/auth/OAuthServerSettings {
 }
 
 public final class io/ktor/auth/OAuthServerSettings$OAuth1aServerSettings : io/ktor/auth/OAuthServerSettings {
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getAccessTokenInterceptor ()Lkotlin/jvm/functions/Function1;
 	public final fun getAccessTokenUrl ()Ljava/lang/String;
 	public final fun getAuthorizeUrl ()Ljava/lang/String;
 	public final fun getConsumerKey ()Ljava/lang/String;
@@ -436,8 +440,11 @@ public final class io/ktor/auth/OAuthServerSettings$OAuth1aServerSettings : io/k
 }
 
 public final class io/ktor/auth/OAuthServerSettings$OAuth2ServerSettings : io/ktor/auth/OAuthServerSettings {
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lio/ktor/http/HttpMethod;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;ZLio/ktor/util/NonceManager;Lkotlin/jvm/functions/Function1;Z)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lio/ktor/http/HttpMethod;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;ZLio/ktor/util/NonceManager;Lkotlin/jvm/functions/Function1;Z)V
 	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lio/ktor/http/HttpMethod;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;ZLio/ktor/util/NonceManager;Lkotlin/jvm/functions/Function1;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lio/ktor/http/HttpMethod;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;ZLio/ktor/util/NonceManager;Lkotlin/jvm/functions/Function1;ZLkotlin/jvm/functions/Function1;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lio/ktor/http/HttpMethod;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;ZLio/ktor/util/NonceManager;Lkotlin/jvm/functions/Function1;ZLkotlin/jvm/functions/Function1;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getAccessTokenInterceptor ()Lkotlin/jvm/functions/Function1;
 	public final fun getAccessTokenRequiresBasicAuth ()Z
 	public final fun getAccessTokenUrl ()Ljava/lang/String;
 	public final fun getAuthorizeUrl ()Ljava/lang/String;

--- a/ktor-features/ktor-auth/jvm/src/io/ktor/auth/OAuth.kt
+++ b/ktor-features/ktor-auth/jvm/src/io/ktor/auth/OAuth.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2014-2020 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package io.ktor.auth
@@ -8,9 +8,9 @@ import io.ktor.application.*
 import io.ktor.client.*
 import io.ktor.client.request.*
 import io.ktor.http.*
-import io.ktor.util.pipeline.*
 import io.ktor.response.*
 import io.ktor.util.*
+import io.ktor.util.pipeline.*
 import kotlinx.coroutines.*
 import org.slf4j.*
 import java.io.*
@@ -79,8 +79,22 @@ public sealed class OAuthServerSettings(public val name: String, public val vers
         public val accessTokenUrl: String,
 
         public val consumerKey: String,
-        public val consumerSecret: String
-    ) : OAuthServerSettings(name, OAuthVersion.V10a)
+        public val consumerSecret: String,
+
+        public val accessTokenInterceptor: HttpRequestBuilder.() -> Unit = {}
+    ) : OAuthServerSettings(name, OAuthVersion.V10a) {
+        @Suppress("unused")
+        @Deprecated("Binary compatibility", level = DeprecationLevel.HIDDEN)
+        public constructor(
+            name: String,
+            requestTokenUrl: String,
+            authorizeUrl: String,
+            accessTokenUrl: String,
+
+            consumerKey: String,
+            consumerSecret: String
+        ) : this(name, requestTokenUrl, authorizeUrl, accessTokenUrl, consumerKey, consumerSecret, {})
+    }
 
     /**
      * OAuth2 server settings
@@ -94,6 +108,7 @@ public sealed class OAuthServerSettings(public val name: String, public val vers
      * @property passParamsInURL whether to pass request parameters in POST requests in URL instead of body.
      * @property nonceManager to be used to produce and verify nonce values
      * @property authorizeUrlInterceptor an interceptor function to customize authorization URL
+     * @property accessTokenInterceptor an interceptor function to customize access token request
      */
     public class OAuth2ServerSettings(
         name: String,
@@ -109,8 +124,32 @@ public sealed class OAuthServerSettings(public val name: String, public val vers
         public val nonceManager: NonceManager = GenerateOnlyNonceManager,
 
         public val authorizeUrlInterceptor: URLBuilder.() -> Unit = {},
-        public val passParamsInURL: Boolean = false
-    ) : OAuthServerSettings(name, OAuthVersion.V20)
+        public val passParamsInURL: Boolean = false,
+        public val accessTokenInterceptor: HttpRequestBuilder.() -> Unit = {}
+    ) : OAuthServerSettings(name, OAuthVersion.V20) {
+        @Deprecated("Binary compatibility", level = DeprecationLevel.HIDDEN)
+        public constructor(
+            name: String,
+            authorizeUrl: String,
+            accessTokenUrl: String,
+            requestMethod: HttpMethod = HttpMethod.Get,
+
+            clientId: String,
+            clientSecret: String,
+            defaultScopes: List<String> = emptyList(),
+            accessTokenRequiresBasicAuth: Boolean = false,
+
+            nonceManager: NonceManager = GenerateOnlyNonceManager,
+
+            authorizeUrlInterceptor: URLBuilder.() -> Unit = {},
+            passParamsInURL: Boolean = false,
+        ) : this(name, authorizeUrl, accessTokenUrl, requestMethod, clientId, clientSecret,
+            defaultScopes, accessTokenRequiresBasicAuth, nonceManager,
+            authorizeUrlInterceptor,
+            passParamsInURL,
+            {}
+        )
+    }
 }
 
 /**
@@ -217,9 +256,28 @@ public suspend fun PipelineContext<Unit, ApplicationCall>.oauthRespondRedirect(
 }
 
 /**
- * Handle OAuth callback
+ * Handle OAuth callback. Usually it leads to requesting an access token.
  */
 @KtorExperimentalAPI
+public suspend fun PipelineContext<Unit, ApplicationCall>.oauthHandleCallback(
+    client: HttpClient,
+    dispatcher: CoroutineDispatcher,
+    provider: OAuthServerSettings,
+    callbackUrl: String,
+    loginPageUrl: String,
+    block: suspend (OAuthAccessTokenResponse) -> Unit
+) {
+    @Suppress("DEPRECATION")
+    oauthHandleCallback(client, dispatcher, provider, callbackUrl, loginPageUrl, {}, block)
+}
+
+/**
+ * Handle OAuth callback.
+ */
+@Deprecated(
+    "Specifying an extra configuration function will be deprecated. " +
+        "Please provide it via OAuthServerSettings."
+)
 public suspend fun PipelineContext<Unit, ApplicationCall>.oauthHandleCallback(
     client: HttpClient,
     dispatcher: CoroutineDispatcher,

--- a/ktor-features/ktor-auth/jvm/src/io/ktor/auth/OAuth1a.kt
+++ b/ktor-features/ktor-auth/jvm/src/io/ktor/auth/OAuth1a.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2014-2020 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package io.ktor.auth
@@ -142,7 +142,8 @@ internal suspend fun requestOAuth1aAccessToken(
     token = callbackResponse.token,
     verifier = callbackResponse.tokenSecret,
     nonce = nonce,
-    extraParameters = extraParameters
+    extraParameters = extraParameters,
+    accessTokenInterceptor = settings.accessTokenInterceptor
 )
 
 private suspend fun requestOAuth1aAccessToken(
@@ -153,7 +154,8 @@ private suspend fun requestOAuth1aAccessToken(
     token: String,
     verifier: String,
     nonce: String = generateNonce(),
-    extraParameters: Map<String, String> = emptyMap()
+    extraParameters: Map<String, String> = emptyMap(),
+    accessTokenInterceptor: (HttpRequestBuilder.() -> Unit)?
 ): OAuthAccessTokenResponse.OAuth1a {
     val params = listOf(HttpAuthHeader.Parameters.OAuthVerifier to verifier) + extraParameters.toList()
     val authHeader = createUpgradeRequestTokenHeader(consumerKey, token, nonce)
@@ -168,6 +170,8 @@ private suspend fun requestOAuth1aAccessToken(
             { params.formUrlEncodeTo(this) },
             ContentType.Application.FormUrlEncoded
         )
+
+        accessTokenInterceptor?.invoke(this)
     }
 
     try {

--- a/ktor-features/ktor-auth/jvm/test/io/ktor/tests/auth/OAuth2.kt
+++ b/ktor-features/ktor-auth/jvm/test/io/ktor/tests/auth/OAuth2.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2014-2020 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package io.ktor.tests.auth
@@ -8,8 +8,10 @@ import io.ktor.application.*
 import io.ktor.auth.*
 import io.ktor.client.*
 import io.ktor.client.engine.*
+import io.ktor.client.engine.mock.*
 import io.ktor.http.*
 import io.ktor.http.auth.*
+import io.ktor.http.content.*
 import io.ktor.request.*
 import io.ktor.response.*
 import io.ktor.routing.*
@@ -18,8 +20,6 @@ import io.ktor.server.testing.client.*
 import io.ktor.util.*
 import kotlinx.coroutines.*
 import org.json.simple.*
-import org.junit.*
-import org.junit.Test
 import java.net.*
 import java.util.*
 import java.util.concurrent.*
@@ -66,6 +66,31 @@ class OAuth2Test {
         requestMethod = HttpMethod.Post
     )
 
+    private fun DefaultSettingsWithAccessTokenInterceptor(post: Boolean) = OAuthServerSettings.OAuth2ServerSettings(
+        name = "oauth2",
+        authorizeUrl = "https://login-server-com/authorize",
+        accessTokenUrl = "https://login-server-com/oauth/access_token",
+        clientId = "clientId1",
+        clientSecret = "clientSecret1",
+        requestMethod = when (post) {
+            false -> HttpMethod.Get
+            true -> HttpMethod.Post
+        },
+        accessTokenInterceptor = {
+            url.parameters.remove("state")
+
+            if (method == HttpMethod.Post) {
+                body = runBlocking {
+                    val query = parseQueryString((body as OutgoingContent).toByteReadPacket().readText())
+                    val filtered = ParametersBuilder().apply {
+                        appendFiltered(query) { key, _ -> key != "state" }
+                    }.build()
+                    TextContent(filtered.formUrlEncode(), ContentType.Application.FormUrlEncoded)
+                }
+            }
+        }
+    )
+
     private val testClient = createOAuth2Server(object : OAuth2Server {
         override fun requestToken(
             clientId: String,
@@ -84,23 +109,42 @@ class OAuth2Test {
                 throw OAuth2Exception.InvalidGrant("Wrong client secret $clientSecret")
             }
             if (grantType == OAuthGrantTypes.AuthorizationCode) {
-                if (state != "state1") {
+                if (state != "state1" && state != null) {
                     throw OAuth2Exception.InvalidGrant("Wrong state $state")
                 }
-                if (code != "code1") {
+                if (code != "code1" && code != "code2") {
                     throw OAuth2Exception.InvalidGrant("Wrong code $code")
+                }
+                if ((code == "code1" && state == null) || (code == "code2" && state != null)) {
+                    throw OAuth2Exception.InvalidGrant("Wrong code $code or state $state")
                 }
                 if (redirectUri != "http://localhost/login") {
                     throw OAuth2Exception.InvalidGrant("Wrong redirect $redirectUri")
                 }
+                if (userName != null || password != null) {
+                    throw OAuth2Exception.UnknownException(
+                        "User/password shouldn't be specified for authorization_code grant type.", "none"
+                    )
+                }
 
-                return OAuthAccessTokenResponse.OAuth2("accessToken1", "type", Long.MAX_VALUE, null)
+                return OAuthAccessTokenResponse.OAuth2(
+                    "accessToken1", "type", Long.MAX_VALUE, null,
+                    when (state) {
+                        null -> parametersOf("noState", "Had no state")
+                        else -> Parameters.Empty
+                    }
+                )
             } else if (grantType == OAuthGrantTypes.Password) {
                 if (userName != "user1") {
                     throw OAuth2Exception.InvalidGrant("Wrong username $userName")
                 }
                 if (password != "password1") {
                     throw OAuth2Exception.InvalidGrant("Wrong password $password")
+                }
+                if (state != null || code != null) {
+                    throw OAuth2Exception.UnknownException(
+                        "State/code shouldn't be specified for password grant type.", "none"
+                    )
                 }
 
                 return OAuthAccessTokenResponse.OAuth2("accessToken1", "type", Long.MAX_VALUE, null)
@@ -144,7 +188,7 @@ class OAuth2Test {
         }
     }
 
-    @After
+    @AfterTest
     fun tearDown() {
         testClient.close()
         executor.shutdownNow()
@@ -389,6 +433,7 @@ class OAuth2Test {
         withTestApplication {
             application.routing {
                 get("/login") {
+                    @Suppress("DEPRECATION")
                     oauthHandleCallback(testClient, dispatcher, DefaultSettings, "http://localhost/login", "/", {
                         url.parameters["badContentType"] = "true"
                     }) { token ->
@@ -418,6 +463,7 @@ class OAuth2Test {
         withTestApplication {
             application.routing {
                 get("/login") {
+                    @Suppress("DEPRECATION")
                     oauthHandleCallback(testClient, dispatcher, DefaultSettings, "http://localhost/login", "/", {
                         url.parameters["respondHttpStatus"] = "500"
                     }) { token ->
@@ -445,6 +491,7 @@ class OAuth2Test {
         withTestApplication {
             application.routing {
                 get("/login") {
+                    @Suppress("DEPRECATION")
                     oauthHandleCallback(testClient, dispatcher, DefaultSettings, "http://localhost/login", "/", {
                         url.parameters["respondHttpStatus"] = "404"
                     }) { token ->
@@ -525,6 +572,58 @@ class OAuth2Test {
             assertEquals(it.response.status(), HttpStatusCode.OK)
             assertEquals(it.response.content, "We're in.")
         }
+    }
+
+    @Test
+    fun testRemoveStateFromAccessTokenRequest(): Unit = withApplication(createTestEnvironment()) {
+        with(application) {
+            routing {
+                get("/login") {
+                    oauthHandleCallback(
+                        testClient, dispatcher, DefaultSettingsWithAccessTokenInterceptor(post = false),
+                        "http://localhost/login", "/login"
+                    ) { token ->
+                        token as OAuthAccessTokenResponse.OAuth2
+                        call.respondText(token.extraParameters["noState"] ?: "Had state")
+                    }
+                }
+            }
+        }
+
+        val result = handleRequest(
+            HttpMethod.Get, "/login?" + listOf(
+                OAuth2RequestParameters.Code to "code2",
+                OAuth2RequestParameters.State to "state1"
+            ).formUrlEncode()
+        ).response.content
+
+        assertEquals("Had no state", result)
+    }
+
+    @Test
+    fun testRemoveStateFromAccessTokenRequestMethodPost(): Unit = withApplication(createTestEnvironment()) {
+        with(application) {
+            routing {
+                get("/login") {
+                    oauthHandleCallback(
+                        testClient, dispatcher, DefaultSettingsWithAccessTokenInterceptor(post = true),
+                        "http://localhost/login", "/login"
+                    ) { token ->
+                        token as OAuthAccessTokenResponse.OAuth2
+                        call.respondText(token.extraParameters["noState"] ?: "Had state")
+                    }
+                }
+            }
+        }
+
+        val result = handleRequest(
+            HttpMethod.Get, "/login?" + listOf(
+                OAuth2RequestParameters.Code to "code2",
+                OAuth2RequestParameters.State to "state1"
+            ).formUrlEncode()
+        ).response.content
+
+        assertEquals("Had no state", result)
     }
 
     private fun waitExecutor() {


### PR DESCRIPTION
**Subsystem**
ktor-auth (Server)

**Motivation**
Most of the OAuth providers do require `state` parameter to be passed when requesting for an access token. However, for some reason, Dropbox prohibits sending it so people need to write hacks to avoid this parameter that we are always sending.

**Solution**
[KTOR-715](https://youtrack.jetbrains.com/issue/KTOR-715)
This will provide the ability to intercept requests and remove the state parameter if needed. 
The reason why I don't want a switch for this particular case is that this is potentially insecure to not send the state so it shouldn't be cheap to do that. 

**Problems**
The disadvantage is that intercepting post body is not that easy (see the corresponding test). 
Adding any options is a change that requires 1.5.x
