### PR TITLE
KTOR-4712 Use Netty's alpn check instead of attempting to load jetty-alpn class

### DIFF
--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyChannelInitializer.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyChannelInitializer.kt
@@ -175,14 +175,15 @@ public class NettyChannelInitializer(
 
         private fun findAlpnProvider(): SslProvider? {
             try {
-                Class.forName("sun.security.ssl.ALPNExtension", true, null)
-                return SslProvider.JDK
+                if (SslProvider.isAlpnSupported(SslProvider.OPENSSL)) {
+                    return SslProvider.OPENSSL
+                }
             } catch (ignore: Throwable) {
             }
 
             try {
-                if (SslProvider.isAlpnSupported(SslProvider.OPENSSL)) {
-                    return SslProvider.OPENSSL
+                if (SslProvider.isAlpnSupported(SslProvider.JDK)) {
+                    return SslProvider.JDK
                 }
             } catch (ignore: Throwable) {
             }


### PR DESCRIPTION
**Subsystem**
Server - Netty

**Motivation**
See [KTOR4712](https://youtrack.jetbrains.com/issue/KTOR-4712): "sun.security.ssl.A**LPN**Extension" is only available if jetty-alpn is on the boot classpath, the class included in the jdk since 8u251 is called "sun.security.ssl.A**lpn**Extension". This leads to ktor refusing to use alpn with the jdk's implementation.

**Solution**
I've reused the same check provided by netty that was already in use for checking for openssl. Additionally I moved openssl to the top since `netty-tcnative` is an optional dependency, so if it is on the classpath it's probably the user's intention to use it in preference over the default jdk implementation.
