### PR TITLE
Chore(infra): fix reading of build_snapshot_train gradlew property.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -16,10 +16,10 @@ buildscript {
      * Additionally, mavenLocal and Sonatype snapshots are added to repository list and stress tests are disabled.
      * DO NOT change the name of these properties without adapting kotlinx.train build chain.
      */
-    extra["build_snapshot_train"] = rootProject.properties["build_snapshot_train"].let { it != null && it != "" }
-    val build_snapshot_train: Boolean by extra
+    extra["build_snapshot_train"] = rootProject.properties["build_snapshot_train"]
+    val build_snapshot_train: String? by extra
 
-    if (build_snapshot_train) {
+    if (build_snapshot_train?.toBoolean() == true) {
         extra["kotlin_version"] = rootProject.properties["kotlin_snapshot_version"]
         val kotlin_version: String? by extra
         if (kotlin_version == null) {

--- a/buildSrc/src/main/kotlin/Train.kt
+++ b/buildSrc/src/main/kotlin/Train.kt
@@ -6,8 +6,8 @@ import org.gradle.api.tasks.testing.*
 import org.gradle.kotlin.dsl.*
 
 fun Project.filterSnapshotTests() {
-    val build_snapshot_train: Boolean by extra
-    if (!build_snapshot_train) return
+    val build_snapshot_train: String? by extra
+    if (build_snapshot_train?.toBoolean() != true) return
 
     println("Hacking test tasks, removing stress and flaky tests")
     subprojects {
@@ -47,9 +47,10 @@ fun Project.filterSnapshotTests() {
 
 fun Project.setupTrainForSubproject() {
     if (COMMON_JVM_ONLY) return
-
-    val build_snapshot_train: Boolean? by extra
-    if (build_snapshot_train != true) return
+    val build_snapshot_train: String? by extra
+    if (build_snapshot_train?.toBoolean() != true) {
+        return
+    }
 
     val atomicfu_version: String by extra
     val coroutines_version: String by extra


### PR DESCRIPTION
Reason: build_snapshot_train type had Boolean  for the root project ktor, while in the rest of projects it is String? (:ktor-bom, :ktor-client, :ktor-http). That led to the java.lang.ClassCastException.


