### PR TITLE
KTOR-1103 handle 304 response without Vary header

### DIFF
--- a/ktor-client/ktor-client-tests/jvm/src/io/ktor/client/tests/utils/tests/Cache.kt
+++ b/ktor-client/ktor-client-tests/jvm/src/io/ktor/client/tests/utils/tests/Cache.kt
@@ -67,6 +67,17 @@ internal fun Application.cacheTestServer() {
                 call.respond(response)
             }
 
+            get("/vary-stale") {
+                val current = counter.incrementAndGet()
+                val response = TextContent("$current", ContentType.Text.Plain).apply {
+                    caching = CachingOptions(CacheControl.MaxAge(0))
+                }
+                response.versions += LastModifiedVersion(GMTDate.START)
+
+                call.response.header(HttpHeaders.Vary, HttpHeaders.ContentLanguage)
+                call.respond(response)
+            }
+
             get("/public") {
                 call.response.cacheControl(CacheControl.MaxAge(60))
                 call.respondText("public")


### PR DESCRIPTION
**Subsystem**
Client cache

**Motivation**
[Client: InvalidCacheStateException when Vary header differs for 200 and 304 responses](https://youtrack.jetbrains.com/issue/KTOR-1103)

**Solution**
According to [Calculating Secondary Keys with Vary](https://tools.ietf.org/html/rfc7234#section-4.1), if 304 response doesn't have `Vary` headers, the client should compare headers listed in Vary from cached responses with new request to find a match. 

