### PR TITLE
KTOR-2505 fix testRoutingWithTracing on windows

### DIFF
--- a/ktor-server/ktor-server-tests/jvm/test/io/ktor/tests/server/routing/RoutingProcessingTest.kt
+++ b/ktor-server/ktor-server-tests/jvm/test/io/ktor/tests/server/routing/RoutingProcessingTest.kt
@@ -679,7 +679,7 @@ class RoutingProcessingTest {
   /baz, segment:0 -> FAILURE "Selector didn't match" @ /baz)
   /{param}, segment:0 -> FAILURE "Better match was already found" @ /{param})
   /*, segment:0 -> FAILURE "Better match was already found" @ /*)
-""".toPlatformLineSeparators(),
+""",
                 trace?.buildText()
             )
         }
@@ -701,7 +701,7 @@ class RoutingProcessingTest {
       /{param}/x/(method:GET), segment:2 -> SUCCESS @ /{param}/x/(method:GET))
       /{param}/x/z, segment:2 -> FAILURE "Selector didn't match" @ /{param}/x/z)
   /*, segment:0 -> FAILURE "Better match was already found" @ /*)
-""".toPlatformLineSeparators(),
+""",
                 trace?.buildText()
             )
         }
@@ -723,7 +723,7 @@ class RoutingProcessingTest {
     /baz/{y}, segment:1 -> FAILURE "Better match was already found" @ /baz/{y})
   /{param}, segment:0 -> FAILURE "Better match was already found" @ /{param})
   /*, segment:0 -> FAILURE "Better match was already found" @ /*)
-""".toPlatformLineSeparators(),
+""",
                 trace?.buildText()
             )
         }
@@ -745,7 +745,7 @@ class RoutingProcessingTest {
       /baz/{y}/value, segment:2 -> FAILURE "Selector didn't match" @ /baz/{y}/value)
   /{param}, segment:0 -> FAILURE "Better match was already found" @ /{param})
   /*, segment:0 -> FAILURE "Better match was already found" @ /*)
-""".toPlatformLineSeparators(),
+""",
                 trace?.buildText()
             )
         }
@@ -768,7 +768,7 @@ class RoutingProcessingTest {
     /baz/{y}, segment:1 -> FAILURE "Better match was already found" @ /baz/{y})
   /{param}, segment:0 -> FAILURE "Better match was already found" @ /{param})
   /*, segment:0 -> FAILURE "Better match was already found" @ /*)
-""".toPlatformLineSeparators(),
+""",
                 trace?.buildText()
             )
         }
@@ -791,7 +791,7 @@ class RoutingProcessingTest {
     /baz/{y}, segment:1 -> FAILURE "Better match was already found" @ /baz/{y})
   /{param}, segment:0 -> FAILURE "Better match was already found" @ /{param})
   /*, segment:0 -> FAILURE "Better match was already found" @ /*)
-""".toPlatformLineSeparators(),
+""",
                 trace?.buildText()
             )
         }
@@ -810,7 +810,7 @@ class RoutingProcessingTest {
     /{param}/(method:GET), segment:1 -> SUCCESS @ /{param}/(method:GET))
     /{param}/x, segment:1 -> FAILURE "Selector didn't match" @ /{param}/x)
   /*, segment:0 -> FAILURE "Better match was already found" @ /*)
-""".toPlatformLineSeparators(),
+""",
                 trace?.buildText()
             )
         }
@@ -831,7 +831,7 @@ class RoutingProcessingTest {
       /{param}/x/(method:GET), segment:2 -> SUCCESS @ /{param}/x/(method:GET))
       /{param}/x/z, segment:2 -> FAILURE "Selector didn't match" @ /{param}/x/z)
   /*, segment:0 -> FAILURE "Better match was already found" @ /*)
-""".toPlatformLineSeparators(),
+""",
                 trace?.buildText()
             )
         }
@@ -866,8 +866,6 @@ class RoutingProcessingTest {
             assertEquals(call.response.content, "bar")
         }
     }
-
-    private fun String.toPlatformLineSeparators() = lines().joinToString(System.lineSeparator())
 
     private fun Route.transparent(build: Route.() -> Unit): Route {
         val route = createChild(


### PR DESCRIPTION
`appendLn` was changed to `appendLine` in tracing, which always uses `\n` instead of platform line separators