### PR TITLE
Fixed incorrect placement of setMaxConnPerRoute and setMaxConnTotal ApacheEngine

### DIFF
--- a/ktor-client/ktor-client-apache/jvm/src/io/ktor/client/engine/apache/ApacheEngine.kt
+++ b/ktor-client/ktor-client-apache/jvm/src/io/ktor/client/engine/apache/ApacheEngine.kt
@@ -58,11 +58,11 @@ internal class ApacheEngine(override val config: ApacheEngineConfig) : HttpClien
             disableAuthCaching()
             disableConnectionState()
             disableCookieManagement()
-            setDefaultIOReactorConfig(IOReactorConfig.custom().apply {
-                setMaxConnPerRoute(MAX_CONNECTIONS_COUNT)
-                setMaxConnTotal(MAX_CONNECTIONS_COUNT)
-                setIoThreadCount(IO_THREAD_COUNT_DEFAULT)
-            }.build())
+            setMaxConnPerRoute(MAX_CONNECTIONS_COUNT)
+            setMaxConnTotal(MAX_CONNECTIONS_COUNT)
+            setDefaultIOReactorConfig(IOReactorConfig.custom()
+                .setIoThreadCount(IO_THREAD_COUNT_DEFAULT)
+                .build())
 
             setupProxy()
         }


### PR DESCRIPTION
`setMaxConnPerRoute` and `setMaxConnPerRoute` configure the client, not the IO reactor.
Moving the two lines to the outer scope doesn't change what they do but make their intent clearer.

**Subsystem**
Apache Client Engine

**Motivation**
Code was confusing to read because it looked like that the two lines configure the IO reactor instead of the client.

**Solution**
Move calls to correct scope.