### PR TITLE
"ADDRINUSE (98): Address already in use" issue fix for ktor-server-cio

### DIFF
--- a/ktor-server/ktor-server-cio/jvmAndNix/src/io/ktor/server/cio/backend/HttpServer.kt
+++ b/ktor-server/ktor-server-cio/jvmAndNix/src/io/ktor/server/cio/backend/HttpServer.kt
@@ -45,7 +45,9 @@ public fun CoroutineScope.httpServer(
     )
 
     val acceptJob = launch(serverJob + CoroutineName("accept-${settings.port}")) {
-        aSocket(selector).tcp().bind(settings.host, settings.port).use { server ->
+        aSocket(selector).tcp().bind(settings.host, settings.port) {
+            reuseAddress = true
+        }.use { server ->
             socket.complete(server)
 
             val exceptionHandler = coroutineContext[CoroutineExceptionHandler]


### PR DESCRIPTION
**Subsystem**
ktor-server-cio

**Motivation**
After terminating a http server its socket remains in the system for some time. Trying to restart the server during this time causes an exception:

`Uncaught Kotlin exception: io.ktor.utils.io.errors.PosixException.AddressAlreadyInUseException: EADDRINUSE (98): Address already in use`

**Solution**
With reuseAddress option the remained socket shall be reused and no exception is thrown.

Also a similar issue with a similar solution can be found here: https://youtrack.jetbrains.com/issue/KTOR-4442/EADDRINUSE-on-socket-bind-on-Linux

