### PR TITLE
KTOR-5118 Add BearerAuthenticationProvider

### DIFF
--- a/ktor-http/api/ktor-http.api
+++ b/ktor-http/api/ktor-http.api
@@ -1064,6 +1064,8 @@ public abstract class io/ktor/http/auth/HttpAuthHeader {
 
 public final class io/ktor/http/auth/HttpAuthHeader$Companion {
 	public final fun basicAuthChallenge (Ljava/lang/String;Ljava/nio/charset/Charset;)Lio/ktor/http/auth/HttpAuthHeader$Parameterized;
+	public final fun bearerAuthChallenge (Ljava/lang/String;Ljava/lang/String;)Lio/ktor/http/auth/HttpAuthHeader;
+	public static synthetic fun bearerAuthChallenge$default (Lio/ktor/http/auth/HttpAuthHeader$Companion;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lio/ktor/http/auth/HttpAuthHeader;
 	public final fun digestAuthChallenge (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;)Lio/ktor/http/auth/HttpAuthHeader$Parameterized;
 	public static synthetic fun digestAuthChallenge$default (Lio/ktor/http/auth/HttpAuthHeader$Companion;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;ILjava/lang/Object;)Lio/ktor/http/auth/HttpAuthHeader$Parameterized;
 }

--- a/ktor-http/common/src/io/ktor/http/auth/HttpAuthHeader.kt
+++ b/ktor-http/common/src/io/ktor/http/auth/HttpAuthHeader.kt
@@ -222,7 +222,6 @@ public sealed class HttpAuthHeader(public val authScheme: String) {
                         replaced = true
                         HeaderValueParam(name, value)
                     }
-
                     else -> null
                 }
             }

--- a/ktor-http/common/src/io/ktor/http/auth/HttpAuthHeader.kt
+++ b/ktor-http/common/src/io/ktor/http/auth/HttpAuthHeader.kt
@@ -222,6 +222,7 @@ public sealed class HttpAuthHeader(public val authScheme: String) {
                         replaced = true
                         HeaderValueParam(name, value)
                     }
+
                     else -> null
                 }
             }
@@ -229,8 +230,11 @@ public sealed class HttpAuthHeader(public val authScheme: String) {
             return Parameterized(authScheme, newParameters, encoding)
         }
 
-        override fun render(encoding: HeaderValueEncoding): String =
+        override fun render(encoding: HeaderValueEncoding): String = if (parameters.isEmpty()) {
+            authScheme
+        } else {
             parameters.joinToString(", ", prefix = "$authScheme ") { "${it.name}=${it.value.encode(encoding)}" }
+        }
 
         /**
          * Tries to extract the first value of a parameter [name]. Returns null when not found.
@@ -285,6 +289,14 @@ public sealed class HttpAuthHeader(public val authScheme: String) {
                     put(Parameters.Charset, charset.name)
                 }
             }
+        )
+
+        /**
+         * Generates an [AuthScheme.Bearer] challenge as a [HttpAuthHeader].
+         */
+        public fun bearerAuthChallenge(scheme: String, realm: String?): HttpAuthHeader = Parameterized(
+            authScheme = scheme,
+            parameters = if (realm == null) emptyMap() else mapOf(Parameters.Realm to realm)
         )
 
         /**

--- a/ktor-http/common/src/io/ktor/http/auth/HttpAuthHeader.kt
+++ b/ktor-http/common/src/io/ktor/http/auth/HttpAuthHeader.kt
@@ -293,7 +293,7 @@ public sealed class HttpAuthHeader(public val authScheme: String) {
         /**
          * Generates an [AuthScheme.Bearer] challenge as a [HttpAuthHeader].
          */
-        public fun bearerAuthChallenge(scheme: String, realm: String?): HttpAuthHeader = Parameterized(
+        public fun bearerAuthChallenge(scheme: String, realm: String? = null): HttpAuthHeader = Parameterized(
             authScheme = scheme,
             parameters = if (realm == null) emptyMap() else mapOf(Parameters.Realm to realm)
         )

--- a/ktor-server/ktor-server-plugins/ktor-server-auth-jwt/jvm/src/io/ktor/server/auth/jwt/JWTAuth.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-auth-jwt/jvm/src/io/ktor/server/auth/jwt/JWTAuth.kt
@@ -139,7 +139,7 @@ public typealias JWTConfigureFunction = Verification.() -> Unit
 /**
  * A JWT [Authentication] provider.
  *
- * @see [bearer]
+ * @see [jwt]
  */
 public class JWTAuthenticationProvider internal constructor(config: Config) : AuthenticationProvider(config) {
 

--- a/ktor-server/ktor-server-plugins/ktor-server-auth-jwt/jvm/src/io/ktor/server/auth/jwt/JWTAuth.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-auth-jwt/jvm/src/io/ktor/server/auth/jwt/JWTAuth.kt
@@ -139,7 +139,7 @@ public typealias JWTConfigureFunction = Verification.() -> Unit
 /**
  * A JWT [Authentication] provider.
  *
- * @see [jwt]
+ * @see [bearer]
  */
 public class JWTAuthenticationProvider internal constructor(config: Config) : AuthenticationProvider(config) {
 

--- a/ktor-server/ktor-server-plugins/ktor-server-auth/api/ktor-server-auth.api
+++ b/ktor-server/ktor-server-plugins/ktor-server-auth/api/ktor-server-auth.api
@@ -143,8 +143,11 @@ public final class io/ktor/server/auth/BearerAuthenticationProvider : io/ktor/se
 public final class io/ktor/server/auth/BearerAuthenticationProvider$Config : io/ktor/server/auth/AuthenticationProvider$Config {
 	public fun <init> (Ljava/lang/String;)V
 	public final fun authHeader (Lkotlin/jvm/functions/Function1;)V
-	public final fun authSchemes ([Ljava/lang/String;)V
+	public final fun authSchemes (Ljava/lang/String;[Ljava/lang/String;)V
+	public static synthetic fun authSchemes$default (Lio/ktor/server/auth/BearerAuthenticationProvider$Config;Ljava/lang/String;[Ljava/lang/String;ILjava/lang/Object;)V
 	public final fun authenticate (Lkotlin/jvm/functions/Function3;)V
+	public final fun getRealm ()Ljava/lang/String;
+	public final fun setRealm (Ljava/lang/String;)V
 }
 
 public final class io/ktor/server/auth/BearerTokenCredential : io/ktor/server/auth/Credential {

--- a/ktor-server/ktor-server-plugins/ktor-server-auth/api/ktor-server-auth.api
+++ b/ktor-server/ktor-server-plugins/ktor-server-auth/api/ktor-server-auth.api
@@ -131,6 +131,33 @@ public final class io/ktor/server/auth/BasicAuthenticationProvider$Config : io/k
 	public final fun validate (Lkotlin/jvm/functions/Function3;)V
 }
 
+public final class io/ktor/server/auth/BearerAuthKt {
+	public static final fun bearer (Lio/ktor/server/auth/AuthenticationConfig;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)V
+	public static synthetic fun bearer$default (Lio/ktor/server/auth/AuthenticationConfig;Ljava/lang/String;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+}
+
+public final class io/ktor/server/auth/BearerAuthenticationProvider : io/ktor/server/auth/AuthenticationProvider {
+	public fun onAuthenticate (Lio/ktor/server/auth/AuthenticationContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class io/ktor/server/auth/BearerAuthenticationProvider$Config : io/ktor/server/auth/AuthenticationProvider$Config {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun authHeader (Lkotlin/jvm/functions/Function1;)V
+	public final fun authSchemes ([Ljava/lang/String;)V
+	public final fun authenticate (Lkotlin/jvm/functions/Function3;)V
+}
+
+public final class io/ktor/server/auth/BearerTokenCredential : io/ktor/server/auth/Credential {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lio/ktor/server/auth/BearerTokenCredential;
+	public static synthetic fun copy$default (Lio/ktor/server/auth/BearerTokenCredential;Ljava/lang/String;ILjava/lang/Object;)Lio/ktor/server/auth/BearerTokenCredential;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getToken ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
 public abstract interface class io/ktor/server/auth/Credential {
 }
 

--- a/ktor-server/ktor-server-plugins/ktor-server-auth/jvmAndNix/src/io/ktor/server/auth/BearerAuth.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-auth/jvmAndNix/src/io/ktor/server/auth/BearerAuth.kt
@@ -7,7 +7,7 @@ import io.ktor.server.response.respond
 /**
  * A Bearer [Authentication] provider.
  *
- * @see [jwt]
+ * @see [bearer]
  */
 public class BearerAuthenticationProvider internal constructor(config: Config) : AuthenticationProvider(config) {
 

--- a/ktor-server/ktor-server-plugins/ktor-server-auth/jvmAndNix/src/io/ktor/server/auth/BearerAuth.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-auth/jvmAndNix/src/io/ktor/server/auth/BearerAuth.kt
@@ -4,6 +4,11 @@ import io.ktor.http.auth.HttpAuthHeader
 import io.ktor.server.application.*
 import io.ktor.server.response.respond
 
+/**
+ * A Bearer [Authentication] provider.
+ *
+ * @see [jwt]
+ */
 public class BearerAuthenticationProvider internal constructor(config: Config) : AuthenticationProvider(config) {
 
     private val schemes: List<String> = config.schemes
@@ -33,6 +38,9 @@ public class BearerAuthenticationProvider internal constructor(config: Config) :
         context.principal(principal)
     }
 
+    /**
+     * A configuration for the [bearer] authentication provider.
+     */
     public class Config(name: String?) : AuthenticationProvider.Config(name) {
         internal var authenticate: AuthenticationFunction<BearerTokenCredential> = {
             throw NotImplementedError(
@@ -74,6 +82,11 @@ public class BearerAuthenticationProvider internal constructor(config: Config) :
     }
 }
 
+/**
+ * Installs the Bearer [Authentication] provider.
+ * Bearer auth requires the developer to provide a custom 'authenticate' function to authorize the token,
+ * and return the associated principal.
+ */
 public fun AuthenticationConfig.bearer(
     name: String? = null,
     configure: BearerAuthenticationProvider.Config.() -> Unit,

--- a/ktor-server/ktor-server-plugins/ktor-server-auth/jvmAndNix/src/io/ktor/server/auth/BearerAuth.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-auth/jvmAndNix/src/io/ktor/server/auth/BearerAuth.kt
@@ -1,3 +1,7 @@
+/*
+ * Copyright 2014-2021 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
 package io.ktor.server.auth
 
 import io.ktor.http.auth.HttpAuthHeader

--- a/ktor-server/ktor-server-plugins/ktor-server-auth/jvmAndNix/src/io/ktor/server/auth/BearerAuth.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-auth/jvmAndNix/src/io/ktor/server/auth/BearerAuth.kt
@@ -1,0 +1,85 @@
+package io.ktor.server.auth
+
+import io.ktor.http.auth.HttpAuthHeader
+import io.ktor.server.application.*
+import io.ktor.server.response.respond
+
+public class BearerAuthenticationProvider internal constructor(config: Config) : AuthenticationProvider(config) {
+
+    private val schemes: List<String> = config.schemes
+    private val authenticate = config.authenticate
+    private val getAuthHeader: (ApplicationCall) -> HttpAuthHeader? = config.getAuthHeader
+
+    override suspend fun onAuthenticate(context: AuthenticationContext) {
+        val authHeader = getAuthHeader(context.call) ?: let {
+            context.challenge(challengeKey, AuthenticationFailedCause.NoCredentials) { challenge, call ->
+                call.respond(UnauthorizedResponse())
+                challenge.complete()
+            }
+            return
+        }
+
+        val principal = (authHeader as? HttpAuthHeader.Single)
+            ?.takeIf { it.authScheme.lowercase() in schemes }
+            ?.let { authenticate(context.call, BearerTokenCredential(it.blob)) }
+            ?: let {
+                context.challenge(challengeKey, AuthenticationFailedCause.InvalidCredentials) { challenge, call ->
+                    call.respond(UnauthorizedResponse())
+                    challenge.complete()
+                }
+                return
+            }
+
+        context.principal(principal)
+    }
+
+    public class Config(name: String?) : AuthenticationProvider.Config(name) {
+        internal var authenticate: AuthenticationFunction<BearerTokenCredential> = {
+            throw NotImplementedError(
+                "Bearer auth authenticate function is not specified. Use bearer { authenticate { ... } } to fix."
+            )
+        }
+
+        internal var getAuthHeader: (ApplicationCall) -> HttpAuthHeader? = { call ->
+            call.request.parseAuthorizationHeader()
+        }
+
+        internal var schemes = listOf("bearer")
+
+        /**
+         * Exchanges the token for a Principal.
+         * @return a principal or `null`
+         */
+        public fun authenticate(authenticate: suspend ApplicationCall.(BearerTokenCredential) -> Principal?) {
+            this.authenticate = authenticate
+        }
+
+        /**
+         * Retrieves an HTTP authentication header.
+         * By default, it parses the `Authorization` header content.
+         */
+        public fun authHeader(getAuthHeader: (ApplicationCall) -> HttpAuthHeader?) {
+            this.getAuthHeader = getAuthHeader
+        }
+
+        /**
+         * Provide the auth schemes accepted when validating the authentication.
+         * By default, it accepts "Bearer" scheme.
+         */
+        public fun authSchemes(vararg schemes: String) {
+            this.schemes = schemes.map { it.lowercase() }
+        }
+
+        internal fun build() = BearerAuthenticationProvider(this)
+    }
+}
+
+public fun AuthenticationConfig.bearer(
+    name: String? = null,
+    configure: BearerAuthenticationProvider.Config.() -> Unit,
+) {
+    val provider = BearerAuthenticationProvider.Config(name).apply(configure).build()
+    register(provider)
+}
+
+private val challengeKey: Any = "BearerAuth"

--- a/ktor-server/ktor-server-plugins/ktor-server-auth/jvmAndNix/src/io/ktor/server/auth/SimpleAuth.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-auth/jvmAndNix/src/io/ktor/server/auth/SimpleAuth.kt
@@ -24,6 +24,8 @@ public data class UserIdPrincipal(val name: String) : Principal
  */
 public data class UserPasswordCredential(val name: String, val password: String) : Credential
 
+public data class BearerTokenCredential(val token: String) : Credential
+
 /**
  * An in-memory table that keeps usernames and password hashes.
  * This allows you not to compromise user passwords if your data source is leaked.

--- a/ktor-server/ktor-server-plugins/ktor-server-auth/jvmAndNix/test/io/ktor/tests/auth/BearerAuthTest.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-auth/jvmAndNix/test/io/ktor/tests/auth/BearerAuthTest.kt
@@ -1,0 +1,121 @@
+package io.ktor.tests.auth
+
+import io.ktor.client.request.*
+import io.ktor.client.statement.*
+import io.ktor.http.*
+import io.ktor.server.application.*
+import io.ktor.server.auth.*
+import io.ktor.server.response.*
+import io.ktor.server.routing.*
+import io.ktor.server.testing.*
+import kotlin.test.*
+
+class BearerAuthTest {
+
+    @Test
+    fun `unauthorized with no auth`() = testApplication {
+        configureServer()
+
+        val response = createClient {  }.get("/")
+
+        assertEquals(HttpStatusCode.Unauthorized, response.status)
+        assertNotEquals("Secret info", response.bodyAsText())
+    }
+
+    @Test
+    fun `successful with valid token`() = testApplication {
+        configureServer()
+
+        val response = createClient {  }.get("/") {
+            withToken("letmein")
+        }
+
+        assertEquals(HttpStatusCode.OK, response.status)
+        assertEquals("Secret info", response.bodyAsText())
+    }
+
+    @Test
+    fun `unauthorized with wrong scheme`() = testApplication {
+        configureServer()
+
+        val response = createClient {  }.get("/") {
+            header(HttpHeaders.Authorization, "Barer letmein")
+        }
+
+        assertEquals(HttpStatusCode.Unauthorized, response.status)
+        assertNotEquals("Secret info", response.bodyAsText())
+    }
+
+    @Test
+    fun `unauthorized with wrong token`() = testApplication {
+        configureServer()
+
+        val response = createClient {  }.get("/") {
+            withToken("opensaysme")
+        }
+
+        assertEquals(HttpStatusCode.Unauthorized, response.status)
+        assertNotEquals("Secret info", response.bodyAsText())
+    }
+
+    @Test
+    fun `unauthorized with parameterized header`() = testApplication {
+        configureServer()
+
+        val response = createClient { }.get("/") {
+            withToken("Token=letmein")
+        }
+
+        assertEquals(HttpStatusCode.Unauthorized, response.status)
+        assertNotEquals("Secret info", response.bodyAsText())
+    }
+
+    @Test
+    fun `exception when auth not configured`() = testApplication {
+        install(Authentication) {
+            bearer { }
+        }
+
+        routing {
+            authenticate {
+                get("/") {
+                }
+            }
+        }
+
+        assertFailsWith<NotImplementedError> {
+            createClient {  }.get("/") {
+                withToken("letmein")
+            }
+        }
+    }
+
+    private fun HttpRequestBuilder.withToken(token: String) {
+        header(HttpHeaders.Authorization, "Bearer $token")
+    }
+
+    private fun ApplicationTestBuilder.configureServer(
+        authenticate: suspend (BearerTokenCredential) -> Principal? = { token ->
+            if (token.token == "letmein") UserIdPrincipal("admin") else null
+        }
+    ) {
+        application {
+            install(Authentication) {
+                bearer {
+                    authenticate {
+                        authenticate(it)
+                    }
+                }
+            }
+
+            routing {
+                authenticate {
+                    route("/") {
+                        handle { call.respondText("Secret info") }
+                    }
+                }
+            }
+        }
+
+    }
+}

--- a/ktor-server/ktor-server-plugins/ktor-server-auth/jvmAndNix/test/io/ktor/tests/auth/BearerAuthTest.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-auth/jvmAndNix/test/io/ktor/tests/auth/BearerAuthTest.kt
@@ -1,3 +1,7 @@
+/*
+ * Copyright 2014-2021 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
 package io.ktor.tests.auth
 
 import io.ktor.client.request.*

--- a/ktor-server/ktor-server-plugins/ktor-server-auth/jvmAndNix/test/io/ktor/tests/auth/BearerAuthTest.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-auth/jvmAndNix/test/io/ktor/tests/auth/BearerAuthTest.kt
@@ -19,7 +19,7 @@ class BearerAuthTest {
         val response = createClient {  }.get("/")
 
         assertEquals(HttpStatusCode.Unauthorized, response.status)
-        assertNotEquals("Secret info", response.bodyAsText())
+        assertEquals("", response.bodyAsText())
     }
 
     @Test
@@ -31,7 +31,7 @@ class BearerAuthTest {
         }
 
         assertEquals(HttpStatusCode.OK, response.status)
-        assertEquals("Secret info", response.bodyAsText())
+        assertEquals("admin", response.bodyAsText())
     }
 
     @Test
@@ -43,7 +43,7 @@ class BearerAuthTest {
         }
 
         assertEquals(HttpStatusCode.Unauthorized, response.status)
-        assertNotEquals("Secret info", response.bodyAsText())
+        assertEquals("", response.bodyAsText())
     }
 
     @Test
@@ -55,7 +55,7 @@ class BearerAuthTest {
         }
 
         assertEquals(HttpStatusCode.Unauthorized, response.status)
-        assertNotEquals("Secret info", response.bodyAsText())
+        assertEquals("", response.bodyAsText())
     }
 
     @Test
@@ -67,7 +67,7 @@ class BearerAuthTest {
         }
 
         assertEquals(HttpStatusCode.Unauthorized, response.status)
-        assertNotEquals("Secret info", response.bodyAsText())
+        assertEquals("", response.bodyAsText())
     }
 
     @Test
@@ -111,7 +111,7 @@ class BearerAuthTest {
             routing {
                 authenticate {
                     route("/") {
-                        handle { call.respondText("Secret info") }
+                        handle { call.respondText(call.principal<UserIdPrincipal>()?.name ?: "") }
                     }
                 }
             }

--- a/ktor-server/ktor-server-plugins/ktor-server-auth/jvmAndNix/test/io/ktor/tests/auth/BearerAuthTest.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-auth/jvmAndNix/test/io/ktor/tests/auth/BearerAuthTest.kt
@@ -16,7 +16,7 @@ class BearerAuthTest {
     fun `unauthorized with no auth`() = testApplication {
         configureServer()
 
-        val response = createClient {  }.get("/")
+        val response = createClient { }.get("/")
 
         assertEquals(HttpStatusCode.Unauthorized, response.status)
         assertEquals("", response.bodyAsText())
@@ -26,7 +26,7 @@ class BearerAuthTest {
     fun `successful with valid token`() = testApplication {
         configureServer()
 
-        val response = createClient {  }.get("/") {
+        val response = createClient { }.get("/") {
             withToken("letmein")
         }
 
@@ -51,7 +51,7 @@ class BearerAuthTest {
             }
         }
 
-        val response = createClient {  }.get("/") {
+        val response = createClient { }.get("/") {
             header(HttpHeaders.Authorization, "Custom letmein")
         }
 
@@ -63,7 +63,7 @@ class BearerAuthTest {
     fun `unauthorized with wrong scheme`() = testApplication {
         configureServer()
 
-        val response = createClient {  }.get("/") {
+        val response = createClient { }.get("/") {
             header(HttpHeaders.Authorization, "Custom letmein")
         }
 
@@ -75,7 +75,7 @@ class BearerAuthTest {
     fun `unauthorized with wrong token`() = testApplication {
         configureServer()
 
-        val response = createClient {  }.get("/") {
+        val response = createClient { }.get("/") {
             withToken("opensaysme")
         }
 
@@ -109,7 +109,7 @@ class BearerAuthTest {
         }
 
         assertFailsWith<NotImplementedError> {
-            createClient {  }.get("/") {
+            createClient { }.get("/") {
                 withToken("letmein")
             }
         }

--- a/ktor-server/ktor-server-plugins/ktor-server-auth/jvmAndNix/test/io/ktor/tests/auth/BearerAuthTest.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-auth/jvmAndNix/test/io/ktor/tests/auth/BearerAuthTest.kt
@@ -20,7 +20,7 @@ class BearerAuthTest {
     fun `unauthorized with no auth`() = testApplication {
         configureServer()
 
-        val response = createClient { }.get("/")
+        val response = client.get("/")
 
         assertEquals(HttpStatusCode.Unauthorized, response.status)
         assertEquals("", response.bodyAsText())
@@ -30,7 +30,7 @@ class BearerAuthTest {
     fun `successful with valid token`() = testApplication {
         configureServer()
 
-        val response = createClient { }.get("/") {
+        val response = client.get("/") {
             withToken("letmein")
         }
 
@@ -55,7 +55,7 @@ class BearerAuthTest {
             }
         }
 
-        val response = createClient { }.get("/") {
+        val response = client.get("/") {
             header(HttpHeaders.Authorization, "Custom letmein")
         }
 
@@ -67,7 +67,7 @@ class BearerAuthTest {
     fun `unauthorized with wrong scheme`() = testApplication {
         configureServer()
 
-        val response = createClient { }.get("/") {
+        val response = client.get("/") {
             header(HttpHeaders.Authorization, "Custom letmein")
         }
 
@@ -79,7 +79,7 @@ class BearerAuthTest {
     fun `unauthorized with wrong token`() = testApplication {
         configureServer()
 
-        val response = createClient { }.get("/") {
+        val response = client.get("/") {
             withToken("opensaysme")
         }
 
@@ -91,7 +91,7 @@ class BearerAuthTest {
     fun `unauthorized with parameterized header`() = testApplication {
         configureServer()
 
-        val response = createClient { }.get("/") {
+        val response = client.get("/") {
             withToken("Token=letmein")
         }
 
@@ -113,7 +113,7 @@ class BearerAuthTest {
         }
 
         assertFailsWith<NotImplementedError> {
-            createClient { }.get("/") {
+            client.get("/") {
                 withToken("letmein")
             }
         }


### PR DESCRIPTION
**Subsystem**
ktor-server-auth

**Motivation**
[KTOR-5118](https://youtrack.jetbrains.com/issue/KTOR-5118/Add-Server-BearerAuthenticationProvider)

While Ktor provides mechanisms for authorizing JWTs and OAuth tokens, sometimes the developer needs to authorize bearer tokens with a custom lookup. I propose a new BearerAuthenticationProvider that extracts the bearer token from the Authorization header, and delegates the Principal lookup to the provided AuthenticationFunction<String>.

**Solution**
Added `BearerAuthenticationProvider` that authenticates a `BearerTokenCredential` via the provided `AuthenticateFunction`.

