### PR TITLE
KTOR-368 Introduce Netty tcpKeepAlive flag

### DIFF
--- a/ktor-server/ktor-server-netty/api/ktor-server-netty.api
+++ b/ktor-server/ktor-server-netty/api/ktor-server-netty.api
@@ -90,6 +90,7 @@ public final class io/ktor/server/netty/NettyApplicationEngine$Configuration : i
 	public final fun getResponseWriteTimeoutSeconds ()I
 	public final fun getRunningLimit ()I
 	public final fun getShareWorkGroup ()Z
+	public final fun getTcpKeepAlive ()Z
 	public final fun setConfigureBootstrap (Lkotlin/jvm/functions/Function1;)V
 	public final fun setHttpServerCodec (Lkotlin/jvm/functions/Function0;)V
 	public final fun setRequestQueueLimit (I)V
@@ -97,6 +98,7 @@ public final class io/ktor/server/netty/NettyApplicationEngine$Configuration : i
 	public final fun setResponseWriteTimeoutSeconds (I)V
 	public final fun setRunningLimit (I)V
 	public final fun setShareWorkGroup (Z)V
+	public final fun setTcpKeepAlive (Z)V
 }
 
 public abstract class io/ktor/server/netty/NettyApplicationRequest : io/ktor/server/engine/BaseApplicationRequest, kotlinx/coroutines/CoroutineScope {

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyApplicationEngine.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyApplicationEngine.kt
@@ -66,6 +66,14 @@ public class NettyApplicationEngine(
         public var requestReadTimeoutSeconds: Int = 0
 
         /**
+         * If set to `true`, enables TCP keep alive for connections so all
+         * dead client connections will be discarded.
+         * The timeout period is configured by the system so configure
+         * your host accordingly.
+         */
+        public var tcpKeepAlive: Boolean = false
+
+        /**
          * User-provided function to configure Netty's [HttpServerCodec]
          */
         public var httpServerCodec: () -> HttpServerCodec = ::HttpServerCodec
@@ -133,6 +141,9 @@ public class NettyApplicationEngine(
                         configuration.httpServerCodec
                     )
                 )
+                if (configuration.tcpKeepAlive) {
+                    option(NioChannelOption.SO_KEEPALIVE, true)
+                }
             }
         }
     }
@@ -210,7 +221,7 @@ public class EventLoopGroupProxy(public val channel: KClass<out ServerSocketChan
         public fun create(parallelism: Int): EventLoopGroupProxy {
             val defaultFactory = DefaultThreadFactory(EventLoopGroupProxy::class.java)
 
-            val factory: ThreadFactory = ThreadFactory { runnable ->
+            val factory = ThreadFactory { runnable ->
                 defaultFactory.newThread {
                     markParkingProhibited()
                     runnable.run()

--- a/ktor-server/ktor-server-netty/jvm/test/io/ktor/tests/server/netty/NettyEngineTest.kt
+++ b/ktor-server/ktor-server-netty/jvm/test/io/ktor/tests/server/netty/NettyEngineTest.kt
@@ -35,6 +35,7 @@ class NettyHttpServerTest : HttpServerTestSuite<NettyApplicationEngine, NettyApp
 
     override fun configure(configuration: NettyApplicationEngine.Configuration) {
         configuration.shareWorkGroup = true
+        configuration.tcpKeepAlive = true
     }
 }
 


### PR DESCRIPTION
**Subsystem**
ktor-server-netty

**Motivation**
[KTOR-368 ktor not closing user connections](https://youtrack.jetbrains.com/issue/KTOR-368) 
Unlike other backends, the netty backend doesn't have either read timeout, IDLE timeout or TCP keep alive option. So dead clients that don't close TCP connections properly, may get stuck forever. We only have read timeout that is disabled by default and still doesn't solve the problem because it's difficult to find the best time value for it as it may break WebSockets, SSE and long polling, including old techniques like "comet".

**Solution**
Introduce a way to enable TCP keep alive for Netty via option. It is disabled by default.

**Problems**
I see no way to write a reliable and fast enough test for this. So I decided to enable that flag for one of our server test suites for netty so we can ensure at least that setting this option doesn't lead to a crash. 
