### PR TITLE
Issue #1903. Added code to parse the url if valid else return null

### DIFF
--- a/ktor-http/common/src/io/ktor/http/Url.kt
+++ b/ktor-http/common/src/io/ktor/http/Url.kt
@@ -116,7 +116,11 @@ public class Url internal constructor(
         return urlString.hashCode()
     }
 
-    public companion object
+    public companion object {
+        public fun parse(urlString: String) : Url? {
+            return Url(urlString)
+        }
+    }
 }
 
 @Suppress("UNUSED_PARAMETER")

--- a/ktor-http/common/src/io/ktor/http/Url.kt
+++ b/ktor-http/common/src/io/ktor/http/Url.kt
@@ -117,7 +117,7 @@ public class Url internal constructor(
     }
 
     public companion object {
-        public fun parse(urlString: String) : Url? {
+        public fun parse(urlString: String): Url? {
             return Url(urlString)
         }
     }

--- a/ktor-http/common/src/io/ktor/http/Url.kt
+++ b/ktor-http/common/src/io/ktor/http/Url.kt
@@ -117,7 +117,7 @@ public class Url internal constructor(
     }
 
     public companion object {
-        public fun parse(urlString: String): Url {
+        public fun parse(urlString: String) : Url? {
             return Url(urlString)
         }
     }

--- a/ktor-http/common/src/io/ktor/http/Url.kt
+++ b/ktor-http/common/src/io/ktor/http/Url.kt
@@ -117,7 +117,7 @@ public class Url internal constructor(
     }
 
     public companion object {
-        public fun parse(urlString: String) : Url? {
+        public fun parse(urlString: String): Url {
             return Url(urlString)
         }
     }

--- a/ktor-http/common/test/io/ktor/tests/http/UrlTest.kt
+++ b/ktor-http/common/test/io/ktor/tests/http/UrlTest.kt
@@ -302,4 +302,18 @@ class UrlTest {
         val url = Url(urlString)
         assertEquals(urlString, "$url")
     }
+
+
+    @Test
+    fun testUrlWithGivenString() {
+        val validUrl = "https://localhost:8080/validUrl"
+        assertNotNull(Url.parse(validUrl), "Invalid Url")
+    }
+
+
+    @Test
+    fun testInvalidUrlReturnsNull() {
+        val bogusUrl = "bogus"
+        assertNull(Url.parse(bogusUrl))
+    }
 }

--- a/ktor-http/common/test/io/ktor/tests/http/UrlTest.kt
+++ b/ktor-http/common/test/io/ktor/tests/http/UrlTest.kt
@@ -303,11 +303,13 @@ class UrlTest {
         assertEquals(urlString, "$url")
     }
 
+
     @Test
     fun testUrlWithGivenString() {
         val validUrl = "https://localhost:8080/validUrl"
         assertNotNull(Url.parse(validUrl), "Invalid Url")
     }
+
 
     @Test
     fun testInvalidUrlReturnsNull() {

--- a/ktor-http/common/test/io/ktor/tests/http/UrlTest.kt
+++ b/ktor-http/common/test/io/ktor/tests/http/UrlTest.kt
@@ -303,13 +303,11 @@ class UrlTest {
         assertEquals(urlString, "$url")
     }
 
-
     @Test
     fun testUrlWithGivenString() {
         val validUrl = "https://localhost:8080/validUrl"
         assertNotNull(Url.parse(validUrl), "Invalid Url")
     }
-
 
     @Test
     fun testInvalidUrlReturnsNull() {


### PR DESCRIPTION
**Subsystem**
ktor-Http

**Motivation**
**issue #1903**. Currently the Url parse return valid url when a bogus url is passed.

**Solution**
Added a function to the Url Companion object, which parse the urlstring and return the valid url if present else returns null instead of appending `http://localhost` to the invalid url

