### PR TITLE
KTOR-2519 fix ByteBufferChannel.readRemaining suspend when should not

### DIFF
--- a/ktor-io/common/test/io/ktor/utils/io/ByteChannelSmokeTest.kt
+++ b/ktor-io/common/test/io/ktor/utils/io/ByteChannelSmokeTest.kt
@@ -662,6 +662,14 @@ open class ByteChannelSmokeTest : ByteChannelTestBase() {
         assertFailsWith<IOException> { ch.readByte() }
     }
 
+    @Test
+    fun testReadRemainingAvailable() = runTest {
+        ch.writeFully(byteArrayOf(1, 2, 3))
+        ch.flush()
+        val remaining = ch.readRemaining(3).remaining
+        assertEquals(3, remaining)
+    }
+
     private fun assertEquals(expected: Float, actual: Float) {
         if (abs(expected - actual) > 0.000001f) {
             kotlin.test.assertEquals(expected, actual)

--- a/ktor-io/jvm/src/io/ktor/utils/io/ByteBufferChannel.kt
+++ b/ktor-io/jvm/src/io/ktor/utils/io/ByteBufferChannel.kt
@@ -2153,8 +2153,7 @@ internal open class ByteBufferChannel(
 
             val rc = readAsMuchAsPossible(buffer)
             remaining -= rc
-            readSuspend(1)
-            remaining > 0L && !isClosedForRead
+            remaining > 0L && !isClosedForRead && readSuspend(1)
         }
 
         closedCause?.let { throw it }


### PR DESCRIPTION
Fix [KTOR-2519](https://youtrack.jetbrains.com/issue/KTOR-2519)