### PR TITLE
KTOR-383 Request may not include Host parameter

### DIFF
--- a/ktor-http/ktor-http-cio/common/src/io/ktor/http/cio/HttpParser.kt
+++ b/ktor-http/ktor-http-cio/common/src/io/ktor/http/cio/HttpParser.kt
@@ -52,6 +52,14 @@ public suspend fun parseRequest(input: ByteReadChannel): Request? {
 
             val headers = parseHeaders(input, builder, range) ?: return null
 
+            val host = headers[HttpHeaders.Host]
+            if (host == null && version == "HTTP/1.1") {
+                throw ParserException(
+                    "A client MUST include a Host header field in all HTTP/1.1 " +
+                        "request messages as per RFC2616."
+                )
+            }
+
             return Request(method, uri, version, headers, builder)
         }
     } catch (t: Throwable) {

--- a/ktor-http/ktor-http-cio/jvm/test/io/ktor/tests/http/cio/RequestParserTest.kt
+++ b/ktor-http/ktor-http-cio/jvm/test/io/ktor/tests/http/cio/RequestParserTest.kt
@@ -42,4 +42,19 @@ class RequestParserTest {
         assertEquals("localhost", request.headers["Host"]?.toString())
         assertEquals("close", request.headers["Connection"]?.toString())
     }
+
+    @Test
+    fun testParseHostMustBePresented() = runBlocking {
+        val requestText = "GET / HTTP/1.1\nConnection:close\n\n"
+        val ch = ByteReadChannel(requestText.toByteArray())
+
+        assertFailsWith<ParserException> {
+            parseRequest(ch)
+        }.let {
+            assertTrue(
+                "A client MUST include a Host header field in all HTTP/1.1 request " +
+                    "messages as per RFC2616." in it.message.orEmpty()
+            )
+        }
+    }
 }


### PR DESCRIPTION
**Subsystem**
Core

**Motivation**
[KTOR-383](https://youtrack.jetbrains.com/issue/KTOR-383)

**Solution**
The parser should check the version of HTTP and throw parse exception accordingly lacking host header and HTTP 1.1

