### PR TITLE
Simplify the logic of deciding if a header value is valid or not

### DIFF
--- a/ktor-http/common/src/io/ktor/http/HttpHeaders.kt
+++ b/ktor-http/common/src/io/ktor/http/HttpHeaders.kt
@@ -156,8 +156,7 @@ public object HttpHeaders {
      */
     public fun checkHeaderValue(value: String) {
         value.forEachIndexed { index, ch ->
-            if (ch == ' ' || ch == '\u0009') return@forEachIndexed
-            if (ch < ' ') {
+            if (ch < ' ' && ch != '\u0009') {
                 throw IllegalHeaderValueException(value, index)
             }
         }


### PR DESCRIPTION
**Subsystem**
Client

**Motivation**
This PR simplifies the logic of [checkHeaderValue](https://github.com/ktorio/ktor/blob/f97c1a3432041471c1ae3eed2ecc9047c8ad44a7/ktor-http/common/src/io/ktor/http/HttpHeaders.kt#L157) function.

