### PR TITLE
KTOR-1091 Fix netty authority parser to process missing port properly

### DIFF
--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http2/Http2LocalConnectionPoint.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http2/Http2LocalConnectionPoint.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2014-2020 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package io.ktor.server.netty.http2
@@ -9,9 +9,9 @@ import io.netty.handler.codec.http2.*
 import java.net.*
 
 internal class Http2LocalConnectionPoint(
-                    private val nettyHeaders: Http2Headers,
-                    private val localAddress: InetSocketAddress?,
-                    private val remoteAddress: InetSocketAddress?
+    private val nettyHeaders: Http2Headers,
+    private val localAddress: InetSocketAddress?,
+    private val remoteAddress: InetSocketAddress?
 ) : RequestConnectionPoint {
     override val method: HttpMethod = nettyHeaders.method()?.let { HttpMethod.parse(it.toString()) } ?: HttpMethod.Get
 
@@ -25,12 +25,13 @@ internal class Http2LocalConnectionPoint(
         get() = nettyHeaders.path()?.toString() ?: "/"
 
     override val host: String
-        get() = nettyHeaders.authority()?.toString() ?: "localhost"
+        get() = nettyHeaders.authority()?.toString()?.substringBefore(":") ?: "localhost"
 
     override val port: Int
-        get() = nettyHeaders.authority()?.toString()?.substringAfter(":")?.toInt()
-                ?: localAddress?.port
-                ?: 80
+        get() = nettyHeaders.authority()?.toString()
+            ?.substringAfter(":", "-1")?.toInt()?.takeIf { it > 0 }
+            ?: localAddress?.port
+            ?: 80
 
     override val remoteHost: String
         get() = remoteAddress?.let {

--- a/ktor-server/ktor-server-netty/jvm/test/io/ktor/tests/server/netty/NettyHttp2LocalConnectionPointTest.kt
+++ b/ktor-server/ktor-server-netty/jvm/test/io/ktor/tests/server/netty/NettyHttp2LocalConnectionPointTest.kt
@@ -1,0 +1,152 @@
+/*
+ * Copyright 2014-2020 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.tests.server.netty
+
+import io.ktor.http.*
+import io.ktor.server.netty.http2.*
+import io.netty.handler.codec.http2.*
+import java.net.*
+import kotlin.test.*
+
+class NettyHttp2LocalConnectionPointTest {
+    @Test
+    fun testMethod() {
+        val point = point {
+            method("PUT")
+        }
+
+        assertEquals(HttpMethod.Put, point.method)
+    }
+
+    @Test
+    fun testVersion() {
+        val point = point {
+            method("PUT")
+        }
+
+        assertEquals("HTTP/2", point.version)
+    }
+
+    @Test
+    fun testScheme() {
+        val point = point {
+            scheme("https")
+        }
+
+        assertEquals("https", point.scheme)
+    }
+
+    @Test
+    fun testSchemeMissing() {
+        val point = point {
+        }
+
+        assertEquals("http", point.scheme)
+    }
+
+    @Test
+    fun testPort() {
+        val point = point {
+            authority("host:443")
+        }
+
+        assertEquals(443, point.port)
+    }
+
+    @Test
+    fun testPortUnspecified() {
+        val point = point {
+            authority("host")
+        }
+
+        assertEquals(80, point.port)
+    }
+
+    @Test
+    fun testPortUnspecifiedWithAddress() {
+        val point = point(localAddress = InetSocketAddress(8443)) {
+            authority("host")
+        }
+
+        assertEquals(8443, point.port)
+    }
+
+    @Test
+    fun testHost() {
+        val point = point {
+            authority("host1")
+        }
+
+        assertEquals("host1", point.host)
+    }
+
+    @Test
+    fun testHostWithPort() {
+        val point = point {
+            authority("host1:80")
+        }
+
+        assertEquals("host1", point.host)
+    }
+
+    @Test
+    fun testHostMissing() {
+        val point = point {
+        }
+
+        assertEquals("localhost", point.host)
+    }
+
+    @Test
+    fun testUri() {
+        val point = point {
+            path("/path/to/resource")
+        }
+
+        assertEquals("/path/to/resource", point.uri)
+    }
+
+    @Test
+    fun testUriMissing() {
+        val point = point {
+        }
+
+        assertEquals("/", point.uri)
+    }
+
+    @Test
+    fun testRemoteAddress() {
+        val address = InetSocketAddress.createUnresolved("some-host", 8554)
+        val point = point(remoteAddress = address) {
+        }
+
+        assertEquals("some-host", point.remoteHost)
+        assertTrue(address.isUnresolved)
+    }
+
+    @Test
+    fun testRemoteAddressResolved() {
+        val address = InetSocketAddress(Inet4Address.getByAddress("z", byteArrayOf(192.toByte(), 168.toByte(), 1, 1)), 7777)
+        val point = point(remoteAddress = address) {
+        }
+
+        assertEquals("z", point.remoteHost)
+    }
+
+    private fun headers(block: DefaultHttp2Headers.() -> Unit): Http2Headers {
+        val headers = DefaultHttp2Headers()
+        block(headers)
+        return headers
+    }
+
+    private fun point(
+        localAddress: InetSocketAddress? = null,
+        remoteAddress: InetSocketAddress? = null,
+        block: DefaultHttp2Headers.() -> Unit
+    ): Http2LocalConnectionPoint {
+        val headers = headers(block)
+        return Http2LocalConnectionPoint(headers, localAddress, remoteAddress)
+    }
+}


### PR DESCRIPTION
**Subsystem**
ktor-server-netty

**Motivation**
[KTOR-1091](https://youtrack.jetbrains.com/issue/KTOR-1091) Netty: NumberFormatException when make a request via HTTP/2 without explicit port 


**Solution**
Handle this case and write unit tests

