### PR TITLE
KTOR-5035 - Remove internal class check

### DIFF
--- a/ktor-network/nix/src/io/ktor/network/selector/WorkerSelectorManager.kt
+++ b/ktor-network/nix/src/io/ktor/network/selector/WorkerSelectorManager.kt
@@ -27,8 +27,6 @@ internal class WorkerSelectorManager : SelectorManager {
         selectable: Selectable,
         interest: SelectInterest
     ) {
-        require(selectable is SelectableNative)
-
         return suspendCancellableCoroutine { continuation ->
             val selectorState = EventInfo(selectable.descriptor, interest, continuation)
             if (!selector.interest(selectorState)) {


### PR DESCRIPTION
**Subsystem**
Network - CIO Native

**Motivation**
https://youtrack.jetbrains.com/issue/KTOR-5035/Remove-check-for-internal-class-in-Select

**Solution**
Remove internal class check

**Current workaround**
I copied this code in postgresql driver: https://github.com/hfhbd/postgres-native-sqldelight/blob/main/postgres-native-sqldelight-driver/src/commonMain/kotlin/app/softwork/sqldelight/postgresdriver/Ktor_select.kt but would like to switch to ktor.