### PR TITLE
~ Make CIO selector do wakeup on close/suspend

### DIFF
--- a/ktor-network/posix/src/io/ktor/network/selector/SelectUtils.kt
+++ b/ktor-network/posix/src/io/ktor/network/selector/SelectUtils.kt
@@ -6,111 +6,169 @@ package io.ktor.network.selector
 import io.ktor.network.interop.*
 import io.ktor.network.util.*
 import io.ktor.util.collections.*
+import io.ktor.utils.io.*
 import kotlinx.cinterop.*
 import kotlinx.coroutines.*
+import kotlinx.coroutines.CancellationException
 import platform.posix.*
+import kotlin.coroutines.*
 import kotlin.math.*
 import kotlin.native.concurrent.*
 
-internal fun selectHelper(eventQueue: LockFreeMPSCQueue<EventInfo>): Unit = memScoped {
-    val readSet = alloc<fd_set>()
-    val writeSet = alloc<fd_set>()
-    val errorSet = alloc<fd_set>()
+internal class SelectorHelper {
+    private val wakeupSignal = SignalPoint()
+    private val interestQueue = LockFreeMPSCQueue<EventInfo>()
 
-    val completed = mutableSetOf<EventInfo>()
-    val watchSet = mutableSetOf<EventInfo>()
+    private val wakeupSignalEvent = EventInfo(
+        wakeupSignal.selectionDescriptor,
+        SelectInterest.READ,
+        Continuation(EmptyCoroutineContext) {
+        }
+    )
 
-    while (!eventQueue.isClosed) {
-        val maxDescriptor = fillHandlers(eventQueue, watchSet, readSet, writeSet, errorSet)
-        if (maxDescriptor == 0) {
-            continue
+    init {
+        makeShared()
+    }
+
+    fun interest(event: EventInfo): Boolean {
+        if (interestQueue.addLast(event)) {
+            wakeupSignal.signal()
+            return true
         }
 
-        val count = pselect(maxDescriptor + 1, readSet.ptr, writeSet.ptr, errorSet.ptr, null, /*cValue { tv_nsec = 100000 }*/ null)
-            .check()
-
-        processSelectedEvents(watchSet, completed, readSet, writeSet, errorSet)
+        return false
     }
 
-    val exception = CancellationException("Selector closed").freeze()
-    while (!eventQueue.isEmpty) {
-        eventQueue.removeFirstOrNull()?.fail(exception)
-    }
-
-    for (item in watchSet) {
-        item.fail(exception)
-    }
-}
-
-internal fun fillHandlers(
-    eventQueue: LockFreeMPSCQueue<EventInfo>,
-    watchSet: MutableSet<EventInfo>,
-    readSet: fd_set,
-    writeSet: fd_set,
-    errorSet: fd_set
-): Int {
-    var maxDescriptor = 0
-    val repeatQueue = watchSet.iterator()
-
-    select_fd_clear(readSet.ptr)
-    select_fd_clear(writeSet.ptr)
-    select_fd_clear(errorSet.ptr)
-    while (true) {
-        val event = if (repeatQueue.hasNext()) {
-            repeatQueue.next()
-        } else {
-            eventQueue.removeFirstOrNull()
-        } ?: break
-
-        watchSet.add(event)
-
-        val set = when (event.interest) {
-            SelectInterest.READ -> readSet
-            SelectInterest.WRITE -> writeSet
-            SelectInterest.ACCEPT -> readSet
-            else -> error("Interest value invalid ${event.interest} set")
+    fun start(scope: CoroutineScope) {
+        scope.launch(CoroutineName("selector")) {
+            selectionLoop()
+        }.invokeOnCompletion {
+            cleanup()
         }
+    }
+
+    fun requestTermination() {
+        interestQueue.close()
+        wakeupSignal.signal()
+    }
+
+    private fun cleanup() {
+        wakeupSignal.close()
+    }
+
+    private fun selectionLoop(): Unit = memScoped {
+        val readSet = alloc<fd_set>()
+        val writeSet = alloc<fd_set>()
+        val errorSet = alloc<fd_set>()
+
+        val completed = mutableListOf<EventInfo>()
+        val watchSet = mutableSetOf<EventInfo>()
+
+        while (!interestQueue.isClosed) {
+            watchSet.add(wakeupSignalEvent)
+            val maxDescriptor = fillHandlers(watchSet, readSet, writeSet, errorSet)
+            if (maxDescriptor == 0) {
+                continue
+            }
+
+            pselect(maxDescriptor + 1, readSet.ptr, writeSet.ptr, errorSet.ptr, null, null)
+                .check()
+
+            processSelectedEvents(watchSet, completed, readSet, writeSet, errorSet)
+        }
+
+        val exception = CancellationException("Selector closed").freeze()
+        while (!interestQueue.isEmpty) {
+            interestQueue.removeFirstOrNull()?.fail(exception)
+        }
+
+        for (item in watchSet) {
+            item.fail(exception)
+        }
+    }
+
+    private fun fillHandlers(
+        watchSet: MutableSet<EventInfo>,
+        readSet: fd_set,
+        writeSet: fd_set,
+        errorSet: fd_set
+    ): Int {
+        var maxDescriptor = 0
+
+        select_fd_clear(readSet.ptr)
+        select_fd_clear(writeSet.ptr)
+        select_fd_clear(errorSet.ptr)
+
+        while (true) {
+            val event = interestQueue.removeFirstOrNull() ?: break
+            watchSet.add(event)
+        }
+
+        for (event in watchSet) {
+            addInterest(event, readSet, writeSet, errorSet)
+            maxDescriptor = max(maxDescriptor, event.descriptor)
+        }
+
+        return maxDescriptor
+    }
+
+    private fun addInterest(
+        event: EventInfo,
+        readSet: fd_set,
+        writeSet: fd_set,
+        errorSet: fd_set
+    ) {
+        val set = descriptorSetByInterestKind(event, readSet, writeSet)
 
         select_fd_add(event.descriptor, set.ptr)
         select_fd_add(event.descriptor, errorSet.ptr)
 
         check(select_fd_isset(event.descriptor, set.ptr) != 0)
         check(select_fd_isset(event.descriptor, errorSet.ptr) != 0)
-        maxDescriptor = max(maxDescriptor, event.descriptor)
     }
 
-    return maxDescriptor
-}
+    private fun processSelectedEvents(
+        watchSet: MutableSet<EventInfo>,
+        completed: MutableList<EventInfo>,
+        readSet: fd_set,
+        writeSet: fd_set,
+        errorSet: fd_set
+    ) {
+        for (event in watchSet) {
+            val set = descriptorSetByInterestKind(event, readSet, writeSet)
 
-internal fun processSelectedEvents(
-    watchSet: MutableSet<EventInfo>,
-    completed: MutableSet<EventInfo>,
-    readSet: fd_set,
-    writeSet: fd_set,
-    errorSet: fd_set
-) {
-    for (event in watchSet) {
-        val set = when (event.interest) {
-            SelectInterest.READ -> readSet
-            SelectInterest.WRITE -> writeSet
-            SelectInterest.ACCEPT -> readSet
-            else -> error("invalid interest")
+            if (select_fd_isset(event.descriptor, errorSet.ptr) != 0) {
+                completed.add(event)
+                @Suppress("DEPRECATION")
+                event.fail(SocketError())
+                continue
+            }
+            if (select_fd_isset(event.descriptor, set.ptr) != 0) {
+                if (event.descriptor == wakeupSignal.selectionDescriptor) {
+                    wakeupSignal.check()
+                } else {
+                    completed.add(event)
+                    event.complete()
+                }
+                continue
+            }
         }
 
-        if (select_fd_isset(event.descriptor, errorSet.ptr) != 0) {
-            completed.add(event)
-            event.fail(SocketError())
-            continue
-        }
-        if (select_fd_isset(event.descriptor, set.ptr) != 0) {
-            completed.add(event)
-            event.complete()
-            continue
-        }
+        watchSet.removeAll(completed)
+        completed.clear()
     }
 
-    watchSet.removeAll(completed)
-    completed.clear()
+    private fun descriptorSetByInterestKind(
+        event: EventInfo,
+        readSet: fd_set,
+        writeSet: fd_set
+    ) = when (event.interest) {
+        SelectInterest.READ -> readSet
+        SelectInterest.WRITE -> writeSet
+        SelectInterest.ACCEPT -> readSet
+        else -> error("Unsupported interest ${event.interest}.")
+    }
 }
 
+@Deprecated("This will not be thrown since 2.0.0.")
 public class SocketError : IllegalStateException()

--- a/ktor-network/posix/src/io/ktor/network/selector/SignalPoint.kt
+++ b/ktor-network/posix/src/io/ktor/network/selector/SignalPoint.kt
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2014-2021 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.network.selector
+
+import io.ktor.network.util.*
+import io.ktor.utils.io.*
+import io.ktor.utils.io.core.*
+import io.ktor.utils.io.errors.*
+import kotlinx.atomicfu.*
+import kotlinx.cinterop.*
+import platform.posix.*
+
+internal class SignalPoint : Closeable {
+    private val readDescriptor: Int
+    private val writeDescriptor: Int
+    private val signalCounter = atomic(0)
+
+    val selectionDescriptor: Int
+        get() = readDescriptor
+
+    init {
+        val (read, write) = memScoped {
+            val pipeDescriptors = allocArray<IntVar>(2)
+            pipe(pipeDescriptors).check()
+
+            repeat(2) { index ->
+                makeNonBlocking(pipeDescriptors[index])
+            }
+
+            Pair(pipeDescriptors[0], pipeDescriptors[1])
+        }
+
+        readDescriptor = read
+        writeDescriptor = write
+
+        makeShared()
+    }
+
+    fun check(): Boolean {
+        if (signalCounter.getAndSet(0) > 0) {
+            return true
+        }
+
+        return drainDescriptor() > 0
+    }
+
+    fun signal() {
+        if (signalCounter.getAndIncrement() > 0) {
+            return
+        }
+
+        memScoped {
+            val array = allocArray<ByteVar>(1)
+            array[0] = 7
+            // note: here we ignore the result of write intentionally
+            // we simply don't care whether the buffer is full or the pipe is already closed
+            write(writeDescriptor, array, 1.convert())
+        }
+    }
+
+    override fun close() {
+        close(writeDescriptor)
+        drainDescriptor()
+        close(readDescriptor)
+    }
+
+    private fun drainDescriptor(): Int {
+        var count = 0
+
+        memScoped {
+            val buffer = allocArray<ByteVar>(1024)
+
+            do {
+                val result = read(readDescriptor, buffer, 1024.convert()).convert<Int>()
+                if (result < 0) {
+                    when (val error = PosixException.forErrno()) {
+                        is PosixException.TryAgainException -> {}
+                        else -> throw error
+                    }
+
+                    break
+                }
+
+                if (result == 0) {
+                    break
+                }
+
+                count += result
+            } while (true)
+        }
+
+        return count
+    }
+
+    private fun makeNonBlocking(descriptor: Int) {
+        fcntl(descriptor, F_SETFL, fcntl(descriptor, F_GETFL) or O_NONBLOCK).check()
+    }
+}

--- a/ktor-network/posix/src/io/ktor/network/selector/WorkerSelectorManager.kt
+++ b/ktor-network/posix/src/io/ktor/network/selector/WorkerSelectorManager.kt
@@ -3,7 +3,6 @@
  */
 package io.ktor.network.selector
 
-import io.ktor.util.collections.*
 import io.ktor.utils.io.*
 import kotlinx.coroutines.*
 import kotlinx.coroutines.CancellationException
@@ -13,38 +12,31 @@ import kotlin.coroutines.*
 internal class WorkerSelectorManager : SelectorManager {
     private val selectorContext = newSingleThreadContext("WorkerSelectorManager")
     override val coroutineContext: CoroutineContext = selectorContext
-    override fun notifyClosed(selectable: Selectable) {}
+    override fun notifyClosed(s: Selectable) {}
 
-    private val events: LockFreeMPSCQueue<EventInfo> = LockFreeMPSCQueue()
+    private val selector = SelectorHelper()
 
     init {
         makeShared()
-
-        launch {
-            selectHelper(events)
-        }
+        selector.start(this)
     }
 
     override suspend fun select(
         selectable: Selectable,
         interest: SelectInterest
     ) {
-        if (events.isClosed) {
-            throw CancellationException("Socket closed.")
-        }
+        require(selectable is SelectableNative)
 
         return suspendCancellableCoroutine { continuation ->
-            require(selectable is SelectableNative)
-
             val selectorState = EventInfo(selectable.descriptor, interest, continuation)
-            if (!events.addLast(selectorState)) {
-                continuation.resumeWithException(CancellationException("Socked closed."))
+            if (!selector.interest(selectorState)) {
+                continuation.resumeWithException(CancellationException("Selector closed."))
             }
         }
     }
 
     override fun close() {
-        events.close()
+        selector.requestTermination()
         selectorContext.close()
     }
 }


### PR DESCRIPTION
**Subsystem**
ktor-client-cio

**Motivation**
Currently, CIO selector does blocking select. Closing it or adding interests don't wakeup so no new interests will be selected and close operation may hang forever.

**Solution**
Use a signal pipe and do selection on it. When a new interest is configured or close request arrived, we do signal to force abort blocking selection.


