### PR TITLE
KTOR-5443 Fix FileNotFoundException for long file names in FileStorage

### DIFF
--- a/buildSrc/src/main/kotlin/test/server/tests/Cache.kt
+++ b/buildSrc/src/main/kotlin/test/server/tests/Cache.kt
@@ -94,6 +94,9 @@ internal fun Application.cacheTestServer() {
                 call.response.cacheControl(CacheControl.NoCache(CacheControl.Visibility.Private))
                 call.respondText("private")
             }
+            get("/cache_${"a".repeat(256)}") {
+                call.respondText { "abc" }
+            }
         }
     }
 }

--- a/ktor-client/ktor-client-core/jvm/src/io/ktor/client/plugins/cache/storage/FileCacheStorage.kt
+++ b/ktor-client/ktor-client-core/jvm/src/io/ktor/client/plugins/cache/storage/FileCacheStorage.kt
@@ -14,6 +14,7 @@ import io.ktor.utils.io.jvm.javaio.*
 import kotlinx.coroutines.*
 import kotlinx.coroutines.sync.*
 import java.io.*
+import java.security.*
 
 /**
  * Creates storage that uses file system to store cache data.
@@ -77,7 +78,7 @@ private class FileCacheStorage(
         return readCache(key(url)).find { it.varyKeys == varyKeys }
     }
 
-    private fun key(url: Url) = hex(url.toString().encodeToByteArray())
+    private fun key(url: Url) = hex(MessageDigest.getInstance("MD5").digest(url.toString().encodeToByteArray()))
 
     private suspend fun writeCache(urlHex: String, caches: List<CachedResponseData>) = coroutineScope {
         val mutex = mutexes.computeIfAbsent(urlHex) { Mutex() }

--- a/ktor-client/ktor-client-tests/jvm/test/io/ktor/client/tests/FileCacheTest.kt
+++ b/ktor-client/ktor-client-tests/jvm/test/io/ktor/client/tests/FileCacheTest.kt
@@ -7,6 +7,7 @@ import io.ktor.client.call.*
 import io.ktor.client.plugins.cache.*
 import io.ktor.client.plugins.cache.storage.*
 import io.ktor.client.request.*
+import io.ktor.client.statement.*
 import io.ktor.client.tests.utils.*
 import io.ktor.http.*
 import java.nio.file.*
@@ -71,6 +72,20 @@ class FileCacheTest : ClientLoader() {
 
             assertEquals(3, publicStorage.findAll(url).size)
             assertEquals(0, privateStorage.findAll(url).size)
+        }
+    }
+
+    @Test
+    fun testLongPath() = clientTests {
+        config {
+            install(HttpCache) {
+                publicStorage(this@FileCacheTest.publicStorage)
+            }
+        }
+
+        test { client ->
+            val response = client.get("$TEST_SERVER/cache/cache_${"a".repeat(256)}")
+            assertEquals("abc", response.bodyAsText())
         }
     }
 }


### PR DESCRIPTION
**Subsystem**
Client

**Motivation**
[KTOR-5443](https://youtrack.jetbrains.com/issue/KTOR-5443/FileStorage-throws-java.io.FileNotFoundException-File-name-too-long-when-request-path-is-long)

**Solution**
Use a hash of URLs  instead URLs for keys

