### PR TITLE
KTOR-1584 Increase test server delay to fix missing timeouts

### DIFF
--- a/ktor-client/ktor-client-tests/jvm/src/io/ktor/client/tests/utils/tests/Timeout.kt
+++ b/ktor-client/ktor-client-tests/jvm/src/io/ktor/client/tests/utils/tests/Timeout.kt
@@ -61,7 +61,7 @@ internal fun Application.timeoutTest() {
                     count += read
                     if (count >= 1024 * 1024) {
                         count = 0
-                        delay(1000)
+                        delay(2000)
                     }
                 }
 


### PR DESCRIPTION
**Subsystem**
ktor-client-tests, ktor-client-apache

**Motivation**
[KTOR-1584 HttpTimeout.testSocketTimeoutWriteFail is flaky](https://youtrack.jetbrains.com/issue/KTOR-1584)
The possible reason is that sleep duration is only one second while timeouts are checked by Apache every selection (that is also 1sec by default). So if the test server is too fast or selection is a little bit slower, we may get a response too early so no timeout happens in this case so the tests do fail because timeouts were expected.

This is a test bug.

**Solution**
Increase server delay to ensure that Apache detects timeout in time.


