### PR TITLE
KTOR-1125 - Rename misleading CIO config property

### DIFF
--- a/ktor-client/ktor-client-cio/api/ktor-client-cio.api
+++ b/ktor-client/ktor-client-cio/api/ktor-client-cio.api
@@ -38,6 +38,7 @@ public class io/ktor/client/engine/cio/ConnectException : java/lang/Exception {
 public final class io/ktor/client/engine/cio/EndpointConfig {
 	public fun <init> ()V
 	public final fun getAllowHalfClose ()Z
+	public final fun getConnectAttempts ()I
 	public final fun getConnectRetryAttempts ()I
 	public final fun getConnectTimeout ()J
 	public final fun getKeepAliveTime ()J
@@ -45,6 +46,7 @@ public final class io/ktor/client/engine/cio/EndpointConfig {
 	public final fun getPipelineMaxSize ()I
 	public final fun getSocketTimeout ()J
 	public final fun setAllowHalfClose (Z)V
+	public final fun setConnectAttempts (I)V
 	public final fun setConnectRetryAttempts (I)V
 	public final fun setConnectTimeout (J)V
 	public final fun setKeepAliveTime (J)V

--- a/ktor-client/ktor-client-cio/common/src/io/ktor/client/engine/cio/CIOEngineConfig.kt
+++ b/ktor-client/ktor-client-cio/common/src/io/ktor/client/engine/cio/CIOEngineConfig.kt
@@ -77,7 +77,7 @@ public class EndpointConfig {
     /**
      * Maximum number of connection attempts.
      */
-    @Deprecated("Misleading name.", replaceWith = ReplaceWith("connectAttempts"))
+    @Deprecated("This is deprecated due to the misleading name. Use connectAttempts instead.", replaceWith = ReplaceWith("connectAttempts"))
     public var connectRetryAttempts: Int
         get() = connectAttempts
         set(value) {
@@ -86,6 +86,7 @@ public class EndpointConfig {
 
     /**
      * Maximum number of connection attempts.
+     * Note: this property affects only connection retries, but not request retries
      */
     public var connectAttempts: Int = 1
 

--- a/ktor-client/ktor-client-cio/common/src/io/ktor/client/engine/cio/CIOEngineConfig.kt
+++ b/ktor-client/ktor-client-cio/common/src/io/ktor/client/engine/cio/CIOEngineConfig.kt
@@ -16,6 +16,7 @@ public class CIOEngineConfig : HttpClientEngineConfig() {
      * [Endpoint] settings.
      */
     public val endpoint: EndpointConfig = EndpointConfig()
+
     /**
      * [https] settings.
      */
@@ -76,7 +77,17 @@ public class EndpointConfig {
     /**
      * Maximum number of connection attempts.
      */
-    public var connectRetryAttempts: Int = 1
+    @Deprecated("Misleading name.", replaceWith = ReplaceWith("connectAttempts"))
+    public var connectRetryAttempts: Int
+        get() = connectAttempts
+        set(value) {
+            connectAttempts = value
+        }
+
+    /**
+     * Maximum number of connection attempts.
+     */
+    public var connectAttempts: Int = 1
 
     /**
      * Allow socket to close output channel immediately on writing completion (TCP connection half close).

--- a/ktor-client/ktor-client-cio/common/src/io/ktor/client/engine/cio/Endpoint.kt
+++ b/ktor-client/ktor-client-cio/common/src/io/ktor/client/engine/cio/Endpoint.kt
@@ -147,14 +147,14 @@ internal class Endpoint(
     }
 
     private suspend fun connect(requestData: HttpRequestData): Socket {
-        val retryAttempts = config.endpoint.connectRetryAttempts
+        val connectAttempts = config.endpoint.connectAttempts
         val (connectTimeout, socketTimeout) = retrieveTimeouts(requestData)
         var timeoutFails = 0
 
         connections.incrementAndGet()
 
         try {
-            repeat(retryAttempts) {
+            repeat(connectAttempts) {
                 val connect: suspend CoroutineScope.() -> Socket = {
                     connectionFactory.connect(address) {
                         this.socketTimeout = socketTimeout
@@ -197,15 +197,15 @@ internal class Endpoint(
 
         connections.decrementAndGet()
 
-        throw getTimeoutException(retryAttempts, timeoutFails, requestData)
+        throw getTimeoutException(connectAttempts, timeoutFails, requestData)
     }
 
     /**
-     * Defines exact type of exception based on [retryAttempts] and [timeoutFails].
+     * Defines exact type of exception based on [connectAttempts] and [timeoutFails].
      */
-    private fun getTimeoutException(retryAttempts: Int, timeoutFails: Int, request: HttpRequestData) =
+    private fun getTimeoutException(connectAttempts: Int, timeoutFails: Int, request: HttpRequestData) =
         when (timeoutFails) {
-            retryAttempts -> ConnectTimeoutException(request)
+            connectAttempts -> ConnectTimeoutException(request)
             else -> FailToConnectException()
         }
 

--- a/ktor-client/ktor-client-cio/jvm/test/io/ktor/client/engine/cio/CIOConfigTest.kt
+++ b/ktor-client/ktor-client-cio/jvm/test/io/ktor/client/engine/cio/CIOConfigTest.kt
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2014-2019 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.client.engine.cio
+
+import kotlin.test.*
+
+class CIOConfigTest {
+
+    @Suppress("DEPRECATION")
+    @Test
+    fun connectRetryAttemptsShouldDelegateToConnectAttempts() {
+        val config = CIOEngineConfig()
+
+        config.endpoint { connectRetryAttempts = 3 }
+        assertEquals(3, config.endpoint.connectAttempts)
+
+        config.endpoint { connectAttempts = 5 }
+        assertEquals(5, config.endpoint.connectRetryAttempts)
+    }
+}

--- a/ktor-client/ktor-client-cio/jvm/test/io/ktor/client/engine/cio/CIOHttpsTest.kt
+++ b/ktor-client/ktor-client-cio/jvm/test/io/ktor/client/engine/cio/CIOHttpsTest.kt
@@ -179,7 +179,7 @@ class CIOHttpsTest : TestWithKtor() {
                 maxConnectionsCount = 1_000_000
                 pipelining = true
                 endpoint.apply {
-                    connectRetryAttempts = 1
+                    connectAttempts = 1
                     maxConnectionsPerRoute = 10_000
                 }
             }


### PR DESCRIPTION
**Subsystem**
Client/Server, related modules

**Motivation**
[CIO: client throws ConnectTimeoutException when endpoint.connectRetryAttempts = 0](https://youtrack.jetbrains.com/issue/KTOR-1125)

**Solution**
Deprecate misleading property. Add new property and delegate the old one to the new one.
