### PR TITLE
KTOR-3945 Fix OAuth scopes encoded to %2B

### DIFF
--- a/ktor-server/ktor-server-plugins/ktor-server-auth/jvm/src/io/ktor/server/auth/OAuth2.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-auth/jvm/src/io/ktor/server/auth/OAuth2.kt
@@ -142,7 +142,7 @@ private suspend fun ApplicationCall.redirectAuthenticateOAuth2(
         append(OAuth2RequestParameters.ClientId, clientId)
         append(OAuth2RequestParameters.RedirectUri, callbackRedirectUrl)
         if (scopes.isNotEmpty()) {
-            append(OAuth2RequestParameters.Scope, scopes.joinToString("+"))
+            append(OAuth2RequestParameters.Scope, scopes.joinToString(" "))
         }
         append(OAuth2RequestParameters.State, state)
         append(OAuth2RequestParameters.ResponseType, "code")

--- a/ktor-server/ktor-server-plugins/ktor-server-auth/jvm/test/io/ktor/tests/auth/OAuth2Test.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-auth/jvm/test/io/ktor/tests/auth/OAuth2Test.kt
@@ -220,7 +220,7 @@ class OAuth2Test {
         assertEquals("/authorize", url.path)
         assertEquals("login-server-com", url.host)
 
-        val query = parseQueryString(url.query)
+        val query = parseQueryString(url.rawQuery)
         assertEquals("clientId1", query[OAuth2RequestParameters.ClientId])
         assertEquals("code", query[OAuth2RequestParameters.ResponseType])
         assertNotNull(query[OAuth2RequestParameters.State])
@@ -242,7 +242,7 @@ class OAuth2Test {
         assertEquals("/authorize", url.path)
         assertEquals("login-server-com", url.host)
 
-        val query = parseQueryString(url.query)
+        val query = parseQueryString(url.rawQuery)
         assertEquals("clientId1", query[OAuth2RequestParameters.ClientId])
         assertEquals("code", query[OAuth2RequestParameters.ResponseType])
         assertNotNull(query[OAuth2RequestParameters.State])
@@ -265,7 +265,7 @@ class OAuth2Test {
         assertEquals("/authorize", url.path)
         assertEquals("login-server-com", url.host)
 
-        val query = parseQueryString(url.query)
+        val query = parseQueryString(url.rawQuery)
         assertEquals("clientId1", query[OAuth2RequestParameters.ClientId])
         assertEquals("code", query[OAuth2RequestParameters.ResponseType])
         assertNotNull(query[OAuth2RequestParameters.State])


### PR DESCRIPTION
**Subsystem**
Server, OAuth2 module.

**Motivation**
See KTOR-3945

**Solution**
Separate scopes with space. These are encoded to "+" by the URL encoder. (Generally encoding to "%20" is also acceptable, so I'm not going to test that here.)

Also fix the tests that were failing to catch this due to accidental double-decoding of query string.

Question: Can we catch these double-decoding errors systematically? IDE inspections? Type-level guards?
