### PR TITLE
Update Mimes.kt

### DIFF
--- a/ktor-http/common/src/io/ktor/http/Mimes.kt
+++ b/ktor-http/common/src/io/ktor/http/Mimes.kt
@@ -1067,6 +1067,7 @@ N/A,application/andrew-inset
 .weba,audio/webm
 .web,application/vnd.xara
 .webm,video/webm
+.webmanifest,application/manifest+json
 .webp,image/webp
 .wg,application/vnd.pmi.widget
 .wgt,application/widget


### PR DESCRIPTION
**Subsystem**
`ktor-http`

**Motivation**
.webmanifest was  treated as octet-stream, but should be `application/manifest+json`:

> The `.webmanifest` extension is recommended in the spec, and should be served with an `application/manifest+json` mime type
([MDN](https://firefox-source-docs.mozilla.org/devtools-user/application/manifests/index.html))


**Solution**
Add MIME type for `application/manifest+json` 
