### PR TITLE
KTOR-1412 Move response validation to the receive pipeline

### DIFF
--- a/ktor-client/ktor-client-core/api/ktor-client-core.api
+++ b/ktor-client/ktor-client-core/api/ktor-client-core.api
@@ -317,12 +317,16 @@ public final class io/ktor/client/features/HttpCallValidator$Companion : io/ktor
 
 public final class io/ktor/client/features/HttpCallValidator$Config {
 	public fun <init> ()V
+	public final fun getExpectSuccess ()Z
 	public final fun handleResponseException (Lkotlin/jvm/functions/Function2;)V
+	public final fun setExpectSuccess (Z)V
 	public final fun validateResponse (Lkotlin/jvm/functions/Function2;)V
 }
 
 public final class io/ktor/client/features/HttpCallValidatorKt {
 	public static final fun HttpResponseValidator (Lio/ktor/client/HttpClientConfig;Lkotlin/jvm/functions/Function1;)V
+	public static final fun getExpectSuccess (Lio/ktor/client/request/HttpRequestBuilder;)Z
+	public static final fun setExpectSuccess (Lio/ktor/client/request/HttpRequestBuilder;Z)V
 }
 
 public abstract interface class io/ktor/client/features/HttpClientFeature {

--- a/ktor-client/ktor-client-core/common/src/io/ktor/client/HttpClient.kt
+++ b/ktor-client/ktor-client-core/common/src/io/ktor/client/HttpClient.kt
@@ -162,10 +162,7 @@ public class HttpClient(
 
             config += this
 
-            if (expectSuccess) {
-                // it's important to install validators last
-                config.addDefaultResponseValidation()
-            }
+            config.addDefaultResponseValidation()
 
             config.install(this@HttpClient)
         }

--- a/ktor-client/ktor-client-core/common/src/io/ktor/client/HttpClient.kt
+++ b/ktor-client/ktor-client-core/common/src/io/ktor/client/HttpClient.kt
@@ -154,10 +154,6 @@ public class HttpClient(
                 config.install("DefaultTransformers") { defaultTransformers() }
             }
 
-            if (expectSuccess) {
-                config.addDefaultResponseValidation()
-            }
-
             config.install(HttpSend)
 
             if (followRedirects) {
@@ -165,6 +161,12 @@ public class HttpClient(
             }
 
             config += this
+
+            if (expectSuccess) {
+                // it's important to install validators last
+                config.addDefaultResponseValidation()
+            }
+
             config.install(this@HttpClient)
         }
 

--- a/ktor-client/ktor-client-core/common/src/io/ktor/client/HttpClientConfig.kt
+++ b/ktor-client/ktor-client-core/common/src/io/ktor/client/HttpClientConfig.kt
@@ -45,7 +45,7 @@ public class HttpClientConfig<T : HttpClientEngineConfig> {
     public var useDefaultTransformers: Boolean by shared(true)
 
     /**
-     * Terminate [HttpClient.responsePipeline] if status code is not success(>=300).
+     * Terminate [HttpClient.receivePipeline] if status code is not success(>=300).
      */
     public var expectSuccess: Boolean by shared(true)
 

--- a/ktor-client/ktor-client-core/common/src/io/ktor/client/features/DefaultResponseValidation.kt
+++ b/ktor-client/ktor-client-core/common/src/io/ktor/client/features/DefaultResponseValidation.kt
@@ -20,6 +20,8 @@ private val ValidateMark = AttributeKey<Unit>("ValidateMark")
  */
 public fun HttpClientConfig<*>.addDefaultResponseValidation() {
     HttpResponseValidator {
+        expectSuccess = this@addDefaultResponseValidation.expectSuccess
+
         validateResponse { response ->
             val statusCode = response.status.value
             val originCall = response.call

--- a/ktor-client/ktor-client-features/ktor-client-auth/common/test/io/ktor/client/features/auth/AuthTest.kt
+++ b/ktor-client/ktor-client-features/ktor-client-auth/common/test/io/ktor/client/features/auth/AuthTest.kt
@@ -73,6 +73,7 @@ class AuthTest : ClientLoader() {
                     password = "pw"
                 }
             }
+            expectSuccess = false
         }
 
         test { client ->

--- a/ktor-server/ktor-server-tests/jvm/test/io/ktor/tests/server/testing/TestApplicationEngineTest.kt
+++ b/ktor-server/ktor-server-tests/jvm/test/io/ktor/tests/server/testing/TestApplicationEngineTest.kt
@@ -208,6 +208,7 @@ class TestApplicationEngineTest {
                 }
             }
 
+            val client = client.config { expectSuccess = false }
             runBlocking {
                 val notExistingResponse = client.get<HttpResponse>("/notExist")
                 assertEquals(HttpStatusCode.NotFound, notExistingResponse.status)


### PR DESCRIPTION
**Subsystem**
Client/Server, related modules

**Motivation**
[KTOR-1412](https://youtrack.jetbrains.com/issue/KTOR-1412) Response validation happens only on call to `receive<T>()`

**Solution**
Move validation from `HttpResponsePipeline` to `HttpReceivePipeline` 

