### PR TITLE
KTOR-1187 Replace JUnit with kotlin.test

### DIFF
--- a/ktor-client/ktor-client-apache/jvm/test/io/ktor/client/engine/apache/RequestProducerTest.kt
+++ b/ktor-client/ktor-client-apache/jvm/test/io/ktor/client/engine/apache/RequestProducerTest.kt
@@ -11,7 +11,6 @@ import io.ktor.http.content.*
 import io.ktor.util.*
 import kotlinx.coroutines.*
 import org.apache.http.*
-import org.junit.Test
 import kotlin.coroutines.*
 import kotlin.test.*
 

--- a/ktor-client/ktor-client-features/ktor-client-tracing/ktor-client-tracing-stetho/android/test/io/ktor/client/features/tracing/StethoTracerTest.kt
+++ b/ktor-client/ktor-client-features/ktor-client-tracing/ktor-client-tracing-stetho/android/test/io/ktor/client/features/tracing/StethoTracerTest.kt
@@ -11,7 +11,6 @@ import io.ktor.client.engine.*
 import io.ktor.client.engine.cio.*
 import io.ktor.client.request.*
 import kotlinx.coroutines.*
-import org.junit.Test
 import org.mockito.Mockito.*
 import kotlin.test.*
 

--- a/ktor-features/ktor-auth/jvm/test/io/ktor/tests/auth/AuthTests.kt
+++ b/ktor-features/ktor-auth/jvm/test/io/ktor/tests/auth/AuthTests.kt
@@ -7,22 +7,21 @@ package io.ktor.tests.auth
 import io.ktor.http.auth.*
 import java.util.*
 import kotlin.test.*
-import org.junit.Test as test
 
 class AuthorizeHeaderParserTest {
-    @org.junit.Test fun empty() {
+    @Test fun empty() {
         testParserParameterized("Basic", emptyMap(), "Basic")
     }
 
-    @org.junit.Test fun emptyWithTrailingSpaces() {
+    @Test fun emptyWithTrailingSpaces() {
         testParserParameterized("Basic", emptyMap(), "Basic ")
     }
 
-    @org.junit.Test fun singleSimple() {
+    @Test fun singleSimple() {
         testParserSingle("Basic", "abc==", "Basic abc==")
     }
 
-    @org.junit.Test fun testParameterizedSimple() {
+    @Test fun testParameterizedSimple() {
         testParserParameterized("Basic", mapOf("a" to "1"), "Basic a=1")
         testParserParameterized("Basic", mapOf("a" to "1"), "Basic a =1")
         testParserParameterized("Basic", mapOf("a" to "1"), "Basic a = 1")
@@ -31,7 +30,7 @@ class AuthorizeHeaderParserTest {
         testParserParameterized("Basic", mapOf("a" to "1"), "Basic a=1 ")
     }
 
-    @org.junit.Test fun testParameterizedSimpleTwoParams() {
+    @Test fun testParameterizedSimpleTwoParams() {
         testParserParameterized("Basic", mapOf("a" to "1", "b" to "2"), "Basic a=1, b=2")
         testParserParameterized("Basic", mapOf("a" to "1", "b" to "2"), "Basic a=1,b=2")
         testParserParameterized("Basic", mapOf("a" to "1", "b" to "2"), "Basic a=1 ,b=2")
@@ -39,20 +38,20 @@ class AuthorizeHeaderParserTest {
         testParserParameterized("Basic", mapOf("a" to "1", "b" to "2"), "Basic a=1 , b=2 ")
     }
 
-    @org.junit.Test fun testParameterizedQuoted() {
+    @Test fun testParameterizedQuoted() {
         testParserParameterized("Basic", mapOf("a" to "1 2"), "Basic a=\"1 2\"")
     }
 
-    @org.junit.Test fun testParameterizedQuotedEscaped() {
+    @Test fun testParameterizedQuotedEscaped() {
         testParserParameterized("Basic", mapOf("a" to "1 \" 2"), "Basic a=\"1 \\\" 2\"")
         testParserParameterized("Basic", mapOf("a" to "1 A 2"), "Basic a=\"1 \\A 2\"")
     }
 
-    @org.junit.Test fun testParameterizedQuotedEscapedInTheMiddle() {
+    @Test fun testParameterizedQuotedEscapedInTheMiddle() {
         testParserParameterized("Basic", mapOf("a" to "1 \" 2", "b" to "2"), "Basic a=\"1 \\\" 2\", b= 2")
     }
 
-    @org.junit.Test fun testGarbage() {
+    @Test fun testGarbage() {
         Random().let { rnd ->
             repeat(10000) {
                 val random = rnd.nextString(3 + rnd.nextInt(7)) + " " + rnd.nextString(10, ('a'..'z') + ('A'..'Z') + ('0'..'9') + listOf(',', ' ', '/'))

--- a/ktor-features/ktor-auth/jvm/test/io/ktor/tests/auth/CryptoTest.kt
+++ b/ktor-features/ktor-auth/jvm/test/io/ktor/tests/auth/CryptoTest.kt
@@ -5,7 +5,6 @@
 package io.ktor.tests.auth
 
 import io.ktor.util.*
-import org.junit.Test
 import kotlin.test.*
 
 class CryptoTest {

--- a/ktor-features/ktor-auth/jvm/test/io/ktor/tests/auth/DigestTest.kt
+++ b/ktor-features/ktor-auth/jvm/test/io/ktor/tests/auth/DigestTest.kt
@@ -13,7 +13,6 @@ import io.ktor.routing.*
 import io.ktor.server.testing.*
 import io.ktor.util.*
 import kotlinx.coroutines.*
-import org.junit.Test
 import java.security.*
 import kotlin.test.*
 

--- a/ktor-features/ktor-auth/jvm/test/io/ktor/tests/auth/OAuth1a.kt
+++ b/ktor-features/ktor-auth/jvm/test/io/ktor/tests/auth/OAuth1a.kt
@@ -17,8 +17,6 @@ import io.ktor.server.testing.*
 import io.ktor.server.testing.client.*
 import io.ktor.util.*
 import kotlinx.coroutines.*
-import org.junit.*
-import org.junit.Test
 import java.time.*
 import java.util.concurrent.*
 import kotlin.test.*
@@ -59,7 +57,7 @@ class OAuth1aSignatureTest {
 class OAuth1aFlowTest {
     var testClient: HttpClient? = null
 
-    @Before
+    @BeforeTest
     fun createServer() {
         testClient = createOAuthServer(object : TestingOAuthServer {
 
@@ -113,7 +111,7 @@ class OAuth1aFlowTest {
         })
     }
 
-    @After
+    @AfterTest
     fun destroyServer() {
         testClient?.close()
         testClient = null
@@ -132,7 +130,7 @@ class OAuth1aFlowTest {
             consumerSecret = "0xPR3CQaGOilgXCGUt4g6SpBkhti9DOGkWtBCOImNFomedZ3ZU"
     )
 
-    @After
+    @AfterTest
     fun tearDown() {
         executor.shutdownNow()
     }

--- a/ktor-features/ktor-freemarker/jvm/test/io/ktor/tests/freemarker/FreeMarkerTest.kt
+++ b/ktor-features/ktor-freemarker/jvm/test/io/ktor/tests/freemarker/FreeMarkerTest.kt
@@ -12,7 +12,6 @@ import io.ktor.http.*
 import io.ktor.response.*
 import io.ktor.routing.*
 import io.ktor.server.testing.*
-import org.junit.Test
 import java.util.zip.*
 import kotlin.test.*
 

--- a/ktor-features/ktor-html-builder/jvm/test/io/ktor/tests/html/HtmlBuilderTest.kt
+++ b/ktor-features/ktor-html-builder/jvm/test/io/ktor/tests/html/HtmlBuilderTest.kt
@@ -11,7 +11,6 @@ import io.ktor.http.*
 import io.ktor.routing.*
 import io.ktor.server.testing.*
 import kotlinx.html.*
-import org.junit.Test
 import kotlin.test.*
 
 class HtmlBuilderTest {

--- a/ktor-features/ktor-html-builder/jvm/test/io/ktor/tests/html/HtmlTemplateTest.kt
+++ b/ktor-features/ktor-html-builder/jvm/test/io/ktor/tests/html/HtmlTemplateTest.kt
@@ -10,7 +10,6 @@ import io.ktor.http.*
 import io.ktor.routing.*
 import io.ktor.server.testing.*
 import kotlinx.html.*
-import org.junit.Test
 import kotlin.test.*
 
 class MenuTemplate : Template<FlowContent> {

--- a/ktor-features/ktor-jackson/jvm/test/io/ktor/tests/jackson/JacksonTest.kt
+++ b/ktor-features/ktor-jackson/jvm/test/io/ktor/tests/jackson/JacksonTest.kt
@@ -13,7 +13,6 @@ import io.ktor.request.*
 import io.ktor.response.*
 import io.ktor.routing.*
 import io.ktor.server.testing.*
-import org.junit.Test
 import kotlin.test.*
 
 class JacksonTest {

--- a/ktor-features/ktor-locations/jvm/test/io/ktor/tests/locations/CustomLocationsTest.kt
+++ b/ktor-features/ktor-locations/jvm/test/io/ktor/tests/locations/CustomLocationsTest.kt
@@ -14,7 +14,6 @@ import io.ktor.response.*
 import io.ktor.routing.*
 import io.ktor.server.testing.*
 import io.ktor.util.*
-import org.junit.Test
 import kotlin.reflect.*
 import kotlin.test.*
 

--- a/ktor-features/ktor-locations/jvm/test/io/ktor/tests/locations/LocationsTest.kt
+++ b/ktor-features/ktor-locations/jvm/test/io/ktor/tests/locations/LocationsTest.kt
@@ -11,7 +11,6 @@ import io.ktor.locations.*
 import io.ktor.response.*
 import io.ktor.routing.*
 import io.ktor.server.testing.*
-import org.junit.Test
 import java.math.*
 import kotlin.test.*
 

--- a/ktor-features/ktor-locations/jvm/test/io/ktor/tests/locations/OAuthLocationsTest.kt
+++ b/ktor-features/ktor-locations/jvm/test/io/ktor/tests/locations/OAuthLocationsTest.kt
@@ -13,7 +13,6 @@ import io.ktor.locations.*
 import io.ktor.routing.*
 import io.ktor.server.testing.*
 import io.ktor.server.testing.client.*
-import org.junit.Test
 import java.net.*
 import kotlin.test.*
 

--- a/ktor-features/ktor-metrics-micrometer/jvm/test/io/ktor/metrics/micrometer/MicrometerMetricsTests.kt
+++ b/ktor-features/ktor-metrics-micrometer/jvm/test/io/ktor/metrics/micrometer/MicrometerMetricsTests.kt
@@ -16,8 +16,6 @@ import io.micrometer.core.instrument.binder.jvm.*
 import io.micrometer.core.instrument.binder.system.*
 import io.micrometer.core.instrument.distribution.*
 import io.micrometer.core.instrument.simple.*
-import org.junit.*
-import org.junit.Test
 import kotlin.reflect.*
 import kotlin.test.*
 
@@ -27,7 +25,7 @@ class MicrometerMetricsTests {
     var noHandlerHandledReqeust = false
     var throwableCaughtInEngine: Throwable? = null
 
-    @Before
+    @BeforeTest
     fun reset() {
         noHandlerHandledReqeust = false
         throwableCaughtInEngine = null

--- a/ktor-features/ktor-server-sessions/jvm/test/io/ktor/tests/sessions/CacheTest.kt
+++ b/ktor-features/ktor-server-sessions/jvm/test/io/ktor/tests/sessions/CacheTest.kt
@@ -6,7 +6,6 @@ package io.ktor.tests.sessions
 
 import io.ktor.sessions.*
 import kotlinx.coroutines.*
-import org.junit.Test
 import java.util.concurrent.*
 import java.util.concurrent.atomic.*
 import kotlin.test.*

--- a/ktor-features/ktor-server-sessions/jvm/test/io/ktor/tests/sessions/DirectorySessionStorageTest.kt
+++ b/ktor-features/ktor-server-sessions/jvm/test/io/ktor/tests/sessions/DirectorySessionStorageTest.kt
@@ -8,8 +8,6 @@ import io.ktor.sessions.*
 import kotlinx.coroutines.*
 import io.ktor.utils.io.*
 import io.ktor.utils.io.jvm.javaio.*
-import org.junit.*
-import org.junit.Test
 import java.io.*
 import java.nio.file.*
 import java.util.*
@@ -19,7 +17,7 @@ class DirectorySessionStorageTest {
     private val dir = Files.createTempDirectory("ktor-tests-").toFile()!!
     private val storage = directorySessionStorage(dir, false)
 
-    @After
+    @AfterTest
     fun tearDown() {
         (storage as Closeable).close()
         assertTrue { dir.deleteRecursively() }

--- a/ktor-features/ktor-thymeleaf/jvm/test/it/ktor/thymeleaf/ThymeleafTest.kt
+++ b/ktor-features/ktor-thymeleaf/jvm/test/it/ktor/thymeleaf/ThymeleafTest.kt
@@ -21,12 +21,10 @@ import io.ktor.server.testing.withTestApplication
 import io.ktor.thymeleaf.Thymeleaf
 import io.ktor.thymeleaf.ThymeleafContent
 import io.ktor.thymeleaf.respondTemplate
-import org.junit.Test
 import org.thymeleaf.templateresolver.ClassLoaderTemplateResolver
 import org.thymeleaf.templateresolver.StringTemplateResolver
 import java.util.zip.GZIPInputStream
-import kotlin.test.assertEquals
-import kotlin.test.assertNotNull
+import kotlin.test.*
 
 class ThymeleafTest {
     @Test

--- a/ktor-features/ktor-velocity/jvm/test/io/ktor/tests/velocity/VelocityTest.kt
+++ b/ktor-features/ktor-velocity/jvm/test/io/ktor/tests/velocity/VelocityTest.kt
@@ -13,7 +13,6 @@ import io.ktor.server.testing.*
 import io.ktor.velocity.*
 import org.apache.velocity.runtime.resource.loader.*
 import org.apache.velocity.runtime.resource.util.*
-import org.junit.Test
 import java.util.zip.*
 import kotlin.test.*
 

--- a/ktor-features/ktor-websockets/jvm/test/io/ktor/tests/websocket/ParserTest.kt
+++ b/ktor-features/ktor-websockets/jvm/test/io/ktor/tests/websocket/ParserTest.kt
@@ -6,7 +6,6 @@ package io.ktor.tests.websocket
 
 import io.ktor.http.cio.websocket.*
 import io.ktor.util.*
-import org.junit.Test
 import java.nio.*
 import kotlin.test.*
 

--- a/ktor-features/ktor-websockets/jvm/test/io/ktor/tests/websocket/WebSocketEngineSuite.kt
+++ b/ktor-features/ktor-websockets/jvm/test/io/ktor/tests/websocket/WebSocketEngineSuite.kt
@@ -18,7 +18,6 @@ import io.ktor.websocket.*
 import kotlinx.coroutines.*
 import kotlinx.coroutines.channels.*
 import org.junit.*
-import org.junit.Test
 import org.junit.rules.*
 import java.io.*
 import java.net.*
@@ -29,6 +28,7 @@ import java.util.concurrent.*
 import java.util.concurrent.CancellationException
 import kotlin.test.*
 import kotlin.test.Ignore
+import kotlin.test.Test
 
 @OptIn(
     WebSocketInternalAPI::class, ObsoleteCoroutinesApi::class

--- a/ktor-features/ktor-websockets/jvm/test/io/ktor/tests/websocket/WriterTest.kt
+++ b/ktor-features/ktor-websockets/jvm/test/io/ktor/tests/websocket/WriterTest.kt
@@ -8,7 +8,6 @@ import io.ktor.util.cio.*
 import io.ktor.http.cio.websocket.*
 import kotlinx.coroutines.*
 import io.ktor.utils.io.*
-import org.junit.Test
 import java.nio.ByteBuffer
 import kotlin.test.*
 

--- a/ktor-http/ktor-http-cio/jvm/test/io/ktor/tests/http/cio/ChunkedTest.kt
+++ b/ktor-http/ktor-http-cio/jvm/test/io/ktor/tests/http/cio/ChunkedTest.kt
@@ -8,7 +8,6 @@ import io.ktor.http.cio.*
 import kotlinx.coroutines.*
 import io.ktor.utils.io.*
 import io.ktor.utils.io.streams.*
-import org.junit.Test
 import java.io.*
 import java.nio.*
 import kotlin.test.*

--- a/ktor-http/ktor-http-cio/jvm/test/io/ktor/tests/http/cio/HeadersTest.kt
+++ b/ktor-http/ktor-http-cio/jvm/test/io/ktor/tests/http/cio/HeadersTest.kt
@@ -6,17 +6,15 @@ package io.ktor.tests.http.cio
 
 import io.ktor.http.cio.*
 import io.ktor.http.cio.internals.*
-import kotlinx.coroutines.*
 import io.ktor.utils.io.*
-import org.junit.*
-import org.junit.Test
+import kotlinx.coroutines.*
 import kotlin.test.*
 
 class HeadersTest {
     private val ch = ByteChannel(true)
     private val builder = CharArrayBuilder()
 
-    @After
+    @AfterTest
     fun tearDown() {
         ch.close()
         builder.release()

--- a/ktor-http/ktor-http-cio/jvm/test/io/ktor/tests/http/cio/IntegrationTest.kt
+++ b/ktor-http/ktor-http-cio/jvm/test/io/ktor/tests/http/cio/IntegrationTest.kt
@@ -6,10 +6,8 @@ package io.ktor.tests.http.cio
 
 import io.ktor.http.*
 import io.ktor.http.cio.*
-import kotlinx.coroutines.*
 import io.ktor.utils.io.*
-import org.junit.*
-import org.junit.Test
+import kotlinx.coroutines.*
 import java.net.*
 import java.nio.channels.*
 import java.util.concurrent.*
@@ -25,7 +23,7 @@ class IntegrationTest {
         o.close()
     }
 
-    @Before
+    @BeforeTest
     fun setUp() {
         val dispatcher = pool.asCoroutineDispatcher()
         val (j, s) = testHttpServer(0, dispatcher, dispatcher) { request ->
@@ -55,7 +53,7 @@ class IntegrationTest {
         }
     }
 
-    @After
+    @AfterTest
     @OptIn(ExperimentalCoroutinesApi::class)
     fun tearDown() {
         server.invokeOnCompletion { t ->

--- a/ktor-http/ktor-http-cio/jvm/test/io/ktor/tests/http/cio/RequestParserTest.kt
+++ b/ktor-http/ktor-http-cio/jvm/test/io/ktor/tests/http/cio/RequestParserTest.kt
@@ -8,7 +8,6 @@ import io.ktor.http.*
 import io.ktor.http.cio.*
 import kotlinx.coroutines.*
 import io.ktor.utils.io.*
-import org.junit.Test
 import kotlin.test.*
 
 class RequestParserTest {

--- a/ktor-http/ktor-http-cio/jvm/test/io/ktor/tests/http/cio/RequestResponseBuilderTest.kt
+++ b/ktor-http/ktor-http-cio/jvm/test/io/ktor/tests/http/cio/RequestResponseBuilderTest.kt
@@ -4,17 +4,15 @@
 
 package io.ktor.tests.http.cio
 
-import io.ktor.http.cio.RequestResponseBuilder
 import io.ktor.http.*
+import io.ktor.http.cio.*
 import io.ktor.utils.io.streams.*
-import org.junit.*
-import org.junit.Test
 import kotlin.test.*
 
 class RequestResponseBuilderTest {
     private val builder = RequestResponseBuilder()
 
-    @After
+    @AfterTest
     fun tearDown() {
         builder.release()
     }

--- a/ktor-io/jvm/test/io/ktor/utils/io/charsets/ByteChannelTextTest.kt
+++ b/ktor-io/jvm/test/io/ktor/utils/io/charsets/ByteChannelTextTest.kt
@@ -6,7 +6,6 @@ package io.ktor.utils.io.charsets
 
 import io.ktor.utils.io.*
 import kotlinx.coroutines.*
-import org.junit.Test
 import kotlin.test.*
 
 class ByteChannelTextTest {

--- a/ktor-io/jvm/test/io/ktor/utils/io/charsets/UTFTest.kt
+++ b/ktor-io/jvm/test/io/ktor/utils/io/charsets/UTFTest.kt
@@ -4,7 +4,6 @@
 
 package io.ktor.utils.io.charsets
 
-import org.junit.Test
 import java.nio.*
 import kotlin.test.*
 

--- a/ktor-io/jvm/test/io/ktor/utils/io/tests/BytePacketReaderWriterTest.kt
+++ b/ktor-io/jvm/test/io/ktor/utils/io/tests/BytePacketReaderWriterTest.kt
@@ -3,7 +3,6 @@ package io.ktor.utils.io.tests
 import io.ktor.utils.io.core.*
 import io.ktor.utils.io.core.internal.*
 import io.ktor.utils.io.streams.*
-import org.junit.Test
 import org.junit.Rule
 import java.util.*
 import kotlin.test.*
@@ -269,9 +268,9 @@ class BytePacketReaderWriterTest {
 
         val outer = buildPacket {
             append("123")
-            kotlin.test.assertEquals(3, size)
+            assertEquals(3, size)
             writePacket(inner)
-            kotlin.test.assertEquals(6, size)
+            assertEquals(6, size)
             append(".")
         }
 
@@ -322,9 +321,9 @@ class BytePacketReaderWriterTest {
 
         val outer = buildPacket {
             append("1234")
-            kotlin.test.assertEquals(4, size)
+            assertEquals(4, size)
             writePacket(inner)
-            kotlin.test.assertEquals(5, size)
+            assertEquals(5, size)
         }
 
         assertEquals("1234.", outer.readText())
@@ -339,9 +338,9 @@ class BytePacketReaderWriterTest {
 
         val outer = buildPacket {
             append("1234")
-            kotlin.test.assertEquals(4, size)
+            assertEquals(4, size)
             writePacket(inner)
-            kotlin.test.assertEquals(5, size)
+            assertEquals(5, size)
         }
 
         assertEquals("1234.", outer.readText())
@@ -356,9 +355,9 @@ class BytePacketReaderWriterTest {
 
         val outer = buildPacket {
             append("123")
-            kotlin.test.assertEquals(3, size)
+            assertEquals(3, size)
             writePacket(inner.copy())
-            kotlin.test.assertEquals(6, size)
+            assertEquals(6, size)
             append(".")
         }
 
@@ -375,9 +374,9 @@ class BytePacketReaderWriterTest {
 
         val outer = buildPacket {
             append("123")
-            kotlin.test.assertEquals(3, size)
+            assertEquals(3, size)
             writePacket(inner.copy())
-            kotlin.test.assertEquals(100003, size)
+            assertEquals(100003, size)
             append(".")
         }
 

--- a/ktor-io/jvm/test/io/ktor/utils/io/tests/PacketInteropTest.kt
+++ b/ktor-io/jvm/test/io/ktor/utils/io/tests/PacketInteropTest.kt
@@ -3,8 +3,6 @@ package io.ktor.utils.io.tests
 import io.ktor.utils.io.core.*
 import io.ktor.utils.io.nio.*
 import io.ktor.utils.io.streams.*
-import org.junit.Test
-import org.junit.Ignore
 import java.io.*
 import java.nio.*
 import java.nio.ByteOrder

--- a/ktor-network/jvm/test/io/ktor/network/sockets/tests/ClientSocketTest.kt
+++ b/ktor-network/jvm/test/io/ktor/network/sockets/tests/ClientSocketTest.kt
@@ -7,17 +7,17 @@ package io.ktor.network.sockets.tests
 import io.ktor.network.selector.*
 import io.ktor.network.sockets.*
 import io.ktor.network.sockets.Socket
+import io.ktor.utils.io.*
 import kotlinx.coroutines.*
 import kotlinx.coroutines.debug.junit4.*
-import io.ktor.utils.io.*
 import org.junit.*
-import org.junit.Test
 import org.junit.rules.*
 import java.net.ServerSocket
 import java.nio.*
 import java.util.concurrent.*
 import kotlin.concurrent.*
 import kotlin.test.*
+import kotlin.test.Test
 
 class ClientSocketTest {
     private val exec = Executors.newCachedThreadPool()
@@ -30,7 +30,7 @@ class ClientSocketTest {
     @get:Rule
     val errors = ErrorCollector()
 
-    @After
+    @AfterTest
     fun tearDown() {
         server?.let { (server, thread) ->
             server.close()
@@ -100,7 +100,7 @@ class ClientSocketTest {
     }
 
     private fun server(block: (java.net.Socket) -> Unit) {
-        val server = java.net.ServerSocket(0)
+        val server = ServerSocket(0)
         val thread = thread(start = false) {
             try {
                 while (true) {

--- a/ktor-network/jvm/test/io/ktor/network/sockets/tests/ServerSocketTest.kt
+++ b/ktor-network/jvm/test/io/ktor/network/sockets/tests/ServerSocketTest.kt
@@ -40,7 +40,7 @@ class ServerSocketTest : CoroutineScope {
     @get:Rule
     val timeout = CoroutinesTimeout.seconds(15)
 
-    @After
+    @AfterTest
     fun tearDown() {
         testJob.cancel()
         tearDown = true

--- a/ktor-network/ktor-network-tls/jvm/test/io/ktor/network/tls/tests/ConnectionTests.kt
+++ b/ktor-network/ktor-network-tls/jvm/test/io/ktor/network/tls/tests/ConnectionTests.kt
@@ -27,7 +27,6 @@ import java.net.ServerSocket
 import java.security.*
 import java.security.cert.*
 import javax.net.ssl.*
-import kotlin.io.use
 import kotlin.test.*
 
 class ConnectionTests {

--- a/ktor-server/ktor-server-cio/jvm/test/io/ktor/tests/server/cio/CIOHttpClientTest.kt
+++ b/ktor-server/ktor-server-cio/jvm/test/io/ktor/tests/server/cio/CIOHttpClientTest.kt
@@ -16,7 +16,6 @@ import io.ktor.client.utils.*
 import io.ktor.http.*
 import io.ktor.http.content.*
 import kotlinx.coroutines.*
-import org.junit.Test
 import java.io.*
 import java.net.*
 import java.time.*

--- a/ktor-server/ktor-server-core/jvm/test/io/ktor/tests/routing/RouteSelectorTest.kt
+++ b/ktor-server/ktor-server-core/jvm/test/io/ktor/tests/routing/RouteSelectorTest.kt
@@ -5,7 +5,6 @@
 package io.ktor.tests.routing
 
 import io.ktor.routing.*
-import org.junit.Test
 import kotlin.test.*
 
 internal class RouteSelectorTest {

--- a/ktor-server/ktor-server-host-common/jvm/test/io/ktor/tests/hosts/ApplicationEngineEnvironmentReloadingTests.kt
+++ b/ktor-server/ktor-server-host-common/jvm/test/io/ktor/tests/hosts/ApplicationEngineEnvironmentReloadingTests.kt
@@ -9,7 +9,6 @@ import io.ktor.application.*
 import io.ktor.config.*
 import io.ktor.server.engine.*
 import io.ktor.util.*
-import org.junit.Test
 import kotlin.reflect.*
 import kotlin.reflect.jvm.*
 import kotlin.test.*

--- a/ktor-server/ktor-server-host-common/jvm/test/io/ktor/tests/hosts/CommandLineTest.kt
+++ b/ktor-server/ktor-server-host-common/jvm/test/io/ktor/tests/hosts/CommandLineTest.kt
@@ -7,7 +7,6 @@ package io.ktor.tests.hosts
 import com.typesafe.config.*
 import io.ktor.server.engine.*
 import org.junit.*
-import org.junit.Test
 import org.junit.rules.*
 import org.junit.runner.*
 import org.junit.runners.model.*
@@ -15,6 +14,7 @@ import java.io.*
 import java.net.*
 import java.util.*
 import kotlin.test.*
+import kotlin.test.Test
 
 class CommandLineTest {
 

--- a/ktor-server/ktor-server-jetty/jvm/test/io/ktor/tests/server/jetty/JettyBlockingServletContainerTest.kt
+++ b/ktor-server/ktor-server-jetty/jvm/test/io/ktor/tests/server/jetty/JettyBlockingServletContainerTest.kt
@@ -6,7 +6,7 @@ package io.ktor.tests.server.jetty
 
 import io.ktor.server.jetty.*
 import io.ktor.server.testing.suites.*
-import org.junit.*
+import kotlin.test.*
 
 class JettyBlockingServletContainerCompressionTest :
     CompressionTestSuite<JettyApplicationEngineBase, JettyApplicationEngineBase.Configuration>(Servlet(async = false))

--- a/ktor-server/ktor-server-jetty/jvm/test/io/ktor/tests/server/jetty/MultipleDispatchOnTimeout.kt
+++ b/ktor-server/ktor-server-jetty/jvm/test/io/ktor/tests/server/jetty/MultipleDispatchOnTimeout.kt
@@ -9,7 +9,6 @@ import io.ktor.response.*
 import io.ktor.server.engine.*
 import io.ktor.server.jetty.*
 import io.ktor.server.servlet.*
-import org.junit.Test
 import org.slf4j.*
 import java.net.*
 import java.util.concurrent.*

--- a/ktor-server/ktor-server-jetty/ktor-server-jetty-test-http2/jvm/test/io/ktor/tests/server/jetty/http2/JettyHttp2ServletBlockingTest.kt
+++ b/ktor-server/ktor-server-jetty/ktor-server-jetty-test-http2/jvm/test/io/ktor/tests/server/jetty/http2/JettyHttp2ServletBlockingTest.kt
@@ -6,7 +6,7 @@ package io.ktor.tests.server.jetty.http2
 
 import io.ktor.server.jetty.*
 import io.ktor.server.testing.suites.*
-import org.junit.*
+import kotlin.test.*
 
 class JettyHttp2BlockingServletContainerCompressionTest :
     CompressionTestSuite<JettyApplicationEngineBase, JettyApplicationEngineBase.Configuration>(Servlet(async = false))

--- a/ktor-server/ktor-server-jetty/ktor-server-jetty-test-http2/jvm/test/io/ktor/tests/server/jetty/http2/MultipleDispatchOnTimeout.kt
+++ b/ktor-server/ktor-server-jetty/ktor-server-jetty-test-http2/jvm/test/io/ktor/tests/server/jetty/http2/MultipleDispatchOnTimeout.kt
@@ -9,7 +9,6 @@ import io.ktor.response.*
 import io.ktor.server.engine.*
 import io.ktor.server.jetty.*
 import io.ktor.server.servlet.*
-import org.junit.Test
 import org.slf4j.*
 import java.net.*
 import java.util.concurrent.*

--- a/ktor-server/ktor-server-test-host/jvm/src/io/ktor/server/testing/EngineTestBase.kt
+++ b/ktor-server/ktor-server-test-host/jvm/src/io/ktor/server/testing/EngineTestBase.kt
@@ -86,7 +86,7 @@ public abstract class EngineTestBase<TEngine : ApplicationEngine, TConfiguration
 
     protected val socketReadTimeout: Int by lazy { TimeUnit.SECONDS.toMillis(timeout).toInt() }
 
-    @Before
+    @BeforeTest
     public fun setUpBase() {
         val method = this.javaClass.getMethod(test.methodName) ?: fail("Method ${test.methodName} not found")
 
@@ -106,7 +106,7 @@ public abstract class EngineTestBase<TEngine : ApplicationEngine, TConfiguration
         exceptions.clear()
     }
 
-    @After
+    @AfterTest
     public fun tearDownBase() {
         try {
             allConnections.forEach { it.disconnect() }

--- a/ktor-server/ktor-server-test-suites/jvm/src/io/ktor/server/testing/suites/EngineStressSuite.kt
+++ b/ktor-server/ktor-server-test-suites/jvm/src/io/ktor/server/testing/suites/EngineStressSuite.kt
@@ -18,7 +18,6 @@ import io.ktor.server.testing.*
 import kotlinx.coroutines.*
 import io.ktor.utils.io.*
 import io.ktor.utils.io.streams.*
-import org.junit.Test
 import org.junit.runner.*
 import org.junit.runners.model.*
 import java.net.*

--- a/ktor-server/ktor-server-tests/jvm/test/io/ktor/tests/server/application/ApplicationEventTest.kt
+++ b/ktor-server/ktor-server-tests/jvm/test/io/ktor/tests/server/application/ApplicationEventTest.kt
@@ -6,7 +6,6 @@ package io.ktor.tests.server.application
 
 import io.ktor.application.*
 import io.ktor.server.testing.*
-import org.junit.Test
 import kotlin.test.*
 
 class ApplicationEventTest {

--- a/ktor-server/ktor-server-tests/jvm/test/io/ktor/tests/server/application/ApplicationRequestHeaderTest.kt
+++ b/ktor-server/ktor-server-tests/jvm/test/io/ktor/tests/server/application/ApplicationRequestHeaderTest.kt
@@ -10,7 +10,6 @@ import io.ktor.request.*
 import io.ktor.response.*
 import io.ktor.routing.*
 import io.ktor.server.testing.*
-import org.junit.Test
 import kotlin.test.*
 
 class ApplicationRequestHeaderTest {

--- a/ktor-server/ktor-server-tests/jvm/test/io/ktor/tests/server/application/HandlerTest.kt
+++ b/ktor-server/ktor-server-tests/jvm/test/io/ktor/tests/server/application/HandlerTest.kt
@@ -9,7 +9,6 @@ import io.ktor.http.*
 import io.ktor.request.*
 import io.ktor.response.*
 import io.ktor.server.testing.*
-import org.junit.Test
 import kotlin.test.*
 
 class HandlerTest {

--- a/ktor-server/ktor-server-tests/jvm/test/io/ktor/tests/server/features/CORSTest.kt
+++ b/ktor-server/ktor-server-tests/jvm/test/io/ktor/tests/server/features/CORSTest.kt
@@ -10,7 +10,6 @@ import io.ktor.http.*
 import io.ktor.response.*
 import io.ktor.routing.*
 import io.ktor.server.testing.*
-import org.junit.Test
 import kotlin.test.*
 
 class CORSTest {

--- a/ktor-server/ktor-server-tests/jvm/test/io/ktor/tests/server/features/CallIdTest.kt
+++ b/ktor-server/ktor-server-tests/jvm/test/io/ktor/tests/server/features/CallIdTest.kt
@@ -11,7 +11,6 @@ import io.ktor.request.*
 import io.ktor.response.*
 import io.ktor.server.testing.*
 import io.ktor.util.pipeline.*
-import org.junit.Test
 import kotlin.test.*
 
 class CallIdTest {

--- a/ktor-server/ktor-server-tests/jvm/test/io/ktor/tests/server/features/CallLoggingTest.kt
+++ b/ktor-server/ktor-server-tests/jvm/test/io/ktor/tests/server/features/CallLoggingTest.kt
@@ -12,8 +12,6 @@ import io.ktor.response.*
 import io.ktor.routing.*
 import io.ktor.server.testing.*
 import kotlinx.coroutines.*
-import org.junit.*
-import org.junit.Test
 import org.slf4j.*
 import org.slf4j.event.*
 import kotlin.test.*
@@ -50,7 +48,7 @@ class CallLoggingTest {
     }
 
 
-    @Before
+    @BeforeTest
     fun setup() {
         messages = ArrayList()
     }

--- a/ktor-server/ktor-server-tests/jvm/test/io/ktor/tests/server/features/ConditionalHeadersTests.kt
+++ b/ktor-server/ktor-server-tests/jvm/test/io/ktor/tests/server/features/ConditionalHeadersTests.kt
@@ -5,9 +5,9 @@
 package io.ktor.tests.server.features
 
 import io.ktor.application.*
-import io.ktor.http.content.*
 import io.ktor.features.*
 import io.ktor.http.*
+import io.ktor.http.content.*
 import io.ktor.response.*
 import io.ktor.routing.*
 import io.ktor.server.testing.*
@@ -574,7 +574,7 @@ class LastModifiedVersionTest {
             }
 
             // guard: file lastmodified is actually set as expected
-            Assert.assertEquals(input.time, file.lastModified())
+            assertEquals(input.time, file.lastModified())
 
             // setup: object to test
             LastModifiedVersion(Files.getLastModifiedTime(file.toPath()))

--- a/ktor-server/ktor-server-tests/jvm/test/io/ktor/tests/server/features/DataConversionTest.kt
+++ b/ktor-server/ktor-server-tests/jvm/test/io/ktor/tests/server/features/DataConversionTest.kt
@@ -8,7 +8,6 @@ import io.ktor.application.*
 import io.ktor.features.*
 import io.ktor.server.testing.*
 import io.ktor.util.*
-import org.junit.Test
 import java.math.*
 import kotlin.reflect.jvm.*
 import kotlin.test.*

--- a/ktor-server/ktor-server-tests/jvm/test/io/ktor/tests/server/features/HeadTest.kt
+++ b/ktor-server/ktor-server-tests/jvm/test/io/ktor/tests/server/features/HeadTest.kt
@@ -12,7 +12,6 @@ import io.ktor.response.*
 import io.ktor.routing.*
 import io.ktor.server.testing.*
 import io.ktor.utils.io.*
-import org.junit.Test
 import java.lang.IllegalStateException
 import kotlin.test.*
 

--- a/ktor-server/ktor-server-tests/jvm/test/io/ktor/tests/server/features/HttpsRedirectFeatureTest.kt
+++ b/ktor-server/ktor-server-tests/jvm/test/io/ktor/tests/server/features/HttpsRedirectFeatureTest.kt
@@ -10,7 +10,6 @@ import io.ktor.http.*
 import io.ktor.response.*
 import io.ktor.routing.*
 import io.ktor.server.testing.*
-import org.junit.Test
 import kotlin.test.*
 
 class HttpsRedirectFeatureTest {

--- a/ktor-server/ktor-server-tests/jvm/test/io/ktor/tests/server/features/PartialContentTest.kt
+++ b/ktor-server/ktor-server-tests/jvm/test/io/ktor/tests/server/features/PartialContentTest.kt
@@ -12,7 +12,6 @@ import io.ktor.response.*
 import io.ktor.routing.*
 import io.ktor.server.testing.*
 import io.ktor.util.date.*
-import org.junit.Test
 import java.io.*
 import java.util.*
 import kotlin.test.*

--- a/ktor-server/ktor-server-tests/jvm/test/io/ktor/tests/server/features/StaticContentTest.kt
+++ b/ktor-server/ktor-server-tests/jvm/test/io/ktor/tests/server/features/StaticContentTest.kt
@@ -12,7 +12,6 @@ import io.ktor.request.*
 import io.ktor.response.*
 import io.ktor.routing.*
 import io.ktor.server.testing.*
-import org.junit.Test
 import java.io.*
 import java.nio.file.*
 import kotlin.test.*

--- a/ktor-server/ktor-server-tests/jvm/test/io/ktor/tests/server/http/HeadersTest.kt
+++ b/ktor-server/ktor-server-tests/jvm/test/io/ktor/tests/server/http/HeadersTest.kt
@@ -9,8 +9,6 @@ import io.ktor.http.*
 import io.ktor.response.*
 import io.ktor.routing.*
 import io.ktor.server.testing.*
-import io.ktor.util.*
-import org.junit.Test
 import kotlin.test.*
 
 class HeadersTest {

--- a/ktor-server/ktor-server-tests/jvm/test/io/ktor/tests/server/http/RespondFunctionsTest.kt
+++ b/ktor-server/ktor-server-tests/jvm/test/io/ktor/tests/server/http/RespondFunctionsTest.kt
@@ -9,7 +9,6 @@ import io.ktor.http.*
 import io.ktor.response.*
 import io.ktor.routing.*
 import io.ktor.server.testing.*
-import org.junit.Test
 import kotlin.test.*
 
 class RespondFunctionsTest {

--- a/ktor-server/ktor-server-tests/jvm/test/io/ktor/tests/server/http/RespondWriteTest.kt
+++ b/ktor-server/ktor-server-tests/jvm/test/io/ktor/tests/server/http/RespondWriteTest.kt
@@ -10,7 +10,6 @@ import io.ktor.response.*
 import io.ktor.routing.*
 import io.ktor.server.testing.*
 import kotlinx.coroutines.*
-import org.junit.Test
 import java.util.concurrent.*
 import kotlin.test.*
 

--- a/ktor-server/ktor-server-tests/jvm/test/io/ktor/tests/server/http/TestEngineMultipartTest.kt
+++ b/ktor-server/ktor-server-tests/jvm/test/io/ktor/tests/server/http/TestEngineMultipartTest.kt
@@ -12,7 +12,6 @@ import io.ktor.server.testing.*
 import io.ktor.util.*
 import io.ktor.utils.io.core.*
 import io.ktor.utils.io.streams.*
-import org.junit.Test
 import kotlin.test.*
 
 class TestEngineMultipartTest {

--- a/ktor-server/ktor-server-tests/jvm/test/io/ktor/tests/server/http/URLBuilderTest.kt
+++ b/ktor-server/ktor-server-tests/jvm/test/io/ktor/tests/server/http/URLBuilderTest.kt
@@ -9,7 +9,6 @@ import io.ktor.features.*
 import io.ktor.http.*
 import io.ktor.server.testing.*
 import io.ktor.util.*
-import org.junit.Test
 import kotlin.test.*
 
 class URLBuilderTest {

--- a/ktor-server/ktor-server-tests/jvm/test/io/ktor/tests/server/http/UrlEncodedTest.kt
+++ b/ktor-server/ktor-server-tests/jvm/test/io/ktor/tests/server/http/UrlEncodedTest.kt
@@ -8,7 +8,6 @@ import io.ktor.http.*
 import io.ktor.request.*
 import io.ktor.server.testing.*
 import kotlinx.coroutines.*
-import org.junit.Test
 import kotlin.test.*
 
 class UrlEncodedTest {

--- a/ktor-server/ktor-server-tests/jvm/test/io/ktor/tests/server/routing/RoutingBuildTest.kt
+++ b/ktor-server/ktor-server-tests/jvm/test/io/ktor/tests/server/routing/RoutingBuildTest.kt
@@ -6,7 +6,6 @@ package io.ktor.tests.server.routing
 
 import io.ktor.routing.*
 import io.ktor.server.testing.*
-import org.junit.Test
 import kotlin.test.*
 
 class RoutingBuildTest {

--- a/ktor-server/ktor-server-tests/jvm/test/io/ktor/tests/server/routing/RoutingProcessingTest.kt
+++ b/ktor-server/ktor-server-tests/jvm/test/io/ktor/tests/server/routing/RoutingProcessingTest.kt
@@ -10,7 +10,6 @@ import io.ktor.request.*
 import io.ktor.response.*
 import io.ktor.routing.*
 import io.ktor.server.testing.*
-import org.junit.Test
 import kotlin.test.*
 
 private enum class SelectedRoute { Get, Param, Header, None }

--- a/ktor-server/ktor-server-tests/jvm/test/io/ktor/tests/server/sessions/AutoSerializerTest.kt
+++ b/ktor-server/ktor-server-tests/jvm/test/io/ktor/tests/server/sessions/AutoSerializerTest.kt
@@ -6,7 +6,6 @@ package io.ktor.tests.server.sessions
 
 import io.ktor.http.*
 import io.ktor.sessions.*
-import org.junit.Test
 import java.math.*
 import java.util.*
 import kotlin.test.*

--- a/ktor-server/ktor-server-tests/jvm/test/io/ktor/tests/server/testing/TestApplicationEngineTest.kt
+++ b/ktor-server/ktor-server-tests/jvm/test/io/ktor/tests/server/testing/TestApplicationEngineTest.kt
@@ -14,7 +14,6 @@ import io.ktor.routing.*
 import io.ktor.server.testing.*
 import io.ktor.sessions.*
 import kotlinx.coroutines.*
-import org.junit.Test
 import java.util.concurrent.atomic.AtomicInteger
 import kotlin.coroutines.*
 import kotlin.system.*

--- a/ktor-server/ktor-server-tomcat/jvm/test/io/ktor/tests/server/tomcat/TomcatEngineTest.kt
+++ b/ktor-server/ktor-server-tomcat/jvm/test/io/ktor/tests/server/tomcat/TomcatEngineTest.kt
@@ -6,7 +6,7 @@ package io.ktor.tests.server.tomcat
 
 import io.ktor.server.testing.suites.*
 import io.ktor.server.tomcat.*
-import org.junit.*
+import kotlin.test.*
 import java.util.logging.*
 
 class TomcatCompressionTest :

--- a/ktor-utils/jvm/test/io/ktor/tests/utils/InputJvmTest.kt
+++ b/ktor-utils/jvm/test/io/ktor/tests/utils/InputJvmTest.kt
@@ -6,7 +6,6 @@ package io.ktor.tests.utils
 
 import io.ktor.util.*
 import io.ktor.utils.io.streams.*
-import org.junit.Test
 import kotlin.test.*
 
 class InputJvmTest {

--- a/ktor-utils/jvm/test/io/ktor/tests/utils/PipelineStackFramesTest.kt
+++ b/ktor-utils/jvm/test/io/ktor/tests/utils/PipelineStackFramesTest.kt
@@ -7,7 +7,6 @@ package io.ktor.tests.utils
 import io.ktor.util.*
 import io.ktor.util.pipeline.*
 import kotlinx.coroutines.*
-import org.junit.Test
 import kotlin.coroutines.*
 import kotlin.coroutines.intrinsics.*
 import kotlin.test.*


### PR DESCRIPTION
**Motivation**
Replace JUnit with kotlin.test as much as possible (https://youtrack.jetbrains.com/issue/KTOR-1187)

*Reason*
- Better Kotlin support, like assertEquals
- theoretical platform independent

JUnit will still used under the hood by kotlin.test-junit.

When using a `Runner` or a `Rule`, JUnit is still required.
