### PR TITLE
KTOR-5518 Fix Exception type for OkHttp channel adapter

### DIFF
--- a/ktor-client/ktor-client-okhttp/jvm/src/io/ktor/client/engine/okhttp/OkUtils.kt
+++ b/ktor-client/ktor-client-okhttp/jvm/src/io/ktor/client/engine/okhttp/OkUtils.kt
@@ -72,6 +72,7 @@ private fun mapOkHttpException(
     requestData: HttpRequestData,
     origin: IOException
 ): Throwable = when (val cause = origin.unwrapSuppressed()) {
+    is StreamAdapterIOException -> cause.cause ?: cause
     is SocketTimeoutException ->
         if (cause.isConnectException()) {
             ConnectTimeoutException(requestData, cause)

--- a/ktor-client/ktor-client-okhttp/jvm/src/io/ktor/client/engine/okhttp/StreamRequestBody.kt
+++ b/ktor-client/ktor-client-okhttp/jvm/src/io/ktor/client/engine/okhttp/StreamRequestBody.kt
@@ -17,8 +17,14 @@ internal class StreamRequestBody(
     override fun contentType(): MediaType? = null
 
     override fun writeTo(sink: BufferedSink) {
-        block().toInputStream().source().use {
-            sink.writeAll(it)
+        try {
+            block().toInputStream().source().use {
+                sink.writeAll(it)
+            }
+        } catch (cause: IOException) {
+            throw cause
+        } catch (cause: Throwable) {
+            throw IOException(cause)
         }
     }
 

--- a/ktor-client/ktor-client-okhttp/jvm/src/io/ktor/client/engine/okhttp/StreamRequestBody.kt
+++ b/ktor-client/ktor-client-okhttp/jvm/src/io/ktor/client/engine/okhttp/StreamRequestBody.kt
@@ -9,6 +9,8 @@ import io.ktor.utils.io.jvm.javaio.*
 import okhttp3.*
 import okio.*
 
+internal class StreamAdapterIOException(cause: Throwable) : IOException(cause)
+
 internal class StreamRequestBody(
     private val contentLength: Long?,
     private val block: () -> ByteReadChannel
@@ -24,7 +26,7 @@ internal class StreamRequestBody(
         } catch (cause: IOException) {
             throw cause
         } catch (cause: Throwable) {
-            throw IOException(cause)
+            throw StreamAdapterIOException(cause)
         }
     }
 

--- a/ktor-client/ktor-client-okhttp/jvm/test/io/ktor/client/engine/okhttp/StreamRequestBodyTest.kt
+++ b/ktor-client/ktor-client-okhttp/jvm/test/io/ktor/client/engine/okhttp/StreamRequestBodyTest.kt
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2014-2023 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.client.engine.okhttp
+
+import okio.*
+import kotlin.test.*
+
+class StreamRequestBodyTest {
+
+    @Test
+    fun testChannelThrowException() {
+        val body = StreamRequestBody(0) {
+            error("Can't read body")
+        }
+
+        assertFailsWith<IOException> {
+            body.writeTo(Buffer())
+        }
+    }
+}


### PR DESCRIPTION
Fix [KTOR-5518](https://youtrack.jetbrains.com/issue/KTOR-5518/OkHttp-Cancelling-while-writing-to-ByteWriteChannel-when-overriding-WriteChannelContent-causes-propagation-of)