### PR TITLE
Make ChunkBuffer constructor public to allow leak tests

### DIFF
--- a/ktor-io/common/src/io/ktor/utils/io/core/internal/ChunkBuffer.kt
+++ b/ktor-io/common/src/io/ktor/utils/io/core/internal/ChunkBuffer.kt
@@ -7,8 +7,7 @@ import io.ktor.utils.io.core.*
 import io.ktor.utils.io.pool.*
 import kotlinx.atomicfu.*
 
-@DangerousInternalIoApi
-public open class ChunkBuffer internal constructor(
+public open class ChunkBuffer(
     memory: Memory,
     origin: ChunkBuffer?,
     internal val parentPool: ObjectPool<ChunkBuffer>?


### PR DESCRIPTION
Fix [KTOR-2442](https://youtrack.jetbrains.com/issue/KTOR-2442)