### PR TITLE
KTOR-378 Fix empty header name diagnostic

### DIFF
--- a/ktor-http/ktor-http-cio/common/src/io/ktor/http/cio/HttpParser.kt
+++ b/ktor-http/ktor-http-cio/common/src/io/ktor/http/cio/HttpParser.kt
@@ -237,6 +237,9 @@ internal fun parseHeaderName(text: CharArrayBuilder, range: MutableRange): Int {
 }
 
 private fun parseHeaderNameFailed(text: CharArrayBuilder, index: Int, start: Int, ch: Char): Nothing {
+    if (ch == ':') {
+        throw ParserException("Empty header names are not allowed as per RFC7230.")
+    }
     if (index == start) {
         throw ParserException("Multiline headers via line folding is not supported " +
             "since it is deprecated as per RFC7230.")

--- a/ktor-http/ktor-http-cio/common/test/io/ktor/tests/http/cio/HttpParserTest.kt
+++ b/ktor-http/ktor-http-cio/common/test/io/ktor/tests/http/cio/HttpParserTest.kt
@@ -137,6 +137,8 @@ class HttpParserTest {
 
         assertFailsWith<ParserException> {
             parseHeaders(channel).release()
+        }.let {
+            assertTrue("Empty header names are not allowed" in it.message.orEmpty())
         }
     }
 


### PR DESCRIPTION
**Subsystem**
ktor-cio-http

**Motivation**
After applying fix #2288 we are reporting the wrong error message.

**Solution**
Detect empty header name case more precisely and report the proper error.

