### PR TITLE
KTOR-2776 Fix race condition in closing ByteChannelSequential

### DIFF
--- a/ktor-io/common/src/io/ktor/utils/io/ByteChannelSequential.kt
+++ b/ktor-io/common/src/io/ktor/utils/io/ByteChannelSequential.kt
@@ -95,6 +95,7 @@ public abstract class ByteChannelSequentialBase(
 
     private fun flushImpl(): Boolean {
         if (writable.isEmpty) {
+            slot.resume()
             return false
         }
 


### PR DESCRIPTION

```
    internal suspend fun awaitAtLeastNBytesAvailableForRead(count: Int) {
        while (availableForRead < count && !closed) {
            // !!! writer can flush here !!!
            slot.sleep()
        }
    }
```
Usually it's ok, because the next writer will wake up reader. But if it was the last writing, only `close` will try to do it. Internally, it checks that if there is nothing to flush, then no need to resume the `slot`, which is wrong. Reader should be woken up anyway. 