### PR TITLE
Allow to pin only the leaf certificate

### DIFF
--- a/ktor-client/ktor-client-ios/darwin/src/io/ktor/client/engine/ios/certificates/CertificatePinner.kt
+++ b/ktor-client/ktor-client-ios/darwin/src/io/ktor/client/engine/ios/certificates/CertificatePinner.kt
@@ -168,7 +168,7 @@ public data class CertificatePinner internal constructor(
             return
         }
 
-        val result = areCertificatesPinned(certificates)
+        val result = check(certificates)
         if (result) {
             completionHandler(NSURLSessionAuthChallengeUseCredential, challenge.proposedCredential)
         } else {
@@ -179,12 +179,12 @@ public data class CertificatePinner internal constructor(
     }
 
     /**
-     * Check each of the certificates to see if they pinned
+     * Confirms that at least one of the certificates pinned
      */
-    private fun areCertificatesPinned(
+    private fun check(
         certificates: List<SecCertificateRef>
-    ): Boolean = certificates.all { certificate ->
-        val publicKey = certificate.getPublicKeyBytes() ?: return@all false
+    ): Boolean = certificates.any { certificate ->
+        val publicKey = certificate.getPublicKeyBytes() ?: return@any false
         // Lazily compute the hashes for each public key.
         var sha1: String? = null
         var sha256: String? = null

--- a/ktor-client/ktor-client-ios/darwin/src/io/ktor/client/engine/ios/certificates/CertificatePinner.kt
+++ b/ktor-client/ktor-client-ios/darwin/src/io/ktor/client/engine/ios/certificates/CertificatePinner.kt
@@ -168,7 +168,7 @@ public data class CertificatePinner internal constructor(
             return
         }
 
-        val result = check(certificates)
+        val result = hasOnePinnedCertificate(certificates)
         if (result) {
             completionHandler(NSURLSessionAuthChallengeUseCredential, challenge.proposedCredential)
         } else {
@@ -179,9 +179,9 @@ public data class CertificatePinner internal constructor(
     }
 
     /**
-     * Confirms that at least one of the certificates pinned
+     * Confirms that at least one of the certificates is pinned
      */
-    private fun check(
+    private fun hasOnePinnedCertificate(
         certificates: List<SecCertificateRef>
     ): Boolean = certificates.any { certificate ->
         val publicKey = certificate.getPublicKeyBytes() ?: return@any false


### PR DESCRIPTION
If you check okhttp implementation, the pinning require only one valid certificate https://github.com/1184893257/okhttp/blob/master/okhttp/src/main/java/com/squareup/okhttp/CertificatePinner.java
```
for (int i = 0, size = peerCertificates.size(); i < size; i++) {
      X509Certificate x509Certificate = (X509Certificate) peerCertificates.get(i);
      if (pins.contains(sha1(x509Certificate))) return; // Success!
    }
```

**Subsystem**
HttpClient ios CertificatePinner

**Motivation**
Pinning should allow to pin only the leaf certificate public key

**Solution**
Replace all by any

