### PR TITLE
KTOR-1403 Add plus/minus Duration Support for GMTDate

### DIFF
--- a/ktor-utils/api/ktor-utils.api
+++ b/ktor-utils/api/ktor-utils.api
@@ -569,13 +569,16 @@ public final class io/ktor/util/date/DateJvmKt {
 	public static final fun GMTDate (IIIILio/ktor/util/date/Month;I)Lio/ktor/util/date/GMTDate;
 	public static final fun GMTDate (Ljava/lang/Long;)Lio/ktor/util/date/GMTDate;
 	public static synthetic fun GMTDate$default (Ljava/lang/Long;ILjava/lang/Object;)Lio/ktor/util/date/GMTDate;
+	public static final fun getTimeMillis ()J
 	public static final fun toDate (Ljava/util/Calendar;Ljava/lang/Long;)Lio/ktor/util/date/GMTDate;
 	public static final fun toJvmDate (Lio/ktor/util/date/GMTDate;)Ljava/util/Date;
 }
 
 public final class io/ktor/util/date/DateKt {
 	public static final fun minus (Lio/ktor/util/date/GMTDate;J)Lio/ktor/util/date/GMTDate;
+	public static final fun minus-DXA3NOw (Lio/ktor/util/date/GMTDate;D)Lio/ktor/util/date/GMTDate;
 	public static final fun plus (Lio/ktor/util/date/GMTDate;J)Lio/ktor/util/date/GMTDate;
+	public static final fun plus-DXA3NOw (Lio/ktor/util/date/GMTDate;D)Lio/ktor/util/date/GMTDate;
 	public static final fun truncateToSeconds (Lio/ktor/util/date/GMTDate;)Lio/ktor/util/date/GMTDate;
 }
 

--- a/ktor-utils/common/src/io/ktor/util/date/Date.kt
+++ b/ktor-utils/common/src/io/ktor/util/date/Date.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2014-2020 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package io.ktor.util.date

--- a/ktor-utils/common/src/io/ktor/util/date/Date.kt
+++ b/ktor-utils/common/src/io/ktor/util/date/Date.kt
@@ -4,7 +4,7 @@
 
 package io.ktor.util.date
 
-import io.ktor.util.*
+import kotlin.time.*
 
 /**
  * According to:
@@ -132,6 +132,19 @@ public operator fun GMTDate.plus(milliseconds: Long): GMTDate = GMTDate(timestam
  * Subtracts the specified number of [milliseconds]
  */
 public operator fun GMTDate.minus(milliseconds: Long): GMTDate = GMTDate(timestamp - milliseconds)
+
+/**
+ * Adds the specified [duration]
+ */
+@ExperimentalTime
+public operator fun GMTDate.plus(duration: Duration): GMTDate = GMTDate(timestamp + duration.toLongMilliseconds())
+
+/**
+ * Subtracts the specified [duration]
+ */
+@ExperimentalTime
+public operator fun GMTDate.minus(duration: Duration): GMTDate = GMTDate(timestamp - duration.toLongMilliseconds())
+
 
 /**
  * Truncate to seconds by discarding sub-second part

--- a/ktor-utils/common/test/io/ktor/util/GMTDateTest.kt
+++ b/ktor-utils/common/test/io/ktor/util/GMTDateTest.kt
@@ -6,6 +6,7 @@ package io.ktor.util
 
 import io.ktor.util.date.*
 import kotlin.test.*
+import kotlin.time.*
 
 class GMTDateTest {
 
@@ -43,5 +44,15 @@ class GMTDateTest {
         assertTrue { before < farDate }
         assertTrue { farDate == farDate }
         assertEquals(0, farDate.compareTo(farDate))
+    }
+
+    @ExperimentalTime
+    @Test
+    fun testDurationArithmetic() {
+        val now = GMTDate()
+        val plus10Secs = now + 10.seconds
+        assertTrue { now < plus10Secs }
+        assertEquals(now.plus(10_000), plus10Secs)
+        assertEquals(now, plus10Secs - 10.seconds)
     }
 }


### PR DESCRIPTION
**Subsystem**
Utils, GMTDate

**Motivation**
As Ktor already has some overloads for kotlin.time.Duration in ktor-server-core/features/KotlinTimeJvm.kt, this overload would be nice too, [KTOR-1403](https://youtrack.jetbrains.com/issue/KTOR-1403)

**Solution**
Added plus/minus fun for GMTDate

