### PR TITLE
KTOR-481 Add more flexibility while client logging

### DIFF
--- a/ktor-client/ktor-client-plugins/ktor-client-logging/common/src/io/ktor/client/plugins/logging/LogWriter.kt
+++ b/ktor-client/ktor-client-plugins/ktor-client-logging/common/src/io/ktor/client/plugins/logging/LogWriter.kt
@@ -1,0 +1,139 @@
+/*
+ * Copyright 2014-2021 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.client.plugins.logging
+
+import io.ktor.client.request.*
+import io.ktor.client.statement.*
+import io.ktor.http.*
+import io.ktor.http.content.*
+import io.ktor.util.*
+import io.ktor.utils.io.*
+import io.ktor.utils.io.charsets.*
+import kotlinx.coroutines.*
+
+public interface LogWriter {
+    public suspend fun write(request: HttpRequestBuilder): OutgoingContent?
+    public suspend fun write(request: HttpRequest): OutgoingContent?
+    public fun write(response: HttpResponse)
+    public fun write(request: HttpRequestBuilder, cause: Throwable)
+    public fun write(response: HttpResponse, cause: Throwable)
+    public suspend fun logResponseBody(response: HttpResponse)
+}
+
+@OptIn(InternalAPI::class)
+internal class SimpleLogWriter(
+    private val logger: Logger,
+    private val level: LogLevel,
+) : LogWriter {
+    override fun write(response: HttpResponse) {
+        if (level.info) {
+            logger.log("RESPONSE: ${response.status}")
+            logger.log("METHOD: ${response.call.request.method}")
+            logger.log("FROM: ${response.call.request.url}")
+        }
+
+        if (level.headers) {
+            logger.log("COMMON HEADERS")
+            logHeaders(response.headers.entries())
+        }
+    }
+
+    override suspend fun write(request: HttpRequestBuilder): OutgoingContent? {
+        if (level.info) {
+            logger.log("REQUEST: ${Url(request.url)}")
+            logger.log("METHOD: ${request.method}")
+        }
+
+        val content = request.body as OutgoingContent
+
+        if (level.headers) {
+            logger.log("COMMON HEADERS")
+            logHeaders(request.headers.entries())
+
+            logger.log("CONTENT HEADERS")
+            content.contentLength?.let { logger.logHeader(HttpHeaders.ContentLength, it.toString()) }
+            content.contentType?.let { logger.logHeader(HttpHeaders.ContentType, it.toString()) }
+            logHeaders(content.headers.entries())
+        }
+
+        return if (level.body) {
+            logRequestBody(content)
+        } else null
+    }
+
+    override suspend fun write(request: HttpRequest): OutgoingContent? {
+        if (level.info) {
+            logger.log("REQUEST: ${request.url}")
+            logger.log("METHOD: ${request.method}")
+        }
+
+        val content = request.content
+
+        if (level.headers) {
+            logger.log("COMMON HEADERS")
+            logHeaders(request.headers.entries())
+
+            logger.log("CONTENT HEADERS")
+            content.contentLength?.let { logger.logHeader(HttpHeaders.ContentLength, it.toString()) }
+            content.contentType?.let { logger.logHeader(HttpHeaders.ContentType, it.toString()) }
+            logHeaders(content.headers.entries())
+        }
+
+        return if (level.body) {
+            logRequestBody(content)
+        } else null
+    }
+
+    override suspend fun logResponseBody(response: HttpResponse): Unit = with(logger) {
+        val contentType = response.contentType()
+        log("BODY Content-Type: $contentType")
+        log("BODY START")
+        val message = response.content.tryReadText(contentType?.charset() ?: Charsets.UTF_8)
+            ?: "[response body omitted]"
+        log(message)
+        log("BODY END")
+    }
+
+    override fun write(request: HttpRequestBuilder, cause: Throwable) {
+        if (level.info) {
+            logger.log("REQUEST ${Url(request.url)} failed with exception: $cause")
+        }
+    }
+
+    override fun write(response: HttpResponse, cause: Throwable) {
+        if (level.info) {
+            logger.log("RESPONSE ${response.call.request.url} failed with exception: $cause")
+        }
+    }
+
+    @OptIn(DelicateCoroutinesApi::class)
+    private suspend fun logRequestBody(content: OutgoingContent): OutgoingContent {
+        logger.log("BODY Content-Type: ${content.contentType}")
+
+        val charset = content.contentType?.charset() ?: Charsets.UTF_8
+
+        val channel = ByteChannel()
+        GlobalScope.launch(Dispatchers.Unconfined) {
+            val text = channel.tryReadText(charset) ?: "[request body omitted]"
+            logger.log("BODY START")
+            logger.log(text)
+            logger.log("BODY END")
+        }
+
+        return content.observe(channel)
+    }
+
+    private fun logHeaders(headers: Set<Map.Entry<String, List<String>>>) {
+        val sortedHeaders = headers.toList().sortedBy { it.key }
+
+        sortedHeaders.forEach { (key, values) ->
+            logger.logHeader(key, values.joinToString("; "))
+        }
+    }
+
+    private fun Logger.logHeader(key: String, value: String) {
+        log("-> $key: $value")
+    }
+}

--- a/ktor-client/ktor-client-plugins/ktor-client-logging/common/src/io/ktor/client/plugins/logging/Logging.kt
+++ b/ktor-client/ktor-client-plugins/ktor-client-logging/common/src/io/ktor/client/plugins/logging/Logging.kt
@@ -5,18 +5,15 @@
 package io.ktor.client.plugins.logging
 
 import io.ktor.client.*
-import io.ktor.client.call.*
 import io.ktor.client.plugins.*
 import io.ktor.client.plugins.observer.*
 import io.ktor.client.request.*
 import io.ktor.client.statement.*
 import io.ktor.http.*
-import io.ktor.http.content.*
 import io.ktor.util.*
 import io.ktor.utils.io.*
 import io.ktor.utils.io.charsets.*
 import io.ktor.utils.io.core.*
-import kotlinx.coroutines.*
 import kotlinx.coroutines.sync.*
 
 /**
@@ -25,7 +22,9 @@ import kotlinx.coroutines.sync.*
 public class Logging private constructor(
     public val logger: Logger,
     public var level: LogLevel,
-    public var filters: List<(HttpRequestBuilder) -> Boolean> = emptyList()
+    public var filters: List<(HttpRequestBuilder) -> Boolean> = emptyList(),
+    public var strategy: Strategy,
+    public var logWriter: LogWriter,
 ) {
 
     private val mutex = Mutex()
@@ -55,6 +54,8 @@ public class Logging private constructor(
         public fun filter(predicate: (HttpRequestBuilder) -> Boolean) {
             filters.add(predicate)
         }
+
+        public var strategy: Strategy = Strategy.DEFAULT
     }
 
     private suspend fun beginLogging() {
@@ -65,97 +66,18 @@ public class Logging private constructor(
         mutex.unlock()
     }
 
-    private suspend fun logRequest(request: HttpRequestBuilder): OutgoingContent? {
-        if (level.info) {
-            logger.log("REQUEST: ${Url(request.url)}")
-            logger.log("METHOD: ${request.method}")
-        }
-
-        val content = request.body as OutgoingContent
-
-        if (level.headers) {
-            logger.log("COMMON HEADERS")
-            logHeaders(request.headers.entries())
-
-            logger.log("CONTENT HEADERS")
-            content.contentLength?.let { logger.logHeader(HttpHeaders.ContentLength, it.toString()) }
-            content.contentType?.let { logger.logHeader(HttpHeaders.ContentType, it.toString()) }
-            logHeaders(content.headers.entries())
-        }
-
-        return if (level.body) {
-            logRequestBody(content)
-        } else null
-    }
-
-    private fun logResponse(response: HttpResponse) {
-        if (level.info) {
-            logger.log("RESPONSE: ${response.status}")
-            logger.log("METHOD: ${response.call.request.method}")
-            logger.log("FROM: ${response.call.request.url}")
-        }
-
-        if (level.headers) {
-            logger.log("COMMON HEADERS")
-            logHeaders(response.headers.entries())
-        }
-    }
-
-    private suspend fun logResponseBody(contentType: ContentType?, content: ByteReadChannel): Unit = with(logger) {
-        log("BODY Content-Type: $contentType")
-        log("BODY START")
-        val message = content.tryReadText(contentType?.charset() ?: Charsets.UTF_8) ?: "[response body omitted]"
-        log(message)
-        log("BODY END")
-    }
-
-    private fun logRequestException(context: HttpRequestBuilder, cause: Throwable) {
-        if (level.info) {
-            logger.log("REQUEST ${Url(context.url)} failed with exception: $cause")
-        }
-    }
-
-    private fun logResponseException(request: HttpRequest, cause: Throwable) {
-        if (level.info) {
-            logger.log("RESPONSE ${request.url} failed with exception: $cause")
-        }
-    }
-
-    private fun logHeaders(headers: Set<Map.Entry<String, List<String>>>) {
-        val sortedHeaders = headers.toList().sortedBy { it.key }
-
-        sortedHeaders.forEach { (key, values) ->
-            logger.logHeader(key, values.joinToString("; "))
-        }
-    }
-
-    private fun Logger.logHeader(key: String, value: String) {
-        log("-> $key: $value")
-    }
-
-    @OptIn(DelicateCoroutinesApi::class)
-    private suspend fun logRequestBody(content: OutgoingContent): OutgoingContent? {
-        logger.log("BODY Content-Type: ${content.contentType}")
-
-        val charset = content.contentType?.charset() ?: Charsets.UTF_8
-
-        val channel = ByteChannel()
-        GlobalScope.launch(Dispatchers.Unconfined) {
-            val text = channel.tryReadText(charset) ?: "[request body omitted]"
-            logger.log("BODY START")
-            logger.log(text)
-            logger.log("BODY END")
-        }
-
-        return content.observe(channel)
-    }
-
     public companion object : HttpClientPlugin<Config, Logging> {
         override val key: AttributeKey<Logging> = AttributeKey("ClientLogging")
 
         override fun prepare(block: Config.() -> Unit): Logging {
             val config = Config().apply(block)
-            return Logging(config.logger, config.level, config.filters)
+            return Logging(
+                config.logger,
+                config.level,
+                config.filters,
+                config.strategy,
+                SimpleLogWriter(config.logger, config.level)
+            )
         }
 
         @OptIn(InternalAPI::class)
@@ -164,7 +86,7 @@ public class Logging private constructor(
                 val response = if (plugin.filters.isEmpty() || plugin.filters.any { it(context) }) {
                     try {
                         plugin.beginLogging()
-                        plugin.logRequest(context)
+                        plugin.strategy.log(context, plugin.logWriter)
                     } catch (_: Throwable) {
                         null
                     } finally {
@@ -175,7 +97,7 @@ public class Logging private constructor(
                 try {
                     proceedWith(response ?: subject)
                 } catch (cause: Throwable) {
-                    plugin.logRequestException(context, cause)
+                    plugin.logWriter.write(context, cause)
                     throw cause
                 } finally {
                 }
@@ -184,10 +106,10 @@ public class Logging private constructor(
             scope.receivePipeline.intercept(HttpReceivePipeline.State) { response ->
                 try {
                     plugin.beginLogging()
-                    plugin.logResponse(response.call.response)
+                    plugin.strategy.log(response, plugin.logWriter)
                     proceedWith(subject)
                 } catch (cause: Throwable) {
-                    plugin.logResponseException(response.call.request, cause)
+                    plugin.logWriter.write(response, cause)
                     throw cause
                 } finally {
                     if (!plugin.level.body) {
@@ -200,7 +122,7 @@ public class Logging private constructor(
                 try {
                     proceed()
                 } catch (cause: Throwable) {
-                    plugin.logResponseException(context.request, cause)
+                    plugin.logWriter.write(context.response, cause)
                     throw cause
                 }
             }
@@ -211,7 +133,7 @@ public class Logging private constructor(
 
             val observer: ResponseHandler = {
                 try {
-                    plugin.logResponseBody(it.contentType(), it.content)
+                    plugin.strategy.logResponseBody(it, plugin.logWriter)
                 } catch (_: Throwable) {
                 } finally {
                     plugin.doneLogging()

--- a/ktor-client/ktor-client-plugins/ktor-client-logging/common/src/io/ktor/client/plugins/logging/Strategy.kt
+++ b/ktor-client/ktor-client-plugins/ktor-client-logging/common/src/io/ktor/client/plugins/logging/Strategy.kt
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2014-2021 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.client.plugins.logging
+
+import io.ktor.client.request.*
+import io.ktor.client.statement.*
+import io.ktor.http.*
+import io.ktor.http.content.*
+
+public interface Strategy {
+    /**
+     * Log request during [HttpSendPipeline.Monitoring]
+     */
+    public suspend fun log(request: HttpRequestBuilder, logWriter: LogWriter): OutgoingContent?
+
+    /**
+     * Log response during [HttpReceivePipeline.State]
+     */
+    public suspend fun log(response: HttpResponse, logWriter: LogWriter)
+
+    /**
+     * Log body of response
+     */
+    public suspend fun logResponseBody(response: HttpResponse, logWriter: LogWriter)
+
+    public companion object
+}
+
+public val Strategy.Companion.DEFAULT: Strategy get() = SimpleStrategy()
+
+public class StatusAtLeastStrategy(private val status: HttpStatusCode) : Strategy {
+    override suspend fun log(request: HttpRequestBuilder, logWriter: LogWriter): OutgoingContent? = null
+
+    override suspend fun log(response: HttpResponse, logWriter: LogWriter) {
+        if (response.call.response.status.value >= status.value) {
+            logWriter.write(response.call.request)
+            logWriter.write(response)
+        }
+    }
+
+    override suspend fun logResponseBody(response: HttpResponse, logWriter: LogWriter) {
+        if (response.call.response.status.value >= status.value) {
+            logWriter.logResponseBody(response)
+        }
+    }
+}
+
+private class SimpleStrategy : Strategy {
+    override suspend fun log(request: HttpRequestBuilder, logWriter: LogWriter): OutgoingContent? =
+        logWriter.write(request)
+
+    override suspend fun log(response: HttpResponse, logWriter: LogWriter): Unit =
+        logWriter.write(response)
+
+    override suspend fun logResponseBody(response: HttpResponse, logWriter: LogWriter): Unit =
+        logWriter.logResponseBody(response)
+}

--- a/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/LoggingTest.kt
+++ b/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/LoggingTest.kt
@@ -625,4 +625,31 @@ class LoggingTest : ClientLoader() {
             testLogger.verify()
         }
     }
+
+    @Test
+    fun testStatusAtLeastStrategy() = clientTests(listOf("native:CIO")) {
+        val testLogger = TestLogger()
+
+        config {
+            Logging {
+                logger = testLogger
+                level = LogLevel.ALL
+                strategy = StatusAtLeastStrategy(HttpStatusCode.BadRequest)
+            }
+        }
+
+        test { client ->
+            val response = client.request {
+                method = HttpMethod.Post
+                setBody("test")
+                url("$TEST_SERVER/content/echo")
+            }.body<ByteReadChannel>()
+            assertNotNull(response)
+            assertEquals("test", response.readRemaining().readText())
+        }
+
+        after {
+            testLogger.verify()
+        }
+    }
 }


### PR DESCRIPTION
**Subsystem**
Client, Logging plugin

**Motivation**
[KTOR-481](https://youtrack.jetbrains.com/issue/KTOR-481), [KTOR-443](https://youtrack.jetbrains.com/issue/KTOR-443)

**Solution**
The strategy has access to both entities (request, response) thus it is able to make decisions on how to log them.
For example, a strategy will help define a rule for logging request/response pair for failed responses.

