### PR TITLE
KTOR-3069 Register native engines in tests

### DIFF
--- a/ktor-client/ktor-client-curl/posix/test/io/ktor/client/engine/curl/test/CurlNativeTests.kt
+++ b/ktor-client/ktor-client-curl/posix/test/io/ktor/client/engine/curl/test/CurlNativeTests.kt
@@ -20,7 +20,7 @@ class CurlNativeTests {
     fun testDownloadInBackground() {
         backgroundWorker.execute(TransferMode.SAFE, { Unit }) {
             runBlocking {
-                val client = HttpClient()
+                val client = HttpClient(Curl)
                 client.get<String>("http://google.com")
             }
         }.consume { assert(it.isNotEmpty()) }
@@ -29,7 +29,7 @@ class CurlNativeTests {
     @Test
     fun testDownload() {
         runBlocking {
-            val client = HttpClient()
+            val client = HttpClient(Curl)
             val res = client.get<String>("http://google.com")
             assert(res.isNotEmpty())
         }

--- a/ktor-client/ktor-client-features/ktor-client-websockets/common/test/io/ktor/client/tests/features/WebSocketRemoteTest.kt
+++ b/ktor-client/ktor-client-features/ktor-client-websockets/common/test/io/ktor/client/tests/features/WebSocketRemoteTest.kt
@@ -14,7 +14,7 @@ import kotlin.test.*
 
 class WebSocketRemoteTest : ClientLoader() {
     private val echoWebsocket = "$TEST_WEBSOCKET_SERVER/websockets/echo"
-    private val skipEngines = listOf("Android", "Apache")
+    private val skipEngines = listOf("Android", "Apache", "Curl", "native:CIO")
 
     @Test
     fun testRemotePingPong() = clientTests(skipEngines) {


### PR DESCRIPTION
Native engines were not registered for tests outside of `ktor-client-tests` modules.
