### PR TITLE
Curl: Use parameter api

### DIFF
--- a/ktor-client/ktor-client-curl/desktop/src/io/ktor/client/engine/curl/CurlProcessor.kt
+++ b/ktor-client/ktor-client-curl/desktop/src/io/ktor/client/engine/curl/CurlProcessor.kt
@@ -60,8 +60,6 @@ internal class CurlProcessor(coroutineContext: CoroutineContext) {
     }
 
     private suspend fun drainRequestQueue(api: CurlMultiApiHandler) {
-        val api = curlApi!!
-
         while (true) {
             val container = if (api.hasHandlers()) {
                 requestQueue.tryReceive()


### PR DESCRIPTION
Fix warning: CurlProcessor.kt: (62, 43): Parameter 'api' is never used

**Subsystem**
Client Curl

**Motivation**
The Parameter 'api' is never used, because it is overridden in the next line.

**Solution**
Remove the overridden variable, because the value of the parameter is the same (line 54).
