### PR TITLE
KTOR-3900 Make Darwin engine work in runBlocking

### DIFF
--- a/ktor-client/ktor-client-darwin/darwin/test/DarwinEngineTest.kt
+++ b/ktor-client/ktor-client-darwin/darwin/test/DarwinEngineTest.kt
@@ -1,0 +1,27 @@
+import io.ktor.client.*
+import io.ktor.client.engine.darwin.*
+import io.ktor.client.request.*
+import io.ktor.client.statement.*
+import kotlinx.coroutines.*
+import kotlin.test.*
+
+/*
+ * Copyright 2014-2022 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+class DarwinEngineTest {
+
+    @Test
+    fun testRequestInRunBlocking() = runBlocking {
+        val client = HttpClient(Darwin)
+
+        try {
+            withTimeout(1000) {
+                val response = client.get("http://127.0.0.1:8080")
+                assertEquals("Hello, world!", response.bodyAsText())
+            }
+        } finally {
+            client.close()
+        }
+    }
+}

--- a/ktor-client/ktor-client-tests/jvm/src/io/ktor/client/tests/utils/ClientTestServer.kt
+++ b/ktor-client/ktor-client-tests/jvm/src/io/ktor/client/tests/utils/ClientTestServer.kt
@@ -44,6 +44,9 @@ internal fun Application.tests() {
     eventsTest()
 
     routing {
+        get("/") {
+            call.respondText("Hello, world!")
+        }
         post("/echo") {
             val response = call.receiveText()
             call.respond(response)


### PR DESCRIPTION
Fix [KTOR-3900](https://youtrack.jetbrains.com/issue/KTOR-3900/A-native-application-with-the-Darwin-engine-doesn-t-make-a-reque)