### PR TITLE
KTOR-1583 Fix wrong connect timeout exception with OkHttp

### DIFF
--- a/ktor-network/jvm/test/io/ktor/network/util/StartTimeoutTest.kt
+++ b/ktor-network/jvm/test/io/ktor/network/util/StartTimeoutTest.kt
@@ -6,7 +6,6 @@ package io.ktor.network.util
 
 import kotlinx.coroutines.*
 import kotlin.test.*
-import org.junit.Test
 
 class StartTimeoutTest {
 
@@ -106,12 +105,11 @@ class StartTimeoutTest {
         val scope = CoroutineScope(GlobalScope.coroutineContext)
         val timeout = scope.createTimeout("test", timeoutMs, clock::timeMs) { timeoutInvoked = true }
         timeout.start()
-        yield()
 
-        clock.timeMs += timeoutMs
         runCatching { scope.cancel(CancellationException()) }
+        clock.timeMs += timeoutMs
+
         delay(timeoutMs)
-        yield()
         assertFalse(timeoutInvoked)
     }
 }


### PR DESCRIPTION
**Subsystem**
ktor-client-okhttp

**Motivation**
[KTOR-1583 HttpTimeoutTest.testConnect are flaky](https://youtrack.jetbrains.com/issue/KTOR-1583)
Sometimes, a timeout exception is not get mapped to the correct exception type because the platform exception text may be different. In particular, on Mac it may contain "Connect" so the contains check may fail

**Solution**
- Split and simplify code
- use case-insensitive contains check instead


