### PR TITLE
KTOR-2194 Force ContentNegotiation to verify Accept and ContentType header compliance

### DIFF
--- a/ktor-server/ktor-server-core/api/ktor-server-core.api
+++ b/ktor-server/ktor-server-core/api/ktor-server-core.api
@@ -438,15 +438,17 @@ public abstract interface class io/ktor/features/ContentConverter {
 
 public final class io/ktor/features/ContentNegotiation {
 	public static final field Feature Lio/ktor/features/ContentNegotiation$Feature;
-	public fun <init> (Ljava/util/List;Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/util/List;Ljava/util/List;)V
 	public final fun getRegistrations ()Ljava/util/List;
 }
 
 public final class io/ktor/features/ContentNegotiation$Configuration {
 	public fun <init> ()V
 	public final fun accept (Lkotlin/jvm/functions/Function2;)V
+	public final fun getCheckAcceptHeaderCompliance ()Z
 	public final fun register (Lio/ktor/http/ContentType;Lio/ktor/features/ContentConverter;Lkotlin/jvm/functions/Function1;)V
 	public static synthetic fun register$default (Lio/ktor/features/ContentNegotiation$Configuration;Lio/ktor/http/ContentType;Lio/ktor/features/ContentConverter;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+	public final fun setCheckAcceptHeaderCompliance (Z)V
 }
 
 public final class io/ktor/features/ContentNegotiation$ConverterRegistration {

--- a/ktor-server/ktor-server-core/jvm/src/io/ktor/features/ContentNegotiation.kt
+++ b/ktor-server/ktor-server-core/jvm/src/io/ktor/features/ContentNegotiation.kt
@@ -71,9 +71,11 @@ public class ContentNegotiation internal constructor(
             return true
         }
         return acceptItems.any {
-            it.contentType.contentType == "*"
-                || (it.contentType.contentType == contentType.contentType
-                && (it.contentType.contentSubtype == "*" || it.contentType.contentSubtype == contentType.contentSubtype))
+            val isWildcard = it.contentType.contentType == "*"
+            val isSameType = it.contentType.contentType == contentType.contentType
+            val isSameSubtype = it.contentType.contentSubtype == "*" ||
+                it.contentType.contentSubtype == contentType.contentSubtype
+            isWildcard || (isSameType && isSameSubtype)
         }
     }
 
@@ -238,7 +240,8 @@ public class ContentNegotiation internal constructor(
 /**
  * A custom content converted that could be registered in [ContentNegotiation] feature for any particular content type
  * Could provide bi-directional conversion implementation.
- * One of the most typical examples of content converter is a json content converter that provides both serialization and deserialization
+ * One of the most typical examples of content converter is a
+ * json content converter that provides both serialization and deserialization
  */
 public interface ContentConverter {
     /**

--- a/ktor-server/ktor-server-core/jvm/src/io/ktor/features/ContentNegotiation.kt
+++ b/ktor-server/ktor-server-core/jvm/src/io/ktor/features/ContentNegotiation.kt
@@ -70,13 +70,7 @@ public class ContentNegotiation internal constructor(
         if (contentType == null) {
             return true
         }
-        return acceptItems.any {
-            val isWildcard = it.contentType.contentType == "*"
-            val isSameType = it.contentType.contentType == contentType.contentType
-            val isSameSubtype = it.contentType.contentSubtype == "*" ||
-                it.contentType.contentSubtype == contentType.contentSubtype
-            isWildcard || (isSameType && isSameSubtype)
-        }
+        return acceptItems.any { contentType.match(it.contentType) }
     }
 
     /**


### PR DESCRIPTION
**Subsystem**
Server, ContentNegotiation

**Motivation**
[call.respond() will not check or apply ContentNegotiation for some types](https://youtrack.jetbrains.com/issue/KTOR-2194)

**Solution**
Add a flag to `ContentNegotiation` feature that will check accept header of response and content-type header of the request
