### PR TITLE
KTOR-1619 Use placeholder text if response body decoding fails in default validator

### DIFF
--- a/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/DefaultResponseValidation.kt
+++ b/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/DefaultResponseValidation.kt
@@ -43,7 +43,7 @@ public fun HttpClientConfig<*>.addDefaultResponseValidation() {
             val exceptionResponse = exceptionCall.response
             val exceptionResponseText = try {
                 exceptionResponse.bodyAsText()
-            } catch (reason: MalformedInputException) {
+            } catch (_: MalformedInputException) {
                 BODY_FAILED_DECODING
             }
             when (statusCode) {
@@ -56,9 +56,9 @@ public fun HttpClientConfig<*>.addDefaultResponseValidation() {
     }
 }
 
-internal const val NO_RESPONSE_TEXT: String = "<no response text provided>"
-internal const val BODY_FAILED_DECODING: String = "<body failed decoding>"
-internal const val DEPRECATED_EXCEPTION_CTOR: String = "Please, provide response text in constructor"
+private const val NO_RESPONSE_TEXT: String = "<no response text provided>"
+private const val BODY_FAILED_DECODING: String = "<body failed decoding>"
+private const val DEPRECATED_EXCEPTION_CTOR: String = "Please, provide response text in constructor"
 
 /**
  * Base for default response exceptions.

--- a/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/CallValidatorTest.kt
+++ b/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/CallValidatorTest.kt
@@ -465,6 +465,28 @@ class CallValidatorTest {
             }
         }
     }
+
+    @Test
+    fun testResponseValidationThrowsResponseExceptionWithByteArray() = testWithEngine(MockEngine) {
+        val content = byteArrayOf(0x08.toByte(), 0x96.toByte(), 0x01.toByte())
+        config {
+            expectSuccess = true
+            engine {
+                addHandler {
+                    val status = HttpStatusCode(900, "Awesome code")
+                    respond(content, status)
+                }
+            }
+        }
+        test { client ->
+            try {
+                client.get {}
+                fail("Should fail")
+            } catch (cause: ResponseException) {
+                assertEquals(cause.message?.contains("<body failed decoding>"), true)
+            }
+        }
+    }
 }
 
 internal class CallValidatorTestException : Throwable()


### PR DESCRIPTION
**Subsystem**
Client

**Motivation**
Resolves [KTOR-1619](https://youtrack.jetbrains.com/issue/KTOR-1619)
HTTP responses with non-2XX status codes and non-text bodies cause an unexpected exception in default response validation. This is because the validator attempts to decode the body as text to generate the exception message. This causes issues with endpoints that respond with a generic error image when requesting a non-existent record.

**Solution**
Attempt to decode the body in a `try` block, then on `MalformedInputException`, use a placeholder string to represent the non-decodable body in the resulting exception message. Also includes unit test written by original issue creator Takahiro Menju.

