### PR TITLE
KTOR-750 Improve multiple cache-control directives behaviour (Stage 1)

### DIFF
--- a/ktor-http/api/ktor-http.api
+++ b/ktor-http/api/ktor-http.api
@@ -14,20 +14,26 @@ public abstract class io/ktor/http/CacheControl {
 public final class io/ktor/http/CacheControl$MaxAge : io/ktor/http/CacheControl {
 	public fun <init> (ILjava/lang/Integer;ZZLio/ktor/http/CacheControl$Visibility;)V
 	public synthetic fun <init> (ILjava/lang/Integer;ZZLio/ktor/http/CacheControl$Visibility;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun equals (Ljava/lang/Object;)Z
 	public final fun getMaxAgeSeconds ()I
 	public final fun getMustRevalidate ()Z
 	public final fun getProxyMaxAgeSeconds ()Ljava/lang/Integer;
 	public final fun getProxyRevalidate ()Z
+	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }
 
 public final class io/ktor/http/CacheControl$NoCache : io/ktor/http/CacheControl {
 	public fun <init> (Lio/ktor/http/CacheControl$Visibility;)V
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }
 
 public final class io/ktor/http/CacheControl$NoStore : io/ktor/http/CacheControl {
 	public fun <init> (Lio/ktor/http/CacheControl$Visibility;)V
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }
 

--- a/ktor-http/common/src/io/ktor/http/CacheControl.kt
+++ b/ktor-http/common/src/io/ktor/http/CacheControl.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2014-2020 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package io.ktor.http
@@ -35,6 +35,14 @@ public sealed class CacheControl(public val visibility: Visibility?) {
         } else {
             "no-cache, ${visibility.headerValue}"
         }
+
+        override fun equals(other: Any?): Boolean {
+            return other is NoCache && visibility == other.visibility
+        }
+
+        override fun hashCode(): Int {
+            return visibility.hashCode()
+        }
     }
 
     /**
@@ -45,6 +53,14 @@ public sealed class CacheControl(public val visibility: Visibility?) {
             "no-store"
         } else {
             "no-store, ${visibility.headerValue}"
+        }
+
+        override fun equals(other: Any?): Boolean {
+            return other is NoStore && other.visibility == visibility
+        }
+
+        override fun hashCode(): Int {
+            return visibility.hashCode()
         }
     }
 
@@ -79,6 +95,26 @@ public sealed class CacheControl(public val visibility: Visibility?) {
             }
 
             return parts.joinToString(", ")
+        }
+
+        override fun equals(other: Any?): Boolean {
+            return other === this ||
+                (other is MaxAge &&
+                    other.maxAgeSeconds == maxAgeSeconds &&
+                    other.proxyMaxAgeSeconds == proxyMaxAgeSeconds &&
+                    other.mustRevalidate == mustRevalidate &&
+                    other.proxyRevalidate == proxyRevalidate &&
+                    other.visibility == visibility
+                    )
+        }
+
+        override fun hashCode(): Int {
+            var result = maxAgeSeconds
+            result = 31 * result + (proxyMaxAgeSeconds ?: 0)
+            result = 31 * result + mustRevalidate.hashCode()
+            result = 31 * result + proxyRevalidate.hashCode()
+            result = 31 * result + visibility.hashCode()
+            return result
         }
     }
 }

--- a/ktor-server/ktor-server-core/jvm/src/io/ktor/features/CachingHeaders.kt
+++ b/ktor-server/ktor-server-core/jvm/src/io/ktor/features/CachingHeaders.kt
@@ -1,15 +1,15 @@
 /*
- * Copyright 2014-2019 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2014-2020 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package io.ktor.features
 
 import io.ktor.application.*
-import io.ktor.http.content.*
 import io.ktor.http.*
-import io.ktor.util.pipeline.*
+import io.ktor.http.content.*
 import io.ktor.response.*
 import io.ktor.util.*
+import io.ktor.util.pipeline.*
 
 /**
  * Feature that set [CachingOptions] headers for every response.
@@ -40,10 +40,13 @@ public class CachingHeaders(private val optionsProviders: List<(OutgoingContent)
 
         if (options.isNotEmpty()) {
             val headers = Headers.build {
-                options.forEach {
-                    if (it.cacheControl != null)
-                        append(HttpHeaders.CacheControl, it.cacheControl.toString())
-                    it.expires?.let { expires -> append(HttpHeaders.Expires, expires.toHttpDate()) }
+                options.mapNotNull { it.cacheControl }
+                    .mergeCacheControlDirectives()
+                    .ifEmpty { null }?.let { directives ->
+                        append(HttpHeaders.CacheControl, directives.joinToString(separator = ", "))
+                    }
+                options.firstOrNull { it.expires != null }?.expires?.let { expires ->
+                    append(HttpHeaders.Expires, expires.toHttpDate())
                 }
             }
 
@@ -70,7 +73,12 @@ public class CachingHeaders(private val optionsProviders: List<(OutgoingContent)
             val configuration = Configuration().apply(configure)
             val feature = CachingHeaders(configuration.optionsProviders)
 
-            pipeline.sendPipeline.intercept(ApplicationSendPipeline.After) { message -> feature.interceptor(this, message) }
+            pipeline.sendPipeline.intercept(ApplicationSendPipeline.After) { message ->
+                feature.interceptor(
+                    this,
+                    message
+                )
+            }
 
             return feature
         }

--- a/ktor-server/ktor-server-core/jvm/src/io/ktor/util/CacheControlMerge.kt
+++ b/ktor-server/ktor-server-core/jvm/src/io/ktor/util/CacheControlMerge.kt
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2014-2020 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.util
+
+import io.ktor.http.*
+
+/**
+ * Merge a list of cache control directives.
+ *
+ * Currently, visibility is pinned to the expiration directive,
+ * then to the first no-cache,
+ * then to the no-store directive.
+ * The RFC doesn't state, where a visibility modifier should be so we can place it at any place
+ * so there is nothing behind the rule beyond, therefore could be changed.
+ *
+ * Only one visibility specifier is kept.
+ *
+ * If there are different visibility modifiers specified, then the private wins.
+ * All max ages directives are reduced to a single with all minimal max age values.
+ *
+ * A no-cache directive is always placed first.
+ * A no-store directive is always placed after no-cache, otherwise it's placed first.
+ * A max-age directive is always the last.
+ *
+ * Revalidation directives are collected as well.
+ * Currently, revalidation directives are tied to max age by-design.
+ * This is not fair according to RFC so will be changed in the future.
+ */
+internal fun List<CacheControl>.mergeCacheControlDirectives(): List<CacheControl> {
+    if (size < 2) return this
+
+    val visibility = when {
+        any { it.visibility == CacheControl.Visibility.Private } -> CacheControl.Visibility.Private
+        any { it.visibility == CacheControl.Visibility.Public } -> CacheControl.Visibility.Public
+        else -> null
+    }
+
+    val noCacheDirective = firstOrNull { it is CacheControl.NoCache } as CacheControl.NoCache?
+    val noStoreDirective = firstOrNull { it is CacheControl.NoStore } as CacheControl.NoStore?
+
+    val maxAgeDirectives = filterIsInstance<CacheControl.MaxAge>()
+    val minMaxAge = maxAgeDirectives.minByOrNull { it.maxAgeSeconds }?.maxAgeSeconds
+    val minProxyMaxAge = maxAgeDirectives.mapNotNull { it.proxyMaxAgeSeconds }.minByOrNull { it }
+    val mustRevalidate = maxAgeDirectives.any { it.mustRevalidate }
+    val proxyRevalidate = maxAgeDirectives.any { it.proxyRevalidate }
+
+    return mutableListOf<CacheControl>().apply {
+        noCacheDirective?.let { add(CacheControl.NoCache(null)) }
+        noStoreDirective?.let { add(CacheControl.NoStore(null)) }
+
+        if (maxAgeDirectives.isNotEmpty()) {
+            add(
+                CacheControl.MaxAge(
+                    minMaxAge!!,
+                    minProxyMaxAge,
+                    mustRevalidate,
+                    proxyRevalidate,
+                    visibility
+                )
+            )
+        } else {
+            when {
+                noCacheDirective != null -> set(0, CacheControl.NoCache(visibility))
+                noStoreDirective != null -> set(0, CacheControl.NoStore(visibility))
+            }
+        }
+    }
+}

--- a/ktor-server/ktor-server-core/jvm/test/io/ktor/tests/utils/CacheControlMergeTest.kt
+++ b/ktor-server/ktor-server-core/jvm/test/io/ktor/tests/utils/CacheControlMergeTest.kt
@@ -1,0 +1,260 @@
+/*
+ * Copyright 2014-2020 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.tests.utils
+
+import io.ktor.http.*
+import io.ktor.http.CacheControl.*
+import io.ktor.util.*
+import kotlin.test.*
+
+class CacheControlMergeTest {
+    @Test
+    fun testMergeEmpty() {
+        assertEquals(emptyList(), merge())
+    }
+
+    @Test
+    fun testMergeSingleEntry() {
+        assertEquals(listOf(NoStore(null)), merge(NoStore(null)))
+        assertEquals(listOf(NoStore(Visibility.Public)), merge(NoStore(Visibility.Public)))
+        assertEquals(listOf(NoStore(Visibility.Private)), merge(NoStore(Visibility.Private)))
+        assertEquals(listOf(NoCache(null)), merge(NoCache(null)))
+        assertEquals(listOf(NoCache(Visibility.Public)), merge(NoCache(Visibility.Public)))
+        assertEquals(listOf(NoCache(Visibility.Private)), merge(NoCache(Visibility.Private)))
+        assertEquals(listOf(MaxAge(1)), merge(MaxAge(1)))
+        assertEquals(listOf(MaxAge(2)), merge(MaxAge(2)))
+        assertEquals(
+            listOf(MaxAge(3, visibility = Visibility.Private)),
+            merge(MaxAge(3, visibility = Visibility.Private))
+        )
+    }
+
+    @Test
+    fun testOrderNoMaxAge() {
+        assertEquals(listOf(NoCache(null), NoStore(null)), merge(NoCache(null), NoStore(null)))
+        assertEquals(listOf(NoCache(null), NoStore(null)), merge(NoStore(null), NoCache(null)))
+    }
+
+    @Test
+    fun testMergeNoMaxAge() {
+        assertEquals(listOf(NoCache(null), NoStore(null)), merge(NoCache(null), NoStore(null)))
+        assertEquals(listOf(NoCache(null)), merge(NoCache(null), NoCache(null)))
+        assertEquals(listOf(NoCache(Visibility.Private)), merge(NoCache(null), NoCache(Visibility.Private)))
+        assertEquals(listOf(NoCache(Visibility.Private)), merge(NoCache(Visibility.Private), NoCache(null)))
+    }
+
+    @Test
+    fun testTripleMergeNoMaxAge() {
+        assertEquals(
+            listOf(NoCache(Visibility.Private)), merge(
+                NoCache(Visibility.Private),
+                NoCache(null),
+                NoCache(Visibility.Public),
+            )
+        )
+        assertEquals(
+            listOf(NoCache(Visibility.Public)), merge(
+                NoCache(Visibility.Public),
+                NoCache(null),
+                NoCache(Visibility.Public),
+            )
+        )
+
+    }
+
+    @Test
+    fun testPrivateMergeNoMaxAge() {
+        assertEquals(
+            listOf(NoCache(Visibility.Private), NoStore(null)),
+            merge(NoCache(Visibility.Private), NoStore(null))
+        )
+        assertEquals(
+            listOf(NoCache(Visibility.Private), NoStore(null)),
+            merge(NoCache(Visibility.Private), NoStore(Visibility.Private))
+        )
+        assertEquals(
+            listOf(NoCache(Visibility.Private), NoStore(null)),
+            merge(NoCache(Visibility.Private), NoStore(Visibility.Public))
+        )
+        assertEquals(
+            listOf(NoCache(Visibility.Private), NoStore(null)),
+            merge(NoCache(Visibility.Public), NoStore(Visibility.Private))
+        )
+    }
+
+    @Test
+    fun testPublicMergeNoMaxAge() {
+        assertEquals(
+            listOf(NoCache(Visibility.Public), NoStore(null)),
+            merge(NoCache(Visibility.Public), NoStore(null))
+        )
+        assertEquals(
+            listOf(NoCache(Visibility.Public), NoStore(null)),
+            merge(NoCache(null), NoStore(Visibility.Public))
+        )
+        assertEquals(
+            listOf(NoCache(Visibility.Public), NoStore(null)),
+            merge(NoCache(Visibility.Public), NoStore(Visibility.Public))
+        )
+    }
+
+    @Test
+    fun testSimpleMaxAgeMerge() {
+        assertEquals(
+            listOf(MaxAge(1, 1, true, true, Visibility.Private)),
+            merge(
+                MaxAge(1, 2, true, false, null),
+                MaxAge(2, 1, false, true, Visibility.Public),
+                MaxAge(20, 10, false, false, Visibility.Private)
+            )
+        )
+    }
+
+    @Test
+    fun testAgeMergeWithNoCache() {
+        assertEquals(
+            listOf(
+                NoCache(null),
+                MaxAge(1, 2, true, false, Visibility.Private)
+            ),
+            merge(
+                MaxAge(1, 2, true, false, null),
+                NoCache(Visibility.Private)
+            )
+        )
+
+        assertEquals(
+            listOf(
+                NoCache(null),
+                MaxAge(1, 2, true, false, Visibility.Private)
+            ),
+            merge(
+                MaxAge(1, 2, true, false, Visibility.Public),
+                NoCache(Visibility.Private)
+            )
+        )
+
+        assertEquals(
+            listOf(
+                NoCache(null),
+                MaxAge(1, 2, true, false, Visibility.Public)
+            ),
+            merge(
+                MaxAge(1, 2, true, false, Visibility.Public),
+                NoCache(null)
+            )
+        )
+    }
+
+    @Test
+    fun testAgeMergeWithNoStore() {
+        assertEquals(
+            listOf(
+                NoStore(null),
+                MaxAge(1, 2, true, false, Visibility.Private)
+            ),
+            merge(
+                MaxAge(1, 2, true, false, null),
+                NoStore(Visibility.Private)
+            )
+        )
+
+        assertEquals(
+            listOf(
+                NoStore(null),
+                MaxAge(1, 2, true, false, Visibility.Private)
+            ),
+            merge(
+                MaxAge(1, 2, true, false, Visibility.Public),
+                NoStore(Visibility.Private)
+            )
+        )
+
+        assertEquals(
+            listOf(
+                NoStore(null),
+                MaxAge(1, 2, true, false, Visibility.Public)
+            ),
+            merge(
+                MaxAge(1, 2, true, false, Visibility.Public),
+                NoStore(null)
+            )
+        )
+    }
+
+    @Test
+    fun testAgeMergeWithNoCacheAndNoStore() {
+        assertEquals(
+            listOf(
+                NoCache(null),
+                NoStore(null),
+                MaxAge(1, 2, true, false, Visibility.Private)
+            ),
+            merge(
+                MaxAge(1, 2, true, false, null),
+                NoStore(Visibility.Private),
+                NoCache(Visibility.Private)
+            )
+        )
+
+        assertEquals(
+            listOf(
+                NoCache(null),
+                NoStore(null),
+                MaxAge(1, 2, true, false, null)
+            ),
+            merge(
+                MaxAge(1, 2, true, false, null),
+                NoStore(null),
+                NoCache(null)
+            )
+        )
+
+        assertEquals(
+            listOf(
+                NoCache(null),
+                NoStore(null),
+                MaxAge(1, 2, true, false, Visibility.Public)
+            ),
+            merge(
+                MaxAge(1, 2, true, false, null),
+                NoStore(Visibility.Public),
+                NoCache(Visibility.Public)
+            )
+        )
+
+        assertEquals(
+            listOf(
+                NoCache(null),
+                NoStore(null),
+                MaxAge(1, 2, true, false, Visibility.Private)
+            ),
+            merge(
+                MaxAge(1, 2, true, false, Visibility.Private),
+                NoStore(null),
+                NoCache(null)
+            )
+        )
+
+        assertEquals(
+            listOf(
+                NoCache(null),
+                NoStore(null),
+                MaxAge(1, 2, true, false, Visibility.Private)
+            ),
+            merge(
+                MaxAge(1, 2, true, false, Visibility.Public),
+                NoStore(null),
+                NoCache(null),
+                NoCache(Visibility.Public),
+                NoStore(Visibility.Private),
+            )
+        )
+    }
+
+    private fun merge(vararg cacheControl: CacheControl): List<CacheControl> {
+        return cacheControl.asList().mergeCacheControlDirectives()
+    }
+}

--- a/ktor-server/ktor-server-tests/jvm/test/io/ktor/tests/server/features/CachingHeadersTest.kt
+++ b/ktor-server/ktor-server-tests/jvm/test/io/ktor/tests/server/features/CachingHeadersTest.kt
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2014-2020 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.tests.server.features
+
+import io.ktor.application.*
+import io.ktor.features.*
+import io.ktor.http.*
+import io.ktor.http.content.*
+import io.ktor.response.*
+import io.ktor.routing.*
+import io.ktor.server.testing.*
+import kotlin.test.*
+
+class CachingHeadersTest {
+    @Test
+    fun testNoFeatureInstalled(): Unit = test(configure = {
+    }, test = { call ->
+        assertEquals(null, call.response.headers[HttpHeaders.CacheControl])
+    })
+
+    @Test
+    fun testByPass(): Unit = test(configure = {
+        install(CachingHeaders)
+    }, test = { call ->
+        assertEquals("no-cache", call.response.headers[HttpHeaders.CacheControl])
+    })
+
+    @Test
+    fun addNoStore(): Unit = test(configure = {
+        install(CachingHeaders) {
+            options { CachingOptions(CacheControl.NoStore(CacheControl.Visibility.Private)) }
+        }
+    }, test = { call ->
+        assertEquals("no-cache, private, no-store", call.response.headers[HttpHeaders.CacheControl])
+    })
+
+    @Test
+    fun testAddMaxAgeAndNoStore(): Unit = test(configure = {
+        install(CachingHeaders) {
+            options { CachingOptions(CacheControl.NoStore(CacheControl.Visibility.Private)) }
+            options { CachingOptions(CacheControl.MaxAge(15)) }
+        }
+    }, test = { call ->
+        assertEquals("no-cache, no-store, max-age=15, private", call.response.headers[HttpHeaders.CacheControl])
+    })
+
+    private fun test(
+        configure: Application.() -> Unit,
+        test: (ApplicationCall) -> Unit
+    ): Unit = withTestApplication {
+        configure(application)
+
+        application.routing {
+            get("/") {
+                call.respondText("test") {
+                    caching = CachingOptions(CacheControl.NoCache(null))
+                }
+            }
+        }
+
+        handleRequest(HttpMethod.Get, "/").let { call ->
+            assertTrue(call.requestHandled)
+            assertEquals("test", call.response.content?.trim())
+            test(call)
+        }
+    }
+}


### PR DESCRIPTION
**Subsystem**
ktor-server-core (Server), [CachingHeaders](https://ktor.io/docs/caching-headers.html) feature

**Motivation**
[KTOR-750](https://youtrack.jetbrains.com/issue/KTOR-750) Setting multiple cache control directives is impossible with current API 

Currently, specifying multiple cache-control directives causes server to produce multiple headers. In spite of it is not prohibited by the RFC, some clients may "don't like" this and stop caching at all. Also, repeating the same directive multiple time doesn't look smart. 

The other issue is that not all directives and options covered by the current API. For example, one can't specify `must-revalidate` without `max-age` that looks weird.

**Solution**
- Introduce merging caching directives

**Notes**
Adding extra-capabilities that not covered by the API is a change we can't afford in 1.4.x. This "Stage 1" is not intended to provide such functionality. We only merge directives into a single header (actually two).

