### PR TITLE
KTOR-4695 Fix UnixSocketAddress.path

### DIFF
--- a/ktor-network/jvm/src/io/ktor/network/sockets/SocketAddressJvm.kt
+++ b/ktor-network/jvm/src/io/ktor/network/sockets/SocketAddressJvm.kt
@@ -65,7 +65,7 @@ public actual class UnixSocketAddress internal constructor(
     public actual val path: String
         get() {
             val getPath: Method = checkSupportForUnixDomainSockets().getMethod("getPath")
-            return getPath.invoke(this).toString()
+            return getPath.invoke(address).toString()
         }
 
     public actual constructor(path: String) : this(


### PR DESCRIPTION
**Subsystem**
ktor-network

**Motivation**
Fixes a regression in the JVM version of UnixSocketAddress (cf [KTOR-4695](https://youtrack.jetbrains.com/issue/KTOR-4695/Regression-UnixSocketAddresspath-fails-on-JVM))

**Solution**
Simply give the right object to the call to `getPath.invoke()`.
