### PR TITLE
[docs] fix URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 <img src="https://repository-images.githubusercontent.com/40136600/f3f5fd00-c59e-11e9-8284-cb297d193133" alt="Ktor" width="500" style="max-width:100%;">
 
-[![Official JetBrains project](http://jb.gg/badges/official.svg)](https://confluence.jetbrains.com/display/ALL/JetBrains+on+GitHub)
+[![Official JetBrains project](https://jb.gg/badges/official.svg)](https://confluence.jetbrains.com/display/ALL/JetBrains+on+GitHub)
 [![Download](https://api.bintray.com/packages/kotlin/ktor/ktor/images/download.svg) ](https://bintray.com/kotlin/ktor/ktor/_latestVersion)
-[![Kotlin](https://img.shields.io/badge/kotlin-1.4.10-blue.svg?logo=kotlin)](http://kotlinlang.org)
+[![Kotlin](https://img.shields.io/badge/kotlin-1.4.10-blue.svg?logo=kotlin)](https://kotlinlang.org)
 [![Slack channel](https://img.shields.io/badge/chat-slack-green.svg?logo=slack)](https://kotlinlang.slack.com/messages/ktor/)
-[![GitHub License](https://img.shields.io/badge/license-Apache%20License%202.0-blue.svg?style=flat)](http://www.apache.org/licenses/LICENSE-2.0)
+[![GitHub License](https://img.shields.io/badge/license-Apache%20License%202.0-blue.svg?style=flat)](https://www.apache.org/licenses/LICENSE-2.0)
 
 Ktor is a framework for quickly creating web applications in Kotlin with minimal effort.
 
@@ -62,11 +62,11 @@ embedded web server are of course possible, too.
 
 ## Documentation
 
-Please visit [ktor.io](http://ktor.io) for Quick Start and detailed explanations of features, usage and machinery.
+Please visit [ktor.io](https://ktor.io) for Quick Start and detailed explanations of features, usage and machinery.
 
-* Getting started with [Gradle](http://ktor.io/quickstart/gradle.html) 
-* Getting started with [Maven](http://ktor.io/quickstart/maven.html) 
-* Getting started with [IDEA](http://ktor.io/quickstart/intellij-idea.html) 
+* Getting started with [Gradle](https://ktor.io/docs/gradle.html) 
+* Getting started with [Maven](https://ktor.io/docs/maven.html) 
+* Getting started with [IDEA](https://ktor.io/docs/intellij-idea.html) 
 
 ## Reporting Issues / Support
 


### PR DESCRIPTION
Fix broken links to documentation;
Use HTTPS protocol in all URLs