### PR TITLE
KTOR-905 Fix Netty HTTP 400 BadRequest response

### DIFF
--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyApplicationEngine.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyApplicationEngine.kt
@@ -80,7 +80,6 @@ public class NettyApplicationEngine(
         EventLoopGroupProxy.create(configuration.connectionGroupSize)
     }
 
-
     /**
      * [EventLoopGroupProxy] for processing incoming requests and doing engine's internal work
      */

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyApplicationRequest.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyApplicationRequest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2014-2020 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package io.ktor.server.netty
@@ -9,11 +9,11 @@ import io.ktor.http.*
 import io.ktor.request.*
 import io.ktor.server.engine.*
 import io.ktor.util.*
+import io.ktor.utils.io.*
 import io.netty.channel.*
 import io.netty.handler.codec.http.*
 import io.netty.handler.codec.http.multipart.*
 import kotlinx.coroutines.*
-import io.ktor.utils.io.*
 import java.io.*
 import kotlin.coroutines.*
 
@@ -25,7 +25,8 @@ public abstract class NettyApplicationRequest(
     public val context: ChannelHandlerContext,
     private val requestBodyChannel: ByteReadChannel,
     protected val uri: String,
-    internal val keepAlive: Boolean) : BaseApplicationRequest(call), CoroutineScope {
+    internal val keepAlive: Boolean
+) : BaseApplicationRequest(call), CoroutineScope {
 
     public final override val queryParameters: Parameters = object : Parameters {
         private val decoder = QueryStringDecoder(uri)

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyApplicationResponse.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyApplicationResponse.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2014-2020 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package io.ktor.server.netty
@@ -77,7 +77,16 @@ public abstract class NettyApplicationResponse(
     internal fun sendResponse(chunked: Boolean = true, content: ByteReadChannel) {
         if (!responseMessageSent) {
             responseChannel = content
-            responseMessage.complete(responseMessage(chunked, content.isClosedForRead))
+            responseMessage.complete(
+                when {
+                    content.isClosedForRead -> {
+                        responseMessage(chunked = false, data = EmptyByteArray)
+                    }
+                    else -> {
+                        responseMessage(chunked, last = false)
+                    }
+                }
+            )
             responseMessageSent = true
         }
     }

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyChannelInitializer.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyChannelInitializer.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2014-2020 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package io.ktor.server.netty
@@ -113,14 +113,13 @@ public class NettyChannelInitializer(
 
                 with(pipeline) {
                     //                    addLast(LoggingHandler(LogLevel.WARN))
-                    if(requestReadTimeout > 0) {
+                    if (requestReadTimeout > 0) {
                         addLast("readTimeout", ReadTimeoutHandler(requestReadTimeout))
                     }
                     addLast("codec", httpServerCodec())
                     addLast("continue", HttpServerExpectContinueHandler())
                     addLast("timeout", WriteTimeoutHandler(responseWriteTimeout))
                     addLast("http1", handler)
-
                 }
 
                 pipeline.context("codec").fireChannelActive()

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http1/NettyHttp1ApplicationRequest.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http1/NettyHttp1ApplicationRequest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2014-2020 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package io.ktor.server.netty.http1
@@ -7,10 +7,10 @@ package io.ktor.server.netty.http1
 import io.ktor.application.*
 import io.ktor.http.*
 import io.ktor.server.netty.*
+import io.ktor.utils.io.*
 import io.netty.channel.*
 import io.netty.handler.codec.http.*
 import io.netty.handler.codec.http.multipart.*
-import io.ktor.utils.io.*
 import kotlin.coroutines.*
 
 internal class NettyHttp1ApplicationRequest(
@@ -20,7 +20,12 @@ internal class NettyHttp1ApplicationRequest(
     val httpRequest: HttpRequest,
     requestBodyChannel: ByteReadChannel
 ) : NettyApplicationRequest(
-    call, coroutineContext, context, requestBodyChannel, httpRequest.uri(), HttpUtil.isKeepAlive(httpRequest)
+    call,
+    coroutineContext,
+    context,
+    requestBodyChannel,
+    httpRequest.uri(),
+    HttpUtil.isKeepAlive(httpRequest)
 ) {
     override val local = NettyConnectionPoint(httpRequest, context)
     override val headers: Headers = NettyApplicationRequestHeaders(httpRequest)

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http1/NettyHttp1ApplicationResponse.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http1/NettyHttp1ApplicationResponse.kt
@@ -1,11 +1,11 @@
 /*
- * Copyright 2014-2019 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2014-2020 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package io.ktor.server.netty.http1
 
-import io.ktor.http.content.*
 import io.ktor.http.*
+import io.ktor.http.content.*
 import io.ktor.response.*
 import io.ktor.server.netty.*
 import io.ktor.server.netty.cio.*
@@ -59,7 +59,11 @@ internal class NettyHttp1ApplicationResponse(
 
     override fun responseMessage(chunked: Boolean, data: ByteArray): Any {
         val responseMessage = DefaultFullHttpResponse(
-            protocol, responseStatus, Unpooled.wrappedBuffer(data), responseHeaders, EmptyHttpHeaders.INSTANCE
+            protocol,
+            responseStatus,
+            Unpooled.wrappedBuffer(data),
+            responseHeaders,
+            EmptyHttpHeaders.INSTANCE
         )
         if (chunked) {
             setChunked(responseMessage)


### PR DESCRIPTION
**Subsystem**
ktor-server-netty

**Motivation**
[KTOR-905](https://youtrack.jetbrains.com/issue/KTOR-905) Request headers exceeding expected threshold are not handled correctly

Before this fix, we didn't send content-length so clients were simply hanging when waiting for response content since neither content-length nor connection nor chunked specified.

**Solution**
Supply both `Connection: close` and `Content-Length` in this case. Add a test to ensure the same on all servers.


