### PR TITLE
KTOR-1552 Mark _response transient in ResponseException

### DIFF
--- a/ktor-client/ktor-client-core/common/src/io/ktor/client/features/DefaultResponseValidation.kt
+++ b/ktor-client/ktor-client-core/common/src/io/ktor/client/features/DefaultResponseValidation.kt
@@ -9,6 +9,7 @@ import io.ktor.client.call.*
 import io.ktor.client.statement.*
 import io.ktor.util.*
 import io.ktor.utils.io.concurrent.*
+import kotlin.jvm.*
 import kotlin.native.concurrent.*
 
 @SharedImmutable
@@ -57,6 +58,7 @@ public open class ResponseException(
     @Deprecated(level = DeprecationLevel.WARNING, message = DEPRECATED_EXCEPTION_CTOR)
     public constructor(response: HttpResponse): this(response, NO_RESPONSE_TEXT)
 
+    @delegate:Transient
     private val _response: HttpResponse? by threadLocal(response)
     public val response: HttpResponse
         get() = _response ?: error("Failed to access response from a different native thread")

--- a/ktor-client/ktor-client-core/jvm/test/ExceptionsTest.kt
+++ b/ktor-client/ktor-client-core/jvm/test/ExceptionsTest.kt
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2014-2020 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+import io.ktor.client.call.*
+import io.ktor.client.features.*
+import io.ktor.client.statement.*
+import io.ktor.http.*
+import io.ktor.util.date.*
+import io.ktor.utils.io.*
+import java.io.*
+import kotlin.coroutines.*
+import kotlin.test.*
+
+class ExceptionsTest {
+
+    @Test
+    fun testResponseExceptionSerializable() {
+        val exception = createResponseException()
+
+        val serialized = serialize(exception)
+        val deserialized = deserialize(serialized)
+
+        deserialized as ResponseException
+    }
+
+    private fun serialize(obj: Any): ByteArray {
+        val baos = ByteArrayOutputStream()
+        val oos = ObjectOutputStream(baos)
+        oos.writeObject(obj)
+        return baos.toByteArray()
+    }
+
+    private fun deserialize(bytes: ByteArray): Any? {
+        val bais = ByteArrayInputStream(bytes)
+        val ois = ObjectInputStream(bais)
+        return ois.readObject()
+    }
+}
+
+private fun createResponseException(): ResponseException = ResponseException(object : HttpResponse() {
+    override val call: HttpClientCall
+        get() = TODO("Not yet implemented")
+    override val status: HttpStatusCode
+        get() = TODO("Not yet implemented")
+    override val version: HttpProtocolVersion
+        get() = TODO("Not yet implemented")
+    override val requestTime: GMTDate
+        get() = TODO("Not yet implemented")
+    override val responseTime: GMTDate
+        get() = TODO("Not yet implemented")
+    override val content: ByteReadChannel
+        get() = TODO("Not yet implemented")
+    override val headers: Headers
+        get() = TODO("Not yet implemented")
+    override val coroutineContext: CoroutineContext
+        get() = TODO("Not yet implemented")
+
+    override fun toString(): String = "FakeCall"
+}, cachedResponseText = "Fake text")


### PR DESCRIPTION
**Subsystem**
ktor-client-core, JVM

**Motivation**
https://youtrack.jetbrains.com/issue/KTOR-1552
https://github.com/ktorio/ktor/issues/1256

**Solution**
Mark _response transient in ResponseException.

Note: accessing the response field of the deserialized exception will throw a NullPointerException. That is the same behaviour as it was before. This cannot be improved unless the response field is made nullable.