### PR TITLE
KTOR-728 Use conditional headers from response too

### DIFF
--- a/ktor-server/ktor-server-plugins/ktor-server-conditional-headers/api/ktor-server-conditional-headers.api
+++ b/ktor-server/ktor-server-plugins/ktor-server-conditional-headers/api/ktor-server-conditional-headers.api
@@ -1,6 +1,6 @@
 public final class io/ktor/server/plugins/conditionalheaders/ConditionalHeadersConfig {
 	public fun <init> ()V
-	public final fun version (Lkotlin/jvm/functions/Function2;)V
+	public final fun version (Lkotlin/jvm/functions/Function3;)V
 }
 
 public final class io/ktor/server/plugins/conditionalheaders/ConditionalHeadersKt {

--- a/ktor-server/ktor-server-plugins/ktor-server-conditional-headers/jvmAndNix/src/io/ktor/server/plugins/conditionalheaders/ConditionalHeaders.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-conditional-headers/jvmAndNix/src/io/ktor/server/plugins/conditionalheaders/ConditionalHeaders.kt
@@ -16,30 +16,33 @@ import io.ktor.util.*
  */
 @KtorDsl
 public class ConditionalHeadersConfig {
-    internal val versionProviders = mutableListOf<suspend (OutgoingContent) -> List<Version>>()
+    internal val versionProviders = mutableListOf<suspend (ApplicationCall, OutgoingContent) -> List<Version>>()
 
     init {
-        versionProviders.add { content -> content.versions }
-        versionProviders.add { content -> content.headers.parseVersions() }
+        versionProviders.add { _, content -> content.versions }
+        versionProviders.add { call, content ->
+            content.headers.parseVersions().takeIf { it.isNotEmpty() }
+                ?: call.response.headers.allValues().parseVersions()
+        }
     }
 
     /**
-     * Registers a function that can fetch version list for a given [OutgoingContent]
+     * Registers a function that can fetch version list for a given [ApplicationCall] and [OutgoingContent]
      */
-    public fun version(provider: suspend (OutgoingContent) -> List<Version>) {
+    public fun version(provider: suspend (ApplicationCall, OutgoingContent) -> List<Version>) {
         versionProviders.add(provider)
     }
 }
 
-internal val ConditionalHeadersKey: AttributeKey<List<suspend (OutgoingContent) -> List<Version>>> =
+internal val VersionProvidersKey: AttributeKey<List<suspend (ApplicationCall, OutgoingContent) -> List<Version>>> =
     AttributeKey("ConditionalHeadersKey")
 
 /**
  * Retrieves versions such as [LastModifiedVersion] or [EntityTagVersion] for a given content
  */
 public suspend fun ApplicationCall.versionsFor(content: OutgoingContent): List<Version> {
-    val versionProviders = application.attributes.getOrNull(ConditionalHeadersKey)
-    return versionProviders?.flatMapTo(ArrayList(versionProviders.size)) { it(content) } ?: emptyList()
+    val versionProviders = application.attributes.getOrNull(VersionProvidersKey)
+    return versionProviders?.flatMap { it(this, content) } ?: emptyList()
 }
 
 /**
@@ -51,7 +54,7 @@ public val ConditionalHeaders: RouteScopedPlugin<ConditionalHeadersConfig, Plugi
 ) {
     val versionProviders = pluginConfig.versionProviders
 
-    application.attributes.put(ConditionalHeadersKey, versionProviders)
+    application.attributes.put(VersionProvidersKey, versionProviders)
 
     fun checkVersions(call: ApplicationCall, versions: List<Version>): VersionCheckResult {
         for (version in versions) {

--- a/ktor-server/ktor-server-plugins/ktor-server-partial-content/jvmAndNix/src/io/ktor/server/plugins/partialcontent/PartialContent.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-partial-content/jvmAndNix/src/io/ktor/server/plugins/partialcontent/PartialContent.kt
@@ -130,7 +130,7 @@ private suspend fun checkIfRangeHeader(
     val versions = if (conditionalHeadersPlugin != null) {
         call.versionsFor(content)
     } else {
-        content.headers.parseVersions()
+        content.headers.parseVersions().takeIf { it.isNotEmpty() } ?: call.response.headers.allValues().parseVersions()
     }
 
     return versions.all { version ->

--- a/ktor-server/ktor-server-tests/jvmAndNix/test/io/ktor/tests/server/plugins/ConditionalHeadersTests.kt
+++ b/ktor-server/ktor-server-tests/jvmAndNix/test/io/ktor/tests/server/plugins/ConditionalHeadersTests.kt
@@ -21,7 +21,7 @@ class ETagsTest {
     private fun withConditionalApplication(body: suspend ApplicationTestBuilder.() -> Unit) = testApplication {
         application {
             install(ConditionalHeaders) {
-                version { listOf(EntityTagVersion("tag1")) }
+                version { _, _ -> listOf(EntityTagVersion("tag1")) }
             }
             routing {
                 handle {


### PR DESCRIPTION
When replying with data class, there is no way to set headers on `OutgoingContent` and headers set on response are ignored
https://youtrack.jetbrains.com/issue/KTOR-728