### PR TITLE
KTOR-316 Add custom validation support for origin in CORS plugin

### DIFF
--- a/ktor-server/ktor-server-plugins/ktor-server-cors/api/ktor-server-cors.api
+++ b/ktor-server/ktor-server-plugins/ktor-server-cors/api/ktor-server-cors.api
@@ -8,6 +8,7 @@ public final class io/ktor/server/plugins/cors/CORSConfig {
 	public final fun allowHost (Ljava/lang/String;Ljava/util/List;Ljava/util/List;)V
 	public static synthetic fun allowHost$default (Lio/ktor/server/plugins/cors/CORSConfig;Ljava/lang/String;Ljava/util/List;Ljava/util/List;ILjava/lang/Object;)V
 	public final fun allowMethod (Lio/ktor/http/HttpMethod;)V
+	public final fun allowOrigins (Lkotlin/jvm/functions/Function1;)V
 	public final fun allowXHttpMethodOverride ()V
 	public final fun anyHost ()V
 	public final fun exposeHeader (Ljava/lang/String;)V

--- a/ktor-server/ktor-server-plugins/ktor-server-cors/jvmAndNix/src/io/ktor/server/plugins/cors/CORSConfig.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-cors/jvmAndNix/src/io/ktor/server/plugins/cors/CORSConfig.kt
@@ -97,6 +97,11 @@ public class CORSConfig {
     public var allowCredentials: Boolean = false
 
     /**
+     * If present allows any origin matching any of the predicates.
+     */
+    internal val originPredicates: MutableList<(String) -> Boolean> = mutableListOf()
+
+    /**
      * If present represents the prefix for headers which are permitted in CORS requests.
      */
     public val headerPredicates: MutableList<(String) -> Boolean> = mutableListOf()
@@ -191,6 +196,13 @@ public class CORSConfig {
     @Suppress("unused")
     public fun allowXHttpMethodOverride() {
         allowHeader(HttpHeaders.XHttpMethodOverride)
+    }
+
+    /**
+     * Allows using an origin matching [predicate] for the actual [CORS] request.
+     */
+    public fun allowOrigins(predicate: (String) -> Boolean) {
+        this.originPredicates.add(predicate)
     }
 
     /**


### PR DESCRIPTION
**Subsystem**
`ktor-server-cors` plugin

**Motivation**
https://youtrack.jetbrains.com/issue/KTOR-316
Ktor Server has been lacking proper CORS support for years.
In our specific case, we validate CORS origins using a regex defined externally and injected into various API projects by the CI/CD. Note that these projects are developed using various languages and frameworks, hence why a single, simple regex was chosen to implement CORS check globally.

Until now, our way to implement this in our Ktor backends was using an altered copy of the CORS plugin made like 2 or 3 years ago, largely unmaintained. I'm in the process of upgrading a very old (more than 4 years) important Kotlin API project to the latest and greatest, including Ktor 2. During this process I checked on the linked issue above and realized it was improperly closed and still not implemented, and I actually could spent the time doing it.

**Solution**
My specific case is matching the origin against a single `Regex`, but I decided to make something a little more open and close to what is already available for headers as `config.headerPredicates` (populated using `config.allowHeaders(predicate: (String) -> Boolean)`).

With the proposed solution, the user can configure multiple predicates used to check the origin of the CORS request. If any matches, the origin is allowed. Basically what is done for headers.

Check the implemented tests to see the usage. I made a simple usage and one with a regex.