### PR TITLE
[PROTOTYPE] CIO server HTTPS support

### DIFF
--- a/ktor-network/ktor-network-tls/build.gradle.kts
+++ b/ktor-network/ktor-network-tls/build.gradle.kts
@@ -1,16 +1,40 @@
 val netty_version: String by project.extra
 
-kotlin.sourceSets {
-    jvmAndNixMain {
-        dependencies {
-            api(project(":ktor-network"))
-            api(project(":ktor-utils"))
+kotlin {
+    jvm {
+        testRuns.all {
+            executionTask.get().apply {
+//                systemProperty("javax.net.debug", "all") //debug ssl engine
+            }
         }
     }
-    jvmTest {
-        dependencies {
-            api(project(":ktor-network:ktor-network-tls:ktor-network-tls-certificates"))
-            api("io.netty:netty-handler:$netty_version")
+
+    val paths = listOf(
+        "/usr/include",
+        "/usr/include/x86_64-linux-gnu"
+    )
+    nixTargets().forEach {
+        val main by it.compilations.getting {
+            val openssl by cinterops.creating {
+                defFile(project.file("nix/interop/openssl.def"))
+                compilerOpts(paths.map { "-I$it" })
+                includeDirs.allHeaders(paths)
+            }
+        }
+    }
+
+    sourceSets {
+        jvmAndNixMain {
+            dependencies {
+                api(project(":ktor-network"))
+                api(project(":ktor-utils"))
+            }
+        }
+        jvmTest {
+            dependencies {
+                api(project(":ktor-network:ktor-network-tls:ktor-network-tls-certificates"))
+                api("io.netty:netty-handler:$netty_version")
+            }
         }
     }
 }

--- a/ktor-network/ktor-network-tls/jvm/src/io/ktor/network/tls/Ssl.kt
+++ b/ktor-network/ktor-network-tls/jvm/src/io/ktor/network/tls/Ssl.kt
@@ -1,0 +1,354 @@
+/*
+ * Copyright 2014-2022 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.network.tls
+
+import io.ktor.network.sockets.*
+import io.ktor.util.*
+import io.ktor.utils.io.*
+import kotlinx.atomicfu.*
+import kotlinx.coroutines.*
+import kotlinx.coroutines.sync.*
+import java.nio.*
+import javax.net.ssl.*
+import kotlin.coroutines.*
+
+@InternalAPI
+public fun Socket.ssl(
+    coroutineContext: CoroutineContext,
+    engine: SSLEngine
+): Socket = SslSocket(this, engine, coroutineContext)
+
+private class SslSocket(
+    private val socket: Socket,
+    private val engine: SSLEngine,
+    override val coroutineContext: CoroutineContext
+) : Socket, CoroutineScope {
+    private val closed = atomic(false)
+    private val lock = Mutex()
+
+    private val buffers = Buffers(engine)
+    private val wrapper = Wrapper(engine, buffers, socket.openWriteChannel())
+    private val unwrapper = Unwrapper(engine, buffers, socket.openReadChannel())
+
+    override val socketContext: Job get() = socket.socketContext
+    override val remoteAddress: SocketAddress get() = socket.remoteAddress
+    override val localAddress: SocketAddress get() = socket.localAddress
+
+    override fun attachForReading(channel: ByteChannel): WriterJob =
+        writer(CoroutineName("cio-ssl-input"), channel) {
+            var error: Throwable? = null
+            try {
+                var destination = buffers.allocateApplication(0)
+                loop@ while (true) {
+                    destination.clear()
+                    //println("READING_BEFORE_UNWRAP: $destination")
+                    val result = unwrapper.readAndUnwrap(destination) { destination = it } ?: break@loop
+                    //println("READING_AFTER_UNWRAP: $destination")
+                    destination.flip()
+                    //println("READING_WRITE_BEFORE: $destination")
+                    if (destination.remaining() > 0) {
+                        this.channel.writeFully(destination)
+                        this.channel.flush()
+                    }
+                    //println("READING_WRITE_AFTER: $destination")
+
+                    handleResult(result)
+                    if (result.status == SSLEngineResult.Status.CLOSED) break@loop
+                }
+            } catch (cause: Throwable) {
+                error = cause
+                throw cause
+            } finally {
+                //println(error)
+                unwrapper.cancel(error)
+                engine.closeOutbound()
+                doClose(error)
+            }
+        }
+
+    @Suppress("BlockingMethodInNonBlockingContext")
+    override fun attachForWriting(channel: ByteChannel): ReaderJob =
+        reader(CoroutineName("cio-ssl-output"), channel) {
+            var error: Throwable? = null
+            try {
+                val source = buffers.allocateApplication(0)
+                loop@ while (true) {
+                    source.clear()
+                    //println("WRITING_READ_BEFORE: $source")
+                    if (this.channel.readAvailable(source) == -1) break@loop
+                    //println("WRITING_READ_AFTER: $source")
+                    source.flip()
+                    //println("WRITING_BEFORE_SOURCE: $source")
+                    while (source.remaining() > 0) {
+                        //println("WRITING_BEFORE_WRAP: $source")
+                        val result = wrapper.wrapAndWrite(source)
+                        //println("WRITING_AFTER_WRAP: $source")
+
+                        handleResult(result)
+                        if (result.status == SSLEngineResult.Status.CLOSED) break@loop
+                    }
+                }
+            } catch (cause: Throwable) {
+                error = cause
+                throw cause
+            } finally {
+                //println(error)
+                engine.closeInbound() //TODO: when this should be called???
+                doClose(error)
+            }
+        }
+
+    //TODO proper close implementation?
+    override fun close() {
+        engine.closeOutbound()
+        if (isActive) launch {
+            doClose(null)
+        } else {
+            if (closed.compareAndSet(expect = false, update = true)) socket.close()
+        }
+    }
+
+    private suspend fun handleResult(result: SSLEngineResult) {
+        if (result.status == SSLEngineResult.Status.CLOSED) {
+            doClose(null)
+            return
+        }
+        if (result.handshakeStatus.needHandshake) {
+            doHandshake(result.handshakeStatus)
+        }
+    }
+
+    private suspend fun doClose(cause: Throwable?) = lock.withLock {
+        if (closed.compareAndSet(expect = false, update = true)) {
+            socket.use {
+                wrapper.close(cause)
+            }
+        }
+    }
+
+    private suspend fun doHandshake(initialStatus: SSLEngineResult.HandshakeStatus) = lock.withLock {
+        var temp = buffers.allocateApplication(0)
+        var status = initialStatus
+        while (true) {
+            //println("HANDSHAKE: $status")
+            when (status) {
+                SSLEngineResult.HandshakeStatus.NEED_TASK -> {
+                    coroutineScope {
+                        while (true) {
+                            val task = engine.delegatedTask ?: break
+                            launch(Dispatchers.IO) { task.run() }
+                        }
+                    }
+                    status = engine.handshakeStatus
+                }
+                SSLEngineResult.HandshakeStatus.NEED_WRAP -> {
+                    temp.clear()
+                    temp.flip()
+                    //println("HANDSHAKE: wrapAndWrite")
+                    status = wrapper.wrapAndWrite(temp).handshakeStatus
+                }
+                SSLEngineResult.HandshakeStatus.NEED_UNWRAP -> {
+                    temp.clear()
+                    status = unwrapper.readAndUnwrap(temp) { temp = it }?.handshakeStatus ?: break
+                }
+                else -> break
+            }
+        }
+    }
+
+    private val SSLEngineResult.HandshakeStatus.needHandshake: Boolean
+        get() = this != SSLEngineResult.HandshakeStatus.FINISHED && this != SSLEngineResult.HandshakeStatus.NOT_HANDSHAKING
+
+    private class Buffers(private val engine: SSLEngine) {
+        private var packetBufferSize = 0
+        private var applicationBufferSize = 0
+
+        fun allocatePacket(length: Int): ByteBuffer = allocate(
+            length,
+            get = { packetBufferSize },
+            set = { packetBufferSize = it },
+            new = { engine.session.packetBufferSize }
+        )
+
+        fun allocateApplication(length: Int): ByteBuffer = allocate(
+            length,
+            get = { applicationBufferSize },
+            set = { applicationBufferSize = it },
+            new = { engine.session.applicationBufferSize }
+        )
+
+        fun reallocatePacket(buffer: ByteBuffer, flip: Boolean): ByteBuffer =
+            reallocate(buffer, flip, ::allocatePacket)
+
+        fun reallocateApplication(buffer: ByteBuffer, flip: Boolean): ByteBuffer =
+            reallocate(buffer, flip, ::allocateApplication)
+
+        private inline fun allocate(
+            length: Int,
+            get: () -> Int,
+            set: (Int) -> Unit,
+            new: () -> Int
+        ): ByteBuffer = synchronized(this) {
+            if (get() == 0) {
+                set(new())
+            }
+            if (length > get()) {
+                set(length)
+            }
+            return ByteBuffer.allocate(get())
+        }
+
+        private inline fun reallocate(
+            buffer: ByteBuffer,
+            flip: Boolean,
+            allocate: (length: Int) -> ByteBuffer
+        ): ByteBuffer {
+            val newSize = buffer.capacity() * 2
+            val new = allocate(newSize)
+            if (flip) {
+                new.flip()
+            }
+            new.put(buffer)
+            return new
+        }
+
+    }
+
+    private class Wrapper(
+        private val engine: SSLEngine,
+        private val buffers: Buffers,
+        private val writer: ByteWriteChannel
+    ) {
+        private val wrapLock = Mutex()
+        private var wrapDestination = buffers.allocatePacket(0)
+
+        @Suppress("BlockingMethodInNonBlockingContext")
+        suspend fun wrapAndWrite(wrapSource: ByteBuffer): SSLEngineResult = wrapLock.withLock {
+            wrapAndWriteX(wrapSource)
+        }
+
+        @Suppress("BlockingMethodInNonBlockingContext")
+        private suspend fun wrapAndWriteX(wrapSource: ByteBuffer): SSLEngineResult {
+            var result: SSLEngineResult
+            wrapDestination.clear()
+            while (true) {
+                //println("WRAP_BEFORE: $wrapDestination")
+                result = engine.wrap(wrapSource, wrapDestination)
+                //println("WRAP_RESULT: $result")
+                //println("WRAP_AFTER: $wrapDestination")
+                if (result.status != SSLEngineResult.Status.BUFFER_OVERFLOW) break
+                //println("WRAP_OVERFLOW: $wrapDestination")
+                wrapDestination = buffers.reallocatePacket(wrapDestination, flip = true)
+                //println("WRAP_OVERFLOW_REALLOCATE: $wrapDestination")
+            }
+            //println("WRAP_WRITE_BEFORE: $wrapDestination")
+            if (result.bytesProduced() > 0) {
+                wrapDestination.flip()
+                //println("WRAP_WRITE: $wrapDestination")
+                writer.writeFully(wrapDestination)
+                writer.flush()
+            }
+            //println("WRAP_WRITE_AFTER: $wrapDestination")
+            return result
+        }
+
+        suspend fun close(cause: Throwable?): SSLEngineResult = wrapLock.withLock {
+            //println("CLOSE: $cause")
+            val temp = buffers.allocateApplication(0)
+            var result: SSLEngineResult
+            do {
+                result = wrapAndWriteX(temp)
+            } while (
+                result.status != SSLEngineResult.Status.CLOSED &&
+                !(result.status == SSLEngineResult.Status.OK && result.handshakeStatus == SSLEngineResult.HandshakeStatus.NOT_HANDSHAKING)
+            )
+
+            writer.close(cause)
+
+            return result
+        }
+    }
+
+    private class Unwrapper(
+        private val engine: SSLEngine,
+        private val buffers: Buffers,
+        private val reader: ByteReadChannel
+    ) {
+        private val unwrapLock = Mutex()
+        private var unwrapSource = buffers.allocatePacket(0)
+        private var unwrapRemaining = 0
+
+        fun cancel(cause: Throwable?) {
+            reader.cancel(cause)
+        }
+
+        suspend inline fun readAndUnwrap(
+            initialUnwrapDestination: ByteBuffer,
+            updateUnwrapDestination: (ByteBuffer) -> Unit
+        ): SSLEngineResult? = unwrapLock.withLock {
+            var unwrapDestination: ByteBuffer = initialUnwrapDestination
+            var result: SSLEngineResult?
+
+            if (unwrapRemaining > 0) {
+                unwrapSource.compact()
+                unwrapSource.flip()
+            } else {
+                unwrapSource.clear()
+                if (!readData()) return@withLock null
+            }
+
+            //println("UNWRAP_INIT[DST]: $unwrapDestination")
+            //println("UNWRAP_INIT[SRC]: $unwrapSource")
+            while (true) {
+                //println("UNWRAP_BEFORE[DST]: $unwrapDestination")
+                //println("UNWRAP_BEFORE[SRC]: $unwrapSource")
+                result = engine.unwrap(unwrapSource, unwrapDestination)
+                //println("UNWRAP_RESULT: $result")
+                //println("UNWRAP_AFTER[DST]: $unwrapDestination")
+                //println("UNWRAP_AFTER[SRC]: $unwrapSource")
+
+                when (result.status!!) {
+                    SSLEngineResult.Status.BUFFER_UNDERFLOW -> {
+                        //println("UNWRAP_UNDERFLOW_BEFORE[SRC]: $unwrapSource")
+                        if (unwrapSource.limit() == unwrapSource.capacity()) {
+                            //println("UNWRAP_UNDERFLOW_1")
+                            //buffer is too small to read all needed data
+                            unwrapSource = buffers.reallocatePacket(unwrapSource, flip = false)
+                        } else {
+                            //println("UNWRAP_UNDERFLOW_2")
+                            //not all data received
+                            unwrapSource.position(unwrapSource.limit())
+                            unwrapSource.limit(unwrapSource.capacity())
+                        }
+                        //println("UNWRAP_UNDERFLOW_AFTER[SRC]: $unwrapSource")
+                        if (!readData()) return@withLock null
+                    }
+                    SSLEngineResult.Status.BUFFER_OVERFLOW -> {
+                        //println("UNWRAP_OVERFLOW_BEFORE[DST]: $unwrapDestination")
+                        unwrapDestination = buffers.reallocateApplication(unwrapDestination, flip = true)
+                        //println("UNWRAP_OVERFLOW_AFTER[DST]: $unwrapDestination")
+                    }
+                    else -> break
+                }
+            }
+            //println("UNWRAP_FINAL[DST]: $unwrapDestination")
+            //println("UNWRAP_FINAL[SRC]: $unwrapSource")
+            unwrapRemaining = unwrapSource.remaining()
+            if (unwrapDestination !== initialUnwrapDestination) updateUnwrapDestination(unwrapDestination)
+            result
+        }
+
+        private suspend fun readData(): Boolean {
+            //println("UNWRAP_READ_BEFORE[SRC]: $unwrapSource")
+            val read = reader.readAvailable(unwrapSource)
+            unwrapSource.flip()
+            //println("UNWRAP_READ_AFTER[SRC]: $unwrapSource")
+
+            //println("UNWRAP_READ_COMPLETE[SRC]: $unwrapSource")
+            return read != -1
+        }
+    }
+
+}

--- a/ktor-network/ktor-network-tls/jvm/src/io/ktor/network/tls/SslConfig.kt
+++ b/ktor-network/ktor-network-tls/jvm/src/io/ktor/network/tls/SslConfig.kt
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2014-2022 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.network.tls
+
+import io.ktor.network.sockets.*
+import io.ktor.util.*
+import java.security.*
+import javax.net.ssl.*
+import kotlin.coroutines.*
+import kotlin.time.*
+
+@InternalAPI
+public fun Socket.ssl(
+    coroutineContext: CoroutineContext,
+    config: SslConfig
+): Socket = TODO()
+
+public fun SslConfig(block: SslConfigBuilder.() -> Unit): SslConfig = TODO()
+
+public sealed interface SslConfig {
+    //TODO: what should be here
+}
+
+public sealed interface SslConfigBuilder {
+
+    public fun contextProvider(provider: Provider?)
+    public fun keyManager(factory: KeyManagerFactory?)
+    public fun trustManager(factory: TrustManagerFactory?)
+    public fun secureRandom(random: SecureRandom?)
+
+    public fun session(cacheSize: Int, timeout: Duration) //timeout should be in seconds
+
+    //delicate api
+    public fun parameters(block: SSLParameters.() -> Unit)
+}
+
+public sealed interface SslClientConfigBuilder : SslConfigBuilder {
+    public fun reuseSession(value: Boolean)
+}
+
+public sealed interface SslServerConfigBuilder : SslConfigBuilder {
+    public fun clientAuthType(value: SslClientAuthType)
+}
+
+public enum class SslClientAuthType {
+    NONE,           // turn off client authentication
+    OPTIONAL,       // need to request client authentication
+    REQUIRED        // require client authentication
+}

--- a/ktor-network/ktor-network-tls/jvmAndNix/src/io/ktor/network/tls/ssl.kt
+++ b/ktor-network/ktor-network-tls/jvmAndNix/src/io/ktor/network/tls/ssl.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2014-2022 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.network.tls
+
+import io.ktor.network.sockets.*
+import io.ktor.util.*
+import kotlin.coroutines.*
+
+@InternalAPI
+public expect fun SslContext(builder: TLSConfigBuilder): SslContext
+
+@InternalAPI
+public expect class SslContext() {
+    public fun createClientEngine(): SslEngine
+    public fun createClientEngine(peerHost: String, peerPort: Int): SslEngine
+
+    //TODO: client auth type
+    public fun createServerEngine(): SslEngine
+}
+
+@InternalAPI
+public expect abstract class SslEngine
+
+@InternalAPI
+public expect fun Socket.ssl(
+    coroutineContext: CoroutineContext,
+    engine: SslEngine
+): Socket
+
+@InternalAPI
+public expect fun Connection.ssl(
+    coroutineContext: CoroutineContext,
+    engine: SslEngine
+): Connection

--- a/ktor-network/ktor-network-tls/nix/interop/openssl.def
+++ b/ktor-network/ktor-network-tls/nix/interop/openssl.def
@@ -1,0 +1,4 @@
+package = openssl
+headers = openssl/ssl.h openssl/err.h
+headerFilter = openssl/*
+linkerOpts.linux = -L/home/oleg/IdeaProjects/learn/ktor/ktor-network/ktor-network-tls/nix/interop/libs/linux -lssl -lcrypto

--- a/ktor-network/ktor-network-tls/nix/src/io/ktor/network/tls/Ssl.kt
+++ b/ktor-network/ktor-network-tls/nix/src/io/ktor/network/tls/Ssl.kt
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2014-2022 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.network.tls
+
+import io.ktor.util.*
+import io.ktor.utils.io.*
+import kotlinx.atomicfu.locks.*
+import kotlinx.cinterop.*
+import openssl.*
+
+@OptIn(InternalAPI::class)
+internal class Ssl(private val ssl: CPointer<SSL>) : SslEngine() {
+    private val lock = SynchronizedObject()
+    fun attach(reader: ByteReadChannel, writer: ByteWriteChannel): SslPipe {
+        val output = BIO_new(BIO_s_mem())!!
+        val input = BIO_new(BIO_s_mem())!!
+        SSL_set_bio(s = ssl, rbio = output, wbio = input)
+        return SslPipe(reader, writer, input, output)
+    }
+
+    inline fun <T> write(
+        source: CPointer<ByteVar>, sourceOffset: Int, sourceLength: Int,
+        onSuccess: (consumed: Int) -> T,
+        onError: (error: SslError) -> T
+    ): T = ssl.operation({
+        //println("ENGINE.WRITE.SUCCESS: $it")
+        onSuccess(it)
+    }, {
+        //println("ENGINE.WRITE.ERROR: $it")
+        onError(it)
+    }) {
+        SSL_write(this, source + sourceOffset, sourceLength - sourceOffset)
+    }
+
+    internal inline fun <T> read(
+        destination: CPointer<ByteVar>, destinationOffset: Int, destinationLength: Int,
+        onSuccess: (produced: Int) -> T,
+        onError: (error: SslError) -> T
+    ): T = ssl.operation({
+        //println("ENGINE.READ.SUCCESS: $it")
+        onSuccess(it)
+    }, {
+        //println("ENGINE.READ.ERROR: $it")
+        onError(it)
+    }) {
+        SSL_read(this, destination + destinationOffset, destinationLength - destinationOffset)
+    }
+
+    private inline fun <T> CPointer<SSL>.operation(
+        onSuccess: (result: Int) -> T,
+        onError: (error: SslError) -> T,
+        block: CPointer<SSL>.() -> Int
+    ): T = lock.withLock {
+        ERR_clear_error()
+        val result = block(this)
+        if (result > 0) {
+            onSuccess(result)
+        } else {
+            onError(
+                when (val code = SSL_get_error(this, result)) {
+                    SSL_ERROR_NONE -> TODO("never")
+                    SSL_ERROR_SSL -> {
+                        val message = getSslErrorMessage()
+                        error("SSL error: $message")
+                    }
+                    SSL_ERROR_SYSCALL -> {
+                        val message = getSslErrorMessage()
+                        error("SSL SYSCALL error: $message")
+                    }
+                    else -> SslError(code)
+                }
+            )
+        }
+    }
+
+    private fun getSslErrorMessage(): String? = when (val errorCode = ERR_get_error()) {
+        0UL -> null
+        else -> memScoped {
+            val pointer = allocArray<ByteVar>(256)
+            ERR_error_string(errorCode, pointer)
+            pointer.toKString()
+        }
+    }
+}
+
+internal enum class SslError(private val code: Int) {
+    WantRead(SSL_ERROR_WANT_READ),
+    WantWrite(SSL_ERROR_WANT_WRITE),
+    WANT_ASYNC(SSL_ERROR_WANT_ASYNC),
+    WANT_ASYNC_JOB(SSL_ERROR_WANT_ASYNC_JOB),
+    WANT_CLIENT_HELLO_CB(SSL_ERROR_WANT_CLIENT_HELLO_CB),
+    WANT_X509_LOOKUP(SSL_ERROR_WANT_X509_LOOKUP),
+    Closed(SSL_ERROR_ZERO_RETURN);
+
+    //    WANT_ACCEPT(SSL_ERROR_WANT_ACCEPT),
+    //    WANT_CONNECT(SSL_ERROR_WANT_CONNECT),
+    companion object {
+        private val values: Array<SslError?>
+
+        init {
+            val enums = values()
+            val maxCode = enums.maxOf { it.code }
+            values = arrayOfNulls<SslError?>(maxCode + 1)
+            enums.forEach { values[it.code] = it }
+        }
+
+        operator fun invoke(code: Int): SslError = values[code] ?: error("Unknown code: $code")
+    }
+}

--- a/ktor-network/ktor-network-tls/nix/src/io/ktor/network/tls/SslNix.kt
+++ b/ktor-network/ktor-network-tls/nix/src/io/ktor/network/tls/SslNix.kt
@@ -1,0 +1,205 @@
+/*
+ * Copyright 2014-2022 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.network.tls
+
+import io.ktor.network.sockets.*
+import io.ktor.util.*
+import io.ktor.utils.io.*
+import io.ktor.utils.io.core.*
+import kotlinx.atomicfu.*
+import kotlinx.coroutines.*
+import kotlinx.coroutines.sync.*
+import openssl.*
+import kotlin.coroutines.*
+
+@InternalAPI
+public actual fun SslContext(builder: TLSConfigBuilder): SslContext = SslContext()
+
+@InternalAPI
+public actual class SslContext {
+    private val ctx = SSL_CTX_new(TLS_method())!!
+
+    init {
+        //TODO
+        SSL_CTX_set_verify(ctx, SSL_VERIFY_NONE, null)
+    }
+
+    public actual fun createClientEngine(): SslEngine {
+        val ssl = SSL_new(ctx)!!
+        SSL_set_connect_state(ssl)
+        return Ssl(ssl)
+    }
+
+    public actual fun createClientEngine(peerHost: String, peerPort: Int): SslEngine {
+        val ssl = SSL_new(ctx)!!
+        SSL_set_connect_state(ssl)
+        return Ssl(ssl)
+    }
+
+    public actual fun createServerEngine(): SslEngine {
+        TODO("Not yet implemented")
+    }
+
+}
+
+@InternalAPI
+public actual abstract class SslEngine
+
+@InternalAPI
+public actual fun Socket.ssl(
+    coroutineContext: CoroutineContext,
+    engine: SslEngine
+): Socket = SslSocket(
+    socket = this,
+    writer = openWriteChannel(),
+    reader = openReadChannel(),
+    engine = engine as Ssl,
+    coroutineContext = coroutineContext
+)
+
+@InternalAPI
+public actual fun Connection.ssl(
+    coroutineContext: CoroutineContext,
+    engine: SslEngine
+): Connection = SslSocket(socket, output, input, engine as Ssl, coroutineContext).connection()
+
+private class SslSocket(
+    private val socket: Socket,
+    writer: ByteWriteChannel,
+    reader: ByteReadChannel,
+    private val engine: Ssl,
+    override val coroutineContext: CoroutineContext
+) : Socket, CoroutineScope {
+    private val closed = atomic(false)
+    private val lock = Mutex()
+
+    override val socketContext: Job get() = socket.socketContext
+    override val remoteAddress: SocketAddress get() = socket.remoteAddress
+    override val localAddress: SocketAddress get() = socket.localAddress
+
+    private val pipe = engine.attach(reader, writer)
+
+    override fun attachForReading(channel: ByteChannel): WriterJob =
+        writer(CoroutineName("cio-ssl-input"), channel) {
+            var error: Throwable? = null
+            try {
+                do {
+                    val result = this.channel.write { destination, startOffset, endExclusive ->
+                        val destinationLength = (endExclusive - startOffset).toInt()
+                        //println("READING START: size=${destination.size} | offset=$startOffset | length=$destinationLength")
+                        if (destinationLength <= 0) {
+                            //println("READING STOP: NO MORE TO WRITE")
+                            return@write 0
+                        }
+                        var destinationOffset = startOffset.toInt()
+
+                        while (destinationLength - destinationOffset > 0) {
+                            //println("READING STEP: size=${destination.size} | offset=$destinationOffset | length=$destinationLength")
+                            val sslError = engine.read(
+                                destination.pointer, destinationOffset, destinationLength,
+                                onSuccess = {
+                                    destinationOffset += it //TODO: caps at 1378
+                                    null
+                                },
+                                onError = { it }
+                            )
+
+                            when (sslError) {
+                                null -> {}
+                                SslError.WantRead -> if (pipe.readAvailable() == 0) {
+                                    //println("READING STOP: NO MORE TO READ FROM SOCKET")
+                                    return@write 0
+                                }
+                                else -> TODO("READ_ERROR: $sslError")
+                            }
+                        }
+                        //println("READING STOP: size=${destination.size} | offset=$destinationOffset | length=$destinationLength")
+                        destinationOffset - startOffset.toInt()
+                    }
+                    this.channel.flush()
+                    //println("READING STEP RESULT: $result")
+                } while (result > 0)
+            } catch (cause: Throwable) {
+                error = cause
+                throw cause
+            } finally {
+                //println(error)
+//                unwrapper.cancel(error)
+//                engine.closeOutbound()
+//                doClose(error)
+            }
+        }
+
+    @Suppress("BlockingMethodInNonBlockingContext")
+    override fun attachForWriting(channel: ByteChannel): ReaderJob =
+        reader(CoroutineName("cio-ssl-output"), channel) {
+            var error: Throwable? = null
+            try {
+                do {
+                    val result = this@reader.channel.read { source, startOffset, endExclusive ->
+                        val sourceLength = (endExclusive - startOffset).toInt()
+                        //println("WRITING START: size=${source.size} | offset=$startOffset | length=$sourceLength")
+                        if (sourceLength <= 0) {
+                            //println("WRITING STOP: NO MORE TO READ")
+                            return@read 0
+                        }
+                        var sourceOffset = startOffset.toInt()
+
+                        while (sourceLength - sourceOffset > 0) {
+                            //println("WRITING STEP: size=${source.size} | offset=$sourceOffset | length=$sourceLength")
+                            val sslError = engine.write(
+                                source.pointer, sourceOffset, sourceLength,
+                                onSuccess = {
+                                    sourceOffset += it
+                                    null
+                                },
+                                onError = { it }
+                            )
+                            pipe.writeFully() //TODO?
+
+                            when (sslError) {
+                                null -> {}
+                                SslError.WantRead -> if (pipe.readAvailable() == 0) {
+                                    //println("WRITING STOP: NO MORE TO READ FROM SOCKET")
+                                    return@read 0
+                                }
+                                else -> TODO("WRITE_ERROR: $sslError")
+                            }
+                        }
+                        //println("WRITING STOP: size=${source.size} | offset=$sourceOffset | length=$sourceLength")
+                        sourceOffset - startOffset.toInt()
+                    }
+                    //println("WRITING STEP RESULT: $result")
+                } while (result > 0)
+            } catch (cause: Throwable) {
+                error = cause
+                throw cause
+            } finally {
+                //println(error)
+//                engine.closeInbound() //TODO: when this should be called???
+//                doClose(error)
+            }
+        }
+
+    //TODO proper close implementation?
+    override fun close() {
+//        engine.closeOutbound()
+//        if (isActive) launch {
+//            doClose(null)
+//        } else {
+//            if (closed.compareAndSet(expect = false, update = true)) socket.close()
+//        }
+    }
+
+    private suspend fun doClose(cause: Throwable?) = lock.withLock {
+        if (closed.compareAndSet(expect = false, update = true)) {
+            socket.use {
+//                wrapper.close(cause)
+            }
+        }
+    }
+
+
+}

--- a/ktor-network/ktor-network-tls/nix/src/io/ktor/network/tls/SslPipe.kt
+++ b/ktor-network/ktor-network-tls/nix/src/io/ktor/network/tls/SslPipe.kt
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2014-2022 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.network.tls
+
+import io.ktor.utils.io.*
+import kotlinx.atomicfu.locks.*
+import kotlinx.cinterop.*
+import kotlinx.coroutines.*
+import kotlinx.coroutines.sync.*
+import openssl.*
+import kotlin.coroutines.*
+
+//TODO handle BIO_eof
+//TODO handle not fully write
+//TODO handle partiol read
+internal class SslPipe(
+    private val reader: ByteReadChannel,
+    private val writer: ByteWriteChannel,
+    private val input: CPointer<BIO>,
+    private val output: CPointer<BIO>
+) {
+    private val readerLock = Mutex()
+    private var readerCont: CancellableContinuation<Int>? = null
+    private var readerContLock = SynchronizedObject()
+
+    private val writerLock = Mutex()
+
+    //TODO: revisit
+    suspend fun readAvailable(): Int {
+        // if read is in progress, await it result
+        if (!readerLock.tryLock()) return suspendCancellableCoroutine {
+            synchronized(readerContLock) {
+                readerCont = it
+            }
+        }
+
+        try {
+            val result = reader.read { source, start, endExclusive ->
+                val bytesWritten = BIO_write(output, source.pointer + start, (endExclusive - start).toInt())
+                //println("PIPE.READ: $bytesWritten")
+                if (bytesWritten == -2) TODO("BIO operation isn't implemented")
+                else if (bytesWritten < 0) 0
+                else bytesWritten
+            }
+            synchronized(readerContLock) {
+                readerCont?.resume(result)
+                readerCont = null
+            }
+
+            return result
+        } catch (cause: Throwable) {
+            synchronized(readerContLock) {
+                readerCont?.resumeWithException(cause)
+                readerCont = null
+            }
+            throw cause
+        } finally {
+            readerLock.unlock()
+        }
+    }
+
+    suspend fun writeFully(): Int = writerLock.withLock {
+        val result = writer.write { freeSpace, startOffset, endExclusive ->
+            val bytesRead = BIO_read(input, freeSpace.pointer + startOffset, (endExclusive - startOffset).toInt())
+            //println("PIPE.WRITE: $bytesRead")
+            if (bytesRead == -2) TODO("BIO operation isn't implemented")
+            else if (bytesRead < 0) 0
+            else bytesRead
+        }
+        writer.flush()
+        return result
+    }
+}

--- a/ktor-network/ktor-network-tls/nix/src/io/ktor/network/tls/init.kt
+++ b/ktor-network/ktor-network-tls/nix/src/io/ktor/network/tls/init.kt
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2014-2022 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.network.tls
+
+import kotlinx.cinterop.*
+import openssl.*
+
+@Suppress("DEPRECATION")
+@OptIn(ExperimentalStdlibApi::class)
+@EagerInitialization
+private val opensslInitReturnCode = opensslInitBridge()
+
+internal fun opensslInitBridge() {
+    OPENSSL_init_crypto(OPENSSL_INIT_ADD_ALL_CIPHERS.convert(), null)
+    OPENSSL_init_crypto(OPENSSL_INIT_ADD_ALL_DIGESTS.convert(), null)
+    OPENSSL_init_ssl(0.convert(), null)
+}

--- a/ktor-network/ktor-network-tls/nix/test/io/ktor/network/tls/SslTest.kt
+++ b/ktor-network/ktor-network-tls/nix/test/io/ktor/network/tls/SslTest.kt
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2014-2022 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.network.tls
+
+import io.ktor.network.selector.*
+import io.ktor.network.sockets.*
+import io.ktor.util.*
+import io.ktor.utils.io.*
+import io.ktor.utils.io.core.*
+import kotlinx.coroutines.*
+import kotlin.test.*
+
+class SslTest {
+
+    @OptIn(InternalAPI::class)
+    @Test
+    fun sslWithoutCloseTest(): Unit = runBlocking {
+        SelectorManager().use { selector ->
+            aSocket(selector).tcp().connect("www.google.com", port = 443).use { noSecureSocket ->
+                val socket = noSecureSocket.ssl(Dispatchers.Default, SslContext().createClientEngine())
+
+                val channel = socket.openWriteChannel()
+                channel.apply {
+                    writeStringUtf8("GET / HTTP/1.1\r\n")
+                    writeStringUtf8("Host: www.google.com\r\n")
+                    writeStringUtf8("Connection: close\r\n\r\n")
+                    flush()
+                }
+//                delay(1000)
+                println(socket.openReadChannel().readRemaining().readText())
+//                socket.openReadChannel().readRemaining()
+            }
+        }
+    }
+
+}

--- a/ktor-network/ktor-network-tls/nix/test/io/ktor/network/tls/SslTest.kt
+++ b/ktor-network/ktor-network-tls/nix/test/io/ktor/network/tls/SslTest.kt
@@ -35,4 +35,47 @@ class SslTest {
         }
     }
 
+    @OptIn(InternalAPI::class, DelicateCoroutinesApi::class)
+    @Test
+    fun sslClientServerTest(): Unit = runBlocking {
+        val context = SslContext()
+
+        SelectorManager().use { clientSelector ->
+            val tcp = aSocket(clientSelector).tcp()
+            tcp.bind().use { serverSocket ->
+                val serverJob = GlobalScope.launch {
+                    while (true) serverSocket.accept()
+                        .ssl(Dispatchers.Default + CoroutineName("SERVER"), context.createServerEngine())
+                        .use { socket ->
+                            val reader = socket.openReadChannel()
+                            val writer = socket.openWriteChannel()
+                            repeat(3) {
+                                val line = assertNotNull(reader.readUTF8Line())
+                                println("SSS: $line")
+                                writer.writeStringUtf8("$line\r\n")
+                                writer.flush()
+                            }
+                            delay(2000) //await reading from client socket
+                        }
+                }
+
+                tcp.connect(serverSocket.localAddress)
+                    .ssl(Dispatchers.Default + CoroutineName("CLIENT"), context.createClientEngine())
+                    .use { socket ->
+                        socket.openWriteChannel().apply {
+                            writeStringUtf8("GET / HTTP/1.1\r\n")
+                            writeStringUtf8("Host: www.google.com\r\n")
+                            writeStringUtf8("Connection: close\r\n")
+                            flush()
+                        }
+                        val reader = socket.openReadChannel()
+                        repeat(3) {
+                            println("CCC: ${assertNotNull(reader.readUTF8Line())}")
+                        }
+                    }
+                serverJob.cancelAndJoin()
+            }
+        }
+    }
+
 }

--- a/ktor-server/ktor-server-cio/build.gradle.kts
+++ b/ktor-server/ktor-server-cio/build.gradle.kts
@@ -7,8 +7,12 @@ kotlin.sourceSets {
         dependencies {
             api(project(":ktor-server:ktor-server-host-common"))
             api(project(":ktor-http:ktor-http-cio"))
-            api(project(":ktor-shared:ktor-websockets"))
             api(project(":ktor-network"))
+        }
+    }
+    jvmMain {
+        dependencies {
+            api(project(":ktor-network:ktor-network-tls"))
         }
     }
     val jvmAndNixTest by getting {

--- a/ktor-server/ktor-server-cio/jvm/src/io/ktor/server/cio/HttpServerSettingsJvm.kt
+++ b/ktor-server/ktor-server-cio/jvm/src/io/ktor/server/cio/HttpServerSettingsJvm.kt
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2014-2022 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.server.cio
+
+import io.ktor.network.tls.*
+import io.ktor.server.engine.*
+import io.ktor.util.*
+import kotlinx.coroutines.*
+import java.io.*
+import java.security.*
+import javax.net.ssl.*
+
+@OptIn(InternalAPI::class)
+internal actual fun HttpServerSettings(
+    connectionIdleTimeoutSeconds: Long,
+    connectorConfig: EngineConnectorConfig
+): HttpServerSettings {
+    if (connectorConfig is EngineSSLConnectorConfig) {
+        return HttpServerSettings(
+            host = connectorConfig.host,
+            port = connectorConfig.port,
+            connectionIdleTimeoutSeconds = connectionIdleTimeoutSeconds
+        ) { socket ->
+            val context = SSLContext.getInstance("TLS")
+
+            context.init(
+                connectorConfig.keyManagerFactory().keyManagers,
+                connectorConfig.trustManagerFactory()?.trustManagers,
+                null
+            )
+
+            val engine = context.createSSLEngine()
+            engine.useClientMode = false
+            if (connectorConfig.hasTrustStore()) {
+                engine.needClientAuth = true
+            }
+
+            socket.ssl(Dispatchers.IO, engine)
+        }
+    }
+    return HttpServerSettings(
+        host = connectorConfig.host,
+        port = connectorConfig.port,
+        connectionIdleTimeoutSeconds = connectionIdleTimeoutSeconds
+    )
+}
+
+private fun EngineSSLConnectorConfig.hasTrustStore() = trustStore != null || trustStorePath != null
+
+private fun EngineSSLConnectorConfig.trustManagerFactory(): TrustManagerFactory? {
+    val trustStore = trustStore ?: trustStorePath?.let { file ->
+        FileInputStream(file).use { fis ->
+            KeyStore.getInstance("JKS").also { it.load(fis, null) }
+        }
+    }
+    return trustStore?.let { store ->
+        TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm()).also { it.init(store) }
+    }
+}
+
+private fun EngineSSLConnectorConfig.keyManagerFactory(): KeyManagerFactory {
+    val keyStore = keyStorePath?.let { file ->
+        FileInputStream(file).use { fis ->
+            val password = keyStorePassword()
+            val instance = KeyStore.getInstance("JKS").also { it.load(fis, password) }
+            password.fill('\u0000')
+            instance
+        }
+    } ?: keyStore
+    val kmf = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm())
+    val password = privateKeyPassword()
+    kmf.init(keyStore, password)
+    password.fill('\u0000')
+    return kmf
+}

--- a/ktor-server/ktor-server-cio/jvm/src/io/ktor/server/cio/HttpServerSettingsJvm.kt
+++ b/ktor-server/ktor-server-cio/jvm/src/io/ktor/server/cio/HttpServerSettingsJvm.kt
@@ -37,7 +37,7 @@ internal actual fun HttpServerSettings(
                 engine.needClientAuth = true
             }
 
-            socket.ssl(Dispatchers.IO, engine)
+            socket.ssl(Dispatchers.IO + CoroutineName("SERVER"), engine)
         }
     }
     return HttpServerSettings(

--- a/ktor-server/ktor-server-cio/jvm/test/io/ktor/tests/server/cio/CIOClientCertTest.kt
+++ b/ktor-server/ktor-server-cio/jvm/test/io/ktor/tests/server/cio/CIOClientCertTest.kt
@@ -8,11 +8,4 @@ import io.ktor.server.cio.*
 import io.ktor.server.testing.suites.*
 import kotlin.test.*
 
-class CIOClientCertTest : ClientCertTestSuite<CIOApplicationEngine, CIOApplicationEngine.Configuration>(CIO) {
-    @Test
-    public override fun `Server requesting Client Certificate from CIO Client`() {
-        assertFailsWith<UnsupportedOperationException> {
-            super.`Server requesting Client Certificate from CIO Client`()
-        }
-    }
-}
+class CIOClientCertTest : ClientCertTestSuite<CIOApplicationEngine, CIOApplicationEngine.Configuration>(CIO)

--- a/ktor-server/ktor-server-cio/jvm/test/io/ktor/tests/server/cio/CIOEngineTestJvm.kt
+++ b/ktor-server/ktor-server-cio/jvm/test/io/ktor/tests/server/cio/CIOEngineTestJvm.kt
@@ -11,21 +11,21 @@ import kotlin.test.*
 class CIOCompressionTest : CompressionTestSuite<CIOApplicationEngine, CIOApplicationEngine.Configuration>(CIO) {
     init {
         enableHttp2 = false
-        enableSsl = false
+        enableSsl = true
     }
 }
 
 class CIOContentTest : ContentTestSuite<CIOApplicationEngine, CIOApplicationEngine.Configuration>(CIO) {
     init {
         enableHttp2 = false
-        enableSsl = false
+        enableSsl = true
     }
 }
 
 class CIOHttpServerJvmTest : HttpServerJvmTestSuite<CIOApplicationEngine, CIOApplicationEngine.Configuration>(CIO) {
     init {
         enableHttp2 = false
-        enableSsl = false
+        enableSsl = true
     }
 
     @Ignore
@@ -40,7 +40,7 @@ class CIOHttpServerJvmTest : HttpServerJvmTestSuite<CIOApplicationEngine, CIOApp
 class CIOSustainabilityTest : SustainabilityTestSuite<CIOApplicationEngine, CIOApplicationEngine.Configuration>(CIO) {
     init {
         enableHttp2 = false
-        enableSsl = false
+        enableSsl = true
     }
 }
 

--- a/ktor-server/ktor-server-cio/jvmAndNix/src/io/ktor/server/cio/HttpServer.kt
+++ b/ktor-server/ktor-server-cio/jvmAndNix/src/io/ktor/server/cio/HttpServer.kt
@@ -31,7 +31,8 @@ public class HttpServer(
 public data class HttpServerSettings(
     val host: String = "0.0.0.0",
     val port: Int = 8080,
-    val connectionIdleTimeoutSeconds: Long = 45
+    val connectionIdleTimeoutSeconds: Long = 45,
+    val interceptor: (Socket) -> Socket = { it }, //TODO ssl
 )
 
 /**

--- a/ktor-server/ktor-server-cio/jvmAndNix/src/io/ktor/server/cio/backend/HttpServer.kt
+++ b/ktor-server/ktor-server-cio/jvmAndNix/src/io/ktor/server/cio/backend/HttpServer.kt
@@ -60,7 +60,7 @@ public fun CoroutineScope.httpServer(
 
             try {
                 while (true) {
-                    val client: Socket = server.accept()
+                    val client: Socket = settings.interceptor(server.accept())
 
                     val connection = ServerIncomingConnection(
                         client.openReadChannel(),

--- a/ktor-server/ktor-server-cio/jvmAndNix/test/io/ktor/tests/server/cio/CIOEngineTest.kt
+++ b/ktor-server/ktor-server-cio/jvmAndNix/test/io/ktor/tests/server/cio/CIOEngineTest.kt
@@ -13,13 +13,14 @@ import io.ktor.server.cio.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
 import io.ktor.server.testing.suites.*
+import io.ktor.util.*
 import io.ktor.utils.io.*
 import kotlin.test.*
 
 class CIOHttpServerTest : HttpServerCommonTestSuite<CIOApplicationEngine, CIOApplicationEngine.Configuration>(CIO) {
     init {
         enableHttp2 = false
-        enableSsl = false
+        enableSsl = PlatformUtils.IS_JVM
     }
 
     @Test

--- a/ktor-server/ktor-server-cio/nix/src/io/ktor/server/cio/HttpServerSettingsNix.kt
+++ b/ktor-server/ktor-server-cio/nix/src/io/ktor/server/cio/HttpServerSettingsNix.kt
@@ -1,0 +1,16 @@
+/*
+ * Copyright 2014-2022 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.server.cio
+
+import io.ktor.server.engine.*
+
+internal actual fun HttpServerSettings(
+    connectionIdleTimeoutSeconds: Long,
+    connectorConfig: EngineConnectorConfig
+): HttpServerSettings = HttpServerSettings(
+    host = connectorConfig.host,
+    port = connectorConfig.port,
+    connectionIdleTimeoutSeconds = connectionIdleTimeoutSeconds
+)

--- a/ktor-server/ktor-server-host-common/jvm/src/io/ktor/server/engine/EngineConnectorConfigJvm.kt
+++ b/ktor-server/ktor-server-host-common/jvm/src/io/ktor/server/engine/EngineConnectorConfigJvm.kt
@@ -42,7 +42,7 @@ public interface EngineSSLConnectorConfig : EngineConnectorConfig {
     /**
      * KeyStore where a certificate is stored
      */
-    public val keyStore: KeyStore
+    public val keyStore: KeyStore //TODO optional?, to use keyStorePath + password instead of KeyStore
 
     /**
      * File where the keystore is located


### PR DESCRIPTION
**Subsystem**
CIO, Server, network-tls

**Motivation**
No support for TLS in CIO

**Solution**
On current moment, there is only CIO client JVM TLS implementation, which uses handwritten TLS handshake mechanism. This is for now also don't support TLS 1.3. 
I propose to switch CIO SSL to `SSLEngine` (netty also uses it under the hood if not using native openssl).
For now PR contains just a POC of integration. But all server tests(except one) works with SSL enabled.
Also, I'm in progress of adding SSL support to `native(nix)` via native openssl for both server and client.

Questions:
* What is the best way to integrate/replace CIO client SSL configuration?
* SSL configuration
  * As for now, servers HTTPS configuration is done via connectors, so no engine-specific API exists to configure it, but there are several configuration properties, and only part of them are used in different engines
  * On the other side, on client side, all https configuration happened in engine specific configuration
  * May be we can somehow improve it?
* It's also possible to do a secure UDP connection, via `SSLEngine`, do we need it?