### PR TITLE
KTOR-613 - Add transparent quality for route evaluation result

### DIFF
--- a/ktor-features/ktor-auth/jvm/src/io/ktor/auth/Authentication.kt
+++ b/ktor-features/ktor-auth/jvm/src/io/ktor/auth/Authentication.kt
@@ -322,9 +322,9 @@ public fun Route.authenticate(
  * unless you are writing an extension
  * @param names of authentication providers to be applied to this route
  */
-public class AuthenticationRouteSelector(public val names: List<String?>) : RouteSelector(RouteSelectorEvaluation.qualityConstant) {
+public class AuthenticationRouteSelector(public val names: List<String?>) : RouteSelector(RouteSelectorEvaluation.qualityTransparent) {
     override fun evaluate(context: RoutingResolveContext, segmentIndex: Int): RouteSelectorEvaluation {
-        return RouteSelectorEvaluation.Constant
+        return RouteSelectorEvaluation(true, RouteSelectorEvaluation.qualityTransparent)
     }
 
     override fun toString(): String = "(authenticate ${names.joinToString { it ?: "\"default\"" }})"

--- a/ktor-server/ktor-server-core/api/ktor-server-core.api
+++ b/ktor-server/ktor-server-core/api/ktor-server-core.api
@@ -1371,6 +1371,7 @@ public final class io/ktor/routing/RouteSelectorEvaluation {
 	public static final field qualityPathParameter D
 	public static final field qualityQueryParameter D
 	public static final field qualityTailcard D
+	public static final field qualityTransparent D
 	public static final field qualityWildcard D
 	public fun <init> (ZDLio/ktor/http/Parameters;I)V
 	public synthetic fun <init> (ZDLio/ktor/http/Parameters;IILkotlin/jvm/internal/DefaultConstructorMarker;)V

--- a/ktor-server/ktor-server-core/jvm/src/io/ktor/routing/RouteSelector.kt
+++ b/ktor-server/ktor-server-core/jvm/src/io/ktor/routing/RouteSelector.kt
@@ -71,6 +71,11 @@ public data class RouteSelectorEvaluation(
         public const val qualityTailcard: Double = 0.1
 
         /**
+         * Quality of [RouteSelectorEvaluation] that doesn't have it's own priority but should delegate evaluation to it's children
+         */
+        public const val qualityTransparent: Double = -1.0
+
+        /**
          * Route evaluation failed to succeed, route doesn't match a context
          */
         public val Failed: RouteSelectorEvaluation = RouteSelectorEvaluation(false, 0.0)

--- a/ktor-server/ktor-server-tests/jvm/test/io/ktor/tests/server/routing/RoutingProcessingTest.kt
+++ b/ktor-server/ktor-server-tests/jvm/test/io/ktor/tests/server/routing/RoutingProcessingTest.kt
@@ -495,6 +495,22 @@ class RoutingProcessingTest {
     }
 
     @Test
+    fun testTransparentSelectorWithHandler() = withTestApplication {
+        application.routing {
+            route("") {
+                transparent {
+                    handle { call.respond("OK") }
+                }
+            }
+        }
+
+        handleRequest(HttpMethod.Get, "/").let { call ->
+            assertTrue(call.requestHandled)
+            assertEquals("OK", call.response.content)
+        }
+    }
+
+    @Test
     fun testHostAndPortRoutingProcessing(): Unit = withTestApplication {
         application.routing {
             route("/") {
@@ -827,4 +843,14 @@ class RoutingProcessingTest {
     }
 
     private fun String.toPlatformLineSeparators() = lines().joinToString(System.lineSeparator())
+
+    private fun Route.transparent(build: Route.() -> Unit): Route {
+        val route = createChild(object : RouteSelector(RouteSelectorEvaluation.qualityTransparent) {
+            override fun evaluate(context: RoutingResolveContext, segmentIndex: Int): RouteSelectorEvaluation {
+                return RouteSelectorEvaluation(true, RouteSelectorEvaluation.qualityTransparent)
+            }
+        })
+        route.build()
+        return route
+    }
 }

--- a/ktor-server/ktor-server-tests/jvm/test/io/ktor/tests/server/routing/RoutingResolveTest.kt
+++ b/ktor-server/ktor-server-tests/jvm/test/io/ktor/tests/server/routing/RoutingResolveTest.kt
@@ -851,4 +851,49 @@ class RoutingResolveTest {
             }
         }
     }
+
+    @Test
+    fun testRoutingWithTransparentQualitySibling() {
+        val root = routing()
+        val siblingTop = root.handle(PathSegmentParameterRouteSelector("sibling", "top"))
+        val transparentEntryTop = root.createChild(object : RouteSelector(RouteSelectorEvaluation.qualityTransparent) {
+            override fun evaluate(context: RoutingResolveContext, segmentIndex: Int): RouteSelectorEvaluation {
+                return RouteSelectorEvaluation(true, RouteSelectorEvaluation.qualityTransparent)
+            }
+        })
+        // inner entry has lower priority then its siblings
+        val innerEntryTop = transparentEntryTop.handle(PathSegmentParameterRouteSelector("inner"))
+        val siblingBottom = root.handle(PathSegmentParameterRouteSelector("sibling", "bottom"))
+
+        on("resolving /topSibling") {
+            val result = resolve(root, "/topSibling")
+
+            it("should successfully resolve") {
+                assertTrue(result is RoutingResolveResult.Success)
+            }
+            it("should resolve to siblingFirst") {
+                assertEquals(siblingTop, result.route)
+            }
+        }
+        on("resolving /innerEntry") {
+            val result = resolve(root, "/innerEntry")
+
+            it("should successfully resolve") {
+                assertTrue(result is RoutingResolveResult.Success)
+            }
+            it("should resolve to innerEntryTop") {
+                assertEquals(innerEntryTop, result.route)
+            }
+        }
+        on("resolving /bottomSibling") {
+            val result = resolve(root, "/bottomSibling")
+
+            it("should successfully resolve") {
+                assertTrue(result is RoutingResolveResult.Success)
+            }
+            it("should resolve to siblingBottom") {
+                assertEquals(siblingBottom, result.route)
+            }
+        }
+    }
 }


### PR DESCRIPTION
**Subsystem**
server routing

**Motivation**
https://youtrack.jetbrains.com/issue/KTOR-613

**Solution**
Introduce `RouteSelectorEvaluation.qualityTransparent` constant for route items that don't have their own quality and should delegate evaluation to their children

