### PR TITLE
KTOR-1220 Fix terminating curl processor worker on close

### DIFF
--- a/ktor-client/ktor-client-curl/posix/src/io/ktor/client/engine/curl/CurlProcessor.kt
+++ b/ktor-client/ktor-client-curl/posix/src/io/ktor/client/engine/curl/CurlProcessor.kt
@@ -60,6 +60,7 @@ internal class CurlProcessor(
 
     public fun close() {
         worker.execute(TransferMode.SAFE, { Unit }) { curlApi.close() }
+        worker.requestTermination()
     }
 
     private fun poll(): Future<List<CurlResponseData>> =


### PR DESCRIPTION
**Subsystem**
ktor-client-curl

**Motivation**
[KTOR-1220 "Unfinished workers detected" using client on native](https://youtrack.jetbrains.com/issue/KTOR-1220)

**Solution**
Terminate worker on client close

**Known issues**
We can't force memory checker to run in tests, so no tests provided
