### PR TITLE
KTOR-1358 Propagate parentCoroutineContext to handlers

### DIFF
--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyApplicationEngine.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyApplicationEngine.kt
@@ -122,7 +122,9 @@ public class NettyApplicationEngine(
                 childHandler(
                     NettyChannelInitializer(
                         pipeline, environment,
-                        callEventGroup, engineDispatcherWithShutdown, dispatcherWithShutdown,
+                        callEventGroup,
+                        engineDispatcherWithShutdown,
+                        environment.parentCoroutineContext + dispatcherWithShutdown,
                         connector,
                         configuration.requestQueueLimit,
                         configuration.runningLimit,

--- a/ktor-server/ktor-server-servlet/jvm/src/io/ktor/server/servlet/KtorServlet.kt
+++ b/ktor-server/ktor-server-servlet/jvm/src/io/ktor/server/servlet/KtorServlet.kt
@@ -46,10 +46,17 @@ public abstract class KtorServlet : HttpServlet(), CoroutineScope {
      */
     protected abstract val upgrade: ServletUpgrade
 
-    override val coroutineContext: CoroutineContext =
+    /**
+     * Base context for call handling
+     */
+    protected abstract val parentCoroutineContext: CoroutineContext
+
+    override val coroutineContext: CoroutineContext by lazy {
         Dispatchers.Unconfined + SupervisorJob() +
+            parentCoroutineContext +
             CoroutineName("servlet") +
             DefaultUncaughtExceptionHandler { logger }
+    }
 
     /**
      * Called by the servlet container when loading the servlet (on load)

--- a/ktor-server/ktor-server-servlet/jvm/src/io/ktor/server/servlet/KtorServlet.kt
+++ b/ktor-server/ktor-server-servlet/jvm/src/io/ktor/server/servlet/KtorServlet.kt
@@ -46,17 +46,10 @@ public abstract class KtorServlet : HttpServlet(), CoroutineScope {
      */
     protected abstract val upgrade: ServletUpgrade
 
-    /**
-     * Base context for call handling
-     */
-    protected abstract val parentCoroutineContext: CoroutineContext
-
-    override val coroutineContext: CoroutineContext by lazy {
+    override val coroutineContext: CoroutineContext =
         Dispatchers.Unconfined + SupervisorJob() +
-            parentCoroutineContext +
             CoroutineName("servlet") +
             DefaultUncaughtExceptionHandler { logger }
-    }
 
     /**
      * Called by the servlet container when loading the servlet (on load)

--- a/ktor-server/ktor-server-servlet/jvm/src/io/ktor/server/servlet/ServletApplicationEngine.kt
+++ b/ktor-server/ktor-server-servlet/jvm/src/io/ktor/server/servlet/ServletApplicationEngine.kt
@@ -12,6 +12,7 @@ import io.ktor.util.*
 import org.slf4j.*
 import javax.servlet.*
 import javax.servlet.annotation.*
+import kotlin.coroutines.*
 
 /**
  * This servlet need to be installed into a servlet container
@@ -62,6 +63,9 @@ public open class ServletApplicationEngine : KtorServlet() {
     override val application: Application get() = environment.application
 
     override val logger: Logger get() = environment.log
+
+    override val parentCoroutineContext: CoroutineContext
+        get() = environment.parentCoroutineContext
 
     override val enginePipeline: EnginePipeline by lazy {
         defaultEnginePipeline(environment).also {

--- a/ktor-server/ktor-server-servlet/jvm/src/io/ktor/server/servlet/ServletApplicationEngine.kt
+++ b/ktor-server/ktor-server-servlet/jvm/src/io/ktor/server/servlet/ServletApplicationEngine.kt
@@ -64,9 +64,6 @@ public open class ServletApplicationEngine : KtorServlet() {
 
     override val logger: Logger get() = environment.log
 
-    override val parentCoroutineContext: CoroutineContext
-        get() = environment.parentCoroutineContext
-
     override val enginePipeline: EnginePipeline by lazy {
         defaultEnginePipeline(environment).also {
             BaseApplicationResponse.setupSendPipeline(it.sendPipeline)
@@ -78,6 +75,9 @@ public open class ServletApplicationEngine : KtorServlet() {
             jettyUpgrade ?: DefaultServletUpgrade
         } else DefaultServletUpgrade
     }
+
+    override val coroutineContext: CoroutineContext
+        get() = super.coroutineContext + environment.parentCoroutineContext
 
     /**
      * Called by the servlet container when loading the servlet (on load)

--- a/ktor-server/ktor-server-tomcat/jvm/src/io/ktor/server/tomcat/TomcatApplicationEngine.kt
+++ b/ktor-server/ktor-server-tomcat/jvm/src/io/ktor/server/tomcat/TomcatApplicationEngine.kt
@@ -20,6 +20,7 @@ import org.slf4j.*
 import java.nio.file.*
 import java.util.concurrent.*
 import javax.servlet.*
+import kotlin.coroutines.*
 
 /**
  * Tomcat application engine that runs it in embedded mode
@@ -52,6 +53,8 @@ public class TomcatApplicationEngine(environment: ApplicationEngineEnvironment, 
             get() = DefaultServletUpgrade
         override val logger: Logger
             get() = this@TomcatApplicationEngine.environment.log
+        override val parentCoroutineContext: CoroutineContext
+            get() = environment.parentCoroutineContext
     }
 
     private val server = Tomcat().apply {

--- a/ktor-server/ktor-server-tomcat/jvm/src/io/ktor/server/tomcat/TomcatApplicationEngine.kt
+++ b/ktor-server/ktor-server-tomcat/jvm/src/io/ktor/server/tomcat/TomcatApplicationEngine.kt
@@ -53,8 +53,8 @@ public class TomcatApplicationEngine(environment: ApplicationEngineEnvironment, 
             get() = DefaultServletUpgrade
         override val logger: Logger
             get() = this@TomcatApplicationEngine.environment.log
-        override val parentCoroutineContext: CoroutineContext
-            get() = environment.parentCoroutineContext
+        override val coroutineContext: CoroutineContext
+            get() = super.coroutineContext + environment.parentCoroutineContext
     }
 
     private val server = Tomcat().apply {


### PR DESCRIPTION
**Subsystem**
Server

**Motivation**
[Netty engine doesn't keep coroutine elements in coroutine context](https://youtrack.jetbrains.com/issue/KTOR-1358)

**Solution**
Use `parentCoroutineContext` as base context for handlers coroutines

