### PR TITLE
KTOR-2512 Require forces webpack to resolve dependency

### DIFF
--- a/ktor-client/ktor-client-core/js/src/io/ktor/client/engine/js/JsClientEngine.kt
+++ b/ktor-client/ktor-client-core/js/src/io/ktor/client/engine/js/JsClientEngine.kt
@@ -59,7 +59,7 @@ internal class JsClientEngine(override val config: HttpClientEngineConfig) : Htt
     // so it can be accessed inside js("") function
     private fun createWebSocket(urlString_capturingHack: String): WebSocket {
         return if (PlatformUtils.IS_NODE) {
-            val ws_capturingHack = js("require('ws')")
+            val ws_capturingHack = js("eval('require')('ws')")
             js("new ws_capturingHack(urlString_capturingHack)")
         } else {
             js("new WebSocket(urlString_capturingHack)")

--- a/ktor-client/ktor-client-core/js/src/io/ktor/client/engine/js/compatibility/Utils.kt
+++ b/ktor-client/ktor-client-core/js/src/io/ktor/client/engine/js/compatibility/Utils.kt
@@ -43,7 +43,7 @@ internal fun AbortController(): AbortController {
     return if (PlatformUtils.IS_BROWSER) {
         js("new AbortController()")
     } else {
-        val controller = js("require('abort-controller')")
+        val controller = js("eval('require')('abort-controller')")
         js("new controller()")
     }
 }
@@ -57,7 +57,7 @@ internal fun CoroutineScope.readBody(
 }
 
 private fun jsRequireNodeFetch(): dynamic = try {
-    js("require('node-fetch')")
+    js("eval('require')('node-fetch')")
 } catch (cause: dynamic) {
     throw Error("Error loading module 'node-fetch': $cause")
 }

--- a/ktor-client/ktor-client-core/js/src/io/ktor/client/fetch/LibDom.kt
+++ b/ktor-client/ktor-client-core/js/src/io/ktor/client/fetch/LibDom.kt
@@ -336,8 +336,7 @@ public external interface EventTarget {
     public fun removeEventListener(type: String, callback: EventListenerObject)
 }
 
-public external interface EventListener {
-}
+public external interface EventListener
 
 @Suppress("NOTHING_TO_INLINE")
 public inline operator fun EventListener.invoke(evt: Event) {

--- a/ktor-utils/js/src/io/ktor/util/CryptoJs.kt
+++ b/ktor-utils/js/src/io/ktor/util/CryptoJs.kt
@@ -48,7 +48,11 @@ public actual fun Digest(name: String): Digest = object : Digest {
 
 // Variable is renamed to `_crypto` so it wouldn't clash with existing `crypto` variable.
 // JS IR backend doesn't reserve names accessed inside js("") calls
-private val _crypto: Crypto = if (PlatformUtils.IS_NODE) js("require('crypto')") else js("(crypto ? crypto : msCrypto)")
+private val _crypto: Crypto = if (PlatformUtils.IS_NODE) {
+    js("eval('require')('crypto')")
+} else {
+    js("(crypto ? crypto : msCrypto)")
+}
 
 private external class Crypto {
     val subtle: SubtleCrypto


### PR DESCRIPTION
**Subsystem**
Client

**Motivation**
Even when it under `if` condition and standard Node.JS module, in webpack 4, it polyfill it into final bundle.
Since webpack 5, webpack not longer polyfill standard Node.JS modules, and report error.
So for WA this problem, need to use `eval('require')` instead of `require`

https://youtrack.jetbrains.com/issue/KT-46082

**Solution**
Webpack will not resolve `eval('require')('crypto')`, and it will be false branch of `if`

