### PR TITLE
KTOR-1684 Deprecate locationOrNull

### DIFF
--- a/ktor-features/ktor-locations/api/ktor-locations.api
+++ b/ktor-features/ktor-locations/api/ktor-locations.api
@@ -38,6 +38,7 @@ public final class io/ktor/locations/LocationKt {
 	public static final fun href (Lio/ktor/util/pipeline/PipelineContext;Ljava/lang/Object;)Ljava/lang/String;
 	public static final fun location (Lio/ktor/routing/Route;Lkotlin/reflect/KClass;Lkotlin/jvm/functions/Function1;)Lio/ktor/routing/Route;
 	public static final fun locationOrNull (Lio/ktor/application/ApplicationCall;Lkotlin/reflect/KClass;)Ljava/lang/Object;
+	public static final fun locationOrThrow (Lio/ktor/application/ApplicationCall;Lkotlin/reflect/KClass;)Ljava/lang/Object;
 }
 
 public abstract class io/ktor/locations/LocationPropertyInfo {

--- a/ktor-features/ktor-locations/jvm/src/io/ktor/locations/Location.kt
+++ b/ktor-features/ktor-locations/jvm/src/io/ktor/locations/Location.kt
@@ -228,14 +228,30 @@ public fun <T : Any> Route.handle(dataClass: KClass<T>, body: suspend PipelineCo
 }
 
 /**
- * Retrieves the current call's location or `null` if it is not available (request is not handled by a location class),
+ * Retrieves the current call's location or fails if it is not available (request is not handled by a location class),
+ * or not yet available (invoked too early before the locations feature takes place).
+ *
+ * Despite of the name, the function fails if no location found. This is why it's deprecated.
+ */
+@KtorExperimentalLocationsAPI
+@Deprecated("Use location function instead.", ReplaceWith("location()"))
+public inline fun <reified T : Any> ApplicationCall.locationOrNull(): T = location()
+
+/**
+ * Retrieves the current call's location or fails if it is not available (request is not handled by a location class),
  * or not yet available (invoked too early before the locations feature takes place).
  */
 @KtorExperimentalLocationsAPI
-public inline fun <reified T : Any> ApplicationCall.locationOrNull(): T = locationOrNull(T::class)
+public inline fun <reified T : Any> ApplicationCall.location(): T = locationOrThrow(T::class)
 
 @PublishedApi
 internal fun <T : Any> ApplicationCall.locationOrNull(type: KClass<T>): T =
+    attributes.getOrNull(LocationInstanceKey)?.let { instance ->
+        type.cast(instance)
+    } ?: error("Location instance is not available for this call.)")
+
+@PublishedApi
+internal fun <T : Any> ApplicationCall.locationOrThrow(type: KClass<T>): T =
     attributes.getOrNull(LocationInstanceKey)?.let { instance ->
         type.cast(instance)
     } ?: error("Location instance is not available for this call.)")

--- a/ktor-features/ktor-locations/jvm/test/io/ktor/tests/locations/LocationsTest.kt
+++ b/ktor-features/ktor-locations/jvm/test/io/ktor/tests/locations/LocationsTest.kt
@@ -499,5 +499,31 @@ class LocationsTest {
             assertEquals(HttpStatusCode.BadRequest, call.response.status())
         }
     }
+
+    @Test
+    @Suppress("DEPRECATION")
+    fun testLocationOrNull() {
+        withLocationsApplication {
+            application.routing {
+                get<index> { index ->
+                    assertSame(index, call.locationOrNull())
+                    assertSame(index, call.location())
+                    call.respondText("OK")
+                }
+                get("/no-location") {
+                    assertFails {
+                        assertNull(call.locationOrNull<index>())
+                    }
+                    assertFails {
+                        assertNull(call.location<index>())
+                    }
+                    call.respondText("OK")
+                }
+            }
+
+            urlShouldBeHandled("/", "OK")
+            urlShouldBeHandled("/no-location", "OK")
+        }
+    }
 }
 


### PR DESCRIPTION
**Subsystem**
Ktor-locations

**Motivation**
[KTOR-1684 ApplicationCall.locationOrNull raises error](https://youtrack.jetbrains.com/issue/KTOR-1684)

**Solution**
At the first step in 1.6.0 we will simply add `location` function and deprecate `locationOrNull` pointing to the new function. This will help us to fix this in 2.0.0 when we can make `locationOrNull` return the nullable `T`

