### PR TITLE
KTOR-574 Add support for different application profiles

### DIFF
--- a/ktor-server/ktor-server-host-common/jvm/src/io/ktor/server/engine/CommandLineJvm.kt
+++ b/ktor-server/ktor-server-host-common/jvm/src/io/ktor/server/engine/CommandLineJvm.kt
@@ -29,7 +29,10 @@ public fun commandLineEnvironment(
             else -> File(it).toURI().toURL()
         }
     }
-    val configFile = argsMap["-config"]?.let { File(it) }
+
+    val profile = argsMap["-profile"]
+    val configFile = argsMap["-config"]?.let { File(it) } ?: profile?.let { File("application-${profile}.conf") }
+
     val commandLineMap = argsMap.filterKeys { it.startsWith("-P:") }.mapKeys { it.key.removePrefix("-P:") }
 
     val environmentConfig = ConfigFactory.systemProperties().withOnlyPath("ktor")

--- a/ktor-server/ktor-server-host-common/jvm/src/io/ktor/server/engine/EnvironmentUtilsJvm.kt
+++ b/ktor-server/ktor-server-host-common/jvm/src/io/ktor/server/engine/EnvironmentUtilsJvm.kt
@@ -19,7 +19,8 @@ internal actual fun buildApplicationConfig(args: Array<String>): ApplicationConf
         .filterKeys { it.startsWith("-P:") }
         .mapKeys { it.key.removePrefix("-P:") }
 
-    val configFile = argumentsPairs["-config"]?.let { File(it) }
+    val profile = argumentsPairs["-profile"]
+    val configFile = argumentsPairs["-config"]?.let { File(it) } ?: profile?.let { File("application-${profile}.conf") }
 
     val argConfig = ConfigFactory.parseMap(commandLineProperties, "Command-line options")
 

--- a/ktor-server/ktor-server-host-common/jvm/test-resources/application-test.conf
+++ b/ktor-server/ktor-server-host-common/jvm/test-resources/application-test.conf
@@ -1,0 +1,9 @@
+ktor {
+     deployment {
+         port = 4000
+     }
+
+     application {
+         class = <org.company.ApplicationClass>
+     }
+ }

--- a/ktor-server/ktor-server-host-common/jvm/test/io/ktor/tests/hosts/CommandLineTest.kt
+++ b/ktor-server/ktor-server-host-common/jvm/test/io/ktor/tests/hosts/CommandLineTest.kt
@@ -66,6 +66,12 @@ class CommandLineTest {
         assertEquals("8080", port)
     }
 
+    @Test
+    fun configFileWithProfile() {
+        val port = commandLineEnvironment(arrayOf("-profile=test")).config.property("ktor.deployment.port").getString()
+        assertEquals("4000", port)
+    }
+
     private tailrec fun findContainingZipFileOrUri(uri: URI): Pair<File?, URI?> {
         if (uri.scheme == "file") {
             return Pair(File(uri.path.substringBefore("!")), null)


### PR DESCRIPTION
**Subsystem**
Server-Host-Common

**Motivation**
It is useful to have the ability to change profiles via env parameters.

Solves [#KTOR-574](https://youtrack.jetbrains.com/issue/KTOR-574)

**Solution**
Added additional "-profile" env parameter which if present adds a postfix to the "application.conf" file.

