### PR TITLE
Update BaseApplicationEngine.kt

### DIFF
--- a/ktor-server/ktor-server-host-common/jvmAndNix/src/io/ktor/server/engine/BaseApplicationEngine.kt
+++ b/ktor-server/ktor-server-host-common/jvmAndNix/src/io/ktor/server/engine/BaseApplicationEngine.kt
@@ -93,7 +93,7 @@ private suspend fun PipelineContext<Unit, ApplicationCall>.verifyHostHeader() {
 }
 
 private class StartupInfo {
-    var isFirstLoading = false
+    var isFirstLoading = true
     var initializedStartAt = currentTimeMillisBridge()
 }
 


### PR DESCRIPTION
**Subsystem**
Server JVM module

**Motivation**
https://youtrack.jetbrains.com/issue/KTOR-4319/Application-started-is-never-printed-even-when-not-in-developmen

Not sure how important this is more like slightly inconvenient to see the `"Application auto-reloaded in 2 seconds."` instead of the correct `"Application started in 2 seconds."` so decided to fix it.

**Solution**
I changed the default value of `isFirstLoading` to `true` and it should work as expected now :)