### PR TITLE
KTOR-2712 deprecate TestApplicationCall::requestHandled property

### DIFF
--- a/ktor-features/ktor-auth-jwt/jvm/test/io/ktor/auth/jwt/JWTAuthTest.kt
+++ b/ktor-features/ktor-auth-jwt/jvm/test/io/ktor/auth/jwt/JWTAuthTest.kt
@@ -143,7 +143,6 @@ class JWTAuthTest {
 
             val response = handleRequestWithToken(token)
 
-            assertTrue(response.requestHandled)
             assertEquals(HttpStatusCode.OK, response.response.status())
             assertNotNull(response.response.content)
         }
@@ -160,7 +159,6 @@ class JWTAuthTest {
 
             val response = handleRequestWithToken(token)
 
-            assertTrue(response.requestHandled)
             assertEquals(HttpStatusCode.OK, response.response.status())
             assertNotNull(response.response.content)
         }
@@ -177,7 +175,6 @@ class JWTAuthTest {
 
             val response = handleRequestWithToken(token)
 
-            assertTrue(response.requestHandled)
             assertEquals(HttpStatusCode.OK, response.response.status())
             assertNotNull(response.response.content)
         }
@@ -235,7 +232,6 @@ class JWTAuthTest {
 
             val response = handleRequestWithToken(token)
 
-            assertTrue(response.requestHandled)
             assertEquals(HttpStatusCode.OK, response.response.status())
             assertNotNull(response.response.content)
         }
@@ -250,7 +246,6 @@ class JWTAuthTest {
 
             val response = handleRequestWithToken(token)
 
-            assertTrue(response.requestHandled)
             assertEquals(HttpStatusCode.OK, response.response.status())
             assertNotNull(response.response.content)
         }
@@ -265,7 +260,6 @@ class JWTAuthTest {
 
             val response = handleRequestWithToken(token)
 
-            assertTrue(response.requestHandled)
             assertEquals(HttpStatusCode.OK, response.response.status())
             assertNotNull(response.response.content)
         }
@@ -457,25 +451,21 @@ class JWTAuthTest {
             addHeader(HttpHeaders.Cookie, "JWT=${token.encodeURLParameter()}")
         }
 
-        assertTrue(response.requestHandled)
         assertEquals(HttpStatusCode.OK, response.response.status())
         assertNotNull(response.response.content)
     }
 
     private fun verifyResponseUnauthorized(response: TestApplicationCall) {
-        assertTrue(response.requestHandled)
         assertEquals(HttpStatusCode.Unauthorized, response.response.status())
         assertNull(response.response.content)
     }
 
     private fun verifyResponseBadRequest(response: TestApplicationCall) {
-        assertTrue(response.requestHandled)
         assertEquals(HttpStatusCode.BadRequest, response.response.status())
         assertNull(response.response.content)
     }
 
     private fun verifyResponseForbidden(response: TestApplicationCall) {
-        assertTrue(response.requestHandled)
         assertEquals(HttpStatusCode.Forbidden, response.response.status())
         assertNull(response.response.content)
     }

--- a/ktor-features/ktor-auth-ldap/jvm/test/io/ktor/tests/auth/ldap/LdapAuthTest.kt
+++ b/ktor-features/ktor-auth-ldap/jvm/test/io/ktor/tests/auth/ldap/LdapAuthTest.kt
@@ -58,7 +58,6 @@ class LdapAuthTest {
             }
 
             handleRequest(HttpMethod.Get, "/").let { result ->
-                assertTrue(result.requestHandled)
                 result.response.headers[HttpHeaders.WWWAuthenticate].let {
                     assertNotNull(it, "No auth challenge sent")
                     val challenge = parseAuthorizationHeader(it)
@@ -76,7 +75,6 @@ class LdapAuthTest {
                     "Basic " + Base64.getEncoder().encodeToString("admin:secret".toByteArray())
                 )
             }.let { result ->
-                assertTrue(result.requestHandled)
                 assertEquals(HttpStatusCode.OK, result.response.status())
                 assertEquals("admin", result.response.content)
             }
@@ -86,7 +84,6 @@ class LdapAuthTest {
                     "Basic " + Base64.getEncoder().encodeToString("admin:bad-pass".toByteArray())
                 )
             }.let { result ->
-                assertTrue(result.requestHandled)
                 assertEquals(HttpStatusCode.Unauthorized, result.response.status())
                 assertNull(result.response.content)
             }
@@ -96,7 +93,6 @@ class LdapAuthTest {
                     "Basic " + Base64.getEncoder().encodeToString("bad-user:bad-pass".toByteArray())
                 )
             }.let { result ->
-                assertTrue(result.requestHandled)
                 assertEquals(HttpStatusCode.Unauthorized, result.response.status())
                 assertNull(result.response.content)
             }
@@ -106,7 +102,6 @@ class LdapAuthTest {
                     "Basic " + Base64.getEncoder().encodeToString(" \",; \u0419:pass".toByteArray())
                 )
             }.let { result ->
-                assertTrue(result.requestHandled)
                 assertEquals(HttpStatusCode.Unauthorized, result.response.status())
                 assertNull(result.response.content)
             }
@@ -157,7 +152,6 @@ class LdapAuthTest {
                     "Basic " + Base64.getEncoder().encodeToString("user-test:test".toByteArray())
                 )
             }.let { result ->
-                assertTrue(result.requestHandled)
                 assertEquals(HttpStatusCode.OK, result.response.status())
                 assertEquals("user-test", result.response.content)
             }
@@ -167,7 +161,6 @@ class LdapAuthTest {
                     "Basic " + Base64.getEncoder().encodeToString("user-test:bad-pass".toByteArray())
                 )
             }.let { result ->
-                assertTrue(result.requestHandled)
                 assertEquals(HttpStatusCode.Unauthorized, result.response.status())
             }
             handleRequest(HttpMethod.Get, "/") {
@@ -176,7 +169,6 @@ class LdapAuthTest {
                     "Basic " + Base64.getEncoder().encodeToString("bad-user:bad-pass".toByteArray())
                 )
             }.let { result ->
-                assertTrue(result.requestHandled)
                 assertEquals(HttpStatusCode.Unauthorized, result.response.status())
             }
             handleRequest(HttpMethod.Get, "/") {
@@ -185,7 +177,6 @@ class LdapAuthTest {
                     "Basic " + Base64.getEncoder().encodeToString(" \",; \u0419:pass".toByteArray())
                 )
             }.let { result ->
-                assertTrue(result.requestHandled)
                 assertEquals(HttpStatusCode.Unauthorized, result.response.status())
                 assertNull(result.response.content)
             }

--- a/ktor-features/ktor-auth/jvm/test/io/ktor/tests/auth/AuthBuildersTest.kt
+++ b/ktor-features/ktor-auth/jvm/test/io/ktor/tests/auth/AuthBuildersTest.kt
@@ -277,7 +277,6 @@ class AuthBuildersTest {
 
             on("Index should be available for everyone") {
                 val call = handleRequest(HttpMethod.Get, "/")
-                assertTrue { call.requestHandled }
                 assertTrue { call.response.status()!!.isSuccess() }
                 assertEquals("Public index. Not logged in.", call.response.content)
             }
@@ -286,32 +285,27 @@ class AuthBuildersTest {
                     addCookie()
                 }
 
-                assertTrue { call.requestHandled }
                 assertTrue { call.response.status()!!.isSuccess() }
                 assertEquals("Public index. Logged in as tester.", call.response.content)
             }
             on("User profile page should redirect to login page") {
                 val call = handleRequest(HttpMethod.Get, "/user/profile")
-                assertTrue { call.requestHandled }
                 assertEquals("/login", call.response.headers[HttpHeaders.Location])
             }
             on("User profile page should be show for an authenticated user") {
                 val call = handleRequest(HttpMethod.Get, "/user/profile") {
                     addCookie()
                 }
-                assertTrue { call.requestHandled }
                 assertEquals("Profile for tester.", call.response.content)
             }
             on("Login page shouldn't be shown for an authenticated user (with cookies)") {
                 val call = handleRequest(HttpMethod.Get, "/login") {
                     addCookie()
                 }
-                assertTrue { call.requestHandled }
                 assertEquals(HttpStatusCode.Found.value, call.response.status()?.value)
             }
             on("Login page should be shown for clean user") {
                 val call = handleRequest(HttpMethod.Get, "/login")
-                assertTrue { call.requestHandled }
                 assertEquals("Login form goes here.", call.response.content)
             }
             on("Login page should create session on form post") {
@@ -320,7 +314,6 @@ class AuthBuildersTest {
                 }
                 val cookies = call.response.headers[HttpHeaders.SetCookie]?.let { parseServerSetCookieHeader(it) }
 
-                assertTrue { call.requestHandled }
                 assertNotNull(cookies, "Set-Cookie should be sent")
                 assertEquals(serializedSession, cookies.value)
                 assertEquals("Logged in successfully as tester.", call.response.content)
@@ -329,12 +322,10 @@ class AuthBuildersTest {
                 val call = handleRequest(HttpMethod.Get, "/user/files/doc1.txt") {
                     addCookie()
                 }
-                assertTrue { call.requestHandled }
                 assertEquals("File doc1.txt for user tester.", call.response.content)
             }
             on("A download manager or wget/curl tool could download file using basic auth") {
                 val firstAttempt = handleRequest(HttpMethod.Get, "/user/files/doc1.txt")
-                assertTrue { firstAttempt.requestHandled }
                 // with no auth header we should get basic auth challenge
                 assertEquals(
                     "Basic realm=test-app, charset=UTF-8",
@@ -346,7 +337,6 @@ class AuthBuildersTest {
                 val call = handleRequest(HttpMethod.Get, "/user/files/doc1.txt") {
                     addBasicAuth()
                 }
-                assertTrue { call.requestHandled }
                 assertEquals("File doc1.txt for user tester.", call.response.content)
             }
         }

--- a/ktor-features/ktor-auth/jvm/test/io/ktor/tests/auth/BasicAuthTest.kt
+++ b/ktor-features/ktor-auth/jvm/test/io/ktor/tests/auth/BasicAuthTest.kt
@@ -26,7 +26,6 @@ class BasicAuthTest {
                 uri = "/"
             }
 
-            assertTrue(call.requestHandled)
             assertEquals(HttpStatusCode.Unauthorized, call.response.status())
             assertNull(call.response.content)
 
@@ -85,7 +84,6 @@ class BasicAuthTest {
 
             val call = handleRequestWithBasic("/", user, p)
 
-            assertTrue(call.requestHandled)
             assertEquals(HttpStatusCode.OK, call.response.status())
             assertEquals("ok", call.response.content)
         }
@@ -100,7 +98,6 @@ class BasicAuthTest {
 
             val call = handleRequestWithBasic("/", user, p)
 
-            assertTrue(call.requestHandled)
             assertEquals(HttpStatusCode.OK, call.response.status())
             assertEquals("Secret info", call.response.content)
         }
@@ -113,7 +110,6 @@ class BasicAuthTest {
 
             val call = handleRequest { addHeader(HttpHeaders.Authorization, "B<sic code") }
 
-            assertTrue(call.requestHandled)
             assertEquals(HttpStatusCode.BadRequest, call.response.status())
         }
     }
@@ -130,7 +126,6 @@ class BasicAuthTest {
 
             val call = handleRequestWithBasic("/", user, p, charset = Charsets.UTF_8)
 
-            assertTrue(call.requestHandled)
             assertEquals(HttpStatusCode.OK, call.response.status())
             assertEquals("Secret info", call.response.content)
         }
@@ -145,7 +140,6 @@ class BasicAuthTest {
 
             val call = handleRequestWithBasic("/", user, p)
 
-            assertTrue(call.requestHandled)
             assertEquals(HttpStatusCode.Unauthorized, call.response.status())
             assertNotEquals("Secret info", call.response.content)
 
@@ -163,7 +157,6 @@ class BasicAuthTest {
                 addHeader(HttpHeaders.Authorization, "Bearer some-token")
             }
 
-            assertTrue(call.requestHandled)
             assertEquals(HttpStatusCode.Unauthorized, call.response.status())
             assertNotEquals("Secret info", call.response.content)
 
@@ -181,7 +174,6 @@ class BasicAuthTest {
                 addHeader(HttpHeaders.Authorization, "Basic +-test")
             }
 
-            assertTrue(call.requestHandled)
             assertEquals(HttpStatusCode.Unauthorized, call.response.status())
             assertNotEquals("Secret info", call.response.content)
 
@@ -198,7 +190,6 @@ class BasicAuthTest {
 
             val call = handleRequestWithBasic("/?backdoor", user, p)
 
-            assertTrue(call.requestHandled)
             assertEquals(HttpStatusCode.OK, call.response.status())
             assertEquals("Secret info", call.response.content)
         }
@@ -221,7 +212,6 @@ class BasicAuthTest {
             }
 
             handleRequestWithBasic("/", "bad", "").let { call ->
-                assertTrue(call.requestHandled)
                 assertEquals(HttpStatusCode.Unauthorized, call.response.status())
                 assertNotEquals("Secret info", call.response.content)
 
@@ -229,7 +219,6 @@ class BasicAuthTest {
             }
 
             handleRequestWithBasic("/", "good", "").let { call ->
-                assertTrue(call.requestHandled)
                 assertEquals(HttpStatusCode.OK, call.response.status())
                 assertEquals("Secret info", call.response.content)
             }

--- a/ktor-features/ktor-auth/jvm/test/io/ktor/tests/auth/DigestTest.kt
+++ b/ktor-features/ktor-auth/jvm/test/io/ktor/tests/auth/DigestTest.kt
@@ -35,7 +35,6 @@ class DigestTest {
             val response = handleRequest {
             }
 
-            assertTrue(response.requestHandled)
             assertEquals(HttpStatusCode.Unauthorized, response.response.status())
             assertEquals(
                 """Digest
@@ -167,7 +166,6 @@ class DigestTest {
                 )
             }
 
-            assertTrue(response.requestHandled)
             assertEquals(HttpStatusCode.OK, response.response.status())
             assertEquals("Secret info", response.response.content)
         }
@@ -195,7 +193,6 @@ class DigestTest {
                 )
             }
 
-            assertTrue(response.requestHandled)
             assertEquals(HttpStatusCode.Unauthorized, response.response.status())
         }
     }
@@ -207,7 +204,6 @@ class DigestTest {
 
             val call = handleRequest { addHeader(HttpHeaders.Authorization, "D<gest code") }
 
-            assertTrue(call.requestHandled)
             assertEquals(HttpStatusCode.BadRequest, call.response.status())
         }
     }
@@ -234,7 +230,6 @@ class DigestTest {
                 )
             }
 
-            assertTrue(response.requestHandled)
             assertEquals(HttpStatusCode.Unauthorized, response.response.status())
         }
     }
@@ -261,7 +256,6 @@ class DigestTest {
                 )
             }
 
-            assertTrue(response.requestHandled)
             assertEquals(HttpStatusCode.Unauthorized, response.response.status())
         }
     }
@@ -322,7 +316,6 @@ class DigestTest {
                     authHeader.withReplacedParameter("response", hex(expectedDigest)).render()
                 )
             }.let { call ->
-                assertTrue(call.requestHandled)
                 assertEquals(HttpStatusCode.OK, call.response.status())
             }
 
@@ -337,7 +330,6 @@ class DigestTest {
                     ).render()
                 )
             }.let { call ->
-                assertTrue(call.requestHandled)
                 assertEquals(HttpStatusCode.Unauthorized, call.response.status())
             }
         }

--- a/ktor-features/ktor-auth/jvm/test/io/ktor/tests/auth/OAuth1a.kt
+++ b/ktor-features/ktor-auth/jvm/test/io/ktor/tests/auth/OAuth1a.kt
@@ -199,7 +199,6 @@ class OAuth1aFlowTest {
 
             waitExecutor()
 
-            assertTrue(result.requestHandled, "request should be handled")
             assertEquals(HttpStatusCode.Found, result.response.status())
             assertNull(result.response.content)
             assertEquals(
@@ -231,7 +230,6 @@ class OAuth1aFlowTest {
 
             waitExecutor()
 
-            assertTrue(result.requestHandled, "request should be handled")
             assertEquals(HttpStatusCode.OK, result.response.status())
             assertEquals("Ho, null", result.response.content)
         }
@@ -246,7 +244,6 @@ class OAuth1aFlowTest {
 
             waitExecutor()
 
-            assertTrue(result.requestHandled, "request should be handled")
             assertEquals(HttpStatusCode.OK, result.response.status())
             assertEquals("Ho, null", result.response.content)
         }
@@ -264,7 +261,6 @@ class OAuth1aFlowTest {
 
             waitExecutor()
 
-            assertTrue(result.requestHandled, "request should be handled")
             assertEquals(HttpStatusCode.OK, result.response.status())
             assertTrue { result.response.content!!.startsWith("Ho, ") }
             assertFalse { result.response.content!!.contains("[]") }
@@ -283,7 +279,6 @@ class OAuth1aFlowTest {
 
             waitExecutor()
 
-            assertTrue(result.requestHandled, "request should be handled")
             assertEquals(HttpStatusCode.Found, result.response.status())
             assertNotNull(result.response.headers[HttpHeaders.Location])
             assertTrue {
@@ -307,7 +302,6 @@ class OAuth1aFlowTest {
 
             waitExecutor()
 
-            assertTrue(result.requestHandled, "request should be handled")
             assertEquals(HttpStatusCode.Found, result.response.status())
             assertEquals(
                 "https://login-server-com/oauth/authorize?oauth_token=token1",
@@ -342,7 +336,6 @@ class OAuth1aFlowTest {
 
             waitExecutor()
 
-            assertTrue(result.requestHandled, "request should be handled")
             assertEquals(HttpStatusCode.OK, result.response.status())
             assertTrue { result.response.content!!.startsWith("Ho, ") }
             assertFalse { result.response.content!!.contains("null") }
@@ -371,7 +364,6 @@ class OAuth1aFlowTest {
                 HttpMethod.Get,
                 "/login?redirected=true&oauth_token=token1&error_description=failed"
             )
-            assertTrue(result.requestHandled, "request should be handled asynchronously")
 
             assertEquals(HttpStatusCode.Found, result.response.status())
         }

--- a/ktor-features/ktor-auth/jvm/test/io/ktor/tests/auth/OAuth2.kt
+++ b/ktor-features/ktor-auth/jvm/test/io/ktor/tests/auth/OAuth2.kt
@@ -208,7 +208,6 @@ class OAuth2Test {
             uri = "/login"
         }
 
-        assertTrue(result.requestHandled)
         assertEquals(HttpStatusCode.Found, result.response.status())
 
         val url = URI(
@@ -231,7 +230,6 @@ class OAuth2Test {
             uri = "/login"
         }
 
-        assertTrue(result.requestHandled)
         assertEquals(HttpStatusCode.Found, result.response.status())
 
         val url = URI(
@@ -255,7 +253,6 @@ class OAuth2Test {
             uri = "/login"
         }
 
-        assertTrue(result.requestHandled)
         assertEquals(HttpStatusCode.Found, result.response.status())
 
         val url = URI(
@@ -284,7 +281,6 @@ class OAuth2Test {
 
         waitExecutor()
 
-        assertTrue(result.requestHandled, "request should be handled")
         assertEquals(HttpStatusCode.OK, result.response.status())
     }
 
@@ -299,7 +295,6 @@ class OAuth2Test {
 
         waitExecutor()
 
-        assertTrue(result.requestHandled, "request should be handled")
         assertEquals(HttpStatusCode.OK, result.response.status())
     }
 
@@ -314,7 +309,6 @@ class OAuth2Test {
 
         waitExecutor()
 
-        assertTrue(call.requestHandled, "request should be handled")
         assertEquals(HttpStatusCode.Found, call.response.status())
         assertNotNull(call.response.headers[HttpHeaders.Location])
         assertTrue { call.response.headers[HttpHeaders.Location]!!.startsWith("https://login-server-com/authorize") }
@@ -330,7 +324,6 @@ class OAuth2Test {
             }
 
             val result = handleRequest(HttpMethod.Get, "/login")
-            assertTrue(result.requestHandled, "request should not be handled asynchronously")
 
             assertEquals(HttpStatusCode.Found, result.response.status())
             val redirectUrl = URI.create(
@@ -375,7 +368,6 @@ class OAuth2Test {
 
             waitExecutor()
 
-            assertTrue(result.requestHandled, "request should be handled")
             assertEquals(HttpStatusCode.OK, result.response.status())
             assertTrue { result.response.content!!.startsWith("Ho, ") }
             assertTrue { result.response.content!!.contains("OAuth2") }
@@ -409,7 +401,6 @@ class OAuth2Test {
 
             waitExecutor()
 
-            assertTrue(result.requestHandled, "request should be handled")
             assertEquals(HttpStatusCode.Found, result.response.status())
         }
     }
@@ -432,7 +423,6 @@ class OAuth2Test {
             }
 
             val result = handleRequest(HttpMethod.Get, "/login?error=failed")
-            assertTrue(result.requestHandled, "request should not be handled asynchronously")
 
             assertEquals(HttpStatusCode.Found, result.response.status())
         }
@@ -467,7 +457,6 @@ class OAuth2Test {
 
             waitExecutor()
 
-            assertTrue(result.requestHandled, "request should be handled")
             assertEquals(HttpStatusCode.OK, result.response.status())
             assertTrue { result.response.content!!.startsWith("Ho, ") }
             assertTrue { result.response.content!!.contains("OAuth2") }
@@ -503,7 +492,6 @@ class OAuth2Test {
 
             waitExecutor()
 
-            assertTrue(result.requestHandled, "request should be handled")
             assertEquals(HttpStatusCode.Found, result.response.status())
         }
     }
@@ -537,7 +525,6 @@ class OAuth2Test {
 
             waitExecutor()
 
-            assertTrue(result.requestHandled, "request should be handled")
             assertEquals(HttpStatusCode.Found, result.response.status())
         }
     }
@@ -594,7 +581,6 @@ class OAuth2Test {
         handleRequest {
             uri = "/login?code=mow&state=wow"
         }.also {
-            assertTrue(it.requestHandled)
             // Usually 401 here means, that tests above failed.
             assertEquals(it.response.status(), HttpStatusCode.OK)
             assertEquals(it.response.content, "We're in.")

--- a/ktor-features/ktor-auth/jvm/test/io/ktor/tests/auth/UserHashedTableAuthTest.kt
+++ b/ktor-features/ktor-auth/jvm/test/io/ktor/tests/auth/UserHashedTableAuthTest.kt
@@ -58,32 +58,26 @@ class UserHashedTableAuthTest {
             }
 
             handlePost("/deny").let { result ->
-                assertTrue(result.requestHandled)
                 assertEquals(HttpStatusCode.Unauthorized, result.response.status())
                 assertEquals(null, result.response.content)
             }
             handlePost("/redirect").let { result ->
-                assertTrue(result.requestHandled)
                 assertEquals(HttpStatusCode.Found, result.response.status())
                 assertEquals(null, result.response.content)
             }
             handlePost("/deny?user=test&pass=test").let { result ->
-                assertTrue(result.requestHandled)
                 assertEquals(HttpStatusCode.Unauthorized, result.response.status())
                 assertEquals(null, result.response.content)
             }
             handlePost("/deny", "test", "bad-pass").let { result ->
-                assertTrue(result.requestHandled)
                 assertEquals(HttpStatusCode.Unauthorized, result.response.status())
                 assertEquals(null, result.response.content)
             }
             handlePost("/deny?bad-user=bad-pass", "test").let { result ->
-                assertTrue(result.requestHandled)
                 assertEquals(HttpStatusCode.Unauthorized, result.response.status())
                 assertEquals(null, result.response.content)
             }
             handlePost("/deny", "test", "test").let { result ->
-                assertTrue(result.requestHandled)
                 assertEquals(HttpStatusCode.OK, result.response.status())
                 assertEquals("ok", result.response.content)
             }

--- a/ktor-features/ktor-locations/jvm/test/io/ktor/tests/locations/Verifiers.kt
+++ b/ktor-features/ktor-locations/jvm/test/io/ktor/tests/locations/Verifiers.kt
@@ -14,9 +14,6 @@ fun TestApplicationEngine.urlShouldBeHandled(url: String, content: String? = nul
             uri = url
             method = HttpMethod.Get
         }
-        it("should be handled") {
-            assertTrue(result.requestHandled)
-        }
         it("should have a response with OK status") {
             assertEquals(HttpStatusCode.OK, result.response.status())
         }
@@ -35,7 +32,7 @@ fun TestApplicationEngine.urlShouldBeUnhandled(url: String) {
             method = HttpMethod.Post
         }
         it("should not be handled") {
-            assertFalse(result.requestHandled)
+            assertFalse(result.response.status()!!.isSuccess())
         }
     }
 }

--- a/ktor-server/ktor-server-jetty/jvm/test/io/ktor/tests/server/jetty/WebResourcesTest.kt
+++ b/ktor-server/ktor-server-jetty/jvm/test/io/ktor/tests/server/jetty/WebResourcesTest.kt
@@ -63,7 +63,7 @@ class WebResourcesTest {
                 assertEquals(HtmlContent, response.content)
             }
             handleRequest(HttpMethod.Get, "/webapp/password.txt").apply {
-                assertFalse(requestHandled)
+                assertFalse(response.status()!!.isSuccess())
             }
         }
     }

--- a/ktor-server/ktor-server-test-host/jvm/src/io/ktor/server/testing/TestApplicationCall.kt
+++ b/ktor-server/ktor-server-test-host/jvm/src/io/ktor/server/testing/TestApplicationCall.kt
@@ -23,12 +23,17 @@ public class TestApplicationCall(
      * Set to `true` when the request has been handled and a response has been produced
      */
     @Volatile
+    @Deprecated(
+        "This property may have unpredictable behaviour. " +
+            "Please use asserts on response status, headers or content"
+    )
     var requestHandled: Boolean = false
         internal set
 
     override val request: TestApplicationRequest = TestApplicationRequest(this, closeRequest)
     override val response: TestApplicationResponse = TestApplicationResponse(this, readResponse)
 
+    @Suppress("DEPRECATION")
     override fun toString(): String = "TestApplicationCall(uri=${request.uri}) : handled = $requestHandled"
 
     init {

--- a/ktor-server/ktor-server-test-host/jvm/src/io/ktor/server/testing/TestApplicationResponse.kt
+++ b/ktor-server/ktor-server-test-host/jvm/src/io/ktor/server/testing/TestApplicationResponse.kt
@@ -62,6 +62,7 @@ public class TestApplicationResponse(
         private val builder = HeadersBuilder()
 
         override fun engineAppendHeader(name: String, value: String) {
+            @Suppress("DEPRECATION")
             if (call.requestHandled) {
                 throw UnsupportedOperationException(
                     "Headers can no longer be set because response was already completed"
@@ -76,6 +77,7 @@ public class TestApplicationResponse(
 
     init {
         pipeline.intercept(ApplicationSendPipeline.Engine) {
+            @Suppress("DEPRECATION")
             call.requestHandled = call.response.status() != HttpStatusCode.NotFound
         }
     }

--- a/ktor-server/ktor-server-test-host/jvm/src/io/ktor/server/testing/Utils.kt
+++ b/ktor-server/ktor-server-test-host/jvm/src/io/ktor/server/testing/Utils.kt
@@ -4,6 +4,7 @@
 
 package io.ktor.server.testing
 
+import io.ktor.application.*
 import io.ktor.http.*
 
 /**

--- a/ktor-server/ktor-server-test-host/jvm/src/io/ktor/server/testing/client/TestHttpClientEngine.kt
+++ b/ktor-server/ktor-server-test-host/jvm/src/io/ktor/server/testing/client/TestHttpClientEngine.kt
@@ -32,26 +32,14 @@ public class TestHttpClientEngine(override val config: TestHttpClientConfig) : H
     override suspend fun execute(data: HttpRequestData): HttpResponseData {
         val testServerCall = with(data) { runRequest(method, url.fullPath, headers, body) }
 
-        return if (testServerCall.requestHandled) {
-            with(testServerCall.response) {
-                HttpResponseData(
-                    status()!!,
-                    GMTDate(),
-                    headers.allValues(),
-                    HttpProtocolVersion.HTTP_1_1,
-                    ByteReadChannel(byteContent ?: byteArrayOf()),
-                    callContext()
-                )
-            }
-        } else {
+        return with(testServerCall.response) {
             HttpResponseData(
-                HttpStatusCode.NotFound,
+                status() ?: HttpStatusCode.NotFound,
                 GMTDate(),
-                Headers.build {
-                    this[HttpHeaders.ContentLength] = "0"
-                },
+                headers.allValues().takeUnless { it.isEmpty() } ?: Headers
+                    .build { this[HttpHeaders.ContentLength] = "0" },
                 HttpProtocolVersion.HTTP_1_1,
-                ByteReadChannel(byteArrayOf()),
+                ByteReadChannel(byteContent ?: byteArrayOf()),
                 callContext()
             )
         }

--- a/ktor-server/ktor-server-tests/jvm/test/io/ktor/tests/server/application/HandlerTest.kt
+++ b/ktor-server/ktor-server-tests/jvm/test/io/ktor/tests/server/application/HandlerTest.kt
@@ -18,7 +18,7 @@ class HandlerTest {
         on("making a request") {
             val call = handleRequest { }
             it("should not be handled") {
-                assertFalse(call.requestHandled)
+                assertFalse(call.response.status()!!.isSuccess())
             }
         }
     }
@@ -29,7 +29,7 @@ class HandlerTest {
         on("making a request") {
             val call = handleRequest { }
             it("should not be handled") {
-                assertFalse(call.requestHandled)
+                assertFalse(call.response.status()!!.isSuccess())
             }
         }
     }
@@ -40,7 +40,7 @@ class HandlerTest {
         on("making a request") {
             val call = handleRequest { }
             it("should be handled") {
-                assertTrue(call.requestHandled)
+                assertTrue(call.response.status()!!.isSuccess())
             }
         }
     }
@@ -57,7 +57,7 @@ class HandlerTest {
             method = HttpMethod.Post
             setBody("Body")
         }
-        assertTrue(call.requestHandled)
+        assertTrue(call.response.status()!!.isSuccess())
     }
 
     @Test
@@ -70,13 +70,13 @@ class HandlerTest {
         on("making a GET request") {
             val call = handleRequest { method = HttpMethod.Get }
             it("should not be handled") {
-                assertFalse(call.requestHandled)
+                assertFalse(call.response.status()!!.isSuccess())
             }
         }
         on("making a POST request") {
             val call = handleRequest { method = HttpMethod.Post }
             it("should be handled") {
-                assertTrue(call.requestHandled)
+                assertTrue(call.response.status()!!.isSuccess())
             }
         }
     }

--- a/ktor-server/ktor-server-tests/jvm/test/io/ktor/tests/server/features/CachingHeadersTest.kt
+++ b/ktor-server/ktor-server-tests/jvm/test/io/ktor/tests/server/features/CachingHeadersTest.kt
@@ -75,7 +75,7 @@ class CachingHeadersTest {
         }
 
         handleRequest(HttpMethod.Get, "/").let { call ->
-            assertTrue(call.requestHandled)
+            assertTrue(call.response.status()!!.isSuccess())
             assertEquals("test", call.response.content?.trim())
             test(call)
         }

--- a/ktor-server/ktor-server-tests/jvm/test/io/ktor/tests/server/features/CallIdTest.kt
+++ b/ktor-server/ktor-server-tests/jvm/test/io/ktor/tests/server/features/CallIdTest.kt
@@ -21,7 +21,6 @@ class CallIdTest {
         }
 
         handleRequest(HttpMethod.Get, "/").let { call ->
-            assertTrue { call.requestHandled }
             assertEquals("null", call.response.content)
         }
     }
@@ -50,12 +49,10 @@ class CallIdTest {
         }
 
         handleRequest(HttpMethod.Get, "/") { addHeader(HttpHeaders.XRequestId, "test-id") }.let { call ->
-            assertTrue { call.requestHandled }
             assertEquals("test-id", call.response.content)
         }
 
         handleRequest(HttpMethod.Get, "/") { }.let { call ->
-            assertTrue { call.requestHandled }
             assertEquals("null", call.response.content)
         }
     }
@@ -73,12 +70,10 @@ class CallIdTest {
         }
 
         handleRequest(HttpMethod.Get, "/") { addHeader(HttpHeaders.XRequestId, "test-id") }.let { call ->
-            assertTrue { call.requestHandled }
             assertEquals("test-id", call.response.content)
         }
 
         handleRequest(HttpMethod.Get, "/") { }.let { call ->
-            assertTrue { call.requestHandled }
             assertEquals("generated-id", call.response.content)
         }
     }
@@ -97,12 +92,10 @@ class CallIdTest {
         }
 
         handleRequest(HttpMethod.Get, "/") { addHeader(HttpHeaders.XRequestId, "test-id") }.let { call ->
-            assertTrue { call.requestHandled }
             assertEquals("test-id", call.response.content)
         }
 
         handleRequest(HttpMethod.Get, "/") { }.let { call ->
-            assertTrue { call.requestHandled }
             val generatedId = call.response.content!!
             assertNotEquals("null", generatedId)
             assertNotEquals("test-id", generatedId)
@@ -131,12 +124,10 @@ class CallIdTest {
         handleRequest(HttpMethod.Get, "/") {
             addHeader(HttpHeaders.XRequestId, "test-id")
         }.let { call ->
-            assertTrue { call.requestHandled }
             assertEquals("test-id", call.response.content)
         }
 
         handleRequest(HttpMethod.Get, "/") { }.let { call ->
-            assertTrue { call.requestHandled }
             val generatedId = call.response.content!!
             assertNotEquals("null", generatedId)
             assertNotEquals("test-id", generatedId)
@@ -160,14 +151,12 @@ class CallIdTest {
 
         // call id is provided by client
         handleRequest(HttpMethod.Get, "/") { addHeader(HttpHeaders.XRequestId, "client-id") }.let { call ->
-            assertTrue { call.requestHandled }
             assertEquals("client-id", call.response.content)
             assertEquals("client-id", call.response.headers[HttpHeaders.XRequestId])
         }
 
         // call id is generated
         handleRequest(HttpMethod.Get, "/").let { call ->
-            assertTrue { call.requestHandled }
             assertEquals("generated-call-id", call.response.content)
             assertEquals("generated-call-id", call.response.headers[HttpHeaders.XRequestId])
         }
@@ -186,7 +175,6 @@ class CallIdTest {
         handleRequest(HttpMethod.Get, "/") {
             addHeader(HttpHeaders.XRequestId, CALL_ID_DEFAULT_DICTIONARY)
         }.let { call ->
-            assertTrue { call.requestHandled }
             assertEquals(CALL_ID_DEFAULT_DICTIONARY, call.response.content)
             assertEquals(CALL_ID_DEFAULT_DICTIONARY, call.response.headers[HttpHeaders.XRequestId])
         }
@@ -195,7 +183,6 @@ class CallIdTest {
         handleRequest(HttpMethod.Get, "/") {
             addHeader(HttpHeaders.XRequestId, "\u1000")
         }.let { call ->
-            assertTrue { call.requestHandled }
             assertEquals("null", call.response.content)
         }
     }
@@ -211,13 +198,11 @@ class CallIdTest {
 
         // valid call id
         handleRequest(HttpMethod.Get, "/valid").let { call ->
-            assertTrue { call.requestHandled }
             assertEquals(CALL_ID_DEFAULT_DICTIONARY, call.response.content)
         }
 
         // invalid call id
         handleRequest(HttpMethod.Get, "/invalid").let { call ->
-            assertTrue { call.requestHandled }
             assertEquals("null", call.response.content)
         }
     }
@@ -234,19 +219,16 @@ class CallIdTest {
 
         // valid call id
         handleRequest(HttpMethod.Get, "/") { addHeader(HttpHeaders.XRequestId, "12345") }.let { call ->
-            assertTrue { call.requestHandled }
             assertEquals("12345", call.response.content)
         }
 
         // invalid call id that should be ignored
         handleRequest(HttpMethod.Get, "/") { addHeader(HttpHeaders.XRequestId, "123") }.let { call ->
-            assertTrue { call.requestHandled }
             assertEquals("null", call.response.content)
         }
 
         // invalid call id that should be rejected with error
         handleRequest(HttpMethod.Get, "/") { addHeader(HttpHeaders.XRequestId, "1") }.let { call ->
-            assertTrue { call.requestHandled }
             assertEquals(HttpStatusCode.BadRequest.value, call.response.status()?.value)
         }
     }

--- a/ktor-server/ktor-server-tests/jvm/test/io/ktor/tests/server/features/CallLoggingTest.kt
+++ b/ktor-server/ktor-server-tests/jvm/test/io/ktor/tests/server/features/CallLoggingTest.kt
@@ -128,7 +128,6 @@ class CallLoggingTest {
         }
         withApplication(environment) {
             handleRequest(HttpMethod.Get, "/uri-123").let { call ->
-                assertTrue(call.requestHandled)
                 assertEquals("OK", call.response.content)
 
                 assertTrue("TRACE: /uri-123 -> 200 OK" in messages)
@@ -209,8 +208,6 @@ class CallLoggingTest {
                 }
 
                 handleRequest(HttpMethod.Get, "/uri1").let { call ->
-                    assertTrue { call.requestHandled }
-
                     assertTrue { "INFO: test message [mdc-call-id=generated-call-id-0, mdc-uri=/uri1]" in messages }
                     assertTrue {
                         "TRACE: 200 OK: GET - /uri1 [mdc-call-id=generated-call-id-0, mdc-uri=/uri1]" in messages
@@ -250,8 +247,6 @@ class CallLoggingTest {
                 }
 
                 handleRequest(HttpMethod.Get, "/uri1").let { call ->
-                    assertTrue { call.requestHandled }
-
                     assertTrue { "INFO: test message [mdc-call-id=generated-call-id-0, mdc-uri=/uri1]" in messages }
                     assertTrue {
                         "TRACE: 200 OK: GET - /uri1 [mdc-call-id=generated-call-id-0, mdc-uri=/uri1]" in messages

--- a/ktor-server/ktor-server-tests/jvm/test/io/ktor/tests/server/features/CompressionTest.kt
+++ b/ktor-server/ktor-server-tests/jvm/test/io/ktor/tests/server/features/CompressionTest.kt
@@ -187,7 +187,6 @@ class CompressionTest {
             val result = handleRequest(HttpMethod.Get, "/") {
                 addHeader(HttpHeaders.AcceptEncoding, "special")
             }
-            assertTrue(result.requestHandled)
             assertEquals(HttpStatusCode.OK, result.response.status())
             assertEquals("special", result.response.headers[HttpHeaders.ContentEncoding])
             assertEquals(textToCompress, result.response.byteContent!!.toString(Charsets.UTF_8))
@@ -207,7 +206,6 @@ class CompressionTest {
             val result = handleRequest(HttpMethod.Get, "/") {
                 addHeader(HttpHeaders.AcceptEncoding, "*")
             }
-            assertTrue(result.requestHandled)
             assertEquals(HttpStatusCode.Found, result.response.status())
             assertEquals(textToCompress, result.response.byteContent!!.toString(Charsets.UTF_8))
         }
@@ -669,7 +667,6 @@ class CompressionTest {
             assertNotNull(result.response.headers[HttpHeaders.ContentLength])
         }
 
-        assertTrue(result.requestHandled)
         return result
     }
 

--- a/ktor-server/ktor-server-tests/jvm/test/io/ktor/tests/server/features/ConditionalHeadersTests.kt
+++ b/ktor-server/ktor-server-tests/jvm/test/io/ktor/tests/server/features/ConditionalHeadersTests.kt
@@ -40,7 +40,6 @@ class ETagsTest {
     @Test
     fun testNoConditions(): Unit = withConditionalApplication {
         val result = handleRequest {}
-        assertTrue(result.requestHandled)
         assertEquals(HttpStatusCode.OK, result.response.status())
         assertEquals("response", result.response.content)
         assertEquals("\"tag1\"", result.response.headers[HttpHeaders.ETag])
@@ -51,7 +50,6 @@ class ETagsTest {
         val result = handleRequest {
             addHeader(HttpHeaders.IfMatch, "tag1")
         }
-        assertTrue(result.requestHandled)
         assertEquals(HttpStatusCode.OK, result.response.status())
         assertEquals("response", result.response.content)
         assertEquals("\"tag1\"", result.response.headers[HttpHeaders.ETag])
@@ -62,7 +60,6 @@ class ETagsTest {
         val result = handleRequest {
             addHeader(HttpHeaders.IfMatch, "tag2")
         }
-        assertTrue(result.requestHandled)
         assertEquals(HttpStatusCode.PreconditionFailed, result.response.status())
     }
 
@@ -71,7 +68,6 @@ class ETagsTest {
         val result = handleRequest {
             addHeader(HttpHeaders.IfNoneMatch, "tag1")
         }
-        assertTrue(result.requestHandled)
         assertEquals(HttpStatusCode.NotModified, result.response.status())
         assertEquals("\"tag1\"", result.response.headers[HttpHeaders.ETag])
     }
@@ -81,7 +77,6 @@ class ETagsTest {
         val result = handleRequest {
             addHeader(HttpHeaders.IfNoneMatch, "W/tag1")
         }
-        assertTrue(result.requestHandled)
         assertEquals(HttpStatusCode.NotModified, result.response.status())
     }
 
@@ -90,7 +85,6 @@ class ETagsTest {
         val result = handleRequest {
             addHeader(HttpHeaders.IfNoneMatch, "tag2")
         }
-        assertTrue(result.requestHandled)
         assertEquals(HttpStatusCode.OK, result.response.status())
         assertEquals("response", result.response.content)
         assertEquals("\"tag1\"", result.response.headers[HttpHeaders.ETag])
@@ -101,7 +95,6 @@ class ETagsTest {
         val result = handleRequest {
             addHeader(HttpHeaders.IfMatch, "*")
         }
-        assertTrue(result.requestHandled)
         assertEquals(HttpStatusCode.OK, result.response.status())
         assertEquals("response", result.response.content)
         assertEquals("\"tag1\"", result.response.headers[HttpHeaders.ETag])
@@ -112,7 +105,6 @@ class ETagsTest {
         val result = handleRequest {
             addHeader(HttpHeaders.IfNoneMatch, "*")
         }
-        assertTrue(result.requestHandled)
         assertEquals(HttpStatusCode.OK, result.response.status())
         // note: star for if-none-match is a special case
         // that should be handled separately
@@ -124,7 +116,6 @@ class ETagsTest {
         val result = handleRequest {
             addHeader(HttpHeaders.IfNoneMatch, "tag0,tag1,tag3")
         }
-        assertTrue(result.requestHandled)
         assertEquals(HttpStatusCode.NotModified, result.response.status())
     }
 
@@ -133,7 +124,6 @@ class ETagsTest {
         val result = handleRequest {
             addHeader(HttpHeaders.IfNoneMatch, "tag2")
         }
-        assertTrue(result.requestHandled)
         assertEquals(HttpStatusCode.OK, result.response.status())
         assertEquals("response", result.response.content)
         assertEquals("\"tag1\"", result.response.headers[HttpHeaders.ETag])
@@ -144,7 +134,6 @@ class ETagsTest {
         val result = handleRequest {
             addHeader(HttpHeaders.IfMatch, "tag0,tag1,tag3")
         }
-        assertTrue(result.requestHandled)
         assertEquals(HttpStatusCode.OK, result.response.status())
         assertEquals("response", result.response.content)
         assertEquals("\"tag1\"", result.response.headers[HttpHeaders.ETag])
@@ -155,7 +144,6 @@ class ETagsTest {
         val result = handleRequest {
             addHeader(HttpHeaders.IfMatch, "tag0,tag2,tag3")
         }
-        assertTrue(result.requestHandled)
         assertEquals(HttpStatusCode.PreconditionFailed, result.response.status())
     }
 }

--- a/ktor-server/ktor-server-tests/jvm/test/io/ktor/tests/server/features/HeadTest.kt
+++ b/ktor-server/ktor-server-tests/jvm/test/io/ktor/tests/server/features/HeadTest.kt
@@ -142,12 +142,10 @@ class HeadTest {
 
         // ensure with GET
         handleRequest(HttpMethod.Get, "/page1").let { call ->
-            assertTrue { call.requestHandled }
             assertEquals("page1 OK", call.response.content)
         }
 
         handleRequest(HttpMethod.Get, "/page2").let { call ->
-            assertTrue { call.requestHandled }
             assertEquals(500, call.response.status()?.value)
             assertEquals("ISE: page2 failed", call.response.content)
         }
@@ -159,13 +157,11 @@ class HeadTest {
 
         // test HEAD itself
         handleRequest(HttpMethod.Head, "/page1").let { call ->
-            assertTrue { call.requestHandled }
             assertEquals("page1 OK".length.toString(), call.response.headers[HttpHeaders.ContentLength])
             assertNull(call.response.content)
         }
 
         handleRequest(HttpMethod.Head, "/page2").let { call ->
-            assertTrue { call.requestHandled }
             assertEquals(500, call.response.status()?.value)
             assertEquals("ISE: page2 failed".length.toString(), call.response.headers[HttpHeaders.ContentLength])
             assertNull(call.response.content)

--- a/ktor-server/ktor-server-tests/jvm/test/io/ktor/tests/server/features/PartialContentTest.kt
+++ b/ktor-server/ktor-server-tests/jvm/test/io/ktor/tests/server/features/PartialContentTest.kt
@@ -63,7 +63,6 @@ class PartialContentTest {
         handleRequest(HttpMethod.Get, localPath) {
             addHeader(HttpHeaders.Range, "bytes=0-0,2-2")
         }.let { result ->
-            assertTrue(result.requestHandled)
             assertEquals(HttpStatusCode.PartialContent, result.response.status())
             assertEquals(null, result.response.headers[HttpHeaders.ContentRange])
             assertNotNull(result.response.headers[HttpHeaders.LastModified])
@@ -75,7 +74,6 @@ class PartialContentTest {
         handleRequest(HttpMethod.Get, localPath) {
             addHeader(HttpHeaders.Range, "bytes=0-0,2-2,4-4")
         }.let { result ->
-            assertTrue(result.requestHandled)
             assertEquals(HttpStatusCode.PartialContent, result.response.status())
             assertEquals("bytes 0-4/${file.length()}", result.response.headers[HttpHeaders.ContentRange])
             assertEquals(file.readChars(0, 4), result.response.content)
@@ -88,7 +86,6 @@ class PartialContentTest {
         handleRequest(HttpMethod.Get, localPath) {
             addHeader(HttpHeaders.Range, "bytes=0-0")
         }.let { result ->
-            assertTrue(result.requestHandled)
             assertEquals(HttpStatusCode.PartialContent, result.response.status())
             assertEquals("bytes 0-0/${file.length()}", result.response.headers[HttpHeaders.ContentRange])
             assertEquals(file.readChars(0, 0), result.response.content)
@@ -101,7 +98,6 @@ class PartialContentTest {
         handleRequest(HttpMethod.Get, localPath) {
             addHeader(HttpHeaders.Range, "bytes=1-2")
         }.let { result ->
-            assertTrue(result.requestHandled)
             assertEquals(HttpStatusCode.PartialContent, result.response.status())
             assertEquals(file.readChars(1, 2), result.response.content)
             assertEquals("bytes 1-2/${file.length()}", result.response.headers[HttpHeaders.ContentRange])
@@ -114,7 +110,6 @@ class PartialContentTest {
         handleRequest(HttpMethod.Get, localPath) {
             addHeader(HttpHeaders.Range, "bytes=-0") // unsatisfiable
         }.let { result ->
-            assertTrue(result.requestHandled)
             assertEquals(HttpStatusCode.RequestedRangeNotSatisfiable.value, result.response.status()?.value)
             assertEquals("bytes */${file.length()}", result.response.headers[HttpHeaders.ContentRange])
         }
@@ -125,7 +120,6 @@ class PartialContentTest {
         handleRequest(HttpMethod.Get, localPath) {
             addHeader(HttpHeaders.Range, "bytes=1000000-1000004") // unsatisfiable
         }.let { result ->
-            assertTrue(result.requestHandled)
             assertEquals(HttpStatusCode.RequestedRangeNotSatisfiable.value, result.response.status()?.value)
             assertEquals("bytes */${file.length()}", result.response.headers[HttpHeaders.ContentRange])
         }
@@ -137,7 +131,6 @@ class PartialContentTest {
             addHeader(HttpHeaders.Range, "bytes=1000000-7") // syntactically incorrect
         }.let { result ->
             assertEquals(HttpStatusCode.OK, result.response.status())
-            assertTrue(result.requestHandled)
         }
     }
 
@@ -146,7 +139,6 @@ class PartialContentTest {
         handleRequest(HttpMethod.Get, localPath) {
             addHeader(HttpHeaders.Range, "bytes=0-0,-0") // good + unsatisfiable
         }.let { result ->
-            assertTrue(result.requestHandled)
             assertEquals(HttpStatusCode.PartialContent, result.response.status())
             assertEquals(file.readChars(0), result.response.content)
             assertEquals("bytes 0-0/${file.length()}", result.response.headers[HttpHeaders.ContentRange])
@@ -159,7 +151,6 @@ class PartialContentTest {
         handleRequest(HttpMethod.Get, localPath) {
             addHeader(HttpHeaders.Range, "bytes=0-0,1000000-1000004") // good + unsatisfiable
         }.let { result ->
-            assertTrue(result.requestHandled)
             assertEquals(HttpStatusCode.PartialContent, result.response.status())
             assertEquals(file.readChars(0), result.response.content)
             assertEquals("bytes 0-0/${file.length()}", result.response.headers[HttpHeaders.ContentRange])
@@ -173,7 +164,6 @@ class PartialContentTest {
         handleRequest(HttpMethod.Head, localPath) {
             addHeader(HttpHeaders.Range, "bytes=0-0")
         }.let { result ->
-            assertTrue(result.requestHandled)
             assertEquals(HttpStatusCode.OK, result.response.status())
             assertNotNull(result.response.headers[HttpHeaders.LastModified])
             assertEquals(RangeUnits.Bytes.unitToken, result.response.headers[HttpHeaders.AcceptRanges])
@@ -187,7 +177,6 @@ class PartialContentTest {
         handleRequest(HttpMethod.Post, localPath) {
             addHeader(HttpHeaders.Range, "bytes=0-0")
         }.let { result ->
-            assertTrue(result.requestHandled)
             assertEquals(
                 HttpStatusCode.MethodNotAllowed.description("Method POST is not allowed with range request"),
                 result.response.status()
@@ -200,7 +189,6 @@ class PartialContentTest {
         // post request with no range
         handleRequest(HttpMethod.Post, localPath) {
         }.let { result ->
-            assertTrue(result.requestHandled)
             assertEquals(RangeUnits.Bytes.unitToken, result.response.headers[HttpHeaders.AcceptRanges])
             assertEquals(HttpStatusCode.OK, result.response.status())
         }
@@ -234,7 +222,6 @@ class PartialContentTest {
         handleRequest(HttpMethod.Get, localPath) {
             addHeader(HttpHeaders.Range, "bytes=0-0,1-2")
         }.let { result ->
-            assertTrue(result.requestHandled)
             assertEquals(HttpStatusCode.PartialContent, result.response.status())
             assertEquals("bytes 0-2/${file.length()}", result.response.headers[HttpHeaders.ContentRange])
             assertEquals(file.readChars(0, 2), result.response.content)
@@ -315,7 +302,6 @@ class PartialContentTest {
     }
 
     private fun assertMultipart(result: TestApplicationCall, block: (List<String>) -> Unit) {
-        assertTrue(result.requestHandled)
         assertEquals(HttpStatusCode.PartialContent, result.response.status())
         assertNotNull(result.response.headers[HttpHeaders.LastModified])
         val contentType = ContentType.parse(result.response.headers[HttpHeaders.ContentType]!!)

--- a/ktor-server/ktor-server-tests/jvm/test/io/ktor/tests/server/features/StaticContentTest.kt
+++ b/ktor-server/ktor-server-tests/jvm/test/io/ktor/tests/server/features/StaticContentTest.kt
@@ -47,49 +47,41 @@ class StaticContentTest {
 
         // get file from nested folder
         handleRequest(HttpMethod.Get, "/files/features/StaticContentTest.kt").let { result ->
-            assertTrue(result.requestHandled)
             assertEquals(HttpStatusCode.OK, result.response.status())
         }
         // get file from a subfolder
         handleRequest(HttpMethod.Get, "/selected/StaticContentTest.kt").let { result ->
-            assertTrue(result.requestHandled)
             assertEquals(HttpStatusCode.OK, result.response.status())
         }
         // can't get up to containing folder
         handleRequest(HttpMethod.Get, "/selected/../features/StaticContentTest.kt").let { result ->
-            assertFalse(result.requestHandled)
+            assertFalse(result.response.status()!!.isSuccess())
         }
 
         // can serve select file from other dir
         handleRequest(HttpMethod.Get, "/selected/routing/RoutingBuildTest.kt").let { result ->
-            assertTrue(result.requestHandled)
             assertEquals(HttpStatusCode.OK, result.response.status())
         }
         // can't serve file from other dir that was not published explicitly
         handleRequest(HttpMethod.Get, "/selected/routing/RoutingResolveTest.kt").let { result ->
-            assertFalse(result.requestHandled)
+            assertFalse(result.response.status()!!.isSuccess())
         }
         // can't serve dir itself
         handleRequest(HttpMethod.Get, "/selected/routing").let { result ->
-            assertFalse(result.requestHandled)
+            assertFalse(result.response.status()!!.isSuccess())
         }
         // can serve file from virtual folder with a renamed file
         handleRequest(HttpMethod.Get, "/selected/virtual/foobar.kt").let { result ->
-            assertTrue(result.requestHandled)
             assertEquals(HttpStatusCode.OK, result.response.status())
         }
         // can serve dir itself if default was given
         handleRequest(HttpMethod.Get, "/selected/virtual").let { result ->
-            assertTrue(result.requestHandled)
             assertEquals(HttpStatusCode.OK, result.response.status())
         }
         // can serve mapped file from root folder
         handleRequest(HttpMethod.Get, "/foobar.kt").let { result ->
-            assertTrue(result.requestHandled)
             assertEquals(HttpStatusCode.OK, result.response.status())
         }
-
-        Unit
     }
 
     @Test
@@ -114,7 +106,6 @@ class StaticContentTest {
         }
 
         handleRequest(HttpMethod.Get, "/StaticContentTest.class").let { result ->
-            assertTrue(result.requestHandled)
             assertEquals(HttpStatusCode.OK, result.response.status())
         }
 
@@ -123,13 +114,12 @@ class StaticContentTest {
         handleRequest(HttpMethod.Get, "/ArrayList.class2")
 
         handleRequest(HttpMethod.Get, "/features/StaticContentTest.kt").let { result ->
-            assertTrue(result.requestHandled)
             assertEquals(HttpStatusCode.OK, result.response.status())
             assertEquals(RangeUnits.Bytes.unitToken, result.response.headers[HttpHeaders.AcceptRanges])
             assertNotNull(result.response.headers[HttpHeaders.LastModified])
         }
         handleRequest(HttpMethod.Get, "/f/features/StaticContentTest.kt").let { result ->
-            assertTrue(result.requestHandled)
+            assertTrue(result.response.status()!!.isSuccess())
         }
     }
 
@@ -149,7 +139,7 @@ class StaticContentTest {
             "/./.././../build.gradle"
         ).forEach { path ->
             handleRequest(HttpMethod.Get, path).let { result ->
-                assertFalse(result.requestHandled, "Should be unhandled for path $path")
+                assertFalse(result.response.status()!!.isSuccess())
             }
         }
     }
@@ -172,7 +162,6 @@ class StaticContentTest {
         handleRequest(HttpMethod.Get, "/${temp.nameWithoutExtension}") {
             addHeader(HttpHeaders.AcceptEncoding, "br, gzip, deflate, identity")
         }.let { result ->
-            assertTrue(result.requestHandled)
             assertEquals(temp.readText(), result.response.content)
             assertEquals(ContentType.defaultForFileExtension(ext), result.response.contentType())
             assertEquals("br", result.response.headers[HttpHeaders.ContentEncoding].orEmpty())
@@ -197,7 +186,6 @@ class StaticContentTest {
         handleRequest(HttpMethod.Get, "/${temp.nameWithoutExtension}") {
             addHeader(HttpHeaders.AcceptEncoding, "br, gzip, deflate, identity")
         }.let { result ->
-            assertTrue(result.requestHandled)
             assertEquals(temp.readText(), result.response.content)
             assertEquals(ContentType.defaultForFileExtension(ext), result.response.contentType())
             assertEquals("gzip", result.response.headers[HttpHeaders.ContentEncoding].orEmpty())
@@ -224,7 +212,6 @@ class StaticContentTest {
         handleRequest(HttpMethod.Get, "/${temp.nameWithoutExtension}") {
             addHeader(HttpHeaders.AcceptEncoding, "gzip")
         }.let { result ->
-            assertTrue(result.requestHandled)
             assertEquals(temp.readText(), result.response.content)
             assertEquals(ContentType.defaultForFileExtension(ext), result.response.contentType())
             assertEquals("gzip", result.response.headers[HttpHeaders.ContentEncoding].orEmpty())
@@ -257,7 +244,6 @@ class StaticContentTest {
         handleRequest(HttpMethod.Get, "/firstgz/$publicFile") {
             addHeader(HttpHeaders.AcceptEncoding, "gzip, br")
         }.let { result ->
-            assertTrue(result.requestHandled)
             assertEquals(cType, result.response.contentType())
             assertEquals("gzip", result.response.headers[HttpHeaders.ContentEncoding].orEmpty())
         }
@@ -265,7 +251,6 @@ class StaticContentTest {
         handleRequest(HttpMethod.Get, "/firstbr/$publicFile") {
             addHeader(HttpHeaders.AcceptEncoding, "gzip, br")
         }.let { result ->
-            assertTrue(result.requestHandled)
             assertEquals(cType, result.response.contentType())
             assertEquals("br", result.response.headers[HttpHeaders.ContentEncoding].orEmpty())
         }
@@ -297,7 +282,6 @@ class StaticContentTest {
         handleRequest(HttpMethod.Get, "/assets/$publicFile.js") {
             addHeader(HttpHeaders.AcceptEncoding, "gzip, br")
         }.let { result ->
-            assertTrue(result.requestHandled)
             assertEquals(ContentType.defaultForFileExtension("js"), result.response.contentType())
             assertEquals("gzip", result.response.headers[HttpHeaders.ContentEncoding].orEmpty())
         }
@@ -305,7 +289,6 @@ class StaticContentTest {
         handleRequest(HttpMethod.Get, "/assets/$publicFile.css") {
             addHeader(HttpHeaders.AcceptEncoding, "gzip, br")
         }.let { result ->
-            assertTrue(result.requestHandled)
             assertEquals(ContentType.defaultForFileExtension("css"), result.response.contentType())
             assertEquals("br", result.response.headers[HttpHeaders.ContentEncoding].orEmpty())
         }
@@ -335,7 +318,6 @@ class StaticContentTest {
         handleRequest(HttpMethod.Get, "/assets/$publicFile.js") {
             addHeader(HttpHeaders.AcceptEncoding, "gzip, br")
         }.let { result ->
-            assertTrue(result.requestHandled)
             assertEquals(ContentType.defaultForFileExtension("js"), result.response.contentType())
             assertEquals("gzip", result.response.headers[HttpHeaders.ContentEncoding].orEmpty())
         }
@@ -343,7 +325,6 @@ class StaticContentTest {
         handleRequest(HttpMethod.Get, "/assets/$publicFile.css") {
             addHeader(HttpHeaders.AcceptEncoding, "gzip, br")
         }.let { result ->
-            assertTrue(result.requestHandled)
             assertEquals(ContentType.defaultForFileExtension("css"), result.response.contentType())
             assertEquals("br", result.response.headers[HttpHeaders.ContentEncoding].orEmpty())
         }
@@ -365,7 +346,6 @@ class StaticContentTest {
                 File(basedir, "features/StaticContentTest.kt".replaceSeparators()).readText(),
                 result.response.content
             )
-            assertTrue(result.requestHandled)
         }
     }
 
@@ -419,7 +399,7 @@ class StaticContentTest {
         }
 
         handleRequest(HttpMethod.Get, "/").let { result ->
-            assertFalse(result.requestHandled)
+            assertFalse(result.response.status()!!.isSuccess())
         }
     }
 
@@ -454,7 +434,7 @@ class StaticContentTest {
         }
 
         handleRequest(HttpMethod.Get, "/").let { result ->
-            assertFalse(result.requestHandled)
+            assertFalse(result.response.status()!!.isSuccess())
         }
     }
 
@@ -478,7 +458,6 @@ class StaticContentTest {
                 result.response.content
             )
             assertEquals(listOf("max-age=300"), result.response.headers.values(HttpHeaders.CacheControl))
-            assertTrue(result.requestHandled)
         }
     }
 

--- a/ktor-server/ktor-server-tests/jvm/test/io/ktor/tests/server/routing/RoutingProcessingTest.kt
+++ b/ktor-server/ktor-server-tests/jvm/test/io/ktor/tests/server/routing/RoutingProcessingTest.kt
@@ -30,9 +30,6 @@ class RoutingProcessingTest {
                 uri = "/foo/bar"
                 method = HttpMethod.Get
             }
-            it("should be handled") {
-                assertTrue(result.requestHandled)
-            }
             it("should have a response with OK status") {
                 assertEquals(HttpStatusCode.OK, result.response.status())
             }
@@ -44,7 +41,7 @@ class RoutingProcessingTest {
                 method = HttpMethod.Post
             }
             it("should not be handled") {
-                assertFalse(result.requestHandled)
+                assertFalse(result.response.status()!!.isSuccess())
             }
         }
     }
@@ -483,27 +480,24 @@ class RoutingProcessingTest {
         handleRequest(HttpMethod.Get, "/") {
             addHeader(HttpHeaders.Accept, "text/plain")
         }.let { call ->
-            assertTrue { call.requestHandled }
             assertEquals("OK", call.response.content)
         }
 
         handleRequest(HttpMethod.Get, "/") {
             addHeader(HttpHeaders.Accept, "application/json")
         }.let { call ->
-            assertTrue { call.requestHandled }
             assertEquals("{\"status\": \"OK\"}", call.response.content)
         }
 
         handleRequest(HttpMethod.Get, "/") {
         }.let { call ->
-            assertTrue { call.requestHandled }
             assertEquals("OK", call.response.content)
         }
 
         handleRequest(HttpMethod.Get, "/") {
             addHeader(HttpHeaders.Accept, "text/html")
         }.let { call ->
-            assertFalse { call.requestHandled }
+            assertFalse(call.response.status()!!.isSuccess())
         }
 
         handleRequest(HttpMethod.Get, "/") {
@@ -524,7 +518,6 @@ class RoutingProcessingTest {
         }
 
         handleRequest(HttpMethod.Get, "/").let { call ->
-            assertTrue(call.requestHandled)
             assertEquals("OK", call.response.content)
         }
     }
@@ -547,11 +540,9 @@ class RoutingProcessingTest {
         }
 
         handleRequest(HttpMethod.Get, "/root?param=123").let { call ->
-            assertTrue(call.requestHandled)
             assertEquals("param", call.response.content)
         }
         handleRequest(HttpMethod.Get, "/root").let { call ->
-            assertTrue(call.requestHandled)
             assertEquals("get", call.response.content)
         }
     }
@@ -991,17 +982,14 @@ Route resolve result:
         }
 
         handleRequest(HttpMethod.Get, "/foo:bar").let { call ->
-            assertTrue { call.requestHandled }
             assertEquals(call.response.content, "foo")
         }
 
         handleRequest(HttpMethod.Get, "/baz").let { call ->
-            assertTrue { call.requestHandled }
             assertEquals(call.response.content, "baz")
         }
 
         handleRequest(HttpMethod.Get, "/baz:bar").let { call ->
-            assertTrue { call.requestHandled }
             assertEquals(call.response.content, "bar")
         }
     }

--- a/ktor-server/ktor-server-tests/jvm/test/io/ktor/tests/server/routing/RoutingResolveTest.kt
+++ b/ktor-server/ktor-server-tests/jvm/test/io/ktor/tests/server/routing/RoutingResolveTest.kt
@@ -762,7 +762,7 @@ class RoutingResolveTest {
                 method = HttpMethod.Get
             }
             it("/foo/ should not be called") {
-                assertFalse(result.requestHandled)
+                assertFalse(result.response.status()!!.isSuccess())
             }
         }
 
@@ -781,7 +781,7 @@ class RoutingResolveTest {
                 method = HttpMethod.Get
             }
             it("/bar should not be called") {
-                assertFalse(result.requestHandled)
+                assertFalse(result.response.status()!!.isSuccess())
             }
         }
     }
@@ -907,7 +907,7 @@ class RoutingResolveTest {
                 method = HttpMethod.Get
             }
             it("/foo/ should not be called") {
-                assertFalse(result.requestHandled)
+                assertFalse(result.response.status()!!.isSuccess())
             }
         }
     }
@@ -1066,7 +1066,7 @@ class RoutingResolveTest {
                 method = HttpMethod.Get
             }
             it("bar should not be called") {
-                assertFalse(result.requestHandled)
+                assertFalse(result.response.status()!!.isSuccess())
             }
         }
         on("making baz request") {
@@ -1075,7 +1075,7 @@ class RoutingResolveTest {
                 method = HttpMethod.Get
             }
             it("baz/ should not be called") {
-                assertFalse(result.requestHandled)
+                assertFalse(result.response.status()!!.isSuccess())
             }
         }
     }
@@ -1202,7 +1202,7 @@ class RoutingResolveTest {
                 method = HttpMethod.Get
             }
             it("/test should not be called") {
-                assertFalse(result.requestHandled)
+                assertFalse(result.response.status()!!.isSuccess())
             }
         }
         on("making /test/ request") {
@@ -1211,7 +1211,7 @@ class RoutingResolveTest {
                 method = HttpMethod.Get
             }
             it("/test/ should not be called") {
-                assertFalse(result.requestHandled)
+                assertFalse(result.response.status()!!.isSuccess())
             }
         }
         on("making /test/foo request") {
@@ -1238,7 +1238,7 @@ class RoutingResolveTest {
                 method = HttpMethod.Get
             }
             it("/test/*/foo should not be called") {
-                assertFalse(result.requestHandled)
+                assertFalse(result.response.status()!!.isSuccess())
             }
         }
         on("making /test/bar/foo request") {
@@ -1265,7 +1265,7 @@ class RoutingResolveTest {
                 method = HttpMethod.Get
             }
             it("/test/ should not be called") {
-                assertFalse(result.requestHandled)
+                assertFalse(result.response.status()!!.isSuccess())
             }
         }
         on("making /test/foo request") {

--- a/ktor-server/ktor-server-tests/jvm/test/io/ktor/tests/server/testing/TestApplicationEngineTest.kt
+++ b/ktor-server/ktor-server-tests/jvm/test/io/ktor/tests/server/testing/TestApplicationEngineTest.kt
@@ -69,7 +69,7 @@ class TestApplicationEngineTest {
         ) {
             val elapsedTime = measureTimeMillis {
                 handleRequest(HttpMethod.Get, "/").let { call ->
-                    assertTrue(call.requestHandled)
+                    assertTrue(call.response.status()!!.isSuccess())
                 }
             }
             assertEquals(listOf("Delay($delayTime)", "Delay($delayTime)"), delayLog)


### PR DESCRIPTION
And replace all usages in tests


https://youtrack.jetbrains.com/issue/KTOR-2712