### PR TITLE
KTOR-621 Add extensions to check if the Url is absolute or relative

### DIFF
--- a/ktor-http/api/ktor-http.api
+++ b/ktor-http/api/ktor-http.api
@@ -991,6 +991,10 @@ public final class io/ktor/http/URLUtilsKt {
 	public static final fun appendUrlFullPath (Ljava/lang/Appendable;Ljava/lang/String;Lio/ktor/http/ParametersBuilder;Z)V
 	public static final fun getFullPath (Lio/ktor/http/Url;)Ljava/lang/String;
 	public static final fun getHostWithPort (Lio/ktor/http/Url;)Ljava/lang/String;
+	public static final fun isAbsolute (Lio/ktor/http/URLBuilder;)Z
+	public static final fun isAbsolute (Lio/ktor/http/Url;)Z
+	public static final fun isRelative (Lio/ktor/http/URLBuilder;)Z
+	public static final fun isRelative (Lio/ktor/http/Url;)Z
 	public static final fun takeFrom (Lio/ktor/http/URLBuilder;Lio/ktor/http/URLBuilder;)Lio/ktor/http/URLBuilder;
 	public static final fun takeFrom (Lio/ktor/http/URLBuilder;Lio/ktor/http/Url;)Lio/ktor/http/URLBuilder;
 }

--- a/ktor-http/api/ktor-http.api
+++ b/ktor-http/api/ktor-http.api
@@ -991,10 +991,10 @@ public final class io/ktor/http/URLUtilsKt {
 	public static final fun appendUrlFullPath (Ljava/lang/Appendable;Ljava/lang/String;Lio/ktor/http/ParametersBuilder;Z)V
 	public static final fun getFullPath (Lio/ktor/http/Url;)Ljava/lang/String;
 	public static final fun getHostWithPort (Lio/ktor/http/Url;)Ljava/lang/String;
-	public static final fun isAbsolute (Lio/ktor/http/URLBuilder;)Z
-	public static final fun isAbsolute (Lio/ktor/http/Url;)Z
-	public static final fun isRelative (Lio/ktor/http/URLBuilder;)Z
-	public static final fun isRelative (Lio/ktor/http/Url;)Z
+	public static final fun isAbsolutePath (Lio/ktor/http/URLBuilder;)Z
+	public static final fun isAbsolutePath (Lio/ktor/http/Url;)Z
+	public static final fun isRelativePath (Lio/ktor/http/URLBuilder;)Z
+	public static final fun isRelativePath (Lio/ktor/http/Url;)Z
 	public static final fun takeFrom (Lio/ktor/http/URLBuilder;Lio/ktor/http/URLBuilder;)Lio/ktor/http/URLBuilder;
 	public static final fun takeFrom (Lio/ktor/http/URLBuilder;Lio/ktor/http/Url;)Lio/ktor/http/URLBuilder;
 }

--- a/ktor-http/common/src/io/ktor/http/URLUtils.kt
+++ b/ktor-http/common/src/io/ktor/http/URLUtils.kt
@@ -132,22 +132,22 @@ public fun Appendable.appendUrlFullPath(
 /**
  * Checks if [Url] has absolute path.
  */
-public val Url.isAbsolute: Boolean get() = pathSegments.firstOrNull() == ""
+public val Url.isAbsolutePath: Boolean get() = pathSegments.firstOrNull() == ""
 
 /**
  * Checks if [Url] has absolute path.
  */
-public val Url.isRelative: Boolean get() = !isAbsolute
+public val Url.isRelativePath: Boolean get() = !isAbsolutePath
 
 /**
  * Checks if [Url] has absolute path.
  */
-public val URLBuilder.isAbsolute: Boolean get() = pathSegments.firstOrNull() == ""
+public val URLBuilder.isAbsolutePath: Boolean get() = pathSegments.firstOrNull() == ""
 
 /**
  * Checks if [Url] has absolute path.
  */
-public val URLBuilder.isRelative: Boolean get() = !isAbsolute
+public val URLBuilder.isRelativePath: Boolean get() = !isAbsolutePath
 
 internal fun StringBuilder.appendUserAndPassword(encodedUser: String?, encodedPassword: String?) {
     if (encodedUser == null) {

--- a/ktor-http/common/src/io/ktor/http/URLUtils.kt
+++ b/ktor-http/common/src/io/ktor/http/URLUtils.kt
@@ -129,6 +129,26 @@ public fun Appendable.appendUrlFullPath(
         }
 }
 
+/**
+ * Checks if [Url] has absolute path.
+ */
+public val Url.isAbsolute: Boolean get() = pathSegments.firstOrNull() == ""
+
+/**
+ * Checks if [Url] has absolute path.
+ */
+public val Url.isRelative: Boolean get() = !isAbsolute
+
+/**
+ * Checks if [Url] has absolute path.
+ */
+public val URLBuilder.isAbsolute: Boolean get() = pathSegments.firstOrNull() == ""
+
+/**
+ * Checks if [Url] has absolute path.
+ */
+public val URLBuilder.isRelative: Boolean get() = !isAbsolute
+
 internal fun StringBuilder.appendUserAndPassword(encodedUser: String?, encodedPassword: String?) {
     if (encodedUser == null) {
         return

--- a/ktor-http/common/test/io/ktor/tests/http/URLBuilderTest.kt
+++ b/ktor-http/common/test/io/ktor/tests/http/URLBuilderTest.kt
@@ -494,6 +494,20 @@ internal class URLBuilderTest {
         assertEquals("hello/world", urlBuilder.encodedPath)
     }
 
+    @Test
+    fun testIsAbsolute() {
+        assertTrue(URLBuilder("https://ktor.io/").isAbsolute)
+        assertTrue(URLBuilder("/").isAbsolute)
+        assertTrue(URLBuilder("/hello").isAbsolute)
+    }
+
+    @Test
+    fun testIsRelative() {
+        assertTrue(URLBuilder("hello").isRelative)
+        assertTrue(URLBuilder("").isRelative)
+        assertTrue(URLBuilder("hello/world").isRelative)
+    }
+
     /**
      * Checks that the given [url] and the result of [URLBuilder.buildString] is equal (case insensitive).
      */

--- a/ktor-http/common/test/io/ktor/tests/http/URLBuilderTest.kt
+++ b/ktor-http/common/test/io/ktor/tests/http/URLBuilderTest.kt
@@ -496,16 +496,16 @@ internal class URLBuilderTest {
 
     @Test
     fun testIsAbsolute() {
-        assertTrue(URLBuilder("https://ktor.io/").isAbsolute)
-        assertTrue(URLBuilder("/").isAbsolute)
-        assertTrue(URLBuilder("/hello").isAbsolute)
+        assertTrue(URLBuilder("https://ktor.io/").isAbsolutePath)
+        assertTrue(URLBuilder("/").isAbsolutePath)
+        assertTrue(URLBuilder("/hello").isAbsolutePath)
     }
 
     @Test
     fun testIsRelative() {
-        assertTrue(URLBuilder("hello").isRelative)
-        assertTrue(URLBuilder("").isRelative)
-        assertTrue(URLBuilder("hello/world").isRelative)
+        assertTrue(URLBuilder("hello").isRelativePath)
+        assertTrue(URLBuilder("").isRelativePath)
+        assertTrue(URLBuilder("hello/world").isRelativePath)
     }
 
     /**

--- a/ktor-http/common/test/io/ktor/tests/http/UrlTest.kt
+++ b/ktor-http/common/test/io/ktor/tests/http/UrlTest.kt
@@ -305,15 +305,15 @@ class UrlTest {
 
     @Test
     fun testIsAbsolute() {
-        assertTrue(Url("https://ktor.io/").isAbsolute)
-        assertTrue(Url("/").isAbsolute)
-        assertTrue(Url("/hello").isAbsolute)
+        assertTrue(Url("https://ktor.io/").isAbsolutePath)
+        assertTrue(Url("/").isAbsolutePath)
+        assertTrue(Url("/hello").isAbsolutePath)
     }
 
     @Test
     fun testIsRelative() {
-        assertTrue(Url("hello").isRelative)
-        assertTrue(Url("").isRelative)
-        assertTrue(Url("hello/world").isRelative)
+        assertTrue(Url("hello").isRelativePath)
+        assertTrue(Url("").isRelativePath)
+        assertTrue(Url("hello/world").isRelativePath)
     }
 }

--- a/ktor-http/common/test/io/ktor/tests/http/UrlTest.kt
+++ b/ktor-http/common/test/io/ktor/tests/http/UrlTest.kt
@@ -302,4 +302,18 @@ class UrlTest {
         val url = Url(urlString)
         assertEquals(urlString, "$url")
     }
+
+    @Test
+    fun testIsAbsolute() {
+        assertTrue(Url("https://ktor.io/").isAbsolute)
+        assertTrue(Url("/").isAbsolute)
+        assertTrue(Url("/hello").isAbsolute)
+    }
+
+    @Test
+    fun testIsRelative() {
+        assertTrue(Url("hello").isRelative)
+        assertTrue(Url("").isRelative)
+        assertTrue(Url("hello/world").isRelative)
+    }
 }


### PR DESCRIPTION
Fix [KTOR-621](https://youtrack.jetbrains.com/issue/KTOR-621/The-beginning-character-of-endodedPath-fieldUrl-class-is-wrong-when-relative-path)