### PR TITLE
Update Dokka to 1.6.10 and remove ZipException workaround for JS files

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -101,7 +101,7 @@ val disabledExplicitApiModeProjects = listOf(
 apply(from = "gradle/compatibility.gradle")
 
 plugins {
-    id("org.jetbrains.dokka") version "1.6.0"
+    id("org.jetbrains.dokka") version "1.6.10"
 }
 
 allprojects {
@@ -186,14 +186,6 @@ if (project.hasProperty("enable-coverage")) {
 
 subprojects {
     plugins.apply("org.jetbrains.dokka")
-
-    tasks.withType<DokkaTaskPartial> {
-        dokkaSourceSets.configureEach {
-            if (platform.get().name == "js") {
-                suppress.set(true)
-            }
-        }
-    }
 }
 
 val docs: String? by extra


### PR DESCRIPTION
This PR updates dokka to 1.6.10 and removes a workaround for the [ZipException](https://youtrack.jetbrains.com/issue/KTOR-1032#focus=Comments-27-4865014.0-0) as it has been [fixed](https://github.com/Kotlin/dokka/pull/2258).

I've built docs via `./gradlew clean dokkaHtmlMultiModule` - everything seems OK