### PR TITLE
CIO Client: Useless lazy

### DIFF
--- a/ktor-client/ktor-client-cio/jvmAndNix/src/io/ktor/client/engine/cio/CIOEngine.kt
+++ b/ktor-client/ktor-client-cio/jvmAndNix/src/io/ktor/client/engine/cio/CIOEngine.kt
@@ -31,7 +31,7 @@ internal class CIOEngine(
 
     private val endpoints = ConcurrentMap<String, Endpoint>()
 
-    private val selectorManager: SelectorManager by lazy { SelectorManager(dispatcher) }
+    private val selectorManager = SelectorManager(dispatcher)
 
     private val connectionFactory = ConnectionFactory(
         selectorManager,

--- a/ktor-client/ktor-client-cio/jvmAndNix/src/io/ktor/client/engine/cio/CIOEngine.kt
+++ b/ktor-client/ktor-client-cio/jvmAndNix/src/io/ktor/client/engine/cio/CIOEngine.kt
@@ -23,7 +23,8 @@ internal class CIOEngine(
     override val config: CIOEngineConfig
 ) : HttpClientEngineBase("ktor-cio") {
 
-    override val dispatcher: CoroutineDispatcher = Dispatchers.clientDispatcher(config.threadsCount, "ktor-cio-dispatcher")
+    override val dispatcher: CoroutineDispatcher =
+        Dispatchers.clientDispatcher(config.threadsCount, "ktor-cio-dispatcher")
 
     override val supportedCapabilities = setOf(HttpTimeout, WebSocketCapability, WebSocketExtensionsCapability)
 

--- a/ktor-client/ktor-client-cio/jvmAndNix/src/io/ktor/client/engine/cio/CIOEngine.kt
+++ b/ktor-client/ktor-client-cio/jvmAndNix/src/io/ktor/client/engine/cio/CIOEngine.kt
@@ -23,9 +23,7 @@ internal class CIOEngine(
     override val config: CIOEngineConfig
 ) : HttpClientEngineBase("ktor-cio") {
 
-    override val dispatcher: CoroutineDispatcher by lazy {
-        Dispatchers.clientDispatcher(config.threadsCount, "ktor-cio-dispatcher")
-    }
+    override val dispatcher: CoroutineDispatcher = Dispatchers.clientDispatcher(config.threadsCount, "ktor-cio-dispatcher")
 
     override val supportedCapabilities = setOf(HttpTimeout, WebSocketCapability, WebSocketExtensionsCapability)
 

--- a/ktor-client/ktor-client-cio/jvmAndNix/src/io/ktor/client/engine/cio/CIOEngine.kt
+++ b/ktor-client/ktor-client-cio/jvmAndNix/src/io/ktor/client/engine/cio/CIOEngine.kt
@@ -23,8 +23,7 @@ internal class CIOEngine(
     override val config: CIOEngineConfig
 ) : HttpClientEngineBase("ktor-cio") {
 
-    override val dispatcher: CoroutineDispatcher = 
-        Dispatchers.clientDispatcher(config.threadsCount, "ktor-cio-dispatcher")
+    override val dispatcher: CoroutineDispatcher = Dispatchers.clientDispatcher(config.threadsCount, "ktor-cio-dispatcher")
 
     override val supportedCapabilities = setOf(HttpTimeout, WebSocketCapability, WebSocketExtensionsCapability)
 

--- a/ktor-client/ktor-client-cio/jvmAndNix/src/io/ktor/client/engine/cio/CIOEngine.kt
+++ b/ktor-client/ktor-client-cio/jvmAndNix/src/io/ktor/client/engine/cio/CIOEngine.kt
@@ -23,7 +23,8 @@ internal class CIOEngine(
     override val config: CIOEngineConfig
 ) : HttpClientEngineBase("ktor-cio") {
 
-    override val dispatcher: CoroutineDispatcher = Dispatchers.clientDispatcher(config.threadsCount, "ktor-cio-dispatcher")
+    override val dispatcher: CoroutineDispatcher = 
+        Dispatchers.clientDispatcher(config.threadsCount, "ktor-cio-dispatcher")
 
     override val supportedCapabilities = setOf(HttpTimeout, WebSocketCapability, WebSocketExtensionsCapability)
 


### PR DESCRIPTION
**Subsystem**
CIO Client

**Motivation**
Both lazy implementations are immediately called on line 37, so making these properties lazy is useless and adds synchronization overhead: 

https://github.com/hfhbd/ktor/blob/248fca49fbdf63003d731dfc58ef7062b52b4435/ktor-client/ktor-client-cio/jvmAndNix/src/io/ktor/client/engine/cio/CIOEngine.kt#L34

**Solution**
Remove the laziness

