### PR TITLE
Fix for KTOR-2128.

### DIFF
--- a/ktor-features/ktor-auth/jvm/src/io/ktor/auth/OAuth.kt
+++ b/ktor-features/ktor-auth/jvm/src/io/ktor/auth/OAuth.kt
@@ -109,6 +109,7 @@ public sealed class OAuthServerSettings(public val name: String, public val vers
      * @property nonceManager to be used to produce and verify nonce values
      * @property authorizeUrlInterceptor an interceptor function to customize authorization URL
      * @property accessTokenInterceptor an interceptor function to customize access token request
+     * @property extraParameters extra parameters to send provider during authentication
      */
     public class OAuth2ServerSettings(
         name: String,
@@ -125,7 +126,8 @@ public sealed class OAuthServerSettings(public val name: String, public val vers
 
         public val authorizeUrlInterceptor: URLBuilder.() -> Unit = {},
         public val passParamsInURL: Boolean = false,
-        public val accessTokenInterceptor: HttpRequestBuilder.() -> Unit = {}
+        public val accessTokenInterceptor: HttpRequestBuilder.() -> Unit = {},
+        public val extraParameters: Map<String, String> = emptyMap()
     ) : OAuthServerSettings(name, OAuthVersion.V20) {
         @Deprecated("Binary compatibility", level = DeprecationLevel.HIDDEN)
         public constructor(
@@ -143,6 +145,7 @@ public sealed class OAuthServerSettings(public val name: String, public val vers
 
             authorizeUrlInterceptor: URLBuilder.() -> Unit = {},
             passParamsInURL: Boolean = false,
+            extraParameters: Map<String, String> = emptyMap(),
         ) : this(
             name,
             authorizeUrl,
@@ -155,7 +158,8 @@ public sealed class OAuthServerSettings(public val name: String, public val vers
             nonceManager,
             authorizeUrlInterceptor,
             passParamsInURL,
-            {}
+            {},
+            extraParameters
         )
     }
 }
@@ -326,7 +330,7 @@ public suspend fun PipelineContext<Unit, ApplicationCall>.oauthHandleCallback(
                             provider,
                             callbackUrl,
                             code,
-                            emptyMap(),
+                            provider.extraParameters.toMap(),
                             configure
                         )
 

--- a/ktor-features/ktor-auth/jvm/src/io/ktor/auth/OAuth2.kt
+++ b/ktor-features/ktor-auth/jvm/src/io/ktor/auth/OAuth2.kt
@@ -38,7 +38,8 @@ internal suspend fun PipelineContext<Unit, ApplicationCall>.oauth2(
                 callbackRedirectUrl,
                 state = provider.nonceManager.newNonce(),
                 scopes = provider.defaultScopes,
-                interceptor = provider.authorizeUrlInterceptor
+                interceptor = provider.authorizeUrlInterceptor,
+                extraParameters = provider.extraParameters
             )
         } else {
             withContext(dispatcher) {
@@ -74,7 +75,7 @@ internal suspend fun ApplicationCall.redirectAuthenticateOAuth2(
     settings: OAuthServerSettings.OAuth2ServerSettings,
     callbackRedirectUrl: String,
     state: String,
-    extraParameters: List<Pair<String, String>> = emptyList(),
+    extraParameters: Map<String, String> = emptyMap(),
     scopes: List<String> = emptyList(),
     interceptor: URLBuilder.() -> Unit
 ) {
@@ -128,7 +129,7 @@ private suspend fun ApplicationCall.redirectAuthenticateOAuth2(
     clientId: String,
     state: String,
     scopes: List<String> = emptyList(),
-    parameters: List<Pair<String, String>> = emptyList(),
+    parameters: Map<String, String> = emptyMap(),
     interceptor: URLBuilder.() -> Unit = {}
 ) {
     val url = URLBuilder()

--- a/ktor-features/ktor-auth/jvm/src/io/ktor/auth/OAuthProcedure.kt
+++ b/ktor-features/ktor-auth/jvm/src/io/ktor/auth/OAuthProcedure.kt
@@ -94,7 +94,8 @@ internal fun OAuthAuthenticationProvider.oauth2() {
                         callbackRedirectUrl,
                         state = provider.nonceManager.newNonce(),
                         scopes = provider.defaultScopes,
-                        interceptor = provider.authorizeUrlInterceptor
+                        interceptor = provider.authorizeUrlInterceptor,
+                        extraParameters = provider.extraParameters
                     )
                     it.complete()
                 }


### PR DESCRIPTION
**Subsystem**
ktor-features in oauth2 parameters.

**Motivation**
This exposes extraParameters in OAuth2 access token from settings to allow providers who need this to supply refresh tokens.  See the KTOR-2128 for examples of Google and another provider of what extra parameters they need for refresh tokens towork.

**Solution**
There were already parameters being passed in but were unused by anything AFAICT, so felt ok changing the parameter type from List<Pair<String, String>> to Map<String, String> since that's how the URL builder wanted.