### PR TITLE
KTOR-5444 Fix FileNotFoundException thrown by FileCacheStorage

### DIFF
--- a/ktor-client/ktor-client-core/jvm/src/io/ktor/client/plugins/cache/storage/FileCacheStorage.kt
+++ b/ktor-client/ktor-client-core/jvm/src/io/ktor/client/plugins/cache/storage/FileCacheStorage.kt
@@ -97,7 +97,7 @@ private class FileCacheStorage(
                     channel.copyTo(output)
                 }
             } catch (cause: Exception) {
-                LOGGER.trace("Exception during saving cache to file: ${cause.stackTraceToString()}")
+                LOGGER.trace("Exception during saving a cache to a file: ${cause.stackTraceToString()}")
             }
         }
     }
@@ -120,7 +120,7 @@ private class FileCacheStorage(
                     return caches
                 }
             } catch (cause: Exception) {
-                LOGGER.trace("Exception during cache lookup in file: ${cause.stackTraceToString()}")
+                LOGGER.trace("Exception during cache lookup in a file: ${cause.stackTraceToString()}")
                 return emptySet()
             }
         }

--- a/ktor-client/ktor-client-core/jvm/src/io/ktor/client/plugins/cache/storage/FileCacheStorage.kt
+++ b/ktor-client/ktor-client-core/jvm/src/io/ktor/client/plugins/cache/storage/FileCacheStorage.kt
@@ -96,8 +96,8 @@ private class FileCacheStorage(
                     }
                     channel.copyTo(output)
                 }
-            } catch (e: Exception) {
-                LOGGER.trace("Exception during caching: ${e.stackTraceToString()}")
+            } catch (cause: Exception) {
+                LOGGER.trace("Exception during saving cache to file: ${cause.stackTraceToString()}")
             }
         }
     }
@@ -119,8 +119,8 @@ private class FileCacheStorage(
                     channel.discard()
                     return caches
                 }
-            } catch (e: Exception) {
-                LOGGER.trace("Exception during cache lookup: ${e.stackTraceToString()}")
+            } catch (cause: Exception) {
+                LOGGER.trace("Exception during cache lookup in file: ${cause.stackTraceToString()}")
                 return emptySet()
             }
         }


### PR DESCRIPTION
**Subsystem**
Client

**Motivation**
Any exceptions thrown while accessing the cache are expected not to fail the request but instead continue the request as if there was a cache miss.

**Solution**
Add try-catch for FileCacheStorage

