### PR TITLE
KTOR-3966 add links to a migration guide

### DIFF
--- a/ktor-client/ktor-client-core/common/src/io/ktor/client/HttpClient.kt
+++ b/ktor-client/ktor-client-core/common/src/io/ktor/client/HttpClient.kt
@@ -23,7 +23,7 @@ import kotlin.coroutines.*
  * Constructs an asynchronous [HttpClient] using optional [block] for configuring this client.
  *
  * The [HttpClientEngine] is selected from the dependencies.
- * https://ktor.io/clients/http-client/engines.html
+ * https://ktor.io/docs/http-client-engines.html
  */
 @KtorDsl
 public expect fun HttpClient(

--- a/ktor-client/ktor-client-core/js/src/io/ktor/client/HttpClientJs.kt
+++ b/ktor-client/ktor-client-core/js/src/io/ktor/client/HttpClientJs.kt
@@ -10,7 +10,7 @@ import io.ktor.client.engine.js.*
  * Constructs an asynchronous [HttpClient] using optional [block] for configuring this client.
  *
  * The [HttpClientEngine] is selected from the dependencies.
- * https://ktor.io/clients/http-client/engines.html
+ * https://ktor.io/docs/http-client-engines.html
  */
 public actual fun HttpClient(
     block: HttpClientConfig<*>.() -> Unit

--- a/ktor-client/ktor-client-core/jvm/src/io/ktor/client/HttpClientJvm.kt
+++ b/ktor-client/ktor-client-core/jvm/src/io/ktor/client/HttpClientJvm.kt
@@ -14,7 +14,7 @@ import java.util.*
  * The first found implementation that provides [HttpClientEngineContainer] service implementation is used.
  * An exception is thrown if no implementations found.
  *
- * See https://ktor.io/clients/http-client/engines.html
+ * See https://ktor.io/docs/http-client-engines.html
  */
 public actual fun HttpClient(
     block: HttpClientConfig<*>.() -> Unit
@@ -41,5 +41,5 @@ private val engines: List<HttpClientEngineContainer> = HttpClientEngineContainer
 
 private val FACTORY = engines.firstOrNull()?.factory ?: error(
     "Failed to find HTTP client engine implementation in the classpath: consider adding client engine dependency. " +
-        "See https://ktor.io/clients/http-client/engines.html"
+        "See https://ktor.io/docs/http-client-engines.html"
 )

--- a/ktor-client/ktor-client-core/posix/src/io/ktor/client/HttpClient.kt
+++ b/ktor-client/ktor-client-core/posix/src/io/ktor/client/HttpClient.kt
@@ -11,7 +11,7 @@ import io.ktor.util.*
  * Constructs an asynchronous [HttpClient] using optional [block] for configuring this client.
  *
  * The [HttpClientEngine] is selected from the dependencies.
- * https://ktor.io/clients/http-client/engines.html
+ * https://ktor.io/docs/http-client-engines.html
  */
 @OptIn(InternalAPI::class)
 @KtorDsl

--- a/ktor-client/ktor-client-plugins/ktor-client-json/common/src/io/ktor/client/plugins/json/JsonPlugin.kt
+++ b/ktor-client/ktor-client-plugins/ktor-client-json/common/src/io/ktor/client/plugins/json/JsonPlugin.kt
@@ -39,7 +39,7 @@ public expect fun defaultSerializer(): JsonSerializer
  * @property serializer that is used to serialize and deserialize request/response bodies
  * @property acceptContentTypes that are allowed when receiving content
  */
-@Deprecated("Please use ContentNegotiation plugin")
+@Deprecated("Please use ContentNegotiation plugin: https://ktor.io/docs/migrating-2.html#serialization-client")
 public class JsonPlugin internal constructor(
     public val serializer: JsonSerializer,
     public val acceptContentTypes: List<ContentType> = listOf(ContentType.Application.Json),
@@ -170,7 +170,7 @@ public class JsonPlugin internal constructor(
 /**
  * Install [JsonPlugin].
  */
-@Deprecated("Please use ContentNegotiation plugin")
+@Deprecated("Please use ContentNegotiation plugin: https://ktor.io/docs/migrating-2.html#serialization-client")
 public fun HttpClientConfig<*>.Json(block: JsonPlugin.Config.() -> Unit) {
     install(JsonPlugin, block)
 }

--- a/ktor-client/ktor-client-plugins/ktor-client-json/common/src/io/ktor/client/plugins/json/JsonSerializer.kt
+++ b/ktor-client/ktor-client-plugins/ktor-client-json/common/src/io/ktor/client/plugins/json/JsonSerializer.kt
@@ -12,7 +12,9 @@ import io.ktor.utils.io.core.*
 /**
  * Client json serializer.
  */
-@Deprecated("Please use ContentNegotiation plugin and its converters: https://ktor.io/docs/migrating-2.html#serialization-client") // ktlint-disable max-line-length
+@Deprecated(
+    "Please use ContentNegotiation plugin and its converters: https://ktor.io/docs/migrating-2.html#serialization-client" // ktlint-disable max-line-length
+)
 public interface JsonSerializer {
     /**
      * Convert data object to [OutgoingContent].

--- a/ktor-client/ktor-client-plugins/ktor-client-json/common/src/io/ktor/client/plugins/json/JsonSerializer.kt
+++ b/ktor-client/ktor-client-plugins/ktor-client-json/common/src/io/ktor/client/plugins/json/JsonSerializer.kt
@@ -12,7 +12,7 @@ import io.ktor.utils.io.core.*
 /**
  * Client json serializer.
  */
-@Deprecated("Please use ContentNegotiation plugin and its converters: https://ktor.io/docs/migrating-2.html#serialization-client")
+@Deprecated("Please use ContentNegotiation plugin and its converters: https://ktor.io/docs/migrating-2.html#serialization-client") // ktlint-disable max-line-length
 public interface JsonSerializer {
     /**
      * Convert data object to [OutgoingContent].

--- a/ktor-client/ktor-client-plugins/ktor-client-json/common/src/io/ktor/client/plugins/json/JsonSerializer.kt
+++ b/ktor-client/ktor-client-plugins/ktor-client-json/common/src/io/ktor/client/plugins/json/JsonSerializer.kt
@@ -12,7 +12,7 @@ import io.ktor.utils.io.core.*
 /**
  * Client json serializer.
  */
-@Deprecated("Please use ContentNegotiation plugin and its converters")
+@Deprecated("Please use ContentNegotiation plugin and its converters: https://ktor.io/docs/migrating-2.html#serialization-client")
 public interface JsonSerializer {
     /**
      * Convert data object to [OutgoingContent].

--- a/ktor-client/ktor-client-plugins/ktor-client-json/ktor-client-gson/jvm/src/io/ktor/client/plugins/gson/GsonSerializer.kt
+++ b/ktor-client/ktor-client-plugins/ktor-client-json/ktor-client-gson/jvm/src/io/ktor/client/plugins/gson/GsonSerializer.kt
@@ -15,7 +15,9 @@ import io.ktor.utils.io.core.*
 /**
  * [JsonSerializer] using [Gson] as backend.
  */
-@Deprecated("Please use ContentNegotiation plugin and its converters: https://ktor.io/docs/migrating-2.html#serialization-client") // ktlint-disable max-line-length
+@Deprecated(
+    "Please use ContentNegotiation plugin and its converters: https://ktor.io/docs/migrating-2.html#serialization-client" // ktlint-disable max-line-length
+)
 public class GsonSerializer(block: GsonBuilder.() -> Unit = {}) : JsonSerializer {
     private val backend: Gson = GsonBuilder().apply(block).create()
 

--- a/ktor-client/ktor-client-plugins/ktor-client-json/ktor-client-gson/jvm/src/io/ktor/client/plugins/gson/GsonSerializer.kt
+++ b/ktor-client/ktor-client-plugins/ktor-client-json/ktor-client-gson/jvm/src/io/ktor/client/plugins/gson/GsonSerializer.kt
@@ -15,7 +15,7 @@ import io.ktor.utils.io.core.*
 /**
  * [JsonSerializer] using [Gson] as backend.
  */
-@Deprecated("Please use ContentNegotiation plugin and its converters")
+@Deprecated("Please use ContentNegotiation plugin and its converters: https://ktor.io/docs/migrating-2.html#serialization-client")
 public class GsonSerializer(block: GsonBuilder.() -> Unit = {}) : JsonSerializer {
     private val backend: Gson = GsonBuilder().apply(block).create()
 

--- a/ktor-client/ktor-client-plugins/ktor-client-json/ktor-client-gson/jvm/src/io/ktor/client/plugins/gson/GsonSerializer.kt
+++ b/ktor-client/ktor-client-plugins/ktor-client-json/ktor-client-gson/jvm/src/io/ktor/client/plugins/gson/GsonSerializer.kt
@@ -15,7 +15,7 @@ import io.ktor.utils.io.core.*
 /**
  * [JsonSerializer] using [Gson] as backend.
  */
-@Deprecated("Please use ContentNegotiation plugin and its converters: https://ktor.io/docs/migrating-2.html#serialization-client")
+@Deprecated("Please use ContentNegotiation plugin and its converters: https://ktor.io/docs/migrating-2.html#serialization-client") // ktlint-disable max-line-length
 public class GsonSerializer(block: GsonBuilder.() -> Unit = {}) : JsonSerializer {
     private val backend: Gson = GsonBuilder().apply(block).create()
 

--- a/ktor-client/ktor-client-plugins/ktor-client-json/ktor-client-jackson/jvm/src/io/ktor/client/plugins/jackson/JacksonSerializer.kt
+++ b/ktor-client/ktor-client-plugins/ktor-client-json/ktor-client-jackson/jvm/src/io/ktor/client/plugins/jackson/JacksonSerializer.kt
@@ -15,7 +15,7 @@ import io.ktor.util.reflect.*
 import io.ktor.utils.io.core.*
 
 @Deprecated(
-    "Please use ContentNegotiation plugin and its converters: https://ktor.io/docs/migrating-2.html#serialization-client"
+    "Please use ContentNegotiation plugin and its converters: https://ktor.io/docs/migrating-2.html#serialization-client" // ktlint-disable max-line-length
 )
 public class JacksonSerializer(
     jackson: ObjectMapper = jacksonObjectMapper(),

--- a/ktor-client/ktor-client-plugins/ktor-client-json/ktor-client-jackson/jvm/src/io/ktor/client/plugins/jackson/JacksonSerializer.kt
+++ b/ktor-client/ktor-client-plugins/ktor-client-json/ktor-client-jackson/jvm/src/io/ktor/client/plugins/jackson/JacksonSerializer.kt
@@ -15,7 +15,7 @@ import io.ktor.util.reflect.*
 import io.ktor.utils.io.core.*
 
 @Deprecated(
-    "Please use ContentNegotiation plugin and its converters"
+    "Please use ContentNegotiation plugin and its converters: https://ktor.io/docs/migrating-2.html#serialization-client"
 )
 public class JacksonSerializer(
     jackson: ObjectMapper = jacksonObjectMapper(),

--- a/ktor-client/ktor-client-plugins/ktor-client-json/ktor-client-serialization/common/src/io/ktor/client/plugins/kotlinx/serializer/KotlinxSerializer.kt
+++ b/ktor-client/ktor-client-plugins/ktor-client-json/ktor-client-serialization/common/src/io/ktor/client/plugins/kotlinx/serializer/KotlinxSerializer.kt
@@ -19,7 +19,9 @@ import kotlinx.serialization.modules.*
 /**
  * A [JsonSerializer] implemented for kotlinx [Serializable] classes.
  */
-@Deprecated("Please use ContentNegotiation plugin and its converters: https://ktor.io/docs/migrating-2.html#serialization-client") // ktlint-disable max-line-length
+@Deprecated(
+    "Please use ContentNegotiation plugin and its converters: https://ktor.io/docs/migrating-2.html#serialization-client" // ktlint-disable max-line-length
+)
 public class KotlinxSerializer(
     private val json: Json = DefaultJson
 ) : JsonSerializer {

--- a/ktor-client/ktor-client-plugins/ktor-client-json/ktor-client-serialization/common/src/io/ktor/client/plugins/kotlinx/serializer/KotlinxSerializer.kt
+++ b/ktor-client/ktor-client-plugins/ktor-client-json/ktor-client-serialization/common/src/io/ktor/client/plugins/kotlinx/serializer/KotlinxSerializer.kt
@@ -19,7 +19,7 @@ import kotlinx.serialization.modules.*
 /**
  * A [JsonSerializer] implemented for kotlinx [Serializable] classes.
  */
-@Deprecated("Please use ContentNegotiation plugin and its converters: https://ktor.io/docs/migrating-2.html#serialization-client")
+@Deprecated("Please use ContentNegotiation plugin and its converters: https://ktor.io/docs/migrating-2.html#serialization-client") // ktlint-disable max-line-length
 public class KotlinxSerializer(
     private val json: Json = DefaultJson
 ) : JsonSerializer {

--- a/ktor-client/ktor-client-plugins/ktor-client-json/ktor-client-serialization/common/src/io/ktor/client/plugins/kotlinx/serializer/KotlinxSerializer.kt
+++ b/ktor-client/ktor-client-plugins/ktor-client-json/ktor-client-serialization/common/src/io/ktor/client/plugins/kotlinx/serializer/KotlinxSerializer.kt
@@ -19,7 +19,7 @@ import kotlinx.serialization.modules.*
 /**
  * A [JsonSerializer] implemented for kotlinx [Serializable] classes.
  */
-@Deprecated("Please use ContentNegotiation plugin and its converters")
+@Deprecated("Please use ContentNegotiation plugin and its converters: https://ktor.io/docs/migrating-2.html#serialization-client")
 public class KotlinxSerializer(
     private val json: Json = DefaultJson
 ) : JsonSerializer {

--- a/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/routing/Routing.kt
+++ b/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/routing/Routing.kt
@@ -32,7 +32,7 @@ public class Routing(
 
     /**
      * Register a route resolution trace function.
-     * See https://ktor.io/servers/plugins/routing.html#tracing for details
+     * See https://ktor.io/docs/tracing-routes.html for details
      */
     public fun trace(block: (RoutingResolveTrace) -> Unit) {
         tracers.add(block)

--- a/ktor-server/ktor-server-plugins/ktor-server-hsts/jvmAndNix/src/io/ktor/server/plugins/hsts/HSTS.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-hsts/jvmAndNix/src/io/ktor/server/plugins/hsts/HSTS.kt
@@ -44,7 +44,7 @@ internal const val DEFAULT_HSTS_MAX_AGE: Long = 365L * 24 * 3600 // 365 days
 
 /**
  * HSTS plugin that appends `Strict-Transport-Security` HTTP header to every response.
- * See http://ktor.io/servers/features/hsts.html for details
+ * See https://ktor.io/docs/hsts.html for details
  * See RFC 6797 https://tools.ietf.org/html/rfc6797
  */
 public val HSTS: RouteScopedPlugin<HSTSConfig> = createRouteScopedPlugin("HSTS", ::HSTSConfig) {

--- a/ktor-server/ktor-server-plugins/ktor-server-metrics/jvm/src/io/ktor/server/metrics/dropwizard/DropwizardMetrics.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-metrics/jvm/src/io/ktor/server/metrics/dropwizard/DropwizardMetrics.kt
@@ -35,7 +35,7 @@ public class DropwizardMetricsConfig {
 }
 
 /**
- * Dropwizard metrics support plugin. See https://ktor.io/servers/features/metrics.html for details.
+ * Dropwizard metrics support plugin. See https://ktor.io/docs/dropwizard-metrics.html for details.
  */
 public val DropwizardMetrics: ApplicationPlugin<DropwizardMetricsConfig> =
     createApplicationPlugin("DropwizardMetrics", ::DropwizardMetricsConfig) {

--- a/ktor-server/ktor-server-test-host/jvmAndNix/src/io/ktor/server/testing/TestEngine.kt
+++ b/ktor-server/ktor-server-test-host/jvmAndNix/src/io/ktor/server/testing/TestEngine.kt
@@ -43,7 +43,7 @@ public fun TestApplicationEngine.handleRequest(
 /**
  * Starts a test application engine, passes it to the [test] function and stops it
  */
-@Deprecated("Please use new `testApplication` API")
+@Deprecated("Please use new `testApplication` API: https://ktor.io/docs/migrating-2.html#testing-api")
 public fun <R> withApplication(
     environment: ApplicationEngineEnvironment = createTestEnvironment(),
     configure: TestApplicationEngine.Configuration.() -> Unit = {},
@@ -61,7 +61,7 @@ public fun <R> withApplication(
 /**
  * Starts a test application engine, passes it to the [test] function and stops it
  */
-@Deprecated("Please use new `testApplication` API")
+@Deprecated("Please use new `testApplication` API: https://ktor.io/docs/migrating-2.html#testing-api")
 public fun <R> withTestApplication(test: TestApplicationEngine.() -> R): R {
     return withApplication(createTestEnvironment(), test = test)
 }
@@ -69,7 +69,7 @@ public fun <R> withTestApplication(test: TestApplicationEngine.() -> R): R {
 /**
  * Starts a test application engine, passes it to the [test] function and stops it
  */
-@Deprecated("Please use new `testApplication` API")
+@Deprecated("Please use new `testApplication` API: https://ktor.io/docs/migrating-2.html#testing-api")
 public fun <R> withTestApplication(moduleFunction: Application.() -> Unit, test: TestApplicationEngine.() -> R): R {
     return withApplication(createTestEnvironment()) {
         moduleFunction(application)
@@ -80,7 +80,7 @@ public fun <R> withTestApplication(moduleFunction: Application.() -> Unit, test:
 /**
  * Starts a test application engine, passes it to the [test] function and stops it
  */
-@Deprecated("Please use new `testApplication` API")
+@Deprecated("Please use new `testApplication` API: https://ktor.io/docs/migrating-2.html#testing-api")
 public fun <R> withTestApplication(
     moduleFunction: Application.() -> Unit,
     configure: TestApplicationEngine.Configuration.() -> Unit = {},


### PR DESCRIPTION
Added links to a migration guide for some deprecated members.
Note that these links will work AFTER releasing v2.0.0 as currently a migration guide is only available under https://ktor.io/docs/eap.