### PR TITLE
KTOR-455 quote separator fields in header values

### DIFF
--- a/ktor-http/common/src/io/ktor/http/HeaderValueWithParameters.kt
+++ b/ktor-http/common/src/io/ktor/http/HeaderValueWithParameters.kt
@@ -6,6 +6,10 @@ package io.ktor.http
 
 import io.ktor.util.*
 
+/** Separator symbols listed in RFC https://tools.ietf.org/html/rfc2616#section-2.2 */
+private val HeaderFieldValueSeparators =
+    setOf('(', ')', '<', '>', '@', ',', ';', ':', '\\', '\"', '/', '[', ']', '?', '=', '{', '}', ' ', '\t', '\n', '\r')
+
 /**
  * Represents a header value that consist of [content] followed by [parameters].
  * Useful for headers such as `Content-Type`, `Content-Disposition` and so on.
@@ -79,29 +83,7 @@ private fun String.checkNeedEscape(): Boolean {
     if (isEmpty()) return true
 
     for (index in 0 until length) {
-        when (this[index]) {
-            '(',
-            ')',
-            '<',
-            '>',
-            '@',
-            ',',
-            ';',
-            ':',
-            '\\',
-            '\"',
-            '/',
-            '[',
-            ']',
-            '?',
-            '=',
-            '{',
-            '}',
-            ' ',
-            '\t',
-            '\n',
-            '\r' -> return true
-        }
+        if (HeaderFieldValueSeparators.contains(this[index])) return true
     }
 
     return false

--- a/ktor-http/common/src/io/ktor/http/HeaderValueWithParameters.kt
+++ b/ktor-http/common/src/io/ktor/http/HeaderValueWithParameters.kt
@@ -80,15 +80,27 @@ private fun String.checkNeedEscape(): Boolean {
 
     for (index in 0 until length) {
         when (this[index]) {
-            '\\',
-            '\n',
-            '\r',
-            '\"',
-            ' ',
-            '=',
-            ';',
+            '(',
+            ')',
+            '<',
+            '>',
+            '@',
             ',',
-            '/' -> return true
+            ';',
+            ':',
+            '\\',
+            '\"',
+            '/',
+            '[',
+            ']',
+            '?',
+            '=',
+            '{',
+            '}',
+            ' ',
+            '\t',
+            '\n',
+            '\r' -> return true
         }
     }
 
@@ -109,6 +121,7 @@ private fun String.quoteTo(out: StringBuilder) {
             '\\' -> out.append("\\\\")
             '\n' -> out.append("\\n")
             '\r' -> out.append("\\r")
+            '\t' -> out.append("\\t")
             '\"' -> out.append("\\\"")
             else -> out.append(ch)
         }

--- a/ktor-http/common/test/io/ktor/tests/http/HeadersTest.kt
+++ b/ktor-http/common/test/io/ktor/tests/http/HeadersTest.kt
@@ -216,15 +216,22 @@ class HeadersTest {
 
     @Test
     fun testRenderEscaped() {
-        assertEquals("file; k=\"v,v\"", ContentDisposition.File.withParameter("k", "v,v").toString())
-        assertEquals(
-            "file; k=\"v,v\"; k2=\"=\"",
-            ContentDisposition.File.withParameter("k", "v,v").withParameter("k2", "=").toString()
-        )
-        assertEquals(
-            "file; k=\"v,v\"; k2=v2",
-            ContentDisposition.File.withParameter("k", "v,v").withParameter("k2", "v2").toString()
-        )
+        assertEquals("file; k=\"v\\nv\"", ContentDisposition.File.withParameter("k", "v\nv").toString())
+        assertEquals("file; k=\"v\\rv\"", ContentDisposition.File.withParameter("k", "v\rv").toString())
+        assertEquals("file; k=\"v\\tv\"", ContentDisposition.File.withParameter("k", "v\tv").toString())
+        assertEquals("file; k=\"v\\\\v\"", ContentDisposition.File.withParameter("k", "v\\v").toString())
+        assertEquals("file; k=\"v\\\"v\"", ContentDisposition.File.withParameter("k", "v\"v").toString())
+    }
+
+    @Test
+    fun testRenderQuoted() {
+        val separators = setOf('(', ')', '<', '>', '@', ',', ';', ':', '/', '[', ']', '?', '=', '{', '}', ' ')
+        separators.forEach { separator ->
+            assertEquals(
+                "file; k=\"v${separator}v\"",
+                ContentDisposition.File.withParameter("k", "v${separator}v").toString()
+            )
+        }
     }
 
     @Test


### PR DESCRIPTION
**Subsystem**
Client/Server

**Motivation**
[Content-Disposition additional parameters should be inside quotes](https://youtrack.jetbrains.com/issue/KTOR-455)

**Solution**
Handle all separator symbols listed in [RFC](https://tools.ietf.org/html/rfc2616#section-2.2)

