### PR TITLE
KTOR-1059 handle surrogate symbols in url path

### DIFF
--- a/ktor-http/common/src/io/ktor/http/Codecs.kt
+++ b/ktor-http/common/src/io/ktor/http/Codecs.kt
@@ -36,6 +36,7 @@ private val VALID_PATH_PART = listOf(
     '!', '$', '&', '\'', '(', ')', '*', '+', ',', ';', '=',
     '-', '.', '_', '~'
 )
+
 /**
  * Oauth specific percent encoding
  * https://tools.ietf.org/html/rfc5849#section-3.6
@@ -49,7 +50,7 @@ internal val LETTERS_AND_NUMBERS = ('a'..'z').toSet() + ('A'..'Z').toSet() + ('0
  * https://tools.ietf.org/html/rfc7230#section-3.2.6
  */
 internal val TOKENS: Set<Char> =
-    setOf('!', '#', '%', '&', '\'', '*', '+', '-', '.', '^', '_', '`', '|', '~') +  LETTERS_AND_NUMBERS
+    setOf('!', '#', '%', '&', '\'', '*', '+', '-', '.', '^', '_', '`', '|', '~') + LETTERS_AND_NUMBERS
 
 /**
  * Encode url part as specified in
@@ -98,11 +99,12 @@ public fun String.encodeURLPath(): String = buildString {
             continue
         }
 
+        val symbolSize = if (current.isSurrogate()) 2 else 1
         // we need to call newEncoder() for every symbol, otherwise it won't work
-        charset.newEncoder().encode(this@encodeURLPath, index, index + 1).forEach {
+        charset.newEncoder().encode(this@encodeURLPath, index, index + symbolSize).forEach {
             append(it.percentEncode())
         }
-        index++
+        index += symbolSize
     }
 }
 
@@ -230,7 +232,7 @@ private fun CharSequence.decodeImpl(
  */
 public class URLDecodeException(message: String) : Exception(message)
 
-private fun Byte.percentEncode(): String= buildString(3) {
+private fun Byte.percentEncode(): String = buildString(3) {
     val code = toInt() and 0xff
     append('%')
     append(hexDigitToChar(code shr 4))

--- a/ktor-http/common/test/io/ktor/tests/http/CodecTest.kt
+++ b/ktor-http/common/test/io/ktor/tests/http/CodecTest.kt
@@ -12,6 +12,7 @@ class CodecTest {
     private val swissAndGerman = "\u0047\u0072\u00fc\u0065\u007a\u0069\u005f\u007a\u00e4\u006d\u00e4"
     private val russian = "\u0412\u0441\u0435\u043c\u005f\u043f\u0440\u0438\u0432\u0435\u0442"
     private val urlPath = "/wikipedia/commons/9/9c/University_of_Illinois_at_Urbana\u2013Champaign_logo.svg"
+    private val surrogateSymbolUrlPath = "/path/🐕"
 
     @Test/*(timeout = 1000L)*/
     @Ignore
@@ -114,13 +115,18 @@ class CodecTest {
     fun testFormUrlEncode() {
         val result = StringBuilder()
 
-        val source = mapOf<String, List<String>>(
+        mapOf(
             "a" to listOf("b", "c", "d"),
             "1" to listOf("2"),
             "x" to listOf("y", "z"),
         ).entries.formUrlEncodeTo(result)
 
         assertEquals("a=b&a=c&a=d&1=2&x=y&x=z", result.toString())
+    }
+
+    @Test
+    fun testEncodeURLPathSurrogateSymbol() {
+        assertEquals("/path/%F0%9F%90%95", surrogateSymbolUrlPath.encodeURLPath())
     }
 
     private fun encodeAndDecodeTest(text: String) {

--- a/ktor-http/common/test/io/ktor/tests/http/URLBuilderTest.kt
+++ b/ktor-http/common/test/io/ktor/tests/http/URLBuilderTest.kt
@@ -174,6 +174,12 @@ internal class URLBuilderTest {
         assertEquals("", url.encodedPath)
     }
 
+    @Test
+    fun testSurrogateInPath() {
+        val url = URLBuilder("http://www.ktor.io/path/🐕")
+        assertEquals("/path/%F0%9F%90%95", url.encodedPath)
+    }
+
     /**
      * Checks that the given [url] and the result of [URLBuilder.buildString] is equal (case insensitive).
      */


### PR DESCRIPTION
**Subsystem**
common URL parser

**Motivation**
[Emoji in URL leads to an infinite loop](https://youtrack.jetbrains.com/issue/KTOR-1059)

**Solution**
Read surrogate symbols in pairs when encoding path
