### PR TITLE
Force eager initialization for initHook on Native

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -19,7 +19,7 @@ org.gradle.vfs.watch=true
 org.gradle.jvmargs=-Xmx6g -XX:MaxPermSize=6g -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
 
 # kotlin
-kotlin_version=1.5.30-M1-136
+kotlin_version=1.5.30-RC
 kotlin.native.ignoreDisabledTargets=true
 kotlin.mpp.stability.nowarn=true
 kotlin.native.cacheKind=none

--- a/ktor-client/ktor-client-cio/posix/src/io/ktor/client/engine/cio/LoaderNative.kt
+++ b/ktor-client/ktor-client-cio/posix/src/io/ktor/client/engine/cio/LoaderNative.kt
@@ -6,6 +6,8 @@ package io.ktor.client.engine.cio
 
 import io.ktor.client.engine.*
 
+@OptIn(ExperimentalStdlibApi::class)
+@EagerInitialization
 private val initHook = CIO
 
 internal actual fun addToLoader() {

--- a/ktor-client/ktor-client-curl/posix/src/io/ktor/client/engine/curl/Curl.kt
+++ b/ktor-client/ktor-client-curl/posix/src/io/ktor/client/engine/curl/Curl.kt
@@ -17,6 +17,8 @@ import kotlin.native.SharedImmutable
 @SharedImmutable
 private val curlGlobalInitReturnCode = curl_global_init(CURL_GLOBAL_ALL.convert())
 
+@OptIn(ExperimentalStdlibApi::class)
+@EagerInitialization
 private val initHook = Curl
 
 /**

--- a/ktor-client/ktor-client-ios/darwin/src/io/ktor/client/engine/ios/Ios.kt
+++ b/ktor-client/ktor-client-ios/darwin/src/io/ktor/client/engine/ios/Ios.kt
@@ -7,6 +7,8 @@ package io.ktor.client.engine.ios
 import io.ktor.client.engine.*
 import platform.Foundation.*
 
+@OptIn(ExperimentalStdlibApi::class)
+@EagerInitialization
 private val initHook = Ios
 
 /**


### PR DESCRIPTION
**Subsystem**
Client

**Motivation**
Prepare for lazy top-level property initialization strategy in Kotlin/Native.
We consider enabling this strategy by default with new memory manager.

**Solution**
`@EagerInitialization` annotation forces a property to be initialized eagerly on program startup, like it happens for any top-level property in current non-lazy init strategy.
If lazy init strategy is not enabled, this annotation doesn't have any effect, so it is safe to merge it to `main` branch. But the annotation is available since Kotlin 1.5.30-RC, so the version update would be required.