### PR TITLE
Fix TestLocal repo URL is incorrect.

### DIFF
--- a/buildSrc/src/main/kotlin/Publication.kt
+++ b/buildSrc/src/main/kotlin/Publication.kt
@@ -86,7 +86,7 @@ fun Project.configurePublication() {
             }
             maven {
                 name = "testLocal"
-                setUrl("$rootProject.buildDir/m2")
+                setUrl("${rootProject.buildDir}/m2")
             }
         }
 


### PR DESCRIPTION
**Subsystem**
Maven publication

**Motivation**
The testLocal repo url in Publication.kt is incorrectly written, which will result in publishing to the `$rootProject.buildDir/m2` folder of all subprojects.

**Solution**
Replace `$rootProject.buildDir/m2` with `${rootProject.buildDir}/m2`

