### PR TITLE
add enabledProtocols to ssl connector config

### DIFF
--- a/ktor-server/ktor-server-host-common/api/ktor-server-host-common.api
+++ b/ktor-server/ktor-server-host-common/api/ktor-server-host-common.api
@@ -276,6 +276,7 @@ public final class io/ktor/server/engine/EnginePipeline$Companion {
 
 public final class io/ktor/server/engine/EngineSSLConnectorBuilder : io/ktor/server/engine/EngineConnectorBuilder, io/ktor/server/engine/EngineSSLConnectorConfig {
 	public fun <init> (Ljava/security/KeyStore;Ljava/lang/String;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;)V
+	public fun getEnabledProtocols ()Ljava/util/List;
 	public fun getKeyAlias ()Ljava/lang/String;
 	public fun getKeyStore ()Ljava/security/KeyStore;
 	public fun getKeyStorePassword ()Lkotlin/jvm/functions/Function0;
@@ -284,6 +285,7 @@ public final class io/ktor/server/engine/EngineSSLConnectorBuilder : io/ktor/ser
 	public fun getPrivateKeyPassword ()Lkotlin/jvm/functions/Function0;
 	public fun getTrustStore ()Ljava/security/KeyStore;
 	public fun getTrustStorePath ()Ljava/io/File;
+	public fun setEnabledProtocols (Ljava/util/List;)V
 	public fun setKeyAlias (Ljava/lang/String;)V
 	public fun setKeyStore (Ljava/security/KeyStore;)V
 	public fun setKeyStorePassword (Lkotlin/jvm/functions/Function0;)V
@@ -295,6 +297,7 @@ public final class io/ktor/server/engine/EngineSSLConnectorBuilder : io/ktor/ser
 }
 
 public abstract interface class io/ktor/server/engine/EngineSSLConnectorConfig : io/ktor/server/engine/EngineConnectorConfig {
+	public abstract fun getEnabledProtocols ()Ljava/util/List;
 	public abstract fun getKeyAlias ()Ljava/lang/String;
 	public abstract fun getKeyStore ()Ljava/security/KeyStore;
 	public abstract fun getKeyStorePassword ()Lkotlin/jvm/functions/Function0;

--- a/ktor-server/ktor-server-host-common/jvm/src/io/ktor/server/engine/EngineConnectorConfigJvm.kt
+++ b/ktor-server/ktor-server-host-common/jvm/src/io/ktor/server/engine/EngineConnectorConfigJvm.kt
@@ -33,6 +33,7 @@ public class EngineSSLConnectorBuilder(
     override var trustStore: KeyStore? = null
     override var trustStorePath: File? = null
     override var port: Int = 443
+    override var enabledProtocols: List<String>? = null
 }
 
 /**
@@ -81,6 +82,11 @@ public interface EngineSSLConnectorConfig : EngineConnectorConfig {
      * If [trustStore] and [trustStorePath] are both null, the endpoint's certificate will not be verified.
      */
     public val trustStorePath: File?
+
+    /**
+     *  Enabled protocol versions
+     */
+    public val enabledProtocols: List<String>?
 }
 
 /**

--- a/ktor-server/ktor-server-jetty/jvm/src/io/ktor/server/jetty/ServerInitializer.kt
+++ b/ktor-server/ktor-server-jetty/jvm/src/io/ktor/server/jetty/ServerInitializer.kt
@@ -65,6 +65,10 @@ internal fun Server.initializeServer(environment: ApplicationEngineEnvironment) 
                             else -> false
                         }
 
+                        ktorConnector.enabledProtocols?.let {
+                            setIncludeProtocols(*it.toTypedArray())
+                        }
+
                         addExcludeCipherSuites(
                             "SSL_RSA_WITH_DES_CBC_SHA",
                             "SSL_DHE_RSA_WITH_DES_CBC_SHA",

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyChannelInitializer.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyChannelInitializer.kt
@@ -86,6 +86,9 @@ public class NettyChannelInitializer(
                         useClientMode = false
                         needClientAuth = true
                     }
+                    connector.enabledProtocols?.let {
+                        enabledProtocols = it.toTypedArray()
+                    }
                 }
                 addLast("ssl", SslHandler(sslEngine))
 

--- a/ktor-server/ktor-server-tomcat/jvm/src/io/ktor/server/tomcat/TomcatApplicationEngine.kt
+++ b/ktor-server/ktor-server-tomcat/jvm/src/io/ktor/server/tomcat/TomcatApplicationEngine.kt
@@ -105,6 +105,10 @@ public class TomcatApplicationEngine(
                             setProperty("sslProtocol", "TLS")
                             setProperty("SSLEnabled", "true")
 
+                            ktorConnector.enabledProtocols?.let {
+                                setProperty("sslEnabledProtocols", it.joinToString())
+                            }
+
                             val sslImpl = chooseSSLImplementation()
 
                             setProperty("sslImplementationName", sslImpl.name)


### PR DESCRIPTION
**Subsystem**
Server

**Motivation**
Addresses https://youtrack.jetbrains.com/issue/KTOR-4587, providing mechanism to enable use of particular TLS versions 

**Solution**
Added new `enabledProtocols` property to engine connector config which is then applied in Netty, Jetty and Tomcat engines.

Some additional context in https://kotlinlang.slack.com/archives/C0A974TJ9/p1656335256667499
