### PR TITLE
KTOR-1780 fix source compatibility

### DIFF
--- a/ktor-client/ktor-client-features/ktor-client-json/api/ktor-client-json.api
+++ b/ktor-client/ktor-client-features/ktor-client-json/api/ktor-client-json.api
@@ -42,6 +42,7 @@ public abstract interface class io/ktor/client/features/json/JsonSerializer {
 
 public final class io/ktor/client/features/json/JsonSerializer$DefaultImpls {
 	public static fun read (Lio/ktor/client/features/json/JsonSerializer;Lio/ktor/client/call/TypeInfo;Lio/ktor/utils/io/core/Input;)Ljava/lang/Object;
+	public static fun read (Lio/ktor/client/features/json/JsonSerializer;Lio/ktor/util/reflect/TypeInfo;Lio/ktor/utils/io/core/Input;)Ljava/lang/Object;
 	public static fun write (Lio/ktor/client/features/json/JsonSerializer;Ljava/lang/Object;)Lio/ktor/http/content/OutgoingContent;
 }
 

--- a/ktor-client/ktor-client-features/ktor-client-json/common/src/io/ktor/client/features/json/JsonSerializer.kt
+++ b/ktor-client/ktor-client-features/ktor-client-json/common/src/io/ktor/client/features/json/JsonSerializer.kt
@@ -33,5 +33,6 @@ public interface JsonSerializer {
     /**
      * Read content from response using information specified in [type].
      */
-    public fun read(type: TypeInfo, body: Input): Any
+    public fun read(type: TypeInfo, body: Input): Any =
+        read(DeprecatedTypeInfo(type.type, type.reifiedType, type.kotlinType), body)
 }


### PR DESCRIPTION
One of the commits added a new method to the interface which broke source compatibility. Add circular delegations between old and new methods to fix it.
Side effect: new implementations of the interface will need to manually peek the method to override.