### PR TITLE
Update changelog with some missing breaking changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,7 +67,7 @@
 * HTTP-client auth with Bearer token ([KTOR-331](https://youtrack.jetbrains.com/issue/KTOR-331))
 * Expose TrailingSlashRouteSelector ([KTOR-2511](https://youtrack.jetbrains.com/issue/KTOR-2511))
 * Add an option to disable URL Encoding ([KTOR-553](https://youtrack.jetbrains.com/issue/KTOR-553))
-* Upgrade kotlin to 1.5.1 ([KTOR-2722](https://youtrack.jetbrains.com/issue/KTOR-2722))
+* Upgrade kotlin to 1.5.10 ([KTOR-2722](https://youtrack.jetbrains.com/issue/KTOR-2722))
 
 # 1.5.4
 > Published 30 Apr 2021

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@
 * HTTP-client auth with Bearer token ([KTOR-331](https://youtrack.jetbrains.com/issue/KTOR-331))
 * Expose TrailingSlashRouteSelector ([KTOR-2511](https://youtrack.jetbrains.com/issue/KTOR-2511))
 * Add an option to disable URL Encoding ([KTOR-553](https://youtrack.jetbrains.com/issue/KTOR-553))
+* Upgrade kotlin to 1.5.1 ([KTOR-2722](https://youtrack.jetbrains.com/issue/KTOR-2722))
 
 # 1.5.4
 > Published 30 Apr 2021
@@ -102,6 +103,7 @@
 *  Fixed flaky JavaEngineTests.testThreadLeak[jvm] ([KTOR-2098](https://youtrack.jetbrains.com/issue/KTOR-2098))
 *  Fixed flaky JettyStressTest.highLoadStressTest ([KTOR-2080](https://youtrack.jetbrains.com/issue/KTOR-2080))
 *  Fixed flaky ExceptionsJvmTest.testConnectionClosedDuringRequest[jvm] ([KTOR-2063](https://youtrack.jetbrains.com/issue/KTOR-2063))
+* Upgrade kotlin to 1.4.32 ([KTOR-2403](https://youtrack.jetbrains.com/issue/KTOR-2403))
 
 # 1.5.2
 > Published 25 Feb 2021
@@ -123,6 +125,7 @@
 * Fixed default Headers feature adds duplicated Server header ([KTOR-1976](https://youtrack.jetbrains.com/issue/KTOR-1976))
 * Fixed custom response validation is not running when default is disabled ([KTOR-2007](https://youtrack.jetbrains.com/issue/KTOR-2007))
 * Fixed session cookie with very long max age duration ([KTOR-692](https://youtrack.jetbrains.com/issue/KTOR-692))
+* Upgrade kotlin to 1.4.30 ([KTOR-1639](https://youtrack.jetbrains.com/issue/KTOR-1639))
 
 # 1.5.1
 > Published 27 Jan 2021

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -187,7 +187,8 @@
 * Implemented development mode for Ktor ([KTOR-1184](https://youtrack.jetbrains.com/issue/KTOR-1184))
 * Implemented proper unhandled exception handling strategy ([KTOR-835](https://youtrack.jetbrains.com/issue/KTOR-835))
 * Added OAuth feature config to avoid Dropbox issue ([KTOR-715](https://youtrack.jetbrains.com/issue/KTOR-715))
-* Fixed trailing slashes handling in routing ([KTOR-372](https://youtrack.jetbrains.com/issue/KTOR-372))
+* **Breaking change**: Fixed trailing slashes handling in routing ([KTOR-372](https://youtrack.jetbrains.com/issue/KTOR-372))  
+  Routes registered without trailing slashes no longer match URLs with trailing slashes, and vice versa. To keep the previous behavior, install the `IgnoreTrailingSlash` feature.
 * Added CIO client proxy tunneling support ([KTOR-1458](https://youtrack.jetbrains.com/issue/KTOR-1458))
 * Supported Sealed Classes inside Session-Objects ([KTOR-826](https://youtrack.jetbrains.com/issue/KTOR-826))
 * Fixed code autoreload ([KTOR-664](https://youtrack.jetbrains.com/issue/KTOR-664))


### PR DESCRIPTION
**Subsystem**
Documentation

**Motivation**
Updating Kotlin / coroutines / serialization dependencies is a breaking change. It's hard to find the compatible version of ktor with the corresponding Kotlin version as is, because of the disparate versioning. Including them in the changelog along with any other behavior change is the minimum, because updating ktor might pull any project's Kotlin version over to a new major version.

Version 1.2.3 and 1.4.1 gave the right significance to these updates, it would be nice if that convention was kept.

**Solution**
Updated version history based on Git Blame of gradle.properties.

Also included the suggested change by https://youtrack.jetbrains.com/issue/KTOR-372#focus=Comments-27-4951326.0-0