### PR TITLE
KTOR-1435: add support for client request single line logging

### DIFF
--- a/ktor-client/ktor-client-plugins/ktor-client-logging/common/src/io/ktor/client/plugins/logging/Logger.kt
+++ b/ktor-client/ktor-client-plugins/ktor-client-logging/common/src/io/ktor/client/plugins/logging/Logger.kt
@@ -13,6 +13,8 @@ public interface Logger {
      */
     public fun log(message: String)
 
+    public fun flush() { }
+
     public companion object
 }
 

--- a/ktor-client/ktor-client-plugins/ktor-client-logging/common/src/io/ktor/client/plugins/logging/Logging.kt
+++ b/ktor-client/ktor-client-plugins/ktor-client-logging/common/src/io/ktor/client/plugins/logging/Logging.kt
@@ -61,6 +61,7 @@ public class Logging private constructor(
     }
 
     private fun doneLogging() {
+        logger.flush()
         mutex.unlock()
     }
 


### PR DESCRIPTION
**Subsystem**
Logging plugin

**Motivation**
The client logging plugin does not allow logging to a single line easily - this can be a problem when using elastic search etc. making centralised logs very messy. https://youtrack.jetbrains.com/issue/KTOR-1435

**Solution**
Add a flush method to the Logger interface (defaulting to nothing) which is called by Logging.kt.doneLogging() - this way the user can supply their own Logger implementation and gather the logs in a client request before Flushing to a single log line.

