### PR TITLE
 KTOR-4390 Fix Query Parameters for UrlBuilder.set method

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -24,6 +24,8 @@ sourceSets.main {
 dependencies {
     implementation(kotlin("gradle-plugin", libs.versions.kotlin.version.get()))
     implementation(kotlin("serialization", libs.versions.kotlin.version.get()))
+    testImplementation("io.ktor:ktor-server-tests-jvm:2.0.2")
+    testImplementation("org.jetbrains.kotlin:kotlin-test-junit:1.6.21")
 
     val ktlint_version = libs.versions.ktlint.version.get()
     implementation("org.jmailen.gradle:kotlinter-gradle:$ktlint_version")

--- a/buildSrc/src/main/kotlin/test/server/ClientTestServer.kt
+++ b/buildSrc/src/main/kotlin/test/server/ClientTestServer.kt
@@ -12,6 +12,7 @@ import io.ktor.server.request.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
 import io.ktor.websocket.*
+import test.server.tests.*
 
 internal fun Application.tests() {
     install(io.ktor.server.websocket.WebSockets) {

--- a/buildSrc/src/main/kotlin/test/server/TestServer.kt
+++ b/buildSrc/src/main/kotlin/test/server/TestServer.kt
@@ -4,13 +4,11 @@
 
 package test.server
 
-import ch.qos.logback.classic.*
-import io.ktor.client.tests.utils.tests.*
 import io.ktor.network.tls.certificates.*
 import io.ktor.server.cio.*
 import io.ktor.server.engine.*
 import io.ktor.server.jetty.*
-import org.slf4j.*
+import test.server.tests.*
 import java.io.*
 import java.util.concurrent.*
 

--- a/buildSrc/src/main/kotlin/test/server/tests/Auth.kt
+++ b/buildSrc/src/main/kotlin/test/server/tests/Auth.kt
@@ -2,7 +2,7 @@
  * Copyright 2014-2019 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
-package io.ktor.client.tests.utils.tests
+package test.server.tests
 
 import io.ktor.http.*
 import io.ktor.server.application.*

--- a/buildSrc/src/main/kotlin/test/server/tests/Builders.kt
+++ b/buildSrc/src/main/kotlin/test/server/tests/Builders.kt
@@ -2,7 +2,7 @@
 * Copyright 2014-2021 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
 */
 
-package io.ktor.client.tests.utils.tests
+package test.server.tests
 
 import io.ktor.server.application.*
 import io.ktor.server.response.*

--- a/buildSrc/src/main/kotlin/test/server/tests/Cache.kt
+++ b/buildSrc/src/main/kotlin/test/server/tests/Cache.kt
@@ -2,7 +2,7 @@
 * Copyright 2014-2021 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
 */
 
-package io.ktor.client.tests.utils.tests
+package test.server.tests
 
 import io.ktor.http.*
 import io.ktor.http.content.*

--- a/buildSrc/src/main/kotlin/test/server/tests/CloseableGroup.kt
+++ b/buildSrc/src/main/kotlin/test/server/tests/CloseableGroup.kt
@@ -2,7 +2,7 @@
  * Copyright 2014-2021 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
-package io.ktor.client.tests.utils.tests
+package test.server.tests
 
 import java.io.*
 

--- a/buildSrc/src/main/kotlin/test/server/tests/Content.kt
+++ b/buildSrc/src/main/kotlin/test/server/tests/Content.kt
@@ -2,9 +2,8 @@
  * Copyright 2014-2019 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
-package io.ktor.client.tests.utils.tests
+package test.server.tests
 
-import io.ktor.client.tests.utils.*
 import io.ktor.http.*
 import io.ktor.http.content.*
 import io.ktor.server.application.*

--- a/buildSrc/src/main/kotlin/test/server/tests/Cookies.kt
+++ b/buildSrc/src/main/kotlin/test/server/tests/Cookies.kt
@@ -2,7 +2,7 @@
 * Copyright 2014-2021 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
 */
 
-package io.ktor.client.tests.utils.tests
+package test.server.tests
 
 import io.ktor.http.*
 import io.ktor.server.application.*

--- a/buildSrc/src/main/kotlin/test/server/tests/Download.kt
+++ b/buildSrc/src/main/kotlin/test/server/tests/Download.kt
@@ -2,7 +2,7 @@
 * Copyright 2014-2021 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
 */
 
-package io.ktor.client.tests.utils.tests
+package test.server.tests
 
 import io.ktor.http.*
 import io.ktor.http.content.*

--- a/buildSrc/src/main/kotlin/test/server/tests/Encoding.kt
+++ b/buildSrc/src/main/kotlin/test/server/tests/Encoding.kt
@@ -2,7 +2,7 @@
  * Copyright 2014-2019 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
-package io.ktor.client.tests.utils.tests
+package test.server.tests
 
 import io.ktor.http.*
 import io.ktor.server.application.*

--- a/buildSrc/src/main/kotlin/test/server/tests/Events.kt
+++ b/buildSrc/src/main/kotlin/test/server/tests/Events.kt
@@ -1,7 +1,7 @@
 /*
  * Copyright 2014-2021 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
-package io.ktor.client.tests.utils.tests
+package test.server.tests
 
 import io.ktor.http.*
 import io.ktor.server.application.*

--- a/buildSrc/src/main/kotlin/test/server/tests/Features.kt
+++ b/buildSrc/src/main/kotlin/test/server/tests/Features.kt
@@ -2,7 +2,7 @@
  * Copyright 2014-2019 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
-package io.ktor.client.tests.utils.tests
+package test.server.tests
 
 import io.ktor.server.application.*
 import io.ktor.server.response.*

--- a/buildSrc/src/main/kotlin/test/server/tests/Forms.kt
+++ b/buildSrc/src/main/kotlin/test/server/tests/Forms.kt
@@ -2,7 +2,7 @@
  * Copyright 2014-2019 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
-package io.ktor.client.tests.utils.tests
+package test.server.tests
 
 import io.ktor.http.*
 import io.ktor.server.application.*

--- a/buildSrc/src/main/kotlin/test/server/tests/Headers.kt
+++ b/buildSrc/src/main/kotlin/test/server/tests/Headers.kt
@@ -2,7 +2,7 @@
  * Copyright 2014-2019 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
-package io.ktor.client.tests.utils.tests
+package test.server.tests
 
 import io.ktor.http.*
 import io.ktor.server.application.*

--- a/buildSrc/src/main/kotlin/test/server/tests/Json.kt
+++ b/buildSrc/src/main/kotlin/test/server/tests/Json.kt
@@ -2,7 +2,7 @@
 * Copyright 2014-2021 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
 */
 
-package io.ktor.client.tests.utils.tests
+package test.server.tests
 
 import io.ktor.http.*
 import io.ktor.server.application.*

--- a/buildSrc/src/main/kotlin/test/server/tests/Logging.kt
+++ b/buildSrc/src/main/kotlin/test/server/tests/Logging.kt
@@ -2,7 +2,7 @@
  * Copyright 2014-2019 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
-package io.ktor.client.tests.utils.tests
+package test.server.tests
 
 import io.ktor.http.*
 import io.ktor.server.application.*

--- a/buildSrc/src/main/kotlin/test/server/tests/MultiPartFormData.kt
+++ b/buildSrc/src/main/kotlin/test/server/tests/MultiPartFormData.kt
@@ -2,7 +2,7 @@
  * Copyright 2014-2019 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
-package io.ktor.client.tests.utils.tests
+package test.server.tests
 
 import io.ktor.http.*
 import io.ktor.http.content.*

--- a/buildSrc/src/main/kotlin/test/server/tests/Multithreaded.kt
+++ b/buildSrc/src/main/kotlin/test/server/tests/Multithreaded.kt
@@ -8,6 +8,7 @@ import io.ktor.server.application.*
 import io.ktor.server.http.content.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
+import test.server.tests.counter
 
 internal fun Application.multithreadedTest() {
     routing {

--- a/buildSrc/src/main/kotlin/test/server/tests/Redirect.kt
+++ b/buildSrc/src/main/kotlin/test/server/tests/Redirect.kt
@@ -2,9 +2,8 @@
  * Copyright 2014-2019 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
-package io.ktor.client.tests.utils.tests
+package test.server.tests
 
-import io.ktor.client.tests.utils.*
 import io.ktor.server.application.*
 import io.ktor.server.request.*
 import io.ktor.server.response.*

--- a/buildSrc/src/main/kotlin/test/server/tests/Serialization.kt
+++ b/buildSrc/src/main/kotlin/test/server/tests/Serialization.kt
@@ -2,7 +2,7 @@
  * Copyright 2014-2019 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
-package io.ktor.client.tests.utils.tests
+package test.server.tests
 
 import io.ktor.http.*
 import io.ktor.server.application.*

--- a/buildSrc/src/main/kotlin/test/server/tests/Tcp.kt
+++ b/buildSrc/src/main/kotlin/test/server/tests/Tcp.kt
@@ -2,7 +2,7 @@
 * Copyright 2014-2021 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
 */
 
-package io.ktor.client.tests.utils.tests
+package test.server.tests
 
 import io.ktor.client.utils.*
 import io.ktor.http.*

--- a/buildSrc/src/main/kotlin/test/server/tests/Timeout.kt
+++ b/buildSrc/src/main/kotlin/test/server/tests/Timeout.kt
@@ -2,7 +2,7 @@
  * Copyright 2014-2019 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
-package io.ktor.client.tests.utils.tests
+package test.server.tests
 
 import io.ktor.http.*
 import io.ktor.http.content.*

--- a/buildSrc/src/main/kotlin/test/server/tests/Upload.kt
+++ b/buildSrc/src/main/kotlin/test/server/tests/Upload.kt
@@ -2,14 +2,14 @@
 * Copyright 2014-2021 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
 */
 
-package io.ktor.client.tests.utils.tests
+package test.server.tests
 
 import io.ktor.http.*
 import io.ktor.server.application.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
 
-public fun Application.uploadTest() {
+internal fun Application.uploadTest() {
     routing {
         route("upload") {
             post("content") {

--- a/buildSrc/src/main/kotlin/test/server/tests/WebSockets.kt
+++ b/buildSrc/src/main/kotlin/test/server/tests/WebSockets.kt
@@ -1,4 +1,4 @@
-package io.ktor.client.tests.utils.tests
+package test.server.tests
 
 import io.ktor.server.application.*
 import io.ktor.server.routing.*
@@ -23,14 +23,11 @@ internal fun Application.webSockets() {
                     }
                 }
             }
-
             webSocket("headers") {
                 val headers = call.request.headers.toMap()
-                @OptIn(ExperimentalSerializationApi::class)
                 val headersJson = Json.encodeToString(headers)
                 send(Frame.Text(headersJson))
             }
-
             webSocket("close") {
                 for (packet in incoming) {
                     val data = packet.data
@@ -38,6 +35,10 @@ internal fun Application.webSockets() {
                         close(CloseReason(1000, "End"))
                     }
                 }
+            }
+            webSocket("echo-query") {
+                val param = call.parameters["param"] ?: error("No param provided")
+                send(Frame.Text(param))
             }
         }
     }

--- a/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/WebSocketTest.kt
+++ b/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/WebSocketTest.kt
@@ -18,7 +18,7 @@ import kotlin.test.*
 
 private const val TEST_SIZE: Int = 100
 
-class WebSocketTest : ClientLoader(100000) {
+class WebSocketTest : ClientLoader() {
     data class Data(val stringValue: String)
 
     private val customContentConverter = object : WebsocketContentConverter {
@@ -160,6 +160,25 @@ class WebSocketTest : ClientLoader(100000) {
                 assertFailsWith<WebsocketConverterNotFoundException>("No converter was found for websocket") {
                     receiveDeserialized<Data>()
                 }
+            }
+        }
+    }
+
+    @Test
+    fun testQueryParameters() = clientTests(listOf("Android", "Apache", "Curl")) {
+        config {
+            install(WebSockets)
+        }
+
+        test { client ->
+            client.ws(
+                host = "127.0.0.1",
+                port = 8080,
+                path = "/websockets/echo-query?param=hello"
+            ) {
+                val response = incoming.receive() as Frame.Text
+                val query = response.readText()
+                assertEquals("hello", query)
             }
         }
     }

--- a/ktor-http/common/src/io/ktor/http/Url.kt
+++ b/ktor-http/common/src/io/ktor/http/Url.kt
@@ -55,14 +55,12 @@ public class Url internal constructor(
     }
 
     public val encodedQuery: String by lazy {
-        if (parameters.isEmpty()) {
-            return@lazy ""
-        }
         val queryStart = urlString.indexOf('?') + 1
+        if (queryStart == 0) return@lazy ""
+
         val queryEnd = urlString.indexOf('#', queryStart)
-        if (queryEnd == -1) {
-            return@lazy urlString.substring(queryStart)
-        }
+        if (queryEnd == -1) return@lazy urlString.substring(queryStart)
+
         urlString.substring(queryStart, queryEnd)
     }
 
@@ -95,8 +93,9 @@ public class Url internal constructor(
     }
 
     public val encodedFragment: String by lazy {
-        if (fragment.isEmpty()) return@lazy ""
         val fragmentStart = urlString.indexOf('#') + 1
+        if (fragmentStart == 0) return@lazy ""
+
         urlString.substring(fragmentStart)
     }
 

--- a/ktor-http/common/test/io/ktor/tests/http/URLBuilderTest.kt
+++ b/ktor-http/common/test/io/ktor/tests/http/URLBuilderTest.kt
@@ -378,6 +378,39 @@ internal class URLBuilderTest {
         }
     }
 
+    @Test
+    fun testUrlBuilderSetQueryInPath() {
+        val url = URLBuilder().apply {
+            set(
+                "ws",
+                "0.0.0.0",
+                8080,
+                "/ws/v1?action=get&id=1"
+            )
+        }.build()
+
+        assertEquals("/ws/v1", url.encodedPath)
+        assertEquals("action=get&id=1", url.encodedQuery)
+        assertEquals("/ws/v1?action=get&id=1", url.encodedPathAndQuery)
+    }
+
+    @Test
+    fun testUrlBuilderSetFragmentInPath() {
+        val url = URLBuilder().apply {
+            set(
+                "ws",
+                "0.0.0.0",
+                8080,
+                "/ws/v1?action=get&id=1#hello"
+            )
+        }.build()
+
+        assertEquals("/ws/v1", url.encodedPath)
+        assertEquals("action=get&id=1", url.encodedQuery)
+        assertEquals("hello", url.encodedFragment)
+        assertEquals("/ws/v1?action=get&id=1", url.encodedPathAndQuery)
+    }
+
     /**
      * Checks that the given [url] and the result of [URLBuilder.buildString] is equal (case insensitive).
      */

--- a/ktor-server/ktor-server-tests/jvmAndNix/test/io/ktor/tests/server/http/ServerURLBuilderTest.kt
+++ b/ktor-server/ktor-server-tests/jvmAndNix/test/io/ktor/tests/server/http/ServerURLBuilderTest.kt
@@ -12,7 +12,7 @@ import io.ktor.server.util.*
 import kotlin.test.*
 
 @Suppress("DEPRECATION")
-class URLBuilderTest {
+class ServerURLBuilderTest {
 
     @Test
     fun testPathFirstSlash() {

--- a/ktor-shared/ktor-resources/common/test/io/ktor/tests/resources/ResourceUrlBuilderTest.kt
+++ b/ktor-shared/ktor-resources/common/test/io/ktor/tests/resources/ResourceUrlBuilderTest.kt
@@ -9,7 +9,7 @@ import io.ktor.resources.serialization.*
 import kotlinx.serialization.*
 import kotlin.test.*
 
-class UrlBuilderTest {
+class ResourceUrlBuilderTest {
 
     private val resourcesFormat = ResourcesFormat()
 


### PR DESCRIPTION
Fix [KTOR-4390](https://youtrack.jetbrains.com/issue/KTOR-4390/CIO-Websockets-request-doesnt-include-query-parameters)