### PR TITLE
Fix the high load generator

### DIFF
--- a/ktor-server/ktor-server-test-host/api/ktor-server-test-host.api
+++ b/ktor-server/ktor-server-test-host/api/ktor-server-test-host.api
@@ -69,6 +69,7 @@ public final class io/ktor/server/testing/HighLoadHttpGenerator {
 	public static final fun main ([Ljava/lang/String;)V
 	public final fun mainLoop ()V
 	public final fun shutdown ()V
+	public final fun stat ()Ljava/lang/String;
 	public final fun stop ()V
 }
 

--- a/ktor-server/ktor-server-test-host/api/ktor-server-test-host.api
+++ b/ktor-server/ktor-server-test-host/api/ktor-server-test-host.api
@@ -69,7 +69,6 @@ public final class io/ktor/server/testing/HighLoadHttpGenerator {
 	public static final fun main ([Ljava/lang/String;)V
 	public final fun mainLoop ()V
 	public final fun shutdown ()V
-	public final fun stat ()Ljava/lang/String;
 	public final fun stop ()V
 }
 

--- a/ktor-server/ktor-server-test-host/jvm/src/io/ktor/server/testing/HighLoadHttpGenerator.kt
+++ b/ktor-server/ktor-server-test-host/jvm/src/io/ktor/server/testing/HighLoadHttpGenerator.kt
@@ -7,6 +7,7 @@ package io.ktor.server.testing
 import io.ktor.http.*
 import io.ktor.http.cio.RequestResponseBuilder
 import io.ktor.utils.io.core.*
+import java.lang.StringBuilder
 import java.net.*
 import java.nio.*
 import java.nio.ByteOrder
@@ -88,9 +89,9 @@ public class HighLoadHttpGenerator(
         CODE
     }
 
-    private inner class ClientState(internal val channel: SocketChannel) {
+    private inner class ClientState(val channel: SocketChannel) {
         private val current = requestByteBuffer.duplicate()
-        internal var remaining = 0
+        var remaining = 0
             private set
 
         private var parseState = ParseState.HTTP
@@ -102,7 +103,7 @@ public class HighLoadHttpGenerator(
         var readPending: Boolean = false
         var currentOps = 0
 
-        public fun calcOps(): Int {
+        private fun calcOps(): Int {
             var ops = 0
             if (writePending) {
                 ops = ops or SelectionKey.OP_WRITE
@@ -432,7 +433,8 @@ public class HighLoadHttpGenerator(
             val bb = ByteBuffer.allocateDirect(65536)!!
             bb.order(ByteOrder.BIG_ENDIAN)
 
-            while (!cancelled) {
+            var connectFailureInRowCount = 0
+            while (!cancelled && connectFailureInRowCount < 100) {
                 if (connectionsCount < numberOfConnections) {
                     val ch = provider.openSocketChannel()!!
                     ch.configureBlocking(false)
@@ -449,7 +451,9 @@ public class HighLoadHttpGenerator(
                         }
                         connectionsCount++
                     } catch (t: Throwable) {
+                        ch.close()
                         connectErrors.incrementAndGet()
+                        connectFailureInRowCount++
 //                            println("connect() or register() failed: $t")
                     }
                 }
@@ -457,6 +461,8 @@ public class HighLoadHttpGenerator(
                 for (idx in 0 until writeReady.size) {
                     if (cancelled) break
                     val c = writeReady[idx]
+                    if (!c.channel.isConnected) continue
+
                     try {
                         if (!c.doWrite()) {
                             c.writePending = true
@@ -488,6 +494,7 @@ public class HighLoadHttpGenerator(
                 for (idx in 0 until readReady.size) {
                     if (cancelled) break
                     val c = readReady[idx]
+                    if (!c.channel.isConnected) continue
 
                     try {
                         while (true) {
@@ -541,9 +548,11 @@ public class HighLoadHttpGenerator(
                         val key = iter.next()!!
                         val client = key.attachment() as ClientState
 
-                        if (client.channel.isConnectionPending) {
+                        if (!client.channel.isOpen) {
+                            client.close()
+                        } else if (client.channel.isConnectionPending) {
                             try {
-                                client.channel.finishConnect()
+                                check(client.channel.finishConnect())
                                 writeReady.add(client)
                             } catch (t: Throwable) {
                                 client.close()
@@ -578,6 +587,20 @@ public class HighLoadHttpGenerator(
             }
         }
     }
+
+    fun stat(): String = StringBuilder().apply {
+        appendLine("count: ${count.get()}")
+        appendLine("errors: read ${readErrors.get()}, write ${writeErrors.get()}, connect: ${connectErrors.get()}")
+        if (codeCounts.any { it.get() > 0 }) {
+            appendLine("statuses:")
+            codeCounts.forEachIndexed { idx, a ->
+                val cnt = a.get()
+                if (cnt > 0) {
+                    appendLine("  $idx    $cnt")
+                }
+            }
+        }
+    }.toString()
 
     public companion object {
         private val HTTP11 = "HTTP/1.1".toByteArray()
@@ -674,6 +697,7 @@ public class HighLoadHttpGenerator(
                 threads.forEach { it.interrupt() }
                 joiner.join()
                 println("Terminated.")
+                println(loadGenerator.stat())
             }
         }
 
@@ -727,17 +751,7 @@ public class HighLoadHttpGenerator(
                 println("There are threads get stuck")
             }
 
-            with(manager) {
-                println("count: ${count.get()}")
-                println("errors: read ${readErrors.get()}, write ${writeErrors.get()}, connect: ${connectErrors.get()}")
-                println("statuses:")
-                codeCounts.forEachIndexed { idx, a ->
-                    val cnt = a.get()
-                    if (cnt > 0) {
-                        println("  $idx    $cnt")
-                    }
-                }
-            }
+            println(manager.stat())
         }
     }
 }

--- a/ktor-server/ktor-server-test-host/jvm/src/io/ktor/server/testing/HighLoadHttpGenerator.kt
+++ b/ktor-server/ktor-server-test-host/jvm/src/io/ktor/server/testing/HighLoadHttpGenerator.kt
@@ -450,6 +450,7 @@ public class HighLoadHttpGenerator(
                             client.currentOps = SelectionKey.OP_CONNECT
                         }
                         connectionsCount++
+                        connectFailureInRowCount = 0
                     } catch (t: Throwable) {
                         ch.close()
                         connectErrors.incrementAndGet()
@@ -588,7 +589,7 @@ public class HighLoadHttpGenerator(
         }
     }
 
-    fun stat(): String = StringBuilder().apply {
+    private fun stat(): String = StringBuilder().apply {
         appendLine("count: ${count.get()}")
         appendLine("errors: read ${readErrors.get()}, write ${writeErrors.get()}, connect: ${connectErrors.get()}")
         if (codeCounts.any { it.get() > 0 }) {

--- a/ktor-server/ktor-server-test-host/jvm/src/io/ktor/server/testing/HighLoadHttpGenerator.kt
+++ b/ktor-server/ktor-server-test-host/jvm/src/io/ktor/server/testing/HighLoadHttpGenerator.kt
@@ -7,7 +7,6 @@ package io.ktor.server.testing
 import io.ktor.http.*
 import io.ktor.http.cio.RequestResponseBuilder
 import io.ktor.utils.io.core.*
-import java.lang.StringBuilder
 import java.net.*
 import java.nio.*
 import java.nio.ByteOrder

--- a/ktor-server/ktor-server-test-suites/jvm/src/io/ktor/server/testing/suites/EngineStressSuite.kt
+++ b/ktor-server/ktor-server-test-suites/jvm/src/io/ktor/server/testing/suites/EngineStressSuite.kt
@@ -18,6 +18,7 @@ import io.ktor.server.testing.*
 import io.ktor.utils.io.*
 import io.ktor.utils.io.streams.*
 import kotlinx.coroutines.*
+import kotlinx.coroutines.debug.junit4.*
 import org.junit.runner.*
 import org.junit.runners.model.*
 import java.net.*
@@ -48,6 +49,9 @@ public abstract class EngineStressSuite<TEngine : ApplicationEngine, TConfigurat
     private val endMarkerCrLfBytes = endMarkerCrLf.toByteArray()
 
     public override val timeout: Long = TimeUnit.MILLISECONDS.toSeconds(timeMillis + gracefulMillis + shutdownMillis)
+
+    @get:org.junit.Rule
+    val timout1 = CoroutinesTimeout(200000L, true)
 
     @Test
     public fun singleConnectionSingleThreadNoPipelining() {
@@ -194,6 +198,8 @@ public abstract class EngineStressSuite<TEngine : ApplicationEngine, TConfigurat
 
         HighLoadHttpGenerator.doRun("/", "localhost", port, 8, 50, 10, true, gracefulMillis, timeMillis)
 
+        Thread.sleep(10000)
+
         withUrl("/") {
             assertEquals(endMarkerCrLf, readText())
         }
@@ -313,6 +319,7 @@ public abstract class EngineStressSuite<TEngine : ApplicationEngine, TConfigurat
             }
         }
 
+        println("Starting...")
         HighLoadHttpGenerator.doRun("/ll", "localhost", port, 8, 50, 10, true, gracefulMillis, timeMillis)
 
         withUrl("/") {

--- a/ktor-server/ktor-server-test-suites/jvm/src/io/ktor/server/testing/suites/EngineStressSuite.kt
+++ b/ktor-server/ktor-server-test-suites/jvm/src/io/ktor/server/testing/suites/EngineStressSuite.kt
@@ -168,6 +168,8 @@ public abstract class EngineStressSuite<TEngine : ApplicationEngine, TConfigurat
 
         HighLoadHttpGenerator.doRun("/", "localhost", port, 1, 1, 10, true, gracefulMillis, timeMillis)
 
+        sleepWhileServerIsRestoring()
+
         withUrl("/") {
             assertEquals(endMarkerCrLf, readText())
         }
@@ -182,6 +184,8 @@ public abstract class EngineStressSuite<TEngine : ApplicationEngine, TConfigurat
         }
 
         HighLoadHttpGenerator.doRun("/", "localhost", port, 1, 100, 10, true, gracefulMillis, timeMillis)
+
+        sleepWhileServerIsRestoring()
 
         withUrl("/") {
             assertEquals(endMarkerCrLf, readText())
@@ -198,7 +202,7 @@ public abstract class EngineStressSuite<TEngine : ApplicationEngine, TConfigurat
 
         HighLoadHttpGenerator.doRun("/", "localhost", port, 8, 50, 10, true, gracefulMillis, timeMillis)
 
-        Thread.sleep(10000)
+        sleepWhileServerIsRestoring()
 
         withUrl("/") {
             assertEquals(endMarkerCrLf, readText())
@@ -322,8 +326,16 @@ public abstract class EngineStressSuite<TEngine : ApplicationEngine, TConfigurat
         println("Starting...")
         HighLoadHttpGenerator.doRun("/ll", "localhost", port, 8, 50, 10, true, gracefulMillis, timeMillis)
 
+        sleepWhileServerIsRestoring()
+
         withUrl("/") {
             assertEquals("OK", readText())
         }
+    }
+
+    private fun sleepWhileServerIsRestoring() {
+        // after a high-pressure run it takes time for server to completely recover
+        // so we sleep a little bit before doing a request
+        Thread.sleep(10000)
     }
 }


### PR DESCRIPTION
**Subsystem**
ktor server stress tests

**Motivation**
THis is fix for [KTOR-2081 NettyStressTest.testLongResponse](https://youtrack.jetbrains.com/issue/KTOR-2081) and [KTOR-2080 JettyStressTest.highLoadStressTest](https://youtrack.jetbrains.com/issue/KTOR-2080)

**Solution**
Fix the load generator to close channels and don't fail in the cases when it shouldn't just because of already closed channel.
The second fix is to introduce a delay between the high pressure and a regular request otherwise we get connection timeout. 

