### PR TITLE
KTOR-2709 Use kotlin.reflect.javaType instead of type token

### DIFF
--- a/ktor-utils/jvm/src/io/ktor/util/reflect/TypeInfoJvm.kt
+++ b/ktor-utils/jvm/src/io/ktor/util/reflect/TypeInfoJvm.kt
@@ -8,6 +8,10 @@ import kotlin.reflect.*
 
 public actual typealias Type = java.lang.reflect.Type
 
+@PublishedApi
+@Deprecated("Will be removed")
+internal open class TypeBase<T>
+
 @OptIn(ExperimentalStdlibApi::class)
 public actual inline fun <reified T> typeInfo(): TypeInfo {
     val kType = typeOf<T>()

--- a/ktor-utils/jvm/src/io/ktor/util/reflect/TypeInfoJvm.kt
+++ b/ktor-utils/jvm/src/io/ktor/util/reflect/TypeInfoJvm.kt
@@ -4,22 +4,15 @@
 
 package io.ktor.util.reflect
 
-import java.lang.reflect.*
-import java.lang.reflect.Type
 import kotlin.reflect.*
 
 public actual typealias Type = java.lang.reflect.Type
 
-@PublishedApi
-internal open class TypeBase<T>
-
 @OptIn(ExperimentalStdlibApi::class)
 public actual inline fun <reified T> typeInfo(): TypeInfo {
-    val base = object : TypeBase<T>() {}
-    val superType = base::class.java.genericSuperclass!!
-
-    val reifiedType = (superType as ParameterizedType).actualTypeArguments.first()!!
-    return typeInfoImpl(reifiedType, T::class, typeOf<T>())
+    val kType = typeOf<T>()
+    val reifiedType = kType.javaType
+    return typeInfoImpl(reifiedType, T::class, kType)
 }
 
 public fun typeInfoImpl(reifiedType: Type, kClass: KClass<*>, kType: KType): TypeInfo =


### PR DESCRIPTION
**Subsystem**
JVM Utils

**Motivation**
Fix https://youtrack.jetbrains.com/issue/KTOR-2709
Using kotlin.reflect.javaType doesn't produce an anonymous class for each call site. Also, this prevents Ktor from being affected by this compiler bug: https://youtrack.jetbrains.com/issue/KT-46797.

**Solution**
Use kotlin.reflect.javaType instead of type token pattern.

