### PR TITLE
KTOR-1797 Prevent double quotes on header params

### DIFF
--- a/ktor-client/ktor-client-core/common/test/FormDslTest.kt
+++ b/ktor-client/ktor-client-core/common/test/FormDslTest.kt
@@ -31,4 +31,16 @@ class FormDslTest {
         assertEquals(data.first().headers.getAll(HttpHeaders.ContentDisposition)!![0], "form-data; name=\"file 1\"")
         assertEquals(data.first().headers.getAll(HttpHeaders.ContentDisposition)!![1], "filename=\"file 1.name\"")
     }
+
+    @Test
+    fun testAppendDoesNotAddDoubleQuotes() {
+        val data = formData {
+            append(
+                key = "\"file 1\"",
+                filename = "\"file 1.name\""
+            ) {}
+        }
+        assertEquals("form-data; name=\"file 1\"", data.first().headers.getAll(HttpHeaders.ContentDisposition)!![0])
+        assertEquals("filename=\"file 1.name\"", data.first().headers.getAll(HttpHeaders.ContentDisposition)!![1])
+    }
 }

--- a/ktor-http/common/src/io/ktor/http/HeaderValueWithParameters.kt
+++ b/ktor-http/common/src/io/ktor/http/HeaderValueWithParameters.kt
@@ -84,6 +84,7 @@ private inline fun String.escapeIfNeededTo(out: StringBuilder) {
 
 private fun String.checkNeedEscape(): Boolean {
     if (isEmpty()) return true
+    if (isQuoted()) return false
 
     for (index in 0 until length) {
         if (HeaderFieldValueSeparators.contains(this[index])) return true
@@ -91,6 +92,8 @@ private fun String.checkNeedEscape(): Boolean {
 
     return false
 }
+
+private fun String.isQuoted(): Boolean = length > 1 && first() == '\"' && last() == '\"'
 
 /**
  * Escape string using double quotes

--- a/ktor-http/common/test/io/ktor/tests/http/HeadersTest.kt
+++ b/ktor-http/common/test/io/ktor/tests/http/HeadersTest.kt
@@ -235,6 +235,17 @@ class HeadersTest {
     }
 
     @Test
+    fun testRenderDoesNotDoubleQuote() {
+        val separators = setOf('(', ')', '<', '>', '@', ',', ';', ':', '/', '[', ']', '?', '=', '{', '}', ' ')
+        separators.forEach { separator ->
+            assertEquals(
+                "file; k=\"v${separator}v\"",
+                ContentDisposition.File.withParameter("k", "\"v${separator}v\"").toString()
+            )
+        }
+    }
+
+    @Test
     fun headersOfShouldBeCaseInsensitive() {
         val value = "world"
         assertEquals(value, headersOf("hello", value)["HELLO"])


### PR DESCRIPTION
**Subsystem**
Client/Server

**Motivation**
[KTOR-1797](https://youtrack.jetbrains.com/issue/KTOR-1797) Do not quote already quoted parameters


