### PR TITLE
KTOR-2054 Fix routing with non optional trailing path parameter

### DIFF
--- a/ktor-server/ktor-server-core/jvm/test/io/ktor/tests/routing/RouteSelectorTest.kt
+++ b/ktor-server/ktor-server-core/jvm/test/io/ktor/tests/routing/RouteSelectorTest.kt
@@ -59,8 +59,6 @@ internal class RouteSelectorTest {
             segments = listOf("PARAM"),
             segmentIndex = 0,
             name = "param",
-            prefix = null,
-            suffix = null,
             isOptional = false
         )
 
@@ -122,5 +120,41 @@ internal class RouteSelectorTest {
         )
 
         assertEquals(evaluation, RouteSelectorEvaluation.Missing)
+    }
+
+    @Test
+    fun testEvaluateWithTrailingSlashAndOptional() {
+        val evaluation = evaluatePathSegmentParameter(
+            segments = listOf("foo", ""),
+            segmentIndex = 1,
+            name = "param",
+            isOptional = true
+        )
+
+        assertEquals(evaluation, RouteSelectorEvaluation.Missing.copy(segmentIncrement = 1))
+    }
+
+    @Test
+    fun testEvaluateWithoutTrailingSlashAndOptional() {
+        val evaluation = evaluatePathSegmentParameter(
+            segments = listOf("foo"),
+            segmentIndex = 1,
+            name = "param",
+            isOptional = true
+        )
+
+        assertEquals(evaluation, RouteSelectorEvaluation.Missing)
+    }
+
+    @Test
+    fun testEvaluateWithTrailingSlashAndNonOptional() {
+        val evaluation = evaluatePathSegmentParameter(
+            segments = listOf("foo", ""),
+            segmentIndex = 1,
+            name = "param",
+            isOptional = false
+        )
+
+        assertEquals(evaluation, RouteSelectorEvaluation.Failed)
     }
 }

--- a/ktor-server/ktor-server-tests/jvm/test/io/ktor/tests/server/routing/RoutingResolveTest.kt
+++ b/ktor-server/ktor-server-tests/jvm/test/io/ktor/tests/server/routing/RoutingResolveTest.kt
@@ -1042,6 +1042,125 @@ class RoutingResolveTest {
     }
 
     @Test
+    fun testRoutingWithWildcardTrailingPathParameter() = withTestApplication {
+        application.routing {
+            get("test/*") {
+                call.respondText("test")
+            }
+        }
+        on("making /test request") {
+            val result = handleRequest {
+                uri = "test"
+                method = HttpMethod.Get
+            }
+            it("/test should not be called") {
+                assertFalse(result.requestHandled)
+            }
+        }
+        on("making /test/ request") {
+            val result = handleRequest {
+                uri = "test/"
+                method = HttpMethod.Get
+            }
+            it("/test/ should not be called") {
+                assertFalse(result.requestHandled)
+            }
+        }
+        on("making /test/foo request") {
+            val result = handleRequest {
+                uri = "test/foo"
+                method = HttpMethod.Get
+            }
+            it("/test/foo should be called") {
+                assertEquals("test", result.response.content)
+            }
+        }
+    }
+
+    @Test
+    fun testRoutingWithWildcardPathParameter() = withTestApplication {
+        application.routing {
+            get("test/*/foo") {
+                call.respondText("foo")
+            }
+        }
+        on("making /test/foo request") {
+            val result = handleRequest {
+                uri = "test/foo"
+                method = HttpMethod.Get
+            }
+            it("/test/*/foo should not be called") {
+                assertFalse(result.requestHandled)
+            }
+        }
+        on("making /test/bar/foo request") {
+            val result = handleRequest {
+                uri = "test/bar/foo"
+                method = HttpMethod.Get
+            }
+            it("/test/*/foo should be called") {
+                assertEquals("foo", result.response.content)
+            }
+        }
+    }
+
+    @Test
+    fun testRoutingWithNonOptionalTrailingPathParameter() = withTestApplication {
+        application.routing {
+            get("test/{foo}") {
+                call.respondText(call.parameters["foo"]!!)
+            }
+        }
+        on("making /test/ request") {
+            val result = handleRequest {
+                uri = "test/"
+                method = HttpMethod.Get
+            }
+            it("/test/ should not be called") {
+                assertFalse(result.requestHandled)
+            }
+        }
+        on("making /test/foo request") {
+            val result = handleRequest {
+                uri = "test/foo"
+                method = HttpMethod.Get
+            }
+            it("/test/foo should be called") {
+                assertEquals("foo", result.response.content)
+            }
+        }
+    }
+
+    @Test
+    fun testRoutingWithOptionalTrailingPathParameter() = withTestApplication {
+        application.routing {
+            get("test/{foo?}") {
+                call.respondText(call.parameters["foo"] ?: "null")
+            }
+        }
+
+        on("making /test/ request") {
+            val result = handleRequest {
+                uri = "test/"
+                method = HttpMethod.Get
+            }
+            it("/test/ should be called") {
+                assertEquals("null", result.response.content)
+            }
+        }
+
+        on("making /test/foo request") {
+            val result = handleRequest {
+                uri = "test/foo"
+                method = HttpMethod.Get
+            }
+            it("/test/foo should be called") {
+                assertEquals("foo", result.response.content)
+            }
+        }
+    }
+
+    @Test
     fun testRoutingWithTransparentQualitySibling() {
         val root = routing()
         val siblingTop = root.handle(PathSegmentParameterRouteSelector("sibling", "top"))


### PR DESCRIPTION
**Subsystem**
Server, routing

**Motivation**
[Mandatory Path Segment parameter can be empty, if no explicit route with trailing / is defined](https://youtrack.jetbrains.com/issue/KTOR-2054)


