### PR TITLE
KTOR-343 Fix exception in template can't be handled in StatusPages

### DIFF
--- a/ktor-features/ktor-mustache/jvm/test/io/ktor/mustache/MustacheTest.kt
+++ b/ktor-features/ktor-mustache/jvm/test/io/ktor/mustache/MustacheTest.kt
@@ -99,7 +99,9 @@ class MustacheTest {
     fun `Render template compressed with GZIP`() {
         withTestApplication {
             application.setupMustache()
-            application.install(Compression)
+            application.install(Compression) {
+                gzip { minimumSize(10) }
+            }
             application.install(ConditionalHeaders)
 
             application.routing {

--- a/ktor-features/ktor-pebble/jvm/test/io/ktor/pebble/PebbleTest.kt
+++ b/ktor-features/ktor-pebble/jvm/test/io/ktor/pebble/PebbleTest.kt
@@ -100,7 +100,9 @@ class PebbleTest {
     fun `Render template compressed with GZIP`() {
         withTestApplication {
             application.setupPebble()
-            application.install(Compression)
+            application.install(Compression) {
+                gzip { minimumSize(10) }
+            }
             application.install(ConditionalHeaders)
 
             application.routing {

--- a/ktor-features/ktor-thymeleaf/jvm/test/io/ktor/thymeleaf/ThymeleafTest.kt
+++ b/ktor-features/ktor-thymeleaf/jvm/test/io/ktor/thymeleaf/ThymeleafTest.kt
@@ -44,7 +44,9 @@ class ThymeleafTest {
     fun testCompression() {
         withTestApplication {
             application.setUpThymeleafStringTemplate()
-            application.install(Compression)
+            application.install(Compression) {
+                gzip { minimumSize(10) }
+            }
             application.install(ConditionalHeaders)
 
             application.routing {

--- a/ktor-features/ktor-velocity/jvm/src/io/ktor/velocity/VelocityTools.kt
+++ b/ktor-features/ktor-velocity/jvm/src/io/ktor/velocity/VelocityTools.kt
@@ -5,6 +5,7 @@
 package io.ktor.velocity
 
 import io.ktor.application.*
+import io.ktor.http.content.*
 import io.ktor.response.*
 import io.ktor.util.*
 import org.apache.velocity.app.*
@@ -54,8 +55,8 @@ public class VelocityTools private constructor(private val toolManager: ToolMana
         }
     }
 
-    internal fun process(content: VelocityContent): VelocityOutgoingContent {
-        return VelocityOutgoingContent(
+    internal fun process(content: VelocityContent): OutgoingContent {
+        return velocityOutgoingContent(
             toolManager.velocityEngine.getTemplate(content.template),
             toolManager.createContext().also { it.putAll(content.model) },
             content.etag,

--- a/ktor-features/ktor-velocity/jvm/test/io/ktor/tests/velocity/VelocityTest.kt
+++ b/ktor-features/ktor-velocity/jvm/test/io/ktor/tests/velocity/VelocityTest.kt
@@ -46,7 +46,9 @@ class VelocityTest {
     fun testCompression() {
         withTestApplication {
             application.setUpTestTemplates()
-            application.install(Compression)
+            application.install(Compression) {
+                gzip { minimumSize(10) }
+            }
             application.install(ConditionalHeaders)
 
             application.routing {


### PR DESCRIPTION
`StatusPages` can't handle errors that happen in writing bodies, because response was already sent at this point. To fix this, move all the templates rendering before responding. 