### PR TITLE
KTOR-3055 Add @ThreadLocal annotation to top level constants

### DIFF
--- a/ktor-client/ktor-client-features/ktor-client-auth/common/src/io/ktor/client/features/auth/Auth.kt
+++ b/ktor-client/ktor-client-features/ktor-client-auth/common/src/io/ktor/client/features/auth/Auth.kt
@@ -82,5 +82,5 @@ public fun HttpClientConfig<*>.Auth(block: Auth.() -> Unit) {
  * be removed after that.
  */
 @PublicAPICandidate("1.6.0")
-@ThreadLocal
+@SharedImmutable
 internal val AuthHeaderAttribute = AttributeKey<HttpAuthHeader>("AuthHeader")

--- a/ktor-client/ktor-client-features/ktor-client-auth/common/src/io/ktor/client/features/auth/Auth.kt
+++ b/ktor-client/ktor-client-features/ktor-client-auth/common/src/io/ktor/client/features/auth/Auth.kt
@@ -10,6 +10,7 @@ import io.ktor.client.request.*
 import io.ktor.http.*
 import io.ktor.http.auth.*
 import io.ktor.util.*
+import kotlin.native.concurrent.*
 
 /**
  * Client authentication feature.
@@ -81,4 +82,5 @@ public fun HttpClientConfig<*>.Auth(block: Auth.() -> Unit) {
  * be removed after that.
  */
 @PublicAPICandidate("1.6.0")
+@ThreadLocal
 internal val AuthHeaderAttribute = AttributeKey<HttpAuthHeader>("AuthHeader")

--- a/ktor-client/ktor-client-features/ktor-client-auth/common/test/io/ktor/client/features/auth/AuthTest.kt
+++ b/ktor-client/ktor-client-features/ktor-client-auth/common/test/io/ktor/client/features/auth/AuthTest.kt
@@ -324,6 +324,26 @@ class AuthTest : ClientLoader() {
         }
     }
 
+    @Test
+    fun testRefreshOnBackgroundThread() = clientTests {
+        config {
+            install(Auth) {
+                bearer {
+                    refreshTokens { BearerTokens("valid", "refresh") }
+                    loadTokens { BearerTokens("invalid", "refresh") }
+                    realm = "TestServer"
+                }
+            }
+        }
+
+        test { client ->
+            val response = withContext(Dispatchers.Default) {
+                client.get<HttpStatement>("$TEST_SERVER/auth/bearer/test-refresh").execute()
+            }
+            assertEquals(HttpStatusCode.OK, response.status)
+        }
+    }
+
     @Suppress("JoinDeclarationAndAssignment")
     @Test
     fun testRefreshWithSameClient() = clientTests {

--- a/ktor-http/common/src/io/ktor/http/auth/HttpAuthHeader.kt
+++ b/ktor-http/common/src/io/ktor/http/auth/HttpAuthHeader.kt
@@ -13,6 +13,7 @@ import kotlin.native.concurrent.*
 @ThreadLocal
 private val TOKEN_EXTRA = setOf('!', '#', '$', '%', '&', '\'', '*', '+', '-', '.', '^', '_', '`', '|', '~')
 
+@ThreadLocal
 private val TOKEN68_EXTRA = setOf('-', '.', '_', '~', '+', '/')
 
 @ThreadLocal


### PR DESCRIPTION
**Subsystem**
Ktor Client, Auth Feature

**Motivation**
Auth feature uses global constants during token refresh process which are not marked with @ThreadLocal annotation. This makes it impossible to perform refresh from non-main thread in Kotlin/Native targets.
I attached a stack trace to [the YouTrack issue](https://youtrack.jetbrains.com/issue/KTOR-3055).

**Solution**
In order to make it work on iOS I annotated 2 constants as ThreadLocal.

