### PR TITLE
Rewrite ApacheRequestProducer

### DIFF
--- a/ktor-client/ktor-client-apache/jvm/src/io/ktor/client/engine/apache/ApacheEngine.kt
+++ b/ktor-client/ktor-client-apache/jvm/src/io/ktor/client/engine/apache/ApacheEngine.kt
@@ -33,14 +33,8 @@ internal class ApacheEngine(override val config: ApacheEngineConfig) : HttpClien
     override suspend fun execute(data: HttpRequestData): HttpResponseData {
         val callContext = callContext()
 
-        try {
-            val apacheRequest = ApacheRequestProducer(data, config, callContext)
-            return engine.sendRequest(apacheRequest, callContext, data)
-        } catch (cause: Exception) {
-            val mappedCause = mapCause(cause, data)
-            callContext.cancel(CancellationException("Failed to execute request.", mappedCause))
-            throw mappedCause
-        }
+        val apacheRequest = ApacheRequestProducer(data, config, callContext)
+        return engine.sendRequest(apacheRequest, callContext, data)
     }
 
     override fun close() {

--- a/ktor-client/ktor-client-apache/jvm/src/io/ktor/client/engine/apache/ApacheHttpRequest.kt
+++ b/ktor-client/ktor-client-apache/jvm/src/io/ktor/client/engine/apache/ApacheHttpRequest.kt
@@ -49,8 +49,11 @@ internal suspend fun CloseableHttpAsyncClient.sendRequest(
 
         val headers = HeadersImpl(rawHeaders)
         return HttpResponseData(status, requestTime, headers, version, consumer.responseChannel, callContext)
-    } finally {
+    } catch (cause: Exception) {
         future.cancel(true)
+        val mappedCause = mapCause(cause, requestData)
+        callContext.cancel(CancellationException("Failed to execute request.", mappedCause))
+        throw mappedCause
     }
 }
 

--- a/ktor-client/ktor-client-apache/jvm/src/io/ktor/client/engine/apache/ApacheHttpRequest.kt
+++ b/ktor-client/ktor-client-apache/jvm/src/io/ktor/client/engine/apache/ApacheHttpRequest.kt
@@ -49,11 +49,8 @@ internal suspend fun CloseableHttpAsyncClient.sendRequest(
 
         val headers = HeadersImpl(rawHeaders)
         return HttpResponseData(status, requestTime, headers, version, consumer.responseChannel, callContext)
-    } catch (cause: Exception) {
+    } finally {
         future.cancel(true)
-        val mappedCause = mapCause(cause, requestData)
-        callContext.cancel(CancellationException("Failed to execute request.", mappedCause))
-        throw mappedCause
     }
 }
 

--- a/ktor-client/ktor-client-apache/jvm/src/io/ktor/client/engine/apache/ApacheRequestProducer.kt
+++ b/ktor-client/ktor-client-apache/jvm/src/io/ktor/client/engine/apache/ApacheRequestProducer.kt
@@ -67,8 +67,9 @@ internal class ApacheRequestProducer(
     override fun resetRequest() {}
 
     override fun failed(cause: Exception) {
-        channel.cancel(cause)
-        producerJob.completeExceptionally(cause)
+        val mappedCause = mapCause(cause, requestData)
+        channel.cancel(mappedCause)
+        producerJob.completeExceptionally(mappedCause)
     }
 
     override fun produceContent(encoder: ContentEncoder, ioctrl: IOControl) {

--- a/ktor-client/ktor-client-apache/jvm/src/io/ktor/client/engine/apache/ApacheRequestProducer.kt
+++ b/ktor-client/ktor-client-apache/jvm/src/io/ktor/client/engine/apache/ApacheRequestProducer.kt
@@ -8,13 +8,11 @@ import io.ktor.client.call.*
 import io.ktor.client.engine.*
 import io.ktor.client.features.*
 import io.ktor.client.request.*
-import io.ktor.client.utils.*
 import io.ktor.http.*
 import io.ktor.http.content.*
 import io.ktor.utils.io.*
 import kotlinx.atomicfu.*
 import kotlinx.coroutines.*
-import kotlinx.coroutines.channels.*
 import org.apache.http.*
 import org.apache.http.HttpHeaders
 import org.apache.http.HttpRequest
@@ -31,29 +29,31 @@ import kotlin.coroutines.*
 internal class ApacheRequestProducer(
     private val requestData: HttpRequestData,
     private val config: ApacheEngineConfig,
-    private val callContext: CoroutineContext
-) : HttpAsyncRequestProducer {
-    private val requestChannel = Channel<ByteBuffer>(1)
+    callContext: CoroutineContext
+) : HttpAsyncRequestProducer, CoroutineScope {
+
     private val request: HttpUriRequest = setupRequest()
     private val host = URIUtils.extractHost(request.uri)!!
 
-    private val ioControl: AtomicRef<IOControl?> = atomic(null)
-    private val currentBuffer: AtomicRef<ByteBuffer?> = atomic(null)
+    private val waiting = atomic(false)
+    private val interestController = InterestControllerHolder()
+    private val channel: ByteReadChannel
+
+    private val producerJob = Job(callContext[Job])
+    override val coroutineContext: CoroutineContext = callContext + producerJob
 
     init {
-        when (val body = requestData.body) {
-            is OutgoingContent.ByteArrayContent -> {
-                requestChannel.offer(ByteBuffer.wrap(body.bytes()))
-                requestChannel.close()
-            }
+        channel = when (val body = requestData.body) {
+            is OutgoingContent.ByteArrayContent -> ByteReadChannel(body.bytes())
             is OutgoingContent.ProtocolUpgrade -> throw UnsupportedContentTypeException(body)
-            is OutgoingContent.NoContent -> requestChannel.close()
-            is OutgoingContent.ReadChannelContent -> prepareBody(body.readFrom())
-            is OutgoingContent.WriteChannelContent -> prepareBody(
-                GlobalScope.writer(Dispatchers.Unconfined, autoFlush = true) {
-                    body.writeTo(channel)
-                }.channel
-            )
+            is OutgoingContent.NoContent -> ByteReadChannel.Empty
+            is OutgoingContent.ReadChannelContent -> body.readFrom()
+            is OutgoingContent.WriteChannelContent -> GlobalScope.writer(callContext, autoFlush = true) {
+                body.writeTo(channel)
+            }.channel
+        }
+        producerJob.invokeOnCompletion { cause ->
+            channel.cancel(cause)
         }
     }
 
@@ -69,55 +69,41 @@ internal class ApacheRequestProducer(
     override fun resetRequest() {}
 
     override fun failed(cause: Exception) {
-        requestChannel.close(cause)
-
-        try {
-            requestChannel.poll()?.recycle()
-        } catch (_: Throwable) {
-        }
+        channel.cancel(cause)
+        producerJob.completeExceptionally(cause)
     }
 
     override fun produceContent(encoder: ContentEncoder, ioctrl: IOControl) {
-        var buffer = currentBuffer.getAndSet(null) ?: requestChannel.poll()
-
-        if (buffer == null) {
-            @OptIn(ExperimentalCoroutinesApi::class)
-            if (requestChannel.isClosedForReceive) {
-                encoder.complete()
-                return
-            }
-
-            ioctrl.suspendOutput()
-
-            ioControl.value = ioctrl
-            buffer = requestChannel.poll() ?: return
-
-            ioControl.value = null
-            try {
-                ioctrl.requestOutput()
-            } catch (cause: Throwable) {
-                buffer.recycle()
-                throw cause
-            }
+        if (waiting.value) {
+            return
         }
 
-        try {
-            encoder.write(buffer)
-        } catch (cause: Throwable) {
-            buffer.recycle()
-            throw cause
+        var result: Int
+        do {
+            result = channel.readAvailable { buffer: ByteBuffer ->
+                encoder.write(buffer)
+            }
+        } while (result > 0)
+
+        if (channel.isClosedForRead) {
+            encoder.complete()
+            return
         }
 
-        if (buffer.hasRemaining()) {
-            currentBuffer.value = buffer
-        } else {
-            buffer.recycle()
+        if (result == -1) {
+            interestController.suspendOutput(ioctrl)
+            launch(Dispatchers.Unconfined) {
+                waiting.getAndSet(true)
+                channel.awaitContent()
+                waiting.getAndSet(false)
+                interestController.resumeOutputIfPossible()
+            }
         }
     }
 
     override fun close() {
-        requestChannel.close()
-        currentBuffer.value?.recycle()
+        channel.cancel()
+        producerJob.complete()
     }
 
     private fun setupRequest(): HttpUriRequest = with(requestData) {
@@ -161,42 +147,6 @@ internal class ApacheRequestProducer(
         }
 
         return builder.build()
-    }
-
-    private fun prepareBody(bodyChannel: ByteReadChannel): Job {
-        val result = GlobalScope.launch(callContext) {
-            while (!bodyChannel.isClosedForRead) {
-                val buffer = HttpClientDefaultPool.borrow()
-                try {
-                    while (bodyChannel.readAvailable(buffer) != -1 && buffer.remaining() > 0) {
-                    }
-                    buffer.flip()
-                    requestChannel.send(buffer)
-                } catch (cause: Throwable) {
-                    HttpClientDefaultPool.recycle(buffer)
-                    currentBuffer.getAndSet(null)?.recycle()
-                    throw cause
-                }
-
-                ioControl.getAndSet(null)?.requestOutput()
-            }
-        }
-
-        result.invokeOnCompletion { cause ->
-            requestChannel.close(cause)
-            if (cause != null) callContext.cancel()
-            ioControl.getAndSet(null)?.requestOutput()
-        }
-
-        return result
-    }
-
-    private fun ByteBuffer.recycle() {
-        if (requestData.body is OutgoingContent.WriteChannelContent ||
-            requestData.body is OutgoingContent.ReadChannelContent
-        ) {
-            HttpClientDefaultPool.recycle(this)
-        }
     }
 }
 

--- a/ktor-client/ktor-client-apache/jvm/src/io/ktor/client/engine/apache/ApacheResponseConsumer.kt
+++ b/ktor-client/ktor-client-apache/jvm/src/io/ktor/client/engine/apache/ApacheResponseConsumer.kt
@@ -45,7 +45,7 @@ internal class ApacheResponseConsumer(
     override fun consumeContent(decoder: ContentDecoder, ioctrl: IOControl) {
         check(!waiting.value)
 
-        var result: Int = 0
+        var result: Int
         do {
             result = 0
             channel.writeAvailable {

--- a/ktor-client/ktor-client-apache/jvm/src/io/ktor/client/engine/apache/InterestControllerHolder.kt
+++ b/ktor-client/ktor-client-apache/jvm/src/io/ktor/client/engine/apache/InterestControllerHolder.kt
@@ -35,4 +35,24 @@ internal class InterestControllerHolder {
     public fun resumeInputIfPossible() {
         interestController.getAndSet(null)?.requestInput()
     }
+
+    /**
+     * Suspend output using [ioControl] and remember it so we may resume later.
+     * @throws IllegalStateException if there is another control saved before that wasn't resumed
+     */
+    public fun suspendOutput(ioControl: IOControl) {
+        ioControl.suspendOutput()
+        interestController.update { before ->
+            check(before == null || before === ioControl) { "IOControl is already published" }
+            ioControl
+        }
+    }
+
+    /**
+     * Try to resume an io control previously saved. Does nothing if wasn't suspended or already resumed.
+     * Stealing is atomic, so for every suspend invocation, only single resume is possible.
+     */
+    public fun resumeOutputIfPossible() {
+        interestController.getAndSet(null)?.requestOutput()
+    }
 }

--- a/ktor-client/ktor-client-apache/jvm/src/io/ktor/client/engine/apache/InterestControllerHolder.kt
+++ b/ktor-client/ktor-client-apache/jvm/src/io/ktor/client/engine/apache/InterestControllerHolder.kt
@@ -16,11 +16,27 @@ internal class InterestControllerHolder {
      */
     private val interestController = atomic<IOControl?>(null)
 
+    private val waitingInput = atomic(false)
+    private val waitingOutput = atomic(false)
+
+    /**
+     * Flag showing if input is suspended
+     */
+    public val inputSuspended: Boolean
+        get() = waitingInput.value
+
+    /**
+     * Flag showing if output is suspended
+     */
+    public val outputSuspended: Boolean
+        get() = waitingOutput.value
+
     /**
      * Suspend input using [ioControl] and remember it so we may resume later.
      * @throws IllegalStateException if there is another control saved before that wasn't resumed
      */
     public fun suspendInput(ioControl: IOControl) {
+        waitingInput.value = true
         ioControl.suspendInput()
         interestController.update { before ->
             check(before == null || before === ioControl) { "IOControl is already published" }
@@ -34,6 +50,7 @@ internal class InterestControllerHolder {
      */
     public fun resumeInputIfPossible() {
         interestController.getAndSet(null)?.requestInput()
+        waitingInput.value = false
     }
 
     /**
@@ -41,6 +58,7 @@ internal class InterestControllerHolder {
      * @throws IllegalStateException if there is another control saved before that wasn't resumed
      */
     public fun suspendOutput(ioControl: IOControl) {
+        waitingOutput.value = true
         ioControl.suspendOutput()
         interestController.update { before ->
             check(before == null || before === ioControl) { "IOControl is already published" }
@@ -54,5 +72,6 @@ internal class InterestControllerHolder {
      */
     public fun resumeOutputIfPossible() {
         interestController.getAndSet(null)?.requestOutput()
+        waitingOutput.value = false
     }
 }

--- a/ktor-client/ktor-client-apache/jvm/test/io/ktor/client/engine/apache/RequestProducerTest.kt
+++ b/ktor-client/ktor-client-apache/jvm/test/io/ktor/client/engine/apache/RequestProducerTest.kt
@@ -9,15 +9,18 @@ import io.ktor.http.*
 import io.ktor.http.HttpHeaders
 import io.ktor.http.content.*
 import io.ktor.util.*
+import io.ktor.utils.io.*
 import kotlinx.coroutines.*
 import org.apache.http.*
+import org.apache.http.nio.*
+import java.nio.*
 import kotlin.coroutines.*
 import kotlin.test.*
 
 class RequestProducerTest {
 
     @Test
-    fun testHeadersMerge() {
+    fun testHeadersMerge() = runBlocking {
         val request = ApacheRequestProducer(
             HttpRequestData(
                 Url("http://127.0.0.1/"),
@@ -36,5 +39,210 @@ class RequestProducerTest {
 
         assertEquals(ContentType.Application.Json.toString(), request.entity.contentType.value)
         assertEquals(2, request.entity.contentLength)
+    }
+
+    @Test
+    fun testProducingByteArrayContent() = runBlocking {
+        val bytes = "x".repeat(10000).toByteArray()
+        val producer = producer(ByteArrayContent(bytes), coroutineContext)
+
+        val encoder = TestEncoder()
+        val ioctrl = TestIOControl()
+
+        val result = async {
+            encoder.channel.readRemaining().readText()
+        }
+
+        while (!encoder.isCompleted) {
+            if (ioctrl.outputSuspended) continue
+            producer.produceContent(encoder, ioctrl)
+        }
+
+        assertEquals("x".repeat(10000), result.await())
+        producer.close()
+    }
+
+    @Test
+    fun testProducingNoContent() = runBlocking {
+        val producer = producer(object : OutgoingContent.NoContent() {}, coroutineContext)
+
+        val encoder = TestEncoder()
+        val ioctrl = TestIOControl()
+
+        val result = async {
+            encoder.channel.readRemaining().readText()
+        }
+
+        while (!encoder.isCompleted) {
+            if (ioctrl.outputSuspended) continue
+            producer.produceContent(encoder, ioctrl)
+        }
+
+        assertEquals("", result.await())
+        producer.close()
+    }
+
+    @Test
+    fun testProducingReadChannelContent() = runBlocking {
+        val content = ByteChannel(true)
+        val body = object : OutgoingContent.ReadChannelContent() {
+            override fun readFrom(): ByteReadChannel = content
+        }
+        val producer = producer(body, coroutineContext)
+
+        val encoder = TestEncoder()
+        val ioctrl = TestIOControl()
+
+        GlobalScope.launch {
+            content.writeStringUtf8("x")
+            delay(10)
+            content.writeStringUtf8("x")
+            delay(10)
+            content.writeStringUtf8("x")
+            delay(10)
+            content.writeStringUtf8("x")
+            delay(10)
+            content.writeStringUtf8("x")
+            delay(10)
+            content.close()
+        }
+
+        val result = async {
+            encoder.channel.readRemaining().readText()
+        }
+
+        while (!encoder.isCompleted) {
+            if (ioctrl.outputSuspended) continue
+            producer.produceContent(encoder, ioctrl)
+        }
+
+        assertEquals("xxxxx", result.await())
+        producer.close()
+    }
+
+    @Test
+    fun testProducingWriteChannelContent() = runBlocking {
+        val body = ChannelWriterContent(
+            body = {
+                writeStringUtf8("x")
+                delay(100)
+                writeStringUtf8("x")
+                delay(100)
+                writeStringUtf8("x")
+                delay(100)
+                writeStringUtf8("x")
+                delay(100)
+                writeStringUtf8("x")
+                delay(100)
+            },
+            contentType = null
+        )
+        val producer = producer(body, coroutineContext)
+
+        val encoder = TestEncoder()
+        val ioctrl = TestIOControl()
+
+        val result = async {
+            encoder.channel.readRemaining().readText()
+        }
+
+        GlobalScope.launch {
+            while (!encoder.isCompleted) {
+                if (ioctrl.outputSuspended) continue
+                producer.produceContent(encoder, ioctrl)
+            }
+        }
+
+        assertEquals("xxxxx", result.await())
+        producer.close()
+    }
+
+    @Test
+    fun testProducingWriteChannelContentOnScale() = runBlocking {
+        repeat(5000) {
+            val chunk = (0 until 10_000).map { it.toByte() }.toByteArray()
+            val body = ChannelWriterContent(
+                body = { writeFully(chunk) },
+                contentType = null
+            )
+            val producer = producer(body, coroutineContext)
+
+            val encoder = TestEncoder()
+            val ioctrl = TestIOControl()
+
+            val result = async {
+                val result = ByteArray(10000)
+                encoder.channel.readFully(result)
+                result
+            }
+
+            GlobalScope.launch {
+                while (!encoder.isCompleted) {
+                    if (ioctrl.outputSuspended) continue
+                    producer.produceContent(encoder, ioctrl)
+                }
+            }
+
+            assertEquals(chunk.toList(), result.await().toList())
+            producer.close()
+        }
+    }
+
+    private fun producer(body: OutgoingContent, context: CoroutineContext) = ApacheRequestProducer(
+        requestData = HttpRequestData(
+            URLBuilder("https://example.com").build(),
+            HttpMethod.Get,
+            Headers.Empty,
+            body,
+            Job(),
+            Attributes()
+        ),
+        config = ApacheEngineConfig(),
+        callContext = context
+    )
+}
+
+private class TestEncoder : ContentEncoder {
+    val channel = ByteChannel()
+
+    override fun write(src: ByteBuffer): Int = runBlocking {
+        channel.writeAvailable(src)
+        src.limit()
+    }
+
+    override fun complete() {
+        channel.close()
+    }
+
+    override fun isCompleted(): Boolean = channel.isClosedForWrite
+}
+
+private class TestIOControl : IOControl {
+
+    @Volatile
+    var inputSuspended = false
+        private set
+
+    @Volatile
+    var outputSuspended = false
+        private set
+
+    override fun requestInput() {
+        inputSuspended = false
+    }
+
+    override fun suspendInput() {
+        inputSuspended = true
+    }
+
+    override fun requestOutput() {
+        outputSuspended = false
+    }
+
+    override fun suspendOutput() {
+        outputSuspended = true
+    }
+
+    override fun shutdown() {
     }
 }

--- a/ktor-io/api/ktor-io.api
+++ b/ktor-io/api/ktor-io.api
@@ -56,6 +56,7 @@ public abstract class io/ktor/utils/io/ByteChannelSequentialBase : io/ktor/utils
 	public fun isClosedForRead ()Z
 	public fun isClosedForWrite ()Z
 	public final fun peekTo-vHUFkk8 (Ljava/nio/ByteBuffer;JJJJLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	protected final fun prepareFlushedBytes ()V
 	public fun readAvailable (Lio/ktor/utils/io/core/IoBuffer;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun readAvailable ([BIILkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	protected final fun readAvailableClosed ()I

--- a/ktor-io/api/ktor-io.api
+++ b/ktor-io/api/ktor-io.api
@@ -98,10 +98,12 @@ public abstract class io/ktor/utils/io/ByteChannelSequentialBase : io/ktor/utils
 public final class io/ktor/utils/io/ByteChannelSequentialJVM : io/ktor/utils/io/ByteChannelSequentialBase {
 	public fun <init> (Lio/ktor/utils/io/core/IoBuffer;Z)V
 	public fun attachJob (Lkotlinx/coroutines/Job;)V
+	public fun awaitContent (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public synthetic fun consumeEachBufferRange (Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun lookAhead (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
 	public fun lookAheadSuspend (Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun read (ILkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun readAvailable (ILkotlin/jvm/functions/Function1;)I
 	public fun readAvailable (Ljava/nio/ByteBuffer;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun readFully (Ljava/nio/ByteBuffer;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun write (ILkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -119,6 +121,7 @@ public final class io/ktor/utils/io/ByteChannelSequentialKt {
 
 public abstract interface class io/ktor/utils/io/ByteReadChannel {
 	public static final field Companion Lio/ktor/utils/io/ByteReadChannel$Companion;
+	public abstract fun awaitContent (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun cancel (Ljava/lang/Throwable;)Z
 	public abstract synthetic fun consumeEachBufferRange (Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun discard (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -131,6 +134,7 @@ public abstract interface class io/ktor/utils/io/ByteReadChannel {
 	public abstract fun lookAheadSuspend (Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun peekTo-vHUFkk8 (Ljava/nio/ByteBuffer;JJJJLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun read (ILkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun readAvailable (ILkotlin/jvm/functions/Function1;)I
 	public abstract fun readAvailable (Lio/ktor/utils/io/core/IoBuffer;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun readAvailable (Ljava/nio/ByteBuffer;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun readAvailable ([BIILkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -161,6 +165,7 @@ public final class io/ktor/utils/io/ByteReadChannel$DefaultImpls {
 	public static synthetic fun consumeEachBufferRange (Lio/ktor/utils/io/ByteReadChannel;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun peekTo-vHUFkk8$default (Lio/ktor/utils/io/ByteReadChannel;Ljava/nio/ByteBuffer;JJJJLkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public static synthetic fun read$default (Lio/ktor/utils/io/ByteReadChannel;ILkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun readAvailable$default (Lio/ktor/utils/io/ByteReadChannel;ILkotlin/jvm/functions/Function1;ILjava/lang/Object;)I
 }
 
 public final class io/ktor/utils/io/ByteReadChannelJVMKt {

--- a/ktor-io/common/src/io/ktor/utils/io/ByteChannelSequential.kt
+++ b/ktor-io/common/src/io/ktor/utils/io/ByteChannelSequential.kt
@@ -116,7 +116,7 @@ public abstract class ByteChannelSequentialBase(
      *
      * This method is reader-only safe.
      */
-    private fun prepareFlushedBytes() {
+    protected fun prepareFlushedBytes() {
         synchronized(flushMutex) {
             readable.unsafeAppend(flushBuffer)
         }

--- a/ktor-io/jvm/src/io/ktor/utils/io/ByteBufferChannel.kt
+++ b/ktor-io/jvm/src/io/ktor/utils/io/ByteBufferChannel.kt
@@ -601,6 +601,45 @@ internal open class ByteBufferChannel(
         }
     }
 
+    override fun readAvailable(min: Int, block: (ByteBuffer) -> Unit): Int {
+        require(min > 0) { "min should be positive" }
+        require(min <= BYTE_BUFFER_CAPACITY) { "Min($min) shouldn't be greater than $BYTE_BUFFER_CAPACITY" }
+
+        var result = 0
+        val read = reading { state ->
+            val locked = state.tryReadAtLeast(min)
+
+            if (locked > 0 && locked >= min) {
+                // here we have locked all available for read bytes
+                // however we don't know how many bytes will be actually read
+                // so later we have to return (locked - actuallyRead) bytes back
+
+                // it is important to lock bytes to fail concurrent tryLockForRelease
+                // once we have locked some bytes, tryLockForRelease will fail so it is safe to use buffer
+
+                val position = position()
+                val limit = limit()
+                block(this)
+                if (limit != limit()) throw IllegalStateException("buffer limit modified")
+
+                result = position() - position
+                if (result < 0) throw IllegalStateException("position has been moved backward: pushback is not supported")
+
+                bytesRead(state, result)
+
+                if (result < locked) {
+                    state.completeWrite(locked - result) // return back extra bytes (see note above)
+                    // we use completeWrite in spite of that it is read block
+                    // we don't need to resume read as we are already in read block
+                }
+                true
+            } else false
+        }
+
+        if (!read) return -1
+        return result
+    }
+
     override suspend fun readAvailable(dst: ByteArray, offset: Int, length: Int): Int {
         val consumed = readAsMuchAsPossible(dst, offset, length)
 
@@ -2272,6 +2311,11 @@ internal open class ByteBufferChannel(
         WriteOp.getAndSet(this, null)?.resumeWithException(
             cause ?: ClosedWriteChannelException(DEFAULT_CLOSE_MESSAGE)
         )
+    }
+
+    @ExperimentalIoApi
+    override suspend fun awaitContent() {
+        readSuspend(1)
     }
 
     private suspend fun readSuspend(size: Int): Boolean {

--- a/ktor-io/jvm/src/io/ktor/utils/io/ByteBufferChannel.kt
+++ b/ktor-io/jvm/src/io/ktor/utils/io/ByteBufferChannel.kt
@@ -2313,7 +2313,6 @@ internal open class ByteBufferChannel(
         )
     }
 
-    @ExperimentalIoApi
     override suspend fun awaitContent() {
         readSuspend(1)
     }

--- a/ktor-io/jvm/src/io/ktor/utils/io/ByteChannelSequentialJVM.kt
+++ b/ktor-io/jvm/src/io/ktor/utils/io/ByteChannelSequentialJVM.kt
@@ -89,8 +89,10 @@ public class ByteChannelSequentialJVM(initial: IoBuffer, autoFlush: Boolean) : B
         }
 
         if (availableForRead < min) {
-            return 0
+            return -1
         }
+
+        prepareFlushedBytes()
 
         var result = 0
         readable.readDirect(min) {

--- a/ktor-io/jvm/src/io/ktor/utils/io/ByteReadChannelJVM.kt
+++ b/ktor-io/jvm/src/io/ktor/utils/io/ByteReadChannelJVM.kt
@@ -1,9 +1,9 @@
 package io.ktor.utils.io
 
-import io.ktor.utils.io.internal.*
-import io.ktor.utils.io.bits.Memory
+import io.ktor.utils.io.bits.*
 import io.ktor.utils.io.core.*
 import io.ktor.utils.io.core.ByteOrder
+import io.ktor.utils.io.internal.*
 import java.nio.*
 
 /**
@@ -43,6 +43,22 @@ public actual interface ByteReadChannel {
      */
     @Deprecated("Don't use byte count")
     public actual val totalBytesRead: Long
+
+    /**
+     * Invokes [block] if it is possible to read at least [min] byte
+     * providing byte buffer to it so lambda can read from the buffer
+     * up to [ByteBuffer.available] bytes. If there are no [min] bytes available then the invocation returns 0.
+     *
+     * Warning: it is not guaranteed that all of available bytes will be represented as a single byte buffer
+     * eg: it could be 4 bytes available for read but the provided byte buffer could have only 2 available bytes:
+     * in this case you have to invoke read again (with decreased [min] accordingly).
+     *
+     * @param min amount of bytes available for read, should be positive
+     * @param block to be invoked when at least [min] bytes available
+     *
+     * @return number of consumed bytes or -1 if the block wasn't executed.
+     */
+    public fun readAvailable(min: Int = 1, block: (ByteBuffer) -> Unit): Int
 
     /**
      * Reads all available bytes to [dst] buffer and returns immediately or suspends if no bytes available
@@ -235,6 +251,9 @@ public actual interface ByteReadChannel {
         min: Long,
         max: Long
     ): Long
+
+    @ExperimentalIoApi
+    public suspend fun awaitContent()
 
     public actual companion object {
         public actual val Empty: ByteReadChannel by lazy { ByteChannel().apply { close() } }

--- a/ktor-io/jvm/src/io/ktor/utils/io/ByteReadChannelJVM.kt
+++ b/ktor-io/jvm/src/io/ktor/utils/io/ByteReadChannelJVM.kt
@@ -252,7 +252,6 @@ public actual interface ByteReadChannel {
         max: Long
     ): Long
 
-    @ExperimentalIoApi
     public suspend fun awaitContent()
 
     public actual companion object {

--- a/ktor-io/jvm/src/io/ktor/utils/io/internal/RingBufferCapacity.kt
+++ b/ktor-io/jvm/src/io/ktor/utils/io/internal/RingBufferCapacity.kt
@@ -25,6 +25,15 @@ internal class RingBufferCapacity(private val totalCapacity: Int) {
         pendingToFlush = 0
     }
 
+    fun tryReadAtLeast(n: Int): Int {
+        val AvailableForRead = AvailableForRead
+        while (true) {
+            val remaining = availableForRead
+            if (remaining < n) return 0
+            if (AvailableForRead.compareAndSet(this, remaining, 0)) return remaining
+        }
+    }
+
     fun tryReadExact(n: Int): Boolean {
         val AvailableForRead = AvailableForRead
         while (true) {

--- a/ktor-io/jvm/test/io/ktor/utils/io/ByteChannelSequentialTest.kt
+++ b/ktor-io/jvm/test/io/ktor/utils/io/ByteChannelSequentialTest.kt
@@ -4,34 +4,15 @@
 
 package io.ktor.utils.io
 
+import io.ktor.utils.io.core.*
 import kotlinx.coroutines.*
-import java.io.*
 import kotlin.test.*
 
-class ByteBufferChannelTest {
-    @Test
-    fun testCompleteExceptionallyJob() {
-        val channel = ByteBufferChannel(false)
-        Job().also { channel.attachJob(it) }.completeExceptionally(IOException("Text exception"))
-
-        assertFailsWith<IOException> { runBlocking { channel.readByte() } }
-    }
-
-    @Test
-    fun readRemainingThrowsOnClosed() = runBlocking {
-        val channel = ByteBufferChannel(false)
-        channel.writeFully(byteArrayOf(1, 2, 3, 4, 5))
-        channel.close(IllegalStateException("closed"))
-
-        assertFailsWith<IllegalStateException>("closed") {
-            channel.readRemaining()
-        }
-        Unit
-    }
+class ByteChannelSequentialTest {
 
     @Test
     fun testReadAvailable() = runBlocking {
-        val channel = ByteBufferChannel(true)
+        val channel = ByteChannelSequentialJVM(IoBuffer.Empty, true)
         channel.writeFully(byteArrayOf(1, 2))
 
         val read1 = channel.readAvailable(4) { it.position(it.position() + 4) }
@@ -44,7 +25,7 @@ class ByteBufferChannelTest {
 
     @Test
     fun testAwaitContent() = runBlocking {
-        val channel = ByteBufferChannel(true)
+        val channel = ByteChannelSequentialJVM(IoBuffer.Empty, true)
 
         var awaitingContent = false
         launch {


### PR DESCRIPTION
**Subsystem**
Client, Apache

**Motivation**
[Apache client engine sometimes hits an unrecoverable socket timeout when using ChannelWriterContent](https://youtrack.jetbrains.com/issue/KTOR-1149)

**Solution**
There was a race condition in `ApacheRequestProducer`. Fixed by rewriting it to a better approach.
