### PR TITLE
KTOR-730 Add baseURL option to DefaultRequest

### DIFF
--- a/ktor-client/ktor-client-core/api/ktor-client-core.api
+++ b/ktor-client/ktor-client-core/api/ktor-client-core.api
@@ -272,6 +272,12 @@ public final class io/ktor/client/plugins/DefaultRequest {
 	public fun <init> (Lkotlin/jvm/functions/Function1;)V
 }
 
+public final class io/ktor/client/plugins/DefaultRequest$Builder : io/ktor/client/request/HttpRequestBuilder {
+	public fun <init> (Lio/ktor/client/request/HttpRequestBuilder;)V
+	public final fun baseURL (Lio/ktor/http/URLBuilder;)V
+	public final fun baseURL (Ljava/lang/String;)V
+}
+
 public final class io/ktor/client/plugins/DefaultRequest$Plugin : io/ktor/client/plugins/HttpClientPlugin {
 	public fun getKey ()Lio/ktor/util/AttributeKey;
 	public fun install (Lio/ktor/client/plugins/DefaultRequest;Lio/ktor/client/HttpClient;)V
@@ -939,7 +945,7 @@ public final class io/ktor/client/request/HttpRequest$DefaultImpls {
 	public static fun getCoroutineContext (Lio/ktor/client/request/HttpRequest;)Lkotlin/coroutines/CoroutineContext;
 }
 
-public final class io/ktor/client/request/HttpRequestBuilder : io/ktor/http/HttpMessageBuilder {
+public class io/ktor/client/request/HttpRequestBuilder : io/ktor/http/HttpMessageBuilder {
 	public static final field Companion Lio/ktor/client/request/HttpRequestBuilder$Companion;
 	public fun <init> ()V
 	public final fun build ()Lio/ktor/client/request/HttpRequestData;

--- a/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/DefaultRequest.kt
+++ b/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/DefaultRequest.kt
@@ -6,23 +6,71 @@ package io.ktor.client.plugins
 
 import io.ktor.client.*
 import io.ktor.client.request.*
+import io.ktor.http.*
 import io.ktor.util.*
 
 /**
  * [Plugin] is used to set request default parameters.
  */
-public class DefaultRequest(private val builder: HttpRequestBuilder.() -> Unit) {
+public class DefaultRequest(private val builder: Builder.() -> Unit) {
 
-    public companion object Plugin : HttpClientPlugin<HttpRequestBuilder, DefaultRequest> {
+    public class Builder(requested: HttpRequestBuilder) : HttpRequestBuilder() {
+        init {
+            takeFrom(requested)
+        }
+
+        /**
+         * Set the [baseUrl] to use it in sub-requests.
+         * To override the existing [baseURL] in a sub-request, the full [URL] is needed in the [HttpRequestBuilder].
+         *
+         * The given [baseUrl] cannot have a query or a fragment part.
+         */
+        public fun baseURL(baseUrl: String) {
+            baseURL(URLBuilder().takeFrom(baseUrl))
+        }
+
+        /**
+         * Set the [baseURL] to use it in sub-requests.
+         * To override the existing [baseURL] in a sub-request, the full [URL] is needed in the [HttpRequestBuilder].
+         *
+         * The given [baseURL] cannot have a query or a fragment part.
+         */
+        public fun baseURL(baseUrl: URLBuilder) {
+            require(baseUrl.parameters.build() == Parameters.Empty && baseUrl.fragment.isEmpty()) {
+                "The baseURL cannot have a query or a fragment"
+            }
+            url {
+                val origin = Url(URLBuilder.Companion.origin)
+                if (host == origin.host && port == origin.port) {
+                    val requestedPath = encodedPath.removePrefix("/")
+                    takeFrom(baseUrl)
+                    encodedPath += if (encodedPath.endsWith("/")) {
+                        requestedPath
+                    } else {
+                        "/$requestedPath"
+                    }
+                }
+            }
+        }
+    }
+
+    public companion object Plugin : HttpClientPlugin<Builder, DefaultRequest> {
         override val key: AttributeKey<DefaultRequest> = AttributeKey("DefaultRequest")
 
-        override fun prepare(block: HttpRequestBuilder.() -> Unit): DefaultRequest =
+        override fun prepare(block: Builder.() -> Unit): DefaultRequest =
             DefaultRequest(block)
 
         override fun install(plugin: DefaultRequest, scope: HttpClient) {
             scope.requestPipeline.intercept(HttpRequestPipeline.Before) {
-                context.apply(plugin.builder)
+                context.apply {
+                    install(plugin.builder)
+                }
             }
+        }
+
+        internal fun HttpRequestBuilder.install(builder: Builder.() -> Unit) {
+            val defaultRequest = Builder(this).apply(builder)
+            takeFrom(defaultRequest)
         }
     }
 }
@@ -30,7 +78,7 @@ public class DefaultRequest(private val builder: HttpRequestBuilder.() -> Unit) 
 /**
  * Set request default parameters.
  */
-public fun HttpClientConfig<*>.defaultRequest(block: HttpRequestBuilder.() -> Unit) {
+public fun HttpClientConfig<*>.defaultRequest(block: DefaultRequest.Builder.() -> Unit) {
     install(DefaultRequest) {
         block()
     }

--- a/ktor-client/ktor-client-core/common/src/io/ktor/client/request/HttpRequest.kt
+++ b/ktor-client/ktor-client-core/common/src/io/ktor/client/request/HttpRequest.kt
@@ -54,7 +54,7 @@ public interface HttpRequest : HttpMessage, CoroutineScope {
 /**
  * Class for building [HttpRequestData].
  */
-public class HttpRequestBuilder : HttpMessageBuilder {
+public open class HttpRequestBuilder : HttpMessageBuilder {
     /**
      * [URLBuilder] to configure the URL for this request.
      */

--- a/ktor-client/ktor-client-core/common/test/io/ktor/client/DefaultRequestTest.kt
+++ b/ktor-client/ktor-client-core/common/test/io/ktor/client/DefaultRequestTest.kt
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2014-2020 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.client
+
+import io.ktor.client.plugins.*
+import io.ktor.client.plugins.DefaultRequest.Plugin.install
+import io.ktor.client.request.*
+import io.ktor.http.*
+import kotlin.test.*
+
+class DefaultRequestTest {
+    private fun HttpRequestBuilder.defaultRequest(block: DefaultRequest.Builder.() -> Unit) = apply {
+        install(block)
+    }
+
+    @Test
+    fun testUsingBaseURLMatchingCurrentPipelineBehaviour() {
+        val todoURL = HttpRequestBuilder().apply {
+            url.takeFrom(URLBuilder("/sub").build())
+        }.defaultRequest {
+            baseURL("https://ktor.io/docs")
+        }.build().url
+        assertEquals("https://ktor.io/docs/sub", todoURL.toString())
+    }
+
+    @Test
+    fun overrideOther() {
+        val overridden = HttpRequestBuilder().apply {
+            url.takeFrom("https://kotlinlang.org/blog")
+        }.defaultRequest {
+            baseURL("https://ktor.io/docs")
+        }.build().url
+        assertEquals("https://kotlinlang.org/blog", overridden.toString())
+    }
+
+    @Test
+    fun overriddenLocalhostOnly() {
+        val localhost = HttpRequestBuilder().apply {
+            url.takeFrom("http://localhost/")
+        }.defaultRequest {
+            baseURL("https://ktor.io/docs")
+        }.build().url
+        assertEquals("http://localhost/", localhost.toString())
+    }
+
+    @Test
+    fun overriddenLocalhostWithPath() {
+        val localhost = HttpRequestBuilder().apply {
+            url.takeFrom("http://localhost/sub")
+        }.defaultRequest {
+            baseURL("https://ktor.io/docs")
+        }.build().url
+        assertEquals("http://localhost/sub", localhost.toString())
+    }
+
+    @Test
+    fun useDefaultAsBaseURL() {
+        val localhost = HttpRequestBuilder().apply {
+            url.takeFrom("http://localhost/sub")
+        }.defaultRequest {
+            baseURL(URLBuilder())
+        }.build().url
+        assertEquals("http://localhost/sub", localhost.toString())
+    }
+
+    @Test
+    fun malformedBaseURL() {
+        assertFailsWith<IllegalArgumentException> {
+            HttpRequestBuilder().apply {
+                url.takeFrom("http://localhost/sub")
+            }.defaultRequest {
+                baseURL("https://ktor.io?a")
+            }
+        }
+    }
+}

--- a/ktor-client/ktor-client-core/common/test/io/ktor/client/TestEngine.kt
+++ b/ktor-client/ktor-client-core/common/test/io/ktor/client/TestEngine.kt
@@ -1,3 +1,5 @@
+package io.ktor.client
+
 import io.ktor.client.engine.*
 import io.ktor.client.request.*
 import io.ktor.util.*

--- a/ktor-client/ktor-client-core/common/test/io/ktor/client/plugins/cache/CacheExpiresTest.kt
+++ b/ktor-client/ktor-client-core/common/test/io/ktor/client/plugins/cache/CacheExpiresTest.kt
@@ -1,10 +1,9 @@
 /*
 * Copyright 2014-2021 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
 */
-package io.ktor.client.plugins.cache.tests
+package io.ktor.client.plugins.cache
 
 import io.ktor.client.call.*
-import io.ktor.client.plugins.cache.*
 import io.ktor.client.statement.*
 import io.ktor.client.utils.*
 import io.ktor.http.*

--- a/ktor-client/ktor-client-core/common/test/io/ktor/client/plugins/cookies/CookiesTest.kt
+++ b/ktor-client/ktor-client-core/common/test/io/ktor/client/plugins/cookies/CookiesTest.kt
@@ -1,12 +1,12 @@
-import io.ktor.client.plugins.cookies.*
+/*
+* Copyright 2014-2021 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+*/
+package io.ktor.client.plugins.cookies
+
 import io.ktor.client.request.*
 import io.ktor.http.*
 import io.ktor.test.dispatcher.*
 import kotlin.test.*
-
-/*
-* Copyright 2014-2021 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
-*/
 
 class CookiesTest {
 

--- a/ktor-client/ktor-client-core/common/test/io/ktor/client/request/forms/FormDslTest.kt
+++ b/ktor-client/ktor-client-core/common/test/io/ktor/client/request/forms/FormDslTest.kt
@@ -1,4 +1,9 @@
-import io.ktor.client.request.forms.*
+/*
+ * Copyright 2014-2021 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.client.request.forms
+
 import io.ktor.http.*
 import kotlin.test.*
 

--- a/ktor-client/ktor-client-core/common/test/io/ktor/client/request/forms/MultiPartFormDataContentTest.kt
+++ b/ktor-client/ktor-client-core/common/test/io/ktor/client/request/forms/MultiPartFormDataContentTest.kt
@@ -1,4 +1,5 @@
-import io.ktor.client.request.forms.*
+package io.ktor.client.request.forms
+
 import io.ktor.test.dispatcher.*
 import io.ktor.utils.io.*
 import io.ktor.utils.io.core.*

--- a/ktor-client/ktor-client-core/common/test/io/ktor/client/statement/HttpStatementTest.kt
+++ b/ktor-client/ktor-client-core/common/test/io/ktor/client/statement/HttpStatementTest.kt
@@ -1,11 +1,12 @@
-import io.ktor.client.*
-import io.ktor.client.request.*
-import io.ktor.client.statement.*
-import kotlin.test.*
-
 /*
 * Copyright 2014-2021 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
 */
+
+package io.ktor.client.statement
+
+import io.ktor.client.*
+import io.ktor.client.request.*
+import kotlin.test.*
 
 class HttpStatementTest {
 

--- a/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/plugins/DefaultRequestTest.kt
+++ b/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/plugins/DefaultRequestTest.kt
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2014-2020 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.client.tests.plugins
+
+import io.ktor.client.plugins.*
+import io.ktor.client.request.*
+import io.ktor.client.tests.utils.*
+import kotlin.test.*
+
+class DefaultRequestTest : ClientLoader() {
+    @Test
+    fun testBaseURLConfig() = clientTests {
+        config {
+            defaultRequest {
+                header("foo", "bar")
+                baseURL(TEST_SERVER)
+                header("something", "42")
+            }
+        }
+
+        test { client ->
+            with(client.post("/echo").call.request) {
+                assertEquals("$TEST_SERVER/echo", url.toString())
+                assertEquals("42", headers["something"])
+                assertEquals("bar", headers["foo"])
+            }
+        }
+    }
+}

--- a/ktor-server/ktor-server-tests/jvm/test/io/ktor/tests/server/plugins/CallLoggingTest.kt
+++ b/ktor-server/ktor-server-tests/jvm/test/io/ktor/tests/server/plugins/CallLoggingTest.kt
@@ -311,5 +311,4 @@ class CallLoggingTest {
 
     private fun colored(value: Any, color: Ansi.Color): String =
         Ansi.ansi().fg(color).a(value).reset().toString()
-
 }


### PR DESCRIPTION
**Subsystem**
Client Core - DefaultRequest

**Motivation**
The `defaultRequest` feature is missing a `baseURL` setting, see [KTOR-730](https://youtrack.jetbrains.com/issue/KTOR-730)

**Solution**
Add a baseURL option to `HttpRequestBuilder`

- [x] ApiDump