### PR TITLE
KTOR-27 Add netty HttpServerCodec config to ktor.deployment

### DIFF
--- a/ktor-server/ktor-server-netty/api/ktor-server-netty.api
+++ b/ktor-server/ktor-server-netty/api/ktor-server-netty.api
@@ -82,6 +82,9 @@ public final class io/ktor/server/netty/NettyApplicationEngine$Configuration : i
 	public final fun getChannelPipelineConfig ()Lkotlin/jvm/functions/Function1;
 	public final fun getConfigureBootstrap ()Lkotlin/jvm/functions/Function1;
 	public final fun getHttpServerCodec ()Lkotlin/jvm/functions/Function0;
+	public final fun getMaxChunkSize ()I
+	public final fun getMaxHeaderLength ()I
+	public final fun getMaxInitialLineLength ()I
 	public final fun getRequestQueueLimit ()I
 	public final fun getRequestReadTimeoutSeconds ()I
 	public final fun getResponseWriteTimeoutSeconds ()I
@@ -91,6 +94,9 @@ public final class io/ktor/server/netty/NettyApplicationEngine$Configuration : i
 	public final fun setChannelPipelineConfig (Lkotlin/jvm/functions/Function1;)V
 	public final fun setConfigureBootstrap (Lkotlin/jvm/functions/Function1;)V
 	public final fun setHttpServerCodec (Lkotlin/jvm/functions/Function0;)V
+	public final fun setMaxChunkSize (I)V
+	public final fun setMaxHeaderLength (I)V
+	public final fun setMaxInitialLineLength (I)V
 	public final fun setRequestQueueLimit (I)V
 	public final fun setRequestReadTimeoutSeconds (I)V
 	public final fun setResponseWriteTimeoutSeconds (I)V

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/EngineMain.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/EngineMain.kt
@@ -38,5 +38,14 @@ public object EngineMain {
         deploymentConfig.propertyOrNull("responseWriteTimeoutSeconds")?.getString()?.toInt()?.let {
             responseWriteTimeoutSeconds = it
         }
+        deploymentConfig.propertyOrNull("maxInitialLineLength")?.getString()?.toInt()?.let {
+            maxInitialLineLength = it
+        }
+        deploymentConfig.propertyOrNull("maxHeaderLength")?.getString()?.toInt()?.let {
+            maxHeaderLength = it
+        }
+        deploymentConfig.propertyOrNull("maxChunkSize")?.getString()?.toInt()?.let {
+            maxChunkSize = it
+        }
     }
 }

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyApplicationEngine.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyApplicationEngine.kt
@@ -17,6 +17,7 @@ import io.netty.channel.nio.*
 import io.netty.channel.socket.*
 import io.netty.channel.socket.nio.*
 import io.netty.handler.codec.http.*
+import io.netty.handler.codec.*
 import io.netty.util.concurrent.*
 import kotlinx.coroutines.*
 import java.lang.reflect.*
@@ -76,9 +77,35 @@ public class NettyApplicationEngine(
         public var tcpKeepAlive: Boolean = false
 
         /**
+         * The maximum length of the initial line (e.g. "GET / HTTP/1.0" or "HTTP/1.0 200
+         * OK") If the length of the initial line exceeds this value, a Netty's [TooLongFrameException] will
+         * be raised.
+         */
+        public var maxInitialLineLength: Int = HttpObjectDecoder.DEFAULT_MAX_INITIAL_LINE_LENGTH
+
+        /**
+         * The maximum length of all headers. If the sum of the length of each header exceeds this
+         * value, a Netty's [TooLongFrameException] will be raised.
+         */
+        public var maxHeaderLength: Int = HttpObjectDecoder.DEFAULT_MAX_HEADER_SIZE
+
+        /**
+         * The maximum length of the content or each chunk. If the content length (or the length
+         * of each chunk) exceeds this value, the content or chunk will be split into multiple
+         * Netty's [HttpContent]s whose length is maxChunkSize at maximum.
+         */
+        public var maxChunkSize: Int = HttpObjectDecoder.DEFAULT_MAX_CHUNK_SIZE
+
+        /**
          * User-provided function to configure Netty's [HttpServerCodec]
          */
-        public var httpServerCodec: () -> HttpServerCodec = ::HttpServerCodec
+        public var httpServerCodec: () -> HttpServerCodec = {
+            HttpServerCodec(
+                maxInitialLineLength,
+                maxHeaderLength,
+                maxChunkSize
+            )
+        }
 
         /**
          * User-provided function to configure Netty's [ChannelPipeline]

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyApplicationEngine.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyApplicationEngine.kt
@@ -16,8 +16,8 @@ import io.netty.channel.kqueue.*
 import io.netty.channel.nio.*
 import io.netty.channel.socket.*
 import io.netty.channel.socket.nio.*
-import io.netty.handler.codec.http.*
 import io.netty.handler.codec.*
+import io.netty.handler.codec.http.*
 import io.netty.util.concurrent.*
 import kotlinx.coroutines.*
 import java.lang.reflect.*


### PR DESCRIPTION
**Subsystem**
Server, ktor-server-netty

**Motivation**
[KTOR-27](https://youtrack.jetbrains.com/issue/KTOR-27) AWS Cognito tends to send relatively large cookies to the server, or larger bearer tokens with JWT authentication. This means the standard 8KB limit for HTTP headers isn't enough.

**Solution**
Make it can config from ktor.deployment  for EngineMain or  embeddedServer.

### for EngineMain
``` yaml
ktor {
    deployment {
        maxHeaderLength= 8192
    }
}
```
### for embeddedServer
``` kotlin
fun main() {
    embeddedServer(Netty, port = 8000, configure = {
        maxHeaderLength= 8192
    }) {
        // ...
    }.start(wait = true)
}
```