### PR TITLE
KTOR-4715  Fix crash in browser web workers where window is undefined

### DIFF
--- a/ktor-http/js/src/io/ktor/http/URLBuilderJs.kt
+++ b/ktor-http/js/src/io/ktor/http/URLBuilderJs.kt
@@ -16,7 +16,7 @@ import org.w3c.workers.*
  */
 public actual val URLBuilder.Companion.origin: String
     get() = when {
-        PlatformUtils.IS_BROWSER -> if (window !== undefined) {
+        PlatformUtils.IS_BROWSER -> if (js("typeof window !== 'undefined'") as Boolean) {
             window.location.origin
         } else {
             js("self.location.origin") as String


### PR DESCRIPTION
**Subsystem**
Clients

**Motivation**
In web workers `window` will be undefined, and `window === undefined` will crash because `window` is not dynamic.

**Solution**
I'm sure there is a more elegant way to accomplish this, but it seems like the best solution for now might be to just execute raw JS to check for `undefined`.

