### PR TITLE
~ fix floating log entry

### DIFF
--- a/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/LoggingMockedTests.kt
+++ b/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/LoggingMockedTests.kt
@@ -80,11 +80,11 @@ class LoggingMockedTests {
             "METHOD: HttpMethod(value=GET)",
             "FROM: http://localhost/",
             "COMMON HEADERS",
+            "+++RESPONSE http://localhost/ failed with exception: CustomError[PARSE ERROR]",
             "BODY Content-Type: null",
             "BODY START",
             "Hello",
-            "BODY END",
-            "RESPONSE http://localhost/ failed with exception: CustomError[PARSE ERROR]"
+            "BODY END"
         )
 
         config {

--- a/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/utils/Logging.kt
+++ b/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/utils/Logging.kt
@@ -8,6 +8,14 @@ import io.ktor.client.features.logging.*
 import io.ktor.util.collections.*
 import kotlin.test.*
 
+/**
+ * Test logger that provides ability to verify it's content after test.
+ * The [expectedLog] contains expected log entries
+ * optionally prepended with control prefixes. The following prefixes are supported:
+ * - "???" means that the log entry is optional and could be missing
+ * - "!!!" the log entry is flaky: it's required but it's content is changing
+ * - "+++" the log entry is required but the exact place is not known
+ */
 internal class TestLogger(private vararg val expectedLog: String) : Logger {
     private val log = ConcurrentList<String>()
 
@@ -24,6 +32,7 @@ internal class TestLogger(private vararg val expectedLog: String) : Logger {
         var actualIndex = 0
 
         val message = StringBuilder()
+        val stashed = ArrayList<String>()
 
         while (expectedIndex < expectedLog.size && actualIndex < log.size) {
             var expected = expectedLog[expectedIndex].toLowerCase()
@@ -42,8 +51,20 @@ internal class TestLogger(private vararg val expectedLog: String) : Logger {
                 optional = true
             }
 
+            if (expected.startsWith("+++")) {
+                stashed.add(expected.drop(3))
+                expectedIndex++
+                continue
+            }
+
             if (expected == actual || flaky) {
                 expectedIndex++
+                actualIndex++
+                continue
+            }
+
+            if (actual in stashed) {
+                stashed.remove(actual)
                 actualIndex++
                 continue
             }
@@ -74,6 +95,16 @@ internal class TestLogger(private vararg val expectedLog: String) : Logger {
             }
         }
 
+        while (actualIndex < log.size && stashed.isNotEmpty()) {
+            val actual = log[actualIndex].toLowerCase()
+            if (actual in stashed) {
+                actualIndex++
+                stashed.remove(actual)
+            } else {
+                break
+            }
+        }
+
         if (actualIndex < log.size) {
             message.append("Actual log was not fully processed:\n")
             message.appendLog(log.subList(actualIndex, log.size))
@@ -82,6 +113,11 @@ internal class TestLogger(private vararg val expectedLog: String) : Logger {
         if (expectedIndex < expectedLog.size) {
             message.append("Expected log was not fully processed:\n")
             message.appendLog(expectedLog.asList().subList(expectedIndex, expectedLog.size))
+        }
+
+        if (stashed.isNotEmpty()) {
+            message.append("Expected log entries were not encountered:")
+            message.appendLog(stashed)
         }
 
         if (message.isNotEmpty()) {


### PR DESCRIPTION
**Subsystem**
ktor-client-tests

**Motivation**
Test `testLogResponseWithException` is flaky because there is a floating log entry that appears in different places.

**Solution**
Provide the ability to specify a log entry that is required but could appear later in the log

