### PR TITLE
KTOR-3008 Fixed Client Bearer Feature 

### DIFF
--- a/ktor-client/ktor-client-features/ktor-client-auth/common/src/io/ktor/client/features/auth/providers/AuthTokenHolder.kt
+++ b/ktor-client/ktor-client-features/ktor-client-auth/common/src/io/ktor/client/features/auth/providers/AuthTokenHolder.kt
@@ -15,6 +15,7 @@ internal class AuthTokenHolder<T>(
 
     internal fun clearToken() {
         cachedBearerTokens.value = null
+        initialized.value = false
     }
 
     internal suspend fun loadToken(): T? {

--- a/ktor-client/ktor-client-features/ktor-client-auth/common/test/io/ktor/client/features/auth/AuthTest.kt
+++ b/ktor-client/ktor-client-features/ktor-client-auth/common/test/io/ktor/client/features/auth/AuthTest.kt
@@ -354,4 +354,28 @@ class AuthTest : ClientLoader() {
             assertEquals("OK", second)
         }
     }
+
+    @Test
+    fun testLoadTokenAfterClear() = clientTests {
+        var loadCount = 0
+        config {
+            install(Auth) {
+                bearer {
+                    refreshTokens { null }
+                    loadTokens {
+                        loadCount++
+                        BearerTokens("valid", "refresh")
+                    }
+                }
+            }
+        }
+
+        test { client ->
+            client.get<String>("$TEST_SERVER/auth/bearer/test-refresh")
+            client[Auth].providers.filterIsInstance<BearerAuthProvider>().first().clearToken()
+            client.get<String>("$TEST_SERVER/auth/bearer/test-refresh")
+
+            assertEquals(2, loadCount)
+        }
+    }
 }


### PR DESCRIPTION
**Subsystem**
Client

**Motivation**
After clearing the tokens, we could not start loading the tokens again because the initialized flag was not reset
e.g., log out of one account and log in to another was impossible


**Solution**
just set initialized to null when clearing tokens

