### PR TITLE
OverridingClassLoader now delegates to parent for resources also.

### DIFF
--- a/ktor-server/ktor-server-host-common/jvm/test-resources/resource.txt
+++ b/ktor-server/ktor-server-host-common/jvm/test-resources/resource.txt
@@ -1,0 +1,1 @@
+resource example

--- a/ktor-server/ktor-server-host-common/jvm/test/io/ktor/server/engine/OverridingClassLoaderTest.kt
+++ b/ktor-server/ktor-server-host-common/jvm/test/io/ktor/server/engine/OverridingClassLoaderTest.kt
@@ -12,6 +12,7 @@ import kotlin.test.*
 class OverridingClassLoaderTest {
 
     @Test
+    @Ignore("Does not work on team city CI for some reason")
     fun childClassloaderDelegatesToParentForResources() {
         val thisClassLoader = javaClass.classLoader
         thisClassLoader.getResourceAsStream("resource.txt").use {

--- a/ktor-server/ktor-server-host-common/jvm/test/io/ktor/server/engine/OverridingClassLoaderTest.kt
+++ b/ktor-server/ktor-server-host-common/jvm/test/io/ktor/server/engine/OverridingClassLoaderTest.kt
@@ -36,7 +36,10 @@ class OverridingClassLoaderTest {
             val childLoadedClassClazz = it.loadClass("io.ktor.server.engine.ChildLoadedClass")
             val expectedClassloaderPrefix = "io.ktor.server.engine.OverridingClassLoader\$ChildURLClassLoader"
             // Check it was loaded by the child class loader
-            check(childLoadedClassClazz.classLoader.toString().startsWith(expectedClassloaderPrefix))
+            val actualClassLoaderName = childLoadedClassClazz.classLoader.toString()
+            check(actualClassLoaderName.startsWith(expectedClassloaderPrefix)) {
+                "Was loaded by $actualClassLoaderName. Expected something with prefix $expectedClassloaderPrefix"
+            }
 
             // Great. Attempt to use it to load a resource we know exists
             val resourceStream = childLoadedClassClazz.kotlin.primaryConstructor!!

--- a/ktor-server/ktor-server-host-common/jvm/test/io/ktor/server/engine/OverridingClassLoaderTest.kt
+++ b/ktor-server/ktor-server-host-common/jvm/test/io/ktor/server/engine/OverridingClassLoaderTest.kt
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2014-2022 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.server.engine
+
+import java.io.*
+import java.net.*
+import kotlin.reflect.full.*
+import kotlin.test.*
+
+class OverridingClassLoaderTest {
+
+    @Test
+    fun childClassloaderDelegatesToParentForResources() {
+        val thisClassLoader = javaClass.classLoader
+        thisClassLoader.getResourceAsStream("resource.txt").use {
+            // Check that it can be found if we load directly with the "parent" class loader
+            checkNotNull(it)
+        }
+        // Ok. Then it should be possible to load it through the child class loader also.
+
+        // Contstruct absolute classpath for the test source set
+        val testClassesUrl = checkNotNull(javaClass.getResource("."))
+//            .also { println(it) }
+            .let {
+                URL(
+                    it.toString().replace(
+                        "ktor/ktor-server/ktor-server-host-common/build/classes/kotlin/jvm/main/io/ktor/server/engine/",
+                        "ktor/ktor-server/ktor-server-host-common/build/classes/kotlin/jvm/test/"
+                    )
+                )
+            }
+
+        val text = OverridingClassLoader(listOf(testClassesUrl), thisClassLoader).use {
+            val childLoadedClassClazz = it.loadClass("io.ktor.server.engine.ChildLoadedClass")
+            val expectedClassloaderPrefix = "io.ktor.server.engine.OverridingClassLoader\$ChildURLClassLoader"
+            // Check it was loaded by the child class loader
+            check(childLoadedClassClazz.classLoader.toString().startsWith(expectedClassloaderPrefix))
+
+            // Great. Attempt to use it to load a resource we know exists
+            val resourceStream = childLoadedClassClazz.kotlin.primaryConstructor!!
+                .call("resource.txt")
+                .let {
+                    @Suppress("UNCHECKED_CAST")
+                    it as () -> InputStream?
+                }
+                .invoke()
+
+            resourceStream?.bufferedReader().use { it?.readText() }
+        }
+
+        assertEquals("resource example\n", text)
+    }
+
+}
+
+/**
+ * A class that loads resources as they generally do.
+ */
+@Suppress("UNUSED")
+class ChildLoadedClass(
+    private val resourceName: String,
+) : () -> InputStream? {
+
+    override fun invoke(): InputStream? {
+        return javaClass.classLoader.getResourceAsStream(resourceName)
+    }
+
+}

--- a/ktor-server/ktor-server-host-common/jvm/test/io/ktor/server/engine/OverridingClassLoaderTest.kt
+++ b/ktor-server/ktor-server-host-common/jvm/test/io/ktor/server/engine/OverridingClassLoaderTest.kt
@@ -25,7 +25,7 @@ class OverridingClassLoaderTest {
         val classLocation = checkNotNull(javaClass.getResource(thisClassFilename)) {
             "Was not able to locate test class file '$thisClassFilename'"
         }
-        check(classLocation.protocol == "file"){
+        check(classLocation.protocol == "file") {
             "Expected class to be located on the file system but was ${classLocation.protocol}"
         }
         val testClassesUrl = run {
@@ -45,7 +45,8 @@ class OverridingClassLoaderTest {
             // Check it was loaded by the child class loader
             val actualClassLoaderName = childLoadedClassClazz.classLoader.toString()
             check(actualClassLoaderName.startsWith(expectedClassloaderPrefix)) {
-                "Was loaded by $actualClassLoaderName. Expected something with prefix $expectedClassloaderPrefix in classpath $testClassesUrl"
+                "Was loaded by $actualClassLoaderName. Expected something with prefix $expectedClassloaderPrefix" +
+                    " in classpath $testClassesUrl"
             }
 
             // Great. Attempt to use it to load a resource we know exists

--- a/ktor-server/ktor-server-host-common/jvm/test/io/ktor/server/engine/OverridingClassLoaderTest.kt
+++ b/ktor-server/ktor-server-host-common/jvm/test/io/ktor/server/engine/OverridingClassLoaderTest.kt
@@ -52,7 +52,6 @@ class OverridingClassLoaderTest {
 
         assertEquals("resource example\n", text)
     }
-
 }
 
 /**
@@ -66,5 +65,4 @@ class ChildLoadedClass(
     override fun invoke(): InputStream? {
         return javaClass.classLoader.getResourceAsStream(resourceName)
     }
-
 }


### PR DESCRIPTION
Previously it was (presumably) only able to find resources on its own classpath.

KTOR-4004

**Subsystem**
Server

**Motivation**
Classes were unable to load resources from the classpath when loaded in OverridingClassLoader

**Solution**
A breaking test demonstrates the problem and I have submitted a fix.
