### PR TITLE
KTOR-836 Fix Location href stripping trailing slash.

### DIFF
--- a/ktor-server/ktor-server-plugins/ktor-server-locations/jvm/src/io/ktor/server/locations/BackwardCompatibleImpl.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-locations/jvm/src/io/ktor/server/locations/BackwardCompatibleImpl.kt
@@ -168,7 +168,7 @@ internal class BackwardCompatibleImpl(
         trailingSlash: Boolean,
     ): ResolvedUriInfo {
         val pathElements = (path.split("/") + relativePath.split("/")).filterNot { it.isEmpty() }
-        val combinedPath = if (pathElements.isNotEmpty()){
+        val combinedPath = if (pathElements.isNotEmpty()) {
             pathElements.joinToString("/", "/", if (trailingSlash) "/" else "")
         } else "/"
 

--- a/ktor-server/ktor-server-plugins/ktor-server-locations/jvm/src/io/ktor/server/locations/BackwardCompatibleImpl.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-locations/jvm/src/io/ktor/server/locations/BackwardCompatibleImpl.kt
@@ -112,7 +112,7 @@ internal class BackwardCompatibleImpl(
             conversionService.toValues(value).map { property.name to it }
         }
 
-        return parentInfo.combine(relativePath, queryValues)
+        return parentInfo.combine(relativePath, queryValues, info.path.endsWith('/'))
     }
 
     private fun LocationInfo.create(allParameters: Parameters): Any {
@@ -164,10 +164,14 @@ internal class BackwardCompatibleImpl(
 
     private fun ResolvedUriInfo.combine(
         relativePath: String,
-        queryValues: List<Pair<String, String>>
+        queryValues: List<Pair<String, String>>,
+        trailingSlash: Boolean,
     ): ResolvedUriInfo {
         val pathElements = (path.split("/") + relativePath.split("/")).filterNot { it.isEmpty() }
-        val combinedPath = pathElements.joinToString("/", "/")
+        val combinedPath = if (pathElements.isNotEmpty()){
+            pathElements.joinToString("/", "/", if (trailingSlash) "/" else "")
+        } else "/"
+
         return ResolvedUriInfo(combinedPath, query + queryValues)
     }
 

--- a/ktor-server/ktor-server-plugins/ktor-server-locations/jvm/test/io/ktor/tests/locations/LocationsTest.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-locations/jvm/test/io/ktor/tests/locations/LocationsTest.kt
@@ -587,4 +587,78 @@ class LocationsTest {
             urlShouldBeHandled("/no-location", "OK")
         }
     }
+
+    @Location("/trailing")
+    object notrailing
+
+    @Location("/trailing/")
+    object trailing
+
+    @Test
+    fun `location href with no trailing slash`() = withLocationsApplication {
+        val href = application.locations.href(notrailing)
+        assertEquals("/trailing", href)
+    }
+
+    @Test
+    fun `location href with trailing slash`() = withLocationsApplication {
+        val href = application.locations.href(trailing)
+        assertEquals("/trailing/", href)
+    }
+
+    @Location("/parent/")
+    class parent {
+        @Location("/trailing")
+        class notrailing
+
+        @Location("/trailing/")
+        class trailing
+    }
+
+    @Test
+    fun `nested location href with no trailing slash`() = withLocationsApplication {
+        val href = application.locations.href(parent.notrailing())
+        assertEquals("/parent/trailing", href)
+    }
+
+    @Test
+    fun `nested location href with trailing slash`() = withLocationsApplication {
+        val href = application.locations.href(parent.trailing())
+        assertEquals("/parent/trailing/", href)
+    }
+
+    @Location("/parent")
+    class notrailingparent {
+        @Location("/trailing/")
+        class trailing
+    }
+
+    @Test
+    fun `nested location href with parent with no trailing slash`() = withLocationsApplication {
+        val href = application.locations.href(notrailingparent.trailing())
+        assertEquals("/parent/trailing/", href)
+    }
+
+    @Test
+    fun `location routing with no trailing`() = withLocationsApplication {
+        application.routing {
+            get<notrailing> {
+                call.respond(HttpStatusCode.OK)
+            }
+        }
+        urlShouldBeHandled("/trailing")
+        urlShouldBeUnhandled("/trailing/")
+    }
+
+    @Test
+    fun `location routing with trailing`() = withLocationsApplication {
+        application.routing {
+            get<trailing> {
+                call.respond(HttpStatusCode.OK)
+            }
+        }
+        urlShouldBeHandled("/trailing/")
+        urlShouldBeUnhandled("/trailing")
+    }
+
 }

--- a/ktor-server/ktor-server-plugins/ktor-server-locations/jvm/test/io/ktor/tests/locations/LocationsTest.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-locations/jvm/test/io/ktor/tests/locations/LocationsTest.kt
@@ -660,5 +660,4 @@ class LocationsTest {
         urlShouldBeHandled("/trailing/")
         urlShouldBeUnhandled("/trailing")
     }
-
 }


### PR DESCRIPTION
**Subsystem**
Locations feature/plugin

**Motivation**
Fixes KTOR-836

**Solution**
Restore trailing slash if it was present prior to all the `.split("/")` calls. It is kind of similar to how it always prefixes a "/" except that is always required.
