### PR TITLE
Build scripts: Bump the toolchain version to 11

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -176,15 +176,23 @@ fun configureDokka() {
 configureDokka()
 
 fun Project.setupJvmToolchain() {
-    val jdk = when (project.name) {
-        in jdk11Modules -> 11
-        else -> 8
-    }
-
     kotlin {
         jvmToolchain {
             check(this is JavaToolchainSpec)
-            languageVersion.set(JavaLanguageVersion.of(jdk))
+            languageVersion.set(JavaLanguageVersion.of(11))
+        }
+    }
+
+    tasks.withType(KotlinCompile::class.java).configureEach {
+        kotlinOptions {
+            when (this) {
+                is KotlinJvmOptions -> {
+                    jvmTarget = when (project.name) {
+                        in jdk11Modules -> "11"
+                        else -> "1.8"
+                    }
+                }
+            }
         }
     }
 }

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -48,6 +48,6 @@ dependencies {
 kotlin {
     jvmToolchain {
         check(this is JavaToolchainSpec)
-        languageVersion.set(JavaLanguageVersion.of(8))
+        languageVersion.set(JavaLanguageVersion.of(11))
     }
 }


### PR DESCRIPTION
Looks like Adoptium did not release Java8 versions of their M1 JDKs leading to errors like below:

```
> Unable to download toolchain matching the requirements ({languageVersion=8, vendor=any, implementation=vendor-specific}) from 'https://api.adoptium.net/v3/binary/latest/8/ga/mac/aarch64/jdk/hotspot/normal/eclipse'.
  > Could not read 'https://api.adoptium.net/v3/binary/latest/8/ga/mac/aarch64/jdk/hotspot/normal/eclipse' as it does not exist.
```

Bump to Java 11 which exists. This fixes building on a M1 mac without JDK8 installed. Given this is used to compile buildSrc, it shouldn't impact the published artifacts. 

Tests fail on my `:ktor-client:ktor-client-tests:iosSimulatorArm64TestCompileKlibraries` but this fails no matter if I have a JDK8 installed or not so it seems unrelated ?
