### PR TITLE
Add shortcut function to configure the json instance

### DIFF
--- a/ktor-features/ktor-serialization/jvm/src/io/ktor/serialization/JsonSupport.kt
+++ b/ktor-features/ktor-serialization/jvm/src/io/ktor/serialization/JsonSupport.kt
@@ -36,6 +36,19 @@ public val DefaultJsonConfiguration: Json = Json {
 }
 
 /**
+ * Applies the default json configuration for Ktor to this [JsonBuilder].
+ * @see DefaultJson
+ */
+public fun JsonBuilder.setKtorDefaults() {
+    encodeDefaults = true
+    isLenient = true
+    allowSpecialFloatingPointValues = true
+    allowStructuredMapKeys = true
+    prettyPrint = false
+    useArrayPolymorphism = true
+}
+
+/**
  * The default json configuration used in [SerializationConverter]. The settings are:
  * - defaults are serialized
  * - mode is not strict so extra json fields are ignored
@@ -46,12 +59,7 @@ public val DefaultJsonConfiguration: Json = Json {
  * See [Json] for more details.
  */
 public val DefaultJson: Json = Json {
-    encodeDefaults = true
-    isLenient = true
-    allowSpecialFloatingPointValues = true
-    allowStructuredMapKeys = true
-    prettyPrint = false
-    useArrayPolymorphism = true
+    setKtorDefaults()
 }
 
 /**
@@ -97,14 +105,23 @@ public fun ContentNegotiation.Configuration.json(
  * to [ContentNegotiation] feature using kotlinx.serialization.
  *
  * @param contentType to register with, application/json by default
+ * @param applyDefaultConfiguration specifies whether the standard configuration for ktor should be applied
  * @param jsonBuilder to configure the json instance
  */
 @OptIn(ExperimentalSerializationApi::class)
 public inline fun ContentNegotiation.Configuration.json(
     contentType: ContentType = ContentType.Application.Json,
+    applyDefaultConfiguration: Boolean = true,
     crossinline jsonBuilder: JsonBuilder.() -> Unit
 ) {
-    json(Json { jsonBuilder() }, contentType)
+    json(
+        Json {
+            if (applyDefaultConfiguration)
+                setKtorDefaults()
+            jsonBuilder()
+        },
+        contentType
+    )
 }
 
 /**

--- a/ktor-features/ktor-serialization/jvm/src/io/ktor/serialization/JsonSupport.kt
+++ b/ktor-features/ktor-serialization/jvm/src/io/ktor/serialization/JsonSupport.kt
@@ -16,6 +16,7 @@ import kotlinx.serialization.modules.*
  */
 public fun JsonBuilder.setKtorDefaults() {
     encodeDefaults = true
+    ignoreUnknownKeys = true
     isLenient = true
     allowSpecialFloatingPointValues = true
     allowStructuredMapKeys = true

--- a/ktor-features/ktor-serialization/jvm/src/io/ktor/serialization/JsonSupport.kt
+++ b/ktor-features/ktor-serialization/jvm/src/io/ktor/serialization/JsonSupport.kt
@@ -93,6 +93,21 @@ public fun ContentNegotiation.Configuration.json(
 }
 
 /**
+ * Register `application/json` (or another specified [contentType]) content type
+ * to [ContentNegotiation] feature using kotlinx.serialization.
+ *
+ * @param contentType to register with, application/json by default
+ * @param jsonBuilder to configure the json instance
+ */
+@OptIn(ExperimentalSerializationApi::class)
+public inline fun ContentNegotiation.Configuration.json(
+    contentType: ContentType = ContentType.Application.Json,
+    crossinline jsonBuilder: JsonBuilder.() -> Unit
+) {
+    json(Json { jsonBuilder() }, contentType)
+}
+
+/**
  * Register kotlinx.serialization converter into [ContentNegotiation] feature
  */
 @Suppress("unused")

--- a/ktor-features/ktor-serialization/jvm/src/io/ktor/serialization/JsonSupport.kt
+++ b/ktor-features/ktor-serialization/jvm/src/io/ktor/serialization/JsonSupport.kt
@@ -11,6 +11,19 @@ import kotlinx.serialization.json.*
 import kotlinx.serialization.modules.*
 
 /**
+ * Applies the default json configuration for Ktor to this [JsonBuilder].
+ * @see DefaultJson
+ */
+public fun JsonBuilder.setKtorDefaults() {
+    encodeDefaults = true
+    isLenient = true
+    allowSpecialFloatingPointValues = true
+    allowStructuredMapKeys = true
+    prettyPrint = false
+    useArrayPolymorphism = true
+}
+
+/**
  * The default json configuration used in [SerializationConverter]. The settings are:
  * - defaults are serialized
  * - mode is not strict so extra json fields are ignored
@@ -27,25 +40,7 @@ import kotlinx.serialization.modules.*
 )
 @Suppress("unused")
 public val DefaultJsonConfiguration: Json = Json {
-    encodeDefaults = true
-    isLenient = true
-    allowSpecialFloatingPointValues = true
-    allowStructuredMapKeys = true
-    prettyPrint = false
-    useArrayPolymorphism = true
-}
-
-/**
- * Applies the default json configuration for Ktor to this [JsonBuilder].
- * @see DefaultJson
- */
-public fun JsonBuilder.setKtorDefaults() {
-    encodeDefaults = true
-    isLenient = true
-    allowSpecialFloatingPointValues = true
-    allowStructuredMapKeys = true
-    prettyPrint = false
-    useArrayPolymorphism = true
+    setKtorDefaults()
 }
 
 /**


### PR DESCRIPTION
**Subsystem**
ktor-features/ktor-serialization

**Motivation**
While with gson and jackson together with ktor you can do the following to configure the instances:
```kt
install(ContentNegotiation) {
    gson {
        // Configure Gson here
    }
}
```
... with kotlinx.serialization you have to do the following:
```kt
install(ContentNegotiation) {
    json(Json {
        // Configure kotlinx.serialization here
    })
}
```
... which most new users do not know.

**Solution**
With the new function I added, this is not the case anymore:
```kt
install(ContentNegotiation) {
    json {
        // Configure kotlinx.serialization here
    }
}
```

In my opinion, this is much more intuitive to use.
