### PR TITLE
Fix NullPointerException when clearToken is called on AuthTokenHolder while suspended

### DIFF
--- a/ktor-client/ktor-client-plugins/ktor-client-auth/common/test/io/ktor/client/plugins/auth/AuthTokenHolderTest.kt
+++ b/ktor-client/ktor-client-plugins/ktor-client-auth/common/test/io/ktor/client/plugins/auth/AuthTokenHolderTest.kt
@@ -63,4 +63,68 @@ class AuthTokenHolderTest {
         assertNotNull(first.await())
         assertNotNull(second.await())
     }
+
+    @Test
+    @OptIn(DelicateCoroutinesApi::class)
+    fun testClearCalledWhileLoadingTokens() = testSuspend {
+        val monitor = Job()
+
+        var clearTokenCalled = false
+        val holder = AuthTokenHolder {
+
+            // suspend until clearToken is called
+            while (!clearTokenCalled) {
+                delay(10)
+            }
+
+            monitor.join()
+            BearerTokens("1", "2")
+        }
+
+        val first = GlobalScope.async(Dispatchers.Unconfined) {
+            holder.loadToken()
+        }
+
+        val second = GlobalScope.async(Dispatchers.Unconfined) {
+            holder.clearToken()
+            clearTokenCalled = true
+        }
+
+        monitor.complete()
+        assertNotNull(first.await())
+        assertNotNull(second.await())
+        assertTrue(clearTokenCalled)
+    }
+
+    @Test
+    @OptIn(DelicateCoroutinesApi::class)
+    fun testClearCalledWhileSettingTokens() = testSuspend {
+        val monitor = Job()
+
+        var clearTokenCalled = false
+        val holder = AuthTokenHolder<BearerTokens> {
+            fail("unexpected call")
+        }
+
+        val first = GlobalScope.async(Dispatchers.Unconfined) {
+            holder.setToken {
+                // suspend until clearToken is called
+                while (!clearTokenCalled) {
+                    delay(10)
+                }
+                monitor.join()
+                BearerTokens("1", "2")
+            }
+        }
+
+        val second = GlobalScope.async(Dispatchers.Unconfined) {
+            holder.clearToken()
+            clearTokenCalled = true
+        }
+
+        monitor.complete()
+        assertNotNull(first.await())
+        assertNotNull(second.await())
+        assertTrue(clearTokenCalled)
+    }
 }


### PR DESCRIPTION
**Subsystem**
Client

**Motivation**

This fixes a crash that is occasionally affecting the project I'm working on. I haven't seen an existing issue for it in YouTrack.

The crash happens when force unwrapping `loadTokensDeferred.value!!.complete(newTokens)`.

My theory was that `clearToken` must have been called during the execution of that function, which I was able to confirm by writing new unit tests.

`loadToken` and `setToken` are suspending functions that call a suspending lambda at some point during their execution.
If `clearToken` is called while they are waiting for that suspending lamba call to return, the code crashes with a `NullPointerException` when we force unwrap `refreshTokensDeferred.value` or `loadTokensDeferred.value`.

**Solution**

One solution to avoid the crash would be to simply not force unwrap and use the `?` notation. However, that also means that if there are several callers waiting for `loadToken()` to complete, they will be suspended forever. Only the 1st caller of `loadToken()` will get its value back.

So I opted for capturing the deferred value when the function starts and calling `.complete(newTokens)` on it instead. This ensures all function calls will eventually complete.

Tested by running the new unit tests and confirmed all other tests still passed.