### PR TITLE
Reduce number of experimental/obsolete API usages

### DIFF
--- a/gradle/experimental.gradle
+++ b/gradle/experimental.gradle
@@ -1,9 +1,12 @@
+/*
+ * Copyright 2014-2020 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
 ext.experimentalAnnotations = [
     "kotlin.RequiresOptIn",
     "kotlin.ExperimentalUnsignedTypes",
     "io.ktor.util.KtorExperimentalAPI",
     "io.ktor.util.InternalAPI",
-    "kotlinx.coroutines.ExperimentalCoroutinesApi",
     "io.ktor.utils.io.core.ExperimentalIoApi",
     "io.ktor.utils.io.core.internal.DangerousInternalIoApi",
     "kotlin.contracts.ExperimentalContracts"

--- a/ktor-client/ktor-client-cio/common/src/io/ktor/client/engine/cio/CIOEngine.kt
+++ b/ktor-client/ktor-client-cio/common/src/io/ktor/client/engine/cio/CIOEngine.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2014-2020 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package io.ktor.client.engine.cio
@@ -57,6 +57,7 @@ internal class CIOEngine(
         val requestJob = requestField[Job]!!
         val selector = selectorManager
 
+        @OptIn(ExperimentalCoroutinesApi::class)
         GlobalScope.launch(parentContext, start = CoroutineStart.ATOMIC) {
             try {
                 requestJob.join()

--- a/ktor-client/ktor-client-core/js/src/io/ktor/client/features/websocket/JsWebSocketSession.kt
+++ b/ktor-client/ktor-client-core/js/src/io/ktor/client/features/websocket/JsWebSocketSession.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2014-2020 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package io.ktor.client.features.websocket
@@ -71,6 +71,7 @@ internal class JsWebSocketSession(
         })
 
         launch {
+            @OptIn(ExperimentalCoroutinesApi::class)
             _outgoing.consumeEach {
                 when (it.frameType) {
                     FrameType.TEXT -> {

--- a/ktor-client/ktor-client-ios/darwin/src/io/ktor/client/engine/ios/IosResponseReader.kt
+++ b/ktor-client/ktor-client-ios/darwin/src/io/ktor/client/engine/ios/IosResponseReader.kt
@@ -39,6 +39,7 @@ internal class IosResponseReader(
 
         val responseBody = GlobalScope.writer(callContext + Dispatchers.Unconfined, autoFlush = true) {
             try {
+                @OptIn(ExperimentalCoroutinesApi::class)
                 chunks.consumeEach {
                     channel.writeFully(it)
                     channel.flush()

--- a/ktor-client/ktor-client-jetty/jvm/src/io/ktor/client/engine/jetty/JettyResponseListener.kt
+++ b/ktor-client/ktor-client-jetty/jvm/src/io/ktor/client/engine/jetty/JettyResponseListener.kt
@@ -8,8 +8,8 @@ import io.ktor.client.request.*
 import io.ktor.http.*
 import io.ktor.http.HttpMethod
 import kotlinx.coroutines.*
-import kotlinx.coroutines.channels.*
 import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.CancellationException
 import io.ktor.utils.io.*
 import org.eclipse.jetty.http.*
 import org.eclipse.jetty.http2.*
@@ -99,10 +99,9 @@ internal class JettyResponseListener(
         return StatusWithHeaders(statusCode, headersBuilder.build())
     }
 
-    @OptIn(ExperimentalCoroutinesApi::class)
     private fun runResponseProcessing() = GlobalScope.launch(callContext) {
-        while (!backendChannel.isClosedForReceive) {
-            val (buffer, callback) = backendChannel.receiveOrNull() ?: break
+        while (true) {
+            val (buffer, callback) = backendChannel.receive()
             try {
                 if (buffer.remaining() > 0) channel.writeFully(buffer)
                 callback.succeeded()
@@ -117,9 +116,13 @@ internal class JettyResponseListener(
             }
         }
     }.invokeOnCompletion { cause ->
-        channel.close(cause)
+        channel.close(cause?.takeIf { it !is CancellationException })
         backendChannel.close()
-        GlobalScope.launch { backendChannel.consumeEach { it.callback.succeeded() } }
+        GlobalScope.launch {
+            for ((_, callback) in backendChannel) {
+                callback.succeeded()
+            }
+        }
     }
 
     public companion object {

--- a/ktor-client/ktor-client-jetty/jvm/src/io/ktor/client/engine/jetty/JettyResponseListener.kt
+++ b/ktor-client/ktor-client-jetty/jvm/src/io/ktor/client/engine/jetty/JettyResponseListener.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2014-2020 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package io.ktor.client.engine.jetty
@@ -11,7 +11,6 @@ import kotlinx.coroutines.*
 import kotlinx.coroutines.channels.*
 import kotlinx.coroutines.channels.Channel
 import io.ktor.utils.io.*
-import kotlinx.coroutines.selects.*
 import org.eclipse.jetty.http.*
 import org.eclipse.jetty.http2.*
 import org.eclipse.jetty.http2.api.*
@@ -96,17 +95,14 @@ internal class JettyResponseListener(
     }
 
     public suspend fun awaitHeaders(): StatusWithHeaders {
-        onHeadersReceived.await()
-        val statusCode = onHeadersReceived.getCompleted() ?: throw IOException("Connection reset")
+        val statusCode = onHeadersReceived.await() ?: throw IOException("Connection reset")
         return StatusWithHeaders(statusCode, headersBuilder.build())
     }
 
-    @OptIn(
-        ExperimentalCoroutinesApi::class, ObsoleteCoroutinesApi::class
-    )
+    @OptIn(ExperimentalCoroutinesApi::class)
     private fun runResponseProcessing() = GlobalScope.launch(callContext) {
         while (!backendChannel.isClosedForReceive) {
-            val (buffer, callback) = @Suppress("DEPRECATION") backendChannel.receiveOrNull() ?: break
+            val (buffer, callback) = backendChannel.receiveOrNull() ?: break
             try {
                 if (buffer.remaining() > 0) channel.writeFully(buffer)
                 callback.succeeded()

--- a/ktor-client/ktor-client-okhttp/jvm/src/io/ktor/client/engine/okhttp/OkHttpEngine.kt
+++ b/ktor-client/ktor-client-okhttp/jvm/src/io/ktor/client/engine/okhttp/OkHttpEngine.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2014-2020 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package io.ktor.client.engine.okhttp
@@ -11,7 +11,6 @@ import io.ktor.client.request.*
 import io.ktor.client.utils.*
 import io.ktor.http.*
 import io.ktor.http.content.*
-import io.ktor.network.sockets.*
 import io.ktor.util.*
 import io.ktor.util.date.*
 import io.ktor.utils.io.*
@@ -50,6 +49,7 @@ public class OkHttpEngine(override val config: OkHttpConfig) : HttpClientEngineB
         requestsJob = SilentSupervisor(parent)
         coroutineContext = super.coroutineContext + requestsJob
 
+        @OptIn(ExperimentalCoroutinesApi::class)
         GlobalScope.launch(super.coroutineContext, start = CoroutineStart.ATOMIC) {
             try {
                 requestsJob[Job]!!.join()

--- a/ktor-client/ktor-client-okhttp/jvm/src/io/ktor/client/engine/okhttp/OkHttpWebsocketSession.kt
+++ b/ktor-client/ktor-client-okhttp/jvm/src/io/ktor/client/engine/okhttp/OkHttpWebsocketSession.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2014-2020 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package io.ktor.client.engine.okhttp
@@ -97,6 +97,7 @@ internal class OkHttpWebsocketSession(
         )
     }
 
+    @OptIn(ExperimentalCoroutinesApi::class)
     override fun onClosing(webSocket: WebSocket, code: Int, reason: String) {
         super.onClosing(webSocket, code, reason)
 
@@ -135,6 +136,7 @@ internal class OkHttpWebsocketSession(
     }
 }
 
+@OptIn(ExperimentalCoroutinesApi::class)
 @Suppress("KDocMissingDocumentation")
 public class UnsupportedFrameTypeException(
     private val frame: Frame

--- a/ktor-client/ktor-client-tests/jvm/src/io/ktor/client/tests/utils/ClientLoaderJvm.kt
+++ b/ktor-client/ktor-client-tests/jvm/src/io/ktor/client/tests/utils/ClientLoaderJvm.kt
@@ -1,11 +1,12 @@
 /*
- * Copyright 2014-2019 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2014-2020 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package io.ktor.client.tests.utils
 
 import io.ktor.client.*
 import io.ktor.client.engine.*
+import kotlinx.coroutines.*
 import kotlinx.coroutines.debug.*
 import kotlinx.coroutines.debug.junit4.*
 import org.junit.*
@@ -53,6 +54,7 @@ public actual abstract class ClientLoader {
         testWithEngine(engine.factory, this, block)
     }
 
+    @OptIn(ExperimentalCoroutinesApi::class)
     public actual fun dumpCoroutines() {
         DebugProbes.dumpCoroutines()
     }
@@ -63,6 +65,7 @@ public actual abstract class ClientLoader {
      * 2. Nonce generator
      */
     // @After
+    @OptIn(ExperimentalCoroutinesApi::class)
     public fun waitForAllCoroutines() {
         check(DebugProbes.isInstalled) {
             "Debug probes isn't installed."
@@ -103,6 +106,7 @@ private val OS_NAME: String
     }
 
 
+@OptIn(ExperimentalCoroutinesApi::class)
 private fun List<CoroutineInfo>.dump(): String = buildString {
     this@dump.forEach { info ->
         appendln("Coroutine: $info")

--- a/ktor-features/ktor-auth/jvm/src/io/ktor/auth/OAuth2.kt
+++ b/ktor-features/ktor-auth/jvm/src/io/ktor/auth/OAuth2.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2014-2020 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package io.ktor.auth
@@ -375,6 +375,7 @@ public sealed class OAuth2Exception(message: String, public val errorCode: Strin
      * Throw when an OAuth2 server replied with error "unsupported_grant_type"
      * @param grantType that was passed to the server
      */
+    @OptIn(ExperimentalCoroutinesApi::class)
     @KtorExperimentalAPI
     public class UnsupportedGrantType(public val grantType: String) : OAuth2Exception(
         "OAuth2 server doesn't support grant type $grantType", "unsupported_grant_type"
@@ -388,6 +389,7 @@ public sealed class OAuth2Exception(message: String, public val errorCode: Strin
      * OAuth2 server responded with an error code [errorCode]
      * @param errorCode the OAuth2 server replied with
      */
+    @OptIn(ExperimentalCoroutinesApi::class)
     @KtorExperimentalAPI
     public class UnknownException(
         private val details: String, errorCode: String

--- a/ktor-features/ktor-gson/jvm/src/io/ktor/gson/GsonSupport.kt
+++ b/ktor-features/ktor-gson/jvm/src/io/ktor/gson/GsonSupport.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2014-2020 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package io.ktor.gson
@@ -57,6 +57,7 @@ public fun ContentNegotiation.Configuration.gson(
     register(contentType, converter)
 }
 
+@OptIn(ExperimentalCoroutinesApi::class)
 internal class ExcludedTypeGsonException(
     val type: KClass<*>
 ) : Exception("Type ${type.jvmName} is excluded so couldn't be used in receive"),

--- a/ktor-features/ktor-websockets/jvm/test/io/ktor/tests/websocket/DefaultWebSocketTest.kt
+++ b/ktor-features/ktor-websockets/jvm/test/io/ktor/tests/websocket/DefaultWebSocketTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2014-2020 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package io.ktor.tests.websocket
@@ -13,6 +13,7 @@ import kotlinx.coroutines.debug.junit4.*
 import org.junit.Rule
 import kotlin.test.*
 
+@OptIn(ExperimentalCoroutinesApi::class)
 class DefaultWebSocketTest {
     @get:Rule
     val timeout: CoroutinesTimeout = CoroutinesTimeout.seconds(10, true)

--- a/ktor-features/ktor-websockets/jvm/test/io/ktor/tests/websocket/RawWebSocketTest.kt
+++ b/ktor-features/ktor-websockets/jvm/test/io/ktor/tests/websocket/RawWebSocketTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2014-2020 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package io.ktor.tests.websocket
@@ -16,6 +16,7 @@ import java.io.*
 import kotlin.reflect.*
 import kotlin.test.*
 
+@OptIn(ExperimentalCoroutinesApi::class)
 class RawWebSocketTest {
     @get:Rule
     val timeout: CoroutinesTimeout = CoroutinesTimeout.seconds(10, true)

--- a/ktor-features/ktor-websockets/jvm/test/io/ktor/tests/websocket/WebSocketEngineSuite.kt
+++ b/ktor-features/ktor-websockets/jvm/test/io/ktor/tests/websocket/WebSocketEngineSuite.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2014-2020 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package io.ktor.tests.websocket
@@ -30,9 +30,7 @@ import java.util.concurrent.CancellationException
 import kotlin.test.*
 import kotlin.test.Ignore
 
-@OptIn(
-    WebSocketInternalAPI::class, ObsoleteCoroutinesApi::class
-)
+@OptIn(WebSocketInternalAPI::class, ExperimentalCoroutinesApi::class)
 abstract class WebSocketEngineSuite<TEngine : ApplicationEngine, TConfiguration : ApplicationEngine.Configuration>(
     hostFactory: ApplicationEngineFactory<TEngine, TConfiguration>
 ) : EngineTestBase<TEngine, TConfiguration>(hostFactory) {

--- a/ktor-features/ktor-websockets/jvm/test/io/ktor/tests/websocket/WebSocketTest.kt
+++ b/ktor-features/ktor-websockets/jvm/test/io/ktor/tests/websocket/WebSocketTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2014-2020 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package io.ktor.tests.websocket
@@ -24,7 +24,7 @@ import java.util.*
 import java.util.concurrent.CancellationException
 import kotlin.test.*
 
-@OptIn(WebSocketInternalAPI::class)
+@OptIn(WebSocketInternalAPI::class, ExperimentalCoroutinesApi::class)
 class WebSocketTest {
     @get:Rule
     val timeout = CoroutinesTimeout.seconds(30)

--- a/ktor-http/ktor-http-cio/jvm/src/io/ktor/http/cio/Multipart.kt
+++ b/ktor-http/ktor-http-cio/jvm/src/io/ktor/http/cio/Multipart.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2014-2020 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package io.ktor.http.cio
@@ -311,6 +311,7 @@ public fun parseMultipart(
 /**
  * Starts a multipart parser coroutine producing multipart events
  */
+@OptIn(ExperimentalCoroutinesApi::class)
 @Deprecated("This is going to be removed. Use parseMultipart(contentType) instead.")
 public fun CoroutineScope.parseMultipart(
     boundaryPrefixed: ByteBuffer, input: ByteReadChannel, totalLength: Long?

--- a/ktor-http/ktor-http-cio/jvm/src/io/ktor/http/cio/Pipeline.kt
+++ b/ktor-http/ktor-http-cio/jvm/src/io/ktor/http/cio/Pipeline.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2014-2020 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package io.ktor.http.cio
@@ -54,9 +54,6 @@ public val RequestHandlerCoroutine: CoroutineName = CoroutineName("request-handl
 @Deprecated(
     "This is going to become internal. " +
         "Start ktor server or raw cio server from ktor-server-cio module instead of constructing server from parts."
-)
-@OptIn(
-    ObsoleteCoroutinesApi::class, ExperimentalCoroutinesApi::class
 )
 public fun CoroutineScope.startConnectionPipeline(
     input: ByteReadChannel,

--- a/ktor-http/ktor-http-cio/jvm/src/io/ktor/http/cio/websocket/DefaultWebSocketSessionImpl.kt
+++ b/ktor-http/ktor-http-cio/jvm/src/io/ktor/http/cio/websocket/DefaultWebSocketSessionImpl.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2014-2020 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package io.ktor.http.cio.websocket
@@ -11,7 +11,6 @@ import io.ktor.utils.io.pool.*
 import kotlinx.atomicfu.*
 import kotlinx.coroutines.*
 import kotlinx.coroutines.channels.*
-import java.lang.IllegalStateException
 import java.nio.*
 import kotlin.coroutines.*
 
@@ -88,15 +87,13 @@ public class DefaultWebSocketSessionImpl(
         raw.cancel()
     }
 
-    @OptIn(
-        ExperimentalCoroutinesApi::class, ObsoleteCoroutinesApi::class
-    )
     private fun runIncomingProcessor(ponger: SendChannel<Frame.Ping>): Job = launch(
         IncomingProcessorCoroutineName + Dispatchers.Unconfined
     ) {
         var last: BytePacketBuilder? = null
         var closeFramePresented = false
         try {
+            @OptIn(ExperimentalCoroutinesApi::class)
             raw.incoming.consumeEach { frame ->
                 when (frame) {
                     is Frame.Close -> {
@@ -144,9 +141,7 @@ public class DefaultWebSocketSessionImpl(
         }
     }
 
-    @OptIn(
-        ExperimentalCoroutinesApi::class, ObsoleteCoroutinesApi::class
-    )
+    @OptIn(ExperimentalCoroutinesApi::class)
     private fun runOutgoingProcessor(): Job = launch(
         OutgoingProcessorCoroutineName + Dispatchers.Unconfined, start = CoroutineStart.UNDISPATCHED
     ) {

--- a/ktor-http/ktor-http-cio/jvm/src/io/ktor/http/cio/websocket/PingPong.kt
+++ b/ktor-http/ktor-http-cio/jvm/src/io/ktor/http/cio/websocket/PingPong.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2014-2020 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package io.ktor.http.cio.websocket
@@ -46,9 +46,6 @@ public fun CoroutineScope.ponger(
  * Launch pinger coroutine on [CoroutineScope] that is sending ping every specified [periodMillis] to [outgoing] channel,
  * waiting for and verifying client's pong frames. It is also handling [timeoutMillis] and sending timeout close frame
  */
-@OptIn(
-    ExperimentalCoroutinesApi::class, ObsoleteCoroutinesApi::class
-)
 public fun CoroutineScope.pinger(
     outgoing: SendChannel<Frame>,
     periodMillis: Long,
@@ -56,6 +53,7 @@ public fun CoroutineScope.pinger(
     pool: ObjectPool<ByteBuffer> = KtorDefaultPool
 ): SendChannel<Frame.Pong> {
     val actorJob = Job()
+    @OptIn(ObsoleteCoroutinesApi::class)
     val result = actor<Frame.Pong>(
         actorJob + PingerCoroutineName, capacity = Channel.UNLIMITED, start = CoroutineStart.LAZY
     ) {
@@ -66,7 +64,7 @@ public fun CoroutineScope.pinger(
         val pingIdBytes = ByteArray(32)
 
         try {
-            while (!isClosedForReceive) {
+            while (true) {
                 // drop pongs during period delay as they are irrelevant
                 // here we expect a timeout, so ignore it
                 withTimeoutOrNull(periodMillis) {

--- a/ktor-http/ktor-http-cio/jvm/src/io/ktor/http/cio/websocket/WebSocketReader.kt
+++ b/ktor-http/ktor-http-cio/jvm/src/io/ktor/http/cio/websocket/WebSocketReader.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2014-2020 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package io.ktor.http.cio.websocket
@@ -33,6 +33,7 @@ public class WebSocketReader(
 
     private val queue = Channel<Frame>(8)
 
+    @OptIn(ExperimentalCoroutinesApi::class)
     private val readerJob = launch(CoroutineName("ws-reader"), start = CoroutineStart.ATOMIC) {
         val buffer = pool.borrow()
         try {
@@ -112,6 +113,7 @@ public class WebSocketReader(
      * Raised when the frame is bigger than allowed in a current websocket session
      * @param frameSize size of received or posted frame that is too big
      */
+    @OptIn(ExperimentalCoroutinesApi::class)
     public class FrameTooBigException(public val frameSize: Long) : Exception(), CopyableThrowable<FrameTooBigException> {
 
         override val message: String

--- a/ktor-http/ktor-http-cio/jvm/src/io/ktor/http/cio/websocket/WebSocketWriter.kt
+++ b/ktor-http/ktor-http-cio/jvm/src/io/ktor/http/cio/websocket/WebSocketWriter.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2014-2020 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package io.ktor.http.cio.websocket
@@ -20,9 +20,6 @@ import kotlin.coroutines.*
  * @property pool: [ByteBuffer] pool to be used by this writer
  */
 @WebSocketInternalAPI
-@OptIn(
-    ExperimentalCoroutinesApi::class, ObsoleteCoroutinesApi::class
-)
 public class WebSocketWriter(
     private val writeChannel: ByteWriteChannel,
     override val coroutineContext: CoroutineContext,
@@ -39,7 +36,7 @@ public class WebSocketWriter(
      */
     public val outgoing: SendChannel<Frame> get() = queue
 
-    @Suppress("RemoveExplicitTypeArguments") // workaround for new kotlin inference issue
+    @OptIn(ExperimentalCoroutinesApi::class)
     private val writeLoopJob = launch(context = CoroutineName("ws-writer"), start = CoroutineStart.ATOMIC) {
         pool.useInstance { writeLoop(it) }
     }
@@ -67,6 +64,7 @@ public class WebSocketWriter(
     }
 
     private fun drainQueueAndDiscard() {
+        @OptIn(ExperimentalCoroutinesApi::class)
         check(queue.isClosedForSend)
 
         try {

--- a/ktor-http/ktor-http-cio/jvm/src/io/ktor/http/cio/websocket/WebSocketWriter.kt
+++ b/ktor-http/ktor-http-cio/jvm/src/io/ktor/http/cio/websocket/WebSocketWriter.kt
@@ -64,8 +64,7 @@ public class WebSocketWriter(
     }
 
     private fun drainQueueAndDiscard() {
-        @OptIn(ExperimentalCoroutinesApi::class)
-        check(queue.isClosedForSend)
+        queue.close()
 
         try {
             do {

--- a/ktor-http/ktor-http-cio/jvm/src/io/ktor/server/cio/backend/ServerPipeline.kt
+++ b/ktor-http/ktor-http-cio/jvm/src/io/ktor/server/cio/backend/ServerPipeline.kt
@@ -26,12 +26,12 @@ import java.io.*
  */
 @Suppress("DEPRECATION")
 @InternalAPI
-@OptIn(ObsoleteCoroutinesApi::class)
 public fun CoroutineScope.startServerConnectionPipeline(
     connection: ServerIncomingConnection,
     timeout: WeakTimeoutQueue,
     handler: HttpRequestHandler
 ): Job = launch(HttpPipelineCoroutine) {
+    @OptIn(ObsoleteCoroutinesApi::class, ExperimentalCoroutinesApi::class)
     val outputsActor = actor<ByteReadChannel>(
         context = HttpPipelineWriterCoroutine,
         capacity = 3,
@@ -116,6 +116,7 @@ public fun CoroutineScope.startServerConnectionPipeline(
 
             val upgraded = if (expectedHttpUpgrade) CompletableDeferred<Boolean>() else null
 
+            @OptIn(ExperimentalCoroutinesApi::class)
             launch(requestContext, start = CoroutineStart.UNDISPATCHED) {
                 val handlerScope = ServerRequestScope(
                     coroutineContext,
@@ -169,7 +170,6 @@ public fun CoroutineScope.startServerConnectionPipeline(
     }
 }
 
-@OptIn(ObsoleteCoroutinesApi::class)
 private suspend fun pipelineWriterLoop(
     channel: ReceiveChannel<ByteReadChannel>,
     timeout: WeakTimeoutQueue,
@@ -177,7 +177,7 @@ private suspend fun pipelineWriterLoop(
 ) {
     val receiveChildOrNull =
         suspendLambda<CoroutineScope, ByteReadChannel?> {
-            @Suppress("DEPRECATION")
+            @OptIn(ExperimentalCoroutinesApi::class)
             channel.receiveOrNull()
         }
     while (true) {

--- a/ktor-http/ktor-http-cio/jvm/test/io/ktor/tests/http/cio/MultipartTest.kt
+++ b/ktor-http/ktor-http-cio/jvm/test/io/ktor/tests/http/cio/MultipartTest.kt
@@ -10,6 +10,7 @@ import kotlinx.coroutines.channels.*
 import io.ktor.utils.io.*
 import kotlin.test.*
 
+@OptIn(ExperimentalCoroutinesApi::class)
 class MultipartTest {
     @Test
     fun smokeTest() = runBlocking {

--- a/ktor-http/ktor-http-cio/jvm/test/io/ktor/tests/http/cio/MultipartTest.kt
+++ b/ktor-http/ktor-http-cio/jvm/test/io/ktor/tests/http/cio/MultipartTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2014-2020 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package io.ktor.tests.http.cio
@@ -54,7 +54,6 @@ class MultipartTest {
         val mp = parseMultipart(ch, request.headers)
 
         val allEvents = ArrayList<MultipartEvent>()
-        @OptIn(ObsoleteCoroutinesApi::class)
         mp.consumeEach { allEvents.add(it) }
 
         assertEquals(7, allEvents.size)
@@ -124,7 +123,6 @@ class MultipartTest {
         val mp = parseMultipart(ch, request.headers)
 
         val allEvents = ArrayList<MultipartEvent>()
-        @OptIn(ObsoleteCoroutinesApi::class)
         mp.consumeEach { allEvents.add(it) }
 
         assertEquals(7, allEvents.size)
@@ -195,7 +193,7 @@ class MultipartTest {
         val mp = parseMultipart(ch, request.headers)
 
         val allEvents = ArrayList<MultipartEvent>()
-        @OptIn(ObsoleteCoroutinesApi::class)
+        @OptIn(ExperimentalCoroutinesApi::class)
         mp.consumeEach { allEvents.add(it) }
 
         val parts = allEvents.filterIsInstance<MultipartEvent.MultipartPart>()
@@ -251,7 +249,7 @@ class MultipartTest {
         val mp = GlobalScope.parseMultipart(decoded.channel, request.headers)
 
         val allEvents = ArrayList<MultipartEvent>()
-        @OptIn(ObsoleteCoroutinesApi::class)
+        @OptIn(ExperimentalCoroutinesApi::class)
         mp.consumeEach { allEvents.add(it) }
 
         assertEquals(7, allEvents.size)

--- a/ktor-http/ktor-http-cio/jvm/test/io/ktor/tests/http/cio/TrySkipDelimiterTest.kt
+++ b/ktor-http/ktor-http-cio/jvm/test/io/ktor/tests/http/cio/TrySkipDelimiterTest.kt
@@ -11,6 +11,7 @@ import kotlinx.coroutines.test.*
 import java.nio.*
 import kotlin.test.*
 
+@OptIn(ExperimentalCoroutinesApi::class)
 class TrySkipDelimiterTest {
     private val ch = ByteChannel()
 

--- a/ktor-io/jvm/src/io/ktor/utils/io/ExceptionUtilsJvm.kt
+++ b/ktor-io/jvm/src/io/ktor/utils/io/ExceptionUtilsJvm.kt
@@ -34,6 +34,7 @@ private val exceptionCtors: WeakHashMap<Class<out Throwable>, Ctor> = WeakHashMa
  * Try copy [exception] using [cause] as cause.
  */
 @DangerousInternalIoApi
+@OptIn(ExperimentalCoroutinesApi::class)
 public fun <E : Throwable> tryCopyException(exception: E, cause: Throwable): E? {
     // Fast path for CopyableThrowable
     if (exception is CopyableThrowable<*>) {

--- a/ktor-network/jvm/src/io/ktor/network/sockets/DatagramSocketImpl.kt
+++ b/ktor-network/jvm/src/io/ktor/network/sockets/DatagramSocketImpl.kt
@@ -15,7 +15,6 @@ import java.nio.*
 import java.nio.channels.*
 
 @Suppress("BlockingMethodInNonBlockingContext")
-@OptIn(ExperimentalCoroutinesApi::class)
 internal class DatagramSocketImpl(override val channel: DatagramChannel, selector: SelectorManager)
     : BoundDatagramSocket, ConnectedDatagramSocket, NIOSocketImpl<DatagramChannel>(channel, selector, DefaultDatagramByteBufferPool) {
 
@@ -29,13 +28,14 @@ internal class DatagramSocketImpl(override val channel: DatagramChannel, selecto
         get() = socket.remoteSocketAddress as? NetworkAddress
             ?: throw IllegalStateException("Channel is not yet connected")
 
-    @OptIn(ObsoleteCoroutinesApi::class)
+    @OptIn(ObsoleteCoroutinesApi::class, ExperimentalCoroutinesApi::class)
     private val sender = actor<Datagram>(Dispatchers.IO) {
         consumeEach { datagram ->
             sendImpl(datagram)
         }
     }
 
+    @OptIn(ExperimentalCoroutinesApi::class)
     private val receiver = produce<Datagram>(Dispatchers.IO) {
         while (true) {
             channel.send(receiveImpl())

--- a/ktor-network/jvm/src/io/ktor/network/sockets/DatagramSocketImpl.kt
+++ b/ktor-network/jvm/src/io/ktor/network/sockets/DatagramSocketImpl.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2014-2020 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package io.ktor.network.sockets
@@ -14,9 +14,8 @@ import java.net.*
 import java.nio.*
 import java.nio.channels.*
 
-@OptIn(
-    ObsoleteCoroutinesApi::class, ExperimentalCoroutinesApi::class
-)
+@Suppress("BlockingMethodInNonBlockingContext")
+@OptIn(ExperimentalCoroutinesApi::class)
 internal class DatagramSocketImpl(override val channel: DatagramChannel, selector: SelectorManager)
     : BoundDatagramSocket, ConnectedDatagramSocket, NIOSocketImpl<DatagramChannel>(channel, selector, DefaultDatagramByteBufferPool) {
 
@@ -30,6 +29,7 @@ internal class DatagramSocketImpl(override val channel: DatagramChannel, selecto
         get() = socket.remoteSocketAddress as? NetworkAddress
             ?: throw IllegalStateException("Channel is not yet connected")
 
+    @OptIn(ObsoleteCoroutinesApi::class)
     private val sender = actor<Datagram>(Dispatchers.IO) {
         consumeEach { datagram ->
             sendImpl(datagram)

--- a/ktor-network/ktor-network-tls/jvm/src/io/ktor/network/tls/TLSClientHandshake.kt
+++ b/ktor-network/ktor-network-tls/jvm/src/io/ktor/network/tls/TLSClientHandshake.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2014-2020 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package io.ktor.network.tls
@@ -390,6 +390,7 @@ internal class TLSClientHandshake(
         }
     }
 
+    @OptIn(ExperimentalCoroutinesApi::class)
     private suspend fun sendChangeCipherSpec() {
         if (!output.isClosedForSend) {
             output.send(TLSRecord(TLSRecordType.ChangeCipherSpec, packet = buildPacket { writeByte(1) }))
@@ -425,6 +426,7 @@ internal class TLSClientHandshake(
         }
     }
 
+    @OptIn(ExperimentalCoroutinesApi::class)
     private suspend fun sendHandshakeRecord(handshakeType: TLSHandshakeType, block: BytePacketBuilder.() -> Unit) {
         val handshakeBody = buildPacket(block = block)
 

--- a/ktor-network/ktor-network-tls/jvm/src/io/ktor/network/tls/TLSClientSessionJvm.kt
+++ b/ktor-network/ktor-network-tls/jvm/src/io/ktor/network/tls/TLSClientSessionJvm.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2014-2020 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package io.ktor.network.tls
@@ -42,7 +42,7 @@ private class TLSSocket(
             appDataOutputLoop(this.channel)
         }
 
-    @OptIn(ObsoleteCoroutinesApi::class)
+    @OptIn(ExperimentalCoroutinesApi::class)
     private suspend fun appDataInputLoop(pipe: ByteWriteChannel) {
         try {
             input.consumeEach { record ->

--- a/ktor-network/ktor-network-tls/jvm/src/io/ktor/network/tls/TLSClientSessionJvm.kt
+++ b/ktor-network/ktor-network-tls/jvm/src/io/ktor/network/tls/TLSClientSessionJvm.kt
@@ -21,7 +21,11 @@ internal actual suspend fun openTLSSession(
     context: CoroutineContext
 ): Socket {
     val handshake = TLSClientHandshake(input, output, config, context)
-    handshake.negotiate()
+    try {
+        handshake.negotiate()
+    } catch (cause: ClosedSendChannelException) {
+        throw TLSException("Negotiation failed due to EOS", cause)
+    }
     return TLSSocket(handshake.input, handshake.output, socket, context)
 }
 

--- a/ktor-network/ktor-network-tls/jvm/src/io/ktor/network/tls/TLSConfigBuilder.kt
+++ b/ktor-network/ktor-network-tls/jvm/src/io/ktor/network/tls/TLSConfigBuilder.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2014-2020 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package io.ktor.network.tls
@@ -110,6 +110,7 @@ public fun TLSConfigBuilder.addKeyStore(store: KeyStore, password: CharArray) {
 /**
  * Throws if failed to find [PrivateKey] for any alias in [KeyStore].
  */
+@OptIn(ExperimentalCoroutinesApi::class)
 public class NoPrivateKeyException(
     private val alias: String, private val store: KeyStore
 ) : IllegalStateException("Failed to find private key for alias $alias. Please check your key store: $store"),

--- a/ktor-network/posix/src/io/ktor/network/selector/WorkerSelectorManager.kt
+++ b/ktor-network/posix/src/io/ktor/network/selector/WorkerSelectorManager.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2014-2020 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 package io.ktor.network.selector
 
@@ -9,6 +9,7 @@ import kotlinx.coroutines.*
 import kotlinx.coroutines.CancellationException
 import kotlin.coroutines.*
 
+@OptIn(ExperimentalCoroutinesApi::class)
 internal class WorkerSelectorManager : SelectorManager {
     private val selectorContext = newSingleThreadContext("WorkerSelectorManager")
     override val coroutineContext: CoroutineContext = selectorContext

--- a/ktor-server/ktor-server-cio/jvm/src/io/ktor/server/cio/backend/HttpServer.kt
+++ b/ktor-server/ktor-server-cio/jvm/src/io/ktor/server/cio/backend/HttpServer.kt
@@ -26,6 +26,8 @@ public fun CoroutineScope.httpServer(
     val socket = CompletableDeferred<ServerSocket>()
 
     val serverLatch: CompletableJob = Job()
+
+    @OptIn(ExperimentalCoroutinesApi::class)
     val serverJob = launch(
         context = CoroutineName("server-root-${settings.port}"),
         start = CoroutineStart.UNDISPATCHED

--- a/ktor-server/ktor-server-core/jvm/src/io/ktor/application/ApplicationFeature.kt
+++ b/ktor-server/ktor-server-core/jvm/src/io/ktor/application/ApplicationFeature.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2014-2020 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package io.ktor.application
@@ -118,6 +118,7 @@ public class DuplicateApplicationFeatureException(message: String) : Exception(m
  * Thrown when Application Feature has been attempted to be accessed but has not been installed before
  * @param key application feature's attribute key
  */
+@OptIn(ExperimentalCoroutinesApi::class)
 public class MissingApplicationFeatureException(
     public val key: AttributeKey<*>
 ) : IllegalStateException(), CopyableThrowable<MissingApplicationFeatureException> {

--- a/ktor-server/ktor-server-core/jvm/src/io/ktor/features/CallId.kt
+++ b/ktor-server/ktor-server-core/jvm/src/io/ktor/features/CallId.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2014-2020 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package io.ktor.features
@@ -30,6 +30,7 @@ public typealias CallIdVerifier = (String) -> Boolean
  * An exception that could be thrown to reject a call due to illegal call id
  * @param illegalCallId that caused rejection
  */
+@OptIn(ExperimentalCoroutinesApi::class)
 public class RejectedCallIdException(
     public val illegalCallId: String
 ) : IllegalArgumentException(), CopyableThrowable<RejectedCallIdException> {

--- a/ktor-server/ktor-server-core/jvm/src/io/ktor/features/Errors.kt
+++ b/ktor-server/ktor-server-core/jvm/src/io/ktor/features/Errors.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2014-2020 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package io.ktor.features
@@ -29,6 +29,7 @@ public class NotFoundException(message: String? = "Resource not found") : Except
  * This exception is thrown when a required parameter with name [parameterName] is missing
  * @property parameterName of missing request parameter
  */
+@OptIn(ExperimentalCoroutinesApi::class)
 @KtorExperimentalAPI
 public class MissingRequestParameterException(
     public val parameterName: String
@@ -46,6 +47,7 @@ public class MissingRequestParameterException(
  * @property type this parameter is unable to convert to
  */
 @KtorExperimentalAPI
+@OptIn(ExperimentalCoroutinesApi::class)
 public class ParameterConversionException(
     public val parameterName: String,
     public val type: String,
@@ -66,6 +68,7 @@ public class ParameterConversionException(
  */
 public abstract class ContentTransformationException(message: String) : Exception(message)
 
+@OptIn(ExperimentalCoroutinesApi::class)
 internal class CannotTransformContentToTypeException(
     private val type: KType
 ) : ContentTransformationException("Cannot transform this request's content to $type"),
@@ -84,6 +87,7 @@ internal class CannotTransformContentToTypeException(
  * Thrown when there is no conversion for a content type configured.
  * HTTP status 415 Unsupported Media Type will be replied when this exception is thrown and not caught.
  */
+@OptIn(ExperimentalCoroutinesApi::class)
 public class UnsupportedMediaTypeException(
     private val contentType: ContentType
 ) : ContentTransformationException("Content type $contentType is not supported"),

--- a/ktor-server/ktor-server-host-common/jvm/src/io/ktor/server/engine/BaseApplicationResponse.kt
+++ b/ktor-server/ktor-server-host-common/jvm/src/io/ktor/server/engine/BaseApplicationResponse.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2014-2020 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package io.ktor.server.engine
@@ -250,6 +250,7 @@ public abstract class BaseApplicationResponse(override val call: ApplicationCall
      * [OutgoingContent] is trying to set some header that is not allowed for this content type.
      * For example, only upgrade content can set `Upgrade` header.
      */
+    @OptIn(ExperimentalCoroutinesApi::class)
     public class InvalidHeaderForContent(
         private val name: String, private val content: String
     ) : IllegalStateException("Header $name is not allowed for $content"),
@@ -263,6 +264,7 @@ public abstract class BaseApplicationResponse(override val call: ApplicationCall
     /**
      * Content's actual body size doesn't match the provided one in `Content-Length` header
      */
+    @OptIn(ExperimentalCoroutinesApi::class)
     public class BodyLengthIsTooSmall(
         private val expected: Long, private val actual: Long
     ) : IllegalStateException("Body.size is too small. Body: $actual, Content-Length: $expected"),
@@ -275,6 +277,7 @@ public abstract class BaseApplicationResponse(override val call: ApplicationCall
     /**
      * Content's actual body size doesn't match the provided one in `Content-Length` header
      */
+    @OptIn(ExperimentalCoroutinesApi::class)
     public class BodyLengthIsTooLong(private val expected: Long) : IllegalStateException(
         "Body.size is too long. Expected $expected"
     ), CopyableThrowable<BodyLengthIsTooLong> {

--- a/ktor-server/ktor-server-host-common/jvm/src/io/ktor/server/engine/EngineContextCancellationHelper.kt
+++ b/ktor-server/ktor-server-host-common/jvm/src/io/ktor/server/engine/EngineContextCancellationHelper.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2014-2020 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package io.ktor.server.engine
@@ -25,6 +25,7 @@ public fun ApplicationEngine.stopServerOnCancellation(): CompletableJob =
 public fun Job.launchOnCancellation(block: suspend () -> Unit): CompletableJob {
     val deferred: CompletableJob = Job(parent = this)
 
+    @OptIn(ExperimentalCoroutinesApi::class)
     GlobalScope.launch(this + Dispatchers.IO, start = CoroutineStart.UNDISPATCHED) {
         var cancelled = false
         try {

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyApplicationCallHandler.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyApplicationCallHandler.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2014-2020 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package io.ktor.server.netty
@@ -31,6 +31,7 @@ internal class NettyApplicationCallHandler(
         }
     }
 
+    @OptIn(ExperimentalCoroutinesApi::class)
     private fun handleRequest(context: ChannelHandlerContext, call: ApplicationCall) {
         val callContext = CallHandlerCoroutineName + NettyDispatcher.CurrentContext(context)
 

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/cio/NettyResponsePipeline.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/cio/NettyResponsePipeline.kt
@@ -35,6 +35,7 @@ internal class NettyResponsePipeline(private val dst: ChannelHandlerContext,
     private val ready = ArrayDeque<NettyRequestQueue.CallElement>(readyQueueSize)
     private val running = ArrayDeque<NettyRequestQueue.CallElement>(runningQueueSize)
 
+    @OptIn(ExperimentalCoroutinesApi::class)
     private val responses = launch(
         dst.executor().asCoroutineDispatcher() + ResponsePipelineCoroutineName,
         start = CoroutineStart.UNDISPATCHED

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/cio/NettyResponsePipeline.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/cio/NettyResponsePipeline.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2014-2020 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package io.ktor.server.netty.cio
@@ -87,9 +87,9 @@ internal class NettyResponsePipeline(private val dst: ChannelHandlerContext,
         }
     }
 
-    @OptIn(ExperimentalCoroutinesApi::class, ObsoleteCoroutinesApi::class)
     private suspend fun fillSuspend() {
         if (running.isEmpty()) {
+            @OptIn(ExperimentalCoroutinesApi::class)
             val e = incoming.receiveOrNull()
 
             if (e != null && e.ensureRunning()) {

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/cio/RequestBodyHandler.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/cio/RequestBodyHandler.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2014-2020 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package io.ktor.server.netty.cio
@@ -26,17 +26,15 @@ internal class RequestBodyHandler(
 
     override val coroutineContext: CoroutineContext get() = handlerJob
 
-    @OptIn(
-        ExperimentalCoroutinesApi::class, ObsoleteCoroutinesApi::class
-    )
     private val job = launch(context.executor().asCoroutineDispatcher(), start = CoroutineStart.LAZY) {
         var current: ByteWriteChannel? = null
         var upgraded = false
 
         try {
             while (true) {
+                @OptIn(ExperimentalCoroutinesApi::class)
                 val event = queue.poll()
-                    ?: run { current?.flush(); @Suppress("DEPRECATION") queue.receiveOrNull() }
+                    ?: run { current?.flush(); queue.receiveOrNull() }
                     ?: break
 
                 if (event is ByteBufHolder) {

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http2/HttpFrameAdapter.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http2/HttpFrameAdapter.kt
@@ -6,15 +6,13 @@ package io.ktor.server.netty.http2
 
 import io.netty.buffer.*
 import io.netty.handler.codec.http2.*
-import kotlinx.coroutines.*
 import kotlinx.coroutines.channels.*
 import io.ktor.utils.io.*
 
-@OptIn(ExperimentalCoroutinesApi::class)
 internal suspend fun ReceiveChannel<Http2DataFrame>.http2frameLoop(bc: ByteWriteChannel) {
     try {
-        while (!isClosedForReceive) {
-            val message = receiveOrNull() ?: break
+        while (true) {
+            val message = receive()
             val content = message.content() ?: Unpooled.EMPTY_BUFFER
 
             while (content.readableBytes() > 0) {

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http2/HttpFrameAdapter.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http2/HttpFrameAdapter.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2014-2020 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package io.ktor.server.netty.http2
@@ -10,13 +10,10 @@ import kotlinx.coroutines.*
 import kotlinx.coroutines.channels.*
 import io.ktor.utils.io.*
 
-@OptIn(
-    ExperimentalCoroutinesApi::class, ObsoleteCoroutinesApi::class
-)
+@OptIn(ExperimentalCoroutinesApi::class)
 internal suspend fun ReceiveChannel<Http2DataFrame>.http2frameLoop(bc: ByteWriteChannel) {
     try {
         while (!isClosedForReceive) {
-            @Suppress("DEPRECATION")
             val message = receiveOrNull() ?: break
             val content = message.content() ?: Unpooled.EMPTY_BUFFER
 

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http2/HttpFrameAdapter.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http2/HttpFrameAdapter.kt
@@ -36,6 +36,7 @@ internal suspend fun ReceiveChannel<Http2DataFrame>.http2frameLoop(bc: ByteWrite
                 break
             }
         }
+    } catch (closed: ClosedReceiveChannelException) {
     } catch (t: Throwable) {
         bc.close(t)
     } finally {

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http2/NettyHttp2Handler.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http2/NettyHttp2Handler.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2014-2020 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package io.ktor.server.netty.http2
@@ -154,6 +154,7 @@ internal class NettyHttp2Handler(
         return superclass.findIdField()
     }
 
+    @OptIn(ExperimentalCoroutinesApi::class)
     private class Http2ClosedChannelException(
         val errorCode: Long
     ) : ClosedChannelException(), CopyableThrowable<Http2ClosedChannelException> {

--- a/ktor-server/ktor-server-servlet/jvm/src/io/ktor/server/servlet/ServletReader.kt
+++ b/ktor-server/ktor-server-servlet/jvm/src/io/ktor/server/servlet/ServletReader.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2014-2020 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package io.ktor.server.servlet
@@ -36,10 +36,7 @@ private class ServletReader(val input: ServletInputStream) : ReadListener {
                 events.close()
                 return
             }
-            @Suppress("DEPRECATION")
-            @OptIn(
-                ExperimentalCoroutinesApi::class, ObsoleteCoroutinesApi::class
-            )
+            @OptIn(ExperimentalCoroutinesApi::class)
             events.receiveOrNull() ?: return
             loop(buffer)
 
@@ -67,10 +64,7 @@ private class ServletReader(val input: ServletInputStream) : ReadListener {
                 channel.writeFully(buffer, 0, rc)
             } else {
                 channel.flush()
-                @Suppress("DEPRECATION")
-                @OptIn(
-                    ExperimentalCoroutinesApi::class, ObsoleteCoroutinesApi::class
-                )
+                @OptIn(ExperimentalCoroutinesApi::class)
                 events.receiveOrNull() ?: break
             }
         }

--- a/ktor-server/ktor-server-servlet/jvm/src/io/ktor/server/servlet/ServletUpgrade.kt
+++ b/ktor-server/ktor-server-servlet/jvm/src/io/ktor/server/servlet/ServletUpgrade.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2014-2020 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package io.ktor.server.servlet
@@ -105,6 +105,7 @@ public class ServletUpgradeHandler : HttpUpgradeHandler, CoroutineScope {
 
         val outputChannel = servletWriter(webConnection.outputStream).channel
 
+        @OptIn(ExperimentalCoroutinesApi::class)
         launch(up.userContext + ServletUpgradeCoroutineName, start = CoroutineStart.UNDISPATCHED) {
             val job = up.upgradeMessage.upgrade(
                 inputChannel, outputChannel,

--- a/ktor-server/ktor-server-tests/jvm/test/io/ktor/tests/server/features/CallLoggingTest.kt
+++ b/ktor-server/ktor-server-tests/jvm/test/io/ktor/tests/server/features/CallLoggingTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2014-2020 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package io.ktor.tests.server.features
@@ -16,9 +16,9 @@ import org.junit.*
 import org.junit.Test
 import org.slf4j.*
 import org.slf4j.event.*
+import java.util.concurrent.*
 import kotlin.test.*
 
-@OptIn(ObsoleteCoroutinesApi::class)
 class CallLoggingTest {
 
     private lateinit var messages: MutableList<String>
@@ -188,7 +188,7 @@ class CallLoggingTest {
         }
 
         withApplication(environment) {
-            newSingleThreadContext("mdc-test-ctx").use { dispatcher ->
+            Executors.newSingleThreadExecutor().asCoroutineDispatcher().use { dispatcher ->
                 application.routing {
                     get("/*") {
                         withContext(dispatcher) {
@@ -226,6 +226,7 @@ class CallLoggingTest {
         }
 
         withApplication(environment) {
+            @OptIn(ObsoleteCoroutinesApi::class)
             newFixedThreadPoolContext(1, "test-dispatcher").use { dispatcher ->
                 application.routing {
                     get("/*") {


### PR DESCRIPTION
**Subsystem**
all

**Motivation**
At the moment, we are using too much experimental/obsolete API, especially because we have it whitelisted in the buildscript for all modules.

**Solution**
- Remove the annotation from the whitelist
- Reduce the number of usages
- make required opt-ins where necessary, as a small block as possible


