### PR TITLE
Rework user's PR for adding servlet attributes access

### DIFF
--- a/ktor-server/ktor-server-jetty/jvm/test/io/ktor/tests/server/jetty/JettyEngineTest.kt
+++ b/ktor-server/ktor-server-jetty/jvm/test/io/ktor/tests/server/jetty/JettyEngineTest.kt
@@ -4,15 +4,69 @@
 
 package io.ktor.tests.server.jetty
 
+import io.ktor.application.*
+import io.ktor.client.statement.*
+import io.ktor.response.*
+import io.ktor.routing.*
 import io.ktor.server.jetty.*
+import io.ktor.server.servlet.*
 import io.ktor.server.testing.suites.*
+import org.eclipse.jetty.server.*
+import org.eclipse.jetty.server.handler.*
+import org.eclipse.jetty.util.component.*
+import javax.servlet.http.*
+import kotlin.test.*
 
 class JettyCompressionTest :
     CompressionTestSuite<JettyApplicationEngine, JettyApplicationEngineBase.Configuration>(Jetty)
 
 class JettyContentTest : ContentTestSuite<JettyApplicationEngine, JettyApplicationEngineBase.Configuration>(Jetty)
 
-class JettyHttpServerTest : HttpServerTestSuite<JettyApplicationEngine, JettyApplicationEngineBase.Configuration>(Jetty)
+class JettyHttpServerTest : HttpServerTestSuite<JettyApplicationEngine, JettyApplicationEngineBase.Configuration>(
+    Jetty
+) {
+    override fun configure(configuration: JettyApplicationEngineBase.Configuration) {
+        super.configure(configuration)
+        configuration.configureServer = {
+            addAttributesHandler()
+        }
+    }
+
+    @Test
+    fun testServletAttributes() {
+        createAndStartServer {
+            get("/tomcat/attributes") {
+                call.respondText(
+                    call.request.servletRequestAttributes["ktor.test.attribute"]?.toString() ?: "Not found"
+                )
+            }
+        }
+
+        withUrl("/tomcat/attributes") {
+            assertEquals("135", call.response.readText())
+        }
+    }
+
+    private fun Server.addAttributesHandler() {
+        addLifeCycleListener(object : AbstractLifeCycle.AbstractLifeCycleListener() {
+            override fun lifeCycleStarting(event: LifeCycle?) {
+                super.lifeCycleStarting(event)
+                val delegate = handler
+                handler = object : DefaultHandler() {
+                    override fun handle(
+                        target: String?,
+                        baseRequest: Request?,
+                        request: HttpServletRequest?,
+                        response: HttpServletResponse?
+                    ) {
+                        request?.setAttribute("ktor.test.attribute", "135")
+                        delegate?.handle(target, baseRequest, request, response)
+                    }
+                }
+            }
+        })
+    }
+}
 
 class JettySustainabilityTest :
     SustainabilityTestSuite<JettyApplicationEngine, JettyApplicationEngineBase.Configuration>(Jetty)

--- a/ktor-server/ktor-server-servlet/api/ktor-server-servlet.api
+++ b/ktor-server/ktor-server-servlet/api/ktor-server-servlet.api
@@ -28,6 +28,11 @@ public class io/ktor/server/servlet/AsyncServletApplicationResponse : io/ktor/se
 public final class io/ktor/server/servlet/AsyncServletApplicationResponse$Companion {
 }
 
+public final class io/ktor/server/servlet/AttributesKt {
+	public static final fun getServletRequestAttributes (Lio/ktor/request/ApplicationRequest;)Ljava/util/Map;
+	public static final fun putServletAttributes (Lio/ktor/application/ApplicationCall;Ljavax/servlet/ServletRequest;)V
+}
+
 public final class io/ktor/server/servlet/DefaultServletUpgrade : io/ktor/server/servlet/ServletUpgrade {
 	public static final field INSTANCE Lio/ktor/server/servlet/DefaultServletUpgrade;
 	public fun performUpgrade (Lio/ktor/http/content/OutgoingContent$ProtocolUpgrade;Ljavax/servlet/http/HttpServletRequest;Ljavax/servlet/http/HttpServletResponse;Lkotlin/coroutines/CoroutineContext;Lkotlin/coroutines/CoroutineContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;

--- a/ktor-server/ktor-server-servlet/jvm/src/io/ktor/server/servlet/AsyncServlet.kt
+++ b/ktor-server/ktor-server-servlet/jvm/src/io/ktor/server/servlet/AsyncServlet.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2014-2020 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package io.ktor.server.servlet
@@ -41,6 +41,10 @@ public open class AsyncServletApplicationCall(
         ).also {
             putResponseAttribute(it)
         }
+    }
+
+    init {
+        putServletAttributes(servletRequest)
     }
 }
 

--- a/ktor-server/ktor-server-servlet/jvm/src/io/ktor/server/servlet/Attributes.kt
+++ b/ktor-server/ktor-server-servlet/jvm/src/io/ktor/server/servlet/Attributes.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2014-2020 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.server.servlet
+
+import io.ktor.application.*
+import io.ktor.request.*
+import io.ktor.server.engine.*
+import io.ktor.util.*
+import javax.servlet.*
+
+/**
+ * Provides javax.servlet request attributes or fail it the underlying engine is not
+ * servlet-backed.
+ */
+public val ApplicationRequest.servletRequestAttributes: Map<String, Any>
+    get() = call.attributes[servletRequestAttributesKey]
+
+/**
+ * A key for call attribute containing java.servlet attributes.
+ */
+internal val servletRequestAttributesKey: AttributeKey<Map<String, Any>> = AttributeKey("ServletRequestAttributes")
+
+@EngineAPI
+public fun ApplicationCall.putServletAttributes(request: ServletRequest) {
+    val servletAttributes = request.attributeNames?.asSequence()?.associateWith { attributeName ->
+        request.getAttribute(attributeName)
+    }?.filterValues { it != null } ?: emptyMap()
+
+    attributes.put(servletRequestAttributesKey, servletAttributes)
+}

--- a/ktor-server/ktor-server-servlet/jvm/src/io/ktor/server/servlet/BlockingServlet.kt
+++ b/ktor-server/ktor-server-servlet/jvm/src/io/ktor/server/servlet/BlockingServlet.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2014-2020 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package io.ktor.server.servlet
@@ -27,6 +27,7 @@ internal class BlockingServletApplicationCall(
 
     init {
         putResponseAttribute()
+        putServletAttributes(servletRequest)
     }
 }
 

--- a/ktor-server/ktor-server-servlet/jvm/src/io/ktor/server/servlet/ServletApplicationRequest.kt
+++ b/ktor-server/ktor-server-servlet/jvm/src/io/ktor/server/servlet/ServletApplicationRequest.kt
@@ -8,6 +8,7 @@ import io.ktor.application.*
 import io.ktor.http.*
 import io.ktor.request.*
 import io.ktor.server.engine.*
+import io.ktor.util.*
 import javax.servlet.http.*
 
 @Suppress("KDocMissingDocumentation")
@@ -17,6 +18,10 @@ public abstract class ServletApplicationRequest(
     public val servletRequest: HttpServletRequest
 ) : BaseApplicationRequest(call) {
 
+    companion object {
+        val servletRequestAttributes = AttributeKey<Map<String, Any>>("ServletRequestAttributes")
+    }
+
     override val local: RequestConnectionPoint = ServletConnectionPoint(servletRequest)
 
     override val queryParameters: Parameters by lazy {
@@ -24,6 +29,10 @@ public abstract class ServletApplicationRequest(
     }
 
     override val headers: Headers = ServletApplicationRequestHeaders(servletRequest)
+
+    val attributes = servletRequest.attributeNames.toList().associateWith { servletRequest.getAttribute(it) }.also {
+        call.attributes.put(servletRequestAttributes, it)
+    }
 
     @Suppress("LeakingThis") // this is safe because we don't access any content in the request
     override val cookies: RequestCookies = ServletApplicationRequestCookies(servletRequest, this)

--- a/ktor-server/ktor-server-servlet/jvm/src/io/ktor/server/servlet/ServletApplicationRequest.kt
+++ b/ktor-server/ktor-server-servlet/jvm/src/io/ktor/server/servlet/ServletApplicationRequest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2014-2020 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package io.ktor.server.servlet
@@ -8,7 +8,6 @@ import io.ktor.application.*
 import io.ktor.http.*
 import io.ktor.request.*
 import io.ktor.server.engine.*
-import io.ktor.util.*
 import javax.servlet.http.*
 
 @Suppress("KDocMissingDocumentation")
@@ -17,11 +16,6 @@ public abstract class ServletApplicationRequest(
     call: ApplicationCall,
     public val servletRequest: HttpServletRequest
 ) : BaseApplicationRequest(call) {
-
-    companion object {
-        val servletRequestAttributes = AttributeKey<Map<String, Any>>("ServletRequestAttributes")
-    }
-
     override val local: RequestConnectionPoint = ServletConnectionPoint(servletRequest)
 
     override val queryParameters: Parameters by lazy {
@@ -29,10 +23,6 @@ public abstract class ServletApplicationRequest(
     }
 
     override val headers: Headers = ServletApplicationRequestHeaders(servletRequest)
-
-    val attributes = servletRequest.attributeNames.toList().associateWith { servletRequest.getAttribute(it) }.also {
-        call.attributes.put(servletRequestAttributes, it)
-    }
 
     @Suppress("LeakingThis") // this is safe because we don't access any content in the request
     override val cookies: RequestCookies = ServletApplicationRequestCookies(servletRequest, this)

--- a/ktor-server/ktor-server-tomcat/jvm/test/io/ktor/tests/server/tomcat/TomcatEngineTest.kt
+++ b/ktor-server/ktor-server-tomcat/jvm/test/io/ktor/tests/server/tomcat/TomcatEngineTest.kt
@@ -1,13 +1,22 @@
 /*
- * Copyright 2014-2019 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2014-2020 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package io.ktor.tests.server.tomcat
 
+import io.ktor.application.*
+import io.ktor.client.statement.*
+import io.ktor.response.*
+import io.ktor.routing.*
+import io.ktor.server.servlet.*
 import io.ktor.server.testing.suites.*
 import io.ktor.server.tomcat.*
+import org.apache.catalina.core.*
+import org.apache.tomcat.util.descriptor.web.*
 import kotlin.test.*
 import java.util.logging.*
+import javax.servlet.*
+import javax.servlet.Filter
 
 class TomcatCompressionTest :
     CompressionTestSuite<TomcatApplicationEngine, TomcatApplicationEngine.Configuration>(Tomcat) {
@@ -45,6 +54,54 @@ class TomcatHttpServerTest :
     @Test
     override fun testUpgrade() {
         super.testUpgrade()
+    }
+
+    override fun configure(configuration: TomcatApplicationEngine.Configuration) {
+        super.configure(configuration)
+        configuration.configureTomcat = {
+            addAttributesFilter()
+        }
+    }
+
+    @Test
+    fun testServletAttributes() {
+        createAndStartServer {
+            get ("/tomcat/attributes") {
+                call.respondText(call.request.servletRequestAttributes["ktor.test.attribute"]?.toString() ?: "Not found")
+            }
+        }
+
+        withUrl("/tomcat/attributes") {
+            assertEquals("135", call.response.readText())
+        }
+    }
+
+
+    private fun org.apache.catalina.startup.Tomcat.addAttributesFilter() {
+        server.addLifecycleListener {
+            host.findChildren().forEach {
+                if (it is StandardContext) {
+                    if (it.findFilterConfig("AttributeFilter") == null) {
+                        it.addFilterDef(FilterDef().apply {
+                            filterName = "AttributeFilter"
+                            filterClass = AttributeFilter::class.java.name
+                            filter = AttributeFilter()
+                        })
+                        it.addFilterMap(FilterMap().apply {
+                            addURLPattern("/*")
+                            filterName = "AttributeFilter"
+                        })
+                    }
+                }
+            }
+        }
+    }
+
+    internal class AttributeFilter : Filter {
+        override fun doFilter(request: ServletRequest, response: ServletResponse, chain: FilterChain) {
+            request.setAttribute("ktor.test.attribute", "135")
+            chain.doFilter(request, response)
+        }
     }
 }
 


### PR DESCRIPTION
**Subsystem**
ktor-server-servlet, ktor-server-jetty

**Motivation**
[KTOR-424 Get client certificate information from request](https://youtrack.jetbrains.com/issue/KTOR-424)

**Solution**
Rework user's [PR #1771](https://github.com/ktorio/ktor/pull/1771) to provide access to servlet attributes. In particular, it provides a way to look at client' certificate from servlet request attributes.

