### PR TITLE
KTOR-2468 New routing resolve algorithm

### DIFF
--- a/ktor-features/ktor-auth/jvm/src/io/ktor/auth/Authentication.kt
+++ b/ktor-features/ktor-auth/jvm/src/io/ktor/auth/Authentication.kt
@@ -325,8 +325,7 @@ public fun Route.authenticate(
  * unless you are writing an extension
  * @param names of authentication providers to be applied to this route
  */
-public class AuthenticationRouteSelector(public val names: List<String?>) :
-    RouteSelector(RouteSelectorEvaluation.qualityTransparent) {
+public class AuthenticationRouteSelector(public val names: List<String?>) : RouteSelector() {
     override fun evaluate(context: RoutingResolveContext, segmentIndex: Int): RouteSelectorEvaluation {
         return RouteSelectorEvaluation(true, RouteSelectorEvaluation.qualityTransparent)
     }

--- a/ktor-features/ktor-websockets/jvm/src/io/ktor/websocket/Routing.kt
+++ b/ktor-features/ktor-websockets/jvm/src/io/ktor/websocket/Routing.kt
@@ -260,7 +260,7 @@ private suspend fun DefaultWebSocketSessionImpl.handleServerSession(
 
 private class WebSocketProtocolsSelector(
     val requiredProtocol: String
-) : RouteSelector(RouteSelectorEvaluation.qualityConstant) {
+) : RouteSelector() {
     override fun evaluate(context: RoutingResolveContext, segmentIndex: Int): RouteSelectorEvaluation {
         val protocols = context.call.request.headers[HttpHeaders.SecWebSocketProtocol]
             ?: return RouteSelectorEvaluation.Failed

--- a/ktor-server/ktor-server-core/api/ktor-server-core.api
+++ b/ktor-server/ktor-server-core/api/ktor-server-core.api
@@ -1409,6 +1409,7 @@ public class io/ktor/routing/Route : io/ktor/application/ApplicationCallPipeline
 }
 
 public abstract class io/ktor/routing/RouteSelector {
+	public fun <init> ()V
 	public fun <init> (D)V
 	public abstract fun evaluate (Lio/ktor/routing/RoutingResolveContext;I)Lio/ktor/routing/RouteSelectorEvaluation;
 	public final fun getQuality ()D
@@ -1448,6 +1449,7 @@ public final class io/ktor/routing/RouteSelectorEvaluation$Companion {
 	public final fun getConstantPath ()Lio/ktor/routing/RouteSelectorEvaluation;
 	public final fun getFailed ()Lio/ktor/routing/RouteSelectorEvaluation;
 	public final fun getMissing ()Lio/ktor/routing/RouteSelectorEvaluation;
+	public final fun getTransparent ()Lio/ktor/routing/RouteSelectorEvaluation;
 	public final fun getWildcardPath ()Lio/ktor/routing/RouteSelectorEvaluation;
 }
 
@@ -1604,6 +1606,8 @@ public final class io/ktor/routing/RoutingResolveTrace {
 	public final fun finish (Lio/ktor/routing/Route;ILio/ktor/routing/RoutingResolveResult;)V
 	public final fun getCall ()Lio/ktor/application/ApplicationCall;
 	public final fun getSegments ()Ljava/util/List;
+	public final fun registerFinalResult (Lio/ktor/routing/RoutingResolveResult;)V
+	public final fun registerSuccessResults (Ljava/util/List;)V
 	public final fun skip (Lio/ktor/routing/Route;ILio/ktor/routing/RoutingResolveResult;)V
 	public fun toString ()Ljava/lang/String;
 }

--- a/ktor-server/ktor-server-core/jvm/src/io/ktor/routing/HostsRoutingBuilder.kt
+++ b/ktor-server/ktor-server-core/jvm/src/io/ktor/routing/HostsRoutingBuilder.kt
@@ -101,7 +101,7 @@ public data class HostRouteSelector(
     val hostList: List<String>,
     val hostPatterns: List<Regex>,
     val portsList: List<Int>
-) : RouteSelector(RouteSelectorEvaluation.qualityConstant) {
+) : RouteSelector() {
     init {
         require(hostList.isNotEmpty() || hostPatterns.isNotEmpty() || portsList.isNotEmpty())
     }

--- a/ktor-server/ktor-server-core/jvm/src/io/ktor/routing/LocalPortRoutingBuilder.kt
+++ b/ktor-server/ktor-server-core/jvm/src/io/ktor/routing/LocalPortRoutingBuilder.kt
@@ -33,7 +33,7 @@ public fun Route.localPort(port: Int, build: Route.() -> Unit): Route {
  *
  * @param port the port to match against
  */
-public data class LocalPortRouteSelector(val port: Int) : RouteSelector(RouteSelectorEvaluation.qualityConstant) {
+public data class LocalPortRouteSelector(val port: Int) : RouteSelector() {
 
     override fun evaluate(context: RoutingResolveContext, segmentIndex: Int): RouteSelectorEvaluation =
         if (context.call.request.local.port == port) {

--- a/ktor-server/ktor-server-core/jvm/src/io/ktor/routing/RouteSelector.kt
+++ b/ktor-server/ktor-server-core/jvm/src/io/ktor/routing/RouteSelector.kt
@@ -71,7 +71,7 @@ public data class RouteSelectorEvaluation(
         public const val qualityTailcard: Double = 0.1
 
         /**
-         * Quality of [RouteSelectorEvaluation] that doesn't have its own priority but uses priority of its children
+         * Quality of [RouteSelectorEvaluation] that doesn't have its own quality but uses quality of its children
          */
         public const val qualityTransparent: Double = -1.0
 

--- a/ktor-server/ktor-server-core/jvm/src/io/ktor/routing/RouteSelector.kt
+++ b/ktor-server/ktor-server-core/jvm/src/io/ktor/routing/RouteSelector.kt
@@ -71,7 +71,7 @@ public data class RouteSelectorEvaluation(
         public const val qualityTailcard: Double = 0.1
 
         /**
-         * Quality of [RouteSelectorEvaluation] that doesn't have it's own priority but should delegate evaluation to it's children
+         * Quality of [RouteSelectorEvaluation] that doesn't have its own priority but uses priority of its children
          */
         public const val qualityTransparent: Double = -1.0
 
@@ -93,7 +93,8 @@ public data class RouteSelectorEvaluation(
             RouteSelectorEvaluation(true, RouteSelectorEvaluation.qualityConstant)
 
         /**
-         * Route evaluation succeeded for a transparent value
+         * Route evaluation succeeded for a [qualityTransparent] value. Useful for helper DSL methods that may wrap
+         * routes but should not change priority of routing
          */
         public val Transparent: RouteSelectorEvaluation =
             RouteSelectorEvaluation(true, RouteSelectorEvaluation.qualityTransparent)

--- a/ktor-server/ktor-server-core/jvm/src/io/ktor/routing/RouteSelector.kt
+++ b/ktor-server/ktor-server-core/jvm/src/io/ktor/routing/RouteSelector.kt
@@ -271,7 +271,7 @@ public object TrailingSlashRouteSelector : RouteSelector() {
 
     override fun evaluate(context: RoutingResolveContext, segmentIndex: Int): RouteSelectorEvaluation = when {
         context.call.ignoreTrailingSlash -> RouteSelectorEvaluation.Transparent
-        context.segments.isEmpty() -> RouteSelectorEvaluation.Transparent
+        context.segments.isEmpty() -> RouteSelectorEvaluation.Constant
         segmentIndex < context.segments.lastIndex -> RouteSelectorEvaluation.Transparent
         segmentIndex > context.segments.lastIndex -> RouteSelectorEvaluation.Failed
         context.segments[segmentIndex].isNotEmpty() -> RouteSelectorEvaluation.Transparent

--- a/ktor-server/ktor-server-core/jvm/src/io/ktor/routing/RoutingResolve.kt
+++ b/ktor-server/ktor-server-core/jvm/src/io/ktor/routing/RoutingResolve.kt
@@ -29,7 +29,7 @@ public sealed class RoutingResolveResult(public val route: Route) {
         internal val quality: Double
     ) : RoutingResolveResult(route) {
 
-        @Deprecated("Binary compatibility")
+        @Deprecated("This is an implementation detail and will become internal in future releases.")
         public constructor(route: Route, parameters: Parameters) : this(route, parameters, 0.0)
 
         override fun toString(): String = "SUCCESS${if (parameters.isEmpty()) "" else "; $parameters"} @ $route"

--- a/ktor-server/ktor-server-core/jvm/src/io/ktor/routing/RoutingResolve.kt
+++ b/ktor-server/ktor-server-core/jvm/src/io/ktor/routing/RoutingResolve.kt
@@ -23,8 +23,16 @@ public sealed class RoutingResolveResult(public val route: Route) {
     /**
      * Represents a successful result
      */
-    public class Success(route: Route, override val parameters: Parameters) : RoutingResolveResult(route) {
-        override fun toString(): String = "SUCCESS${if (parameters.isEmpty()) "" else "; $parameters"} @ $route)"
+    public class Success internal constructor(
+        route: Route,
+        override val parameters: Parameters,
+        internal val quality: Double
+    ) : RoutingResolveResult(route) {
+
+        @Deprecated("Binary compatibility")
+        public constructor(route: Route, parameters: Parameters) : this(route, parameters, 0.0)
+
+        override fun toString(): String = "SUCCESS${if (parameters.isEmpty()) "" else "; $parameters"} @ $route"
     }
 
     /**
@@ -35,7 +43,7 @@ public sealed class RoutingResolveResult(public val route: Route) {
         override val parameters: Nothing
             get() = throw UnsupportedOperationException("Parameters are available only when routing resolve succeeds")
 
-        override fun toString(): String = "FAILURE \"$reason\" @ $route)"
+        override fun toString(): String = "FAILURE \"$reason\" @ $route"
     }
 }
 
@@ -103,126 +111,119 @@ public class RoutingResolveContext(
      */
     public fun resolve(): RoutingResolveResult {
         val root = routing
-        val rootResult = root.selector.evaluate(this, 0)
-        if (!rootResult.succeeded) {
-            return rootResolveFailed(root)
-        }
-
-        val result = resolve(root, rootResult.segmentIncrement)
-        trace?.apply { tracers.forEach { it(this) } }
-        return result
-    }
-
-    private fun rootResolveFailed(root: Route): RoutingResolveResult.Failure {
-        return RoutingResolveResult.Failure(root, "rootPath didn't match").also { result ->
+        val rootEvaluation = root.selector.evaluate(this, 0)
+        if (!rootEvaluation.succeeded) {
+            val result = RoutingResolveResult.Failure(root, "rootPath didn't match")
             trace?.skip(root, 0, result)
+            return result
         }
+        val successResults = mutableListOf<List<RoutingResolveResult.Success>>()
+
+        val rootResolveResult = RoutingResolveResult.Success(root, rootEvaluation.parameters, rootEvaluation.quality)
+        val rootResolveResults = listOf(rootResolveResult)
+
+        trace?.begin(root, 0)
+        resolveStep(
+            root,
+            successResults,
+            rootResolveResults,
+            rootEvaluation.segmentIncrement
+        )
+        trace?.finish(root, 0, rootResolveResult)
+
+        trace?.registerSuccessResults(successResults)
+        val resolveResult = findBestRoute(root, successResults)
+        trace?.registerFinalResult(resolveResult)
+
+        trace?.apply { tracers.forEach { it(this) } }
+        return resolveResult
     }
 
-    private fun resolve(entry: Route, segmentIndex: Int): RoutingResolveResult {
-        trace?.begin(entry, segmentIndex)
+    private fun resolveStep(
+        entry: Route,
+        successResults: MutableList<List<RoutingResolveResult.Success>>,
+        trait: List<RoutingResolveResult.Success>,
+        segmentIndex: Int
+    ): Boolean {
+        var matched = false
+        if (entry.children.isEmpty() && segmentIndex != segments.size) {
+            trace?.skip(entry, segmentIndex, RoutingResolveResult.Failure(entry, "Not all segments matched"))
+            return false
+        }
+        if (entry.handlers.isNotEmpty() && segmentIndex == segments.size) {
+            successResults.add(trait)
+            matched = true
+        }
 
-        // last failed entry for diagnostics
-        var failEntry: Route? = null
-        // best matched entry (with highest quality)
-        var bestResult: RoutingResolveResult? = null
-        var bestQuality = 0.0
-        var bestChild: Route? = null
+        var bestChildResult: RouteSelectorEvaluation? = null
 
-        val children = flattenChildren(entry.children)
         // iterate using indices to avoid creating iterator
-        for (childIndex in 0..children.lastIndex) {
-            val child = children[childIndex]
+        for (childIndex in 0..entry.children.lastIndex) {
+            val child = entry.children[childIndex]
             val selectorResult = child.selector.evaluate(this, segmentIndex)
             if (!selectorResult.succeeded) {
                 trace?.skip(child, segmentIndex, RoutingResolveResult.Failure(child, "Selector didn't match"))
                 continue // selector didn't match, skip entire subtree
             }
-
-            val immediateSelectQuality = when (selectorResult.quality) {
-                // handlers of routes with qualityTransparent should be treated as ones with qualityConstant
-                RouteSelectorEvaluation.qualityTransparent -> RouteSelectorEvaluation.qualityConstant
-                else -> selectorResult.quality
-            }
-
-            if (immediateSelectQuality < bestQuality) {
+            if (bestChildResult != null && selectorResult.quality < bestChildResult.quality) {
                 trace?.skip(child, segmentIndex, RoutingResolveResult.Failure(child, "Better match was already found"))
                 continue
             }
 
-            if (immediateSelectQuality == bestQuality) {
-                // ambiguity, compare immediate child quality
-                if (bestChild!!.selector.quality >= child.selector.quality) {
-                    trace?.skip(child, segmentIndex, RoutingResolveResult.Failure(child, "Lost in ambiguity tie"))
-                    continue
-                }
+            val result = RoutingResolveResult.Success(child, selectorResult.parameters, selectorResult.quality)
+            val newIndex = segmentIndex + selectorResult.segmentIncrement
+            trace?.begin(child, newIndex)
+            val success = resolveStep(child, successResults, trait + result, newIndex)
+            trace?.finish(child, newIndex, result)
+            if (success && (bestChildResult == null || bestChildResult.quality < result.quality)) {
+                bestChildResult = selectorResult
             }
-
-            val subtreeResult = resolve(child, segmentIndex + selectorResult.segmentIncrement)
-            when (subtreeResult) {
-                is RoutingResolveResult.Failure -> {
-                    // subtree didn't match, skip to next child, remember first failed entry
-                    if (failEntry == null) {
-                        failEntry = subtreeResult.route
-                    }
-                }
-                is RoutingResolveResult.Success -> {
-                    bestChild = child
-                    bestQuality = immediateSelectQuality
-                    bestResult = if (selectorResult.parameters.isEmpty()) {
-                        // do not allocate new RoutingResolveResult if it will be the same as subtreeResult
-                        // TODO: Evaluate if we can make RoutingResolveResult mutable altogether and avoid allocations
-                        subtreeResult
-                    } else {
-                        val combinedValues = selectorResult.parameters + subtreeResult.parameters
-                        RoutingResolveResult.Success(subtreeResult.route, combinedValues)
-                    }
-                }
-            }
+            matched = matched || success
         }
-
-        val result = if (segmentIndex == segments.size && entry.handlers.isNotEmpty()) {
-            if (bestResult != null && bestQuality > RouteSelectorEvaluation.qualityMissing) {
-                // child match is better than missing optional parameter, so choose it
-                bestResult
-            } else {
-                // no child matched, or child matched optionally and this node has a handler
-                RoutingResolveResult.Success(entry, Parameters.Empty)
-            }
-        } else {
-            if (bestResult != null) {
-                // child matched
-                bestResult
-            } else {
-                // nothing more to match and no handler, or there are more segments and no matched child
-                val reason = when (segmentIndex) {
-                    segments.size -> "Segments exhausted but no handlers found"
-                    else -> "Not all segments matched"
-                }
-                RoutingResolveResult.Failure(failEntry ?: entry, reason)
-            }
-        }
-
-        trace?.finish(entry, segmentIndex, result)
-        return result
+        return matched
     }
 
-    private fun flattenChildren(children: List<Route>): List<Route> {
-        // to avoid unnecessary allocations, first check if flattening is required
-        // iterate using indices to avoid creating iterator
-        var hasTransparentChildren = false
-        for (childIndex in 0..children.lastIndex) {
-            hasTransparentChildren = children[childIndex].selector.quality == RouteSelectorEvaluation.qualityTransparent
-            if (hasTransparentChildren) break
+    private fun findBestRoute(
+        root: Route,
+        successResults: List<List<RoutingResolveResult.Success>>
+    ): RoutingResolveResult {
+        if (successResults.isEmpty()) {
+            return RoutingResolveResult.Failure(root, "No matched subtrees found")
         }
-        if (!hasTransparentChildren) return children
+        val bestPath = successResults
+            .maxWithOrNull { result1, result2 ->
+                var index1 = 0
+                var index2 = 0
+                while (index1 < result1.size && index2 < result2.size) {
+                    val quality1 = result1[index1].quality
+                    val quality2 = result2[index2].quality
+                    if (quality1 == RouteSelectorEvaluation.qualityTransparent) {
+                        index1++
+                        continue
+                    }
+                    if (quality2 == RouteSelectorEvaluation.qualityTransparent) {
+                        index2++
+                        continue
+                    }
+                    if (quality1 != quality2) {
+                        return@maxWithOrNull compareValues(quality1, quality2)
+                    }
+                    index1++
+                    index2++
+                }
+                compareValues(result1.size, result2.size)
+            }!!
 
-        return children.flatMap {
-            when (it.selector.quality) {
-                RouteSelectorEvaluation.qualityTransparent ->
-                    flattenChildren(it.children) + if (it.handlers.isNotEmpty()) listOf(it) else emptyList()
-                else -> listOf(it)
+        val parameters = bestPath
+            .fold(ParametersBuilder()) { acc, result -> acc.apply { appendAll(result.parameters) } }
+            .build()
+        return RoutingResolveResult.Success(
+            bestPath.last().route,
+            parameters,
+            bestPath.minOf { result ->
+                result.quality.takeUnless { it == RouteSelectorEvaluation.qualityTransparent }
+                    ?: RouteSelectorEvaluation.qualityConstant
             }
-        }
+        )
     }
 }

--- a/ktor-server/ktor-server-core/jvm/src/io/ktor/routing/RoutingResolve.kt
+++ b/ktor-server/ktor-server-core/jvm/src/io/ktor/routing/RoutingResolve.kt
@@ -215,7 +215,7 @@ public class RoutingResolveContext(
             }!!
 
         val parameters = bestPath
-            .fold(ParametersBuilder()) { acc, result -> acc.apply { appendAll(result.parameters) } }
+            .fold(ParametersBuilder()) { builder, result -> builder.appendAll(result.parameters) }
             .build()
         return RoutingResolveResult.Success(
             bestPath.last().route,

--- a/ktor-server/ktor-server-core/jvm/src/io/ktor/routing/RoutingResolve.kt
+++ b/ktor-server/ktor-server-core/jvm/src/io/ktor/routing/RoutingResolve.kt
@@ -120,13 +120,13 @@ public class RoutingResolveContext(
         val successResults = mutableListOf<List<RoutingResolveResult.Success>>()
 
         val rootResolveResult = RoutingResolveResult.Success(root, rootEvaluation.parameters, rootEvaluation.quality)
-        val rootResolveResults = listOf(rootResolveResult)
+        val rootTrait = listOf(rootResolveResult)
 
         trace?.begin(root, 0)
         resolveStep(
             root,
             successResults,
-            rootResolveResults,
+            rootTrait,
             rootEvaluation.segmentIncrement
         )
         trace?.finish(root, 0, rootResolveResult)

--- a/ktor-server/ktor-server-core/jvm/src/io/ktor/routing/RoutingResolveTrace.kt
+++ b/ktor-server/ktor-server-core/jvm/src/io/ktor/routing/RoutingResolveTrace.kt
@@ -5,6 +5,7 @@
 package io.ktor.routing
 
 import io.ktor.application.*
+import io.ktor.util.*
 
 /**
  * Represents a single entry in the [RoutingResolveTrace].
@@ -49,6 +50,8 @@ public open class RoutingResolveTraceEntry(
 public class RoutingResolveTrace(public val call: ApplicationCall, public val segments: List<String>) {
     private val stack = Stack<RoutingResolveTraceEntry>()
     private var routing: RoutingResolveTraceEntry? = null
+    private lateinit var successResults: List<List<RoutingResolveResult>>
+    private lateinit var finalResult: RoutingResolveResult
 
     private fun register(entry: RoutingResolveTraceEntry) {
         if (stack.empty()) {
@@ -83,6 +86,14 @@ public class RoutingResolveTrace(public val call: ApplicationCall, public val se
         register(RoutingResolveTraceEntry(route, segmentIndex, result))
     }
 
+    public fun registerSuccessResults(successResults: List<List<RoutingResolveResult>>) {
+        this.successResults = successResults
+    }
+
+    public fun registerFinalResult(result: RoutingResolveResult) {
+        this.finalResult = result
+    }
+
     override fun toString(): String = "Trace for $segments"
 
     /**
@@ -91,6 +102,23 @@ public class RoutingResolveTrace(public val call: ApplicationCall, public val se
     public fun buildText(): String = buildString {
         appendLine(this@RoutingResolveTrace.toString())
         routing?.buildText(this, 0)
+        if (!this@RoutingResolveTrace::successResults.isInitialized) {
+            return@buildString
+        }
+        appendLine("Matched routes:")
+        if (successResults.isEmpty()) {
+            appendLine("  No results")
+        } else {
+            appendLine(
+                successResults.joinToString("\n") { path ->
+                    path.joinToString(" -> ", prefix = "  ") {
+                        """"${it.route.selector}""""
+                    }
+                }
+            )
+        }
+        appendLine("Route resolve result:")
+        appendLine("  $finalResult")
     }
 }
 

--- a/ktor-server/ktor-server-tests/jvm/test/io/ktor/tests/server/features/StaticContentTest.kt
+++ b/ktor-server/ktor-server-tests/jvm/test/io/ktor/tests/server/features/StaticContentTest.kt
@@ -481,6 +481,34 @@ class StaticContentTest {
             assertTrue(result.requestHandled)
         }
     }
+
+    @Test
+    fun testStaticContentPriority() = withTestApplication {
+        application.routing {
+            route("/before") {
+                get {
+                    call.respond("before")
+                }
+            }
+            static("/") {
+                defaultResource("index.html", "web-resource")
+                resources("web-resource")
+            }
+            route("/after") {
+                get {
+                    call.respond("after")
+                }
+            }
+        }
+
+        handleRequest(HttpMethod.Get, "/before").let { result ->
+            assertEquals("before", result.response.content)
+        }
+
+        handleRequest(HttpMethod.Get, "/after").let { result ->
+            assertEquals("after", result.response.content)
+        }
+    }
 }
 
 private fun String.replaceSeparators() = replace("/", File.separator)

--- a/ktor-server/ktor-server-tests/jvm/test/io/ktor/tests/server/routing/RoutingProcessingTest.kt
+++ b/ktor-server/ktor-server-tests/jvm/test/io/ktor/tests/server/routing/RoutingProcessingTest.kt
@@ -233,7 +233,7 @@ class RoutingProcessingTest {
                 uri = "/z/a/b/c"
                 method = HttpMethod.Get
             }
-            it("should have handled by more specific rout") {
+            it("should have handled by more specific route") {
                 assertEquals("[Z] a/b/c", path)
             }
         }
@@ -242,7 +242,7 @@ class RoutingProcessingTest {
                 uri = "/x/a/b/c"
                 method = HttpMethod.Get
             }
-            it("should have handled by more specific rout") {
+            it("should have handled by more specific route") {
                 assertEquals("x/a/b/c", path)
             }
         }
@@ -689,6 +689,8 @@ class RoutingProcessingTest {
             get("/{param}/x") { call.respond("/{param}/x") }
             get("/{param}/x/z") { call.respond("/{param}/x/z") }
             get("/*/extra") { call.respond("/*/extra") }
+            header("a", "x") { get { call.respond("a") } }
+            header("b", "x") { get { call.respond("b") } }
         }
 
         handleRequest {
@@ -698,12 +700,18 @@ class RoutingProcessingTest {
             assertEquals("/bar", it.response.content)
             assertEquals(
                 """Trace for [bar]
-/, segment:0 -> SUCCESS @ /bar/(method:GET))
-  /bar, segment:1 -> SUCCESS @ /bar/(method:GET))
-    /bar/(method:GET), segment:1 -> SUCCESS @ /bar/(method:GET))
-  /baz, segment:0 -> FAILURE "Selector didn't match" @ /baz)
-  /{param}, segment:0 -> FAILURE "Better match was already found" @ /{param})
-  /*, segment:0 -> FAILURE "Better match was already found" @ /*)
+/, segment:0 -> SUCCESS @ /
+  /bar, segment:1 -> SUCCESS @ /bar
+    /bar/(method:GET), segment:1 -> SUCCESS @ /bar/(method:GET)
+  /baz, segment:0 -> FAILURE "Selector didn't match" @ /baz
+  /{param}, segment:0 -> FAILURE "Better match was already found" @ /{param}
+  /*, segment:0 -> FAILURE "Better match was already found" @ /*
+  /(header:a = x), segment:0 -> FAILURE "Selector didn't match" @ /(header:a = x)
+  /(header:b = x), segment:0 -> FAILURE "Selector didn't match" @ /(header:b = x)
+Matched routes:
+  "" -> "bar" -> "(method:GET)"
+Route resolve result:
+  SUCCESS @ /bar/(method:GET)
 """,
                 trace?.buildText()
             )
@@ -716,16 +724,24 @@ class RoutingProcessingTest {
             assertEquals("/{param}/x", it.response.content)
             assertEquals(
                 """Trace for [bar, x]
-/, segment:0 -> SUCCESS; Parameters [param=[bar]] @ /{param}/x/(method:GET))
-  /bar, segment:1 -> FAILURE "Not all segments matched" @ /bar/(method:GET))
-    /bar/(method:GET), segment:1 -> FAILURE "Not all segments matched" @ /bar/(method:GET))
-  /baz, segment:0 -> FAILURE "Selector didn't match" @ /baz)
-  /{param}, segment:1 -> SUCCESS @ /{param}/x/(method:GET))
-    /{param}/(method:GET), segment:1 -> FAILURE "Not all segments matched" @ /{param}/(method:GET))
-    /{param}/x, segment:2 -> SUCCESS @ /{param}/x/(method:GET))
-      /{param}/x/(method:GET), segment:2 -> SUCCESS @ /{param}/x/(method:GET))
-      /{param}/x/z, segment:2 -> FAILURE "Selector didn't match" @ /{param}/x/z)
-  /*, segment:0 -> FAILURE "Better match was already found" @ /*)
+/, segment:0 -> SUCCESS @ /
+  /bar, segment:1 -> SUCCESS @ /bar
+    /bar/(method:GET), segment:1 -> SUCCESS @ /bar/(method:GET)
+      /bar/(method:GET), segment:1 -> FAILURE "Not all segments matched" @ /bar/(method:GET)
+  /baz, segment:0 -> FAILURE "Selector didn't match" @ /baz
+  /{param}, segment:1 -> SUCCESS; Parameters [param=[bar]] @ /{param}
+    /{param}/(method:GET), segment:1 -> SUCCESS @ /{param}/(method:GET)
+      /{param}/(method:GET), segment:1 -> FAILURE "Not all segments matched" @ /{param}/(method:GET)
+    /{param}/x, segment:2 -> SUCCESS @ /{param}/x
+      /{param}/x/(method:GET), segment:2 -> SUCCESS @ /{param}/x/(method:GET)
+      /{param}/x/z, segment:2 -> FAILURE "Selector didn't match" @ /{param}/x/z
+  /*, segment:0 -> FAILURE "Better match was already found" @ /*
+  /(header:a = x), segment:0 -> FAILURE "Selector didn't match" @ /(header:a = x)
+  /(header:b = x), segment:0 -> FAILURE "Selector didn't match" @ /(header:b = x)
+Matched routes:
+  "" -> "{param}" -> "x" -> "(method:GET)"
+Route resolve result:
+  SUCCESS; Parameters [param=[bar]] @ /{param}/x/(method:GET)
 """,
                 trace?.buildText()
             )
@@ -738,16 +754,23 @@ class RoutingProcessingTest {
             assertEquals("/baz/x", it.response.content)
             assertEquals(
                 """Trace for [baz, x]
-/, segment:0 -> SUCCESS @ /baz/x/(method:GET))
-  /bar, segment:0 -> FAILURE "Selector didn't match" @ /bar)
-  /baz, segment:1 -> SUCCESS @ /baz/x/(method:GET))
-    /baz/(method:GET), segment:1 -> FAILURE "Not all segments matched" @ /baz/(method:GET))
-    /baz/x, segment:2 -> SUCCESS @ /baz/x/(method:GET))
-      /baz/x/(method:GET), segment:2 -> SUCCESS @ /baz/x/(method:GET))
-      /baz/x/{optional?}, segment:2 -> FAILURE "Better match was already found" @ /baz/x/{optional?})
-    /baz/{y}, segment:1 -> FAILURE "Better match was already found" @ /baz/{y})
-  /{param}, segment:0 -> FAILURE "Better match was already found" @ /{param})
-  /*, segment:0 -> FAILURE "Better match was already found" @ /*)
+/, segment:0 -> SUCCESS @ /
+  /bar, segment:0 -> FAILURE "Selector didn't match" @ /bar
+  /baz, segment:1 -> SUCCESS @ /baz
+    /baz/(method:GET), segment:1 -> SUCCESS @ /baz/(method:GET)
+      /baz/(method:GET), segment:1 -> FAILURE "Not all segments matched" @ /baz/(method:GET)
+    /baz/x, segment:2 -> SUCCESS @ /baz/x
+      /baz/x/(method:GET), segment:2 -> SUCCESS @ /baz/x/(method:GET)
+      /baz/x/{optional?}, segment:2 -> FAILURE "Better match was already found" @ /baz/x/{optional?}
+    /baz/{y}, segment:1 -> FAILURE "Better match was already found" @ /baz/{y}
+  /{param}, segment:0 -> FAILURE "Better match was already found" @ /{param}
+  /*, segment:0 -> FAILURE "Better match was already found" @ /*
+  /(header:a = x), segment:0 -> FAILURE "Selector didn't match" @ /(header:a = x)
+  /(header:b = x), segment:0 -> FAILURE "Selector didn't match" @ /(header:b = x)
+Matched routes:
+  "" -> "baz" -> "x" -> "(method:GET)"
+Route resolve result:
+  SUCCESS @ /baz/x/(method:GET)
 """,
                 trace?.buildText()
             )
@@ -760,16 +783,23 @@ class RoutingProcessingTest {
             assertEquals("/baz/{y}", it.response.content)
             assertEquals(
                 """Trace for [baz, doo]
-/, segment:0 -> SUCCESS; Parameters [y=[doo]] @ /baz/{y}/(method:GET))
-  /bar, segment:0 -> FAILURE "Selector didn't match" @ /bar)
-  /baz, segment:1 -> SUCCESS; Parameters [y=[doo]] @ /baz/{y}/(method:GET))
-    /baz/(method:GET), segment:1 -> FAILURE "Not all segments matched" @ /baz/(method:GET))
-    /baz/x, segment:1 -> FAILURE "Selector didn't match" @ /baz/x)
-    /baz/{y}, segment:2 -> SUCCESS @ /baz/{y}/(method:GET))
-      /baz/{y}/(method:GET), segment:2 -> SUCCESS @ /baz/{y}/(method:GET))
-      /baz/{y}/value, segment:2 -> FAILURE "Selector didn't match" @ /baz/{y}/value)
-  /{param}, segment:0 -> FAILURE "Better match was already found" @ /{param})
-  /*, segment:0 -> FAILURE "Better match was already found" @ /*)
+/, segment:0 -> SUCCESS @ /
+  /bar, segment:0 -> FAILURE "Selector didn't match" @ /bar
+  /baz, segment:1 -> SUCCESS @ /baz
+    /baz/(method:GET), segment:1 -> SUCCESS @ /baz/(method:GET)
+      /baz/(method:GET), segment:1 -> FAILURE "Not all segments matched" @ /baz/(method:GET)
+    /baz/x, segment:1 -> FAILURE "Selector didn't match" @ /baz/x
+    /baz/{y}, segment:2 -> SUCCESS; Parameters [y=[doo]] @ /baz/{y}
+      /baz/{y}/(method:GET), segment:2 -> SUCCESS @ /baz/{y}/(method:GET)
+      /baz/{y}/value, segment:2 -> FAILURE "Selector didn't match" @ /baz/{y}/value
+  /{param}, segment:0 -> FAILURE "Better match was already found" @ /{param}
+  /*, segment:0 -> FAILURE "Better match was already found" @ /*
+  /(header:a = x), segment:0 -> FAILURE "Selector didn't match" @ /(header:a = x)
+  /(header:b = x), segment:0 -> FAILURE "Selector didn't match" @ /(header:b = x)
+Matched routes:
+  "" -> "baz" -> "{y}" -> "(method:GET)"
+Route resolve result:
+  SUCCESS; Parameters [y=[doo]] @ /baz/{y}/(method:GET)
 """,
                 trace?.buildText()
             )
@@ -782,17 +812,25 @@ class RoutingProcessingTest {
             assertEquals("/baz/x/{optional?}", it.response.content)
             assertEquals(
                 """Trace for [baz, x, z]
-/, segment:0 -> SUCCESS; Parameters [optional=[z]] @ /baz/x/{optional?}/(method:GET))
-  /bar, segment:0 -> FAILURE "Selector didn't match" @ /bar)
-  /baz, segment:1 -> SUCCESS; Parameters [optional=[z]] @ /baz/x/{optional?}/(method:GET))
-    /baz/(method:GET), segment:1 -> FAILURE "Not all segments matched" @ /baz/(method:GET))
-    /baz/x, segment:2 -> SUCCESS; Parameters [optional=[z]] @ /baz/x/{optional?}/(method:GET))
-      /baz/x/(method:GET), segment:2 -> FAILURE "Not all segments matched" @ /baz/x/(method:GET))
-      /baz/x/{optional?}, segment:3 -> SUCCESS @ /baz/x/{optional?}/(method:GET))
-        /baz/x/{optional?}/(method:GET), segment:3 -> SUCCESS @ /baz/x/{optional?}/(method:GET))
-    /baz/{y}, segment:1 -> FAILURE "Better match was already found" @ /baz/{y})
-  /{param}, segment:0 -> FAILURE "Better match was already found" @ /{param})
-  /*, segment:0 -> FAILURE "Better match was already found" @ /*)
+/, segment:0 -> SUCCESS @ /
+  /bar, segment:0 -> FAILURE "Selector didn't match" @ /bar
+  /baz, segment:1 -> SUCCESS @ /baz
+    /baz/(method:GET), segment:1 -> SUCCESS @ /baz/(method:GET)
+      /baz/(method:GET), segment:1 -> FAILURE "Not all segments matched" @ /baz/(method:GET)
+    /baz/x, segment:2 -> SUCCESS @ /baz/x
+      /baz/x/(method:GET), segment:2 -> SUCCESS @ /baz/x/(method:GET)
+        /baz/x/(method:GET), segment:2 -> FAILURE "Not all segments matched" @ /baz/x/(method:GET)
+      /baz/x/{optional?}, segment:3 -> SUCCESS; Parameters [optional=[z]] @ /baz/x/{optional?}
+        /baz/x/{optional?}/(method:GET), segment:3 -> SUCCESS @ /baz/x/{optional?}/(method:GET)
+    /baz/{y}, segment:1 -> FAILURE "Better match was already found" @ /baz/{y}
+  /{param}, segment:0 -> FAILURE "Better match was already found" @ /{param}
+  /*, segment:0 -> FAILURE "Better match was already found" @ /*
+  /(header:a = x), segment:0 -> FAILURE "Selector didn't match" @ /(header:a = x)
+  /(header:b = x), segment:0 -> FAILURE "Selector didn't match" @ /(header:b = x)
+Matched routes:
+  "" -> "baz" -> "x" -> "{optional?}" -> "(method:GET)"
+Route resolve result:
+  SUCCESS; Parameters [optional=[z]] @ /baz/x/{optional?}/(method:GET)
 """,
                 trace?.buildText()
             )
@@ -805,17 +843,25 @@ class RoutingProcessingTest {
             assertEquals("/baz/x/{optional?}", it.response.content)
             assertEquals(
                 """Trace for [baz, x, value]
-/, segment:0 -> SUCCESS; Parameters [optional=[value]] @ /baz/x/{optional?}/(method:GET))
-  /bar, segment:0 -> FAILURE "Selector didn't match" @ /bar)
-  /baz, segment:1 -> SUCCESS; Parameters [optional=[value]] @ /baz/x/{optional?}/(method:GET))
-    /baz/(method:GET), segment:1 -> FAILURE "Not all segments matched" @ /baz/(method:GET))
-    /baz/x, segment:2 -> SUCCESS; Parameters [optional=[value]] @ /baz/x/{optional?}/(method:GET))
-      /baz/x/(method:GET), segment:2 -> FAILURE "Not all segments matched" @ /baz/x/(method:GET))
-      /baz/x/{optional?}, segment:3 -> SUCCESS @ /baz/x/{optional?}/(method:GET))
-        /baz/x/{optional?}/(method:GET), segment:3 -> SUCCESS @ /baz/x/{optional?}/(method:GET))
-    /baz/{y}, segment:1 -> FAILURE "Better match was already found" @ /baz/{y})
-  /{param}, segment:0 -> FAILURE "Better match was already found" @ /{param})
-  /*, segment:0 -> FAILURE "Better match was already found" @ /*)
+/, segment:0 -> SUCCESS @ /
+  /bar, segment:0 -> FAILURE "Selector didn't match" @ /bar
+  /baz, segment:1 -> SUCCESS @ /baz
+    /baz/(method:GET), segment:1 -> SUCCESS @ /baz/(method:GET)
+      /baz/(method:GET), segment:1 -> FAILURE "Not all segments matched" @ /baz/(method:GET)
+    /baz/x, segment:2 -> SUCCESS @ /baz/x
+      /baz/x/(method:GET), segment:2 -> SUCCESS @ /baz/x/(method:GET)
+        /baz/x/(method:GET), segment:2 -> FAILURE "Not all segments matched" @ /baz/x/(method:GET)
+      /baz/x/{optional?}, segment:3 -> SUCCESS; Parameters [optional=[value]] @ /baz/x/{optional?}
+        /baz/x/{optional?}/(method:GET), segment:3 -> SUCCESS @ /baz/x/{optional?}/(method:GET)
+    /baz/{y}, segment:1 -> FAILURE "Better match was already found" @ /baz/{y}
+  /{param}, segment:0 -> FAILURE "Better match was already found" @ /{param}
+  /*, segment:0 -> FAILURE "Better match was already found" @ /*
+  /(header:a = x), segment:0 -> FAILURE "Selector didn't match" @ /(header:a = x)
+  /(header:b = x), segment:0 -> FAILURE "Selector didn't match" @ /(header:b = x)
+Matched routes:
+  "" -> "baz" -> "x" -> "{optional?}" -> "(method:GET)"
+Route resolve result:
+  SUCCESS; Parameters [optional=[value]] @ /baz/x/{optional?}/(method:GET)
 """,
                 trace?.buildText()
             )
@@ -828,13 +874,19 @@ class RoutingProcessingTest {
             assertEquals("/{param}", it.response.content)
             assertEquals(
                 """Trace for [p]
-/, segment:0 -> SUCCESS; Parameters [param=[p]] @ /{param}/(method:GET))
-  /bar, segment:0 -> FAILURE "Selector didn't match" @ /bar)
-  /baz, segment:0 -> FAILURE "Selector didn't match" @ /baz)
-  /{param}, segment:1 -> SUCCESS @ /{param}/(method:GET))
-    /{param}/(method:GET), segment:1 -> SUCCESS @ /{param}/(method:GET))
-    /{param}/x, segment:1 -> FAILURE "Selector didn't match" @ /{param}/x)
-  /*, segment:0 -> FAILURE "Better match was already found" @ /*)
+/, segment:0 -> SUCCESS @ /
+  /bar, segment:0 -> FAILURE "Selector didn't match" @ /bar
+  /baz, segment:0 -> FAILURE "Selector didn't match" @ /baz
+  /{param}, segment:1 -> SUCCESS; Parameters [param=[p]] @ /{param}
+    /{param}/(method:GET), segment:1 -> SUCCESS @ /{param}/(method:GET)
+    /{param}/x, segment:1 -> FAILURE "Selector didn't match" @ /{param}/x
+  /*, segment:0 -> FAILURE "Better match was already found" @ /*
+  /(header:a = x), segment:0 -> FAILURE "Selector didn't match" @ /(header:a = x)
+  /(header:b = x), segment:0 -> FAILURE "Selector didn't match" @ /(header:b = x)
+Matched routes:
+  "" -> "{param}" -> "(method:GET)"
+Route resolve result:
+  SUCCESS; Parameters [param=[p]] @ /{param}/(method:GET)
 """,
                 trace?.buildText()
             )
@@ -847,15 +899,50 @@ class RoutingProcessingTest {
             assertEquals("/{param}/x", it.response.content)
             assertEquals(
                 """Trace for [p, x]
-/, segment:0 -> SUCCESS; Parameters [param=[p]] @ /{param}/x/(method:GET))
-  /bar, segment:0 -> FAILURE "Selector didn't match" @ /bar)
-  /baz, segment:0 -> FAILURE "Selector didn't match" @ /baz)
-  /{param}, segment:1 -> SUCCESS @ /{param}/x/(method:GET))
-    /{param}/(method:GET), segment:1 -> FAILURE "Not all segments matched" @ /{param}/(method:GET))
-    /{param}/x, segment:2 -> SUCCESS @ /{param}/x/(method:GET))
-      /{param}/x/(method:GET), segment:2 -> SUCCESS @ /{param}/x/(method:GET))
-      /{param}/x/z, segment:2 -> FAILURE "Selector didn't match" @ /{param}/x/z)
-  /*, segment:0 -> FAILURE "Better match was already found" @ /*)
+/, segment:0 -> SUCCESS @ /
+  /bar, segment:0 -> FAILURE "Selector didn't match" @ /bar
+  /baz, segment:0 -> FAILURE "Selector didn't match" @ /baz
+  /{param}, segment:1 -> SUCCESS; Parameters [param=[p]] @ /{param}
+    /{param}/(method:GET), segment:1 -> SUCCESS @ /{param}/(method:GET)
+      /{param}/(method:GET), segment:1 -> FAILURE "Not all segments matched" @ /{param}/(method:GET)
+    /{param}/x, segment:2 -> SUCCESS @ /{param}/x
+      /{param}/x/(method:GET), segment:2 -> SUCCESS @ /{param}/x/(method:GET)
+      /{param}/x/z, segment:2 -> FAILURE "Selector didn't match" @ /{param}/x/z
+  /*, segment:0 -> FAILURE "Better match was already found" @ /*
+  /(header:a = x), segment:0 -> FAILURE "Selector didn't match" @ /(header:a = x)
+  /(header:b = x), segment:0 -> FAILURE "Selector didn't match" @ /(header:b = x)
+Matched routes:
+  "" -> "{param}" -> "x" -> "(method:GET)"
+Route resolve result:
+  SUCCESS; Parameters [param=[p]] @ /{param}/x/(method:GET)
+""".toPlatformLineSeparators(),
+                trace?.buildText()
+            )
+        }
+
+        handleRequest {
+            uri = "/"
+            addHeader("a", "x")
+            addHeader("b", "x")
+            method = HttpMethod.Get
+        }.let {
+            assertEquals("a", it.response.content)
+            assertEquals(
+                """Trace for []
+/, segment:0 -> SUCCESS @ /
+  /bar, segment:0 -> FAILURE "Selector didn't match" @ /bar
+  /baz, segment:0 -> FAILURE "Selector didn't match" @ /baz
+  /{param}, segment:0 -> FAILURE "Selector didn't match" @ /{param}
+  /*, segment:0 -> FAILURE "Selector didn't match" @ /*
+  /(header:a = x), segment:0 -> SUCCESS @ /(header:a = x)
+    /(header:a = x)/(method:GET), segment:0 -> SUCCESS @ /(header:a = x)/(method:GET)
+  /(header:b = x), segment:0 -> SUCCESS @ /(header:b = x)
+    /(header:b = x)/(method:GET), segment:0 -> SUCCESS @ /(header:b = x)/(method:GET)
+Matched routes:
+  "" -> "(header:a = x)" -> "(method:GET)"
+  "" -> "(header:b = x)" -> "(method:GET)"
+Route resolve result:
+  SUCCESS @ /(header:a = x)/(method:GET)
 """,
                 trace?.buildText()
             )
@@ -863,7 +950,7 @@ class RoutingProcessingTest {
     }
 
     @Test
-    fun testRouteWithParamaterPrefixAndSuffixHasMorePriority() = withTestApplication {
+    fun testRouteWithParameterPrefixAndSuffixHasMorePriority() = withTestApplication {
         application.routing {
             get("/foo:{baz}") {
                 call.respondText("foo")
@@ -894,7 +981,7 @@ class RoutingProcessingTest {
 
     private fun Route.transparent(build: Route.() -> Unit): Route {
         val route = createChild(
-            object : RouteSelector(RouteSelectorEvaluation.qualityTransparent) {
+            object : RouteSelector() {
                 override fun evaluate(context: RoutingResolveContext, segmentIndex: Int): RouteSelectorEvaluation {
                     return RouteSelectorEvaluation(true, RouteSelectorEvaluation.qualityTransparent)
                 }

--- a/ktor-server/ktor-server-tests/jvm/test/io/ktor/tests/server/routing/RoutingResolveTest.kt
+++ b/ktor-server/ktor-server-tests/jvm/test/io/ktor/tests/server/routing/RoutingResolveTest.kt
@@ -76,6 +76,19 @@ class RoutingResolveTest {
     }
 
     @Test
+    fun testMatchingRoot() {
+        val root = routing("context/path")
+        root.handle {  }
+
+        on("resolving /context/path") {
+            val result = resolve(root, "/context/path")
+            it("should succeed") {
+                assertTrue(result is RoutingResolveResult.Success)
+            }
+        }
+    }
+
+    @Test
     fun `custom root path`() {
         val root = routing("context/path")
         root.handle(PathSegmentConstantRouteSelector("foo"))
@@ -94,7 +107,7 @@ class RoutingResolveTest {
         }
         on("resolving /context/path") {
             val result = resolve(root, "/context/path")
-            it("should succeed") {
+            it("shouldn't succeed") {
                 assertTrue(result is RoutingResolveResult.Failure)
             }
         }
@@ -131,7 +144,7 @@ class RoutingResolveTest {
         }
         on("resolving /context/path") {
             val result = resolve(root, "/context/path")
-            it("should succeed") {
+            it("shouldn't succeed") {
                 assertTrue(result is RoutingResolveResult.Failure)
             }
         }
@@ -168,9 +181,6 @@ class RoutingResolveTest {
             it("should not succeed") {
                 assertTrue(result is RoutingResolveResult.Failure)
             }
-            it("should have fooEntry as fail entry") {
-                assertEquals(fooEntry, result.route)
-            }
         }
     }
 
@@ -192,9 +202,6 @@ class RoutingResolveTest {
             val result = resolve(root, "/foo/bar")
             it("should not succeed") {
                 assertTrue(result is RoutingResolveResult.Failure)
-            }
-            it("should have fooEntry as fail entry") {
-                assertEquals(fooEntry, result.route)
             }
         }
     }
@@ -1119,6 +1126,39 @@ class RoutingResolveTest {
     }
 
     @Test
+    fun testRoutingMatchesWithMethod() = withTestApplication {
+        application.routing {
+            route("/") {
+                get {
+                    call.respondText("foo")
+                }
+                handle {
+                    call.respondText("bar")
+                }
+            }
+        }
+
+        on("making get request") {
+            val result = handleRequest {
+                uri = "/"
+                method = HttpMethod.Get
+            }
+            it("/:get should be called") {
+                assertEquals("foo", result.response.content)
+            }
+        }
+        on("making post request") {
+            val result = handleRequest {
+                uri = "/"
+                method = HttpMethod.Post
+            }
+            it("/ should be called") {
+                assertEquals("bar", result.response.content)
+            }
+        }
+    }
+
+    @Test
     fun testRoutingTrailingSlashWithTrailcard() = withTestApplication {
         application.routing {
             get("test/a{foo...}") {
@@ -1273,10 +1313,12 @@ class RoutingResolveTest {
         val root = routing()
         val siblingTop = root.handle(PathSegmentParameterRouteSelector("sibling", "top"))
         val transparentEntryTop = root.createChild(
-            object : RouteSelector(RouteSelectorEvaluation.qualityTransparent) {
+            object : RouteSelector() {
                 override fun evaluate(context: RoutingResolveContext, segmentIndex: Int): RouteSelectorEvaluation {
                     return RouteSelectorEvaluation(true, RouteSelectorEvaluation.qualityTransparent)
                 }
+
+                override fun toString(): String = "transparent"
             }
         )
         // inner entry has lower priority then its siblings


### PR DESCRIPTION
Clean up and make routing resolving algorithm smarter. Compare not only direct children's priorities, but the whole successful path.
Ex: 
Route 1:  path, q=1 -> missing parameter, q=0.2
Route 2: path, q=1 -> parameter, q=0.8
If both of these routes match, the old algorithm would choose route 1, even though it has lower quality overall. It happens because it compares only siblings' quality, and when they are similar, it will choose the first one based on order. The new algorithm will compare the whole paths. 
