### PR TITLE
KTOR-3128 Add method to ResponseException

### DIFF
--- a/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/DefaultResponseValidation.kt
+++ b/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/DefaultResponseValidation.kt
@@ -81,8 +81,9 @@ public class RedirectResponseException(response: HttpResponse, cachedResponseTex
     @Deprecated(level = DeprecationLevel.ERROR, message = DEPRECATED_EXCEPTION_CTOR)
     public constructor(response: HttpResponse) : this(response, NO_RESPONSE_TEXT)
 
-    override val message: String? = "Unhandled redirect: ${response.call.request.url}. " +
-        "Status: ${response.status}. Text: \"$cachedResponseText\""
+    override val message: String =
+        "Unhandled redirect: ${response.call.request.method.value} ${response.call.request.url}. " +
+            "Status: ${response.status}. Text: \"$cachedResponseText\""
 }
 
 /**
@@ -96,7 +97,7 @@ public class ServerResponseException(
     @Deprecated(level = DeprecationLevel.ERROR, message = DEPRECATED_EXCEPTION_CTOR)
     public constructor(response: HttpResponse) : this(response, NO_RESPONSE_TEXT)
 
-    override val message: String? = "Server error(${response.call.request.url}: " +
+    override val message: String = "Server error(${response.call.request.method.value} ${response.call.request.url}: " +
         "${response.status}. Text: \"$cachedResponseText\""
 }
 
@@ -111,6 +112,7 @@ public class ClientRequestException(
     @Deprecated(level = DeprecationLevel.ERROR, message = DEPRECATED_EXCEPTION_CTOR)
     public constructor(response: HttpResponse) : this(response, NO_RESPONSE_TEXT)
 
-    override val message: String = "Client request(${response.call.request.url}) " +
-        "invalid: ${response.status}. Text: \"$cachedResponseText\""
+    override val message: String =
+        "Client request(${response.call.request.method.value} ${response.call.request.url}) " +
+            "invalid: ${response.status}. Text: \"$cachedResponseText\""
 }

--- a/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/ExceptionsTest.kt
+++ b/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/ExceptionsTest.kt
@@ -53,7 +53,9 @@ class ExceptionsTest : ClientLoader() {
             code = HttpStatusCode.PermanentRedirect,
             message = "Some redirect",
             exceptionType = RedirectResponseException::class
-        )
+        ) {
+            assertTrue("GET ${URLBuilder.origin}/www.google.com" in it.message!!)
+        }
 
     @Test
     fun testTextInClientRequestException() =
@@ -61,7 +63,9 @@ class ExceptionsTest : ClientLoader() {
             code = HttpStatusCode.Conflict,
             message = "Some conflict",
             exceptionType = ClientRequestException::class
-        )
+        ) {
+            assertTrue("GET ${URLBuilder.origin}/www.google.com" in it.message!!)
+        }
 
     @Test
     fun testTextInServerRequestException() =
@@ -69,7 +73,9 @@ class ExceptionsTest : ClientLoader() {
             code = HttpStatusCode.VariantAlsoNegotiates,
             message = "Some variant",
             exceptionType = ServerResponseException::class
-        )
+        ) {
+            assertTrue("GET ${URLBuilder.origin}/www.google.com" in it.message!!)
+        }
 
     @Test
     fun testBinaryGarbageInExceptionMessage() = testTextInException(
@@ -93,7 +99,8 @@ class ExceptionsTest : ClientLoader() {
     private fun testTextInException(
         code: HttpStatusCode,
         message: String,
-        exceptionType: KClass<out ResponseException>
+        exceptionType: KClass<out ResponseException>,
+        customValidation: (ResponseException) -> Unit = { }
     ) = testSuspend {
         if (PlatformUtils.IS_NATIVE) return@testSuspend
 
@@ -118,6 +125,7 @@ class ExceptionsTest : ClientLoader() {
                 exception.message!!.endsWith("Text: \"$message\""),
                 "Exception message must contain response text"
             )
+            customValidation(exception)
         }
     }
 


### PR DESCRIPTION
**Subsystem**
Client core

**Motivation**
KTOR-3128 https://youtrack.jetbrains.com/issue/KTOR-3128
Currently, the exception contains only the URL, but the used method is helpful too to understand and find the cause.

**Solution**
Add the method to the exception

