### PR TITLE
KTOR-445 corsCheckRequestHeaders false

### DIFF
--- a/ktor-server/ktor-server-plugins/ktor-server-cors/jvm/src/io/ktor/server/plugins/CORS.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-cors/jvm/src/io/ktor/server/plugins/CORS.kt
@@ -165,9 +165,11 @@ public class CORS internal constructor(configuration: Configuration) {
 
     private suspend fun ApplicationCall.respondPreflight(origin: String) {
         val requestHeaders =
-            request.headers.getAll(HttpHeaders.AccessControlRequestHeaders)?.flatMap { it.split(",") }?.map {
-                it.trim().toLowerCasePreservingASCIIRules()
-            } ?: emptyList()
+            request.headers.getAll(HttpHeaders.AccessControlRequestHeaders)?.flatMap { it.split(",") }
+                ?.filter { it.isNotBlank() }
+                ?.map {
+                    it.trim().toLowerCasePreservingASCIIRules()
+                } ?: emptyList()
 
         if (!corsCheckRequestMethod() || (!corsCheckRequestHeaders(requestHeaders))) {
             respond(HttpStatusCode.Forbidden)

--- a/ktor-server/ktor-server-tests/jvm/test/io/ktor/tests/server/plugins/CORSTest.kt
+++ b/ktor-server/ktor-server-tests/jvm/test/io/ktor/tests/server/plugins/CORSTest.kt
@@ -866,7 +866,10 @@ class CORSTest {
                 addHeader(HttpHeaders.AccessControlRequestHeaders, "")
             }.let { call ->
                 assertEquals(HttpStatusCode.OK, call.response.status())
-                assertEquals("Content-Type, X-Forwarded-Proto", call.response.headers.get(HttpHeaders.AccessControlAllowHeaders))
+                assertEquals(
+                    "Content-Type, X-Forwarded-Proto",
+                    call.response.headers.get(HttpHeaders.AccessControlAllowHeaders)
+                )
             }
         }
     }

--- a/ktor-server/ktor-server-tests/jvm/test/io/ktor/tests/server/plugins/CORSTest.kt
+++ b/ktor-server/ktor-server-tests/jvm/test/io/ktor/tests/server/plugins/CORSTest.kt
@@ -11,6 +11,7 @@ import io.ktor.server.response.*
 import io.ktor.server.routing.*
 import io.ktor.server.testing.*
 import kotlin.test.*
+import kotlin.time.*
 
 class CORSTest {
 
@@ -837,6 +838,35 @@ class CORSTest {
             }.let { call ->
                 assertEquals(HttpStatusCode.OK, call.response.status())
                 assertEquals("custom-matcher-header", call.response.headers.get(HttpHeaders.AccessControlAllowHeaders))
+            }
+        }
+    }
+
+    @Test
+    fun testEmptyAccessControlRequestHeaders() {
+        withTestApplication {
+            application.install(CORS) {
+                method(HttpMethod.Options)
+                header(HttpHeaders.XForwardedProto)
+                host("host")
+                allowSameOrigin = false
+                allowCredentials = true
+                allowNonSimpleContentTypes = true
+            }
+
+            application.routing {
+                post("/") {
+                    call.respond("OK")
+                }
+            }
+
+            handleRequest(HttpMethod.Options, "/") {
+                addHeader(HttpHeaders.Origin, "http://host")
+                addHeader(HttpHeaders.AccessControlRequestMethod, "POST")
+                addHeader(HttpHeaders.AccessControlRequestHeaders, "")
+            }.let { call ->
+                assertEquals(HttpStatusCode.OK, call.response.status())
+                assertEquals("Content-Type, X-Forwarded-Proto", call.response.headers.get(HttpHeaders.AccessControlAllowHeaders))
             }
         }
     }


### PR DESCRIPTION
**Subsystem**
Server

**Motivation**
CORS plugin respond with `4xx` code with empty `Access-Control-Request-Headers` 
[KTOR-445](https://youtrack.jetbrains.com/issue/KTOR-445)

**Solution**
Filter empty elements in `requestHeaders` for preflight requests

