### PR TITLE
KTOR-1349 rewrite Input.copyTo from writeSuspendSession to write

### DIFF
--- a/ktor-client/ktor-client-core/common/src/io/ktor/client/request/forms/FormDataContent.kt
+++ b/ktor-client/ktor-client-core/common/src/io/ktor/client/request/forms/FormDataContent.kt
@@ -145,14 +145,9 @@ private suspend fun Input.copyTo(channel: ByteWriteChannel) {
         return
     }
 
-    channel.writeSuspendSession {
-        while (!this@copyTo.endOfInput) {
-            tryAwait(1)
-            val buffer = request(1)!!
-            val size = this@copyTo.readAvailable(buffer)
-
-            if (size < 0) continue
-            written(size)
+    while (!this@copyTo.endOfInput) {
+        channel.write { freeSpace, startOffset, endExclusive ->
+            this@copyTo.readAvailable(freeSpace, startOffset, endExclusive - startOffset).toInt()
         }
     }
 }


### PR DESCRIPTION
**Subsystem**
Client

**Motivation**
[Client: NPE in FormDataContentKt -> Input.copyTo](https://youtrack.jetbrains.com/issue/KTOR-1349)

**Solution**
TBH I am not sure how to reproduce it, but the crash is happening [here](https://github.com/ktorio/ktor/pull/2221/files#diff-6667837f9857b90b173abc24a146f7cbfaf384d6181180c32d40384363099a12L151)
I rewrote this block to the newer approach to remove the possibility of NPE 
