### PR TITLE
KTOR-1567 Fix freezing Java client

### DIFF
--- a/ktor-client/ktor-client-java/jvm/src/io/ktor/client/engine/java/JavaHttpResponseBodyHandler.kt
+++ b/ktor-client/ktor-client-java/jvm/src/io/ktor/client/engine/java/JavaHttpResponseBodyHandler.kt
@@ -10,6 +10,7 @@ import io.ktor.util.date.*
 import io.ktor.utils.io.*
 import kotlinx.atomicfu.*
 import kotlinx.coroutines.*
+import kotlinx.coroutines.channels.*
 import java.io.*
 import java.net.http.*
 import java.nio.*
@@ -53,6 +54,31 @@ internal class JavaHttpResponseBodyHandler(
         private val closed = atomic(false)
         private val subscription = atomic<Flow.Subscription?>(null)
 
+        private val queue = Channel<ByteBuffer>(Channel.UNLIMITED)
+
+        init {
+            launch {
+                try {
+                    queue.consume {
+                        while (isActive) {
+                            var buffer = queue.poll()
+                            if (buffer == null) {
+                                subscription.value?.request(1)
+                                buffer = queue.receive()
+                            }
+
+                            responseChannel.writeFully(buffer)
+                        }
+                    }
+                } catch (_: ClosedReceiveChannelException) {
+                }
+            }.apply {
+                invokeOnCompletion {
+                    responseChannel.close(it)
+                }
+            }
+        }
+
         override fun onSubscribe(s: Flow.Subscription) {
             try {
                 if (!subscription.compareAndSet(null, s)) {
@@ -80,16 +106,10 @@ internal class JavaHttpResponseBodyHandler(
         }
 
         override fun onNext(items: List<ByteBuffer>) {
-            runBlocking {
-                try {
-                    items.forEach { buffer ->
-                        responseChannel.writeFully(buffer)
-                    }
-                } catch (cause: Throwable) {
-                    close(cause)
+            items.forEach {
+                if (it.hasRemaining()) {
+                    queue.offer(it)
                 }
-
-                subscription.value?.request(1)
             }
         }
 
@@ -99,7 +119,7 @@ internal class JavaHttpResponseBodyHandler(
 
         override fun onComplete() {
             subscription.getAndSet(null)
-            responseChannel.close()
+            queue.close()
         }
 
         override fun getBody(): CompletionStage<HttpResponseData> {
@@ -112,6 +132,7 @@ internal class JavaHttpResponseBodyHandler(
             }
 
             try {
+                queue.close(cause)
                 subscription.getAndSet(null)?.cancel()
             } finally {
                 consumerJob.completeExceptionally(cause)


### PR DESCRIPTION
**Subsystem**
ktor-client-java

**Motivation**
[KTOR-1567 Java client freeze](https://youtrack.jetbrains.com/issue/KTOR-1567)

**Solution**
Stop doing runBlocking in a reactive handler. Launch a separate coroutine to push bytes from reactive stream to byte channel

