### PR TITLE
KTOR-5492 Javadoc for Resources.kt cannot be compiled

### DIFF
--- a/ktor-client/ktor-client-plugins/ktor-client-resources/common/src/io/ktor/client/plugins/resources/Resources.kt
+++ b/ktor-client/ktor-client-plugins/ktor-client-resources/common/src/io/ktor/client/plugins/resources/Resources.kt
@@ -17,12 +17,12 @@ import io.ktor.resources.Resources as ResourcesCore
  * Example:
  * ```kotlin
  * @Resource("/users")
- * data class Users {
+ * class Users {
  *   @Resource("/{id}")
- *   data class ById(val parent: Users = Users(), val id: Long)
+ *   class ById(val parent: Users = Users(), val id: Long)
  *
  *   @Resource("/add")
- *   data class Add(val parent: Users = Users(), val name: String)
+ *   class Add(val parent: Users = Users(), val name: String)
  * }
  *
  * // client-side

--- a/ktor-server/ktor-server-plugins/ktor-server-resources/jvmAndNix/src/io/ktor/server/resources/Resources.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-resources/jvmAndNix/src/io/ktor/server/resources/Resources.kt
@@ -16,12 +16,12 @@ import io.ktor.resources.Resources as ResourcesCore
  * Example:
  * ```kotlin
  * @Resource("/users")
- * data class Users {
+ * class Users {
  *   @Resource("/{id}")
- *   data class ById(val parent: Users = Users(), val id: Long)
+ *   class ById(val parent: Users = Users(), val id: Long)
  *
  *   @Resource("/add")
- *   data class Add(val parent: Users = Users(), val name: String)
+ *   class Add(val parent: Users = Users(), val name: String)
  * }
  *
  * routing {


### PR DESCRIPTION
**Subsystem**
- Client Resources Plugin
- Server Resources Plugin

**Motivation**
The JavaDoc in its current form does not compile as the `Users` data class must have at least one primary constructor parameter, which it doesn't. See [KTOR-5492](https://youtrack.jetbrains.com/issue/KTOR-5492/Javadoc-for-Resources.kt-cannot-be-compiled) for more details.

**Solution**
Replaces the data classes in the example with normal classes analogue to the examples in the documentation.

