### PR TITLE
KTOR-941 CIO TLSConfigBuilder JVM - Use only specific alias

### DIFF
--- a/ktor-network/ktor-network-tls/api/ktor-network-tls.api
+++ b/ktor-network/ktor-network-tls/api/ktor-network-tls.api
@@ -204,8 +204,8 @@ public final class io/ktor/network/tls/TLSConfigBuilder {
 
 public final class io/ktor/network/tls/TLSConfigBuilderKt {
 	public static final fun addCertificateChain (Lio/ktor/network/tls/TLSConfigBuilder;[Ljava/security/cert/X509Certificate;Ljava/security/PrivateKey;)V
+	public static final fun addKeyStore (Lio/ktor/network/tls/TLSConfigBuilder;Ljava/security/KeyStore;[C)V
 	public static final fun addKeyStore (Lio/ktor/network/tls/TLSConfigBuilder;Ljava/security/KeyStore;[CLjava/lang/String;)V
-	public static synthetic fun addKeyStore$default (Lio/ktor/network/tls/TLSConfigBuilder;Ljava/security/KeyStore;[CLjava/lang/String;ILjava/lang/Object;)V
 	public static final fun takeFrom (Lio/ktor/network/tls/TLSConfigBuilder;Lio/ktor/network/tls/TLSConfigBuilder;)V
 }
 

--- a/ktor-network/ktor-network-tls/api/ktor-network-tls.api
+++ b/ktor-network/ktor-network-tls/api/ktor-network-tls.api
@@ -206,6 +206,7 @@ public final class io/ktor/network/tls/TLSConfigBuilderKt {
 	public static final fun addCertificateChain (Lio/ktor/network/tls/TLSConfigBuilder;[Ljava/security/cert/X509Certificate;Ljava/security/PrivateKey;)V
 	public static final fun addKeyStore (Lio/ktor/network/tls/TLSConfigBuilder;Ljava/security/KeyStore;[C)V
 	public static final fun addKeyStore (Lio/ktor/network/tls/TLSConfigBuilder;Ljava/security/KeyStore;[CLjava/lang/String;)V
+	public static synthetic fun addKeyStore$default (Lio/ktor/network/tls/TLSConfigBuilder;Ljava/security/KeyStore;[CLjava/lang/String;ILjava/lang/Object;)V
 	public static final fun takeFrom (Lio/ktor/network/tls/TLSConfigBuilder;Lio/ktor/network/tls/TLSConfigBuilder;)V
 }
 

--- a/ktor-network/ktor-network-tls/api/ktor-network-tls.api
+++ b/ktor-network/ktor-network-tls/api/ktor-network-tls.api
@@ -204,7 +204,8 @@ public final class io/ktor/network/tls/TLSConfigBuilder {
 
 public final class io/ktor/network/tls/TLSConfigBuilderKt {
 	public static final fun addCertificateChain (Lio/ktor/network/tls/TLSConfigBuilder;[Ljava/security/cert/X509Certificate;Ljava/security/PrivateKey;)V
-	public static final fun addKeyStore (Lio/ktor/network/tls/TLSConfigBuilder;Ljava/security/KeyStore;[C)V
+	public static final fun addKeyStore (Lio/ktor/network/tls/TLSConfigBuilder;Ljava/security/KeyStore;[CLjava/lang/String;)V
+	public static synthetic fun addKeyStore$default (Lio/ktor/network/tls/TLSConfigBuilder;Ljava/security/KeyStore;[CLjava/lang/String;ILjava/lang/Object;)V
 	public static final fun takeFrom (Lio/ktor/network/tls/TLSConfigBuilder;Lio/ktor/network/tls/TLSConfigBuilder;)V
 }
 

--- a/ktor-network/ktor-network-tls/jvm/src/io/ktor/network/tls/TLSConfigBuilder.kt
+++ b/ktor-network/ktor-network-tls/jvm/src/io/ktor/network/tls/TLSConfigBuilder.kt
@@ -81,15 +81,17 @@ public fun TLSConfigBuilder.addCertificateChain(chain: Array<X509Certificate>, k
 /**
  * Add client certificates from [store] by using all certificates
  */
+@Suppress("unused") // Keep for binary compatibility
+@Deprecated("Binary compatibility", level = DeprecationLevel.HIDDEN)
 public fun TLSConfigBuilder.addKeyStore(store: KeyStore, password: CharArray) {
-    addKeyStore(store, password, null)
+    addKeyStore(store, password)
 }
 
 /**
  * Add client certificates from [store] by using the certificate with specific [alias]
  * or all certificates, if [alias] is null.
  */
-public fun TLSConfigBuilder.addKeyStore(store: KeyStore, password: CharArray, alias: String?) {
+public fun TLSConfigBuilder.addKeyStore(store: KeyStore, password: CharArray, alias: String? = null) {
     val keyManagerAlgorithm = KeyManagerFactory.getDefaultAlgorithm()!!
     val keyManagerFactory = KeyManagerFactory.getInstance(keyManagerAlgorithm)!!
 

--- a/ktor-network/ktor-network-tls/jvm/src/io/ktor/network/tls/TLSConfigBuilder.kt
+++ b/ktor-network/ktor-network-tls/jvm/src/io/ktor/network/tls/TLSConfigBuilder.kt
@@ -79,16 +79,17 @@ public fun TLSConfigBuilder.addCertificateChain(chain: Array<X509Certificate>, k
 }
 
 /**
- * Add client certificates from [store].
+ * Add client certificates from [store] by using the certificate with specific [alias]
+ * or all certificates, if [alias] is null.
  */
-public fun TLSConfigBuilder.addKeyStore(store: KeyStore, password: CharArray) {
+public fun TLSConfigBuilder.addKeyStore(store: KeyStore, password: CharArray, alias: String? = null) {
     val keyManagerAlgorithm = KeyManagerFactory.getDefaultAlgorithm()!!
     val keyManagerFactory = KeyManagerFactory.getInstance(keyManagerAlgorithm)!!
 
     keyManagerFactory.init(store, password)
     val managers = keyManagerFactory.keyManagers.filterIsInstance<X509KeyManager>()
 
-    val aliases = store.aliases()!!
+    val aliases = alias?.let { listOf(it) } ?: store.aliases()!!.toList()
     loop@ for (alias in aliases) {
         val chain = store.getCertificateChain(alias)
 

--- a/ktor-network/ktor-network-tls/jvm/test/io/ktor/network/tls/tests/TLSConfigBuilderTest.kt
+++ b/ktor-network/ktor-network-tls/jvm/test/io/ktor/network/tls/tests/TLSConfigBuilderTest.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2014-2020 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.network.tls.tests
+
+import io.ktor.network.tls.*
+import io.ktor.network.tls.certificates.*
+import io.ktor.network.tls.extensions.*
+import kotlin.test.*
+
+internal class TLSConfigBuilderTest {
+    @Test
+    fun specificAliasInKeyStore() {
+        val keyStore = buildKeyStore {
+            certificate("first") {
+                hash = HashAlgorithm.SHA256
+                sign = SignatureAlgorithm.RSA
+                password = ""
+            }
+            certificate("second") {
+                hash = HashAlgorithm.SHA256
+                sign = SignatureAlgorithm.RSA
+                password = ""
+            }
+        }
+        with(TLSConfigBuilder().apply {
+            addKeyStore(keyStore, "".toCharArray())
+        }) {
+            assertEquals(2, certificates.size)
+        }
+
+        with(TLSConfigBuilder().apply {
+            addKeyStore(keyStore, "".toCharArray(), "first")
+        }) {
+            assertEquals(1, certificates.size)
+        }
+    }
+}

--- a/ktor-network/ktor-network-tls/jvm/test/io/ktor/network/tls/tests/TLSConfigBuilderTest.kt
+++ b/ktor-network/ktor-network-tls/jvm/test/io/ktor/network/tls/tests/TLSConfigBuilderTest.kt
@@ -10,30 +10,32 @@ import io.ktor.network.tls.extensions.*
 import kotlin.test.*
 
 internal class TLSConfigBuilderTest {
+    private val keyStore = buildKeyStore {
+        certificate("first") {
+            hash = HashAlgorithm.SHA256
+            sign = SignatureAlgorithm.RSA
+            password = ""
+        }
+        certificate("second") {
+            hash = HashAlgorithm.SHA256
+            sign = SignatureAlgorithm.RSA
+            password = ""
+        }
+    }
+
+    @Test
+    fun useAllCertificates() {
+        val config = TLSConfigBuilder().apply {
+            addKeyStore(keyStore, "".toCharArray())
+        }
+        assertEquals(2, config.certificates.size)
+    }
+
     @Test
     fun specificAliasInKeyStore() {
-        val keyStore = buildKeyStore {
-            certificate("first") {
-                hash = HashAlgorithm.SHA256
-                sign = SignatureAlgorithm.RSA
-                password = ""
-            }
-            certificate("second") {
-                hash = HashAlgorithm.SHA256
-                sign = SignatureAlgorithm.RSA
-                password = ""
-            }
-        }
-        with(TLSConfigBuilder().apply {
-            addKeyStore(keyStore, "".toCharArray())
-        }) {
-            assertEquals(2, certificates.size)
-        }
-
-        with(TLSConfigBuilder().apply {
+        val config = TLSConfigBuilder().apply {
             addKeyStore(keyStore, "".toCharArray(), "first")
-        }) {
-            assertEquals(1, certificates.size)
         }
+        assertEquals(1, config.certificates.size)
     }
 }


### PR DESCRIPTION
**Subsystem**
CIO - JVM

Fixing [KTOR-941](https://youtrack.jetbrains.com/issue/KTOR-941)

**Motivation**
This fix adds the option to use only a specific alias instead all alias for a given JVM Keystore.
This change is addictive only, no breaking change.
 
**Solution**
Added null-able default null alias which will be use if present. Otherwise, all aliases from a Keystore will be used as known behavior. 

https://youtrack.jetbrains.com/issue/KTOR-941
Please reopen the issue on youtrack, it was closed after 30 days...

