### PR TITLE
KTOR-1247 - Fix writing race condition in ByteBufferChannel

### DIFF
--- a/ktor-io/jvm/src/io/ktor/utils/io/ByteBufferChannel.kt
+++ b/ktor-io/jvm/src/io/ktor/utils/io/ByteBufferChannel.kt
@@ -886,26 +886,26 @@ internal open class ByteBufferChannel(
         }
     }
 
-    internal fun bytesWrittenFromSesion(buffer: ByteBuffer, c: RingBufferCapacity, n: Int) {
-        buffer.bytesWritten(c, n)
+    internal fun bytesWrittenFromSesion(buffer: ByteBuffer, capacity: RingBufferCapacity, count: Int) {
+        buffer.bytesWritten(capacity, count)
     }
 
-    private fun ByteBuffer.bytesWritten(c: RingBufferCapacity, n: Int) {
-        require(n >= 0)
+    private fun ByteBuffer.bytesWritten(capacity: RingBufferCapacity, count: Int) {
+        require(count >= 0)
 
-        writePosition = carryIndex(writePosition + n)
-        c.completeWrite(n)
+        writePosition = carryIndex(writePosition + count)
+        capacity.completeWrite(count)
         @Suppress("DEPRECATION")
-        totalBytesWritten += n
+        totalBytesWritten += count
     }
 
-    private fun ByteBuffer.bytesRead(c: RingBufferCapacity, n: Int) {
-        require(n >= 0)
+    private fun ByteBuffer.bytesRead(capacity: RingBufferCapacity, count: Int) {
+        require(count >= 0)
 
-        readPosition = carryIndex(readPosition + n)
-        c.completeRead(n)
+        readPosition = carryIndex(readPosition + count)
+        capacity.completeRead(count)
         @Suppress("DEPRECATION")
-        totalBytesRead += n
+        totalBytesRead += count
         resumeWriteOp()
     }
 
@@ -923,10 +923,10 @@ internal open class ByteBufferChannel(
         return null
     }
 
-    private suspend fun delegateByte(b: Byte) {
+    private suspend fun delegateByte(value: Byte) {
         val joined = joining!!
-        if (state === ReadWriteBufferState.Terminated) return joined.delegatedTo.writeByte(b)
-        return delegateSuspend(joined) { writeByte(b) }
+        if (state === ReadWriteBufferState.Terminated) return joined.delegatedTo.writeByte(value)
+        return delegateSuspend(joined) { writeByte(value) }
     }
 
     private suspend fun delegateSuspend(joined: JoiningState, block: suspend ByteBufferChannel.() -> Unit) {
@@ -945,23 +945,23 @@ internal open class ByteBufferChannel(
         return tryWriteByte(buffer, b, c)
     }
 
-    private suspend fun tryWriteByte(buffer: ByteBuffer, b: Byte, c: RingBufferCapacity) {
-        if (!c.tryWriteExact(1)) {
-            return writeByteSuspend(buffer, b, c)
+    private suspend fun tryWriteByte(buffer: ByteBuffer, value: Byte, capacity: RingBufferCapacity) {
+        if (!capacity.tryWriteExact(1)) {
+            return writeByteSuspend(buffer, value, capacity)
         }
 
         prepareWriteBuffer(buffer, 1)
-        doWrite(buffer, b, c)
+        doWrite(buffer, value, capacity)
     }
 
-    private fun doWrite(buffer: ByteBuffer, b: Byte, c: RingBufferCapacity) {
-        buffer.put(b)
-        buffer.bytesWritten(c, 1)
-        if (c.isFull() || autoFlush) flush()
+    private fun doWrite(buffer: ByteBuffer, value: Byte, capacity: RingBufferCapacity) {
+        buffer.put(value)
+        buffer.bytesWritten(capacity, 1)
+        if (capacity.isFull() || autoFlush) flush()
         restoreStateAfterWrite()
     }
 
-    private suspend fun writeByteSuspend(buffer: ByteBuffer, b: Byte, c: RingBufferCapacity) {
+    private suspend fun writeByteSuspend(buffer: ByteBuffer, value: Byte, capacity: RingBufferCapacity) {
         try {
             writeSuspend(1)
         } catch (t: Throwable) {
@@ -972,16 +972,16 @@ internal open class ByteBufferChannel(
 
         if (joining != null) {
             restoreStateAfterWrite()
-            return delegateByte(b)
+            return delegateByte(value)
         }
 
-        return tryWriteByte(buffer, b, c)
+        return tryWriteByte(buffer, value, capacity)
     }
 
-    private suspend fun delegateShort(s: Short) {
+    private suspend fun delegateShort(value: Short) {
         val joined = joining!!
-        if (state === ReadWriteBufferState.Terminated) return joined.delegatedTo.writeShort(s)
-        return delegateSuspend(joined) { writeShort(s) }
+        if (state === ReadWriteBufferState.Terminated) return joined.delegatedTo.writeShort(value)
+        return delegateSuspend(joined) { writeShort(value) }
     }
 
     override suspend fun writeShort(s: Short) {
@@ -993,33 +993,33 @@ internal open class ByteBufferChannel(
         return tryWriteShort(buffer, s, c)
     }
 
-    private fun doWrite(buffer: ByteBuffer, s: Short, c: RingBufferCapacity) {
+    private fun doWrite(buffer: ByteBuffer, value: Short, capacity: RingBufferCapacity) {
         buffer.apply {
             if (remaining() < 2) {
                 limit(capacity())
-                putShort(s)
+                putShort(value)
                 carry()
             } else {
-                putShort(s)
+                putShort(value)
             }
 
-            bytesWritten(c, 2)
+            bytesWritten(capacity, 2)
         }
 
-        if (c.isFull() || autoFlush) flush()
+        if (capacity.isFull() || autoFlush) flush()
         restoreStateAfterWrite()
     }
 
-    private suspend fun tryWriteShort(buffer: ByteBuffer, s: Short, c: RingBufferCapacity) {
-        if (!c.tryWriteExact(2)) {
-            return writeShortSuspend(buffer, s, c)
+    private suspend fun tryWriteShort(buffer: ByteBuffer, value: Short, capacity: RingBufferCapacity) {
+        if (!capacity.tryWriteExact(2)) {
+            return writeShortSuspend(buffer, value, capacity)
         }
 
         prepareWriteBuffer(buffer, 2)
-        return doWrite(buffer, s, c)
+        return doWrite(buffer, value, capacity)
     }
 
-    private suspend fun writeShortSuspend(buffer: ByteBuffer, s: Short, c: RingBufferCapacity) {
+    private suspend fun writeShortSuspend(buffer: ByteBuffer, value: Short, capacity: RingBufferCapacity) {
         try {
             writeSuspend(2)
         } catch (t: Throwable) {
@@ -1030,42 +1030,42 @@ internal open class ByteBufferChannel(
 
         if (joining != null) {
             restoreStateAfterWrite()
-            return delegateShort(s)
+            return delegateShort(value)
         }
 
-        return tryWriteShort(buffer, s, c)
+        return tryWriteShort(buffer, value, capacity)
     }
 
-    private suspend fun delegateInt(i: Int) {
+    private suspend fun delegateInt(value: Int) {
         val joined = joining!!
-        if (state === ReadWriteBufferState.Terminated) return joined.delegatedTo.writeInt(i)
-        return delegateSuspend(joined) { writeInt(i) }
+        if (state === ReadWriteBufferState.Terminated) return joined.delegatedTo.writeInt(value)
+        return delegateSuspend(joined) { writeInt(value) }
     }
 
-    private fun ByteBuffer.tryWriteInt(i: Int, c: RingBufferCapacity): Boolean {
-        if (c.tryWriteExact(4)) {
-            prepareWriteBuffer(this, 4)
-            doWrite(this, i, c)
-            return true
+    private fun ByteBuffer.tryWriteInt(value: Int, capacity: RingBufferCapacity): Boolean {
+        if (!capacity.tryWriteExact(4)) {
+            return false
         }
 
-        return false
+        prepareWriteBuffer(this, 4)
+        doWrite(this, value, capacity)
+        return true
     }
 
-    private fun doWrite(buffer: ByteBuffer, i: Int, c: RingBufferCapacity) {
+    private fun doWrite(buffer: ByteBuffer, value: Int, capacity: RingBufferCapacity) {
         buffer.apply {
             if (remaining() < 4) {
                 limit(capacity())
-                putInt(i)
+                putInt(value)
                 carry()
             } else {
-                putInt(i)
+                putInt(value)
             }
 
-            bytesWritten(c, 4)
+            bytesWritten(capacity, 4)
         }
 
-        if (c.isFull() || autoFlush) flush()
+        if (capacity.isFull() || autoFlush) flush()
         restoreStateAfterWrite()
         tryTerminate()
     }
@@ -1086,7 +1086,7 @@ internal open class ByteBufferChannel(
         return buffer.writeIntSuspend(i, c)
     }
 
-    private tailrec suspend fun ByteBuffer.writeIntSuspend(i: Int, c: RingBufferCapacity) {
+    private tailrec suspend fun ByteBuffer.writeIntSuspend(value: Int, capacity: RingBufferCapacity) {
         try {
             writeSuspend(4)
         } catch (t: Throwable) {
@@ -1097,44 +1097,43 @@ internal open class ByteBufferChannel(
 
         if (joining != null) {
             restoreStateAfterWrite()
-            return delegateInt(i)
+            return delegateInt(value)
         }
 
-        if (!tryWriteInt(i, c)) {
-            return writeIntSuspend(i, c)
+        if (!tryWriteInt(value, capacity)) {
+            return writeIntSuspend(value, capacity)
         }
     }
 
-    private suspend fun delegateLong(l: Long) {
+    private suspend fun delegateLong(value: Long) {
         val joined = joining!!
-        if (state === ReadWriteBufferState.Terminated) return joined.delegatedTo.writeLong(l)
-        return delegateSuspend(joined) { writeLong(l) }
+        if (state === ReadWriteBufferState.Terminated) return joined.delegatedTo.writeLong(value)
+        return delegateSuspend(joined) { writeLong(value) }
     }
 
-    private fun ByteBuffer.tryWriteLong(l: Long, c: RingBufferCapacity): Boolean {
-        if (c.tryWriteExact(8)) {
-            prepareWriteBuffer(this, 8)
-            doWrite(this, l, c)
-            return true
+    private fun ByteBuffer.tryWriteLong(value: Long, capacity: RingBufferCapacity): Boolean {
+        if (!capacity.tryWriteExact(8)) {
+            return false
         }
-
-        return false
+        prepareWriteBuffer(this, 8)
+        doWrite(this, value, capacity)
+        return true
     }
 
-    private fun doWrite(buffer: ByteBuffer, l: Long, c: RingBufferCapacity) {
+    private fun doWrite(buffer: ByteBuffer, value: Long, capacity: RingBufferCapacity) {
         buffer.apply {
             if (remaining() < 8) {
                 limit(capacity())
-                putLong(l)
+                putLong(value)
                 carry()
             } else {
-                putLong(l)
+                putLong(value)
             }
 
-            bytesWritten(c, 8)
+            bytesWritten(capacity, 8)
         }
 
-        if (c.isFull() || autoFlush || joining != null) flush()
+        if (capacity.isFull() || autoFlush || joining != null) flush()
         restoreStateAfterWrite()
         tryTerminate()
     }
@@ -1150,7 +1149,7 @@ internal open class ByteBufferChannel(
         }
     }
 
-    private tailrec suspend fun ByteBuffer.writeLongSuspend(l: Long, c: RingBufferCapacity) {
+    private tailrec suspend fun ByteBuffer.writeLongSuspend(value: Long, capacity: RingBufferCapacity) {
         try {
             writeSuspend(8)
         } catch (t: Throwable) {
@@ -1161,11 +1160,11 @@ internal open class ByteBufferChannel(
 
         if (joining != null) {
             restoreStateAfterWrite()
-            return delegateLong(l)
+            return delegateLong(value)
         }
 
-        if (!tryWriteLong(l, c)) {
-            return writeLongSuspend(l, c)
+        if (!tryWriteLong(value, capacity)) {
+            return writeLongSuspend(value, capacity)
         }
     }
 
@@ -2046,14 +2045,14 @@ internal open class ByteBufferChannel(
         } while (true)
     }
 
-    private fun afterBufferVisited(buffer: ByteBuffer, c: RingBufferCapacity): Int {
+    private fun afterBufferVisited(buffer: ByteBuffer, capacity: RingBufferCapacity): Int {
         val consumed = buffer.position() - readPosition
         if (consumed > 0) {
-            if (!c.tryReadExact(consumed)) throw IllegalStateException("Consumed more bytes than available")
+            if (!capacity.tryReadExact(consumed)) throw IllegalStateException("Consumed more bytes than available")
 
-            buffer.bytesRead(c, consumed)
+            buffer.bytesRead(capacity, consumed)
             @Suppress("DEPRECATION_ERROR")
-            buffer.prepareBuffer(readByteOrder, readPosition, c.availableForRead)
+            buffer.prepareBuffer(readByteOrder, readPosition, capacity.availableForRead)
         }
 
         return consumed


### PR DESCRIPTION
**Subsystem**
Client/Server, ByteBufferChannel

**Motivation**
[KTOR-1247](https://youtrack.jetbrains.com/issue/KTOR-1247)
Race condition:

1. writer calls `channel.writeByte` 
2. writer goes inside `setupStateForWrite` 
3. no bytes available for write -> `buffer.limit() == buffer.position()`
4. reader reads content, creates space for the writer
5. writer checks capacity in state -> success, tries to write to a preconfigured buffer that has no available space
6. crash

**Solution**
* Move setting up buffer position and limit after checking of capacity to avoid race. 
* Unified behavior of `writeByte/Short/Int/Long`
* Cleaned up some unused methods and parameters

