### PR TITLE
Fix flaky CIOSustainabilityTest.testBlockingConcurrency[jvm]

### DIFF
--- a/ktor-network/common/src/io/ktor/network/sockets/SocketOptions.kt
+++ b/ktor-network/common/src/io/ktor/network/sockets/SocketOptions.kt
@@ -4,6 +4,8 @@
 
 package io.ktor.network.sockets
 
+import io.ktor.util.*
+
 internal const val INFINITE_TIMEOUT_MS = Long.MAX_VALUE
 
 /**
@@ -66,6 +68,17 @@ public sealed class SocketOptions(
     public class AcceptorOptions internal constructor(
         customOptions: MutableMap<Any, Any?>
     ) : SocketOptions(customOptions) {
+        /**
+         * Represents TCP server socket backlog size. When a client attempts to connect,
+         * the request is added to the so called backlog until it will be accepted.
+         * Once accept() is invoked, a client socket is removed from the backlog.
+         * If the backlog is too small, it may overflow and upcoming requests will be
+         * rejected by the underlying TCP implementation (usually with RST frame that
+         * usually causes "connection reset by peer" error on the opposite side).
+         */
+        @PublicAPICandidate("1.6.0")
+        internal var backlogSize: Int = 511
+
         override fun copy(): AcceptorOptions {
             return AcceptorOptions(HashMap(customOptions)).apply {
                 copyCommon(this@AcceptorOptions)

--- a/ktor-network/jvm/src/io/ktor/network/sockets/ConnectUtilsJvm.kt
+++ b/ktor-network/jvm/src/io/ktor/network/sockets/ConnectUtilsJvm.kt
@@ -29,6 +29,6 @@ internal actual fun bind(
     nonBlocking()
 
     ServerSocketImpl(this, selector).apply {
-        channel.socket().bind(localAddress)
+        channel.socket().bind(localAddress, socketOptions.backlogSize)
     }
 }

--- a/ktor-server/ktor-server-test-suites/jvm/src/io/ktor/server/testing/suites/SustainabilityTestSuite.kt
+++ b/ktor-server/ktor-server-test-suites/jvm/src/io/ktor/server/testing/suites/SustainabilityTestSuite.kt
@@ -331,7 +331,7 @@ abstract class SustainabilityTestSuite<TEngine : ApplicationEngine, TConfigurati
         val errors = CopyOnWriteArrayList<Throwable>()
 
         val random = Random()
-        for (i in 1..latch.count) {
+        for (i in 1..count) {
             thread {
                 try {
                     withUrl("/$i") {


### PR DESCRIPTION
**Subsystem**
ktor-network, ktor-server-cio

**Motivation**
[KTOR-2265 Fix flaky CIOSustainabilityTest.testBlockingConcurrency](https://youtrack.jetbrains.com/issue/KTOR-2265)

There are two issues around the test. The original issue is that client connections get reset in the test. The other issue is that it wasn't easy to reproduce it on local machines. 

The reason why it was so difficult was a small bug in the test that could reduce the workload accidentally. Fixing it makes it 100% reproducible. 

The reason why connections get reset is that when there is a requests burst, all requests overflows so-called TCP backlog because we use the default backlog size that may vary on different machines and operating systems. Requests that don't fit into the backlog, get replied with an RST frame that causes "connection reset by peer" during the connection establishment.

**Solution**
Introduce the particular TCP backlog size of 511 that is copy-paste from competitors and other TCP server systems like databases.

Created [KTOR-2266 Make TCP backlog size option public](https://youtrack.jetbrains.com/issue/KTOR-2266).
