### PR TITLE
KTOR-2685 Migrate to Any.identityHashCode

### DIFF
--- a/ktor-io/posix/test/io/ktor/utils/io/VerifyingObjectPool.kt
+++ b/ktor-io/posix/test/io/ktor/utils/io/VerifyingObjectPool.kt
@@ -5,12 +5,10 @@
 package io.ktor.utils.io
 
 import io.ktor.utils.io.pool.*
-
-@SymbolName("Kotlin_Any_hashCode")
-private external fun identityHashCodeImpl(any: Any?): Int
+import kotlin.native.*
 
 @Suppress("NOTHING_TO_INLINE")
-internal actual inline fun identityHashCode(instance: Any): Int = identityHashCodeImpl(instance)
+internal actual inline fun identityHashCode(instance: Any): Int = instance.identityHashCode()
 
 actual class VerifyingObjectPool<T : Any> actual constructor(delegate: ObjectPool<T>) : VerifyingPoolBase<T>(delegate) {
     override val allocated = HashSet<IdentityWrapper<T>>()


### PR DESCRIPTION
**Subsystem**
ktor-io

**Motivation**
[KTOR-2685 Avoid using Kotlin_Any_hashCode ](https://youtrack.jetbrains.com/issue/KTOR-2685)

**Solution**
Since there is already `Any.identityHashCode()` in K/N, we no longer need to invoke `Kotlin_Any_hashCode` directly.


