### PR TITLE
KTOR-878 Strengthen session ID generation

### DIFF
--- a/ktor-server/ktor-server-core/api/ktor-server-core.api
+++ b/ktor-server/ktor-server-core/api/ktor-server-core.api
@@ -1661,6 +1661,10 @@ public final class io/ktor/sessions/JavaTimeMigrationKt {
 	public static final fun setDuration (Lio/ktor/sessions/CookieConfiguration;Ljava/time/temporal/TemporalAmount;)V
 }
 
+public final class io/ktor/sessions/SessionIdProviderKt {
+	public static final fun generateSessionId ()Ljava/lang/String;
+}
+
 public final class io/ktor/sessions/SessionNotYetConfiguredException : java/lang/IllegalStateException {
 	public fun <init> ()V
 }

--- a/ktor-server/ktor-server-core/jvm/src/io/ktor/sessions/SessionIdProvider.kt
+++ b/ktor-server/ktor-server-core/jvm/src/io/ktor/sessions/SessionIdProvider.kt
@@ -1,0 +1,12 @@
+/*
+ * Copyright 2014-2020 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.sessions
+
+import io.ktor.util.*
+
+/**
+ * Generates a secure random session ID
+ */
+public fun generateSessionId(): String = generateNonce() + generateNonce()

--- a/ktor-server/ktor-server-core/jvm/src/io/ktor/sessions/SessionsBuilder.kt
+++ b/ktor-server/ktor-server-core/jvm/src/io/ktor/sessions/SessionsBuilder.kt
@@ -277,7 +277,7 @@ constructor(type: KClass<S>) :
     /**
      * Current session ID provider function
      */
-    public var sessionIdProvider: () -> String = { generateNonce() }
+    public var sessionIdProvider: () -> String = { generateSessionId() }
         private set
 }
 
@@ -363,6 +363,6 @@ constructor(type: KClass<S>) :
     /**
      * Current session ID provider function
      */
-    public var sessionIdProvider: () -> String = { generateNonce() }
+    public var sessionIdProvider: () -> String = { generateSessionId() }
         private set
 }


### PR DESCRIPTION
**Subsystem**
ktor-server-core

**Motivation and solution**
[KTOR-878 Possibility of birthday attach for SessionStorage key](https://youtrack.jetbrains.com/issue/KTOR-878)
Currently, the session-id strength is not that high. In spite of that, we have no particular evidence of that it's really unsafe, our competitors usually have longer identifiers. So I decided to twice the id in ktor as well.

Also, the default session-id generation function is now public.
