### PR TITLE
update font mimes

### DIFF
--- a/ktor-http/common/src/io/ktor/http/ContentTypes.kt
+++ b/ktor-http/common/src/io/ktor/http/ContentTypes.kt
@@ -207,6 +207,20 @@ public class ContentType private constructor(
     }
 
     /**
+     * Provides a list of standard subtypes of a `Font` content type.
+     */
+    @Suppress("KDocMissingDocumentation", "unused")
+    public object Font {
+        public val Any: ContentType = ContentType("font", "*")
+        public val Collection: ContentType = ContentType("font", "collection")
+        public val Otf: ContentType = ContentType("font", "otf")
+        public val Sfnt: ContentType = ContentType("font", "sfnt")
+        public val Ttf: ContentType = ContentType("font", "ttf")
+        public val Woff: ContentType = ContentType("font", "woff")
+        public val Woff2: ContentType = ContentType("font", "woff2")
+    }
+
+    /**
      * Provides a list of standard subtypes of a `message` content type.
      */
     @Suppress("KDocMissingDocumentation", "unused")

--- a/ktor-http/common/src/io/ktor/http/Mimes.kt
+++ b/ktor-http/common/src/io/ktor/http/Mimes.kt
@@ -651,7 +651,7 @@ N/A,application/andrew-inset
 .osf,application/vnd.yamaha.openscoreformat
 .osfpvg,application/vnd.yamaha.openscoreformat.osfpvg+xml
 .otc,application/vnd.oasis.opendocument.chart-template
-.otf,application/x-font-otf
+.otf,font/otf
 .otg,application/vnd.oasis.opendocument.graphics-template
 .oth,application/vnd.oasis.opendocument.text-web
 .oti,application/vnd.oasis.opendocument.image-template
@@ -986,7 +986,7 @@ N/A,application/andrew-inset
 .tsp,audio/tsplayer
 .tsv,text/tab-separated-values
 .t,text/troff
-.ttf,application/x-font-ttf
+.ttf,font/ttf
 .ttl,text/turtle
 .turbot,image/florian
 .twd,application/vnd.simtech-mindmapper
@@ -1084,7 +1084,8 @@ N/A,application/andrew-inset
 .wmv,video/x-ms-wmv
 .wmx,video/x-ms-wmx
 .wmz,application/x-ms-wmz
-.woff,application/x-font-woff
+.woff,font/woff
+.woff2,font/woff2
 .word,application/msword
 .wp5,application/wordperfect
 .wp5,application/wordperfect6.0


### PR DESCRIPTION
Use `font/*`mime type for existing entry of fonts that have an [assigned mime](https://www.iana.org/assignments/media-types/media-types.xhtml#font) type.
Added support for woff2 fonts.

**Subsystem**
Server

**Motivation**
The new `font/*` mime type has been standardised in favour of `application/x-font.*` 

**Solution**
added know file extensions to the mimes list and extended the ContentType companion object to include the new Font subtype. 
