### PR TITLE
KTOR-1572 Fix flaky ClassCastExceptionTest

### DIFF
--- a/ktor-server/ktor-server-cio/jvm/test/io/ktor/tests/server/cio/ClassCastExceptionTest.kt
+++ b/ktor-server/ktor-server-cio/jvm/test/io/ktor/tests/server/cio/ClassCastExceptionTest.kt
@@ -10,20 +10,24 @@ import io.ktor.client.request.*
 import io.ktor.routing.*
 import io.ktor.server.cio.*
 import io.ktor.server.engine.*
+import io.ktor.server.testing.*
 import io.ktor.websocket.*
 import kotlinx.coroutines.*
 import java.util.concurrent.*
 import kotlin.test.*
 import kotlin.time.*
 
-class ClassCastExceptionTest {
-    private val port = 58008
+class ClassCastExceptionTest : EngineTestBase<CIOApplicationEngine, CIOApplicationEngine.Configuration>(CIO) {
+    init {
+        enableSsl = false
+    }
 
     /**
      * Regression test for KTOR-349
      */
     @Test
-    @OptIn(ExperimentalTime::class, ExperimentalCoroutinesApi::class)
+    @NoHttp2
+    @OptIn(ExperimentalTime::class)
     fun testClassCastException(): Unit = runBlocking {
         val exceptionHandler = CoroutineExceptionHandler { _, cause ->
             cancel("Uncaught failure", cause)
@@ -39,18 +43,21 @@ class ClassCastExceptionTest {
         }
 
         server.start()
-        delay(1.seconds)
+        try {
+            delay(1.seconds)
 
-        launch {
-            HttpClient(io.ktor.client.engine.cio.CIO).use { client ->
-                try {
-                    client.get<String>(port = port, path = "/hang")
-                } catch (e: Throwable) {
+            launch {
+                HttpClient(io.ktor.client.engine.cio.CIO).use { client ->
+                    try {
+                        client.get<String>(port = port, path = "/hang")
+                    } catch (e: Throwable) {
+                    }
                 }
             }
-        }
 
-        delay(1.seconds)
-        server.stop(1L, 1L, TimeUnit.SECONDS)
+            delay(1.seconds)
+        } finally {
+            server.stop(1L, 1L, TimeUnit.SECONDS)
+        }
     }
 }


### PR DESCRIPTION
**Subsystem**
ktor-server-cio/tests

**Motivation**
From time to time the test is failing because of the address already in use error.

**Solution**
Use server tests infrastructure that is almost tolerant for such kind of problems.

