### PR TITLE
KTOR-364 Update HttpCacheEntry.kt

### DIFF
--- a/ktor-client/ktor-client-core/common/src/io/ktor/client/features/cache/HttpCacheEntry.kt
+++ b/ktor-client/ktor-client-core/common/src/io/ktor/client/features/cache/HttpCacheEntry.kt
@@ -83,9 +83,16 @@ internal fun HttpResponse.cacheExpires(): GMTDate {
     }
 
     val expires = headers[HttpHeaders.Expires]
-    if(expires != null && expires.isNotBlank()) {
-        return expires.fromHttpToGmtDate()
-    } else return GMTDate()
+    return expires?.let {
+        // Handle "0" case faster
+        if (it == "0") return GMTDate()
+
+        return try {
+            it.fromHttpToGmtDate()
+        } catch (e: Throwable) {
+            GMTDate()
+        }
+    } ?: GMTDate()
 }
 
 internal fun HttpCacheEntry.shouldValidate(): Boolean {

--- a/ktor-client/ktor-client-core/common/src/io/ktor/client/features/cache/HttpCacheEntry.kt
+++ b/ktor-client/ktor-client-core/common/src/io/ktor/client/features/cache/HttpCacheEntry.kt
@@ -82,12 +82,10 @@ internal fun HttpResponse.cacheExpires(): GMTDate {
         return call.response.requestTime + maxAge * 1000L
     }
 
-    try {
-        val expires = headers[HttpHeaders.Expires]!!.fromHttpToGmtDate() 
-        return expires
-    } catch(e: Throwable) {
-        return GMTDate()
-    }
+    val expires = headers[HttpHeaders.Expires]
+    if(expires != null && expires.isNotBlank()) {
+        return expires.fromHttpToGmtDate()
+    } else return GMTDate()
 }
 
 internal fun HttpCacheEntry.shouldValidate(): Boolean {

--- a/ktor-client/ktor-client-core/common/src/io/ktor/client/features/cache/HttpCacheEntry.kt
+++ b/ktor-client/ktor-client-core/common/src/io/ktor/client/features/cache/HttpCacheEntry.kt
@@ -82,8 +82,12 @@ internal fun HttpResponse.cacheExpires(): GMTDate {
         return call.response.requestTime + maxAge * 1000L
     }
 
-    headers[HttpHeaders.Expires]?.fromHttpToGmtDate()?.let { return it }
-    return GMTDate()
+    try {
+        val expires = headers[HttpHeaders.Expires]!!.fromHttpToGmtDate() 
+        return expires
+    } catch(e: Throwable) {
+        return GMTDate()
+    }
 }
 
 internal fun HttpCacheEntry.shouldValidate(): Boolean {


### PR DESCRIPTION
Fix crash on empty/invalid expires header

**Subsystem**
Client

**Motivation**
 #1892 .

**Solution**
Handle the case where the Expires header is empty or invalid, and return a GMTDate() as it would if such header was not present.

