### PR TITLE
KTOR-3290 Add support for testing Server-Sent Events (SSE)

### DIFF
--- a/ktor-server/ktor-server-test-host/jvm/src/io/ktor/server/testing/TestApplicationResponse.kt
+++ b/ktor-server/ktor-server-test-host/jvm/src/io/ktor/server/testing/TestApplicationResponse.kt
@@ -142,4 +142,9 @@ public class TestApplicationResponse(
      * Websocket session's channel
      */
     public fun websocketChannel(): ByteReadChannel? = responseChannel
+
+    /**
+     * Server-sent event sessions' channel
+     */
+    public fun serverSentEventsChannel(): ByteReadChannel? = responseChannel
 }


### PR DESCRIPTION
**Subsystem**
Server test host.

**Motivation**
Ktor does not facilitate SSE testing, and doing it all on the application side is cumbersome. [KTOR-3290](https://youtrack.jetbrains.com/issue/KTOR-3290) goes into a bit more detail.

**Solution**
The solution is inspired by `handleWebSocketConversation`. In SSE's case the data flow is unidirectional, so only one channel is setup and used, but most other details, such as keeping the connection alive, or executing server and client side in parallel, remain.

I am using a variant of this successfully [here](https://github.com/goncalossilva/ffs/blob/359c015606680e48d08e9e32d393e0e485c0cedd/ffs-server/src/test/kotlin/ext/TestApplicationEngineExt.kt#L16-L60), albeit with more difficulty due to not having access to `call.response.responseChannelDeferred` on the application side.

**Question**
Something that is not obvious to me is where to add tests for this. `handleWebSocketConversation` is being tested from within the `ktor-server-websockets` module, which also provides the plugin. But there is no plugin for SSE.

Would `TestApplicationEngineTest` inside the `ktor-server-tests` module be the best place?