### PR TITLE
KTOR-3561 Bump nodeJS to 16.13.1

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -209,6 +209,6 @@ if (docs != null) {
 
 // https://youtrack.jetbrains.com/issue/KT-49109
 rootProject.plugins.withType<org.jetbrains.kotlin.gradle.targets.js.nodejs.NodeJsRootPlugin> {
-    val nodeM1Version = "16.0.0"
+    val nodeM1Version = "16.13.1"
     rootProject.the<org.jetbrains.kotlin.gradle.targets.js.nodejs.NodeJsRootExtension>().nodeVersion = nodeM1Version
 }


### PR DESCRIPTION
**Subsystem**
Infrastructure

**Motivation**
https://youtrack.jetbrains.com/issue/KTOR-3561
Current outdated nodeJS version exists build on Apple Arm: `'Resolving NPM dependencies using yarn' returns 139`

**Solution**
Bump nodeJS to 16.13.1

