### PR TITLE
KTOR-4217 Fix sha1 argument

### DIFF
--- a/ktor-utils/common/test/io/ktor/util/HashFunctionTest.kt
+++ b/ktor-utils/common/test/io/ktor/util/HashFunctionTest.kt
@@ -4,6 +4,7 @@
 
 package io.ktor.util
 
+import kotlin.random.*
 import kotlin.test.*
 
 class HashFunctionTest {
@@ -13,5 +14,15 @@ class HashFunctionTest {
             "a9993e364706816aba3e25717850c26c9cd0d89d",
             hex(Sha1().digest("abc".encodeToByteArray()))
         )
+    }
+
+    @Test
+    fun sha1BytesTest() {
+        val bytes = ByteArray(20) { it.toByte() }
+        val result = byteArrayOf(
+            96, 44, 99, -46, -13, -47, 60, -93, 32, 108, -33, 32, 76, -34, 36, -25, -40, -12, 38, 108
+        )
+
+        assertTrue { sha1(bytes).contentEquals(result) }
     }
 }

--- a/ktor-utils/posix/src/io/ktor/util/CryptoNative.kt
+++ b/ktor-utils/posix/src/io/ktor/util/CryptoNative.kt
@@ -23,4 +23,4 @@ public actual fun Digest(name: String): Digest = error("[Digest] is not supporte
 /**
  * Compute SHA-1 hash for the specified [bytes]
  */
-public actual fun sha1(bytes: ByteArray): ByteArray = Sha1().digest()
+public actual fun sha1(bytes: ByteArray): ByteArray = Sha1().digest(bytes)


### PR DESCRIPTION
Fix [KTOR-4217](https://youtrack.jetbrains.com/issue/KTOR-4217/%60io.ktor.util.sha1()%60-always-returns-da39a3ee5e6b4b0d3255bfef956)

