### PR TITLE
KTOR-4593 Add support to automatically use the correct translation file for Pebble based on Accept Language header

### DIFF
--- a/ktor-server/ktor-server-plugins/ktor-server-pebble/api/ktor-server-pebble.api
+++ b/ktor-server/ktor-server-plugins/ktor-server-pebble/api/ktor-server-pebble.api
@@ -1,7 +1,7 @@
 public final class io/ktor/server/pebble/PebbleConfiguration : com/mitchellbosecke/pebble/PebbleEngine$Builder {
 	public fun <init> ()V
-	public final fun getAvailableLanguages ()[Ljava/lang/String;
-	public final fun setAvailableLanguages ([Ljava/lang/String;)V
+	public final fun getAvailableLanguages ()Ljava/util/List;
+	public final fun setAvailableLanguages (Ljava/util/List;)V
 }
 
 public final class io/ktor/server/pebble/PebbleContent {

--- a/ktor-server/ktor-server-plugins/ktor-server-pebble/api/ktor-server-pebble.api
+++ b/ktor-server/ktor-server-plugins/ktor-server-pebble/api/ktor-server-pebble.api
@@ -1,3 +1,9 @@
+public final class io/ktor/server/pebble/PebbleConfiguration : com/mitchellbosecke/pebble/PebbleEngine$Builder {
+	public fun <init> ()V
+	public final fun getAvailableLanguages ()[Ljava/lang/String;
+	public final fun setAvailableLanguages ([Ljava/lang/String;)V
+}
+
 public final class io/ktor/server/pebble/PebbleContent {
 	public fun <init> (Ljava/lang/String;Ljava/util/Map;Ljava/util/Locale;Ljava/lang/String;Lio/ktor/http/ContentType;)V
 	public synthetic fun <init> (Ljava/lang/String;Ljava/util/Map;Ljava/util/Locale;Ljava/lang/String;Lio/ktor/http/ContentType;ILkotlin/jvm/internal/DefaultConstructorMarker;)V

--- a/ktor-server/ktor-server-plugins/ktor-server-pebble/jvm/src/io/ktor/server/pebble/Pebble.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-pebble/jvm/src/io/ktor/server/pebble/Pebble.kt
@@ -23,7 +23,7 @@ public class PebbleConfiguration : PebbleEngine.Builder() {
      * Allows you to define currently available language translations
      * must follow IETF BCP 47 language tag string specification
      */
-    public var availableLanguages: MutableList<String>? = null
+    public var availableLanguages: List<String>? = null
 }
 
 /**
@@ -50,16 +50,16 @@ public class PebbleContent(
  */
 public val Pebble: ApplicationPlugin<PebbleConfiguration> = createApplicationPlugin("Pebble", ::PebbleConfiguration) {
     val engine = pluginConfig.build()
+    val availableLanguages: List<String>? = pluginConfig.availableLanguages?.toList()
 
     fun process(content: PebbleContent, call: ApplicationCall): OutgoingContent = with(content) {
         val writer = StringWriter()
-        val availableLanguages: List<String>? = pluginConfig.availableLanguages?.toList()
         var locale = locale
 
         if (availableLanguages != null && locale == null) {
-            locale = call.request.acceptLanguageItems().firstOrNull {
-                pluginConfig.availableLanguages!!.contains(it.value)
-            }?.value?.let { Locale.forLanguageTag(it) }
+            locale = call.request.acceptLanguageItems()
+                .firstOrNull { pluginConfig.availableLanguages!!.contains(it.value) }
+                ?.value?.let { Locale.forLanguageTag(it) }
         }
         engine.getTemplate(content.template).evaluate(writer, model, locale)
 

--- a/ktor-server/ktor-server-plugins/ktor-server-pebble/jvm/test-resources/i18n_test.properties
+++ b/ktor-server/ktor-server-plugins/ktor-server-pebble/jvm/test-resources/i18n_test.properties
@@ -1,0 +1,5 @@
+#
+# Copyright 2014-2022 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+#
+
+hello_world=Hello, world!

--- a/ktor-server/ktor-server-plugins/ktor-server-pebble/jvm/test-resources/i18n_test_es.properties
+++ b/ktor-server/ktor-server-plugins/ktor-server-pebble/jvm/test-resources/i18n_test_es.properties
@@ -1,0 +1,5 @@
+#
+# Copyright 2014-2022 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+#
+
+hello_world=Hola, mundo!

--- a/ktor-server/ktor-server-plugins/ktor-server-pebble/jvm/test/io/ktor/server/pebble/PebbleTest.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-pebble/jvm/test/io/ktor/server/pebble/PebbleTest.kt
@@ -229,7 +229,7 @@ class PebbleTest {
     private fun Application.setupPebble() {
         install(Pebble) {
             loader(StringLoader())
-            availableLanguages = arrayOf("en", "es")
+            availableLanguages = mutableListOf("en", "es")
         }
     }
 

--- a/ktor-server/ktor-server-plugins/ktor-server-pebble/jvm/test/io/ktor/server/pebble/PebbleTest.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-pebble/jvm/test/io/ktor/server/pebble/PebbleTest.kt
@@ -5,6 +5,8 @@
 package io.ktor.server.pebble
 
 import com.mitchellbosecke.pebble.loader.*
+import io.ktor.client.request.*
+import io.ktor.client.statement.*
 import io.ktor.http.*
 import io.ktor.server.application.*
 import io.ktor.server.plugins.compression.*
@@ -142,9 +144,92 @@ class PebbleTest {
         }
     }
 
+    @Test
+    fun `Render template in Spanish with es accept language`() {
+        testApplication {
+            application {
+                setupPebble()
+                install(ConditionalHeaders)
+                routing {
+                    get("/") {
+                        call.respond(PebbleContent(TemplateI18N, emptyMap()))
+                    }
+                }
+            }
+
+            client.get("/") {
+                headers.append(HttpHeaders.AcceptLanguage, "es")
+            }.apply {
+                assertContains(bodyAsText(), "<p>Hola, mundo!</p>")
+            }
+        }
+    }
+
+    @Test
+    fun `Render template in English with en accept language`() {
+        testApplication {
+            application {
+                setupPebble()
+                install(ConditionalHeaders)
+                routing {
+                    get("/") {
+                        call.respond(PebbleContent(TemplateI18N, emptyMap()))
+                    }
+                }
+            }
+
+            client.get("/") {
+                headers.append(HttpHeaders.AcceptLanguage, "en")
+            }.apply {
+                assertContains(bodyAsText(), "<p>Hello, world!</p>")
+            }
+        }
+    }
+
+    @Test
+    fun `Render template in default language with no valid accept language header set`() {
+        testApplication {
+            application {
+                setupPebble()
+                install(ConditionalHeaders)
+                routing {
+                    get("/") {
+                        call.respond(PebbleContent(TemplateI18N, emptyMap()))
+                    }
+                }
+            }
+
+            client.get("/") {
+                headers.append(HttpHeaders.AcceptLanguage, "jp")
+            }.apply {
+                assertContains(bodyAsText(), "<p>Hello, world!</p>")
+            }
+        }
+    }
+
+    @Test
+    fun `Render template in default language with no accept language header set`() {
+        testApplication {
+            application {
+                setupPebble()
+                install(ConditionalHeaders)
+                routing {
+                    get("/") {
+                        call.respond(PebbleContent(TemplateI18N, emptyMap()))
+                    }
+                }
+            }
+
+            client.get("/").apply {
+                assertContains(bodyAsText(), "<p>Hello, world!</p>")
+            }
+        }
+    }
+
     private fun Application.setupPebble() {
         install(Pebble) {
             loader(StringLoader())
+            availableLanguages = arrayOf("en", "es")
         }
     }
 
@@ -160,6 +245,11 @@ class PebbleTest {
             get() = """
                 <p>Hello, Anonymous</p>
                 <h1>Hi!</h1>
+            """.trimIndent()
+
+        private val TemplateI18N: String
+            get() = """
+                <p>{{ i18n("i18n_test", "hello_world") }}</p>
             """.trimIndent()
     }
 }


### PR DESCRIPTION
**Subsystem**
Ktor-Server-Pebble

**Motivation**
This PR adds support for improving the ergonomics of using pebbles built in I18N support. It essentially makes it so you do not need to match Accept Headers to Locales in every route.

**Solution**
This uses a similar approach as the #1632 using `call.request.acceptLanguages` and validating it against a list of supported translations to either set the Locale or keep it `null` which is the default state.
