### PR TITLE
Save TypeInfo implementation class in HttpResponseContainer

### DIFF
--- a/ktor-client/ktor-client-core/api/ktor-client-core.api
+++ b/ktor-client/ktor-client-core/api/ktor-client-core.api
@@ -1034,14 +1034,17 @@ public abstract class io/ktor/client/statement/HttpResponse : io/ktor/http/HttpM
 }
 
 public final class io/ktor/client/statement/HttpResponseContainer {
-	public fun <init> (Lio/ktor/client/call/TypeInfo;Ljava/lang/Object;)V
+	public synthetic fun <init> (Lio/ktor/client/call/TypeInfo;Ljava/lang/Object;)V
 	public fun <init> (Lio/ktor/util/reflect/TypeInfo;Ljava/lang/Object;)V
-	public final fun component1 ()Lio/ktor/client/call/TypeInfo;
+	public final fun component1 ()Lio/ktor/util/reflect/TypeInfo;
 	public final fun component2 ()Ljava/lang/Object;
-	public final fun copy (Lio/ktor/client/call/TypeInfo;Ljava/lang/Object;)Lio/ktor/client/statement/HttpResponseContainer;
+	public final synthetic fun copy (Lio/ktor/client/call/TypeInfo;Ljava/lang/Object;)Lio/ktor/client/statement/HttpResponseContainer;
+	public final fun copy (Lio/ktor/util/reflect/TypeInfo;Ljava/lang/Object;)Lio/ktor/client/statement/HttpResponseContainer;
 	public static synthetic fun copy$default (Lio/ktor/client/statement/HttpResponseContainer;Lio/ktor/client/call/TypeInfo;Ljava/lang/Object;ILjava/lang/Object;)Lio/ktor/client/statement/HttpResponseContainer;
+	public static synthetic fun copy$default (Lio/ktor/client/statement/HttpResponseContainer;Lio/ktor/util/reflect/TypeInfo;Ljava/lang/Object;ILjava/lang/Object;)Lio/ktor/client/statement/HttpResponseContainer;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getExpectedType ()Lio/ktor/client/call/TypeInfo;
+	public final fun getExpectedTypeInfo ()Lio/ktor/util/reflect/TypeInfo;
 	public final fun getResponse ()Ljava/lang/Object;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;

--- a/ktor-client/ktor-client-core/common/src/io/ktor/client/statement/HttpResponsePipeline.kt
+++ b/ktor-client/ktor-client-core/common/src/io/ktor/client/statement/HttpResponsePipeline.kt
@@ -75,13 +75,22 @@ public class HttpReceivePipeline(
 }
 
 /**
- * Class representing a typed [response] with an attached [expectedType].
- * @param expectedType: information about expected type.
+ * Class representing a typed [response] with an attached [expectedTypeInfo].
+ * @param expectedTypeInfo: information about expected type.
  * @param response: current response state.
  */
-public data class HttpResponseContainer(val expectedType: DeprecatedTypeInfo, val response: Any) {
-    public constructor(expectedType: TypeInfo, response: Any) : this(
-        DeprecatedTypeInfo(expectedType.type, expectedType.reifiedType, expectedType.kotlinType),
-        response
-    )
+public data class HttpResponseContainer(val expectedTypeInfo: TypeInfo, val response: Any) {
+    @Deprecated("Please use expectedTypeInfo with io.ktor.util.reflect.TypeInfo type", replaceWith = ReplaceWith("expectedTypeInfo"))
+    public val expectedType: DeprecatedTypeInfo get() = when(expectedTypeInfo) {
+        is DeprecatedTypeInfo -> expectedTypeInfo
+        else -> DeprecatedTypeInfo(expectedTypeInfo.type, expectedTypeInfo.reifiedType, expectedTypeInfo.kotlinType)
+    }
+
+    @Deprecated("Binary compatibility", level = DeprecationLevel.HIDDEN)
+    public constructor(expectedType: DeprecatedTypeInfo, response: Any) : this(expectedType as TypeInfo, response)
+
+    @Deprecated("Binary compatibility", level = DeprecationLevel.HIDDEN)
+    public fun copy(expectedType: DeprecatedTypeInfo = this.expectedType, response: Any = this.response): HttpResponseContainer {
+        return copy(expectedTypeInfo = expectedType, response = response)
+    }
 }


### PR DESCRIPTION
**Subsystem**
Client core

**Motivation**
In my project I wrote feature plugin which deserializes response bytes with using new `TypeInfo` interface, but it uses custom class extended with some additional info required for that process. But I noticed that `HttpResponseContainer` always re-creates type info with old deprecated data class and there is no any way to preserve original typeinfo class.

**Solution**
I rewrote `HttpResponseContainer` with binary-compatibility way and forced it to save original type info and create old one only by request from old code.
The only ABI breaking change in `component1` fun, but it's source-compatible if end-user not used old typeinfo class directly. Likelly, almost everyone uses it like these:
```kotlin
client.responsePipeline.intercept(HttpResponsePipeline.Transform) { (info, body) ->
  // Implicit usage of component1() here -----------------------------^
  // It will work after recompiling
  ...
}
```
