### PR TITLE
Use DEFAULT_COMPRESSION for java.util.zip.Deflater

### DIFF
--- a/ktor-utils/jvm/src/io/ktor/util/Deflater.kt
+++ b/ktor-utils/jvm/src/io/ktor/util/Deflater.kt
@@ -64,7 +64,7 @@ public fun ByteReadChannel.deflated(
     coroutineContext: CoroutineContext = Dispatchers.Unconfined
 ): ByteReadChannel = GlobalScope.writer(coroutineContext, autoFlush = true) {
     val crc = CRC32()
-    val deflater = Deflater(Deflater.BEST_COMPRESSION, true)
+    val deflater = Deflater(Deflater.DEFAULT_COMPRESSION, true)
     val input = pool.borrow()
     val compressed = pool.borrow()
 


### PR DESCRIPTION
Use DEFAULT_COMPRESSION for java.util.zip.Deflater.
Rather than BEST_COMPRESSION. BEST_COMPRESSION is generally many times
slower than DEFAULT_COMPRESSION for miniscule improvements to compressed
size, making BEST_COMPRESSION almost always the wrong choice when
compression time is part of the equation.

This should probably be configurable, since the optimal choice depends
on expected network speed, CPU speed, and which implementation the JDK
uses, but DEFAULT_COMPRESSION is a pretty good default.

**Subsystem**
ktor-utils

**Motivation**
Started down the rabbit hole that led me here because I noticed a ktor server being significantly slower to transfer a large response than pretty much any other server I tried (if using `Accept-Encoding: deflate, gzip`), and eventually narrowed down the main culprit to this.

**Solution**

```diff
-    val deflater = Deflater(Deflater.BEST_COMPRESSION, true)
+    val deflater = Deflater(Deflater.DEFAULT_COMPRESSION, true)
```

