### PR TITLE
Use JvmName for deprecated-hidden conflicting overloads

### DIFF
--- a/ktor-features/ktor-serialization/jvm/src/io/ktor/serialization/JsonSupport.kt
+++ b/ktor-features/ktor-serialization/jvm/src/io/ktor/serialization/JsonSupport.kt
@@ -115,8 +115,7 @@ public fun ContentNegotiation.Configuration.serialization(
  * Register kotlinx.serialization converter into [ContentNegotiation] feature
  */
 @Deprecated("Use json function instead.", ReplaceWith("json(json, contentType)"))
-@JvmName("serialization")
-public fun ContentNegotiation.Configuration.serialization0(
+public fun ContentNegotiation.Configuration.serialization(
     contentType: ContentType,
     json: Json
 ) {

--- a/ktor-features/ktor-serialization/jvm/src/io/ktor/serialization/JsonSupport.kt
+++ b/ktor-features/ktor-serialization/jvm/src/io/ktor/serialization/JsonSupport.kt
@@ -114,9 +114,9 @@ public fun ContentNegotiation.Configuration.serialization(
 /**
  * Register kotlinx.serialization converter into [ContentNegotiation] feature
  */
-@Suppress("CONFLICTING_OVERLOADS") // conflict with hidden declaration
 @Deprecated("Use json function instead.", ReplaceWith("json(json, contentType)"))
-public fun ContentNegotiation.Configuration.serialization(
+@JvmName("serialization")
+public fun ContentNegotiation.Configuration.serialization0(
     contentType: ContentType,
     json: Json
 ) {

--- a/ktor-features/ktor-serialization/jvm/src/io/ktor/serialization/SerializationConverter.kt
+++ b/ktor-features/ktor-serialization/jvm/src/io/ktor/serialization/SerializationConverter.kt
@@ -145,9 +145,10 @@ private constructor(
     }
 }
 
-@Suppress("unused", "CONFLICTING_OVERLOADS")
+@Suppress("unused")
 @Deprecated("Use json function instead.", level = DeprecationLevel.HIDDEN)
-public fun ContentNegotiation.Configuration.serialization(
+@JvmName("serialization")
+public fun ContentNegotiation.Configuration.serialization0(
     contentType: ContentType = ContentType.Application.Json,
     json: Json = DefaultJson
 ) {

--- a/ktor-http/ktor-http-cio/jvm/src/io/ktor/http/cio/websocket/Frame.kt
+++ b/ktor-http/ktor-http-cio/jvm/src/io/ktor/http/cio/websocket/Frame.kt
@@ -131,6 +131,7 @@ public actual sealed class Frame actual constructor(
     }
 }
 
-@Suppress("CONFLICTING_OVERLOADS", "KDocMissingDocumentation", "unused")
+@Suppress("KDocMissingDocumentation", "unused")
 @Deprecated("Binary compatibility", level = DeprecationLevel.HIDDEN)
-public fun Frame.Close.readReason(): CloseReason? = readReason()
+@JvmName("readReason")
+public fun Frame.Close.readReason0(): CloseReason? = readReason()

--- a/ktor-server/ktor-server-core/jvm/src/io/ktor/http/HttpDate.kt
+++ b/ktor-server/ktor-server-core/jvm/src/io/ktor/http/HttpDate.kt
@@ -19,21 +19,23 @@ public fun Long.toHttpDateString(): String = GMTDate(this).toHttpDate()
 /**
  * Format as HTTP date (GMT)
  */
-@Suppress("CONFLICTING_OVERLOADS", "unused")
+@Suppress("unused")
 @Deprecated("Binary compatibility.", level = DeprecationLevel.HIDDEN)
-public fun Temporal.toHttpDateString(): String = toHttpDateString()
+@JvmName("toHttpDateString")
+public fun Temporal.toHttpDateString0(): String = toHttpDateString()
 
 /**
  * Parse HTTP date to [ZonedDateTime]
  */
-@Suppress("CONFLICTING_OVERLOADS", "unused")
+@Suppress("unused")
 @Deprecated("Binary compatibility.", level = DeprecationLevel.HIDDEN)
-public fun String.fromHttpDateString(): ZonedDateTime = ZonedDateTime.parse(this, httpDateFormat)
+@JvmName("fromHttpDateString")
+public fun String.fromHttpDateString0(): ZonedDateTime = ZonedDateTime.parse(this, httpDateFormat)
 
 /**
  * Default HTTP date format
  */
-@Suppress("CONFLICTING_OVERLOADS", "REDECLARATION", "unused")
+@Suppress("unused")
 @Deprecated("Binary compatibility.", level = DeprecationLevel.HIDDEN)
-public val httpDateFormat: DateTimeFormatter
-    get() = httpDateFormat
+public val httpDateFormat0: DateTimeFormatter
+    @JvmName("httpDateFormat") get() = httpDateFormat

--- a/ktor-server/ktor-server-core/jvm/src/io/ktor/http/HttpDate.kt
+++ b/ktor-server/ktor-server-core/jvm/src/io/ktor/http/HttpDate.kt
@@ -38,4 +38,4 @@ public fun String.fromHttpDateString0(): ZonedDateTime = ZonedDateTime.parse(thi
 @Suppress("unused")
 @Deprecated("Binary compatibility.", level = DeprecationLevel.HIDDEN)
 public val httpDateFormat0: DateTimeFormatter
-    @JvmName("httpDateFormat") get() = httpDateFormat
+    @JvmName("getHttpDateFormat") get() = httpDateFormat


### PR DESCRIPTION
Instead of suppressing errors, which doesn't work with JVM IR.
