### PR TITLE
KTOR-1298 Fix hanging HEAD response with Netty HTTP/2

### DIFF
--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyApplicationCallHandler.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyApplicationCallHandler.kt
@@ -18,7 +18,7 @@ import kotlin.coroutines.*
 internal class NettyApplicationCallHandler(
     userCoroutineContext: CoroutineContext,
     private val enginePipeline: EnginePipeline,
-    private val logger: Logger
+    logger: Logger
 ) : ChannelInboundHandlerAdapter(), CoroutineScope {
     override val coroutineContext: CoroutineContext = userCoroutineContext +
         CallHandlerCoroutineName +

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/cio/NettyResponsePipeline.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/cio/NettyResponsePipeline.kt
@@ -203,6 +203,8 @@ internal class NettyResponsePipeline(private val dst: ChannelHandlerContext,
 
         if (responseMessage is FullHttpResponse) {
             return finishCall(call, null, requestMessageFuture)
+        } else if (responseMessage is Http2HeadersFrame && responseMessage.isEndStream) {
+            return finishCall(call, null, requestMessageFuture)
         }
 
         val responseChannel = response.responseChannel

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http2/NettyHttp2ApplicationResponse.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http2/NettyHttp2ApplicationResponse.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2014-2020 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package io.ktor.server.netty.http2
@@ -29,14 +29,16 @@ internal class NettyHttp2ApplicationResponse(call: NettyApplicationCall,
         responseHeaders.status(statusCode.value.toString())
     }
 
+    override fun responseMessage(chunked: Boolean, data: ByteArray): Any {
+        return responseMessage(false, data.isEmpty())
+    }
+
     override fun responseMessage(chunked: Boolean, last: Boolean): Any {
         // transfer encoding should be never set for HTTP/2
         // so we simply remove header
         // it should be lower case
         responseHeaders.remove("transfer-encoding")
-        return DefaultHttp2HeadersFrame(responseHeaders, false)
-        // endStream should be false
-        // as response pipeline is always sending at least one data frame
+        return DefaultHttp2HeadersFrame(responseHeaders, last)
     }
 
     override suspend fun respondUpgrade(upgrade: OutgoingContent.ProtocolUpgrade) {

--- a/ktor-server/ktor-server-netty/jvm/test/io/ktor/tests/server/netty/NettyEngineTest.kt
+++ b/ktor-server/ktor-server-netty/jvm/test/io/ktor/tests/server/netty/NettyEngineTest.kt
@@ -47,10 +47,6 @@ class NettyHttp2ServerTest : HttpServerTestSuite<NettyApplicationEngine, NettyAp
     override fun configure(configuration: NettyApplicationEngine.Configuration) {
         configuration.shareWorkGroup = true
     }
-
-    @Ignore
-    override fun testHeadRequest() {
-    }
 }
 
 class NettySustainabilityTest :


### PR DESCRIPTION
**Subsystem**
ktor-server-netty

**Motivation**
[KTOR-1298](https://youtrack.jetbrains.com/issue/KTOR-1298)
HttpServerTestSuite.testHeadResponse fails with Netty HTTP/2 because a response message has no actual body but headers have the concrete content length so it leads to the pipeline failure.

**Solution**
- Send head and empty (without body) responses in a single HTTP/2 frame marked as EOS.
- Enable the corresponding test back for HTTP/2

