### PR TITLE
KTOR-5510 Fix isSent when content is ReadChannelContent

### DIFF
--- a/ktor-server/ktor-server-host-common/jvmAndNix/src/io/ktor/server/engine/BaseApplicationResponse.kt
+++ b/ktor-server/ktor-server-host-common/jvmAndNix/src/io/ktor/server/engine/BaseApplicationResponse.kt
@@ -1,6 +1,6 @@
 // ktlint-disable filename
 /*
- * Copyright 2014-2022 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2014-2023 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package io.ktor.server.engine
@@ -139,7 +139,7 @@ public abstract class BaseApplicationResponse(
                 try {
                     // If channel is fine, commit headers and pipe data
                     commitHeaders(content)
-                    return respondFromChannel(readChannel)
+                    respondFromChannel(readChannel)
                 } finally {
                     readChannel.cancel()
                 }

--- a/ktor-server/ktor-server-tests/jvm/test/io/ktor/server/plugins/CompressionTest.kt
+++ b/ktor-server/ktor-server-tests/jvm/test/io/ktor/server/plugins/CompressionTest.kt
@@ -4,6 +4,8 @@
 
 package io.ktor.server.plugins
 
+import io.ktor.client.request.*
+import io.ktor.client.statement.*
 import io.ktor.http.*
 import io.ktor.http.content.*
 import io.ktor.server.application.*
@@ -650,6 +652,23 @@ class CompressionTest {
 
         handleAndAssert("/1", "*", "deflate", textToCompress)
         handleAndAssert("/2", "*", null, textToCompress)
+    }
+
+    @Test
+    fun testResponseShouldBeSentAfterCompression(): Unit = testApplication {
+        install(Compression)
+        routing {
+            get("/isSent") {
+                call.respond(textToCompress)
+                assertTrue(call.response.isSent)
+            }
+        }
+
+        client.get("/isSent") {
+            headers {
+                append(HttpHeaders.AcceptEncoding, "gzip")
+            }
+        }
     }
 
     private fun TestApplicationEngine.handleAndAssert(


### PR DESCRIPTION
**Motivation**
[KTOR-5510](https://youtrack.jetbrains.com/issue/KTOR-5510/Compressing-the-response-will-result-in-unexpected-ERROR-log-output-after-processing-in-the-StatusPages) 

**Solution**
Flag `isSent` wasn't set because of an accident `return` call

