### PR TITLE
Make certificate generation helpers more flexible

### DIFF
--- a/ktor-network/ktor-network-tls/jvmAndNix/src/io/ktor/network/tls/OID.kt
+++ b/ktor-network/ktor-network-tls/jvmAndNix/src/io/ktor/network/tls/OID.kt
@@ -58,6 +58,16 @@ public data class OID(public val identifier: String) {
     }
 }
 
+/**
+ * Converts the provided [algorithm] name from the standard Signature algorithms into the corresponding
+ * KeyPairGenerator algorithm name.
+ *
+ * See the
+ * [Signature](https://docs.oracle.com/en/java/javase/17/docs/specs/security/standard-names.html#signature-algorithms)
+ * and
+ * [KeyPairGenerator](https://docs.oracle.com/en/java/javase/17/docs/specs/security/standard-names.html#keypairgenerator-algorithms)
+ * sections in the Java Security Standard Algorithm Names Specification for information about standard algorithm names.
+ */
 public fun keysGenerationAlgorithm(algorithm: String): String = when {
     algorithm.endsWith("ecdsa", ignoreCase = true) -> "EC"
     algorithm.endsWith("dsa", ignoreCase = true) -> "DSA"

--- a/ktor-network/ktor-network-tls/ktor-network-tls-certificates/api/ktor-network-tls-certificates.api
+++ b/ktor-network/ktor-network-tls/ktor-network-tls-certificates/api/ktor-network-tls-certificates.api
@@ -12,6 +12,7 @@ public final class io/ktor/network/tls/certificates/CertificateBuilder {
 	public final fun getHash ()Lio/ktor/network/tls/extensions/HashAlgorithm;
 	public final fun getIpAddresses ()Ljava/util/List;
 	public final fun getKeySizeInBits ()I
+	public final fun getKeyType ()Lio/ktor/network/tls/certificates/KeyType;
 	public final fun getPassword ()Ljava/lang/String;
 	public final fun getSign ()Lio/ktor/network/tls/extensions/SignatureAlgorithm;
 	public final fun setDaysValid (J)V
@@ -19,6 +20,7 @@ public final class io/ktor/network/tls/certificates/CertificateBuilder {
 	public final fun setHash (Lio/ktor/network/tls/extensions/HashAlgorithm;)V
 	public final fun setIpAddresses (Ljava/util/List;)V
 	public final fun setKeySizeInBits (I)V
+	public final fun setKeyType (Lio/ktor/network/tls/certificates/KeyType;)V
 	public final fun setPassword (Ljava/lang/String;)V
 	public final fun setSign (Lio/ktor/network/tls/extensions/SignatureAlgorithm;)V
 }

--- a/ktor-network/ktor-network-tls/ktor-network-tls-certificates/api/ktor-network-tls-certificates.api
+++ b/ktor-network/ktor-network-tls/ktor-network-tls-certificates/api/ktor-network-tls-certificates.api
@@ -4,9 +4,7 @@ public final class io/ktor/network/tls/certificates/BuildersKt {
 }
 
 public final class io/ktor/network/tls/certificates/CertificateBuilder {
-	public field hash Lio/ktor/network/tls/extensions/HashAlgorithm;
 	public field password Ljava/lang/String;
-	public field sign Lio/ktor/network/tls/extensions/SignatureAlgorithm;
 	public final fun getDaysValid ()J
 	public final fun getDomains ()Ljava/util/List;
 	public final fun getHash ()Lio/ktor/network/tls/extensions/HashAlgorithm;

--- a/ktor-network/ktor-network-tls/ktor-network-tls-certificates/api/ktor-network-tls-certificates.api
+++ b/ktor-network/ktor-network-tls/ktor-network-tls-certificates/api/ktor-network-tls-certificates.api
@@ -8,12 +8,16 @@ public final class io/ktor/network/tls/certificates/CertificateBuilder {
 	public field password Ljava/lang/String;
 	public field sign Lio/ktor/network/tls/extensions/SignatureAlgorithm;
 	public final fun getDaysValid ()J
+	public final fun getDomains ()Ljava/util/List;
 	public final fun getHash ()Lio/ktor/network/tls/extensions/HashAlgorithm;
+	public final fun getIpAddresses ()Ljava/util/List;
 	public final fun getKeySizeInBits ()I
 	public final fun getPassword ()Ljava/lang/String;
 	public final fun getSign ()Lio/ktor/network/tls/extensions/SignatureAlgorithm;
 	public final fun setDaysValid (J)V
+	public final fun setDomains (Ljava/util/List;)V
 	public final fun setHash (Lio/ktor/network/tls/extensions/HashAlgorithm;)V
+	public final fun setIpAddresses (Ljava/util/List;)V
 	public final fun setKeySizeInBits (I)V
 	public final fun setPassword (Ljava/lang/String;)V
 	public final fun setSign (Lio/ktor/network/tls/extensions/SignatureAlgorithm;)V

--- a/ktor-network/ktor-network-tls/ktor-network-tls-certificates/api/ktor-network-tls-certificates.api
+++ b/ktor-network/ktor-network-tls/ktor-network-tls-certificates/api/ktor-network-tls-certificates.api
@@ -13,6 +13,7 @@ public final class io/ktor/network/tls/certificates/CertificateBuilder {
 	public final fun getKeyType ()Lio/ktor/network/tls/certificates/KeyType;
 	public final fun getPassword ()Ljava/lang/String;
 	public final fun getSign ()Lio/ktor/network/tls/extensions/SignatureAlgorithm;
+	public final fun getSubject ()Ljavax/security/auth/x500/X500Principal;
 	public final fun setDaysValid (J)V
 	public final fun setDomains (Ljava/util/List;)V
 	public final fun setHash (Lio/ktor/network/tls/extensions/HashAlgorithm;)V
@@ -21,6 +22,9 @@ public final class io/ktor/network/tls/certificates/CertificateBuilder {
 	public final fun setKeyType (Lio/ktor/network/tls/certificates/KeyType;)V
 	public final fun setPassword (Ljava/lang/String;)V
 	public final fun setSign (Lio/ktor/network/tls/extensions/SignatureAlgorithm;)V
+	public final fun setSubject (Ljavax/security/auth/x500/X500Principal;)V
+	public final fun signWith (Ljava/security/KeyPair;Ljava/security/cert/Certificate;Ljavax/security/auth/x500/X500Principal;)V
+	public final fun signWith (Ljava/security/KeyPair;Ljava/security/cert/X509Certificate;)V
 }
 
 public final class io/ktor/network/tls/certificates/CertificatesKt {

--- a/ktor-network/ktor-network-tls/ktor-network-tls-certificates/build.gradle.kts
+++ b/ktor-network/ktor-network-tls/ktor-network-tls-certificates/build.gradle.kts
@@ -9,5 +9,10 @@ kotlin {
                 api(project(":ktor-network:ktor-network-tls"))
             }
         }
+        jvmTest {
+            dependencies {
+                implementation(libs.mockk)
+            }
+        }
     }
 }

--- a/ktor-network/ktor-network-tls/ktor-network-tls-certificates/jvm/src/io/ktor/network/tls/certificates/Certificates.kt
+++ b/ktor-network/ktor-network-tls/ktor-network-tls-certificates/jvm/src/io/ktor/network/tls/certificates/Certificates.kt
@@ -364,15 +364,6 @@ private fun BytePacketBuilder.writeDerOctetString(block: BytePacketBuilder.() ->
     writePacket(sub)
 }
 
-private fun BytePacketBuilder.writeDerBitString(block: BytePacketBuilder.() -> Unit) {
-    val sub = buildPacket { block() }
-
-    writeDerType(0, 3, true)
-    writeDerLength(sub.remaining.toInt() + 1)
-    writeByte(0)
-    writePacket(sub)
-}
-
 private fun BytePacketBuilder.writeDerBitString(array: ByteArray, unused: Int = 0) {
     require(unused in 0..7)
 
@@ -414,14 +405,6 @@ private fun BytePacketBuilder.writeDerSequence(block: BytePacketBuilder.() -> Un
     val sub = buildPacket { block() }
 
     writeDerType(0, 0x10, false)
-    writeDerLength(sub.remaining.toInt())
-    writePacket(sub)
-}
-
-private fun BytePacketBuilder.writeDerSet(block: BytePacketBuilder.() -> Unit) {
-    val sub = buildPacket { block() }
-
-    writeDerType(0, 0x11, false)
     writeDerLength(sub.remaining.toInt())
     writePacket(sub)
 }

--- a/ktor-network/ktor-network-tls/ktor-network-tls-certificates/jvm/src/io/ktor/network/tls/certificates/Certificates.kt
+++ b/ktor-network/ktor-network-tls/ktor-network-tls-certificates/jvm/src/io/ktor/network/tls/certificates/Certificates.kt
@@ -50,7 +50,7 @@ public fun generateCertificate(
     val cert = certificate(
         subject = id,
         issuer = id,
-        keyPair = keyPair,
+        publicKey = keyPair.public,
         signerKeyPair = keyPair,
         algorithm = algorithm,
         keyType = keyType
@@ -76,7 +76,7 @@ private fun id(commonName: String): Counterparty = Counterparty(
 internal fun certificate(
     subject: Counterparty,
     issuer: Counterparty,
-    keyPair: KeyPair,
+    publicKey: PublicKey,
     signerKeyPair: KeyPair,
     algorithm: String,
     validityDuration: Duration = 3.days,
@@ -89,7 +89,7 @@ internal fun certificate(
         writeCertificate(
             issuer = issuer,
             subject = subject,
-            keyPair = keyPair,
+            publicKey = publicKey,
             signerKeyPair = signerKeyPair,
             algorithm = algorithm,
             validFrom = now,
@@ -145,7 +145,7 @@ public fun KeyStore.generateCertificate(
         issuer = id("localhostCA"),
         subject = id("localhost"),
         algorithm = algorithm,
-        keyPair = certKeyPair,
+        publicKey = certKeyPair.public,
         signerKeyPair = ca,
         keyType = keyType
     )
@@ -348,19 +348,19 @@ private fun BytePacketBuilder.writeX509Counterparty(counterparty: Counterparty) 
 private fun BytePacketBuilder.writeCertificate(
     issuer: Counterparty,
     subject: Counterparty,
-    keyPair: KeyPair,
+    publicKey: PublicKey,
     algorithm: String,
     validFrom: Instant,
     validUntil: Instant,
     domains: List<String>,
     ipAddresses: List<InetAddress>,
-    signerKeyPair: KeyPair = keyPair,
-    keyType: KeyType = KeyType.Server
+    signerKeyPair: KeyPair,
+    keyType: KeyType = KeyType.Server,
 ) {
     require(validFrom < validUntil) { "validFrom must be before validUntil" }
 
     val certInfo = buildPacket {
-        writeX509Info(algorithm, issuer, subject, keyPair.public, validFrom, validUntil, domains, ipAddresses, keyType)
+        writeX509Info(algorithm, issuer, subject, publicKey, validFrom, validUntil, domains, ipAddresses, keyType)
     }
 
     val certInfoBytes = certInfo.readBytes()

--- a/ktor-network/ktor-network-tls/ktor-network-tls-certificates/jvm/src/io/ktor/network/tls/certificates/Certificates.kt
+++ b/ktor-network/ktor-network-tls/ktor-network-tls-certificates/jvm/src/io/ktor/network/tls/certificates/Certificates.kt
@@ -69,14 +69,16 @@ private fun id(commonName: String): Counterparty = Counterparty(
     commonName = commonName
 )
 
-private fun certificate(
+internal fun certificate(
     subject: Counterparty,
     issuer: Counterparty,
     keyPair: KeyPair,
     signerKeyPair: KeyPair,
     algorithm: String,
     daysValid: Long = 3,
-    keyType: KeyType = KeyType.Server
+    keyType: KeyType = KeyType.Server,
+    domains: List<String> = listOf("127.0.0.1", "localhost"),
+    ipAddresses: List<InetAddress> = listOf(Inet4Address.getByName("127.0.0.1")),
 ): Certificate {
     val from = Date()
     val to = Date.from(LocalDateTime.now().plusDays(daysValid).atZone(ZoneId.systemDefault()).toInstant())
@@ -89,8 +91,8 @@ private fun certificate(
             algorithm = algorithm,
             from = from,
             to = to,
-            domains = listOf("127.0.0.1", "localhost"),
-            ipAddresses = listOf(Inet4Address.getByName("127.0.0.1")),
+            domains = domains,
+            ipAddresses = ipAddresses,
             keyType = keyType
         )
     }.readBytes()
@@ -188,7 +190,7 @@ internal data class Counterparty(
     val commonName: String = ""
 )
 
-internal fun BytePacketBuilder.writeX509Info(
+private fun BytePacketBuilder.writeX509Info(
     algorithm: String,
     issuer: Counterparty,
     subject: Counterparty,
@@ -340,7 +342,7 @@ private fun BytePacketBuilder.writeX509Counterparty(counterparty: Counterparty) 
     }
 }
 
-internal fun BytePacketBuilder.writeCertificate(
+private fun BytePacketBuilder.writeCertificate(
     issuer: Counterparty,
     subject: Counterparty,
     keyPair: KeyPair,

--- a/ktor-network/ktor-network-tls/ktor-network-tls-certificates/jvm/src/io/ktor/network/tls/certificates/Certificates.kt
+++ b/ktor-network/ktor-network-tls/ktor-network-tls-certificates/jvm/src/io/ktor/network/tls/certificates/Certificates.kt
@@ -5,6 +5,7 @@
 package io.ktor.network.tls.certificates
 
 import io.ktor.network.tls.*
+import io.ktor.network.tls.extensions.*
 import io.ktor.utils.io.core.*
 import java.io.*
 import java.math.*
@@ -22,8 +23,8 @@ import kotlin.time.*
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.days
 
-private val jbLocalhostPrincipal = X500Principal("CN=localhost, OU=Kotlin, O=JetBrains, C=RU")
-private val jbLocalhostCAPrincipal = X500Principal("CN=localhostCA, OU=Kotlin, O=JetBrains, C=RU")
+internal val DEFAULT_PRINCIPAL = X500Principal("CN=localhost, OU=Kotlin, O=JetBrains, C=RU")
+private val DEFAULT_CA_PRINCIPAL = X500Principal("CN=localhostCA, OU=Kotlin, O=JetBrains, C=RU")
 
 /**
  * Generates simple self-signed certificate with [keyAlias] name, private key is encrypted with [keyPassword].
@@ -43,29 +44,24 @@ public fun generateCertificate(
     keySizeInBits: Int = 1024,
     keyType: KeyType = KeyType.Server
 ): KeyStore {
-    val keyStore = KeyStore.getInstance("JKS")!!
-    keyStore.load(null, null)
+    val keyStore = buildKeyStore {
+        certificate(keyAlias) {
+            val (hashName, signName) = algorithm.split("with")
+            this.hash = HashAlgorithm.valueOf(hashName)
+            this.sign = SignatureAlgorithm.valueOf(signName)
+            this.password = keyPassword
+            this.keySizeInBits = keySizeInBits
+            this.keyType = keyType
+            this.subject = if (keyType == KeyType.CA) DEFAULT_CA_PRINCIPAL else DEFAULT_PRINCIPAL
+            this.domains = listOf("127.0.0.1", "localhost")
+        }
+    }
 
-    val keyPairGenerator = KeyPairGenerator.getInstance(keysGenerationAlgorithm(algorithm))!!
-    keyPairGenerator.initialize(keySizeInBits)
-    val keyPair = keyPairGenerator.genKeyPair()!!
+    // for backwards-compatibility, we also register the certificate under this Cert-suffixed alias
+    keyStore.setCertificateEntry(keyAlias + "Cert", keyStore.getCertificate(keyAlias))
 
-    val id = if (keyType == KeyType.CA) jbLocalhostCAPrincipal else jbLocalhostPrincipal
-    val cert = generateX509Certificate(
-        subject = id,
-        issuer = id,
-        publicKey = keyPair.public,
-        signerKeyPair = keyPair,
-        algorithm = algorithm,
-        keyType = keyType
-    )
-
-    keyStore.setCertificateEntry(keyAlias + "Cert", cert)
-    keyStore.setKeyEntry(keyAlias, keyPair.private, keyPassword.toCharArray(), arrayOf(cert))
-
-    file?.parentFile?.mkdirs()
-    file?.outputStream()?.use {
-        keyStore.store(it, jksPassword.toCharArray())
+    file?.let {
+        keyStore.saveToFile(it, jksPassword)
     }
     return keyStore
 }
@@ -144,30 +140,28 @@ public fun KeyStore.generateCertificate(
     keyType: KeyType = KeyType.Server
 ): KeyStore {
     val caCert = getCertificate(caKeyAlias)
-    val ca = KeyPair(caCert.publicKey, getKey(caKeyAlias, caPassword.toCharArray()) as PrivateKey)
+    val caKeys = KeyPair(caCert.publicKey, getKey(caKeyAlias, caPassword.toCharArray()) as PrivateKey)
 
-    val keyStore = KeyStore.getInstance("JKS")!!
-    keyStore.load(null, null)
+    val keyStore = buildKeyStore {
+        certificate(keyAlias) {
+            val (hashName, signName) = algorithm.split("with")
+            this.hash = HashAlgorithm.valueOf(hashName)
+            this.sign = SignatureAlgorithm.valueOf(signName)
+            this.password = keyPassword
+            this.keySizeInBits = keySizeInBits
+            this.keyType = keyType
+            this.subject = DEFAULT_PRINCIPAL
+            this.domains = listOf("127.0.0.1", "localhost")
+            signWith(
+                issuerKeyPair = caKeys,
+                issuerKeyCertificate = caCert,
+                issuerName = DEFAULT_CA_PRINCIPAL,
+            )
+        }
+    }
 
-    val keyPairGenerator = KeyPairGenerator.getInstance(keysGenerationAlgorithm(algorithm))!!
-    keyPairGenerator.initialize(keySizeInBits)
-
-    val certKeyPair = keyPairGenerator.genKeyPair()!!
-    val cert = generateX509Certificate(
-        issuer = jbLocalhostCAPrincipal,
-        subject = jbLocalhostPrincipal,
-        algorithm = algorithm,
-        publicKey = certKeyPair.public,
-        signerKeyPair = ca,
-        keyType = keyType
-    )
-
-    keyStore.setCertificateEntry(keyAlias, cert)
-    keyStore.setKeyEntry(keyAlias, certKeyPair.private, keyPassword.toCharArray(), arrayOf(cert, caCert))
-
-    file?.parentFile?.mkdirs()
-    file?.outputStream()?.use {
-        keyStore.store(it, jksPassword.toCharArray())
+    file?.let {
+        keyStore.saveToFile(it, jksPassword)
     }
     return keyStore
 }

--- a/ktor-network/ktor-network-tls/ktor-network-tls-certificates/jvm/src/io/ktor/network/tls/certificates/builders.kt
+++ b/ktor-network/ktor-network-tls/ktor-network-tls-certificates/jvm/src/io/ktor/network/tls/certificates/builders.kt
@@ -12,10 +12,16 @@ import java.io.*
 import java.net.*
 import java.security.*
 import java.security.cert.Certificate
+import java.security.cert.X509Certificate
 import javax.security.auth.x500.X500Principal
 import kotlin.time.Duration.Companion.days
 
-internal data class CertificateInfo(val certificate: Certificate, val keys: KeyPair, val password: String)
+internal data class CertificateInfo(
+    val certificate: Certificate,
+    val keys: KeyPair,
+    val password: String,
+    val issuerCertificate: Certificate?,
+)
 
 /**
  * Builder for certificate
@@ -35,6 +41,11 @@ public class CertificateBuilder internal constructor() {
      * Certificate password (required)
      */
     public lateinit var password: String
+
+    /**
+     * The subject of the certificate, owner of the generated public key that we certify.
+     */
+    public var subject: X500Principal = DEFAULT_PRINCIPAL
 
     /**
      * Number of days the certificate is valid
@@ -64,26 +75,70 @@ public class CertificateBuilder internal constructor() {
      */
     public var ipAddresses: List<InetAddress> = listOf(Inet4Address.getByName("127.0.0.1"))
 
+    private var issuer: CertificateIssuer? = null
+
+    private data class CertificateIssuer(
+        val name: X500Principal,
+        val keyPair: KeyPair,
+        val keyCertificate: Certificate,
+    )
+
+    /**
+     * Defines an issuer for this certificate, so it is not self-signed.
+     *
+     * The certificate will be signed with the given [issuerKeyPair], certified by the given [issuerKeyCertificate].
+     * The issuer's name is taken from the provided certificate.
+     *
+     * If this method is not called, this certificate will be self-signed by the subject (with the same generated key
+     * as the one being certified).
+     */
+    public fun signWith(
+        issuerKeyPair: KeyPair,
+        issuerKeyCertificate: X509Certificate,
+    ) {
+        issuer = CertificateIssuer(
+            // the subject of the given certificate is the issuer of the certificate we're creating
+            name = issuerKeyCertificate.subjectX500Principal,
+            keyPair = issuerKeyPair,
+            keyCertificate = issuerKeyCertificate,
+        )
+    }
+
+    /**
+     * Defines an issuer for this certificate, so it is not self-signed.
+     *
+     * The certificate will be signed with the given [issuerKeyPair] in the name of [issuerName], certified by the
+     * given [issuerKeyCertificate].
+     *
+     * If this method is not called, this certificate will be self-signed by the subject (with the same generated key
+     * as the one being certified).
+     */
+    public fun signWith(
+        issuerKeyPair: KeyPair,
+        issuerKeyCertificate: Certificate,
+        issuerName: X500Principal,
+    ) {
+        issuer = CertificateIssuer(name = issuerName, keyPair = issuerKeyPair, keyCertificate = issuerKeyCertificate)
+    }
+
     internal fun build(): CertificateInfo {
         val algorithm = HashAndSign(hash, sign)
-        val keys = KeyPairGenerator.getInstance(keysGenerationAlgorithm(algorithm.name))!!.apply {
+        val keys = KeyPairGenerator.getInstance(keysGenerationAlgorithm(algorithm.name)).apply {
             initialize(keySizeInBits)
         }.genKeyPair()!!
 
-        val id = X500Principal("CN=localhost, OU=Kotlin, O=JetBrains, C=RU")
-
         val cert = generateX509Certificate(
-            issuer = id,
-            subject = id,
+            issuer = issuer?.name ?: subject,
+            subject = subject,
             publicKey = keys.public,
-            signerKeyPair = keys,
+            signerKeyPair = issuer?.keyPair ?: keys,
             algorithm = algorithm.name,
             validityDuration = daysValid.days,
             keyType = keyType,
             domains = domains,
             ipAddresses = ipAddresses,
         )
-        return CertificateInfo(cert, keys, password)
+        return CertificateInfo(cert, keys, password, issuer?.keyCertificate)
     }
 }
 
@@ -106,9 +161,9 @@ public class KeyStoreBuilder internal constructor() {
         store.load(null, null)
 
         certificates.forEach { (alias, info) ->
-            val (certificate, keys, password) = info
-            store.setCertificateEntry(alias, certificate)
-            store.setKeyEntry(alias, keys.private, password.toCharArray(), arrayOf(certificate))
+            val (certificate, keys, password, issuerCertificate) = info
+            val certChain = listOfNotNull(certificate, issuerCertificate).toTypedArray()
+            store.setKeyEntry(alias, keys.private, password.toCharArray(), certChain)
         }
 
         return store

--- a/ktor-network/ktor-network-tls/ktor-network-tls-certificates/jvm/src/io/ktor/network/tls/certificates/builders.kt
+++ b/ktor-network/ktor-network-tls/ktor-network-tls-certificates/jvm/src/io/ktor/network/tls/certificates/builders.kt
@@ -71,7 +71,7 @@ public class CertificateBuilder internal constructor() {
         val cert = certificate(
             issuer = id,
             subject = id,
-            keyPair = keys,
+            publicKey = keys.public,
             signerKeyPair = keys,
             algorithm = algorithm.name,
             validityDuration = daysValid.days,

--- a/ktor-network/ktor-network-tls/ktor-network-tls-certificates/jvm/src/io/ktor/network/tls/certificates/builders.kt
+++ b/ktor-network/ktor-network-tls/ktor-network-tls-certificates/jvm/src/io/ktor/network/tls/certificates/builders.kt
@@ -12,6 +12,7 @@ import java.io.*
 import java.net.*
 import java.security.*
 import java.security.cert.Certificate
+import javax.security.auth.x500.X500Principal
 import kotlin.time.Duration.Companion.days
 
 internal data class CertificateInfo(val certificate: Certificate, val keys: KeyPair, val password: String)
@@ -61,12 +62,7 @@ public class CertificateBuilder internal constructor() {
             initialize(keySizeInBits)
         }.genKeyPair()!!
 
-        val id = Counterparty(
-            country = "RU",
-            organization = "JetBrains",
-            organizationUnit = "Kotlin",
-            commonName = "localhost"
-        )
+        val id = X500Principal("CN=localhost, OU=Kotlin, O=JetBrains, C=RU")
 
         val cert = certificate(
             issuer = id,

--- a/ktor-network/ktor-network-tls/ktor-network-tls-certificates/jvm/src/io/ktor/network/tls/certificates/builders.kt
+++ b/ktor-network/ktor-network-tls/ktor-network-tls-certificates/jvm/src/io/ktor/network/tls/certificates/builders.kt
@@ -11,10 +11,7 @@ import io.ktor.utils.io.core.*
 import java.io.*
 import java.net.*
 import java.security.*
-import java.security.cert.*
 import java.security.cert.Certificate
-import java.time.*
-import java.util.*
 
 internal data class CertificateInfo(val certificate: Certificate, val keys: KeyPair, val password: String)
 
@@ -60,24 +57,16 @@ public class CertificateBuilder internal constructor() {
             commonName = "localhost"
         )
 
-        val from = Date()
-        val to = Date.from(LocalDateTime.now().plusDays(daysValid).atZone(ZoneId.systemDefault()).toInstant())
-
-        val certificateBytes = buildPacket {
-            writeCertificate(
-                issuer = id,
-                subject = id,
-                keyPair = keys,
-                algorithm = algorithm.name,
-                from = from,
-                to = to,
-                domains = listOf("localhost"),
-                ipAddresses = listOf(Inet4Address.getByName("127.0.0.1"))
-            )
-        }.readBytes()
-
-        val cert = CertificateFactory.getInstance("X.509").generateCertificate(certificateBytes.inputStream())
-        cert.verify(keys.public)
+        val cert = certificate(
+            issuer = id,
+            subject = id,
+            keyPair = keys,
+            signerKeyPair = keys,
+            algorithm = algorithm.name,
+            daysValid = daysValid,
+            domains = listOf("localhost"),
+            ipAddresses = listOf(Inet4Address.getByName("127.0.0.1"))
+        )
         return CertificateInfo(cert, keys, password)
     }
 }

--- a/ktor-network/ktor-network-tls/ktor-network-tls-certificates/jvm/src/io/ktor/network/tls/certificates/builders.kt
+++ b/ktor-network/ktor-network-tls/ktor-network-tls-certificates/jvm/src/io/ktor/network/tls/certificates/builders.kt
@@ -12,6 +12,7 @@ import java.io.*
 import java.net.*
 import java.security.*
 import java.security.cert.Certificate
+import kotlin.time.Duration.Companion.days
 
 internal data class CertificateInfo(val certificate: Certificate, val keys: KeyPair, val password: String)
 
@@ -73,7 +74,7 @@ public class CertificateBuilder internal constructor() {
             keyPair = keys,
             signerKeyPair = keys,
             algorithm = algorithm.name,
-            daysValid = daysValid,
+            validityDuration = daysValid.days,
             domains = domains,
             ipAddresses = ipAddresses,
         )

--- a/ktor-network/ktor-network-tls/ktor-network-tls-certificates/jvm/src/io/ktor/network/tls/certificates/builders.kt
+++ b/ktor-network/ktor-network-tls/ktor-network-tls-certificates/jvm/src/io/ktor/network/tls/certificates/builders.kt
@@ -64,7 +64,7 @@ public class CertificateBuilder internal constructor() {
 
         val id = X500Principal("CN=localhost, OU=Kotlin, O=JetBrains, C=RU")
 
-        val cert = certificate(
+        val cert = generateX509Certificate(
             issuer = id,
             subject = id,
             publicKey = keys.public,

--- a/ktor-network/ktor-network-tls/ktor-network-tls-certificates/jvm/src/io/ktor/network/tls/certificates/builders.kt
+++ b/ktor-network/ktor-network-tls/ktor-network-tls-certificates/jvm/src/io/ktor/network/tls/certificates/builders.kt
@@ -47,12 +47,20 @@ public class CertificateBuilder internal constructor() {
     public var keySizeInBits: Int = 1024
 
     /**
-     * Domains for which this certificate is valid.
+     * The usage for the generated key.
+     *
+     * This determines the extensions that should be written in the certificate, such as [OID.ExtKeyUsage] (server or
+     * client authentication), or [OID.BasicConstraints] to use the key as CA.
+     */
+    public var keyType: KeyType = KeyType.Server
+
+    /**
+     * Domains for which this certificate is valid (only relevant for [KeyType.Server], ignored for other key types).
      */
     public var domains: List<String> = listOf("localhost")
 
     /**
-     * IP addresses for which this certificate is valid.
+     * IP addresses for which this certificate is valid (only relevant for [KeyType.Server], ignored for other key types).
      */
     public var ipAddresses: List<InetAddress> = listOf(Inet4Address.getByName("127.0.0.1"))
 
@@ -71,6 +79,7 @@ public class CertificateBuilder internal constructor() {
             signerKeyPair = keys,
             algorithm = algorithm.name,
             validityDuration = daysValid.days,
+            keyType = keyType,
             domains = domains,
             ipAddresses = ipAddresses,
         )

--- a/ktor-network/ktor-network-tls/ktor-network-tls-certificates/jvm/src/io/ktor/network/tls/certificates/builders.kt
+++ b/ktor-network/ktor-network-tls/ktor-network-tls-certificates/jvm/src/io/ktor/network/tls/certificates/builders.kt
@@ -22,17 +22,17 @@ internal data class CertificateInfo(val certificate: Certificate, val keys: KeyP
  */
 public class CertificateBuilder internal constructor() {
     /**
-     * Certificate hash algorithm (required)
+     * Certificate hash algorithm
      */
-    public lateinit var hash: HashAlgorithm
+    public var hash: HashAlgorithm = HashAlgorithm.SHA1
 
     /**
-     * Certificate signature algorithm (required)
+     * Certificate signature algorithm
      */
-    public lateinit var sign: SignatureAlgorithm
+    public var sign: SignatureAlgorithm = SignatureAlgorithm.RSA
 
     /**
-     * Certificate password
+     * Certificate password (required)
      */
     public lateinit var password: String
 

--- a/ktor-network/ktor-network-tls/ktor-network-tls-certificates/jvm/src/io/ktor/network/tls/certificates/builders.kt
+++ b/ktor-network/ktor-network-tls/ktor-network-tls-certificates/jvm/src/io/ktor/network/tls/certificates/builders.kt
@@ -44,6 +44,16 @@ public class CertificateBuilder internal constructor() {
      */
     public var keySizeInBits: Int = 1024
 
+    /**
+     * Domains for which this certificate is valid.
+     */
+    public var domains: List<String> = listOf("localhost")
+
+    /**
+     * IP addresses for which this certificate is valid.
+     */
+    public var ipAddresses: List<InetAddress> = listOf(Inet4Address.getByName("127.0.0.1"))
+
     internal fun build(): CertificateInfo {
         val algorithm = HashAndSign(hash, sign)
         val keys = KeyPairGenerator.getInstance(keysGenerationAlgorithm(algorithm.name))!!.apply {
@@ -64,8 +74,8 @@ public class CertificateBuilder internal constructor() {
             signerKeyPair = keys,
             algorithm = algorithm.name,
             daysValid = daysValid,
-            domains = listOf("localhost"),
-            ipAddresses = listOf(Inet4Address.getByName("127.0.0.1"))
+            domains = domains,
+            ipAddresses = ipAddresses,
         )
         return CertificateInfo(cert, keys, password)
     }

--- a/ktor-network/ktor-network-tls/ktor-network-tls-certificates/jvm/test/io/ktor/network/tls/certificates/CertificatesTest.kt
+++ b/ktor-network/ktor-network-tls/ktor-network-tls-certificates/jvm/test/io/ktor/network/tls/certificates/CertificatesTest.kt
@@ -1,0 +1,188 @@
+/*
+ * Copyright 2014-2022 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.network.tls.certificates
+
+import io.ktor.network.tls.extensions.*
+import java.io.*
+import java.time.temporal.*
+import javax.security.auth.x500.*
+import kotlin.test.*
+
+class CertificatesTest {
+
+    private val jbLocalhost = X500Principal("CN=localhost, OU=Kotlin, O=JetBrains, C=RU")
+    private val jbLocalhostCA = X500Principal("CN=localhostCA, OU=Kotlin, O=JetBrains, C=RU")
+
+    @BeforeTest
+    fun fixCurrentTime() {
+        fixCurrentTimeTo(nowInTests)
+    }
+
+    @Test
+    fun generateCertificate_default() {
+        val keyStore = generateCertificate()
+
+        assertHasPrivateKey(keyStore, alias = "mykey", password = "changeit", algorithm = "RSA", size = 1024)
+        val cert = assertHasX509Certificate(keyStore, alias = "mykey", algorithm = "SHA1withRSA")
+
+        assertValidityRange(cert, from = nowInTests, until = nowInTests.plus(3, ChronoUnit.DAYS))
+
+        assertEquals(jbLocalhost, cert.subjectX500Principal)
+        assertEquals(jbLocalhost, cert.issuerX500Principal)
+
+        val expectedDomains = listOf("127.0.0.1", "localhost")
+        val expectedIPs = listOf("127.0.0.1")
+        assertExtensionsForServerKeyType(cert, expectedDomains, expectedIPs)
+    }
+
+    @Test
+    fun generateCertificate_alsoStoresTheCertificateWithCertSuffix() {
+        val keyStore = generateCertificate(keyAlias = "theKeyAlias")
+
+        val aliases = keyStore.aliases().asSequence().toSet()
+        val expectedAliases = setOf("thekeyalias", "thekeyaliascert") // the keystore lowercases the aliases
+        assertEquals(expectedAliases, aliases, "Should store the certificate also with -cert suffix")
+
+        val certWithKeyAlias = assertHasX509Certificate(keyStore, alias = "theKeyAlias", algorithm = "SHA1withRSA")
+        val certWithOwnAlias = assertHasX509Certificate(keyStore, alias = "theKeyAliasCert", algorithm = "SHA1withRSA")
+        assertEquals(certWithKeyAlias, certWithOwnAlias)
+    }
+
+    @Test
+    fun generateCertificateWithCA_default() {
+        val caKeyStore = generateCertificate(keyAlias = "caKey", keyType = KeyType.CA)
+        val keyStore = caKeyStore.generateCertificate(caKeyAlias = "caKey")
+
+        assertHasPrivateKey(keyStore, alias = "mykey", password = "changeit", algorithm = "RSA", size = 1024)
+        val cert = assertHasX509Certificate(keyStore, alias = "mykey", algorithm = "SHA1withRSA")
+
+        assertValidityRange(cert, from = nowInTests, until = nowInTests.plus(3, ChronoUnit.DAYS))
+
+        assertEquals(jbLocalhost, cert.subjectX500Principal)
+        assertEquals(jbLocalhostCA, cert.issuerX500Principal)
+
+        val expectedDomains = listOf("127.0.0.1", "localhost")
+        val expectedIPs = listOf("127.0.0.1")
+        assertExtensionsForServerKeyType(cert, expectedDomains, expectedIPs)
+    }
+
+    @Test
+    fun generateCertificate_onlyGeneratesOneAlias() {
+        val caKeyStore = generateCertificate(keyAlias = "caKey", keyType = KeyType.CA)
+        val keyStore = caKeyStore.generateCertificate(caKeyAlias = "caKey", keyAlias = "the-key")
+
+        val aliases = keyStore.aliases().asSequence().toSet()
+        assertEquals(setOf("the-key"), aliases)
+    }
+
+    @Test
+    fun generateCertificate_keyTypeClient() {
+        val keyStore = generateCertificate(keyType = KeyType.Client)
+
+        assertHasPrivateKey(keyStore, alias = "mykey", password = "changeit", algorithm = "RSA", size = 1024)
+        val cert = assertHasX509Certificate(keyStore, alias = "mykey", algorithm = "SHA1withRSA")
+
+        assertEquals(jbLocalhost, cert.subjectX500Principal)
+        assertEquals(jbLocalhost, cert.issuerX500Principal)
+
+        assertExtensionsForClientKeyType(cert)
+    }
+
+    @Test
+    fun generateCertificateWithCA_keyTypeClient() {
+        val caKeyStore = generateCertificate(keyAlias = "caKey", keyType = KeyType.CA)
+        val keyStore = caKeyStore.generateCertificate(caKeyAlias = "caKey", keyType = KeyType.Client)
+
+        assertHasPrivateKey(keyStore, alias = "mykey", password = "changeit", algorithm = "RSA", size = 1024)
+        val cert = assertHasX509Certificate(keyStore, alias = "mykey", algorithm = "SHA1withRSA")
+
+        assertEquals(jbLocalhost, cert.subjectX500Principal)
+        assertEquals(jbLocalhostCA, cert.issuerX500Principal)
+
+        assertExtensionsForClientKeyType(cert)
+    }
+
+    @Test
+    fun generateCertificate_keyTypeCA() {
+        val keyStore = generateCertificate(keyType = KeyType.CA)
+
+        assertHasPrivateKey(keyStore, alias = "mykey", password = "changeit", algorithm = "RSA", size = 1024)
+        val cert = assertHasX509Certificate(keyStore, alias = "mykey", algorithm = "SHA1withRSA")
+
+        assertEquals(jbLocalhostCA, cert.subjectX500Principal)
+        assertEquals(jbLocalhostCA, cert.issuerX500Principal)
+
+        assertExtensionsForCAKeyType(cert)
+    }
+
+    @Test
+    fun generateCertificateWithCA_keyTypeCA() {
+        val caKeyStore = generateCertificate(keyAlias = "caKey", keyType = KeyType.CA)
+        val keyStore = caKeyStore.generateCertificate(caKeyAlias = "caKey", keyType = KeyType.CA)
+
+        assertHasPrivateKey(keyStore, alias = "mykey", password = "changeit", algorithm = "RSA", size = 1024)
+        val cert = assertHasX509Certificate(keyStore, alias = "mykey", algorithm = "SHA1withRSA")
+
+        assertEquals(jbLocalhost, cert.subjectX500Principal)
+        assertEquals(jbLocalhostCA, cert.issuerX500Principal)
+
+        assertExtensionsForCAKeyType(cert)
+    }
+
+    @Test
+    fun generateCertificate_customValues() {
+        val keyStore = generateCertificate(
+            algorithm = HashAndSign(HashAlgorithm.SHA256, SignatureAlgorithm.ECDSA).name,
+            keyAlias = "customAlias",
+            keyPassword = "customPassword",
+            keySizeInBits = 128,
+        )
+
+        assertHasPrivateKey(keyStore, alias = "customAlias", password = "customPassword", algorithm = "EC", size = 128)
+        assertHasX509Certificate(keyStore, alias = "customAlias", algorithm = "SHA256withECDSA")
+    }
+
+    @Test
+    fun generateCertificate_writeToFile() {
+        val testKeyStoreFile = File.createTempFile("test-keystore", ".jks")
+        try {
+            generateCertificate(file = testKeyStoreFile)
+            val keyStore = loadJksFromFile(testKeyStoreFile, password = "changeit")
+
+            assertHasPrivateKey(keyStore, alias = "mykey", password = "changeit", algorithm = "RSA", size = 1024)
+            assertHasX509Certificate(keyStore, "mykey", "SHA1withRSA")
+        } finally {
+            testKeyStoreFile.delete()
+        }
+    }
+
+    @Test
+    fun generateCertificate_writeToFile_customKeyPassword() {
+        val testKeyStoreFile = File.createTempFile("test-keystore", ".jks")
+        try {
+            generateCertificate(file = testKeyStoreFile, keyPassword = "new-password")
+            val keyStore = loadJksFromFile(testKeyStoreFile, password = "new-password")
+
+            assertHasPrivateKey(keyStore, alias = "mykey", password = "new-password", algorithm = "RSA", size = 1024)
+            assertHasX509Certificate(keyStore, alias = "mykey", algorithm = "SHA1withRSA")
+        } finally {
+            testKeyStoreFile.delete()
+        }
+    }
+
+    @Test
+    fun generateCertificate_writeToFile_customKeyAndJksPassword() {
+        val testKeyStoreFile = File.createTempFile("test-keystore", ".jks")
+        try {
+            generateCertificate(file = testKeyStoreFile, keyPassword = "keyPass", jksPassword = "jksPass")
+            val keyStore = loadJksFromFile(testKeyStoreFile, password = "jksPass")
+
+            assertHasPrivateKey(keyStore, alias = "mykey", password = "keyPass", algorithm = "RSA", size = 1024)
+            assertHasX509Certificate(keyStore, alias = "mykey", algorithm = "SHA1withRSA")
+        } finally {
+            testKeyStoreFile.delete()
+        }
+    }
+}

--- a/ktor-network/ktor-network-tls/ktor-network-tls-certificates/jvm/test/io/ktor/network/tls/certificates/KeyStoreBuilderTest.kt
+++ b/ktor-network/ktor-network-tls/ktor-network-tls-certificates/jvm/test/io/ktor/network/tls/certificates/KeyStoreBuilderTest.kt
@@ -23,8 +23,6 @@ class KeyStoreBuilderTest {
     fun buildKeyStore_minimal() {
         val keyStore = buildKeyStore {
             certificate(alias = "someKey") {
-                hash = HashAlgorithm.SHA1
-                sign = SignatureAlgorithm.RSA
                 password = "keyPass"
             }
         }
@@ -61,8 +59,6 @@ class KeyStoreBuilderTest {
     fun buildKeyStore_customValidity() {
         val keyStore = buildKeyStore {
             certificate(alias = "someKey") {
-                hash = HashAlgorithm.SHA1
-                sign = SignatureAlgorithm.RSA
                 password = "keyPass"
                 daysValid = 5
             }
@@ -81,8 +77,6 @@ class KeyStoreBuilderTest {
 
         val keyStore = buildKeyStore {
             certificate(alias = "someKey") {
-                hash = HashAlgorithm.SHA1
-                sign = SignatureAlgorithm.RSA
                 password = "keyPass"
                 domains = customDomains
                 ipAddresses = customIps.map { InetAddress.getByName(it) }
@@ -99,8 +93,6 @@ class KeyStoreBuilderTest {
     fun buildKeyStore_keyTypeClient() {
         val keyStore = buildKeyStore {
             certificate(alias = "someKey") {
-                hash = HashAlgorithm.SHA1
-                sign = SignatureAlgorithm.RSA
                 password = "keyPass"
                 keyType = KeyType.Client
             }
@@ -116,8 +108,6 @@ class KeyStoreBuilderTest {
     fun buildKeyStore_keyTypeCA() {
         val keyStore = buildKeyStore {
             certificate(alias = "someKey") {
-                hash = HashAlgorithm.SHA1
-                sign = SignatureAlgorithm.RSA
                 password = "keyPass"
                 keyType = KeyType.CA
             }

--- a/ktor-network/ktor-network-tls/ktor-network-tls-certificates/jvm/test/io/ktor/network/tls/certificates/KeyStoreBuilderTest.kt
+++ b/ktor-network/ktor-network-tls/ktor-network-tls-certificates/jvm/test/io/ktor/network/tls/certificates/KeyStoreBuilderTest.kt
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2014-2022 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.network.tls.certificates
+
+import io.ktor.network.tls.extensions.*
+import java.time.temporal.*
+import javax.security.auth.x500.*
+import kotlin.test.*
+
+class KeyStoreBuilderTest {
+
+    private val jbLocalhost = X500Principal("CN=localhost, OU=Kotlin, O=JetBrains, C=RU")
+
+    @BeforeTest
+    fun fixCurrentTime() {
+        fixCurrentTimeTo(nowInTests)
+    }
+
+    @Test
+    fun buildKeyStore_minimal() {
+        val keyStore = buildKeyStore {
+            certificate(alias = "someKey") {
+                hash = HashAlgorithm.SHA1
+                sign = SignatureAlgorithm.RSA
+                password = "keyPass"
+            }
+        }
+        val aliases = keyStore.aliases().asSequence().toSet()
+        assertEquals(setOf("somekey"), aliases) // the keystore lowercases aliases, and is case-insensitive
+
+        assertHasPrivateKey(keyStore, alias = "someKey", password = "keyPass", algorithm = "RSA", size = 1024)
+        val cert = assertHasX509Certificate(keyStore, alias = "someKey", algorithm = "SHA1withRSA")
+
+        assertValidityRange(cert, from = nowInTests, until = nowInTests.plus(3, ChronoUnit.DAYS))
+
+        assertEquals(jbLocalhost, cert.subjectX500Principal)
+        assertEquals(jbLocalhost, cert.issuerX500Principal)
+
+        assertExtensionsForServerKeyType(cert, expectedDomains = listOf("localhost"), expectedIPs = listOf("127.0.0.1"))
+    }
+
+    @Test
+    fun buildKeyStore_customAlgorithmAndKeySize() {
+        val keyStore = buildKeyStore {
+            certificate(alias = "someKey") {
+                hash = HashAlgorithm.SHA256
+                sign = SignatureAlgorithm.ECDSA
+                password = "keyPass"
+                keySizeInBits = 128
+            }
+        }
+
+        assertHasPrivateKey(keyStore, alias = "someKey", password = "keyPass", algorithm = "EC", size = 128)
+        assertHasX509Certificate(keyStore, alias = "someKey", algorithm = "SHA256withECDSA")
+    }
+
+    @Test
+    fun buildKeyStore_customValidity() {
+        val keyStore = buildKeyStore {
+            certificate(alias = "someKey") {
+                hash = HashAlgorithm.SHA1
+                sign = SignatureAlgorithm.RSA
+                password = "keyPass"
+                daysValid = 5
+            }
+        }
+
+        assertHasPrivateKey(keyStore, alias = "someKey", password = "keyPass", algorithm = "RSA", size = 1024)
+        val cert = assertHasX509Certificate(keyStore, alias = "someKey", algorithm = "SHA1withRSA")
+
+        assertValidityRange(cert, from = nowInTests, until = nowInTests.plus(5, ChronoUnit.DAYS))
+    }
+}

--- a/ktor-network/ktor-network-tls/ktor-network-tls-certificates/jvm/test/io/ktor/network/tls/certificates/KeyStoreBuilderTest.kt
+++ b/ktor-network/ktor-network-tls/ktor-network-tls-certificates/jvm/test/io/ktor/network/tls/certificates/KeyStoreBuilderTest.kt
@@ -94,4 +94,38 @@ class KeyStoreBuilderTest {
 
         assertExtensionsForServerKeyType(cert, expectedDomains = customDomains, expectedIPs = customIps)
     }
+
+    @Test
+    fun buildKeyStore_keyTypeClient() {
+        val keyStore = buildKeyStore {
+            certificate(alias = "someKey") {
+                hash = HashAlgorithm.SHA1
+                sign = SignatureAlgorithm.RSA
+                password = "keyPass"
+                keyType = KeyType.Client
+            }
+        }
+
+        assertHasPrivateKey(keyStore, alias = "someKey", password = "keyPass", algorithm = "RSA", size = 1024)
+        val cert = assertHasX509Certificate(keyStore, alias = "someKey", algorithm = "SHA1withRSA")
+
+        assertExtensionsForClientKeyType(cert)
+    }
+
+    @Test
+    fun buildKeyStore_keyTypeCA() {
+        val keyStore = buildKeyStore {
+            certificate(alias = "someKey") {
+                hash = HashAlgorithm.SHA1
+                sign = SignatureAlgorithm.RSA
+                password = "keyPass"
+                keyType = KeyType.CA
+            }
+        }
+
+        assertHasPrivateKey(keyStore, alias = "someKey", password = "keyPass", algorithm = "RSA", size = 1024)
+        val cert = assertHasX509Certificate(keyStore, alias = "someKey", algorithm = "SHA1withRSA")
+
+        assertExtensionsForCAKeyType(cert)
+    }
 }

--- a/ktor-network/ktor-network-tls/ktor-network-tls-certificates/jvm/test/io/ktor/network/tls/certificates/TestUtils.kt
+++ b/ktor-network/ktor-network-tls/ktor-network-tls-certificates/jvm/test/io/ktor/network/tls/certificates/TestUtils.kt
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2014-2022 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.network.tls.certificates
+
+import io.ktor.network.tls.*
+import java.io.*
+import java.security.*
+import java.security.cert.*
+import java.security.interfaces.*
+import java.time.*
+import java.util.*
+import kotlin.test.*
+
+internal fun assertHasPrivateKey(keyStore: KeyStore, alias: String, password: String, algorithm: String, size: Int) {
+    val key = keyStore.getKey(alias, password.toCharArray())
+    assertNotNull(key, "A key with alias '$alias' should be generated")
+    assertIs<PrivateKey>(key)
+    assertEquals(algorithm, key.algorithm)
+
+    val actualKeySize = when (key) {
+        is RSAKey -> key.modulus.bitLength()
+        is ECKey -> key.params.order.bitLength()
+        else -> error("cannot get key size")
+    }
+    assertEquals(size, actualKeySize)
+}
+
+internal fun assertHasX509Certificate(keyStore: KeyStore, alias: String, algorithm: String): X509Certificate {
+    val cert = keyStore.getCertificate(alias)
+    assertNotNull(cert, "A certificate with alias '$alias' should be generated")
+    assertIs<X509Certificate>(cert)
+    assertEquals("X.509", cert.type)
+    assertEquals(algorithm, cert.sigAlgName)
+    return cert
+}
+
+internal fun assertValidityRange(cert: X509Certificate, from: Instant, until: Instant) {
+    assertEquals(from, cert.notBefore.toInstant())
+    assertEquals(until, cert.notAfter.toInstant())
+
+    assertNotYetValidAt(cert, from.minusSeconds(1))
+    assertValidAt(cert, from)
+    assertValidAt(cert, until)
+    assertExpiredAt(cert, until.plusSeconds(1))
+}
+
+private fun assertNotYetValidAt(cert: X509Certificate, instant: Instant) {
+    assertFailsWith<CertificateNotYetValidException>("the generated certificate should not be valid yet at $instant") {
+        cert.checkValidity(Date.from(instant))
+    }
+}
+
+private fun assertValidAt(cert: X509Certificate, instant: Instant) {
+    try {
+        cert.checkValidity(Date.from(instant))
+    } catch (e: CertificateNotYetValidException) {
+        fail("the generated certificate should already be valid at $instant, but is not yet: $e")
+    } catch (e: CertificateExpiredException) {
+        fail("the generated certificate should still be valid at $instant, but is already expired: $e")
+    }
+}
+
+private fun assertExpiredAt(cert: X509Certificate, instant: Instant) {
+    assertFailsWith<CertificateExpiredException>("the generated certificate should be expired by $instant") {
+        cert.checkValidity(Date.from(instant))
+    }
+}
+
+internal fun assertExtensionsForServerKeyType(
+    cert: X509Certificate,
+    expectedDomains: List<String>,
+    expectedIPs: List<String>,
+) {
+    assertEquals(-1, cert.basicConstraints, "there should be no basic constraints for Server key type")
+    assertEquals(
+        expected = listOf(OID.ServerAuth.identifier),
+        actual = cert.extendedKeyUsage,
+        message = "server auth should be added for Server key type"
+    )
+    val expectedAlternativeNames = expectedDomains.map { listOf(2, it) } + expectedIPs.map { listOf(7, it) }
+    assertContentEquals(expectedAlternativeNames, cert.subjectAlternativeNames)
+}
+
+internal fun assertExtensionsForClientKeyType(cert: X509Certificate) {
+    assertEquals(-1, cert.basicConstraints, "there should be no basic constraints for Client key type")
+    assertEquals(
+        expected = listOf(OID.ClientAuth.identifier),
+        actual = cert.extendedKeyUsage,
+        message = "client auth should be added for Client key type"
+    )
+    assertNull(cert.subjectAlternativeNames, "there should be no subject alternative names for Client key type")
+}
+
+internal fun assertExtensionsForCAKeyType(cert: X509Certificate) {
+    assertEquals(
+        Int.MAX_VALUE,
+        cert.basicConstraints,
+        "basic constraints for CA key type should be Int.MAX_VALUE for 'no limit'"
+    )
+    assertNull(cert.extendedKeyUsage, "there should be no extended key usage info for CA key type")
+    assertNull(cert.subjectAlternativeNames, "there should be no subject alternative names for CA key type")
+}
+
+internal fun loadJksFromFile(file: File, password: String): KeyStore = KeyStore.getInstance("JKS").apply {
+    file.inputStream().use {
+        load(it, password.toCharArray())
+    }
+}

--- a/ktor-network/ktor-network-tls/ktor-network-tls-certificates/jvm/test/io/ktor/network/tls/certificates/TimeMocks.kt
+++ b/ktor-network/ktor-network-tls/ktor-network-tls-certificates/jvm/test/io/ktor/network/tls/certificates/TimeMocks.kt
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2014-2022 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.network.tls.certificates
+
+import io.mockk.*
+import java.time.*
+import java.util.*
+
+internal val nowInTests = Instant.parse("2022-10-20T10:00:00Z")
+
+/**
+ * Mocks time-related classes so "now" is always equal to the given [instant] during tests.
+ *
+ * This includes mocking default [Clock]s, [Instant.now], and [Date]s constructed via the no-arg constructor.
+ */
+internal fun fixCurrentTimeTo(fixedTime: Instant) {
+    mockkStatic(Clock::class)
+    every { Clock.systemUTC() } returns Clock.fixed(fixedTime, ZoneOffset.UTC)
+    every { Clock.systemDefaultZone() } returns Clock.fixed(fixedTime, ZoneId.systemDefault())
+
+    mockkStatic(Instant::class)
+    every { Instant.now() } returns fixedTime
+
+    mockkConstructor(Date::class)
+    every { constructedWith<Date>().time } returns fixedTime.toEpochMilli()
+    every { constructedWith<Date>().toInstant() } returns fixedTime
+}


### PR DESCRIPTION
⚠️ Note: I'm making this PR against the `2.2.0-eap` branch because of a discussion with @e5l , but given the size of the changes, I can also change it to `main` instead if you prefer.

**Subsystem**

The subsystem is only the `ktor-network-tls-certificates` helper library to generate certificates (usually for tests).

**Motivation**

The initial issue I have with the current state of this library is that the allowed domains are hardcoded (`localhost` and `127.0.0.1`), thus preventing me from allowing hosts like `host.docker.internal` or `0.0.0.0` or potentially others when generating test certificates for a docker registry mock.

Also, plenty of things are hardcoded in these certificate generation helpers, and there is a lot of code duplication. So I figured I could also polish a bit the API and deduplicate things while I'm at it. 

**Solution**

The point of this PR is to allow for more customizability of the certificate/keystore builder to solve the initial problem. Eventually, the builder became enough to replace most of the bodies of the "all-in-one" `generateCertificate` functions. Those functions could be deprecated in favor of the more flexible `buildKeyStore` API (which is now concise enough to rival with those functions), but I wanted to keep this PR focused as it's already broad enough.

Since more properties are exposed, I also made sure to use standard Kotlin or Java types whenever possible, for instance using `X500Principal` instead of a custom class to represent distinguished names. Speaking of `X500Principal`, I also wrote a builder for it but it's not part of this PR to avoid an excessive amount of code. If you believe this is interesting to have in the lib too, I can make a separate PR for this.

Because there are a lot of changes which include refactoring, I first wrote a bunch of tests to cover all the existing behaviour and ensure I didn't break anything.

Every commit stands on its own and is quite focused, so don't hesitate to review commit-by-commit. The tests and `.api` changes are updated after each commit that requires it, so they can be manipulated independently.