### PR TITLE
KTOR-2992 Add filtering support in Ktor client response interceptor

### DIFF
--- a/ktor-client/ktor-client-core/api/ktor-client-core.api
+++ b/ktor-client/ktor-client-core/api/ktor-client-core.api
@@ -607,10 +607,12 @@ public final class io/ktor/client/plugins/observer/DelegatedCallKt {
 public final class io/ktor/client/plugins/observer/ResponseObserver {
 	public static final field Plugin Lio/ktor/client/plugins/observer/ResponseObserver$Plugin;
 	public fun <init> (Lkotlin/jvm/functions/Function2;)V
+	public synthetic fun <init> (Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function1;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 }
 
 public final class io/ktor/client/plugins/observer/ResponseObserver$Config {
 	public fun <init> ()V
+	public final fun filter (Lkotlin/jvm/functions/Function1;)V
 	public final fun onResponse (Lkotlin/jvm/functions/Function2;)V
 }
 

--- a/ktor-client/ktor-client-core/api/ktor-client-core.api
+++ b/ktor-client/ktor-client-core/api/ktor-client-core.api
@@ -606,7 +606,7 @@ public final class io/ktor/client/plugins/observer/DelegatedCallKt {
 
 public final class io/ktor/client/plugins/observer/ResponseObserver {
 	public static final field Plugin Lio/ktor/client/plugins/observer/ResponseObserver$Plugin;
-	public fun <init> (Lkotlin/jvm/functions/Function2;)V
+	public fun <init> (Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function1;)V
 	public synthetic fun <init> (Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function1;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 }
 

--- a/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/observer/ResponseObserver.kt
+++ b/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/observer/ResponseObserver.kt
@@ -5,6 +5,7 @@
 package io.ktor.client.plugins.observer
 
 import io.ktor.client.*
+import io.ktor.client.call.*
 import io.ktor.client.plugins.*
 import io.ktor.client.statement.*
 import io.ktor.util.*
@@ -20,10 +21,13 @@ public typealias ResponseHandler = suspend (HttpResponse) -> Unit
  * Observe response plugin.
  */
 public class ResponseObserver(
-    private val responseHandler: ResponseHandler
+    private val responseHandler: ResponseHandler,
+    private val filter: ((HttpClientCall) -> Boolean)? = null
 ) {
     public class Config {
         internal var responseHandler: ResponseHandler = {}
+
+        internal var filter: ((HttpClientCall) -> Boolean)? = null
 
         /**
          * Set response handler for logging.
@@ -31,18 +35,29 @@ public class ResponseObserver(
         public fun onResponse(block: ResponseHandler) {
             responseHandler = block
         }
+
+        /**
+         * Set filter predicate to dynamically control if interceptor is executed or not for each http call.
+         */
+        public fun filter(block: ((HttpClientCall) -> Boolean)) {
+            filter = block
+        }
     }
 
     public companion object Plugin : HttpClientPlugin<Config, ResponseObserver> {
 
         override val key: AttributeKey<ResponseObserver> = AttributeKey("BodyInterceptor")
 
-        override fun prepare(block: Config.() -> Unit): ResponseObserver =
-            ResponseObserver(Config().apply(block).responseHandler)
+        override fun prepare(block: Config.() -> Unit): ResponseObserver {
+            val config = Config().apply(block)
+            return ResponseObserver(config.responseHandler, config.filter)
+        }
 
         @OptIn(InternalAPI::class)
         override fun install(plugin: ResponseObserver, scope: HttpClient) {
             scope.receivePipeline.intercept(HttpReceivePipeline.After) { response ->
+                if (feature.filter?.invoke(context) == false) return@intercept
+
                 val (loggingContent, responseContent) = response.content.split(response)
 
                 val newResponse = response.wrapWithContent(responseContent)

--- a/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/observer/ResponseObserver.kt
+++ b/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/observer/ResponseObserver.kt
@@ -56,7 +56,7 @@ public class ResponseObserver(
         @OptIn(InternalAPI::class)
         override fun install(plugin: ResponseObserver, scope: HttpClient) {
             scope.receivePipeline.intercept(HttpReceivePipeline.After) { response ->
-                if (feature.filter?.invoke(context) == false) return@intercept
+                if (plugin.filter?.invoke(response.call) == false) return@intercept
 
                 val (loggingContent, responseContent) = response.content.split(response)
 

--- a/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/ResponseObserverTest.kt
+++ b/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/ResponseObserverTest.kt
@@ -51,7 +51,7 @@ class ResponseObserverTest : ClientLoader() {
         }
 
         test { client ->
-            client.get<HttpResponse>("$TEST_SERVER/download") {
+            client.get("$TEST_SERVER/download") {
                 parameter("size", (1024 * 10).toString())
             }
             assertEquals(1, observerCalls)
@@ -68,7 +68,7 @@ class ResponseObserverTest : ClientLoader() {
         }
 
         test { client ->
-            client.get<HttpResponse>("$TEST_SERVER/download") {
+            client.get("$TEST_SERVER/download") {
                 parameter("size", (1024 * 10).toString())
             }
             assertEquals(1, observerCalls)
@@ -85,7 +85,7 @@ class ResponseObserverTest : ClientLoader() {
         }
 
         test { client ->
-            client.get<HttpResponse>("$TEST_SERVER/download") {
+            client.get("$TEST_SERVER/download") {
                 parameter("size", (1024 * 10).toString())
             }
             assertEquals(0, observerCalls)

--- a/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/ResponseObserverTest.kt
+++ b/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/ResponseObserverTest.kt
@@ -11,7 +11,7 @@ import io.ktor.utils.io.concurrent.*
 import kotlin.test.*
 
 class ResponseObserverTest : ClientLoader() {
-    private var observerCalls by shared(0)
+    private var observerCalled by shared(false)
 
     @Test
     fun testEmptyResponseObserverIsNotFreezing() = clientTests {
@@ -45,8 +45,8 @@ class ResponseObserverTest : ClientLoader() {
     @Test
     fun testResponseObserverCalledWhenNoFilterPresent() = clientTests {
         config {
-            ResponseObserver {
-                observerCalls++
+            install(ResponseObserver) {
+                onResponse { observerCalled = true }
             }
         }
 
@@ -54,7 +54,7 @@ class ResponseObserverTest : ClientLoader() {
             client.get("$TEST_SERVER/download") {
                 parameter("size", (1024 * 10).toString())
             }
-            assertEquals(1, observerCalls)
+            assertTrue { observerCalled }
         }
     }
 
@@ -62,7 +62,7 @@ class ResponseObserverTest : ClientLoader() {
     fun testResponseObserverCalledWhenFilterMatched() = clientTests {
         config {
             install(ResponseObserver) {
-                onResponse { observerCalls++ }
+                onResponse { observerCalled = true }
                 filter { true }
             }
         }
@@ -71,7 +71,7 @@ class ResponseObserverTest : ClientLoader() {
             client.get("$TEST_SERVER/download") {
                 parameter("size", (1024 * 10).toString())
             }
-            assertEquals(1, observerCalls)
+            assertTrue { observerCalled }
         }
     }
 
@@ -79,7 +79,7 @@ class ResponseObserverTest : ClientLoader() {
     fun testResponseObserverNotCalledWhenFilterNotMatched() = clientTests {
         config {
             install(ResponseObserver) {
-                onResponse { observerCalls++ }
+                onResponse { observerCalled = true }
                 filter { false }
             }
         }
@@ -88,7 +88,7 @@ class ResponseObserverTest : ClientLoader() {
             client.get("$TEST_SERVER/download") {
                 parameter("size", (1024 * 10).toString())
             }
-            assertEquals(0, observerCalls)
+            assertFalse { observerCalled }
         }
     }
 }

--- a/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/ResponseObserverTest.kt
+++ b/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/ResponseObserverTest.kt
@@ -7,9 +7,11 @@ package io.ktor.client.tests
 import io.ktor.client.plugins.observer.*
 import io.ktor.client.request.*
 import io.ktor.client.tests.utils.*
+import io.ktor.utils.io.concurrent.*
 import kotlin.test.*
 
 class ResponseObserverTest : ClientLoader() {
+    private var observerCalls by shared(0)
 
     @Test
     fun testEmptyResponseObserverIsNotFreezing() = clientTests {
@@ -37,6 +39,56 @@ class ResponseObserverTest : ClientLoader() {
             client.get("$TEST_SERVER/download") {
                 parameter("size", (1024 * 10).toString())
             }
+        }
+    }
+
+    @Test
+    fun testResponseObserverCalledWhenNoFilterPresent() = clientTests {
+        config {
+            ResponseObserver {
+                observerCalls++
+            }
+        }
+
+        test { client ->
+            client.get<HttpResponse>("$TEST_SERVER/download") {
+                parameter("size", (1024 * 10).toString())
+            }
+            assertEquals(1, observerCalls)
+        }
+    }
+
+    @Test
+    fun testResponseObserverCalledWhenFilterMatched() = clientTests {
+        config {
+            install(ResponseObserver) {
+                onResponse { observerCalls++ }
+                filter { true }
+            }
+        }
+
+        test { client ->
+            client.get<HttpResponse>("$TEST_SERVER/download") {
+                parameter("size", (1024 * 10).toString())
+            }
+            assertEquals(1, observerCalls)
+        }
+    }
+
+    @Test
+    fun testResponseObserverNotCalledWhenFilterNotMatched() = clientTests {
+        config {
+            install(ResponseObserver) {
+                onResponse { observerCalls++ }
+                filter { false }
+            }
+        }
+
+        test { client ->
+            client.get<HttpResponse>("$TEST_SERVER/download") {
+                parameter("size", (1024 * 10).toString())
+            }
+            assertEquals(0, observerCalls)
         }
     }
 }


### PR DESCRIPTION
**Subsystem**
Ktor Client ResponseObserver interceptor.

**Motivation**
The Ktor Client ResponseObserver interceptor is heavy, therefore it becomes tricky to avoid the overhead when one needs the interceptor just for a subset of requests. Since the interceptor is attached on the Client and not a single call, the only option one has currently is to use two different clients.

**Solution**
The filtering support for the client response interceptor would provide the possibility to enable the interceptor for certain requests only based on a request header or parameter or any other flag.

Example usage:
```
      val responseObserver = ResponseObserver(observer) {
          feature.level(it.callContext()).debug
      }
```

