### PR TITLE
KTOR-1312 Add config flag to MicrometerMetrics to log all 404 request with n/a route

### DIFF
--- a/ktor-features/ktor-metrics-micrometer/api/ktor-metrics-micrometer.api
+++ b/ktor-features/ktor-metrics-micrometer/api/ktor-metrics-micrometer.api
@@ -3,14 +3,17 @@ public final class io/ktor/metrics/micrometer/MicrometerMetrics {
 	public static final field activeGaugeName Ljava/lang/String;
 	public static final field requestTimerName Ljava/lang/String;
 	public fun <init> (Lio/micrometer/core/instrument/MeterRegistry;Lio/micrometer/core/instrument/distribution/DistributionStatisticConfig;Lkotlin/jvm/functions/Function3;)V
+	public synthetic fun <init> (Lio/micrometer/core/instrument/MeterRegistry;Lio/micrometer/core/instrument/distribution/DistributionStatisticConfig;ZLkotlin/jvm/functions/Function3;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 }
 
 public final class io/ktor/metrics/micrometer/MicrometerMetrics$Configuration {
 	public field registry Lio/micrometer/core/instrument/MeterRegistry;
 	public fun <init> ()V
+	public final fun getDistinctNotRegisteredRoutes ()Z
 	public final fun getDistributionStatisticConfig ()Lio/micrometer/core/instrument/distribution/DistributionStatisticConfig;
 	public final fun getMeterBinders ()Ljava/util/List;
 	public final fun getRegistry ()Lio/micrometer/core/instrument/MeterRegistry;
+	public final fun setDistinctNotRegisteredRoutes (Z)V
 	public final fun setDistributionStatisticConfig (Lio/micrometer/core/instrument/distribution/DistributionStatisticConfig;)V
 	public final fun setMeterBinders (Ljava/util/List;)V
 	public final fun setRegistry (Lio/micrometer/core/instrument/MeterRegistry;)V

--- a/ktor-features/ktor-metrics-micrometer/jvm/test/io/ktor/metrics/micrometer/MicrometerMetricsTests.kt
+++ b/ktor-features/ktor-metrics-micrometer/jvm/test/io/ktor/metrics/micrometer/MicrometerMetricsTests.kt
@@ -201,7 +201,7 @@ class MicrometerMetricsTests {
     }
 
     @Test
-    fun `no handler results in status 404 and no exception`(): Unit = withTestApplication {
+    fun `no handler results in status 404 and no exception by default`(): Unit = withTestApplication {
 
         val testRegistry = SimpleMeterRegistry()
 
@@ -224,6 +224,40 @@ class MicrometerMetricsTests {
                 assertTag("throwable", "n/a")
                 assertTag("status", "404")
                 assertTag("route", "/uri")
+                assertTag("method", "GET")
+                assertTag("address", "localhost:80")
+            }
+        }
+
+        assertNull(throwableCaughtInEngine)
+        assertTrue(noHandlerHandledReqeust)
+    }
+
+    @Test
+    fun `no handler results in status 404 no route and no exception if distinctNotRegisteredRoutes is false`(): Unit = withTestApplication {
+
+        val testRegistry = SimpleMeterRegistry()
+
+        application.install(MicrometerMetrics) {
+            registry = testRegistry
+            distinctNotRegisteredRoutes = false
+        }
+
+
+        installDefaultBehaviour()
+
+        // no routing config
+
+        handleRequest {
+            uri = "/uri"
+        }
+
+        with(testRegistry.find(MicrometerMetrics.requestTimerName).timers()) {
+            assertEquals(1, size)
+            this.first().run {
+                assertTag("throwable", "n/a")
+                assertTag("status", "404")
+                assertTag("route", "n/a")
                 assertTag("method", "GET")
                 assertTag("address", "localhost:80")
             }


### PR DESCRIPTION
**Subsystem**
Server, MicrometerMetrics

**Motivation**
[Micrometer metrics: scan of random URLs of a server exhausts available values per tag in influx](https://youtrack.jetbrains.com/issue/KTOR-1312)

**Solution**
To not change existing behavior, I added the flag to opt-in for the new one.

