### PR TITLE
KTOR-2711 Remove redundant completion of response coroutine

### DIFF
--- a/ktor-client/ktor-client-core/common/src/io/ktor/client/features/observer/ResponseObserver.kt
+++ b/ktor-client/ktor-client-core/common/src/io/ktor/client/features/observer/ResponseObserver.kt
@@ -61,9 +61,6 @@ public class ResponseObserver(
 
                 context.response = newClientCall.response
                 context.request = newClientCall.request
-
-                @Suppress("UNCHECKED_CAST")
-                (response.coroutineContext[Job] as CompletableJob).complete()
                 proceedWith(context.response)
             }
         }


### PR DESCRIPTION
**Subsystem**
Client, Logging

**Motivation**
https://youtrack.jetbrains.com/issue/KTOR-2711

**Solution**
Completing the response's context is redundant and even harmful since migrating to `HttpStatement`
