### PR TITLE
Update API docs for AutoHead and CORS

### DIFF
--- a/ktor-server/ktor-server-plugins/ktor-server-auto-head-response/jvmAndNix/src/io/ktor/server/plugins/autohead/AutoHeadResponse.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-auto-head-response/jvmAndNix/src/io/ktor/server/plugins/autohead/AutoHeadResponse.kt
@@ -12,7 +12,10 @@ import io.ktor.server.plugins.*
 import io.ktor.util.*
 
 /**
- * A plugin that automatically respond to HEAD requests.
+ * A plugin that provides the ability to automatically respond to a `HEAD` request for every route that has a `GET` defined.
+ * You can use `AutoHeadResponse` to avoid creating a separate `head` handler if you need to somehow process a response
+ * on the client before getting the actual content.
+ * You can learn more from [AutoHeadResponse](https://ktor.io/docs/autoheadresponse.html).
  */
 public val AutoHeadResponse: ApplicationPlugin<Unit> = createApplicationPlugin("AutoHeadResponse") {
     onCall { call ->

--- a/ktor-server/ktor-server-plugins/ktor-server-cors/jvmAndNix/src/io/ktor/server/plugins/cors/CORS.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-cors/jvmAndNix/src/io/ktor/server/plugins/cors/CORS.kt
@@ -18,7 +18,7 @@ import io.ktor.util.*
  * The configuration below allows requests from the specified address and allows sending the `Content-Type` header:
  * ```kotlin
  * install(CORS) {
- *     host("0.0.0.0:5000")
+ *     host("0.0.0.0:8081")
  *     header(HttpHeaders.ContentType)
  * }
  * ```

--- a/ktor-server/ktor-server-plugins/ktor-server-cors/jvmAndNix/src/io/ktor/server/plugins/cors/CORSConfig.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-cors/jvmAndNix/src/io/ktor/server/plugins/cors/CORSConfig.kt
@@ -8,7 +8,7 @@ import io.ktor.http.*
 import io.ktor.util.*
 
 /**
- * A configuration for the [CORS] plugin.
+ * A configuration for the [io.ktor.server.plugins.cors.routing.CORS] plugin.
  */
 @KtorDsl
 public class CORSConfig {

--- a/ktor-server/ktor-server-plugins/ktor-server-cors/jvmAndNix/src/io/ktor/server/plugins/cors/routing/CORS.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-cors/jvmAndNix/src/io/ktor/server/plugins/cors/routing/CORS.kt
@@ -14,7 +14,7 @@ import io.ktor.server.plugins.cors.*
  * The configuration below allows requests from the specified address and allows sending the `Content-Type` header:
  * ```kotlin
  * install(CORS) {
- *     host("0.0.0.0:5000")
+ *     host("0.0.0.0:8081")
  *     header(HttpHeaders.ContentType)
  * }
  * ```


### PR DESCRIPTION
For CORS, I've referenced a new route scoped plugin and changed a port in a snippet because `5000` can be in use on macOS by the Airplay receiver.