### PR TITLE
KTOR-367 Deprecate uninstallFeature method

### DIFF
--- a/ktor-server/ktor-server-core/jvm/src/io/ktor/application/ApplicationFeature.kt
+++ b/ktor-server/ktor-server-core/jvm/src/io/ktor/application/ApplicationFeature.kt
@@ -89,6 +89,10 @@ public fun <P : Pipeline<*, ApplicationCall>, B : Any, F : Any> P.install(
 /**
  * Uninstalls all features from the pipeline
  */
+@Deprecated(
+    "This method is misleading and will be removed. " +
+        "Please file a ticket and clarify, why do you need it."
+)
 public fun <A : Pipeline<*, ApplicationCall>> A.uninstallAllFeatures() {
     val registry = attributes.computeIfAbsent(featureRegistryKey) { Attributes(true) }
     registry.allKeys.forEach {
@@ -100,6 +104,10 @@ public fun <A : Pipeline<*, ApplicationCall>> A.uninstallAllFeatures() {
 /**
  * Uninstalls [feature] from the pipeline
  */
+@Deprecated(
+    "This method is misleading and will be removed. " +
+        "Please file a ticket and clarify, why do you need it."
+)
 public fun <A : Pipeline<*, ApplicationCall>, B : Any, F : Any> A.uninstall(
     feature: ApplicationFeature<A, B, F>
 ): Unit = uninstallFeature(feature.key)
@@ -107,6 +115,10 @@ public fun <A : Pipeline<*, ApplicationCall>, B : Any, F : Any> A.uninstall(
 /**
  * Uninstalls feature specified by [key] from the pipeline
  */
+@Deprecated(
+    "This method is misleading and will be removed. " +
+        "Please file a ticket and clarify, why do you need it."
+)
 public fun <A : Pipeline<*, ApplicationCall>, F : Any> A.uninstallFeature(key: AttributeKey<F>) {
     val registry = attributes.getOrNull(featureRegistryKey) ?: return
     val instance = registry.getOrNull(key) ?: return

--- a/ktor-server/ktor-server-core/jvm/src/io/ktor/application/ApplicationFeature.kt
+++ b/ktor-server/ktor-server-core/jvm/src/io/ktor/application/ApplicationFeature.kt
@@ -91,7 +91,7 @@ public fun <P : Pipeline<*, ApplicationCall>, B : Any, F : Any> P.install(
  */
 @Deprecated(
     "This method is misleading and will be removed. " +
-        "Please file a ticket and clarify, why do you need it."
+        "If you have use case that requires this functionaity, please add it in KTOR-2696"
 )
 public fun <A : Pipeline<*, ApplicationCall>> A.uninstallAllFeatures() {
     val registry = attributes.computeIfAbsent(featureRegistryKey) { Attributes(true) }
@@ -106,7 +106,7 @@ public fun <A : Pipeline<*, ApplicationCall>> A.uninstallAllFeatures() {
  */
 @Deprecated(
     "This method is misleading and will be removed. " +
-        "Please file a ticket and clarify, why do you need it."
+        "If you have use case that requires this functionaity, please add it in KTOR-2696"
 )
 public fun <A : Pipeline<*, ApplicationCall>, B : Any, F : Any> A.uninstall(
     feature: ApplicationFeature<A, B, F>
@@ -117,7 +117,7 @@ public fun <A : Pipeline<*, ApplicationCall>, B : Any, F : Any> A.uninstall(
  */
 @Deprecated(
     "This method is misleading and will be removed. " +
-        "Please file a ticket and clarify, why do you need it."
+        "If you have use case that requires this functionaity, please add it in KTOR-2696"
 )
 public fun <A : Pipeline<*, ApplicationCall>, F : Any> A.uninstallFeature(key: AttributeKey<F>) {
     val registry = attributes.getOrNull(featureRegistryKey) ?: return


### PR DESCRIPTION
**Subsystem**
Server

**Motivation**
This method is misleading. It only closes open resources, but doesn't remove feature interceptors.
Right now, there is no way to properly uninstall features, but also no clear use case for that. 

