### PR TITLE
KTOR-1449 Add timeout rule

### DIFF
--- a/ktor-io/jvm/test/io/ktor/utils/io/ByteBufferChannelTest.kt
+++ b/ktor-io/jvm/test/io/ktor/utils/io/ByteBufferChannelTest.kt
@@ -5,10 +5,17 @@
 package io.ktor.utils.io
 
 import kotlinx.coroutines.*
+import kotlinx.coroutines.debug.junit4.*
+import org.junit.*
 import java.io.*
 import kotlin.test.*
+import kotlin.test.Test
 
 class ByteBufferChannelTest {
+
+    @get:Rule
+    public val timeoutRule: CoroutinesTimeout by lazy { CoroutinesTimeout.seconds(60) }
+
     @Test
     fun testCompleteExceptionallyJob() {
         val channel = ByteBufferChannel(false)


### PR DESCRIPTION
**Subsystem**
Client/Server

**Motivation**
[testWriteXRaceCondition sometimes hangs on CI](https://youtrack.jetbrains.com/issue/KTOR-1449)

**Solution**
This is not a proper fix but will unblock CI and we can see logs on where the block is.

