### PR TITLE
KTOR-2311 Fix the assertion that the key exists in the key store

### DIFF
--- a/ktor-server/ktor-server-host-common/jvm/src/io/ktor/server/engine/CommandLine.kt
+++ b/ktor-server/ktor-server-host-common/jvm/src/io/ktor/server/engine/CommandLine.kt
@@ -121,7 +121,7 @@ public fun commandLineEnvironment(args: Array<String>): ApplicationEngineEnviron
                     load(it, sslKeyStorePassword.toCharArray())
                 }
 
-                requireNotNull(getKey(sslKeyAlias, sslPrivateKeyPassword.toCharArray()) == null) {
+                requireNotNull(getKey(sslKeyAlias, sslPrivateKeyPassword.toCharArray())) {
                     "The specified key $sslKeyAlias doesn't exist in the key store $sslKeyStorePath"
                 }
             }


### PR DESCRIPTION
**Subsystem**
Server

**Motivation**
The assertion that the TLS key exists in the key store will trigger properly. Otherwise it fails with NPE somewhere in Netty pipepline during startup

**Solution**
Proper null check for absence of the key

