### PR TITLE
KTOR-1329 Add warning annotation for HTTP/2 push

### DIFF
--- a/ktor-server/ktor-server-core/api/ktor-server-core.api
+++ b/ktor-server/ktor-server-core/api/ktor-server-core.api
@@ -1110,6 +1110,9 @@ public abstract interface class io/ktor/response/ResponsePushBuilder {
 	public abstract fun setMethod (Lio/ktor/http/HttpMethod;)V
 }
 
+public abstract interface annotation class io/ktor/response/UseHttp2Push : java/lang/annotation/Annotation {
+}
+
 public final class io/ktor/routing/AndRouteSelector : io/ktor/routing/RouteSelector {
 	public fun <init> (Lio/ktor/routing/RouteSelector;Lio/ktor/routing/RouteSelector;)V
 	public final fun component1 ()Lio/ktor/routing/RouteSelector;

--- a/ktor-server/ktor-server-core/jvm/src/io/ktor/http/Push.kt
+++ b/ktor-server/ktor-server-core/jvm/src/io/ktor/http/Push.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2014-2020 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package io.ktor.http
@@ -13,6 +13,7 @@ import io.ktor.util.*
  * or does nothing.
  * Exact behaviour is up to engine implementation.
  */
+@UseHttp2Push
 public fun ApplicationCall.push(pathAndQuery: String) {
     val (path, query) = pathAndQuery.chomp("?") { pathAndQuery to "" }
     push(path, parseQueryString(query))
@@ -23,6 +24,7 @@ public fun ApplicationCall.push(pathAndQuery: String) {
  * or does nothing.
  * Exact behaviour is up to engine implementation.
  */
+@UseHttp2Push
 public fun ApplicationCall.push(encodedPath: String, parameters: Parameters) {
     push {
         url.encodedPath = encodedPath
@@ -36,6 +38,7 @@ public fun ApplicationCall.push(encodedPath: String, parameters: Parameters) {
  * or does nothing (may call or not call [block]).
  * Exact behaviour is up to engine implementation.
  */
+@UseHttp2Push
 public fun ApplicationCall.push(block: ResponsePushBuilder.() -> Unit) {
     response.push(DefaultResponsePushBuilder(this).apply(block))
 }

--- a/ktor-server/ktor-server-core/jvm/src/io/ktor/response/ApplicationResponse.kt
+++ b/ktor-server/ktor-server-core/jvm/src/io/ktor/response/ApplicationResponse.kt
@@ -45,5 +45,6 @@ public interface ApplicationResponse {
      * Produces HTTP/2 push from server to client or sets HTTP/1.x hint header
      * or does nothing. Exact behaviour is up to engine implementation.
      */
+    @UseHttp2Push
     public fun push(builder: ResponsePushBuilder)
 }

--- a/ktor-server/ktor-server-core/jvm/src/io/ktor/response/DefaultResponsePushBuilder.kt
+++ b/ktor-server/ktor-server-core/jvm/src/io/ktor/response/DefaultResponsePushBuilder.kt
@@ -16,6 +16,7 @@ import io.ktor.util.*
  * @property headers builder
  */
 @InternalAPI
+@UseHttp2Push
 public class DefaultResponsePushBuilder(
     override var method: HttpMethod = HttpMethod.Get,
     override val url: URLBuilder = URLBuilder(),

--- a/ktor-server/ktor-server-core/jvm/src/io/ktor/response/ResponsePushBuilder.kt
+++ b/ktor-server/ktor-server-core/jvm/src/io/ktor/response/ResponsePushBuilder.kt
@@ -15,6 +15,7 @@ import io.ktor.http.content.*
  * @property method request method
  * @property versions request versions (last modification date, etag and so on)
  */
+@UseHttp2Push
 public interface ResponsePushBuilder {
     public val url: URLBuilder
     public val headers: HeadersBuilder

--- a/ktor-server/ktor-server-core/jvm/src/io/ktor/response/UseHttp2Push.kt
+++ b/ktor-server/ktor-server-core/jvm/src/io/ktor/response/UseHttp2Push.kt
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2014-2020 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.response
+
+/**
+ * HTTP/2 push is no longer supported by Chrome web browser.
+ * Other browsers may discard it at some point.
+ * With such browsers, HTTP/2 push will be disabled, therefore
+ * using this feature is safe but it will have no effect.
+ * On the other hand, this feature is not deprecated and generally it is still allowed
+ * to use it, so feel free to opt-in this annotation to eliminate this warning, if
+ * you are sure that you need it. For example, it makes sense to use with
+ * a non-browser client that for sure supports HTTP/2 push.
+ */
+@RequiresOptIn(
+    "HTTP/2 push is no longer supported by some web browsers.",
+    level = RequiresOptIn.Level.WARNING
+)
+public annotation class UseHttp2Push

--- a/ktor-server/ktor-server-host-common/jvm/src/io/ktor/server/engine/BaseApplicationResponse.kt
+++ b/ktor-server/ktor-server-host-common/jvm/src/io/ktor/server/engine/BaseApplicationResponse.kt
@@ -237,6 +237,7 @@ public abstract class BaseApplicationResponse(override val call: ApplicationCall
      */
     protected abstract fun setStatus(statusCode: HttpStatusCode)
 
+    @UseHttp2Push
     override fun push(builder: ResponsePushBuilder) {
         link(builder.url.buildString(), LinkHeader.Rel.Prefetch)
     }

--- a/ktor-server/ktor-server-jetty/jvm/src/io/ktor/server/jetty/JettyApplicationResponse.kt
+++ b/ktor-server/ktor-server-jetty/jvm/src/io/ktor/server/jetty/JettyApplicationResponse.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2014-2020 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package io.ktor.server.jetty
@@ -32,6 +32,7 @@ public class JettyApplicationResponse(
     coroutineContext
 ) {
 
+    @UseHttp2Push
     override fun push(builder: ResponsePushBuilder) {
         if (baseRequest.isPushSupported) {
             baseRequest.pushBuilder.apply {

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http2/NettyHttp2ApplicationResponse.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http2/NettyHttp2ApplicationResponse.kt
@@ -55,6 +55,7 @@ internal class NettyHttp2ApplicationResponse(call: NettyApplicationCall,
         override fun getEngineHeaderValues(name: String): List<String> = responseHeaders.getAll(name).map { it.toString() }
     }
 
+    @UseHttp2Push
     override fun push(builder: ResponsePushBuilder) {
         context.executor().execute {
             handler.startHttp2PushPromise(this@NettyHttp2ApplicationResponse.context, builder)

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http2/NettyHttp2Handler.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http2/NettyHttp2Handler.kt
@@ -88,6 +88,7 @@ internal class NettyHttp2Handler(
         responseWriter.ensureRunning()
     }
 
+    @UseHttp2Push
     internal fun startHttp2PushPromise(context: ChannelHandlerContext, builder: ResponsePushBuilder) {
         val channel = context.channel() as Http2StreamChannel
         val streamId = channel.stream().id()

--- a/ktor-server/ktor-server-servlet/jvm/src/io/ktor/server/servlet/AsyncServlet.kt
+++ b/ktor-server/ktor-server-servlet/jvm/src/io/ktor/server/servlet/AsyncServlet.kt
@@ -95,12 +95,14 @@ public open class AsyncServletApplicationResponse(
         servletUpgradeImpl.performUpgrade(upgrade, servletRequest, servletResponse, engineContext, userContext)
     }
 
+    @UseHttp2Push
     override fun push(builder: ResponsePushBuilder) {
         if (!tryPush(servletRequest, builder)) {
             super.push(builder)
         }
     }
 
+    @UseHttp2Push
     private fun tryPush(request: HttpServletRequest, builder: ResponsePushBuilder): Boolean {
         return foundPushImpls.any { function ->
             tryInvoke(function, request, builder)
@@ -123,6 +125,7 @@ public open class AsyncServletApplicationResponse(
             null
         }
 
+        @UseHttp2Push
         private fun tryInvoke(function: Method, request: HttpServletRequest, builder: ResponsePushBuilder) = try {
             function.invoke(null, request, builder) as Boolean
         } catch (ignore: ReflectiveOperationException) {

--- a/ktor-server/ktor-server-servlet/jvm/src/io/ktor/server/servlet/v4/Push.kt
+++ b/ktor-server/ktor-server-servlet/jvm/src/io/ktor/server/servlet/v4/Push.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2014-2020 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package io.ktor.server.servlet.v4
@@ -12,6 +12,7 @@ import javax.servlet.http.*
 @Suppress("unused", "KDocMissingDocumentation")
 @EngineAPI
 @InternalAPI
+@UseHttp2Push
 public fun doPush(request: HttpServletRequest, builder: ResponsePushBuilder): Boolean {
     request.newPushBuilder()?.apply {
         this.method(builder.method.value)


### PR DESCRIPTION
**Subsystem**
ktor-server-core

**Motivation**
[KTOR-1329 Deprecate HTTP/2 push support](https://youtrack.jetbrains.com/issue/KTOR-1329)

