### PR TITLE
Reformat ktor-http to conform to ktlint

### DIFF
--- a/ktor-http/common/src/io/ktor/http/CacheControl.kt
+++ b/ktor-http/common/src/io/ktor/http/CacheControl.kt
@@ -98,14 +98,14 @@ public sealed class CacheControl(public val visibility: Visibility?) {
         }
 
         override fun equals(other: Any?): Boolean {
-            return other === this ||
-                (other is MaxAge &&
+            return other === this || (
+                other is MaxAge &&
                     other.maxAgeSeconds == maxAgeSeconds &&
                     other.proxyMaxAgeSeconds == proxyMaxAgeSeconds &&
                     other.mustRevalidate == mustRevalidate &&
                     other.proxyRevalidate == proxyRevalidate &&
                     other.visibility == visibility
-                    )
+                )
         }
 
         override fun hashCode(): Int {

--- a/ktor-http/common/src/io/ktor/http/Codecs.kt
+++ b/ktor-http/common/src/io/ktor/http/Codecs.kt
@@ -22,8 +22,8 @@ private val HEX_ALPHABET = ('a'..'f') + ('A'..'F') + ('0'..'9')
  */
 @SharedImmutable
 private val URL_PROTOCOL_PART = listOf(
-    ':', '/', '?', '#', '[', ']', '@',  // general
-    '!', '$', '&', '\'', '(', ')', '*', ',', ';', '=',  // sub-components
+    ':', '/', '?', '#', '[', ']', '@', // general
+    '!', '$', '&', '\'', '(', ')', '*', ',', ';', '=', // sub-components
     '-', '.', '_', '~', '+' // unreserved
 ).map { it.toByte() }
 
@@ -150,7 +150,8 @@ internal fun String.encodeURLParameterValue(
  * Decode URL query component
  */
 public fun String.decodeURLQueryComponent(
-    start: Int = 0, end: Int = length,
+    start: Int = 0,
+    end: Int = length,
     plusIsSpace: Boolean = false,
     charset: Charset = Charsets.UTF_8
 ): String = decodeScan(start, end, plusIsSpace, charset)
@@ -160,7 +161,8 @@ public fun String.decodeURLQueryComponent(
  * This function is not intended to decode urlencoded forms so it doesn't decode plus character to space.
  */
 public fun String.decodeURLPart(
-    start: Int = 0, end: Int = length,
+    start: Int = 0,
+    end: Int = length,
     charset: Charset = Charsets.UTF_8
 ): String = decodeScan(start, end, false, charset)
 
@@ -204,8 +206,9 @@ private fun CharSequence.decodeImpl(
             }
             c == '%' -> {
                 // if ByteArray was not needed before, create it with an estimate of remaining string be all hex
-                if (bytes == null)
+                if (bytes == null) {
                     bytes = ByteArray((end - index) / 3)
+                }
 
                 // fill ByteArray with all the bytes, so Charset can decode text
                 var count = 0

--- a/ktor-http/common/src/io/ktor/http/Cookie.kt
+++ b/ktor-http/common/src/io/ktor/http/Cookie.kt
@@ -50,6 +50,7 @@ public enum class CookieEncoding {
      * No encoding (could be dangerous)
      */
     RAW,
+
     /**
      * Double quotes with slash-escaping
      */
@@ -106,10 +107,12 @@ public fun parseClientCookiesHeader(cookiesHeader: String, skipEscaped: Boolean 
     clientCookieHeaderPattern.findAll(cookiesHeader)
         .map { (it.groups[2]?.value ?: "") to (it.groups[4]?.value ?: "") }
         .filter { !skipEscaped || !it.first.startsWith("$") }
-        .map {
-            if (it.second.startsWith("\"") && it.second.endsWith("\""))
-                it.copy(second = it.second.removeSurrounding("\""))
-            else it
+        .map { cookie ->
+            if (cookie.second.startsWith("\"") && cookie.second.endsWith("\"")) {
+                cookie.copy(second = cookie.second.removeSurrounding("\""))
+            } else {
+                cookie
+            }
         }
         .toMap()
 
@@ -157,27 +160,30 @@ public fun renderCookieHeader(cookie: Cookie): String = with(cookie) {
  */
 @KtorExperimentalAPI
 public fun renderSetCookieHeader(
-    name: String, value: String,
+    name: String,
+    value: String,
     encoding: CookieEncoding = CookieEncoding.URI_ENCODING,
-    maxAge: Int = 0, expires: GMTDate? = null, domain: String? = null,
+    maxAge: Int = 0,
+    expires: GMTDate? = null,
+    domain: String? = null,
     path: String? = null,
-    secure: Boolean = false, httpOnly: Boolean = false,
+    secure: Boolean = false,
+    httpOnly: Boolean = false,
     extensions: Map<String, String?> = emptyMap(),
     includeEncoding: Boolean = true
 ): String = (
-        listOf(
-            cookiePart(name.assertCookieName(), value, encoding),
-            cookiePartUnencoded("Max-Age", if (maxAge > 0) maxAge else null),
-            cookiePartUnencoded("Expires", expires?.toHttpDate()),
-            cookiePart("Domain", domain, CookieEncoding.RAW),
-            cookiePart("Path", path, CookieEncoding.RAW),
+    listOf(
+        cookiePart(name.assertCookieName(), value, encoding),
+        cookiePartUnencoded("Max-Age", if (maxAge > 0) maxAge else null),
+        cookiePartUnencoded("Expires", expires?.toHttpDate()),
+        cookiePart("Domain", domain, CookieEncoding.RAW),
+        cookiePart("Path", path, CookieEncoding.RAW),
 
-            cookiePartFlag("Secure", secure),
-            cookiePartFlag("HttpOnly", httpOnly)
-        )
-                + extensions.map { cookiePartExt(it.key.assertCookieName(), it.value, encoding) }
-                + if (includeEncoding) cookiePartExt("\$x-enc", encoding.name, CookieEncoding.RAW) else ""
-        ).filter { it.isNotEmpty() }
+        cookiePartFlag("Secure", secure),
+        cookiePartFlag("HttpOnly", httpOnly)
+    ) + extensions.map { cookiePartExt(it.key.assertCookieName(), it.value, encoding) } +
+        if (includeEncoding) cookiePartExt("\$x-enc", encoding.name, CookieEncoding.RAW) else ""
+    ).filter { it.isNotEmpty() }
     .joinToString("; ")
 
 /**
@@ -186,11 +192,18 @@ public fun renderSetCookieHeader(
 @KtorExperimentalAPI
 public fun encodeCookieValue(value: String, encoding: CookieEncoding): String = when (encoding) {
     CookieEncoding.RAW -> when {
-        value.any { it.shouldEscapeInCookies() } -> throw IllegalArgumentException("The cookie value contains characters that couldn't be encoded in RAW format. Consider URL_ENCODING mode")
+        value.any { it.shouldEscapeInCookies() } ->
+            throw IllegalArgumentException(
+                "The cookie value contains characters that couldn't be encoded in RAW format. " +
+                    " Consider URL_ENCODING mode"
+            )
         else -> value
     }
     CookieEncoding.DQUOTES -> when {
-        value.contains('"') -> throw IllegalArgumentException("The cookie value contains characters that couldn't be encoded in DQUOTES format. Consider URL_ENCODING mode")
+        value.contains('"') -> throw IllegalArgumentException(
+            "The cookie value contains characters that couldn't be encoded in DQUOTES format. " +
+                "Consider URL_ENCODING mode"
+        )
         value.any { it.shouldEscapeInCookies() } -> "\"$value\""
         else -> value
     }
@@ -229,7 +242,6 @@ private inline fun cookiePart(name: String, value: Any?, encoding: CookieEncodin
 @Suppress("NOTHING_TO_INLINE")
 private inline fun cookiePartUnencoded(name: String, value: Any?) =
     if (value != null) "$name=$value" else ""
-
 
 @Suppress("NOTHING_TO_INLINE")
 private inline fun cookiePartFlag(name: String, value: Boolean) =

--- a/ktor-http/common/src/io/ktor/http/CookieUtils.kt
+++ b/ktor-http/common/src/io/ktor/http/CookieUtils.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2014-2020 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package io.ktor.http
@@ -64,23 +64,23 @@ internal class StringLexer(val source: String) {
  * Delimiter in the rfc grammar
  */
 internal fun Char.isDelimiter(): Boolean =
-    this == '\u0009'
-        || this in ('\u0020'..'\u002f')
-        || this in ('\u003b'..'\u0040')
-        || this in ('\u005b'..'\u0060')
-        || this in ('\u007b'..'\u007e')
+    this == '\u0009' ||
+        this in ('\u0020'..'\u002f') ||
+        this in ('\u003b'..'\u0040') ||
+        this in ('\u005b'..'\u0060') ||
+        this in ('\u007b'..'\u007e')
 
 /**
  * non-delimiter in the rfc grammar
  */
 internal fun Char.isNonDelimiter(): Boolean =
-    this in ('\u0000'..'\u0008')
-        || this in ('\u000a'..'\u001f')
-        || this in ('0'..'9')
-        || this == ':'
-        || this in ('a'..'z')
-        || this in ('A'..'Z')
-        || this in ('\u007f'..'\u00ff')
+    this in ('\u0000'..'\u0008') ||
+        this in ('\u000a'..'\u001f') ||
+        this in ('0'..'9') ||
+        this == ':' ||
+        this in ('a'..'z') ||
+        this in ('A'..'Z') ||
+        this in ('\u007f'..'\u00ff')
 
 /**
  * octet in the rfc grammar
@@ -134,8 +134,9 @@ internal inline fun String.tryParseTime(success: (Int, Int, Int) -> Unit) {
         accept { it.isDigit() }
     }.toInt()
 
-    if (lexer.accept { it.isNonDigit() })
+    if (lexer.accept { it.isNonDigit() }) {
         lexer.acceptWhile { it.isOctet() }
+    }
 
     success(hour, minute, second)
 }
@@ -172,8 +173,9 @@ internal inline fun String.tryParseDayOfMonth(success: (Int) -> Unit) {
         accept { it.isDigit() }
     }.toInt()
 
-    if (lexer.accept { it.isNonDigit() })
+    if (lexer.accept { it.isNonDigit() }) {
         lexer.acceptWhile { it.isOctet() }
+    }
 
     success(day)
 }
@@ -191,8 +193,9 @@ internal inline fun String.tryParseYear(success: (Int) -> Unit) {
         repeat(2) { accept { it.isDigit() } }
     }.toInt()
 
-    if (lexer.accept { it.isNonDigit() })
+    if (lexer.accept { it.isNonDigit() }) {
         lexer.acceptWhile { it.isOctet() }
+    }
 
     success(year)
 }
@@ -267,13 +270,15 @@ internal fun CookieDateBuilder.handleToken(token: String) {
 internal class CookieDateParser {
 
     private fun <T> checkFieldNotNull(source: String, name: String, field: T?) {
-        if (null == field)
+        if (null == field) {
             throw InvalidCookieDateException(source, "Could not find $name")
+        }
     }
 
     private fun checkRequirement(source: String, requirement: Boolean, msg: () -> String) {
-        if (!requirement)
+        if (!requirement) {
             throw InvalidCookieDateException(source, msg())
+        }
     }
 
     /**
@@ -296,10 +301,10 @@ internal class CookieDateParser {
         }
 
         /**
-        3. If the year-value is greater than or equal to 70 and less than or
-        equal to 99, increment the year-value by 1900
-        4. If the year-value is greater than or equal to 0 and less than or
-        equal to 69, increment the year-value by 2000.
+         * 3. If the year-value is greater than or equal to 70 and less than or
+         * equal to 99, increment the year-value by 1900
+         * 4. If the year-value is greater than or equal to 0 and less than or
+         * equal to 69, increment the year-value by 2000.
          */
         when (builder.year) {
             in 70..99 -> builder.year = builder.year!! + 1900
@@ -339,5 +344,6 @@ internal class CookieDateBuilder {
  * Thrown when the date string doesn't satisfy the RFC6265 grammar
  */
 internal class InvalidCookieDateException(
-    data: String, reason: String
+    data: String,
+    reason: String
 ) : IllegalStateException("Failed to parse date string: \"${data}\". Reason: \"$reason\"")

--- a/ktor-http/common/src/io/ktor/http/FileContentType.kt
+++ b/ktor-http/common/src/io/ktor/http/FileContentType.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2014-2020 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package io.ktor.http
@@ -17,7 +17,8 @@ public fun ContentType.Companion.defaultForFileExtension(extension: String): Con
 /**
  * Default [ContentType] for file [path]
  */
-public fun ContentType.Companion.defaultForFilePath(path: String): ContentType = ContentType.fromFilePath(path).selectDefault()
+public fun ContentType.Companion.defaultForFilePath(path: String): ContentType =
+    ContentType.fromFilePath(path).selectDefault()
 
 /**
  * Recommended content types by file [path]
@@ -25,8 +26,9 @@ public fun ContentType.Companion.defaultForFilePath(path: String): ContentType =
 public fun ContentType.Companion.fromFilePath(path: String): List<ContentType> {
     val slashIndex = path.lastIndexOfAny("/\\".toCharArray())
     val index = path.indexOf('.', startIndex = slashIndex + 1)
-    if (index == -1)
+    if (index == -1) {
         return emptyList()
+    }
     return fromFileExtension(path.substring(index + 1))
 }
 
@@ -65,8 +67,10 @@ private val extensionsByContentType: Map<ContentType, List<String>> by lazy {
 
 internal fun List<ContentType>.selectDefault(): ContentType {
     val contentType = firstOrNull() ?: ContentType.Application.OctetStream
-    return if (contentType.contentType == "text" && contentType.charset() == null)
-        contentType.withCharset(Charsets.UTF_8) else contentType
+    return when {
+        contentType.contentType == "text" && contentType.charset() == null -> contentType.withCharset(Charsets.UTF_8)
+        else -> contentType
+    }
 }
 
 internal fun <A, B> Sequence<Pair<A, B>>.groupByPairs() = groupBy { it.first }

--- a/ktor-http/common/src/io/ktor/http/HeaderValueWithParameters.kt
+++ b/ktor-http/common/src/io/ktor/http/HeaderValueWithParameters.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2014-2020 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package io.ktor.http
@@ -27,7 +27,8 @@ public abstract class HeaderValueWithParameters(
     /**
      * The first value for the parameter with [name] comparing case-insensitively or `null` if no such parameters found
      */
-    public fun parameter(name: String): String? = parameters.firstOrNull { it.name.equals(name, ignoreCase = true) }?.value
+    public fun parameter(name: String): String? =
+        parameters.firstOrNull { it.name.equals(name, ignoreCase = true) }?.value
 
     override fun toString(): String = when {
         parameters.isEmpty() -> content

--- a/ktor-http/common/src/io/ktor/http/Headers.kt
+++ b/ktor-http/common/src/io/ktor/http/Headers.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2014-2020 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package io.ktor.http
@@ -46,7 +46,8 @@ public class HeadersBuilder(size: Int = 8) : StringValuesBuilder(true, size) {
 
 @Suppress("KDocMissingDocumentation")
 @Deprecated(
-    "Empty headers is internal", replaceWith = ReplaceWith("Headers.Empty"),
+    "Empty headers is internal",
+    replaceWith = ReplaceWith("Headers.Empty"),
     level = DeprecationLevel.ERROR
 )
 public object EmptyHeaders : Headers {
@@ -89,9 +90,8 @@ public class HeadersImpl(
 @InternalAPI
 @Suppress("KDocMissingDocumentation")
 public class HeadersSingleImpl(
-    name: String, values: List<String>
+    name: String,
+    values: List<String>
 ) : Headers, StringValuesSingleImpl(true, name, values) {
     override fun toString(): String = "Headers ${entries()}"
 }
-
-

--- a/ktor-http/common/src/io/ktor/http/HttpHeaderValueParser.kt
+++ b/ktor-http/common/src/io/ktor/http/HttpHeaderValueParser.kt
@@ -13,9 +13,9 @@ import io.ktor.util.*
  */
 public data class HeaderValueParam(val name: String, val value: String) {
     override fun equals(other: Any?): Boolean {
-        return other is HeaderValueParam
-            && other.name.equals(name, ignoreCase = true)
-            && other.value.equals(value, ignoreCase = true)
+        return other is HeaderValueParam &&
+            other.name.equals(name, ignoreCase = true) &&
+            other.value.equals(value, ignoreCase = true)
     }
 
     override fun hashCode(): Int {
@@ -41,7 +41,8 @@ public data class HeaderValue(val value: String, val params: List<HeaderValuePar
 /**
  * Parse header value and sort multiple values according to qualities
  */
-public fun parseAndSortHeader(header: String?): List<HeaderValue> = parseHeaderValue(header).sortedByDescending { it.quality }
+public fun parseAndSortHeader(header: String?): List<HeaderValue> =
+    parseHeaderValue(header).sortedByDescending { it.quality }
 
 /**
  * Parse `Content-Type` header values and sort them by quality and asterisks quantity
@@ -50,12 +51,15 @@ public fun parseAndSortContentTypeHeader(header: String?): List<HeaderValue> = p
     compareByDescending<HeaderValue> { it.quality }.thenBy {
         val contentType = ContentType.parse(it.value)
         var asterisks = 0
-        if (contentType.contentType == "*")
+        if (contentType.contentType == "*") {
             asterisks += 2
-        if (contentType.contentSubtype == "*")
+        }
+        if (contentType.contentSubtype == "*") {
             asterisks++
+        }
         asterisks
-    }.thenByDescending { it.params.size })
+    }.thenByDescending { it.params.size }
+)
 
 /**
  * Parse header value respecting multi-values
@@ -155,7 +159,6 @@ private fun parseHeaderValueParameter(text: String, start: Int, parameters: Lazy
     addParam(text, start, position, "")
     return position
 }
-
 
 private fun parseHeaderValueParameterValue(value: String, start: Int): Pair<Int, String> {
     if (value.length == start) {

--- a/ktor-http/common/src/io/ktor/http/HttpHeaders.kt
+++ b/ktor-http/common/src/io/ktor/http/HttpHeaders.kt
@@ -123,7 +123,8 @@ public object HttpHeaders {
     private val UnsafeHeadersArray: Array<String> = arrayOf(ContentLength, ContentType, TransferEncoding, Upgrade)
 
     @Deprecated("Use UnsafeHeadersList instead.", replaceWith = ReplaceWith("HttpHeaders.UnsafeHeadersList"))
-    public val UnsafeHeaders: Array<String> get() = UnsafeHeadersArray.copyOf()
+    public val UnsafeHeaders: Array<String>
+        get() = UnsafeHeadersArray.copyOf()
 
     /**
      * A list of header names that are not safe to use unless it is low-level engine implementation.
@@ -169,10 +170,11 @@ public class UnsafeHeaderException(header: String) : IllegalArgumentException(
  * @property headerName that was tried to use
  * @property position at which validation failed
  */
-public class IllegalHeaderNameException(public val headerName: String, public val position: Int) : IllegalArgumentException(
-    "Header name '$headerName' contains illegal character '${headerName[position]}'" +
-        " (code ${(headerName[position].toInt() and 0xff)})"
-)
+public class IllegalHeaderNameException(public val headerName: String, public val position: Int) :
+    IllegalArgumentException(
+        "Header name '$headerName' contains illegal character '${headerName[position]}'" +
+            " (code ${(headerName[position].toInt() and 0xff)})"
+    )
 
 /**
  * Thrown when an illegal header value was used.
@@ -180,9 +182,10 @@ public class IllegalHeaderNameException(public val headerName: String, public va
  * @property headerValue that was tried to use
  * @property position at which validation failed
  */
-public class IllegalHeaderValueException(public val headerValue: String, public val position: Int) : IllegalArgumentException(
-    "Header value '$headerValue' contains illegal character '${headerValue[position]}'" +
-        " (code ${(headerValue[position].toInt() and 0xff)})"
-)
+public class IllegalHeaderValueException(public val headerValue: String, public val position: Int) :
+    IllegalArgumentException(
+        "Header value '$headerValue' contains illegal character '${headerValue[position]}'" +
+            " (code ${(headerValue[position].toInt() and 0xff)})"
+    )
 
 private fun isDelimiter(ch: Char): Boolean = ch in "\"(),/:;<=>?@[\\]{}"

--- a/ktor-http/common/src/io/ktor/http/HttpMessageProperties.kt
+++ b/ktor-http/common/src/io/ktor/http/HttpMessageProperties.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2014-2020 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
 @file:Suppress("unused")
@@ -11,18 +11,21 @@ import io.ktor.utils.io.charsets.*
 /**
  * Set `Content-Type` header.
  */
-public fun HttpMessageBuilder.contentType(type: ContentType): Unit = headers.set(HttpHeaders.ContentType, type.toString())
+public fun HttpMessageBuilder.contentType(type: ContentType): Unit =
+    headers.set(HttpHeaders.ContentType, type.toString())
 
 @Deprecated(
     "Content-Length is controlled by underlying engine. Don't specify it explicitly.",
     level = DeprecationLevel.ERROR
 )
 @Suppress("KDocMissingDocumentation", "unused", "PublicApiImplicitType", "DeprecatedCallableAddReplaceWith")
-public fun HttpMessageBuilder.contentLength(length: Int): Unit = headers.set(HttpHeaders.ContentLength, length.toString())
+public fun HttpMessageBuilder.contentLength(length: Int): Unit =
+    headers.set(HttpHeaders.ContentLength, length.toString())
 
 @Deprecated("Use content with particular content type and charset instead", level = DeprecationLevel.ERROR)
 @Suppress("KDocMissingDocumentation", "unused", "PublicApiImplicitType", "DeprecatedCallableAddReplaceWith")
-public fun HttpMessageBuilder.charset(charset: Charset): Unit? = contentType()?.let { contentType(it.withCharset(charset)) }
+public fun HttpMessageBuilder.charset(charset: Charset): Unit? =
+    contentType()?.let { contentType(it.withCharset(charset)) }
 
 /**
  * Append `Max-Age` header value.
@@ -42,7 +45,8 @@ public fun HttpMessageBuilder.userAgent(content: String): Unit = headers.set(Htt
 /**
  * Parse `Content-Type` header value.
  */
-public fun HttpMessageBuilder.contentType(): ContentType? = headers[HttpHeaders.ContentType]?.let { ContentType.parse(it) }
+public fun HttpMessageBuilder.contentType(): ContentType? =
+    headers[HttpHeaders.ContentType]?.let { ContentType.parse(it) }
 
 /**
  * Parse charset from `Content-Type` header value.
@@ -161,4 +165,3 @@ internal fun String.splitSetCookieHeader(): List<String> {
 
     return result
 }
-

--- a/ktor-http/common/src/io/ktor/http/HttpProtocolVersion.kt
+++ b/ktor-http/common/src/io/ktor/http/HttpProtocolVersion.kt
@@ -1,9 +1,8 @@
 /*
- * Copyright 2014-2019 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2014-2020 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package io.ktor.http
-
 
 /**
  * Represents an HTTP protocol version.

--- a/ktor-http/common/src/io/ktor/http/HttpUrlEncoded.kt
+++ b/ktor-http/common/src/io/ktor/http/HttpUrlEncoded.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2014-2020 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package io.ktor.http

--- a/ktor-http/common/src/io/ktor/http/LinkHeader.kt
+++ b/ktor-http/common/src/io/ktor/http/LinkHeader.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2014-2020 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package io.ktor.http
@@ -8,7 +8,8 @@ package io.ktor.http
  * Represents a `Link` header value as per RFC 5988
  */
 public class LinkHeader(
-    uri: String, params: List<HeaderValueParam>
+    uri: String,
+    params: List<HeaderValueParam>
 ) : HeaderValueWithParameters("<$uri>", params) {
 
     @Suppress("unused")
@@ -21,9 +22,12 @@ public class LinkHeader(
 
     @Suppress("unused")
     public constructor(
-        uri: String, rel: List<String>, type: ContentType
+        uri: String,
+        rel: List<String>,
+        type: ContentType
     ) : this(
-        uri, listOf(
+        uri,
+        listOf(
             HeaderValueParam(Parameters.Rel, rel.joinToString(" ")),
             HeaderValueParam(Parameters.Type, type.toString())
         )

--- a/ktor-http/common/src/io/ktor/http/Parameters.kt
+++ b/ktor-http/common/src/io/ktor/http/Parameters.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2014-2020 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package io.ktor.http
@@ -21,9 +21,9 @@ public interface Parameters : StringValues {
          * Builds a [Parameters] instance with the given [builder] function
          * @param builder specifies a function to build a map
          */
-        public inline fun build(builder: ParametersBuilder.() -> Unit): Parameters = ParametersBuilder().apply(builder).build()
+        public inline fun build(builder: ParametersBuilder.() -> Unit): Parameters =
+            ParametersBuilder().apply(builder).build()
     }
-
 }
 
 @Suppress("KDocMissingDocumentation")
@@ -74,13 +74,15 @@ public fun parametersOf(vararg pairs: Pair<String, List<String>>): Parameters = 
 
 @Suppress("KDocMissingDocumentation")
 @InternalAPI
-public class ParametersImpl(values: Map<String, List<String>> = emptyMap()) : Parameters, StringValuesImpl(true, values) {
+public class ParametersImpl(values: Map<String, List<String>> = emptyMap()) : Parameters,
+    StringValuesImpl(true, values) {
     override fun toString(): String = "Parameters ${entries()}"
 }
 
 @Suppress("KDocMissingDocumentation")
 @InternalAPI
-public class ParametersSingleImpl(name: String, values: List<String>) : Parameters, StringValuesSingleImpl(true, name, values) {
+public class ParametersSingleImpl(name: String, values: List<String>) : Parameters,
+    StringValuesSingleImpl(true, name, values) {
     override fun toString(): String = "Parameters ${entries()}"
 }
 
@@ -93,5 +95,9 @@ public operator fun Parameters.plus(other: Parameters): Parameters = when {
         other.isEmpty() -> this
         else -> Parameters.build { appendAll(this@plus); appendAll(other) }
     }
-    else -> throw IllegalArgumentException("Cannot concatenate Parameters with case-sensitive and case-insensitive names")
+    else -> {
+        throw IllegalArgumentException(
+            "Cannot concatenate Parameters with case-sensitive and case-insensitive names"
+        )
+    }
 }

--- a/ktor-http/common/src/io/ktor/http/Query.kt
+++ b/ktor-http/common/src/io/ktor/http/Query.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2014-2020 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package io.ktor.http
@@ -20,10 +20,10 @@ private fun ParametersBuilder.parse(query: String, startIndex: Int, limit: Int) 
     var nameIndex = startIndex
     var equalIndex = -1
     for (index in startIndex..query.lastIndex) {
-        if (count == limit)
+        if (count == limit) {
             return
-        val ch = query[index]
-        when (ch) {
+        }
+        when (query[index]) {
             '&' -> {
                 appendParam(query, nameIndex, equalIndex, index)
                 nameIndex = index + 1
@@ -31,13 +31,15 @@ private fun ParametersBuilder.parse(query: String, startIndex: Int, limit: Int) 
                 count++
             }
             '=' -> {
-                if (equalIndex == -1)
+                if (equalIndex == -1) {
                     equalIndex = index
+                }
             }
         }
     }
-    if (count == limit)
+    if (count == limit) {
         return
+    }
     appendParam(query, nameIndex, equalIndex, query.length)
 }
 

--- a/ktor-http/common/src/io/ktor/http/URLBuilder.kt
+++ b/ktor-http/common/src/io/ktor/http/URLBuilder.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2014-2020 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package io.ktor.http
@@ -141,7 +141,10 @@ public data class Url(
     val trailingQuery: Boolean
 ) {
     init {
-        require(specifiedPort in 1..65536 || specifiedPort == DEFAULT_PORT) { "port must be between 1 and 65536, or $DEFAULT_PORT if not set" }
+        require(
+            specifiedPort in 1..65536 ||
+                specifiedPort == DEFAULT_PORT
+        ) { "port must be between 1 and 65536, or $DEFAULT_PORT if not set" }
     }
 
     val port: Int get() = specifiedPort.takeUnless { it == DEFAULT_PORT } ?: protocol.defaultPort

--- a/ktor-http/common/src/io/ktor/http/URLParser.kt
+++ b/ktor-http/common/src/io/ktor/http/URLParser.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2014-2020 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package io.ktor.http
@@ -22,7 +22,8 @@ public fun URLBuilder.takeFrom(urlString: String): URLBuilder {
  * Thrown when failed to parse URL
  */
 public class URLParserException(urlString: String, cause: Throwable) : IllegalStateException(
-    "Fail to parse url: $urlString", cause
+    "Fail to parse url: $urlString",
+    cause
 )
 
 internal fun URLBuilder.takeFromUnsafe(urlString: String): URLBuilder {
@@ -137,7 +138,7 @@ private fun URLBuilder.parseFile(urlString: String, startIndex: Int, endIndex: I
 }
 
 private fun URLBuilder.parseMailto(urlString: String, startIndex: Int, endIndex: Int) {
-    val delimiter = urlString.indexOf("@", startIndex);
+    val delimiter = urlString.indexOf("@", startIndex)
     if (delimiter == -1) {
         throw IllegalArgumentException("Invalid mailto url: $urlString, it should contain '@'.")
     }
@@ -213,13 +214,13 @@ private fun findScheme(urlString: String, startIndex: Int, endIndex: Int): Int {
         if (char == '/' || char == '?' || char == '#') return -1
 
         // Update incorrect scheme position is current char is illegal.
-        if (incorrectSchemePosition == -1
-            && char !in 'a'..'z'
-            && char !in 'A'..'Z'
-            && char !in '0'..'9'
-            && char != '.'
-            && char != '+'
-            && char != '-'
+        if (incorrectSchemePosition == -1 &&
+            char !in 'a'..'z' &&
+            char !in 'A'..'Z' &&
+            char !in '0'..'9' &&
+            char != '.' &&
+            char != '+' &&
+            char != '-'
         ) {
             incorrectSchemePosition = current
         }

--- a/ktor-http/common/src/io/ktor/http/URLProtocol.kt
+++ b/ktor-http/common/src/io/ktor/http/URLProtocol.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2014-2020 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package io.ktor.http
@@ -47,7 +47,6 @@ public data class URLProtocol(val name: String, val defaultPort: Int) {
          * Protocols by names map
          */
         public val byName: Map<String, URLProtocol> = listOf(HTTP, HTTPS, WS, WSS, SOCKS).associateBy { it.name }
-
 
         /**
          * Create an instance by [name] or use already existing instance

--- a/ktor-http/common/src/io/ktor/http/auth/HttpAuthHeader.kt
+++ b/ktor-http/common/src/io/ktor/http/auth/HttpAuthHeader.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2014-2020 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package io.ktor.http.auth
@@ -43,7 +43,6 @@ public fun parseAuthorizationHeader(headerValue: String): HttpAuthHeader? {
 
     return HttpAuthHeader.Parameterized(authScheme, parameters)
 }
-
 
 /**
  * Describes an authentication header with a mandatory [authScheme] that usually is a standard [AuthScheme].
@@ -182,7 +181,8 @@ public sealed class HttpAuthHeader(public val authScheme: String) {
          * Generates an [AuthScheme.Basic] challenge as a [HttpAuthHeader].
          */
         public fun basicAuthChallenge(realm: String, charset: Charset?): Parameterized = Parameterized(
-            AuthScheme.Basic, LinkedHashMap<String, String>().apply {
+            AuthScheme.Basic,
+            LinkedHashMap<String, String>().apply {
                 put(Parameters.Realm, realm)
                 if (charset != null) {
                     put(Parameters.Charset, charset.name)
@@ -200,20 +200,24 @@ public sealed class HttpAuthHeader(public val authScheme: String) {
             opaque: String? = null,
             stale: Boolean? = null,
             algorithm: String = "MD5"
-        ): Parameterized = Parameterized(AuthScheme.Digest, linkedMapOf<String, String>().apply {
-            put("realm", realm)
-            put("nonce", nonce)
-            if (domain.isNotEmpty()) {
-                put("domain", domain.joinToString(" "))
-            }
-            if (opaque != null) {
-                put("opaque", opaque)
-            }
-            if (stale != null) {
-                put("stale", stale.toString())
-            }
-            put("algorithm", algorithm)
-        }, HeaderValueEncoding.QUOTED_ALWAYS)
+        ): Parameterized = Parameterized(
+            AuthScheme.Digest,
+            linkedMapOf<String, String>().apply {
+                put("realm", realm)
+                put("nonce", nonce)
+                if (domain.isNotEmpty()) {
+                    put("domain", domain.joinToString(" "))
+                }
+                if (opaque != null) {
+                    put("opaque", opaque)
+                }
+                if (stale != null) {
+                    put("stale", stale.toString())
+                }
+                put("algorithm", algorithm)
+            },
+            HeaderValueEncoding.QUOTED_ALWAYS
+        )
     }
 
     /**
@@ -237,7 +241,6 @@ public sealed class HttpAuthHeader(public val authScheme: String) {
         public const val OAuthCallbackConfirmed: String = "oauth_callback_confirmed"
     }
 }
-
 
 private fun String.substringAfterMatch(result: MatchResult): String = drop(
     result.range.last + if (result.range.isEmpty()) 0 else 1

--- a/ktor-http/common/src/io/ktor/http/content/CachingOptions.kt
+++ b/ktor-http/common/src/io/ktor/http/content/CachingOptions.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2014-2020 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package io.ktor.http.content
@@ -26,4 +26,3 @@ public val CachingProperty: AttributeKey<CachingOptions> = AttributeKey<CachingO
 public var OutgoingContent.caching: CachingOptions?
     get() = getProperty(CachingProperty)
     set(value) = setProperty(CachingProperty, value)
-

--- a/ktor-http/common/src/io/ktor/http/content/Multipart.kt
+++ b/ktor-http/common/src/io/ktor/http/content/Multipart.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2014-2020 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package io.ktor.http.content
@@ -18,14 +18,17 @@ public sealed class PartData(public val dispose: () -> Unit, public val headers:
      * Represents a multipart form item
      * @property value of this field
      */
-    public class FormItem(public val value: String, dispose: () -> Unit, partHeaders: Headers) : PartData(dispose, partHeaders)
+    public class FormItem(public val value: String, dispose: () -> Unit, partHeaders: Headers) :
+        PartData(dispose, partHeaders)
 
     /**
      * Represents a file item
      * @property provider of content bytes
      */
     public class FileItem(
-        public val provider: () -> Input, dispose: () -> Unit, partHeaders: Headers
+        public val provider: () -> Input,
+        dispose: () -> Unit,
+        partHeaders: Headers
     ) : PartData(dispose, partHeaders) {
         /**
          * Original file name if present
@@ -38,7 +41,9 @@ public sealed class PartData(public val dispose: () -> Unit, public val headers:
      * @property provider of content bytes
      */
     public class BinaryItem(
-        public val provider: () -> Input, dispose: () -> Unit, partHeaders: Headers
+        public val provider: () -> Input,
+        dispose: () -> Unit,
+        partHeaders: Headers
     ) : PartData(dispose, partHeaders)
 
     /**
@@ -66,7 +71,8 @@ public sealed class PartData(public val dispose: () -> Unit, public val headers:
 
     @Suppress("KDocMissingDocumentation", "unused")
     @Deprecated(
-        "Use name property instead", ReplaceWith("name"),
+        "Use name property instead",
+        ReplaceWith("name"),
         level = DeprecationLevel.ERROR
     )
     public val partName: String?
@@ -74,7 +80,8 @@ public sealed class PartData(public val dispose: () -> Unit, public val headers:
 
     @Suppress("KDocMissingDocumentation", "unused")
     @Deprecated(
-        "Use headers property instead", ReplaceWith("headers"),
+        "Use headers property instead",
+        ReplaceWith("headers"),
         level = DeprecationLevel.ERROR
     )
     public val partHeaders: Headers

--- a/ktor-http/common/src/io/ktor/http/content/OutgoingContent.kt
+++ b/ktor-http/common/src/io/ktor/http/content/OutgoingContent.kt
@@ -6,8 +6,8 @@ package io.ktor.http.content
 
 import io.ktor.http.*
 import io.ktor.util.*
-import kotlinx.coroutines.*
 import io.ktor.utils.io.*
+import kotlinx.coroutines.*
 import kotlin.coroutines.*
 
 /**
@@ -74,13 +74,16 @@ public sealed class OutgoingContent {
         /**
          * Provides [ByteReadChannel] for the given range of the content
          */
-        public open fun readFrom(range: LongRange): ByteReadChannel = if (range.isEmpty()) ByteReadChannel.Empty else
+        public open fun readFrom(range: LongRange): ByteReadChannel = if (range.isEmpty()) {
+            ByteReadChannel.Empty
+        } else {
             GlobalScope.writer(Dispatchers.Unconfined, autoFlush = true) {
                 val source = readFrom()
                 source.discard(range.start)
                 val limit = range.endInclusive - range.start + 1
                 source.copyTo(channel, limit)
             }.channel
+        }
     }
 
     /**

--- a/ktor-http/common/src/io/ktor/http/parsing/GrammarBuilder.kt
+++ b/ktor-http/common/src/io/ktor/http/parsing/GrammarBuilder.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2014-2020 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package io.ktor.http.parsing
@@ -17,15 +17,15 @@ internal class GrammarBuilder {
         return this
     }
 
-    operator fun (() -> Grammar).unaryPlus(): Unit {
+    operator fun (() -> Grammar).unaryPlus() {
         grammars += this()
     }
 
-    operator fun Grammar.unaryPlus(): Unit {
+    operator fun Grammar.unaryPlus() {
         grammars += this
     }
 
-    operator fun String.unaryPlus(): Unit {
+    operator fun String.unaryPlus() {
         grammars += StringGrammar(this)
     }
 

--- a/ktor-http/common/src/io/ktor/http/websocket/Utils.kt
+++ b/ktor-http/common/src/io/ktor/http/websocket/Utils.kt
@@ -8,7 +8,6 @@ import io.ktor.util.*
 import io.ktor.utils.io.charsets.*
 import io.ktor.utils.io.core.*
 
-
 private const val WEBSOCKET_SERVER_ACCEPT_TAIL = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11"
 
 /**


### PR DESCRIPTION
**Subsystem**
ktor-http (all)

**Motivation**
This is an attempt to make `ktor-http` module conform to [ktlint](https://github.com/pinterest/ktlint). This is under question if we want such changes. Please look at whet I was forced to do.

The only disabled rule is "no-wildcard-imports" to make start imports work. 

