### PR TITLE
Allow `respondTemplate` set HTTP status

### DIFF
--- a/ktor-server/ktor-server-plugins/ktor-server-thymeleaf/api/ktor-server-thymeleaf.api
+++ b/ktor-server/ktor-server-plugins/ktor-server-thymeleaf/api/ktor-server-thymeleaf.api
@@ -1,6 +1,6 @@
 public final class io/ktor/server/thymeleaf/RespondTemplateKt {
-	public static final fun respondTemplate (Lio/ktor/server/application/ApplicationCall;Ljava/lang/String;Ljava/util/Map;Ljava/lang/String;Lio/ktor/http/ContentType;Ljava/util/Locale;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun respondTemplate$default (Lio/ktor/server/application/ApplicationCall;Ljava/lang/String;Ljava/util/Map;Ljava/lang/String;Lio/ktor/http/ContentType;Ljava/util/Locale;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static final fun respondTemplate (Lio/ktor/server/application/ApplicationCall;Ljava/lang/String;Ljava/util/Map;Ljava/lang/String;Lio/ktor/http/ContentType;Ljava/util/Locale;Lio/ktor/http/HttpStatusCode;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun respondTemplate$default (Lio/ktor/server/application/ApplicationCall;Ljava/lang/String;Ljava/util/Map;Ljava/lang/String;Lio/ktor/http/ContentType;Ljava/util/Locale;Lio/ktor/http/HttpStatusCode;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 }
 
 public final class io/ktor/server/thymeleaf/ThymeleafContent {

--- a/ktor-server/ktor-server-plugins/ktor-server-thymeleaf/jvm/src/io/ktor/server/thymeleaf/RespondTemplate.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-thymeleaf/jvm/src/io/ktor/server/thymeleaf/RespondTemplate.kt
@@ -17,5 +17,6 @@ public suspend fun ApplicationCall.respondTemplate(
     model: Map<String, Any> = emptyMap(),
     etag: String? = null,
     contentType: ContentType = ContentType.Text.Html.withCharset(Charsets.UTF_8),
-    locale: Locale = Locale.getDefault()
-): Unit = respond(ThymeleafContent(template, model, etag, contentType, locale))
+    locale: Locale = Locale.getDefault(),
+    status: HttpStatusCode = HttpStatusCode.OK    
+): Unit = respond(status, ThymeleafContent(template, model, etag, contentType, locale))


### PR DESCRIPTION
**Subsystem**
Server, Thymeleaf plugin

**Motivation**
The default HTTP status in `io.ktor.server.engine.BaseApplicationResponse#commitHeaders` is `HttpStatusCode.OK` (200). This is almost always applicable when responding with a template. However, in the case of templates being used along with the `StatusPages` plugin or for response entities for HTTP methods, it is necessary to respond with an appropriate HTTP status code.

**Solution**
This change allows for an optional parameter for the caller to set the status code along with responding with a template. IIUC, it should be binary compatible.

It does not address other templating library plugins. With a little effort all the template plugins could be harmonized under an interface for the `xContent` type and an abstract implementation for the `respondTemplate` function. The only differences I've noticed are for JTE with an additional `varargs params: Pair` signature (which delegates to the `model: Map` implementation), Moustache with any `model: Any?` signature (which doesn't obviate the otherwise common `model: Map`) , a slight difference in parameter order for Pebble, and the additional `fragments: Set` for Thymeleaf (which could be converted to a `fragments: Set?` to harmonize all the other plugins.
