### PR TITLE
KTOR-737 Reply with proper status code on routing mismatch

### DIFF
--- a/ktor-features/ktor-auth/jvm/src/io/ktor/auth/Authentication.kt
+++ b/ktor-features/ktor-auth/jvm/src/io/ktor/auth/Authentication.kt
@@ -327,7 +327,7 @@ public fun Route.authenticate(
  */
 public class AuthenticationRouteSelector(public val names: List<String?>) : RouteSelector() {
     override fun evaluate(context: RoutingResolveContext, segmentIndex: Int): RouteSelectorEvaluation {
-        return RouteSelectorEvaluation(true, RouteSelectorEvaluation.qualityTransparent)
+        return RouteSelectorEvaluation.Transparent
     }
 
     override fun toString(): String = "(authenticate ${names.joinToString { it ?: "\"default\"" }})"

--- a/ktor-features/ktor-locations/jvm/test/io/ktor/tests/locations/LocationsTest.kt
+++ b/ktor-features/ktor-locations/jvm/test/io/ktor/tests/locations/LocationsTest.kt
@@ -528,7 +528,7 @@ class LocationsTest {
         // missing parameter text
         handleRequest(HttpMethod.Get, "/?number=1&longNumber=2").let { call ->
             // null because missing parameter leads to routing miss
-            assertEquals(HttpStatusCode.NotFound, call.response.status())
+            assertEquals(HttpStatusCode.BadRequest, call.response.status())
         }
 
         // illegal value for numeric property

--- a/ktor-features/ktor-websockets/jvm/src/io/ktor/websocket/Routing.kt
+++ b/ktor-features/ktor-websockets/jvm/src/io/ktor/websocket/Routing.kt
@@ -265,12 +265,12 @@ private class WebSocketProtocolsSelector(
 ) : RouteSelector() {
     override fun evaluate(context: RoutingResolveContext, segmentIndex: Int): RouteSelectorEvaluation {
         val protocols = context.call.request.headers[HttpHeaders.SecWebSocketProtocol]
-            ?: return RouteSelectorEvaluation.Failed
+            ?: return RouteSelectorEvaluation.FailedParameter
 
         if (requiredProtocol in parseHeaderValue(protocols).map { it.value }) {
             return RouteSelectorEvaluation.Constant
         }
 
-        return RouteSelectorEvaluation.Failed
+        return RouteSelectorEvaluation.FailedParameter
     }
 }

--- a/ktor-server/ktor-server-core/api/ktor-server-core.api
+++ b/ktor-server/ktor-server-core/api/ktor-server-core.api
@@ -1380,9 +1380,11 @@ public abstract class io/ktor/routing/RouteSelector {
 	public final fun getQuality ()D
 }
 
-public final class io/ktor/routing/RouteSelectorEvaluation {
+public abstract class io/ktor/routing/RouteSelectorEvaluation {
 	public static final field Companion Lio/ktor/routing/RouteSelectorEvaluation$Companion;
 	public static final field qualityConstant D
+	public static final field qualityFailedMethod D
+	public static final field qualityFailedParameter D
 	public static final field qualityMethodParameter D
 	public static final field qualityMissing D
 	public static final field qualityParameter D
@@ -1392,30 +1394,51 @@ public final class io/ktor/routing/RouteSelectorEvaluation {
 	public static final field qualityTailcard D
 	public static final field qualityTransparent D
 	public static final field qualityWildcard D
-	public fun <init> (ZDLio/ktor/http/Parameters;I)V
-	public synthetic fun <init> (ZDLio/ktor/http/Parameters;IILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Z
-	public final fun component2 ()D
-	public final fun component3 ()Lio/ktor/http/Parameters;
-	public final fun component4 ()I
-	public final fun copy (ZDLio/ktor/http/Parameters;I)Lio/ktor/routing/RouteSelectorEvaluation;
-	public static synthetic fun copy$default (Lio/ktor/routing/RouteSelectorEvaluation;ZDLio/ktor/http/Parameters;IILjava/lang/Object;)Lio/ktor/routing/RouteSelectorEvaluation;
-	public fun equals (Ljava/lang/Object;)Z
-	public final fun getParameters ()Lio/ktor/http/Parameters;
-	public final fun getQuality ()D
-	public final fun getSegmentIncrement ()I
+	public synthetic fun <init> (ZLkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getSucceeded ()Z
-	public fun hashCode ()I
-	public fun toString ()Ljava/lang/String;
 }
 
 public final class io/ktor/routing/RouteSelectorEvaluation$Companion {
 	public final fun getConstant ()Lio/ktor/routing/RouteSelectorEvaluation;
 	public final fun getConstantPath ()Lio/ktor/routing/RouteSelectorEvaluation;
-	public final fun getFailed ()Lio/ktor/routing/RouteSelectorEvaluation;
+	public final fun getFailed ()Lio/ktor/routing/RouteSelectorEvaluation$Failure;
+	public final fun getFailedMethod ()Lio/ktor/routing/RouteSelectorEvaluation$Failure;
+	public final fun getFailedParameter ()Lio/ktor/routing/RouteSelectorEvaluation$Failure;
+	public final fun getFailedPath ()Lio/ktor/routing/RouteSelectorEvaluation$Failure;
 	public final fun getMissing ()Lio/ktor/routing/RouteSelectorEvaluation;
 	public final fun getTransparent ()Lio/ktor/routing/RouteSelectorEvaluation;
 	public final fun getWildcardPath ()Lio/ktor/routing/RouteSelectorEvaluation;
+	public final fun invoke (ZDLio/ktor/http/Parameters;I)Lio/ktor/routing/RouteSelectorEvaluation;
+	public static synthetic fun invoke$default (Lio/ktor/routing/RouteSelectorEvaluation$Companion;ZDLio/ktor/http/Parameters;IILjava/lang/Object;)Lio/ktor/routing/RouteSelectorEvaluation;
+}
+
+public final class io/ktor/routing/RouteSelectorEvaluation$Failure : io/ktor/routing/RouteSelectorEvaluation {
+	public fun <init> (DLio/ktor/http/HttpStatusCode;)V
+	public final fun component1 ()D
+	public final fun component2 ()Lio/ktor/http/HttpStatusCode;
+	public final fun copy (DLio/ktor/http/HttpStatusCode;)Lio/ktor/routing/RouteSelectorEvaluation$Failure;
+	public static synthetic fun copy$default (Lio/ktor/routing/RouteSelectorEvaluation$Failure;DLio/ktor/http/HttpStatusCode;ILjava/lang/Object;)Lio/ktor/routing/RouteSelectorEvaluation$Failure;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getFailureStatusCode ()Lio/ktor/http/HttpStatusCode;
+	public final fun getQuality ()D
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/ktor/routing/RouteSelectorEvaluation$Success : io/ktor/routing/RouteSelectorEvaluation {
+	public fun <init> (DLio/ktor/http/Parameters;I)V
+	public synthetic fun <init> (DLio/ktor/http/Parameters;IILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()D
+	public final fun component2 ()Lio/ktor/http/Parameters;
+	public final fun component3 ()I
+	public final fun copy (DLio/ktor/http/Parameters;I)Lio/ktor/routing/RouteSelectorEvaluation$Success;
+	public static synthetic fun copy$default (Lio/ktor/routing/RouteSelectorEvaluation$Success;DLio/ktor/http/Parameters;IILjava/lang/Object;)Lio/ktor/routing/RouteSelectorEvaluation$Success;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getParameters ()Lio/ktor/http/Parameters;
+	public final fun getQuality ()D
+	public final fun getSegmentIncrement ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
 }
 
 public final class io/ktor/routing/Routing : io/ktor/routing/Route {
@@ -1500,6 +1523,7 @@ public final class io/ktor/routing/RoutingBuilderKt {
 
 public final class io/ktor/routing/RoutingKt {
 	public static final fun getApplication (Lio/ktor/routing/Route;)Lio/ktor/application/Application;
+	public static final fun getRoutingFailureStatusCode ()Lio/ktor/util/AttributeKey;
 	public static final fun routing (Lio/ktor/application/Application;Lkotlin/jvm/functions/Function1;)Lio/ktor/routing/Routing;
 }
 
@@ -1552,6 +1576,7 @@ public abstract class io/ktor/routing/RoutingResolveResult {
 
 public final class io/ktor/routing/RoutingResolveResult$Failure : io/ktor/routing/RoutingResolveResult {
 	public fun <init> (Lio/ktor/routing/Route;Ljava/lang/String;)V
+	public final fun getErrorStatusCode ()Lio/ktor/http/HttpStatusCode;
 	public synthetic fun getParameters ()Lio/ktor/http/Parameters;
 	public fun getParameters ()Ljava/lang/Void;
 	public final fun getReason ()Ljava/lang/String;

--- a/ktor-server/ktor-server-core/jvm/src/io/ktor/routing/HostsRoutingBuilder.kt
+++ b/ktor-server/ktor-server-core/jvm/src/io/ktor/routing/HostsRoutingBuilder.kt
@@ -128,7 +128,7 @@ public data class HostRouteSelector(
             append(PortParameter, requestPort.toString())
         }
 
-        return RouteSelectorEvaluation(true, RouteSelectorEvaluation.qualityConstant, params)
+        return RouteSelectorEvaluation.Success(RouteSelectorEvaluation.qualityConstant, params)
     }
 
     override fun toString(): String = "($hostList, $hostPatterns, $portsList)"

--- a/ktor-server/ktor-server-core/jvm/src/io/ktor/routing/LocalPortRoutingBuilder.kt
+++ b/ktor-server/ktor-server-core/jvm/src/io/ktor/routing/LocalPortRoutingBuilder.kt
@@ -38,7 +38,7 @@ public data class LocalPortRouteSelector(val port: Int) : RouteSelector() {
     override fun evaluate(context: RoutingResolveContext, segmentIndex: Int): RouteSelectorEvaluation =
         if (context.call.request.local.port == port) {
             val parameters = parametersOf(LocalPortParameter, port.toString())
-            RouteSelectorEvaluation(true, RouteSelectorEvaluation.qualityConstant, parameters)
+            RouteSelectorEvaluation.Success(RouteSelectorEvaluation.qualityConstant, parameters)
         } else {
             RouteSelectorEvaluation.Failed
         }

--- a/ktor-server/ktor-server-core/jvm/test/io/ktor/tests/routing/RouteSelectorTest.kt
+++ b/ktor-server/ktor-server-core/jvm/test/io/ktor/tests/routing/RouteSelectorTest.kt
@@ -20,6 +20,7 @@ internal class RouteSelectorTest {
             isOptional = false
         )
 
+        assertTrue(evaluation is RouteSelectorEvaluation.Success)
         assertEquals(evaluation.quality, RouteSelectorEvaluation.qualityParameterWithPrefixOrSuffix)
         assertEquals(evaluation.succeeded, true)
         assertEquals(evaluation.parameters["param"], "PARAM")
@@ -36,7 +37,7 @@ internal class RouteSelectorTest {
             isOptional = false
         )
 
-        assertEquals(evaluation, RouteSelectorEvaluation.Failed)
+        assertEquals(evaluation, RouteSelectorEvaluation.FailedPath)
     }
 
     @Test
@@ -50,7 +51,7 @@ internal class RouteSelectorTest {
             isOptional = false
         )
 
-        assertEquals(evaluation, RouteSelectorEvaluation.Failed)
+        assertEquals(evaluation, RouteSelectorEvaluation.FailedPath)
     }
 
     @Test
@@ -62,6 +63,7 @@ internal class RouteSelectorTest {
             isOptional = false
         )
 
+        assertTrue(evaluation is RouteSelectorEvaluation.Success)
         assertEquals(evaluation.succeeded, true)
         assertEquals(evaluation.quality, RouteSelectorEvaluation.qualityParameter)
     }
@@ -77,7 +79,7 @@ internal class RouteSelectorTest {
             isOptional = false
         )
 
-        assertEquals(evaluation, RouteSelectorEvaluation.Failed)
+        assertEquals(evaluation, RouteSelectorEvaluation.FailedPath)
     }
 
     @Test
@@ -131,7 +133,11 @@ internal class RouteSelectorTest {
             isOptional = true
         )
 
-        assertEquals(evaluation, RouteSelectorEvaluation.Missing.copy(segmentIncrement = 1))
+        assertEquals(
+            evaluation,
+            RouteSelectorEvaluation
+                .Success(RouteSelectorEvaluation.qualityMissing, segmentIncrement = 1)
+        )
     }
 
     @Test
@@ -155,6 +161,6 @@ internal class RouteSelectorTest {
             isOptional = false
         )
 
-        assertEquals(evaluation, RouteSelectorEvaluation.Failed)
+        assertEquals(evaluation, RouteSelectorEvaluation.FailedPath)
     }
 }

--- a/ktor-server/ktor-server-host-common/jvm/src/io/ktor/server/engine/BaseApplicationEngine.kt
+++ b/ktor-server/ktor-server-host-common/jvm/src/io/ktor/server/engine/BaseApplicationEngine.kt
@@ -7,6 +7,7 @@ package io.ktor.server.engine
 import io.ktor.application.*
 import io.ktor.http.*
 import io.ktor.response.*
+import io.ktor.routing.*
 
 /**
  * Base class for implementing [ApplicationEngine]
@@ -47,7 +48,8 @@ public abstract class BaseApplicationEngine(
     private fun Application.installDefaultInterceptors() {
         intercept(ApplicationCallPipeline.Fallback) {
             if (call.response.status() == null) {
-                call.respond(HttpStatusCode.NotFound)
+                val errorStatusCode = call.attributes.getOrNull(RoutingFailureStatusCode) ?: HttpStatusCode.NotFound
+                call.respond(errorStatusCode)
             }
         }
     }

--- a/ktor-server/ktor-server-test-host/jvm/src/io/ktor/server/testing/TestApplicationCall.kt
+++ b/ktor-server/ktor-server-test-host/jvm/src/io/ktor/server/testing/TestApplicationCall.kt
@@ -6,8 +6,11 @@ package io.ktor.server.testing
 
 import io.ktor.application.*
 import io.ktor.server.engine.*
+import io.ktor.util.*
 import kotlinx.coroutines.*
 import kotlin.coroutines.*
+
+internal val RequestHandledAttributeKey = AttributeKey<Unit>("RequestHandledAttributeKey")
 
 /**
  * Represents a test application call that is used in [withTestApplication] and [handleRequest]
@@ -22,19 +25,23 @@ public class TestApplicationCall(
     /**
      * Set to `true` when the request has been handled and a response has been produced
      */
-    @Volatile
+    @Suppress("DeprecatedCallableAddReplaceWith")
     @Deprecated(
         "This property may have unpredictable behaviour. " +
-            "Please use asserts on response status, headers or content"
+            "Please use asserts on response status, headers or content",
+        level = DeprecationLevel.ERROR
     )
-    var requestHandled: Boolean = false
-        internal set
+    val requestHandled: Boolean
+        get() = error(
+            "This property may have unpredictable behaviour. " +
+                "Please use asserts on response status, headers or content"
+        )
 
     override val request: TestApplicationRequest = TestApplicationRequest(this, closeRequest)
     override val response: TestApplicationResponse = TestApplicationResponse(this, readResponse)
 
     @Suppress("DEPRECATION")
-    override fun toString(): String = "TestApplicationCall(uri=${request.uri}) : handled = $requestHandled"
+    override fun toString(): String = "TestApplicationCall(uri=${request.uri})"
 
     init {
         putResponseAttribute()

--- a/ktor-server/ktor-server-test-host/jvm/src/io/ktor/server/testing/TestApplicationResponse.kt
+++ b/ktor-server/ktor-server-test-host/jvm/src/io/ktor/server/testing/TestApplicationResponse.kt
@@ -62,24 +62,11 @@ public class TestApplicationResponse(
         private val builder = HeadersBuilder()
 
         override fun engineAppendHeader(name: String, value: String) {
-            @Suppress("DEPRECATION")
-            if (call.requestHandled) {
-                throw UnsupportedOperationException(
-                    "Headers can no longer be set because response was already completed"
-                )
-            }
             builder.append(name, value)
         }
 
         override fun getEngineHeaderNames(): List<String> = builder.names().toList()
         override fun getEngineHeaderValues(name: String): List<String> = builder.getAll(name).orEmpty()
-    }
-
-    init {
-        pipeline.intercept(ApplicationSendPipeline.Engine) {
-            @Suppress("DEPRECATION")
-            call.requestHandled = call.response.status() != HttpStatusCode.NotFound
-        }
     }
 
     override suspend fun responseChannel(): ByteWriteChannel {

--- a/ktor-server/ktor-server-test-host/jvm/src/io/ktor/server/testing/client/TestHttpClientEngine.kt
+++ b/ktor-server/ktor-server-test-host/jvm/src/io/ktor/server/testing/client/TestHttpClientEngine.kt
@@ -37,7 +37,7 @@ public class TestHttpClientEngine(override val config: TestHttpClientConfig) : H
                 status() ?: HttpStatusCode.NotFound,
                 GMTDate(),
                 headers.allValues().takeUnless { it.isEmpty() } ?: Headers
-                    .build { this[HttpHeaders.ContentLength] = "0" },
+                    .build { append(HttpHeaders.ContentLength, "0") },
                 HttpProtocolVersion.HTTP_1_1,
                 ByteReadChannel(byteContent ?: byteArrayOf()),
                 callContext()

--- a/ktor-server/ktor-server-tests/jvm/test/io/ktor/tests/server/routing/RoutingResolveTest.kt
+++ b/ktor-server/ktor-server-tests/jvm/test/io/ktor/tests/server/routing/RoutingResolveTest.kt
@@ -1315,7 +1315,7 @@ class RoutingResolveTest {
         val transparentEntryTop = root.createChild(
             object : RouteSelector() {
                 override fun evaluate(context: RoutingResolveContext, segmentIndex: Int): RouteSelectorEvaluation {
-                    return RouteSelectorEvaluation(true, RouteSelectorEvaluation.qualityTransparent)
+                    return RouteSelectorEvaluation.Success(RouteSelectorEvaluation.qualityTransparent)
                 }
 
                 override fun toString(): String = "transparent"


### PR DESCRIPTION
[Should return 405 when route exists but not for given method instead of 404](https://youtrack.jetbrains.com/issue/KTOR-737)

* Make `RouteSelectorEvaluation` a sealed class with two children: `Success` and `Failure`
* `Failure` has `errorStatusCode` property to reply if the route doesn't match. For example, the `HttpMethodSelector` status code is 405
* The routing resolve algorithm keeps track of the best failed route and uses it to respond if no matches are found.