### PR TITLE
Fix IncorrectDereferenceException when using HttpClient on Dispatchers.Default

### DIFF
--- a/ktor-client/ktor-client-tests/posix/test/io/ktor/client/tests/HttpClientFreezingTest.kt
+++ b/ktor-client/ktor-client-tests/posix/test/io/ktor/client/tests/HttpClientFreezingTest.kt
@@ -8,6 +8,7 @@ import io.ktor.client.*
 import io.ktor.client.request.*
 import io.ktor.client.tests.utils.*
 import io.ktor.utils.io.*
+import kotlinx.coroutines.*
 import kotlin.test.*
 
 class HttpClientFreezingTest : ClientLoader() {
@@ -18,6 +19,18 @@ class HttpClientFreezingTest : ClientLoader() {
             client.makeShared()
             val response = client.get<String>("$TEST_SERVER/content/hello")
             assertEquals("hello", response)
+        }
+    }
+
+    @Test
+    fun testRequestWithDefaultDispatcher() = clientTests {
+        test { client ->
+            withContext(Dispatchers.Default) {
+                val response = client.post<String>("$TEST_SERVER/echo") {
+                    body = "hello"
+                }
+                assertEquals("hello", response)
+            }
         }
     }
 }

--- a/ktor-http/common/src/io/ktor/http/HeaderValueWithParameters.kt
+++ b/ktor-http/common/src/io/ktor/http/HeaderValueWithParameters.kt
@@ -5,8 +5,10 @@
 package io.ktor.http
 
 import io.ktor.util.*
+import kotlin.native.concurrent.*
 
 /** Separator symbols listed in RFC https://tools.ietf.org/html/rfc2616#section-2.2 */
+@SharedImmutable
 private val HeaderFieldValueSeparators =
     setOf('(', ')', '<', '>', '@', ',', ';', ':', '\\', '\"', '/', '[', ']', '?', '=', '{', '}', ' ', '\t', '\n', '\r')
 


### PR DESCRIPTION
**Subsystem**
Client, native

**Motivation**
This PR fixes an `IncorrectDereferenceException` when using the HttpClient on `Dispatchers.Default`. The bug was caused by https://github.com/ktorio/ktor/pull/2110 that added a top level value not marked as `@SharedImmutable`. 

HttpClient on `Dispatchers.Default` was supposed to be fixed in Ktor 1.4.2 with https://github.com/ktorio/ktor/pull/2092 but as explained above unfortunately another issue was introduced. That is why I also added a test to prevent issues like this in the future.

https://kotlinlang.slack.com/archives/C0A974TJ9/p1605058326000100

**Solution**
Mark the top level value with `@SharedImmutable` and add a test.