### PR TITLE
KTOR-5300 Disable body length check for JS Browser target

### DIFF
--- a/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/DefaultTransform.kt
+++ b/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/DefaultTransform.kt
@@ -77,8 +77,8 @@ public fun HttpClient.defaultTransformers() {
                 val bytes = body.toByteArray()
 
                 val contentLength = response.contentLength()
-                val contentEncoding = response.headers[HttpHeaders.ContentEncoding]
-                if (contentEncoding == null && contentLength != null && contentLength > 0) {
+                val notEncoded = !PlatformUtils.IS_BROWSER && response.headers[HttpHeaders.ContentEncoding] == null
+                if (notEncoded && contentLength != null && contentLength > 0) {
                     check(bytes.size == contentLength.toInt()) { "Expected $contentLength, actual ${bytes.size}" }
                 }
                 proceedWith(HttpResponseContainer(info, bytes))


### PR DESCRIPTION
Some browsers do not expose `Content-Encoding` header 
https://youtrack.jetbrains.com/issue/KTOR-5300
