### PR TITLE
KTOR-455 escape file and filename in formData builder

### DIFF
--- a/ktor-client/ktor-client-core/common/src/io/ktor/client/request/forms/formDsl.kt
+++ b/ktor-client/ktor-client-core/common/src/io/ktor/client/request/forms/formDsl.kt
@@ -27,7 +27,7 @@ public fun formData(vararg values: FormPart<*>): List<PartData> {
 
     values.forEach { (key, value, headers) ->
         val partHeaders = HeadersBuilder().apply {
-            append(HttpHeaders.ContentDisposition, "form-data; name=$key")
+            append(HttpHeaders.ContentDisposition, "form-data; name=${key.escapeIfNeeded()}")
             appendAll(headers)
         }
         val part = when (value) {
@@ -185,7 +185,7 @@ public fun FormBuilder.append(
     }
 
     val headersBuilder = HeadersBuilder()
-    headersBuilder[HttpHeaders.ContentDisposition] = "filename=$filename"
+    headersBuilder[HttpHeaders.ContentDisposition] = "filename=${filename.escapeIfNeeded()}"
     contentType?.run { headersBuilder[HttpHeaders.ContentType] = this.toString() }
     val headers = headersBuilder.build()
 

--- a/ktor-client/ktor-client-core/common/test/FormDslTest.kt
+++ b/ktor-client/ktor-client-core/common/test/FormDslTest.kt
@@ -1,0 +1,34 @@
+import io.ktor.client.request.forms.*
+import io.ktor.http.*
+import kotlin.test.*
+
+/*
+ * Copyright 2014-2020 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+class FormDslTest {
+
+    @Test
+    fun testAppendDoesNotEscapeKeyAndFilenameIfNotNeeded() {
+        val data = formData {
+            append(
+                key = "file",
+                filename = "file.name"
+            ) {}
+        }
+        assertEquals(data.first().headers.getAll(HttpHeaders.ContentDisposition)!![0], "form-data; name=file")
+        assertEquals(data.first().headers.getAll(HttpHeaders.ContentDisposition)!![1], "filename=file.name")
+    }
+
+    @Test
+    fun testAppendEscapeKeyAndFilenameIfNeeded() {
+        val data = formData {
+            append(
+                key = "file 1",
+                filename = "file 1.name"
+            ) {}
+        }
+        assertEquals(data.first().headers.getAll(HttpHeaders.ContentDisposition)!![0], "form-data; name=\"file 1\"")
+        assertEquals(data.first().headers.getAll(HttpHeaders.ContentDisposition)!![1], "filename=\"file 1.name\"")
+    }
+}


### PR DESCRIPTION
**Subsystem**
Client

**Motivation**
[Content-Disposition additional parameters should be inside quotes](https://youtrack.jetbrains.com/issue/KTOR-455)

**Solution**
This bug was fixed before, but I forgot to escape values here as well
