### PR TITLE
KTOR-1235 throw EOFException when trying to read empty input on all platforms

### DIFF
--- a/ktor-io/common/test/io/ktor/utils/io/tests/AbstractInputTest.kt
+++ b/ktor-io/common/test/io/ktor/utils/io/tests/AbstractInputTest.kt
@@ -71,4 +71,10 @@ class AbstractInputTest {
         input.copyTo(out)
         assertEquals("test.123.zxc.", out.build().readText())
     }
+
+    @Test
+    fun testReadMoreBytesThenExists() {
+        assertFailsWith<EOFException> { ByteReadPacket.Empty.readTextExactBytes(1) }
+        assertFailsWith<EOFException> { buildPacket { writeByte(1) }.readTextExactBytes(2) }
+    }
 }

--- a/ktor-io/js/src/io/ktor/utils/io/charsets/CharsetJS.kt
+++ b/ktor-io/js/src/io/ktor/utils/io/charsets/CharsetJS.kt
@@ -262,5 +262,8 @@ private fun CharsetDecoder.decodeExactBytesSlow(input: Input, inputLength: Int):
         sb.append(decoder.decode())
     }
 
+    if (inputRemaining > 0) {
+        throw EOFException("Not enough bytes available: had only ${inputLength - inputRemaining} instead of $inputLength")
+    }
     return sb.toString()
 }

--- a/ktor-io/posix/src/io/ktor/utils/io/charsets/CharsetNative.kt
+++ b/ktor-io/posix/src/io/ktor/utils/io/charsets/CharsetNative.kt
@@ -376,6 +376,9 @@ public actual fun CharsetDecoder.decodeExactBytes(input: Input, inputLength: Int
             }
         }
 
+        if (bytesConsumed < inputLength) {
+            throw EOFException("Not enough bytes available: had only $bytesConsumed instead of $inputLength")
+        }
         return String(chars, 0, charsCopied)
     } finally {
         iconv_close(cd)


### PR DESCRIPTION
**Subsystem**
Client/Server, IO

**Motivation**
[Input.readTextExactBytes(n) on empty input different behavior per platform](https://youtrack.jetbrains.com/issue/KTOR-1235)

