### PR TITLE
KTOR-1129 Delegate to original OutgoingContent when logging body

### DIFF
--- a/ktor-client/ktor-client-features/ktor-client-logging/common/src/io/ktor/client/features/logging/LoggedContent.kt
+++ b/ktor-client/ktor-client-features/ktor-client-logging/common/src/io/ktor/client/features/logging/LoggedContent.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2014-2020 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.client.features.logging
+
+import io.ktor.http.*
+import io.ktor.http.content.*
+import io.ktor.util.*
+import io.ktor.utils.io.*
+
+internal class LoggedContent(
+    private val originalContent: OutgoingContent,
+    private val channel: ByteReadChannel
+) : OutgoingContent.ReadChannelContent() {
+
+    override val contentType: ContentType? = originalContent.contentType
+    override val contentLength: Long? = originalContent.contentLength
+    override val status: HttpStatusCode? = originalContent.status
+    override val headers: Headers = originalContent.headers
+
+    override fun <T : Any> getProperty(key: AttributeKey<T>): T? = originalContent.getProperty(key)
+
+    override fun <T : Any> setProperty(key: AttributeKey<T>, value: T?) =
+        originalContent.setProperty(key, value)
+
+    override fun readFrom(): ByteReadChannel = channel
+}

--- a/ktor-client/ktor-client-features/ktor-client-logging/common/src/io/ktor/client/features/logging/ObservingUtils.kt
+++ b/ktor-client/ktor-client-features/ktor-client-logging/common/src/io/ktor/client/features/logging/ObservingUtils.kt
@@ -4,7 +4,6 @@
 
 package io.ktor.client.features.logging
 
-import io.ktor.http.*
 import io.ktor.http.content.*
 import io.ktor.util.*
 import io.ktor.utils.io.*
@@ -21,36 +20,18 @@ internal suspend fun OutgoingContent.observe(log: ByteWriteChannel): OutgoingCon
         val content = readFrom()
 
         content.copyToBoth(log, responseChannel)
-        LoggingContent(this, responseChannel)
+        LoggedContent(this, responseChannel)
     }
     is OutgoingContent.WriteChannelContent -> {
         val responseChannel = ByteChannel()
         val content = toReadChannel()
         content.copyToBoth(log, responseChannel)
-        LoggingContent(this, responseChannel)
+        LoggedContent(this, responseChannel)
     }
     else -> {
         log.close()
         this
     }
-}
-
-internal class LoggingContent(
-    private val originalContent: OutgoingContent,
-    private val channel: ByteReadChannel
-) : OutgoingContent.ReadChannelContent() {
-
-    override val contentType: ContentType? = originalContent.contentType
-    override val contentLength: Long? = originalContent.contentLength
-    override val status: HttpStatusCode? = originalContent.status
-    override val headers: Headers = originalContent.headers
-
-    override fun <T : Any> getProperty(key: AttributeKey<T>): T? = originalContent.getProperty(key)
-
-    override fun <T : Any> setProperty(key: AttributeKey<T>, value: T?) =
-        originalContent.setProperty(key, value)
-
-    override fun readFrom(): ByteReadChannel = channel
 }
 
 private fun OutgoingContent.WriteChannelContent.toReadChannel(


### PR DESCRIPTION
**Subsystem**
Client, Logging

**Motivation**
[Ktor 1.4.1 fails to upload file (submit form) when logging level = LogLevel.BODY](https://youtrack.jetbrains.com/issue/KTOR-1129)

**Solution**
Logging creates a new instance for the content of the request and drops its properties. This PR keeps them by delegating from new content to the old one. 

