### PR TITLE
KTOR-1370 Fix CORS simple content types processing

### DIFF
--- a/ktor-http/common/src/io/ktor/http/ContentTypes.kt
+++ b/ktor-http/common/src/io/ktor/http/ContentTypes.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2014-2020 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package io.ktor.http
@@ -47,7 +47,10 @@ public class ContentType private constructor(
     /**
      * Creates a copy of `this` type without any parameters
      */
-    public fun withoutParameters(): ContentType = ContentType(contentType, contentSubtype)
+    public fun withoutParameters(): ContentType = when {
+        parameters.isEmpty() -> this
+        else -> ContentType(contentType, contentSubtype)
+    }
 
     /**
      * Checks if `this` type matches a [pattern] type taking into account placeholder symbols `*` and parameters.

--- a/ktor-http/common/test/io/ktor/tests/http/ContentTypeTest.kt
+++ b/ktor-http/common/test/io/ktor/tests/http/ContentTypeTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2014-2020 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package io.ktor.tests.http
@@ -99,5 +99,24 @@ class ContentTypeTest {
     fun testContentTypeQuotedAtStartAndMiddle() {
         val result = ContentType.parse("image/png; charset=\"utf-8\" but not really")
         assertEquals(ContentType.Image.PNG.withParameter("charset", "\"utf-8\" but not really"), result)
+    }
+
+    @Test
+    fun testWithoutParameters() {
+        assertEquals(ContentType.Text.Plain, ContentType.Text.Plain.withoutParameters())
+        assertEquals(
+            ContentType.Text.Plain,
+            ContentType.Text.Plain.withParameter("a", "1").withoutParameters()
+        )
+
+        assertEquals(
+            "text/plain",
+            ContentType.Text.Plain.withParameter("a", "1").withoutParameters().toString()
+        )
+
+        assertEquals(
+            "text/html",
+            ContentType.parse("text/html;charset=utf-8").withoutParameters().toString()
+        )
     }
 }

--- a/ktor-server/ktor-server-core/jvm/src/io/ktor/features/CORS.kt
+++ b/ktor-server/ktor-server-core/jvm/src/io/ktor/features/CORS.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2014-2020 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
 @file:Suppress("MemberVisibilityCanBePrivate")
@@ -102,7 +102,7 @@ public class CORS(configuration: Configuration) {
         if (!allowNonSimpleContentTypes) {
             val contentType = call.request.header(HttpHeaders.ContentType)?.let { ContentType.parse(it) }
             if (contentType != null) {
-                if (contentType !in Configuration.CorsSimpleContentTypes) {
+                if (contentType.withoutParameters() !in Configuration.CorsSimpleContentTypes) {
                     context.respondCorsFailed()
                     return
                 }

--- a/ktor-server/ktor-server-tests/jvm/test/io/ktor/tests/server/features/CORSTest.kt
+++ b/ktor-server/ktor-server-tests/jvm/test/io/ktor/tests/server/features/CORSTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2014-2020 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package io.ktor.tests.server.features
@@ -485,6 +485,20 @@ class CORSTest {
                 addHeader(HttpHeaders.ContentType, "application/json") // non-simple Content-Type value
             }.let { call ->
                 assertEquals(HttpStatusCode.Forbidden, call.response.status())
+            }
+
+            handleRequest(HttpMethod.Post, "/") {
+                addHeader(HttpHeaders.Origin, "http://my-host")
+                addHeader(HttpHeaders.ContentType, "text/plain") // simple Content-Type value
+            }.let { call ->
+                assertEquals(HttpStatusCode.OK, call.response.status())
+            }
+
+            handleRequest(HttpMethod.Post, "/") {
+                addHeader(HttpHeaders.Origin, "http://my-host")
+                addHeader(HttpHeaders.ContentType, "text/plain;charset=utf-8") // still simple Content-Type value
+            }.let { call ->
+                assertEquals(HttpStatusCode.OK, call.response.status())
             }
         }
     }


### PR DESCRIPTION
**Subsystem**
ktor-server-core (CORS)

**Motivation**
[KTOR-1370 CORS denies simple request where the content type includes a character encoding](https://youtrack.jetbrains.com/issue/KTOR-1370) 

**Solution**
Discard content type parameters and use only type and subtype as specified as per the fetch spec. 

