### PR TITLE
Fix websocket of browser received array buffer size is 0

### DIFF
--- a/ktor-utils/jvm/src/io/ktor/util/NIO.kt
+++ b/ktor-utils/jvm/src/io/ktor/util/NIO.kt
@@ -32,9 +32,7 @@ public fun ByteBuffer.moveTo(destination: ByteBuffer, limit: Int = Int.MAX_VALUE
  * Moves bytes from `this` buffer into newly created [ByteArray] and returns it
  */
 public fun ByteBuffer.moveToByteArray(): ByteArray {
-    val array = ByteArray(remaining())
-    get(array)
-    return array
+    return array()
 }
 
 /**


### PR DESCRIPTION
**Subsystem**
Server

**Motivation**
websocket of browser received array buffer size is 0

**Solution**
Use ByteBuffer.array() return ByteArray can work well

