### PR TITLE
Return correct route in Resources (KTOR-4239)

### DIFF
--- a/ktor-server/ktor-server-plugins/ktor-server-resources/jvmAndNix/src/io/ktor/server/resources/Routing.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-resources/jvmAndNix/src/io/ktor/server/resources/Routing.kt
@@ -32,11 +32,13 @@ public inline fun <reified T : Any> Route.resource(noinline body: Route.() -> Un
 public inline fun <reified T : Any> Route.get(
     noinline body: suspend PipelineContext<Unit, ApplicationCall>.(T) -> Unit
 ): Route {
-    return resource<T> {
-        method(HttpMethod.Get) {
+    lateinit var builtRoute: Route
+    resource<T> {
+        builtRoute = method(HttpMethod.Get) {
             handle(body)
         }
     }
+    return builtRoute
 }
 
 /**
@@ -49,11 +51,13 @@ public inline fun <reified T : Any> Route.get(
 public inline fun <reified T : Any> Route.options(
     noinline body: suspend PipelineContext<Unit, ApplicationCall>.(T) -> Unit
 ): Route {
-    return resource<T> {
-        method(HttpMethod.Options) {
+    lateinit var builtRoute: Route
+    resource<T> {
+        builtRoute = method(HttpMethod.Options) {
             handle(body)
         }
     }
+    return builtRoute
 }
 
 /**
@@ -66,11 +70,13 @@ public inline fun <reified T : Any> Route.options(
 public inline fun <reified T : Any> Route.head(
     noinline body: suspend PipelineContext<Unit, ApplicationCall>.(T) -> Unit
 ): Route {
-    return resource<T> {
-        method(HttpMethod.Head) {
+    lateinit var builtRoute: Route
+    resource<T> {
+        builtRoute = method(HttpMethod.Head) {
             handle(body)
         }
     }
+    return builtRoute
 }
 
 /**
@@ -83,11 +89,13 @@ public inline fun <reified T : Any> Route.head(
 public inline fun <reified T : Any> Route.post(
     noinline body: suspend PipelineContext<Unit, ApplicationCall>.(T) -> Unit
 ): Route {
-    return resource<T> {
-        method(HttpMethod.Post) {
+    lateinit var builtRoute: Route
+    resource<T> {
+        builtRoute = method(HttpMethod.Post) {
             handle(body)
         }
     }
+    return builtRoute
 }
 
 /**
@@ -100,11 +108,13 @@ public inline fun <reified T : Any> Route.post(
 public inline fun <reified T : Any> Route.put(
     noinline body: suspend PipelineContext<Unit, ApplicationCall>.(T) -> Unit
 ): Route {
-    return resource<T> {
-        method(HttpMethod.Put) {
+    lateinit var builtRoute: Route
+    resource<T> {
+        builtRoute = method(HttpMethod.Put) {
             handle(body)
         }
     }
+    return builtRoute
 }
 
 /**
@@ -117,11 +127,13 @@ public inline fun <reified T : Any> Route.put(
 public inline fun <reified T : Any> Route.delete(
     noinline body: suspend PipelineContext<Unit, ApplicationCall>.(T) -> Unit
 ): Route {
-    return resource<T> {
-        method(HttpMethod.Delete) {
+    lateinit var builtRoute: Route
+    resource<T> {
+        builtRoute = method(HttpMethod.Delete) {
             handle(body)
         }
     }
+    return builtRoute
 }
 
 /**
@@ -134,11 +146,13 @@ public inline fun <reified T : Any> Route.delete(
 public inline fun <reified T : Any> Route.patch(
     noinline body: suspend PipelineContext<Unit, ApplicationCall>.(T) -> Unit
 ): Route {
-    return resource<T> {
-        method(HttpMethod.Patch) {
+    lateinit var builtRoute: Route
+    resource<T> {
+        builtRoute = method(HttpMethod.Patch) {
             handle(body)
         }
     }
+    return builtRoute
 }
 
 /**

--- a/ktor-server/ktor-server-plugins/ktor-server-resources/jvmAndNix/test/io/ktor/tests/resources/ResourcesTest.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-resources/jvmAndNix/test/io/ktor/tests/resources/ResourcesTest.kt
@@ -4,7 +4,6 @@
 
 package io.ktor.tests.resources
 
-import io.ktor.client.plugins.*
 import io.ktor.client.request.*
 import io.ktor.http.*
 import io.ktor.resources.*
@@ -12,7 +11,11 @@ import io.ktor.resources.serialization.*
 import io.ktor.server.application.*
 import io.ktor.server.resources.*
 import io.ktor.server.resources.Resources
+import io.ktor.server.resources.patch
+import io.ktor.server.resources.post
+import io.ktor.server.resources.put
 import io.ktor.server.response.*
+import io.ktor.server.routing.*
 import io.ktor.server.testing.*
 import kotlinx.coroutines.*
 import kotlinx.serialization.*
@@ -493,6 +496,23 @@ class ResourcesTest {
                 HttpStatusCode.BadRequest,
                 client.get("/?text=abc&number=${Long.MAX_VALUE}&longNumber=2").status
             )
+        }
+    }
+
+    @Test
+    fun resourceShouldReturnHttpMethodRouteObject() = withResourcesApplication {
+        @Resource("/resource")
+        @Serializable
+        class someResource
+
+        routing {
+            get<someResource> { call.respondText("Hi!") }.apply { assertIs<HttpMethodRouteSelector>(selector) }
+            options<someResource> { call.respondText("Hi!") }.apply { assertIs<HttpMethodRouteSelector>(selector) }
+            head<someResource> { call.respondText("Hi!") }.apply { assertIs<HttpMethodRouteSelector>(selector) }
+            post<someResource> { call.respondText("Hi!") }.apply { assertIs<HttpMethodRouteSelector>(selector) }
+            put<someResource> { call.respondText("Hi!") }.apply { assertIs<HttpMethodRouteSelector>(selector) }
+            delete<someResource> { call.respondText("Hi!") }.apply { assertIs<HttpMethodRouteSelector>(selector) }
+            patch<someResource> { call.respondText("Hi!") }.apply { assertIs<HttpMethodRouteSelector>(selector) }
         }
     }
 }


### PR DESCRIPTION
**Subsystem**
Server (`ktor-server-resources`)

**Motivation**
This PR aims to solve KTOR-4239, see that ticket for more information.

**Solution**
Simply retrieve the result of the `method()` call and return it. There may be a more idiomatic way to do this, but I could not figure out a simpler solution.

