### PR TITLE
KT-43901 Use WA for Enum.values in companion object

### DIFF
--- a/ktor-http/ktor-http-cio/common/src/io/ktor/http/cio/websocket/FrameType.kt
+++ b/ktor-http/ktor-http-cio/common/src/io/ktor/http/cio/websocket/FrameType.kt
@@ -35,10 +35,16 @@ public enum class FrameType(public val controlFrame: Boolean, public val opcode:
      */
     PONG(true, 0xa);
 
+    // WA: lazy delegate instead of just assignment
+    // https://youtrack.jetbrains.com/issue/KT-43901
     public companion object {
-        private val maxOpcode = values().maxBy { it.opcode }!!.opcode
+        private val maxOpcode by lazy {
+            values().maxBy { it.opcode }!!.opcode
+        }
 
-        private val byOpcodeArray = Array(maxOpcode + 1) { op -> values().singleOrNull { it.opcode == op } }
+        private val byOpcodeArray by lazy {
+            Array(maxOpcode + 1) { op -> values().singleOrNull { it.opcode == op } }
+        }
 
         /**
          * Find [FrameType] instance by numeric [opcode]

--- a/ktor-http/ktor-http-cio/common/test/io/ktor/tests/http/cio/websocket/FrameCloseTest.kt
+++ b/ktor-http/ktor-http-cio/common/test/io/ktor/tests/http/cio/websocket/FrameCloseTest.kt
@@ -8,26 +8,26 @@ import kotlin.test.*
 import io.ktor.http.cio.websocket.*
 
 class FrameCloseTest {
-//    @Test
-//    fun testASCII() {
-//        testClose(1000, "websocket closed")
-//    }
+    @Test
+    fun testASCII() {
+        testClose(1000, "websocket closed")
+    }
 
-//    @Test
-//    fun testUnicode() {
-//        testClose(1000, "websocket закрыт")
-//    }
-//
-//    @Test
-//    fun testEmptyMessage() {
-//        testClose(1000, "")
-//    }
-//
-//    @Test
-//    fun testEmptyFrame() {
-//        val reason = Frame.Close(byteArrayOf()).readReason()
-//        assertNull(reason)
-//    }
+    @Test
+    fun testUnicode() {
+        testClose(1000, "websocket закрыт")
+    }
+
+    @Test
+    fun testEmptyMessage() {
+        testClose(1000, "")
+    }
+
+    @Test
+    fun testEmptyFrame() {
+        val reason = Frame.Close(byteArrayOf()).readReason()
+        assertNull(reason)
+    }
 
     private fun testClose(code: Short, message: String) {
         val reason = Frame.Close(CloseReason(code, message)).readReason()


### PR DESCRIPTION
**Solution**
WA for [KT-43901](https://youtrack.jetbrains.com/issue/KT-43901) to pass `FrameCloseTest` in JS IR compiler backend in Node.JS.

