### PR TITLE
KTOR-2991 Do not treat semicolon as separator in Netty engine.

### DIFF
--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyApplicationRequest.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyApplicationRequest.kt
@@ -29,7 +29,7 @@ public abstract class NettyApplicationRequest(
 ) : BaseApplicationRequest(call), CoroutineScope {
 
     public final override val queryParameters: Parameters = object : Parameters {
-        private val decoder = QueryStringDecoder(uri)
+        private val decoder = QueryStringDecoder(uri, HttpConstants.DEFAULT_CHARSET, true, 1024, true)
         override val caseInsensitiveName: Boolean get() = true
         override fun getAll(name: String) = decoder.parameters()[name]
         override fun names() = decoder.parameters().keys

--- a/ktor-server/ktor-server-test-suites/jvm/src/io/ktor/server/testing/suites/HttpServerTestSuite.kt
+++ b/ktor-server/ktor-server-test-suites/jvm/src/io/ktor/server/testing/suites/HttpServerTestSuite.kt
@@ -785,6 +785,28 @@ abstract class HttpServerTestSuite<TEngine : ApplicationEngine, TConfiguration :
         }
     }
 
+    @Test
+    fun queryParameterContainingSemicolon() {
+        createAndStartServer {
+            handle {
+                assertEquals("01;21", call.request.queryParameters["code"])
+                call.respond(HttpStatusCode.OK)
+            }
+        }
+
+        withUrl(
+            "/",
+            {
+                url {
+                    parameters.urlEncodingOption = UrlEncodingOption.NO_ENCODING
+                    parameters.append("code", "01;21")
+                }
+            }
+        ) {
+            assertEquals(200, status.value)
+        }
+    }
+
     private data class TestData(
         val name: String
     ) : AbstractCoroutineContextElement(TestData) {


### PR DESCRIPTION
This fix unifies behavior with other engines
