### PR TITLE
KTOR-4877 Fix UDP already connected

### DIFF
--- a/ktor-network/jvmAndNix/test/io/ktor/network/sockets/tests/UDPSocketTest.kt
+++ b/ktor-network/jvmAndNix/test/io/ktor/network/sockets/tests/UDPSocketTest.kt
@@ -4,7 +4,9 @@
 
 package io.ktor.network.sockets.tests
 
+import io.ktor.network.selector.*
 import io.ktor.network.sockets.*
+import io.ktor.test.dispatcher.*
 import io.ktor.utils.io.core.*
 import kotlinx.atomicfu.*
 import kotlinx.coroutines.*
@@ -212,6 +214,18 @@ class UDPSocketTest {
                     assertEquals("hello", incoming.packet.readText())
                 }
             }
+    }
+
+    @Test
+    fun testUdpConnect() = testSockets { selector ->
+        val server = aSocket(selector)
+            .udp()
+            .bind()
+
+        val socket = aSocket(selector).udp().connect(server.localAddress)
+
+        socket.send(Datagram(buildPacket { writeText("hello") }, server.localAddress))
+        assertEquals("hello", server.receive().packet.readText())
     }
 }
 

--- a/ktor-network/jvmAndNix/test/io/ktor/network/sockets/tests/UDPSocketTest.kt
+++ b/ktor-network/jvmAndNix/test/io/ktor/network/sockets/tests/UDPSocketTest.kt
@@ -7,6 +7,7 @@ package io.ktor.network.sockets.tests
 import io.ktor.network.selector.*
 import io.ktor.network.sockets.*
 import io.ktor.test.dispatcher.*
+import io.ktor.util.network.*
 import io.ktor.utils.io.core.*
 import kotlinx.atomicfu.*
 import kotlinx.coroutines.*
@@ -222,9 +223,10 @@ class UDPSocketTest {
             .udp()
             .bind()
 
-        val socket = aSocket(selector).udp().connect(server.localAddress)
+        val remoteAddress = InetSocketAddress("127.0.0.1", (server.localAddress as InetSocketAddress).port)
+        val socket = aSocket(selector).udp().connect(remoteAddress)
 
-        socket.send(Datagram(buildPacket { writeText("hello") }, server.localAddress))
+        socket.send(Datagram(buildPacket { writeText("hello") }, remoteAddress))
         assertEquals("hello", server.receive().packet.readText())
     }
 }

--- a/ktor-network/nix/src/io/ktor/network/sockets/DatagramSendChannel.kt
+++ b/ktor-network/nix/src/io/ktor/network/sockets/DatagramSendChannel.kt
@@ -22,7 +22,8 @@ private val CLOSED_INVOKED: (Throwable?) -> Unit = {}
 
 internal class DatagramSendChannel(
     val descriptor: Int,
-    val socket: DatagramSocketNative
+    val socket: DatagramSocketNative,
+    val remote: SocketAddress?
 ) : SendChannel<Datagram> {
     private val onCloseHandler = atomic<((Throwable?) -> Unit)?>(null)
     private val closed = atomic(false)
@@ -52,6 +53,11 @@ internal class DatagramSendChannel(
     @OptIn(InternalCoroutinesApi::class, UnsafeNumber::class)
     override fun trySend(element: Datagram): ChannelResult<Unit> {
         if (!lock.tryLock()) return ChannelResult.failure()
+        if (remote != null) {
+            check(element.address == remote) {
+                "Datagram address ${element.address} doesn't match the connected address $remote"
+            }
+        }
 
         var result = false
 
@@ -60,20 +66,9 @@ internal class DatagramSendChannel(
                 element.packet.copy().readAvailable(buffer)
 
                 val bytes = element.packet.copy().readBytes()
-                var bytesWritten: Int? = null
-                bytes.usePinned { pinned ->
-                    element.address.address.nativeAddress { address, addressSize ->
-                        bytesWritten = sendto(
-                            descriptor,
-                            pinned.addressOf(0),
-                            bytes.size.convert(),
-                            0,
-                            address,
-                            addressSize
-                        ).toInt()
-                    }
-                }
-                result = when (bytesWritten ?: error("bytesWritten cannot be null")) {
+                val bytesWritten = sento(element, bytes)
+
+                result = when (bytesWritten) {
                     0 -> throw IOException("Failed writing to closed socket")
                     -1 -> {
                         if (errno == EAGAIN) {
@@ -97,9 +92,43 @@ internal class DatagramSendChannel(
     }
 
     override suspend fun send(element: Datagram) {
+        if (remote != null) {
+            check(element.address == remote) {
+                "Datagram address ${element.address} doesn't match the connected address $remote"
+            }
+        }
+
         lock.withLock {
             sendImpl(element)
         }
+    }
+
+    private fun sento(datagram: Datagram, bytes: ByteArray): Int {
+        var bytesWritten: Int? = null
+        bytes.usePinned { pinned ->
+            if (remote == null) {
+                datagram.address.address.nativeAddress { address, addressSize ->
+                    bytesWritten = sendto(
+                        descriptor,
+                        pinned.addressOf(0),
+                        bytes.size.convert(),
+                        0,
+                        address,
+                        addressSize
+                    ).toInt()
+                }
+            } else {
+                bytesWritten = sendto(
+                    descriptor,
+                    pinned.addressOf(0),
+                    bytes.size.convert(),
+                    0,
+                    null,
+                    0
+                ).toInt()
+            }
+        }
+        return bytesWritten ?: error("bytesWritten cannot be null")
     }
 
     @OptIn(UnsafeNumber::class)
@@ -107,20 +136,9 @@ internal class DatagramSendChannel(
         datagram: Datagram,
         bytes: ByteArray = datagram.packet.readBytes()
     ) {
-        var bytesWritten: Int? = null
-        bytes.usePinned { pinned ->
-            datagram.address.address.nativeAddress { address, addressSize ->
-                bytesWritten = sendto(
-                    descriptor,
-                    pinned.addressOf(0),
-                    bytes.size.convert(),
-                    0,
-                    address,
-                    addressSize
-                ).toInt()
-            }
-        }
-        when (bytesWritten ?: error("bytesWritten cannot be null")) {
+        val bytesWritten: Int = sento(datagram, bytes)
+
+        when (bytesWritten) {
             0 -> throw IOException("Failed writing to closed socket")
             -1 -> {
                 if (errno == EAGAIN) {

--- a/ktor-network/nix/src/io/ktor/network/sockets/DatagramSocketNative.kt
+++ b/ktor-network/nix/src/io/ktor/network/sockets/DatagramSocketNative.kt
@@ -18,6 +18,7 @@ import kotlin.coroutines.*
 internal class DatagramSocketNative(
     private val descriptor: Int,
     val selector: SelectorManager,
+    private val remote: SocketAddress?,
     parent: CoroutineContext = EmptyCoroutineContext
 ) : BoundDatagramSocket, ConnectedDatagramSocket, Socket, CoroutineScope {
     private val _context: CompletableJob = Job(parent[Job])
@@ -34,7 +35,7 @@ internal class DatagramSocketNative(
     override val remoteAddress: SocketAddress
         get() = getRemoteAddress(descriptor).toSocketAddress()
 
-    private val sender: SendChannel<Datagram> = DatagramSendChannel(descriptor, this)
+    private val sender: SendChannel<Datagram> = DatagramSendChannel(descriptor, this, remote)
 
     override fun toString(): String = "DatagramSocketNative(descriptor=$descriptor)"
 

--- a/ktor-network/nix/src/io/ktor/network/sockets/UDPSocketBuilderNative.kt
+++ b/ktor-network/nix/src/io/ktor/network/sockets/UDPSocketBuilderNative.kt
@@ -34,6 +34,7 @@ internal actual fun UDPSocketBuilder.Companion.connectUDP(
     return DatagramSocketNative(
         descriptor = descriptor,
         selector = selector,
+        remote = remoteAddress,
         parent = selector.coroutineContext
     )
 }
@@ -57,6 +58,7 @@ internal actual fun UDPSocketBuilder.Companion.bindUDP(
     return DatagramSocketNative(
         descriptor = descriptor,
         selector = selector,
+        remote = null,
         parent = selector.coroutineContext
     )
 }


### PR DESCRIPTION
Fix [KTOR-4877](https://youtrack.jetbrains.com/issue/KTOR-4877/POSIX-error-56-Socket-is-already-connected-error-when-a-socket-is-connection-mode-on-Darwin-targets)
