### PR TITLE
Fix DefaultJson documentation

### DIFF
--- a/ktor-shared/ktor-serialization/ktor-serialization-kotlinx/ktor-serialization-kotlinx-json/common/src/io/ktor/serialization/kotlinx/json/JsonSupport.kt
+++ b/ktor-shared/ktor-serialization/ktor-serialization-kotlinx/ktor-serialization-kotlinx-json/common/src/io/ktor/serialization/kotlinx/json/JsonSupport.kt
@@ -15,7 +15,6 @@ import kotlin.native.concurrent.*
 /**
  * The default JSON configuration used in [KotlinxSerializationConverter]. The settings are:
  * - defaults are serialized
- * - mode is not strict so extra json fields are ignored
  * - pretty printing is disabled
  * - array polymorphism is disabled
  * - keys and values are quoted, non-quoted are not allowed

--- a/ktor-shared/ktor-serialization/ktor-serialization-kotlinx/ktor-serialization-kotlinx-json/common/test/JsonSerializationTest.kt
+++ b/ktor-shared/ktor-serialization/ktor-serialization-kotlinx/ktor-serialization-kotlinx-json/common/test/JsonSerializationTest.kt
@@ -106,6 +106,19 @@ class JsonSerializationTest : AbstractSerializationTest<Json>() {
             )
         )
     }
+
+    @Test
+    fun testExtraFields() = testSuspend {
+        val testSerializer = KotlinxSerializationConverter(defaultSerializationFormat)
+        val dogExtraFieldJson = """{"age": 8,"name":"Auri","color":"Black"}"""
+        assertFailsWith<SerializationException> {
+            testSerializer.deserialize(
+                Charsets.UTF_8,
+                typeInfo<DogDTO>(),
+                ByteReadChannel(dogExtraFieldJson.toByteArray())
+            )
+        }
+    }
 }
 
 @Serializable


### PR DESCRIPTION
**Subsystem**
Client

**Motivation**
The documentation says that the JSON configuration is "mode is not strict so extra json fields are ignored" but is not what is actually doing.

**Solution**
Add `ignoreUnknownKeys = true` to make the JSON configuration work as expected.

