### PR TITLE
KTOR-4697 Consider wss to be a secure context

### DIFF
--- a/ktor-server/ktor-server-host-common/jvm/src/io/ktor/server/engine/BaseApplicationResponseJvm.kt
+++ b/ktor-server/ktor-server-host-common/jvm/src/io/ktor/server/engine/BaseApplicationResponseJvm.kt
@@ -30,7 +30,7 @@ public actual abstract class BaseApplicationResponse actual constructor(
         get() = responded
 
     actual override val cookies: ResponseCookies by lazy {
-        ResponseCookies(this, call.request.origin.scheme == "https")
+        ResponseCookies(this, call.request.origin.scheme == "https" || call.request.origin.scheme == "wss")
     }
 
     actual override fun status(): HttpStatusCode? = _status

--- a/ktor-server/ktor-server-host-common/nix/src/io/ktor/server/engine/BaseApplicationResponseNative.kt
+++ b/ktor-server/ktor-server-host-common/nix/src/io/ktor/server/engine/BaseApplicationResponseNative.kt
@@ -27,7 +27,7 @@ public actual abstract class BaseApplicationResponse actual constructor(
         get() = responded
 
     actual override val cookies: ResponseCookies by lazy {
-        ResponseCookies(this, call.request.origin.scheme == "https")
+        ResponseCookies(this, call.request.origin.scheme == "https" || call.request.origin.scheme == "wss")
     }
 
     actual override fun status(): HttpStatusCode? = _status


### PR DESCRIPTION
**Subsystem**
`ktor-server-host-common`

**Motivation**
It solves https://youtrack.jetbrains.com/issue/KTOR-4697 

**Solution**
The application now considers `wss` secure context and allows setting `Secure` cookies even  `wss` is used as a request scheme (for example in case when reverse proxy uses `X-Forwarded-Proto: wss` as described in  KTOR-4697)

