### PR TITLE
KTOR-1434 Remove always included native targets

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -55,8 +55,6 @@ if (native_targets_enabled) {
     include ':ktor-client:ktor-client-curl'
     include ':ktor-client:ktor-client-ios'
 }
-include ':ktor-client:ktor-client-curl'
-include ':ktor-client:ktor-client-ios'
 if (ext.currentJdk >= 11) {
     include ':ktor-client:ktor-client-java'
 }


### PR DESCRIPTION
**Subsystem**
Gradle

**Motivation**
The native targets are always include, ignoring the variable. https://youtrack.jetbrains.com/issue/KTOR-1434

