### PR TITLE
KTOR-5208 Add ApplicationConfig merge with reversed priority

### DIFF
--- a/ktor-server/ktor-server-core/api/ktor-server-core.api
+++ b/ktor-server/ktor-server-core/api/ktor-server-core.api
@@ -314,6 +314,8 @@ protected final class io/ktor/server/config/MapApplicationConfig$MapApplicationC
 
 public final class io/ktor/server/config/MergedApplicationConfigKt {
 	public static final fun merge (Ljava/util/List;)Lio/ktor/server/config/ApplicationConfig;
+	public static final fun mergeWith (Lio/ktor/server/config/ApplicationConfig;Lio/ktor/server/config/ApplicationConfig;)Lio/ktor/server/config/ApplicationConfig;
+	public static final fun mergeWithFallback (Lio/ktor/server/config/ApplicationConfig;Lio/ktor/server/config/ApplicationConfig;)Lio/ktor/server/config/ApplicationConfig;
 }
 
 public final class io/ktor/server/http/HttpDateJvmKt {

--- a/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/config/MergedApplicationConfig.kt
+++ b/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/config/MergedApplicationConfig.kt
@@ -8,9 +8,18 @@ package io.ktor.server.config
  * Merge configuration combining all their keys.
  * If key is not found in one of the configs, search will continue in the next config in the list.
  */
+@Deprecated("Use mergeWith/mergeWithFallback instead.")
 public fun List<ApplicationConfig>.merge(): ApplicationConfig {
     require(isNotEmpty()) { "List of configs can not be empty" }
-    return foldRight(last()) { config, acc -> MergedApplicationConfig(config, acc) }
+    return foldRight(last()) { config, acc -> config.mergeWithFallback(acc) }
+}
+
+public fun ApplicationConfig.mergeWith(other: ApplicationConfig): ApplicationConfig {
+    return MergedApplicationConfig(other, this)
+}
+
+public fun ApplicationConfig.mergeWithFallback(other: ApplicationConfig): ApplicationConfig {
+    return MergedApplicationConfig(this, other)
 }
 
 internal class MergedApplicationConfig(

--- a/ktor-server/ktor-server-host-common/jvmAndNix/src/io/ktor/server/engine/CommandLine.kt
+++ b/ktor-server/ktor-server-host-common/jvmAndNix/src/io/ktor/server/engine/CommandLine.kt
@@ -101,7 +101,7 @@ internal fun buildApplicationConfig(args: Array<String>): ApplicationConfig {
     val environmentConfig = getConfigFromEnvironment()
     val fileConfig = ConfigLoader.load(configPath)
 
-    return listOf(commandLineConfig, environmentConfig, fileConfig).merge()
+    return fileConfig.mergeWith(environmentConfig).mergeWith(commandLineConfig)
 }
 
 internal expect fun ApplicationEngineEnvironmentBuilder.configureSSLConnectors(


### PR DESCRIPTION
**Subsystem**
Server

**Motivation**
[KTOR-5208](https://youtrack.jetbrains.com/issue/KTOR-5208) List<ApplicationConfig>.merge() should have reversed priority

**Solution**
Add new method `ApplicationConfig.mergeWith(other: ApplicationConfig): ApplicationConfig` where second config has priority and `ApplicationConfig.mergeWithFallback(other: ApplicationConfig): ApplicationConfig` where first config has priority
