### PR TITLE
KTOR-3116 Fix closing installed features

### DIFF
--- a/ktor-client/ktor-client-core/common/src/io/ktor/client/HttpClient.kt
+++ b/ktor-client/ktor-client-core/common/src/io/ktor/client/HttpClient.kt
@@ -217,9 +217,10 @@ public class HttpClient(
         val success = closed.compareAndSet(false, true)
         if (!success) return
 
-        attributes.allKeys.forEach { key ->
+        val installedFeatures = attributes[FEATURE_INSTALLED_LIST]
+        installedFeatures.allKeys.forEach { key ->
             @Suppress("UNCHECKED_CAST")
-            val feature = attributes[key as AttributeKey<Any>]
+            val feature = installedFeatures[key as AttributeKey<Any>]
 
             if (feature is Closeable) {
                 feature.close()

--- a/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/CommonHttpClientTest.kt
+++ b/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/CommonHttpClientTest.kt
@@ -8,6 +8,7 @@ import io.ktor.client.*
 import io.ktor.client.engine.mock.*
 import io.ktor.client.features.*
 import io.ktor.util.*
+import io.ktor.utils.io.concurrent.*
 import io.ktor.utils.io.core.*
 import kotlinx.coroutines.*
 import kotlin.test.*
@@ -47,7 +48,7 @@ class CommonHttpClientTest {
         assertTrue(client.feature(TestFeature)!!.closed)
     }
     class TestFeature : Closeable {
-        var closed = false
+        var closed by shared(false)
         override fun close() {
             closed = true
         }


### PR DESCRIPTION
**Subsystem**
Client

**Motivation**
KTOR-3116
It seems that the original intention of closing installed `Closeable` features are not working properly due to an added layer of indirection of `FEATURE_INSTALLED_LIST` key at https://github.com/ktorio/ktor/blob/92f4e96b6f863ffbfc3f6afae52a8ac584a2be3b/ktor-client/ktor-client-core/common/src/io/ktor/client/HttpClientConfig.kt#L75
The demo test fails because the only key in `attributes` is this `FEATURE_INSTALLED_LIST`, and all features are under the `Attributes` value of this key.

**Solution**
This PR retrieves the correct "map" for installed features to invoke the `close()` function on them as originally intended.

