### PR TITLE
KTOR-1598 Fix receving client channel with Logging feature

### DIFF
--- a/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/LoggingTests.kt
+++ b/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/LoggingTests.kt
@@ -434,6 +434,7 @@ class LoggingTest : ClientLoader() {
                 url("$TEST_SERVER/content/echo")
             }
             assertNotNull(response)
+            assertEquals("test", response.readRemaining().readText())
         }
 
         after {


### PR DESCRIPTION
**Subsystem**
ktor-client-core

**Motivation**
[KTOR-1598 Response channel is always cancelled with Logging feature](https://youtrack.jetbrains.com/issue/KTOR-1598)

**Solution**
Launch coroutine under the client's job instead of the request one.

