### PR TITLE
Fix CIO connectors startup

### DIFF
--- a/ktor-server/ktor-server-cio/jvm/src/io/ktor/server/cio/CIOApplicationEngine.kt
+++ b/ktor-server/ktor-server-cio/jvm/src/io/ktor/server/cio/CIOApplicationEngine.kt
@@ -63,7 +63,7 @@ public class CIOApplicationEngine(environment: ApplicationEngineEnvironment, con
             }
 
             environment.connectors.forEach { connectorSpec ->
-                val connector = startConnector(connectorSpec.port)
+                val connector = startConnector(connectorSpec.host, connectorSpec.port)
                 connectors.add(connector)
             }
 
@@ -149,8 +149,9 @@ public class CIOApplicationEngine(environment: ApplicationEngineEnvironment, con
         }
     }
 
-    private fun CoroutineScope.startConnector(port: Int): HttpServer {
+    private fun CoroutineScope.startConnector(host: String, port: Int): HttpServer {
         val settings = HttpServerSettings(
+            host = host,
             port = port,
             connectionIdleTimeoutSeconds = configuration.connectionIdleTimeoutSeconds.toLong()
         )

--- a/ktor-server/ktor-server-cio/jvm/test/io/ktor/tests/server/cio/TestConnectorInterfaceUsed.kt
+++ b/ktor-server/ktor-server-cio/jvm/test/io/ktor/tests/server/cio/TestConnectorInterfaceUsed.kt
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2014-2021 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.tests.server.cio
+
+import io.ktor.server.cio.*
+import io.ktor.server.engine.*
+import kotlin.test.*
+
+class TestConnectorInterfaceUsed {
+    @Test
+    fun testConnectorListenHost() {
+        val engine = CIOApplicationEngine(
+            applicationEngineEnvironment {
+                connector {
+                    host = "some/illegal/host/name"
+                    port = 9091
+                }
+            }
+        ) {}
+
+        assertFails {
+            engine.start()
+
+            // this shouldn't happen
+            try {
+                engine.stop(1000, 2000)
+            } catch (_: Throwable) {
+            }
+        }
+    }
+}


### PR DESCRIPTION
**Subsystem**
ktor-server-cio

**Motivation**
- CIO server startup doesn't fail-fast if connectors are not properly configured or the port is already in use.
- [KTOR-334 Connector host configuration (listen interface) is ignored](https://youtrack.jetbrains.com/issue/KTOR-334)

**Solution**
- Fix startup to crash if any connector is failed to start, block start function before the startup sequence complete
- pass host configuration and add test


