### PR TITLE
KTOR-2278 Fix LookAheadSession on closed channel

### DIFF
--- a/ktor-io/jvm/src/io/ktor/utils/io/ByteBufferChannel.kt
+++ b/ktor-io/jvm/src/io/ktor/utils/io/ByteBufferChannel.kt
@@ -1800,6 +1800,7 @@ internal open class ByteBufferChannel(
     }
 
     override fun <R> lookAhead(visitor: LookAheadSession.() -> R): R {
+        closedCause?.let { return visitor(FailedLookAhead(it)) }
         if (state === ReadWriteBufferState.Terminated) {
             return visitor(TerminatedLookAhead)
         }
@@ -1811,6 +1812,7 @@ internal open class ByteBufferChannel(
         }
 
         if (!continueReading) {
+            closedCause?.let { return visitor(FailedLookAhead(it)) }
             return visitor(TerminatedLookAhead)
         }
 
@@ -1818,6 +1820,7 @@ internal open class ByteBufferChannel(
     }
 
     override suspend fun <R> lookAheadSuspend(visitor: suspend LookAheadSuspendSession.() -> R): R {
+        closedCause?.let { return visitor(FailedLookAhead(it)) }
         if (state === ReadWriteBufferState.Terminated) {
             return visitor(TerminatedLookAhead)
         }
@@ -1829,7 +1832,8 @@ internal open class ByteBufferChannel(
         }
 
         if (!rc) {
-            if (closed != null || state === ReadWriteBufferState.Terminated) {
+            closedCause?.let { return visitor(FailedLookAhead(it)) }
+            if (state === ReadWriteBufferState.Terminated) {
                 return visitor(TerminatedLookAhead)
             }
 

--- a/ktor-io/jvm/src/io/ktor/utils/io/ByteReadChannelJVM.kt
+++ b/ktor-io/jvm/src/io/ktor/utils/io/ByteReadChannelJVM.kt
@@ -139,7 +139,7 @@ public actual interface ByteReadChannel {
 
     /**
      * Starts non-suspendable read session. After channel preparation [consumer] lambda will be invoked immediately
-     * event if there are no bytes available for read yet.
+     * even if there are no bytes available for read yet.
      */
     @Suppress("DEPRECATION")
     @Deprecated("Use read { } instead.")

--- a/ktor-io/jvm/src/io/ktor/utils/io/internal/ByteBufferChannelInternals.kt
+++ b/ktor-io/jvm/src/io/ktor/utils/io/internal/ByteBufferChannelInternals.kt
@@ -54,6 +54,13 @@ internal object TerminatedLookAhead : LookAheadSuspendSession {
     }
 }
 
+@Suppress("DEPRECATION")
+internal class FailedLookAhead(val cause: Throwable) : LookAheadSuspendSession {
+    override fun consumed(n: Int) = throw cause
+    override fun request(skip: Int, atLeast: Int): ByteBuffer = throw cause
+    override suspend fun awaitAtLeast(n: Int): Boolean = throw cause
+}
+
 internal class ClosedElement(val cause: Throwable?) {
     val sendException: Throwable
         get() = cause ?: ClosedWriteChannelException("The channel was closed")

--- a/ktor-io/jvm/test/io/ktor/utils/io/ByteBufferChannelLookAheadTest.kt
+++ b/ktor-io/jvm/test/io/ktor/utils/io/ByteBufferChannelLookAheadTest.kt
@@ -28,6 +28,25 @@ class ByteBufferChannelLookAheadTest : ByteChannelTestBase() {
     }
 
     @Test
+    fun testLookAheadSuspendOnFailedChannel() = runTest {
+        ch.close(RuntimeException("Closed"))
+        ch.lookAheadSuspend {
+            assertFailsWith<RuntimeException> { request(1, 1) }
+            assertFailsWith<RuntimeException> { awaitAtLeast(1) }
+            assertFailsWith<RuntimeException> { consumed(1) }
+        }
+    }
+
+    @Test
+    fun testLookAheadOnFailedChannel() = runTest {
+        ch.close(RuntimeException("Closed"))
+        ch.lookAhead {
+            assertFailsWith<RuntimeException> { request(1, 1) }
+            assertFailsWith<RuntimeException> { consumed(1) }
+        }
+    }
+
+    @Test
     fun testReadDuringWriting() = runTest {
         ch.writeSuspendSession {
             ch.lookAheadSuspend {


### PR DESCRIPTION
There were two issues:
* Channel closed with error didn't propagate it on reading through LookAheadSession
* Successfully closed channel that still has available to read bytes wasn't returning them when reading through LookAheadSession
