### PR TITLE
KTOR-3461 Exceptions are Swallowed in `HttpClient.wss` block

### DIFF
--- a/ktor-client/ktor-client-plugins/ktor-client-websockets/common/test/io/ktor/client/tests/plugins/WebSocketRemoteTest.kt
+++ b/ktor-client/ktor-client-plugins/ktor-client-websockets/common/test/io/ktor/client/tests/plugins/WebSocketRemoteTest.kt
@@ -118,7 +118,7 @@ class WebSocketRemoteTest : ClientLoader() {
         assertEquals(data.contentToString(), buffer.contentToString())
     }
 
-    private class CustomException: Exception()
+    private class CustomException : Exception()
 
     @Test
     fun testErrorHandling() = clientTests(listOf("Android", "Apache", "Curl")) {
@@ -127,15 +127,13 @@ class WebSocketRemoteTest : ClientLoader() {
         }
 
         test { client ->
-            repeat(1000) {
-                assertFailsWith<CustomException> {
-                    client.wss(echoWebsocket) {
-                        outgoing.send(Frame.Text("Hello"))
-                        val frame = incoming.receive()
-                        check(frame is Frame.Text)
+            assertFailsWith<CustomException> {
+                client.wss(echoWebsocket) {
+                    outgoing.send(Frame.Text("Hello"))
+                    val frame = incoming.receive()
+                    check(frame is Frame.Text)
 
-                        throw CustomException()
-                    }
+                    throw CustomException()
                 }
             }
         }

--- a/ktor-client/ktor-client-plugins/ktor-client-websockets/common/test/io/ktor/client/tests/plugins/WebSocketRemoteTest.kt
+++ b/ktor-client/ktor-client-plugins/ktor-client-websockets/common/test/io/ktor/client/tests/plugins/WebSocketRemoteTest.kt
@@ -118,6 +118,8 @@ class WebSocketRemoteTest : ClientLoader() {
         assertEquals(data.contentToString(), buffer.contentToString())
     }
 
+    private class CustomException: Exception()
+
     @Test
     fun testErrorHandling() = clientTests(listOf("Android", "Apache", "Curl")) {
         config {
@@ -126,9 +128,13 @@ class WebSocketRemoteTest : ClientLoader() {
 
         test { client ->
             repeat(1000) {
-                assertFailsWith<IllegalStateException> {
+                assertFailsWith<CustomException> {
                     client.wss(echoWebsocket) {
-                        error("error")
+                        outgoing.send(Frame.Text("Hello"))
+                        val frame = incoming.receive()
+                        check(frame is Frame.Text)
+
+                        throw CustomException()
                     }
                 }
             }

--- a/ktor-client/ktor-client-plugins/ktor-client-websockets/common/test/io/ktor/client/tests/plugins/WebSocketRemoteTest.kt
+++ b/ktor-client/ktor-client-plugins/ktor-client-websockets/common/test/io/ktor/client/tests/plugins/WebSocketRemoteTest.kt
@@ -64,23 +64,6 @@ class WebSocketRemoteTest : ClientLoader() {
     }
 
     @Test
-    fun testErrorHandling() = clientTests(skipEngines) {
-        config {
-            install(WebSockets)
-        }
-
-        test { client ->
-            repeat(1000) {
-                assertFailsWith<IllegalStateException> {
-                    client.wss(echoWebsocket) {
-                        error("error")
-                    }
-                }
-            }
-        }
-    }
-
-    @Test
     fun testSessionClose() = clientTests(skipEngines) {
         config {
             install(WebSockets)
@@ -133,5 +116,22 @@ class WebSocketRemoteTest : ClientLoader() {
 
         val buffer = binaryFrame.data
         assertEquals(data.contentToString(), buffer.contentToString())
+    }
+
+    @Test
+    fun testErrorHandling() = clientTests(listOf("Android", "Apache", "Curl")) {
+        config {
+            install(WebSockets)
+        }
+
+        test { client ->
+            repeat(1000) {
+                assertFailsWith<IllegalStateException> {
+                    client.wss(echoWebsocket) {
+                        error("error")
+                    }
+                }
+            }
+        }
     }
 }

--- a/ktor-client/ktor-client-plugins/ktor-client-websockets/common/test/io/ktor/client/tests/plugins/WebSocketRemoteTest.kt
+++ b/ktor-client/ktor-client-plugins/ktor-client-websockets/common/test/io/ktor/client/tests/plugins/WebSocketRemoteTest.kt
@@ -64,6 +64,23 @@ class WebSocketRemoteTest : ClientLoader() {
     }
 
     @Test
+    fun testErrorHandling() = clientTests(skipEngines) {
+        config {
+            install(WebSockets)
+        }
+
+        test { client ->
+            repeat(1000) {
+                assertFailsWith<IllegalStateException> {
+                    client.wss(echoWebsocket) {
+                        error("error")
+                    }
+                }
+            }
+        }
+    }
+
+    @Test
     fun testSessionClose() = clientTests(skipEngines) {
         config {
             install(WebSockets)

--- a/ktor-server/ktor-server-cio/jvmAndNix/src/io/ktor/server/cio/backend/HttpServer.kt
+++ b/ktor-server/ktor-server-cio/jvmAndNix/src/io/ktor/server/cio/backend/HttpServer.kt
@@ -4,12 +4,10 @@
 
 package io.ktor.server.cio.backend
 
-import io.ktor.http.cio.*
-import io.ktor.http.cio.internals.*
 import io.ktor.network.selector.*
 import io.ktor.network.sockets.*
 import io.ktor.server.cio.*
-import io.ktor.server.cio.internal.*
+import io.ktor.server.cio.internal.WeakTimeoutQueue
 import io.ktor.server.engine.*
 import io.ktor.server.engine.internal.*
 import io.ktor.util.*

--- a/ktor-server/ktor-server-cio/jvmAndNix/src/io/ktor/server/cio/backend/ServerPipeline.kt
+++ b/ktor-server/ktor-server-cio/jvmAndNix/src/io/ktor/server/cio/backend/ServerPipeline.kt
@@ -32,7 +32,7 @@ import kotlin.native.concurrent.*
 @InternalAPI
 public fun CoroutineScope.startServerConnectionPipeline(
     connection: ServerIncomingConnection,
-    timeout: io.ktor.server.cio.internal.WeakTimeoutQueue,
+    timeout: WeakTimeoutQueue,
     handler: HttpRequestHandler
 ): Job = launch(HttpPipelineCoroutine) {
     @OptIn(ObsoleteCoroutinesApi::class, ExperimentalCoroutinesApi::class)

--- a/ktor-server/ktor-server-cio/jvmAndNix/src/io/ktor/server/cio/backend/ServerPipeline.kt
+++ b/ktor-server/ktor-server-cio/jvmAndNix/src/io/ktor/server/cio/backend/ServerPipeline.kt
@@ -8,7 +8,7 @@ import io.ktor.http.*
 import io.ktor.http.cio.*
 import io.ktor.http.cio.internals.*
 import io.ktor.server.cio.*
-import io.ktor.server.cio.internal.*
+import io.ktor.server.cio.internal.WeakTimeoutQueue
 import io.ktor.util.*
 import io.ktor.util.cio.*
 import io.ktor.utils.io.*
@@ -32,7 +32,7 @@ import kotlin.native.concurrent.*
 @InternalAPI
 public fun CoroutineScope.startServerConnectionPipeline(
     connection: ServerIncomingConnection,
-    timeout: WeakTimeoutQueue,
+    timeout: io.ktor.server.cio.internal.WeakTimeoutQueue,
     handler: HttpRequestHandler
 ): Job = launch(HttpPipelineCoroutine) {
     @OptIn(ObsoleteCoroutinesApi::class, ExperimentalCoroutinesApi::class)


### PR DESCRIPTION
[KTOR-3461](https://youtrack.jetbrains.com/issue/KTOR-3461)

