### PR TITLE
KTOR-1120 Fix caching of jetty client

### DIFF
--- a/ktor-client/ktor-client-core/api/ktor-client-core.api
+++ b/ktor-client/ktor-client-core/api/ktor-client-core.api
@@ -428,9 +428,11 @@ public final class io/ktor/client/features/HttpTimeout$HttpTimeoutCapabilityConf
 	public static final field Companion Lio/ktor/client/features/HttpTimeout$HttpTimeoutCapabilityConfiguration$Companion;
 	public fun <init> (Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;)V
 	public synthetic fun <init> (Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun equals (Ljava/lang/Object;)Z
 	public final fun getConnectTimeoutMillis ()Ljava/lang/Long;
 	public final fun getRequestTimeoutMillis ()Ljava/lang/Long;
 	public final fun getSocketTimeoutMillis ()Ljava/lang/Long;
+	public fun hashCode ()I
 	public final fun setConnectTimeoutMillis (Ljava/lang/Long;)V
 	public final fun setRequestTimeoutMillis (Ljava/lang/Long;)V
 	public final fun setSocketTimeoutMillis (Ljava/lang/Long;)V

--- a/ktor-client/ktor-client-core/common/src/io/ktor/client/features/HttpTimeout.kt
+++ b/ktor-client/ktor-client-core/common/src/io/ktor/client/features/HttpTimeout.kt
@@ -79,6 +79,26 @@ public class HttpTimeout(
             return value
         }
 
+        override fun equals(other: Any?): Boolean {
+            if (this === other) return true
+            if (other == null || this::class != other::class) return false
+
+            other as HttpTimeoutCapabilityConfiguration
+
+            if (_requestTimeoutMillis != other._requestTimeoutMillis) return false
+            if (_connectTimeoutMillis != other._connectTimeoutMillis) return false
+            if (_socketTimeoutMillis != other._socketTimeoutMillis) return false
+
+            return true
+        }
+
+        override fun hashCode(): Int {
+            var result = _requestTimeoutMillis?.hashCode() ?: 0
+            result = 31 * result + (_connectTimeoutMillis?.hashCode() ?: 0)
+            result = 31 * result + (_socketTimeoutMillis?.hashCode() ?: 0)
+            return result
+        }
+
         public companion object {
             public val key: AttributeKey<HttpTimeoutCapabilityConfiguration> = AttributeKey("TimeoutConfiguration")
         }

--- a/ktor-client/ktor-client-jetty/build.gradle.kts
+++ b/ktor-client/ktor-client-jetty/build.gradle.kts
@@ -2,12 +2,19 @@ description = "Jetty based client engine"
 
 val jetty_version: String by project.extra
 
-kotlin.sourceSets.jvmMain {
-    dependencies {
-        api(project(":ktor-client:ktor-client-core"))
+kotlin.sourceSets {
+    jvmMain {
+        dependencies {
+            api(project(":ktor-client:ktor-client-core"))
 
-        api("org.eclipse.jetty.http2:http2-client:$jetty_version")
-        api("org.eclipse.jetty:jetty-alpn-openjdk8-client:$jetty_version")
-        api("org.eclipse.jetty:jetty-alpn-java-client:$jetty_version")
+            api("org.eclipse.jetty.http2:http2-client:$jetty_version")
+            api("org.eclipse.jetty:jetty-alpn-openjdk8-client:$jetty_version")
+            api("org.eclipse.jetty:jetty-alpn-java-client:$jetty_version")
+        }
+    }
+    commonTest {
+        dependencies {
+            api(project(":ktor-client:ktor-client-tests"))
+        }
     }
 }

--- a/ktor-client/ktor-client-jetty/jvm/src/io/ktor/client/engine/jetty/JettyHttp2Engine.kt
+++ b/ktor-client/ktor-client-jetty/jvm/src/io/ktor/client/engine/jetty/JettyHttp2Engine.kt
@@ -27,15 +27,19 @@ internal class JettyHttp2Engine(override val config: JettyEngineConfig) : HttpCl
     /**
      * Cache that keeps least recently used [HTTP2Client] instances. Set "0" to avoid caching.
      */
-    private val clientCache = createLRUCache(::createJettyClient, HTTP2Client::stop, config.clientCacheSize)
+    internal val clientCache = createLRUCache(::createJettyClient, HTTP2Client::stop, config.clientCacheSize)
 
     override suspend fun execute(data: HttpRequestData): HttpResponseData {
         val callContext = callContext()
-        val jettyClient =
-            clientCache[data.getCapabilityOrNull(HttpTimeout)]
-                ?: error("Http2Client can't be constructed because HttpTimeout feature is not installed")
+        val jettyClient = getOrCreateClient(data)
 
         return data.executeRequest(jettyClient, config, callContext)
+    }
+
+    /** Only for tests */
+    internal fun getOrCreateClient(data: HttpRequestData): HTTP2Client {
+        return clientCache[data.getCapabilityOrNull(HttpTimeout)]
+            ?: error("Http2Client can't be constructed because HttpTimeout feature is not installed")
     }
 
     override fun close() {

--- a/ktor-client/ktor-client-jetty/jvm/test/io/ktor/client/engine/jetty/JettyHttp2EngineTest.kt
+++ b/ktor-client/ktor-client-jetty/jvm/test/io/ktor/client/engine/jetty/JettyHttp2EngineTest.kt
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2014-2020 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.client.engine.jetty
+
+import io.ktor.client.features.*
+import io.ktor.client.request.*
+import io.ktor.test.dispatcher.*
+import kotlin.test.*
+
+class JettyHttp2EngineTest {
+
+    @Test
+    fun testReuseClientsInCache() = testSuspend {
+        val engine = JettyHttp2Engine(JettyEngineConfig())
+
+        val timeoutConfig11 = HttpTimeout.HttpTimeoutCapabilityConfiguration(
+            requestTimeoutMillis = 1,
+            connectTimeoutMillis = 1,
+            socketTimeoutMillis = 1
+        )
+        val timeoutConfig12 = HttpTimeout.HttpTimeoutCapabilityConfiguration(
+            requestTimeoutMillis = 1,
+            connectTimeoutMillis = 1,
+            socketTimeoutMillis = 1
+        )
+        val timeoutConfig21 = HttpTimeout.HttpTimeoutCapabilityConfiguration(
+            requestTimeoutMillis = 2,
+            connectTimeoutMillis = 2,
+            socketTimeoutMillis = 2
+        )
+        val timeoutConfig22 = HttpTimeout.HttpTimeoutCapabilityConfiguration(
+            requestTimeoutMillis = 2,
+            connectTimeoutMillis = 2,
+            socketTimeoutMillis = 2
+        )
+
+        val request11 = HttpRequestBuilder().apply {
+            setCapability(HttpTimeout, timeoutConfig11)
+        }.build()
+        engine.getOrCreateClient(request11)
+        assertEquals(1, engine.clientCache.size)
+
+        val request12 = HttpRequestBuilder().apply {
+            setCapability(HttpTimeout, timeoutConfig12)
+        }.build()
+        engine.getOrCreateClient(request12)
+        assertEquals(1, engine.clientCache.size)
+
+        val request21 = HttpRequestBuilder().apply {
+            setCapability(HttpTimeout, timeoutConfig21)
+        }.build()
+        engine.getOrCreateClient(request21)
+        assertEquals(2, engine.clientCache.size)
+
+        val request22 = HttpRequestBuilder().apply {
+            setCapability(HttpTimeout, timeoutConfig22)
+        }.build()
+        engine.getOrCreateClient(request22)
+        assertEquals(2, engine.clientCache.size)
+    }
+}


### PR DESCRIPTION
**Subsystem**
Client, Jetty

**Motivation**
[KTOR-1120](https://youtrack.jetbrains.com/issue/KTOR-1120) Jetty client engine with high concurrency randomly freezes, throws NPEs, ISEs or EofExceptions

**Solution**
Timeout config was used as a key for HTTP clients cache, but it didn't have an implementation for `equals`/`hashcode`. That caused LRU cache overflow and closing of clients that were in use

