### PR TITLE
KTOR-4267 Fixed routing returns 405 even for not completely matched paths

### DIFF
--- a/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/routing/RoutingResolveContext.kt
+++ b/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/routing/RoutingResolveContext.kt
@@ -102,7 +102,9 @@ public class RoutingResolveContext(
                 segmentIndex,
                 RoutingResolveResult.Failure(entry, "Selector didn't match", evaluation.failureStatusCode)
             )
-            failedEvaluation = max(failedEvaluation, evaluation)
+            if (segmentIndex == segments.size) {
+                failedEvaluation = max(failedEvaluation, evaluation)
+            }
             return MIN_QUALITY
         }
 

--- a/ktor-server/ktor-server-tests/jvmAndNix/test/io/ktor/tests/server/routing/RoutingProcessingTest.kt
+++ b/ktor-server/ktor-server-tests/jvmAndNix/test/io/ktor/tests/server/routing/RoutingProcessingTest.kt
@@ -863,6 +863,30 @@ class RoutingProcessingTest {
         }
     }
 
+    @Test
+    fun testRoutingSpecificErrorStatusCodeOnlyWhenPathMatched() = testApplication {
+        routing {
+            route("a") {
+                get {
+                    call.respond(HttpStatusCode.OK)
+                }
+            }
+            post {
+                call.respond(HttpStatusCode.OK)
+            }
+        }
+
+        client.post("/a").let { response ->
+            assertEquals(HttpStatusCode.MethodNotAllowed, response.status)
+        }
+        client.get("/").let { response ->
+            assertEquals(HttpStatusCode.MethodNotAllowed, response.status)
+        }
+        client.get("/notfound").let { response ->
+            assertEquals(HttpStatusCode.NotFound, response.status)
+        }
+    }
+
     private fun Route.transparent(build: Route.() -> Unit): Route {
         val route = createChild(
             object : RouteSelector() {


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KTOR-4267