### PR TITLE
KTOR-581 Add API to get list of all method routes

### DIFF
--- a/ktor-server/ktor-server-core/api/ktor-server-core.api
+++ b/ktor-server/ktor-server-core/api/ktor-server-core.api
@@ -958,6 +958,7 @@ public class io/ktor/server/routing/Route : io/ktor/server/application/Applicati
 	public synthetic fun <init> (Lio/ktor/server/routing/Route;Lio/ktor/server/routing/RouteSelector;ZLio/ktor/server/application/ApplicationEnvironment;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun afterIntercepted ()V
 	public final fun createChild (Lio/ktor/server/routing/RouteSelector;)Lio/ktor/server/routing/Route;
+	public final fun getAllHttpMethodRoutes ()Ljava/util/List;
 	public final fun getChildren ()Ljava/util/List;
 	public final fun getParent ()Lio/ktor/server/routing/Route;
 	public final fun getSelector ()Lio/ktor/server/routing/RouteSelector;

--- a/ktor-server/ktor-server-core/jvm/src/io/ktor/server/routing/Route.kt
+++ b/ktor-server/ktor-server-core/jvm/src/io/ktor/server/routing/Route.kt
@@ -75,6 +75,21 @@ public open class Route(
         cachedPipeline = null
     }
 
+    public fun getAllHttpMethodRoutes(): List<Route> {
+        val methodRoutes = mutableListOf<Route>()
+        fillHttpMethodRouteListRecursively(this, methodRoutes)
+
+        return methodRoutes
+    }
+
+    private fun fillHttpMethodRouteListRecursively(route: Route, methodRoutes: MutableList<Route>) {
+        if (route.selector is HttpMethodRouteSelector) {
+            methodRoutes.add(route)
+        } else {
+            route.children.forEach { fillHttpMethodRouteListRecursively(it, methodRoutes) }
+        }
+    }
+
     override fun afterIntercepted() {
         // Adding an interceptor invalidates pipelines for all children
         // We don't need synchronisation here, because order of intercepting and acquiring pipeline is indeterminate

--- a/ktor-server/ktor-server-core/jvm/test/io/ktor/tests/routing/RouteTest.kt
+++ b/ktor-server/ktor-server-core/jvm/test/io/ktor/tests/routing/RouteTest.kt
@@ -4,6 +4,7 @@
 
 package io.ktor.tests.routing
 
+import io.ktor.http.*
 import io.ktor.server.routing.*
 import kotlin.test.*
 
@@ -36,5 +37,47 @@ class RouteTest {
         val simpleChild = root.createChild(PathSegmentConstantRouteSelector("simpleChild"))
         assertTrue(root.developmentMode)
         assertTrue(simpleChild.developmentMode)
+    }
+
+    @Test
+    fun `test empty http method routes`() {
+        val root = Route(parent = null, selector = RootRouteSelector())
+        val methodRoutes = root.getAllHttpMethodRoutes()
+        assertTrue(methodRoutes.isEmpty())
+    }
+
+    @Test
+    fun `test find a few http method routes`() {
+        val root = Route(parent = null, selector = RootRouteSelector())
+        val firstChild = root.createChild(PathSegmentConstantRouteSelector("firstChild"))
+        val firstGrandChild = firstChild.createChild(PathSegmentConstantRouteSelector("firstGrandChild"))
+        val lastPathChild = firstGrandChild.createChild(PathSegmentConstantRouteSelector("lastPathChild"))
+
+        val firstMethod = firstChild.createChild(HttpMethodRouteSelector(HttpMethod.Get))
+        val secondMethod = lastPathChild.createChild(HttpMethodRouteSelector(HttpMethod.Post))
+        val thirdMethod = lastPathChild.createChild(HttpMethodRouteSelector(HttpMethod.Put))
+
+        val methodRoutes = root.getAllHttpMethodRoutes()
+        assertEquals(3, methodRoutes.size)
+        assertTrue(methodRoutes.contains(firstMethod))
+        assertTrue(methodRoutes.contains(secondMethod))
+        assertTrue(methodRoutes.contains(thirdMethod))
+    }
+
+    @Test
+    fun `test find http method routes from a non root route`() {
+        val root = Route(parent = null, selector = RootRouteSelector())
+        val firstChild = root.createChild(PathSegmentConstantRouteSelector("firstChild"))
+        val firstGrandChild = firstChild.createChild(PathSegmentConstantRouteSelector("firstGrandChild"))
+        val lastPathChild = firstGrandChild.createChild(PathSegmentConstantRouteSelector("lastPathChild"))
+
+        firstChild.createChild(HttpMethodRouteSelector(HttpMethod.Get))
+        val secondMethod = lastPathChild.createChild(HttpMethodRouteSelector(HttpMethod.Post))
+        val thirdMethod = lastPathChild.createChild(HttpMethodRouteSelector(HttpMethod.Put))
+
+        val methodRoutes = firstGrandChild.getAllHttpMethodRoutes()
+        assertEquals(2, methodRoutes.size)
+        assertTrue(methodRoutes.contains(secondMethod))
+        assertTrue(methodRoutes.contains(thirdMethod))
     }
 }


### PR DESCRIPTION
**Subsystem**
ktor-server-core

**Motivation**
See: #1252 or [YouTrack Issue](https://youtrack.jetbrains.com/issue/KTOR-581)

**Solution**
Find of all routes of the http method using recursion DFS for a tree.
Usage example:

```
val root = plugin(Routing)
val allMethodRoutes = root.getAllHttpMethodRoutes()
```
This can be used on any node of routing tree.


