### PR TITLE
KTOR-735 Support WinHTTP engine

### DIFF
--- a/buildSrc/src/main/kotlin/KotlinExtensions.kt
+++ b/buildSrc/src/main/kotlin/KotlinExtensions.kt
@@ -72,3 +72,13 @@ fun NamedDomainObjectContainer<KotlinSourceSet>.desktopTest(block: KotlinSourceS
     block(sourceSet)
 }
 
+fun NamedDomainObjectContainer<KotlinSourceSet>.windowsMain(block: KotlinSourceSet.() -> Unit) {
+    val sourceSet = findByName("windowsMain") ?: return
+    block(sourceSet)
+}
+
+fun NamedDomainObjectContainer<KotlinSourceSet>.windowsTest(block: KotlinSourceSet.() -> Unit) {
+    val sourceSet = findByName("windowsTest") ?: return
+    block(sourceSet)
+}
+

--- a/buildSrc/src/main/kotlin/NativeUtils.kt
+++ b/buildSrc/src/main/kotlin/NativeUtils.kt
@@ -11,7 +11,9 @@ fun Project.fastOr(block: () -> List<String>): List<String> {
     return block()
 }
 
-fun Project.posixTargets(): List<String> = fastOr { nixTargets() + kotlin.mingwX64().name }
+fun Project.posixTargets(): List<String> = fastOr {
+    nixTargets() + windowsTargets()
+}
 
 fun Project.nixTargets(): List<String> = fastOr {
     darwinTargets() + kotlin.linuxX64().name
@@ -69,6 +71,14 @@ fun Project.desktopTargets(): List<String> = fastOr {
             macosX64(),
             macosArm64(),
             linuxX64(),
+            mingwX64()
+        ).map { it.name }
+    }
+}
+
+fun Project.windowsTargets(): List<String> = fastOr {
+    with(kotlin) {
+        listOf(
             mingwX64()
         ).map { it.name }
     }

--- a/buildSrc/src/main/kotlin/TargetsConfig.kt
+++ b/buildSrc/src/main/kotlin/TargetsConfig.kt
@@ -16,9 +16,10 @@ val Project.hasPosix: Boolean get() = hasCommon || files.any { it.name == "posix
 val Project.hasDesktop: Boolean get() = hasPosix || files.any { it.name == "desktop" }
 val Project.hasNix: Boolean get() = hasPosix || hasJvmAndNix || files.any { it.name == "nix" }
 val Project.hasDarwin: Boolean get() = hasNix || files.any { it.name == "darwin" }
+val Project.hasWindows: Boolean get() = hasPosix || files.any { it.name == "windows" }
 val Project.hasJs: Boolean get() = hasCommon || files.any { it.name == "js" }
 val Project.hasJvm: Boolean get() = hasCommon || hasJvmAndNix || files.any { it.name == "jvm" }
-val Project.hasNative: Boolean get() = hasCommon || hasNix || hasPosix || hasDarwin || hasDesktop
+val Project.hasNative: Boolean get() = hasCommon || hasNix || hasPosix || hasDarwin || hasDesktop || hasWindows
 
 fun Project.configureTargets() {
     configureCommon()
@@ -36,7 +37,7 @@ fun Project.configureTargets() {
             configureJs()
         }
 
-        if (hasPosix || hasDarwin) extra.set("hasNative", true)
+        if (hasPosix || hasDarwin || hasWindows) extra.set("hasNative", true)
 
         sourceSets {
             if (hasPosix) {
@@ -69,6 +70,11 @@ fun Project.configureTargets() {
             if (hasDesktop) {
                 val desktopMain by creating
                 val desktopTest by creating
+            }
+
+            if (hasWindows) {
+                val windowsMain by creating
+                val windowsTest by creating
             }
 
             if (hasJvmAndNix) {
@@ -178,6 +184,19 @@ fun Project.configureTargets() {
                 desktopTargets().forEach {
                     getByName("${it}Main").dependsOn(desktopMain)
                     getByName("${it}Test").dependsOn(desktopTest)
+                }
+            }
+
+            if (hasWindows) {
+                val windowsMain by getting {
+                    findByName("posixMain")?.let { dependsOn(it) }
+                }
+
+                val windowsTest by getting
+
+                windowsTargets().forEach {
+                    getByName("${it}Main").dependsOn(windowsMain)
+                    getByName("${it}Test").dependsOn(windowsTest)
                 }
             }
 

--- a/gradle/compatibility.gradle
+++ b/gradle/compatibility.gradle
@@ -18,6 +18,7 @@ apiValidation {
             'ktor-client-curl',
             'ktor-client-ios',
             'ktor-client-darwin',
+            'ktor-client-winhttp',
         ]
     }
 

--- a/ktor-client/ktor-client-tests/build.gradle.kts
+++ b/ktor-client/ktor-client-tests/build.gradle.kts
@@ -89,6 +89,12 @@ kotlin.sourceSets {
             api(project(":ktor-client:ktor-client-darwin"))
         }
     }
+
+    windowsTest {
+        dependencies {
+            api(project(":ktor-client:ktor-client-winhttp"))
+        }
+    }
 }
 
 useJdkVersionForJvmTests(11)

--- a/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/ClientHeadersTest.kt
+++ b/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/ClientHeadersTest.kt
@@ -14,7 +14,7 @@ import kotlin.test.*
 class ClientHeadersTest : ClientLoader() {
 
     @Test
-    fun testHeadersReturnNullWhenMissing() = clientTests(listOf("Java", "Curl", "Js", "Darwin")) {
+    fun testHeadersReturnNullWhenMissing() = clientTests(listOf("Java", "Curl", "Js", "Darwin", "WinHttp")) {
         test { client ->
             client.get("$TEST_SERVER/headers").let {
                 assertEquals(HttpStatusCode.OK, it.status)
@@ -106,7 +106,7 @@ class ClientHeadersTest : ClientLoader() {
     }
 
     @Test
-    fun testRequestHasContentLength() = clientTests(listOf("Java", "Curl", "Js", "Darwin")) {
+    fun testRequestHasContentLength() = clientTests(listOf("Java", "Curl", "Js", "Darwin", "WinHttp")) {
         test { client ->
             val get = client.get("$TEST_SERVER/headers").bodyAsText()
             assertEquals("", get)

--- a/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/PostTest.kt
+++ b/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/PostTest.kt
@@ -24,7 +24,7 @@ class PostTest : ClientLoader() {
     }
 
     @Test
-    fun testHugePost() = clientTests(listOf("Js", "Darwin", "CIO", "Curl")) {
+    fun testHugePost() = clientTests(listOf("Js", "Darwin", "CIO", "Curl", "WinHttp")) {
         test { client ->
             client.postHelper(makeString(32 * 1024 * 1024))
         }

--- a/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/plugins/CookiesTest.kt
+++ b/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/plugins/CookiesTest.kt
@@ -203,7 +203,7 @@ class CookiesTest : ClientLoader() {
     }
 
     @Test
-    fun testCookiesWithWrongValue() = clientTests(listOf("js", "Darwin")) {
+    fun testCookiesWithWrongValue() = clientTests(listOf("js", "Darwin", "WinHttp")) {
         config {
             install(HttpCookies)
         }

--- a/ktor-client/ktor-client-winhttp/build.gradle.kts
+++ b/ktor-client/ktor-client-winhttp/build.gradle.kts
@@ -1,0 +1,38 @@
+import org.jetbrains.kotlin.gradle.targets.native.tasks.*
+
+apply<test.server.TestServerPlugin>()
+
+val WIN_LIBRARY_PATH = "c:\\msys64\\mingw64\\bin;c:\\tools\\msys64\\mingw64\\bin;C:\\Tools\\msys2\\mingw64\\bin"
+
+plugins {
+    id("kotlinx-serialization")
+}
+
+kotlin {
+    fastTarget()
+
+    createCInterop("winhttp", windowsTargets()) {
+        defFile = File(projectDir, "windows/interop/winhttp.def")
+    }
+
+    sourceSets {
+        windowsMain {
+            dependencies {
+                api(project(":ktor-client:ktor-client-core"))
+                api(project(":ktor-http:ktor-http-cio"))
+            }
+        }
+        windowsTest {
+            dependencies {
+                api(project(":ktor-client:ktor-client-plugins:ktor-client-logging"))
+                api(project(":ktor-client:ktor-client-plugins:ktor-client-json"))
+            }
+        }
+    }
+
+    afterEvaluate {
+        if (HOST_NAME != "windows") return@afterEvaluate
+        val winTests = tasks.findByName("mingwX64Test") as? KotlinNativeTest? ?: return@afterEvaluate
+        winTests.environment("PATH", WIN_LIBRARY_PATH)
+    }
+}

--- a/ktor-client/ktor-client-winhttp/windows/interop/winhttp.def
+++ b/ktor-client/ktor-client-winhttp/windows/interop/winhttp.def
@@ -1,27 +1,12 @@
-package = platform.windows
-headers = minwindef.h minwinbase.h winhttp.h
-headerFilter = *
+package = ktor.cinterop.winhttp
+headers = wtypes.h winhttp.h
+headerFilter = winhttp.h
 
 compilerOpts = -DUNICODE
 linkerOpts = -lwinhttp
-
 ---
-static unsigned int GetHResultFromError(unsigned int errorCode) {
-    int result;
-    if (errorCode < 0) {
-        result = errorCode;
-    }
-    else {
-        result = (int)(((unsigned int)errorCode & 0x0000FFFF) | (7 << 16) | 0x80000000);
-    }
-
-    return result;
-}
-
-static unsigned int MakeLanguageId(unsigned int primaryLanguageId, unsigned int subLanguageId) {
-    return (((subLanguageId) << 10) | (primaryLanguageId));
-}
-
+// These WebSocket declarations are not present in our sysroots,
+// so we add them here.
 #define WINHTTP_OPTION_UPGRADE_TO_WEB_SOCKET            114
 
 typedef enum _WINHTTP_WEB_SOCKET_OPERATION

--- a/ktor-client/ktor-client-winhttp/windows/interop/winhttp.def
+++ b/ktor-client/ktor-client-winhttp/windows/interop/winhttp.def
@@ -1,0 +1,142 @@
+package = platform.windows
+headers = minwindef.h minwinbase.h winhttp.h
+headerFilter = *
+
+compilerOpts = -DUNICODE
+linkerOpts = -lwinhttp
+
+---
+static unsigned int GetHResultFromError(unsigned int errorCode) {
+    int result;
+    if (errorCode < 0) {
+        result = errorCode;
+    }
+    else {
+        result = (int)(((unsigned int)errorCode & 0x0000FFFF) | (7 << 16) | 0x80000000);
+    }
+
+    return result;
+}
+
+static unsigned int MakeLanguageId(unsigned int primaryLanguageId, unsigned int subLanguageId) {
+    return (((subLanguageId) << 10) | (primaryLanguageId));
+}
+
+#define WINHTTP_OPTION_UPGRADE_TO_WEB_SOCKET            114
+
+typedef enum _WINHTTP_WEB_SOCKET_OPERATION
+{
+    WINHTTP_WEB_SOCKET_SEND_OPERATION                   = 0,
+    WINHTTP_WEB_SOCKET_RECEIVE_OPERATION                = 1,
+    WINHTTP_WEB_SOCKET_CLOSE_OPERATION                  = 2,
+    WINHTTP_WEB_SOCKET_SHUTDOWN_OPERATION               = 3
+} WINHTTP_WEB_SOCKET_OPERATION;
+
+typedef enum _WINHTTP_WEB_SOCKET_BUFFER_TYPE
+{
+    WINHTTP_WEB_SOCKET_BINARY_MESSAGE_BUFFER_TYPE       = 0,
+    WINHTTP_WEB_SOCKET_BINARY_FRAGMENT_BUFFER_TYPE      = 1,
+    WINHTTP_WEB_SOCKET_UTF8_MESSAGE_BUFFER_TYPE         = 2,
+    WINHTTP_WEB_SOCKET_UTF8_FRAGMENT_BUFFER_TYPE        = 3,
+    WINHTTP_WEB_SOCKET_CLOSE_BUFFER_TYPE                = 4
+} WINHTTP_WEB_SOCKET_BUFFER_TYPE;
+
+typedef enum _WINHTTP_WEB_SOCKET_CLOSE_STATUS
+{
+    WINHTTP_WEB_SOCKET_SUCCESS_CLOSE_STATUS                = 1000,
+    WINHTTP_WEB_SOCKET_ENDPOINT_TERMINATED_CLOSE_STATUS    = 1001,
+    WINHTTP_WEB_SOCKET_PROTOCOL_ERROR_CLOSE_STATUS         = 1002,
+    WINHTTP_WEB_SOCKET_INVALID_DATA_TYPE_CLOSE_STATUS      = 1003,
+    WINHTTP_WEB_SOCKET_EMPTY_CLOSE_STATUS                  = 1005,
+    WINHTTP_WEB_SOCKET_ABORTED_CLOSE_STATUS                = 1006,
+    WINHTTP_WEB_SOCKET_INVALID_PAYLOAD_CLOSE_STATUS        = 1007,
+    WINHTTP_WEB_SOCKET_POLICY_VIOLATION_CLOSE_STATUS       = 1008,
+    WINHTTP_WEB_SOCKET_MESSAGE_TOO_BIG_CLOSE_STATUS        = 1009,
+    WINHTTP_WEB_SOCKET_UNSUPPORTED_EXTENSIONS_CLOSE_STATUS = 1010,
+    WINHTTP_WEB_SOCKET_SERVER_ERROR_CLOSE_STATUS           = 1011,
+    WINHTTP_WEB_SOCKET_SECURE_HANDSHAKE_ERROR_CLOSE_STATUS = 1015
+} WINHTTP_WEB_SOCKET_CLOSE_STATUS;
+
+typedef struct _WINHTTP_WEB_SOCKET_ASYNC_RESULT
+{
+    WINHTTP_ASYNC_RESULT AsyncResult;
+    WINHTTP_WEB_SOCKET_OPERATION Operation;
+} WINHTTP_WEB_SOCKET_ASYNC_RESULT;
+
+typedef struct _WINHTTP_WEB_SOCKET_STATUS
+{
+    DWORD dwBytesTransferred;
+    WINHTTP_WEB_SOCKET_BUFFER_TYPE eBufferType;
+} WINHTTP_WEB_SOCKET_STATUS;
+
+#define WINHTTP_WEB_SOCKET_MAX_CLOSE_REASON_LENGTH 123
+#define WINHTTP_WEB_SOCKET_MIN_KEEPALIVE_VALUE 15000
+
+#define WINHTTP_CALLBACK_STATUS_CLOSE_COMPLETE          0x02000000
+#define WINHTTP_CALLBACK_STATUS_SHUTDOWN_COMPLETE       0x04000000
+
+WINHTTPAPI
+HINTERNET
+WINAPI
+WinHttpWebSocketCompleteUpgrade
+(
+    _In_ HINTERNET hRequest,
+    _In_opt_ DWORD_PTR pContext
+);
+
+WINHTTPAPI
+DWORD
+WINAPI
+WinHttpWebSocketSend
+(
+    _In_ HINTERNET hWebSocket,
+    _In_ WINHTTP_WEB_SOCKET_BUFFER_TYPE eBufferType,
+    _In_reads_opt_(dwBufferLength) PVOID pvBuffer,
+    _In_ DWORD dwBufferLength
+);
+
+WINHTTPAPI
+DWORD
+WINAPI
+WinHttpWebSocketReceive
+(
+    _In_ HINTERNET hWebSocket,
+    _Out_writes_bytes_to_(dwBufferLength, *pdwBytesRead) PVOID pvBuffer,
+    _In_ DWORD dwBufferLength,
+    _Out_range_(0, dwBufferLength) DWORD *pdwBytesRead,
+    _Out_ WINHTTP_WEB_SOCKET_BUFFER_TYPE *peBufferType
+);
+
+WINHTTPAPI
+DWORD
+WINAPI
+WinHttpWebSocketShutdown
+(
+    _In_ HINTERNET hWebSocket,
+    _In_ USHORT usStatus,
+    _In_reads_bytes_opt_(dwReasonLength) PVOID pvReason,
+    _In_range_(0, WINHTTP_WEB_SOCKET_MAX_CLOSE_REASON_LENGTH) DWORD dwReasonLength
+);
+
+WINHTTPAPI
+DWORD
+WINAPI
+WinHttpWebSocketClose
+(
+    _In_ HINTERNET hWebSocket,
+    _In_ USHORT usStatus,
+    _In_reads_bytes_opt_(dwReasonLength) PVOID pvReason,
+    _In_range_(0, WINHTTP_WEB_SOCKET_MAX_CLOSE_REASON_LENGTH) DWORD dwReasonLength
+);
+
+WINHTTPAPI
+DWORD
+WINAPI
+WinHttpWebSocketQueryCloseStatus
+(
+    _In_ HINTERNET hWebSocket,
+    _Out_ USHORT *pusStatus,
+    _Out_writes_bytes_to_opt_(dwReasonLength, *pdwReasonLengthConsumed) PVOID pvReason,
+    _In_range_(0, WINHTTP_WEB_SOCKET_MAX_CLOSE_REASON_LENGTH) DWORD dwReasonLength,
+    _Out_range_(0, WINHTTP_WEB_SOCKET_MAX_CLOSE_REASON_LENGTH) DWORD *pdwReasonLengthConsumed
+);

--- a/ktor-client/ktor-client-winhttp/windows/src/io/ktor/client/engine/winhttp/WinHttp.kt
+++ b/ktor-client/ktor-client-winhttp/windows/src/io/ktor/client/engine/winhttp/WinHttp.kt
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2014-2022 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.client.engine.winhttp
+
+import io.ktor.client.engine.*
+import io.ktor.util.*
+
+@Suppress("DEPRECATION")
+@OptIn(ExperimentalStdlibApi::class)
+@EagerInitialization
+private val initHook = WinHttp
+
+/**
+ * A Kotlin/Native client engine that targets Windows-based operating systems.
+ *
+ * To create the client with this engine, pass it to the `HttpClient` constructor:
+ * ```kotlin
+ * val client = HttpClient(WinHttp)
+ * ```
+ * To configure the engine, pass settings exposed by [WinHttpClientEngineConfig] to the `engine` method:
+ * ```kotlin
+ * val client = HttpClient(WinHttp) {
+ *     engine {
+ *         // this: WinHttpClientEngineConfig
+ *     }
+ * }
+ * ```
+ *
+ * You can learn more about client engines from [Engines](https://ktor.io/docs/http-client-engines.html).
+ */
+@OptIn(InternalAPI::class)
+public object WinHttp : HttpClientEngineFactory<WinHttpClientEngineConfig> {
+    init {
+        engines.append(this)
+    }
+
+    override fun create(block: WinHttpClientEngineConfig.() -> Unit): HttpClientEngine {
+        return WinHttpClientEngine(WinHttpClientEngineConfig().apply(block))
+    }
+
+    override fun toString(): String {
+        return "WinHttp"
+    }
+}

--- a/ktor-client/ktor-client-winhttp/windows/src/io/ktor/client/engine/winhttp/WinHttpClientEngine.kt
+++ b/ktor-client/ktor-client-winhttp/windows/src/io/ktor/client/engine/winhttp/WinHttpClientEngine.kt
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2014-2022 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.client.engine.winhttp
+
+import io.ktor.client.engine.*
+import io.ktor.client.engine.winhttp.internal.*
+import io.ktor.client.plugins.*
+import io.ktor.client.plugins.websocket.*
+import io.ktor.client.request.*
+import io.ktor.util.*
+import io.ktor.util.date.*
+import kotlinx.coroutines.*
+
+internal class WinHttpClientEngine(
+    override val config: WinHttpClientEngineConfig
+) : HttpClientEngineBase("ktor-winhttp") {
+
+    override val dispatcher: CoroutineDispatcher = Dispatchers.Unconfined
+
+    override val supportedCapabilities = setOf(HttpTimeout, WebSocketCapability)
+
+    private val session = WinHttpSession(config)
+
+    init {
+        coroutineContext.job.invokeOnCompletion {
+            session.close()
+        }
+    }
+
+    @OptIn(InternalAPI::class)
+    override suspend fun execute(data: HttpRequestData): HttpResponseData {
+        val callContext = callContext()
+        val requestTime = GMTDate()
+        val request = session.createRequest(data)
+
+        callContext.job.invokeOnCompletion {
+            request.close()
+        }
+
+        val requestProducer = WinHttpRequestProducer(request, data)
+        val headers = requestProducer.getHeaders()
+
+        if (data.isUpgradeRequest()) {
+            request.upgradeToWebSocket()
+        }
+
+        request.sendRequest(headers)
+        requestProducer.writeBody()
+
+        val rawResponse = request.getResponse()
+        val responseBody: Any = if (data.isUpgradeRequest()) {
+            request.createWebSocket(callContext)
+        } else {
+            request.readBody(callContext)
+        }
+
+        return rawResponse.convert(requestTime, responseBody, callContext)
+    }
+}
+
+@Suppress("KDocMissingDocumentation")
+public class WinHttpIllegalStateException(cause: String) : IllegalStateException(cause)

--- a/ktor-client/ktor-client-winhttp/windows/src/io/ktor/client/engine/winhttp/WinHttpClientEngineConfig.kt
+++ b/ktor-client/ktor-client-winhttp/windows/src/io/ktor/client/engine/winhttp/WinHttpClientEngineConfig.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2014-2022 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.client.engine.winhttp
+
+import io.ktor.client.engine.*
+import io.ktor.http.*
+
+public class WinHttpClientEngineConfig : HttpClientEngineConfig() {
+
+    /**
+     * A value indicating whether HTTP 2.0 protocol is enabled in WinHTTP.
+     * The default value is true.
+     */
+    public var protocolVersion: HttpProtocolVersion = HttpProtocolVersion.HTTP_2_0
+
+    /**
+     * A value that allows to set required security protocol versions.
+     * By default will be used system setting.
+     */
+    public var securityProtocols: WinHttpSecurityProtocol = WinHttpSecurityProtocol.Default
+
+    /**
+     * A value that disables TLS verification for outgoing requests.
+     */
+    public var sslVerify: Boolean = true
+}

--- a/ktor-client/ktor-client-winhttp/windows/src/io/ktor/client/engine/winhttp/WinHttpSecurityProtocol.kt
+++ b/ktor-client/ktor-client-winhttp/windows/src/io/ktor/client/engine/winhttp/WinHttpSecurityProtocol.kt
@@ -1,0 +1,13 @@
+/*
+ * Copyright 2014-2022 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.client.engine.winhttp
+
+public enum class WinHttpSecurityProtocol(internal val value: Int) {
+    Default(0),
+    Tls10(0x00000080),
+    Tls11(0x00000200),
+    Tls12(0x00000800),
+    Tls13(0x00002000),
+}

--- a/ktor-client/ktor-client-winhttp/windows/src/io/ktor/client/engine/winhttp/internal/WinHttpCallback.kt
+++ b/ktor-client/ktor-client-winhttp/windows/src/io/ktor/client/engine/winhttp/internal/WinHttpCallback.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2014-2022 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.client.engine.winhttp.internal
+
+import kotlinx.cinterop.*
+import platform.windows.*
+
+internal enum class WinHttpCallbackStatus(val value: UInt) {
+    SecureFailure(WINHTTP_CALLBACK_STATUS_SECURE_FAILURE.convert<UInt>()),
+    HeadersAvailable(WINHTTP_CALLBACK_STATUS_HEADERS_AVAILABLE.convert<UInt>()),
+    DataAvailable(WINHTTP_CALLBACK_STATUS_DATA_AVAILABLE.convert<UInt>()),
+    ReadComplete(WINHTTP_CALLBACK_STATUS_READ_COMPLETE.convert<UInt>()),
+    WriteComplete(WINHTTP_CALLBACK_STATUS_WRITE_COMPLETE.convert<UInt>()),
+    RequestError(WINHTTP_CALLBACK_STATUS_REQUEST_ERROR.convert<UInt>()),
+    SendRequestComplete(WINHTTP_CALLBACK_STATUS_SENDREQUEST_COMPLETE.convert<UInt>()),
+    CloseComplete(WINHTTP_CALLBACK_STATUS_CLOSE_COMPLETE.convert<UInt>())
+}
+
+internal fun winHttpCallback(
+    @Suppress("UNUSED_PARAMETER")
+    hInternet: HINTERNET?,
+    dwContext: DWORD_PTR,
+    dwStatus: DWORD,
+    statusInfo: LPVOID?,
+    statusInfoLength: DWORD
+) {
+    val contextPtr = dwContext.toLong().toCPointer<COpaque>() ?: run {
+        return
+    }
+
+    val connect = contextPtr.asStableRef<WinHttpConnect>().get()
+    if (connect.isClosed) {
+        return
+    }
+
+    connect.handlers[dwStatus]?.invoke(statusInfo, statusInfoLength)
+}

--- a/ktor-client/ktor-client-winhttp/windows/src/io/ktor/client/engine/winhttp/internal/WinHttpCallback.kt
+++ b/ktor-client/ktor-client-winhttp/windows/src/io/ktor/client/engine/winhttp/internal/WinHttpCallback.kt
@@ -5,7 +5,9 @@
 package io.ktor.client.engine.winhttp.internal
 
 import kotlinx.cinterop.*
+import ktor.cinterop.winhttp.*
 import platform.windows.*
+import platform.windows.HINTERNET
 
 internal enum class WinHttpCallbackStatus(val value: UInt) {
     SecureFailure(WINHTTP_CALLBACK_STATUS_SECURE_FAILURE.convert<UInt>()),

--- a/ktor-client/ktor-client-winhttp/windows/src/io/ktor/client/engine/winhttp/internal/WinHttpChunkedMode.kt
+++ b/ktor-client/ktor-client-winhttp/windows/src/io/ktor/client/engine/winhttp/internal/WinHttpChunkedMode.kt
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2014-2022 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.client.engine.winhttp.internal
+
+/**
+ * Specifies transfer mode for request body.
+ */
+internal enum class WinHttpChunkedMode {
+    // Do not encode body
+    Disabled,
+    // Encode body
+    Enabled,
+    // Use native encoder
+    Automatic
+}

--- a/ktor-client/ktor-client-winhttp/windows/src/io/ktor/client/engine/winhttp/internal/WinHttpConnect.kt
+++ b/ktor-client/ktor-client-winhttp/windows/src/io/ktor/client/engine/winhttp/internal/WinHttpConnect.kt
@@ -8,6 +8,7 @@ import io.ktor.http.*
 import io.ktor.utils.io.core.*
 import kotlinx.atomicfu.*
 import kotlinx.cinterop.*
+import ktor.cinterop.winhttp.*
 import platform.windows.*
 
 internal typealias WinHttpStatusHandler = (statusInfo: LPVOID?, statusInfoLength: DWORD) -> Unit

--- a/ktor-client/ktor-client-winhttp/windows/src/io/ktor/client/engine/winhttp/internal/WinHttpConnect.kt
+++ b/ktor-client/ktor-client-winhttp/windows/src/io/ktor/client/engine/winhttp/internal/WinHttpConnect.kt
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2014-2022 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.client.engine.winhttp.internal
+
+import io.ktor.http.*
+import io.ktor.utils.io.core.*
+import kotlinx.atomicfu.*
+import kotlinx.cinterop.*
+import platform.windows.*
+
+internal typealias WinHttpStatusHandler = (statusInfo: LPVOID?, statusInfoLength: DWORD) -> Unit
+
+internal class WinHttpConnect(private val hConnect: COpaquePointer) : Closeable {
+
+    private val closed = atomic(false)
+
+    val handlers = mutableMapOf<UInt, WinHttpStatusHandler>()
+
+    val isClosed: Boolean
+        get() = closed.value
+
+    /**
+     * Opens an HTTP request to the target server.
+     * @param method is request method.
+     * @param url is request URL.
+     * @param chunkedMode is request body chunking mode.
+     */
+    fun openRequest(
+        method: HttpMethod,
+        url: Url,
+        httpVersion: String?,
+        chunkedMode: WinHttpChunkedMode
+    ): COpaquePointer? {
+        var openFlags = WINHTTP_FLAG_ESCAPE_DISABLE or
+            WINHTTP_FLAG_ESCAPE_DISABLE_QUERY or
+            WINHTTP_FLAG_NULL_CODEPAGE
+
+        if (url.protocol.isSecure()) {
+            openFlags = openFlags or WINHTTP_FLAG_SECURE
+        }
+
+        if (chunkedMode == WinHttpChunkedMode.Automatic) {
+            openFlags = openFlags or WINHTTP_FLAG_AUTOMATIC_CHUNKING
+        }
+
+        return WinHttpOpenRequest(
+            hConnect,                     // connection handle
+            method.value,                 // HTTP request method
+            url.fullPath,                 // request path
+            httpVersion,                  // HTTP protocol
+            WINHTTP_NO_REFERER,           // no referring document is specified
+            WINHTTP_DEFAULT_ACCEPT_TYPES, // no types are accepted by the client
+            openFlags.convert()           // request flags
+        )
+    }
+
+    fun on(status: WinHttpCallbackStatus, handler: WinHttpStatusHandler) {
+        handlers[status.value] = handler
+    }
+
+    override fun close() {
+        if (!closed.compareAndSet(expect = false, update = true)) return
+
+        handlers.clear()
+        WinHttpCloseHandle(hConnect)
+    }
+
+    companion object {
+        private const val WINHTTP_FLAG_AUTOMATIC_CHUNKING = 0x00000200
+        private val WINHTTP_NO_REFERER = null
+        private val WINHTTP_DEFAULT_ACCEPT_TYPES = null
+    }
+}

--- a/ktor-client/ktor-client-winhttp/windows/src/io/ktor/client/engine/winhttp/internal/WinHttpConnect.kt
+++ b/ktor-client/ktor-client-winhttp/windows/src/io/ktor/client/engine/winhttp/internal/WinHttpConnect.kt
@@ -47,13 +47,13 @@ internal class WinHttpConnect(private val hConnect: COpaquePointer) : Closeable 
         }
 
         return WinHttpOpenRequest(
-            hConnect,                     // connection handle
-            method.value,                 // HTTP request method
-            url.fullPath,                 // request path
-            httpVersion,                  // HTTP protocol
-            WINHTTP_NO_REFERER,           // no referring document is specified
-            WINHTTP_DEFAULT_ACCEPT_TYPES, // no types are accepted by the client
-            openFlags.convert()           // request flags
+            hConnect,
+            method.value,
+            url.fullPath,
+            httpVersion,
+            WINHTTP_NO_REFERER,
+            WINHTTP_DEFAULT_ACCEPT_TYPES,
+            openFlags.convert()
         )
     }
 

--- a/ktor-client/ktor-client-winhttp/windows/src/io/ktor/client/engine/winhttp/internal/WinHttpCoroutine.kt
+++ b/ktor-client/ktor-client-winhttp/windows/src/io/ktor/client/engine/winhttp/internal/WinHttpCoroutine.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2014-2022 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.client.engine.winhttp.internal
+
+import io.ktor.utils.io.core.*
+import kotlinx.cinterop.*
+import kotlinx.coroutines.*
+import platform.windows.*
+import kotlin.coroutines.*
+
+internal suspend inline fun <T> Closeable.closeableCoroutine(
+    state: WinHttpConnect,
+    errorMessage: String,
+    crossinline block: (CancellableContinuation<T>) -> Unit
+): T = suspendCancellableCoroutine { continuation ->
+    if (!continuation.isActive) {
+        close()
+        return@suspendCancellableCoroutine
+    }
+
+    continuation.invokeOnCancellation {
+        close()
+    }
+
+    state.handlers[WinHttpCallbackStatus.RequestError.value] = { statusInfo, _ ->
+        val result = statusInfo!!.reinterpret<WINHTTP_ASYNC_RESULT>().pointed
+        continuation.resumeWithException(getWinHttpException(errorMessage, result.dwError))
+    }
+
+    state.handlers[WinHttpCallbackStatus.SecureFailure.value] = { statusInfo, _ ->
+        val securityCode = statusInfo!!.reinterpret<UIntVar>().pointed.value
+        continuation.resumeWithException(getWinHttpException(errorMessage, securityCode))
+    }
+
+    try {
+        block(continuation)
+    } catch (cause: Exception) {
+        continuation.resumeWithException(cause)
+    }
+}

--- a/ktor-client/ktor-client-winhttp/windows/src/io/ktor/client/engine/winhttp/internal/WinHttpCoroutine.kt
+++ b/ktor-client/ktor-client-winhttp/windows/src/io/ktor/client/engine/winhttp/internal/WinHttpCoroutine.kt
@@ -7,7 +7,7 @@ package io.ktor.client.engine.winhttp.internal
 import io.ktor.utils.io.core.*
 import kotlinx.cinterop.*
 import kotlinx.coroutines.*
-import platform.windows.*
+import ktor.cinterop.winhttp.*
 import kotlin.coroutines.*
 
 internal suspend inline fun <T> Closeable.closeableCoroutine(

--- a/ktor-client/ktor-client-winhttp/windows/src/io/ktor/client/engine/winhttp/internal/WinHttpExceptions.kt
+++ b/ktor-client/ktor-client-winhttp/windows/src/io/ktor/client/engine/winhttp/internal/WinHttpExceptions.kt
@@ -68,12 +68,12 @@ private fun formatMessage(errorCode: UInt, moduleHandle: HMODULE? = null): Strin
     val buffer = allocArray<UShortVar>(bufferSize)
 
     var readChars = FormatMessageW(
-        formatFlags.convert(),  // format flags
-        moduleHandle,           // DLL handle from which will be received message
-        errorCode,              // error code
-        languageId,             // required language
-        buffer.reinterpret(),   // buffer pointer
-        bufferSize.convert(),   // buffer size
+        formatFlags.convert(),
+        moduleHandle,
+        errorCode,
+        languageId,
+        buffer.reinterpret(),
+        bufferSize.convert(),
         null
     )
 

--- a/ktor-client/ktor-client-winhttp/windows/src/io/ktor/client/engine/winhttp/internal/WinHttpRequest.kt
+++ b/ktor-client/ktor-client-winhttp/windows/src/io/ktor/client/engine/winhttp/internal/WinHttpRequest.kt
@@ -73,7 +73,6 @@ internal class WinHttpRequest(
         configureStatusCallback(enable = true)
     }
 
-
     fun upgradeToWebSocket() {
         if (WinHttpSetOption(hRequest, WINHTTP_OPTION_UPGRADE_TO_WEB_SOCKET, null, 0) == 0) {
             throw getWinHttpException("Unable to request WebSocket upgrade")
@@ -99,13 +98,13 @@ internal class WinHttpRequest(
             // Send request
             val statePtr = connectReference.asCPointer().rawValue.toLong()
             if (WinHttpSendRequest(
-                    hRequest,                       // request handle
-                    headersString,                  // request headers as a string
-                    headersString.length.convert(), // size of request headers string
-                    WINHTTP_NO_REQUEST_DATA,        // optional request body data
-                    0,                         // size of optional request body
-                    0,                         // size of request body, i.e. Content-Length
-                    statePtr.convert()              // pointer to context
+                    hRequest,
+                    headersString,
+                    headersString.length.convert(),
+                    WINHTTP_NO_REQUEST_DATA,
+                    0,
+                    WINHTTP_IGNORE_REQUEST_TOTAL_LENGTH,
+                    statePtr.convert()
                 ) == 0
             ) {
                 throw getWinHttpException(ERROR_FAILED_TO_SEND_REQUEST)
@@ -285,10 +284,12 @@ internal class WinHttpRequest(
      */
     private fun disableTlsVerification() = memScoped {
         val flags = alloc<UIntVar> {
-            value = (SECURITY_FLAG_IGNORE_UNKNOWN_CA or
-                SECURITY_FLAG_IGNORE_CERT_WRONG_USAGE or
-                SECURITY_FLAG_IGNORE_CERT_CN_INVALID or
-                SECURITY_FLAG_IGNORE_CERT_DATE_INVALID).convert()
+            value = (
+                SECURITY_FLAG_IGNORE_UNKNOWN_CA or
+                    SECURITY_FLAG_IGNORE_CERT_WRONG_USAGE or
+                    SECURITY_FLAG_IGNORE_CERT_CN_INVALID or
+                    SECURITY_FLAG_IGNORE_CERT_DATE_INVALID
+                ).convert()
         }
         if (WinHttpSetOption(hRequest, WINHTTP_OPTION_SECURITY_FLAGS, flags.ptr, UINT_SIZE) == 0) {
             throw getWinHttpException("Unable to disable TLS verification")
@@ -310,7 +311,6 @@ internal class WinHttpRequest(
             else -> WinHttpChunkedMode.Enabled
         }
     }
-
 
     /**
      * Gets a string length in bytes.

--- a/ktor-client/ktor-client-winhttp/windows/src/io/ktor/client/engine/winhttp/internal/WinHttpRequest.kt
+++ b/ktor-client/ktor-client-winhttp/windows/src/io/ktor/client/engine/winhttp/internal/WinHttpRequest.kt
@@ -1,0 +1,389 @@
+/*
+ * Copyright 2014-2022 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.client.engine.winhttp.internal
+
+import io.ktor.client.engine.winhttp.*
+import io.ktor.client.request.*
+import io.ktor.http.*
+import io.ktor.utils.io.core.*
+import kotlinx.atomicfu.*
+import kotlinx.cinterop.*
+import platform.windows.*
+import kotlin.coroutines.*
+
+internal class WinHttpRequest(
+    hSession: COpaquePointer,
+    data: HttpRequestData,
+    private val config: WinHttpClientEngineConfig
+) : Closeable {
+    private val connect: WinHttpConnect
+    private val hRequest: COpaquePointer
+    private val closed = atomic(false)
+    private val requestClosed = atomic(false)
+    private val connectReference: StableRef<WinHttpConnect>
+
+    val chunkedMode: WinHttpChunkedMode
+
+    init {
+        val hConnect = WinHttpConnect(hSession, data.url.host, data.url.port.convert(), 0)
+            ?: throw getWinHttpException("Unable to create connection")
+        connect = WinHttpConnect(hConnect)
+        connectReference = StableRef.create(connect)
+
+        // Try using explicitly specified HTTP protocol version
+        val protocolVersion = config.protocolVersion
+        val httpVersion = when (protocolVersion) {
+            HttpProtocolVersion.HTTP_1_0 -> protocolVersion.toString()
+            HttpProtocolVersion.HTTP_1_1 -> protocolVersion.toString()
+            else -> null
+        }
+
+        // Try to open request with proposed chunking encoding.
+        // If it fails fall back to programmatic encoding.
+        var detectedChunkedMode = getChunkedMode(data)
+        val request = connect.openRequest(data.method, data.url, httpVersion, detectedChunkedMode)
+        if (request == null) {
+            val errorCode = GetLastError().toInt()
+            if (errorCode != ERROR_INVALID_PARAMETER || detectedChunkedMode != WinHttpChunkedMode.Automatic) {
+                throw getWinHttpException("Unable to open request")
+            }
+
+            detectedChunkedMode = WinHttpChunkedMode.Enabled
+        }
+
+        hRequest = request ?: connect.openRequest(data.method, data.url, httpVersion, detectedChunkedMode)
+            ?: throw getWinHttpException("Unable to open request")
+
+        chunkedMode = detectedChunkedMode
+
+        configureFeatures()
+
+        enableHttpProtocols(protocolVersion)
+
+        if (!config.sslVerify) {
+            disableTlsVerification()
+        }
+
+        configureStatusCallback(enable = true)
+    }
+
+
+    fun upgradeToWebSocket() {
+        if (WinHttpSetOption(hRequest, WINHTTP_OPTION_UPGRADE_TO_WEB_SOCKET, null, 0) == 0) {
+            throw getWinHttpException("Unable to request WebSocket upgrade")
+        }
+    }
+
+    /**
+     * Sends request with headers to remote server. WinHTTP executes request asynchronously,
+     * where to receive notifications about operations used callback function with context.
+     *
+     * @param headers is request headers.
+     */
+    suspend fun sendRequest(headers: Map<String, String>) {
+        return closeableCoroutine(connect, ERROR_FAILED_TO_SEND_REQUEST) { continuation ->
+            val headersString = headers.map {
+                "${it.key}: ${it.value}"
+            }.joinToString("\r\n")
+
+            connect.on(WinHttpCallbackStatus.SendRequestComplete) { _, _ ->
+                continuation.resume(Unit)
+            }
+
+            // Send request
+            val statePtr = connectReference.asCPointer().rawValue.toLong()
+            if (WinHttpSendRequest(
+                    hRequest,                       // request handle
+                    headersString,                  // request headers as a string
+                    headersString.length.convert(), // size of request headers string
+                    WINHTTP_NO_REQUEST_DATA,        // optional request body data
+                    0,                         // size of optional request body
+                    0,                         // size of request body, i.e. Content-Length
+                    statePtr.convert()              // pointer to context
+                ) == 0
+            ) {
+                throw getWinHttpException(ERROR_FAILED_TO_SEND_REQUEST)
+            }
+        }
+    }
+
+    /**
+     * Writes request body data.
+     *
+     * @param buffer is source buffer.
+     * @param length is a number of bytes to write.
+     */
+    suspend fun writeData(buffer: Pinned<ByteArray>, length: Int = buffer.get().size) {
+        return closeableCoroutine(connect, ERROR_FAILED_TO_WRITE_REQUEST) { continuation ->
+            connect.on(WinHttpCallbackStatus.WriteComplete) { _, _ ->
+                continuation.resume(Unit)
+            }
+
+            if (WinHttpWriteData(hRequest, buffer.addressOf(0), length.convert(), null) == 0) {
+                throw getWinHttpException(ERROR_FAILED_TO_WRITE_REQUEST)
+            }
+        }
+    }
+
+    /**
+     * Request server to send a response.
+     */
+    suspend fun getResponse(): WinHttpResponseData {
+        return closeableCoroutine(connect, ERROR_FAILED_TO_RECEIVE_RESPONSE) { continuation ->
+            connect.on(WinHttpCallbackStatus.HeadersAvailable) { _, _ ->
+                try {
+                    val responseData = getResponseData()
+                    continuation.resume(responseData)
+                } catch (cause: Exception) {
+                    continuation.resumeWithException(cause)
+                }
+            }
+
+            if (WinHttpReceiveResponse(hRequest, null) == 0) {
+                throw getWinHttpException(ERROR_FAILED_TO_RECEIVE_RESPONSE)
+            }
+        }
+    }
+
+    /**
+     * Construct a body after receiving response headers.
+     *
+     * @param produceBody is response body producer.
+     */
+    private fun getResponseData() = memScoped {
+        val dwStatusCode = alloc<UIntVar>()
+        val dwSize = alloc<UIntVar> {
+            value = UINT_SIZE
+        }
+
+        // Get status code
+        val statusCodeFlags = WINHTTP_QUERY_STATUS_CODE or WINHTTP_QUERY_FLAG_NUMBER
+        if (WinHttpQueryHeaders(hRequest, statusCodeFlags.convert(), null, dwStatusCode.ptr, dwSize.ptr, null) == 0) {
+            throw getWinHttpException("Failed to query status code")
+        }
+
+        val httpVersion = if (isHttp2Response()) {
+            "HTTP/2.0"
+        } else {
+            getHeader(WINHTTP_QUERY_VERSION)
+        }
+
+        WinHttpResponseData(
+            statusCode = dwStatusCode.value.convert(),
+            httpProtocol = httpVersion,
+            headers = getHeader(WINHTTP_QUERY_RAW_HEADERS_CRLF)
+        )
+    }
+
+    /**
+     * Requests a number of available bytes of response body.
+     */
+    suspend fun queryDataAvailable(): Int {
+        return closeableCoroutine(connect, ERROR_FAILED_TO_QUERY_DATA) { continuation ->
+            connect.on(WinHttpCallbackStatus.DataAvailable) { statusInfo, _ ->
+                val dataSize = statusInfo!!.reinterpret<ULongVar>().pointed.value
+                continuation.resume(dataSize.convert())
+            }
+
+            if (WinHttpQueryDataAvailable(hRequest, null) == 0) {
+                throw getWinHttpException(ERROR_FAILED_TO_QUERY_DATA)
+            }
+        }
+    }
+
+    /**
+     * Reads a response body into buffer.
+     *
+     * @param buffer is target buffer.
+     * @param length is number of bytes to read.
+     */
+    suspend fun readData(buffer: Pinned<ByteArray>, length: Int): Int {
+        return closeableCoroutine(connect, ERROR_FAILED_TO_READ_RESPONSE) { continuation ->
+            connect.on(WinHttpCallbackStatus.ReadComplete) { _, statusInfoLength ->
+                continuation.resume(statusInfoLength.convert())
+            }
+
+            if (WinHttpReadData(hRequest, buffer.addressOf(0), length.convert(), null) == 0) {
+                throw getWinHttpException(ERROR_FAILED_TO_READ_RESPONSE)
+            }
+        }
+    }
+
+    /**
+     * Creates a new WebSocket.
+     *
+     * @param callContext is call context.
+     */
+    fun createWebSocket(callContext: CoroutineContext): WinHttpWebSocket {
+        val statePtr = connectReference.asCPointer().rawValue.toLong()
+        val hWebsocket = WinHttpWebSocketCompleteUpgrade(hRequest, statePtr.convert())
+            ?: throw getWinHttpException("Unable to upgrade websocket")
+
+        return WinHttpWebSocket(hWebsocket, connect, callContext).also {
+            closeRequest()
+        }
+    }
+
+    /**
+     * Disables built-in features which are handled by Ktor client.
+     */
+    private fun configureFeatures() = memScoped {
+        val options = alloc<DWORDVar> {
+            value = (WINHTTP_DISABLE_COOKIES or WINHTTP_DISABLE_REDIRECTS).convert()
+        }
+
+        if (WinHttpSetOption(
+                hRequest,
+                WINHTTP_OPTION_DISABLE_FEATURE,
+                options.ptr,
+                sizeOf<DWORDVar>().convert()
+            ) == 0
+        ) {
+            throw getWinHttpException("Unable to configure request options")
+        }
+    }
+
+    /**
+     * Receive status callbacks about all operations.
+     */
+    private fun configureStatusCallback(enable: Boolean) = memScoped {
+        val notifications = WINHTTP_CALLBACK_FLAG_ALL_COMPLETIONS.convert<UInt>()
+        val callback = if (enable) {
+            staticCFunction(::winHttpCallback)
+        } else null
+
+        val oldStatusCallback = WinHttpSetStatusCallback(hRequest, callback, notifications, 0)
+        if (oldStatusCallback?.rawValue?.toLong() == WINHTTP_INVALID_STATUS_CALLBACK) {
+            val errorCode = GetLastError()
+            if (errorCode != ERROR_INVALID_HANDLE) {
+                throw getWinHttpException("Unable to set request callback", errorCode)
+            }
+        }
+    }
+
+    /**
+     * Enables requested HTTP protocols.
+     *
+     * @param protocolVersion is required protocol version.
+     */
+    private fun enableHttpProtocols(protocolVersion: HttpProtocolVersion) = memScoped {
+        if (protocolVersion != HttpProtocolVersion.HTTP_2_0) return@memScoped
+        val flags = alloc<UIntVar> {
+            value = WINHTTP_PROTOCOL_FLAG_HTTP2.convert()
+        }
+        WinHttpSetOption(hRequest, WINHTTP_OPTION_ENABLE_HTTP_PROTOCOL, flags.ptr, UINT_SIZE)
+    }
+
+    /**
+     * Disables TLS verification for testing purposes.
+     */
+    private fun disableTlsVerification() = memScoped {
+        val flags = alloc<UIntVar> {
+            value = (SECURITY_FLAG_IGNORE_UNKNOWN_CA or
+                SECURITY_FLAG_IGNORE_CERT_WRONG_USAGE or
+                SECURITY_FLAG_IGNORE_CERT_CN_INVALID or
+                SECURITY_FLAG_IGNORE_CERT_DATE_INVALID).convert()
+        }
+        if (WinHttpSetOption(hRequest, WINHTTP_OPTION_SECURITY_FLAGS, flags.ptr, UINT_SIZE) == 0) {
+            throw getWinHttpException("Unable to disable TLS verification")
+        }
+    }
+
+    /**
+     * Computes possible chunking mode for request body processing.
+     *
+     * In HTTP 1 request must have one of the `Content-Length` or `Transfer-Encoding` headers.
+     * In HTTP 2 supported chunked encoding out of the box.
+     */
+    private fun getChunkedMode(data: HttpRequestData): WinHttpChunkedMode {
+        val contentLength = data.body.contentLength ?: data.body.headers[HttpHeaders.ContentLength]?.toLong()
+        val transferEncoding = data.body.headers[HttpHeaders.TransferEncoding]
+        return when {
+            contentLength != null || transferEncoding != null -> WinHttpChunkedMode.Disabled
+            config.protocolVersion.major >= 2 -> WinHttpChunkedMode.Automatic
+            else -> WinHttpChunkedMode.Enabled
+        }
+    }
+
+
+    /**
+     * Gets a string length in bytes.
+     */
+    private fun getLength(dwSize: UIntVar) = (dwSize.value / sizeOf<ShortVar>().convert()).convert<Int>()
+
+    /**
+     * Returns a header value.
+     *
+     * @param headerId is header identifier.
+     */
+    private fun getHeader(headerId: Int): String = memScoped {
+        val dwSize = alloc<UIntVar>()
+
+        // Get header length
+        if (WinHttpQueryHeaders(hRequest, headerId.convert(), null, null, dwSize.ptr, null) == 0) {
+            val errorCode = GetLastError()
+            if (errorCode != ERROR_INSUFFICIENT_BUFFER.convert<UInt>()) {
+                throw getWinHttpException("Unable to query response headers length")
+            }
+        }
+
+        // Read header into buffer
+        val buffer = allocArray<ShortVar>(getLength(dwSize) + 1)
+        if (WinHttpQueryHeaders(hRequest, headerId.convert(), null, buffer, dwSize.ptr, null) == 0) {
+            throw getWinHttpException("Unable to query response headers")
+        }
+
+        buffer.toKStringFromUtf16()
+    }
+
+    /**
+     * Gets a HTTP protocol version from server response.
+     */
+    private fun isHttp2Response() = memScoped {
+        val flags = alloc<UIntVar>()
+        val dwSize = alloc<UIntVar> {
+            value = UINT_SIZE
+        }
+        if (WinHttpQueryOption(hRequest, WINHTTP_OPTION_HTTP_PROTOCOL_USED, flags.ptr, dwSize.ptr) != 0) {
+            if ((flags.value.convert<Int>() and WINHTTP_PROTOCOL_FLAG_HTTP2) != 0) {
+                return true
+            }
+        }
+        false
+    }
+
+    private fun closeRequest() {
+        if (!requestClosed.compareAndSet(expect = false, update = true)) return
+
+        configureStatusCallback(enable = false)
+        WinHttpCloseHandle(hRequest)
+    }
+
+    override fun close() {
+        if (!closed.compareAndSet(expect = false, update = true)) return
+
+        closeRequest()
+        connect.close()
+
+        connectReference.dispose()
+    }
+
+    companion object {
+        private const val WINHTTP_OPTION_ENABLE_HTTP_PROTOCOL = 133u
+        private const val WINHTTP_OPTION_HTTP_PROTOCOL_USED = 134u
+        private const val WINHTTP_PROTOCOL_FLAG_HTTP2 = 0x1
+        private const val WINHTTP_INVALID_STATUS_CALLBACK: Long = -1
+        private const val ERROR_INVALID_HANDLE = 0x6u
+        private val WINHTTP_NO_REQUEST_DATA = null
+
+        private val UINT_SIZE: UInt = sizeOf<UIntVar>().convert()
+
+        private const val ERROR_FAILED_TO_SEND_REQUEST = "Failed to send request"
+        private const val ERROR_FAILED_TO_WRITE_REQUEST = "Failed to write request data"
+        private const val ERROR_FAILED_TO_RECEIVE_RESPONSE = "Failed to receive response"
+        private const val ERROR_FAILED_TO_QUERY_DATA = "Failed to query data length"
+        private const val ERROR_FAILED_TO_READ_RESPONSE = "Failed to read response data"
+    }
+}

--- a/ktor-client/ktor-client-winhttp/windows/src/io/ktor/client/engine/winhttp/internal/WinHttpRequest.kt
+++ b/ktor-client/ktor-client-winhttp/windows/src/io/ktor/client/engine/winhttp/internal/WinHttpRequest.kt
@@ -10,6 +10,10 @@ import io.ktor.http.*
 import io.ktor.utils.io.core.*
 import kotlinx.atomicfu.*
 import kotlinx.cinterop.*
+import ktor.cinterop.winhttp.*
+import ktor.cinterop.winhttp.SECURITY_FLAG_IGNORE_CERT_CN_INVALID
+import ktor.cinterop.winhttp.SECURITY_FLAG_IGNORE_CERT_DATE_INVALID
+import ktor.cinterop.winhttp.SECURITY_FLAG_IGNORE_UNKNOWN_CA
 import platform.windows.*
 import kotlin.coroutines.*
 

--- a/ktor-client/ktor-client-winhttp/windows/src/io/ktor/client/engine/winhttp/internal/WinHttpRequestProducer.kt
+++ b/ktor-client/ktor-client-winhttp/windows/src/io/ktor/client/engine/winhttp/internal/WinHttpRequestProducer.kt
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2014-2022 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.client.engine.winhttp.internal
+
+import io.ktor.client.call.*
+import io.ktor.client.engine.*
+import io.ktor.client.request.*
+import io.ktor.http.*
+import io.ktor.http.content.*
+import io.ktor.util.*
+import io.ktor.utils.io.*
+import io.ktor.utils.io.core.*
+import io.ktor.utils.io.pool.*
+import kotlinx.atomicfu.*
+import kotlinx.cinterop.*
+import kotlinx.coroutines.*
+import kotlin.collections.MutableMap
+import kotlin.collections.mutableMapOf
+import kotlin.collections.set
+import kotlin.coroutines.*
+
+@OptIn(InternalAPI::class)
+internal class WinHttpRequestProducer(
+    private val request: WinHttpRequest,
+    private val data: HttpRequestData
+) {
+    private val closed = atomic(false)
+    private val chunked: Boolean = request.chunkedMode == WinHttpChunkedMode.Enabled && !data.isUpgradeRequest()
+
+    fun getHeaders(): Map<String, String> {
+        val headers = data.headersToMap()
+
+        if (chunked) {
+            headers[HttpHeaders.TransferEncoding] = "chunked"
+        }
+
+        return headers
+    }
+
+    suspend fun writeBody() {
+        if (closed.value) return
+
+        val requestBody = data.body.toByteChannel()
+        if (requestBody != null) {
+            val readBuffer = ByteArrayPool.borrow()
+            try {
+                if (chunked) {
+                    writeChunkedBody(requestBody, readBuffer)
+                } else {
+                    writeRegularBody(requestBody, readBuffer)
+                }
+            } finally {
+                ByteArrayPool.recycle(readBuffer)
+            }
+        }
+    }
+
+    private suspend fun writeChunkedBody(requestBody: ByteReadChannel, readBuffer: ByteArray) {
+        while (true) {
+            val readBytes = requestBody.readAvailable(readBuffer).takeIf { it > 0 } ?: break
+            writeBodyChunk(readBuffer, readBytes)
+        }
+        chunkTerminator.usePinned { src ->
+            request.writeData(src, chunkTerminator.size)
+        }
+    }
+
+    private suspend fun writeBodyChunk(readBuffer: ByteArray, length: Int) {
+        // Write chunk length
+        val chunkStart = "${length.toString(16)}\r\n".toByteArray()
+        chunkStart.usePinned { src ->
+            request.writeData(src, chunkStart.size)
+        }
+        // Write chunk data
+        readBuffer.usePinned { src ->
+            request.writeData(src, length)
+        }
+        // Write chunk ending
+        chunkEnd.usePinned { src ->
+            request.writeData(src, chunkEnd.size)
+        }
+    }
+
+    private suspend fun writeRegularBody(requestBody: ByteReadChannel, readBuffer: ByteArray) {
+        while (true) {
+            val readBytes = requestBody.readAvailable(readBuffer).takeIf { it > 0 } ?: break
+            readBuffer.usePinned { src ->
+                request.writeData(src, readBytes)
+            }
+        }
+    }
+
+    private fun HttpRequestData.headersToMap(): MutableMap<String, String> {
+        val result = mutableMapOf<String, String>()
+
+        mergeHeaders(headers, body) { key, value ->
+            result[key] = value
+        }
+
+        return result
+    }
+
+    private suspend fun OutgoingContent.toByteChannel(): ByteReadChannel? = when (this) {
+        is OutgoingContent.ByteArrayContent -> ByteReadChannel(bytes())
+        is OutgoingContent.WriteChannelContent -> GlobalScope.writer(coroutineContext) {
+            writeTo(channel)
+        }.channel
+        is OutgoingContent.ReadChannelContent -> readFrom()
+        is OutgoingContent.NoContent -> null
+        else -> throw UnsupportedContentTypeException(this)
+    }
+
+    companion object {
+        private val chunkEnd = "\r\n".toByteArray()
+        private val chunkTerminator = "0\r\n\r\n".toByteArray()
+    }
+}

--- a/ktor-client/ktor-client-winhttp/windows/src/io/ktor/client/engine/winhttp/internal/WinHttpResponseConsumer.kt
+++ b/ktor-client/ktor-client-winhttp/windows/src/io/ktor/client/engine/winhttp/internal/WinHttpResponseConsumer.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2014-2022 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.client.engine.winhttp.internal
+
+import io.ktor.utils.io.*
+import io.ktor.utils.io.pool.*
+import kotlinx.cinterop.*
+import kotlinx.coroutines.*
+import kotlin.coroutines.*
+
+internal fun WinHttpRequest.readBody(callContext: CoroutineContext): ByteReadChannel {
+    return GlobalScope.writer(callContext) {
+        val readBuffer = ByteArrayPool.borrow()
+        try {
+            while (isActive) {
+                val availableBytes = queryDataAvailable()
+                if (availableBytes <= 0) {
+                    break
+                }
+                val bytesToRead = minOf(availableBytes, readBuffer.size)
+                val readBytes = readBuffer.usePinned { dst ->
+                    readData(dst, bytesToRead)
+                }
+                channel.writeFully(readBuffer, 0, readBytes)
+            }
+        } finally {
+            ByteArrayPool.recycle(readBuffer)
+        }
+    }.channel
+}

--- a/ktor-client/ktor-client-winhttp/windows/src/io/ktor/client/engine/winhttp/internal/WinHttpResponseData.kt
+++ b/ktor-client/ktor-client-winhttp/windows/src/io/ktor/client/engine/winhttp/internal/WinHttpResponseData.kt
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2014-2022 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.client.engine.winhttp.internal
+
+import io.ktor.client.engine.winhttp.*
+import io.ktor.client.request.*
+import io.ktor.http.*
+import io.ktor.http.cio.*
+import io.ktor.util.date.*
+import io.ktor.utils.io.*
+import io.ktor.utils.io.core.*
+import kotlin.coroutines.*
+
+internal class WinHttpResponseData(
+    val statusCode: Int,
+    val httpProtocol: String,
+    val headers: String
+)
+
+internal suspend fun WinHttpResponseData.convert(
+    requestTime: GMTDate,
+    responseBody: Any,
+    callContext: CoroutineContext
+): HttpResponseData {
+    val headers = parseResponse(ByteReadChannel(headers))?.use { response ->
+        HeadersImpl(response.headers.toMap())
+    } ?: throw WinHttpIllegalStateException("Failed to parse response header")
+
+    return HttpResponseData(
+        HttpStatusCode.fromValue(statusCode),
+        requestTime,
+        headers,
+        HttpProtocolVersion.parse(httpProtocol),
+        responseBody,
+        callContext
+    )
+}
+
+private fun HttpHeadersMap.toMap(): Map<String, List<String>> {
+    val result = mutableMapOf<String, MutableList<String>>()
+
+    for (index in 0 until size) {
+        val key = nameAt(index).toString()
+        val value = valueAt(index).toString()
+
+        if (result[key]?.add(value) == null) {
+            result[key] = mutableListOf(value)
+        }
+    }
+
+    return result
+}

--- a/ktor-client/ktor-client-winhttp/windows/src/io/ktor/client/engine/winhttp/internal/WinHttpSession.kt
+++ b/ktor-client/ktor-client-winhttp/windows/src/io/ktor/client/engine/winhttp/internal/WinHttpSession.kt
@@ -11,7 +11,7 @@ import io.ktor.client.request.*
 import io.ktor.utils.io.core.*
 import kotlinx.atomicfu.*
 import kotlinx.cinterop.*
-import platform.windows.*
+import ktor.cinterop.winhttp.*
 
 internal class WinHttpSession(private val config: WinHttpClientEngineConfig) : Closeable {
 

--- a/ktor-client/ktor-client-winhttp/windows/src/io/ktor/client/engine/winhttp/internal/WinHttpSession.kt
+++ b/ktor-client/ktor-client-winhttp/windows/src/io/ktor/client/engine/winhttp/internal/WinHttpSession.kt
@@ -21,11 +21,11 @@ internal class WinHttpSession(private val config: WinHttpClientEngineConfig) : C
 
     init {
         hSession = WinHttpOpen(
-            null,                         // User agent will be set in request headers
-            WINHTTP_ACCESS_TYPE_DEFAULT_PROXY, // Use default WinHTTP proxy settings
-            WINHTTP_NO_PROXY_NAME,             // Specifies proxy name
-            WINHTTP_NO_PROXY_BYPASS,           // A semicolon delimited list of hosts to exclude
-            WINHTTP_FLAG_ASYNC.convert()       // Use asynchronous working mode
+            WINHTTP_NO_USER_AGENT,
+            WINHTTP_ACCESS_TYPE_DEFAULT_PROXY,
+            WINHTTP_NO_PROXY_NAME,
+            WINHTTP_NO_PROXY_BYPASS,
+            WINHTTP_FLAG_ASYNC.convert()
         ) ?: throw getWinHttpException("Unable to create session")
 
         setSecurityProtocols(config.securityProtocols)
@@ -44,10 +44,10 @@ internal class WinHttpSession(private val config: WinHttpClientEngineConfig) : C
     private fun configureTimeouts(data: HttpRequestData) {
         if (!timeoutConfigured.compareAndSet(expect = false, update = true)) return
 
-        val resolveTimeout = 10_000 // Domain name resolution timeout
-        var connectTimeout = 60_000 // Server connection request timeout
-        var sendTimeout = 30_000    // Sending request timeout
-        var receiveTimeout = 30_000 // Receive response timeout
+        val resolveTimeout = 10_000
+        var connectTimeout = 60_000
+        var sendTimeout = 30_000
+        var receiveTimeout = 30_000
 
         data.getCapabilityOrNull(HttpTimeout)?.let { timeoutExtension ->
             timeoutExtension.connectTimeoutMillis?.let { value ->
@@ -94,6 +94,7 @@ internal class WinHttpSession(private val config: WinHttpClientEngineConfig) : C
                     throw getWinHttpException("Unable to set proxy")
                 }
             }
+
             else -> throw IllegalStateException("Proxy of type $type is unsupported by WinHTTP engine.")
         }
     }
@@ -107,5 +108,6 @@ internal class WinHttpSession(private val config: WinHttpClientEngineConfig) : C
     companion object {
         private val WINHTTP_NO_PROXY_NAME = null
         private val WINHTTP_NO_PROXY_BYPASS = null
+        private val WINHTTP_NO_USER_AGENT = null
     }
 }

--- a/ktor-client/ktor-client-winhttp/windows/src/io/ktor/client/engine/winhttp/internal/WinHttpSession.kt
+++ b/ktor-client/ktor-client-winhttp/windows/src/io/ktor/client/engine/winhttp/internal/WinHttpSession.kt
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2014-2022 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.client.engine.winhttp.internal
+
+import io.ktor.client.engine.*
+import io.ktor.client.engine.winhttp.*
+import io.ktor.client.plugins.*
+import io.ktor.client.request.*
+import io.ktor.utils.io.core.*
+import kotlinx.atomicfu.*
+import kotlinx.cinterop.*
+import platform.windows.*
+
+internal class WinHttpSession(private val config: WinHttpClientEngineConfig) : Closeable {
+
+    private var hSession: COpaquePointer
+    private val closed = atomic(false)
+    private val timeoutConfigured = atomic(false)
+
+    init {
+        hSession = WinHttpOpen(
+            null,                         // User agent will be set in request headers
+            WINHTTP_ACCESS_TYPE_DEFAULT_PROXY, // Use default WinHTTP proxy settings
+            WINHTTP_NO_PROXY_NAME,             // Specifies proxy name
+            WINHTTP_NO_PROXY_BYPASS,           // A semicolon delimited list of hosts to exclude
+            WINHTTP_FLAG_ASYNC.convert()       // Use asynchronous working mode
+        ) ?: throw getWinHttpException("Unable to create session")
+
+        setSecurityProtocols(config.securityProtocols)
+
+        config.proxy?.let { proxy ->
+            setProxy(proxy)
+        }
+    }
+
+    fun createRequest(data: HttpRequestData): WinHttpRequest {
+        configureTimeouts(data)
+
+        return WinHttpRequest(hSession, data, config)
+    }
+
+    private fun configureTimeouts(data: HttpRequestData) {
+        if (!timeoutConfigured.compareAndSet(expect = false, update = true)) return
+
+        val resolveTimeout = 10_000 // Domain name resolution timeout
+        var connectTimeout = 60_000 // Server connection request timeout
+        var sendTimeout = 30_000    // Sending request timeout
+        var receiveTimeout = 30_000 // Receive response timeout
+
+        data.getCapabilityOrNull(HttpTimeout)?.let { timeoutExtension ->
+            timeoutExtension.connectTimeoutMillis?.let { value ->
+                connectTimeout = value.toInt()
+            }
+            timeoutExtension.socketTimeoutMillis?.let { value ->
+                sendTimeout = value.toInt()
+                receiveTimeout = value.toInt()
+            }
+        }
+
+        setTimeouts(resolveTimeout, connectTimeout, sendTimeout, receiveTimeout)
+    }
+
+    private fun setSecurityProtocols(protocol: WinHttpSecurityProtocol) = memScoped {
+        val options = alloc<UIntVar> {
+            value = protocol.value.convert()
+        }
+        val dwSize = sizeOf<UIntVar>().convert<UInt>()
+        WinHttpSetOption(hSession, WINHTTP_OPTION_SECURE_PROTOCOLS, options.ptr, dwSize)
+    }
+
+    private fun setTimeouts(resolveTimeout: Int, connectTimeout: Int, sendTimeout: Int, receiveTimeout: Int) {
+        if (WinHttpSetTimeouts(hSession, resolveTimeout, connectTimeout, sendTimeout, receiveTimeout) == 0) {
+            throw getWinHttpException("Unable to set session timeouts")
+        }
+    }
+
+    private fun setProxy(proxy: ProxyConfig) = memScoped {
+        when (val type = proxy.type) {
+            ProxyType.HTTP -> {
+                val proxyInfo = alloc<WINHTTP_PROXY_INFO> {
+                    dwAccessType = WINHTTP_ACCESS_TYPE_NAMED_PROXY.convert()
+                    lpszProxy = proxy.url.toString().wcstr.ptr
+                }
+
+                if (WinHttpSetOption(
+                        hSession,
+                        WINHTTP_OPTION_PROXY,
+                        proxyInfo.ptr,
+                        sizeOf<WINHTTP_PROXY_INFO>().convert()
+                    ) == 0
+                ) {
+                    throw getWinHttpException("Unable to set proxy")
+                }
+            }
+            else -> throw IllegalStateException("Proxy of type $type is unsupported by WinHTTP engine.")
+        }
+    }
+
+    override fun close() {
+        if (!closed.compareAndSet(expect = false, update = true)) return
+
+        WinHttpCloseHandle(hSession)
+    }
+
+    companion object {
+        private val WINHTTP_NO_PROXY_NAME = null
+        private val WINHTTP_NO_PROXY_BYPASS = null
+    }
+}

--- a/ktor-client/ktor-client-winhttp/windows/src/io/ktor/client/engine/winhttp/internal/WinHttpWebSocket.kt
+++ b/ktor-client/ktor-client-winhttp/windows/src/io/ktor/client/engine/winhttp/internal/WinHttpWebSocket.kt
@@ -1,0 +1,287 @@
+/*
+ * Copyright 2014-2022 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.client.engine.winhttp.internal
+
+import io.ktor.client.engine.winhttp.*
+import io.ktor.utils.io.core.*
+import io.ktor.utils.io.pool.*
+import io.ktor.websocket.*
+import kotlinx.atomicfu.*
+import kotlinx.cinterop.*
+import kotlinx.coroutines.*
+import kotlinx.coroutines.channels.*
+import platform.windows.*
+import kotlin.coroutines.*
+
+private object WinHttpWebSocketBuffer {
+    val BinaryMessage = WINHTTP_WEB_SOCKET_BINARY_MESSAGE_BUFFER_TYPE
+    val BinaryFragment = WINHTTP_WEB_SOCKET_BINARY_FRAGMENT_BUFFER_TYPE
+    val TextMessage = WINHTTP_WEB_SOCKET_UTF8_MESSAGE_BUFFER_TYPE
+    val TextFragment = WINHTTP_WEB_SOCKET_UTF8_FRAGMENT_BUFFER_TYPE
+    val Close = WINHTTP_WEB_SOCKET_CLOSE_BUFFER_TYPE
+}
+
+internal class WinHttpWebSocket(
+    private val hWebSocket: COpaquePointer,
+    private val connect: WinHttpConnect,
+    callContext: CoroutineContext
+) : WebSocketSession, Closeable {
+
+    private val closed = atomic(false)
+    private val socketJob = Job(callContext[Job])
+
+    private val _incoming = Channel<Frame>(Channel.UNLIMITED)
+    private val _outgoing = Channel<Frame>(Channel.UNLIMITED)
+
+    override val coroutineContext: CoroutineContext = callContext + socketJob
+    override var masking: Boolean
+        get() = true
+        set(_) {}
+
+    override var maxFrameSize: Long
+        get() = Long.MAX_VALUE
+        set(_) {}
+
+    override val incoming: ReceiveChannel<Frame>
+        get() = _incoming
+
+    override val outgoing: SendChannel<Frame>
+        get() = _outgoing
+
+    override val extensions: List<WebSocketExtension<*>>
+        get() = emptyList()
+
+    init {
+        socketJob.invokeOnCompletion {
+            close(it)
+        }
+
+        connect.on(WinHttpCallbackStatus.CloseComplete) { _, _ ->
+            onDisconnect()
+        }
+
+        // Start receiving frames
+        launch {
+            ByteArrayPool.useInstance { readBuffer ->
+                while (!closed.value) {
+                    val frame = readBuffer.usePinned { dst ->
+                        receiveNextFrame(dst)
+                    }
+                    if (frame == null) {
+                        socketJob.complete()
+                        break
+                    }
+                    onFrame(frame, readBuffer)
+                }
+            }
+        }
+
+        // Start sending frames
+        launch {
+            while (!closed.value) {
+                sendNextFrame()
+            }
+        }
+    }
+
+    private suspend fun receiveNextFrame(buffer: Pinned<ByteArray>): WinHttpWebSocketStatus? {
+        return closeableCoroutine(connect, ERROR_FAILED_TO_RECEIVE_FRAME) { continuation ->
+            connect.on(WinHttpCallbackStatus.ReadComplete) { statusInfo, _ ->
+                if (statusInfo == null) {
+                    val exception = WinHttpIllegalStateException(ERROR_FAILED_TO_RECEIVE_FRAME)
+                    continuation.resumeWithException(exception)
+                } else {
+                    val status = statusInfo.reinterpret<WINHTTP_WEB_SOCKET_STATUS>().pointed
+                    continuation.resume(
+                        WinHttpWebSocketStatus(
+                            bufferType = status.eBufferType,
+                            size = status.dwBytesTransferred.toInt()
+                        )
+                    )
+                }
+            }
+
+            if (WinHttpWebSocketReceive(
+                    hWebSocket,
+                    buffer.addressOf(0),
+                    buffer.get().size.convert(),
+                    null,
+                    null
+                ) != 0u
+            ) {
+                continuation.resume(null)
+                return@closeableCoroutine
+            }
+        }
+    }
+
+    private fun onFrame(status: WinHttpWebSocketStatus, readBuffer: ByteArray) {
+        when (status.bufferType) {
+            WinHttpWebSocketBuffer.BinaryMessage -> {
+                val data = readBuffer.copyOf(status.size)
+                _incoming.trySend(Frame.Binary(fin = true, data = data))
+            }
+            WinHttpWebSocketBuffer.BinaryFragment -> {
+                val data = readBuffer.copyOf(status.size)
+                _incoming.trySend(Frame.Binary(fin = false, data = data))
+            }
+            WinHttpWebSocketBuffer.TextMessage -> {
+                val data = readBuffer.copyOf(status.size)
+                _incoming.trySend(Frame.Text(fin = true, data = data))
+            }
+            WinHttpWebSocketBuffer.TextFragment -> {
+                val data = readBuffer.copyOf(status.size)
+                _incoming.trySend(Frame.Text(fin = false, data = data))
+            }
+            WinHttpWebSocketBuffer.Close -> {
+                val data = readBuffer.copyOf(status.size)
+                _incoming.trySend(Frame.Close(data))
+            }
+        }
+    }
+
+    private suspend fun sendNextFrame() {
+        val frame = _outgoing.receive()
+
+        when (frame.frameType) {
+            FrameType.TEXT -> {
+                val type = if (frame.fin) {
+                    WINHTTP_WEB_SOCKET_UTF8_MESSAGE_BUFFER_TYPE
+                } else {
+                    WINHTTP_WEB_SOCKET_UTF8_FRAGMENT_BUFFER_TYPE
+                }
+                frame.data.usePinned { src ->
+                    sendFrame(type, src)
+                }
+            }
+            FrameType.BINARY,
+            FrameType.PING,
+            FrameType.PONG -> {
+                val type = if (frame.fin) {
+                    WINHTTP_WEB_SOCKET_BINARY_MESSAGE_BUFFER_TYPE
+                } else {
+                    WINHTTP_WEB_SOCKET_BINARY_FRAGMENT_BUFFER_TYPE
+                }
+                frame.data.usePinned { src ->
+                    sendFrame(type, src)
+                }
+            }
+            FrameType.CLOSE -> {
+                val data = buildPacket { writeFully(frame.data) }
+                val code = data.readShort().toInt()
+                val reason = data.readText()
+                sendClose(code, reason)
+                socketJob.complete()
+            }
+        }
+    }
+
+    private suspend fun sendFrame(
+        type: WINHTTP_WEB_SOCKET_BUFFER_TYPE,
+        buffer: Pinned<ByteArray>
+    ) {
+        return closeableCoroutine(connect, "") { continuation ->
+            connect.on(WinHttpCallbackStatus.WriteComplete) { _, _ ->
+                continuation.resume(Unit)
+            }
+
+            if (WinHttpWebSocketSend(
+                    hWebSocket,
+                    type,
+                    buffer.addressOf(0),
+                    buffer.get().size.convert()
+                ) != 0u
+            ) {
+                throw getWinHttpException("Unable to send data to WebSocket")
+            }
+        }
+    }
+
+    private fun sendClose(code: Int, reason: String) {
+        val reasonBytes = reason.ifEmpty { null }?.toByteArray()
+        val buffer = reasonBytes?.pin()
+        try {
+            if (WinHttpWebSocketShutdown(
+                    hWebSocket,
+                    code.convert(),
+                    buffer?.addressOf(0),
+                    reasonBytes?.size?.convert() ?: 0u
+                ) != 0u
+            ) {
+                throw getWinHttpException("Unable to close WebSocket")
+            }
+        } finally {
+            buffer?.unpin()
+        }
+    }
+
+    private fun onDisconnect() = memScoped {
+        if (closed.value) return@memScoped
+
+        val status = alloc<UShortVar>()
+        val reason = allocArray<ShortVar>(123)
+        val reasonLengthConsumed = alloc<UIntVar>()
+
+        try {
+            if (WinHttpWebSocketQueryCloseStatus(
+                    hWebSocket,
+                    status.ptr,
+                    null,
+                    0,
+                    reasonLengthConsumed.ptr
+                ) != 0u
+            ) {
+                return@memScoped
+            }
+
+            _incoming.trySend(
+                Frame.Close(
+                    CloseReason(
+                        code = status.value.convert<Short>(),
+                        message = reason.toKStringFromUtf16()
+                    )
+                )
+            )
+        } finally {
+            socketJob.complete()
+        }
+    }
+
+    override suspend fun flush() = Unit
+
+    @Deprecated(
+        "Use cancel() instead.",
+        ReplaceWith("cancel()", "kotlinx.coroutines.cancel")
+    )
+    override fun terminate() {
+        socketJob.cancel()
+    }
+
+    override fun close() {
+        socketJob.complete()
+    }
+
+    private fun close(cause: Throwable? = null) {
+        if (!closed.compareAndSet(expect = false, update = true)) return
+
+        _incoming.close()
+        _outgoing.cancel()
+
+        WinHttpWebSocketClose(
+            hWebSocket,
+            WINHTTP_WEB_SOCKET_SUCCESS_CLOSE_STATUS.convert(),
+            NULL,
+            0
+        )
+        WinHttpCloseHandle(hWebSocket)
+        connect.close()
+    }
+
+    companion object {
+        private const val ERROR_FAILED_TO_RECEIVE_FRAME = "Failed to receive frame"
+    }
+
+    private class WinHttpWebSocketStatus(val bufferType: UInt, val size: Int)
+}

--- a/ktor-client/ktor-client-winhttp/windows/src/io/ktor/client/engine/winhttp/internal/WinHttpWebSocket.kt
+++ b/ktor-client/ktor-client-winhttp/windows/src/io/ktor/client/engine/winhttp/internal/WinHttpWebSocket.kt
@@ -12,6 +12,7 @@ import kotlinx.atomicfu.*
 import kotlinx.cinterop.*
 import kotlinx.coroutines.*
 import kotlinx.coroutines.channels.*
+import ktor.cinterop.winhttp.*
 import platform.windows.*
 import kotlin.coroutines.*
 

--- a/ktor-client/ktor-client-winhttp/windows/test/io/ktor/client/engine/winhttp/WinHttpProxyTest.kt
+++ b/ktor-client/ktor-client-winhttp/windows/test/io/ktor/client/engine/winhttp/WinHttpProxyTest.kt
@@ -1,0 +1,47 @@
+/*
+* Copyright 2014-2022 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+*/
+
+package io.ktor.client.engine.winhttp
+
+import io.ktor.client.*
+import io.ktor.client.call.*
+import io.ktor.client.engine.*
+import io.ktor.client.request.*
+import io.ktor.utils.io.core.*
+import kotlinx.coroutines.*
+import kotlin.test.*
+
+/**
+ * This is a temporary tests that should be moved to the general test suite
+ * once we support TLS options in client configs to connect to the local test TLS server.
+ */
+class WinHttpProxyTest {
+    /**
+     * Copied from ktor-client-tests
+     */
+    private val TEST_SERVER: String = "http://127.0.0.1:8080"
+
+    /**
+     * Proxy server url for tests.
+     * Copied from ktor-client-tests
+     */
+    private val HTTP_PROXY_SERVER: String = "http://127.0.0.1:8082"
+
+    @Test
+    fun plainHttpTest() {
+        val client = HttpClient(WinHttp) {
+            engine {
+                proxy = ProxyBuilder.http(HTTP_PROXY_SERVER)
+            }
+        }
+
+        client.use {
+            runBlocking {
+                // replace with once moved to ktor-client-tests
+                assertEquals("hello", client.get("$TEST_SERVER/content/hello").body())
+                assertEquals("proxy", client.get("http://google.com/").body())
+            }
+        }
+    }
+}

--- a/ktor-client/ktor-client-winhttp/windows/test/io/ktor/client/engine/winhttp/WinHttpTests.kt
+++ b/ktor-client/ktor-client-winhttp/windows/test/io/ktor/client/engine/winhttp/WinHttpTests.kt
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2014-2022 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.client.engine.winhttp
+
+import io.ktor.client.*
+import io.ktor.client.call.*
+import io.ktor.client.request.*
+import kotlinx.coroutines.*
+import kotlin.test.*
+
+class WinHttpTests {
+    @Test
+    fun testDownload() {
+        val client = HttpClient(WinHttp)
+
+        val responseText = runBlocking {
+            client.get("https://google.com").body<String>()
+        }
+
+        assertTrue { responseText.isNotEmpty() }
+    }
+}

--- a/ktor-client/ktor-client-winhttp/windows/test/io/ktor/client/engine/winhttp/WinHttpWebSocketTests.kt
+++ b/ktor-client/ktor-client-winhttp/windows/test/io/ktor/client/engine/winhttp/WinHttpWebSocketTests.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2014-2022 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.client.engine.winhttp
+
+import io.ktor.client.*
+import io.ktor.client.plugins.websocket.*
+import io.ktor.websocket.*
+import kotlinx.coroutines.*
+import kotlin.test.*
+
+class WinHttpWebSocketTests {
+
+    private val TEST_WEBSOCKET_SERVER: String = "ws://127.0.0.1:8080"
+
+    @Test
+    fun testEcho() {
+        val client = HttpClient(WinHttp) {
+            install(WebSockets)
+        }
+
+        runBlocking {
+            client.webSocket("$TEST_WEBSOCKET_SERVER/websockets/echo") {
+                send(Frame.Text("Hello, world"))
+
+                val actual = incoming.receive()
+
+                assertTrue(actual is Frame.Text)
+                assertEquals("Hello, world", actual.readText())
+            }
+        }
+    }
+}

--- a/ktor-client/ktor-client-winhttp/windows/test/io/ktor/client/engine/winhttp/internal/WinHttpExceptionsTest.kt
+++ b/ktor-client/ktor-client-winhttp/windows/test/io/ktor/client/engine/winhttp/internal/WinHttpExceptionsTest.kt
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2014-2022 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.client.engine.winhttp.internal
+
+import kotlin.test.*
+
+class WinHttpExceptionsTest {
+
+    @Test
+    fun formatWinHttpErrorCode() {
+        val message = getErrorMessage(12002u)
+        assertEquals("The operation timed out", message)
+    }
+
+    @Test
+    fun formatSystemErrorCode() {
+        val message = getErrorMessage(0x6u)
+        assertEquals("The handle is invalid.", message)
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -68,6 +68,7 @@ if (native_targets_enabled) {
     include(":ktor-client:ktor-client-curl")
     include(":ktor-client:ktor-client-ios")
     include(":ktor-client:ktor-client-darwin")
+    include(":ktor-client:ktor-client-winhttp")
 }
 if (currentJdk >= 11) {
     include(":ktor-client:ktor-client-java")


### PR DESCRIPTION
This change brings support of new Windows engine built on top of WinHTTP library. It supports HTTP 1.x/2 and WebSocket protocols.

**Subsystem**
Client, native windows engine.

**Motivation**
Fixes #671 WinHTTP API allows using native HTTP client without need to include additional DLLs. Also, it allows using certificate stored in Windows Certificates store.

**Solution**

We’re using WinHTTP in asynchronous working mode. In such mode notifications about operation results are delivered via status callback. The library supports both HTTP request processing as well as WebSockets protocol.

In HTTP engine we are using the following abstractions:
* `WinHttpSession` - create once per HTTP engine and allows configuring common settings like timeouts.
* `WinHttpConnect` - represents connection to HTTP host. In our case it also stores list of callbacks for coroutine continuations.
* `WinHttpRequest` - allows writing/reading request and response messages.
* `WinHttpRequestProducer` - handles request body writing. Allows using chunked body encoding.
* `WinHttpWebSocket` - represents WebSocket session. It's created from WinHttpRequest by closing original request and keeping `WinHttpConnect`ion open.

WinHTTP allows specifying connect and socket (send/receive) timeouts. Request timeout is handled by corresponding Ktor plugin.

**Notes**:
WinHTTP is strict regarding `Content-Length` header validation in HTTP 1.x requests and requires using `Transfer-Encoding: chunked` request body if body length is unknown, e.g. when it's stream or channel based. In such cases we’re trying to use system encoding (modern Windows 10+ OS) or we're using fallback to manual chunks writing.

In case of failures we're converting error codes into human readable messages by using `FormatMessage` function.