### PR TITLE
KTOR-4105 Fixed ContentType.parser crash in Darwin and Browserjs in some case

### DIFF
--- a/ktor-client/ktor-client-core/js/src/io/ktor/client/engine/js/JsClientEngine.kt
+++ b/ktor-client/ktor-client-core/js/src/io/ktor/client/engine/js/JsClientEngine.kt
@@ -131,7 +131,9 @@ private fun Event.asString(): String = buildString {
 
 private fun io.ktor.client.fetch.Headers.mapToKtor(): Headers = buildHeaders {
     this@mapToKtor.asDynamic().forEach { value: String, key: String ->
-        append(key, value)
+        value.split(",").forEach { valueItem ->
+            append(key, valueItem.trim())
+        }
     }
 
     Unit

--- a/ktor-client/ktor-client-darwin/darwin/src/io/ktor/client/engine/darwin/DarwinResponseReader.kt
+++ b/ktor-client/ktor-client-darwin/darwin/src/io/ktor/client/engine/darwin/DarwinResponseReader.kt
@@ -36,7 +36,11 @@ internal class DarwinResponseReader(
 
         val status = HttpStatusCode.fromValue(response.statusCode.toInt())
         val headers = buildHeaders {
-            headersDict.mapKeys { (key, value) -> append(key, value) }
+            headersDict.mapKeys { entry ->
+                entry.value.split(",").forEach{ valueItem ->
+                    append(entry.key, valueItem.trim())
+                }
+            }
         }
 
         val responseBody = GlobalScope.writer(callContext + Dispatchers.Unconfined, autoFlush = true) {

--- a/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/ContentTest.kt
+++ b/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/ContentTest.kt
@@ -291,6 +291,17 @@ class ContentTest : ClientLoader(5 * 60) {
         }
     }
 
+    @Test
+    fun testDuplicatedContentType() = clientTests(listOf("CIO", "Android", "Apache", "Curl", "Java", "Jetty", "Okhttp")) {
+        test { client ->
+            val response = client.get(
+                "$TEST_SERVER/content/duplicatedContentType"
+            ).body<String>()
+
+            assertEquals("test", response)
+        }
+    }
+
     private suspend inline fun <reified Response : Any> HttpClient.echo(
         body: Any
     ): Response = post("$TEST_SERVER/content/echo") {

--- a/ktor-client/ktor-client-tests/jvm/src/io/ktor/client/tests/utils/tests/Content.kt
+++ b/ktor-client/ktor-client-tests/jvm/src/io/ktor/client/tests/utils/tests/Content.kt
@@ -93,6 +93,12 @@ internal fun Application.contentTestServer() {
                     }
                 )
             }
+            get("/duplicatedContentType") {
+                // netty server can not append header with same key
+                // so i join duplicated value with comma to simulate this case[https://youtrack.jetbrains.com/issue/KTOR-4105] in browser and darwin engine
+                call.response.headers.append("Content-Type", "text/html; charset=UTF-8, text/html; charset=UTF-8", false)
+                call.respond("test".toByteArray())
+            }
         }
     }
 }


### PR DESCRIPTION
…ome case

**Subsystem**
ktor-client, related modules : ktor-client-core.jsMain, ktor-client-darwin.darwinMain

**Motivation**
https://youtrack.jetbrains.com/issue/KTOR-4105

**Solution**
split header value with ',' before apend them into HttpHeadersBuilder

