### PR TITLE
KTOR-5493 formbuilder append collection

### DIFF
--- a/ktor-client/ktor-client-core/api/ktor-client-core.api
+++ b/ktor-client/ktor-client-core/api/ktor-client-core.api
@@ -1238,19 +1238,23 @@ public final class io/ktor/client/request/forms/FormBuilder {
 	public final fun append (Ljava/lang/String;Lio/ktor/client/request/forms/ChannelProvider;Lio/ktor/http/Headers;)V
 	public final fun append (Ljava/lang/String;Lio/ktor/client/request/forms/InputProvider;Lio/ktor/http/Headers;)V
 	public final fun append (Ljava/lang/String;Lio/ktor/utils/io/core/ByteReadPacket;Lio/ktor/http/Headers;)V
+	public final fun append (Ljava/lang/String;Ljava/lang/Iterable;Lio/ktor/http/Headers;)V
 	public final fun append (Ljava/lang/String;Ljava/lang/Number;Lio/ktor/http/Headers;)V
 	public final fun append (Ljava/lang/String;Ljava/lang/Object;Lio/ktor/http/Headers;)V
 	public final fun append (Ljava/lang/String;Ljava/lang/String;Lio/ktor/http/Headers;)V
 	public final fun append (Ljava/lang/String;ZLio/ktor/http/Headers;)V
 	public final fun append (Ljava/lang/String;[BLio/ktor/http/Headers;)V
+	public final fun append (Ljava/lang/String;[Ljava/lang/String;Lio/ktor/http/Headers;)V
 	public static synthetic fun append$default (Lio/ktor/client/request/forms/FormBuilder;Ljava/lang/String;Lio/ktor/client/request/forms/ChannelProvider;Lio/ktor/http/Headers;ILjava/lang/Object;)V
 	public static synthetic fun append$default (Lio/ktor/client/request/forms/FormBuilder;Ljava/lang/String;Lio/ktor/client/request/forms/InputProvider;Lio/ktor/http/Headers;ILjava/lang/Object;)V
 	public static synthetic fun append$default (Lio/ktor/client/request/forms/FormBuilder;Ljava/lang/String;Lio/ktor/utils/io/core/ByteReadPacket;Lio/ktor/http/Headers;ILjava/lang/Object;)V
+	public static synthetic fun append$default (Lio/ktor/client/request/forms/FormBuilder;Ljava/lang/String;Ljava/lang/Iterable;Lio/ktor/http/Headers;ILjava/lang/Object;)V
 	public static synthetic fun append$default (Lio/ktor/client/request/forms/FormBuilder;Ljava/lang/String;Ljava/lang/Number;Lio/ktor/http/Headers;ILjava/lang/Object;)V
 	public static synthetic fun append$default (Lio/ktor/client/request/forms/FormBuilder;Ljava/lang/String;Ljava/lang/Object;Lio/ktor/http/Headers;ILjava/lang/Object;)V
 	public static synthetic fun append$default (Lio/ktor/client/request/forms/FormBuilder;Ljava/lang/String;Ljava/lang/String;Lio/ktor/http/Headers;ILjava/lang/Object;)V
 	public static synthetic fun append$default (Lio/ktor/client/request/forms/FormBuilder;Ljava/lang/String;ZLio/ktor/http/Headers;ILjava/lang/Object;)V
 	public static synthetic fun append$default (Lio/ktor/client/request/forms/FormBuilder;Ljava/lang/String;[BLio/ktor/http/Headers;ILjava/lang/Object;)V
+	public static synthetic fun append$default (Lio/ktor/client/request/forms/FormBuilder;Ljava/lang/String;[Ljava/lang/String;Lio/ktor/http/Headers;ILjava/lang/Object;)V
 	public final fun appendInput (Ljava/lang/String;Lio/ktor/http/Headers;Ljava/lang/Long;Lkotlin/jvm/functions/Function0;)V
 	public static synthetic fun appendInput$default (Lio/ktor/client/request/forms/FormBuilder;Ljava/lang/String;Lio/ktor/http/Headers;Ljava/lang/Long;Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)V
 }

--- a/ktor-client/ktor-client-core/common/src/io/ktor/client/request/forms/formDsl.kt
+++ b/ktor-client/ktor-client-core/common/src/io/ktor/client/request/forms/formDsl.kt
@@ -140,6 +140,25 @@ public class FormBuilder internal constructor() {
     }
 
     /**
+     * Appends a pair [key]:[values] with optional [headers].
+     */
+    public fun append(key: String, values: Iterable<String>, headers: Headers = Headers.Empty) {
+        require(key.endsWith("[]")) {
+            "Array parameter must be suffixed with square brackets ie `$key[]`"
+        }
+        values.forEach { value ->
+            parts += FormPart(key, value, headers)
+        }
+    }
+
+    /**
+     * Appends a pair [key]:[values] with optional [headers].
+     */
+    public fun append(key: String, values: Array<String>, headers: Headers = Headers.Empty) {
+        return append(key, values.asIterable(), headers)
+    }
+
+    /**
      * Appends a pair [key]:[ChannelProvider] with optional [headers].
      */
     public fun append(key: String, value: ChannelProvider, headers: Headers = Headers.Empty) {

--- a/ktor-client/ktor-client-core/common/test/MultiPartFormDataContentTest.kt
+++ b/ktor-client/ktor-client-core/common/test/MultiPartFormDataContentTest.kt
@@ -125,6 +125,87 @@ class MultiPartFormDataContentTest {
     }
 
     @Test
+    fun testStringsList() = testSuspend {
+        val data = MultiPartFormDataContent(
+            formData {
+                append("platforms[]", listOf("windows", "linux", "osx"))
+            },
+            boundary = "boundary",
+        )
+
+        assertEquals(
+            listOf(
+                "--boundary",
+                "Content-Disposition: form-data; name=\"platforms[]\"",
+                "Content-Length: 7",
+                "",
+                "windows",
+                "--boundary",
+                "Content-Disposition: form-data; name=\"platforms[]\"",
+                "Content-Length: 5",
+                "",
+                "linux",
+                "--boundary",
+                "Content-Disposition: form-data; name=\"platforms[]\"",
+                "Content-Length: 3",
+                "",
+                "osx",
+                "--boundary--",
+                ""
+            ).joinToString(separator = "\r\n"),
+            data.readString()
+        )
+    }
+
+    @Test
+    fun testStringsArray() = testSuspend {
+        val data = MultiPartFormDataContent(
+            formData {
+                append("platforms[]", arrayOf("windows", "linux", "osx"))
+            },
+            boundary = "boundary",
+        )
+
+        assertEquals(
+            listOf(
+                "--boundary",
+                "Content-Disposition: form-data; name=\"platforms[]\"",
+                "Content-Length: 7",
+                "",
+                "windows",
+                "--boundary",
+                "Content-Disposition: form-data; name=\"platforms[]\"",
+                "Content-Length: 5",
+                "",
+                "linux",
+                "--boundary",
+                "Content-Disposition: form-data; name=\"platforms[]\"",
+                "Content-Length: 3",
+                "",
+                "osx",
+                "--boundary--",
+                ""
+            ).joinToString(separator = "\r\n"),
+            data.readString()
+        )
+    }
+
+    @Test
+    fun testStringsListBadKey() = testSuspend {
+        val attempt = {
+            MultiPartFormDataContent(
+                formData {
+                    append("bad_key", listOf("whatever", "values"))
+                },
+                boundary = "boundary",
+            )
+        }
+
+        val ex = assertFails { attempt() }
+        assertEquals(ex.message, "Array parameter must be suffixed with square brackets ie `bad_key[]`")
+    }
+
+    @Test
     fun testByteReadChannelOverBufferSize() = testSuspend {
         val body = ByteArray(4089) { 'k'.code.toByte() }
         val data = MultiPartFormDataContent(

--- a/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/ContentTest.kt
+++ b/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/ContentTest.kt
@@ -185,6 +185,7 @@ class ContentTest : ClientLoader(5 * 60) {
                 }
                 append("hello", 5)
                 append("world", true)
+                append("engines[]", listOf("Jvm", "Js", "Native"))
             }
         }
 


### PR DESCRIPTION
**Subsystem**
Client multipart/form-data enhancement

**Motivation**
As per [KTOR-5493](https://youtrack.jetbrains.com/issue/KTOR-5493) there is desire to encode `{Array,Iterable}<String>` via convenient dsl.

**Solution**
Adding overload for `append` function which effectively puts contents of collection as separate `FormPart`s.

Supersedes #3381 @rsinukov PTAL