### PR TITLE
KTOR-842 Fix 404 StatusPages in tests

### DIFF
--- a/ktor-features/ktor-locations/jvm/test/io/ktor/tests/locations/LocationsTest.kt
+++ b/ktor-features/ktor-locations/jvm/test/io/ktor/tests/locations/LocationsTest.kt
@@ -487,7 +487,7 @@ class LocationsTest {
         // missing parameter text
         handleRequest(HttpMethod.Get, "/?number=1&longNumber=2").let { call ->
             // null because missing parameter leads to routing miss
-            assertEquals(null, call.response.status())
+            assertEquals(HttpStatusCode.NotFound, call.response.status())
         }
 
         // illegal value for numeric property

--- a/ktor-features/ktor-metrics-micrometer/jvm/test/io/ktor/metrics/micrometer/MicrometerMetricsTests.kt
+++ b/ktor-features/ktor-metrics-micrometer/jvm/test/io/ktor/metrics/micrometer/MicrometerMetricsTests.kt
@@ -233,8 +233,6 @@ class MicrometerMetricsTests {
 
         assertNull(throwableCaughtInEngine)
         assertTrue(noHandlerHandledReqeust)
-
-
     }
 
     private fun TestApplicationEngine.installDefaultBehaviour() {
@@ -242,9 +240,8 @@ class MicrometerMetricsTests {
         this.callInterceptor = {
             try {
                 call.application.execute(call)
-                if (call.response.status() == null) {
+                if (call.response.status() == HttpStatusCode.NotFound) {
                     noHandlerHandledReqeust = true
-                    call.respond(HttpStatusCode.NotFound)
                 }
             } catch (t: Throwable) {
                 throwableCaughtInEngine = t

--- a/ktor-features/ktor-webjars/jvm/test/io/ktor/webjars/WebjarsTest.kt
+++ b/ktor-features/ktor-webjars/jvm/test/io/ktor/webjars/WebjarsTest.kt
@@ -28,7 +28,7 @@ class WebjarsTest {
             application.install(Webjars)
             handleRequest(HttpMethod.Get, "/webjars/foo.js").let { call ->
                 //Should be handled by some other routing
-                assertNull(call.response.status())
+                assertEquals(HttpStatusCode.NotFound, call.response.status())
             }
         }
     }

--- a/ktor-server/ktor-server-host-common/jvm/src/io/ktor/server/engine/BaseApplicationEngine.kt
+++ b/ktor-server/ktor-server-host-common/jvm/src/io/ktor/server/engine/BaseApplicationEngine.kt
@@ -5,6 +5,8 @@
 package io.ktor.server.engine
 
 import io.ktor.application.*
+import io.ktor.http.*
+import io.ktor.response.*
 
 /**
  * Base class for implementing [ApplicationEngine]
@@ -33,10 +35,19 @@ public abstract class BaseApplicationEngine(
             it.sendPipeline.merge(pipeline.sendPipeline)
             it.receivePipeline.installDefaultTransformations()
             it.sendPipeline.installDefaultTransformations()
+            it.installDefaultInterceptors()
         }
         environment.monitor.subscribe(ApplicationStarted) {
             environment.connectors.forEach {
                 environment.log.info("Responding at ${it.type.name.toLowerCase()}://${it.host}:${it.port}")
+            }
+        }
+    }
+
+    private fun Application.installDefaultInterceptors() {
+        intercept(ApplicationCallPipeline.Fallback) {
+            if (call.response.status() == null) {
+                call.respond(HttpStatusCode.NotFound)
             }
         }
     }

--- a/ktor-server/ktor-server-host-common/jvm/src/io/ktor/server/engine/DefaultEnginePipeline.kt
+++ b/ktor-server/ktor-server-host-common/jvm/src/io/ktor/server/engine/DefaultEnginePipeline.kt
@@ -34,9 +34,6 @@ public fun defaultEnginePipeline(environment: ApplicationEnvironment): EnginePip
     pipeline.intercept(EnginePipeline.Call) {
         try {
             call.application.execute(call)
-            if (call.response.status() == null) {
-                call.respond(HttpStatusCode.NotFound)
-            }
         } catch (error: ChannelIOException) {
             with(CallLogging.Internals) {
                 withMDCBlock {

--- a/ktor-server/ktor-server-test-host/jvm/src/io/ktor/server/testing/TestApplicationResponse.kt
+++ b/ktor-server/ktor-server-test-host/jvm/src/io/ktor/server/testing/TestApplicationResponse.kt
@@ -72,7 +72,7 @@ public class TestApplicationResponse(
 
     init {
         pipeline.intercept(ApplicationSendPipeline.Engine) {
-            call.requestHandled = true
+            call.requestHandled = call.response.status() != HttpStatusCode.NotFound
         }
     }
 

--- a/ktor-server/ktor-server-tests/jvm/test/io/ktor/tests/server/features/CallLoggingTest.kt
+++ b/ktor-server/ktor-server-tests/jvm/test/io/ktor/tests/server/features/CallLoggingTest.kt
@@ -74,7 +74,7 @@ class CallLoggingTest {
             handleRequest(HttpMethod.Get, "/")
         }
 
-        assertTrue("TRACE: Unhandled: GET - /" in messages)
+        assertTrue("TRACE: 404 Not Found: GET - /" in messages)
     }
 
     @Test

--- a/ktor-server/ktor-server-tests/jvm/test/io/ktor/tests/server/features/CompressionTest.kt
+++ b/ktor-server/ktor-server-tests/jvm/test/io/ktor/tests/server/features/CompressionTest.kt
@@ -162,7 +162,7 @@ class CompressionTest {
             application.install(Compression)
             application.routing {
                 get("/") {
-                    call.respondText("text to be compressed", status = HttpStatusCode.NotFound)
+                    call.respondText("text to be compressed", status = HttpStatusCode.Found)
                 }
             }
 
@@ -170,7 +170,7 @@ class CompressionTest {
                 addHeader(HttpHeaders.AcceptEncoding, "*")
             }
             assertTrue(result.requestHandled)
-            assertEquals(HttpStatusCode.NotFound, result.response.status())
+            assertEquals(HttpStatusCode.Found, result.response.status())
             assertEquals("text to be compressed", result.response.byteContent!!.toString(Charsets.UTF_8))
         }
     }

--- a/ktor-server/ktor-server-tests/jvm/test/io/ktor/tests/server/features/HeadTest.kt
+++ b/ktor-server/ktor-server-tests/jvm/test/io/ktor/tests/server/features/HeadTest.kt
@@ -137,12 +137,6 @@ class HeadTest {
             }
         }
 
-        application.intercept(ApplicationCallPipeline.Fallback) {
-            if (call.response.status() == null) {
-                call.respond(HttpStatusCode.NotFound)
-            }
-        }
-
         // ensure with GET
         handleRequest(HttpMethod.Get, "/page1").let { call ->
             assertTrue { call.requestHandled }

--- a/ktor-server/ktor-server-tests/jvm/test/io/ktor/tests/server/features/HttpsRedirectFeatureTest.kt
+++ b/ktor-server/ktor-server-tests/jvm/test/io/ktor/tests/server/features/HttpsRedirectFeatureTest.kt
@@ -90,8 +90,10 @@ class HttpsRedirectFeatureTest {
             application.install(HttpsRedirect) {
                 excludePrefix("/exempted")
             }
-            application.intercept(ApplicationCallPipeline.Fallback) {
-                call.respond("ok")
+            application.routing {
+                get("/exempted/path") {
+                    call.respond("ok")
+                }
             }
 
             handleRequest(HttpMethod.Get, "/nonexempted").let { call ->

--- a/ktor-server/ktor-server-tests/jvm/test/io/ktor/tests/server/features/StatusPageTest.kt
+++ b/ktor-server/ktor-server-tests/jvm/test/io/ktor/tests/server/features/StatusPageTest.kt
@@ -71,8 +71,6 @@ class StatusPageTest {
     @Test
     fun testStatus404() {
         withTestApplication {
-            installFallback()
-
             application.install(StatusPages) {
                 status(HttpStatusCode.NotFound) {
                     call.respondText("${it.value} ${it.description}", status = it)
@@ -136,8 +134,6 @@ class StatusPageTest {
         class O
 
         withTestApplication {
-            installFallback()
-
             application.install(StatusPages) {
                 status(HttpStatusCode.NotFound) {
                     call.respondText("${it.value} ${it.description}", status = it)
@@ -236,8 +232,6 @@ class StatusPageTest {
                     call.respondText(cause::class.java.simpleName, status = HttpStatusCode.InternalServerError)
                 }
             }
-
-            installFallback()
 
             handleRequest(HttpMethod.Get, "/").let { call ->
                 assertEquals(HttpStatusCode.InternalServerError, call.response.status())
@@ -429,14 +423,6 @@ class StatusPageTest {
         handleRequest(HttpMethod.Get, "/not-found").let { call ->
             assertEquals(HttpStatusCode.OK, call.response.status())
             assertEquals("NotFound", call.response.content)
-        }
-    }
-}
-
-private fun TestApplicationEngine.installFallback() {
-    application.intercept(ApplicationCallPipeline.Fallback) {
-        if (call.response.status() == null) {
-            call.respond(HttpStatusCode.NotFound)
         }
     }
 }


### PR DESCRIPTION
**Subsystem**
Server, Status pages, tests

**Motivation**
[StatusPages: TestEngine doesn't handle requests when no route selector matches](https://youtrack.jetbrains.com/issue/KTOR-842)

**Solution**
Move replying with 404 status on unhandled response from `defaultEnginePipeline` to `BaseApplicationEngine`, because `TestApplicationEngine` do not use `defaultEnginePipeline` 
This unifies behaviour in tests and real life

