### PR TITLE
KTOR-2387: Bump com.auth0:jwks-rsa to 0.17.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -38,7 +38,7 @@ jetty_version=9.4.31.v20200723
 jetty_alpn_api_version=1.1.3.v20160715
 json_simple_version=1.1.1
 java_jwt_version=3.13.0
-jwks_rsa_version=0.9.0
+jwks_rsa_version=0.17.0
 
 # utility
 logback_version=1.2.3


### PR DESCRIPTION
**Subsystem**
Server, auth with JWT.

**Motivation**
The immediate goal is adding support for Elliptic Curve public keys. See https://youtrack.jetbrains.com/issue/KTOR-2387.

**Solution**
The dependency already supports EC but in the newest version. Starting from 0.16.0, but 0.17.0 I'd the first version in Maven Central so I propose to use it.
Looking at the release notes for behavior changes between 0.9.0 and 0.17.0, I didn't find anything worth attention, but it would be good if Ktor team member cloud double-check it.

**Testing**
`./gradlew jvmTest` locally succeeds. Replacing the dependency in my project that uses Ktor brings desired results - EC algo is supported.

