### PR TITLE
KTOR-4105 Consider only last content-type header

### DIFF
--- a/ktor-http/common/src/io/ktor/http/ContentTypes.kt
+++ b/ktor-http/common/src/io/ktor/http/ContentTypes.kt
@@ -72,6 +72,7 @@ public class ContentType private constructor(
                         else -> parameters.any { p -> p.value.equals(patternValue, ignoreCase = true) }
                     }
                 }
+
                 else -> {
                     val value = parameter(patternName)
                     when (patternValue) {
@@ -117,9 +118,7 @@ public class ContentType private constructor(
                 val slash = parts.indexOf('/')
 
                 if (slash == -1) {
-                    if (parts.trim() == "*") {
-                        return Any
-                    }
+                    if (parts.trim() == "*") return Any
 
                     throw BadContentTypeFormatException(value)
                 }

--- a/ktor-http/common/src/io/ktor/http/HeaderValueWithParameters.kt
+++ b/ktor-http/common/src/io/ktor/http/HeaderValueWithParameters.kt
@@ -60,7 +60,7 @@ public abstract class HeaderValueWithParameters(
          * Parse header with parameter and pass it to [init] function to instantiate particular type
          */
         public inline fun <R> parse(value: String, init: (String, List<HeaderValueParam>) -> R): R {
-            val headerValue = parseHeaderValue(value).single()
+            val headerValue = parseHeaderValue(value).last()
             return init(headerValue.value, headerValue.params)
         }
     }

--- a/ktor-http/common/test/io/ktor/tests/http/ContentTypeTest.kt
+++ b/ktor-http/common/test/io/ktor/tests/http/ContentTypeTest.kt
@@ -133,4 +133,11 @@ class ContentTypeTest {
             ContentType.parse("text/html;charset=utf-8").withoutParameters().toString()
         )
     }
+
+    @Test
+    fun testOnlyLastContentTypeIsProcessed() {
+        val contentType = "text/plain; charset=UTF-8, text/html; charset=UTF-8"
+        val content = ContentType.parse(contentType)
+        assertEquals("text/html; charset=UTF-8", content.toString())
+    }
 }


### PR DESCRIPTION
Fix [KTOR-4105](https://youtrack.jetbrains.com/issue/KTOR-4105/Darwin-and-Kotlin-JS-List-has-more-than-one-element-error-when-h)