### PR TITLE
Fix illegal expires header behaviour

### DIFF
--- a/ktor-client/ktor-client-core/common/src/io/ktor/client/features/cache/HttpCacheEntry.kt
+++ b/ktor-client/ktor-client-core/common/src/io/ktor/client/features/cache/HttpCacheEntry.kt
@@ -82,8 +82,17 @@ internal fun HttpResponse.cacheExpires(): GMTDate {
         return call.response.requestTime + maxAge * 1000L
     }
 
-    headers[HttpHeaders.Expires]?.fromHttpToGmtDate()?.let { return it }
-    return GMTDate()
+    val expires = headers[HttpHeaders.Expires]
+    return expires?.let {
+        // Handle "0" case faster
+        if (it == "0") return GMTDate()
+
+        return try {
+            it.fromHttpToGmtDate()
+        } catch (e: Throwable) {
+            GMTDate()
+        }
+    } ?: GMTDate()
 }
 
 internal fun HttpCacheEntry.shouldValidate(): Boolean {

--- a/ktor-client/ktor-client-core/common/src/io/ktor/client/features/cache/HttpCacheEntry.kt
+++ b/ktor-client/ktor-client-core/common/src/io/ktor/client/features/cache/HttpCacheEntry.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2014-2020 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package io.ktor.client.features.cache
@@ -67,7 +67,7 @@ internal fun HttpResponse.varyKeys(): Map<String, String> {
     return result
 }
 
-internal fun HttpResponse.cacheExpires(): GMTDate {
+internal fun HttpResponse.cacheExpires(fallback: () -> GMTDate = { GMTDate() }): GMTDate {
     val cacheControl = cacheControl()
 
     val isPrivate = CacheControl.PRIVATE in cacheControl
@@ -85,14 +85,14 @@ internal fun HttpResponse.cacheExpires(): GMTDate {
     val expires = headers[HttpHeaders.Expires]
     return expires?.let {
         // Handle "0" case faster
-        if (it == "0") return GMTDate()
+        if (it == "0" || it.isBlank()) return fallback()
 
         return try {
             it.fromHttpToGmtDate()
         } catch (e: Throwable) {
-            GMTDate()
+            fallback()
         }
-    } ?: GMTDate()
+    } ?: fallback()
 }
 
 internal fun HttpCacheEntry.shouldValidate(): Boolean {

--- a/ktor-client/ktor-client-core/common/test/CacheExpiresTest.kt
+++ b/ktor-client/ktor-client-core/common/test/CacheExpiresTest.kt
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2014-2020 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+package io.ktor.client.features.cache.tests
+
+import io.ktor.client.call.*
+import io.ktor.client.features.cache.*
+import io.ktor.client.statement.*
+import io.ktor.client.utils.*
+import io.ktor.http.*
+import io.ktor.util.date.*
+import io.ktor.utils.io.*
+import kotlin.coroutines.*
+import kotlin.test.*
+
+class CacheExpiresTest {
+    @Test
+    fun testValidExpirationDate() {
+        val dateText = "Tue, 27 Oct 2020 15:21:07 GMT"
+        val parsed = dateText.fromHttpToGmtDate()
+
+        val response = response {
+            append(HttpHeaders.Expires, dateText)
+        }
+
+        val result = response.cacheExpires()
+        assertEquals(parsed, result)
+    }
+
+    @Test
+    fun testInvalidExpirationDate() {
+        val dateText = "A1231242323532452345"
+        val expected = GMTDate.START
+
+        val response = response {
+            append(HttpHeaders.Expires, dateText)
+        }
+
+        val result = response.cacheExpires { expected }
+        assertEquals(expected, result)
+    }
+
+    @Test
+    fun testInvalidExpirationDateZero() {
+        val dateText = "0"
+        val expected = GMTDate.START
+
+        val response = response {
+            append(HttpHeaders.Expires, dateText)
+        }
+
+        val result = response.cacheExpires { expected }
+        assertEquals(expected, result)
+    }
+
+    @Test
+    fun testInvalidExpirationDateEmpty() {
+        val dateText = ""
+        val expected = GMTDate.START
+
+        val response = response {
+            append(HttpHeaders.Expires, dateText)
+        }
+
+        val result = response.cacheExpires { expected }
+        assertEquals(expected, result)
+    }
+
+    @Test
+    fun testInvalidExpirationDateBlank() {
+        val dateText = " "
+        val expected = GMTDate.START
+
+        val response = response {
+            append(HttpHeaders.Expires, dateText)
+        }
+
+        val result = response.cacheExpires { expected }
+        assertEquals(expected, result)
+    }
+
+    private fun response(builder: HeadersBuilder.() -> Unit): HttpResponse {
+        return Response(buildHeaders(builder))
+    }
+
+    private class Response(override val headers: Headers) : HttpResponse() {
+        override val call: HttpClientCall get() = error("Shouldn't be used")
+        override val status: HttpStatusCode
+            get() = error("Shouldn't be used")
+        override val version: HttpProtocolVersion
+            get() = error("Shouldn't be used")
+        override val requestTime: GMTDate
+            get() = error("Shouldn't be used")
+        override val responseTime: GMTDate
+            get() = error("Shouldn't be used")
+        override val content: ByteReadChannel
+            get() = error("Shouldn't be used")
+        override val coroutineContext: CoroutineContext
+            get() = error("Shouldn't be used")
+    }
+}

--- a/ktor-client/ktor-client-tests/jvm/src/io/ktor/client/tests/utils/tests/Cache.kt
+++ b/ktor-client/ktor-client-tests/jvm/src/io/ktor/client/tests/utils/tests/Cache.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2014-2020 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package io.ktor.client.tests.utils.tests
@@ -34,6 +34,12 @@ internal fun Application.cacheTestServer() {
             get("/max-age") {
                 val value = counter.incrementAndGet()
                 call.response.cacheControl(CacheControl.MaxAge(2))
+                call.respondText("$value")
+            }
+            get("/expires") {
+                // note: we don't add X-Expires to Vary intentionally
+                val value = counter.incrementAndGet()
+                call.response.header(HttpHeaders.Expires, call.request.headers["X-Expires"] ?: "?")
                 call.respondText("$value")
             }
 


### PR DESCRIPTION
**Subsystem**
ktor-client-core

**Motivation**
[KTOR-364](https://youtrack.jetbrains.com/issue/KTOR-364)  Ktor Client HTTP Cache for invalid or blank Expires header 

This is based on user's PR #2102 


