### PR TITLE
KTOR-4225 Fix ResponseValidator consumes body

### DIFF
--- a/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/DefaultTransform.kt
+++ b/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/DefaultTransform.kt
@@ -5,6 +5,7 @@
 package io.ktor.client.plugins
 
 import io.ktor.client.*
+import io.ktor.client.call.*
 import io.ktor.client.request.*
 import io.ktor.client.statement.*
 import io.ktor.http.*
@@ -59,20 +60,20 @@ public fun HttpClient.defaultTransformers() {
         val response = context.response
 
         when (info.type) {
+            SavedHttpResponse::class -> {
+                proceedWith(HttpResponseContainer(info, response.call.save().response))
+            }
             Unit::class -> {
                 body.cancel()
                 proceedWith(HttpResponseContainer(info, Unit))
             }
-
             Int::class -> {
                 proceedWith(HttpResponseContainer(info, body.readRemaining().readText().toInt()))
             }
-
             ByteReadPacket::class,
             Input::class -> {
                 proceedWith(HttpResponseContainer(info, body.readRemaining()))
             }
-
             ByteArray::class -> {
                 val bytes = body.toByteArray()
 
@@ -83,7 +84,6 @@ public fun HttpClient.defaultTransformers() {
                 }
                 proceedWith(HttpResponseContainer(info, bytes))
             }
-
             ByteReadChannel::class -> {
                 // the response job could be already completed so the job holder
                 // could be cancelled immediately, but it doesn't matter
@@ -109,7 +109,6 @@ public fun HttpClient.defaultTransformers() {
 
                 proceedWith(HttpResponseContainer(info, channel))
             }
-
             HttpStatusCode::class -> {
                 body.cancel()
                 proceedWith(HttpResponseContainer(info, response.status))

--- a/ktor-client/ktor-client-core/common/src/io/ktor/client/statement/HttpStatement.kt
+++ b/ktor-client/ktor-client-core/common/src/io/ktor/client/statement/HttpStatement.kt
@@ -60,9 +60,7 @@ public class HttpStatement(
      * To receive exact type, consider using [body<T>()] method.
      */
     public suspend fun execute(): HttpResponse = execute {
-        val savedCall = it.call.save()
-
-        savedCall.response
+        it.body<SavedHttpResponse>()
     }
 
     /**

--- a/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/ResponseValidatorTest.kt
+++ b/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/ResponseValidatorTest.kt
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2014-2022 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.client.tests
+
+import io.ktor.client.*
+import io.ktor.client.call.*
+import io.ktor.client.engine.mock.*
+import io.ktor.client.plugins.*
+import io.ktor.client.plugins.contentnegotiation.*
+import io.ktor.client.request.*
+import io.ktor.http.*
+import io.ktor.http.content.*
+import io.ktor.serialization.kotlinx.json.*
+import io.ktor.test.dispatcher.*
+import kotlinx.serialization.*
+import kotlinx.serialization.json.*
+import kotlin.test.*
+
+class ResponseValidatorTest {
+    @Serializable
+    data class ResponseJsonData(val status: Int, val message: String)
+
+    @Test
+    fun testValidationWithContentNegotiationPlugin() = testSuspend {
+        val client = HttpClient(
+            MockEngine { request ->
+                val bodyBytes = (request.body as OutgoingContent.ByteArrayContent).bytes()
+                respondOk(String(bodyBytes))
+            }
+        ) {
+            install(ContentNegotiation) { json() }
+            HttpResponseValidator {
+                validateResponse {
+                    val body: String = it.body()
+                    val response = Json.decodeFromString<ResponseJsonData>(body)
+                    if (response.status != 200) {
+                        throw ClientRequestException(it, response.message)
+                    }
+                }
+            }
+        }
+
+        val response: String = client.get {
+            setBody(ResponseJsonData(200, "OK"))
+            contentType(ContentType.Application.Json)
+        }.body()
+
+        assertEquals("{\"status\":200,\"message\":\"OK\"}", response)
+        assertEquals(ResponseJsonData(200,"OK"), Json.decodeFromString(response))
+    }
+}


### PR DESCRIPTION
Fix [KTOR-4225](https://youtrack.jetbrains.com/issue/KTOR-4225/HttpResponseValidator-consumes-HTTP-response-body)

