### PR TITLE
KTOR-2472 Replace deprecated EventDefinition usages

### DIFF
--- a/ktor-server/ktor-server-core/jvm/src/io/ktor/application/ApplicationEvents.kt
+++ b/ktor-server/ktor-server-core/jvm/src/io/ktor/application/ApplicationEvents.kt
@@ -37,6 +37,6 @@ public typealias EventHandler<T> = io.ktor.events.EventHandler<T>
 @Deprecated(
     "EventDefinition<T> has been moved to io.ktor.events",
     level = DeprecationLevel.WARNING,
-    replaceWith = ReplaceWith("Events", "io.ktor.events.EventDefinition")
+    replaceWith = ReplaceWith("EventDefinition<T>", "io.ktor.events.EventDefinition")
 )
 public typealias EventDefinition<T> = io.ktor.events.EventDefinition<T>

--- a/ktor-server/ktor-server-core/jvm/src/io/ktor/application/DefaultApplicationEvents.kt
+++ b/ktor-server/ktor-server-core/jvm/src/io/ktor/application/DefaultApplicationEvents.kt
@@ -6,13 +6,15 @@
 
 package io.ktor.application
 
+import io.ktor.events.EventDefinition
+
 /**
  * Event definition for Application Starting event
  *
  * Note, that application itself cannot receive this event because it fires before application is created
  * It is meant to be used by engines.
  */
-public val ApplicationStarting: EventDefinition<Application> = EventDefinition<Application>()
+public val ApplicationStarting: EventDefinition<Application> = EventDefinition()
 
 /**
  * Event definition for Application Started event

--- a/ktor-server/ktor-server-core/jvm/src/io/ktor/routing/Routing.kt
+++ b/ktor-server/ktor-server-core/jvm/src/io/ktor/routing/Routing.kt
@@ -5,6 +5,7 @@
 package io.ktor.routing
 
 import io.ktor.application.*
+import io.ktor.events.EventDefinition
 import io.ktor.http.*
 import io.ktor.request.*
 import io.ktor.response.*
@@ -96,14 +97,12 @@ public class Routing(
         /**
          * Event definition for when a routing-based call processing starts
          */
-        public val RoutingCallStarted: EventDefinition<RoutingApplicationCall> =
-            EventDefinition<RoutingApplicationCall>()
+        public val RoutingCallStarted: EventDefinition<RoutingApplicationCall> = EventDefinition()
 
         /**
          * Event definition for when a routing-based call processing finished
          */
-        public val RoutingCallFinished: EventDefinition<RoutingApplicationCall> =
-            EventDefinition<RoutingApplicationCall>()
+        public val RoutingCallFinished: EventDefinition<RoutingApplicationCall> = EventDefinition()
 
         override val key: AttributeKey<Routing> = AttributeKey("Routing")
 

--- a/ktor-server/ktor-server-host-common/jvm/src/io/ktor/server/engine/ApplicationEngineEnvironmentReloading.kt
+++ b/ktor-server/ktor-server-host-common/jvm/src/io/ktor/server/engine/ApplicationEngineEnvironmentReloading.kt
@@ -5,9 +5,9 @@
 package io.ktor.server.engine
 
 import io.ktor.application.*
-import io.ktor.application.EventDefinition
 import io.ktor.config.*
 import io.ktor.events.*
+import io.ktor.events.EventDefinition
 import io.ktor.http.*
 import io.ktor.server.engine.internal.*
 import io.ktor.util.*


### PR DESCRIPTION
Kotlin doesn't like having mixed usages
