### PR TITLE
KTOR - 378 Fix request/response accepting empty header name (#1868)

### DIFF
--- a/ktor-http/ktor-http-cio/common/src/io/ktor/http/cio/HttpParser.kt
+++ b/ktor-http/ktor-http-cio/common/src/io/ktor/http/cio/HttpParser.kt
@@ -215,7 +215,7 @@ internal fun parseHeaderName(text: CharArrayBuilder, range: MutableRange): Int {
 
     while (index < end) {
         val ch = text[index]
-        if (ch == ':') {
+        if (ch == ':' && index != range.start) {
             range.start = index + 1
             return index
         }

--- a/ktor-http/ktor-http-cio/common/test/io/ktor/tests/http/cio/HttpParserTest.kt
+++ b/ktor-http/ktor-http-cio/common/test/io/ktor/tests/http/cio/HttpParserTest.kt
@@ -129,6 +129,18 @@ class HttpParserTest {
     }
 
     @Test
+    fun parseHeadersEmptyHeaderNameShouldBeProhibited(): Unit = test {
+        val encodedHeaders = """
+            : value
+        """.trimIndent() + "\r\n\r\n"
+        val channel = ByteReadChannel(encodedHeaders)
+
+        assertFailsWith<ParserException> {
+            parseHeaders(channel).release()
+        }
+    }
+
+    @Test
     fun parseHeadersFoldingShouldBeProhibited(): Unit = test {
         val encodedHeaders = "A:\r\n folding\r\n\r\n"
         val channel = ByteReadChannel(encodedHeaders)


### PR DESCRIPTION
**Subsystem**
ktor-http

**Motivation**
#1868 

**Solution**
Check if the header name is valid before parsing.
