### PR TITLE
Check if there are multiple unsafe headers in request

### DIFF
--- a/ktor-client/ktor-client-core/common/src/io/ktor/client/engine/HttpClientEngine.kt
+++ b/ktor-client/ktor-client-core/common/src/io/ktor/client/engine/HttpClientEngine.kt
@@ -133,9 +133,10 @@ internal expect suspend fun HttpClientEngine.createCallContext(parentJob: Job): 
  */
 private fun validateHeaders(request: HttpRequestData) {
     val requestHeaders = request.headers
-    for (header in HttpHeaders.UnsafeHeadersList) {
-        if (header in requestHeaders) {
-            throw UnsafeHeaderException(header)
-        }
+    val unsafeRequestHeaders = requestHeaders.names().filter {
+        it in HttpHeaders.UnsafeHeadersList
+    }
+    if (unsafeRequestHeaders.isNotEmpty()) {
+        throw UnsafeHeaderException(unsafeRequestHeaders.toString())
     }
 }

--- a/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/HeadersTest.kt
+++ b/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/HeadersTest.kt
@@ -68,4 +68,18 @@ class HeadersTest : ClientLoader() {
             }
         }
     }
+
+    @Test
+    fun testUnsafeHeaders() = clientTests {
+        test { client ->
+            assertFailsWith<UnsafeHeaderException>("Header(s) ${HttpHeaders.UnsafeHeadersList} are controlled by the engine and cannot be set explicitly") {
+                client.get<HttpResponse>("$TEST_SERVER/headers") {
+                    header(HttpHeaders.ContentLength, 0)
+                    header(HttpHeaders.ContentType, ContentType.Application.Json)
+                    header(HttpHeaders.TransferEncoding, "chunked")
+                    header(HttpHeaders.Upgrade, "upgrade")
+                }
+            }
+        }
+    }
 }

--- a/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/HeadersTest.kt
+++ b/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/HeadersTest.kt
@@ -72,7 +72,9 @@ class HeadersTest : ClientLoader() {
     @Test
     fun testUnsafeHeaders() = clientTests {
         test { client ->
-            assertFailsWith<UnsafeHeaderException>("Header(s) ${HttpHeaders.UnsafeHeadersList} are controlled by the engine and cannot be set explicitly") {
+            assertFailsWith<UnsafeHeaderException>(
+                "Header(s) ${HttpHeaders.UnsafeHeadersList} are controlled by the engine and cannot be set explicitly"
+            ) {
                 client.get<HttpResponse>("$TEST_SERVER/headers") {
                     header(HttpHeaders.ContentLength, 0)
                     header(HttpHeaders.ContentType, ContentType.Application.Json)

--- a/ktor-http/common/src/io/ktor/http/HttpHeaders.kt
+++ b/ktor-http/common/src/io/ktor/http/HttpHeaders.kt
@@ -159,7 +159,7 @@ public object HttpHeaders {
  * Thrown when an attempt to set unsafe header detected. A header is unsafe if listed in [HttpHeaders.UnsafeHeadersList].
  */
 public class UnsafeHeaderException(header: String) : IllegalArgumentException(
-    "Header $header is controlled by the engine and " +
+    "Header(s) $header are controlled by the engine and " +
         "cannot be set explicitly"
 )
 


### PR DESCRIPTION
**Subsystem**
ktor-client

**Motivation**
If a user adds multiple unsafe headers to a request, then an UnsafeHeadersException will only be thrown on the first unsafe header it finds. The user will then remove that header from their request, try again, and then see another error with the other unsafe header that it finds.

**Solution**
All of the unsafe headers in a request should be identified and then returned to the user, rather than just the first one.
