### PR TITLE
KTOR-399 Add variant of parametersOf() that takes in Map<String, List…

### DIFF
--- a/ktor-http/common/src/io/ktor/http/Parameters.kt
+++ b/ktor-http/common/src/io/ktor/http/Parameters.kt
@@ -81,6 +81,11 @@ public fun parametersOf(name: String, value: String): Parameters = ParametersSin
 public fun parametersOf(name: String, values: List<String>): Parameters = ParametersSingleImpl(name, values)
 
 /**
+ * Creates a parameters instance from the entries of the given [map]
+ */
+public fun parametersOf(map: Map<String, List<String>>): Parameters = ParametersImpl(map)
+
+/**
  * Creates a parameters instance from the specified [pairs]
  */
 public fun parametersOf(vararg pairs: Pair<String, List<String>>): Parameters = ParametersImpl(pairs.asList().toMap())


### PR DESCRIPTION
…<String>>

**Subsystem**
ktor-http

**Motivation**
parametersOf() function returns a Parameters instance that internally stores a map. Yet there existed no way to instantiate a Parameters instance using a map directly. See: [Issue 399](https://youtrack.jetbrains.com/issue/KTOR-399)

**Solution**
Added a new function parametersOf(Map<String, List<String>>) that aims to solve the problem

