### PR TITLE
KTOR-4636: Unable to configure netty codec limits via application.config

### DIFF
--- a/ktor-server/ktor-server-netty/api/ktor-server-netty.api
+++ b/ktor-server/ktor-server-netty/api/ktor-server-netty.api
@@ -81,6 +81,9 @@ public final class io/ktor/server/netty/NettyApplicationEngine$Configuration : i
 	public final fun getChannelPipelineConfig ()Lkotlin/jvm/functions/Function1;
 	public final fun getConfigureBootstrap ()Lkotlin/jvm/functions/Function1;
 	public final fun getHttpServerCodec ()Lkotlin/jvm/functions/Function0;
+	public final fun getMaxChunkSize ()I
+	public final fun getMaxHeaderSize ()I
+	public final fun getMaxInitialLineLength ()I
 	public final fun getRequestQueueLimit ()I
 	public final fun getRequestReadTimeoutSeconds ()I
 	public final fun getResponseWriteTimeoutSeconds ()I
@@ -90,6 +93,9 @@ public final class io/ktor/server/netty/NettyApplicationEngine$Configuration : i
 	public final fun setChannelPipelineConfig (Lkotlin/jvm/functions/Function1;)V
 	public final fun setConfigureBootstrap (Lkotlin/jvm/functions/Function1;)V
 	public final fun setHttpServerCodec (Lkotlin/jvm/functions/Function0;)V
+	public final fun setMaxChunkSize (I)V
+	public final fun setMaxHeaderSize (I)V
+	public final fun setMaxInitialLineLength (I)V
 	public final fun setRequestQueueLimit (I)V
 	public final fun setRequestReadTimeoutSeconds (I)V
 	public final fun setResponseWriteTimeoutSeconds (I)V

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/EngineMain.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/EngineMain.kt
@@ -26,7 +26,7 @@ public object EngineMain {
         engine.start(true)
     }
 
-    private fun NettyApplicationEngine.Configuration.loadConfiguration(config: ApplicationConfig) {
+    internal fun NettyApplicationEngine.Configuration.loadConfiguration(config: ApplicationConfig) {
         val deploymentConfig = config.config("ktor.deployment")
         loadCommonConfiguration(deploymentConfig)
         deploymentConfig.propertyOrNull("requestQueueLimit")?.getString()?.toInt()?.let {
@@ -46,6 +46,15 @@ public object EngineMain {
         }
         deploymentConfig.propertyOrNull("tcpKeepAlive")?.getString()?.toBoolean()?.let {
             tcpKeepAlive = it
+        }
+        deploymentConfig.propertyOrNull("maxInitialLineLength")?.getString()?.toInt()?.let {
+            maxInitialLineLength = it
+        }
+        deploymentConfig.propertyOrNull("maxHeaderSize")?.getString()?.toInt()?.let {
+            maxHeaderSize = it
+        }
+        deploymentConfig.propertyOrNull("maxChunkSize")?.getString()?.toInt()?.let {
+            maxChunkSize = it
         }
     }
 }

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyApplicationEngine.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyApplicationEngine.kt
@@ -74,14 +74,39 @@ public class NettyApplicationEngine(
         public var tcpKeepAlive: Boolean = false
 
         /**
+         * The url limit including query parameters
+         */
+        public var maxInitialLineLength: Int = HttpObjectDecoder.DEFAULT_MAX_INITIAL_LINE_LENGTH
+
+        /**
+         * The maximum length of all headers.
+         * If the sum of the length of each header exceeds this value, a TooLongFrameException will be raised.
+         */
+        public var maxHeaderSize: Int = HttpObjectDecoder.DEFAULT_MAX_HEADER_SIZE
+
+        /**
+         * The maximum length of the content or each chunk
+         */
+        public var maxChunkSize: Int = HttpObjectDecoder.DEFAULT_MAX_CHUNK_SIZE
+
+        /**
          * User-provided function to configure Netty's [HttpServerCodec]
          */
-        public var httpServerCodec: () -> HttpServerCodec = ::HttpServerCodec
+        public var httpServerCodec: () -> HttpServerCodec = this::defaultHttpServerCodec
 
         /**
          * User-provided function to configure Netty's [ChannelPipeline]
          */
         public var channelPipelineConfig: ChannelPipeline.() -> Unit = {}
+
+        /**
+         * Default function to configure Netty's
+         */
+        private fun defaultHttpServerCodec() = HttpServerCodec(
+            maxInitialLineLength,
+            maxHeaderSize,
+            maxChunkSize
+        )
     }
 
     private val configuration = Configuration().apply(configure)

--- a/ktor-server/ktor-server-netty/jvm/test/io/ktor/tests/server/netty/EngineMainTest.kt
+++ b/ktor-server/ktor-server-netty/jvm/test/io/ktor/tests/server/netty/EngineMainTest.kt
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2014-2022 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.tests.server.netty
+
+import com.typesafe.config.ConfigFactory
+import io.ktor.server.config.*
+import io.ktor.server.netty.*
+import io.ktor.server.netty.EngineMain.loadConfiguration
+import io.netty.handler.codec.http.*
+import org.junit.*
+import org.junit.Assert.*
+
+class EngineMainTest {
+
+    @Test
+    fun testNettyCodecConfiguration() {
+        val config = HoconApplicationConfig(
+            ConfigFactory.parseString(
+                """
+                    ktor {
+                        deployment {
+                            maxInitialLineLength: 2048,
+                            maxHeaderSize: 1024,
+                            maxChunkSize: 42
+                        }
+                    }
+                """.trimIndent()
+            )
+        )
+
+        val configuration = NettyApplicationEngine.Configuration().apply { loadConfiguration(config) }
+
+        assertEquals(2048, configuration.maxInitialLineLength)
+        assertEquals(1024, configuration.maxHeaderSize)
+        assertEquals(42, configuration.maxChunkSize)
+    }
+
+    @Test
+    fun testNettyCodecDefaultConfiguration() {
+        val config = HoconApplicationConfig(
+            ConfigFactory.parseString(
+                """
+                    ktor {
+                        deployment {
+                        }
+                    }
+                """.trimIndent()
+            )
+        )
+
+        val configuration = NettyApplicationEngine.Configuration().apply { loadConfiguration(config) }
+
+        assertEquals(HttpObjectDecoder.DEFAULT_MAX_INITIAL_LINE_LENGTH, configuration.maxInitialLineLength)
+        assertEquals(HttpObjectDecoder.DEFAULT_MAX_HEADER_SIZE, configuration.maxHeaderSize)
+        assertEquals(HttpObjectDecoder.DEFAULT_MAX_CHUNK_SIZE, configuration.maxChunkSize)
+    }
+}


### PR DESCRIPTION
**Subsystem**
ktor-server-netty
Server configuration

**Motivation**
In our company we had to increase netty limits slightly. We a using EngineMain and application.conf.
Unfortionally, this configuration approach does not support netty configuration.
We should create an embeded version . . . It is not conviniant . . .

**Solution**
This pull request allow to configure common netty limits via application.conf

I will also push these changes to the documentation (after merge)

