### PR TITLE
KTOR-326 Allow to set followRedirect property for js client engine

### DIFF
--- a/ktor-client/ktor-client-core/common/src/io/ktor/client/engine/HttpClientEngine.kt
+++ b/ktor-client/ktor-client-core/common/src/io/ktor/client/engine/HttpClientEngine.kt
@@ -16,6 +16,7 @@ import kotlinx.coroutines.*
 import kotlin.coroutines.*
 
 internal val CALL_COROUTINE = CoroutineName("call-context")
+internal val CLIENT_CONFIG = AttributeKey<HttpClientConfig<*>>("client-config")
 
 /**
  * Base interface use to define engines for [HttpClient].
@@ -59,7 +60,10 @@ public interface HttpClientEngine : CoroutineScope, Closeable {
 
             client.monitor.raise(HttpRequestIsReadyForSending, builder)
 
-            val requestData = builder.build()
+            val requestData = builder.build().apply {
+                attributes.put(CLIENT_CONFIG, client.config)
+            }
+
             validateHeaders(requestData)
             checkExtensions(requestData)
 

--- a/ktor-client/ktor-client-core/js/src/io/ktor/client/engine/js/JsUtils.kt
+++ b/ktor-client/ktor-client-core/js/src/io/ktor/client/engine/js/JsUtils.kt
@@ -4,6 +4,7 @@
 
 package io.ktor.client.engine.js
 
+import io.ktor.client.*
 import io.ktor.client.engine.*
 import io.ktor.client.fetch.RequestInit
 import io.ktor.client.request.*
@@ -17,7 +18,10 @@ import org.w3c.fetch.*
 import kotlin.coroutines.*
 
 @OptIn(InternalAPI::class, DelicateCoroutinesApi::class)
-internal suspend fun HttpRequestData.toRaw(callContext: CoroutineContext): RequestInit {
+internal suspend fun HttpRequestData.toRaw(
+    clientConfig: HttpClientConfig<*>,
+    callContext: CoroutineContext
+): RequestInit {
     val jsHeaders = js("({})")
     mergeHeaders(this@toRaw.headers, this@toRaw.body) { key, value ->
         jsHeaders[key] = value
@@ -37,7 +41,7 @@ internal suspend fun HttpRequestData.toRaw(callContext: CoroutineContext): Reque
     return buildObject {
         method = this@toRaw.method.value
         headers = jsHeaders
-        redirect = RequestRedirect.FOLLOW
+        redirect = if (clientConfig.followRedirects) RequestRedirect.FOLLOW else RequestRedirect.MANUAL
 
         bodyBytes?.let { body = Uint8Array(it.toTypedArray()) }
     }

--- a/ktor-client/ktor-client-core/js/src/io/ktor/client/engine/js/ReadableStream.kt
+++ b/ktor-client/ktor-client-core/js/src/io/ktor/client/engine/js/ReadableStream.kt
@@ -4,34 +4,7 @@
 
 package io.ktor.client.engine.js
 
-import kotlinx.coroutines.*
 import org.khronos.webgl.*
-import kotlin.coroutines.*
-import kotlin.js.*
-
-internal external interface ReadableStream {
-    public fun getReader(): ReadableStreamReader
-}
-
-internal external interface ReadResult {
-    val done: Boolean
-    val value: Uint8Array?
-}
-
-internal external interface ReadableStreamReader {
-    public fun cancel(reason: dynamic): Promise<dynamic>
-    public fun read(): Promise<ReadResult>
-}
-
-internal suspend fun ReadableStreamReader.readChunk(): Uint8Array? = suspendCancellableCoroutine { continuation ->
-    read().then {
-        val chunk = it.value
-        val result = if (it.done || chunk == null) null else chunk
-        continuation.resumeWith(Result.success(result))
-    }.catch { cause ->
-        continuation.resumeWithException(cause)
-    }
-}
 
 @Suppress("UnsafeCastFromDynamic")
 internal fun Uint8Array.asByteArray(): ByteArray {

--- a/ktor-client/ktor-client-core/js/src/io/ktor/client/engine/js/compatibility/Utils.kt
+++ b/ktor-client/ktor-client-core/js/src/io/ktor/client/engine/js/compatibility/Utils.kt
@@ -15,7 +15,7 @@ import kotlin.js.Promise
 internal suspend fun commonFetch(
     input: String,
     init: RequestInit
-): Response = suspendCancellableCoroutine { continuation ->
+): org.w3c.fetch.Response = suspendCancellableCoroutine { continuation ->
     val controller = AbortController()
     init.signal = controller.signal
 
@@ -23,7 +23,7 @@ internal suspend fun commonFetch(
         controller.abort()
     }
 
-    val promise: Promise<Response> = if (PlatformUtils.IS_BROWSER) {
+    val promise: Promise<org.w3c.fetch.Response> = if (PlatformUtils.IS_BROWSER) {
         fetch(input, init)
     } else {
         jsRequireNodeFetch()(input, init)
@@ -50,7 +50,7 @@ internal fun AbortController(): AbortController {
 }
 
 internal fun CoroutineScope.readBody(
-    response: Response
+    response: org.w3c.fetch.Response
 ): ByteReadChannel = if (PlatformUtils.IS_BROWSER) {
     readBodyBrowser(response)
 } else {

--- a/ktor-client/ktor-client-core/js/src/io/ktor/client/engine/js/node/NodeFetch.kt
+++ b/ktor-client/ktor-client-core/js/src/io/ktor/client/engine/js/node/NodeFetch.kt
@@ -5,12 +5,11 @@
 package io.ktor.client.engine.js.node
 
 import io.ktor.client.engine.js.*
-import io.ktor.client.fetch.*
 import io.ktor.utils.io.*
 import kotlinx.coroutines.*
 import kotlinx.coroutines.channels.*
-import org.khronos.webgl.ArrayBuffer
-import org.khronos.webgl.Uint8Array
+import org.khronos.webgl.*
+import org.w3c.fetch.*
 
 internal fun CoroutineScope.readBodyNode(response: Response): ByteReadChannel = writer {
     val body: dynamic = response.body ?: error("Fail to get body")

--- a/ktor-client/ktor-client-core/js/src/io/ktor/client/fetch/LibDom.kt
+++ b/ktor-client/ktor-client-core/js/src/io/ktor/client/fetch/LibDom.kt
@@ -8,7 +8,7 @@ import kotlin.js.Promise
 
 // external fun fetch(input: Request, init: RequestInit? = definedExternally): Promise<Response>
 
-public external fun fetch(input: String, init: RequestInit? = definedExternally): Promise<Response>
+public external fun fetch(input: String, init: RequestInit? = definedExternally): Promise<org.w3c.fetch.Response>
 
 public external interface Request : Body {
     /* "default" | "no-store" | "reload" | "no-cache" | "force-cache" | "only-if-cached" */

--- a/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/HttpRedirectTest.kt
+++ b/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/HttpRedirectTest.kt
@@ -10,6 +10,7 @@ import io.ktor.client.request.*
 import io.ktor.client.statement.*
 import io.ktor.client.tests.utils.*
 import io.ktor.http.*
+import io.ktor.util.*
 import kotlin.test.*
 
 @Suppress("PublicApiImplicitType")
@@ -23,7 +24,7 @@ class HttpRedirectTest : ClientLoader() {
         }
 
         test { client ->
-            client.prepareGet("$TEST_URL_BASE").execute {
+            client.prepareGet(TEST_URL_BASE).execute {
                 assertEquals(HttpStatusCode.OK, it.status)
                 assertEquals("OK", it.bodyAsText())
             }
@@ -130,6 +131,20 @@ class HttpRedirectTest : ClientLoader() {
                 assertEquals("OK", it.bodyAsText())
                 assertEquals("$TEST_URL_BASE/get", it.call.request.url.toString())
             }
+        }
+    }
+
+    @Test
+    fun testRedirectDisabled() = clientTests {
+        config {
+            followRedirects = false
+        }
+
+        test { client ->
+            if (PlatformUtils.IS_BROWSER) return@test
+
+            val response = client.get(TEST_URL_BASE)
+            assertEquals(HttpStatusCode.Found, response.status)
         }
     }
 }


### PR DESCRIPTION
Fix [KTOR-326](https://youtrack.jetbrains.com/issue/KTOR-326/JS-client-Cannot-change-redirect-policy-by-followRedirectsfalse)