### PR TITLE
KTOR-3497 HttpCookies: parse / in the name of a cookie

### DIFF
--- a/ktor-http/common/src/io/ktor/http/Cookie.kt
+++ b/ktor-http/common/src/io/ktor/http/Cookie.kt
@@ -92,7 +92,7 @@ public fun parseServerSetCookieHeader(cookiesHeader: String): Cookie {
 }
 
 @ThreadLocal
-private val clientCookieHeaderPattern = """(^|;)\s*([^()<>@;:/\\"\[\]\?=\{\}\s]+)\s*(=\s*("[^"]*"|[^;]*))?""".toRegex()
+private val clientCookieHeaderPattern = """(^|;)\s*([^;, [\x00-\x1F]\x7F\=\{\}\s]+)\s*(=\s*("[^"]*"|[^;]*))?""".toRegex()
 
 /**
  * Parse client's `Cookie` header value

--- a/ktor-http/common/src/io/ktor/http/Cookie.kt
+++ b/ktor-http/common/src/io/ktor/http/Cookie.kt
@@ -92,7 +92,7 @@ public fun parseServerSetCookieHeader(cookiesHeader: String): Cookie {
 }
 
 @ThreadLocal
-private val clientCookieHeaderPattern = """(^|;)\s*([^;, [\x00-\x1F]\x7F\=\{\}\s]+)\s*(=\s*("[^"]*"|[^;]*))?""".toRegex()
+private val clientCookieHeaderPattern = """(^|;)\s*([^;=\{\}\s]+)\s*(=\s*("[^"]*"|[^;]*))?""".toRegex()
 
 /**
  * Parse client's `Cookie` header value

--- a/ktor-server/ktor-server-tests/jvm/test/io/ktor/tests/server/plugins/CookiesTest.kt
+++ b/ktor-server/ktor-server-tests/jvm/test/io/ktor/tests/server/plugins/CookiesTest.kt
@@ -403,4 +403,14 @@ class ParserServerSetCookieTest {
         assertEquals("aaa", parsed.value)
         assertEquals(Int.MAX_VALUE, parsed.maxAge)
     }
+
+    @Test
+    fun testSlash() {
+        val header = "384f8bdb/sessid=GLU787LwmQa9uLqnM7nWHzBm; path=/"
+        val parsed = parseServerSetCookieHeader(header)
+
+        assertEquals("384f8bdb/sessid", parsed.name)
+        assertEquals("GLU787LwmQa9uLqnM7nWHzBm", parsed.value)
+        assertEquals("/", parsed.path)
+    }
 }


### PR DESCRIPTION
Ticket: [KTOR-3497](https://youtrack.jetbrains.com/issue/KTOR-3497)

**Motivation**
Current cookie implementation supports [rfc6265](https://datatracker.ietf.org/doc/html/rfc6265#page-13), but browsers support old [netscape spec](https://curl.se/rfc/cookie_spec.html) in cookie names

**Solution**
Support netscape spec: allow characters ()<>@:/\"[]? in cookie names. 
Also browsers support comma and white space as [stackowerflow question](https://stackoverflow.com/questions/1969232/what-are-allowed-characters-in-cookies) says, so this changes allow them too.

