### PR TITLE
KTOR-384 Add a host check for illegal symbols

### DIFF
--- a/ktor-http/ktor-http-cio/common/src/io/ktor/http/cio/HttpParser.kt
+++ b/ktor-http/ktor-http-cio/common/src/io/ktor/http/cio/HttpParser.kt
@@ -125,6 +125,11 @@ internal suspend fun parseHeaders(
             headers.put(nameHash, valueHash, nameStart, nameEnd, valueStart, valueEnd)
         }
 
+        val host = headers[HttpHeaders.Host]
+        if (host != null && host.matches(".*[/?#@].*".toRegex())) {
+            error("Host cannot contain any of the following symbols: \'/\', \'?\', \'#\', \'@\'")
+        }
+
         return headers
     } catch (t: Throwable) {
         headers.release()

--- a/ktor-http/ktor-http-cio/jvm/test/io/ktor/tests/http/cio/HeadersTest.kt
+++ b/ktor-http/ktor-http-cio/jvm/test/io/ktor/tests/http/cio/HeadersTest.kt
@@ -248,4 +248,40 @@ class HeadersTest {
             }
         }
     }
+
+    @Test
+    fun `Host header with invalid character (slash)`() = runBlocking<Unit> {
+        ch.writeStringUtf8("Host: www/exam/ple.com\n\n")
+
+        assertFailsWith<IllegalStateException> {
+            parseHeaders(ch, builder)
+        }
+    }
+
+    @Test
+    fun `Host header with invalid character (question mark)`() = runBlocking<Unit> {
+        ch.writeStringUtf8("Host: www.example?com\n\n")
+
+        assertFailsWith<IllegalStateException> {
+            parseHeaders(ch, builder)
+        }
+    }
+
+    @Test
+    fun `Host header with invalid '#' character`() = runBlocking<Unit> {
+        ch.writeStringUtf8("Host: www.ex#mple.com\n\n")
+
+        assertFailsWith<IllegalStateException> {
+            parseHeaders(ch, builder)
+        }
+    }
+
+    @Test
+    fun `Host header with invalid '@' character`() = runBlocking<Unit> {
+        ch.writeStringUtf8("Host: www.ex@mple.com\n\n")
+
+        assertFailsWith<IllegalStateException> {
+            parseHeaders(ch, builder)
+        }
+    }
 }


### PR DESCRIPTION
**Subsystem**
ktor-http-cio

**Motivation**
The current implementation allows forbidden characters to be sent to HOST. I think it's better to throw an exception early on.
See: #1862 or [YouTrack Issue](https://youtrack.jetbrains.com/issue/KTOR-384)

**Solution**
Added a regular expression to check for invalid characters in the 'Host' parameter (HttpParser.parseHeaders function). If the condition is true, an exception with description will be thrown.

