### PR TITLE
Make HttpStatusCode comparable

### DIFF
--- a/ktor-http/common/src/io/ktor/http/HttpStatusCode.kt
+++ b/ktor-http/common/src/io/ktor/http/HttpStatusCode.kt
@@ -10,7 +10,7 @@ package io.ktor.http
  * @param description is free form description of a status.
  */
 @Suppress("unused")
-public data class HttpStatusCode(val value: Int, val description: String) {
+public data class HttpStatusCode(val value: Int, val description: String) : Comparable<HttpStatusCode> {
     override fun toString(): String = "$value $description"
 
     override fun equals(other: Any?): Boolean = other is HttpStatusCode && other.value == value
@@ -21,6 +21,8 @@ public data class HttpStatusCode(val value: Int, val description: String) {
      * Returns a copy of `this` code with a description changed to [value].
      */
     public fun description(value: String): HttpStatusCode = copy(description = value)
+    
+    override fun compareTo(other: HttpStatusCode): Int = value - other.value
 
     @Suppress("KDocMissingDocumentation", "PublicApiImplicitType")
     public companion object {


### PR DESCRIPTION
## Subsystem

Client/Server

## Motivation

It is much more useful to compare status codes between each other. For example:

```kotlin
httpResponse.status < HttpStatusCode.OK
```

Currently, in case, if I want to compare status codes I should use next comparison:

```kotlin
httpResponse.status.value < HttpStatusCode.OK.value
```

## Solution

In my PR `HttpStatusCode` will implements `Comparable` interface and realize `compareTo` with any other `HttpStatusCode`



