### PR TITLE
return status 400 with a useful error message when json parsing fails

### DIFF
--- a/ktor-server/ktor-server-core/jvm/src/io/ktor/features/ContentNegotiation.kt
+++ b/ktor-server/ktor-server-core/jvm/src/io/ktor/features/ContentNegotiation.kt
@@ -110,6 +110,8 @@ public class ContentNegotiation(
                     proceed()
                 } catch (e: UnsupportedMediaTypeException) {
                     call.respond(HttpStatusCode.UnsupportedMediaType)
+                } catch (e: ContentTransformationException) {
+                    call.respond(HttpStatusCode.BadRequest, e.message ?: "Error transforming content")
                 }
             }
 


### PR DESCRIPTION

**Subsystem**
Content Negotiation, Jackson

**Motivation**
in current master ktor just fails with 500 internal server error when a post request contains malformed json.

**Solution**
Jackson now throws a JsonTransformationException which is a subclass of CannotTransformContentToTypeException (which is abstract), and ContentNegotiation catches that and returns Http Status 400 and the exception message which contains a useful error message. (see unit test)



