### PR TITLE
KTOR-1292 Fix Netty HTTP2 cookies

### DIFF
--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyApplicationCallHandler.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyApplicationCallHandler.kt
@@ -18,7 +18,7 @@ import kotlin.coroutines.*
 internal class NettyApplicationCallHandler(
     userCoroutineContext: CoroutineContext,
     private val enginePipeline: EnginePipeline,
-    private val logger: Logger
+    logger: Logger
 ) : ChannelInboundHandlerAdapter(), CoroutineScope {
     override val coroutineContext: CoroutineContext = userCoroutineContext +
         CallHandlerCoroutineName +

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyApplicationRequestCookies.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyApplicationRequestCookies.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2014-2020 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package io.ktor.server.netty
@@ -13,8 +13,7 @@ internal class NettyApplicationRequestCookies(request: ApplicationRequest) : Req
         val cookieHeaders = request.headers.getAll("Cookie") ?: return emptyMap()
         val map = HashMap<String, String>(cookieHeaders.size)
         for (cookieHeader in cookieHeaders) {
-            val cookies = ServerCookieDecoder.LAX.decode(cookieHeader).associateBy({ it.name() }, { it.value() })
-            map.putAll(cookies)
+            ServerCookieDecoder.LAX.decode(cookieHeader).associateByTo(map, { it.name() }, { it.value() })
         }
         return map
     }

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/cio/NettyResponsePipeline.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/cio/NettyResponsePipeline.kt
@@ -203,6 +203,8 @@ internal class NettyResponsePipeline(private val dst: ChannelHandlerContext,
 
         if (responseMessage is FullHttpResponse) {
             return finishCall(call, null, requestMessageFuture)
+        } else if (responseMessage is Http2HeadersFrame && responseMessage.isEndStream) {
+            return finishCall(call, null, requestMessageFuture)
         }
 
         val responseChannel = response.responseChannel

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http2/NettyHttp2ApplicationRequest.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http2/NettyHttp2ApplicationRequest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2014-2020 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package io.ktor.server.netty.http2
@@ -60,8 +60,7 @@ internal class NettyHttp2ApplicationRequest(
         context.channel().remoteAddress() as? InetSocketAddress
     )
 
-    override val cookies: RequestCookies
-        get() = throw UnsupportedOperationException()
+    override val cookies: RequestCookies = NettyApplicationRequestCookies(this)
 
     override fun newDecoder(): HttpPostMultipartRequestDecoder {
         val hh = DefaultHttpHeaders(false)

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http2/NettyHttp2ApplicationResponse.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http2/NettyHttp2ApplicationResponse.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2014-2020 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package io.ktor.server.netty.http2
@@ -29,14 +29,16 @@ internal class NettyHttp2ApplicationResponse(call: NettyApplicationCall,
         responseHeaders.status(statusCode.value.toString())
     }
 
+    override fun responseMessage(chunked: Boolean, data: ByteArray): Any {
+        return responseMessage(false, data.isEmpty())
+    }
+
     override fun responseMessage(chunked: Boolean, last: Boolean): Any {
         // transfer encoding should be never set for HTTP/2
         // so we simply remove header
         // it should be lower case
         responseHeaders.remove("transfer-encoding")
-        return DefaultHttp2HeadersFrame(responseHeaders, false)
-        // endStream should be false
-        // as response pipeline is always sending at least one data frame
+        return DefaultHttp2HeadersFrame(responseHeaders, last)
     }
 
     override suspend fun respondUpgrade(upgrade: OutgoingContent.ProtocolUpgrade) {

--- a/ktor-server/ktor-server-netty/jvm/test/io/ktor/tests/server/netty/NettyEngineTest.kt
+++ b/ktor-server/ktor-server-netty/jvm/test/io/ktor/tests/server/netty/NettyEngineTest.kt
@@ -47,10 +47,6 @@ class NettyHttp2ServerTest : HttpServerTestSuite<NettyApplicationEngine, NettyAp
     override fun configure(configuration: NettyApplicationEngine.Configuration) {
         configuration.shareWorkGroup = true
     }
-
-    @Ignore
-    override fun testHeadRequest() {
-    }
 }
 
 class NettySustainabilityTest :

--- a/ktor-server/ktor-server-netty/jvm/test/io/ktor/tests/server/netty/NettyEngineTest.kt
+++ b/ktor-server/ktor-server-netty/jvm/test/io/ktor/tests/server/netty/NettyEngineTest.kt
@@ -1,11 +1,12 @@
 /*
- * Copyright 2014-2019 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2014-2020 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package io.ktor.tests.server.netty
 
 import io.ktor.server.netty.*
 import io.ktor.server.testing.suites.*
+import kotlin.test.*
 
 class NettyCompressionTest : CompressionTestSuite<NettyApplicationEngine, NettyApplicationEngine.Configuration>(Netty) {
     init {
@@ -34,6 +35,21 @@ class NettyHttpServerTest : HttpServerTestSuite<NettyApplicationEngine, NettyApp
 
     override fun configure(configuration: NettyApplicationEngine.Configuration) {
         configuration.shareWorkGroup = true
+    }
+}
+
+class NettyHttp2ServerTest : HttpServerTestSuite<NettyApplicationEngine, NettyApplicationEngine.Configuration>(Netty) {
+    init {
+        enableSsl = true
+        enableHttp2 = true
+    }
+
+    override fun configure(configuration: NettyApplicationEngine.Configuration) {
+        configuration.shareWorkGroup = true
+    }
+
+    @Ignore
+    override fun testHeadRequest() {
     }
 }
 

--- a/ktor-server/ktor-server-test-suites/jvm/src/io/ktor/server/testing/suites/HttpServerTestSuite.kt
+++ b/ktor-server/ktor-server-test-suites/jvm/src/io/ktor/server/testing/suites/HttpServerTestSuite.kt
@@ -78,7 +78,7 @@ public abstract class HttpServerTestSuite<TEngine : ApplicationEngine, TConfigur
     }
 
     @Test
-    public fun testHeadRequest() {
+    public open fun testHeadRequest() {
         createAndStartServer {
             install(AutoHeadResponse)
             handle {


### PR DESCRIPTION
**Subsystem**
ktor-server-netty

**Motivation**
Netty HTTP/2 doesn't support cookies since 2016 and nobody cared before. 
[KTOR-1292](https://youtrack.jetbrains.com/issue/KTOR-1292)

**Solution**
- Fix cookies
- Enable HTTP/2 netty test

**Known issues**
testHeadRequest doesn't work: will investigate separately


