### PR TITLE
Revert KTOR-2872 due regression

### DIFF
--- a/ktor-server/ktor-server-plugins/ktor-server-cors/jvm/src/io/ktor/server/plugins/CORS.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-cors/jvm/src/io/ktor/server/plugins/CORS.kt
@@ -93,15 +93,6 @@ public class CORS internal constructor(configuration: Configuration) {
                 }
         )
 
-    init {
-        if (configuration.allowCredentials) {
-            require(!allowsAnyHost) {
-                "AnyHost * is not allowed in combination with Allow-Credentials, see " +
-                    "https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS/Errors/CORSNotSupportingCredentials."
-            }
-        }
-    }
-
     /**
      * Plugin's call interceptor that does all the job. Usually there is no need to install it as it is done during
      * plugin installation
@@ -193,7 +184,7 @@ public class CORS internal constructor(configuration: Configuration) {
     }
 
     private fun ApplicationCall.accessControlAllowOrigin(origin: String) {
-        if (allowsAnyHost) {
+        if (allowsAnyHost && !allowCredentials) {
             response.header(HttpHeaders.AccessControlAllowOrigin, "*")
         } else {
             response.header(HttpHeaders.AccessControlAllowOrigin, origin)

--- a/ktor-server/ktor-server-plugins/ktor-server-cors/jvm/test/io/ktor/tests/CORSTest.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-cors/jvm/test/io/ktor/tests/CORSTest.kt
@@ -12,17 +12,6 @@ import kotlin.test.*
 class CORSTest {
 
     @Test
-    fun anyHostWithAllowCredentialsShouldFail() {
-        val config = CORS.Configuration().apply {
-            allowCredentials = true
-            anyHost()
-        }
-        assertFailsWith<IllegalArgumentException> {
-            CORS(config)
-        }
-    }
-
-    @Test
     fun originValidation() {
         val plugin = CORS(
             CORS.Configuration().apply {


### PR DESCRIPTION
**Subsystem**
Server CORS plugin

**Motivation**
Regression caused by https://youtrack.jetbrains.com/issue/KTOR-2872

well-intentioned check changed behavior of `Access-Control-Allow-Origin`.

**Solution**
Revert KTOR-2872

- No revert commit due to changed package name and new testApplication api

@rsinukov Do you plan to release `1.6.8` or similar? If so, I would also patch this change into `1.6` branch.
