### PR TITLE
KTOR-1464 Fix client Digest auth realm handling

### DIFF
--- a/ktor-client/ktor-client-features/ktor-client-auth/common/src/io/ktor/client/features/auth/Auth.kt
+++ b/ktor-client/ktor-client-features/ktor-client-auth/common/src/io/ktor/client/features/auth/Auth.kt
@@ -50,6 +50,7 @@ public class Auth(
 
                     val request = HttpRequestBuilder()
                     request.takeFromWithExecutionContext(context)
+                    request.attributes.put(AuthHeaderAttribute, authHeader)
                     provider.addRequestHeaders(request)
                     request.attributes.put(circuitBreaker, Unit)
 
@@ -67,3 +68,11 @@ public class Auth(
 public fun HttpClientConfig<*>.Auth(block: Auth.() -> Unit) {
     install(Auth, block)
 }
+
+/**
+ * AuthHeader from the previous unsuccessful request. This actually should be passed as
+ * parameter to AuthProvider.addRequestHeaders instead in the future and the attribute will
+ * be removed after that.
+ */
+@PublicAPICandidate("1.6.0")
+internal val AuthHeaderAttribute = AttributeKey<HttpAuthHeader>("AuthHeader")

--- a/ktor-client/ktor-client-features/ktor-client-auth/common/test/io/ktor/client/features/auth/DigestProviderTest.kt
+++ b/ktor-client/ktor-client-features/ktor-client-auth/common/test/io/ktor/client/features/auth/DigestProviderTest.kt
@@ -57,6 +57,32 @@ class DigestProviderTest {
     }
 
     @Test
+    fun addRequestHeadersMissingRealm() = testSuspend {
+        if (!PlatformUtils.IS_JVM) return@testSuspend
+
+        val providerWithoutRealm = DigestAuthProvider("username", "pass", null)
+        val authHeader = parseAuthorizationHeader(authAllFields)!!
+        requestBuilder.attributes.put(AuthHeaderAttribute, authHeader)
+
+        assertTrue(providerWithoutRealm.isApplicable(authHeader))
+        providerWithoutRealm.addRequestHeaders(requestBuilder)
+
+        val resultAuthHeader = requestBuilder.headers[HttpHeaders.Authorization]!!
+        checkStandardFields(resultAuthHeader)
+    }
+
+    @Test
+    fun addRequestHeadersChangedRealm() = testSuspend {
+        if (!PlatformUtils.IS_JVM) return@testSuspend
+
+        val providerWithoutRealm = DigestAuthProvider("username", "pass", "wrong!")
+        val authHeader = parseAuthorizationHeader(authAllFields)!!
+        requestBuilder.attributes.put(AuthHeaderAttribute, authHeader)
+
+        assertFalse(providerWithoutRealm.isApplicable(authHeader))
+    }
+
+    @Test
     fun addRequestHeadersOmitsQopAndOpaqueWhenMissing() = testSuspend {
         if (!PlatformUtils.IS_JVM) return@testSuspend
 


### PR DESCRIPTION
Fix client digest auth realm handling to use the realm provided by the server if the realm is not configured in the client feature

**Subsystem**
ktor-client-auth

**Motivation**
[Digest authentition: using the realm of the 401 response to an initial incomplete request for an immediate second complete request including realm.](https://youtrack.jetbrains.com/issue/KTOR-1464)

This replaces PR #2236 
