### PR TITLE
KTOR-5595 Fix ClassCastException when DropwizardMetrics is used together with MicrometerMetrics

### DIFF
--- a/ktor-server/ktor-server-plugins/ktor-server-metrics-micrometer/build.gradle.kts
+++ b/ktor-server/ktor-server-plugins/ktor-server-metrics-micrometer/build.gradle.kts
@@ -6,5 +6,10 @@ kotlin {
                 implementation(project(":ktor-server:ktor-server-host-common"))
             }
         }
+        jvmTest {
+            dependencies{
+                implementation(project(":ktor-server:ktor-server-plugins:ktor-server-metrics"))
+            }
+        }
     }
 }

--- a/ktor-server/ktor-server-plugins/ktor-server-metrics-micrometer/jvm/src/io/ktor/server/metrics/micrometer/MicrometerMetrics.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-metrics-micrometer/jvm/src/io/ktor/server/metrics/micrometer/MicrometerMetrics.kt
@@ -114,7 +114,7 @@ public val MicrometerMetrics: ApplicationPlugin<MicrometerMetricsConfig> =
         val activeRequestsGaugeName = "$metricName.active"
         val registry = pluginConfig.registry
         val active = registry.gauge(activeRequestsGaugeName, AtomicInteger(0))
-        val measureKey = AttributeKey<CallMeasure>("metrics")
+        val measureKey = AttributeKey<CallMeasure>("micrometerMetrics")
 
         fun Timer.Builder.addDefaultTags(call: ApplicationCall, throwable: Throwable?): Timer.Builder {
             val route = call.attributes[measureKey].route

--- a/ktor-server/ktor-server-plugins/ktor-server-metrics-micrometer/jvm/test/io/ktor/server/metrics/micrometer/MicrometerMetricsTests.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-metrics-micrometer/jvm/test/io/ktor/server/metrics/micrometer/MicrometerMetricsTests.kt
@@ -399,7 +399,6 @@ class MicrometerMetricsTests {
         assertEquals("OK", response.bodyAsText())
     }
 
-
     private fun TestApplicationEngine.metersAreRegistered(
         meterBinder: KClass<out MeterBinder>,
         vararg meterNames: String

--- a/ktor-server/ktor-server-plugins/ktor-server-metrics-micrometer/jvm/test/io/ktor/server/metrics/micrometer/MicrometerMetricsTests.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-metrics-micrometer/jvm/test/io/ktor/server/metrics/micrometer/MicrometerMetricsTests.kt
@@ -4,8 +4,11 @@
 
 package io.ktor.server.metrics.micrometer
 
+import io.ktor.client.request.*
+import io.ktor.client.statement.*
 import io.ktor.http.*
 import io.ktor.server.application.*
+import io.ktor.server.metrics.dropwizard.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
 import io.ktor.server.testing.*
@@ -377,6 +380,25 @@ class MicrometerMetricsTests {
             assertEquals(gauge, configurableGauge)
         }
     }
+
+    @Test
+    fun `with DropwizardMetrics plugin`(): Unit = testApplication {
+        application {
+            install(MicrometerMetrics)
+            install(DropwizardMetrics)
+
+            routing {
+                get("/") {
+                    call.respondText { "OK" }
+                }
+            }
+        }
+
+        val response = client.get("/")
+        assertEquals(HttpStatusCode.OK, response.status)
+        assertEquals("OK", response.bodyAsText())
+    }
+
 
     private fun TestApplicationEngine.metersAreRegistered(
         meterBinder: KClass<out MeterBinder>,

--- a/ktor-server/ktor-server-plugins/ktor-server-metrics/jvm/src/io/ktor/server/metrics/dropwizard/DropwizardMetricsUtils.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-metrics/jvm/src/io/ktor/server/metrics/dropwizard/DropwizardMetricsUtils.kt
@@ -8,7 +8,7 @@ import com.codahale.metrics.*
 import io.ktor.util.*
 
 internal class RoutingMetrics(val name: String, val context: Timer.Context)
-internal val routingMetricsKey = AttributeKey<RoutingMetrics>("routingMetrics")
+internal val routingMetricsKey = AttributeKey<RoutingMetrics>("dropwizardRoutingMetrics")
 
 internal data class CallMeasure constructor(val timer: Timer.Context)
-internal val measureKey = AttributeKey<CallMeasure>("metrics")
+internal val measureKey = AttributeKey<CallMeasure>("dropwizardMetrics")


### PR DESCRIPTION
**Motivation**
[KTOR-5595](https://youtrack.jetbrains.com/issue/KTOR-5595/Metrics-ClassCastException-when-the-DropwizardMetrics-plugin-is-installed-after-the-MicrometerMetrics-plugin)

**Solution**
The problem was that both plugins used the same name "metrics" for their `measureKey`

