### PR TITLE
Fixes iOS unit test deadlock occurring with DarwinClientEngine

### DIFF
--- a/ktor-client/ktor-client-darwin/darwin/src/io/ktor/client/engine/darwin/DarwinClientEngine.kt
+++ b/ktor-client/ktor-client-darwin/darwin/src/io/ktor/client/engine/darwin/DarwinClientEngine.kt
@@ -18,7 +18,7 @@ import kotlin.coroutines.*
 
 @OptIn(InternalAPI::class)
 internal class DarwinClientEngine(override val config: DarwinClientEngineConfig) : HttpClientEngineBase("ktor-darwin") {
-    private val requestQueue = NSOperationQueue()
+    private val requestQueue: NSOperationQueue? = NSOperationQueue.currentQueue()
 
     override val dispatcher = Dispatchers.Unconfined
 

--- a/ktor-client/ktor-client-darwin/darwin/src/io/ktor/client/engine/darwin/internal/DarwinSession.kt
+++ b/ktor-client/ktor-client-darwin/darwin/src/io/ktor/client/engine/darwin/internal/DarwinSession.kt
@@ -13,7 +13,7 @@ import kotlin.coroutines.*
 @OptIn(UnsafeNumber::class)
 internal class DarwinSession(
     private val config: DarwinClientEngineConfig,
-    requestQueue: NSOperationQueue
+    requestQueue: NSOperationQueue?
 ) : Closeable {
     private val closed = atomic(false)
 
@@ -54,7 +54,7 @@ internal class DarwinSession(
 @OptIn(UnsafeNumber::class)
 internal fun createSession(
     config: DarwinClientEngineConfig,
-    requestQueue: NSOperationQueue
+    requestQueue: NSOperationQueue?
 ): Pair<NSURLSession, KtorNSURLSessionDelegate> {
     val configuration = NSURLSessionConfiguration.defaultSessionConfiguration().apply {
         setupProxy(config)


### PR DESCRIPTION
**Subsystem**
ktor-client-darwin

**Motivation**
About a year ago, a [pull request](https://github.com/ktorio/ktor/pull/2476) was made to fix iOS engine deadlock happening when running iOS unit tests. Since recently upgrading to the ktor 2.0, our team has begun to experience this issue in our iOS unit tests. Looking at DarwinClientEngine.kt, the request queue does not specify `currentQueue()` like the now deprecated [IosClientEngine](https://github.com/ktorio/ktor/blob/1.6.8/ktor-client/ktor-client-ios/darwin/src/io/ktor/client/engine/ios/IosClientEngine.kt) did prior to the ktor 2.0 update.

**Solution**
Use the current thread for the request queue

