### PR TITLE
fix youtrack links

### DIFF
--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -12,15 +12,15 @@ validation, it is recommended to check the corresponding status, header, or cont
 * [Updates to `basic` and `digest` authentication providers](https://youtrack.jetbrains.com/issue/KTOR-2637), deprecating
 `sendWithoutRequest` property, and favouring `sendWithoutRequest` function. Also, `username` and `password` properties are
   deprecated in favour of `credentials` function, which takes as parameter `BasicAuthCredentials` or `DigestAuthCredentials` data classes.
-* Application extension functions `uninstallAllFeatures`, `uninstall`, and `uninstallFeature` have been [deprecated](youtrack.jetbrains.com/issue/KTOR-367). Currently, there are no replacements
+* Application extension functions `uninstallAllFeatures`, `uninstall`, and `uninstallFeature` have been [deprecated](https://youtrack.jetbrains.com/issue/KTOR-367). Currently, there are no replacements
 for these functions. Please [consider commenting on your use-cases on the corresponding issue](https://youtrack.jetbrains.com/issue/KTOR-2696).
-* `ApplicationCall.locationOrNull` has been [deprecated](youtrack.jetbrains.com/issue/KTOR-1684). Please use `ApplicationCall.location`.
-* `ContentNegotiation` constructor has been [deprecated](youtrack.jetbrains.com/issue/KTOR-2194) as it will become internal. It should not be 
+* `ApplicationCall.locationOrNull` has been [deprecated](https://youtrack.jetbrains.com/issue/KTOR-1684). Please use `ApplicationCall.location`.
+* `ContentNegotiation` constructor has been [deprecated](https://youtrack.jetbrains.com/issue/KTOR-2194) as it will become internal. It should not be 
 explicitly called from the application code. Please consider passing in the necessary configuration options during installation of the `ContentNegotiation` plugin.
-*  `ByteChannelSequentialBase.readByteOrder` and `ByteChannelSequentialBase.writeByOrder` have been [deprecated](youtrack.jetbrains.com/issue/KTOR-1094). Please read/write
+*  `ByteChannelSequentialBase.readByteOrder` and `ByteChannelSequentialBase.writeByOrder` have been [deprecated](https://youtrack.jetbrains.com/issue/KTOR-1094). Please read/write
 using big endian, and call the `ByteChannelSequentialBase.reverseByteOrder()` extension function if necessary.
-* `AbstractInput` class has been [deprecated](youtrack.jetbrains.com/issue/KTOR-2204) and will be merged with `Input` class as of version 2.0.0.
-* `AbstractOutput` class has been [deprecated](youtrack.jetbrains.com/issue/KTOR-2204) and will be merged with `Output` class as of version 2.0.0.
-* `IoBuffer` class has been [deprecated](youtrack.jetbrains.com/issue/KTOR-2204). Please use `ChunkBuffer` instead.
+* `AbstractInput` class has been [deprecated](https://youtrack.jetbrains.com/issue/KTOR-2204) and will be merged with `Input` class as of version 2.0.0.
+* `AbstractOutput` class has been [deprecated](https://youtrack.jetbrains.com/issue/KTOR-2204) and will be merged with `Output` class as of version 2.0.0.
+* `IoBuffer` class has been [deprecated](https://youtrack.jetbrains.com/issue/KTOR-2204). Please use `ChunkBuffer` instead.
 
 


### PR DESCRIPTION
Added `https://` to Youtrack links since GitHub adds `https://github.com/ktorio/ktor/blob/main/` before the address and links lead to 404.