### PR TITLE
KTOR-345 Do no send extra new line in multipart requests

### DIFF
--- a/ktor-client/ktor-client-core/common/src/io/ktor/client/request/forms/FormDataContent.kt
+++ b/ktor-client/ktor-client-core/common/src/io/ktor/client/request/forms/FormDataContent.kt
@@ -42,7 +42,7 @@ public class MultiPartFormDataContent(
 ) : OutgoingContent.WriteChannelContent() {
     private val boundary: String = generateBoundary()
     private val BOUNDARY_BYTES = "--$boundary\r\n".toByteArray()
-    private val LAST_BOUNDARY_BYTES = "--$boundary--\r\n\r\n".toByteArray()
+    private val LAST_BOUNDARY_BYTES = "--$boundary--\r\n".toByteArray()
 
     private val BODY_OVERHEAD_SIZE = LAST_BOUNDARY_BYTES.size
     private val PART_OVERHEAD_SIZE = RN_BYTES.size * 2 + BOUNDARY_BYTES.size

--- a/ktor-http/ktor-http-cio/jvm/src/io/ktor/http/cio/Multipart.kt
+++ b/ktor-http/ktor-http-cio/jvm/src/io/ktor/http/cio/Multipart.kt
@@ -375,6 +375,7 @@ public fun CoroutineScope.parseMultipart(
 
         body.close()
     } while (!skipBoundary(boundaryPrefixed, input))
+    input.skipDelimiter(CrLf)
 
     if (totalLength != null) {
         @Suppress("DEPRECATION")

--- a/ktor-http/ktor-http-cio/jvm/test/io/ktor/tests/http/cio/MultipartTest.kt
+++ b/ktor-http/ktor-http-cio/jvm/test/io/ktor/tests/http/cio/MultipartTest.kt
@@ -78,7 +78,7 @@ class MultipartTest {
         assertEquals("JFIF second", jpeg2.body.readRemaining().readText())
 
         val epilogue = allEvents[6] as MultipartEvent.Epilogue
-        assertEquals("\r\nepilogue", epilogue.body.readText())
+        assertEquals("epilogue", epilogue.body.readText())
     }
 
     @Test
@@ -274,7 +274,7 @@ class MultipartTest {
         assertEquals("JFIF second", jpeg2.body.readRemaining().readText())
 
         val epilogue = allEvents[6] as MultipartEvent.Epilogue
-        assertEquals("\r\nepilogue", epilogue.body.readText())
+        assertEquals("epilogue", epilogue.body.readText())
     }
 
     @Test

--- a/ktor-server/ktor-server-test-host/jvm/src/io/ktor/server/testing/TestApplicationRequest.kt
+++ b/ktor-server/ktor-server-test-host/jvm/src/io/ktor/server/testing/TestApplicationRequest.kt
@@ -131,7 +131,7 @@ public fun TestApplicationRequest.setBody(boundary: String, parts: List<PartData
                 append("\r\n")
             }
 
-            append("--$boundary--\r\n\r\n")
+            append("--$boundary--\r\n")
         } finally {
             parts.forEach { it.dispose() }
         }

--- a/ktor-server/ktor-server-tests/jvm/test/io/ktor/tests/server/testing/TestApplicationEngineTest.kt
+++ b/ktor-server/ktor-server-tests/jvm/test/io/ktor/tests/server/testing/TestApplicationEngineTest.kt
@@ -9,10 +9,13 @@ import io.ktor.client.request.*
 import io.ktor.client.statement.*
 import io.ktor.features.*
 import io.ktor.http.*
+import io.ktor.http.content.*
+import io.ktor.request.*
 import io.ktor.response.*
 import io.ktor.routing.*
 import io.ktor.server.testing.*
 import io.ktor.sessions.*
+import io.ktor.utils.io.core.*
 import kotlinx.coroutines.*
 import java.util.concurrent.atomic.AtomicInteger
 import kotlin.coroutines.*
@@ -216,6 +219,42 @@ class TestApplicationEngineTest {
                 val existingResponse = client.get<HttpResponse>("/exist")
                 assertEquals(HttpStatusCode.OK, existingResponse.status)
             }
+        }
+    }
+
+    @Test
+    fun testMultipart() {
+        withTestApplication {
+            application.routing {
+                post("/multipart") {
+                    call.receiveMultipart().readPart()
+                    call.respond(HttpStatusCode.OK, "OK")
+                }
+            }
+
+            val boundary = "***bbb***"
+            val multipart = listOf(
+                PartData.FileItem(
+                    { buildPacket { writeText("BODY") } },
+                    {},
+                    headersOf(
+                        HttpHeaders.ContentDisposition,
+                        ContentDisposition.File
+                            .withParameter(ContentDisposition.Parameters.Name, "file")
+                            .withParameter(ContentDisposition.Parameters.FileName, "test.jpg")
+                            .toString()
+                    )
+                )
+            )
+
+            val response = handleRequest(method = HttpMethod.Post, uri = "/multipart") {
+                addHeader(
+                    HttpHeaders.ContentType,
+                    ContentType.MultiPart.FormData.withParameter("boundary", boundary).toString()
+                )
+                setBody(boundary, multipart)
+            }
+            assertEquals(HttpStatusCode.OK, response.response.status())
         }
     }
 }


### PR DESCRIPTION
**Subsystem**
Client/Server, multipart

**Motivation**
[Test a POST with MultiPart using TestApplicationEngine does not succeed or fail](https://youtrack.jetbrains.com/issue/KTOR-345)

**Solution**
1. Send one CRLF instead of two after the last boundary (https://www.w3.org/Protocols/rfc1341/7_2_Multipart.html)
2. Skip one CRLF after the last boundary when parsing multipart
