### PR TITLE
KTOR-5474 Add property to avoid logging static file request

### DIFF
--- a/ktor-server/ktor-server-core/api/ktor-server-core.api
+++ b/ktor-server/ktor-server-core/api/ktor-server-core.api
@@ -436,6 +436,7 @@ public final class io/ktor/server/http/content/StaticContentKt {
 	public static final fun files (Lio/ktor/server/routing/Route;Ljava/lang/String;)V
 	public static final fun getStaticBasePackage (Lio/ktor/server/routing/Route;)Ljava/lang/String;
 	public static final fun getStaticRootFolder (Lio/ktor/server/routing/Route;)Ljava/io/File;
+	public static final fun isStaticContent (Lio/ktor/server/application/ApplicationCall;)Z
 	public static final fun preCompressed (Lio/ktor/server/routing/Route;[Lio/ktor/server/http/content/CompressedFileType;Lkotlin/jvm/functions/Function1;)V
 	public static synthetic fun preCompressed$default (Lio/ktor/server/routing/Route;[Lio/ktor/server/http/content/CompressedFileType;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
 	public static final fun resource (Lio/ktor/server/routing/Route;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V

--- a/ktor-server/ktor-server-core/jvm/src/io/ktor/server/http/content/StaticContent.kt
+++ b/ktor-server/ktor-server-core/jvm/src/io/ktor/server/http/content/StaticContent.kt
@@ -319,4 +319,7 @@ public fun Route.defaultResource(resource: String, resourcePackage: String? = nu
     }
 }
 
+/**
+ *  Checks if the application call is requesting static content
+ */
 public fun ApplicationCall.isStaticContent(): Boolean = parameters.contains(pathParameterName)

--- a/ktor-server/ktor-server-core/jvm/src/io/ktor/server/http/content/StaticContent.kt
+++ b/ktor-server/ktor-server-core/jvm/src/io/ktor/server/http/content/StaticContent.kt
@@ -318,3 +318,5 @@ public fun Route.defaultResource(resource: String, resourcePackage: String? = nu
         }
     }
 }
+
+public fun ApplicationCall.isStaticContent(): Boolean = parameters.contains(pathParameterName)

--- a/ktor-server/ktor-server-plugins/ktor-server-call-logging/api/ktor-server-call-logging.api
+++ b/ktor-server/ktor-server-plugins/ktor-server-call-logging/api/ktor-server-call-logging.api
@@ -2,7 +2,7 @@ public final class io/ktor/server/plugins/callloging/CallLoggingConfig {
 	public fun <init> ()V
 	public final fun clock (Lkotlin/jvm/functions/Function0;)V
 	public final fun disableDefaultColors ()V
-	public final fun disableStaticContent ()V
+	public final fun disableForStaticContent ()V
 	public final fun filter (Lkotlin/jvm/functions/Function1;)V
 	public final fun format (Lkotlin/jvm/functions/Function1;)V
 	public final fun getLevel ()Lorg/slf4j/event/Level;

--- a/ktor-server/ktor-server-plugins/ktor-server-call-logging/api/ktor-server-call-logging.api
+++ b/ktor-server/ktor-server-plugins/ktor-server-call-logging/api/ktor-server-call-logging.api
@@ -2,6 +2,7 @@ public final class io/ktor/server/plugins/callloging/CallLoggingConfig {
 	public fun <init> ()V
 	public final fun clock (Lkotlin/jvm/functions/Function0;)V
 	public final fun disableDefaultColors ()V
+	public final fun disableStaticContent ()V
 	public final fun filter (Lkotlin/jvm/functions/Function1;)V
 	public final fun format (Lkotlin/jvm/functions/Function1;)V
 	public final fun getLevel ()Lorg/slf4j/event/Level;

--- a/ktor-server/ktor-server-plugins/ktor-server-call-logging/jvm/src/io/ktor/server/plugins/callloging/CallLogging.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-call-logging/jvm/src/io/ktor/server/plugins/callloging/CallLogging.kt
@@ -48,11 +48,10 @@ public val CallLogging: ApplicationPlugin<CallLoggingConfig> = createApplication
     }
 
     fun logSuccess(call: ApplicationCall) {
-        if (filters.isEmpty() || filters.any { it(call) }) {
-            if (!(ignoreStaticContent && call.isStaticContent())) {
-                log(formatCall(call))
-            }
+        if ((ignoreStaticContent && call.isStaticContent()) || (filters.isNotEmpty() && filters.none { it(call) })) {
+            return
         }
+        log(formatCall(call))
     }
 
     setupMDCProvider()

--- a/ktor-server/ktor-server-plugins/ktor-server-call-logging/jvm/src/io/ktor/server/plugins/callloging/CallLogging.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-call-logging/jvm/src/io/ktor/server/plugins/callloging/CallLogging.kt
@@ -7,6 +7,7 @@ package io.ktor.server.plugins.callloging
 import io.ktor.events.*
 import io.ktor.server.application.*
 import io.ktor.server.application.hooks.*
+import io.ktor.server.http.content.*
 import io.ktor.util.*
 import io.ktor.util.date.*
 import org.slf4j.event.*
@@ -36,6 +37,7 @@ public val CallLogging: ApplicationPlugin<CallLoggingConfig> = createApplication
     val filters = pluginConfig.filters
     val formatCall = pluginConfig.formatCall
     val clock = pluginConfig.clock
+    val ignoreStaticContent = pluginConfig.ignoreStaticContent
 
     fun log(message: String) = when (pluginConfig.level) {
         Level.ERROR -> log.error(message)
@@ -47,7 +49,9 @@ public val CallLogging: ApplicationPlugin<CallLoggingConfig> = createApplication
 
     fun logSuccess(call: ApplicationCall) {
         if (filters.isEmpty() || filters.any { it(call) }) {
-            log(formatCall(call))
+            if (!(ignoreStaticContent && call.isStaticContent())) {
+                log(formatCall(call))
+            }
         }
     }
 

--- a/ktor-server/ktor-server-plugins/ktor-server-call-logging/jvm/src/io/ktor/server/plugins/callloging/CallLoggingConfig.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-call-logging/jvm/src/io/ktor/server/plugins/callloging/CallLoggingConfig.kt
@@ -88,9 +88,9 @@ public class CallLoggingConfig {
     }
 
     /**
-     * Disables logging of static content files.
+     * Disables logging for static content files.
      * */
-    public fun disableStaticContent() {
+    public fun disableForStaticContent() {
         ignoreStaticContent = true
     }
 

--- a/ktor-server/ktor-server-plugins/ktor-server-call-logging/jvm/src/io/ktor/server/plugins/callloging/CallLoggingConfig.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-call-logging/jvm/src/io/ktor/server/plugins/callloging/CallLoggingConfig.kt
@@ -23,6 +23,7 @@ public class CallLoggingConfig {
     internal val mdcEntries = mutableListOf<MDCEntry>()
     internal var formatCall: (ApplicationCall) -> String = ::defaultFormat
     internal var isColorsEnabled: Boolean = true
+    internal var ignoreStaticContent: Boolean = false
 
     /**
      * Specifies a logging level for the [CallLogging] plugin.
@@ -84,6 +85,13 @@ public class CallLoggingConfig {
      * */
     public fun disableDefaultColors() {
         isColorsEnabled = false
+    }
+
+    /**
+     * Disables logging of static content files.
+     * */
+    public fun disableStaticContent() {
+        ignoreStaticContent = true
     }
 
     private fun defaultFormat(call: ApplicationCall): String =

--- a/ktor-server/ktor-server-plugins/ktor-server-call-logging/jvm/test/io/ktor/server/plugins/callloging/CallLoggingTest.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-call-logging/jvm/test/io/ktor/server/plugins/callloging/CallLoggingTest.kt
@@ -441,7 +441,7 @@ class CallLoggingTest {
                     level = Level.INFO
                     clock { 0 }
                     disableDefaultColors()
-                    disableStaticContent()
+                    disableForStaticContent()
                 }
             }
             log = logger

--- a/ktor-server/ktor-server-plugins/ktor-server-call-logging/jvm/test/io/ktor/server/plugins/callloging/CallLoggingTest.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-call-logging/jvm/test/io/ktor/server/plugins/callloging/CallLoggingTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2022 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2014-2023 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package io.ktor.server.plugins.callloging
@@ -9,6 +9,7 @@ import io.ktor.client.statement.*
 import io.ktor.http.*
 import io.ktor.server.application.*
 import io.ktor.server.engine.*
+import io.ktor.server.http.content.*
 import io.ktor.server.plugins.*
 import io.ktor.server.plugins.callid.*
 import io.ktor.server.plugins.statuspages.*
@@ -21,6 +22,7 @@ import kotlinx.coroutines.*
 import org.fusesource.jansi.*
 import org.slf4j.*
 import org.slf4j.event.*
+import java.io.*
 import java.util.concurrent.*
 import kotlin.test.*
 
@@ -429,6 +431,33 @@ class CallLoggingTest {
 
         assertEquals("OK", client.get("/").bodyAsText())
         assertEquals(6, failed)
+    }
+
+    @Test
+    fun `ignore static file request`() = testApplication {
+        environment {
+            module {
+                install(CallLogging) {
+                    level = Level.INFO
+                    clock { 0 }
+                    disableDefaultColors()
+                    disableStaticContent()
+                }
+            }
+            log = logger
+        }
+        application {
+            routing {
+                static {
+                    staticRootFolder = File("jvm/test/io/ktor/server/plugins/callloging")
+                    files(".")
+                    default("CallLoggingTest.kt")
+                }
+            }
+        }
+        val response = client.get("/CallLoggingTest.kt")
+        assertEquals(HttpStatusCode.OK, response.status)
+        assertFalse("INFO: 200 OK: GET - /CallLoggingTest.kt in 0ms" in messages)
     }
 
     private fun green(value: Any): String = colored(value, Ansi.Color.GREEN)


### PR DESCRIPTION
**Subsystem**
Server

**Motivation**
[KTOR-5474](https://youtrack.jetbrains.com/issue/KTOR-5474/CallLogging-plugin-add-config-to-avoid-logging-static-file-request)

**Solution**
Add property `ignoreStaticContent` to `CallLoggingConfig` (by default false)

