### PR TITLE
KTOR-1692 Support custom kotlin modules in jackson {} DSL

### DIFF
--- a/ktor-features/ktor-jackson/jvm/src/io/ktor/jackson/JacksonConverter.kt
+++ b/ktor-features/ktor-jackson/jvm/src/io/ktor/jackson/JacksonConverter.kt
@@ -74,7 +74,7 @@ public fun ContentNegotiation.Configuration.jackson(
     contentType: ContentType = ContentType.Application.Json,
     block: ObjectMapper.() -> Unit = {}
 ) {
-    val mapper = jacksonObjectMapper()
+    val mapper = ObjectMapper()
     mapper.apply {
         setDefaultPrettyPrinter(
             DefaultPrettyPrinter().apply {
@@ -84,6 +84,7 @@ public fun ContentNegotiation.Configuration.jackson(
         )
     }
     mapper.apply(block)
+    mapper.registerKotlinModule()
     val converter = JacksonConverter(mapper)
     register(contentType, converter)
 }


### PR DESCRIPTION
**Subsystem**
Server, jackson

**Motivation**
[Can't override Kotlin module configuration using jackson dsl function](https://youtrack.jetbrains.com/issue/KTOR-1692)

**Solution**
Move default kotlin module registration after user-specified one. Jackson will ignore registering module that already exists.

