### PR TITLE
KTOR-2057 Fix decoding of equals sign in query value

### DIFF
--- a/ktor-http/common/src/io/ktor/http/Codecs.kt
+++ b/ktor-http/common/src/io/ktor/http/Codecs.kt
@@ -148,12 +148,12 @@ internal fun String.encodeURLParameterValue(): String = buildString {
         } else {
             val byte1 = content.readByte()
             val byte2 = content.readByte()
-            if (byte1 != '3'.toByte() || (byte2 != 'D'.toByte() && byte2 != 'd'.toByte())) {
+            if (byte1 == '3'.toByte() && (byte2 == 'D'.toByte() || byte2 == 'd'.toByte())) {
+                append("%3D")
+            } else {
                 encodeSymbol(symbol)
                 encodeSymbol(byte1)
                 encodeSymbol(byte2)
-            } else {
-                append("%3D")
             }
         }
     }

--- a/ktor-http/common/test/io/ktor/tests/http/URLBuilderTest.kt
+++ b/ktor-http/common/test/io/ktor/tests/http/URLBuilderTest.kt
@@ -190,6 +190,14 @@ internal class URLBuilderTest {
         assertEquals("http://ktor.io/id+test&test~test%23test", url)
     }
 
+    @Test
+    fun testEncodedEqualsSignParam() {
+        testBuildString("https://test.net?s=t%3Bv")
+        testBuildString("https://test.net?s=k=v")
+        testBuildString("https://test.net?s=k%3Dv")
+        testBuildString("https://test.net?s=k%3Dv%3D%3D%3B%3D")
+    }
+
     /**
      * Checks that the given [url] and the result of [URLBuilder.buildString] is equal (case insensitive).
      */


### PR DESCRIPTION
**Subsystem**
Client/Server, HTTP

**Motivation**
['%3D' inside query of redirect target location will be replaced to '='](https://youtrack.jetbrains.com/issue/KTOR-2057)

**Solution**
We have a special case when creating a string from URL for `=` sign in query argument to not encode it. But we need the mirrored special case when creating URL from string to not decode `%3D`. Otherwise, the transformation from string to URL and back will not be idempotent.
