### PR TITLE
KTOR-3795 Break infinite refresh token cycle on 401

### DIFF
--- a/ktor-client/ktor-client-plugins/ktor-client-auth/api/ktor-client-auth.api
+++ b/ktor-client/ktor-client-plugins/ktor-client-auth/api/ktor-client-auth.api
@@ -4,6 +4,7 @@ public final class io/ktor/client/plugins/auth/Auth {
 }
 
 public final class io/ktor/client/plugins/auth/Auth$Plugin : io/ktor/client/plugins/HttpClientPlugin {
+	public final fun getAuthCircuitBreaker ()Lio/ktor/util/AttributeKey;
 	public fun getKey ()Lio/ktor/util/AttributeKey;
 	public fun install (Lio/ktor/client/plugins/auth/Auth;Lio/ktor/client/HttpClient;)V
 	public synthetic fun install (Ljava/lang/Object;Lio/ktor/client/HttpClient;)V
@@ -141,5 +142,6 @@ public final class io/ktor/client/plugins/auth/providers/RefreshTokensParams {
 	public final fun getClient ()Lio/ktor/client/HttpClient;
 	public final fun getOldTokens ()Lio/ktor/client/plugins/auth/providers/BearerTokens;
 	public final fun getResponse ()Lio/ktor/client/statement/HttpResponse;
+	public final fun markAsRefreshTokenRequest (Lio/ktor/client/request/HttpRequestBuilder;)V
 }
 

--- a/ktor-client/ktor-client-plugins/ktor-client-auth/common/src/io/ktor/client/plugins/auth/providers/BearerAuthProvider.kt
+++ b/ktor-client/ktor-client-plugins/ktor-client-auth/common/src/io/ktor/client/plugins/auth/providers/BearerAuthProvider.kt
@@ -33,7 +33,15 @@ public class RefreshTokensParams(
     public val client: HttpClient,
     public val response: HttpResponse,
     public val oldTokens: BearerTokens?
-)
+) {
+
+    /**
+     * Marks that this request is for refreshing auth tokens, resulting in a special handling of it.
+     */
+    public fun HttpRequestBuilder.markAsRefreshTokenRequest() {
+        attributes.put(Auth.AuthCircuitBreaker, Unit)
+    }
+}
 
 /**
  * [BearerAuthProvider] configuration.

--- a/ktor-client/ktor-client-tests/jvm/src/io/ktor/client/tests/utils/tests/Auth.kt
+++ b/ktor-client/ktor-client-tests/jvm/src/io/ktor/client/tests/utils/tests/Auth.kt
@@ -126,6 +126,9 @@ internal fun Application.authTestServer() {
                         delay(call.parameters["delay"]?.toLong() ?: 0)
                         call.respond("second")
                     }
+                    get("refresh-401") {
+                        call.respond(HttpStatusCode.Unauthorized)
+                    }
                 }
                 get("first") {
                     val header = call.request.headers[HttpHeaders.Authorization]


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KTOR-3795

When refresh token request fails with 401 it tries to refresh token again, resulting in an infinite cycle. Since token refreshing in a client's code, they need to mark such requests, so we can have a special case for them.  
Marking function is only available inside `refreshToken {}` block.