### PR TITLE
KTOR-1914 : Allow 256 bits Cipher Suites to be used

### DIFF
--- a/ktor-client/ktor-client-cio/jvm/test/io/ktor/client/engine/cio/CIOHttpsTest.kt
+++ b/ktor-client/ktor-client-cio/jvm/test/io/ktor/client/engine/cio/CIOHttpsTest.kt
@@ -156,7 +156,8 @@ class CIOHttpsTest : TestWithKtor() {
             "https://google.com",
             "https://facebook.com",
             "https://elster.de",
-            "https://freenode.net"
+            "https://freenode.net",
+            "https://tls-v1-2.badssl.com:1012/"
         )
 
         config {

--- a/ktor-network/ktor-network-tls/jvm/src/io/ktor/network/tls/CipherSuitesJvm.kt
+++ b/ktor-network/ktor-network-tls/jvm/src/io/ktor/network/tls/CipherSuitesJvm.kt
@@ -7,6 +7,8 @@ package io.ktor.network.tls
 import io.ktor.network.tls.platform.*
 
 internal actual fun CipherSuite.isSupported(): Boolean = when (platformVersion.major) {
-    "1.8.0" -> platformVersion.minor >= 161 || keyStrength <= 256
-    else -> keyStrength <= 256
+    "1.8.0" -> platformVersion.minor >= 161 || keyStrength <= 128
+    "1.7.0" -> platformVersion.minor >= 171 || keyStrength <= 128
+    "1.6.0" -> platformVersion.minor >= 181 || keyStrength <= 128
+    else -> true
 }

--- a/ktor-network/ktor-network-tls/jvm/src/io/ktor/network/tls/CipherSuitesJvm.kt
+++ b/ktor-network/ktor-network-tls/jvm/src/io/ktor/network/tls/CipherSuitesJvm.kt
@@ -7,6 +7,6 @@ package io.ktor.network.tls
 import io.ktor.network.tls.platform.*
 
 internal actual fun CipherSuite.isSupported(): Boolean = when (platformVersion.major) {
-    "1.8.0" -> platformVersion.minor >= 161 || keyStrength <= 128
-    else -> keyStrength <= 128
+    "1.8.0" -> platformVersion.minor >= 161 || keyStrength <= 256
+    else -> keyStrength <= 256
 }


### PR DESCRIPTION
**Subsystem**
Client, ktor-network-tls

**Motivation**
Issue : [1914](https://youtrack.jetbrains.com/issue/KTOR-1914)

The list contains TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384 here :
https://github.com/ktorio/ktor/blob/master/ktor-network/ktor-network-tls/common/src/io/ktor/network/tls/CipherSuites.kt#L144-L152

but it is ignored by isSupported method here :
https://github.com/ktorio/ktor/blob/master/ktor-network/ktor-network-tls/jvm/src/io/ktor/network/tls/CipherSuitesJvm.kt#L9-L12

which makes these cipher suites unavailable to be used because of :
https://github.com/ktorio/ktor/blob/master/ktor-network/ktor-network-tls/jvm/src/io/ktor/network/tls/TLSHandshakeType.kt#L70

**Solution**
This PR increases this limit from 128 bits to 256 bits, adds a test to verify it.

