### PR TITLE
Cy/micrometer defaults

### DIFF
--- a/ktor-features/ktor-metrics-micrometer/jvm/src/io/ktor/metrics/micrometer/MicrometerMetrics.kt
+++ b/ktor-features/ktor-metrics-micrometer/jvm/src/io/ktor/metrics/micrometer/MicrometerMetrics.kt
@@ -17,6 +17,7 @@ import io.micrometer.core.instrument.binder.jvm.*
 import io.micrometer.core.instrument.binder.system.*
 import io.micrometer.core.instrument.config.*
 import io.micrometer.core.instrument.distribution.*
+import io.micrometer.core.instrument.logging.*
 import java.util.concurrent.atomic.*
 
 /**
@@ -87,12 +88,12 @@ public class MicrometerMetrics private constructor(
      * contain request path or fallback to common `n/a` value. `true` by default
      * */
     public class Configuration {
-
-        public lateinit var registry: MeterRegistry
+        public var registry: MeterRegistry = LoggingMeterRegistry()
 
         public var distinctNotRegisteredRoutes: Boolean = true
 
-        internal fun isRegistryInitialized() = this::registry.isInitialized
+        @Deprecated("Will be removed because there is always registry")
+        internal fun isRegistryInitialized() = true
 
         public var meterBinders: List<MeterBinder> = listOf(
             ClassLoaderMetrics(),
@@ -184,12 +185,6 @@ public class MicrometerMetrics private constructor(
 
         override fun install(pipeline: Application, configure: Configuration.() -> Unit): MicrometerMetrics {
             val configuration = Configuration().apply(configure)
-
-            if (!configuration.isRegistryInitialized()) {
-                throw IllegalArgumentException(
-                    "Meter registry is missing. Please initialize the field 'registry'"
-                )
-            }
 
             val feature = MicrometerMetrics(
                 configuration.registry,

--- a/ktor-features/ktor-metrics-micrometer/jvm/test/io/ktor/metrics/micrometer/MicrometerMetricsTests.kt
+++ b/ktor-features/ktor-metrics-micrometer/jvm/test/io/ktor/metrics/micrometer/MicrometerMetricsTests.kt
@@ -20,13 +20,12 @@ import kotlin.reflect.*
 import kotlin.test.*
 
 class MicrometerMetricsTests {
-
-    var noHandlerHandledReqeust = false
-    var throwableCaughtInEngine: Throwable? = null
+    private var noHandlerHandledRequest = false
+    private var throwableCaughtInEngine: Throwable? = null
 
     @BeforeTest
     fun reset() {
-        noHandlerHandledReqeust = false
+        noHandlerHandledRequest = false
         throwableCaughtInEngine = null
     }
 
@@ -226,7 +225,7 @@ class MicrometerMetricsTests {
         }
 
         assertNull(throwableCaughtInEngine)
-        assertTrue(noHandlerHandledReqeust)
+        assertTrue(noHandlerHandledRequest)
     }
 
     @Test
@@ -259,7 +258,7 @@ class MicrometerMetricsTests {
             }
 
             assertNull(throwableCaughtInEngine)
-            assertTrue(noHandlerHandledReqeust)
+            assertTrue(noHandlerHandledRequest)
         }
 
     private fun TestApplicationEngine.installDefaultBehaviour() {
@@ -267,7 +266,7 @@ class MicrometerMetricsTests {
             try {
                 call.application.execute(call)
                 if (call.response.status() == HttpStatusCode.NotFound) {
-                    noHandlerHandledReqeust = true
+                    noHandlerHandledRequest = true
                 }
             } catch (t: Throwable) {
                 throwableCaughtInEngine = t


### PR DESCRIPTION
**Subsystem**
Ktor-metrics-micrometer

**Motivation**
[KTOR-1781 Set Default Registry for MicrometerMetrics feature](https://youtrack.jetbrains.com/issue/KTOR-1781)
There is no default for micrometer registry so the empty configuration does always crash.

**Solution**
Make `LoggingMeterRegistry` the default registry with it's default options so it will log metrics every minute using an slf4j logger.

I believe it is not a breaking change so we can release this change in 1.5.2