### PR TITLE
KTOR-5589 Add resource route builders accepting typed body as second parameter

### DIFF
--- a/ktor-server/ktor-server-plugins/ktor-server-resources/jvmAndNix/src/io/ktor/server/resources/Routing.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-resources/jvmAndNix/src/io/ktor/server/resources/Routing.kt
@@ -7,6 +7,7 @@ package io.ktor.server.resources
 import io.ktor.http.*
 import io.ktor.server.application.*
 import io.ktor.server.plugins.*
+import io.ktor.server.request.*
 import io.ktor.server.routing.*
 import io.ktor.util.*
 import io.ktor.util.pipeline.*
@@ -99,6 +100,20 @@ public inline fun <reified T : Any> Route.post(
 }
 
 /**
+ * Registers a typed handler [body] for a `POST` resource defined by the [T] class.
+ *
+ * A class [T] **must** be annotated with [io.ktor.resources.Resource].
+ *
+ * @param body receives an instance of the typed resource [T] as the first parameter
+ * and typed request body [R] as second parameter.
+ */
+public inline fun <reified T : Any, reified R : Any> Route.post(
+    noinline body: suspend PipelineContext<Unit, ApplicationCall>.(T, R) -> Unit,
+): Route = post<T> { resource ->
+    body(resource, call.receive())
+}
+
+/**
  * Registers a typed handler [body] for a `PUT` resource defined by the [T] class.
  *
  * A class [T] **must** be annotated with [io.ktor.resources.Resource].
@@ -115,6 +130,20 @@ public inline fun <reified T : Any> Route.put(
         }
     }
     return builtRoute
+}
+
+/**
+ * Registers a typed handler [body] for a `PUT` resource defined by the [T] class.
+ *
+ * A class [T] **must** be annotated with [io.ktor.resources.Resource].
+ *
+ * @param body receives an instance of the typed resource [T] as the first parameter
+ * and typed request body [R] as second parameter.
+ */
+public inline fun <reified T : Any, reified R : Any> Route.put(
+    noinline body: suspend PipelineContext<Unit, ApplicationCall>.(T, R) -> Unit,
+): Route = put<T> { resource ->
+    body(resource, call.receive())
 }
 
 /**
@@ -153,6 +182,20 @@ public inline fun <reified T : Any> Route.patch(
         }
     }
     return builtRoute
+}
+
+/**
+ * Registers a typed handler [body] for a `PATCH` resource defined by the [T] class.
+ *
+ * A class [T] **must** be annotated with [io.ktor.resources.Resource].
+ *
+ * @param body receives an instance of the typed resource [T] as the first parameter
+ * and typed request body [R] as second parameter.
+ */
+public inline fun <reified T : Any, reified R : Any> Route.patch(
+    noinline body: suspend PipelineContext<Unit, ApplicationCall>.(T, R) -> Unit,
+): Route = patch<T> { resource ->
+    body(resource, call.receive())
 }
 
 /**

--- a/ktor-server/ktor-server-plugins/ktor-server-resources/jvmAndNix/test/io/ktor/tests/resources/ResourcesTest.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-resources/jvmAndNix/test/io/ktor/tests/resources/ResourcesTest.kt
@@ -5,6 +5,7 @@
 package io.ktor.tests.resources
 
 import io.ktor.client.request.*
+import io.ktor.client.statement.*
 import io.ktor.http.*
 import io.ktor.resources.*
 import io.ktor.resources.serialization.*
@@ -501,6 +502,32 @@ class ResourcesTest {
             put<someResource> { call.respondText("Hi!") }.apply { assertIs<HttpMethodRouteSelector>(selector) }
             delete<someResource> { call.respondText("Hi!") }.apply { assertIs<HttpMethodRouteSelector>(selector) }
             patch<someResource> { call.respondText("Hi!") }.apply { assertIs<HttpMethodRouteSelector>(selector) }
+        }
+    }
+
+    @Resource("/body")
+    object resourceWithBody
+
+    @Test
+    fun resourceWithBody() = withResourcesApplication {
+        routing {
+            post<resourceWithBody, String> { _, body ->
+                call.respondText(body)
+            }
+            put<resourceWithBody, String> { _, body ->
+                call.respondText(body)
+            }
+            patch<resourceWithBody, String> { _, body ->
+                call.respondText(body)
+            }
+        }
+
+        val body = "test"
+
+        runBlocking {
+            assertEquals(client.post("/body") { setBody(body) }.bodyAsText(), body)
+            assertEquals(client.put("/body") { setBody(body) }.bodyAsText(), body)
+            assertEquals(client.patch("/body") { setBody(body) }.bodyAsText(), body)
         }
     }
 }


### PR DESCRIPTION
**Subsystem**
Server, Routing, Resources

**Motivation**
This PR adds resource route builders accepting typed body as second parameter.
They are very convenient and are in pair with classic routing builders.

**Solution**
```kotlin
// classic routing builder (already in framework)
post<LoginCredentials>("/login") { credentials ->
    // ...
}

// compatible resource builder (this PR)
post<LoginRoute, LoginCredentials> { route, credentials ->
    // ...
}
```

