### PR TITLE
KTOR-2162: Fix JettyKtorHandler dispatcher grow problem.

### DIFF
--- a/ktor-server/ktor-server-jetty/jvm/src/io/ktor/server/jetty/JettyKtorHandler.kt
+++ b/ktor-server/ktor-server-jetty/jvm/src/io/ktor/server/jetty/JettyKtorHandler.kt
@@ -33,13 +33,12 @@ internal class JettyKtorHandler(
     configuration: JettyApplicationEngineBase.Configuration
 ) : AbstractHandler(), CoroutineScope {
     private val environmentName = environment.connectors.joinToString("-") { it.port.toString() }
-    private val queue: BlockingQueue<Runnable> = LinkedBlockingQueue()
     private val executor = ThreadPoolExecutor(
         configuration.callGroupSize,
         configuration.callGroupSize * 8,
         THREAD_KEEP_ALIVE_TIME,
         TimeUnit.MINUTES,
-        queue
+        SynchronousQueue<Runnable>(),
     ) { r ->
         Thread(r, "ktor-jetty-$environmentName-${JettyKtorCounter.incrementAndGet()}")
     }


### PR DESCRIPTION
**Subsystem**
Jetty engine

**Motivation**
From the issue:
JettyKtorHandler has the following code
```
    private val queue: BlockingQueue<Runnable> = LinkedBlockingQueue()
    private val executor = ThreadPoolExecutor(
        configuration.callGroupSize,
        configuration.callGroupSize * 8,
        THREAD_KEEP_ALIVE_TIME,
        TimeUnit.MINUTES,
        queue
    ) { r ->
        Thread(r, "ktor-jetty-$environmentName-${JettyKtorCounter.incrementAndGet()}")
    }
```
I believe the intention is to have an executor of size `configuration.callGroupSize`, burstable to `configuration.callGroupSize * 8` and then queue the tasks once that has been reached. However, this is not the case since `ThreadPoolExecutor` will only increase number of threads above core size if `queue.offer()` returns `false` which it never will since it is unbounded. See https://stackoverflow.com/a/19528305/422924 . However I am not a fan of the "solution" described.

**Solution**
I will instead suggest that queue is replaced with `SynchronousQueue<Runnable>()` which is what `Executors` uses in the non-fixed thread count cases. The new resulting behavior is the same except that, after growing to `configuration.callGroupSize * 8` threads (which is quite a fair amount) then instead of queuing tasks it will block and provide much needed back pressure to Jetty.

