### PR TITLE
KTOR-340 Prevent sending close to already closed outgoing ws channel

### DIFF
--- a/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/WebSocketTest.kt
+++ b/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/WebSocketTest.kt
@@ -9,6 +9,7 @@ import io.ktor.client.features.websocket.*
 import io.ktor.client.tests.utils.*
 import io.ktor.http.cio.websocket.*
 import kotlinx.coroutines.*
+import kotlinx.coroutines.channels.*
 import kotlin.test.*
 
 internal val ENGINES_WITHOUT_WEBSOCKETS = listOf("Apache", "Android", "iOS", "Curl", "native:CIO")
@@ -138,4 +139,26 @@ class WebSocketTest : ClientLoader() {
         }
     }
 
+    @Test
+    fun testExplicitClose() = clientTests(ENGINES_WITHOUT_WEBSOCKETS) {
+        config {
+            install(WebSockets)
+        }
+
+        test { client ->
+            client.ws("$TEST_WEBSOCKET_SERVER/websockets/echo") {
+                send(Frame.Text("Hello World"))
+                delay(1000) // wait for server response
+                close()
+
+                var packetsCount = 0
+                incoming.consumeEach {
+                    val text = (it as? Frame.Text)?.readText() ?: return@consumeEach
+                    assertEquals("Hello World", text)
+                    packetsCount++
+                }
+                assertEquals(1, packetsCount)
+            }
+        }
+    }
 }

--- a/ktor-http/ktor-http-cio/jvm/src/io/ktor/http/cio/websocket/DefaultWebSocketSessionImpl.kt
+++ b/ktor-http/ktor-http-cio/jvm/src/io/ktor/http/cio/websocket/DefaultWebSocketSessionImpl.kt
@@ -111,7 +111,9 @@ public class DefaultWebSocketSessionImpl(
             raw.incoming.consumeEach { frame ->
                 when (frame) {
                     is Frame.Close -> {
-                        outgoing.send(Frame.Close(frame.readReason() ?: NORMAL_CLOSE))
+                        if (!outgoing.isClosedForSend) {
+                            outgoing.send(Frame.Close(frame.readReason() ?: NORMAL_CLOSE))
+                        }
                         closeFramePresented = true
                         return@launch
                     }


### PR DESCRIPTION
**Subsystem**
Web socket

**Motivation**
[Support explicit WebSocket session close](https://youtrack.jetbrains.com/issue/KTOR-340)

**Solution**
Calling `close` on `WebSocketSession` closes `outgoing` channel. When `incoming` receives `Frame.Close` it sends close to the outgoing channel, resulting in the crash. To fix just check that the outgoing channel is open.