### PR TITLE
KTOR-2276 Fix unbound public symbol error for SocketTimeoutException

### DIFF
--- a/ktor-network/js/src/io/ktor/network/sockets/SocketTimeoutException.kt
+++ b/ktor-network/js/src/io/ktor/network/sockets/SocketTimeoutException.kt
@@ -6,4 +6,9 @@ package io.ktor.network.sockets
 
 import io.ktor.utils.io.errors.*
 
-public actual class SocketTimeoutException actual constructor(message: String) : IOException(message)
+public actual class SocketTimeoutException(
+    message: String,
+    cause: Throwable?
+) : IOException(message, cause) {
+    public actual constructor(message: String) : this(message, null)
+}

--- a/ktor-network/posix/src/io/ktor/network/sockets/SocketTimeoutException.kt
+++ b/ktor-network/posix/src/io/ktor/network/sockets/SocketTimeoutException.kt
@@ -7,4 +7,9 @@ package io.ktor.network.sockets
 import io.ktor.utils.io.errors.*
 
 @Suppress("EXPECT_WITHOUT_ACTUAL")
-public actual class SocketTimeoutException actual constructor(message: String) : IOException(message)
+public actual class SocketTimeoutException(
+    message: String,
+    cause: Throwable?
+) : IOException(message, cause) {
+    public actual constructor(message: String) : this(message, null)
+}


### PR DESCRIPTION
Fix https://youtrack.jetbrains.com/issue/KTOR-2276

The `SocketTimeoutException` class is duplicated in the Ktor source code in `ktor-network` and `ktor-client-core` modules, which is causing issues for native targets. See the expect classes in the same packages here:

https://github.com/ktorio/ktor/blob/082156982d894297fa2408829845b71683dc54bf/ktor-network/common/src/io/ktor/network/sockets/Sockets.kt#L128
https://github.com/ktorio/ktor/blob/082156982d894297fa2408829845b71683dc54bf/ktor-client/ktor-client-core/common/src/io/ktor/network/sockets/TimeoutExceptionsCommon.kt#L22

On the JVM, one of the actuals is a typealias to `java.net.SocketTimeoutException` so there are no duplicate classes.

However, in the posix and js source sets, they are both declared as `public actual class`. On native this is causing issues:
```
e: java.lang.IllegalStateException: Symbol for public io.ktor.network.sockets/SocketTimeoutException.<init>|-4324620762574333298[0] is unbound
```

I think a real solution would be to only declare the `SocketTimeoutException` once in Ktor source code. That could be done by moving it to the ktor-utils module. If that is acceptable I could do that if you want.

An easier fix, I think without breaking API changes (please check), is to make sure that the actual classes for posix and js are identical. That is what I did in this PR.

Please let me know what you prefer: what I did in this PR, or moving the classes to ktor-utils so they are only declared once.

To reproduce the error:
1. Clone: https://github.com/Thomas-Vos/KtorSocketBug
2. Run: `./gradlew linkDebugFrameworkIosArm64`

If you build this PR and run publishToMavenLocal, and include it in the sample project, the error is gone.