### PR TITLE
KTOR-1374 Avoid using reserved web socket close reason codes in OkHtt…

### DIFF
--- a/ktor-client/ktor-client-features/ktor-client-websockets/common/test/io/ktor/client/tests/features/WebSocketRemoteTest.kt
+++ b/ktor-client/ktor-client-features/ktor-client-websockets/common/test/io/ktor/client/tests/features/WebSocketRemoteTest.kt
@@ -95,6 +95,19 @@ class WebSocketRemoteTest : ClientLoader() {
         }
     }
 
+    @Test
+    fun testBadCloseReason() = clientTests(skipEngines) {
+        config {
+            install(WebSockets)
+        }
+
+        test { client ->
+            client.webSocket(host = echoWebsocket) {
+                close(CloseReason(1005, "Reserved close code"))
+            }
+        }
+    }
+
     private suspend fun WebSocketSession.ping(salt: String) {
         outgoing.send(Frame.Text("text: $salt"))
         val frame = incoming.receive()

--- a/ktor-client/ktor-client-okhttp/jvm/src/io/ktor/client/engine/okhttp/OkHttpWebsocketSession.kt
+++ b/ktor-client/ktor-client-okhttp/jvm/src/io/ktor/client/engine/okhttp/OkHttpWebsocketSession.kt
@@ -58,6 +58,7 @@ internal class OkHttpWebsocketSession(
     @OptIn(ObsoleteCoroutinesApi::class)
     override val outgoing: SendChannel<Frame> = actor {
         val websocket: WebSocket = webSocketFactory.newWebSocket(engineRequest, self.await())
+        var closeReason = DEFAULT_CLOSE_REASON_ERROR
 
         try {
             for (frame in channel) {
@@ -65,15 +66,22 @@ internal class OkHttpWebsocketSession(
                     is Frame.Binary -> websocket.send(frame.data.toByteString(0, frame.data.size))
                     is Frame.Text -> websocket.send(String(frame.data))
                     is Frame.Close -> {
-                        val reason = frame.readReason()!!
-                        websocket.close(reason.code.toInt(), reason.message)
+                        val outgoingCloseReason = frame.readReason()!!
+                        if (!outgoingCloseReason.isReserved()) {
+                            closeReason = outgoingCloseReason
+                        }
                         return@actor
                     }
                     else -> throw UnsupportedFrameTypeException(frame)
                 }
             }
         } finally {
-            websocket.close(CloseReason.Codes.INTERNAL_ERROR.code.toInt(), "Client failure")
+            try {
+                websocket.close(closeReason.code.toInt(), closeReason.message)
+            } catch (cause: Throwable) {
+                websocket.cancel()
+                throw cause
+            }
         }
     }
 
@@ -156,3 +164,11 @@ public class UnsupportedFrameTypeException(
         it.initCause(this)
     }
 }
+
+@Suppress("DEPRECATION")
+private fun CloseReason.isReserved() = CloseReason.Codes.byCode(code).let { recognized ->
+    recognized == null || recognized == CloseReason.Codes.CLOSED_ABNORMALLY
+}
+
+private val DEFAULT_CLOSE_REASON_ERROR: CloseReason =
+    CloseReason(CloseReason.Codes.INTERNAL_ERROR, "Client failure")


### PR DESCRIPTION
…p client engine

**Subsystem**
ktor-client-okhttp

**Motivation**
[KTOR-1374 OkHTTP client engine tries to close the connection twice during the closing handshake](https://youtrack.jetbrains.com/issue/KTOR-1374)

**Solution**
- Make a single close function invocation
- Cancel OkHttp `WebSocket` when close fails due to any reason to avoid leak
- Prevent reserved close reason codes from being sent to okhttp that simply fails in this case


