### PR TITLE
ByteReadChannel.readUTF8Line() indefinitely returns empty lines when `\r` is not followed by `\n`

### DIFF
--- a/ktor-io/common/test/io/ktor/utils/io/StringsTest.kt
+++ b/ktor-io/common/test/io/ktor/utils/io/StringsTest.kt
@@ -307,4 +307,13 @@ open class StringsTest : ByteChannelTestBase(true) {
             channel.close()
         }
     }
+
+    @Test
+    fun testCarriageReturnIsTreatedLikeEndOfLine() = runTest {
+        val channel = ByteChannel()
+        channel.writeStringUtf8("start\rend")
+        channel.close()
+        assertEquals("start", channel.readUTF8Line())
+        assertEquals("end", channel.readUTF8Line())
+    }
 }

--- a/ktor-io/jvm/src/io/ktor/utils/io/internal/Strings.kt
+++ b/ktor-io/jvm/src/io/ktor/utils/io/internal/Strings.kt
@@ -86,7 +86,6 @@ private fun ByteBuffer.decodeASCIILine_buffer(out: CharArray, offset: Int, lengt
         val decoded = (rc shr 32).toInt()
         // found EOL
         if (cr) {
-            position(position() - 1) // push back a character after CR
             return decodeUtf8Result(decoded - 1, -1) // don't return CR
         }
 


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KTOR-2868
