### PR TITLE
Remove unnecessary command from Linux CONTRIBUTING.md setup instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,7 +40,6 @@ Run the following commands to install `libcurl` and `libncurses`:
 
 ```
         sudo apt-get update
-        sudo apt-get libcurl
         sudo apt-get install libncurses5 libncursesw5 libtinfo5
         sudo apt-get install libcurl4-openssl-dev
 ```


### PR DESCRIPTION
**Subsystem**
Contributers documentation

**Motivation**
Remove an invalid command - `sudo apt-get libcurl` simply prints `E: Invalid operation libcurl` for me.

**Solution**
The intention looks to have been to provide header files for `libcurl`. `sudo apt-get install libcurl-dev` returns me 3 candidates, one of which is `libcurl4-openssl-dev`, which is installed anyway. (The other two for me on Ubuntu 20.04 are libcurl4-nss-dev and libcurl4-gnutls-dev).

