### PR TITLE
KTOR-1308 throw BadRequestException on malformed path

### DIFF
--- a/ktor-server/ktor-server-tests/jvm/test/io/ktor/tests/server/routing/RoutingResolveTest.kt
+++ b/ktor-server/ktor-server-tests/jvm/test/io/ktor/tests/server/routing/RoutingResolveTest.kt
@@ -4,6 +4,7 @@
 
 package io.ktor.tests.server.routing
 
+import io.ktor.features.*
 import io.ktor.http.*
 import io.ktor.routing.*
 import io.ktor.server.testing.*
@@ -35,6 +36,14 @@ class RoutingResolveTest {
         val result = resolve(root, "/foo/bar")
         assertTrue(result is RoutingResolveResult.Failure)
         assertEquals(root, result.route)
+    }
+
+    @Test
+    fun testMalformedPath() {
+        val root = routing()
+        assertFailsWith<BadRequestException>("Url decode failed for /%uff0") {
+            resolve(root, "/%uff0")
+        }
     }
 
     @Test


### PR DESCRIPTION
**Subsystem**
Server, routing

**Motivation**
["Wrong HEX escape": gracefully handle invalid URLs](https://youtrack.jetbrains.com/issue/KTOR-1308)


