### PR TITLE
KTOR-1543 Fix URL path encoding using incorrect encoding function

### DIFF
--- a/ktor-http/common/src/io/ktor/http/URLBuilder.kt
+++ b/ktor-http/common/src/io/ktor/http/URLBuilder.kt
@@ -54,7 +54,7 @@ public class URLBuilder(
      * Encode [components] to [encodedPath]
      */
     public fun path(components: List<String>): URLBuilder {
-        encodedPath = components.joinToString("/", prefix = "/") { it.encodeURLQueryComponent() }
+        encodedPath = components.joinToString("/", prefix = "/") { it.encodeURLPath() }
 
         return this
     }

--- a/ktor-http/common/test/io/ktor/tests/http/URLBuilderTest.kt
+++ b/ktor-http/common/test/io/ktor/tests/http/URLBuilderTest.kt
@@ -180,6 +180,17 @@ internal class URLBuilderTest {
         assertEquals("/path/%F0%9F%90%95", url.encodedPath)
     }
 
+    @Test
+    fun testPathEncoding() {
+        val url = URLBuilder().apply {
+            host = "ktor.io"
+            port = 80
+            path("id+test&test~test#test")
+        }.buildString()
+
+        assertEquals("http://ktor.io/id+test&test~test%23test", url)
+    }
+
     /**
      * Checks that the given [url] and the result of [URLBuilder.buildString] is equal (case insensitive).
      */


### PR DESCRIPTION
KTOR-1543
Fixes #1293

**Subsystem**
`URLBuilder`

**Motivation**
The `URLBuilder` was using the wrong url encoding method for the path, which wasn't encoding some characters as they should have been.

**Solution**
Switch the encoder function call from `path.encodeURLQueryComponent()` to `path.encodeURLPath()`.

