### PR TITLE
KTOR-1464 Use realm value in header if not otherwise specified by user

### DIFF
--- a/ktor-client/ktor-client-features/ktor-client-auth/common/src/io/ktor/client/features/auth/providers/DigestAuthProvider.kt
+++ b/ktor-client/ktor-client-features/ktor-client-auth/common/src/io/ktor/client/features/auth/providers/DigestAuthProvider.kt
@@ -55,11 +55,18 @@ public class DigestAuthProvider(
 
     override fun isApplicable(auth: HttpAuthHeader): Boolean {
         if (auth !is HttpAuthHeader.Parameterized ||
-            auth.parameter("realm") != realm ||
             auth.authScheme != AuthScheme.Digest
         ) return false
 
         val newNonce = auth.parameter("nonce") ?: return false
+        val newRealm = auth.parameter("realm") ?: return false
+        if (realm == null) {
+            realm = newRealm
+        } else {
+            if (newRealm != realm) {
+                return false
+            }
+        }
         val newQop = auth.parameter("qop")
         val newOpaque = auth.parameter("opaque")
 


### PR DESCRIPTION
**Subsystem**
client-auth
 
**Motivation**
If no realm value is provided, the DigestAuthProvider returns false instead of applying the realm value present in the 401 response header. 
 
**Solution**
Use realm value in 401 header for authentication if no other realm value has been specified.