### PR TITLE
KTOR-3346 ContentNegotiation plugins don't accept null-responses from ContentConverts

### DIFF
--- a/ktor-client/ktor-client-plugins/ktor-client-content-negotiation/common/src/io/ktor/client/plugins/ContentNegotiation.kt
+++ b/ktor-client/ktor-client-plugins/ktor-client-content-negotiation/common/src/io/ktor/client/plugins/ContentNegotiation.kt
@@ -97,16 +97,19 @@ public class ContentNegotiation internal constructor(
                     proceedWith(EmptyContent)
                     return@intercept
                 }
-                val registration = registrations
-                    .firstOrNull { it.contentTypeMatcher.contains(contentType) } ?: return@intercept
 
-                val serializedContent = registration.converter.serialize(
-                    contentType,
-                    contentType.charset() ?: Charsets.UTF_8,
-                    context.bodyType!!,
-                    payload
-                ) ?: throw ContentConverterException(
-                    "Can't convert $payload with contentType $contentType using converter ${registration.converter}"
+                val matchingRegistrations = registrations.filter { it.contentTypeMatcher.contains(contentType) }
+                    .takeIf { it.isNotEmpty() } ?: return@intercept
+
+                val serializedContent = matchingRegistrations.firstNotNullOfOrNull { registration ->
+                    registration.converter.serialize(
+                        contentType,
+                        contentType.charset() ?: Charsets.UTF_8,
+                        context.bodyType!!,
+                        payload
+                    )
+                } ?: throw ContentConverterException(
+                    "Can't convert $payload with contentType $contentType using converters ${matchingRegistrations.joinToString { it.converter.toString() }}"
                 )
 
                 proceedWith(serializedContent)

--- a/ktor-client/ktor-client-plugins/ktor-client-content-negotiation/common/src/io/ktor/client/plugins/ContentNegotiation.kt
+++ b/ktor-client/ktor-client-plugins/ktor-client-content-negotiation/common/src/io/ktor/client/plugins/ContentNegotiation.kt
@@ -101,6 +101,7 @@ public class ContentNegotiation internal constructor(
                 val matchingRegistrations = registrations.filter { it.contentTypeMatcher.contains(contentType) }
                     .takeIf { it.isNotEmpty() } ?: return@intercept
 
+                // Pick the first one that can convert the subject successfully
                 val serializedContent = matchingRegistrations.firstNotNullOfOrNull { registration ->
                     registration.converter.serialize(
                         contentType,
@@ -124,6 +125,7 @@ public class ContentNegotiation internal constructor(
                     .filter { it.contentTypeMatcher.contains(contentType) }
                     .takeIf { it.isNotEmpty() }?: return@intercept
 
+                // Pick the first one that can convert the subject successfully
                 val parsedBody = matchingRegistrations.firstNotNullOfOrNull { registration ->
                     registration.converter
                         .deserialize(context.request.headers.suitableCharset(), info, body)

--- a/ktor-client/ktor-client-plugins/ktor-client-content-negotiation/common/src/io/ktor/client/plugins/ContentNegotiation.kt
+++ b/ktor-client/ktor-client-plugins/ktor-client-content-negotiation/common/src/io/ktor/client/plugins/ContentNegotiation.kt
@@ -110,7 +110,9 @@ public class ContentNegotiation internal constructor(
                         payload
                     )
                 } ?: throw ContentConverterException(
-                    "Can't convert $payload with contentType $contentType using converters ${matchingRegistrations.joinToString { it.converter.toString() }}"
+                    "Can't convert $payload with contentType $contentType using converters ${
+                        matchingRegistrations.joinToString { it.converter.toString() }
+                    }"
                 )
 
                 proceedWith(serializedContent)
@@ -123,13 +125,13 @@ public class ContentNegotiation internal constructor(
                 val registrations = plugin.registrations
                 val matchingRegistrations = registrations
                     .filter { it.contentTypeMatcher.contains(contentType) }
-                    .takeIf { it.isNotEmpty() }?: return@intercept
+                    .takeIf { it.isNotEmpty() } ?: return@intercept
 
                 // Pick the first one that can convert the subject successfully
                 val parsedBody = matchingRegistrations.firstNotNullOfOrNull { registration ->
                     registration.converter
                         .deserialize(context.request.headers.suitableCharset(), info, body)
-                }?: return@intercept
+                } ?: return@intercept
                 val response = HttpResponseContainer(info, parsedBody)
                 proceedWith(response)
             }

--- a/ktor-client/ktor-client-plugins/ktor-client-content-negotiation/common/test/io/ktor/client/plugins/ContentNegotiationTests.kt
+++ b/ktor-client/ktor-client-plugins/ktor-client-content-negotiation/common/test/io/ktor/client/plugins/ContentNegotiationTests.kt
@@ -16,7 +16,9 @@ class ContentNegotiationTests {
     @Suppress("PrivatePropertyName")
     private val XReturnAs = "X-Return-As"
 
-    private fun TestClientBuilder<MockEngineConfig>.setupWithContentNegotiation(block: ContentNegotiation.Config.() -> Unit) {
+    private fun TestClientBuilder<MockEngineConfig>.setupWithContentNegotiation(
+        block: ContentNegotiation.Config.() -> Unit
+    ) {
         config {
             engine {
                 addHandler { request ->
@@ -131,7 +133,6 @@ class ContentNegotiationTests {
             // StringWrapper to avoid string body decoder
             contentType to StringWrapper("Deserialized matching: $contentType")
         }
-
 
         setupWithContentNegotiation {
             responsesPerType.forEach { (contentType, response) ->

--- a/ktor-client/ktor-client-plugins/ktor-client-content-negotiation/common/test/io/ktor/client/plugins/ContentNegotiationTests.kt
+++ b/ktor-client/ktor-client-plugins/ktor-client-content-negotiation/common/test/io/ktor/client/plugins/ContentNegotiationTests.kt
@@ -1,0 +1,279 @@
+/*
+ * Copyright 2014-2021 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.client.plugins
+
+import io.ktor.client.call.*
+import io.ktor.client.engine.mock.*
+import io.ktor.client.request.*
+import io.ktor.client.tests.utils.*
+import io.ktor.http.*
+import io.ktor.http.content.*
+import kotlin.test.*
+
+class ContentNegotiationTests {
+    @Suppress("PrivatePropertyName")
+    private val XReturnAs = "X-Return-As"
+
+    private fun TestClientBuilder<MockEngineConfig>.setupWithContentNegotiation(block: ContentNegotiation.Config.() -> Unit) {
+        config {
+            engine {
+                addHandler { request ->
+                    respond(
+                        content = "Generic Server Response",
+                        headers = headersOf(
+                            HttpHeaders.ContentType,
+                            request.headers[XReturnAs] ?: ContentType.Text.Plain.toString()
+                        )
+                    )
+                }
+            }
+            install(ContentNegotiation) {
+                block()
+            }
+        }
+    }
+
+    @Test
+    fun `adds accept headers`(): Unit = testWithEngine(MockEngine) {
+        val registeredTypesToSend = listOf(
+            ContentType("testing", "a"),
+            ContentType("testing", "b"),
+            ContentType("testing", "c"),
+        )
+
+        setupWithContentNegotiation {
+            for (typeToSend in registeredTypesToSend) {
+                register(typeToSend, TestContentConverter())
+            }
+        }
+
+        test { client ->
+            client.get("https://test.com/").apply {
+                val sentTypes = assertNotNull(call.request.headers.getAll(HttpHeaders.Accept))
+                    .map { ContentType.parse(it) }
+
+                // Order NOT tested
+                for (typeToSend in registeredTypesToSend) {
+                    assertContains(sentTypes, typeToSend)
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `replaces content type in request pipeline`(): Unit = testWithEngine(MockEngine) {
+        val bodyContentType = ContentType("testing", "a")
+        val sentContentType = ContentType("testing", "b")
+        val serializedOutgoingContent = TextContent("CONTENT", sentContentType)
+
+        setupWithContentNegotiation {
+            register(bodyContentType, TestContentConverter()) {
+                serializeFn = { _, _, _, _ -> serializedOutgoingContent }
+            }
+        }
+
+        test { client ->
+            client.post("https://test.com") {
+                setBody(Thing)
+                contentType(bodyContentType)
+            }.apply {
+                // Should be removed when proceeding with serialization
+                assertNull(call.request.contentType())
+
+                // The serialized OutgoingContent should contain the new type
+                assertEquals(sentContentType, call.request.content.contentType)
+            }
+        }
+    }
+
+    @Test
+    fun `selects matching converter in request pipeline`(): Unit = testWithEngine(MockEngine) {
+        val types = listOf(
+            ContentType("testing", "a"),
+            ContentType("testing", "b"),
+        )
+
+        val outgoingContentPerType = types.map { contentType ->
+            contentType to TextContent("Serialise for: $contentType", contentType)
+        }
+
+        setupWithContentNegotiation {
+            outgoingContentPerType.forEach { (contentType, outgoingContent) ->
+                register(contentType, TestContentConverter()) {
+                    serializeFn = { _, _, _, _ -> outgoingContent }
+                }
+            }
+        }
+
+        test { client ->
+            outgoingContentPerType.forEach { (contentType, expectedOutgoingContent) ->
+                client.post("https://test.com/") {
+                    setBody(Thing)
+                    contentType(contentType)
+                }.apply {
+                    assertEquals(expectedOutgoingContent, call.request.content)
+                    assertEquals(contentType, call.request.content.contentType)
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `selects matching converter in response pipeline`(): Unit = testWithEngine(MockEngine) {
+        val types = listOf(
+            ContentType("testing", "a"),
+            ContentType("testing", "b")
+        )
+
+        val responsesPerType = types.map { contentType ->
+            // StringWrapper to avoid string body decoder
+            contentType to StringWrapper("Deserialized matching: $contentType")
+        }
+
+
+        setupWithContentNegotiation {
+            responsesPerType.forEach { (contentType, response) ->
+                register(contentType, TestContentConverter()) {
+                    deserializeFn = { a, b, c -> response }
+                }
+            }
+        }
+
+        test { client ->
+            responsesPerType.forEach { (contentType, expectedResponse) ->
+                client.get("https://test.com") {
+                    header(XReturnAs, contentType) // Ask server to send back the correct type
+                }.apply {
+                    assertEquals(contentType(), contentType)
+                    assertEquals(expectedResponse, body())
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `selects converters in order in request pipeline`() = testWithEngine(MockEngine) {
+        val contentTypeToSend = ContentType("testing", "client-to-send")
+        val outgoingContents = listOf(
+            TextContent("FIRST CONVERTER", contentTypeToSend),
+            TextContent("SECOND CONVERTER", contentTypeToSend),
+        )
+
+        assertTrue(outgoingContents.size > 1, "Must have more than 1 content converter registered for this test")
+
+        setupWithContentNegotiation {
+            // All converters match the same content type
+            // outgoingContents[0] should be sent based on registration order
+            outgoingContents.forEach { outgoingContent ->
+                register(contentTypeToSend, TestContentConverter()) {
+                    serializeFn = { _, _, _, _ -> outgoingContent }
+                }
+            }
+        }
+
+        test { client ->
+            client.post("https://test.com/") {
+                setBody(Thing)
+                contentType(contentTypeToSend)
+            }.apply {
+                assertEquals(contentTypeToSend, call.request.content.contentType)
+                assertEquals(outgoingContents.first(), call.request.content)
+            }
+        }
+    }
+
+    @Test
+    fun `selects converters in order in response pipeline`() = testWithEngine(MockEngine) {
+        val contentTypeToReceive = ContentType("testing", "client-to-receive")
+        val deserializedValues = listOf(
+            StringWrapper("FIRST CONVERTER"),
+            StringWrapper("SECOND CONVERTER"),
+        )
+
+        assertTrue(deserializedValues.size > 1, "Must have more than 1 converter registered for this test")
+
+        setupWithContentNegotiation {
+            // All converters match the same content type
+            // deserializedValues[0] should be returned based on registration order
+            deserializedValues.forEach { value ->
+                register(contentTypeToReceive, TestContentConverter()) {
+                    deserializeFn = { _, _, _ -> value }
+                }
+            }
+        }
+
+        test { client ->
+            client.get("https://test.com/") {
+                header(XReturnAs, contentTypeToReceive)
+            }.apply {
+                assertEquals(contentTypeToReceive, contentType())
+                assertEquals(deserializedValues.first(), body())
+            }
+        }
+    }
+
+    @Test
+    fun `selects first non-null converter output in request pipeline`(): Unit = testWithEngine(MockEngine) {
+        val contentTypeToSend = ContentType("testing", "client-send")
+        val sentOutgoingContent = TextContent("NON-NULL-RESULT", contentTypeToSend)
+
+        setupWithContentNegotiation {
+            // All converters match the same content type
+
+            register(contentTypeToSend, TestContentConverter())
+            register(contentTypeToSend, TestContentConverter())
+
+            // This one should yield the final result as it doesn't return null
+            register(contentTypeToSend, TestContentConverter()) {
+                serializeFn = { _, _, _, _ -> sentOutgoingContent }
+            }
+
+            register(contentTypeToSend, TestContentConverter())
+        }
+
+        test { client ->
+            client.get("https://test.com/") {
+                setBody(Thing)
+                contentType(contentTypeToSend)
+            }.apply {
+                assertEquals(contentTypeToSend, call.request.content.contentType)
+                assertEquals(sentOutgoingContent, call.request.content)
+            }
+        }
+    }
+
+    @Test
+    fun `selects first non-null converter output in response pipeline`(): Unit = testWithEngine(MockEngine) {
+        val contentTypeToReceive = ContentType("testing", "client-send")
+        val receivedValue = StringWrapper("NON-NULL-DESERIALIZATION")
+
+        setupWithContentNegotiation {
+            // All converters match the same content type
+
+            register(contentTypeToReceive, TestContentConverter())
+            register(contentTypeToReceive, TestContentConverter())
+
+            // This one should yield the final result as it doesn't return null
+            register(contentTypeToReceive, TestContentConverter()) {
+                deserializeFn = { _, _, _ -> receivedValue }
+            }
+
+            register(contentTypeToReceive, TestContentConverter())
+        }
+
+        test { client ->
+            client.get("https://test.com/") {
+                header(XReturnAs, contentTypeToReceive)
+            }.apply {
+                assertEquals(contentTypeToReceive, contentType())
+                assertEquals(receivedValue, body())
+            }
+        }
+    }
+
+    object Thing
+
+    data class StringWrapper(val value: String)
+}

--- a/ktor-client/ktor-client-plugins/ktor-client-content-negotiation/common/test/io/ktor/client/plugins/ContentNegotiationTests.kt
+++ b/ktor-client/ktor-client-plugins/ktor-client-content-negotiation/common/test/io/ktor/client/plugins/ContentNegotiationTests.kt
@@ -137,7 +137,7 @@ class ContentNegotiationTests {
         setupWithContentNegotiation {
             responsesPerType.forEach { (contentType, response) ->
                 register(contentType, TestContentConverter()) {
-                    deserializeFn = { a, b, c -> response }
+                    deserializeFn = { _, _, _ -> response }
                 }
             }
         }

--- a/ktor-client/ktor-client-plugins/ktor-client-content-negotiation/common/test/io/ktor/client/plugins/ContentNegotiationTests.kt
+++ b/ktor-client/ktor-client-plugins/ktor-client-content-negotiation/common/test/io/ktor/client/plugins/ContentNegotiationTests.kt
@@ -38,7 +38,7 @@ class ContentNegotiationTests {
     }
 
     @Test
-    fun `adds accept headers`(): Unit = testWithEngine(MockEngine) {
+    fun addAcceptHeaders(): Unit = testWithEngine(MockEngine) {
         val registeredTypesToSend = listOf(
             ContentType("testing", "a"),
             ContentType("testing", "b"),
@@ -65,7 +65,7 @@ class ContentNegotiationTests {
     }
 
     @Test
-    fun `replaces content type in request pipeline`(): Unit = testWithEngine(MockEngine) {
+    fun replaceContentTypeInRequestPipeline(): Unit = testWithEngine(MockEngine) {
         val bodyContentType = ContentType("testing", "a")
         val sentContentType = ContentType("testing", "b")
         val serializedOutgoingContent = TextContent("CONTENT", sentContentType)
@@ -91,7 +91,7 @@ class ContentNegotiationTests {
     }
 
     @Test
-    fun `selects matching converter in request pipeline`(): Unit = testWithEngine(MockEngine) {
+    fun selectMatchingConverterInRequestPipeline(): Unit = testWithEngine(MockEngine) {
         val types = listOf(
             ContentType("testing", "a"),
             ContentType("testing", "b"),
@@ -123,7 +123,7 @@ class ContentNegotiationTests {
     }
 
     @Test
-    fun `selects matching converter in response pipeline`(): Unit = testWithEngine(MockEngine) {
+    fun selectMatchingConverterInResponsePipeline(): Unit = testWithEngine(MockEngine) {
         val types = listOf(
             ContentType("testing", "a"),
             ContentType("testing", "b")
@@ -155,7 +155,7 @@ class ContentNegotiationTests {
     }
 
     @Test
-    fun `selects converters in order in request pipeline`() = testWithEngine(MockEngine) {
+    fun selectConvertersInOrderInRequestPipeline() = testWithEngine(MockEngine) {
         val contentTypeToSend = ContentType("testing", "client-to-send")
         val outgoingContents = listOf(
             TextContent("FIRST CONVERTER", contentTypeToSend),
@@ -186,7 +186,7 @@ class ContentNegotiationTests {
     }
 
     @Test
-    fun `selects converters in order in response pipeline`() = testWithEngine(MockEngine) {
+    fun selectConvertersInOrderInResponsePipeline() = testWithEngine(MockEngine) {
         val contentTypeToReceive = ContentType("testing", "client-to-receive")
         val deserializedValues = listOf(
             StringWrapper("FIRST CONVERTER"),
@@ -216,7 +216,7 @@ class ContentNegotiationTests {
     }
 
     @Test
-    fun `selects first non-null converter output in request pipeline`(): Unit = testWithEngine(MockEngine) {
+    fun selectFirstNonNullConverterOutputInRequestPipeline(): Unit = testWithEngine(MockEngine) {
         val contentTypeToSend = ContentType("testing", "client-send")
         val sentOutgoingContent = TextContent("NON-NULL-RESULT", contentTypeToSend)
 
@@ -246,7 +246,7 @@ class ContentNegotiationTests {
     }
 
     @Test
-    fun `selects first non-null converter output in response pipeline`(): Unit = testWithEngine(MockEngine) {
+    fun selectFirstNonNullConverterOutputInResponsePipeline(): Unit = testWithEngine(MockEngine) {
         val contentTypeToReceive = ContentType("testing", "client-send")
         val receivedValue = StringWrapper("NON-NULL-DESERIALIZATION")
 

--- a/ktor-client/ktor-client-plugins/ktor-client-content-negotiation/common/test/io/ktor/client/plugins/TestContentConverter.kt
+++ b/ktor-client/ktor-client-plugins/ktor-client-content-negotiation/common/test/io/ktor/client/plugins/TestContentConverter.kt
@@ -6,7 +6,7 @@ package io.ktor.client.plugins
 
 import io.ktor.http.*
 import io.ktor.http.content.*
-import io.ktor.shared.serialization.*
+import io.ktor.serialization.*
 import io.ktor.util.reflect.*
 import io.ktor.utils.io.*
 import io.ktor.utils.io.charsets.*

--- a/ktor-client/ktor-client-plugins/ktor-client-content-negotiation/common/test/io/ktor/client/plugins/TestContentConverter.kt
+++ b/ktor-client/ktor-client-plugins/ktor-client-content-negotiation/common/test/io/ktor/client/plugins/TestContentConverter.kt
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2014-2021 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.client.plugins
+
+import io.ktor.http.*
+import io.ktor.http.content.*
+import io.ktor.shared.serialization.*
+import io.ktor.util.reflect.*
+import io.ktor.utils.io.*
+import io.ktor.utils.io.charsets.*
+
+typealias ContentConverterSerialize = suspend (ContentType, Charset, TypeInfo, Any) -> OutgoingContent?
+typealias ContentConverterDeserialize = suspend (Charset, TypeInfo, ByteReadChannel) -> Any?
+
+class TestContentConverter(
+    var serializeFn: ContentConverterSerialize = { _, _, _, _ -> null },
+    var deserializeFn: ContentConverterDeserialize = { _, _, _ -> null },
+) : ContentConverter {
+
+    override suspend fun serialize(
+        contentType: ContentType,
+        charset: Charset,
+        typeInfo: TypeInfo,
+        value: Any
+    ): OutgoingContent? = serializeFn(contentType, charset, typeInfo, value)
+
+    override suspend fun deserialize(charset: Charset, typeInfo: TypeInfo, content: ByteReadChannel): Any? =
+        deserializeFn(charset, typeInfo, content)
+}

--- a/ktor-server/ktor-server-plugins/ktor-server-content-negotiation/jvm/src/io/ktor/server/plugins/ContentNegotiation.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-content-negotiation/jvm/src/io/ktor/server/plugins/ContentNegotiation.kt
@@ -177,7 +177,7 @@ public class ContentNegotiation internal constructor(
                 }
 
                 // Pick the first one that can convert the subject successfully
-                val converted = suitableConverters.mapFirstNotNull {
+                val converted = suitableConverters.firstNotNullOfOrNull {
                     it.converter.serialize(
                         contentType = it.contentType,
                         charset = call.request.headers.suitableCharset(),
@@ -264,15 +264,4 @@ public fun List<ContentTypeWithQuality>.sortedByQuality(): List<ContentTypeWithQ
             asterisks
         }.thenByDescending { it.contentType.parameters.size }
     )
-}
-
-private inline fun <F, T> Iterable<F>.mapFirstNotNull(block: (F) -> T?): T? {
-    @Suppress("LoopToCallChain")
-    for (element in this) {
-        val mapped = block(element)
-        if (mapped != null) {
-            return mapped
-        }
-    }
-    return null
 }


### PR DESCRIPTION
**Subsystem**
Client

**Motivation**
The `ContentConverter` documentation as well as the server implementation of `ContentNegotiation` both specify that `ContentConverter::(de)serialize` should return null when the converter is not suitable for the current content-type/body. This is to allow other registrations / converters to (de)serialize the content.

The client implementation of `ContentNegotiation` only tried (de)serialization with the first matching registration.

**Solution**
Instead of only (de)serializing with the first matching registration, this PR changes the behaviour to filter out matching registrations and try (de)serialization on each until one succeeds.

