### PR TITLE
KTOR-4828 NumberFormatException when Content-Length header value cont…

### DIFF
--- a/ktor-client/ktor-client-cio/jvmAndNix/src/io/ktor/client/engine/cio/utils.kt
+++ b/ktor-client/ktor-client-cio/jvmAndNix/src/io/ktor/client/engine/cio/utils.kt
@@ -133,7 +133,7 @@ internal suspend fun readResponse(
 
     rawResponse.use {
         val status = HttpStatusCode(rawResponse.status, rawResponse.statusText.toString())
-        val contentLength = rawResponse.headers[HttpHeaders.ContentLength]?.toString()?.toLong() ?: -1L
+        val contentLength = rawResponse.headers[HttpHeaders.ContentLength]?.toString()?.toLongOrNull() ?: -1L
         val transferEncoding = rawResponse.headers[HttpHeaders.TransferEncoding]?.toString()
         val connectionType = ConnectionOptions.parse(rawResponse.headers[HttpHeaders.Connection])
 


### PR DESCRIPTION
**Subsystem**
ktor-client-cio

**Motivation**
Fix [KTOR-4828](https://youtrack.jetbrains.com/issue/KTOR-4828) NumberFormatException when Content-Length header value contains null bytes

```log
Exception in thread "main" java.lang.NumberFormatException: For input string: "35                      "
	at java.lang.NumberFormatException.forInputString(NumberFormatException.java:65)
	at java.lang.Long.parseLong(Long.java:589)
	at java.lang.Long.parseLong(Long.java:631)
	at io.ktor.client.engine.cio.UtilsKt$readResponse$2.invokeSuspend(utils.kt:136)
	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
	at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:106)
	at kotlinx.coroutines.internal.LimitedDispatcher.run(LimitedDispatcher.kt:42)
	at kotlinx.coroutines.scheduling.TaskImpl.run(Tasks.kt:95)
	at kotlinx.coroutines.scheduling.CoroutineScheduler.runSafely(CoroutineScheduler.kt:570)
	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.executeTask(CoroutineScheduler.kt:750)
	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.runWorker(CoroutineScheduler.kt:677)
	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run(CoroutineScheduler.kt:664)

```

**Solution**
Replace `toLong()`  with `toLongOrNull()`

