### PR TITLE
KTOR-2482 Fixed remove on ConcurrentMap

### DIFF
--- a/ktor-utils/common/src/io/ktor/util/collections/ConcurrentMap.kt
+++ b/ktor-utils/common/src/io/ktor/util/collections/ConcurrentMap.kt
@@ -198,8 +198,8 @@ public class ConcurrentMap<Key : Any, Value : Any>(
         "This is accidentally does insert instead of get. Use computeIfAbsent or getOrElse instead.",
         level = DeprecationLevel.ERROR
     )
-    public fun getOrDefault(key: Key, block: () -> Value): Value = lock.withLock {
-        return@withLock computeIfAbsent(key, block)
+    public fun getOrDefault(key: Key, block: () -> Value): Value = locked {
+        return@locked computeIfAbsent(key, block)
     }
 
     /**

--- a/ktor-utils/common/src/io/ktor/util/collections/internal/ForwardListNode.kt
+++ b/ktor-utils/common/src/io/ktor/util/collections/internal/ForwardListNode.kt
@@ -22,6 +22,7 @@ internal class ForwardListNode<T : Any>(
 
     fun insertAfter(value: T): ForwardListNode<T> {
         val result = ForwardListNode(list, next, value, this)
+        next?.previous = result
         next = result
         return result
     }

--- a/ktor-utils/common/test/io/ktor/util/collections/ConcurrentMapTest.kt
+++ b/ktor-utils/common/test/io/ktor/util/collections/ConcurrentMapTest.kt
@@ -126,5 +126,22 @@ class ConcurrentMapTest {
         }
     }
 
+    @Test
+    fun testRemoveWithOverlappingHashCodes() {
+        val map = ConcurrentMap<A, Any>()
+        map[A("x")] = "val"
+        map[A("y")] = true
+        assertEquals(true, map[A("y")])
+        map.remove(A("x"))
+        assertNull(map[A("x")])
+        assertEquals(true, map[A("y")])
+    }
+
+    class A(val x: String) {
+        override fun equals(other: Any?): Boolean = (other as A).x == x
+        override fun hashCode(): Int = 1
+        override fun toString(): String = "A($x)"
+    }
+
     private fun create(): ConcurrentMap<Int, Int> = ConcurrentMap()
 }


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KTOR-2482

`insertAfter` was not updating `previous` for current `next`, resulting in all `previous` pointing to `head`. That's why `previous.removeNext()` always removed first element after `head`

