### PR TITLE
KTOR-789 Use UTF-8 as default charset for text and forms

### DIFF
--- a/ktor-server/ktor-server-host-common/jvmAndNix/src/io/ktor/server/engine/DefaultTransform.kt
+++ b/ktor-server/ktor-server-host-common/jvmAndNix/src/io/ktor/server/engine/DefaultTransform.kt
@@ -41,14 +41,13 @@ public fun ApplicationReceivePipeline.installDefaultTransformations() {
             ByteReadChannel::class -> channel
             ByteArray::class -> channel.toByteArray()
             String::class -> channel.readText(
-                charset = withContentType(call) { call.request.contentCharset() }
-                    ?: Charsets.ISO_8859_1
+                charset = withContentType(call) { call.request.contentCharset() } ?: Charsets.UTF_8
             )
             Parameters::class -> {
                 val contentType = withContentType(call) { call.request.contentType() }
                 when {
                     contentType.match(ContentType.Application.FormUrlEncoded) -> {
-                        val string = channel.readText(charset = call.request.contentCharset() ?: Charsets.ISO_8859_1)
+                        val string = channel.readText(charset = call.request.contentCharset() ?: Charsets.UTF_8)
                         parseQueryString(string)
                     }
                     contentType.match(ContentType.MultiPart.FormData) -> {


### PR DESCRIPTION
According to  https://www.rfc-editor.org/rfc/rfc2046.html#section-4.1.2 the default charset to `Text/*` is ASCII, so using `Charsets.ISO_8859_1` doesn't make sense here. `Application/json` and other popular types have `UTF-8` as default charset. 