### PR TITLE
KTOR-4193 Log CallLogging MDC values in StatusPages exception handlers.

### DIFF
--- a/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/logging/Logging.kt
+++ b/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/logging/Logging.kt
@@ -34,5 +34,5 @@ private object EmptyMDCProvider : MDCProvider {
 public val Application.mdcProvider: MDCProvider
     @Suppress("UNCHECKED_CAST")
     get() = pluginRegistry.allKeys
-        .firstNotNullOfOrNull { attributes.getOrNull(it as AttributeKey<Any>) as? MDCProvider }
+        .firstNotNullOfOrNull { pluginRegistry.getOrNull(it as AttributeKey<Any>) as? MDCProvider }
         ?: EmptyMDCProvider

--- a/ktor-server/ktor-server-plugins/ktor-server-call-logging/build.gradle.kts
+++ b/ktor-server/ktor-server-plugins/ktor-server-call-logging/build.gradle.kts
@@ -16,6 +16,7 @@ kotlin {
         val jvmTest by getting {
             dependencies {
                 implementation(project(":ktor-server:ktor-server-plugins:ktor-server-call-id"))
+                implementation(project(":ktor-server:ktor-server-plugins:ktor-server-status-pages"))
             }
         }
     }

--- a/ktor-server/ktor-server-plugins/ktor-server-status-pages/jvmAndNix/src/io/ktor/server/plugins/statuspages/StatusPages.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-status-pages/jvmAndNix/src/io/ktor/server/plugins/statuspages/StatusPages.kt
@@ -8,6 +8,7 @@ import io.ktor.http.*
 import io.ktor.http.content.*
 import io.ktor.server.application.*
 import io.ktor.server.application.hooks.*
+import io.ktor.server.logging.*
 import io.ktor.util.*
 import io.ktor.util.reflect.*
 import kotlin.jvm.*
@@ -63,7 +64,9 @@ public val StatusPages: ApplicationPlugin<StatusPagesConfig> = createApplication
         handler ?: throw cause
 
         call.attributes.put(statusPageMarker, Unit)
-        handler(call, cause)
+        call.application.mdcProvider.withMDCBlock(call) {
+            handler(call, cause)
+        }
 
         if (!call.isHandled) {
             throw cause


### PR DESCRIPTION
**Subsystem**
Server Call Logging & Server Status Pages

**Motivation**
https://youtrack.jetbrains.com/issue/KTOR-4193/CallLogging-configured-MDC-entries-are-not-passed-to-StatusPages-exception-handlers

**Solution**
Fix `mdcProvider`, and use it to wrap the exception handlers in the mdc block.
I'm open to other solutions, may be possible to change CallLogging to not remove MDC entries once the try/finally has finished, but instead to remove them in a dedicated phase after fallback, but that feels more brittle.
Perhaps KtorMDCProvider should use a AttributeKey accessible in core, instead of the current "Look through all the plugins for the one we want" method.

