### PR TITLE
Cleanup ByteBufferChannel

### DIFF
--- a/ktor-io/common/src/io/ktor/utils/io/bits/MemoryFactory.kt
+++ b/ktor-io/common/src/io/ktor/utils/io/bits/MemoryFactory.kt
@@ -12,6 +12,11 @@ import kotlin.contracts.contract
  * By default, if neither [offset] nor [length] specified, the whole array is used.
  * An instance of [Memory] provided into the [block] should be never captured and used outside of lambda.
  */
+/**
+ * TODO: Solve design problems
+ * 1. length has no default
+ * 2. no inline -> can't suspend inside block
+ */
 @ExperimentalIoApi
 public expect fun <R> ByteArray.useMemory(offset: Int = 0, length: Int, block: (Memory) -> R): R
 

--- a/ktor-io/common/src/io/ktor/utils/io/bits/MemoryFactory.kt
+++ b/ktor-io/common/src/io/ktor/utils/io/bits/MemoryFactory.kt
@@ -13,9 +13,9 @@ import kotlin.contracts.contract
  * An instance of [Memory] provided into the [block] should be never captured and used outside of lambda.
  */
 /**
- * TODO: Solve design problems
- * 1. length has no default
- * 2. no inline -> can't suspend inside block
+ * TODO KTOR-1673: Solve design problems
+ * 1. length has no default (blocked by expect/actual with default value compiler bug (fixed in KT 1.4.3))
+ * 2. no inline -> can't suspend inside block (blocked by inline compiler bug)
  */
 @ExperimentalIoApi
 public expect fun <R> ByteArray.useMemory(offset: Int = 0, length: Int, block: (Memory) -> R): R

--- a/ktor-io/common/test/io/ktor/utils/io/ByteChannelTest.kt
+++ b/ktor-io/common/test/io/ktor/utils/io/ByteChannelTest.kt
@@ -1,0 +1,197 @@
+/*
+ * Copyright 2014-2020 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.utils.io
+
+import io.ktor.test.dispatcher.*
+import io.ktor.utils.io.bits.*
+import kotlinx.coroutines.*
+import kotlin.test.*
+
+class ByteChannelTest {
+
+    @Test
+    fun testPeekToFromEmptyToEmpty() = testSuspend {
+        val empty = ByteChannel()
+        empty.close()
+
+        withMemory(1024) {
+            empty.peekTo(it, 0)
+        }
+    }
+
+    @Test
+    fun testPeekToMemoryLessThanContent() = testSuspend {
+        val channel = ByteChannel()
+        launch {
+            repeat(2048) {
+                channel.writeByte(42)
+            }
+            channel.close()
+        }
+
+        val total = withMemory(1024) {
+            channel.peekTo(it, 0, min = 1, max = Long.MAX_VALUE)
+        }
+        assertEquals(1024, total)
+    }
+
+    @Test
+    fun testPeekToMemoryLargerThanContent() = testSuspend {
+        val channel = ByteChannel()
+        launch {
+            repeat(1024) {
+                channel.writeByte(42)
+            }
+            channel.close()
+        }
+
+        val total = withMemory(4096) {
+            channel.peekTo(it, 0, min = 1, max = Long.MAX_VALUE)
+        }
+        assertEquals(1024, total)
+    }
+
+    @Test
+    fun testPeekToMemoryEqualsToContent() = testSuspend {
+        val channel = ByteChannel()
+        launch {
+            repeat(1024) {
+                channel.writeByte(42)
+            }
+            channel.close()
+        }
+
+        val total = withMemory(1024) {
+            channel.peekTo(it, 0, min = 1, max = Long.MAX_VALUE)
+        }
+        assertEquals(1024, total)
+    }
+
+    @Test
+    fun testPeekToWithMax() = testSuspend {
+        val channel = ByteChannel()
+        launch {
+            repeat(1024) {
+                channel.writeByte(42)
+            }
+            channel.close()
+        }
+
+        val total = withMemory(1024) {
+            channel.peekTo(it, 0, min = 1, max = 16)
+        }
+        assertEquals(16, total)
+    }
+
+    @Test
+    fun testPeekToWithMin() = testSuspend {
+        val channel = ByteChannel()
+        val writeJob = launch {
+            repeat(16) {
+                channel.writeByte(42)
+            }
+            channel.flush()
+            delay(5000)
+            repeat(16) {
+                channel.writeByte(42)
+            }
+            channel.close()
+        }
+
+        val total = withMemory(1024) {
+            channel.peekTo(it, 0, min = 16, max = Long.MAX_VALUE)
+        }
+        assertEquals(16, total)
+        writeJob.cancel()
+    }
+
+    @Test
+    fun testPeekToWithDestinationOffset() = testSuspend {
+        val channel = ByteChannel()
+        launch {
+            repeat(1024) {
+                channel.writeByte(42)
+            }
+            channel.close()
+        }
+
+        val total = withMemory(1024) {
+            channel.peekTo(it, destinationOffset = 16, min = 1, max = Long.MAX_VALUE)
+        }
+        assertEquals(1024 - 16, total)
+    }
+
+    @Test
+    fun testPeekToWithSourceOffset() = testSuspend {
+        val channel = ByteChannel()
+        launch {
+            repeat(1024) {
+                channel.writeByte(42)
+            }
+            channel.close()
+        }
+
+        val total = withMemory(1024) {
+            channel.peekTo(it, destinationOffset = 0, offset = 16, min = 1, max = Long.MAX_VALUE)
+        }
+        assertEquals(1024 - 16, total)
+    }
+
+    @Test
+    fun testPeekToWithSourceAndDestinationOffset() = testSuspend {
+        val channel = ByteChannel()
+        launch {
+            repeat(1024) {
+                channel.writeByte(42)
+            }
+            channel.close()
+        }
+
+        val total = withMemory(1024) {
+            channel.peekTo(it, destinationOffset = 16, offset = 16, min = 1, max = Long.MAX_VALUE)
+        }
+        assertEquals(1024 - 16, total)
+    }
+
+    @Test
+    fun testPeekToProduceCorrectResult() = testSuspend {
+        val channel = ByteChannel()
+        launch {
+            repeat(Byte.MAX_VALUE.toInt() + 1) {
+                channel.writeByte(it.toByte())
+            }
+            channel.close()
+        }
+
+        withMemory(1024) {
+            channel.peekTo(it, destinationOffset = 2, offset = 2, min = 1, max = Long.MAX_VALUE)
+
+            assertEquals(it[0], 0)
+            assertEquals(it[1], 0)
+            for (i in 2..Byte.MAX_VALUE) {
+                assertEquals(it[i], i.toByte())
+            }
+            for (i in (Byte.MAX_VALUE + 1) until 1024) {
+                assertEquals(it[i], 0)
+            }
+        }
+    }
+
+    @Test
+    fun testPeekToDoNotMovePosition() = testSuspend {
+        val channel = ByteChannel()
+        launch {
+            repeat(1024) {
+                channel.writeByte(42)
+            }
+            channel.close()
+        }
+
+        withMemory(1024) {
+            channel.peekTo(it, destinationOffset = 1, offset = 1, min = 1, max = Long.MAX_VALUE)
+        }
+        assertEquals(channel.totalBytesRead, 0)
+    }
+}

--- a/ktor-io/js/src/io/ktor/utils/io/ByteReadChannelJs.kt
+++ b/ktor-io/js/src/io/ktor/utils/io/ByteReadChannelJs.kt
@@ -39,7 +39,6 @@ public actual interface ByteReadChannel {
      * Number of bytes read from the channel.
      * It is not guaranteed to be atomic so could be updated in the middle of long running read operation.
      */
-    @Deprecated("Don't use byte count")
     public actual val totalBytesRead: Long
 
     /**

--- a/ktor-io/jvm/src/io/ktor/utils/io/ByteBufferChannel.kt
+++ b/ktor-io/jvm/src/io/ktor/utils/io/ByteBufferChannel.kt
@@ -31,7 +31,7 @@ internal open class ByteBufferChannel(
 ) : ByteChannel, ByteReadChannel, ByteWriteChannel, LookAheadSuspendSession, HasReadSession, HasWriteSession {
 
     constructor(content: ByteBuffer) : this(false, BufferObjectNoPool, 0) {
-        state = ReadWriteBufferState.Initial(content.slice(), 0).apply {
+        _state.value = ReadWriteBufferState.Initial(content.slice(), 0).apply {
             capacity.resetForRead()
         }.startWriting()
         restoreStateAfterWrite()
@@ -41,11 +41,8 @@ internal open class ByteBufferChannel(
 
     private val _state: AtomicRef<ReadWriteBufferState> = atomic(ReadWriteBufferState.IdleEmpty)
 
-    private var state: ReadWriteBufferState
+    private val state: ReadWriteBufferState
         get() = _state.value
-        set(value) {
-            _state.value = value
-        }
 
     private val _closed: AtomicRef<ClosedElement?> = atomic(null)
     private var closed: ClosedElement?

--- a/ktor-io/jvm/src/io/ktor/utils/io/ByteReadChannelJVM.kt
+++ b/ktor-io/jvm/src/io/ktor/utils/io/ByteReadChannelJVM.kt
@@ -41,7 +41,6 @@ public actual interface ByteReadChannel {
      * Number of bytes read from the channel.
      * It is not guaranteed to be atomic so could be updated in the middle of long running read operation.
      */
-    @Deprecated("Don't use byte count")
     public actual val totalBytesRead: Long
 
     /**

--- a/ktor-io/jvm/src/io/ktor/utils/io/ByteWriteChannel.kt
+++ b/ktor-io/jvm/src/io/ktor/utils/io/ByteWriteChannel.kt
@@ -45,7 +45,6 @@ public actual interface ByteWriteChannel {
      * Number of bytes written to the channel.
      * It is not guaranteed to be atomic so could be updated in the middle of write operation.
      */
-    @Deprecated("Counter is no longer supported")
     public actual val totalBytesWritten: Long
 
     /**

--- a/ktor-io/jvm/src/io/ktor/utils/io/internal/ByteBufferChannelInternals.kt
+++ b/ktor-io/jvm/src/io/ktor/utils/io/internal/ByteBufferChannelInternals.kt
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2014-2020 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.utils.io.internal
+
+import io.ktor.utils.io.*
+import io.ktor.utils.io.ByteBufferChannel
+import kotlinx.atomicfu.*
+import kotlinx.coroutines.*
+import java.nio.*
+
+internal class JoiningState(val delegatedTo: ByteBufferChannel, val delegateClose: Boolean) {
+    private val _closeWaitJob = atomic<Job?>(null)
+    private val closed = atomic(0)
+
+    private val closeWaitJob: Job
+        get() {
+            while (true) {
+                val current = _closeWaitJob.value
+                if (current != null) return current
+                val newJob = Job()
+                if (_closeWaitJob.compareAndSet(null, newJob)) {
+                    if (closed.value == 1) newJob.cancel()
+                    return newJob
+                }
+            }
+        }
+
+    fun complete() {
+        closed.value = 1
+        _closeWaitJob.getAndSet(null)?.cancel()
+    }
+
+    suspend fun awaitClose() {
+        if (closed.value == 1) return
+        return closeWaitJob.join()
+    }
+}
+
+@Suppress("DEPRECATION")
+internal object TerminatedLookAhead : LookAheadSuspendSession {
+    override fun consumed(n: Int) {
+        if (n > 0) throw IllegalStateException("Unable to mark $n bytes consumed for already terminated channel")
+    }
+
+    override fun request(skip: Int, atLeast: Int): ByteBuffer? = null
+
+    override suspend fun awaitAtLeast(n: Int): Boolean {
+        require(n >= 0) { "atLeast parameter shouldn't be negative: $n" }
+        require(n <= 4088) { "atLeast parameter shouldn't be larger than max buffer size of 4088: $n" }
+
+        return false
+    }
+}
+
+internal class ClosedElement(val cause: Throwable?) {
+    val sendException: Throwable
+        get() = cause ?: ClosedWriteChannelException("The channel was closed")
+
+    override fun toString(): String = "Closed[$sendException]"
+
+    companion object {
+        val EmptyCause = ClosedElement(null)
+    }
+}

--- a/ktor-io/jvm/src/io/ktor/utils/io/internal/RingBufferCapacity.kt
+++ b/ktor-io/jvm/src/io/ktor/utils/io/internal/RingBufferCapacity.kt
@@ -2,17 +2,27 @@ package io.ktor.utils.io.internal
 
 @Suppress("LocalVariableName")
 internal class RingBufferCapacity(private val totalCapacity: Int) {
-    @Volatile
-    @JvmField
-    var availableForRead = 0
+    val _availableForRead: AtomicInt = atomic(0)
+    val _availableForWrite: AtomicInt = atomic(totalCapacity)
+    val _pendingToFlush: AtomicInt = atomic(0)
 
-    @Volatile
-    @JvmField
-    var availableForWrite = totalCapacity
+    inline var availableForRead: Int
+        get() = _availableForRead.value
+        set(value) {
+            _availableForRead.value = value
+        }
 
-    @Volatile
-    @JvmField
-    var pendingToFlush = 0
+    inline var availableForWrite: Int
+        get() = _availableForWrite.value
+        set(value) {
+            _availableForWrite.value = value
+        }
+
+    inline var pendingToFlush: Int
+        get() = _pendingToFlush.value
+        set(value) {
+            _pendingToFlush.value = value
+        }
 
     // concurrent unsafe!
     fun resetForWrite() {

--- a/ktor-io/jvm/src/io/ktor/utils/io/internal/RingBufferCapacity.kt
+++ b/ktor-io/jvm/src/io/ktor/utils/io/internal/RingBufferCapacity.kt
@@ -4,19 +4,19 @@ import kotlinx.atomicfu.*
 
 @Suppress("LocalVariableName")
 internal class RingBufferCapacity(private val totalCapacity: Int) {
-    val _availableForRead: AtomicInt = atomic(0)
-    val _availableForWrite: AtomicInt = atomic(totalCapacity)
-    val _pendingToFlush: AtomicInt = atomic(0)
+    private val _availableForRead: AtomicInt = atomic(0)
+    private val _availableForWrite: AtomicInt = atomic(totalCapacity)
+    private val _pendingToFlush: AtomicInt = atomic(0)
 
     inline var availableForRead: Int
         get() = _availableForRead.value
-        set(value) {
+        private set(value) {
             _availableForRead.value = value
         }
 
     inline var availableForWrite: Int
         get() = _availableForWrite.value
-        set(value) {
+        private set(value) {
             _availableForWrite.value = value
         }
 
@@ -109,7 +109,7 @@ internal class RingBufferCapacity(private val totalCapacity: Int) {
         }
     }
 
-    private fun completeReadOverflow(pending: Int, n: Int): Nothing {
+    private fun completeWriteOverflow(pending: Int, n: Int): Nothing {
         throw IllegalArgumentException("Complete write overflow: $pending + $n > $totalCapacity")
     }
 

--- a/ktor-io/jvm/src/io/ktor/utils/io/internal/RingBufferCapacity.kt
+++ b/ktor-io/jvm/src/io/ktor/utils/io/internal/RingBufferCapacity.kt
@@ -29,8 +29,8 @@ internal class RingBufferCapacity(private val totalCapacity: Int) {
     // concurrent unsafe!
     fun resetForWrite() {
         _availableForRead.value = 0
-        _availableForWrite.value = totalCapacity
         _pendingToFlush.value = 0
+        _availableForWrite.value = totalCapacity
     }
 
     fun resetForRead() {

--- a/ktor-io/jvm/src/io/ktor/utils/io/internal/Utils.kt
+++ b/ktor-io/jvm/src/io/ktor/utils/io/internal/Utils.kt
@@ -7,18 +7,6 @@ import kotlin.reflect.*
 
 internal fun ByteBuffer.isEmpty() = !hasRemaining()
 
-internal inline fun <reified Owner : Any> longUpdater(p: KProperty1<Owner, Long>): AtomicLongFieldUpdater<Owner> {
-    return AtomicLongFieldUpdater.newUpdater(Owner::class.java, p.name)
-}
-
-internal inline fun <reified Owner : Any> intUpdater(p: KProperty1<Owner, Int>): AtomicIntegerFieldUpdater<Owner> {
-    return AtomicIntegerFieldUpdater.newUpdater(Owner::class.java, p.name)
-}
-
-internal inline fun <reified Owner : Any, reified T> updater(p: KProperty1<Owner, T>): AtomicReferenceFieldUpdater<Owner, T> {
-    return AtomicReferenceFieldUpdater.newUpdater(Owner::class.java, T::class.java, p.name)
-}
-
 internal fun getIOIntProperty(name: String, default: Int): Int =
     try { System.getProperty("io.ktor.utils.io.$name") }
     catch (e: SecurityException) { null }
@@ -81,5 +69,3 @@ internal fun ByteBuffer.putAtMost(src: ByteBuffer, n: Int = src.remaining()): In
 internal fun ByteBuffer.putLimited(src: ByteBuffer, limit: Int = limit()): Int {
     return putAtMost(src, limit - src.position())
 }
-
-internal fun ByteArray.asByteBuffer(offset: Int = 0, length: Int = size): ByteBuffer = ByteBuffer.wrap(this, offset, length)

--- a/ktor-io/jvm/src/io/ktor/utils/io/internal/WriteSessionImpl.kt
+++ b/ktor-io/jvm/src/io/ktor/utils/io/internal/WriteSessionImpl.kt
@@ -48,7 +48,7 @@ internal class WriteSessionImpl(channel: ByteBufferChannel) : WriterSuspendSessi
             writtenFailed(n)
         }
         locked -= n
-        current.bytesWrittenFromSesion(byteBuffer, ringBufferCapacity, n)
+        current.bytesWrittenFromSession(byteBuffer, ringBufferCapacity, n)
     }
 
     private fun writtenFailed(n: Int): Nothing {


### PR DESCRIPTION
**Subsystem**
Client/Server, ktor-io

**Motivation**
https://youtrack.jetbrains.com/issue/KTOR-1449
https://youtrack.jetbrains.com/issue/KTOR-1557

**Solution**
* Cleanup code, remove unused code, add early returns, simplify expressions
* Migrate from tailrec to loops
* Remove duplication in `readByte`/`Int`/`Short`/`etc` and `writeByte`/`Int`/`Short`/`etc`
* Add tests for `peekTo` method and fix failures
* Fix race condition in `ByteBufferChannel`
