### PR TITLE
KTOR-2683 fixed iOS engine deadlock

### DIFF
--- a/ktor-client/ktor-client-ios/darwin/src/io/ktor/client/engine/ios/IosClientEngine.kt
+++ b/ktor-client/ktor-client-ios/darwin/src/io/ktor/client/engine/ios/IosClientEngine.kt
@@ -50,7 +50,7 @@ internal class IosClientEngine(override val config: IosClientEngineConfig) : Htt
         val session = NSURLSession.sessionWithConfiguration(
             configuration,
             responseReader.freeze(),
-            delegateQueue = NSOperationQueue.mainQueue()
+            delegateQueue = NSOperationQueue.currentQueue()
         )
 
         val task = session.dataTaskWithRequest(nativeRequest)


### PR DESCRIPTION
**Subsystem**
ktor-client-ios

**Motivation**
When executing the Http request test in the iOS unit test. You need to use runBlocking to block the current thread, but the IosEngine response uses the main thread to return the result, which will cause deadlock.

In fact, IosEngine does **NOT NEED** to consider using the main thread to return data. **This part of the logic should be guaranteed by Ktor users.**

**Solution**
Use the current thread to return the result
