### PR TITLE
KTOR-5405 allow booleans as multipart values

### DIFF
--- a/ktor-client/ktor-client-core/api/ktor-client-core.api
+++ b/ktor-client/ktor-client-core/api/ktor-client-core.api
@@ -1237,6 +1237,7 @@ public final class io/ktor/client/request/forms/FormBuilder {
 	public final fun append (Ljava/lang/String;Ljava/lang/Number;Lio/ktor/http/Headers;)V
 	public final fun append (Ljava/lang/String;Ljava/lang/Object;Lio/ktor/http/Headers;)V
 	public final fun append (Ljava/lang/String;Ljava/lang/String;Lio/ktor/http/Headers;)V
+	public final fun append (Ljava/lang/String;ZLio/ktor/http/Headers;)V
 	public final fun append (Ljava/lang/String;[BLio/ktor/http/Headers;)V
 	public static synthetic fun append$default (Lio/ktor/client/request/forms/FormBuilder;Ljava/lang/String;Lio/ktor/client/request/forms/ChannelProvider;Lio/ktor/http/Headers;ILjava/lang/Object;)V
 	public static synthetic fun append$default (Lio/ktor/client/request/forms/FormBuilder;Ljava/lang/String;Lio/ktor/client/request/forms/InputProvider;Lio/ktor/http/Headers;ILjava/lang/Object;)V
@@ -1244,6 +1245,7 @@ public final class io/ktor/client/request/forms/FormBuilder {
 	public static synthetic fun append$default (Lio/ktor/client/request/forms/FormBuilder;Ljava/lang/String;Ljava/lang/Number;Lio/ktor/http/Headers;ILjava/lang/Object;)V
 	public static synthetic fun append$default (Lio/ktor/client/request/forms/FormBuilder;Ljava/lang/String;Ljava/lang/Object;Lio/ktor/http/Headers;ILjava/lang/Object;)V
 	public static synthetic fun append$default (Lio/ktor/client/request/forms/FormBuilder;Ljava/lang/String;Ljava/lang/String;Lio/ktor/http/Headers;ILjava/lang/Object;)V
+	public static synthetic fun append$default (Lio/ktor/client/request/forms/FormBuilder;Ljava/lang/String;ZLio/ktor/http/Headers;ILjava/lang/Object;)V
 	public static synthetic fun append$default (Lio/ktor/client/request/forms/FormBuilder;Ljava/lang/String;[BLio/ktor/http/Headers;ILjava/lang/Object;)V
 	public final fun appendInput (Ljava/lang/String;Lio/ktor/http/Headers;Ljava/lang/Long;Lkotlin/jvm/functions/Function0;)V
 	public static synthetic fun appendInput$default (Lio/ktor/client/request/forms/FormBuilder;Ljava/lang/String;Lio/ktor/http/Headers;Ljava/lang/Long;Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)V

--- a/ktor-client/ktor-client-core/common/src/io/ktor/client/request/forms/formDsl.kt
+++ b/ktor-client/ktor-client-core/common/src/io/ktor/client/request/forms/formDsl.kt
@@ -37,6 +37,7 @@ public fun formData(vararg values: FormPart<*>): List<PartData> {
         val part = when (value) {
             is String -> PartData.FormItem(value, {}, partHeaders.build())
             is Number -> PartData.FormItem(value.toString(), {}, partHeaders.build())
+            is Boolean -> PartData.FormItem(value.toString(), {}, partHeaders.build())
             is ByteArray -> {
                 partHeaders.append(HttpHeaders.ContentLength, value.size.toString())
                 PartData.BinaryItem({ ByteReadPacket(value) }, {}, partHeaders.build())
@@ -100,6 +101,13 @@ public class FormBuilder internal constructor() {
      * Appends a pair [key]:[value] with optional [headers].
      */
     public fun append(key: String, value: Number, headers: Headers = Headers.Empty) {
+        parts += FormPart(key, value, headers)
+    }
+
+    /**
+     * Appends a pair [key]:[value] with optional [headers].
+     */
+    public fun append(key: String, value: Boolean, headers: Headers = Headers.Empty) {
         parts += FormPart(key, value, headers)
     }
 

--- a/ktor-client/ktor-client-core/common/test/MultiPartFormDataContentTest.kt
+++ b/ktor-client/ktor-client-core/common/test/MultiPartFormDataContentTest.kt
@@ -79,6 +79,52 @@ class MultiPartFormDataContentTest {
     }
 
     @Test
+    fun testNumberQuoted() = testSuspend {
+        val data = MultiPartFormDataContent(
+            formData {
+                append("not_a_forty_two", 1337)
+            },
+            boundary = "boundary",
+        )
+
+        assertEquals(
+            listOf(
+                "--boundary",
+                "Content-Disposition: form-data; name=not_a_forty_two",
+                "Content-Length: 4",
+                "",
+                "1337", // note quotes
+                "--boundary--",
+                ""
+            ).joinToString(separator = "\r\n"),
+            data.readString()
+        )
+    }
+
+    @Test
+    fun testBooleanQuoted() = testSuspend {
+        val data = MultiPartFormDataContent(
+            formData {
+                append("is_forty_two", false)
+            },
+            boundary = "boundary",
+        )
+
+        assertEquals(
+            listOf(
+                "--boundary",
+                "Content-Disposition: form-data; name=is_forty_two",
+                "Content-Length: 5",
+                "",
+                "false", // note quotes
+                "--boundary--",
+                ""
+            ).joinToString(separator = "\r\n"),
+            data.readString()
+        )
+    }
+
+    @Test
     fun testByteReadChannelOverBufferSize() = testSuspend {
         val body = ByteArray(4089) { 'k'.code.toByte() }
         val data = MultiPartFormDataContent(

--- a/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/ContentTest.kt
+++ b/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/ContentTest.kt
@@ -165,7 +165,6 @@ class ContentTest : ClientLoader(5 * 60) {
     }
 
     @Test
-    @Ignore
     fun testMultipartFormData() = clientTests(listOf("Js")) {
         val data = {
             formData {
@@ -184,6 +183,7 @@ class ContentTest : ClientLoader(5 * 60) {
                     }
                 }
                 append("hello", 5)
+                append("world", true)
             }
         }
 

--- a/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/ContentTest.kt
+++ b/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/ContentTest.kt
@@ -165,6 +165,7 @@ class ContentTest : ClientLoader(5 * 60) {
     }
 
     @Test
+    @Ignore
     fun testMultipartFormData() = clientTests(listOf("Js")) {
         val data = {
             formData {


### PR DESCRIPTION
**Subsystem**
Client multipart/form-data enhancement

**Motivation**
As per [KTOR-5405](https://youtrack.jetbrains.com/issue/KTOR-5405) there is desire to encode `Boolean` values the same way as `Number` values are encoded.

**Solution**
Wrapping `Boolean`s in `PartData.FormItem` which effectively puts quotes around string representation of the value.

