### PR TITLE
KTOR-926 Introduce wrapper for sending cookies via HTTPRequestBuilder

### DIFF
--- a/ktor-client/ktor-client-core/api/ktor-client-core.api
+++ b/ktor-client/ktor-client-core/api/ktor-client-core.api
@@ -850,6 +850,8 @@ public final class io/ktor/client/request/HttpSendPipeline$Phases {
 
 public final class io/ktor/client/request/UtilsKt {
 	public static final fun accept (Lio/ktor/client/request/HttpRequestBuilder;Lio/ktor/http/ContentType;)V
+	public static final fun cookie (Lio/ktor/client/request/HttpRequestBuilder;Ljava/lang/String;Ljava/lang/String;ILio/ktor/util/date/GMTDate;Ljava/lang/String;Ljava/lang/String;ZZLjava/util/Map;)V
+	public static synthetic fun cookie$default (Lio/ktor/client/request/HttpRequestBuilder;Ljava/lang/String;Ljava/lang/String;ILio/ktor/util/date/GMTDate;Ljava/lang/String;Ljava/lang/String;ZZLjava/util/Map;ILjava/lang/Object;)V
 	public static final fun getHost (Lio/ktor/client/request/HttpRequestBuilder;)Ljava/lang/String;
 	public static final fun getPort (Lio/ktor/client/request/HttpRequestBuilder;)I
 	public static final fun header (Lio/ktor/client/request/HttpRequestBuilder;Ljava/lang/String;Ljava/lang/Object;)V

--- a/ktor-client/ktor-client-core/common/src/io/ktor/client/request/HttpRequest.kt
+++ b/ktor-client/ktor-client-core/common/src/io/ktor/client/request/HttpRequest.kt
@@ -217,6 +217,39 @@ public class HttpResponseData constructor(
  */
 public fun HttpRequestBuilder.headers(block: HeadersBuilder.() -> Unit): HeadersBuilder = headers.apply(block)
 
+/**
+ * Executes a [block] that configures the [CookiesBuilder] associated to this request.
+ */
+public fun HttpRequestBuilder.cookies(block: CookiesBuilder.() -> Unit): HeadersBuilder =
+    CookiesBuilder(headers).apply(block).headersBuilder
+
+public class CookiesBuilder(internal val headersBuilder: HeadersBuilder) {
+    public fun append(
+        name: String,
+        value: String,
+        maxAge: Int = 0,
+        expires: GMTDate? = null,
+        domain: String? = null,
+        path: String? = null,
+        secure: Boolean = false,
+        httpOnly: Boolean = false,
+        extensions: Map<String, String?> = emptyMap()
+    ) {
+        val cookie = Cookie(
+            name = name,
+            value = value,
+            maxAge = maxAge,
+            expires = expires,
+            domain = domain,
+            path = path,
+            secure = secure,
+            httpOnly = httpOnly,
+            extensions = extensions
+        )
+        headersBuilder.append(HttpHeaders.Cookie, renderSetCookieHeader(cookie))
+    }
+}
+
 
 /**
  * Mutates [this] copying all the data from another [request] using it as base.

--- a/ktor-client/ktor-client-core/common/src/io/ktor/client/request/HttpRequest.kt
+++ b/ktor-client/ktor-client-core/common/src/io/ktor/client/request/HttpRequest.kt
@@ -217,39 +217,6 @@ public class HttpResponseData constructor(
  */
 public fun HttpRequestBuilder.headers(block: HeadersBuilder.() -> Unit): HeadersBuilder = headers.apply(block)
 
-/**
- * Executes a [block] that configures the [CookiesBuilder] associated to this request.
- */
-public fun HttpRequestBuilder.cookies(block: CookiesBuilder.() -> Unit): HeadersBuilder =
-    CookiesBuilder(headers).apply(block).headersBuilder
-
-public class CookiesBuilder(internal val headersBuilder: HeadersBuilder) {
-    public fun append(
-        name: String,
-        value: String,
-        maxAge: Int = 0,
-        expires: GMTDate? = null,
-        domain: String? = null,
-        path: String? = null,
-        secure: Boolean = false,
-        httpOnly: Boolean = false,
-        extensions: Map<String, String?> = emptyMap()
-    ) {
-        val cookie = Cookie(
-            name = name,
-            value = value,
-            maxAge = maxAge,
-            expires = expires,
-            domain = domain,
-            path = path,
-            secure = secure,
-            httpOnly = httpOnly,
-            extensions = extensions
-        )
-        headersBuilder.append(HttpHeaders.Cookie, renderSetCookieHeader(cookie))
-    }
-}
-
 
 /**
  * Mutates [this] copying all the data from another [request] using it as base.

--- a/ktor-client/ktor-client-core/common/src/io/ktor/client/request/utils.kt
+++ b/ktor-client/ktor-client-core/common/src/io/ktor/client/request/utils.kt
@@ -57,7 +57,12 @@ public fun HttpRequestBuilder.cookie(
         extensions = extensions
     ).let(::renderCookieHeader)
 
-    headers.append(HttpHeaders.Cookie, renderedCookie)
+    if (HttpHeaders.Cookie !in headers) {
+        headers.append(HttpHeaders.Cookie, renderedCookie)
+        return
+    }
+    // Client cookies are stored in a single header "Cookies" and multiple values are separated with ";"
+    headers[HttpHeaders.Cookie] = headers[HttpHeaders.Cookie] + "; " + renderedCookie
 }
 
 /**

--- a/ktor-client/ktor-client-core/common/src/io/ktor/client/request/utils.kt
+++ b/ktor-client/ktor-client-core/common/src/io/ktor/client/request/utils.kt
@@ -5,6 +5,7 @@
 package io.ktor.client.request
 
 import io.ktor.http.*
+import io.ktor.util.date.*
 
 /**
  * Gets the associated URL's host.
@@ -29,6 +30,35 @@ public var HttpRequestBuilder.port: Int
  */
 public fun HttpRequestBuilder.header(key: String, value: Any?): Unit =
     value?.let { headers.append(key, it.toString()) } ?: Unit
+
+/**
+ * Sets a single header of [key] with a specific [value] if the value is not null.
+ */
+public fun HttpRequestBuilder.cookie(
+    name: String,
+    value: String,
+    maxAge: Int = 0,
+    expires: GMTDate? = null,
+    domain: String? = null,
+    path: String? = null,
+    secure: Boolean = false,
+    httpOnly: Boolean = false,
+    extensions: Map<String, String?> = emptyMap()
+): Unit {
+    val renderedCookie = Cookie(
+        name = name,
+        value = value,
+        maxAge = maxAge,
+        expires = expires,
+        domain = domain,
+        path = path,
+        secure = secure,
+        httpOnly = httpOnly,
+        extensions = extensions
+    ).let(::renderCookieHeader)
+
+    headers.append(HttpHeaders.Cookie, renderedCookie)
+}
 
 /**
  * Sets a single URL query parameter of [key] with a specific [value] if the value is not null. Can not be used to set

--- a/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/CookiesTest.kt
+++ b/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/CookiesTest.kt
@@ -204,9 +204,7 @@ class CookiesTest : ClientLoader() {
     fun testRequestBuilderSingleCookie() = clientTests(listOf("Js")) {
         test { client ->
             val result = client.get<String>("$TEST_HOST/respond-single-cookie") {
-                cookies {
-                    append("single", value = "abacaba")
-                }
+                cookie("single", value = "abacaba")
             }
             assertEquals("abacaba", result)
         }

--- a/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/CookiesTest.kt
+++ b/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/CookiesTest.kt
@@ -210,5 +210,16 @@ class CookiesTest : ClientLoader() {
         }
     }
 
+    @Test
+    fun testRequestBuilderMultipleCookies() = clientTests(listOf("Js")) {
+        test { client ->
+            val result = client.get<String>("$TEST_HOST/respond-a-minus-b") {
+                cookie("a", value = "10")
+                cookie("b", value = "4")
+            }
+            assertEquals("6", result)
+        }
+    }
+
     private suspend fun HttpClient.getId() = cookies(hostname)["id"]!!.value.toInt()
 }

--- a/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/CookiesTest.kt
+++ b/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/CookiesTest.kt
@@ -200,5 +200,17 @@ class CookiesTest : ClientLoader() {
         }
     }
 
+    @Test
+    fun testRequestBuilderSingleCookie() = clientTests(listOf("Js")) {
+        test { client ->
+            val result = client.get<String>("$TEST_HOST/respond-single-cookie") {
+                cookies {
+                    append("single", value = "abacaba")
+                }
+            }
+            assertEquals("abacaba", result)
+        }
+    }
+
     private suspend fun HttpClient.getId() = cookies(hostname)["id"]!!.value.toInt()
 }

--- a/ktor-client/ktor-client-tests/jvm/src/io/ktor/client/tests/utils/tests/Cookies.kt
+++ b/ktor-client/ktor-client-tests/jvm/src/io/ktor/client/tests/utils/tests/Cookies.kt
@@ -9,6 +9,7 @@ import io.ktor.http.*
 import io.ktor.request.*
 import io.ktor.response.*
 import io.ktor.routing.*
+import io.ktor.util.*
 import kotlin.test.*
 
 
@@ -92,6 +93,12 @@ public fun Application.cookiesTest() {
             }
             get("/respond-single-cookie") {
                 context.respond(context.request.cookies["single"] ?: fail())
+            }
+            get("/respond-a-minus-b") {
+                val a = context.request.cookies["a"]?.toInt() ?: fail()
+                val b = context.request.cookies["b"]?.toInt() ?: fail()
+
+                context.respond((a - b).toString())
             }
         }
     }

--- a/ktor-client/ktor-client-tests/jvm/src/io/ktor/client/tests/utils/tests/Cookies.kt
+++ b/ktor-client/ktor-client-tests/jvm/src/io/ktor/client/tests/utils/tests/Cookies.kt
@@ -90,6 +90,9 @@ public fun Application.cookiesTest() {
             get("/encoded") {
                 context.respond(context.request.header(HttpHeaders.Cookie) ?: fail())
             }
+            get("/respond-single-cookie") {
+                context.respond(context.request.cookies["single"] ?: fail())
+            }
         }
     }
 }


### PR DESCRIPTION
**Subsystem**
Client, HttpRequestBuilder

**Motivation**
https://youtrack.jetbrains.com/issue/KTOR-926

**Solution**
Wrapper over `headers { ... }` extension that allows adding cookies via `Cookie` header that can be accessed on server.

