### PR TITLE
KTOR-356 fix to provide a way to configure netty pipeline with user provided custom channel handler

### DIFF
--- a/ktor-server/ktor-server-netty/api/ktor-server-netty.api
+++ b/ktor-server/ktor-server-netty/api/ktor-server-netty.api
@@ -83,6 +83,7 @@ public final class io/ktor/server/netty/NettyApplicationEngine : io/ktor/server/
 
 public final class io/ktor/server/netty/NettyApplicationEngine$Configuration : io/ktor/server/engine/BaseApplicationEngine$Configuration {
 	public fun <init> ()V
+	public final fun getChannelPipelineConfig ()Lkotlin/jvm/functions/Function1;
 	public final fun getConfigureBootstrap ()Lkotlin/jvm/functions/Function1;
 	public final fun getHttpServerCodec ()Lkotlin/jvm/functions/Function0;
 	public final fun getRequestQueueLimit ()I
@@ -91,6 +92,7 @@ public final class io/ktor/server/netty/NettyApplicationEngine$Configuration : i
 	public final fun getRunningLimit ()I
 	public final fun getShareWorkGroup ()Z
 	public final fun getTcpKeepAlive ()Z
+	public final fun setChannelPipelineConfig (Lkotlin/jvm/functions/Function1;)V
 	public final fun setConfigureBootstrap (Lkotlin/jvm/functions/Function1;)V
 	public final fun setHttpServerCodec (Lkotlin/jvm/functions/Function0;)V
 	public final fun setRequestQueueLimit (I)V
@@ -150,7 +152,7 @@ public final class io/ktor/server/netty/NettyApplicationResponse$Companion {
 
 public final class io/ktor/server/netty/NettyChannelInitializer : io/netty/channel/ChannelInitializer {
 	public static final field Companion Lio/ktor/server/netty/NettyChannelInitializer$Companion;
-	public fun <init> (Lio/ktor/server/engine/EnginePipeline;Lio/ktor/server/engine/ApplicationEngineEnvironment;Lio/netty/util/concurrent/EventExecutorGroup;Lkotlin/coroutines/CoroutineContext;Lkotlin/coroutines/CoroutineContext;Lio/ktor/server/engine/EngineConnectorConfig;IIIILkotlin/jvm/functions/Function0;)V
+	public fun <init> (Lio/ktor/server/engine/EnginePipeline;Lio/ktor/server/engine/ApplicationEngineEnvironment;Lio/netty/util/concurrent/EventExecutorGroup;Lkotlin/coroutines/CoroutineContext;Lkotlin/coroutines/CoroutineContext;Lio/ktor/server/engine/EngineConnectorConfig;IIIILkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;)V
 	public synthetic fun initChannel (Lio/netty/channel/Channel;)V
 }
 

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyApplicationEngine.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyApplicationEngine.kt
@@ -77,6 +77,11 @@ public class NettyApplicationEngine(
          * User-provided function to configure Netty's [HttpServerCodec]
          */
         public var httpServerCodec: () -> HttpServerCodec = ::HttpServerCodec
+
+        /**
+         * User-provided function to configure Netty's [ChannelPipeline]
+         */
+        public var channelPipelineConfig: ChannelPipeline.() -> Unit = {}
     }
 
     private val configuration = Configuration().apply(configure)
@@ -153,7 +158,8 @@ public class NettyApplicationEngine(
                     configuration.runningLimit,
                     configuration.responseWriteTimeoutSeconds,
                     configuration.requestReadTimeoutSeconds,
-                    configuration.httpServerCodec
+                    configuration.httpServerCodec,
+                    configuration.channelPipelineConfig
                 )
             )
             if (configuration.tcpKeepAlive) {

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyChannelInitializer.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyChannelInitializer.kt
@@ -36,10 +36,36 @@ public class NettyChannelInitializer(
     private val runningLimit: Int,
     private val responseWriteTimeout: Int,
     private val requestReadTimeout: Int,
-    private val httpServerCodec: () -> HttpServerCodec
+    private val httpServerCodec: () -> HttpServerCodec,
+    private val channelPipelineConfig: ChannelPipeline.() -> Unit
 ) : ChannelInitializer<SocketChannel>() {
     private var sslContext: SslContext? = null
 
+    internal constructor(
+        enginePipeline: EnginePipeline,
+        environment: ApplicationEngineEnvironment,
+        callEventGroup: EventExecutorGroup,
+        engineContext: CoroutineContext,
+        userContext: CoroutineContext,
+        connector: EngineConnectorConfig,
+        requestQueueLimit: Int,
+        runningLimit: Int,
+        responseWriteTimeout: Int,
+        requestReadTimeout: Int,
+        httpServerCodec: () -> HttpServerCodec
+    ) : this(
+        enginePipeline,
+        environment,
+        callEventGroup,
+        engineContext,
+        userContext,
+        connector,
+        requestQueueLimit,
+        runningLimit,
+        responseWriteTimeout,
+        requestReadTimeout,
+        httpServerCodec,
+        {})
     init {
         if (connector is EngineSSLConnectorConfig) {
 
@@ -99,6 +125,7 @@ public class NettyChannelInitializer(
                 pipeline.channel().closeFuture().addListener {
                     handler.cancel()
                 }
+                channelPipelineConfig(pipeline)
             }
             ApplicationProtocolNames.HTTP_1_1 -> {
                 val requestQueue = NettyRequestQueue(requestQueueLimit, runningLimit)
@@ -120,6 +147,7 @@ public class NettyChannelInitializer(
                     addLast("continue", HttpServerExpectContinueHandler())
                     addLast("timeout", WriteTimeoutHandler(responseWriteTimeout))
                     addLast("http1", handler)
+                    channelPipelineConfig()
                 }
 
                 pipeline.context("codec").fireChannelActive()

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyChannelInitializer.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyChannelInitializer.kt
@@ -65,7 +65,9 @@ public class NettyChannelInitializer(
         responseWriteTimeout,
         requestReadTimeout,
         httpServerCodec,
-        {})
+        {}
+    )
+
     init {
         if (connector is EngineSSLConnectorConfig) {
 

--- a/ktor-server/ktor-server-netty/jvm/test/io/ktor/tests/server/netty/NettyCustomChannelPipelineConfigurationTest.kt
+++ b/ktor-server/ktor-server-netty/jvm/test/io/ktor/tests/server/netty/NettyCustomChannelPipelineConfigurationTest.kt
@@ -13,7 +13,6 @@ import io.ktor.server.testing.*
 import io.netty.channel.*
 import kotlin.test.*
 
-
 abstract class NettyCustomChannelTest<TEngine : ApplicationEngine, TConfiguration : ApplicationEngine.Configuration>(
     hostFactory: ApplicationEngineFactory<TEngine, TConfiguration>
 ) : EngineTestBase<TEngine, TConfiguration>(hostFactory) {
@@ -41,12 +40,15 @@ class NettyCustomChannelPipelineConfigurationTest :
     override fun configure(configuration: NettyApplicationEngine.Configuration) {
         configuration.shareWorkGroup = true
         configuration.channelPipelineConfig = {
-            addLast("customHandler", object : ChannelInboundHandlerAdapter() {
-                override fun channelRead(ctx: ChannelHandlerContext, msg: Any) {
-                    counter = counter.plus(1)
-                    super.channelRead(ctx, msg)
+            addLast(
+                "customHandler",
+                object : ChannelInboundHandlerAdapter() {
+                    override fun channelRead(ctx: ChannelHandlerContext, msg: Any) {
+                        counter = counter.plus(1)
+                        super.channelRead(ctx, msg)
+                    }
                 }
-            })
+            )
         }
     }
 }

--- a/ktor-server/ktor-server-netty/jvm/test/io/ktor/tests/server/netty/NettyCustomChannelPipelineConfigurationTest.kt
+++ b/ktor-server/ktor-server-netty/jvm/test/io/ktor/tests/server/netty/NettyCustomChannelPipelineConfigurationTest.kt
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2014-2021 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.tests.server.netty
+
+import io.ktor.application.*
+import io.ktor.http.*
+import io.ktor.response.*
+import io.ktor.server.engine.*
+import io.ktor.server.netty.*
+import io.ktor.server.testing.*
+import io.netty.channel.*
+import kotlin.test.*
+
+
+abstract class NettyCustomChannelTest<TEngine : ApplicationEngine, TConfiguration : ApplicationEngine.Configuration>(
+    hostFactory: ApplicationEngineFactory<TEngine, TConfiguration>
+) : EngineTestBase<TEngine, TConfiguration>(hostFactory) {
+
+    var counter = 0
+
+    @Test
+    fun testCustomChannelHandlerInvoked() {
+        createAndStartServer {
+            handle {
+                call.respondText("Hello")
+            }
+        }
+
+        withUrl("/") {
+            assertEquals(HttpStatusCode.OK.value, status.value)
+            assertNotEquals(0, counter)
+        }
+    }
+}
+
+class NettyCustomChannelPipelineConfigurationTest :
+    NettyCustomChannelTest<NettyApplicationEngine, NettyApplicationEngine.Configuration>(Netty) {
+
+    override fun configure(configuration: NettyApplicationEngine.Configuration) {
+        configuration.shareWorkGroup = true
+        configuration.channelPipelineConfig = {
+            addLast("customHandler", object : ChannelInboundHandlerAdapter() {
+                override fun channelRead(ctx: ChannelHandlerContext, msg: Any) {
+                    counter = counter.plus(1)
+                    super.channelRead(ctx, msg)
+                }
+            })
+        }
+    }
+}

--- a/ktor-server/ktor-server-tests/jvm/test/io/ktor/tests/server/routing/RoutingResolveTest.kt
+++ b/ktor-server/ktor-server-tests/jvm/test/io/ktor/tests/server/routing/RoutingResolveTest.kt
@@ -78,7 +78,7 @@ class RoutingResolveTest {
     @Test
     fun testMatchingRoot() {
         val root = routing("context/path")
-        root.handle {  }
+        root.handle { }
 
         on("resolving /context/path") {
             val result = resolve(root, "/context/path")


### PR DESCRIPTION
**Subsystem**
Server, ktor-server, ktor-server-netty

**Motivation**
I'm working on project where we need to add few organization cross cutting channel handler. Current implementation doesn't expose any ways to add our channel handler.
https://github.com/ktorio/ktor/issues/1909

Fix for [KTOR-356](https://youtrack.jetbrains.com/issue/KTOR-356).

**Solution**

provide a way to configure netty pipeline with user provided custom `channelHandler`.  The user provided channel handler will be added in the channel pipeline along with the default channelHandler added [here].(https://github.com/ktorio/ktor/blob/master/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyChannelInitializer.kt#L94).

```
embeddedServer(Netty, port = configuration.server.port, configure = {
        channelPipelineConfig = {
            addAfter("codec","trafficMonitoring", TrafficMonitoringHandler())
        }
    }) {
        module()
    }.start(true)
```