### PR TITLE
KTOR-1647 Avoid reflection access for SensitivityWatchEventModifier on Android

### DIFF
--- a/ktor-server/ktor-server-host-common/jvm/src/io/ktor/server/engine/internal/AutoReloadUtils.kt
+++ b/ktor-server/ktor-server-host-common/jvm/src/io/ktor/server/engine/internal/AutoReloadUtils.kt
@@ -65,10 +65,14 @@ internal fun Class<*>.takeIfNotFacade(): KClass<*>? =
     if (getAnnotation(Metadata::class.java)?.takeIf { it.kind == 1 } != null) kotlin else null
 
 @Suppress("FunctionName")
-internal fun get_com_sun_nio_file_SensitivityWatchEventModifier_HIGH(): WatchEvent.Modifier? = try {
-    val modifierClass = Class.forName("com.sun.nio.file.SensitivityWatchEventModifier")
-    val field = modifierClass.getField("HIGH")
-    field.get(modifierClass) as? WatchEvent.Modifier
-} catch (cause: Exception) {
-    null
+internal fun get_com_sun_nio_file_SensitivityWatchEventModifier_HIGH(): WatchEvent.Modifier? {
+    if (System.getenv("ANDROID_DATA") != null) return null
+
+    return try {
+        val modifierClass = Class.forName("com.sun.nio.file.SensitivityWatchEventModifier")
+        val field = modifierClass.getField("HIGH")
+        field.get(modifierClass) as? WatchEvent.Modifier
+    } catch (cause: Throwable) {
+        null
+    }
 }


### PR DESCRIPTION
Fix [KTOR-1647](https://youtrack.jetbrains.com/issue/KTOR-1647/comsunniofileSensitivityWatchEventModifier-Move-the-reflection-call-of-this-modifier-out-from-the-Ktor-Core)
