### PR TITLE
KTOR-2143 Fixed CIO server wrong requested URL

### DIFF
--- a/ktor-server/ktor-server-cio/jvm/src/io/ktor/server/cio/CIOApplicationRequest.kt
+++ b/ktor-server/ktor-server-cio/jvm/src/io/ktor/server/cio/CIOApplicationRequest.kt
@@ -43,8 +43,8 @@ internal class CIOApplicationRequest(
             get() = request.uri.toString()
 
         override val host: String
-            get() = localAddress?.let { it.hostName ?: it.address.hostAddress }
-                ?: request.headers["Host"]?.toString()?.substringBefore(":")
+            get() = request.headers["Host"]?.toString()?.substringBefore(":")
+                ?: localAddress?.let { it.hostName ?: it.address.hostAddress }
                 ?: "localhost"
 
         override val port: Int


### PR DESCRIPTION
**Subsystem**
CIO Server

**Motivation**
CIO server would use wrong request URL, causing OAuth to return `redirect_uri_mismatch`. [KTOR-2143](https://youtrack.jetbrains.com/issue/KTOR-2143).

**Solution**
Reverse `host`'s get condition logic to be like `Netty` and `Jetty`.

