### PR TITLE
KTOR-536 Support for adding values to the MDC later on in the pipeline.

### DIFF
--- a/ktor-server/ktor-server-test-host/jvmAndNix/src/io/ktor/server/testing/TestApplication.kt
+++ b/ktor-server/ktor-server-test-host/jvmAndNix/src/io/ktor/server/testing/TestApplication.kt
@@ -191,5 +191,6 @@ public fun testApplication(
         .apply { runBlocking { block() } }
 
     val testApplication = TestApplication(builder)
+    testApplication.engine.start()
     testApplication.stop()
 }


### PR DESCRIPTION
Call `withMdcBlock` multiple times, to add new MDC entries to the context.
Also, migrate test to the new API