### PR TITLE
KTOR-4655 Fix ContentLength validation by default

### DIFF
--- a/ktor-http/ktor-http-cio/common/src/io/ktor/http/cio/HttpBody.kt
+++ b/ktor-http/ktor-http-cio/common/src/io/ktor/http/cio/HttpBody.kt
@@ -84,11 +84,7 @@ public suspend fun parseHttpBody(
     }
 
     if (contentLength != -1L) {
-        val size = input.copyTo(out, contentLength)
-
-        if (size != contentLength) {
-            throw IOException("Unexpected body length: expected $contentLength, actual $size")
-        }
+        input.copyTo(out, contentLength)
         return
     }
 

--- a/ktor-network/ios/test/io/ktor/network/sockets/tests/TestUtilsIos.kt
+++ b/ktor-network/ios/test/io/ktor/network/sockets/tests/TestUtilsIos.kt
@@ -1,0 +1,7 @@
+/*
+ * Copyright 2014-2021 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.network.sockets.tests
+
+internal actual fun Any.supportsUnixDomainSockets(): Boolean = false

--- a/ktor-network/linuxX64/test/io/ktor/network/sockets/tests/TestUtilsLinux.kt
+++ b/ktor-network/linuxX64/test/io/ktor/network/sockets/tests/TestUtilsLinux.kt
@@ -1,0 +1,7 @@
+/*
+ * Copyright 2014-2021 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.network.sockets.tests
+
+internal actual fun Any.supportsUnixDomainSockets(): Boolean = true

--- a/ktor-network/macos/test/io/ktor/network/sockets/tests/TestUtilsMacos.kt
+++ b/ktor-network/macos/test/io/ktor/network/sockets/tests/TestUtilsMacos.kt
@@ -1,0 +1,7 @@
+/*
+ * Copyright 2014-2021 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.network.sockets.tests
+
+internal actual fun Any.supportsUnixDomainSockets(): Boolean = true

--- a/ktor-network/nix/test/io/ktor/network/sockets/tests/TestUtilsNix.kt
+++ b/ktor-network/nix/test/io/ktor/network/sockets/tests/TestUtilsNix.kt
@@ -6,8 +6,6 @@ package io.ktor.network.sockets.tests
 
 import platform.posix.*
 
-internal actual fun Any.supportsUnixDomainSockets(): Boolean = true
-
 internal actual fun createTempFilePath(basename: String): String = "/tmp/$basename"
 
 internal actual fun removeFile(path: String) {

--- a/ktor-network/tvos/test/io/ktor/network/sockets/tests/TestUtilsTvos.kt
+++ b/ktor-network/tvos/test/io/ktor/network/sockets/tests/TestUtilsTvos.kt
@@ -1,0 +1,7 @@
+/*
+ * Copyright 2014-2022 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.network.sockets.tests
+
+internal actual fun Any.supportsUnixDomainSockets(): Boolean = false

--- a/ktor-network/watchos/test/io/ktor/network/sockets/tests/TestUtilsWatchos.kt
+++ b/ktor-network/watchos/test/io/ktor/network/sockets/tests/TestUtilsWatchos.kt
@@ -1,0 +1,7 @@
+/*
+ * Copyright 2014-2022 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.network.sockets.tests
+
+internal actual fun Any.supportsUnixDomainSockets(): Boolean = false

--- a/ktor-server/ktor-server-core/api/ktor-server-core.api
+++ b/ktor-server/ktor-server-core/api/ktor-server-core.api
@@ -196,6 +196,12 @@ public final class io/ktor/server/application/hooks/MonitoringEvent : io/ktor/se
 	public fun install (Lio/ktor/server/application/ApplicationCallPipeline;Lkotlin/jvm/functions/Function1;)V
 }
 
+public final class io/ktor/server/application/hooks/ReceiveRequestBytes : io/ktor/server/application/Hook {
+	public static final field INSTANCE Lio/ktor/server/application/hooks/ReceiveRequestBytes;
+	public synthetic fun install (Lio/ktor/server/application/ApplicationCallPipeline;Ljava/lang/Object;)V
+	public fun install (Lio/ktor/server/application/ApplicationCallPipeline;Lkotlin/jvm/functions/Function2;)V
+}
+
 public final class io/ktor/server/application/hooks/ResponseBodyReadyForSend : io/ktor/server/application/Hook {
 	public static final field INSTANCE Lio/ktor/server/application/hooks/ResponseBodyReadyForSend;
 	public synthetic fun install (Lio/ktor/server/application/ApplicationCallPipeline;Ljava/lang/Object;)V

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http1/NettyHttp1Handler.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http1/NettyHttp1Handler.kt
@@ -8,7 +8,6 @@ import io.ktor.server.application.*
 import io.ktor.server.engine.*
 import io.ktor.server.netty.*
 import io.ktor.server.netty.cio.*
-import io.ktor.util.*
 import io.ktor.util.cio.*
 import io.ktor.utils.io.*
 import io.netty.channel.*
@@ -156,8 +155,7 @@ internal class NettyHttp1Handler(
         message: HttpRequest
     ): ByteReadChannel {
         val bodyHandler = context.pipeline().get(RequestBodyHandler::class.java)
-        val length = message.headers()[io.ktor.http.HttpHeaders.ContentLength]?.toLongOrNull() ?: -1
-        val result = bodyHandler.newChannel(length)
+        val result = bodyHandler.newChannel()
 
         if (message is HttpContent) {
             bodyHandler.channelRead(context, message)

--- a/ktor-server/ktor-server-plugins/ktor-server-request-validation/api/ktor-server-request-validation.api
+++ b/ktor-server/ktor-server-plugins/ktor-server-request-validation/api/ktor-server-request-validation.api
@@ -3,6 +3,7 @@ public final class io/ktor/server/plugins/requestvalidation/RequestValidationCon
 	public final fun validate (Lio/ktor/server/plugins/requestvalidation/Validator;)V
 	public final fun validate (Lkotlin/jvm/functions/Function1;)V
 	public final fun validate (Lkotlin/reflect/KClass;Lkotlin/jvm/functions/Function2;)V
+	public final fun validateContentLength ()V
 }
 
 public final class io/ktor/server/plugins/requestvalidation/RequestValidationConfig$ValidatorBuilder {

--- a/ktor-server/ktor-server-plugins/ktor-server-request-validation/jvmAndNix/src/io/ktor/server/plugins/requestvalidation/RequestValidation.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-request-validation/jvmAndNix/src/io/ktor/server/plugins/requestvalidation/RequestValidation.kt
@@ -9,7 +9,6 @@ import io.ktor.server.application.hooks.*
 import io.ktor.server.request.*
 import io.ktor.utils.io.*
 import io.ktor.utils.io.errors.*
-import kotlinx.coroutines.*
 
 /**
  * A result of validation.
@@ -96,10 +95,10 @@ public val RequestValidation: RouteScopedPlugin<RequestValidationConfig> = creat
  * @property value - invalid request body
  * @property reasons - combined reasons of all validation failures for this request
  */
-public class RequestValidationException(public val value: Any, public val reasons: List<String>) :
-    IllegalArgumentException(
-        "Validation failed for $value. Reasons: ${reasons.joinToString(".")}"
-    )
+public class RequestValidationException(
+    public val value: Any,
+    public val reasons: List<String>
+) : IllegalArgumentException("Validation failed for $value. Reasons: ${reasons.joinToString(".")}")
 
 private object RequestBodyTransformed : Hook<suspend (content: Any) -> Unit> {
     override fun install(

--- a/ktor-server/ktor-server-plugins/ktor-server-request-validation/jvmAndNix/src/io/ktor/server/plugins/requestvalidation/RequestValidation.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-request-validation/jvmAndNix/src/io/ktor/server/plugins/requestvalidation/RequestValidation.kt
@@ -20,9 +20,14 @@ public sealed class ValidationResult {
     public object Valid : ValidationResult()
 
     /**
-     * An unsuccessful result of validation
+     * An unsuccessful result of validation. All errors are stored in the [reasons] list.
      */
-    public class Invalid(public val reasons: List<String>) : ValidationResult() {
+    public class Invalid(
+        /**
+         * List of errors.
+         */
+        public val reasons: List<String>
+    ) : ValidationResult() {
         public constructor (reason: String) : this(listOf(reason))
     }
 }

--- a/ktor-server/ktor-server-plugins/ktor-server-request-validation/jvmAndNix/src/io/ktor/server/plugins/requestvalidation/RequestValidationConfig.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-request-validation/jvmAndNix/src/io/ktor/server/plugins/requestvalidation/RequestValidationConfig.kt
@@ -16,8 +16,8 @@ public class RequestValidationConfig {
     internal var validateContentLength: Boolean = false
 
     /**
-     * Check if the request body length match [Content-Length] header. Otherwise, the body channel will be cancelled
-     * with [IOException].
+     * Enables validation of the request body length matches the [Content-Length] header.
+     * If the length doesn't match, body channel will be cancelled with [IOException].
      */
     public fun validateContentLength() {
         validateContentLength = true

--- a/ktor-server/ktor-server-plugins/ktor-server-request-validation/jvmAndNix/src/io/ktor/server/plugins/requestvalidation/RequestValidationConfig.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-request-validation/jvmAndNix/src/io/ktor/server/plugins/requestvalidation/RequestValidationConfig.kt
@@ -13,6 +13,16 @@ public class RequestValidationConfig {
 
     internal val validators: MutableList<Validator> = mutableListOf()
 
+    internal var validateContentLength: Boolean = false
+
+    /**
+     * Check if the request body length match [Content-Length] header. Otherwise, the body channel will be cancelled
+     * with [IOException].
+     */
+    public fun validateContentLength() {
+        validateContentLength = true
+    }
+
     /**
      * Registers [validator]
      */

--- a/ktor-server/ktor-server-servlet/jvm/src/io/ktor/server/servlet/ServletReader.kt
+++ b/ktor-server/ktor-server-servlet/jvm/src/io/ktor/server/servlet/ServletReader.kt
@@ -78,14 +78,7 @@ private class ServletReader(val input: ServletInputStream, val contentLength: In
                 break
             }
 
-            val message = if (bodySize > contentLength) {
-                "Client provided more bytes than content length. Expected $contentLength but got $bodySize."
-            } else {
-                "Client provided less bytes than content length. Expected $contentLength but got $bodySize."
-            }
-
-            val cause = IOException(message)
-            channel.close(cause)
+            channel.close()
             events.close()
             break
         }

--- a/ktor-server/ktor-server-test-suites/build.gradle.kts
+++ b/ktor-server/ktor-server-test-suites/build.gradle.kts
@@ -18,6 +18,7 @@ kotlin.sourceSets {
             implementation(project(":ktor-server:ktor-server-plugins:ktor-server-partial-content"))
             implementation(project(":ktor-server:ktor-server-plugins:ktor-server-conditional-headers"))
             implementation(project(":ktor-server:ktor-server-plugins:ktor-server-default-headers"))
+            implementation(project(":ktor-server:ktor-server-plugins:ktor-server-request-validation"))
 
             implementation(kotlin("test-junit"))
 

--- a/ktor-server/ktor-server-test-suites/jvm/src/io/ktor/server/testing/suites/SustainabilityTestSuite.kt
+++ b/ktor-server/ktor-server-test-suites/jvm/src/io/ktor/server/testing/suites/SustainabilityTestSuite.kt
@@ -16,6 +16,7 @@ import io.ktor.server.engine.*
 import io.ktor.server.http.content.*
 import io.ktor.server.plugins.*
 import io.ktor.server.plugins.compression.*
+import io.ktor.server.plugins.requestvalidation.*
 import io.ktor.server.request.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
@@ -853,9 +854,13 @@ abstract class SustainabilityTestSuite<TEngine : ApplicationEngine, TConfigurati
         val result = Job()
 
         createAndStartServer {
+            install(RequestValidation) {
+                validateContentLength()
+            }
+
             post("/") {
                 try {
-                    println(call.receive<ByteArray>().size)
+                    call.receive<ByteArray>().size
                 } catch (cause: Throwable) {
                     failCause = cause
                 } finally {

--- a/ktor-server/ktor-server-test-suites/jvm/src/io/ktor/server/testing/suites/SustainabilityTestSuite.kt
+++ b/ktor-server/ktor-server-test-suites/jvm/src/io/ktor/server/testing/suites/SustainabilityTestSuite.kt
@@ -38,6 +38,7 @@ import java.util.*
 import java.util.concurrent.*
 import java.util.concurrent.atomic.*
 import kotlin.concurrent.*
+import kotlin.test.*
 
 abstract class SustainabilityTestSuite<TEngine : ApplicationEngine, TConfiguration : ApplicationEngine.Configuration>(
     hostFactory: ApplicationEngineFactory<TEngine, TConfiguration>
@@ -892,7 +893,7 @@ abstract class SustainabilityTestSuite<TEngine : ApplicationEngine, TConfigurati
         }
 
         assertTrue(failCause != null)
-        assertTrue(failCause is IOException)
+        assertIs<RequestValidationException>(failCause)
     }
 }
 

--- a/ktor-server/ktor-server-test-suites/jvm/src/io/ktor/server/testing/suites/SustainabilityTestSuite.kt
+++ b/ktor-server/ktor-server-test-suites/jvm/src/io/ktor/server/testing/suites/SustainabilityTestSuite.kt
@@ -892,7 +892,7 @@ abstract class SustainabilityTestSuite<TEngine : ApplicationEngine, TConfigurati
         }
 
         assertTrue(failCause != null)
-        assertIs<RequestValidationException>(failCause)
+        assertIs<IOException>(failCause)
     }
 }
 

--- a/ktor-server/ktor-server-test-suites/jvm/src/io/ktor/server/testing/suites/SustainabilityTestSuite.kt
+++ b/ktor-server/ktor-server-test-suites/jvm/src/io/ktor/server/testing/suites/SustainabilityTestSuite.kt
@@ -8,13 +8,11 @@ import io.ktor.client.call.*
 import io.ktor.client.request.*
 import io.ktor.client.statement.*
 import io.ktor.http.*
-import io.ktor.http.HttpStatusCode.Companion.InternalServerError
 import io.ktor.http.cio.*
 import io.ktor.http.content.*
 import io.ktor.server.application.*
 import io.ktor.server.engine.*
 import io.ktor.server.http.content.*
-import io.ktor.server.plugins.*
 import io.ktor.server.plugins.compression.*
 import io.ktor.server.plugins.requestvalidation.*
 import io.ktor.server.request.*
@@ -28,8 +26,9 @@ import io.ktor.utils.io.jvm.javaio.*
 import io.ktor.utils.io.streams.*
 import kotlinx.coroutines.*
 import kotlinx.coroutines.debug.*
-import org.junit.*
 import org.junit.Assert.*
+import org.junit.Ignore
+import org.junit.Test
 import org.junit.runners.model.*
 import org.slf4j.*
 import java.io.*
@@ -69,7 +68,7 @@ abstract class SustainabilityTestSuite<TEngine : ApplicationEngine, TConfigurati
         }
 
         withUrl("/") {
-            assertEquals(InternalServerError.value, status.value)
+            assertEquals(HttpStatusCode.InternalServerError.value, status.value)
 
             while (true) {
                 val exception = collected.poll(timeout.inWholeSeconds, TimeUnit.SECONDS)
@@ -136,7 +135,7 @@ abstract class SustainabilityTestSuite<TEngine : ApplicationEngine, TConfigurati
                                 val contentLength = response.headers[HttpHeaders.ContentLength].toString().toLong()
                                 channel.discardExact(contentLength)
                                 response.release()
-                            } ?: fail("No response found for request #$requestNumber")
+                            } ?: kotlin.test.fail("No response found for request #$requestNumber")
                         }
                     }
                 }
@@ -288,7 +287,7 @@ abstract class SustainabilityTestSuite<TEngine : ApplicationEngine, TConfigurati
             // ensure that the server is not running anymore
             withUrl("/") {
                 call.body<String>()
-                fail("Shouldn't happen")
+                kotlin.test.fail("Shouldn't happen")
             }
         }
     }
@@ -356,7 +355,7 @@ abstract class SustainabilityTestSuite<TEngine : ApplicationEngine, TConfigurati
                         content.toInputStream().reader().use { reader ->
                             val firstByte = reader.read()
                             if (firstByte == -1) {
-                                fail("Premature end of response stream at iteration $i")
+                                kotlin.test.fail("Premature end of response stream at iteration $i")
                             } else {
                                 assertEquals('O', firstByte.toChar())
                                 Thread.sleep(random.nextInt(1000).toLong())
@@ -537,7 +536,7 @@ abstract class SustainabilityTestSuite<TEngine : ApplicationEngine, TConfigurati
             "3\r\n",
             "a=1\r\n",
             "0\r\n",
-            "\r\n",
+            "\r\n"
         )
 
         socket {
@@ -564,7 +563,7 @@ abstract class SustainabilityTestSuite<TEngine : ApplicationEngine, TConfigurati
             }
             post("/") {
                 call.receiveParameters()
-                fail("We should NOT receive any content")
+                kotlin.test.fail("We should NOT receive any content")
             }
         }
 
@@ -671,7 +670,7 @@ abstract class SustainabilityTestSuite<TEngine : ApplicationEngine, TConfigurati
                 startServer(server)
 
                 withUrl("/") {
-                    assertEquals("Failed in phase $phase", InternalServerError, status)
+                    assertEquals("Failed in phase $phase", HttpStatusCode.InternalServerError, status)
                     assertEquals("Failed in phase $phase", exceptions.size, 1)
                     assertEquals("Failed in phase $phase", exceptions[0].message)
                     exceptions.clear()
@@ -710,7 +709,7 @@ abstract class SustainabilityTestSuite<TEngine : ApplicationEngine, TConfigurati
                     "/",
                     { method = HttpMethod.Post; setBody("body") }
                 ) {
-                    assertEquals("Failed in phase $phase", InternalServerError, status)
+                    assertEquals("Failed in phase $phase", HttpStatusCode.InternalServerError, status)
                     assertEquals("Failed in phase $phase", exceptions.size, 1)
                     assertEquals(exceptions[0].message, "Failed in phase $phase")
                     exceptions.clear()
@@ -752,7 +751,7 @@ abstract class SustainabilityTestSuite<TEngine : ApplicationEngine, TConfigurati
 
                 withUrl("/", { intercepted = false }) {
                     body<String>()
-                    assertEquals("Failed in phase $phase", InternalServerError, status)
+                    assertEquals("Failed in phase $phase", HttpStatusCode.InternalServerError, status)
                     assertEquals("Failed in phase $phase", exceptions.size, 1)
                     assertEquals("Failed in phase $phase", exceptions[0].message)
                     exceptions.clear()
@@ -786,7 +785,7 @@ abstract class SustainabilityTestSuite<TEngine : ApplicationEngine, TConfigurati
         startServer(server)
 
         withUrl("/req") {
-            assertEquals("Failed in engine pipeline", InternalServerError, status)
+            assertEquals("Failed in engine pipeline", HttpStatusCode.InternalServerError, status)
             assertEquals("Failed in phase $phase", exceptions.size, 1)
             assertEquals(exceptions[0].message, "Failed in engine pipeline")
             exceptions.clear()

--- a/ktor-utils/posix/test/io/ktor/util/MultiWorkerDispatcherTest.kt
+++ b/ktor-utils/posix/test/io/ktor/util/MultiWorkerDispatcherTest.kt
@@ -7,7 +7,7 @@ import kotlinx.coroutines.*
 import kotlin.coroutines.intrinsics.*
 import kotlin.test.*
 
-@OptIn(InternalAPI::class)
+@OptIn(InternalAPI::class, DelicateCoroutinesApi::class)
 class MultiWorkerDispatcherTest {
 
     private val dispatcher = Dispatchers.createFixedThreadDispatcher(


### PR DESCRIPTION
Fix [KTOR-4655](https://youtrack.jetbrains.com/issue/KTOR-4655/Validate-ContentLength-Header-with-flag-only)