### PR TITLE
KTOR-895 Fix overwriting the default Jetty cipher exclusion list

### DIFF
--- a/ktor-server/ktor-server-jetty/jvm/src/io/ktor/server/jetty/ServerInitializer.kt
+++ b/ktor-server/ktor-server-jetty/jvm/src/io/ktor/server/jetty/ServerInitializer.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2014-2020 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package io.ktor.server.jetty
@@ -51,7 +51,7 @@ internal fun Server.initializeServer(environment: ApplicationEngineEnvironment) 
                 setKeyManagerPassword(String(ktorConnector.privateKeyPassword()))
                 setKeyStorePassword(String(ktorConnector.keyStorePassword()))
 
-                setExcludeCipherSuites("SSL_RSA_WITH_DES_CBC_SHA",
+                addExcludeCipherSuites("SSL_RSA_WITH_DES_CBC_SHA",
                         "SSL_DHE_RSA_WITH_DES_CBC_SHA", "SSL_DHE_DSS_WITH_DES_CBC_SHA",
                         "SSL_RSA_EXPORT_WITH_RC4_40_MD5",
                         "SSL_RSA_EXPORT_WITH_DES40_CBC_SHA",


### PR DESCRIPTION
**Subsystem**
ktor-server-jetty

**Motivation**
[KTOR-895](https://youtrack.jetbrains.com/issue/KTOR-895) 

**Solution**
Don't overwrite but amend the default Jetty cipher exlusion list.

