### PR TITLE
Adding standard document content types (xlsx, docx, pptx)

### DIFF
--- a/ktor-http/common/src/io/ktor/http/ContentTypes.kt
+++ b/ktor-http/common/src/io/ktor/http/ContentTypes.kt
@@ -172,6 +172,18 @@ public class ContentType private constructor(
             ContentType("application", "x-www-form-urlencoded")
 
         public val Pdf: ContentType = ContentType("application", "pdf")
+        public val Xlsx: ContentType = ContentType(
+            "application",
+            "vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+        )
+        public val Docx: ContentType = ContentType(
+            "application",
+            "vnd.openxmlformats-officedocument.wordprocessingml.document"
+        )
+        public val Pptx: ContentType = ContentType(
+            "application",
+            "vnd.openxmlformats-officedocument.presentationml.presentation"
+        )
         public val ProtoBuf: ContentType = ContentType("application", "protobuf")
         public val Wasm: ContentType = ContentType("application", "wasm")
         public val ProblemJson: ContentType = ContentType("application", "problem+json")


### PR DESCRIPTION
**Subsystem**
Client and Server. ktor-http

**Motivation**
The main purpose of this PR is adding standard report context types. In commercial development we develop a lot of reports in Pdf and Excel formats. But there is no any Xlsx content type in ktor sources.

So kotlin and ktor offer commercial ready solutions for fast developing. I think we can add some well-known conteтt types in ktor. It will help every developer in this hard world :-).

**Solution**
Simply add it.

