### PR TITLE
Correct private max age key to s-maxage

### DIFF
--- a/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/cache/HttpCacheEntry.kt
+++ b/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/cache/HttpCacheEntry.kt
@@ -68,7 +68,7 @@ internal fun HttpResponse.cacheExpires(fallback: () -> GMTDate = { GMTDate() }):
 
     val isPrivate = CacheControl.PRIVATE in cacheControl
 
-    val maxAgeKey = if (isPrivate) "s-max-age" else "max-age"
+    val maxAgeKey = if (isPrivate) "s-maxage" else "max-age"
 
     val maxAge = cacheControl.firstOrNull { it.value.startsWith(maxAgeKey) }
         ?.value?.split("=")


### PR DESCRIPTION
**Subsystem**
Client

**Motivation**
Fixing incorrect key name causing cache not to respect max age on private caches

