### PR TITLE
KTOR-4028 Fix Compression plugin memory leak

### DIFF
--- a/ktor-utils/jvm/src/io/ktor/util/Deflater.kt
+++ b/ktor-utils/jvm/src/io/ktor/util/Deflater.kt
@@ -54,15 +54,14 @@ private suspend fun ByteWriteChannel.deflateWhile(deflater: Deflater, buffer: By
 }
 
 /**
- * Launch a coroutine on [coroutineContext] that does deflate compression
+ * Does deflate compression
  * optionally doing CRC and writing GZIP header and trailer if [gzip] = `true`
  */
-@OptIn(DelicateCoroutinesApi::class)
-public fun ByteReadChannel.deflated(
+private suspend fun ByteReadChannel.deflateTo(
+    destination: ByteWriteChannel,
     gzip: Boolean = true,
-    pool: ObjectPool<ByteBuffer> = KtorDefaultPool,
-    coroutineContext: CoroutineContext = Dispatchers.Unconfined
-): ByteReadChannel = GlobalScope.writer(coroutineContext, autoFlush = true) {
+    pool: ObjectPool<ByteBuffer> = KtorDefaultPool
+) {
     val crc = CRC32()
     val deflater = Deflater(Deflater.DEFAULT_COMPRESSION, true)
     val input = pool.borrow()
@@ -70,7 +69,7 @@ public fun ByteReadChannel.deflated(
 
     try {
         if (gzip) {
-            channel.putGzipHeader()
+            destination.putGzipHeader()
         }
 
         while (!isClosedForRead) {
@@ -80,22 +79,35 @@ public fun ByteReadChannel.deflated(
 
             crc.updateKeepPosition(input)
             deflater.setInputBuffer(input)
-            channel.deflateWhile(deflater, compressed) { !deflater.needsInput() }
+            destination.deflateWhile(deflater, compressed) { !deflater.needsInput() }
         }
 
         closedCause?.let { throw it }
 
         deflater.finish()
-        channel.deflateWhile(deflater, compressed) { !deflater.finished() }
+        destination.deflateWhile(deflater, compressed) { !deflater.finished() }
 
         if (gzip) {
-            channel.putGzipTrailer(crc, deflater)
+            destination.putGzipTrailer(crc, deflater)
         }
     } finally {
         deflater.end()
         pool.recycle(input)
         pool.recycle(compressed)
     }
+}
+
+/**
+ * Launch a coroutine on [coroutineContext] that does deflate compression
+ * optionally doing CRC and writing GZIP header and trailer if [gzip] = `true`
+ */
+@OptIn(DelicateCoroutinesApi::class)
+public fun ByteReadChannel.deflated(
+    gzip: Boolean = true,
+    pool: ObjectPool<ByteBuffer> = KtorDefaultPool,
+    coroutineContext: CoroutineContext = Dispatchers.Unconfined
+): ByteReadChannel = GlobalScope.writer(coroutineContext, autoFlush = true) {
+    this@deflated.deflateTo(channel, gzip, pool)
 }.channel
 
 /**
@@ -108,5 +120,5 @@ public fun ByteWriteChannel.deflated(
     pool: ObjectPool<ByteBuffer> = KtorDefaultPool,
     coroutineContext: CoroutineContext = Dispatchers.Unconfined
 ): ByteWriteChannel = GlobalScope.reader(coroutineContext, autoFlush = true) {
-    channel.deflated(gzip, pool, coroutineContext).copyTo(this@deflated)
+    channel.deflateTo(this@deflated, gzip, pool)
 }.channel


### PR DESCRIPTION
**Subsystem**
Utils

**Motivation**
The Deflater implementation is causing memory leaks when the response channel gets closed (for example when a peer resets the connection) and the gzipped content is larger than the ByteBufferChannel backing buffer (4088). More details in the YT ticket: https://youtrack.jetbrains.com/issue/KTOR-4028

**Solution**
Refactored the `ByteWriteChannel.deflated` method to not use an intermediary channel, but instead to write the compressed body directly into the response channel. This will fix the memory leak and maybe at the same time bring also a small performance improvement by not needing to spawn an extra coroutine and an extra copy across buffers.

Another solution could have been to pass the coroutineContext of the first coroutine to the second one, instead of the coroutineContext received as parameter: 

```kotlin
public fun ByteWriteChannel.deflated(
    ..,
    coroutineContext: CoroutineContext = Dispatchers.Unconfined
): ByteWriteChannel = GlobalScope.reader(coroutineContext, autoFlush = true) {
    // Use this.coroutineContext to not break parent-child relationship
    channel.deflated(gzip, pool, this.coroutineContext).copyTo(this@deflated)
}.channel
```
Through this when the coroutine started by `GlobalScope.reader` would have finished it would have cancelled the one started by `channel.deflated(...)`, but I think the refactor is a better approach. 
