### PR TITLE
KTOR-4198 Add native stacktrace on timeout

### DIFF
--- a/ktor-server/ktor-server-test-host/build.gradle.kts
+++ b/ktor-server/ktor-server-test-host/build.gradle.kts
@@ -9,6 +9,7 @@ kotlin.sourceSets {
             api(project(":ktor-server:ktor-server-core"))
             api(project(":ktor-client:ktor-client-core"))
             api(project(":ktor-client:ktor-client-cio"))
+            api(project(":ktor-test-dispatcher"))
         }
     }
 

--- a/ktor-test-dispatcher/build.gradle.kts
+++ b/ktor-test-dispatcher/build.gradle.kts
@@ -1,0 +1,13 @@
+/*
+ * Copyright 2014-2022 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+kotlin {
+    sourceSets {
+        posixMain {
+            dependencies {
+                implementation(project(":ktor-utils"))
+            }
+        }
+    }
+}

--- a/ktor-test-dispatcher/darwin/src/TestDarwin.kt
+++ b/ktor-test-dispatcher/darwin/src/TestDarwin.kt
@@ -6,8 +6,6 @@ import kotlinx.coroutines.*
 import platform.Foundation.*
 import platform.posix.*
 import kotlin.coroutines.*
-import kotlin.native.concurrent.*
-import kotlin.system.*
 
 /**
  * Amount of time any task is processed and can't be rescheduled.

--- a/ktor-test-dispatcher/linuxX64/src/TestLinuxX64.kt
+++ b/ktor-test-dispatcher/linuxX64/src/TestLinuxX64.kt
@@ -1,6 +1,7 @@
 package io.ktor.test.dispatcher
 
 import kotlinx.coroutines.*
+import platform.posix.*
 import kotlin.coroutines.*
 
 /**

--- a/ktor-test-dispatcher/mingwX64/src/TestMingwX64.kt
+++ b/ktor-test-dispatcher/mingwX64/src/TestMingwX64.kt
@@ -1,6 +1,7 @@
 package io.ktor.test.dispatcher
 
 import kotlinx.coroutines.*
+import platform.posix.*
 import kotlin.coroutines.*
 
 /**

--- a/ktor-utils/build.gradle.kts
+++ b/ktor-utils/build.gradle.kts
@@ -1,4 +1,14 @@
 kotlin {
+    targets {
+        nixTargets().forEach {
+            it.compilations.getByName("main") {
+                cinterops.create("threadUtils") {
+                    defFile = File(projectDir, "nix/interop/threadUtils.def")
+                }
+            }
+        }
+    }
+
     sourceSets {
         commonMain {
             dependencies {

--- a/ktor-utils/darwin/src/io/ktor/util/ThreadInfoDarwin.kt
+++ b/ktor-utils/darwin/src/io/ktor/util/ThreadInfoDarwin.kt
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2014-2022 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.util
+
+import kotlinx.cinterop.*
+import platform.darwin.*
+import platform.posix.*
+import threadUtils.*
+
+internal actual fun collectStack(thread: pthread_t): List<String> {
+    val size = collect_stack(thread)
+    if (size < 0) throw IllegalArgumentException("Thread is stopped")
+    val symbols = backtrace_symbols(callstack, size)!!
+    return List(stack_size) { symbols[it]!!.toKString() }
+}
+
+internal actual fun setSignalHandler() {
+    set_signal_handler()
+}

--- a/ktor-utils/linuxX64/src/io/ktor/util/ThreadInfoLinux.kt
+++ b/ktor-utils/linuxX64/src/io/ktor/util/ThreadInfoLinux.kt
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2014-2022 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.util
+
+import kotlinx.cinterop.*
+import platform.linux.*
+import platform.posix.*
+import threadUtils.*
+
+internal actual fun collectStack(thread: pthread_t): List<String> {
+    val size = collect_stack(thread)
+    if (size < 0) throw IllegalArgumentException("Thread is stopped")
+    val symbols = backtrace_symbols(callstack, size)!!
+    return List(stack_size) { symbols[it]!!.toKString() }
+}
+
+internal actual fun setSignalHandler() {
+    set_signal_handler()
+}

--- a/ktor-utils/mingwX64/src/io/ktor/util/ThreadInfoMingw.kt
+++ b/ktor-utils/mingwX64/src/io/ktor/util/ThreadInfoMingw.kt
@@ -1,0 +1,11 @@
+/*
+ * Copyright 2014-2022 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.util
+
+import platform.posix.*
+
+internal actual fun collectStack(thread: pthread_t): List<String> = emptyList()
+
+internal actual fun setSignalHandler() = Unit

--- a/ktor-utils/nix/interop/threadUtils.def
+++ b/ktor-utils/nix/interop/threadUtils.def
@@ -1,0 +1,37 @@
+---
+#include <execinfo.h>
+#include <signal.h>
+#include <stdatomic.h>
+#include <printf.h>
+#include <unistd.h>
+ 
+void* callstack[256];
+int stack_size;
+
+#define STARTED 1
+#define DONE 0
+_Atomic int state;
+
+void dump_backtrace(int signum) {
+    stack_size = backtrace(callstack, 256);
+    atomic_store(&state, DONE);
+}
+
+int collect_stack(pthread_t thread) {
+    atomic_store(&state, STARTED);
+    signal(SIGUSR2, dump_backtrace);
+
+    int result = pthread_kill(thread, SIGUSR2);
+    if (result != 0) {
+        printf("Fail to signal: %d\n", result);
+        atomic_store(&state, DONE);
+        return -1;
+    }
+
+    while (atomic_load(&state) != DONE) {}
+
+    return stack_size;
+}
+
+void set_signal_handler() {
+}

--- a/ktor-utils/posix/src/io/ktor/util/CoroutineUtils.kt
+++ b/ktor-utils/posix/src/io/ktor/util/CoroutineUtils.kt
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2014-2022 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.util
+
+import kotlinx.coroutines.*
+import kotlinx.coroutines.channels.*
+import kotlin.coroutines.*
+import kotlin.native.concurrent.*
+
+@InternalAPI
+public fun Dispatchers.createFixedThreadDispatcher(name: String, threads: Int): CloseableCoroutineDispatcher =
+    MultiWorkerDispatcher(name, threads)
+
+@OptIn(InternalAPI::class)
+private class MultiWorkerDispatcher(name: String, workersCount: Int) : CloseableCoroutineDispatcher() {
+    private val tasksQueue = Channel<Runnable>(Channel.UNLIMITED)
+    private val workers = Array(workersCount) { Worker.start(name = "$name-$it") }
+
+    init {
+        workers.forEach { worker ->
+            worker.executeAfter(0L) {
+                ThreadInfo.registerCurrentThread()
+                workerRunLoop()
+            }
+        }
+    }
+
+    private fun workerRunLoop() = runBlocking {
+        for (task in tasksQueue) {
+            task.run()
+        }
+    }
+
+    override fun dispatch(context: CoroutineContext, block: Runnable) {
+        tasksQueue.trySend(block)
+    }
+
+    override fun close() {
+        tasksQueue.close()
+        workers.forEach { it.requestTermination().result }
+    }
+}

--- a/ktor-utils/posix/src/io/ktor/util/ThreadInfo.kt
+++ b/ktor-utils/posix/src/io/ktor/util/ThreadInfo.kt
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2014-2022 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.util
+
+import io.ktor.util.collections.*
+import platform.posix.*
+import kotlin.native.concurrent.*
+
+@Suppress("DEPRECATION")
+@OptIn(ExperimentalStdlibApi::class)
+@EagerInitialization
+private val init = setSignalHandler()
+
+@InternalAPI
+public object ThreadInfo {
+    private val threads = ConcurrentMap<Worker, pthread_t>(initialCapacity = 32)
+
+    init {
+        init
+    }
+
+    public fun registerCurrentThread() {
+        val thread = pthread_self()!!
+        threads[Worker.current] = thread
+    }
+
+    public fun dropWorker(worker: Worker) {
+        threads.remove(worker)
+    }
+
+    public fun getAllStackTraces(): List<WorkerStacktrace> {
+        if (Platform.osFamily == OsFamily.WINDOWS) return emptyList()
+
+        val result = mutableListOf<WorkerStacktrace>()
+        val removed = mutableSetOf<Worker>()
+        for ((worker, thread) in threads.entries) {
+            try {
+                val name = worker.name
+                val stack = collectStack(thread)
+                result += WorkerStacktrace(name, stack)
+            } catch (_: Throwable) {
+                removed.add(worker)
+            }
+        }
+
+        removed.forEach {
+            threads.remove(it)
+        }
+
+        return result
+    }
+
+    public fun printAllStackTraces() {
+        getAllStackTraces().forEach {
+            println(it.worker)
+            it.stacktrace.forEach {
+                println("\tat $it")
+            }
+        }
+    }
+
+    public fun stopAllWorkers() {
+        for (worker in threads.keys) {
+            if (worker == Worker.current) continue
+            worker.requestTermination(processScheduledJobs = false)
+        }
+
+        threads.clear()
+        registerCurrentThread()
+    }
+}
+
+@InternalAPI
+public class WorkerStacktrace(
+    public val worker: String,
+    public val stacktrace: List<String>
+)
+
+internal expect fun collectStack(thread: pthread_t): List<String>
+
+internal expect fun setSignalHandler()


### PR DESCRIPTION
Fix [KTOR-4198](https://youtrack.jetbrains.com/issue/KTOR-4198/Print-Native-Stacktrace-on-Timeout)