### PR TITLE
KTOR-5586 Fix DefaultRequest overwriting explicitly provided http protocol

### DIFF
--- a/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/DefaultRequest.kt
+++ b/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/DefaultRequest.kt
@@ -86,14 +86,14 @@ public class DefaultRequest private constructor(private val block: DefaultReques
         }
 
         private fun mergeUrls(baseUrl: Url, requestUrl: URLBuilder) {
-            if (requestUrl.protocol == URLProtocol.HTTP) {
-                requestUrl.protocol = baseUrl.protocol
+            if (requestUrl.protocolOrNull == null) {
+                requestUrl.protocolOrNull = baseUrl.protocolOrNull
             }
             if (requestUrl.host.isNotEmpty()) return
 
             val resultUrl = URLBuilder(baseUrl)
             with(requestUrl) {
-                resultUrl.protocol = requestUrl.protocol
+                resultUrl.protocolOrNull = requestUrl.protocolOrNull
                 if (port != DEFAULT_PORT) {
                     resultUrl.port = port
                 }

--- a/ktor-client/ktor-client-core/common/test/DefaultRequestTest.kt
+++ b/ktor-client/ktor-client-core/common/test/DefaultRequestTest.kt
@@ -120,6 +120,7 @@ class DefaultRequestTest {
         assertEquals("https://other.host/", client.get("//other.host/").bodyAsText())
         assertEquals("ws://other.host/", client.get("ws://other.host/").bodyAsText())
         assertEquals("ws://other.host:123", client.get("ws://other.host:123").bodyAsText())
+        assertEquals("http://other.host", client.get("http://other.host").bodyAsText())
     }
 
     @Test

--- a/ktor-http/common/src/io/ktor/http/URLBuilder.kt
+++ b/ktor-http/common/src/io/ktor/http/URLBuilder.kt
@@ -23,7 +23,7 @@ public const val DEFAULT_PORT: Int = 0
  * @property trailingQuery keep a trailing question character even if there are no query parameters
  */
 public class URLBuilder(
-    public var protocol: URLProtocol = URLProtocol.HTTP,
+    protocol: URLProtocol? = null,
     public var host: String = "",
     public var port: Int = DEFAULT_PORT,
     user: String? = null,
@@ -33,6 +33,11 @@ public class URLBuilder(
     fragment: String = "",
     public var trailingQuery: Boolean = false
 ) {
+    public var protocolOrNull: URLProtocol? = protocol
+    public var protocol: URLProtocol
+        get() = protocolOrNull ?: URLProtocol.HTTP
+        set(value) { protocolOrNull = value }
+
     public var encodedUser: String? = user?.encodeURLParameter()
 
     public var user: String?
@@ -91,7 +96,7 @@ public class URLBuilder(
     public fun build(): Url {
         applyOrigin()
         return Url(
-            protocol = protocol,
+            protocol = protocolOrNull,
             host = host,
             specifiedPort = port,
             pathSegments = pathSegments,
@@ -107,7 +112,7 @@ public class URLBuilder(
     private fun applyOrigin() {
         if (host.isNotEmpty() || protocol.name == "file") return
         host = originUrl.host
-        if (protocol == URLProtocol.HTTP) protocol = originUrl.protocol
+        if (protocolOrNull == null) protocolOrNull = originUrl.protocolOrNull
         if (port == DEFAULT_PORT) port = originUrl.specifiedPort
     }
 

--- a/ktor-http/common/src/io/ktor/http/URLUtils.kt
+++ b/ktor-http/common/src/io/ktor/http/URLUtils.kt
@@ -40,7 +40,7 @@ public fun URLBuilder(builder: URLBuilder): URLBuilder = URLBuilder().takeFrom(b
  * Take components from another [url] builder
  */
 public fun URLBuilder.takeFrom(url: URLBuilder): URLBuilder {
-    protocol = url.protocol
+    protocolOrNull = url.protocolOrNull
     host = url.host
     port = url.port
     encodedPathSegments = url.encodedPathSegments
@@ -57,7 +57,7 @@ public fun URLBuilder.takeFrom(url: URLBuilder): URLBuilder {
  * Take components from another [url]
  */
 public fun URLBuilder.takeFrom(url: Url): URLBuilder {
-    protocol = url.protocol
+    protocolOrNull = url.protocolOrNull
     host = url.host
     port = url.port
     encodedPath = url.encodedPath

--- a/ktor-http/common/src/io/ktor/http/Url.kt
+++ b/ktor-http/common/src/io/ktor/http/Url.kt
@@ -19,7 +19,7 @@ package io.ktor.http
  * @property trailingQuery keep trailing question character even if there are no query parameters
  */
 public class Url internal constructor(
-    public val protocol: URLProtocol,
+    protocol: URLProtocol?,
     public val host: String,
     public val specifiedPort: Int,
     public val pathSegments: List<String>,
@@ -37,13 +37,16 @@ public class Url internal constructor(
         ) { "port must be between 0 and 65535, or $DEFAULT_PORT if not set" }
     }
 
+    public val protocolOrNull: URLProtocol? = protocol
+    public val protocol: URLProtocol = protocolOrNull ?: URLProtocol.HTTP
+
     public val port: Int get() = specifiedPort.takeUnless { it == DEFAULT_PORT } ?: protocol.defaultPort
 
     public val encodedPath: String by lazy {
         if (pathSegments.isEmpty()) {
             return@lazy ""
         }
-        val pathStartIndex = urlString.indexOf('/', protocol.name.length + 3)
+        val pathStartIndex = urlString.indexOf('/', this.protocol.name.length + 3)
         if (pathStartIndex == -1) {
             return@lazy ""
         }
@@ -65,7 +68,7 @@ public class Url internal constructor(
     }
 
     public val encodedPathAndQuery: String by lazy {
-        val pathStart = urlString.indexOf('/', protocol.name.length + 3)
+        val pathStart = urlString.indexOf('/', this.protocol.name.length + 3)
         if (pathStart == -1) {
             return@lazy ""
         }
@@ -79,7 +82,7 @@ public class Url internal constructor(
     public val encodedUser: String? by lazy {
         if (user == null) return@lazy null
         if (user.isEmpty()) return@lazy ""
-        val usernameStart = protocol.name.length + 3
+        val usernameStart = this.protocol.name.length + 3
         val usernameEnd = urlString.indexOfAny(charArrayOf(':', '@'), usernameStart)
         urlString.substring(usernameStart, usernameEnd)
     }
@@ -87,7 +90,7 @@ public class Url internal constructor(
     public val encodedPassword: String? by lazy {
         if (password == null) return@lazy null
         if (password.isEmpty()) return@lazy ""
-        val passwordStart = urlString.indexOf(':', protocol.name.length + 3) + 1
+        val passwordStart = urlString.indexOf(':', this.protocol.name.length + 3) + 1
         val passwordEnd = urlString.indexOf('@')
         urlString.substring(passwordStart, passwordEnd)
     }


### PR DESCRIPTION
Fix for [KTOR-5586](https://youtrack.jetbrains.com/issue/KTOR-5586).

The solution is to move the source of truth for the protocol into a nullable property (`protocolOrNull`) while delegating the original (`protocol`) to it, defaulting to `URLProtocol.HTTP` as before. This way the original behavior remains unchanged, but if necessary it's now possible to tell whether or not http came about as the default, or if it was provided explicitly: In the first case `protocolOrNull == null` while in the latter `protocolOrNull == URLProtocol.HTTP`.

I believe the only change to the public api brought about by this (aside from the new `protocolOrNull` property) is that `protocol` is now nullable in the `URLBuilder` constructor, which shouldn't be a problem i believe?