### PR TITLE
KTOR-2527 using baseName prefix for all metrics

### DIFF
--- a/ktor-features/ktor-metrics/jvm/src/io/ktor/metrics/dropwizard/DropwizardMetrics.kt
+++ b/ktor-features/ktor-metrics/jvm/src/io/ktor/metrics/dropwizard/DropwizardMetrics.kt
@@ -5,6 +5,7 @@
 package io.ktor.metrics.dropwizard
 
 import com.codahale.metrics.*
+import com.codahale.metrics.MetricRegistry.*
 import com.codahale.metrics.jvm.*
 import io.ktor.application.*
 import io.ktor.routing.*
@@ -19,11 +20,11 @@ import java.util.concurrent.*
  */
 public class DropwizardMetrics(
     public val registry: MetricRegistry,
-    public val baseName: String = MetricRegistry.name("ktor.calls")
+    public val baseName: String = name("ktor.calls")
 ) {
-    private val duration = registry.timer(MetricRegistry.name(baseName, "duration"))
-    private val active = registry.counter(MetricRegistry.name(baseName, "active"))
-    private val exceptions = registry.meter(MetricRegistry.name(baseName, "exceptions"))
+    private val duration = registry.timer(name(baseName, "duration"))
+    private val active = registry.counter(name(baseName, "active"))
+    private val exceptions = registry.meter(name(baseName, "exceptions"))
     private val httpStatus = ConcurrentHashMap<Int, Meter>()
 
     /**
@@ -33,7 +34,7 @@ public class DropwizardMetrics(
         /**
          * Dropwizard metrics base name (prefix)
          */
-        public var baseName: String = MetricRegistry.name("ktor.calls")
+        public var baseName: String = name("ktor.calls")
 
         /**
          * Dropwizard metric registry.
@@ -92,8 +93,8 @@ public class DropwizardMetrics(
 
             pipeline.environment.monitor.subscribe(Routing.RoutingCallStarted) { call ->
                 val name = call.route.toString()
-                val meter = feature.registry.meter(MetricRegistry.name(name, "meter"))
-                val timer = feature.registry.timer(MetricRegistry.name(name, "timer"))
+                val meter = feature.registry.meter(name(configuration.baseName, name, "meter"))
+                val timer = feature.registry.timer(name(configuration.baseName, name, "timer"))
                 meter.mark()
                 val context = timer.time()
                 call.attributes.put(
@@ -105,7 +106,7 @@ public class DropwizardMetrics(
             pipeline.environment.monitor.subscribe(Routing.RoutingCallFinished) { call ->
                 val routingMetrics = call.attributes.take(routingMetricsKey)
                 val status = call.response.status()?.value ?: 0
-                val statusMeter = feature.registry.meter(MetricRegistry.name(routingMetrics.name, status.toString()))
+                val statusMeter = feature.registry.meter(name(configuration.baseName, routingMetrics.name, status.toString()))
                 statusMeter.mark()
                 routingMetrics.context.stop()
             }
@@ -126,7 +127,7 @@ public class DropwizardMetrics(
     private fun after(call: ApplicationCall) {
         active.dec()
         val meter = httpStatus.computeIfAbsent(call.response.status()?.value ?: 0) {
-            registry.meter(MetricRegistry.name(baseName, "status", it.toString()))
+            registry.meter(name(baseName, "status", it.toString()))
         }
         meter.mark()
         call.attributes.getOrNull(measureKey)?.apply {

--- a/ktor-features/ktor-metrics/jvm/test/io/ktor/metrics/dropwizard/DropwizardMetricsTests.kt
+++ b/ktor-features/ktor-metrics/jvm/test/io/ktor/metrics/dropwizard/DropwizardMetricsTests.kt
@@ -5,11 +5,11 @@
 package io.ktor.metrics.dropwizard
 
 import com.codahale.metrics.*
-import com.codahale.metrics.jvm.*
 import io.ktor.application.*
 import io.ktor.response.*
 import io.ktor.routing.*
 import io.ktor.server.testing.*
+import org.hamcrest.CoreMatchers.*
 import org.junit.*
 import org.junit.Assert.*
 
@@ -33,29 +33,7 @@ class DropwizardMetricsTests {
             uri = "/uri"
         }
 
-        assertEquals(1, testRegistry.meter("/uri/(method:GET).200").count)
-    }
-
-    @Test
-    fun testUsePreconfiguredRegistry(): Unit = withTestApplication {
-        val testRegistry = MetricRegistry()
-        testRegistry.register("jvm.memory", MemoryUsageGaugeSet())
-
-        application.install(DropwizardMetrics) {
-            registry = testRegistry
-        }
-
-        application.routing {
-            get("/uri") {
-                call.respond("hello")
-            }
-        }
-
-        handleRequest {
-            uri = "/uri"
-        }
-
-        assertEquals(1, testRegistry.meter("/uri/(method:GET).200").count)
+        assertEquals(1, testRegistry.meter("ktor.calls./uri/(method:GET).200").count)
     }
 
     @Test
@@ -68,5 +46,25 @@ class DropwizardMetricsTests {
         }
 
         assertEquals(setOf("ktor.calls.active", "ktor.calls.duration", "ktor.calls.exceptions"), testRegistry.names)
+    }
+
+    @Test
+    fun `should prefix all metrics with baseName`(): Unit = withTestApplication {
+        val prefix = "foo.bar"
+        val registry =
+            application.install(DropwizardMetrics) {
+                baseName = prefix
+                registerJvmMetricSets = false
+            }.registry
+
+        application.routing {
+            get("/uri") {
+                call.respond("hello")
+            }
+        }
+
+        handleRequest { uri = "/uri" }
+
+        assertThat(registry.names, everyItem(startsWith(prefix)))
     }
 }


### PR DESCRIPTION
**Subsystem**
server

**Motivation**
[KTOR-2527](https://youtrack.jetbrains.com/issue/KTOR-2527)
#2527

**Solution**
Prefix all metrics with `baseName`. Previously only a small part of the metrics was prefixed.

