### PR TITLE
Adding application startup time log

### DIFF
--- a/ktor-server/ktor-server-host-common/jvm/src/io/ktor/server/engine/BaseApplicationEngine.kt
+++ b/ktor-server/ktor-server-host-common/jvm/src/io/ktor/server/engine/BaseApplicationEngine.kt
@@ -29,6 +29,7 @@ public abstract class BaseApplicationEngine(
     public open class Configuration : ApplicationEngine.Configuration()
 
     init {
+        val initializedAt = System.currentTimeMillis()
         BaseApplicationResponse.setupSendPipeline(pipeline.sendPipeline)
         environment.monitor.subscribe(ApplicationStarting) {
             it.receivePipeline.merge(pipeline.receivePipeline)
@@ -38,9 +39,12 @@ public abstract class BaseApplicationEngine(
             it.installDefaultInterceptors()
         }
         environment.monitor.subscribe(ApplicationStarted) {
+            val finishedAt = System.currentTimeMillis()
             environment.connectors.forEach {
                 environment.log.info("Responding at ${it.type.name.toLowerCase()}://${it.host}:${it.port}")
             }
+            val elapsedTimeInSeconds = (finishedAt - initializedAt) / 1_000.0
+            environment.log.info("Started application in $elapsedTimeInSeconds seconds.")
         }
     }
 


### PR DESCRIPTION
**Subsystem**
Server - core

**Motivation**
I've been using Ktor in production for a few months and it is a simple thing that I miss.
I saw a issue (#2006) and that sounds good for me too.
There is a open pull requests from Sep/2020 (#2093) by @pavelgordon that looks like it has been left out, so I basically remade the solution, breaking it down into smaller variables and removing from `forEach` loop.

**Solution**
Calculating the time difference between the Engine `init` and receiving the `ApplicationStarted` event.

```
2021-03-30 21:47:20.370 [main] INFO  ktor.application - Responding at http://0.0.0.0:8090
2021-03-30 21:47:20.370 [main] INFO  ktor.application - Started application in 1.517 seconds
```
> example

--- 
PS: this is my first contribution to an open source project, so sorry for any inconvenience.

