### PR TITLE
KTOR-5529 Add option to CIO HttpServer to reuse the address

### DIFF
--- a/ktor-server/ktor-server-cio/api/ktor-server-cio.api
+++ b/ktor-server/ktor-server-cio/api/ktor-server-cio.api
@@ -13,7 +13,9 @@ public final class io/ktor/server/cio/CIOApplicationEngine : io/ktor/server/engi
 public final class io/ktor/server/cio/CIOApplicationEngine$Configuration : io/ktor/server/engine/BaseApplicationEngine$Configuration {
 	public fun <init> ()V
 	public final fun getConnectionIdleTimeoutSeconds ()I
+	public final fun getReuseAddress ()Z
 	public final fun setConnectionIdleTimeoutSeconds (I)V
+	public final fun setReuseAddress (Z)V
 }
 
 public final class io/ktor/server/cio/EngineMain {
@@ -34,17 +36,19 @@ public final class io/ktor/server/cio/HttpServerKt {
 
 public final class io/ktor/server/cio/HttpServerSettings {
 	public fun <init> ()V
-	public fun <init> (Ljava/lang/String;IJ)V
-	public synthetic fun <init> (Ljava/lang/String;IJILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;IJZ)V
+	public synthetic fun <init> (Ljava/lang/String;IJZILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;
 	public final fun component2 ()I
 	public final fun component3 ()J
-	public final fun copy (Ljava/lang/String;IJ)Lio/ktor/server/cio/HttpServerSettings;
-	public static synthetic fun copy$default (Lio/ktor/server/cio/HttpServerSettings;Ljava/lang/String;IJILjava/lang/Object;)Lio/ktor/server/cio/HttpServerSettings;
+	public final fun component4 ()Z
+	public final fun copy (Ljava/lang/String;IJZ)Lio/ktor/server/cio/HttpServerSettings;
+	public static synthetic fun copy$default (Lio/ktor/server/cio/HttpServerSettings;Ljava/lang/String;IJZILjava/lang/Object;)Lio/ktor/server/cio/HttpServerSettings;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getConnectionIdleTimeoutSeconds ()J
 	public final fun getHost ()Ljava/lang/String;
 	public final fun getPort ()I
+	public final fun getReuseAddress ()Z
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }

--- a/ktor-server/ktor-server-cio/jvmAndNix/src/io/ktor/server/cio/CIOApplicationEngine.kt
+++ b/ktor-server/ktor-server-cio/jvmAndNix/src/io/ktor/server/cio/CIOApplicationEngine.kt
@@ -31,6 +31,10 @@ public class CIOApplicationEngine(
          * A connection is IDLE if there are no active requests running.
          */
         public var connectionIdleTimeoutSeconds: Int = 45
+        /**
+         * Allow the server to bind to an address that is already in use
+         */
+        public var reuseAddress: Boolean = false
     }
 
     private val configuration: Configuration = Configuration().apply(configure)
@@ -105,7 +109,8 @@ public class CIOApplicationEngine(
         val settings = HttpServerSettings(
             host = host,
             port = port,
-            connectionIdleTimeoutSeconds = configuration.connectionIdleTimeoutSeconds.toLong()
+            connectionIdleTimeoutSeconds = configuration.connectionIdleTimeoutSeconds.toLong(),
+            reuseAddress = configuration.reuseAddress
         )
 
         return httpServer(settings) { request ->

--- a/ktor-server/ktor-server-cio/jvmAndNix/src/io/ktor/server/cio/HttpServer.kt
+++ b/ktor-server/ktor-server-cio/jvmAndNix/src/io/ktor/server/cio/HttpServer.kt
@@ -27,11 +27,13 @@ public class HttpServer(
  * @property host to listen to
  * @property port to listen to
  * @property connectionIdleTimeoutSeconds time to live for IDLE connections
+ * @property reuseAddress allow the server to bind to an address that is already in use
  */
 public data class HttpServerSettings(
     val host: String = "0.0.0.0",
     val port: Int = 8080,
-    val connectionIdleTimeoutSeconds: Long = 45
+    val connectionIdleTimeoutSeconds: Long = 45,
+    val reuseAddress: Boolean = false
 )
 
 /**

--- a/ktor-server/ktor-server-cio/jvmAndNix/src/io/ktor/server/cio/backend/HttpServer.kt
+++ b/ktor-server/ktor-server-cio/jvmAndNix/src/io/ktor/server/cio/backend/HttpServer.kt
@@ -45,7 +45,9 @@ public fun CoroutineScope.httpServer(
     )
 
     val acceptJob = launch(serverJob + CoroutineName("accept-${settings.port}")) {
-        aSocket(selector).tcp().bind(settings.host, settings.port).use { server ->
+        aSocket(selector).tcp().bind(settings.host, settings.port) {
+            reuseAddress = settings.reuseAddress
+        }.use { server ->
             socket.complete(server)
 
             val exceptionHandler = coroutineContext[CoroutineExceptionHandler]


### PR DESCRIPTION
**Subsystem**
 ktor-server-cio

**Motivation**
There is a feature request open on YouTrack for this https://youtrack.jetbrains.com/issue/KTOR-5527

Related to that is this bug, however I wouldn't consider this PR a permanent fix to it https://youtrack.jetbrains.com/issue/KTOR-5529

This also extends the work done in this PR to make it configurable https://github.com/ktorio/ktor/pull/3387

**Solution**
Bubble up the socket option `reuseAddress` to CIOApplicationEngine's `Configuration` class

