### PR TITLE
KT-754 Fix applying compression option defaults

### DIFF
--- a/ktor-server/ktor-server-core/jvm/src/io/ktor/features/Compression.kt
+++ b/ktor-server/ktor-server-core/jvm/src/io/ktor/features/Compression.kt
@@ -1,21 +1,26 @@
 /*
- * Copyright 2014-2019 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2014-2020 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package io.ktor.features
 
 import io.ktor.application.*
-import io.ktor.util.cio.*
-import io.ktor.http.content.*
 import io.ktor.http.*
-import io.ktor.util.pipeline.*
+import io.ktor.http.content.*
 import io.ktor.request.*
 import io.ktor.response.*
 import io.ktor.util.*
-import kotlinx.coroutines.*
+import io.ktor.util.cio.*
+import io.ktor.util.pipeline.*
 import io.ktor.utils.io.*
-import java.util.ArrayList
+import kotlinx.coroutines.*
+import java.util.*
 import kotlin.coroutines.*
+
+/**
+ * The default minimal content size to compress
+ */
+internal const val DEFAULT_MINIMAL_COMPRESSION_SIZE: Long = 200L
 
 /**
  * Compression feature configuration
@@ -57,6 +62,7 @@ public data class CompressionEncoderConfig(
  * Feature to compress a response based on conditions and ability of client to decompress it
  */
 public class Compression(compression: Configuration) {
+    @Suppress("DEPRECATION")
     private val options = compression.build()
     private val comparator = compareBy<Pair<CompressionEncoderConfig, HeaderValue>>(
         { it.second.quality }, { it.first.priority }
@@ -202,7 +208,11 @@ public class Compression(compression: Configuration) {
         /**
          * Appends an encoder to the configuration
          */
-        public fun encoder(name: String, encoder: CompressionEncoder, block: CompressionEncoderBuilder.() -> Unit = {}) {
+        public fun encoder(
+            name: String,
+            encoder: CompressionEncoder,
+            block: CompressionEncoderBuilder.() -> Unit = {}
+        ) {
             require(name.isNotBlank()) { "encoder name couldn't be blank" }
             if (name in encoders) {
                 throw IllegalArgumentException("Encoder $name is already registered")
@@ -212,27 +222,30 @@ public class Compression(compression: Configuration) {
         }
 
         /**
-         * Appends default configuration
+         * Appends default configuration having gzip and deflate.
          */
         public fun default() {
             gzip()
             deflate()
             identity()
-
-            excludeContentType(
-                ContentType.Video.Any,
-                ContentType.Image.Any,
-                ContentType.Audio.Any,
-                ContentType.MultiPart.Any,
-                ContentType.Text.EventStream
-            )
         }
 
         /**
          * Builds `CompressionOptions`
          */
+        @Deprecated(
+            "This is going to become internal. " +
+                "Please stop building it manually or file a ticket with explanation why do you need it."
+        )
         public fun build(): CompressionOptions = CompressionOptions(
-            encoders = encoders.mapValues { it.value.build() },
+            encoders = encoders.mapValues {
+                @Suppress("DEPRECATION")
+                it.value.also { config ->
+                    if (conditions.none() && config.conditions.none()) {
+                        config.defaultConditions()
+                    }
+                }.build()
+            },
             conditions = conditions.toList()
         )
     }
@@ -294,7 +307,7 @@ public object DeflateEncoder : CompressionEncoder {
  *  Implementation of the identity encoder
  */
 public object IdentityEncoder : CompressionEncoder {
-    override fun predictCompressedLength(originalLength: Long): Long? = originalLength
+    override fun predictCompressedLength(originalLength: Long): Long = originalLength
 
     override fun compress(
         readChannel: ByteReadChannel,
@@ -339,6 +352,10 @@ public class CompressionEncoderBuilder internal constructor(
     /**
      * Builds [CompressionEncoderConfig] instance
      */
+    @Deprecated(
+        "This is going to become internal. " +
+            "Please stop building it manually or file a ticket with explanation why do you need it."
+    )
     public fun build(): CompressionEncoderConfig {
         return CompressionEncoderConfig(name, encoder, conditions.toList(), priority)
     }
@@ -373,20 +390,26 @@ public fun Compression.Configuration.identity(block: CompressionEncoderBuilder.(
  * Appends a custom condition to the encoder or Compression configuration.
  * A predicate returns `true` when a response need to be compressed.
  * If at least one condition is not met then the response compression is skipped.
+ *
+ * Please note that adding a single condition removes the default configuration.
  */
 public fun ConditionsHolderBuilder.condition(predicate: ApplicationCall.(OutgoingContent) -> Boolean) {
     conditions.add(predicate)
 }
 
 /**
- * Appends a minimum size condition to the encoder or Compression configuration
+ * Appends a minimum size condition to the encoder or Compression configuration.
+ *
+ * Please note that adding a single minimum size condition removes the default configuration.
  */
 public fun ConditionsHolderBuilder.minimumSize(minSize: Long) {
     condition { content -> content.contentLength?.let { it >= minSize } ?: true }
 }
 
 /**
- * Appends a content type condition to the encoder or Compression configuration
+ * Appends a content type condition to the encoder or Compression configuration.
+ *
+ * Please note that adding a single match condition removes the default configuration.
  */
 public fun ConditionsHolderBuilder.matchContentType(vararg mimeTypes: ContentType) {
     condition { content ->
@@ -396,7 +419,9 @@ public fun ConditionsHolderBuilder.matchContentType(vararg mimeTypes: ContentTyp
 }
 
 /**
- * Appends a content type exclusion condition to the encoder or Compression configuration
+ * Appends a content type exclusion condition to the encoder or Compression configuration.
+ *
+ * Please note that adding a single match condition removes the default configuration.
  */
 public fun ConditionsHolderBuilder.excludeContentType(vararg mimeTypes: ContentType) {
     condition { content ->
@@ -406,4 +431,20 @@ public fun ConditionsHolderBuilder.excludeContentType(vararg mimeTypes: ContentT
 
         mimeTypes.none { excludePattern -> contentType.match(excludePattern) }
     }
+}
+
+/**
+ * Configures default compression options
+ */
+private fun ConditionsHolderBuilder.defaultConditions() {
+    excludeContentType(
+        ContentType.Video.Any,
+        ContentType.Image.JPEG,
+        ContentType.Image.PNG,
+        ContentType.Audio.Any,
+        ContentType.MultiPart.Any,
+        ContentType.Text.EventStream
+    )
+
+    minimumSize(DEFAULT_MINIMAL_COMPRESSION_SIZE)
 }

--- a/ktor-server/ktor-server-tests/jvm/test/io/ktor/tests/server/features/CompressionTest.kt
+++ b/ktor-server/ktor-server-tests/jvm/test/io/ktor/tests/server/features/CompressionTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2014-2020 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package io.ktor.tests.server.features
@@ -19,17 +19,20 @@ import kotlin.coroutines.*
 import kotlin.test.*
 
 class CompressionTest {
+    private val textToCompress = "text to be compressed\n".repeat(100)
+    private val textToCompressAsBytes = textToCompress.encodeToByteArray()
+
     @Test
     fun testCompressionNotSpecified() {
         withTestApplication {
             application.install(Compression)
             application.routing {
                 get("/") {
-                    call.respondText("text to be compressed")
+                    call.respondText(textToCompress)
                 }
             }
 
-            handleAndAssert("/", null, null, "text to be compressed")
+            handleAndAssert("/", null, null, textToCompress)
         }
     }
 
@@ -39,11 +42,11 @@ class CompressionTest {
             application.install(Compression)
             application.routing {
                 get("/") {
-                    call.respondText("text to be compressed")
+                    call.respondText(textToCompress)
                 }
             }
 
-            handleAndAssert("/", "a,b,c", null, "text to be compressed")
+            handleAndAssert("/", "a,b,c", null, textToCompress)
         }
     }
 
@@ -53,11 +56,11 @@ class CompressionTest {
             application.install(Compression)
             application.routing {
                 get("/") {
-                    call.respondText("text to be compressed")
+                    call.respondText(textToCompress)
                 }
             }
 
-            handleAndAssert("/", "deflate", "deflate", "text to be compressed")
+            handleAndAssert("/", "deflate", "deflate", textToCompress)
         }
     }
 
@@ -67,11 +70,11 @@ class CompressionTest {
             application.install(Compression)
             application.routing {
                 get("/") {
-                    call.respondText("text to be compressed")
+                    call.respondText(textToCompress)
                 }
             }
 
-            handleAndAssert("/", "gzip,deflate", "gzip", "text to be compressed")
+            handleAndAssert("/", "gzip,deflate", "gzip", textToCompress)
         }
     }
 
@@ -84,11 +87,43 @@ class CompressionTest {
 
             application.routing {
                 get("/") {
-                    call.respondText("text to be compressed")
+                    call.respondText(textToCompress)
                 }
             }
 
-            handleAndAssert("/", "*", "gzip", "text to be compressed")
+            handleAndAssert("/", "*", "gzip", textToCompress)
+        }
+    }
+
+    @Test
+    fun testShouldNotCompressVideoByDefault() {
+        withTestApplication {
+            application.install(Compression)
+
+            application.routing {
+                get("/") {
+                    call.respondText(textToCompress, ContentType.Video.MP4)
+                }
+            }
+
+            handleAndAssert("/", "*", null, textToCompress)
+        }
+    }
+
+    @Test
+    fun testGzipShouldNotCompressVideoByDefault() {
+        withTestApplication {
+            application.install(Compression) {
+                gzip()
+            }
+
+            application.routing {
+                get("/") {
+                    call.respondText(textToCompress, ContentType.Video.MP4)
+                }
+            }
+
+            handleAndAssert("/", "*", null, textToCompress)
         }
     }
 
@@ -101,11 +136,11 @@ class CompressionTest {
 
             application.routing {
                 get("/") {
-                    call.respondText("text to be compressed")
+                    call.respondText(textToCompress)
                 }
             }
 
-            handleAndAssert("/", "*", "deflate", "text to be compressed")
+            handleAndAssert("/", "*", "deflate", textToCompress)
         }
     }
 
@@ -115,11 +150,11 @@ class CompressionTest {
             application.install(Compression)
             application.routing {
                 get("/") {
-                    call.respondText("text to be compressed")
+                    call.respondText(textToCompress)
                 }
             }
 
-            handleAndAssert("/", "special,gzip,deflate", "gzip", "text to be compressed")
+            handleAndAssert("/", "special,gzip,deflate", "gzip", textToCompress)
         }
     }
 
@@ -142,7 +177,7 @@ class CompressionTest {
             }
             application.routing {
                 get("/") {
-                    call.respondText("text to be compressed")
+                    call.respondText(textToCompress)
                 }
             }
 
@@ -152,7 +187,7 @@ class CompressionTest {
             assertTrue(result.requestHandled)
             assertEquals(HttpStatusCode.OK, result.response.status())
             assertEquals("special", result.response.headers[HttpHeaders.ContentEncoding])
-            assertEquals("text to be compressed", result.response.byteContent!!.toString(Charsets.UTF_8))
+            assertEquals(textToCompress, result.response.byteContent!!.toString(Charsets.UTF_8))
         }
     }
 
@@ -162,7 +197,7 @@ class CompressionTest {
             application.install(Compression)
             application.routing {
                 get("/") {
-                    call.respondText("text to be compressed", status = HttpStatusCode.Found)
+                    call.respondText(textToCompress, status = HttpStatusCode.Found)
                 }
             }
 
@@ -171,7 +206,7 @@ class CompressionTest {
             }
             assertTrue(result.requestHandled)
             assertEquals(HttpStatusCode.Found, result.response.status())
-            assertEquals("text to be compressed", result.response.byteContent!!.toString(Charsets.UTF_8))
+            assertEquals(textToCompress, result.response.byteContent!!.toString(Charsets.UTF_8))
         }
     }
 
@@ -179,7 +214,32 @@ class CompressionTest {
     fun testMinSize() {
         withTestApplication {
             application.install(Compression) {
-                default()
+                minimumSize(10)
+            }
+
+            application.routing {
+                get("/small") {
+                    call.respondText("0123")
+                }
+                get("/big") {
+                    call.respondText("01234567890123456789")
+                }
+                get("/stream") {
+                    call.respondText("stream content")
+                }
+            }
+
+            handleAndAssert("/big", "gzip,deflate", "gzip", "01234567890123456789")
+            handleAndAssert("/small", "gzip,deflate", null, "0123")
+            handleAndAssert("/stream", "gzip,deflate", "gzip", "stream content")
+        }
+    }
+
+    @Test
+    fun testMinSizeGzip() {
+        withTestApplication {
+            application.install(Compression) {
+                gzip()
                 minimumSize(10)
             }
 
@@ -212,13 +272,13 @@ class CompressionTest {
 
             application.routing {
                 get("/") {
-                    call.respondText("OK", ContentType.parse(call.parameters["t"]!!))
+                    call.respondText(textToCompress, ContentType.parse(call.parameters["t"]!!))
                 }
             }
 
-            handleAndAssert("/?t=text/plain", "gzip,deflate", "gzip", "OK")
-            handleAndAssert("/?t=text/vcard", "gzip,deflate", null, "OK")
-            handleAndAssert("/?t=some/other", "gzip,deflate", null, "OK")
+            handleAndAssert("/?t=text/plain", "gzip,deflate", "gzip", textToCompress)
+            handleAndAssert("/?t=text/vcard", "gzip,deflate", null, textToCompress)
+            handleAndAssert("/?t=some/other", "gzip,deflate", null, textToCompress)
         }
     }
 
@@ -236,13 +296,13 @@ class CompressionTest {
 
             application.routing {
                 get("/") {
-                    call.respondText("OK")
+                    call.respondText(textToCompress)
                 }
             }
 
-            handleAndAssert("/?e=1", "gzip", "gzip", "OK")
-            handleAndAssert("/?e", "gzip", null, "OK")
-            handleAndAssert("/?e", "gzip,deflate", "deflate", "OK")
+            handleAndAssert("/?e=1", "gzip", "gzip", textToCompress)
+            handleAndAssert("/?e", "gzip", null, textToCompress)
+            handleAndAssert("/?e", "gzip,deflate", "deflate", textToCompress)
         }
     }
 
@@ -260,13 +320,13 @@ class CompressionTest {
 
             application.routing {
                 get("/") {
-                    call.respondText("OK")
+                    call.respondText(textToCompress)
                 }
             }
 
-            handleAndAssert("/", "gzip", "gzip", "OK")
-            handleAndAssert("/", "deflate", "deflate", "OK")
-            handleAndAssert("/", "gzip,deflate", "gzip", "OK")
+            handleAndAssert("/", "gzip", "gzip", textToCompress)
+            handleAndAssert("/", "deflate", "deflate", textToCompress)
+            handleAndAssert("/", "gzip,deflate", "gzip", textToCompress)
         }
     }
 
@@ -284,13 +344,13 @@ class CompressionTest {
 
             application.routing {
                 get("/") {
-                    call.respondText("OK")
+                    call.respondText(textToCompress)
                 }
             }
 
-            handleAndAssert("/", "gzip", "gzip", "OK")
-            handleAndAssert("/", "deflate", "deflate", "OK")
-            handleAndAssert("/", "gzip,deflate", "deflate", "OK")
+            handleAndAssert("/", "gzip", "gzip", textToCompress)
+            handleAndAssert("/", "deflate", "deflate", textToCompress)
+            handleAndAssert("/", "gzip,deflate", "deflate", textToCompress)
         }
     }
 
@@ -304,14 +364,14 @@ class CompressionTest {
 
             application.routing {
                 get("/") {
-                    call.respondText("OK")
+                    call.respondText(textToCompress)
                 }
             }
 
-            handleAndAssert("/", "gzip", "gzip", "OK")
-            handleAndAssert("/", "deflate", "deflate", "OK")
-            handleAndAssert("/", "gzip;q=1,deflate;q=0.1", "gzip", "OK")
-            handleAndAssert("/", "gzip;q=0.1,deflate;q=1", "deflate", "OK")
+            handleAndAssert("/", "gzip", "gzip", textToCompress)
+            handleAndAssert("/", "deflate", "deflate", textToCompress)
+            handleAndAssert("/", "gzip;q=1,deflate;q=0.1", "gzip", textToCompress)
+            handleAndAssert("/", "gzip;q=0.1,deflate;q=1", "deflate", textToCompress)
         }
     }
 
@@ -327,12 +387,12 @@ class CompressionTest {
 
             application.routing {
                 get("/") {
-                    call.respondText("content")
+                    call.respondText(textToCompress)
                 }
             }
 
-            handleAndAssert("/", "gzip,deflate", null, "content")
-            handleAndAssert("/?compress=true", "gzip,deflate", "gzip", "content")
+            handleAndAssert("/", "gzip,deflate", null, textToCompress)
+            handleAndAssert("/?compress=true", "gzip,deflate", "gzip", textToCompress)
         }
     }
 
@@ -357,13 +417,13 @@ class CompressionTest {
                         }
 
                         override val contentType = ContentType.Text.Plain
-                        override val contentLength = 4L
-                        override fun readFrom() = ByteReadChannel("test".toByteArray())
+                        override val contentLength = textToCompressAsBytes.size.toLong()
+                        override fun readFrom() = ByteReadChannel(textToCompressAsBytes)
                     })
                 }
             }
 
-            handleAndAssert("/", "gzip", "gzip", "test").let { call ->
+            handleAndAssert("/", "gzip", "gzip", textToCompress).let { call ->
                 assertEquals("text/plain", call.response.headers[HttpHeaders.ContentType])
                 assertEquals(dateTime.toHttpDateString(), call.response.headers[HttpHeaders.Expires])
                 assertEquals("no-cache, public", call.response.headers[HttpHeaders.CacheControl])
@@ -462,15 +522,15 @@ class CompressionTest {
 
         application.routing {
             get("/text") {
-                call.respondText("123")
+                call.respondText(textToCompress)
             }
             get("/bytes") {
-                call.respondBytes("1234".toByteArray(), ContentType.Application.OctetStream)
+                call.respondBytes(textToCompressAsBytes, ContentType.Application.OctetStream)
             }
         }
 
-        handleAndAssert("/text", "identity", "identity", "123")
-        handleAndAssert("/bytes", "identity", "identity", "1234")
+        handleAndAssert("/text", "identity", "identity", textToCompress)
+        handleAndAssert("/bytes", "identity", "identity", textToCompress)
     }
 
     @Test


### PR DESCRIPTION
**Subsystem**
ktor-server-core ([Compression](https://ktor.io/docs/compression.html))

**Motivation**
[KTOR-754](https://youtrack.jetbrains.com/issue/KTOR-754) Sensible defaults for compression feature 

At the moment, the default configuration is only applied when no configuration for the feature provided. Consider the following example:

```kotlin
install(Compression) {
    gzip() // this disables all defaults
}
```

So doing this one need to configure everything manually to avoid "steel compression".

**Solution**
Apply default config in more cases so the example above will have the defaults with content types and size.
Note that any attempt to change the config still removes the default config so improved kdocs. Unfortunately, we can't fix that behaviour without breaking changes.

```kotlin
install(Compression) {
    gzip() // after fix will have defaults
}

install(Compression) {
    gzip()
    minimalSize(100) // this still reset defaults
}
```