### PR TITLE
KTOR-5533 Add MIME type for .mjs extension

### DIFF
--- a/ktor-http/common/src/io/ktor/http/Mimes.kt
+++ b/ktor-http/common/src/io/ktor/http/Mimes.kt
@@ -5,7 +5,6 @@
 package io.ktor.http
 
 import io.ktor.util.*
-import kotlin.native.concurrent.*
 
 private val rawMimes: String
     get() = """
@@ -532,6 +531,7 @@ private val rawMimes: String
 .mj2,video/mj2
 .mjf,audio/x-vnd.audioexplosion.mjuicemediafile
 .mjpg,video/x-motion-jpeg
+.mjs,text/javascript
 .mkv,video/x-matroska
 .mkv,audio/x-matroska
 .mlp,application/vnd.dolby.mlp


### PR DESCRIPTION
[KTOR-5533](https://youtrack.jetbrains.com/issue/KTOR-5533/Wrong-ContentType-for-.mjs-files)

