### PR TITLE
KTOR-1229 Fix mapping of SocketTimeoutException in Android engine

### DIFF
--- a/ktor-client/ktor-client-android/jvm/src/io/ktor/client/engine/android/AndroidClientEngine.kt
+++ b/ktor-client/ktor-client-android/jvm/src/io/ktor/client/engine/android/AndroidClientEngine.kt
@@ -80,22 +80,22 @@ public class AndroidClientEngine(override val config: AndroidEngineConfig) : Htt
             }
         }
 
-        connection.timeoutAwareConnect(data)
+        return connection.timeoutAwareConnection(data) { connection ->
+            val responseCode = connection.responseCode
+            val responseMessage = connection.responseMessage
+            val statusCode = responseMessage?.let { HttpStatusCode(responseCode, it) }
+                ?: HttpStatusCode.fromValue(responseCode)
 
-        val responseCode = connection.responseCode
-        val responseMessage = connection.responseMessage
-        val statusCode = responseMessage?.let { HttpStatusCode(responseCode, it) }
-            ?: HttpStatusCode.fromValue(responseCode)
+            val content: ByteReadChannel = connection.content(callContext, data)
+            val headerFields: Map<String, List<String>> = connection.headerFields
+                .mapKeys { it.key?.toLowerCase() ?: "" }
+                .filter { it.key.isNotBlank() }
 
-        val content: ByteReadChannel = connection.content(callContext, data)
-        val headerFields: Map<String, List<String>> = connection.headerFields
-            .mapKeys { it.key?.toLowerCase() ?: "" }
-            .filter { it.key.isNotBlank() }
+            val version: HttpProtocolVersion = HttpProtocolVersion.HTTP_1_1
+            val responseHeaders = HeadersImpl(headerFields)
 
-        val version: HttpProtocolVersion = HttpProtocolVersion.HTTP_1_1
-        val responseHeaders = HeadersImpl(headerFields)
-
-        return HttpResponseData(statusCode, requestTime, responseHeaders, version, content, callContext)
+            HttpResponseData(statusCode, requestTime, responseHeaders, version, content, callContext)
+        }
     }
 
     private fun getProxyAwareConnection(urlString: String): HttpURLConnection {

--- a/ktor-client/ktor-client-android/jvm/src/io/ktor/client/engine/android/AndroidURLConnectionUtils.kt
+++ b/ktor-client/ktor-client-android/jvm/src/io/ktor/client/engine/android/AndroidURLConnectionUtils.kt
@@ -6,6 +6,7 @@ package io.ktor.client.engine.android
 
 import io.ktor.client.features.*
 import io.ktor.client.request.*
+import io.ktor.http.*
 import io.ktor.network.sockets.*
 import io.ktor.util.cio.*
 import io.ktor.utils.io.*
@@ -43,12 +44,15 @@ private fun HttpURLConnection.setupRequestTimeoutAttributes(
 }
 
 /**
- * Call [HttpURLConnection.connect] catching [java.net.SocketTimeoutException] and returning [SocketTimeoutException] instead
+ * Executes [block] catching [java.net.SocketTimeoutException] and returning [SocketTimeoutException] instead
  * of it. If request timeout happens earlier [HttpRequestTimeoutException] will be thrown.
  */
-internal suspend fun HttpURLConnection.timeoutAwareConnect(request: HttpRequestData) {
+internal suspend fun <T> HttpURLConnection.timeoutAwareConnection(
+    request: HttpRequestData,
+    block: (HttpURLConnection) -> T
+): T {
     try {
-        connect()
+        return block(this)
     } catch (cause: Throwable) {
         // Allow to throw request timeout cancellation exception instead of connect timeout exception if needed.
         yield()

--- a/ktor-client/ktor-client-android/jvm/test/io/ktor/client/engine/android/UrlConnectionUtilsTest.kt
+++ b/ktor-client/ktor-client-android/jvm/test/io/ktor/client/engine/android/UrlConnectionUtilsTest.kt
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2014-2019 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.client.engine.android
+
+import io.ktor.client.request.*
+import kotlinx.coroutines.*
+import java.net.*
+import kotlin.test.*
+
+class UrlConnectionUtilsTest {
+
+    private val data = HttpRequestBuilder().build()
+
+    @Test
+    fun testTimeoutAwareConnectionCatchesErrorInConnect(): Unit = runBlocking {
+        val connection = TestConnection(true, false)
+        assertFailsWith<Throwable>("Connect timeout has been expired") {
+            connection.timeoutAwareConnection(data) {
+                it.connect()
+            }
+        }
+    }
+
+    @Test
+    fun testTimeoutAwareConnectionCatchesErrorInResponseStatusCode(): Unit = runBlocking {
+        val connection = TestConnection(false, true)
+        assertFailsWith<Throwable>("Connect timeout has been expired") {
+            connection.timeoutAwareConnection(data) {
+                it.responseCode
+            }
+        }
+    }
+}
+
+private class TestConnection(
+    private val throwInConnect: Boolean,
+    private val throwInResponseCode: Boolean,
+) : HttpURLConnection(URL("https://example.com")) {
+
+    override fun getResponseCode(): Int {
+        if (throwInResponseCode) throw ConnectException("Connect timed out")
+        return 200
+    }
+
+    override fun connect() {
+        if (throwInConnect) throw SocketTimeoutException()
+    }
+
+    override fun disconnect() {
+        throw NotImplementedError()
+    }
+
+    override fun usingProxy(): Boolean {
+        throw NotImplementedError()
+    }
+}


### PR DESCRIPTION
**Subsystem**
Client, Android

**Motivation** 
[Timeout﻿ feature: android engine throws Java's SocketTimeoutException instead of ConnectTimeoutException](https://youtrack.jetbrains.com/issue/KTOR-1229)

**Solution**
Not only `connect()`, but also `statusCode` and other methods on `HttpURLConnection` can throw an exception that we need to map. This PR wraps all of them in a block.

Note: Not sure how to write a proper test for it, since only some versions of Android has this behavior. 

