### PR TITLE
Support other http methods than POST for OAuth 1a

### DIFF
--- a/ktor-server/ktor-server-plugins/ktor-server-auth/jvm/src/io/ktor/server/auth/OAuth.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-auth/jvm/src/io/ktor/server/auth/OAuth.kt
@@ -38,6 +38,7 @@ public sealed class OAuthServerSettings(public val name: String, public val vers
      * @property accessTokenUrl OAuth server access token request URL
      * @property consumerKey consumer key parameter (provided by OAuth server vendor)
      * @property consumerSecret a secret key parameter (provided by OAuth server vendor)
+     * @property httpMethod HTTP method to use for requests
      */
     public class OAuth1aServerSettings(
         name: String,
@@ -48,7 +49,8 @@ public sealed class OAuthServerSettings(public val name: String, public val vers
         public val consumerKey: String,
         public val consumerSecret: String,
 
-        public val accessTokenInterceptor: HttpRequestBuilder.() -> Unit = {}
+        public val accessTokenInterceptor: HttpRequestBuilder.() -> Unit = {},
+        public val httpMethod: HttpMethod = HttpMethod.Post
     ) : OAuthServerSettings(name, OAuthVersion.V10a)
 
     /**


### PR DESCRIPTION
**Subsystem**
Server -> auth -> oauth

**Motivation**
Some OAuth 1a providers require HTTP methods or than POST for the authorization flow. Specifically, [Schoology](https://developers.schoology.com/api-documentation/authentication) (one of the providers my company needs to integrate with) only supports GET requests and fails with POST requests.

**Solution**
Add an `httpMethod` setting to control what method is used for the requests

