### PR TITLE
KTOR-348 Fix testErrorInWritingPropagates

### DIFF
--- a/ktor-client/ktor-client-java/jvm/src/io/ktor/client/engine/java/JavaHttpRequestBodyPublisher.kt
+++ b/ktor-client/ktor-client-java/jvm/src/io/ktor/client/engine/java/JavaHttpRequestBodyPublisher.kt
@@ -97,6 +97,7 @@ internal class JavaHttpRequestBodyPublisher(
         private fun readData() {
             // It's possible to have another request for data come in after we've closed the channel.
             if (inputChannel.isClosedForRead) {
+                tryToSignalOnErrorFromChannel()
                 return
             }
 
@@ -149,6 +150,12 @@ internal class JavaHttpRequestBodyPublisher(
         private fun signalOnError(cause: Throwable) {
             if (done.compareAndSet(expect = false, update = true)) {
                 subscriber.onError(cause)
+            }
+        }
+
+        private fun tryToSignalOnErrorFromChannel() {
+            (inputChannel as? ByteWriteChannel)?.closedCause?.let { cause ->
+                signalOnError(cause)
             }
         }
     }

--- a/ktor-client/ktor-client-java/jvm/test/io/ktor/client/engine/java/RequestTests.kt
+++ b/ktor-client/ktor-client-java/jvm/test/io/ktor/client/engine/java/RequestTests.kt
@@ -39,6 +39,7 @@ class RequestTests : TestWithKtor() {
                         get() = call.request.contentType()
                     override val contentLength: Long?
                         get() = call.request.header(HttpHeaders.ContentLength)?.toLong()
+
                     override fun readFrom(): ByteReadChannel {
                         return readChannel
                     }
@@ -91,12 +92,12 @@ class RequestTests : TestWithKtor() {
         val payload = "ktor"
 
         val response = HttpClient(Java).use { client ->
-           runBlocking {
-               client.post<String>("$testUrl/echo"){
-                   contentType(ContentType.Text.Plain)
-                   body = ByteReadChannel(payload)
-               }
-           }
+            runBlocking {
+                client.post<String>("$testUrl/echo") {
+                    contentType(ContentType.Text.Plain)
+                    body = ByteReadChannel(payload)
+                }
+            }
         }
 
         assertEquals(payload, response)


### PR DESCRIPTION
**Subsystem**
ktor-client-java

**Motivation**
Test testErrorInWritingPropagates is failing in master

**Solution**
If the body channel is closed too quickly, a publisher quits with no signalling error so the whole engine freezes. The solution is to propagate the cause in this case instead of just quitting.
