### PR TITLE
KTOR-695 Remove content-type from unsafe headers (#882)

### DIFF
--- a/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/HeadersTest.kt
+++ b/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/HeadersTest.kt
@@ -77,7 +77,6 @@ class HeadersTest : ClientLoader() {
             try {
                 client.get("$TEST_SERVER/headers") {
                     header(HttpHeaders.ContentLength, 0)
-                    header(HttpHeaders.ContentType, ContentType.Application.Json)
                     header(HttpHeaders.TransferEncoding, "chunked")
                     header(HttpHeaders.Upgrade, "upgrade")
                 }
@@ -89,6 +88,44 @@ class HeadersTest : ClientLoader() {
                 "Header(s) ${HttpHeaders.UnsafeHeadersList} are controlled by the engine and cannot be set explicitly"
 
             assertEquals(expected, message)
+        }
+    }
+
+    @Test
+    fun testContentTypeHeaderOverride() = clientTests {
+        test { client ->
+            val body = "test"
+            client.post("$TEST_SERVER/headers/content-type") {
+                contentType(ContentType.Application.FormUrlEncoded)
+                setBody(body)
+            }.let {
+                assertEquals(HttpStatusCode.OK, it.status)
+                assertEquals("application/x-www-form-urlencoded", it.bodyAsText())
+            }
+
+            client.post("$TEST_SERVER/headers/content-type") {
+                contentType(ContentType.Application.Json)
+                setBody(body)
+            }.let {
+                assertEquals(HttpStatusCode.OK, it.status)
+                assertEquals("application/json", it.bodyAsText())
+            }
+
+            client.put("$TEST_SERVER/headers/content-type") {
+                contentType(ContentType.Application.FormUrlEncoded)
+                setBody(body)
+            }.let {
+                assertEquals(HttpStatusCode.OK, it.status)
+                assertEquals("application/x-www-form-urlencoded", it.bodyAsText())
+            }
+
+            client.put("$TEST_SERVER/headers/content-type") {
+                contentType(ContentType.Application.Json)
+                setBody(body)
+            }.let {
+                assertEquals(HttpStatusCode.OK, it.status)
+                assertEquals("application/json", it.bodyAsText())
+            }
         }
     }
 

--- a/ktor-client/ktor-client-tests/jvm/src/io/ktor/client/tests/utils/tests/Headers.kt
+++ b/ktor-client/ktor-client-tests/jvm/src/io/ktor/client/tests/utils/tests/Headers.kt
@@ -52,6 +52,16 @@ internal fun Application.headersTestServer() {
 
                 call.respond(HttpStatusCode.OK)
             }
+            route("/content-type") {
+                post {
+                    val message = call.request.header(HttpHeaders.ContentType) ?: ""
+                    call.respond(HttpStatusCode.OK, message)
+                }
+                put {
+                    val message = call.request.header(HttpHeaders.ContentType) ?: ""
+                    call.respond(HttpStatusCode.OK, message)
+                }
+            }
         }
 
         route("/headers-merge") {

--- a/ktor-http/common/src/io/ktor/http/HttpHeaders.kt
+++ b/ktor-http/common/src/io/ktor/http/HttpHeaders.kt
@@ -131,7 +131,7 @@ public object HttpHeaders {
      */
     public fun isUnsafe(header: String): Boolean = UnsafeHeadersArray.any { it.equals(header, ignoreCase = true) }
 
-    private val UnsafeHeadersArray: Array<String> = arrayOf(ContentLength, ContentType, TransferEncoding, Upgrade)
+    private val UnsafeHeadersArray: Array<String> = arrayOf(ContentLength, TransferEncoding, Upgrade)
 
     @Deprecated("Use UnsafeHeadersList instead.", replaceWith = ReplaceWith("HttpHeaders.UnsafeHeadersList"))
     public val UnsafeHeaders: Array<String>


### PR DESCRIPTION
**Subsystem**
ktor-client, ktor-http

**Motivation**
https://youtrack.jetbrains.com/issue/KTOR-695

As it's mentioned in the link above, in some cases we need to override `Content-Type` header.
`contentType` can't be set in this code because it's included in `usafeHeaders` and it will throw `UnsafeHeaderException`.

```kotlin 
client.post("url") {
    contentType(ContentType.Application.FormUrlEncoded)
    setBody("test")
}
```
**Solution**
To override the `Content-Type`, It needs to be removed from `unsafeHeaders`.

