### PR TITLE
Don't report websocket extensions when there is nothing to report

### DIFF
--- a/ktor-client/ktor-client-core/common/src/io/ktor/client/features/websocket/WebSockets.kt
+++ b/ktor-client/ktor-client-core/common/src/io/ktor/client/features/websocket/WebSockets.kt
@@ -90,8 +90,10 @@ internal constructor(
 
     @OptIn(ExperimentalWebSocketExtensionApi::class)
     private fun addNegotiatedProtocols(context: HttpRequestBuilder, protocols: List<WebSocketExtensionHeader>) {
-        val headerValue = protocols.joinToString(";")
-        context.header(HttpHeaders.SecWebSocketExtensions, headerValue)
+        if (protocols.isNotEmpty()) {
+            val headerValue = protocols.joinToString(";")
+            context.header(HttpHeaders.SecWebSocketExtensions, headerValue)
+        }
     }
 
     internal fun convertSessionToDefault(session: WebSocketSession): DefaultWebSocketSession {


### PR DESCRIPTION
**Subsystem**
Client

**Motivation**
In case there is no any extensions for websocket client, ktor sends empty `Sec-WebSocket-Extensions` header. Some servers (CloudFlare in my case) responds with 400 bad request when sees that empty header.

**Solution**
Disable sending `Sec-WebSocket-Extensions` when there is no extensions

https://youtrack.jetbrains.com/issue/KTOR-2388