### PR TITLE
Deprecate KtorExperimentalAPI

### DIFF
--- a/gradle/experimental.gradle
+++ b/gradle/experimental.gradle
@@ -5,7 +5,6 @@
 ext.experimentalAnnotations = [
     "kotlin.RequiresOptIn",
     "kotlin.ExperimentalUnsignedTypes",
-    "io.ktor.util.KtorExperimentalAPI",
     "io.ktor.util.InternalAPI",
     "io.ktor.utils.io.core.ExperimentalIoApi",
     "io.ktor.utils.io.core.internal.DangerousInternalIoApi",

--- a/ktor-client/ktor-client-core/common/src/io/ktor/client/HttpClient.kt
+++ b/ktor-client/ktor-client-core/common/src/io/ktor/client/HttpClient.kt
@@ -178,7 +178,6 @@ public class HttpClient(
     /**
      * Creates a new [HttpRequest] from a request [data] and a specific client [call].
      */
-
     @Deprecated(
         "Unbound [HttpClientCall] is deprecated. Consider using [request<HttpResponse>(builder)] instead.",
         level = DeprecationLevel.ERROR,

--- a/ktor-client/ktor-client-core/common/src/io/ktor/client/call/SavedCall.kt
+++ b/ktor-client/ktor-client-core/common/src/io/ktor/client/call/SavedCall.kt
@@ -67,7 +67,6 @@ internal class SavedHttpResponse(
 /**
  * Fetch data for [HttpClientCall] and close the origin.
  */
-@KtorExperimentalAPI
 public suspend fun HttpClientCall.save(): HttpClientCall {
     val currentClient = client ?: error("Failed to save call in different native thread.")
 

--- a/ktor-client/ktor-client-core/common/src/io/ktor/client/engine/HttpClientEngine.kt
+++ b/ktor-client/ktor-client-core/common/src/io/ktor/client/engine/HttpClientEngine.kt
@@ -36,7 +36,6 @@ public interface HttpClientEngine : CoroutineScope, Closeable {
     /**
      * Set of supported engine extensions.
      */
-    @KtorExperimentalAPI
     public val supportedCapabilities: Set<HttpClientEngineCapability<*>>
         get() = emptySet()
 

--- a/ktor-client/ktor-client-core/common/src/io/ktor/client/engine/HttpClientEngineCapability.kt
+++ b/ktor-client/ktor-client-core/common/src/io/ktor/client/engine/HttpClientEngineCapability.kt
@@ -11,7 +11,6 @@ import kotlin.native.concurrent.*
 /**
  * Key required to access capabilities.
  */
-@KtorExperimentalAPI
 @SharedImmutable
 internal val ENGINE_CAPABILITIES_KEY =
     AttributeKey<MutableMap<HttpClientEngineCapability<*>, Any>>("EngineCapabilities")
@@ -19,7 +18,6 @@ internal val ENGINE_CAPABILITIES_KEY =
 /**
  * Default capabilities expected to be supported by engine.
  */
-@KtorExperimentalAPI
 @SharedImmutable
 public val DEFAULT_CAPABILITIES: Set<HttpTimeout.Feature> = setOf(HttpTimeout)
 

--- a/ktor-client/ktor-client-core/common/src/io/ktor/client/engine/HttpClientEngineConfig.kt
+++ b/ktor-client/ktor-client-core/common/src/io/ktor/client/engine/HttpClientEngineConfig.kt
@@ -15,7 +15,6 @@ public open class HttpClientEngineConfig {
     /**
      * Network threads count advice.
      */
-    @KtorExperimentalAPI
     public var threadsCount: Int = 4
 
     /**
@@ -28,7 +27,6 @@ public open class HttpClientEngineConfig {
      *
      * See [ProxyBuilder] to create proxy.
      */
-    @KtorExperimentalAPI
     public var proxy: ProxyConfig? = null
 
     @Deprecated(

--- a/ktor-client/ktor-client-core/common/src/io/ktor/client/features/HttpCallValidator.kt
+++ b/ktor-client/ktor-client-core/common/src/io/ktor/client/features/HttpCallValidator.kt
@@ -5,7 +5,6 @@
 package io.ktor.client.features
 
 import io.ktor.client.*
-import io.ktor.client.call.*
 import io.ktor.client.features.HttpCallValidator.*
 import io.ktor.client.request.*
 import io.ktor.client.statement.*
@@ -153,4 +152,4 @@ public var HttpRequestBuilder.expectSuccess: Boolean
     set(value) = attributes.put(ExpectSuccessAttributeKey, value)
 
 @SharedImmutable
-internal val ExpectSuccessAttributeKey = AttributeKey<Boolean>("ExpectSuccessAttribyteKey")
+internal val ExpectSuccessAttributeKey = AttributeKey<Boolean>("ExpectSuccessAttributeKey")

--- a/ktor-client/ktor-client-core/common/src/io/ktor/client/features/HttpSend.kt
+++ b/ktor-client/ktor-client-core/common/src/io/ktor/client/features/HttpSend.kt
@@ -27,7 +27,6 @@ public typealias HttpSendInterceptorBackwardCompatible = suspend Sender.(HttpCli
 /**
  * This interface represents a request send pipeline interceptor chain
  */
-@KtorExperimentalAPI
 public interface Sender {
     /**
      * Execute send pipeline. It could start pipeline execution or replace the call
@@ -39,7 +38,6 @@ public interface Sender {
  * This is internal feature that is always installed.
  * @property maxSendCount is a maximum number of requests that can be sent during a call
  */
-@KtorExperimentalAPI
 public class HttpSend(
     maxSendCount: Int = 20
 ) {

--- a/ktor-client/ktor-client-core/common/src/io/ktor/client/features/cache/HttpCacheEntry.kt
+++ b/ktor-client/ktor-client-core/common/src/io/ktor/client/features/cache/HttpCacheEntry.kt
@@ -7,7 +7,6 @@ package io.ktor.client.features.cache
 import io.ktor.client.call.*
 import io.ktor.client.statement.*
 import io.ktor.http.*
-import io.ktor.util.*
 import io.ktor.util.date.*
 import io.ktor.utils.io.*
 import io.ktor.utils.io.core.*
@@ -21,8 +20,6 @@ internal suspend fun HttpCacheEntry(response: HttpResponse): HttpCacheEntry {
 /**
  * Client single response cache with [expires] and [varyKeys].
  */
-@KtorExperimentalAPI
-@Suppress("KDocMissingDocumentation")
 public class HttpCacheEntry internal constructor(
     public val expires: GMTDate,
     public val varyKeys: Map<String, String>,

--- a/ktor-client/ktor-client-core/common/src/io/ktor/client/features/cache/storage/HttpCacheStorage.kt
+++ b/ktor-client/ktor-client-core/common/src/io/ktor/client/features/cache/storage/HttpCacheStorage.kt
@@ -12,7 +12,6 @@ import io.ktor.util.*
 /**
  * Cache storage interface.
  */
-@KtorExperimentalAPI
 public abstract class HttpCacheStorage {
 
     /**

--- a/ktor-client/ktor-client-core/common/src/io/ktor/client/features/observer/DelegatedCall.kt
+++ b/ktor-client/ktor-client-core/common/src/io/ktor/client/features/observer/DelegatedCall.kt
@@ -30,7 +30,6 @@ public fun HttpClientCall.wrapWithContent(
 /**
  * Wrap existing [HttpClientCall] with new [content].
  */
-@KtorExperimentalAPI
 public fun HttpClientCall.wrapWithContent(content: ByteReadChannel): HttpClientCall {
     val currentClient = client ?: error("Fail to create response observer in different native thread.")
 

--- a/ktor-client/ktor-client-core/common/src/io/ktor/client/request/HttpRequest.kt
+++ b/ktor-client/ktor-client-core/common/src/io/ktor/client/request/HttpRequest.kt
@@ -84,7 +84,6 @@ public class HttpRequestBuilder : HttpMessageBuilder {
     /**
      * A deferred used to control the execution of this request.
      */
-    @KtorExperimentalAPI
     public var executionContext: Job = SupervisorJob()
         .also { it.makeShared() }
         internal set(value) {
@@ -147,7 +146,6 @@ public class HttpRequestBuilder : HttpMessageBuilder {
     /**
      * Set capability configuration.
      */
-    @KtorExperimentalAPI
     public fun <T : Any> setCapability(key: HttpClientEngineCapability<T>, capability: T) {
         val capabilities = attributes.computeIfAbsent(ENGINE_CAPABILITIES_KEY) { sharedMap() }
         capabilities[key] = capability
@@ -156,7 +154,6 @@ public class HttpRequestBuilder : HttpMessageBuilder {
     /**
      * Retrieve capability by key.
      */
-    @KtorExperimentalAPI
     public fun <T : Any> getCapabilityOrNull(key: HttpClientEngineCapability<T>): T? {
         @Suppress("UNCHECKED_CAST")
         return attributes.getOrNull(ENGINE_CAPABILITIES_KEY)?.get(key) as T?
@@ -180,7 +177,6 @@ public class HttpRequestData @InternalAPI constructor(
     /**
      * Retrieve extension by it's key.
      */
-    @KtorExperimentalAPI
     public fun <T> getCapabilityOrNull(key: HttpClientEngineCapability<T>): T? {
         @Suppress("UNCHECKED_CAST")
         return attributes.getOrNull(ENGINE_CAPABILITIES_KEY)?.get(key) as T?

--- a/ktor-client/ktor-client-core/common/src/io/ktor/client/request/forms/formDsl.kt
+++ b/ktor-client/ktor-client-core/common/src/io/ktor/client/request/forms/formDsl.kt
@@ -30,6 +30,7 @@ public fun formData(vararg values: FormPart<*>): List<PartData> {
             append(HttpHeaders.ContentDisposition, "form-data; name=${key.escapeIfNeeded()}")
             appendAll(headers)
         }
+
         val part = when (value) {
             is String -> PartData.FormItem(value, {}, partHeaders.build())
             is Number -> PartData.FormItem(value.toString(), {}, partHeaders.build())
@@ -165,7 +166,6 @@ public inline fun FormBuilder.append(
  * @property size estimate for data produced by the block or `null` if no size estimation known
  * @param block: content generator
  */
-@KtorExperimentalAPI
 public class InputProvider(public val size: Long? = null, public val block: () -> Input)
 
 /**

--- a/ktor-client/ktor-client-core/common/src/io/ktor/client/utils/CacheControl.kt
+++ b/ktor-client/ktor-client-core/common/src/io/ktor/client/utils/CacheControl.kt
@@ -4,13 +4,10 @@
 
 package io.ktor.client.utils
 
-import io.ktor.util.*
-
 /**
  * List of [CacheControl] known values.
  */
 @Suppress("KDocMissingDocumentation", "MemberVisibilityCanBePrivate")
-@KtorExperimentalAPI
 public object CacheControl {
     public const val MAX_AGE: String = "max-age"
     public const val MIN_FRESH: String = "min-fresh"

--- a/ktor-client/ktor-client-curl/posix/test/io/ktor/client/engine/curl/test/CurlProxyTest.kt
+++ b/ktor-client/ktor-client-curl/posix/test/io/ktor/client/engine/curl/test/CurlProxyTest.kt
@@ -7,7 +7,6 @@ package io.ktor.client.engine.curl.test
 import io.ktor.client.*
 import io.ktor.client.engine.*
 import io.ktor.client.engine.curl.*
-import io.ktor.client.features.json.*
 import io.ktor.client.request.*
 import io.ktor.client.statement.*
 import io.ktor.http.*

--- a/ktor-client/ktor-client-features/ktor-client-logging/jvm/src/io/ktor/client/features/logging/LoggerJvm.kt
+++ b/ktor-client/ktor-client-features/ktor-client-logging/jvm/src/io/ktor/client/features/logging/LoggerJvm.kt
@@ -20,7 +20,6 @@ public actual val Logger.Companion.DEFAULT: Logger
  * Android [Logger]: breaks up long log messages that would be truncated by Android's max log
  * length of 4068 characters
  */
-@KtorExperimentalAPI
 public val Logger.Companion.ANDROID: Logger
     get() = MessageLengthLimitingLogger()
 
@@ -30,7 +29,6 @@ public val Logger.Companion.ANDROID: Logger
  * @property minLength if log message is longer than [maxLength], attempt to break the log
  * message at a new line between [minLength] and [maxLength] if one exists
  */
-@KtorExperimentalAPI
 public class MessageLengthLimitingLogger(
     private val maxLength: Int = 4000,
     private val minLength: Int = 3000,

--- a/ktor-client/ktor-client-ios/darwin/src/io/ktor/client/engine/ios/IosUtils.kt
+++ b/ktor-client/ktor-client-ios/darwin/src/io/ktor/client/engine/ios/IosUtils.kt
@@ -48,6 +48,5 @@ internal inline fun <T : CPointed, R> CPointer<T>.use(block: (CPointer<T>) -> R)
     }
 }
 
-@KtorExperimentalAPI
 @Suppress("KDocMissingDocumentation")
 public class IosHttpRequestException(public val origin: NSError) : IOException("Exception in http request: $origin")

--- a/ktor-client/ktor-client-ios/darwin/src/io/ktor/client/engine/ios/certificates/CertificatePinner.kt
+++ b/ktor-client/ktor-client-ios/darwin/src/io/ktor/client/engine/ios/certificates/CertificatePinner.kt
@@ -107,7 +107,6 @@ import platform.Security.*
  * https://square.github.io/okhttp/4.x/okhttp/okhttp3/-certificate-pinner/
  * https://github.com/square/okhttp/blob/master/okhttp/src/main/java/okhttp3/CertificatePinner.kt
  */
-@KtorExperimentalAPI
 public data class CertificatePinner internal constructor(
     private val pinnedCertificates: Set<PinnedCertificate>,
     private val validateTrust: Boolean
@@ -321,7 +320,7 @@ public data class CertificatePinner internal constructor(
     /**
      * Checks that we support the key type and size
      */
-    internal fun checkValidKeyType(publicKeyType: NSString, publicKeySize: NSNumber): Boolean {
+    private fun checkValidKeyType(publicKeyType: NSString, publicKeySize: NSNumber): Boolean {
         val keyTypeRSA = CFBridgingRelease(kSecAttrKeyTypeRSA) as NSString
         val keyTypeECSECPrimeRandom = CFBridgingRelease(kSecAttrKeyTypeECSECPrimeRandom) as NSString
 
@@ -339,7 +338,7 @@ public data class CertificatePinner internal constructor(
      * Get the [IntArray] of Asn1 headers needed to prepend to the public key to create the
      * encoding [ASN1Header](https://docs.oracle.com/middleware/11119/opss/SCRPJ/oracle/security/crypto/asn1/ASN1Header.html)
      */
-    internal fun getAsn1HeaderBytes(publicKeyType: NSString, publicKeySize: NSNumber): IntArray {
+    private fun getAsn1HeaderBytes(publicKeyType: NSString, publicKeySize: NSNumber): IntArray {
         val keyTypeRSA = CFBridgingRelease(kSecAttrKeyTypeRSA) as NSString
         val keyTypeECSECPrimeRandom = CFBridgingRelease(kSecAttrKeyTypeECSECPrimeRandom) as NSString
 
@@ -385,7 +384,6 @@ public data class CertificatePinner internal constructor(
     /**
      * Builds a configured [CertificatePinner].
      */
-    @KtorExperimentalAPI
     public data class Builder(
         private val pinnedCertificates: MutableList<PinnedCertificate> = mutableListOf(),
         private var validateTrust: Boolean = true

--- a/ktor-client/ktor-client-ios/darwin/src/io/ktor/client/engine/ios/certificates/PinnedCertificate.kt
+++ b/ktor-client/ktor-client-ios/darwin/src/io/ktor/client/engine/ios/certificates/PinnedCertificate.kt
@@ -13,7 +13,6 @@ import io.ktor.util.*
  * Represents a pinned certificate. Recommended to use [Builder.add] to construct
  * [CertificatePinner]
  */
-@KtorExperimentalAPI
 public data class PinnedCertificate(
     /**
      * A hostname like `example.com` or a pattern like `*.example.com` (canonical form).

--- a/ktor-client/ktor-client-mock/common/src/io/ktor/client/engine/mock/MockUtils.kt
+++ b/ktor-client/ktor-client-mock/common/src/io/ktor/client/engine/mock/MockUtils.kt
@@ -14,7 +14,6 @@ import io.ktor.utils.io.charsets.*
 import io.ktor.utils.io.core.*
 
 @Suppress("KDocMissingDocumentation")
-@KtorExperimentalAPI
 public suspend fun OutgoingContent.toByteArray(): ByteArray = when (this) {
     is OutgoingContent.ByteArrayContent -> bytes()
     is OutgoingContent.ReadChannelContent -> readFrom().toByteArray()
@@ -25,7 +24,6 @@ public suspend fun OutgoingContent.toByteArray(): ByteArray = when (this) {
 }
 
 @Suppress("KDocMissingDocumentation")
-@KtorExperimentalAPI
 public suspend fun OutgoingContent.toByteReadPacket(): ByteReadPacket = when (this) {
     is OutgoingContent.ByteArrayContent -> ByteReadPacket(bytes())
     is OutgoingContent.ReadChannelContent -> readFrom().readRemaining()

--- a/ktor-http/common/src/io/ktor/http/Cookie.kt
+++ b/ktor-http/common/src/io/ktor/http/Cookie.kt
@@ -73,7 +73,6 @@ private val loweredPartNames = setOf("max-age", "expires", "domain", "path", "se
 /**
  * Parse server's `Set-Cookie` header value
  */
-@KtorExperimentalAPI
 public fun parseServerSetCookieHeader(cookiesHeader: String): Cookie {
     val asMap = parseClientCookiesHeader(cookiesHeader, false)
     val first = asMap.entries.first { !it.key.startsWith("$") }
@@ -102,7 +101,6 @@ private val clientCookieHeaderPattern = """(^|;)\s*([^()<>@;:/\\"\[\]\?=\{\}\s]+
 /**
  * Parse client's `Cookie` header value
  */
-@KtorExperimentalAPI
 public fun parseClientCookiesHeader(cookiesHeader: String, skipEscaped: Boolean = true): Map<String, String> =
     clientCookieHeaderPattern.findAll(cookiesHeader)
         .map { (it.groups[2]?.value ?: "") to (it.groups[4]?.value ?: "") }
@@ -119,7 +117,6 @@ public fun parseClientCookiesHeader(cookiesHeader: String, skipEscaped: Boolean 
 /**
  * Format `Set-Cookie` header value
  */
-@KtorExperimentalAPI
 public fun renderSetCookieHeader(cookie: Cookie): String = with(cookie) {
     renderSetCookieHeader(
         name,
@@ -138,7 +135,6 @@ public fun renderSetCookieHeader(cookie: Cookie): String = with(cookie) {
 /**
  * Format `Set-Cookie` header value
  */
-@KtorExperimentalAPI
 public fun renderCookieHeader(cookie: Cookie): String = with(cookie) {
     renderSetCookieHeader(
         name,
@@ -158,7 +154,6 @@ public fun renderCookieHeader(cookie: Cookie): String = with(cookie) {
 /**
  * Format `Set-Cookie` header value
  */
-@KtorExperimentalAPI
 public fun renderSetCookieHeader(
     name: String,
     value: String,
@@ -189,7 +184,6 @@ public fun renderSetCookieHeader(
 /**
  * Encode cookie value using the specified [encoding]
  */
-@KtorExperimentalAPI
 public fun encodeCookieValue(value: String, encoding: CookieEncoding): String = when (encoding) {
     CookieEncoding.RAW -> when {
         value.any { it.shouldEscapeInCookies() } ->
@@ -214,7 +208,6 @@ public fun encodeCookieValue(value: String, encoding: CookieEncoding): String = 
 /**
  * Decode cookie value using the specified [encoding]
  */
-@KtorExperimentalAPI
 public fun decodeCookieValue(encodedValue: String, encoding: CookieEncoding): String = when (encoding) {
     CookieEncoding.RAW, CookieEncoding.DQUOTES -> when {
         encodedValue.trimStart().startsWith("\"") && encodedValue.trimEnd().endsWith("\"") ->

--- a/ktor-http/common/src/io/ktor/http/HttpUrlEncoded.kt
+++ b/ktor-http/common/src/io/ktor/http/HttpUrlEncoded.kt
@@ -4,14 +4,12 @@
 
 package io.ktor.http
 
-import io.ktor.util.*
 import io.ktor.utils.io.charsets.*
 
 /**
  * Options for URL Encoding.
  * Keys and values are encoded only when [encodeKey] and [encodeValue] are `true` respectively.
  */
-@KtorExperimentalAPI
 public enum class UrlEncodingOption(internal val encodeKey: Boolean, internal val encodeValue: Boolean) {
     DEFAULT(true, true),
     KEY_ONLY(true, false),
@@ -22,7 +20,6 @@ public enum class UrlEncodingOption(internal val encodeKey: Boolean, internal va
 /**
  * Parse URL query parameters. Shouldn't be used for urlencoded forms because of `+` character.
  */
-@KtorExperimentalAPI
 public fun String.parseUrlEncodedParameters(defaultEncoding: Charset = Charsets.UTF_8, limit: Int = 1000): Parameters {
     val parameters: List<Pair<String, String>> =
         split("&", limit = limit).map { it.substringBefore("=") to it.substringAfter("=", "") }
@@ -49,13 +46,13 @@ public fun List<Pair<String, String?>>.formUrlEncode(): String = formUrlEncode(U
 /**
  * Encode form parameters from a list of pairs
  */
-@KtorExperimentalAPI
 public fun List<Pair<String, String?>>.formUrlEncode(option: UrlEncodingOption = UrlEncodingOption.DEFAULT): String =
     buildString { formUrlEncodeTo(this, option) }
 
 /**
  * Encode form parameters from a list of pairs to the specified [out] appendable
  */
+@Suppress("unused")
 @Deprecated("Binary compatibility", level = DeprecationLevel.HIDDEN)
 public fun List<Pair<String, String?>>.formUrlEncodeTo(out: Appendable): Unit =
     formUrlEncodeTo(out, UrlEncodingOption.DEFAULT)
@@ -63,7 +60,6 @@ public fun List<Pair<String, String?>>.formUrlEncodeTo(out: Appendable): Unit =
 /**
  * Encode form parameters from a list of pairs to the specified [out] appendable by using [option]
  */
-@KtorExperimentalAPI
 public fun List<Pair<String, String?>>.formUrlEncodeTo(
     out: Appendable,
     option: UrlEncodingOption = UrlEncodingOption.DEFAULT
@@ -98,11 +94,11 @@ internal fun ParametersBuilder.formUrlEncodeTo(out: Appendable) {
     entries().formUrlEncodeTo(out, urlEncodingOption)
 }
 
+@Suppress("unused")
 @Deprecated("Binary compatibility", level = DeprecationLevel.HIDDEN)
 internal fun Set<Map.Entry<String, List<String>>>.formUrlEncodeTo(out: Appendable) =
     formUrlEncodeTo(out, UrlEncodingOption.DEFAULT)
 
-@KtorExperimentalAPI
 internal fun Set<Map.Entry<String, List<String>>>.formUrlEncodeTo(
     out: Appendable,
     option: UrlEncodingOption = UrlEncodingOption.DEFAULT

--- a/ktor-http/common/src/io/ktor/http/Parameters.kt
+++ b/ktor-http/common/src/io/ktor/http/Parameters.kt
@@ -13,7 +13,6 @@ public interface Parameters : StringValues {
     /**
      * Returns a [UrlEncodingOption] instance
      */
-    @KtorExperimentalAPI
     public val urlEncodingOption: UrlEncodingOption
         get() = UrlEncodingOption.DEFAULT
 

--- a/ktor-network/common/src/io/ktor/network/selector/Selectable.kt
+++ b/ktor-network/common/src/io/ktor/network/selector/Selectable.kt
@@ -6,7 +6,6 @@ import kotlinx.coroutines.*
 /**
  * A selectable entity with selectable NIO [channel], [interestedOps] subscriptions.
  */
-@KtorExperimentalAPI
 public expect interface Selectable
 
 @Suppress("KDocMissingDocumentation")

--- a/ktor-network/common/src/io/ktor/network/selector/SelectorManagerCommon.kt
+++ b/ktor-network/common/src/io/ktor/network/selector/SelectorManagerCommon.kt
@@ -17,7 +17,6 @@ public expect fun SelectorManager(
 /**
  * SelectorManager interface allows [Selectable] wait for [SelectInterest].
  */
-@InternalAPI
 public expect interface SelectorManager : CoroutineScope, Closeable {
     /**
      * Notifies the selector that selectable has been closed.
@@ -40,10 +39,8 @@ public expect interface SelectorManager : CoroutineScope, Closeable {
 
 /**
  * Select interest kind
- * @property [flag] to be set in NIO selector
  */
 @Suppress("KDocMissingDocumentation", "NO_EXPLICIT_VISIBILITY_IN_API_MODE_WARNING")
-@KtorExperimentalAPI
 @InternalAPI
 public expect enum class SelectInterest {
     READ, WRITE, ACCEPT, CONNECT;

--- a/ktor-network/js/src/io/ktor/network/selector/SelectableJs.kt
+++ b/ktor-network/js/src/io/ktor/network/selector/SelectableJs.kt
@@ -10,5 +10,4 @@ import io.ktor.util.*
 /**
  * A selectable entity with selectable NIO [channel], [interestedOps] subscriptions
  */
-@KtorExperimentalAPI
 public actual interface Selectable

--- a/ktor-network/js/src/io/ktor/network/selector/SelectorManagerJs.kt
+++ b/ktor-network/js/src/io/ktor/network/selector/SelectorManagerJs.kt
@@ -14,7 +14,6 @@ public actual fun SelectorManager(dispatcher: CoroutineContext): SelectorManager
     error("Selector manager is unsupported on JS platform")
 }
 
-@InternalAPI
 public actual interface SelectorManager : CoroutineScope, Closeable {
     /**
      * Notifies the selector that selectable has been closed.
@@ -40,7 +39,6 @@ public actual interface SelectorManager : CoroutineScope, Closeable {
 
 /**
  * Select interest kind
- * @property [flag] to be set in NIO selector
  */
 @Suppress("KDocMissingDocumentation", "NO_EXPLICIT_VISIBILITY_IN_API_MODE_WARNING")
 @InternalAPI

--- a/ktor-network/jvm/src/io/ktor/network/selector/ActorSelectorManager.kt
+++ b/ktor-network/jvm/src/io/ktor/network/selector/ActorSelectorManager.kt
@@ -4,7 +4,6 @@
 
 package io.ktor.network.selector
 
-import io.ktor.util.*
 import kotlinx.coroutines.*
 import kotlinx.coroutines.channels.*
 import java.io.*
@@ -179,7 +178,7 @@ public class ActorSelectorManager(context: CoroutineContext) : SelectorManagerSu
     private class ContinuationHolder<R, C : Continuation<R>> {
         private val ref = AtomicReference<C?>(null)
 
-        public fun resume(value: R): Boolean {
+        fun resume(value: R): Boolean {
             val continuation = ref.getAndSet(null)
             if (continuation != null) {
                 continuation.resume(value)

--- a/ktor-network/jvm/src/io/ktor/network/selector/SelectorManagerSupport.kt
+++ b/ktor-network/jvm/src/io/ktor/network/selector/SelectorManagerSupport.kt
@@ -4,7 +4,6 @@
 
 package io.ktor.network.selector
 
-import io.ktor.util.*
 import kotlinx.coroutines.*
 import java.nio.channels.*
 import java.nio.channels.spi.*

--- a/ktor-network/jvm/src/io/ktor/network/sockets/DatagramSendChannel.kt
+++ b/ktor-network/jvm/src/io/ktor/network/sockets/DatagramSendChannel.kt
@@ -99,6 +99,8 @@ internal class DatagramSendChannel(
             socket.interestOp(SelectInterest.WRITE, true)
             socket.selector.select(socket, SelectInterest.WRITE)
 
+            @Suppress("BlockingMethodInNonBlockingContext")
+            // this is actually non-blocking invocation
             if (channel.send(buffer, address) != 0) {
                 socket.interestOp(SelectInterest.WRITE, false)
                 break

--- a/ktor-network/jvm/src/io/ktor/network/sockets/NIOSocketImpl.kt
+++ b/ktor-network/jvm/src/io/ktor/network/sockets/NIOSocketImpl.kt
@@ -37,7 +37,7 @@ internal abstract class NIOSocketImpl<out S>(
     //  that will cause broken data
     // however it is not the case for attachForWriting this is why we use direct writing in any case
 
-    public final override fun attachForReading(channel: ByteChannel): WriterJob {
+    final override fun attachForReading(channel: ByteChannel): WriterJob {
         return attachFor("reading", channel, writerJob) {
             if (pool != null) {
                 attachForReadingImpl(channel, this.channel, this, selector, pool, socketOptions)
@@ -47,7 +47,7 @@ internal abstract class NIOSocketImpl<out S>(
         }
     }
 
-    public final override fun attachForWriting(channel: ByteChannel): ReaderJob {
+    final override fun attachForWriting(channel: ByteChannel): ReaderJob {
         return attachFor("writing", channel, readerJob) {
             attachForWritingDirectImpl(channel, this.channel, this, selector, socketOptions)
         }

--- a/ktor-network/ktor-network-tls/ktor-network-tls-certificates/jvm/src/io/ktor/network/tls/certificates/builders.kt
+++ b/ktor-network/ktor-network-tls/ktor-network-tls-certificates/jvm/src/io/ktor/network/tls/certificates/builders.kt
@@ -21,7 +21,6 @@ internal data class CertificateInfo(val certificate: Certificate, val keys: KeyP
 /**
  * Builder for certificate
  */
-@KtorExperimentalAPI
 public class CertificateBuilder internal constructor() {
     /**
      * Certificate hash algorithm (required)
@@ -119,7 +118,6 @@ public fun buildKeyStore(block: KeyStoreBuilder.() -> Unit): KeyStore = KeyStore
 /**
  * Save [KeyStore] to [output] file with the specified [password]
  */
-@KtorExperimentalAPI
 public fun KeyStore.saveToFile(output: File, password: String) {
     output.parentFile?.mkdirs()
 

--- a/ktor-network/posix/src/io/ktor/network/selector/SelectableNative.kt
+++ b/ktor-network/posix/src/io/ktor/network/selector/SelectableNative.kt
@@ -4,9 +4,6 @@
 
 package io.ktor.network.selector
 
-import io.ktor.util.*
-
-@KtorExperimentalAPI
 public actual interface Selectable {
     public val descriptor: Int
 }

--- a/ktor-network/posix/src/io/ktor/network/selector/SelectorManager.kt
+++ b/ktor-network/posix/src/io/ktor/network/selector/SelectorManager.kt
@@ -39,7 +39,6 @@ public actual interface SelectorManager : CoroutineScope, Closeable {
 
 /**
  * Select interest kind
- * @property [flag] to be set in NIO selector
  */
 @Suppress("KDocMissingDocumentation", "NO_EXPLICIT_VISIBILITY_IN_API_MODE_WARNING")
 @InternalAPI

--- a/ktor-server/ktor-server-cio/jvm/src/io/ktor/server/cio/HttpServer.kt
+++ b/ktor-server/ktor-server-cio/jvm/src/io/ktor/server/cio/HttpServer.kt
@@ -30,7 +30,6 @@ public class HttpServer(
  * @property port to listen to
  * @property connectionIdleTimeoutSeconds time to live for IDLE connections
  */
-@KtorExperimentalAPI
 public data class HttpServerSettings(
     val host: String = "0.0.0.0",
     val port: Int = 8080,

--- a/ktor-server/ktor-server-core/jvm/src/io/ktor/features/HttpsRedirect.kt
+++ b/ktor-server/ktor-server-core/jvm/src/io/ktor/features/HttpsRedirect.kt
@@ -61,7 +61,6 @@ public class HttpsRedirect(config: Configuration) {
         /**
          * Exclude calls with paths matching the [pathSuffix] from being redirected to https by this feature.
          */
-        @KtorExperimentalAPI
         public fun excludeSuffix(pathSuffix: String) {
             exclude { call ->
                 call.request.origin.uri.endsWith(pathSuffix)

--- a/ktor-server/ktor-server-core/jvm/src/io/ktor/features/OriginConnectionPoint.kt
+++ b/ktor-server/ktor-server-core/jvm/src/io/ktor/features/OriginConnectionPoint.kt
@@ -20,7 +20,7 @@ public val ApplicationRequest.origin: RequestConnectionPoint
 /**
  * A key to install a mutable [RequestConnectionPoint]
  */
-@KtorExperimentalAPI
+@Deprecated("This API will be redesigned as per https://youtrack.jetbrains.com/issue/KTOR-2657")
 public val MutableOriginConnectionPointKey: AttributeKey<MutableOriginConnectionPoint> =
     AttributeKey("MutableOriginConnectionPointKey")
 
@@ -50,7 +50,7 @@ internal class OriginConnectionPoint(
     private val local: RequestConnectionPoint,
     private val hostHeaderValue: String?
 ) : RequestConnectionPoint {
-    public constructor(call: ApplicationCall) : this(call.request.local, call.request.header(HttpHeaders.Host))
+    constructor(call: ApplicationCall) : this(call.request.local, call.request.header(HttpHeaders.Host))
 
     override val scheme: String
         get() = local.scheme
@@ -241,12 +241,12 @@ public object ForwardedHeaderSupport : ApplicationFeature<ApplicationCallPipelin
 
     // do we need it public?
     private fun ApplicationRequest.forwarded() =
-        headers.getAll(HttpHeaders.Forwarded)?.flatMap { parseHeaderValue(";$it") }?.mapNotNull {
+        headers.getAll(HttpHeaders.Forwarded)?.flatMap { parseHeaderValue(";$it") }?.map {
             parseForwardedValue(it)
         }
 
-    private fun parseForwardedValue(value: HeaderValue): ForwardedHeaderValue? {
-        val map = value.params.associateByTo(HashMap<String, String>(), { it.name }, { it.value })
+    private fun parseForwardedValue(value: HeaderValue): ForwardedHeaderValue {
+        val map = value.params.associateByTo(HashMap(), { it.name }, { it.value })
 
         return ForwardedHeaderValue(map.remove("host"), map.remove("by"), map.remove("for"), map.remove("proto"), map)
     }

--- a/ktor-server/ktor-server-test-suites/jvm/src/io/ktor/server/testing/suites/SustainabilityTestSuite.kt
+++ b/ktor-server/ktor-server-test-suites/jvm/src/io/ktor/server/testing/suites/SustainabilityTestSuite.kt
@@ -117,8 +117,10 @@ abstract class SustainabilityTestSuite<TEngine : ApplicationEngine, TConfigurati
 
                 launch(CoroutineName("reader") + testDispatcher) {
                     use {
-                        val channel =
-                            getInputStream().toByteReadChannel(context = testDispatcher, pool = KtorDefaultPool)
+                        val channel = getInputStream().toByteReadChannel(
+                            context = testDispatcher,
+                            pool = KtorDefaultPool
+                        )
 
                         repeat(repeatCount) { requestNumber ->
                             parseResponse(channel)?.use { response ->

--- a/ktor-utils/common/src/io/ktor/util/Annotations.kt
+++ b/ktor-utils/common/src/io/ktor/util/Annotations.kt
@@ -46,6 +46,9 @@ public annotation class InternalAPI
     AnnotationTarget.FIELD,
     AnnotationTarget.CONSTRUCTOR
 )
+@Deprecated(
+    "This annotation is no longer used and there is no need to opt-in into it."
+)
 public annotation class KtorExperimentalAPI
 
 /**

--- a/ktor-utils/common/src/io/ktor/util/collections/ConcurrentList.kt
+++ b/ktor-utils/common/src/io/ktor/util/collections/ConcurrentList.kt
@@ -12,7 +12,6 @@ import kotlinx.atomicfu.locks.*
 
 private const val INITIAL_CAPACITY = 32
 
-@KtorExperimentalAPI
 public class ConcurrentList<T> : MutableList<T> {
     private var data by shared(SharedList<T>(INITIAL_CAPACITY))
 

--- a/ktor-utils/jvm/src/io/ktor/util/NioPath.kt
+++ b/ktor-utils/jvm/src/io/ktor/util/NioPath.kt
@@ -18,7 +18,6 @@ public val Path.extension: String get() = fileName.toString().substringAfterLast
  * Append a [relativePath] safely that means that adding any extra `..` path elements will not let
  * access anything out of the reference directory (unless you have symbolic or hard links or multiple mount points)
  */
-@KtorExperimentalAPI
 public fun Path.combineSafe(relativePath: Path): File {
     val normalized = relativePath.normalizeAndRelativize()
     if (normalized.startsWith("..")) {
@@ -45,7 +44,6 @@ private fun Path.dropLeadingTopDirs(): Path {
  * Append a [relativePath] safely that means that adding any extra `..` path elements will not let
  * access anything out of the reference directory (unless you have symbolic or hard links or multiple mount points)
  */
-@KtorExperimentalAPI
 public fun File.combineSafe(relativePath: Path): File {
     val normalized = relativePath.normalizeAndRelativize()
     if (normalized.startsWith("..")) {

--- a/ktor-utils/jvm/src/io/ktor/util/Path.kt
+++ b/ktor-utils/jvm/src/io/ktor/util/Path.kt
@@ -10,7 +10,6 @@ import java.io.*
  * Append a [relativePath] safely that means that adding any extra `..` path elements will not let
  * access anything out of the reference directory (unless you have symbolic or hard links or multiple mount points)
  */
-@KtorExperimentalAPI
 public fun File.combineSafe(relativePath: String): File = combineSafe(this, File(relativePath))
 
 /**

--- a/ktor-utils/jvm/src/io/ktor/util/cio/ByteBufferPool.kt
+++ b/ktor-utils/jvm/src/io/ktor/util/cio/ByteBufferPool.kt
@@ -15,7 +15,6 @@ internal const val DEFAULT_KTOR_POOL_SIZE = 2048
 /**
  * The default ktor byte buffer pool
  */
-@KtorExperimentalAPI
 public val KtorDefaultPool: ObjectPool<ByteBuffer> = ByteBufferPool(DEFAULT_KTOR_POOL_SIZE, DEFAULT_BUFFER_SIZE)
 
 @InternalAPI


### PR DESCRIPTION
**Subsystem**
All

**Motivation**
[KTOR-2204  Deprecate old experimental annotations ](https://youtrack.jetbrains.com/issue/KTOR-2204)

**Solution**
Stabilize and split into new separate experimental annotations, open corresponding tickets, refer to the tickets from the new annotations.

