### PR TITLE
KTOR-1590 Fix CIO server 400 response handling

### DIFF
--- a/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/LoggingMockedTests.kt
+++ b/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/LoggingMockedTests.kt
@@ -80,11 +80,11 @@ class LoggingMockedTests {
             "METHOD: HttpMethod(value=GET)",
             "FROM: http://localhost/",
             "COMMON HEADERS",
+            "+++RESPONSE http://localhost/ failed with exception: CustomError[PARSE ERROR]",
             "BODY Content-Type: null",
             "BODY START",
             "Hello",
-            "BODY END",
-            "RESPONSE http://localhost/ failed with exception: CustomError[PARSE ERROR]"
+            "BODY END"
         )
 
         config {

--- a/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/utils/Logging.kt
+++ b/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/utils/Logging.kt
@@ -8,6 +8,14 @@ import io.ktor.client.features.logging.*
 import io.ktor.util.collections.*
 import kotlin.test.*
 
+/**
+ * Test logger that provides ability to verify it's content after test.
+ * The [expectedLog] contains expected log entries
+ * optionally prepended with control prefixes. The following prefixes are supported:
+ * - "???" means that the log entry is optional and could be missing
+ * - "!!!" the log entry is flaky: it's required but it's content is changing
+ * - "+++" the log entry is required but the exact place is not known
+ */
 internal class TestLogger(private vararg val expectedLog: String) : Logger {
     private val log = ConcurrentList<String>()
 
@@ -24,6 +32,7 @@ internal class TestLogger(private vararg val expectedLog: String) : Logger {
         var actualIndex = 0
 
         val message = StringBuilder()
+        val stashed = ArrayList<String>()
 
         while (expectedIndex < expectedLog.size && actualIndex < log.size) {
             var expected = expectedLog[expectedIndex].toLowerCase()
@@ -42,8 +51,20 @@ internal class TestLogger(private vararg val expectedLog: String) : Logger {
                 optional = true
             }
 
+            if (expected.startsWith("+++")) {
+                stashed.add(expected.drop(3))
+                expectedIndex++
+                continue
+            }
+
             if (expected == actual || flaky) {
                 expectedIndex++
+                actualIndex++
+                continue
+            }
+
+            if (actual in stashed) {
+                stashed.remove(actual)
                 actualIndex++
                 continue
             }
@@ -74,6 +95,16 @@ internal class TestLogger(private vararg val expectedLog: String) : Logger {
             }
         }
 
+        while (actualIndex < log.size && stashed.isNotEmpty()) {
+            val actual = log[actualIndex].toLowerCase()
+            if (actual in stashed) {
+                actualIndex++
+                stashed.remove(actual)
+            } else {
+                break
+            }
+        }
+
         if (actualIndex < log.size) {
             message.append("Actual log was not fully processed:\n")
             message.appendLog(log.subList(actualIndex, log.size))
@@ -82,6 +113,11 @@ internal class TestLogger(private vararg val expectedLog: String) : Logger {
         if (expectedIndex < expectedLog.size) {
             message.append("Expected log was not fully processed:\n")
             message.appendLog(expectedLog.asList().subList(expectedIndex, expectedLog.size))
+        }
+
+        if (stashed.isNotEmpty()) {
+            message.append("Expected log entries were not encountered:")
+            message.appendLog(stashed)
         }
 
         if (message.isNotEmpty()) {

--- a/ktor-http/ktor-http-cio/jvm/src/io/ktor/server/cio/backend/ServerPipeline.kt
+++ b/ktor-http/ktor-http-cio/jvm/src/io/ktor/server/cio/backend/ServerPipeline.kt
@@ -107,7 +107,7 @@ public fun CoroutineScope.startServerConnectionPipeline(
                 request.release()
                 response.writePacket(BadRequestPacket.copy())
                 response.close()
-                throw cause
+                break
             }
 
             val requestBody = if (expectedHttpBody || expectedHttpUpgrade) {


### PR DESCRIPTION
**Subsystem**
ktor-server-cio

**Motivation**
Sometimes 400 Bad Request response is not actually sent to clients because of coroutines hierarchy cancellation so this is why `testChunkedIsNotFinal` is flaky. This small bug is not that serious and doesn't provide a breach, just undesired behaviour.

**Solution**
There are several places when we respond with 400. In the case of wrong transfer encodings, we rethrow an exception after writing 400 response bytes. However, rethrowing exceptions leads to the whole coroutines structure cancellation so sometimes actual bytes don't get passed to the underlying socket in time, so the client sees unexpected EOF instead of 400.


