### PR TITLE
KTOR-1241 Add PS files for key prep and clean-up

### DIFF
--- a/buildScripts/cleanupKeysWindows.ps1
+++ b/buildScripts/cleanupKeysWindows.ps1
@@ -1,0 +1,1 @@
+rm -r -fo "C:/Users/builduser/AppData/Roaming/gnupg/"

--- a/buildScripts/prepareKeysWindows.ps1
+++ b/buildScripts/prepareKeysWindows.ps1
@@ -1,0 +1,20 @@
+md $Env:SIGN_KEY_LOCATION -force
+cd $Env:SIGN_KEY_LOCATION
+
+
+# Hard-coding path for GPG since this fails on TeamCity
+# $gpg=(get-command gpg.exe).Path
+$gpg="C:\Program Files (x86)\Gpg4win\..\GnuPG\bin\gpg.exe"
+
+
+echo "Exporting public key"
+[System.IO.File]::WriteAllText("$pwd\keyfile", $Env:SIGN_KEY_PUBLIC)
+& $gpg --batch --import keyfile
+rm keyfile
+
+
+echo "Exporting private key"
+
+[System.IO.File]::WriteAllText("$pwd\keyfile", $Env:SIGN_KEY_PRIVATE)
+& $gpg --allow-secret-key-import --batch --import keyfile
+rm keyfile


### PR DESCRIPTION
Add prepare and clean-up Powershell files for keys for Windows machines. Currently TeamCity doesn't allow this information [to be stored in its own repository](https://youtrack.jetbrains.com/issue/TW-68479)