### PR TITLE
KTOR-742, KTOR-1122 - Add Jetty, Netty and Tomcat Client Certificate Authentication

### DIFF
--- a/ktor-network/ktor-network-tls/api/ktor-network-tls.api
+++ b/ktor-network/ktor-network-tls/api/ktor-network-tls.api
@@ -84,11 +84,15 @@ public final class io/ktor/network/tls/OID {
 
 public final class io/ktor/network/tls/OID$Companion {
 	public final fun fromAlgorithm (Ljava/lang/String;)Lio/ktor/network/tls/OID;
+	public final fun getBasicConstraints ()Lio/ktor/network/tls/OID;
+	public final fun getClientAuth ()Lio/ktor/network/tls/OID;
 	public final fun getCommonName ()Lio/ktor/network/tls/OID;
 	public final fun getCountryName ()Lio/ktor/network/tls/OID;
 	public final fun getECDSAwithSHA256Encryption ()Lio/ktor/network/tls/OID;
 	public final fun getECDSAwithSHA384Encryption ()Lio/ktor/network/tls/OID;
 	public final fun getECEncryption ()Lio/ktor/network/tls/OID;
+	public final fun getExtKeyUsage ()Lio/ktor/network/tls/OID;
+	public final fun getKeyUsage ()Lio/ktor/network/tls/OID;
 	public final fun getOrganizationName ()Lio/ktor/network/tls/OID;
 	public final fun getOrganizationalUnitName ()Lio/ktor/network/tls/OID;
 	public final fun getRSAEncryption ()Lio/ktor/network/tls/OID;
@@ -97,6 +101,7 @@ public final class io/ktor/network/tls/OID$Companion {
 	public final fun getRSAwithSHA384Encryption ()Lio/ktor/network/tls/OID;
 	public final fun getRSAwithSHA512Encryption ()Lio/ktor/network/tls/OID;
 	public final fun getSecp256r1 ()Lio/ktor/network/tls/OID;
+	public final fun getServerAuth ()Lio/ktor/network/tls/OID;
 	public final fun getSubjectAltName ()Lio/ktor/network/tls/OID;
 }
 

--- a/ktor-network/ktor-network-tls/common/src/io/ktor/network/tls/OID.kt
+++ b/ktor-network/ktor-network-tls/common/src/io/ktor/network/tls/OID.kt
@@ -17,6 +17,15 @@ public data class OID(public val identifier: String) {
         public val SubjectAltName: OID = OID("2.5.29.17")
 
         /**
+         * CA OID
+         * */
+        public val BasicConstraints: OID = OID("2.5.29.19")
+        public val KeyUsage: OID = OID("2.5.29.15")
+        public val ExtKeyUsage: OID = OID("2.5.29.37")
+        public val ServerAuth: OID = OID("1.3.6.1.5.5.7.3.1")
+        public val ClientAuth: OID = OID("1.3.6.1.5.5.7.3.2")
+
+        /**
          * Encryption OID
          */
         public val RSAEncryption: OID = OID("1 2 840 113549 1 1 1")

--- a/ktor-network/ktor-network-tls/ktor-network-tls-certificates/api/ktor-network-tls-certificates.api
+++ b/ktor-network/ktor-network-tls/ktor-network-tls-certificates/api/ktor-network-tls-certificates.api
@@ -20,11 +20,24 @@ public final class io/ktor/network/tls/certificates/CertificateBuilder {
 }
 
 public final class io/ktor/network/tls/certificates/CertificatesKt {
-	public static final fun generateCertificate (Ljava/io/File;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;I)Ljava/security/KeyStore;
-	public static synthetic fun generateCertificate$default (Ljava/io/File;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;IILjava/lang/Object;)Ljava/security/KeyStore;
+	public static final fun generateCertificate (Ljava/io/File;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILio/ktor/network/tls/certificates/KeyType;)Ljava/security/KeyStore;
+	public static final fun generateCertificate (Ljava/security/KeyStore;Ljava/io/File;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/String;Ljava/lang/String;Lio/ktor/network/tls/certificates/KeyType;)Ljava/security/KeyStore;
+	public static synthetic fun generateCertificate$default (Ljava/io/File;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILio/ktor/network/tls/certificates/KeyType;ILjava/lang/Object;)Ljava/security/KeyStore;
+	public static synthetic fun generateCertificate$default (Ljava/security/KeyStore;Ljava/io/File;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/String;Ljava/lang/String;Lio/ktor/network/tls/certificates/KeyType;ILjava/lang/Object;)Ljava/security/KeyStore;
+	public static final fun getTrustManagers (Ljava/security/KeyStore;)Ljava/util/List;
+	public static final fun trustStore (Ljava/security/KeyStore;Ljava/io/File;[C)Ljava/security/KeyStore;
+	public static synthetic fun trustStore$default (Ljava/security/KeyStore;Ljava/io/File;[CILjava/lang/Object;)Ljava/security/KeyStore;
 }
 
 public final class io/ktor/network/tls/certificates/KeyStoreBuilder {
 	public final fun certificate (Ljava/lang/String;Lkotlin/jvm/functions/Function1;)V
+}
+
+public final class io/ktor/network/tls/certificates/KeyType : java/lang/Enum {
+	public static final field CA Lio/ktor/network/tls/certificates/KeyType;
+	public static final field Client Lio/ktor/network/tls/certificates/KeyType;
+	public static final field Server Lio/ktor/network/tls/certificates/KeyType;
+	public static fun valueOf (Ljava/lang/String;)Lio/ktor/network/tls/certificates/KeyType;
+	public static fun values ()[Lio/ktor/network/tls/certificates/KeyType;
 }
 

--- a/ktor-server/ktor-server-cio/jvm/test/io/ktor/tests/server/cio/CIOClientCertTest.kt
+++ b/ktor-server/ktor-server-cio/jvm/test/io/ktor/tests/server/cio/CIOClientCertTest.kt
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2014-2020 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.tests.server.cio
+
+import io.ktor.server.cio.*
+import io.ktor.server.testing.suites.*
+import kotlin.test.*
+
+class CIOClientCertTest : ClientCertTestSuite<CIOApplicationEngine, CIOApplicationEngine.Configuration>(CIO) {
+    @Test
+    public override fun `Server requesting Client Certificate from CIO Client`() {
+        assertFailsWith<UnsupportedOperationException> {
+            super.`Server requesting Client Certificate from CIO Client`()
+        }
+    }
+}

--- a/ktor-server/ktor-server-host-common/api/ktor-server-host-common.api
+++ b/ktor-server/ktor-server-host-common/api/ktor-server-host-common.api
@@ -213,9 +213,11 @@ public final class io/ktor/server/engine/EmbeddedServerKt {
 	public static final fun embeddedServer (Lio/ktor/server/engine/ApplicationEngineFactory;ILjava/lang/String;Ljava/util/List;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Lio/ktor/server/engine/ApplicationEngine;
 	public static final fun embeddedServer (Lio/ktor/server/engine/ApplicationEngineFactory;Lio/ktor/server/engine/ApplicationEngineEnvironment;Lkotlin/jvm/functions/Function1;)Lio/ktor/server/engine/ApplicationEngine;
 	public static final fun embeddedServer (Lkotlinx/coroutines/CoroutineScope;Lio/ktor/server/engine/ApplicationEngineFactory;ILjava/lang/String;Ljava/util/List;Lkotlin/coroutines/CoroutineContext;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Lio/ktor/server/engine/ApplicationEngine;
+	public static final fun embeddedServer (Lkotlinx/coroutines/CoroutineScope;Lio/ktor/server/engine/ApplicationEngineFactory;[Lio/ktor/server/engine/EngineConnectorConfig;Ljava/util/List;Lkotlin/coroutines/CoroutineContext;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Lio/ktor/server/engine/ApplicationEngine;
 	public static synthetic fun embeddedServer$default (Lio/ktor/server/engine/ApplicationEngineFactory;ILjava/lang/String;Ljava/util/List;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lio/ktor/server/engine/ApplicationEngine;
 	public static synthetic fun embeddedServer$default (Lio/ktor/server/engine/ApplicationEngineFactory;Lio/ktor/server/engine/ApplicationEngineEnvironment;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lio/ktor/server/engine/ApplicationEngine;
 	public static synthetic fun embeddedServer$default (Lkotlinx/coroutines/CoroutineScope;Lio/ktor/server/engine/ApplicationEngineFactory;ILjava/lang/String;Ljava/util/List;Lkotlin/coroutines/CoroutineContext;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lio/ktor/server/engine/ApplicationEngine;
+	public static synthetic fun embeddedServer$default (Lkotlinx/coroutines/CoroutineScope;Lio/ktor/server/engine/ApplicationEngineFactory;[Lio/ktor/server/engine/EngineConnectorConfig;Ljava/util/List;Lkotlin/coroutines/CoroutineContext;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lio/ktor/server/engine/ApplicationEngine;
 }
 
 public abstract interface annotation class io/ktor/server/engine/EngineAPI : java/lang/annotation/Annotation {
@@ -270,11 +272,18 @@ public final class io/ktor/server/engine/EngineSSLConnectorBuilder : io/ktor/ser
 	public fun getKeyStore ()Ljava/security/KeyStore;
 	public fun getKeyStorePassword ()Lkotlin/jvm/functions/Function0;
 	public fun getKeyStorePath ()Ljava/io/File;
+	public fun getPort ()I
 	public fun getPrivateKeyPassword ()Lkotlin/jvm/functions/Function0;
+	public fun getTrustStore ()Ljava/security/KeyStore;
+	public fun getTrustStorePath ()Ljava/io/File;
 	public fun setKeyAlias (Ljava/lang/String;)V
 	public fun setKeyStore (Ljava/security/KeyStore;)V
 	public fun setKeyStorePassword (Lkotlin/jvm/functions/Function0;)V
 	public fun setKeyStorePath (Ljava/io/File;)V
+	public fun setPort (I)V
+	public fun setPrivateKeyPassword (Lkotlin/jvm/functions/Function0;)V
+	public fun setTrustStore (Ljava/security/KeyStore;)V
+	public fun setTrustStorePath (Ljava/io/File;)V
 }
 
 public abstract interface class io/ktor/server/engine/EngineSSLConnectorConfig : io/ktor/server/engine/EngineConnectorConfig {
@@ -283,6 +292,8 @@ public abstract interface class io/ktor/server/engine/EngineSSLConnectorConfig :
 	public abstract fun getKeyStorePassword ()Lkotlin/jvm/functions/Function0;
 	public abstract fun getKeyStorePath ()Ljava/io/File;
 	public abstract fun getPrivateKeyPassword ()Lkotlin/jvm/functions/Function0;
+	public abstract fun getTrustStore ()Ljava/security/KeyStore;
+	public abstract fun getTrustStorePath ()Ljava/io/File;
 }
 
 public final class io/ktor/server/engine/ShutDownUrl {

--- a/ktor-server/ktor-server-host-common/jvm/src/io/ktor/server/engine/EngineConnectorConfig.kt
+++ b/ktor-server/ktor-server-host-common/jvm/src/io/ktor/server/engine/EngineConnectorConfig.kt
@@ -79,11 +79,19 @@ public interface EngineSSLConnectorConfig : EngineConnectorConfig {
 
     /**
      * Store of trusted certificates for verifying the remote endpoint's certificate.
+     *
+     * The engine tries to use [trustStore] first and uses [trustStorePath] as a fallback.
+     *
+     * If [trustStore] and [trustStorePath] are both null, the endpoint's certificate will not be verified.
      */
     public val trustStore: KeyStore?
 
     /**
      * File with trusted certificates (JKS) for verifying the remote endpoint's certificate.
+     *
+     * The engine tries to use [trustStore] first and uses [trustStorePath] as a fallback.
+     *
+     * If [trustStore] and [trustStorePath] are both null, the endpoint's certificate will not be verified.
      */
     public val trustStorePath: File?
 }
@@ -129,9 +137,10 @@ public class EngineSSLConnectorBuilder(
     override var keyStore: KeyStore,
     override var keyAlias: String,
     override var keyStorePassword: () -> CharArray,
-    override var privateKeyPassword: () -> CharArray,
+    override var privateKeyPassword: () -> CharArray
 ) : EngineConnectorBuilder(ConnectorType.HTTPS), EngineSSLConnectorConfig {
     override var keyStorePath: File? = null
     override var trustStore: KeyStore? = null
     override var trustStorePath: File? = null
+    override var port: Int = 443
 }

--- a/ktor-server/ktor-server-host-common/jvm/src/io/ktor/server/engine/EngineConnectorConfig.kt
+++ b/ktor-server/ktor-server-host-common/jvm/src/io/ktor/server/engine/EngineConnectorConfig.kt
@@ -76,6 +76,16 @@ public interface EngineSSLConnectorConfig : EngineConnectorConfig {
      * Private key password provider
      */
     public val privateKeyPassword: () -> CharArray
+
+    /**
+     * Store of trusted certificates for verifying the remote endpoint's certificate.
+     */
+    public val trustStore: KeyStore?
+
+    /**
+     * File with trusted certificates (JKS) for verifying the remote endpoint's certificate.
+     */
+    public val trustStorePath: File?
 }
 
 /**
@@ -119,7 +129,9 @@ public class EngineSSLConnectorBuilder(
     override var keyStore: KeyStore,
     override var keyAlias: String,
     override var keyStorePassword: () -> CharArray,
-    override val privateKeyPassword: () -> CharArray
+    override var privateKeyPassword: () -> CharArray,
 ) : EngineConnectorBuilder(ConnectorType.HTTPS), EngineSSLConnectorConfig {
     override var keyStorePath: File? = null
+    override var trustStore: KeyStore? = null
+    override var trustStorePath: File? = null
 }

--- a/ktor-server/ktor-server-jetty/jvm/src/io/ktor/server/jetty/ServerInitializer.kt
+++ b/ktor-server/ktor-server-jetty/jvm/src/io/ktor/server/jetty/ServerInitializer.kt
@@ -52,11 +52,17 @@ internal fun Server.initializeServer(environment: ApplicationEngineEnvironment) 
                         keyStore = (ktorConnector as EngineSSLConnectorConfig).keyStore
                         setKeyManagerPassword(String(ktorConnector.privateKeyPassword()))
                         setKeyStorePassword(String(ktorConnector.keyStorePassword()))
-                        needClientAuth = true
-                        when {
-                            ktorConnector.trustStore != null -> trustStore = ktorConnector.trustStore
-                            ktorConnector.trustStorePath != null -> trustStorePath = ktorConnector.trustStorePath!!.absolutePath
-                            else -> needClientAuth = false
+
+                        needClientAuth = when {
+                            ktorConnector.trustStore != null -> {
+                                trustStore = ktorConnector.trustStore
+                                true
+                            }
+                            ktorConnector.trustStorePath != null -> {
+                                trustStorePath = ktorConnector.trustStorePath!!.absolutePath
+                                true
+                            }
+                            else -> false
                         }
 
                         addExcludeCipherSuites(

--- a/ktor-server/ktor-server-jetty/jvm/src/io/ktor/server/jetty/ServerInitializer.kt
+++ b/ktor-server/ktor-server-jetty/jvm/src/io/ktor/server/jetty/ServerInitializer.kt
@@ -52,6 +52,12 @@ internal fun Server.initializeServer(environment: ApplicationEngineEnvironment) 
                         keyStore = (ktorConnector as EngineSSLConnectorConfig).keyStore
                         setKeyManagerPassword(String(ktorConnector.privateKeyPassword()))
                         setKeyStorePassword(String(ktorConnector.keyStorePassword()))
+                        needClientAuth = true
+                        when {
+                            ktorConnector.trustStore != null -> trustStore = ktorConnector.trustStore
+                            ktorConnector.trustStorePath != null -> trustStorePath = ktorConnector.trustStorePath!!.absolutePath
+                            else -> needClientAuth = false
+                        }
 
                         addExcludeCipherSuites(
                             "SSL_RSA_WITH_DES_CBC_SHA",

--- a/ktor-server/ktor-server-jetty/jvm/test/io/ktor/tests/server/jetty/JettyClientCertTest.kt
+++ b/ktor-server/ktor-server-jetty/jvm/test/io/ktor/tests/server/jetty/JettyClientCertTest.kt
@@ -1,0 +1,10 @@
+/*
+ * Copyright 2014-2020 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.tests.server.jetty
+
+import io.ktor.server.jetty.*
+import io.ktor.server.testing.suites.*
+
+class JettyClientCertTest : ClientCertTestSuite<JettyApplicationEngine, JettyApplicationEngineBase.Configuration>(Jetty)

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyChannelInitializer.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyChannelInitializer.kt
@@ -98,8 +98,8 @@ public class NettyChannelInitializer(
                             ApplicationProtocolNames.HTTP_1_1
                         )
                     )
-                    connector.trustManagerFactory()?.let { this.trustManager(it) }
                 }
+                connector.trustManagerFactory()?.let { this.trustManager(it) }
             }
                 .build()
         }
@@ -176,7 +176,7 @@ public class NettyChannelInitializer(
     private fun EngineSSLConnectorConfig.trustManagerFactory(): TrustManagerFactory? {
         val trustStore = trustStore ?: trustStorePath?.let { file ->
             FileInputStream(file).use { fis ->
-                KeyStore.getInstance(KeyStore.getDefaultType()).also { it.load(fis, null) }
+                KeyStore.getInstance("JKS").also { it.load(fis, null) }
             }
         }
         return trustStore?.let { store ->

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyChannelInitializer.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyChannelInitializer.kt
@@ -16,9 +16,11 @@ import io.netty.handler.ssl.*
 import io.netty.handler.timeout.*
 import io.netty.util.concurrent.*
 import kotlinx.coroutines.*
+import java.io.*
 import java.nio.channels.*
 import java.security.*
 import java.security.cert.*
+import javax.net.ssl.*
 import kotlin.coroutines.*
 
 /**
@@ -96,6 +98,7 @@ public class NettyChannelInitializer(
                             ApplicationProtocolNames.HTTP_1_1
                         )
                     )
+                    connector.trustManagerFactory()?.let { this.trustManager(it) }
                 }
             }
                 .build()
@@ -106,7 +109,13 @@ public class NettyChannelInitializer(
     override fun initChannel(ch: SocketChannel) {
         with(ch.pipeline()) {
             if (connector is EngineSSLConnectorConfig) {
-                addLast("ssl", sslContext!!.newHandler(ch.alloc()))
+                val sslEngine = sslContext!!.newEngine(ch.alloc()).apply {
+                    if (connector.hasTrustStore()) {
+                        useClientMode = false
+                        needClientAuth = true
+                    }
+                }
+                addLast("ssl", SslHandler(sslEngine))
 
                 if (alpnProvider != null) {
                     addLast(NegotiatedPipelineInitializer())
@@ -159,6 +168,19 @@ public class NettyChannelInitializer(
                 environment.log.error("Unsupported protocol $protocol")
                 pipeline.close()
             }
+        }
+    }
+
+    private fun EngineSSLConnectorConfig.hasTrustStore() = trustStore != null || trustStorePath != null
+
+    private fun EngineSSLConnectorConfig.trustManagerFactory(): TrustManagerFactory? {
+        val trustStore = trustStore ?: trustStorePath?.let { file ->
+            FileInputStream(file).use { fis ->
+                KeyStore.getInstance(KeyStore.getDefaultType()).also { it.load(fis, null) }
+            }
+        }
+        return trustStore?.let { store ->
+            TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm()).also { it.init(store) }
         }
     }
 

--- a/ktor-server/ktor-server-netty/jvm/test/io/ktor/tests/server/netty/NettyEngineTest.kt
+++ b/ktor-server/ktor-server-netty/jvm/test/io/ktor/tests/server/netty/NettyEngineTest.kt
@@ -6,7 +6,6 @@ package io.ktor.tests.server.netty
 
 import io.ktor.server.netty.*
 import io.ktor.server.testing.suites.*
-import kotlin.test.*
 
 class NettyCompressionTest : CompressionTestSuite<NettyApplicationEngine, NettyApplicationEngine.Configuration>(Netty) {
     init {
@@ -65,3 +64,5 @@ class NettySustainabilityTest : SustainabilityTestSuite<NettyApplicationEngine, 
 class NettyConfigTest : ConfigTestSuite(Netty)
 
 class NettyConnectionTest : ConnectionTestSuite(Netty)
+
+class NettyClientCertTest : ClientCertTestSuite<NettyApplicationEngine, NettyApplicationEngine.Configuration>(Netty)

--- a/ktor-server/ktor-server-test-host/api/ktor-server-test-host.api
+++ b/ktor-server/ktor-server-test-host/api/ktor-server-test-host.api
@@ -13,6 +13,7 @@ public abstract class io/ktor/server/testing/EngineTestBase : kotlinx/coroutines
 	public final fun getApplicationEngineFactory ()Lio/ktor/server/engine/ApplicationEngineFactory;
 	protected final fun getCallGroupSize ()I
 	public fun getCoroutineContext ()Lkotlin/coroutines/CoroutineContext;
+	protected final fun getEnableCertVerify ()Z
 	protected final fun getEnableHttp2 ()Z
 	protected final fun getEnableSsl ()Z
 	protected final fun getExceptions ()Ljava/util/ArrayList;
@@ -27,6 +28,7 @@ public abstract class io/ktor/server/testing/EngineTestBase : kotlinx/coroutines
 	public final fun getTimeoutRule ()Lkotlinx/coroutines/debug/junit4/CoroutinesTimeout;
 	protected final fun isUnderDebugger ()Z
 	protected fun plugins (Lio/ktor/server/application/Application;Lkotlin/jvm/functions/Function1;)V
+	protected final fun setEnableCertVerify (Z)V
 	protected final fun setEnableHttp2 (Z)V
 	protected final fun setEnableSsl (Z)V
 	protected final fun setPort (I)V

--- a/ktor-server/ktor-server-test-host/jvm/src/io/ktor/server/testing/EngineTestBase.kt
+++ b/ktor-server/ktor-server-test-host/jvm/src/io/ktor/server/testing/EngineTestBase.kt
@@ -54,6 +54,7 @@ abstract class EngineTestBase<TEngine : ApplicationEngine, TConfiguration : Appl
     protected val exceptions: ArrayList<Throwable> = ArrayList<Throwable>()
     protected var enableHttp2: Boolean = System.getProperty("enable.http2") == "true"
     protected var enableSsl: Boolean = System.getProperty("enable.ssl") != "false"
+    protected var enableCertVerify: Boolean = System.getProperty("enable.cert.verify") == "true"
 
     private val allConnections = CopyOnWriteArrayList<HttpURLConnection>()
 
@@ -151,6 +152,10 @@ abstract class EngineTestBase<TEngine : ApplicationEngine, TConfiguration : Appl
                 sslConnector(keyStore, "mykey", { "changeit".toCharArray() }, { "changeit".toCharArray() }) {
                     this.port = sslPort
                     this.keyStorePath = keyStoreFile.absoluteFile
+                    if (enableCertVerify) {
+                        this.trustStore = keyStore
+                        this.trustStorePath = keyStoreFile.absoluteFile
+                    }
                 }
             }
 

--- a/ktor-server/ktor-server-test-suites/build.gradle.kts
+++ b/ktor-server/ktor-server-test-suites/build.gradle.kts
@@ -13,6 +13,8 @@ kotlin.sourceSets {
             implementation(project(":ktor-server:ktor-server-plugins:ktor-server-forwarded-header"))
             implementation(project(":ktor-server:ktor-server-plugins:ktor-server-auto-head-response"))
 
+            implementation(kotlin("test-junit"))
+
             implementation("org.jetbrains.kotlinx:kotlinx-coroutines-debug:$coroutines_version")
         }
     }

--- a/ktor-server/ktor-server-test-suites/jvm/src/io/ktor/server/testing/suites/ClientCertTestSuite.kt
+++ b/ktor-server/ktor-server-test-suites/jvm/src/io/ktor/server/testing/suites/ClientCertTestSuite.kt
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2014-2020 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.server.testing.suites
+
+import io.ktor.client.*
+import io.ktor.client.call.*
+import io.ktor.client.engine.cio.*
+import io.ktor.client.request.*
+import io.ktor.network.tls.*
+import io.ktor.network.tls.certificates.*
+import io.ktor.server.application.*
+import io.ktor.server.engine.*
+import io.ktor.server.response.*
+import io.ktor.server.routing.*
+import kotlinx.coroutines.*
+import kotlin.test.*
+
+/**
+ * This tests uses a CA, which creates server and client certificates.
+ */
+public abstract class ClientCertTestSuite<Engine : ApplicationEngine, Configuration : ApplicationEngine.Configuration>(
+    val engine: ApplicationEngineFactory<Engine, Configuration>
+) {
+    open fun sslConnectorBuilder(): EngineSSLConnectorBuilder = EngineSSLConnectorBuilder(
+        keyAlias = "mykey",
+        keyStore = ca.generateCertificate(keyType = KeyType.Server),
+        keyStorePassword = { "changeit".toCharArray() },
+        privateKeyPassword = { "changeit".toCharArray() },
+    ).apply {
+        trustStore = ca.trustStore()
+    }
+
+    public companion object {
+        public val ca = generateCertificate(keyType = KeyType.CA)
+    }
+
+    @Test
+    public open fun `Server requesting Client Certificate from CIO Client`() {
+        val clientKeys = ca.generateCertificate(keyType = KeyType.Client)
+
+        val client = HttpClient(CIO) {
+            engine {
+                https {
+                    trustManager = ca.trustStore().trustManagers.first()
+                    addKeyStore(clientKeys, "changeit".toCharArray() as CharArray?)
+                }
+            }
+        }
+        runBlocking {
+            launch {
+                val server = embeddedServer(factory = engine, connectors = arrayOf(sslConnectorBuilder())) {
+                    routing {
+                        get {
+                            call.respondText { "Hello World" }
+                        }
+                    }
+                }
+                server.start()
+                assertEquals("Hello World", client.get("https://0.0.0.0:443").body())
+                server.stop(1000, 1000)
+            }
+        }
+    }
+}

--- a/ktor-server/ktor-server-tomcat/jvm/src/io/ktor/server/tomcat/TomcatApplicationEngine.kt
+++ b/ktor-server/ktor-server-tomcat/jvm/src/io/ktor/server/tomcat/TomcatApplicationEngine.kt
@@ -80,15 +80,27 @@ public class TomcatApplicationEngine(
                             if (ktorConnector.keyStorePath == null) {
                                 throw IllegalArgumentException(
                                     "Tomcat requires keyStorePath. Make sure you're setting " +
-                                        "the property in the EngineSSLConnectorConfig class used"
+                                        "the property in the EngineSSLConnectorConfig class."
                                 )
+                            }
+
+                            if (ktorConnector.trustStore != null && ktorConnector.trustStorePath == null) {
+                                throw IllegalArgumentException(
+                                    "Tomcat requires trustStorePath for client certificate authentication." +
+                                        "Make sure you're setting the property in the EngineSSLConnectorConfig class."
+                                )
+                            }
+                            if (ktorConnector.trustStorePath != null) {
+                                setProperty("clientAuth", "true")
+                                setProperty("truststoreFile", ktorConnector.trustStorePath!!.absolutePath)
+                            } else {
+                                setProperty("clientAuth", "false")
                             }
 
                             setProperty("keyAlias", ktorConnector.keyAlias)
                             setProperty("keystorePass", String(ktorConnector.keyStorePassword()))
                             setProperty("keyPass", String(ktorConnector.privateKeyPassword()))
                             setProperty("keystoreFile", ktorConnector.keyStorePath!!.absolutePath)
-                            setProperty("clientAuth", "false")
                             setProperty("sslProtocol", "TLS")
                             setProperty("SSLEnabled", "true")
 

--- a/ktor-server/ktor-server-tomcat/jvm/test/io/ktor/tests/server/tomcat/TomcatEngineTest.kt
+++ b/ktor-server/ktor-server-tomcat/jvm/test/io/ktor/tests/server/tomcat/TomcatEngineTest.kt
@@ -5,7 +5,9 @@
 package io.ktor.tests.server.tomcat
 
 import io.ktor.client.statement.*
+import io.ktor.network.tls.certificates.*
 import io.ktor.server.application.*
+import io.ktor.server.engine.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
 import io.ktor.server.servlet.*
@@ -13,6 +15,7 @@ import io.ktor.server.testing.suites.*
 import io.ktor.server.tomcat.*
 import org.apache.catalina.core.*
 import org.apache.tomcat.util.descriptor.web.*
+import java.io.*
 import java.util.logging.*
 import javax.servlet.*
 import javax.servlet.Filter
@@ -139,3 +142,24 @@ class TomcatSustainabilityTestSuite :
 class TomcatConfigTest : ConfigTestSuite(Tomcat)
 
 class TomcatConnectionTest : ConnectionTestSuite(Tomcat)
+
+class TomcatClientCertTest :
+    ClientCertTestSuite<TomcatApplicationEngine, TomcatApplicationEngine.Configuration>(Tomcat) {
+
+    override fun sslConnectorBuilder(): EngineSSLConnectorBuilder {
+        val serverKeyStorePath = File.createTempFile("serverKeys", "jks")
+
+        return EngineSSLConnectorBuilder(
+            keyAlias = "mykey",
+            keyStore = ca.generateCertificate(file = serverKeyStorePath, keyType = KeyType.Server),
+            keyStorePassword = { "changeit".toCharArray() },
+            privateKeyPassword = { "changeit".toCharArray() },
+        ).apply {
+            keyStorePath = serverKeyStorePath
+
+            val trustStorePath = File.createTempFile("trustStore", "jks")
+            trustStore = ca.trustStore(trustStorePath)
+            this.trustStorePath = trustStorePath
+        }
+    }
+}


### PR DESCRIPTION
**Subsystem**
Netty, Jetty and Tomcat Server

**Motivation**
Some TLS connections are secured by client certificate authentication. This feature is implemented in Netty, Jetty and Tomcat, but it is currently not possible to use it in Ktor.

**Fixing**
[KTOR-742](https://youtrack.jetbrains.com/issue/KTOR-742) (Netty)
[KTOR-1122](https://youtrack.jetbrains.com/issue/KTOR-1122) (Jetty)

**Solution**
@andrey-vasilyev and I implemented the client certificate authentication for the server engines Netty, Jetty and Tomcat.

Note: Smaller PR of #2028

- [x] apiDump