### PR TITLE
KTOR-4766 - Add basic support to use UnixSockets with CIO

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -45,8 +45,8 @@ buildscript {
     extra["native_targets_enabled"] = rootProject.properties["disable_native_targets"] == null
 
     repositories {
-        mavenLocal()
         mavenCentral()
+        mavenLocal()
         google()
         gradlePluginPortal()
         maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/dev")

--- a/ktor-client/ktor-client-cio/api/ktor-client-cio.api
+++ b/ktor-client/ktor-client-cio/api/ktor-client-cio.api
@@ -4,6 +4,18 @@ public final class io/ktor/client/engine/cio/CIO : io/ktor/client/engine/HttpCli
 	public fun toString ()Ljava/lang/String;
 }
 
+public final class io/ktor/client/engine/cio/CIOEngine : io/ktor/client/engine/HttpClientEngineBase, io/ktor/client/engine/cio/CIOHttpClientEngine {
+	public fun <init> (Lio/ktor/client/engine/cio/CIOEngineConfig;)V
+	public fun close ()V
+	public fun createAddress (Ljava/lang/String;I)Lio/ktor/network/sockets/SocketAddress;
+	public fun execute (Lio/ktor/client/request/HttpRequestData;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public synthetic fun getConfig ()Lio/ktor/client/engine/HttpClientEngineConfig;
+	public fun getConfig ()Lio/ktor/client/engine/cio/CIOEngineConfig;
+	public fun getCoroutineContext ()Lkotlin/coroutines/CoroutineContext;
+	public fun getDispatcher ()Lkotlinx/coroutines/CoroutineDispatcher;
+	public fun getSupportedCapabilities ()Ljava/util/Set;
+}
+
 public final class io/ktor/client/engine/cio/CIOEngineConfig : io/ktor/client/engine/HttpClientEngineConfig {
 	public fun <init> ()V
 	public final fun getEndpoint ()Lio/ktor/client/engine/cio/EndpointConfig;

--- a/ktor-client/ktor-client-cio/api/ktor-client-cio.api
+++ b/ktor-client/ktor-client-cio/api/ktor-client-cio.api
@@ -12,7 +12,6 @@ public final class io/ktor/client/engine/cio/CIOEngine : io/ktor/client/engine/H
 	public synthetic fun getConfig ()Lio/ktor/client/engine/HttpClientEngineConfig;
 	public fun getConfig ()Lio/ktor/client/engine/cio/CIOEngineConfig;
 	public fun getCoroutineContext ()Lkotlin/coroutines/CoroutineContext;
-	public fun getDispatcher ()Lkotlinx/coroutines/CoroutineDispatcher;
 	public fun getSupportedCapabilities ()Ljava/util/Set;
 }
 
@@ -35,6 +34,15 @@ public final class io/ktor/client/engine/cio/CIOEngineContainer : io/ktor/client
 	public fun <init> ()V
 	public fun getFactory ()Lio/ktor/client/engine/HttpClientEngineFactory;
 	public fun toString ()Ljava/lang/String;
+}
+
+public abstract interface class io/ktor/client/engine/cio/CIOHttpClientEngine : io/ktor/client/engine/HttpClientEngine {
+	public abstract fun createAddress (Ljava/lang/String;I)Lio/ktor/network/sockets/SocketAddress;
+}
+
+public final class io/ktor/client/engine/cio/CIOHttpClientEngine$DefaultImpls {
+	public static fun getSupportedCapabilities (Lio/ktor/client/engine/cio/CIOHttpClientEngine;)Ljava/util/Set;
+	public static fun install (Lio/ktor/client/engine/cio/CIOHttpClientEngine;Lio/ktor/client/HttpClient;)V
 }
 
 public final class io/ktor/client/engine/cio/EndpointConfig {

--- a/ktor-client/ktor-client-cio/jvmAndNix/src/io/ktor/client/engine/cio/CIOCommon.kt
+++ b/ktor-client/ktor-client-cio/jvmAndNix/src/io/ktor/client/engine/cio/CIOCommon.kt
@@ -30,6 +30,7 @@ public object CIO : HttpClientEngineFactory<CIOEngineConfig> {
         addToLoader()
     }
 
+    @OptIn(InternalAPI::class)
     override fun create(block: CIOEngineConfig.() -> Unit): HttpClientEngine =
         CIOEngine(CIOEngineConfig().apply(block))
 

--- a/ktor-client/ktor-client-cio/jvmAndNix/src/io/ktor/client/engine/cio/CIOCommon.kt
+++ b/ktor-client/ktor-client-cio/jvmAndNix/src/io/ktor/client/engine/cio/CIOCommon.kt
@@ -6,6 +6,7 @@
 package io.ktor.client.engine.cio
 
 import io.ktor.client.engine.*
+import io.ktor.utils.io.*
 
 /**
  * An asynchronous coroutine-based engine that can be used on JVM, Android, and Kotlin/Native.

--- a/ktor-client/ktor-client-cio/jvmAndNix/src/io/ktor/client/engine/cio/ConnectionFactory.kt
+++ b/ktor-client/ktor-client-cio/jvmAndNix/src/io/ktor/client/engine/cio/ConnectionFactory.kt
@@ -15,10 +15,10 @@ internal class ConnectionFactory(
     private val addressConnectionsLimit: Int
 ) {
     private val limit = Semaphore(connectionsLimit)
-    private val addressLimit = ConcurrentMap<InetSocketAddress, Semaphore>()
+    private val addressLimit = ConcurrentMap<SocketAddress, Semaphore>()
 
     suspend fun connect(
-        address: InetSocketAddress,
+        address: SocketAddress,
         configuration: SocketOptions.TCPClientSocketOptions.() -> Unit = {}
     ): Socket {
         limit.acquire()
@@ -39,7 +39,7 @@ internal class ConnectionFactory(
         }
     }
 
-    fun release(address: InetSocketAddress) {
+    fun release(address: SocketAddress) {
         addressLimit[address]!!.release()
         limit.release()
     }

--- a/ktor-server/ktor-server-cio/api/ktor-server-cio.api
+++ b/ktor-server/ktor-server-cio/api/ktor-server-cio.api
@@ -4,9 +4,10 @@ public final class io/ktor/server/cio/CIO : io/ktor/server/engine/ApplicationEng
 	public synthetic fun create (Lio/ktor/server/engine/ApplicationEngineEnvironment;Lkotlin/jvm/functions/Function1;)Lio/ktor/server/engine/ApplicationEngine;
 }
 
-public final class io/ktor/server/cio/CIOApplicationEngine : io/ktor/server/engine/BaseApplicationEngine {
+public final class io/ktor/server/cio/CIOApplicationEngine : io/ktor/server/engine/BaseApplicationEngine, io/ktor/server/cio/CIOApplicationEngineInterface {
 	public fun <init> (Lio/ktor/server/engine/ApplicationEngineEnvironment;Lkotlin/jvm/functions/Function1;)V
 	public fun start (Z)Lio/ktor/server/engine/ApplicationEngine;
+	public fun startHttpServer (Lkotlinx/coroutines/CoroutineScope;Lio/ktor/server/engine/EngineConnectorConfig;JLkotlin/jvm/functions/Function3;)Lio/ktor/server/cio/HttpServer;
 	public fun stop (JJ)V
 }
 
@@ -16,6 +17,14 @@ public final class io/ktor/server/cio/CIOApplicationEngine$Configuration : io/kt
 	public final fun getReuseAddress ()Z
 	public final fun setConnectionIdleTimeoutSeconds (I)V
 	public final fun setReuseAddress (Z)V
+}
+
+public abstract interface class io/ktor/server/cio/CIOApplicationEngineInterface : io/ktor/server/engine/ApplicationEngine {
+	public abstract fun startHttpServer (Lkotlinx/coroutines/CoroutineScope;Lio/ktor/server/engine/EngineConnectorConfig;JLkotlin/jvm/functions/Function3;)Lio/ktor/server/cio/HttpServer;
+}
+
+public final class io/ktor/server/cio/CIOApplicationEngineInterface$DefaultImpls {
+	public static fun getApplication (Lio/ktor/server/cio/CIOApplicationEngineInterface;)Lio/ktor/server/application/Application;
 }
 
 public final class io/ktor/server/cio/EngineMain {
@@ -51,6 +60,7 @@ public final class io/ktor/server/cio/HttpServerSettings {
 
 public final class io/ktor/server/cio/backend/HttpServerKt {
 	public static final fun httpServer (Lkotlinx/coroutines/CoroutineScope;Lio/ktor/server/cio/HttpServerSettings;Lkotlin/jvm/functions/Function3;)Lio/ktor/server/cio/HttpServer;
+	public static final fun httpServer (Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function0;Lio/ktor/server/cio/internal/WeakTimeoutQueue;Lkotlinx/coroutines/CoroutineName;Lkotlinx/coroutines/CoroutineName;Lio/ktor/network/selector/SelectorManager;Lkotlin/jvm/functions/Function3;)Lio/ktor/server/cio/HttpServer;
 }
 
 public final class io/ktor/server/cio/backend/ServerIncomingConnection {

--- a/ktor-server/ktor-server-cio/jvm/test/io/ktor/tests/server/cio/CustomSocketCIOJvmTest.kt
+++ b/ktor-server/ktor-server-cio/jvm/test/io/ktor/tests/server/cio/CustomSocketCIOJvmTest.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2014-2023 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.tests.server.cio
+
+import io.ktor.client.*
+import io.ktor.client.request.*
+import io.ktor.client.statement.*
+import io.ktor.server.engine.*
+import io.ktor.server.response.*
+import io.ktor.server.routing.*
+import io.ktor.test.dispatcher.*
+import java.nio.file.*
+import kotlin.io.path.*
+import kotlin.test.*
+
+class CustomSocketCIOJvmTest {
+
+    @Test
+    fun connectServerAndClientOverUnixSocket() = testSuspend {
+        val socket = Files.createTempFile("network", "socket").absolutePathString()
+
+        val client = HttpClient(CIOSocketClient(socket))
+        val server = embeddedServer(CIOSocket(socket)) {
+            routing {
+                get("/hello") {
+                    call.respondText("Get from Socket")
+                }
+                post("/hello") {
+                    call.respondText("Post from Socket")
+                }
+            }
+        }.start(wait = false)
+        assertEquals("Get from Socket", client.get("/hello").bodyAsText())
+        assertEquals("Post from Socket", client.post("/hello").bodyAsText())
+        server.stop(1000L, 1000L)
+    }
+}

--- a/ktor-server/ktor-server-cio/jvmAndNix/src/io/ktor/server/cio/CIOApplicationEngine.kt
+++ b/ktor-server/ktor-server-cio/jvmAndNix/src/io/ktor/server/cio/CIOApplicationEngine.kt
@@ -6,13 +6,13 @@ package io.ktor.server.cio
 
 import io.ktor.events.*
 import io.ktor.http.*
+import io.ktor.http.cio.*
 import io.ktor.server.application.*
 import io.ktor.server.cio.backend.*
 import io.ktor.server.cio.internal.*
 import io.ktor.server.engine.*
 import io.ktor.server.request.*
 import io.ktor.server.response.*
-import io.ktor.util.*
 import io.ktor.util.pipeline.*
 import io.ktor.utils.io.*
 import kotlinx.atomicfu.*
@@ -170,7 +170,7 @@ public class CIOApplicationEngine(
         return transferEncoding != null || (contentLength != null && contentLength > 0)
     }
 
-    private suspend fun ServerRequestScope.handleRequest(request: io.ktor.http.cio.Request) {
+    private suspend fun ServerRequestScope.handleRequest(request: Request) {
         withContext(userDispatcher) {
             val call = CIOApplicationCall(
                 application,

--- a/ktor-server/ktor-server-cio/jvmAndNix/src/io/ktor/server/cio/CIOApplicationRequest.kt
+++ b/ktor-server/ktor-server-cio/jvmAndNix/src/io/ktor/server/cio/CIOApplicationRequest.kt
@@ -16,8 +16,8 @@ internal class CIOApplicationRequest(
     call: PipelineCall,
     remoteAddress: NetworkAddress?,
     localAddress: NetworkAddress?,
-    private val input: ByteReadChannel,
-    private val request: io.ktor.http.cio.Request
+    input: ByteReadChannel,
+    private val request: Request
 ) : BaseApplicationRequest(call) {
     override val cookies: RequestCookies by lazy { RequestCookies(this) }
 

--- a/ktor-server/ktor-server-cio/jvmAndNix/src/io/ktor/server/cio/backend/HttpServer.kt
+++ b/ktor-server/ktor-server-cio/jvmAndNix/src/io/ktor/server/cio/backend/HttpServer.kt
@@ -30,7 +30,9 @@ public fun CoroutineScope.httpServer(
             aSocket(selector).tcp().bind(
                 hostname = settings.host,
                 port = settings.port
-            )
+            ) {
+                reuseAddress = settings.reuseAddress
+            }
         },
         serverJobName = CoroutineName("server-root-${settings.port}"),
         acceptJobName = CoroutineName("accept-${settings.port}"),
@@ -68,9 +70,7 @@ public fun CoroutineScope.httpServer(
     )
 
     val acceptJob = launch(serverJob + acceptJobName) {
-        createServer() {
-            reuseAddress = settings.reuseAddress
-        }.use { server ->
+        createServer().use { server ->
             socket.complete(server)
 
             val exceptionHandler = coroutineContext[CoroutineExceptionHandler]

--- a/ktor-server/ktor-server-cio/jvmAndNix/test/io/ktor/tests/server/cio/CustomSocketCIOTest.kt
+++ b/ktor-server/ktor-server-cio/jvmAndNix/test/io/ktor/tests/server/cio/CustomSocketCIOTest.kt
@@ -1,0 +1,93 @@
+package io.ktor.tests.server.cio
+
+import io.ktor.client.*
+import io.ktor.client.engine.*
+import io.ktor.client.engine.cio.*
+import io.ktor.client.request.*
+import io.ktor.client.statement.*
+import io.ktor.http.cio.*
+import io.ktor.network.selector.*
+import io.ktor.network.sockets.*
+import io.ktor.server.application.*
+import io.ktor.server.cio.*
+import io.ktor.server.cio.backend.*
+import io.ktor.server.cio.internal.*
+import io.ktor.server.engine.*
+import io.ktor.server.response.*
+import io.ktor.server.routing.*
+import io.ktor.test.dispatcher.*
+import io.ktor.util.*
+import kotlinx.coroutines.*
+import kotlinx.coroutines.channels.*
+import java.nio.file.*
+import kotlin.io.path.*
+import kotlin.test.*
+
+class CustomSocketCIOTest {
+    @Test
+    fun connectServerAndClientOverUnixSocket() = testSuspend {
+        val socket = Files.createTempFile("network", "socket").absolutePathString()
+
+        val client = HttpClient(CIOSocketClient(socket))
+        val server = embeddedServer(CIOSocket(socket)) {
+            routing {
+                get("/hello") {
+                    call.respondText("Get from Socket")
+                }
+                post("/hello") {
+                    call.respondText("Post from Socket")
+                }
+            }
+        }.start(wait = false)
+        assertEquals("Get from Socket", client.get("/hello").bodyAsText())
+        assertEquals("Post from Socket", client.post("/hello").bodyAsText())
+        server.stop(1000L, 1000L)
+    }
+}
+
+class CIOSocketClient(private val socket: String) : HttpClientEngineFactory<CIOEngineConfig> {
+    override fun create(block: CIOEngineConfig.() -> Unit): CIOSocketClientEngine {
+        return CIOSocketClientEngine(socket, CIOEngineConfig().apply(block))
+    }
+}
+
+@OptIn(InternalAPI::class)
+class CIOSocketClientEngine(private val socket: String, config: CIOEngineConfig) :
+    CIOHttpClientEngine by CIOEngine(config) {
+    override fun createAddress(host: String, port: Int): SocketAddress = UnixSocketAddress(socket)
+}
+
+class CIOSocket(private val socket: String) :
+    ApplicationEngineFactory<CIOSocketApplicationEngine, CIOApplicationEngine.Configuration> {
+    override fun create(
+        environment: ApplicationEngineEnvironment,
+        configure: CIOApplicationEngine.Configuration.() -> Unit
+    ): CIOSocketApplicationEngine = CIOSocketApplicationEngine(socket, environment, configure)
+}
+
+class CIOSocketApplicationEngine(
+    private val socket: String,
+    environment: ApplicationEngineEnvironment,
+    configure: CIOApplicationEngine.Configuration.() -> Unit
+) : CIOApplicationEngineInterface by CIOApplicationEngine(environment, configure) {
+
+    @InternalAPI
+    override fun CoroutineScope.startHttpServer(
+        connectorConfig: EngineConnectorConfig,
+        connectionIdleTimeoutSeconds: Long,
+        handleRequest: suspend ServerRequestScope.(Request) -> Unit
+    ): HttpServer {
+        val selector = SelectorManager(coroutineContext)
+        return httpServer(
+            createServer = {
+                aSocket(selector).tcp().bind(UnixSocketAddress(socket))
+            },
+            timeout = WeakTimeoutQueue(connectionIdleTimeoutSeconds * 1000L),
+            serverJobName = CoroutineName("server-root-$socket"),
+            acceptJobName = CoroutineName("accept-$socket"),
+            selector = selector
+        ) { request ->
+            handleRequest(request)
+        }
+    }
+}

--- a/ktor-server/ktor-server-cio/jvmAndNix/test/io/ktor/tests/server/cio/CustomSocketCIOTest.kt
+++ b/ktor-server/ktor-server-cio/jvmAndNix/test/io/ktor/tests/server/cio/CustomSocketCIOTest.kt
@@ -1,49 +1,16 @@
 package io.ktor.tests.server.cio
 
-import io.ktor.client.*
 import io.ktor.client.engine.*
 import io.ktor.client.engine.cio.*
-import io.ktor.client.request.*
-import io.ktor.client.statement.*
 import io.ktor.http.cio.*
 import io.ktor.network.selector.*
 import io.ktor.network.sockets.*
-import io.ktor.server.application.*
 import io.ktor.server.cio.*
 import io.ktor.server.cio.backend.*
 import io.ktor.server.cio.internal.*
 import io.ktor.server.engine.*
-import io.ktor.server.response.*
-import io.ktor.server.routing.*
-import io.ktor.test.dispatcher.*
-import io.ktor.util.*
+import io.ktor.utils.io.*
 import kotlinx.coroutines.*
-import kotlinx.coroutines.channels.*
-import java.nio.file.*
-import kotlin.io.path.*
-import kotlin.test.*
-
-class CustomSocketCIOTest {
-    @Test
-    fun connectServerAndClientOverUnixSocket() = testSuspend {
-        val socket = Files.createTempFile("network", "socket").absolutePathString()
-
-        val client = HttpClient(CIOSocketClient(socket))
-        val server = embeddedServer(CIOSocket(socket)) {
-            routing {
-                get("/hello") {
-                    call.respondText("Get from Socket")
-                }
-                post("/hello") {
-                    call.respondText("Post from Socket")
-                }
-            }
-        }.start(wait = false)
-        assertEquals("Get from Socket", client.get("/hello").bodyAsText())
-        assertEquals("Post from Socket", client.post("/hello").bodyAsText())
-        server.stop(1000L, 1000L)
-    }
-}
 
 class CIOSocketClient(private val socket: String) : HttpClientEngineFactory<CIOEngineConfig> {
     override fun create(block: CIOEngineConfig.() -> Unit): CIOSocketClientEngine {

--- a/ktor-server/ktor-server-cio/jvmAndNix/test/io/ktor/tests/server/cio/RAWExample.kt
+++ b/ktor-server/ktor-server-cio/jvmAndNix/test/io/ktor/tests/server/cio/RAWExample.kt
@@ -8,6 +8,7 @@ import io.ktor.http.*
 import io.ktor.http.cio.*
 import io.ktor.server.cio.*
 import io.ktor.server.cio.backend.*
+import io.ktor.util.*
 import io.ktor.util.date.*
 import io.ktor.utils.io.*
 import io.ktor.utils.io.core.*
@@ -28,7 +29,7 @@ private val notFound404_11 = RequestResponseBuilder().apply {
 /**
  * This is just an example demonstrating how to create CIO low-level http server
  */
-@OptIn(DelicateCoroutinesApi::class)
+@OptIn(InternalAPI::class, DelicateCoroutinesApi::class)
 fun main() {
     val settings = HttpServerSettings()
 


### PR DESCRIPTION
**Subsystem**
CIO Client and Server

**Motivation**
Add basic support for unix sockets with a custom CIO client and server. Native (and better) support would require breaking changes.

**Solution**
Extract resolving the socketAddress into new functions without breaking changes. A user can now implement unix socket support using a custom cio client/server with minimal code.

