### PR TITLE
KTOR-4729 KTOR-4926 Disable auto reload in tests

### DIFF
--- a/ktor-server/ktor-server-test-host/jvm/test/TestApplicationTestJvm.kt
+++ b/ktor-server/ktor-server-test-host/jvm/test/TestApplicationTestJvm.kt
@@ -13,6 +13,7 @@ import io.ktor.server.response.*
 import io.ktor.server.routing.*
 import io.ktor.server.testing.*
 import io.ktor.server.websocket.*
+import io.ktor.util.*
 import io.ktor.websocket.*
 import kotlinx.coroutines.*
 import java.io.*
@@ -199,6 +200,15 @@ class TestApplicationTestJvm {
         }
     }
 
+    @Test
+    fun testRetrievingPluginInstance() = testApplication {
+        install(MyCalculatorPlugin)
+        application {
+            val result = plugin(MyCalculatorPlugin).add(1, 2)
+            assertEquals(3, result)
+        }
+    }
+
     public fun Application.module() {
         routing {
             get { call.respond("OK FROM MODULE") }
@@ -218,5 +228,24 @@ class TestObjectInputStream(input: InputStream) : ObjectInputStream(input) {
         } catch (e: ClassNotFoundException) {
             super.resolveClass(desc)
         }
+    }
+}
+
+class MyCalculatorPlugin {
+    class Configuration
+    companion object Plugin : BaseApplicationPlugin<ApplicationCallPipeline, Configuration, MyCalculatorPlugin> {
+        override val key = AttributeKey<MyCalculatorPlugin>("MyCalculatorPlugin")
+
+        override fun install(
+            pipeline: ApplicationCallPipeline,
+            configure: Configuration.() -> Unit
+        ): MyCalculatorPlugin {
+            return MyCalculatorPlugin()
+        }
+
+    }
+
+    fun add(x: Int, y: Int): Int {
+        return x + y
     }
 }

--- a/ktor-server/ktor-server-test-host/jvmAndNix/src/io/ktor/server/testing/TestEngine.kt
+++ b/ktor-server/ktor-server-test-host/jvmAndNix/src/io/ktor/server/testing/TestEngine.kt
@@ -25,6 +25,7 @@ public fun createTestEnvironment(
         log = KtorSimpleLogger("ktor.test")
         developmentMode = true
         configure()
+        watchPaths = emptyList()
     }
 
 /**


### PR DESCRIPTION
Using empty `watchPaths` disables creating special class loader. In the future, we may add a new property to enable the development mode, but disable auto reload explicitly. But it needs design on how `developmentMode`, `autoReload` and `watchPaths` properties should work together

https://youtrack.jetbrains.com/issue/KTOR-4729
https://youtrack.jetbrains.com/issue/KTOR-4926