### PR TITLE
KTOR-2057 fix http redirect with encoded URL

### DIFF
--- a/ktor-client/ktor-client-core/common/src/io/ktor/client/features/HttpRedirect.kt
+++ b/ktor-client/ktor-client-core/common/src/io/ktor/client/features/HttpRedirect.kt
@@ -76,6 +76,7 @@ public class HttpRedirect {
                 requestBuilder = HttpRequestBuilder().apply {
                     takeFromWithExecutionContext(requestBuilder)
                     url.parameters.clear()
+                    url.parameters.urlEncodingOption = UrlEncodingOption.NO_ENCODING
 
                     location?.let { url.takeFrom(it) }
 

--- a/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/HttpRedirectTest.kt
+++ b/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/HttpRedirectTest.kt
@@ -31,6 +31,20 @@ class HttpRedirectTest : ClientLoader() {
     }
 
     @Test
+    fun testRedirectWithEncodedUri() = clientTests {
+        config {
+            install(HttpRedirect)
+        }
+
+        test { client ->
+            client.get<HttpStatement>("$TEST_URL_BASE/encodedQuery").execute {
+                assertEquals(HttpStatusCode.OK, it.status)
+                assertEquals("/redirect/getWithUri?key=value1%3Bvalue2%3D%22some=thing", it.readText())
+            }
+        }
+    }
+
+    @Test
     fun testInfinityRedirect() = clientTests {
         config {
             install(HttpRedirect)

--- a/ktor-client/ktor-client-tests/jvm/src/io/ktor/client/tests/utils/tests/Redirect.kt
+++ b/ktor-client/ktor-client-tests/jvm/src/io/ktor/client/tests/utils/tests/Redirect.kt
@@ -6,6 +6,7 @@ package io.ktor.client.tests.utils.tests
 
 import io.ktor.application.*
 import io.ktor.client.tests.utils.*
+import io.ktor.request.*
 import io.ktor.response.*
 import io.ktor.routing.*
 
@@ -18,8 +19,14 @@ internal fun Application.redirectTest() {
             get("/get") {
                 call.respondText("OK")
             }
+            get("/getWithUri") {
+                call.respondText(call.request.uri)
+            }
             get("/infinity") {
                 call.respondRedirect("/redirect/infinity")
+            }
+            get("/encodedQuery") {
+                call.respondRedirect("/redirect/getWithUri?key=value1%3Bvalue2%3D%22some=thing")
             }
             get("/cookie") {
                 val token = call.request.cookies["Token"] ?: run {

--- a/ktor-features/ktor-auth/jvm/src/io/ktor/auth/OAuth2.kt
+++ b/ktor-features/ktor-auth/jvm/src/io/ktor/auth/OAuth2.kt
@@ -137,7 +137,7 @@ private suspend fun ApplicationCall.redirectAuthenticateOAuth2(
         append(OAuth2RequestParameters.ClientId, clientId)
         append(OAuth2RequestParameters.RedirectUri, callbackRedirectUrl)
         if (scopes.isNotEmpty()) {
-            append(OAuth2RequestParameters.Scope, scopes.joinToString(" "))
+            append(OAuth2RequestParameters.Scope, scopes.joinToString("+"))
         }
         append(OAuth2RequestParameters.State, state)
         append(OAuth2RequestParameters.ResponseType, "code")

--- a/ktor-http/api/ktor-http.api
+++ b/ktor-http/api/ktor-http.api
@@ -801,6 +801,7 @@ public final class io/ktor/http/ParametersBuilder : io/ktor/util/StringValuesBui
 	public fun build ()Lio/ktor/http/Parameters;
 	public synthetic fun build ()Lio/ktor/util/StringValues;
 	public final fun getUrlEncodingOption ()Lio/ktor/http/UrlEncodingOption;
+	public final fun setUrlEncodingOption (Lio/ktor/http/UrlEncodingOption;)V
 }
 
 public final class io/ktor/http/ParametersImpl : io/ktor/util/StringValuesImpl, io/ktor/http/Parameters {
@@ -830,6 +831,8 @@ public final class io/ktor/http/ParametersSingleImpl : io/ktor/util/StringValues
 public final class io/ktor/http/QueryKt {
 	public static final fun parseQueryString (Ljava/lang/String;II)Lio/ktor/http/Parameters;
 	public static synthetic fun parseQueryString$default (Ljava/lang/String;IIILjava/lang/Object;)Lio/ktor/http/Parameters;
+	public static final fun parseQueryStringTo (Lio/ktor/http/ParametersBuilder;Ljava/lang/String;II)V
+	public static synthetic fun parseQueryStringTo$default (Lio/ktor/http/ParametersBuilder;Ljava/lang/String;IIILjava/lang/Object;)V
 }
 
 public final class io/ktor/http/RangeUnits : java/lang/Enum {

--- a/ktor-http/common/src/io/ktor/http/Codecs.kt
+++ b/ktor-http/common/src/io/ktor/http/Codecs.kt
@@ -133,16 +133,7 @@ public fun String.encodeURLParameter(
 /**
  * Encode [this] as query parameter value.
  */
-internal fun String.encodeURLParameterValue(): String = buildString {
-    val content = Charsets.UTF_8.newEncoder().encode(this@encodeURLParameterValue)
-    content.forEach {
-        when {
-            it in URL_ALPHABET || it in OAUTH_SYMBOLS || it == '='.toByte() -> append(it.toChar())
-            it == ' '.toByte() -> append('+')
-            else -> append(it.percentEncode())
-        }
-    }
-}
+internal fun String.encodeURLParameterValue(): String = encodeURLParameter(spaceToPlus = true)
 
 /**
  * Decode URL query component

--- a/ktor-http/common/src/io/ktor/http/Parameters.kt
+++ b/ktor-http/common/src/io/ktor/http/Parameters.kt
@@ -36,7 +36,7 @@ public interface Parameters : StringValues {
 @Suppress("KDocMissingDocumentation")
 public class ParametersBuilder(
     size: Int = 8,
-    public val urlEncodingOption: UrlEncodingOption = UrlEncodingOption.DEFAULT
+    public var urlEncodingOption: UrlEncodingOption = UrlEncodingOption.DEFAULT
 ) : StringValuesBuilder(true, size) {
 
     @Deprecated("Binary compatibility", level = DeprecationLevel.HIDDEN)

--- a/ktor-http/common/src/io/ktor/http/Query.kt
+++ b/ktor-http/common/src/io/ktor/http/Query.kt
@@ -15,6 +15,21 @@ public fun parseQueryString(query: String, startIndex: Int = 0, limit: Int = 100
     }
 }
 
+/**
+ * Parse query string withing starting at the specified [startIndex] but up to [limit] pairs
+ */
+public fun parseQueryStringTo(
+    parametersBuilder: ParametersBuilder,
+    query: String,
+    startIndex: Int = 0,
+    limit: Int = 1000
+) {
+    if (startIndex > query.lastIndex) {
+        return
+    }
+    parametersBuilder.parse(query, startIndex, limit)
+}
+
 private fun ParametersBuilder.parse(query: String, startIndex: Int, limit: Int) {
     var count = 0
     var nameIndex = startIndex
@@ -49,18 +64,28 @@ private fun ParametersBuilder.appendParam(query: String, nameIndex: Int, equalIn
         val spaceEndIndex = trimEnd(spaceNameIndex, endIndex, query)
 
         if (spaceEndIndex > spaceNameIndex) {
-            val name = query.decodeURLQueryComponent(spaceNameIndex, spaceEndIndex)
+            val name = when {
+                urlEncodingOption.encodeKey -> query.decodeURLQueryComponent(spaceNameIndex, spaceEndIndex)
+                else -> query.substring(spaceNameIndex, spaceEndIndex)
+            }
             appendAll(name, emptyList())
         }
     } else {
         val spaceNameIndex = trimStart(nameIndex, equalIndex, query)
         val spaceEqualIndex = trimEnd(spaceNameIndex, equalIndex, query)
         if (spaceEqualIndex > spaceNameIndex) {
-            val name = query.decodeURLQueryComponent(spaceNameIndex, spaceEqualIndex)
+            val name = when {
+                urlEncodingOption.encodeKey -> query.decodeURLQueryComponent(spaceNameIndex, spaceEqualIndex)
+                else -> query.substring(spaceNameIndex, spaceEqualIndex)
+            }
 
             val spaceValueIndex = trimStart(equalIndex + 1, endIndex, query)
             val spaceEndIndex = trimEnd(spaceValueIndex, endIndex, query)
-            val value = query.decodeURLQueryComponent(spaceValueIndex, spaceEndIndex, plusIsSpace = true)
+            val value = when {
+                urlEncodingOption.encodeValue -> query
+                    .decodeURLQueryComponent(spaceValueIndex, spaceEndIndex, plusIsSpace = true)
+                else -> query.substring(spaceValueIndex, spaceEndIndex)
+            }
             append(name, value)
         }
     }

--- a/ktor-http/common/src/io/ktor/http/URLParser.kt
+++ b/ktor-http/common/src/io/ktor/http/URLParser.kt
@@ -155,10 +155,7 @@ private fun URLBuilder.parseQuery(urlString: String, startIndex: Int, endIndex: 
 
     val fragmentStart = urlString.indexOf('#', startIndex + 1).takeIf { it > 0 } ?: endIndex
 
-    val rawParameters = parseQueryString(urlString.substring(startIndex + 1, fragmentStart))
-    rawParameters.forEach { key, values ->
-        parameters.appendAll(key, values)
-    }
+    parseQueryStringTo(parameters, urlString.substring(startIndex + 1, fragmentStart))
 
     return fragmentStart
 }

--- a/ktor-http/common/src/io/ktor/http/URLUtils.kt
+++ b/ktor-http/common/src/io/ktor/http/URLUtils.kt
@@ -47,6 +47,7 @@ public fun URLBuilder.takeFrom(url: URLBuilder): URLBuilder {
     user = url.user
     password = url.password
     parameters.appendAll(url.parameters)
+    parameters.urlEncodingOption = url.parameters.urlEncodingOption
     fragment = url.fragment
     trailingQuery = url.trailingQuery
 
@@ -64,6 +65,7 @@ public fun URLBuilder.takeFrom(url: Url): URLBuilder {
     user = url.user
     password = url.password
     parameters.appendAll(url.parameters)
+    parameters.urlEncodingOption = url.parameters.urlEncodingOption
     fragment = url.fragment
     trailingQuery = url.trailingQuery
 

--- a/ktor-http/common/test/io/ktor/tests/http/UrlTest.kt
+++ b/ktor-http/common/test/io/ktor/tests/http/UrlTest.kt
@@ -128,6 +128,20 @@ class UrlTest {
                 "?__gda__=exp=1604350711~hmac=417cbd5a97b4c499e2cf7e9eae5dfb9ad95b42cb3ff76c5fb0fae70e2a42db9c&..."
 
         val url = URLBuilder().apply {
+            parameters.urlEncodingOption = UrlEncodingOption.NO_ENCODING
+            takeFrom(urlString)
+        }.build()
+
+        assertEquals(urlString, url.toString())
+    }
+
+    @Test
+    fun testDecodedEqualsInQueryValue() {
+        val urlString = "https://host.com/path?" +
+            "response-content-disposition=attachment%3Bfilename%3D%22ForgeGradle-1.2-1.0.0-javadoc.jar%22"
+
+        val url = URLBuilder().apply {
+            parameters.urlEncodingOption = UrlEncodingOption.NO_ENCODING
             takeFrom(urlString)
         }.build()
 

--- a/ktor-http/jvm/src/io/ktor/http/URLUtilsJvm.kt
+++ b/ktor-http/jvm/src/io/ktor/http/URLUtilsJvm.kt
@@ -32,7 +32,8 @@ public fun URLBuilder.takeFrom(uri: URI): URLBuilder {
 
     uri.host?.let { host = it }
     encodedPath = uri.rawPath
-    uri.query?.let { parameters.appendAll(parseQueryString(it)) }
+    parameters.urlEncodingOption = UrlEncodingOption.NO_ENCODING
+    uri.query?.let { parseQueryStringTo(parameters, it) }
     if (uri.query?.isEmpty() == true) {
         trailingQuery = true
     }

--- a/ktor-server/ktor-server-tests/jvm/test/io/ktor/tests/server/http/UrlEncodedTest.kt
+++ b/ktor-server/ktor-server-tests/jvm/test/io/ktor/tests/server/http/UrlEncodedTest.kt
@@ -84,14 +84,14 @@ class UrlEncodedTest {
     @Test
     fun testRenderUrlEncoded() {
         assertEquals("p1=a+b", listOf("p1" to "a b").formUrlEncode())
-        assertEquals("p%3D1=a=b", listOf("p=1" to "a=b").formUrlEncode())
+        assertEquals("p%3D1=a%3Db", listOf("p=1" to "a=b").formUrlEncode())
         assertEquals("p1=a&p1=b&p2=c", listOf("p1" to "a", "p1" to "b", "p2" to "c").formUrlEncode())
     }
 
     @Test
     fun testRenderUrlEncodedStringValues() {
         assertEquals("p1=a+b", parametersOf("p1", listOf("a b")).formUrlEncode())
-        assertEquals("p%3D1=a=b", parametersOf("p=1", listOf("a=b")).formUrlEncode())
+        assertEquals("p%3D1=a%3Db", parametersOf("p=1", listOf("a=b")).formUrlEncode())
         assertEquals("p1=a&p1=b&p2=c", parametersOf("p1" to listOf("a", "b"), "p2" to listOf("c")).formUrlEncode())
     }
 }


### PR DESCRIPTION
Disable query encoding/decoding when creating url from string

Proper fix is comming in 2.0.0 here #2367