### PR TITLE
KTOR-826 Support sealed classes in server sessions

### DIFF
--- a/ktor-server/ktor-server-core/api/ktor-server-core.api
+++ b/ktor-server/ktor-server-core/api/ktor-server-core.api
@@ -1620,16 +1620,19 @@ public final class io/ktor/sessions/CookieConfiguration {
 
 public final class io/ktor/sessions/CookieIdSessionBuilder : io/ktor/sessions/CookieSessionBuilder {
 	public fun <init> (Lkotlin/reflect/KClass;)V
+	public fun <init> (Lkotlin/reflect/KClass;Lkotlin/reflect/KType;)V
 	public final fun getSessionIdProvider ()Lkotlin/jvm/functions/Function0;
 	public final fun identity (Lkotlin/jvm/functions/Function0;)V
 }
 
 public class io/ktor/sessions/CookieSessionBuilder {
 	public fun <init> (Lkotlin/reflect/KClass;)V
+	public fun <init> (Lkotlin/reflect/KClass;Lkotlin/reflect/KType;)V
 	public final fun getCookie ()Lio/ktor/sessions/CookieConfiguration;
 	public final fun getSerializer ()Lio/ktor/sessions/SessionSerializer;
 	public final fun getTransformers ()Ljava/util/List;
 	public final fun getType ()Lkotlin/reflect/KClass;
+	public final fun getTypeInfo ()Lkotlin/reflect/KType;
 	public final fun setSerializer (Lio/ktor/sessions/SessionSerializer;)V
 	public final fun transform (Lio/ktor/sessions/SessionTransportTransformer;)V
 }
@@ -1643,15 +1646,18 @@ public abstract interface class io/ktor/sessions/CurrentSession {
 
 public final class io/ktor/sessions/HeaderIdSessionBuilder : io/ktor/sessions/HeaderSessionBuilder {
 	public fun <init> (Lkotlin/reflect/KClass;)V
+	public fun <init> (Lkotlin/reflect/KClass;Lkotlin/reflect/KType;)V
 	public final fun getSessionIdProvider ()Lkotlin/jvm/functions/Function0;
 	public final fun identity (Lkotlin/jvm/functions/Function0;)V
 }
 
 public class io/ktor/sessions/HeaderSessionBuilder {
 	public fun <init> (Lkotlin/reflect/KClass;)V
+	public fun <init> (Lkotlin/reflect/KClass;Lkotlin/reflect/KType;)V
 	public final fun getSerializer ()Lio/ktor/sessions/SessionSerializer;
 	public final fun getTransformers ()Ljava/util/List;
 	public final fun getType ()Lkotlin/reflect/KClass;
+	public final fun getTypeInfo ()Lkotlin/reflect/KType;
 	public final fun setSerializer (Lio/ktor/sessions/SessionSerializer;)V
 	public final fun transform (Lio/ktor/sessions/SessionTransportTransformer;)V
 }
@@ -1692,6 +1698,7 @@ public final class io/ktor/sessions/SessionSerializerReflection : io/ktor/sessio
 
 public final class io/ktor/sessions/SessionSerializerReflectionKt {
 	public static final fun autoSerializerOf (Lkotlin/reflect/KClass;)Lio/ktor/sessions/SessionSerializerReflection;
+	public static final fun defaultSessionSerializer (Lkotlin/reflect/KType;)Lio/ktor/sessions/SessionSerializer;
 }
 
 public abstract interface class io/ktor/sessions/SessionStorage {

--- a/ktor-server/ktor-server-core/jvm/src/io/ktor/sessions/SessionSerializerReflection.kt
+++ b/ktor-server/ktor-server-core/jvm/src/io/ktor/sessions/SessionSerializerReflection.kt
@@ -14,12 +14,15 @@ import kotlin.reflect.*
 import kotlin.reflect.full.*
 import kotlin.reflect.jvm.*
 
+private const val TYPE_TOKEN_PARAMETER_NAME: String = "\$type"
+
 /**
  * Creates the the default [SessionSerializer] for type [T]
  */
 @Suppress("DEPRECATION", "UNUSED")
 @Deprecated("Use defaultSessionSerializer instead.", ReplaceWith("defaultSessionSerializer<T>()"))
-public inline fun <reified T : Any> autoSerializerOf(): SessionSerializerReflection<T> = autoSerializerOf(T::class)
+public inline fun <reified T : Any> autoSerializerOf(): SessionSerializerReflection<T> =
+    defaultSessionSerializer<T>() as SessionSerializerReflection<T>
 
 /**
  * Creates the the default [SessionSerializer] for class [type]
@@ -27,13 +30,18 @@ public inline fun <reified T : Any> autoSerializerOf(): SessionSerializerReflect
 @Suppress("DEPRECATION")
 @Deprecated("Use defaultSessionSerializer<T> instead.", replaceWith = ReplaceWith("defaultSessionSerializer<T>()"))
 public fun <T : Any> autoSerializerOf(type: KClass<T>): SessionSerializerReflection<T> =
-    SessionSerializerReflection(type)
+    defaultSessionSerializer<T>(type.starProjectedType) as SessionSerializerReflection<T>
 
 /**
  * Creates the the default [SessionSerializer] for type [T]
  */
+@OptIn(ExperimentalStdlibApi::class)
+public inline fun <reified T : Any> defaultSessionSerializer(): SessionSerializer<T> =
+    defaultSessionSerializer(typeOf<T>())
+
 @Suppress("DEPRECATION")
-public inline fun <reified T : Any> defaultSessionSerializer(): SessionSerializer<T> = autoSerializerOf(T::class)
+public fun <T : Any> defaultSessionSerializer(typeInfo: KType): SessionSerializer<T> =
+    SessionSerializerReflection(typeInfo)
 
 /**
  * Default reflection-based session serializer that does it via reflection.
@@ -45,7 +53,16 @@ public inline fun <reified T : Any> defaultSessionSerializer(): SessionSerialize
     "Don't refer to the implementation class directly. " +
         "Use interface type if possible or use defaultSessionSerializer function to create."
 )
-public class SessionSerializerReflection<T : Any>(public val type: KClass<T>) : SessionSerializer<T> {
+public class SessionSerializerReflection<T : Any> internal constructor(
+    internal val typeInfo: KType
+    ): SessionSerializer<T> {
+
+    @Deprecated("Use defaultSessionSerializer() function instead")
+    public constructor(type: KClass<T>) : this(type.starProjectedType)
+
+    @Suppress("UNCHECKED_CAST")
+    public val type: KClass<T> = typeInfo.jvmErasure as KClass<T>
+
     private val properties by lazy { type.memberProperties.sortedBy { it.name } }
 
     override fun deserialize(text: String): T {
@@ -56,18 +73,7 @@ public class SessionSerializerReflection<T : Any>(public val type: KClass<T>) : 
             return values as T
         }
 
-        val instance = newInstance(values)
-
-        for (p in properties) {
-            val encodedValue = values[p.name]
-            if (encodedValue != null) {
-                val value = deserializeValue(encodedValue)
-                val coerced = coerceType(p.returnType, value)
-                assignValue(instance, p, coerced)
-            }
-        }
-
-        return instance
+        return deserializeObject(type, text)
     }
 
     override fun serialize(session: T): String {
@@ -75,31 +81,74 @@ public class SessionSerializerReflection<T : Any>(public val type: KClass<T>) : 
             return (session as Parameters).formUrlEncode()
         }
         val typed = session.cast(type)
-        return properties.map { it.name to serializeValue(it.get(typed)) }.formUrlEncode()
+        return serializeClassInstance(typed)
     }
 
-    private fun newInstance(bundle: StringValues): T {
-        val constructor = findConstructor(bundle)
+    private fun <T : Any> newInstance(type: KClass<T>, bundle: StringValues): T {
+        type.objectInstance?.let { return it }
+
+        val constructor = findConstructor(type, bundle)
+
         val params = constructor
             .parameters
-            .associateBy({ it }, { coerceType(it.type, deserializeValue(bundle[it.name!!]!!)) })
+            .associateBy({ it }, {
+                when (it.kind) {
+                    KParameter.Kind.INSTANCE,
+                    KParameter.Kind.EXTENSION_RECEIVER -> findParticularType(type, bundle)
+                    KParameter.Kind.VALUE ->
+                        coerceType(it.type, deserializeValue(it.type.jvmErasure, bundle[it.name!!]!!))
+                }
+            })
 
         return constructor.callBy(params)
     }
 
-    private fun findConstructor(bundle: StringValues): KFunction<T> =
-        type.constructors
-            .filter { it.parameters.all { parameter -> parameter.name != null && parameter.name!! in bundle } }
-            .maxBy { it.parameters.size }
-            ?: throw IllegalArgumentException("Couldn't instantiate type $type for parameters ${bundle.names()}")
+    private fun <T : Any> findParticularType(type: KClass<T>, bundle: StringValues): KClass<out T> {
+        if (type.isSealed) {
+            val typeToken = bundle[TYPE_TOKEN_PARAMETER_NAME] ?: error("No typeToken found for sealed $type")
+            return type.sealedSubclasses.firstOrNull { it.simpleName == typeToken }
+                ?: error("No sealed subclass $typeToken found in $type")
+        }
+        if (type.isAbstract) {
+            error("Abstract types are not supported: $type")
+        }
 
-    private fun assignValue(instance: T, p: KProperty1<T, *>, value: Any?) {
+        return type
+    }
+
+    private fun <T : Any> findConstructor(type: KClass<T>, bundle: StringValues): KFunction<T> {
+        if (type.isSealed) {
+            val particularType = findParticularType(type, bundle)
+            val filtered = bundle.filter { key, _ -> key != TYPE_TOKEN_PARAMETER_NAME }
+            return findConstructor(particularType, filtered)
+        }
+        if (type.isAbstract) {
+            error("Abstract types are not supported: $type")
+        }
+
+        bundle[TYPE_TOKEN_PARAMETER_NAME]?.let { typeName ->
+            require(type.simpleName == typeName)
+        }
+
+        if (type.objectInstance != null) {
+            val getter = KClass<T>::objectInstance
+            @Suppress("UNCHECKED_CAST")
+            return getter.getter as KFunction<T>
+        }
+
+        return type.constructors
+            .filter { it.parameters.all { parameter -> parameter.name != null && parameter.name!! in bundle } }
+            .maxByOrNull { it.parameters.size }
+            ?: throw IllegalArgumentException("Couldn't instantiate $type for parameters ${bundle.names()}")
+    }
+
+    private fun <X> assignValue(instance: X, p: KProperty1<X, *>, value: Any?) {
         val originalValue = p.get(instance)
 
         when {
             isListType(p.returnType) -> when {
                 value !is List<*> -> assignValue(instance, p, coerceType(p.returnType, value))
-                p is KMutableProperty1<T, *> -> p.setter.call(instance, coerceType(p.returnType, value))
+                p is KMutableProperty1<X, *> -> p.setter.call(instance, coerceType(p.returnType, value))
                 originalValue is MutableList<*> -> {
                     originalValue.withUnsafe {
                         clear()
@@ -110,7 +159,7 @@ public class SessionSerializerReflection<T : Any>(public val type: KClass<T>) : 
             }
             isSetType(p.returnType) -> when {
                 value !is Set<*> -> assignValue(instance, p, coerceType(p.returnType, value))
-                p is KMutableProperty1<T, *> -> p.setter.call(instance, coerceType(p.returnType, value))
+                p is KMutableProperty1<X, *> -> p.setter.call(instance, coerceType(p.returnType, value))
                 originalValue is MutableSet<*> -> {
                     originalValue.withUnsafe {
                         clear()
@@ -121,7 +170,7 @@ public class SessionSerializerReflection<T : Any>(public val type: KClass<T>) : 
             }
             isMapType(p.returnType) -> when {
                 value !is Map<*, *> -> assignValue(instance, p, coerceType(p.returnType, value))
-                p is KMutableProperty1<T, *> -> p.setter.call(instance, coerceType(p.returnType, value))
+                p is KMutableProperty1<X, *> -> p.setter.call(instance, coerceType(p.returnType, value))
                 originalValue is MutableMap<*, *> -> {
                     originalValue.withUnsafe {
                         clear()
@@ -130,7 +179,7 @@ public class SessionSerializerReflection<T : Any>(public val type: KClass<T>) : 
                 }
                 else -> throw IllegalStateException("Couldn't inject property ${p.name} from value $value")
             }
-            p is KMutableProperty1<T, *> -> when {
+            p is KMutableProperty1<X, *> -> when {
                 value == null && !p.returnType.isMarkedNullable ->
                     throw IllegalArgumentException("Couldn't inject null to property ${p.name}")
                 else -> p.setter.call(instance, coerceType(p.returnType, value))
@@ -268,7 +317,7 @@ public class SessionSerializerReflection<T : Any>(public val type: KClass<T>) : 
     private fun <T : Any> KClass<T>.callNoArgConstructor() = constructors.first { it.parameters.isEmpty() }.call()
 
     @Suppress("IMPLICIT_CAST_TO_ANY")
-    private fun deserializeValue(value: String): Any? =
+    private fun deserializeValue(owner: KClass<*>, value: String): Any? =
         if (!value.startsWith("#")) throw IllegalArgumentException("Bad serialized value")
         else when (value.getOrNull(1)) {
             null, 'n' -> null
@@ -287,7 +336,7 @@ public class SessionSerializerReflection<T : Any>(public val type: KClass<T>) : 
             }
             'o' -> when (value.getOrNull(2)) {
                 'm' -> Optional.empty<Any?>()
-                'p' -> Optional.ofNullable(deserializeValue(value.drop(3)))
+                'p' -> Optional.ofNullable(deserializeValue(owner, value.drop(3)))
                 else -> throw IllegalArgumentException("Unsupported o-value ${value.take(3)}")
             }
             's' -> value.drop(2)
@@ -298,6 +347,7 @@ public class SessionSerializerReflection<T : Any>(public val type: KClass<T>) : 
                 else -> throw IllegalArgumentException("Unsupported c-type ${value.take(3)}")
             }
             'm' -> deserializeMap(value.drop(2))
+            '#' -> deserializeObject(owner, value.drop(2))
             else -> throw IllegalArgumentException("Unsupported type ${value.take(2)}")
         }
 
@@ -322,14 +372,45 @@ public class SessionSerializerReflection<T : Any>(public val type: KClass<T>) : 
             is Map<*, *> -> "#m${serializeMap(value)}"
             is Enum<*> -> "#s${value.name}"
             is UUID -> "#s$value"
-            else -> throw IllegalArgumentException("Unsupported value type ${value::class.java.name}")
+            else -> "##${serializeClassInstance(value)}"
         }
+
+    private fun <T : Any> serializeClassInstance(value: T): String {
+        @Suppress("UNCHECKED_CAST")
+        val type = value::class as KClass<T>
+
+        var bundle = type.memberProperties.sortedBy { it.name }.map { p ->
+            p.name to serializeValue(p.get(value))
+        }
+
+        if (type.simpleName != null && type.superclasses.any { it.isSealed }) {
+            bundle += Pair(TYPE_TOKEN_PARAMETER_NAME, type.simpleName!!)
+        }
+
+        return bundle.formUrlEncode()
+    }
+
+    private fun <Y : Any> deserializeObject(type: KClass<Y>, encoded: String): Y {
+        val bundle = parseQueryString(encoded)
+        val instance = newInstance(type, bundle)
+
+        for (p in type.memberProperties) {
+            val encodedValue = bundle[p.name]
+            if (encodedValue != null) {
+                val value = deserializeValue(p.returnType.jvmErasure, encodedValue)
+                val coerced = coerceType(p.returnType, value)
+                assignValue(instance, p, coerced)
+            }
+        }
+
+        return instance
+    }
 
     private fun deserializeCollection(value: String): List<*> = value
         .decodeURLQueryComponent()
         .split("&")
         .filter { it.isNotEmpty() }
-        .map { deserializeValue(it.decodeURLQueryComponent()) }
+        .map { deserializeValue(Any::class, it.decodeURLQueryComponent()) }
 
     private fun serializeCollection(value: Collection<*>): String = value
         .joinToString("&") { serializeValue(it).encodeURLQueryComponent() }
@@ -340,8 +421,8 @@ public class SessionSerializerReflection<T : Any>(public val type: KClass<T>) : 
         .split("&")
         .filter { it.isNotEmpty() }
         .associateBy(
-            { deserializeValue(it.substringBefore('=').decodeURLQueryComponent()) },
-            { deserializeValue(it.substringAfter('=').decodeURLQueryComponent()) }
+            { deserializeValue(Any::class, it.substringBefore('=').decodeURLQueryComponent()) },
+            { deserializeValue(Any::class, it.substringAfter('=').decodeURLQueryComponent()) }
         )
 
     private fun serializeMap(value: Map<*, *>): String = value

--- a/ktor-server/ktor-server-core/jvm/src/io/ktor/sessions/SessionsBuilder.kt
+++ b/ktor-server/ktor-server-core/jvm/src/io/ktor/sessions/SessionsBuilder.kt
@@ -6,6 +6,7 @@ package io.ktor.sessions
 
 import io.ktor.util.*
 import kotlin.reflect.*
+import kotlin.reflect.full.*
 
 /**
  * Configure sessions to get it from cookie using session [storage]
@@ -293,7 +294,7 @@ constructor(
     /**
      * Session instance serializer
      */
-    public var serializer: SessionSerializer<S> = @Suppress("DEPRECATION") SessionSerializerReflection(type)
+    public var serializer: SessionSerializer<S> = defaultSessionSerializer(type.starProjectedType)
 
     private val _transformers = mutableListOf<SessionTransportTransformer>()
 
@@ -327,7 +328,7 @@ constructor(
     /**
      * Session instance serializer
      */
-    public var serializer: SessionSerializer<S> = @Suppress("DEPRECATION") SessionSerializerReflection(type)
+    public var serializer: SessionSerializer<S> = defaultSessionSerializer(type.starProjectedType)
 
     private val _transformers = mutableListOf<SessionTransportTransformer>()
 

--- a/ktor-server/ktor-server-core/jvm/src/io/ktor/sessions/SessionsBuilder.kt
+++ b/ktor-server/ktor-server-core/jvm/src/io/ktor/sessions/SessionsBuilder.kt
@@ -21,11 +21,11 @@ public fun <S : Any> Sessions.Configuration.cookie(name: String, sessionType: KC
 /**
  * Configure sessions to get it from cookie using session [storage]
  */
+@OptIn(ExperimentalStdlibApi::class)
 public inline fun <reified S : Any> Sessions.Configuration.cookie(name: String, storage: SessionStorage) {
     val sessionType = S::class
 
-    @Suppress("DEPRECATION")
-    val builder = CookieIdSessionBuilder(sessionType)
+    val builder = CookieIdSessionBuilder(sessionType, typeOf<S>())
     cookie(name, builder, sessionType, storage)
 }
 
@@ -47,6 +47,7 @@ internal fun <S : Any> Sessions.Configuration.cookie(
  * The actual content of the session is stored at server side using the specified [storage].
  * The cookie configuration can be set inside [block] using the cookie property exposed by [CookieIdSessionBuilder].
  */
+@OptIn(ExperimentalStdlibApi::class)
 public inline fun <reified S : Any> Sessions.Configuration.cookie(
     name: String,
     storage: SessionStorage,
@@ -54,15 +55,14 @@ public inline fun <reified S : Any> Sessions.Configuration.cookie(
 ) {
     val sessionType = S::class
 
-    @Suppress("DEPRECATION")
-    val builder = CookieIdSessionBuilder(sessionType).apply(block)
+    val builder = CookieIdSessionBuilder(sessionType, typeOf<S>()).apply(block)
     cookie(name, builder, sessionType, storage)
 }
 
 /**
  * Configure sessions to get it from cookie using session [storage]
  */
-@Deprecated("Use reified types intead.")
+@Deprecated("Use reified types instead.")
 public inline fun <S : Any> Sessions.Configuration.cookie(
     name: String,
     sessionType: KClass<S>,
@@ -96,6 +96,7 @@ public inline fun <reified S : Any> Sessions.Configuration.header(name: String, 
  * Configures a session using a header with the specified [name] using it as a session id.
  * The actual content of the session is stored at server side using the specified [storage].
  */
+@OptIn(ExperimentalStdlibApi::class)
 public inline fun <reified S : Any> Sessions.Configuration.header(
     name: String,
     storage: SessionStorage,
@@ -103,8 +104,7 @@ public inline fun <reified S : Any> Sessions.Configuration.header(
 ) {
     val sessionType = S::class
 
-    @Suppress("DEPRECATION")
-    val builder = HeaderIdSessionBuilder(sessionType).apply(block)
+    val builder = HeaderIdSessionBuilder(sessionType, typeOf<S>()).apply(block)
     header(name, sessionType, storage, builder)
 }
 
@@ -159,11 +159,11 @@ public fun <S : Any> Sessions.Configuration.cookie(name: String, sessionType: KC
 /**
  * Configure sessions to serialize to/from HTTP cookie
  */
+@OptIn(ExperimentalStdlibApi::class)
 public inline fun <reified S : Any> Sessions.Configuration.cookie(name: String) {
     val sessionType = S::class
 
-    @Suppress("DEPRECATION")
-    val builder = CookieSessionBuilder(sessionType)
+    val builder = CookieSessionBuilder(sessionType, typeOf<S>())
     cookie(name, sessionType, builder)
 }
 
@@ -172,14 +172,14 @@ public inline fun <reified S : Any> Sessions.Configuration.cookie(name: String) 
  * optionally transformed by specified transforms in [block].
  * The cookie configuration can be set inside [block] using the cookie property exposed by [CookieIdSessionBuilder].
  */
+@OptIn(ExperimentalStdlibApi::class)
 public inline fun <reified S : Any> Sessions.Configuration.cookie(
     name: String,
     block: CookieSessionBuilder<S>.() -> Unit
 ) {
     val sessionType = S::class
 
-    @Suppress("DEPRECATION")
-    val builder = CookieSessionBuilder(sessionType).apply(block)
+    val builder = CookieSessionBuilder(sessionType, typeOf<S>()).apply(block)
     cookie(name, sessionType, builder)
 }
 
@@ -231,14 +231,14 @@ public inline fun <reified S : Any> Sessions.Configuration.header(name: String) 
  * Configures a session using a header with the specified [name] using it for the actual session content
  * optionally transformed by specified transforms in [block].
  */
+@OptIn(ExperimentalStdlibApi::class)
 public inline fun <reified S : Any> Sessions.Configuration.header(
     name: String,
     block: HeaderSessionBuilder<S>.() -> Unit
 ) {
     val sessionType = S::class
 
-    @Suppress("DEPRECATION")
-    val builder = HeaderSessionBuilder(sessionType).apply(block)
+    val builder = HeaderSessionBuilder(sessionType, typeOf<S>()).apply(block)
     header(name, sessionType, null, builder)
 }
 
@@ -263,11 +263,16 @@ public inline fun <S : Any> Sessions.Configuration.header(
 /**
  * Cookie session configuration builder
  */
-@Suppress("DEPRECATION")
 public class CookieIdSessionBuilder<S : Any>
-@Deprecated("Use builder functions instead.")
-constructor(type: KClass<S>) :
-    CookieSessionBuilder<S>(type) {
+@PublishedApi
+internal constructor(
+    type: KClass<S>,
+    typeInfo: KType
+) : CookieSessionBuilder<S>(type, typeInfo) {
+
+    @Deprecated("Use builder functions instead.")
+    public constructor(type: KClass<S>) : this(type, type.starProjectedType)
+
     /**
      * Register session ID generation function
      */
@@ -287,14 +292,18 @@ constructor(type: KClass<S>) :
  * @property type - session instance type
  */
 public open class CookieSessionBuilder<S : Any>
-@Deprecated("Use builder functions instead.")
-constructor(
-    public val type: KClass<S>
+@PublishedApi
+internal constructor(
+    public val type: KClass<S>,
+    public val typeInfo: KType
 ) {
+    @Deprecated("Use builder functions instead.")
+    public constructor(type: KClass<S>) : this(type, type.starProjectedType)
+
     /**
      * Session instance serializer
      */
-    public var serializer: SessionSerializer<S> = defaultSessionSerializer(type.starProjectedType)
+    public var serializer: SessionSerializer<S> = defaultSessionSerializer(typeInfo)
 
     private val _transformers = mutableListOf<SessionTransportTransformer>()
 
@@ -321,14 +330,19 @@ constructor(
  * @property type session instance type
  */
 public open class HeaderSessionBuilder<S : Any>
-@Deprecated("Use builder functions instead.")
-constructor(
-    public val type: KClass<S>
+@PublishedApi
+internal constructor(
+    public val type: KClass<S>,
+    public val typeInfo: KType
 ) {
+
+    @Deprecated("Use builder functions instead.")
+    public constructor(type: KClass<S>) : this(type, type.starProjectedType)
+
     /**
      * Session instance serializer
      */
-    public var serializer: SessionSerializer<S> = defaultSessionSerializer(type.starProjectedType)
+    public var serializer: SessionSerializer<S> = defaultSessionSerializer(typeInfo)
 
     private val _transformers = mutableListOf<SessionTransportTransformer>()
 
@@ -348,12 +362,16 @@ constructor(
 /**
  * Header session configuration builder
  */
-@Suppress("DEPRECATION")
 public class HeaderIdSessionBuilder<S : Any>
-@Deprecated("Use builder functions instead.")
-constructor(type: KClass<S>) :
-    @Suppress("DEPRECATION")
-    HeaderSessionBuilder<S>(type) {
+@PublishedApi
+internal constructor(
+    type: KClass<S>,
+    typeInfo: KType
+) : HeaderSessionBuilder<S>(type, typeInfo) {
+
+    @Deprecated("Use builder functions instead.")
+    public constructor(type: KClass<S>) : this(type, type.starProjectedType)
+
     /**
      * Register session ID generation function
      */

--- a/ktor-server/ktor-server-tests/jvm/test/io/ktor/tests/server/sessions/AutoSerializerTest.kt
+++ b/ktor-server/ktor-server-tests/jvm/test/io/ktor/tests/server/sessions/AutoSerializerTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2014-2020 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package io.ktor.tests.server.sessions
@@ -58,6 +58,28 @@ class AutoSerializerTest {
         assertSerializeDeserialize(EnumCollectionSession(), defaultSessionSerializer())
     }
 
+    @Test
+    fun testCompoundClasses() {
+        assertSerializeDeserialize(CompoundSession(), defaultSessionSerializer())
+    }
+
+    @Test
+    fun testSealedSession() {
+        assertSerializeDeserialize(SealedSession.SS(), defaultSessionSerializer())
+        assertSerializeDeserialize(SealedSession.SS(), defaultSessionSerializer<SealedSession>())
+    }
+
+    @Test
+    fun testSealedSessionObject() {
+        assertSerializeDeserialize(SealedSession.E, defaultSessionSerializer())
+        assertSerializeDeserialize(SealedSession.E, defaultSessionSerializer<SealedSession>())
+    }
+
+    @Test
+    fun testSessionWithSealedMember() {
+        assertSerializeDeserialize(SessionWithSealedMember(), defaultSessionSerializer())
+    }
+
     private fun <T : Any> assertSerializeDeserialize(session: T, serializer: SessionSerializer<T>) {
         val serialized = serializer.serialize(session)
         val deserialized = serializer.deserialize(serialized)
@@ -114,3 +136,13 @@ data class EnumCollectionSession(
     val ss: Set<TestEnum> = setOf(TestEnum.A),
     val mm: Map<TestEnum, TestEnum> = mapOf(TestEnum.A to TestEnum.B)
 )
+
+data class Part(val i: Int)
+data class CompoundSession(val part: Part = Part(779))
+
+sealed class SealedSession {
+    data class SS(val e: Int = 834) : SealedSession()
+    object E : SealedSession()
+}
+
+data class SessionWithSealedMember(val member: SealedSession = SealedSession.SS())


### PR DESCRIPTION
**Subsystem**
ktor-server-core

**Motivation**
[KTOR-826 Support Sealed Classes inside Session-Objects](https://youtrack.jetbrains.com/issue/KTOR-826)

Currently, server sessions feature only supports plain classes with primitive properties + the particular list of supported types.

**Solution**
- Provide the ability to serialize class instances including:
  - sealed classes with subclasses
  - objects
- Pass proper `KType` instead/with `KClass` from DSL to session serializer

