### PR TITLE
KTOR-5006: Close WS when reading fragmented control frames

### DIFF
--- a/ktor-shared/ktor-websockets/api/ktor-websockets.api
+++ b/ktor-shared/ktor-websockets/api/ktor-websockets.api
@@ -171,6 +171,14 @@ public final class io/ktor/websocket/FrameType$Companion {
 	public final fun get (I)Lio/ktor/websocket/FrameType;
 }
 
+public final class io/ktor/websocket/ProtocolViolationException : java/lang/Exception, kotlinx/coroutines/CopyableThrowable {
+	public fun <init> (Ljava/lang/String;)V
+	public fun createCopy ()Lio/ktor/websocket/ProtocolViolationException;
+	public synthetic fun createCopy ()Ljava/lang/Throwable;
+	public fun getMessage ()Ljava/lang/String;
+	public final fun getViolation ()Ljava/lang/String;
+}
+
 public final class io/ktor/websocket/RawWebSocketCommonKt {
 	public static final fun readFrame (Lio/ktor/utils/io/ByteReadChannel;JILkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static final fun writeFrame (Lio/ktor/utils/io/ByteWriteChannel;Lio/ktor/websocket/Frame;ZLkotlin/coroutines/Continuation;)Ljava/lang/Object;

--- a/ktor-shared/ktor-websockets/common/src/io/ktor/websocket/ProtocolViolationException.kt
+++ b/ktor-shared/ktor-websockets/common/src/io/ktor/websocket/ProtocolViolationException.kt
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2014-2022 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.websocket
+
+import io.ktor.util.internal.*
+import kotlinx.coroutines.*
+
+/**
+ * Raised when peers send frames which violate the Websocket RFC
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+public class ProtocolViolationException(
+    public val violation: String
+) : Exception(), CopyableThrowable<ProtocolViolationException> {
+    override val message: String
+        get() = "Received illegal frame: $violation"
+
+    override fun createCopy(): ProtocolViolationException = ProtocolViolationException(violation).also {
+        it.initCauseBridge(this)
+    }
+}

--- a/ktor-shared/ktor-websockets/common/src/io/ktor/websocket/RawWebSocketCommon.kt
+++ b/ktor-shared/ktor-websockets/common/src/io/ktor/websocket/RawWebSocketCommon.kt
@@ -94,6 +94,10 @@ internal class RawWebSocketCommon(
         } catch (cause: FrameTooBigException) {
             outgoing.send(Frame.Close(CloseReason(CloseReason.Codes.TOO_BIG, cause.message)))
             _incoming.close(cause)
+        } catch (cause: ProtocolViolationException) {
+            // same as above
+            outgoing.send(Frame.Close(CloseReason(CloseReason.Codes.PROTOCOL_ERROR, cause.message)))
+            _incoming.close(cause)
         } catch (cause: CancellationException) {
             _incoming.cancel(cause)
         } catch (eof: EOFException) {
@@ -207,10 +211,21 @@ public suspend fun ByteReadChannel.readFrame(maxFrameSize: Long, lastOpcode: Int
     val flagsAndOpcode = readByte().toInt()
     val maskAndLength = readByte().toInt()
 
+    val opcode = (flagsAndOpcode and 0x0f).let { new -> if (new == 0) lastOpcode else new }
+    val frameType = FrameType[opcode] ?: throw IllegalStateException("Unsupported opcode: $opcode")
+
+    val fin = flagsAndOpcode and 0x80 != 0
+    if (frameType.controlFrame && !fin) {
+        throw ProtocolViolationException("control frames can't be fragmented")
+    }
+
     val length = when (val length = maskAndLength and 0x7f) {
         126 -> readShort().toLong() and 0xffff
         127 -> readLong()
         else -> length.toLong()
+    }
+    if (frameType.controlFrame && length > 125) {
+        throw ProtocolViolationException("control frames can't be larger than 125 bytes")
     }
 
     val maskKey = when (maskAndLength and 0x80 != 0) {
@@ -228,10 +243,8 @@ public suspend fun ByteReadChannel.readFrame(maxFrameSize: Long, lastOpcode: Int
         else -> data.mask(maskKey)
     }
 
-    val opcode = (flagsAndOpcode and 0x0f).let { new -> if (new == 0) lastOpcode else new }
-    val frameType = FrameType[opcode] ?: throw IllegalStateException("Unsupported opcode: $opcode")
     return Frame.byType(
-        fin = flagsAndOpcode and 0x80 != 0,
+        fin = fin,
         frameType = frameType,
         data = maskedData.readBytes(),
         rsv1 = flagsAndOpcode and 0x40 != 0,

--- a/ktor-shared/ktor-websockets/jvm/src/io/ktor/websocket/FrameParser.kt
+++ b/ktor-shared/ktor-websockets/jvm/src/io/ktor/websocket/FrameParser.kt
@@ -92,9 +92,15 @@ public class FrameParser {
         opcode = (flagsAndOpcode and 0x0f).let { new -> if (new == 0) lastOpcode else new }
         if (!frameType.controlFrame) {
             lastOpcode = opcode
+        } else if (!fin) {
+            throw ProtocolViolationException("control frames can't be fragmented")
         }
         mask = maskAndLength1 and 0x80 != 0
         val length1 = maskAndLength1 and 0x7f
+
+        if (frameType.controlFrame && length1 > 125) {
+            throw ProtocolViolationException("control frames can't be larger than 125 bytes")
+        }
 
         lengthLength = when (length1) {
             126 -> 2

--- a/ktor-shared/ktor-websockets/jvm/src/io/ktor/websocket/RawWebSocketJvm.kt
+++ b/ktor-shared/ktor-websockets/jvm/src/io/ktor/websocket/RawWebSocketJvm.kt
@@ -70,6 +70,9 @@ internal class RawWebSocketJvm(
             } catch (cause: FrameTooBigException) {
                 outgoing.send(Frame.Close(CloseReason(CloseReason.Codes.TOO_BIG, cause.message)))
                 filtered.close(cause)
+            } catch (cause: ProtocolViolationException) {
+                outgoing.send(Frame.Close(CloseReason(CloseReason.Codes.PROTOCOL_ERROR, cause.message)))
+                filtered.close(cause)
             } catch (cause: CancellationException) {
                 reader.incoming.cancel(cause)
             } catch (cause: Throwable) {

--- a/ktor-shared/ktor-websockets/jvm/src/io/ktor/websocket/WebSocketReader.kt
+++ b/ktor-shared/ktor-websockets/jvm/src/io/ktor/websocket/WebSocketReader.kt
@@ -45,6 +45,9 @@ public class WebSocketReader(
         } catch (cause: FrameTooBigException) {
             // Bypass exception via queue to prevent cancellation and handle it on the top level.
             queue.close(cause)
+        } catch (cause: ProtocolViolationException) {
+            // same as above
+            queue.close(cause)
         } catch (cause: Throwable) {
             throw cause
         } finally {

--- a/ktor-shared/ktor-websockets/jvm/test/WebSocketReaderTest.kt
+++ b/ktor-shared/ktor-websockets/jvm/test/WebSocketReaderTest.kt
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2014-2022 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.tests.websocket
+
+import io.ktor.utils.io.*
+import io.ktor.utils.io.core.*
+import io.ktor.websocket.*
+import kotlinx.coroutines.*
+import kotlin.test.*
+
+class WebSocketReaderTest {
+    @Test
+    fun testFailFragmentedControl() {
+        val serializer = Serializer()
+        val channel = ByteChannel(true)
+        runBlocking {
+            val reader = WebSocketReader(channel, coroutineContext, 1000)
+            val frame = Frame.Ping(ByteArray(126))
+            serializer.enqueue(frame)
+
+            while (serializer.hasOutstandingBytes) {
+                channel.write {
+                    serializer.serialize(it)
+                }
+            }
+            assertFailsWith<ProtocolViolationException> {
+                reader.incoming.receive()
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fragmented control frames are explicitly disallowed by the websocket spec.

**Subsystem**
Server, Websockets

**Motivation**

Ktor's websocket implementation is currently pretty non-compliant. We see a lot of "unknown opcode" errors in our logs, so I'm going on an endevaour to start fixing all the protocol violations. This one specifically fixes https://youtrack.jetbrains.com/issue/KTOR-5006/Websockets-Connection-should-failed-immediately-1002-Protocol-Error-when-control-frame-has-a-payload-with-more-than-125-octets.

**Solution**

For this initial PR we just need to add some Frame validation before forwarding the Frame to the queues. In an earlier version I had the validation directly in the frame, however this'd prevent testing this solution within ktor since invalid frames could not be constructed.

I'm not sure how to add a test for this. @Stexxe had a great standalone test in the issue, but I can't find anything comparable within the Websocket package. Is it "allowed" to create a whole Ktor server in there, or is it better to test this more granularly?

I'm a little uncertain about my choice of `IllegalStateException` as exception type. Let me know if there's a better fit/we should create a new exception type. There'll be a couple more validation like this - maybe create a `ProtocolViolationException` as an aggregator (maybe with an attached close code for unified handling within the framework)?