### PR TITLE
Tiny typo fix in documentation

### DIFF
--- a/ktor-shared/ktor-serialization/ktor-serialization-kotlinx/ktor-serialization-kotlinx-json/common/src/io/ktor/serialization/kotlinx/json/JsonSupport.kt
+++ b/ktor-shared/ktor-serialization/ktor-serialization-kotlinx/ktor-serialization-kotlinx-json/common/src/io/ktor/serialization/kotlinx/json/JsonSupport.kt
@@ -17,7 +17,7 @@ import kotlin.native.concurrent.*
  * - defaults are serialized
  * - mode is not strict so extra json fields are ignored
  * - pretty printing is disabled
- * - array polymorphism is enabled
+ * - array polymorphism is disabled
  * - keys and values are quoted, non-quoted are not allowed
  *
  * See [Json] for more details.


### PR DESCRIPTION
The default for `useArrayPolymorphism` changed from `true` to `false` in version 2.0 but the documentation wasn't updated.

**Subsystem**
Client/Server, related modules

**Motivation**
Describe what problem this PR solves and why it is important. Refer to a bug/ticket #.

**Solution**
Describe your solution.

