### PR TITLE
KTOR 1344 - Unified pre-typed routes

### DIFF
--- a/ktor-server/ktor-server-core/jvm/src/io/ktor/routing/RoutingBuilder.kt
+++ b/ktor-server/ktor-server-core/jvm/src/io/ktor/routing/RoutingBuilder.kt
@@ -118,11 +118,15 @@ public fun Route.post(path: String, body: PipelineInterceptor<Unit, ApplicationC
 @ContextDsl
 @JvmName("postTyped")
 public inline fun <reified R : Any> Route.post(
-    path: String,
+    path: String? = null,
     crossinline body: suspend PipelineContext<Unit, ApplicationCall>.(R) -> Unit
 ): Route {
-    return route(path, HttpMethod.Post) {
-        handle {
+    return if(path != null) {
+        post(path) {
+            body(call.receive())
+        }
+    } else {
+        post {
             body(call.receive())
         }
     }
@@ -169,6 +173,26 @@ public fun Route.put(body: PipelineInterceptor<Unit, ApplicationCall>): Route {
 }
 
 /**
+ * Builds a route to match `PUT` requests with specified [path] receiving request body content of type [R]
+ */
+@ContextDsl
+@JvmName("putTyped")
+public inline fun <reified R : Any> Route.put(
+    path: String? = null,
+    crossinline body: suspend PipelineContext<Unit, ApplicationCall>.(R) -> Unit
+): Route {
+    return if(path != null) {
+        put(path) {
+            body(call.receive())
+        }
+    } else {
+        put {
+            body(call.receive())
+        }
+    }
+}
+
+/**
  * Builds a route to match `PATCH` requests with specified [path]
  */
 @ContextDsl
@@ -182,6 +206,26 @@ public fun Route.patch(path: String, body: PipelineInterceptor<Unit, Application
 @ContextDsl
 public fun Route.patch(body: PipelineInterceptor<Unit, ApplicationCall>): Route {
     return method(HttpMethod.Patch) { handle(body) }
+}
+
+/**
+ * Builds a route to match `PATCH` requests with specified [path] receiving request body content of type [R]
+ */
+@ContextDsl
+@JvmName("patchTyped")
+public inline fun <reified R : Any> Route.patch(
+    path: String? = null,
+    crossinline body: suspend PipelineContext<Unit, ApplicationCall>.(R) -> Unit
+): Route {
+    return if(path != null) {
+        patch(path) {
+            body(call.receive())
+        }
+    } else {
+        patch {
+            body(call.receive())
+        }
+    }
 }
 
 /**

--- a/ktor-server/ktor-server-core/jvm/src/io/ktor/routing/RoutingBuilder.kt
+++ b/ktor-server/ktor-server-core/jvm/src/io/ktor/routing/RoutingBuilder.kt
@@ -113,7 +113,7 @@ public fun Route.post(path: String, body: PipelineInterceptor<Unit, ApplicationC
 }
 
 /**
- * Builds a route to match `POST` requests with specified [path] receiving request body content of type [R]
+ * Builds a route to match `POST` requests receiving request body content of type [R]
  */
 @ContextDsl
 @JvmName("postTyped")
@@ -176,7 +176,7 @@ public fun Route.put(body: PipelineInterceptor<Unit, ApplicationCall>): Route {
 }
 
 /**
- * Builds a route to match `PUT` requests with specified [path] receiving request body content of type [R]
+ * Builds a route to match `PUT` requests with receiving request body content of type [R]
  */
 @ContextDsl
 @JvmName("putTyped")
@@ -215,7 +215,7 @@ public fun Route.patch(body: PipelineInterceptor<Unit, ApplicationCall>): Route 
 }
 
 /**
- * Builds a route to match `PATCH` requests with specified [path] receiving request body content of type [R]
+ * Builds a route to match `PATCH` requests receiving request body content of type [R]
  */
 @ContextDsl
 @JvmName("patchTyped")

--- a/ktor-server/ktor-server-core/jvm/src/io/ktor/routing/RoutingBuilder.kt
+++ b/ktor-server/ktor-server-core/jvm/src/io/ktor/routing/RoutingBuilder.kt
@@ -118,18 +118,21 @@ public fun Route.post(path: String, body: PipelineInterceptor<Unit, ApplicationC
 @ContextDsl
 @JvmName("postTyped")
 public inline fun <reified R : Any> Route.post(
-    path: String? = null,
     crossinline body: suspend PipelineContext<Unit, ApplicationCall>.(R) -> Unit
-): Route {
-    return if(path != null) {
-        post(path) {
-            body(call.receive())
-        }
-    } else {
-        post {
-            body(call.receive())
-        }
-    }
+): Route = post {
+    body(call.receive())
+}
+
+/**
+ * Builds a route to match `POST` requests with specified [path] receiving request body content of type [R]
+ */
+@ContextDsl
+@JvmName("postTypedPath")
+public inline fun <reified R : Any> Route.post(
+    path: String,
+    crossinline body: suspend PipelineContext<Unit, ApplicationCall>.(R) -> Unit
+): Route = post(path) {
+    body(call.receive())
 }
 
 /**
@@ -178,18 +181,21 @@ public fun Route.put(body: PipelineInterceptor<Unit, ApplicationCall>): Route {
 @ContextDsl
 @JvmName("putTyped")
 public inline fun <reified R : Any> Route.put(
-    path: String? = null,
     crossinline body: suspend PipelineContext<Unit, ApplicationCall>.(R) -> Unit
-): Route {
-    return if(path != null) {
-        put(path) {
-            body(call.receive())
-        }
-    } else {
-        put {
-            body(call.receive())
-        }
-    }
+): Route = put {
+    body(call.receive())
+}
+
+/**
+ * Builds a route to match `PUT` requests with specified [path] receiving request body content of type [R]
+ */
+@ContextDsl
+@JvmName("putTypedPath")
+public inline fun <reified R : Any> Route.put(
+    path: String,
+    crossinline body: suspend PipelineContext<Unit, ApplicationCall>.(R) -> Unit
+): Route = put(path) {
+    body(call.receive())
 }
 
 /**
@@ -214,18 +220,21 @@ public fun Route.patch(body: PipelineInterceptor<Unit, ApplicationCall>): Route 
 @ContextDsl
 @JvmName("patchTyped")
 public inline fun <reified R : Any> Route.patch(
-    path: String? = null,
     crossinline body: suspend PipelineContext<Unit, ApplicationCall>.(R) -> Unit
-): Route {
-    return if(path != null) {
-        patch(path) {
-            body(call.receive())
-        }
-    } else {
-        patch {
-            body(call.receive())
-        }
-    }
+): Route = patch {
+    body(call.receive())
+}
+
+/**
+ * Builds a route to match `PATCH` requests with specified [path] receiving request body content of type [R]
+ */
+@ContextDsl
+@JvmName("patchTypedPath")
+public inline fun <reified R : Any> Route.patch(
+    path: String,
+    crossinline body: suspend PipelineContext<Unit, ApplicationCall>.(R) -> Unit
+): Route = patch(path) {
+    body(call.receive())
 }
 
 /**

--- a/ktor-server/ktor-server-tests/jvm/test/io/ktor/tests/server/routing/RoutingProcessingTest.kt
+++ b/ktor-server/ktor-server-tests/jvm/test/io/ktor/tests/server/routing/RoutingProcessingTest.kt
@@ -282,6 +282,42 @@ class RoutingProcessingTest {
     }
 
     @Test
+    fun testRouteWithTypedBody() = withTestApplication({
+        routing {
+            post<String> { answer ->
+                call.respondText(answer)
+            }
+            put<String>("/put") { answer ->
+                call.respondText(answer)
+            }
+            patch<String>("/patching") { answer ->
+                call.respondText(answer)
+            }
+        }
+    }) {
+        with(handleRequest(HttpMethod.Post, "/") {
+            setBody("42")
+        }.response) {
+            assertEquals(HttpStatusCode.OK, status()!!)
+            assertEquals(42.toString(), content!!)
+        }
+
+        with(handleRequest(HttpMethod.Put, "/put") {
+            setBody("42")
+        }.response) {
+            assertEquals(HttpStatusCode.OK, status()!!)
+            assertEquals(42.toString(), content!!)
+        }
+
+        with(handleRequest(HttpMethod.Patch, "/patching") {
+            setBody("42")
+        }.response) {
+            assertEquals(HttpStatusCode.OK, status()!!)
+            assertEquals(42.toString(), content!!)
+        }
+    }
+
+    @Test
     fun testInterceptionOrderWhenOuterShouldBeAfter() = withTestApplication {
         var userIntercepted = false
         var wrappedWithInterceptor = false

--- a/ktor-server/ktor-server-tests/jvm/test/io/ktor/tests/server/routing/RoutingProcessingTest.kt
+++ b/ktor-server/ktor-server-tests/jvm/test/io/ktor/tests/server/routing/RoutingProcessingTest.kt
@@ -282,38 +282,27 @@ class RoutingProcessingTest {
     }
 
     @Test
-    fun testRouteWithTypedBody() = withTestApplication({
-        routing {
+    fun testRouteWithTypedBody(): Unit = withTestApplication {
+        application.routing {
             post<String> { answer ->
-                call.respondText(answer)
+                assertEquals("42", answer)
             }
             put<String>("/put") { answer ->
-                call.respondText(answer)
+                assertEquals("42", answer)
             }
             patch<String>("/patching") { answer ->
-                call.respondText(answer)
+                assertEquals("42", answer)
             }
         }
-    }) {
-        with(handleRequest(HttpMethod.Post, "/") {
-            setBody("42")
-        }.response) {
-            assertEquals(HttpStatusCode.OK, status()!!)
-            assertEquals(42.toString(), content!!)
-        }
 
-        with(handleRequest(HttpMethod.Put, "/put") {
+        handleRequest(HttpMethod.Post, "/") {
             setBody("42")
-        }.response) {
-            assertEquals(HttpStatusCode.OK, status()!!)
-            assertEquals(42.toString(), content!!)
         }
-
-        with(handleRequest(HttpMethod.Patch, "/patching") {
+        handleRequest(HttpMethod.Put, "/put") {
             setBody("42")
-        }.response) {
-            assertEquals(HttpStatusCode.OK, status()!!)
-            assertEquals(42.toString(), content!!)
+        }
+        handleRequest(HttpMethod.Patch, "/patching") {
+            setBody("42")
         }
     }
 


### PR DESCRIPTION
**Subsystem**
Server - Routing

**Motivation**
Currently, only `post` has a typed overload. [KTOR-1344](https://youtrack.jetbrains.com/issue/KTOR-1344)

**Solution**
Added a typed overload to `put` and `patch` as well

