### PR TITLE
KTOR-3342 Support receiving OAuth code response as form post

### DIFF
--- a/ktor-server/ktor-server-plugins/ktor-server-auth/jvm/src/io/ktor/server/auth/OAuth2.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-auth/jvm/src/io/ktor/server/auth/OAuth2.kt
@@ -11,6 +11,7 @@ import io.ktor.http.*
 import io.ktor.http.auth.*
 import io.ktor.http.content.*
 import io.ktor.server.application.*
+import io.ktor.server.request.*
 import io.ktor.server.response.*
 import io.ktor.util.*
 import io.ktor.util.pipeline.*
@@ -60,9 +61,13 @@ internal suspend fun PipelineContext<Unit, ApplicationCall>.oauth2(
     }
 }
 
-internal fun ApplicationCall.oauth2HandleCallback(): OAuthCallback.TokenSingle? {
-    val code = parameters[OAuth2RequestParameters.Code]
-    val state = parameters[OAuth2RequestParameters.State]
+internal suspend fun ApplicationCall.oauth2HandleCallback(): OAuthCallback.TokenSingle? {
+    val params = when (request.contentType()) {
+        ContentType.Application.FormUrlEncoded -> receiveParameters()
+        else -> parameters
+    }
+    val code = params[OAuth2RequestParameters.Code]
+    val state = params[OAuth2RequestParameters.State]
 
     return when {
         code != null && state != null -> OAuthCallback.TokenSingle(code, state)

--- a/ktor-server/ktor-server-plugins/ktor-server-auth/jvm/test/io/ktor/tests/auth/OAuth2.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-auth/jvm/test/io/ktor/tests/auth/OAuth2.kt
@@ -184,9 +184,11 @@ class OAuth2Test {
         }
         routing {
             authenticate("login") {
-                get("/login") {
-                    val principal = call.authentication.principal as? OAuthAccessTokenResponse.OAuth2
-                    call.respondText("Hej, $principal")
+                route("/login") {
+                    handle {
+                        val principal = call.authentication.principal as? OAuthAccessTokenResponse.OAuth2
+                        call.respondText("Hej, $principal")
+                    }
                 }
             }
             authenticate("resource") {
@@ -292,6 +294,25 @@ class OAuth2Test {
                 OAuth2RequestParameters.Code to "code1",
                 OAuth2RequestParameters.State to "state1"
             ).formUrlEncode()
+        }
+
+        waitExecutor()
+
+        assertEquals(HttpStatusCode.OK, result.response.status())
+    }
+
+    @Test
+    fun testRequestTokenFormPost() = withTestApplication({ module() }) {
+        val result = handleRequest {
+            method = HttpMethod.Post
+            uri = "/login"
+            addHeader(HttpHeaders.ContentType, ContentType.Application.FormUrlEncoded.toString())
+            setBody(
+                listOf(
+                    OAuth2RequestParameters.Code to "code1",
+                    OAuth2RequestParameters.State to "state1"
+                ).formUrlEncode()
+            )
         }
 
         waitExecutor()


### PR DESCRIPTION
**Subsystem**
Server -> auth -> oauth

**Motivation**
The [`form_post` OAuth response mode](https://openid.net/specs/oauth-v2-form-post-response-mode-1_0.html) is commonly used and recommended in OAuth providers. Specifically, [Apple **requires** this mode](https://developer.apple.com/forums/thread/121760) when using specific scopes, and [Microsoft recommends it](https://docs.microsoft.com/en-us/azure/active-directory/develop/v2-protocols-oidc#send-the-sign-in-request) for web applications.

Currently, ktor only supports receiving the code/state parameters in the URL query string. While you can set `response_mode=form_post` using an `authorizeUrlInterceptor`, receiving the parameters does not work.

**Solution**
If the content type of the incoming request is `application/x-www-form-urlencoded` it will look in the body parameters instead of the URL query parameters.

