### PR TITLE
KTOR-5420 Fix DropwizardMetricsPlugin when using with StatusPages plugin

### DIFF
--- a/ktor-server/ktor-server-plugins/ktor-server-metrics/build.gradle.kts
+++ b/ktor-server/ktor-server-plugins/ktor-server-metrics/build.gradle.kts
@@ -7,5 +7,10 @@ kotlin {
                 api(libs.dropwizard.jvm)
             }
         }
+        jvmTest {
+            dependencies {
+                api(project(":ktor-server:ktor-server-plugins:ktor-server-status-pages"))
+            }
+        }
     }
 }

--- a/ktor-server/ktor-server-plugins/ktor-server-metrics/build.gradle.kts
+++ b/ktor-server/ktor-server-plugins/ktor-server-metrics/build.gradle.kts
@@ -10,6 +10,7 @@ kotlin {
         jvmTest {
             dependencies {
                 api(project(":ktor-server:ktor-server-plugins:ktor-server-status-pages"))
+                api(project(":ktor-server:ktor-server-plugins:ktor-server-cors"))
             }
         }
     }

--- a/ktor-server/ktor-server-plugins/ktor-server-metrics/jvm/src/io/ktor/server/metrics/dropwizard/DropwizardMetricsUtils.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-metrics/jvm/src/io/ktor/server/metrics/dropwizard/DropwizardMetricsUtils.kt
@@ -5,7 +5,6 @@
 package io.ktor.server.metrics.dropwizard
 
 import com.codahale.metrics.*
-import io.ktor.server.application.*
 import io.ktor.util.*
 
 internal class RoutingMetrics(val name: String, val context: Timer.Context)
@@ -13,15 +12,3 @@ internal val routingMetricsKey = AttributeKey<RoutingMetrics>("metrics")
 
 internal data class CallMeasure constructor(val timer: Timer.Context)
 internal val measureKey = AttributeKey<CallMeasure>("metrics")
-
-internal object AfterCall : Hook<(ApplicationCall) -> Unit> {
-    override fun install(pipeline: ApplicationCallPipeline, handler: (ApplicationCall) -> Unit) {
-        pipeline.intercept(ApplicationCallPipeline.Monitoring) {
-            try {
-                proceed()
-            } finally {
-                handler(call)
-            }
-        }
-    }
-}

--- a/ktor-server/ktor-server-plugins/ktor-server-metrics/jvm/src/io/ktor/server/metrics/dropwizard/DropwizardMetricsUtils.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-metrics/jvm/src/io/ktor/server/metrics/dropwizard/DropwizardMetricsUtils.kt
@@ -8,7 +8,7 @@ import com.codahale.metrics.*
 import io.ktor.util.*
 
 internal class RoutingMetrics(val name: String, val context: Timer.Context)
-internal val routingMetricsKey = AttributeKey<RoutingMetrics>("metrics")
+internal val routingMetricsKey = AttributeKey<RoutingMetrics>("routingMetrics")
 
 internal data class CallMeasure constructor(val timer: Timer.Context)
 internal val measureKey = AttributeKey<CallMeasure>("metrics")

--- a/ktor-server/ktor-server-plugins/ktor-server-metrics/jvm/test/io/ktor/server/metrics/dropwizard/DropwizardMetricsTests.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-metrics/jvm/test/io/ktor/server/metrics/dropwizard/DropwizardMetricsTests.kt
@@ -6,7 +6,10 @@ package io.ktor.server.metrics.dropwizard
 
 import com.codahale.metrics.*
 import com.codahale.metrics.jvm.*
+import io.ktor.client.request.*
+import io.ktor.http.*
 import io.ktor.server.application.*
+import io.ktor.server.plugins.statuspages.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
 import io.ktor.server.testing.*
@@ -94,5 +97,30 @@ class DropwizardMetricsTests {
         handleRequest { uri = "/uri" }
 
         assertThat(registry.names, everyItem(startsWith(prefix)))
+    }
+
+    @Test
+    fun `with StatusPages plugin`() = testApplication {
+        install(StatusPages) {
+            exception<Throwable> { call, _ ->
+                call.respond(HttpStatusCode.InternalServerError)
+            }
+        }
+
+        val testRegistry = MetricRegistry()
+        install(DropwizardMetrics) {
+            registry = testRegistry
+            baseName = ""
+        }
+
+        routing {
+            get("/uri") {
+                throw RuntimeException("Oops")
+            }
+        }
+
+        client.get("/uri")
+
+        assertEquals(1, testRegistry.meter("/uri/(method:GET).500").count)
     }
 }


### PR DESCRIPTION
**Subsystem**
Server

**Motivation**
[KTOR-5420](https://youtrack.jetbrains.com/issue/KTOR-5420/DropwizardMetricsPlugin-logs-status-code-incorrectly-when-is-used-together-with-StatusPages-plugin)

**Solution**
Invoke phases for DropwizardMetricsPlugin after phase `CallFalled`

