### PR TITLE
KTOR-874 Fix jetty client error handling

### DIFF
--- a/ktor-client/ktor-client-jetty/jvm/src/io/ktor/client/engine/jetty/JettyHttp2Engine.kt
+++ b/ktor-client/ktor-client-jetty/jvm/src/io/ktor/client/engine/jetty/JettyHttp2Engine.kt
@@ -13,7 +13,9 @@ import kotlinx.coroutines.*
 import org.eclipse.jetty.http2.client.*
 import org.eclipse.jetty.util.thread.*
 
-internal class JettyHttp2Engine(override val config: JettyEngineConfig) : HttpClientEngineBase("ktor-jetty") {
+internal class JettyHttp2Engine(
+    override val config: JettyEngineConfig
+) : HttpClientEngineBase("ktor-jetty") {
 
     override val dispatcher: CoroutineDispatcher by lazy {
         Dispatchers.clientDispatcher(

--- a/ktor-client/ktor-client-jetty/jvm/src/io/ktor/client/engine/jetty/JettyHttpRequest.kt
+++ b/ktor-client/ktor-client-jetty/jvm/src/io/ktor/client/engine/jetty/JettyHttpRequest.kt
@@ -25,7 +25,9 @@ import java.nio.*
 import kotlin.coroutines.*
 
 internal suspend fun HttpRequestData.executeRequest(
-    client: HTTP2Client, config: JettyEngineConfig, callContext: CoroutineContext
+    client: HTTP2Client,
+    config: JettyEngineConfig,
+    callContext: CoroutineContext
 ): HttpResponseData {
     val requestTime = GMTDate()
     val session: HTTP2ClientSession = client.connect(url, config).apply {

--- a/ktor-client/ktor-client-jetty/jvm/src/io/ktor/client/engine/jetty/JettyResponseListener.kt
+++ b/ktor-client/ktor-client-jetty/jvm/src/io/ktor/client/engine/jetty/JettyResponseListener.kt
@@ -104,11 +104,11 @@ internal class JettyResponseListener(
 
         onHeadersReceived.complete((frame.metaData as? MetaData.Response)?.let {
             val (status, reason) = it.status to it.reason
-            reason?.let { HttpStatusCode(status, it) } ?: HttpStatusCode.fromValue(status)
+            reason?.let { text -> HttpStatusCode(status, text) } ?: HttpStatusCode.fromValue(status)
         })
     }
 
-    public suspend fun awaitHeaders(): StatusWithHeaders {
+    suspend fun awaitHeaders(): StatusWithHeaders {
         val statusCode = onHeadersReceived.await() ?: throw IOException("Connection reset")
         return StatusWithHeaders(statusCode, headersBuilder.build())
     }
@@ -140,7 +140,7 @@ internal class JettyResponseListener(
         }
     }
 
-    public companion object {
+    companion object {
         private val Ignore = Stream.Listener.Adapter()
     }
 }

--- a/ktor-client/ktor-client-jetty/jvm/src/io/ktor/client/engine/jetty/JettyResponseListener.kt
+++ b/ktor-client/ktor-client-jetty/jvm/src/io/ktor/client/engine/jetty/JettyResponseListener.kt
@@ -79,6 +79,20 @@ internal class JettyResponseListener(
         }
     }
 
+    override fun onFailure(stream: Stream?, error: Int, reason: String?, failure: Throwable?, callback: Callback?) {
+        callback?.succeeded()
+
+        val messagePrefix = reason ?: "HTTP/2 failure"
+        val message = when (error) {
+            0 -> messagePrefix
+            else -> "$messagePrefix, code $error"
+        }
+
+        val cause = IOException(message, failure)
+        backendChannel.close(cause)
+        onHeadersReceived.completeExceptionally(cause)
+    }
+
     override fun onHeaders(stream: Stream, frame: HeadersFrame) {
         frame.metaData.fields.forEach { field ->
             headersBuilder.append(field.name, field.value)

--- a/ktor-client/ktor-client-jetty/jvm/test/io/ktor/client/engine/jetty/JettyHttp2EngineTest.kt
+++ b/ktor-client/ktor-client-jetty/jvm/test/io/ktor/client/engine/jetty/JettyHttp2EngineTest.kt
@@ -4,12 +4,24 @@
 
 package io.ktor.client.engine.jetty
 
+import io.ktor.client.*
 import io.ktor.client.features.*
 import io.ktor.client.request.*
+import io.ktor.client.tests.utils.*
 import io.ktor.test.dispatcher.*
+import io.ktor.utils.io.errors.*
 import kotlin.test.*
 
 class JettyHttp2EngineTest {
+
+    @Test
+    fun testConnectingToNonHttp2Server() = testSuspend {
+        HttpClient(Jetty).use { client ->
+            assertFailsWith<IOException> {
+                client.get<String>("$TEST_SERVER/content/hello")
+            }
+        }
+    }
 
     @Test
     fun testReuseClientsInCache() = testSuspend {


### PR DESCRIPTION
**Subsystem**
ktor-client-jetty

**Motivation**
[KTOR-874 Jetty: requests to resources, that doesn't respond with HTTP/2, lead to unexpected behaviour](https://youtrack.jetbrains.com/issue/KTOR-874)

**Solution**
Add error handler and fail requests with more detailed errors rather than EOF at writing.

