### PR TITLE
KTOR-2210 Make base name of micrometer metrics configurable

### DIFF
--- a/ktor-features/ktor-locations/api/ktor-locations.api
+++ b/ktor-features/ktor-locations/api/ktor-locations.api
@@ -38,6 +38,7 @@ public final class io/ktor/locations/LocationKt {
 	public static final fun href (Lio/ktor/util/pipeline/PipelineContext;Ljava/lang/Object;)Ljava/lang/String;
 	public static final fun location (Lio/ktor/routing/Route;Lkotlin/reflect/KClass;Lkotlin/jvm/functions/Function1;)Lio/ktor/routing/Route;
 	public static final fun locationOrNull (Lio/ktor/application/ApplicationCall;Lkotlin/reflect/KClass;)Ljava/lang/Object;
+	public static final fun locationOrThrow (Lio/ktor/application/ApplicationCall;Lkotlin/reflect/KClass;)Ljava/lang/Object;
 }
 
 public abstract class io/ktor/locations/LocationPropertyInfo {

--- a/ktor-features/ktor-locations/api/ktor-locations.api
+++ b/ktor-features/ktor-locations/api/ktor-locations.api
@@ -38,7 +38,6 @@ public final class io/ktor/locations/LocationKt {
 	public static final fun href (Lio/ktor/util/pipeline/PipelineContext;Ljava/lang/Object;)Ljava/lang/String;
 	public static final fun location (Lio/ktor/routing/Route;Lkotlin/reflect/KClass;Lkotlin/jvm/functions/Function1;)Lio/ktor/routing/Route;
 	public static final fun locationOrNull (Lio/ktor/application/ApplicationCall;Lkotlin/reflect/KClass;)Ljava/lang/Object;
-	public static final fun locationOrThrow (Lio/ktor/application/ApplicationCall;Lkotlin/reflect/KClass;)Ljava/lang/Object;
 }
 
 public abstract class io/ktor/locations/LocationPropertyInfo {

--- a/ktor-features/ktor-metrics-micrometer/api/ktor-metrics-micrometer.api
+++ b/ktor-features/ktor-metrics-micrometer/api/ktor-metrics-micrometer.api
@@ -1,7 +1,5 @@
 public final class io/ktor/metrics/micrometer/MicrometerMetrics {
 	public static final field Feature Lio/ktor/metrics/micrometer/MicrometerMetrics$Feature;
-	public static final field activeGaugeName Ljava/lang/String;
-	public static final field requestTimerName Ljava/lang/String;
 	public fun <init> (Lio/micrometer/core/instrument/MeterRegistry;Lio/micrometer/core/instrument/distribution/DistributionStatisticConfig;Lkotlin/jvm/functions/Function3;)V
 	public synthetic fun <init> (Lio/micrometer/core/instrument/MeterRegistry;Lio/micrometer/core/instrument/distribution/DistributionStatisticConfig;ZLkotlin/jvm/functions/Function3;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 }
@@ -9,10 +7,12 @@ public final class io/ktor/metrics/micrometer/MicrometerMetrics {
 public final class io/ktor/metrics/micrometer/MicrometerMetrics$Configuration {
 	public field registry Lio/micrometer/core/instrument/MeterRegistry;
 	public fun <init> ()V
+	public final fun getBaseName ()Ljava/lang/String;
 	public final fun getDistinctNotRegisteredRoutes ()Z
 	public final fun getDistributionStatisticConfig ()Lio/micrometer/core/instrument/distribution/DistributionStatisticConfig;
 	public final fun getMeterBinders ()Ljava/util/List;
 	public final fun getRegistry ()Lio/micrometer/core/instrument/MeterRegistry;
+	public final fun setBaseName (Ljava/lang/String;)V
 	public final fun setDistinctNotRegisteredRoutes (Z)V
 	public final fun setDistributionStatisticConfig (Lio/micrometer/core/instrument/distribution/DistributionStatisticConfig;)V
 	public final fun setMeterBinders (Ljava/util/List;)V
@@ -21,7 +21,9 @@ public final class io/ktor/metrics/micrometer/MicrometerMetrics$Configuration {
 }
 
 public final class io/ktor/metrics/micrometer/MicrometerMetrics$Feature : io/ktor/application/ApplicationFeature {
+	public final fun getActiveGaugeName ()Ljava/lang/String;
 	public fun getKey ()Lio/ktor/util/AttributeKey;
+	public final fun getRequestTimerName ()Ljava/lang/String;
 	public fun install (Lio/ktor/application/Application;Lkotlin/jvm/functions/Function1;)Lio/ktor/metrics/micrometer/MicrometerMetrics;
 	public synthetic fun install (Lio/ktor/util/pipeline/Pipeline;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
 }

--- a/ktor-features/ktor-metrics-micrometer/api/ktor-metrics-micrometer.api
+++ b/ktor-features/ktor-metrics-micrometer/api/ktor-metrics-micrometer.api
@@ -1,5 +1,7 @@
 public final class io/ktor/metrics/micrometer/MicrometerMetrics {
 	public static final field Feature Lio/ktor/metrics/micrometer/MicrometerMetrics$Feature;
+	public static final field activeGaugeName Ljava/lang/String;
+	public static final field requestTimerName Ljava/lang/String;
 	public fun <init> (Lio/micrometer/core/instrument/MeterRegistry;Lio/micrometer/core/instrument/distribution/DistributionStatisticConfig;Lkotlin/jvm/functions/Function3;)V
 	public synthetic fun <init> (Lio/micrometer/core/instrument/MeterRegistry;Lio/micrometer/core/instrument/distribution/DistributionStatisticConfig;ZLkotlin/jvm/functions/Function3;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 }
@@ -21,9 +23,9 @@ public final class io/ktor/metrics/micrometer/MicrometerMetrics$Configuration {
 }
 
 public final class io/ktor/metrics/micrometer/MicrometerMetrics$Feature : io/ktor/application/ApplicationFeature {
-	public final fun getActiveGaugeName ()Ljava/lang/String;
+	public final fun getActiveRequestsGaugeName ()Ljava/lang/String;
 	public fun getKey ()Lio/ktor/util/AttributeKey;
-	public final fun getRequestTimerName ()Ljava/lang/String;
+	public final fun getRequestTimeTimerName ()Ljava/lang/String;
 	public fun install (Lio/ktor/application/Application;Lkotlin/jvm/functions/Function1;)Lio/ktor/metrics/micrometer/MicrometerMetrics;
 	public synthetic fun install (Lio/ktor/util/pipeline/Pipeline;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
 }

--- a/ktor-features/ktor-metrics-micrometer/jvm/src/io/ktor/metrics/micrometer/MicrometerMetrics.kt
+++ b/ktor-features/ktor-metrics-micrometer/jvm/src/io/ktor/metrics/micrometer/MicrometerMetrics.kt
@@ -75,6 +75,7 @@ public class MicrometerMetrics private constructor(
 
     /**
      * Configures this Feature
+     * @property baseName The base prefix for metrics. Default: [Feature.defaultBaseName]
      * @property registry The meter registry where the meters are registered. Mandatory
      * @property meterBinders The binders that are automatically bound to the registry. Default: [ClassLoaderMetrics],
      * [JvmMemoryMetrics], [ProcessorMetrics], [JvmGcMetrics], [ProcessorMetrics], [JvmThreadMetrics], [FileDescriptorMetrics]
@@ -182,6 +183,9 @@ public class MicrometerMetrics private constructor(
         )
         public const val requestTimerName: String = "$defaultBaseName.requests"
 
+        /**
+         * Request time timer name with configurable base name
+         */
         public val requestTimeTimerName: String
             get() = "$baseName.requests"
 
@@ -195,6 +199,9 @@ public class MicrometerMetrics private constructor(
         )
         public const val activeGaugeName: String = "$defaultBaseName.requests.active"
 
+        /**
+         * Active requests gauge name with configurable base name
+         */
         public val activeRequestsGaugeName: String
             get() = "$baseName.requests.active"
 

--- a/ktor-features/ktor-metrics-micrometer/jvm/src/io/ktor/metrics/micrometer/MicrometerMetrics.kt
+++ b/ktor-features/ktor-metrics-micrometer/jvm/src/io/ktor/metrics/micrometer/MicrometerMetrics.kt
@@ -88,6 +88,8 @@ public class MicrometerMetrics private constructor(
      * */
     public class Configuration {
 
+        public var baseName: String = "ktor.http.server"
+
         public lateinit var registry: MeterRegistry
 
         public var distinctNotRegisteredRoutes: Boolean = true
@@ -166,17 +168,19 @@ public class MicrometerMetrics private constructor(
      * Micrometer feature installation object
      */
     public companion object Feature : ApplicationFeature<Application, Configuration, MicrometerMetrics> {
-        private const val baseName: String = "ktor.http.server"
+        private lateinit var baseName: String
 
         /**
          * Request time timer name
          */
-        public const val requestTimerName: String = "$baseName.requests"
+        public val requestTimerName: String
+            get() = "$baseName.requests"
 
         /**
          * Active requests gauge name
          */
-        public const val activeGaugeName: String = "$baseName.requests.active"
+        public val activeGaugeName: String
+            get() = "$baseName.requests.active"
 
         private val measureKey = AttributeKey<CallMeasure>("metrics")
 
@@ -184,6 +188,14 @@ public class MicrometerMetrics private constructor(
 
         override fun install(pipeline: Application, configure: Configuration.() -> Unit): MicrometerMetrics {
             val configuration = Configuration().apply(configure)
+
+            if (configuration.baseName.isBlank()) {
+                throw IllegalArgumentException(
+                    "Base name should be defined"
+                )
+            }
+
+            baseName = configuration.baseName
 
             if (!configuration.isRegistryInitialized()) {
                 throw IllegalArgumentException(

--- a/ktor-features/ktor-metrics-micrometer/jvm/src/io/ktor/metrics/micrometer/MicrometerMetrics.kt
+++ b/ktor-features/ktor-metrics-micrometer/jvm/src/io/ktor/metrics/micrometer/MicrometerMetrics.kt
@@ -5,7 +5,6 @@
 package io.ktor.metrics.micrometer
 
 import io.ktor.application.*
-import io.ktor.metrics.micrometer.MicrometerMetrics.*
 import io.ktor.request.*
 import io.ktor.response.*
 import io.ktor.routing.*
@@ -89,7 +88,7 @@ public class MicrometerMetrics private constructor(
      * */
     public class Configuration {
 
-        public var baseName: String = Feature.baseName
+        public var baseName: String = Feature.defaultBaseName
 
         public lateinit var registry: MeterRegistry
 
@@ -169,36 +168,35 @@ public class MicrometerMetrics private constructor(
      * Micrometer feature installation object
      */
     public companion object Feature : ApplicationFeature<Application, Configuration, MicrometerMetrics> {
-        @Deprecated("static metrics base name deprecated", level = DeprecationLevel.WARNING)
-        private const val baseName: String = "ktor.http.server"
+        private const val defaultBaseName: String = "ktor.http.server"
 
-        private lateinit var metricsBaseName: String
+        private lateinit var baseName: String
 
         /**
          * Request time timer name
          */
         @Deprecated(
-            "static request time timer name deprecated",
+            "static request time timer name is deprecated",
             ReplaceWith("requestTimeTimerName"),
             DeprecationLevel.WARNING
         )
-        public const val requestTimerName: String = "$baseName.requests"
+        public const val requestTimerName: String = "$defaultBaseName.requests"
 
         public val requestTimeTimerName: String
-            get() = "$metricsBaseName.requests"
+            get() = "$baseName.requests"
 
         /**
          * Active requests gauge name
          */
         @Deprecated(
-            "static gauge name deprecated",
+            "static gauge name is deprecated",
             ReplaceWith("activeRequestsGaugeName"),
             DeprecationLevel.WARNING
         )
-        public const val activeGaugeName: String = "$baseName.requests.active"
+        public const val activeGaugeName: String = "$defaultBaseName.requests.active"
 
         public val activeRequestsGaugeName: String
-            get() = "$metricsBaseName.requests.active"
+            get() = "$baseName.requests.active"
 
         private val measureKey = AttributeKey<CallMeasure>("metrics")
 
@@ -213,7 +211,7 @@ public class MicrometerMetrics private constructor(
                 )
             }
 
-            metricsBaseName = configuration.baseName
+            baseName = configuration.baseName
 
             if (!configuration.isRegistryInitialized()) {
                 throw IllegalArgumentException(

--- a/ktor-features/ktor-metrics-micrometer/jvm/test/io/ktor/metrics/micrometer/MicrometerMetricsTests.kt
+++ b/ktor-features/ktor-metrics-micrometer/jvm/test/io/ktor/metrics/micrometer/MicrometerMetricsTests.kt
@@ -346,7 +346,6 @@ class MicrometerMetricsTests {
         assertEquals("$newBaseName.requests.active", MicrometerMetrics.activeGaugeName)
     }
 
-
     private fun TestApplicationEngine.metersAreRegistered(
         meterBinder: KClass<out MeterBinder>,
         vararg meterNames: String


### PR DESCRIPTION
**Subsystem**
Server, Features/Micrometer

**Motivation**
When Ktor service is running in the environment with services written in other frameworks like Spring Boot, having standardized metric names is important for monitoring. Static, non-configurable "ktor.http.server" base name is inconvenient and breaks existing monitoring setup or at least requires special handling for Ktor services.

**Solution**
Make it configurable 

