### PR TITLE
KTOR-3659 Fix sockets on Android

### DIFF
--- a/ktor-network/jvm/src/io/ktor/network/sockets/CIOReader.kt
+++ b/ktor-network/jvm/src/io/ktor/network/sockets/CIOReader.kt
@@ -63,7 +63,11 @@ internal fun CoroutineScope.attachForReadingImpl(
             pool.recycle(buffer)
             if (nioChannel is SocketChannel) {
                 try {
-                    nioChannel.shutdownInput()
+                    if (java7NetworkApisAvailable) {
+                        nioChannel.shutdownInput()
+                    } else {
+                        nioChannel.socket().shutdownInput()
+                    }
                 } catch (ignore: ClosedChannelException) {
                 }
             }
@@ -115,7 +119,11 @@ internal fun CoroutineScope.attachForReadingDirectImpl(
     } finally {
         if (nioChannel is SocketChannel) {
             try {
-                nioChannel.shutdownInput()
+                if (java7NetworkApisAvailable) {
+                    nioChannel.shutdownInput()
+                } else {
+                    nioChannel.socket().shutdownInput()
+                }
             } catch (ignore: ClosedChannelException) {
             }
         }

--- a/ktor-network/jvm/src/io/ktor/network/sockets/CIOWriter.kt
+++ b/ktor-network/jvm/src/io/ktor/network/sockets/CIOWriter.kt
@@ -62,7 +62,11 @@ internal fun CoroutineScope.attachForWritingImpl(
             pool.recycle(buffer)
             if (nioChannel is SocketChannel) {
                 try {
-                    nioChannel.shutdownOutput()
+                    if (java7NetworkApisAvailable) {
+                        nioChannel.shutdownOutput()
+                    } else {
+                        nioChannel.socket().shutdownOutput()
+                    }
                 } catch (ignore: ClosedChannelException) {
                 }
             }
@@ -119,7 +123,11 @@ internal fun CoroutineScope.attachForWritingDirectImpl(
         selectable.interestOp(SelectInterest.WRITE, false)
         if (nioChannel is SocketChannel) {
             try {
-                nioChannel.shutdownOutput()
+                if (java7NetworkApisAvailable) {
+                    nioChannel.shutdownOutput()
+                } else {
+                    nioChannel.socket().shutdownOutput()
+                }
             } catch (ignore: ClosedChannelException) {
             }
         }

--- a/ktor-network/jvm/src/io/ktor/network/sockets/ConnectUtilsJvm.kt
+++ b/ktor-network/jvm/src/io/ktor/network/sockets/ConnectUtilsJvm.kt
@@ -31,7 +31,11 @@ internal actual fun bind(
     nonBlocking()
 
     ServerSocketImpl(this, selector).apply {
-        channel.bind(localAddress?.toJavaAddress(), socketOptions.backlogSize)
+        if (java7NetworkApisAvailable) {
+            channel.bind(localAddress?.toJavaAddress(), socketOptions.backlogSize)
+        } else {
+            channel.socket().bind(localAddress?.toJavaAddress(), socketOptions.backlogSize)
+        }
     }
 }
 

--- a/ktor-network/jvm/src/io/ktor/network/sockets/DatagramSocketImpl.kt
+++ b/ktor-network/jvm/src/io/ktor/network/sockets/DatagramSocketImpl.kt
@@ -21,12 +21,26 @@ internal class DatagramSocketImpl(
     DefaultDatagramByteBufferPool
 ) {
     override val localAddress: SocketAddress
-        get() = channel.localAddress?.toSocketAddress()
-            ?: throw IllegalStateException("Channel is not yet bound")
+        get() {
+            val localAddress = if (java7NetworkApisAvailable) {
+                channel.localAddress
+            } else {
+                channel.socket().localSocketAddress
+            }
+            return localAddress?.toSocketAddress()
+                ?: throw IllegalStateException("Channel is not yet bound")
+        }
 
     override val remoteAddress: SocketAddress
-        get() = channel.remoteAddress?.toSocketAddress()
-            ?: throw IllegalStateException("Channel is not yet connected")
+        get() {
+            val remoteAddress = if (java7NetworkApisAvailable) {
+                channel.remoteAddress
+            } else {
+                channel.socket().remoteSocketAddress
+            }
+            return remoteAddress?.toSocketAddress()
+                ?: throw IllegalStateException("Channel is not yet connected")
+        }
 
     private val sender: SendChannel<Datagram> = DatagramSendChannel(channel, this)
 

--- a/ktor-network/jvm/src/io/ktor/network/sockets/UDPSocketBuilderJvm.kt
+++ b/ktor-network/jvm/src/io/ktor/network/sockets/UDPSocketBuilderJvm.kt
@@ -15,7 +15,11 @@ internal actual fun UDPSocketBuilder.Companion.connectUDP(
     assignOptions(options)
     nonBlocking()
 
-    bind(localAddress?.toJavaAddress())
+    if (java7NetworkApisAvailable) {
+        bind(localAddress?.toJavaAddress())
+    } else {
+        socket().bind(localAddress?.toJavaAddress())
+    }
     connect(remoteAddress.toJavaAddress())
 
     return DatagramSocketImpl(this, selector)
@@ -29,6 +33,10 @@ internal actual fun UDPSocketBuilder.Companion.bindUDP(
     assignOptions(options)
     nonBlocking()
 
-    bind(localAddress?.toJavaAddress())
+    if (java7NetworkApisAvailable) {
+        bind(localAddress?.toJavaAddress())
+    } else {
+        socket().bind(localAddress?.toJavaAddress())
+    }
     return DatagramSocketImpl(this, selector)
 }


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KTOR-3659

Since https://github.com/ktorio/ktor/pull/2603 was merged the sockets no longer work on Android API level < 24.

This PR fixes the issue by only calling Java 1.7 APIs if they are available, and fall back to older APIs otherwise. 

I have not tested this PR yet on Android, will do that soon.