### PR TITLE
KTOR-1599 Fix Java client job structure

### DIFF
--- a/ktor-client/ktor-client-core/common/src/io/ktor/client/features/HttpRequestLifecycle.kt
+++ b/ktor-client/ktor-client-core/common/src/io/ktor/client/features/HttpRequestLifecycle.kt
@@ -18,7 +18,7 @@ internal class HttpRequestLifecycle {
     /**
      * Companion object for feature installation.
      */
-    public companion object Feature : HttpClientFeature<Unit, HttpRequestLifecycle> {
+    companion object Feature : HttpClientFeature<Unit, HttpRequestLifecycle> {
 
         override val key: AttributeKey<HttpRequestLifecycle> = AttributeKey("RequestLifecycle")
 

--- a/ktor-client/ktor-client-java/jvm/src/io/ktor/client/engine/java/JavaHttpResponseBodyHandler.kt
+++ b/ktor-client/ktor-client-java/jvm/src/io/ktor/client/engine/java/JavaHttpResponseBodyHandler.kt
@@ -27,7 +27,7 @@ internal class JavaHttpResponseBodyHandler(
     }
 
     private class JavaHttpResponseBodySubscriber(
-        callContext: CoroutineContext,
+        private val callContext: CoroutineContext,
         response: HttpResponse.ResponseInfo,
         requestTime: GMTDate
     ) : HttpResponse.BodySubscriber<HttpResponseData>, CoroutineScope {
@@ -48,7 +48,7 @@ internal class JavaHttpResponseBodyHandler(
                 else -> throw IllegalStateException("Unknown HTTP protocol version ${version.name}")
             },
             responseChannel,
-            coroutineContext
+            callContext
         )
 
         private val closed = atomic(false)
@@ -75,6 +75,7 @@ internal class JavaHttpResponseBodyHandler(
             }.apply {
                 invokeOnCompletion {
                     responseChannel.close(it)
+                    consumerJob.complete()
                 }
             }
         }

--- a/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/LoggingTests.kt
+++ b/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/LoggingTests.kt
@@ -434,6 +434,7 @@ class LoggingTest : ClientLoader() {
                 url("$TEST_SERVER/content/echo")
             }
             assertNotNull(response)
+            assertEquals("test", response.readRemaining().readText())
         }
 
         after {

--- a/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/LoggingTests.kt
+++ b/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/LoggingTests.kt
@@ -486,6 +486,7 @@ class LoggingTest : ClientLoader() {
             }
 
             assertNotNull(response)
+            response.discard()
         }
 
         after {


### PR DESCRIPTION
**Subsystem**
ktor-client-java

**Motivation**
[KTOR-1599 Java client logging tests are fluky](https://youtrack.jetbrains.com/issue/KTOR-1599)

**Solution**
- Remove unnecessary client jobs and make it work similar to other engines
- Fix using the wrong job instance when creating a `ResponseData` instance
- Add call job cancellation in the case when there was no `ResponseData` produced

Should be only merged after #2282 ([KTOR-1598](https://youtrack.jetbrains.com/issue/KTOR-1598))
