### PR TITLE
Fix perioud typo to period

### DIFF
--- a/ktor-shared/ktor-websockets/common/src/io/ktor/websocket/PingPong.kt
+++ b/ktor-shared/ktor-websockets/common/src/io/ktor/websocket/PingPong.kt
@@ -53,7 +53,7 @@ internal fun CoroutineScope.pinger(
     val channel = Channel<Frame.Pong>(Channel.UNLIMITED)
 
     launch(actorJob + PingerCoroutineName) {
-        LOGGER.trace("Starting WebSocket pinger coroutine with perioud $periodMillis ms and timeout $timeoutMillis ms")
+        LOGGER.trace("Starting WebSocket pinger coroutine with period $periodMillis ms and timeout $timeoutMillis ms")
         val random = Random(getTimeMillis())
         val pingIdBytes = ByteArray(32)
 


### PR DESCRIPTION
**Subsystem**
Server

**Motivation**
The TRACE logs prints typo with WebSocket PingPong. Original message:
```
2023-01-16 15:13:00.799 [eventLoopGroupProxy-3-1] TRACE io.ktor.websocket.WebSocket - Starting WebSocket pinger coroutine with perioud 5000 ms and timeout 5000 ms
```

**Solution**
Fix the typo from `perioud` to `period`

