### PR TITLE
KTOR-1733: Fix ProxyConfig.type checking for DIRECT instead of SOCKS

### DIFF
--- a/ktor-client/ktor-client-core/jvm/src/io/ktor/client/engine/ProxyConfigJvm.kt
+++ b/ktor-client/ktor-client-core/jvm/src/io/ktor/client/engine/ProxyConfigJvm.kt
@@ -39,7 +39,7 @@ public actual fun ProxyConfig.resolveAddress(): NetworkAddress = address()
  */
 public actual val ProxyConfig.type: ProxyType
     get() = when (type()) {
-        Proxy.Type.DIRECT -> ProxyType.SOCKS
+        Proxy.Type.SOCKS -> ProxyType.SOCKS
         Proxy.Type.HTTP -> ProxyType.HTTP
         else -> ProxyType.UNKNOWN
     }


### PR DESCRIPTION
**Subsystem**
Client

**Motivation**
Ticket on YouTrack: ``KTOR-1733``.
This issue prevents anyone from using a SOCKS proxy with Ktor, as it is being treated as a DIRECT proxy. Which isn't supported by CIO.
> Exception in thread "main" java.lang.IllegalStateException: Proxy of type UNKNOWN is unsupported by CIO engine.

**Solution**
Changing ``ProxyType.DIRECT`` to ``ProxyType.SOCKS`` will solve this problem.
