### PR TITLE
KTOR-1127 Rewrite timeout impl for CIO

### DIFF
--- a/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/HttpTimeoutTest.kt
+++ b/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/HttpTimeoutTest.kt
@@ -479,7 +479,7 @@ class HttpTimeoutTest : ClientLoader() {
     }
 
     @Test
-    fun testSocketTimeoutWriteFailOnWrite() = clientTests(listOf("Js", "Curl", "Android", "CIO")) {
+    fun testSocketTimeoutWriteFailOnWrite() = clientTests(listOf("Js", "Curl", "Android", "native:CIO")) {
         config {
             install(HttpTimeout) { socketTimeoutMillis = 500 }
         }
@@ -492,7 +492,7 @@ class HttpTimeoutTest : ClientLoader() {
     }
 
     @Test
-    fun testSocketTimeoutWriteFailOnWritePerRequestAttributes() = clientTests(listOf("Js", "Curl", "Android", "CIO")) {
+    fun testSocketTimeoutWriteFailOnWritePerRequestAttributes() = clientTests(listOf("Js", "Curl", "Android", "native:CIO")) {
         config {
             install(HttpTimeout)
         }

--- a/ktor-network/jvm/src/io/ktor/network/sockets/CIOWriter.kt
+++ b/ktor-network/jvm/src/io/ktor/network/sockets/CIOWriter.kt
@@ -26,6 +26,14 @@ internal fun CoroutineScope.attachForWritingImpl(
 
     return reader(Dispatchers.Unconfined + CoroutineName("cio-to-nio-writer"), channel) {
         try {
+            val timeout = if (socketOptions?.socketTimeout != null) {
+                createTimeout("writing", socketOptions.socketTimeout) {
+                    channel.close(SocketTimeoutException())
+                }
+            } else {
+                null
+            }
+
             while (true) {
                 buffer.clear()
                 if (channel.readAvailable(buffer) == -1) {
@@ -34,9 +42,9 @@ internal fun CoroutineScope.attachForWritingImpl(
                 buffer.flip()
 
                 while (buffer.hasRemaining()) {
-                    var rc: Int
+                    var rc = 0
 
-                    withSocketTimeout(socketOptions?.socketTimeout ?: INFINITE_TIMEOUT_MS) {
+                    timeout.withTimeout {
                         do {
                             rc = nioChannel.write(buffer)
                             if (rc == 0) {
@@ -49,6 +57,7 @@ internal fun CoroutineScope.attachForWritingImpl(
                     selectable.interestOp(SelectInterest.WRITE, false)
                 }
             }
+            timeout?.finish()
         } finally {
             pool.recycle(buffer)
             if (nioChannel is SocketChannel) {
@@ -72,6 +81,14 @@ internal fun CoroutineScope.attachForWritingDirectImpl(
     selectable.interestOp(SelectInterest.WRITE, false)
     try {
         channel.lookAheadSuspend {
+            val timeout = if (socketOptions?.socketTimeout != null) {
+                createTimeout("writing-direct", socketOptions.socketTimeout) {
+                    channel.close(SocketTimeoutException())
+                }
+            } else {
+                null
+            }
+
             while (true) {
                 val buffer = request(0, 1)
                 if (buffer == null) {
@@ -83,7 +100,7 @@ internal fun CoroutineScope.attachForWritingDirectImpl(
                 while (buffer.hasRemaining()) {
                     var rc = 0
 
-                    withSocketTimeout(socketOptions?.socketTimeout ?: INFINITE_TIMEOUT_MS) {
+                    timeout.withTimeout {
                         do {
                             rc = nioChannel.write(buffer)
                             if (rc == 0) {
@@ -96,6 +113,7 @@ internal fun CoroutineScope.attachForWritingDirectImpl(
                     consumed(rc)
                 }
             }
+            timeout?.finish()
         }
     } finally {
         selectable.interestOp(SelectInterest.WRITE, false)

--- a/ktor-network/jvm/src/io/ktor/network/util/Utils.kt
+++ b/ktor-network/jvm/src/io/ktor/network/util/Utils.kt
@@ -4,23 +4,86 @@
 
 package io.ktor.network.util
 
+import io.ktor.util.date.*
+import io.ktor.utils.io.concurrent.*
 import kotlinx.coroutines.*
-import java.net.*
+import kotlin.contracts.*
 
 /**
  * Infinite timeout in milliseconds.
  */
 internal const val INFINITE_TIMEOUT_MS = Long.MAX_VALUE
 
-/**
- * Wrap [block] into [withTimeout] wrapper and throws [SocketTimeoutException] if timeout exceeded.
- */
-internal suspend fun CoroutineScope.withSocketTimeout(socketTimeout: Long, block: suspend CoroutineScope.() -> Unit) {
-    if (socketTimeout == INFINITE_TIMEOUT_MS) {
-        block()
-    } else {
-        async {
-            withTimeoutOrNull(socketTimeout, block) ?: throw SocketTimeoutException()
-        }.await()
+internal class Timeout(
+    private val name: String,
+    private val timeoutMs: Long,
+    private val clock: () -> Long,
+    private val scope: CoroutineScope,
+    private val onTimeout: suspend () -> Unit
+) {
+
+    private var lastActivityTime: Long by shared(0)
+    private var isStarted by shared(false)
+
+    private var workerJob = initTimeoutJob()
+
+    fun start() {
+        lastActivityTime = clock()
+        isStarted = true
     }
+
+    fun stop() {
+        isStarted = false
+    }
+
+    fun finish() {
+        workerJob?.cancel()
+    }
+
+    private fun initTimeoutJob(): Job? {
+        if (timeoutMs == INFINITE_TIMEOUT_MS) return null
+        return scope.launch(scope.coroutineContext + CoroutineName("Timeout $name")) {
+            try {
+                while (true) {
+                    if (!isStarted) {
+                        lastActivityTime = clock()
+                    }
+                    val remaining = lastActivityTime + timeoutMs - clock()
+                    if (remaining <= 0 && isStarted) {
+                        break
+                    }
+
+                    delay(remaining)
+                }
+                yield()
+                onTimeout()
+            } catch (cause: Throwable) {
+                // no op
+            }
+        }
+    }
+}
+
+/**
+ * Starts timeout coroutine that will invoke [onTimeout] after [timeoutMs] of inactivity.
+ * Use [Timeout] object to wrap code that can timeout or cancel this coroutine
+ */
+internal fun CoroutineScope.createTimeout(
+    name: String = "",
+    timeoutMs: Long,
+    clock: () -> Long = { getTimeMillis() },
+    onTimeout: suspend () -> Unit
+): Timeout {
+    return Timeout(name, timeoutMs, clock, this, onTimeout)
+}
+
+internal inline fun <T> Timeout?.withTimeout(block: () -> T): T {
+    if (this == null) {
+        return block()
+    }
+
+    start()
+    val result = block()
+    stop()
+    return result
 }

--- a/ktor-network/jvm/src/io/ktor/network/util/Utils.kt
+++ b/ktor-network/jvm/src/io/ktor/network/util/Utils.kt
@@ -83,7 +83,9 @@ internal inline fun <T> Timeout?.withTimeout(block: () -> T): T {
     }
 
     start()
-    val result = block()
-    stop()
-    return result
+    return try {
+        block()
+    } finally {
+        stop()
+    }
 }

--- a/ktor-network/jvm/test/io/ktor/network/util/StartTimeoutTest.kt
+++ b/ktor-network/jvm/test/io/ktor/network/util/StartTimeoutTest.kt
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2014-2020 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.network.util
+
+import kotlinx.coroutines.*
+import kotlin.test.*
+import org.junit.Test
+
+class StartTimeoutTest {
+
+    private data class TestClock(var timeMs: Long)
+
+    private val timeoutMs: Long = 100
+    private val clock = TestClock(2000)
+
+    @Test
+    fun testTimeoutInvocation() = runBlocking {
+        var timeoutInvoked = false
+
+        val timeout = createTimeout("test", timeoutMs, clock::timeMs) { timeoutInvoked = true }
+        timeout.start()
+        yield()
+
+        clock.timeMs += timeoutMs
+        delay(timeoutMs)
+        yield()
+        assertTrue(timeoutInvoked)
+    }
+
+    @Test
+    fun testTimeoutCancellation() = runBlocking {
+        var timeoutInvoked = false
+
+        val timeout = createTimeout("test", timeoutMs, clock::timeMs) { timeoutInvoked = true }
+        timeout.start()
+        yield()
+
+        clock.timeMs += timeoutMs
+        timeout.finish()
+        delay(timeoutMs)
+        yield()
+        assertFalse(timeoutInvoked)
+    }
+
+    @Test
+    fun testTimeoutUpdateActivityTime() = runBlocking {
+        var timeoutInvoked = false
+        val timeout = createTimeout("test", timeoutMs, clock::timeMs) { timeoutInvoked = true }
+        timeout.start()
+        yield()
+
+        clock.timeMs += timeoutMs
+        timeout.start()
+        delay(timeoutMs)
+        yield()
+        assertFalse(timeoutInvoked)
+
+        clock.timeMs += timeoutMs
+        timeout.start()
+        delay(timeoutMs)
+        yield()
+        assertFalse(timeoutInvoked)
+
+        clock.timeMs += timeoutMs
+        delay(timeoutMs)
+        yield()
+        assertTrue(timeoutInvoked)
+    }
+
+    @Test
+    fun testTimeoutDoesNotTriggerWhenStopped() = runBlocking {
+        var timeoutInvoked = false
+        val timeout = createTimeout("test", timeoutMs, clock::timeMs) { timeoutInvoked = true }
+        timeout.start()
+        yield()
+
+        clock.timeMs += timeoutMs
+        timeout.start()
+        delay(timeoutMs)
+        yield()
+        assertFalse(timeoutInvoked)
+
+        timeout.stop()
+        clock.timeMs += timeoutMs
+        delay(timeoutMs)
+        yield()
+        assertFalse(timeoutInvoked)
+
+        timeout.start()
+        clock.timeMs += timeoutMs / 2
+        delay(timeoutMs / 2)
+        yield()
+        assertFalse(timeoutInvoked)
+
+        clock.timeMs += timeoutMs / 2
+        delay(timeoutMs / 2)
+        yield()
+        assertTrue(timeoutInvoked)
+    }
+
+    @Test
+    fun testTimeoutCancelsWhenParentScopeCancels() = runBlocking {
+        var timeoutInvoked = false
+        val scope = CoroutineScope(GlobalScope.coroutineContext)
+        val timeout = scope.createTimeout("test", timeoutMs, clock::timeMs) { timeoutInvoked = true }
+        timeout.start()
+        yield()
+
+        clock.timeMs += timeoutMs
+        runCatching { scope.cancel(CancellationException()) }
+        delay(timeoutMs)
+        yield()
+        assertFalse(timeoutInvoked)
+    }
+}

--- a/ktor-utils/common/src/io/ktor/util/date/Date.kt
+++ b/ktor-utils/common/src/io/ktor/util/date/Date.kt
@@ -137,3 +137,8 @@ public operator fun GMTDate.minus(milliseconds: Long): GMTDate = GMTDate(timesta
  * Truncate to seconds by discarding sub-second part
  */
 public fun GMTDate.truncateToSeconds(): GMTDate = GMTDate(seconds, minutes, hours, dayOfMonth, month, year)
+
+/**
+ * Gets current system time in milliseconds since certain moment in the past, only delta between two subsequent calls makes sense.
+ */
+public expect fun getTimeMillis(): Long

--- a/ktor-utils/js/src/io/ktor/util/date/DateJs.kt
+++ b/ktor-utils/js/src/io/ktor/util/date/DateJs.kt
@@ -45,3 +45,8 @@ public actual fun GMTDate(seconds: Int, minutes: Int, hours: Int, dayOfMonth: In
 public class InvalidTimestampException(timestamp: Long) : IllegalStateException(
     "Invalid date timestamp exception: $timestamp"
 )
+
+/**
+ * Gets current system time in milliseconds since certain moment in the past, only delta between two subsequent calls makes sense.
+ */
+public actual fun getTimeMillis(): Long = Date().getTime().toLong()

--- a/ktor-utils/jvm/src/io/ktor/util/date/DateJvm.kt
+++ b/ktor-utils/jvm/src/io/ktor/util/date/DateJvm.kt
@@ -64,3 +64,8 @@ public fun Calendar.toDate(timestamp: Long?): GMTDate {
  * Convert to [Date]
  */
 public fun GMTDate.toJvmDate(): Date = Date(timestamp)
+
+/**
+ * Gets current system time in milliseconds since certain moment in the past, only delta between two subsequent calls makes sense.
+ */
+public actual fun getTimeMillis(): Long = System.currentTimeMillis()

--- a/ktor-utils/posix/src/io/ktor/util/date/DateNative.kt
+++ b/ktor-utils/posix/src/io/ktor/util/date/DateNative.kt
@@ -56,3 +56,8 @@ public actual fun GMTDate(
 
     return GMTDate(timestamp * 1000L)
 }
+
+/**
+ * Gets current system time in milliseconds since certain moment in the past, only delta between two subsequent calls makes sense.
+ */
+public actual fun getTimeMillis(): Long = GMTDate().timestamp


### PR DESCRIPTION
**Motivation**
[KTOR-1127 CIO: client engine exceptions are both logged and thrown](https://youtrack.jetbrains.com/issue/KTOR-1127)

**Solution**
The previous implementation of socket timeout was very ineffective and allocated a lot of unnecessary objects. Rewrote it to a more low level one.