### PR TITLE
Correct encoding of path parts in the locations feature.

### DIFF
--- a/ktor-features/ktor-locations/jvm/src/io/ktor/locations/BackwardCompatibleImpl.kt
+++ b/ktor-features/ktor-locations/jvm/src/io/ktor/locations/BackwardCompatibleImpl.kt
@@ -95,7 +95,7 @@ internal class BackwardCompatibleImpl(
 
         val relativePath = substituteParts
             .filterNot { it.isEmpty() }
-            .joinToString("/") { it.encodeURLQueryComponent() }
+            .joinToString("/") { it.encodeURLPathPart() }
 
         val parentInfo = when {
             info.parent == null -> rootUri

--- a/ktor-features/ktor-locations/jvm/test/io/ktor/tests/locations/LocationsTest.kt
+++ b/ktor-features/ktor-locations/jvm/test/io/ktor/tests/locations/LocationsTest.kt
@@ -83,11 +83,11 @@ class LocationsTest {
         urlShouldBeUnhandled("/user?id=123")
     }
 
-    @Location("/user/{id}/{name}") class named(val id: Int, val name: String)
+    @Location("/user/{id}/{name}/tailpart") class named(val id: Int, val name: String)
 
     @Test fun `location with urlencoded path param`() = withLocationsApplication {
-        val href = application.locations.href(named(123, "abc def"))
-        assertEquals("/user/123/abc%20def", href)
+        val href = application.locations.href(named(123, "abc /#def"))
+        assertEquals("/user/123/abc%20%2F%23def", href)
         application.routing {
             get<named> { named ->
                 assertEquals(123, named.id)

--- a/ktor-http/jvm/test/io/ktor/tests/http/CodecTestJvm.kt
+++ b/ktor-http/jvm/test/io/ktor/tests/http/CodecTestJvm.kt
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2014-2020 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.tests.http
+
+import io.ktor.http.*
+import kotlin.test.*
+
+class CodecTestJvm {
+
+    @Test
+    fun testEncodeDecodeUrlPathPathRoundtrippingExhaustivelySingleCodePoints() {
+        val allStrings = allStrings()
+        allStrings.forEachIndexed { index, str ->
+            try {
+                val encoded = str.encodeURLPathPart()
+                val decoded = encoded.decodeURLPart()
+                assertEquals(str, decoded)
+            } catch (e: Throwable) {
+                throw AssertionError("Failed for string '$str' with chars '${str.codePoints().toArray().toList()}", e)
+            }
+        }
+    }
+
+    /**
+     * Extra test method just for the fun of it. Maybe combinations of chars will find some errors.
+     */
+    @Test
+    fun testEncodeDecodeUrlPathPathRoundtrippingExhaustivelyBatchedCodePoints() {
+        val allStrings = allStrings()
+            .chunked(100) { it.joinToString(separator = "") }
+
+        allStrings.forEachIndexed { index, str ->
+            try {
+                val encoded = str.encodeURLPathPart()
+                val decoded = encoded.decodeURLPart()
+                assertEquals(str, decoded)
+            } catch (e: Throwable) {
+                throw AssertionError("Failed for string '$str' with chars '${str.codePoints().toArray().toList()}", e)
+            }
+        }
+    }
+
+    private fun allStrings(): List<String> {
+        val res = mutableListOf<String>()
+//        0xD800 seems to be the first char that breaks everything.. so lets stop here for now
+        for (it in Character.MIN_CODE_POINT/*..Character.MAX_CODE_POINT*/ until 0xD800) {
+            if (Character.isValidCodePoint(it)) {
+                res.add(Character.toString(it))
+            }
+        }
+        return res
+    }
+
+}


### PR DESCRIPTION
**Subsystem**
Locations feature

**Motivation**
Currently locations not escape path values that contains chars such as / or # leading to urls like:
/a/da#/da
for a class
```
@Location("/{foo}/da")
class Foo(name: String)
Foo("a/da#")
```
This is obviously not possible to route back to this location.

**Solution**
Introduce a new encode method only used for url parts between the slashes and exhaustive tests.

The reason I do not exhaustively test characters after codepoint 0xD800 is the encoding utils will loop forever on 0xD800 as can be seen by expanding the range.
