### PR TITLE
KTOR-2637 Add option to update auth credentials after installation

### DIFF
--- a/ktor-client/ktor-client-features/ktor-client-auth/api/ktor-client-auth.api
+++ b/ktor-client/ktor-client-features/ktor-client-auth/api/ktor-client-auth.api
@@ -22,34 +22,47 @@ public abstract interface class io/ktor/client/features/auth/AuthProvider {
 	public abstract fun addRequestHeaders (Lio/ktor/client/request/HttpRequestBuilder;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun getSendWithoutRequest ()Z
 	public abstract fun isApplicable (Lio/ktor/http/auth/HttpAuthHeader;)Z
-	public abstract fun refreshToken (Lio/ktor/client/call/HttpClientCall;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun refreshToken (Lio/ktor/client/statement/HttpResponse;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun sendWithoutRequest (Lio/ktor/client/request/HttpRequestBuilder;)Z
 }
 
 public final class io/ktor/client/features/auth/AuthProvider$DefaultImpls {
-	public static fun refreshToken (Lio/ktor/client/features/auth/AuthProvider;Lio/ktor/client/call/HttpClientCall;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun refreshToken (Lio/ktor/client/features/auth/AuthProvider;Lio/ktor/client/statement/HttpResponse;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun sendWithoutRequest (Lio/ktor/client/features/auth/AuthProvider;Lio/ktor/client/request/HttpRequestBuilder;)Z
 }
 
 public final class io/ktor/client/features/auth/providers/BasicAuthConfig {
 	public field password Ljava/lang/String;
 	public field username Ljava/lang/String;
 	public fun <init> ()V
+	public final fun credentials (Lkotlin/jvm/functions/Function1;)V
 	public final fun getPassword ()Ljava/lang/String;
 	public final fun getRealm ()Ljava/lang/String;
 	public final fun getSendWithoutRequest ()Z
 	public final fun getUsername ()Ljava/lang/String;
+	public final fun sendWithoutRequest (Lkotlin/jvm/functions/Function1;)V
 	public final fun setPassword (Ljava/lang/String;)V
 	public final fun setRealm (Ljava/lang/String;)V
 	public final fun setSendWithoutRequest (Z)V
 	public final fun setUsername (Ljava/lang/String;)V
 }
 
+public final class io/ktor/client/features/auth/providers/BasicAuthCredentials {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public final fun getPassword ()Ljava/lang/String;
+	public final fun getUsername ()Ljava/lang/String;
+}
+
 public final class io/ktor/client/features/auth/providers/BasicAuthProvider : io/ktor/client/features/auth/AuthProvider {
 	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Z)V
 	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lkotlin/jvm/functions/Function1;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)V
+	public synthetic fun <init> (Lkotlin/jvm/functions/Function1;Ljava/lang/String;Lkotlin/jvm/functions/Function1;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun addRequestHeaders (Lio/ktor/client/request/HttpRequestBuilder;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun getSendWithoutRequest ()Z
 	public fun isApplicable (Lio/ktor/http/auth/HttpAuthHeader;)Z
-	public fun refreshToken (Lio/ktor/client/call/HttpClientCall;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun refreshToken (Lio/ktor/client/statement/HttpResponse;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun sendWithoutRequest (Lio/ktor/client/request/HttpRequestBuilder;)Z
 }
 
 public final class io/ktor/client/features/auth/providers/BasicAuthProviderKt {
@@ -61,19 +74,19 @@ public final class io/ktor/client/features/auth/providers/BearerAuthConfig {
 	public final fun getRealm ()Ljava/lang/String;
 	public final fun loadTokens (Lkotlin/jvm/functions/Function1;)V
 	public final fun refreshTokens (Lkotlin/jvm/functions/Function2;)V
+	public final fun sendWithoutRequest (Lkotlin/jvm/functions/Function1;)V
 	public final fun setRealm (Ljava/lang/String;)V
 }
 
 public final class io/ktor/client/features/auth/providers/BearerAuthProvider : io/ktor/client/features/auth/AuthProvider {
-	public fun <init> (Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function1;ZLjava/lang/String;)V
-	public synthetic fun <init> (Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function1;ZLjava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Ljava/lang/String;)V
+	public synthetic fun <init> (Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun addRequestHeaders (Lio/ktor/client/request/HttpRequestBuilder;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun clearToken (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun getLoadTokens ()Lkotlin/jvm/functions/Function1;
-	public final fun getRefreshTokens ()Lkotlin/jvm/functions/Function2;
 	public fun getSendWithoutRequest ()Z
 	public fun isApplicable (Lio/ktor/http/auth/HttpAuthHeader;)Z
-	public fun refreshToken (Lio/ktor/client/call/HttpClientCall;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun refreshToken (Lio/ktor/client/statement/HttpResponse;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun sendWithoutRequest (Lio/ktor/client/request/HttpRequestBuilder;)Z
 }
 
 public final class io/ktor/client/features/auth/providers/BearerAuthProviderKt {
@@ -87,7 +100,10 @@ public final class io/ktor/client/features/auth/providers/BearerTokens {
 }
 
 public final class io/ktor/client/features/auth/providers/DigestAuthConfig {
+	public field password Ljava/lang/String;
+	public field username Ljava/lang/String;
 	public fun <init> ()V
+	public final fun credentials (Lkotlin/jvm/functions/Function1;)V
 	public final fun getAlgorithmName ()Ljava/lang/String;
 	public final fun getPassword ()Ljava/lang/String;
 	public final fun getRealm ()Ljava/lang/String;
@@ -98,9 +114,17 @@ public final class io/ktor/client/features/auth/providers/DigestAuthConfig {
 	public final fun setUsername (Ljava/lang/String;)V
 }
 
+public final class io/ktor/client/features/auth/providers/DigestAuthCredentials {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public final fun getPassword ()Ljava/lang/String;
+	public final fun getUsername ()Ljava/lang/String;
+}
+
 public final class io/ktor/client/features/auth/providers/DigestAuthProvider : io/ktor/client/features/auth/AuthProvider {
 	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
 	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lkotlin/jvm/functions/Function1;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Lkotlin/jvm/functions/Function1;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun addRequestHeaders (Lio/ktor/client/request/HttpRequestBuilder;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun getAlgorithmName ()Ljava/lang/String;
 	public final fun getPassword ()Ljava/lang/String;
@@ -108,7 +132,8 @@ public final class io/ktor/client/features/auth/providers/DigestAuthProvider : i
 	public fun getSendWithoutRequest ()Z
 	public final fun getUsername ()Ljava/lang/String;
 	public fun isApplicable (Lio/ktor/http/auth/HttpAuthHeader;)Z
-	public fun refreshToken (Lio/ktor/client/call/HttpClientCall;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun refreshToken (Lio/ktor/client/statement/HttpResponse;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun sendWithoutRequest (Lio/ktor/client/request/HttpRequestBuilder;)Z
 }
 
 public final class io/ktor/client/features/auth/providers/DigestAuthProviderKt {

--- a/ktor-client/ktor-client-features/ktor-client-auth/common/src/io/ktor/client/features/auth/AuthProvider.kt
+++ b/ktor-client/ktor-client-features/ktor-client-auth/common/src/io/ktor/client/features/auth/AuthProvider.kt
@@ -6,6 +6,7 @@ package io.ktor.client.features.auth
 
 import io.ktor.client.call.*
 import io.ktor.client.request.*
+import io.ktor.client.statement.*
 import io.ktor.http.*
 import io.ktor.http.auth.*
 
@@ -16,7 +17,10 @@ public interface AuthProvider {
     /**
      * Wait for [HttpStatusCode.Unauthorized] to send credentials.
      */
+    @Deprecated("Please use sendWithoutRequest function instead")
     public val sendWithoutRequest: Boolean
+
+    public fun sendWithoutRequest(request: HttpRequestBuilder): Boolean = sendWithoutRequest
 
     /**
      * Check if current provider is applicable to the request.
@@ -34,5 +38,5 @@ public interface AuthProvider {
      * @param call - response triggered token refresh.
      * @return if the token was successfully refreshed.
      */
-    public suspend fun refreshToken(call: HttpClientCall): Boolean = true
+    public suspend fun refreshToken(response: HttpResponse): Boolean = true
 }

--- a/ktor-client/ktor-client-features/ktor-client-auth/common/src/io/ktor/client/features/auth/providers/AuthTokenHolder.kt
+++ b/ktor-client/ktor-client-features/ktor-client-auth/common/src/io/ktor/client/features/auth/providers/AuthTokenHolder.kt
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2014-2021 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.client.features.auth.providers
+
+import kotlinx.atomicfu.*
+import kotlinx.coroutines.*
+import kotlinx.coroutines.sync.*
+
+internal class AuthTokenHolder<T>(
+    private val loadTokens: suspend () -> T?
+) {
+
+    private val lock = Mutex()
+
+    private val cachedBearerTokens: AtomicRef<CompletableDeferred<T?>> = atomic(
+        CompletableDeferred<T?>().apply {
+            complete(null)
+        }
+    )
+
+    internal suspend fun clearToken() {
+        lock.withLock {
+            cachedBearerTokens.value = CompletableDeferred<T?>().apply { complete(null) }
+        }
+    }
+
+    internal suspend fun loadToken(): T? = lock.withLock {
+        val cachedToken = cachedBearerTokens.value.await()
+        if (cachedToken != null) return cachedToken
+
+        return setToken(loadTokens)
+    }
+
+    internal suspend fun setToken(block: suspend () -> T?): T? {
+        val old = cachedBearerTokens.value
+        if (!old.isCompleted) {
+            return old.await()
+        }
+
+        val deferred = CompletableDeferred<T?>()
+        if (!cachedBearerTokens.compareAndSet(old, deferred)) {
+            return cachedBearerTokens.value.await()
+        }
+
+        try {
+            val token = block()
+            deferred.complete(token)
+            return token
+        } catch (cause: Throwable) {
+            deferred.completeExceptionally(cause)
+            throw cause
+        }
+    }
+}

--- a/ktor-client/ktor-client-features/ktor-client-auth/common/src/io/ktor/client/features/auth/providers/BasicAuthProvider.kt
+++ b/ktor-client/ktor-client-features/ktor-client-auth/common/src/io/ktor/client/features/auth/providers/BasicAuthProvider.kt
@@ -6,6 +6,7 @@ package io.ktor.client.features.auth.providers
 
 import io.ktor.client.features.auth.*
 import io.ktor.client.request.*
+import io.ktor.client.statement.*
 import io.ktor.http.*
 import io.ktor.http.auth.*
 import io.ktor.util.*
@@ -17,7 +18,7 @@ import io.ktor.utils.io.core.*
  */
 public fun Auth.basic(block: BasicAuthConfig.() -> Unit) {
     with(BasicAuthConfig().apply(block)) {
-        providers.add(BasicAuthProvider(username, password, realm, sendWithoutRequest))
+        providers.add(BasicAuthProvider(_credentials, realm, _sendWithoutRequest))
     }
 }
 
@@ -28,34 +29,82 @@ public class BasicAuthConfig {
     /**
      * Required: The username of the basic auth.
      */
+    @Deprecated("Please use `credentials {}` function instead")
     public lateinit var username: String
 
     /**
      * Required: The password of the basic auth.
      */
+    @Deprecated("Please use `credentials {}` function instead")
     public lateinit var password: String
+
+    /**
+     * Send credentials in without waiting for [HttpStatusCode.Unauthorized].
+     */
+    @Deprecated("Please use `sendWithoutRequest {}` function instead")
+    public var sendWithoutRequest: Boolean = false
 
     /**
      * Optional: current provider realm
      */
     public var realm: String? = null
 
+    internal var _sendWithoutRequest: (HttpRequestBuilder) -> Boolean = { sendWithoutRequest }
+
+    internal var _credentials: suspend () -> BasicAuthCredentials? = {
+        BasicAuthCredentials(username = username, password = password)
+    }
+
     /**
      * Send credentials in without waiting for [HttpStatusCode.Unauthorized].
      */
-    public var sendWithoutRequest: Boolean = false
+    public fun sendWithoutRequest(block: (HttpRequestBuilder) -> Boolean) {
+        _sendWithoutRequest = block
+    }
+
+    /**
+     * Required: Credentials provider.
+     */
+    public fun credentials(block: suspend () -> BasicAuthCredentials?) {
+        _credentials = block
+    }
 }
+
+/**
+ * Credentials for [BasicAuthProvider].
+ */
+public class BasicAuthCredentials(
+    public val username: String,
+    public val password: String
+)
 
 /**
  * Client basic authentication provider.
  */
 public class BasicAuthProvider(
-    private val username: String,
-    private val password: String,
+    private val credentials: suspend () -> BasicAuthCredentials?,
     private val realm: String? = null,
-    override val sendWithoutRequest: Boolean = false
+    private val sendWithoutRequestCallback: (HttpRequestBuilder) -> Boolean = { false }
 ) : AuthProvider {
-    private val defaultCharset = Charsets.UTF_8
+
+    @Deprecated("Please use another constructor")
+    public constructor(
+        username: String,
+        password: String,
+        realm: String? = null,
+        sendWithoutRequest: Boolean = false
+    ) : this(
+        credentials = { BasicAuthCredentials(username, password) },
+        realm = realm,
+        sendWithoutRequestCallback = { sendWithoutRequest }
+    )
+
+    private val tokensHolder = AuthTokenHolder(credentials)
+
+    override val sendWithoutRequest: Boolean
+        get() = error("Deprecated")
+
+    override fun sendWithoutRequest(request: HttpRequestBuilder): Boolean = sendWithoutRequestCallback(request)
 
     override fun isApplicable(auth: HttpAuthHeader): Boolean {
         if (auth.authScheme != AuthScheme.Basic) return false
@@ -69,13 +118,19 @@ public class BasicAuthProvider(
     }
 
     override suspend fun addRequestHeaders(request: HttpRequestBuilder) {
-        request.headers[HttpHeaders.Authorization] = constructBasicAuthValue()
+        val credentials = tokensHolder.loadToken() ?: return
+        request.headers[HttpHeaders.Authorization] = constructBasicAuthValue(credentials)
     }
 
-    internal fun constructBasicAuthValue(): String {
-        val authString = "$username:$password"
-        val authBuf = authString.toByteArray(defaultCharset).encodeBase64()
-
-        return "Basic $authBuf"
+    override suspend fun refreshToken(response: HttpResponse): Boolean {
+        tokensHolder.setToken(credentials)
+        return true
     }
+}
+
+internal fun constructBasicAuthValue(credentials: BasicAuthCredentials): String {
+    val authString = "${credentials.username}:${credentials.password}"
+    val authBuf = authString.toByteArray(Charsets.UTF_8).encodeBase64()
+
+    return "Basic $authBuf"
 }

--- a/ktor-client/ktor-client-features/ktor-client-auth/common/src/io/ktor/client/features/auth/providers/DigestAuthProvider.kt
+++ b/ktor-client/ktor-client-features/ktor-client-auth/common/src/io/ktor/client/features/auth/providers/DigestAuthProvider.kt
@@ -6,6 +6,7 @@ package io.ktor.client.features.auth.providers
 
 import io.ktor.client.features.auth.*
 import io.ktor.client.request.*
+import io.ktor.client.statement.*
 import io.ktor.http.*
 import io.ktor.http.auth.*
 import io.ktor.util.*
@@ -19,7 +20,7 @@ import kotlinx.atomicfu.*
 public fun Auth.digest(block: DigestAuthConfig.() -> Unit) {
     val config = DigestAuthConfig().apply(block)
     with(config) {
-        providers += DigestAuthProvider(username, password, realm, algorithmName)
+        providers += DigestAuthProvider(_credentials, realm, algorithmName)
     }
 }
 
@@ -28,30 +29,90 @@ public fun Auth.digest(block: DigestAuthConfig.() -> Unit) {
  */
 @Suppress("KDocMissingDocumentation")
 public class DigestAuthConfig {
-    public var username: String = ""
-    public var password: String = ""
-    public var realm: String? = null
+
     public var algorithmName: String = "MD5"
+
+    /**
+     * Required: The username of the basic auth.
+     */
+    @Deprecated("Please use `credentials {}` function instead")
+    public lateinit var username: String
+
+    /**
+     * Required: The password of the basic auth.
+     */
+    @Deprecated("Please use `credentials {}` function instead")
+    public lateinit var password: String
+
+    /**
+     * Optional: current provider realm
+     */
+    public var realm: String? = null
+
+    internal var _credentials: suspend () -> DigestAuthCredentials? = {
+        DigestAuthCredentials(username = username, password = password)
+    }
+
+    /**
+     * Required: Credentials provider.
+     */
+    public fun credentials(block: suspend () -> DigestAuthCredentials?) {
+        this._credentials = block
+    }
 }
+
+/**
+ * Credentials for [DigestAuthProvider].
+ */
+public class DigestAuthCredentials(
+    public val username: String,
+    public val password: String
+)
 
 /**
  * Client digest [AuthProvider].
  */
 @Suppress("KDocMissingDocumentation")
 public class DigestAuthProvider(
-    public val username: String,
-    public val password: String,
-    public val realm: String?,
-    public val algorithmName: String = "MD5"
+    private val credentials: suspend () -> DigestAuthCredentials?,
+    @Deprecated("This will become private") public val realm: String? = null,
+    @Deprecated("This will become private") public val algorithmName: String = "MD5",
 ) : AuthProvider {
-    override val sendWithoutRequest: Boolean = false
+
+    @Deprecated("Please use another constructor")
+    public constructor(
+        username: String,
+        password: String,
+        realm: String? = null,
+        algorithmName: String = "MD5"
+    ) : this(
+        credentials = { DigestAuthCredentials(username = username, password = password) },
+        realm = realm,
+        algorithmName = algorithmName
+    )
+
+    @Deprecated("This will be removed")
+    public val username: String
+        get() = error("Static username is not supported anymore")
+
+    @Deprecated("This will be removed")
+    public val password: String
+        get() = error("Static username is not supported anymore")
+
+    override val sendWithoutRequest: Boolean
+        get() = error("Deprecated")
 
     private val serverNonce = atomic<String?>(null)
+
     private val qop = atomic<String?>(null)
     private val opaque = atomic<String?>(null)
     private val clientNonce = generateNonce()
 
     private val requestCounter = atomic(0)
+
+    private val tokenHolder = AuthTokenHolder(credentials)
+
+    override fun sendWithoutRequest(request: HttpRequestBuilder): Boolean = false
 
     override fun isApplicable(auth: HttpAuthHeader): Boolean {
         if (auth !is HttpAuthHeader.Parameterized ||
@@ -83,7 +144,8 @@ public class DigestAuthProvider(
         val serverOpaque = opaque.value
         val actualQop = qop.value
 
-        val credential = makeDigest("$username:$realm:$password")
+        val credentials = tokenHolder.loadToken() ?: return
+        val credential = makeDigest("${credentials.username}:$realm:${credentials.password}")
 
         val start = hex(credential)
         val end = hex(makeDigest("$methodName:${url.fullPath}"))
@@ -103,7 +165,7 @@ public class DigestAuthProvider(
             linkedMapOf<String, String>().apply {
                 realm?.let { this["realm"] = it }
                 serverOpaque?.let { this["opaque"] = it }
-                this["username"] = username
+                this["username"] = credentials.username
                 this["nonce"] = nonce
                 this["cnonce"] = clientNonce
                 this["response"] = hex(token)
@@ -116,6 +178,11 @@ public class DigestAuthProvider(
         request.headers {
             append(HttpHeaders.Authorization, auth.render())
         }
+    }
+
+    override suspend fun refreshToken(response: HttpResponse): Boolean {
+        tokenHolder.setToken(credentials)
+        return true
     }
 
     private suspend fun makeDigest(data: String): ByteArray {

--- a/ktor-client/ktor-client-features/ktor-client-auth/common/test/io/ktor/client/features/auth/BasicProviderTest.kt
+++ b/ktor-client/ktor-client-features/ktor-client-auth/common/test/io/ktor/client/features/auth/BasicProviderTest.kt
@@ -33,5 +33,5 @@ class BasicProviderTest {
     }
 
     private fun buildAuthString(username: String, password: String): String =
-        BasicAuthProvider(username, password).constructBasicAuthValue()
+        constructBasicAuthValue(BasicAuthCredentials(username, password))
 }

--- a/ktor-client/ktor-client-features/ktor-client-auth/common/test/io/ktor/client/features/auth/DigestProviderTest.kt
+++ b/ktor-client/ktor-client-features/ktor-client-auth/common/test/io/ktor/client/features/auth/DigestProviderTest.kt
@@ -28,7 +28,9 @@ class DigestProviderTest {
         "Digest algorithm=MD5, username=\"username\", realm=\"realm\", nonce=\"nonce\", snonce=\"server-nonce\", " +
             "cnonce=\"client-nonce\", uri=\"requested-uri\", request=\"client-digest\", message=\"message-digest\""
 
-    private val digestAuthProvider by lazy { DigestAuthProvider("username", "password", "realm") }
+    private val digestAuthProvider by lazy {
+        DigestAuthProvider({ DigestAuthCredentials("username", "password") }, "realm")
+    }
 
     lateinit var requestBuilder: HttpRequestBuilder
 

--- a/ktor-client/ktor-client-features/ktor-client-auth/common/test/io/ktor/client/features/auth/TokenHolderTest.kt
+++ b/ktor-client/ktor-client-features/ktor-client-auth/common/test/io/ktor/client/features/auth/TokenHolderTest.kt
@@ -9,22 +9,17 @@ import io.ktor.test.dispatcher.*
 import kotlinx.coroutines.*
 import kotlin.test.*
 
-class BearerAuthProviderTest {
+class TokenHolderTest {
 
     @Test
     fun testSetTokenCalledOnce() = testSuspend {
-        val provider = BearerAuthProvider(
-            { TODO() },
-            { TODO() },
-            true,
-            null
-        )
+        val holder = AuthTokenHolder<BearerTokens> { TODO() }
 
         val monitor = Job()
         var firstExecuted = false
         var secondExecuted = false
         val first = GlobalScope.launch(Dispatchers.Unconfined) {
-            provider.setToken {
+            holder.setToken {
                 println(1)
                 firstExecuted = true
                 monitor.join()
@@ -33,7 +28,7 @@ class BearerAuthProviderTest {
         }
 
         val second = GlobalScope.launch(Dispatchers.Unconfined) {
-            provider.setToken {
+            holder.setToken {
                 println(2)
                 secondExecuted = true
                 BearerTokens("1", "2")

--- a/ktor-client/ktor-client-tests/jvm/src/io/ktor/client/tests/utils/tests/Auth.kt
+++ b/ktor-client/ktor-client-tests/jvm/src/io/ktor/client/tests/utils/tests/Auth.kt
@@ -32,6 +32,16 @@ internal fun Application.authTestServer() {
             }
         }
 
+        digest("digest-2") {
+            val password = "some password"
+            algorithmName = "MD5"
+            realm = "testrealm-2@host.com"
+
+            digestProvider { userName, realm ->
+                digest(MessageDigest.getInstance(algorithmName), "$userName:$realm:$password")
+            }
+        }
+
         basic("basic") {
             validate { credential ->
                 check("MyUser" == credential.name)
@@ -67,6 +77,11 @@ internal fun Application.authTestServer() {
 
             authenticate("digest") {
                 get("digest") {
+                    call.respondText("ok")
+                }
+            }
+            authenticate("digest-2") {
+                get("digest-2") {
                     call.respondText("ok")
                 }
             }


### PR DESCRIPTION
**Subsystem**
Client, Auth

**Motivation**
* `sendWithoutRequest` can't be configured at per request level. 
* credentials can be installed only during the initialization of a client and can't be updated later.

**Solution**
* `sendWithoutRequest` is now a function that takes request builder as a parameter.
* Credentials are now suspended functions. The result is cached and will be updated after a 401 request from the server.

