### PR TITLE
KTOR-1139 Fix CertificatePinner buildErrorMessage outputs CertificatesInfo reference

### DIFF
--- a/ktor-client/ktor-client-ios/darwin/src/io/ktor/client/engine/ios/certificates/CertificatePinner.kt
+++ b/ktor-client/ktor-client-ios/darwin/src/io/ktor/client/engine/ios/certificates/CertificatePinner.kt
@@ -225,7 +225,7 @@ public data class CertificatePinner internal constructor(
         for (certificate in certificates) {
             append("\n    ")
             val publicKeyStr = certificate.getPublicKeyBytes()?.toSha256String()
-            append("$CertificatesInfo.HASH_ALGORITHM_SHA_256$publicKeyStr")
+            append("${CertificatesInfo.HASH_ALGORITHM_SHA_256}$publicKeyStr")
             append(": ")
             val summaryRef = SecCertificateCopySubjectSummary(certificate)
             val summary = CFBridgingRelease(summaryRef) as NSString


### PR DESCRIPTION
**Subsystem**
Client iOS

**Motivation**
This PR fixes a wrong error message output when the iOS certificate pinning check fails.
https://youtrack.jetbrains.com/issue/KTOR-1139

**Solution**
Instead of outputting a reference value to the CertificatesInfo object, it now outputs "sha256/" as expected.

