### PR TITLE
KTOR-5740 Add opportunity to pass type info into receiveDeserializedBase and other

### DIFF
--- a/ktor-client/ktor-client-core/api/ktor-client-core.api
+++ b/ktor-client/ktor-client-core/api/ktor-client-core.api
@@ -861,6 +861,8 @@ public final class io/ktor/client/plugins/websocket/BuildersKt {
 
 public final class io/ktor/client/plugins/websocket/ClientSessionsKt {
 	public static final fun getConverter (Lio/ktor/client/plugins/websocket/DefaultClientWebSocketSession;)Lio/ktor/serialization/WebsocketContentConverter;
+	public static final fun receiveDeserialized (Lio/ktor/client/plugins/websocket/DefaultClientWebSocketSession;Lio/ktor/util/reflect/TypeInfo;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun sendSerialized (Lio/ktor/client/plugins/websocket/DefaultClientWebSocketSession;Ljava/lang/Object;Lio/ktor/util/reflect/TypeInfo;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public abstract interface class io/ktor/client/plugins/websocket/ClientWebSocketSession : io/ktor/websocket/WebSocketSession {

--- a/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/websocket/ClientSessions.kt
+++ b/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/websocket/ClientSessions.kt
@@ -68,6 +68,8 @@ public suspend inline fun <reified T> DefaultClientWebSocketSession.sendSerializ
  * In this case, [WebsocketDeserializeException.frame] contains the received frame.
  * May throw [ClosedReceiveChannelException] if a channel was closed
  *
+ * @param typeInfo Type info of [T]. Can be retrieved with [typeInfo] fun and will be used to work with result [T] type
+ *
  * @throws WebsocketConverterNotFoundException if no [contentConverter] is found for the [WebSockets] plugin
  * @throws WebsocketDeserializeException if the received frame can't be deserialized to type [T]
  */

--- a/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/websocket/ClientSessions.kt
+++ b/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/websocket/ClientSessions.kt
@@ -7,6 +7,7 @@ package io.ktor.client.plugins.websocket
 import io.ktor.client.call.*
 import io.ktor.client.plugins.*
 import io.ktor.serialization.*
+import io.ktor.util.*
 import io.ktor.util.reflect.*
 import io.ktor.utils.io.*
 import io.ktor.websocket.*
@@ -48,17 +49,34 @@ public val DefaultClientWebSocketSession.converter: WebsocketContentConverter?
  * Frames sent after a Close frame are silently ignored.
  * Note that a Close frame could be sent automatically in reply to a peer's Close frame unless it is a raw WebSocket session.
  *
+ * @param typeInfo Type info of [T]. Can be retrieved with [typeInfo] function.
+ *
  * @throws WebsocketConverterNotFoundException if no [contentConverter] is found for the [WebSockets] plugin
  */
-public suspend inline fun <reified T> DefaultClientWebSocketSession.sendSerialized(data: T) {
+@OptIn(InternalAPI::class)
+public suspend fun DefaultClientWebSocketSession.sendSerialized(data: Any?, typeInfo: TypeInfo) {
     val converter = converter
         ?: throw WebsocketConverterNotFoundException("No converter was found for websocket")
 
     sendSerializedBase(
         data,
+        typeInfo,
         converter,
         call.request.headers.suitableCharset()
     )
+}
+
+/**
+ * Serializes [data] to a frame and enqueues this frame.
+ * May suspend if the outgoing queue is full.
+ * If the outgoing channel is already closed, throws an exception, so it is impossible to transfer any message.
+ * Frames sent after a Close frame are silently ignored.
+ * Note that a Close frame could be sent automatically in reply to a peer's Close frame unless it is a raw WebSocket session.
+ *
+ * @throws WebsocketConverterNotFoundException if no [contentConverter] is found for the [WebSockets] plugin
+ */
+public suspend inline fun <reified T> DefaultClientWebSocketSession.sendSerialized(data: T) {
+    sendSerialized(data, typeInfo<T>())
 }
 
 /**
@@ -68,16 +86,18 @@ public suspend inline fun <reified T> DefaultClientWebSocketSession.sendSerializ
  * In this case, [WebsocketDeserializeException.frame] contains the received frame.
  * May throw [ClosedReceiveChannelException] if a channel was closed
  *
- * @param typeInfo Type info of [T]. Can be retrieved with [typeInfo] fun and will be used to work with result [T] type
+ * @param typeInfo Type info of [T]. Can be retrieved with [typeInfo] function.
  *
  * @throws WebsocketConverterNotFoundException if no [contentConverter] is found for the [WebSockets] plugin
  * @throws WebsocketDeserializeException if the received frame can't be deserialized to type [T]
  */
-public suspend inline fun <T> DefaultClientWebSocketSession.receiveDeserialized(typeInfo: TypeInfo): T {
+@OptIn(InternalAPI::class)
+public suspend fun <T> DefaultClientWebSocketSession.receiveDeserialized(typeInfo: TypeInfo): T {
     val converter = converter
         ?: throw WebsocketConverterNotFoundException("No converter was found for websocket")
 
-    return receiveDeserializedBase<T>(
+    @Suppress("UNCHECKED_CAST")
+    return receiveDeserializedBase(
         typeInfo,
         converter,
         call.request.headers.suitableCharset()
@@ -94,6 +114,5 @@ public suspend inline fun <T> DefaultClientWebSocketSession.receiveDeserialized(
  * @throws WebsocketConverterNotFoundException if no [contentConverter] is found for the [WebSockets] plugin
  * @throws WebsocketDeserializeException if the received frame can't be deserialized to type [T]
  */
-public suspend inline fun <reified T> DefaultClientWebSocketSession.receiveDeserialized(): T = receiveDeserialized(
-    typeInfo<T>()
-)
+public suspend inline fun <reified T> DefaultClientWebSocketSession.receiveDeserialized(): T =
+    receiveDeserialized(typeInfo<T>())

--- a/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/websocket/ClientSessions.kt
+++ b/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/websocket/ClientSessions.kt
@@ -71,12 +71,27 @@ public suspend inline fun <reified T> DefaultClientWebSocketSession.sendSerializ
  * @throws WebsocketConverterNotFoundException if no [contentConverter] is found for the [WebSockets] plugin
  * @throws WebsocketDeserializeException if the received frame can't be deserialized to type [T]
  */
-public suspend inline fun <reified T> DefaultClientWebSocketSession.receiveDeserialized(): T {
+public suspend inline fun <T> DefaultClientWebSocketSession.receiveDeserialized(typeInfo: TypeInfo): T {
     val converter = converter
         ?: throw WebsocketConverterNotFoundException("No converter was found for websocket")
 
     return receiveDeserializedBase<T>(
+        typeInfo,
         converter,
         call.request.headers.suitableCharset()
     ) as T
 }
+
+/**
+ * Dequeues a frame and deserializes it to the type [T] using WebSocket content converter.
+ * May throw an exception [WebsocketDeserializeException] if the converter can't deserialize frame data to type [T].
+ * May throw [WebsocketDeserializeException] if the received frame type is not [Frame.Text] or [Frame.Binary].
+ * In this case, [WebsocketDeserializeException.frame] contains the received frame.
+ * May throw [ClosedReceiveChannelException] if a channel was closed
+ *
+ * @throws WebsocketConverterNotFoundException if no [contentConverter] is found for the [WebSockets] plugin
+ * @throws WebsocketDeserializeException if the received frame can't be deserialized to type [T]
+ */
+public suspend inline fun <reified T> DefaultClientWebSocketSession.receiveDeserialized(): T = receiveDeserialized(
+    typeInfo<T>()
+)

--- a/ktor-client/ktor-client-plugins/ktor-client-content-negotiation/ktor-client-content-negotiation-tests/jvm/src/io/ktor/client/plugins/contentnegotiation/tests/JsonContentNegotiationTest.kt
+++ b/ktor-client/ktor-client-plugins/ktor-client-content-negotiation/ktor-client-content-negotiation-tests/jvm/src/io/ktor/client/plugins/contentnegotiation/tests/JsonContentNegotiationTest.kt
@@ -311,7 +311,6 @@ sealed class Data
 @Serializable
 class DataType(val value: String) : Data()
 
-
 @Serializable
 class SealedWrapper(val value: Sealed)
 

--- a/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/WebSocketTest.kt
+++ b/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/WebSocketTest.kt
@@ -177,6 +177,26 @@ class WebSocketTest : ClientLoader() {
     }
 
     @Test
+    fun testWebSocketSerializationWithExplicitTypeInfo() = clientTests(ENGINES_WITHOUT_WS) {
+        config {
+            WebSockets {
+                contentConverter = customContentConverter
+            }
+        }
+
+        test { client ->
+            client.webSocket("$TEST_WEBSOCKET_SERVER/websockets/echo") {
+                repeat(TEST_SIZE) {
+                    val originalData = Data("hello")
+                    sendSerialized(originalData, typeInfo<Data>())
+                    val actual = receiveDeserialized<Data>(typeInfo<Data>())
+                    assertTrue { actual == originalData }
+                }
+            }
+        }
+    }
+
+    @Test
     fun testSerializationWithNoConverter() = clientTests(ENGINES_WITHOUT_WS) {
         config {
             WebSockets {

--- a/ktor-server/ktor-server-plugins/ktor-server-websockets/api/ktor-server-websockets.api
+++ b/ktor-server/ktor-server-plugins/ktor-server-websockets/api/ktor-server-websockets.api
@@ -53,6 +53,8 @@ public final class io/ktor/server/websocket/WebSocketServerSession$DefaultImpls 
 public final class io/ktor/server/websocket/WebSocketServerSessionKt {
 	public static final fun getApplication (Lio/ktor/server/websocket/WebSocketServerSession;)Lio/ktor/server/application/Application;
 	public static final fun getConverter (Lio/ktor/server/websocket/WebSocketServerSession;)Lio/ktor/serialization/WebsocketContentConverter;
+	public static final fun receiveDeserialized (Lio/ktor/server/websocket/WebSocketServerSession;Lio/ktor/util/reflect/TypeInfo;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun sendSerialized (Lio/ktor/server/websocket/WebSocketServerSession;Ljava/lang/Object;Lio/ktor/util/reflect/TypeInfo;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public final class io/ktor/server/websocket/WebSocketUpgrade : io/ktor/http/content/OutgoingContent$ProtocolUpgrade {

--- a/ktor-server/ktor-server-plugins/ktor-server-websockets/build.gradle.kts
+++ b/ktor-server/ktor-server-plugins/ktor-server-websockets/build.gradle.kts
@@ -11,6 +11,7 @@ kotlin.sourceSets {
     jvmAndNixTest {
         dependencies {
             api(project(":ktor-server:ktor-server-plugins:ktor-server-content-negotiation"))
+            api(project(":ktor-client:ktor-client-plugins:ktor-client-websockets"))
         }
     }
 }

--- a/ktor-server/ktor-server-plugins/ktor-server-websockets/jvmAndNix/src/io/ktor/server/websocket/WebSocketServerSession.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-websockets/jvmAndNix/src/io/ktor/server/websocket/WebSocketServerSession.kt
@@ -6,6 +6,7 @@ package io.ktor.server.websocket
 
 import io.ktor.serialization.*
 import io.ktor.server.application.*
+import io.ktor.util.*
 import io.ktor.util.reflect.*
 import io.ktor.utils.io.*
 import io.ktor.websocket.*
@@ -46,17 +47,29 @@ public val WebSocketServerSession.converter: WebsocketContentConverter?
  * Frames sent after a Close frame are silently ignored.
  * Note that a Close frame could be sent automatically in reply to a peer's Close frame unless it is a raw WebSocket session.
  *
+ * @param typeInfo Type info of [T]. Can be retrieved with [typeInfo] function.
+ *
  * @throws WebsocketConverterNotFoundException if no [contentConverter] is found for the [WebSockets] plugin
  */
-public suspend inline fun <reified T> WebSocketServerSession.sendSerialized(data: T) {
+@OptIn(InternalAPI::class)
+public suspend fun WebSocketServerSession.sendSerialized(data: Any?, typeInfo: TypeInfo) {
     val converter = converter
         ?: throw WebsocketConverterNotFoundException("No converter was found for websocket")
 
-    sendSerializedBase(
-        data,
-        converter,
-        call.request.headers.suitableCharset()
-    )
+    sendSerializedBase(data, typeInfo, converter, call.request.headers.suitableCharset())
+}
+
+/**
+ * Serializes [data] to a frame and enqueues this frame.
+ * May suspend if the outgoing queue is full.
+ * If the outgoing channel is already closed, throws an exception, so it is impossible to transfer any message.
+ * Frames sent after a Close frame are silently ignored.
+ * Note that a Close frame could be sent automatically in reply to a peer's Close frame unless it is a raw WebSocket session.
+ *
+ * @throws WebsocketConverterNotFoundException if no [contentConverter] is found for the [WebSockets] plugin
+ */
+public suspend inline fun <reified T> WebSocketServerSession.sendSerialized(data: T) {
+    sendSerialized(data, typeInfo<T>())
 }
 
 /**
@@ -66,18 +79,22 @@ public suspend inline fun <reified T> WebSocketServerSession.sendSerialized(data
  * In this case, [WebsocketDeserializeException.frame] contains the received frame.
  * May throw [ClosedReceiveChannelException] if a channel was closed
  *
+ * @param typeInfo Type info of [T]. Can be retrieved with [typeInfo] function.
+
  * @throws WebsocketConverterNotFoundException if no [contentConverter] is found for the [WebSockets] plugin
  * @throws WebsocketDeserializeException if the received frame can't be deserialized to type [T]
  */
-public suspend inline fun <reified T> WebSocketServerSession.receiveDeserialized(): T {
+@OptIn(InternalAPI::class)
+public suspend fun <T> WebSocketServerSession.receiveDeserialized(typeInfo: TypeInfo): T {
     val converter = converter
         ?: throw WebsocketConverterNotFoundException("No converter was found for websocket")
 
-    return receiveDeserializedBase<T>(
-        converter,
-        call.request.headers.suitableCharset()
-    ) as T
+    @Suppress("UNCHECKED_CAST")
+    return receiveDeserializedBase(typeInfo, converter, call.request.headers.suitableCharset()) as T
 }
+
+public suspend inline fun <reified T> WebSocketServerSession.receiveDeserialized(): T =
+    receiveDeserialized(typeInfo<T>())
 
 internal fun WebSocketSession.toServerSession(call: ApplicationCall): WebSocketServerSession =
     DelegatedWebSocketServerSession(call, this)

--- a/ktor-shared/ktor-websocket-serialization/api/ktor-websocket-serialization.api
+++ b/ktor-shared/ktor-websocket-serialization/api/ktor-websocket-serialization.api
@@ -1,0 +1,5 @@
+public final class io/ktor/websocket/serialization/WebsocketChannelSerializationKt {
+	public static final fun receiveDeserializedBase (Lio/ktor/websocket/WebSocketSession;Lio/ktor/util/reflect/TypeInfo;Lio/ktor/serialization/WebsocketContentConverter;Ljava/nio/charset/Charset;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun sendSerializedBase (Lio/ktor/websocket/WebSocketSession;Ljava/lang/Object;Lio/ktor/util/reflect/TypeInfo;Lio/ktor/serialization/WebsocketContentConverter;Ljava/nio/charset/Charset;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+

--- a/ktor-shared/ktor-websocket-serialization/common/src/io/ktor/websocket/serialization/WebsocketChannelSerialization.kt
+++ b/ktor-shared/ktor-websocket-serialization/common/src/io/ktor/websocket/serialization/WebsocketChannelSerialization.kt
@@ -39,6 +39,7 @@ public suspend inline fun <reified T> WebSocketSession.sendSerializedBase(
  * In this case, [WebsocketDeserializeException.frame] contains the received frame.
  * May throw [ClosedReceiveChannelException] if a channel was closed
  *
+ * @param typeInfo Type info of [T]. Can be retrieved with [typeInfo] fun and will be used to work with result [T] type
  * @param converter The WebSocket converter
  * @param charset Response charset
  *

--- a/ktor-shared/ktor-websocket-serialization/common/src/io/ktor/websocket/serialization/WebsocketChannelSerialization.kt
+++ b/ktor-shared/ktor-websocket-serialization/common/src/io/ktor/websocket/serialization/WebsocketChannelSerialization.kt
@@ -1,13 +1,14 @@
-package io.ktor.websocket.serialization
-
-import io.ktor.serialization.*
-import io.ktor.util.reflect.*
-import io.ktor.utils.io.charsets.*
-import io.ktor.websocket.*
-
 /*
  * Copyright 2014-2021 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
+
+package io.ktor.websocket.serialization
+
+import io.ktor.serialization.*
+import io.ktor.util.*
+import io.ktor.util.reflect.*
+import io.ktor.utils.io.charsets.*
+import io.ktor.websocket.*
 
 /**
  * Serializes [data] to a frame and enqueues this frame.
@@ -20,14 +21,35 @@ import io.ktor.websocket.*
  * @param converter The WebSocket converter
  * @param charset Response charset
  */
+@InternalAPI
 public suspend inline fun <reified T> WebSocketSession.sendSerializedBase(
-    data: T,
+    data: Any?,
+    converter: WebsocketContentConverter,
+    charset: Charset
+): Unit = sendSerializedBase(data, typeInfo<T>(), converter, charset)
+
+/**
+ * Serializes [data] to a frame and enqueues this frame.
+ * May suspend if the [outgoing] queue is full.
+ * If the [outgoing] channel is already closed, throws an exception, so it is impossible to transfer any message.
+ * Frames sent after a Close frame are silently ignored.
+ * Note that a Close frame could be sent automatically in reply to a peer's Close frame unless it is a raw WebSocket session.
+ *
+ * @param data The data to serialize
+ * @param typeInfo Type info of [T]. Can be retrieved with [typeInfo] function.
+ * @param converter The WebSocket converter
+ * @param charset Response charset
+ */
+@InternalAPI
+public suspend fun WebSocketSession.sendSerializedBase(
+    data: Any?,
+    typeInfo: TypeInfo,
     converter: WebsocketContentConverter,
     charset: Charset
 ) {
     val serializedData = converter.serializeNullable(
         charset = charset,
-        typeInfo = typeInfo<T>(),
+        typeInfo = typeInfo,
         value = data
     )
     outgoing.send(serializedData)
@@ -39,14 +61,33 @@ public suspend inline fun <reified T> WebSocketSession.sendSerializedBase(
  * In this case, [WebsocketDeserializeException.frame] contains the received frame.
  * May throw [ClosedReceiveChannelException] if a channel was closed
  *
- * @param typeInfo Type info of [T]. Can be retrieved with [typeInfo] fun and will be used to work with result [T] type
  * @param converter The WebSocket converter
  * @param charset Response charset
  *
  * @returns A deserialized value or throws [WebsocketDeserializeException] if the [converter]
  * can't deserialize frame data to type [T]
  */
+@InternalAPI
 public suspend inline fun <reified T> WebSocketSession.receiveDeserializedBase(
+    converter: WebsocketContentConverter,
+    charset: Charset
+): Any? = receiveDeserializedBase(typeInfo<T>(), converter, charset)
+
+/**
+ * Dequeues a frame and deserializes it to the type [T] using [converter].
+ * May throw [WebsocketDeserializeException] if the received frame type is not [Frame.Text] or [Frame.Binary].
+ * In this case, [WebsocketDeserializeException.frame] contains the received frame.
+ * May throw [ClosedReceiveChannelException] if a channel was closed
+ *
+ * @param typeInfo Type info of [T]. Can be retrieved with [typeInfo] function.
+ * @param converter The WebSocket converter
+ * @param charset Response charset
+ *
+ * @returns A deserialized value or throws [WebsocketDeserializeException] if the [converter]
+ * can't deserialize frame data to type [T]
+ */
+@InternalAPI
+public suspend fun WebSocketSession.receiveDeserializedBase(
     typeInfo: TypeInfo,
     converter: WebsocketContentConverter,
     charset: Charset
@@ -65,7 +106,7 @@ public suspend inline fun <reified T> WebSocketSession.receiveDeserializedBase(
         typeInfo = typeInfo,
         content = frame
     )
-    
+
     when {
         typeInfo.type.isInstance(result) -> return result
         result == null -> {
@@ -75,29 +116,8 @@ public suspend inline fun <reified T> WebSocketSession.receiveDeserializedBase(
     }
 
     throw WebsocketDeserializeException(
-        "Can't deserialize value : expected value of type ${T::class.simpleName}," +
-            " got ${result::class.simpleName}",
+        "Can't deserialize value: expected value of type ${typeInfo.type.simpleName}," +
+            " got ${result!!::class.simpleName}",
         frame = frame
     )
 }
-
-/**
- * Dequeues a frame and deserializes it to the type [T] using [converter].
- * May throw [WebsocketDeserializeException] if the received frame type is not [Frame.Text] or [Frame.Binary].
- * In this case, [WebsocketDeserializeException.frame] contains the received frame.
- * May throw [ClosedReceiveChannelException] if a channel was closed
- *
- * @param converter The WebSocket converter
- * @param charset Response charset
- *
- * @returns A deserialized value or throws [WebsocketDeserializeException] if the [converter]
- * can't deserialize frame data to type [T]
- */
-public suspend inline fun <reified T> WebSocketSession.receiveDeserializedBase(
-    converter: WebsocketContentConverter,
-    charset: Charset
-): Any? = receiveDeserializedBase(
-    typeInfo<T>(),
-    converter,
-    charset
-)


### PR DESCRIPTION
**Subsystem**

Client, Websockets

**Motivation**

Sometimes it is not possible to use reified parameters when creating websockets and use deserialization of result

**Solution**

In that case it is reasonable to extract type info into parameters and provide API to use websockets with the prepared type info
