### PR TITLE
Add Turbo Streams content type "text/vnd.turbo-stream.html"

### DIFF
--- a/ktor-http/common/src/io/ktor/http/ContentTypes.kt
+++ b/ktor-http/common/src/io/ktor/http/ContentTypes.kt
@@ -255,6 +255,7 @@ public class ContentType private constructor(
         public val VCard: ContentType = ContentType("text", "vcard")
         public val Xml: ContentType = ContentType("text", "xml")
         public val EventStream: ContentType = ContentType("text", "event-stream")
+        public val TurboStream: ContentType = ContentType("text", "vnd.turbo-stream.html")
     }
 
     /**


### PR DESCRIPTION
**Subsystem**
Client, Server, Http

**Motivation**
Using content type for Turbo Stream from standard location `ContentType.Text.TurboStream`

**Solution**
Add Turbo Streams content type `text/vnd.turbo-stream.html`
See https://turbo.hotwired.dev/handbook/streams#streaming-from-http-responses

**Alternative**
Create empty `companion object` in `ContentType.Text` to allow add this in ktor Turbo plugin (which i now work on to contribute to server templating plugins)

