### PR TITLE
KTOR-1615 Fix apidump

### DIFF
--- a/ktor-client/ktor-client-java/api/ktor-client-java.api
+++ b/ktor-client/ktor-client-java/api/ktor-client-java.api
@@ -10,11 +10,9 @@ public final class io/ktor/client/engine/java/JavaHttpConfig : io/ktor/client/en
 
 public final class io/ktor/client/engine/java/JavaHttpEngine : io/ktor/client/engine/HttpClientEngineBase {
 	public fun <init> (Lio/ktor/client/engine/java/JavaHttpConfig;)V
-	public fun close ()V
 	public fun execute (Lio/ktor/client/request/HttpRequestData;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public synthetic fun getConfig ()Lio/ktor/client/engine/HttpClientEngineConfig;
 	public fun getConfig ()Lio/ktor/client/engine/java/JavaHttpConfig;
-	public fun getCoroutineContext ()Lkotlin/coroutines/CoroutineContext;
 	public fun getDispatcher ()Lkotlinx/coroutines/CoroutineDispatcher;
 	public fun getSupportedCapabilities ()Ljava/util/Set;
 }

--- a/ktor-io/api/ktor-io.api
+++ b/ktor-io/api/ktor-io.api
@@ -1594,6 +1594,7 @@ public final class io/ktor/utils/io/core/OutputPrimitivesKt {
 
 public final class io/ktor/utils/io/core/PacketDirectKt {
 	public static final fun read (Lio/ktor/utils/io/core/AbstractInput;ILkotlin/jvm/functions/Function1;)V
+	public static synthetic fun read$default (Lio/ktor/utils/io/core/AbstractInput;ILkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
 }
 
 public final class io/ktor/utils/io/core/PacketJVMKt {


### PR DESCRIPTION
**Subsystem**
ktor-io, ktor-client-java

**Description**
[KTOR-1637 Upgrade kotlin to 1.4.21](https://youtrack.jetbrains.com/issue/KTOR-1637)

Upgrade to Kotlin 1.4.21 introduced binary changes.

The changes:
- The added method with suffix "default" was added by the new API dumper (wasn't dumped before due to the bug + this is inline function so nobody actually call it)
  - note that the function actually was always there
- The removed methods are safe changes because we don't override the methods and there are such functions in the base class so method resolution will work anyway
  - they seems to be not checked because the build configuration on TC uses the wrong JDK so java client is not checked (will open a PR on this)
  


