### PR TITLE
Ktor client content encoding: do not decode empty body

### DIFF
--- a/ktor-client/ktor-client-plugins/ktor-client-encoding/common/src/ContentEncoding.kt
+++ b/ktor-client/ktor-client-plugins/ktor-client-encoding/common/src/ContentEncoding.kt
@@ -126,6 +126,11 @@ public class ContentEncoding private constructor(
             }
 
             scope.responsePipeline.intercept(HttpResponsePipeline.Receive) { (type, content) ->
+                val method = context.request.method
+                val contentLength = context.response.contentLength()
+
+                if (contentLength == 0L) return@intercept
+                if (contentLength == null && method == HttpMethod.Head) return@intercept
                 if (content !is ByteReadChannel) return@intercept
 
                 val response = with(plugin) {

--- a/ktor-client/ktor-client-plugins/ktor-client-encoding/common/test/ContentEncodingTest.kt
+++ b/ktor-client/ktor-client-plugins/ktor-client-encoding/common/test/ContentEncodingTest.kt
@@ -29,7 +29,7 @@ class ContentEncodingTest : ClientLoader() {
     }
 
     @Test
-    fun testDeflate() = clientTests {
+    fun testDeflate() = clientTests(listOf("native:CIO")) {
         config {
             ContentEncoding {
                 deflate()
@@ -44,7 +44,7 @@ class ContentEncodingTest : ClientLoader() {
     }
 
     @Test
-    fun testGZip() = clientTests {
+    fun testGZip() = clientTests(listOf("native:CIO")) {
         config {
             ContentEncoding {
                 gzip()

--- a/ktor-client/ktor-client-plugins/ktor-client-encoding/common/test/ContentEncodingTest.kt
+++ b/ktor-client/ktor-client-plugins/ktor-client-encoding/common/test/ContentEncodingTest.kt
@@ -23,7 +23,11 @@ class ContentEncodingTest : ClientLoader() {
 
         test { client ->
             val response = client.get("$TEST_URL/identity")
-            assertEquals("identity", response.headers[HttpHeaders.ContentEncoding])
+            val contentEncoding = response.headers[HttpHeaders.ContentEncoding]
+            // JS browser engines don't have Content-Encoding header for identity encoding
+            if (contentEncoding != null) {
+                assertEquals("identity", contentEncoding)
+            }
             assertEquals("Compressed response!", response.body<String>())
         }
     }

--- a/ktor-client/ktor-client-plugins/ktor-client-encoding/common/test/ContentEncodingTest.kt
+++ b/ktor-client/ktor-client-plugins/ktor-client-encoding/common/test/ContentEncodingTest.kt
@@ -7,6 +7,7 @@ package io.ktor.client.plugins.compression
 import io.ktor.client.call.*
 import io.ktor.client.request.*
 import io.ktor.client.tests.utils.*
+import io.ktor.http.*
 import kotlin.test.*
 
 private const val TEST_URL = "$TEST_SERVER/compression"
@@ -21,8 +22,9 @@ class ContentEncodingTest : ClientLoader() {
         }
 
         test { client ->
-            val response = client.get("$TEST_URL/identity").body<String>()
-            assertEquals("Compressed response!", response)
+            val response = client.get("$TEST_URL/identity")
+            assertEquals("identity", response.headers[HttpHeaders.ContentEncoding])
+            assertEquals("Compressed response!", response.body<String>())
         }
     }
 
@@ -35,8 +37,9 @@ class ContentEncodingTest : ClientLoader() {
         }
 
         test { client ->
-            val response = client.get("$TEST_URL/deflate").body<String>()
-            assertEquals("Compressed response!", response)
+            val response = client.get("$TEST_URL/deflate")
+            assertEquals("deflate", response.headers[HttpHeaders.ContentEncoding])
+            assertEquals("Compressed response!", response.body<String>())
         }
     }
 
@@ -49,8 +52,24 @@ class ContentEncodingTest : ClientLoader() {
         }
 
         test { client ->
-            val response = client.get("$TEST_URL/gzip").body<String>()
-            assertEquals("Compressed response!", response)
+            val response = client.get("$TEST_URL/gzip")
+            assertEquals("gzip", response.headers[HttpHeaders.ContentEncoding])
+            assertEquals("Compressed response!", response.body<String>())
+        }
+    }
+
+    @Test
+    fun testGZipEmpty() = clientTests {
+        config {
+            ContentEncoding {
+                gzip()
+            }
+        }
+
+        test { client ->
+            val response = client.get("$TEST_URL/gzip-empty")
+            assertEquals("gzip", response.headers[HttpHeaders.ContentEncoding])
+            assertEquals("", response.body<String>())
         }
     }
 }

--- a/ktor-client/ktor-client-tests/jvm/src/io/ktor/client/tests/utils/tests/Encoding.kt
+++ b/ktor-client/ktor-client-tests/jvm/src/io/ktor/client/tests/utils/tests/Encoding.kt
@@ -4,6 +4,7 @@
 
 package io.ktor.client.tests.utils.tests
 
+import io.ktor.http.*
 import io.ktor.server.application.*
 import io.ktor.server.plugins.compression.*
 import io.ktor.server.response.*
@@ -13,15 +14,30 @@ internal fun Application.encodingTestServer() {
     routing {
         route("/compression") {
             route("/deflate") {
-                install(Compression) { deflate() }
+                install(Compression) {
+                    deflate()
+                    minimumSize(0)
+                }
                 setCompressionEndpoints()
             }
             route("/gzip") {
-                install(Compression) { gzip() }
+                install(Compression) {
+                    gzip()
+                    minimumSize(0)
+                }
                 setCompressionEndpoints()
             }
+            route("/gzip-empty") {
+                get {
+                    call.response.headers.append(HttpHeaders.ContentEncoding, "gzip")
+                    call.respondText("")
+                }
+            }
             route("/identity") {
-                install(Compression) { identity() }
+                install(Compression) {
+                    identity()
+                    minimumSize(0)
+                }
                 setCompressionEndpoints()
             }
         }


### PR DESCRIPTION
**Subsystem**
- Client
- ContentEncoding plugin

**Motivation**
Client should not decode empty body: https://youtrack.jetbrains.com/issue/KTOR-3781

```
Unexpected exception occurred during switching: kotlinx.coroutines.channels.ClosedReceiveChannelException: Unexpected EOF: expected 10 more bytes
        at io.ktor.utils.io.ByteBufferChannel.readFullySuspend(ByteBufferChannel.kt:594)
        at io.ktor.utils.io.ByteBufferChannel.readFully(ByteBufferChannel.kt:586)
        at io.ktor.utils.io.ByteBufferChannel.readPacketSuspend(ByteBufferChannel.kt:802)
        at io.ktor.utils.io.ByteBufferChannel.readPacket$suspendImpl(ByteBufferChannel.kt:788)
        at io.ktor.utils.io.ByteBufferChannel.readPacket(ByteBufferChannel.kt)
        at io.ktor.utils.io.ByteReadChannelKt.readPacket(ByteReadChannel.kt:207)
        at io.ktor.util.EncodersJvmKt$inflate$1.invokeSuspend(EncodersJvm.kt:68)
        at io.ktor.util.EncodersJvmKt$inflate$1.invoke(EncodersJvm.kt) 
        at io.ktor.util.EncodersJvmKt$inflate$1.invoke(EncodersJvm.kt) 
        at io.ktor.utils.io.CoroutinesKt$launchChannel$job$1.invokeSuspend(Coroutines.kt:132)
        at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
        at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:106)
        at kotlinx.coroutines.scheduling.CoroutineScheduler.runSafely(CoroutineScheduler.kt:571)
        at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.executeTask(CoroutineScheduler.kt:750)
        at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.runWorker(CoroutineScheduler.kt:678)
        at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run(CoroutineScheduler.kt:665)
```

**Solution**
Do not decode body when content length is `0` or method is `HEAD` and content length is missing.

