### PR TITLE
Fix CIO client tunneling https through http proxy

### DIFF
--- a/ktor-client/ktor-client-cio/common/src/io/ktor/client/engine/cio/utils.kt
+++ b/ktor-client/ktor-client-cio/common/src/io/ktor/client/engine/cio/utils.kt
@@ -146,9 +146,7 @@ internal suspend fun startTunnel(
     val builder = RequestResponseBuilder()
 
     try {
-        val urlString = request.url.toString()
-
-        builder.requestLine(HttpMethod("CONNECT"), urlString, HttpProtocolVersion.HTTP_1_1.toString())
+        builder.requestLine(HttpMethod("CONNECT"), request.url.hostWithPort, HttpProtocolVersion.HTTP_1_1.toString())
         // this will only add the port to the host header if the port is non-standard for the protocol
         val host = if (request.url.protocol.defaultPort == request.url.port) {
             request.url.host

--- a/ktor-client/ktor-client-tests/jvm/src/io/ktor/client/tests/utils/tests/Proxy.kt
+++ b/ktor-client/ktor-client-tests/jvm/src/io/ktor/client/tests/utils/tests/Proxy.kt
@@ -82,8 +82,7 @@ private suspend fun handleProxyTunnel(
     output.writeStringUtf8("HTTP/1.1 200 Connection established\r\n\r\n")
     output.flush()
 
-    val hostPort = statusLine.split(" ")[1].substringAfter("://").dropLastWhile { it == '/' }
-
+    val hostPort = statusLine.split(" ")[1]
     val host = hostPort.substringBefore(":")
     val port = hostPort.substringAfter(":", "80").toInt()
 


### PR DESCRIPTION
**Subsystem**
CIO client

**Motivation**
Fixes wrong http `CONNECT` request when tunneling https through a http proxy.
The request line should be `CONNECT $host:$port HTTP/1.1` (e.g. `CONNECT example.com:443 HTTP/1.1`)
Not `CONNECT $url HTTP/1.1` (e.g. `CONNECT https://example.com/ HTTP/1.1`)
According to [MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/CONNECT)

**Related PR**
#2256 

