### PR TITLE
Add name to ShutdownHook thread, for better logging experience

### DIFF
--- a/ktor-server/ktor-server-host-common/jvm/src/io/ktor/server/engine/ShutdownHook.kt
+++ b/ktor-server/ktor-server-host-common/jvm/src/io/ktor/server/engine/ShutdownHook.kt
@@ -29,7 +29,7 @@ public fun ApplicationEngine.addShutdownHook(stop: () -> Unit) {
     }
 }
 
-private class ShutdownHook(private val stopFunction: () -> Unit) : Thread() {
+private class ShutdownHook(private val stopFunction: () -> Unit) : Thread("KtorShutdownHook") {
     private val shouldStop = AtomicBoolean(true)
 
     override fun run() {


### PR DESCRIPTION
**Subsystem**
Server

**Motivation**
Logging in shutdown thread looks not informative:

```
14:02:10  INFO Thread-1 link.kotlin.server.ApplicationFactory Going to shutdown X
```

**Solution**
Set thread name to ShutdownHook thread

