### PR TITLE
Initializer should be initialized eagerly

### DIFF
--- a/ktor-client/ktor-client-plugins/ktor-client-json/ktor-client-serialization/js/src/SerializerInitializer.kt
+++ b/ktor-client/ktor-client-plugins/ktor-client-json/ktor-client-serialization/js/src/SerializerInitializer.kt
@@ -7,6 +7,8 @@ import io.ktor.client.plugins.json.serializer.*
 import io.ktor.util.*
 
 @InternalAPI
+@OptIn(ExperimentalStdlibApi::class)
+@EagerInitialization
 @Suppress("unused")
 public val initializer: SerializerInitializer = SerializerInitializer
 


### PR DESCRIPTION
**Subsystem**
Client

**Motivation**
Since 1.6.20 there is lazy initialization of properties. So now using of properties as side effect is not possible.
For compatibility annotation `@EagerInitialization` can be used.

**Solution**
Using of `@EagerInitialization` on side-effect property

