### PR TITLE
KTOR-4130 Only load default config if custom is not set in tests

### DIFF
--- a/ktor-server/ktor-server-test-host/jvmAndNix/src/io/ktor/server/testing/TestApplication.kt
+++ b/ktor-server/ktor-server-test-host/jvmAndNix/src/io/ktor/server/testing/TestApplication.kt
@@ -117,10 +117,13 @@ public open class TestApplicationBuilder {
     internal val environment by lazy {
         built = true
         createTestEnvironment {
-            config = DefaultTestConfig()
             modules.addAll(this@TestApplicationBuilder.applicationModules)
             developmentMode = true
+            val oldConfig = config
             this@TestApplicationBuilder.environmentBuilder(this)
+            if (config == oldConfig) { // config was not set by user. load the default one
+                config = DefaultTestConfig()
+            }
             parentCoroutineContext += this@TestApplicationBuilder.job
         }
     }


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KTOR-4130

I am not sure how to add a test for it, since there is no side effect of loading a config, unless it's invalid and fails on crashing. But then we lose the ability to test proper default config, which is more important.