### PR TITLE
KTOR-1458 Add tunneling functionality to CIO

### DIFF
--- a/ktor-client/ktor-client-android/jvm/test/io/ktor/client/engine/android/CommonTests.kt
+++ b/ktor-client/ktor-client-android/jvm/test/io/ktor/client/engine/android/CommonTests.kt
@@ -5,5 +5,22 @@
 package io.ktor.client.engine.android
 
 import io.ktor.client.tests.*
+import javax.net.ssl.*
+import kotlin.test.*
 
 class AndroidHttpClientTest : HttpClientTest(Android)
+
+class AndroidSslOverProxyTest : SslOverProxyTest<AndroidEngineConfig>(Android) {
+
+    private lateinit var defaultSslSocketFactory: SSLSocketFactory
+
+    override fun AndroidEngineConfig.disableCertificatePinning() {
+        defaultSslSocketFactory = HttpsURLConnection.getDefaultSSLSocketFactory()
+        HttpsURLConnection.setDefaultSSLSocketFactory(unsafeSslContext.socketFactory)
+    }
+
+    @AfterTest
+    fun tearDown() {
+        HttpsURLConnection.setDefaultSSLSocketFactory(defaultSslSocketFactory)
+    }
+}

--- a/ktor-client/ktor-client-apache/jvm/test/io/ktor/client/engine/apache/CommonTests.kt
+++ b/ktor-client/ktor-client-apache/jvm/test/io/ktor/client/engine/apache/CommonTests.kt
@@ -7,3 +7,10 @@ package io.ktor.client.engine.apache
 import io.ktor.client.tests.*
 
 class ApacheHttpClientTest : HttpClientTest(Apache)
+
+class ApacheSslOverProxyTest : SslOverProxyTest<ApacheEngineConfig>(Apache) {
+
+    override fun ApacheEngineConfig.disableCertificatePinning() {
+        this.sslContext = this@ApacheSslOverProxyTest.unsafeSslContext
+    }
+}

--- a/ktor-client/ktor-client-cio/common/src/io/ktor/client/engine/cio/CIOEngine.kt
+++ b/ktor-client/ktor-client-cio/common/src/io/ktor/client/engine/cio/CIOEngine.kt
@@ -121,7 +121,7 @@ internal class CIOEngine(
         return endpoints.computeIfAbsent(endpointId) {
             val secure = (protocol.isSecure())
             Endpoint(
-                host, port, proxy != null, secure,
+                host, port, proxy, secure,
                 config,
                 connectionFactory, coroutineContext,
                 onDone = { endpoints.remove(endpointId) }

--- a/ktor-client/ktor-client-cio/common/src/io/ktor/client/engine/cio/ConnectionPipelineCommon.kt
+++ b/ktor-client/ktor-client-cio/common/src/io/ktor/client/engine/cio/ConnectionPipelineCommon.kt
@@ -12,7 +12,7 @@ import kotlin.coroutines.*
 internal expect class ConnectionPipeline(
     keepAliveTime: Long,
     pipelineMaxSize: Int,
-    socket: Socket,
+    connection: Connection,
     overProxy: Boolean,
     tasks: Channel<RequestTask>,
     parentContext: CoroutineContext

--- a/ktor-client/ktor-client-cio/common/src/io/ktor/client/engine/cio/utils.kt
+++ b/ktor-client/ktor-client-cio/common/src/io/ktor/client/engine/cio/utils.kt
@@ -138,6 +138,55 @@ internal suspend fun readResponse(
     }
 }
 
+internal suspend fun startTunnel(
+    request: HttpRequestData,
+    output: ByteWriteChannel,
+    input: ByteReadChannel
+) {
+    val builder = RequestResponseBuilder()
+
+    try {
+        val urlString = request.url.toString()
+
+        builder.requestLine(HttpMethod("CONNECT"), urlString, HttpProtocolVersion.HTTP_1_1.toString())
+        // this will only add the port to the host header if the port is non-standard for the protocol
+        val host = if (request.url.protocol.defaultPort == request.url.port) {
+            request.url.host
+        } else {
+            request.url.hostWithPort
+        }
+
+        builder.headerLine(HttpHeaders.Host, host)
+        builder.headerLine("Proxy-Connection", "Keep-Alive") // For HTTP/1.0 proxies like Squid.
+        request.headers[HttpHeaders.UserAgent]?.let {
+            builder.headerLine(HttpHeaders.UserAgent, it)
+        }
+        request.headers[HttpHeaders.ProxyAuthenticate]?.let {
+            builder.headerLine(HttpHeaders.ProxyAuthenticate, it)
+        }
+        request.headers[HttpHeaders.ProxyAuthorization]?.let {
+            builder.headerLine(HttpHeaders.ProxyAuthorization, it)
+        }
+
+        builder.emptyLine()
+        output.writePacket(builder.build())
+        output.flush()
+
+        val rawResponse = parseResponse(input)
+            ?: throw EOFException("Failed to parse CONNECT response: unexpected EOF")
+        rawResponse.use {
+            if (rawResponse.status / 200 != 1) {
+                throw IOException("Can not establish tunnel connection")
+            }
+            rawResponse.headers[HttpHeaders.ContentLength]?.let {
+                input.discard(it.toString().toLong())
+            }
+        }
+    } finally {
+        builder.release()
+    }
+}
+
 internal fun HttpHeadersMap.toMap(): Map<String, List<String>> {
     val result = mutableMapOf<String, MutableList<String>>()
 

--- a/ktor-client/ktor-client-cio/jvm/src/io/ktor/client/engine/cio/ConnectionPipeline.kt
+++ b/ktor-client/ktor-client-cio/jvm/src/io/ktor/client/engine/cio/ConnectionPipeline.kt
@@ -25,15 +25,15 @@ import kotlin.coroutines.*
 internal actual class ConnectionPipeline actual constructor(
     keepAliveTime: Long,
     pipelineMaxSize: Int,
-    socket: Socket,
+    connection: Connection,
     overProxy: Boolean,
     tasks: Channel<RequestTask>,
     parentContext: CoroutineContext
 ) : CoroutineScope {
     override val coroutineContext: CoroutineContext = parentContext + Job()
 
-    private val networkInput = socket.openReadChannel()
-    private val networkOutput = socket.openWriteChannel()
+    private val networkInput = connection.input
+    private val networkOutput = connection.output
     private val requestLimit = Semaphore(pipelineMaxSize)
     private val responseChannel = Channel<ConnectionResponseTask>(Channel.UNLIMITED)
 
@@ -137,7 +137,7 @@ internal actual class ConnectionPipeline actual constructor(
             }
         } finally {
             networkOutput.close()
-            socket.close()
+            connection.socket.close()
         }
     }
 

--- a/ktor-client/ktor-client-cio/jvm/test/io/ktor/client/engine/cio/CommonTests.kt
+++ b/ktor-client/ktor-client-cio/jvm/test/io/ktor/client/engine/cio/CommonTests.kt
@@ -7,3 +7,12 @@ package io.ktor.client.engine.cio
 import io.ktor.client.tests.*
 
 class CIOHttpClientTest : HttpClientTest(CIO)
+
+class CIOSslOverProxyTest : SslOverProxyTest<CIOEngineConfig>(CIO) {
+
+    override fun CIOEngineConfig.disableCertificatePinning() {
+        https {
+            trustManager = trustAllCertificates[0]
+        }
+    }
+}

--- a/ktor-client/ktor-client-cio/posix/src/io/ktor/client/engine/cio/ConnectionPipelineNative.kt
+++ b/ktor-client/ktor-client-cio/posix/src/io/ktor/client/engine/cio/ConnectionPipelineNative.kt
@@ -12,7 +12,7 @@ import kotlin.coroutines.*
 internal actual class ConnectionPipeline actual constructor(
     keepAliveTime: Long,
     pipelineMaxSize: Int,
-    socket: Socket,
+    connection: Connection,
     overProxy: Boolean,
     tasks: Channel<RequestTask>,
     parentContext: CoroutineContext

--- a/ktor-client/ktor-client-java/jvm/test/io/ktor/client/engine/java/CommonTests.kt
+++ b/ktor-client/ktor-client-java/jvm/test/io/ktor/client/engine/java/CommonTests.kt
@@ -7,3 +7,12 @@ package io.ktor.client.engine.java
 import io.ktor.client.tests.*
 
 class JavaClientTest : HttpClientTest(Java)
+
+class JavaSslOverProxyTest : SslOverProxyTest<JavaHttpConfig>(Java) {
+
+    override fun JavaHttpConfig.disableCertificatePinning() {
+        config {
+            sslContext(unsafeSslContext)
+        }
+    }
+}

--- a/ktor-client/ktor-client-okhttp/jvm/test/io/ktor/client/engine/okhttp/CommonTests.kt
+++ b/ktor-client/ktor-client-okhttp/jvm/test/io/ktor/client/engine/okhttp/CommonTests.kt
@@ -7,3 +7,12 @@ package io.ktor.client.engine.okhttp
 import io.ktor.client.tests.*
 
 class OkHttpHttpClientTest : HttpClientTest(OkHttp)
+
+class OkHttpSslOverProxyTest : SslOverProxyTest<OkHttpConfig>(OkHttp) {
+
+    override fun OkHttpConfig.disableCertificatePinning() {
+        config {
+            sslSocketFactory(unsafeSslContext.socketFactory, trustAllCertificates[0])
+        }
+    }
+}

--- a/ktor-client/ktor-client-tests/jvm/src/io/ktor/client/tests/SslOverProxyTest.kt
+++ b/ktor-client/ktor-client-tests/jvm/src/io/ktor/client/tests/SslOverProxyTest.kt
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2014-2020 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.client.tests
+
+import io.ktor.client.call.*
+import io.ktor.client.engine.*
+import io.ktor.client.request.*
+import io.ktor.client.statement.*
+import io.ktor.client.tests.utils.*
+import io.ktor.server.engine.*
+import io.ktor.server.jetty.*
+import java.security.*
+import java.security.cert.*
+import javax.net.ssl.*
+import kotlin.test.*
+
+abstract class SslOverProxyTest<T : HttpClientEngineConfig>(private val factory: HttpClientEngineFactory<T>) : TestWithKtor() {
+
+    override val server = embeddedServer(Jetty, serverPort) {}
+
+    protected val trustAllCertificates = arrayOf<X509TrustManager>(
+        object : X509TrustManager {
+            override fun getAcceptedIssuers(): Array<X509Certificate> = emptyArray()
+            override fun checkClientTrusted(certs: Array<X509Certificate>, authType: String) {}
+            override fun checkServerTrusted(certs: Array<X509Certificate>, authType: String) {}
+        }
+    )
+
+    protected val unsafeSslContext = SSLContext.getInstance("SSL").apply {
+        init(null, trustAllCertificates, SecureRandom())
+    }
+
+    protected abstract fun T.disableCertificatePinning()
+
+    @Test
+    fun testHttpsOverProxy() = testWithEngine(factory) {
+        config {
+            engine {
+                proxy = ProxyBuilder.http(HTTP_PROXY_SERVER)
+                disableCertificatePinning()
+            }
+        }
+
+        test { client ->
+            val response = client.get<HttpResponse>("https://localhost:8089/")
+            assertEquals("Hello, TLS!", response.receive())
+            assertEquals("TLS test server", response.headers["X-Comment"])
+        }
+    }
+}

--- a/ktor-client/ktor-client-tests/jvm/src/io/ktor/client/tests/utils/tests/Proxy.kt
+++ b/ktor-client/ktor-client-tests/jvm/src/io/ktor/client/tests/utils/tests/Proxy.kt
@@ -82,7 +82,7 @@ private suspend fun handleProxyTunnel(
     output.writeStringUtf8("HTTP/1.1 200 Connection established\r\n\r\n")
     output.flush()
 
-    val hostPort = statusLine.split(" ")[1]
+    val hostPort = statusLine.split(" ")[1].substringAfter("://").dropLastWhile { it == '/' }
 
     val host = hostPort.substringBefore(":")
     val port = hostPort.substringAfter(":", "80").toInt()

--- a/ktor-network/api/ktor-network.api
+++ b/ktor-network/api/ktor-network.api
@@ -149,6 +149,13 @@ public final class io/ktor/network/sockets/ConnectedDatagramSocket$DefaultImpls 
 	public static fun send (Lio/ktor/network/sockets/ConnectedDatagramSocket;Lio/ktor/network/sockets/Datagram;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
+public final class io/ktor/network/sockets/Connection {
+	public fun <init> (Lio/ktor/network/sockets/Socket;Lio/ktor/utils/io/ByteReadChannel;Lio/ktor/utils/io/ByteWriteChannel;)V
+	public final fun getInput ()Lio/ktor/utils/io/ByteReadChannel;
+	public final fun getOutput ()Lio/ktor/utils/io/ByteWriteChannel;
+	public final fun getSocket ()Lio/ktor/network/sockets/Socket;
+}
+
 public final class io/ktor/network/sockets/Datagram {
 	public fun <init> (Lio/ktor/utils/io/core/ByteReadPacket;Ljava/net/SocketAddress;)V
 	public final fun getAddress ()Ljava/net/SocketAddress;
@@ -260,6 +267,7 @@ public final class io/ktor/network/sockets/SocketOptions$UDPSocketOptions : io/k
 
 public final class io/ktor/network/sockets/SocketsKt {
 	public static final fun awaitClosed (Lio/ktor/network/sockets/ASocket;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun connection (Lio/ktor/network/sockets/Socket;)Lio/ktor/network/sockets/Connection;
 	public static final fun isClosed (Lio/ktor/network/sockets/ASocket;)Z
 	public static final fun openReadChannel (Lio/ktor/network/sockets/AReadable;)Lio/ktor/utils/io/ByteReadChannel;
 	public static final fun openWriteChannel (Lio/ktor/network/sockets/AWritable;Z)Lio/ktor/utils/io/ByteWriteChannel;

--- a/ktor-network/common/src/io/ktor/network/sockets/Sockets.kt
+++ b/ktor-network/common/src/io/ktor/network/sockets/Sockets.kt
@@ -126,3 +126,17 @@ public interface ServerSocket : ASocket, ABoundSocket, Acceptable<Socket>
 
 @Suppress("EXPECT_WITHOUT_ACTUAL", "KDocMissingDocumentation")
 public expect class SocketTimeoutException(message: String) : IOException
+
+/**
+ * Represents a connected socket with its input and output
+ */
+public class Connection(
+    public val socket: Socket,
+    public val input: ByteReadChannel,
+    public val output: ByteWriteChannel
+)
+
+/**
+ * Opens socket input and output channels and returns connection object
+ */
+public fun Socket.connection(): Connection = Connection(this, openReadChannel(), openWriteChannel())

--- a/ktor-network/ktor-network-tls/api/ktor-network-tls.api
+++ b/ktor-network/ktor-network-tls/api/ktor-network-tls.api
@@ -176,6 +176,9 @@ public final class io/ktor/network/tls/TLSAlertType$Companion {
 }
 
 public final class io/ktor/network/tls/TLSCommonKt {
+	public static final fun tls (Lio/ktor/network/sockets/Connection;Lkotlin/coroutines/CoroutineContext;Lio/ktor/network/tls/TLSConfig;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun tls (Lio/ktor/network/sockets/Connection;Lkotlin/coroutines/CoroutineContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun tls (Lio/ktor/network/sockets/Connection;Lkotlin/coroutines/CoroutineContext;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static final fun tls (Lio/ktor/network/sockets/Socket;Lkotlin/coroutines/CoroutineContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 

--- a/ktor-network/ktor-network-tls/common/src/io/ktor/network/tls/TLSCommon.kt
+++ b/ktor-network/ktor-network-tls/common/src/io/ktor/network/tls/TLSCommon.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2014-2020 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package io.ktor.network.tls
@@ -15,13 +15,42 @@ public expect suspend fun Socket.tls(
 ): Socket
 
 /**
- * Make [Socket] connection secure with TLS configured with [block].
+ * Make [Socket] connection secure with TLS.
  *
  * TODO: report YT issue
  */
-public suspend fun Socket.tls(coroutineContext: CoroutineContext): Socket =  tls(coroutineContext) {}
+public suspend fun Socket.tls(coroutineContext: CoroutineContext): Socket = tls(coroutineContext) {}
 
 /**
  * Make [Socket] connection secure with TLS configured with [block].
  */
 public expect suspend fun Socket.tls(coroutineContext: CoroutineContext, block: TLSConfigBuilder.() -> Unit): Socket
+
+/**
+ * Make [Socket] connection secure with TLS using [TLSConfig].
+ */
+public suspend fun Connection.tls(
+    coroutineContext: CoroutineContext,
+    config: TLSConfig
+): Socket {
+    return try {
+        openTLSSession(socket, input, output, config, coroutineContext)
+    } catch (cause: Throwable) {
+        input.cancel(cause)
+        output.close(cause)
+        socket.close()
+        throw cause
+    }
+}
+
+/**
+ * Make [Socket] connection secure with TLS.
+ */
+public suspend fun Connection.tls(coroutineContext: CoroutineContext): Socket = tls(coroutineContext) {}
+
+/**
+* Make [Socket] connection secure with TLS configured with [block].
+*/
+public suspend fun Connection.tls(coroutineContext: CoroutineContext, block: TLSConfigBuilder.() -> Unit): Socket =
+    tls(coroutineContext, TLSConfigBuilder().apply(block).build())
+


### PR DESCRIPTION
**Subsystem**
Client

**Motivation**
[KTOR-1458](https://youtrack.jetbrains.com/issue/KTOR-1458) Support SSL over HTTP proxy for CIO

Since we need to use raw input of Socket before starting TLS handshake, we can't open it for reading inside TLS methods. That's why the new class `Connection` was introduced. It holds the socket and its input and output.