### PR TITLE
KTOR-1858 Sanitize url in Darwin engine

### DIFF
--- a/ktor-client/ktor-client-darwin/darwin/src/io/ktor/client/engine/darwin/DarwinClientEngine.kt
+++ b/ktor-client/ktor-client-darwin/darwin/src/io/ktor/client/engine/darwin/DarwinClientEngine.kt
@@ -5,10 +5,10 @@
 package io.ktor.client.engine.darwin
 
 import io.ktor.client.engine.*
+import io.ktor.client.engine.darwin.internal.*
 import io.ktor.client.plugins.*
 import io.ktor.client.plugins.websocket.*
 import io.ktor.client.request.*
-import io.ktor.http.*
 import io.ktor.util.*
 import io.ktor.util.date.*
 import kotlinx.cinterop.*
@@ -27,9 +27,9 @@ internal class DarwinClientEngine(override val config: DarwinClientEngineConfig)
     override suspend fun execute(data: HttpRequestData): HttpResponseData {
         val callContext = callContext()
 
-        val url = URLBuilder().takeFrom(data.url).buildString()
+        val url = data.url.toNSUrl()
 
-        val nativeRequest = NSMutableURLRequest.requestWithURL(NSURL(string = url)).apply {
+        val nativeRequest = NSMutableURLRequest.requestWithURL(url).apply {
             setupSocketTimeout(data)
 
             val content = data.body

--- a/ktor-client/ktor-client-darwin/darwin/src/io/ktor/client/engine/darwin/internal/DarwinUrlUtils.kt
+++ b/ktor-client/ktor-client-darwin/darwin/src/io/ktor/client/engine/darwin/internal/DarwinUrlUtils.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2014-2022 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.client.engine.darwin.internal
+
+import io.ktor.http.*
+import platform.Foundation.*
+
+internal fun Url.toNSUrl(): NSURL {
+    val urlString = URLBuilder().also {
+        it.protocol = protocol
+        it.host = host.sanitize(NSCharacterSet.URLHostAllowedCharacterSet)
+        it.port = port
+        it.encodedPath = encodedPath.sanitize(NSCharacterSet.URLPathAllowedCharacterSet)
+        it.encodedUser = encodedUser?.sanitize(NSCharacterSet.URLUserAllowedCharacterSet)
+        it.encodedPassword = encodedPassword?.sanitize(NSCharacterSet.URLPasswordAllowedCharacterSet)
+
+        val query = encodedQuery.sanitize(NSCharacterSet.URLQueryAllowedCharacterSet)
+
+        it.encodedParameters = ParametersBuilder().apply { appendAll(parseQueryString(query, decode = false)) }
+        it.encodedFragment = encodedFragment.sanitize(NSCharacterSet.URLFragmentAllowedCharacterSet)
+        it.trailingQuery = trailingQuery
+    }.buildString()
+
+    return NSURL(string = urlString)
+}
+
+private fun String.asNSString(): NSString = this as NSString
+
+private fun String.sanitize(allowed: NSCharacterSet): String =
+    asNSString().stringByAddingPercentEncodingWithAllowedCharacters(allowed)!!

--- a/ktor-client/ktor-client-darwin/darwin/test/DarwinEngineTest.kt
+++ b/ktor-client/ktor-client-darwin/darwin/test/DarwinEngineTest.kt
@@ -1,7 +1,9 @@
 import io.ktor.client.*
 import io.ktor.client.engine.darwin.*
+import io.ktor.client.engine.darwin.internal.*
 import io.ktor.client.request.*
 import io.ktor.client.statement.*
+import io.ktor.http.*
 import kotlinx.coroutines.*
 import kotlin.test.*
 
@@ -23,5 +25,40 @@ class DarwinEngineTest {
         } finally {
             client.close()
         }
+    }
+
+    @Test
+    fun testPathWithCyrillic() = runBlocking {
+    }
+
+    @Test
+    fun testQueryWithCyrillic() = runBlocking {
+        val client = HttpClient(Darwin)
+
+        try {
+            withTimeout(1000) {
+                val response = client.get("http://127.0.0.1:8080/echo_query?привет")
+                assertEquals("привет=[]", response.bodyAsText())
+            }
+        } finally {
+            client.close()
+        }
+    }
+
+    @Test
+    fun testNSUrlSanitize() {
+        assertEquals(
+            "http://127.0.0.1/echo_query?%D0%BF%D1%80%D0%B8%D0%B2%D0%B5%D1%82",
+            stringToNSUrlString("http://127.0.0.1/echo_query?привет")
+        )
+
+        assertEquals(
+            "http://%D0%BF%D1%80%D0%B8%D0%B2%D0%B5%D1%82.%D0%BF%D1%80%D0%B8%D0%B2%D0%B5%D1%82/",
+            stringToNSUrlString("http://привет.привет/")
+        )
+    }
+
+    private fun stringToNSUrlString(value: String): String {
+        return Url(value).toNSUrl().absoluteString!!
     }
 }

--- a/ktor-client/ktor-client-tests/jvm/src/io/ktor/client/tests/utils/ClientTestServer.kt
+++ b/ktor-client/ktor-client-tests/jvm/src/io/ktor/client/tests/utils/ClientTestServer.kt
@@ -51,6 +51,10 @@ internal fun Application.tests() {
             val response = call.receiveText()
             call.respond(response)
         }
+        get("/echo_query") {
+            val parameters = call.request.queryParameters.entries().joinToString { "${it.key}=${it.value}" }
+            call.respondText(parameters)
+        }
         post("/echo-with-content-type") {
             val response = call.receiveText()
             val contentType = call.request.header(HttpHeaders.ContentType)?.let { ContentType.parse(it) }

--- a/ktor-http/common/src/io/ktor/http/ContentTypes.kt
+++ b/ktor-http/common/src/io/ktor/http/ContentTypes.kt
@@ -72,6 +72,7 @@ public class ContentType private constructor(
                         else -> parameters.any { p -> p.value.equals(patternValue, ignoreCase = true) }
                     }
                 }
+
                 else -> {
                     val value = parameter(patternName)
                     when (patternValue) {
@@ -117,9 +118,7 @@ public class ContentType private constructor(
                 val slash = parts.indexOf('/')
 
                 if (slash == -1) {
-                    if (parts.trim() == "*") {
-                        return Any
-                    }
+                    if (parts.trim() == "*") return Any
 
                     throw BadContentTypeFormatException(value)
                 }

--- a/ktor-http/common/src/io/ktor/http/HeaderValueWithParameters.kt
+++ b/ktor-http/common/src/io/ktor/http/HeaderValueWithParameters.kt
@@ -60,7 +60,7 @@ public abstract class HeaderValueWithParameters(
          * Parse header with parameter and pass it to [init] function to instantiate particular type
          */
         public inline fun <R> parse(value: String, init: (String, List<HeaderValueParam>) -> R): R {
-            val headerValue = parseHeaderValue(value).single()
+            val headerValue = parseHeaderValue(value).last()
             return init(headerValue.value, headerValue.params)
         }
     }

--- a/ktor-http/common/src/io/ktor/http/URLBuilder.kt
+++ b/ktor-http/common/src/io/ktor/http/URLBuilder.kt
@@ -33,8 +33,8 @@ public class URLBuilder(
     fragment: String = "",
     public var trailingQuery: Boolean = false
 ) {
-
     public var encodedUser: String? = user?.encodeURLParameter()
+
     public var user: String?
         get() = encodedUser?.decodeURLPart()
         set(value) {
@@ -68,6 +68,7 @@ public class URLBuilder(
             field = value
             parameters = UrlDecodedParametersBuilder(value)
         }
+
     public var parameters: ParametersBuilder = UrlDecodedParametersBuilder(encodedParameters)
         private set
 

--- a/ktor-http/common/test/io/ktor/tests/http/ContentTypeTest.kt
+++ b/ktor-http/common/test/io/ktor/tests/http/ContentTypeTest.kt
@@ -133,4 +133,11 @@ class ContentTypeTest {
             ContentType.parse("text/html;charset=utf-8").withoutParameters().toString()
         )
     }
+
+    @Test
+    fun testOnlyLastContentTypeIsProcessed() {
+        val contentType = "text/plain; charset=UTF-8, text/html; charset=UTF-8"
+        val content = ContentType.parse(contentType)
+        assertEquals("text/html; charset=UTF-8", content.toString())
+    }
 }


### PR DESCRIPTION
Fix [KTOR-1858](https://youtrack.jetbrains.com/issue/KTOR-1858/Ios-NullPointerException-when-query-parameters-contain-cyrillic-)