### PR TITLE
KTOR-4515 set realm before it's used to create credential

### DIFF
--- a/ktor-client/ktor-client-plugins/ktor-client-auth/common/src/io/ktor/client/plugins/auth/providers/DigestAuthProvider.kt
+++ b/ktor-client/ktor-client-plugins/ktor-client-auth/common/src/io/ktor/client/plugins/auth/providers/DigestAuthProvider.kt
@@ -163,7 +163,7 @@ public class DigestAuthProvider(
         val realm = realm ?: authHeader?.let { auth ->
             (auth as? HttpAuthHeader.Parameterized)?.parameter("realm")
         }
-        
+
         val credentials = tokenHolder.loadToken() ?: return
         val credential = makeDigest("${credentials.username}:$realm:${credentials.password}")
 

--- a/ktor-client/ktor-client-plugins/ktor-client-auth/common/src/io/ktor/client/plugins/auth/providers/DigestAuthProvider.kt
+++ b/ktor-client/ktor-client-plugins/ktor-client-auth/common/src/io/ktor/client/plugins/auth/providers/DigestAuthProvider.kt
@@ -160,6 +160,10 @@ public class DigestAuthProvider(
         val serverOpaque = opaque.value
         val actualQop = qop.value
 
+        val realm = realm ?: authHeader?.let { auth ->
+            (auth as? HttpAuthHeader.Parameterized)?.parameter("realm")
+        }
+        
         val credentials = tokenHolder.loadToken() ?: return
         val credential = makeDigest("${credentials.username}:$realm:${credentials.password}")
 
@@ -172,9 +176,6 @@ public class DigestAuthProvider(
         }
 
         val token = makeDigest(tokenSequence.joinToString(":"))
-        val realm = realm ?: authHeader?.let { auth ->
-            (auth as? HttpAuthHeader.Parameterized)?.parameter("realm")
-        }
 
         val auth = HttpAuthHeader.Parameterized(
             AuthScheme.Digest,

--- a/ktor-client/ktor-client-plugins/ktor-client-auth/common/test/io/ktor/client/plugins/auth/DigestProviderTest.kt
+++ b/ktor-client/ktor-client-plugins/ktor-client-auth/common/test/io/ktor/client/plugins/auth/DigestProviderTest.kt
@@ -98,6 +98,21 @@ class DigestProviderTest {
         checkStandardFields(authHeader)
     }
 
+    @Test
+    fun testTokenWhenMissingRealmAndQop() = testSuspend {
+        if (!PlatformUtils.IS_JVM) return@testSuspend
+
+        val providerWithoutRealm = DigestAuthProvider("username", "pass", null)
+        val authHeader = parseAuthorizationHeader(authMissingQopAndOpaque)!!
+
+        assertTrue(providerWithoutRealm.isApplicable(authHeader))
+        providerWithoutRealm.addRequestHeaders(requestBuilder, authHeader)
+
+        val resultAuthHeader = requestBuilder.headers[HttpHeaders.Authorization]!!
+        val response = (parseAuthorizationHeader(resultAuthHeader) as HttpAuthHeader.Parameterized).parameter("response")!!
+        assertEquals("d51dd4b72db592e321b80d006d24c34c", response)
+    }
+
     private fun runIsApplicable(headerValue: String) =
         digestAuthProvider.isApplicable(parseAuthorizationHeader(headerValue)!!)
 

--- a/ktor-http/common/src/io/ktor/http/HttpStatusCode.kt
+++ b/ktor-http/common/src/io/ktor/http/HttpStatusCode.kt
@@ -21,7 +21,7 @@ public data class HttpStatusCode(val value: Int, val description: String) : Comp
      * Returns a copy of `this` code with a description changed to [value].
      */
     public fun description(value: String): HttpStatusCode = copy(description = value)
-    
+
     override fun compareTo(other: HttpStatusCode): Int = value - other.value
 
     @Suppress("KDocMissingDocumentation", "PublicApiImplicitType")


### PR DESCRIPTION
**Subsystem**
ktor-client-auth 

**Motivation**
https://youtrack.jetbrains.com/issue/KTOR-4514/DigestAuthProvider-realm-sent-from-the-server-doesnt-participate-in-the-computation-of-response

Connecting to Axis cameras fails without this fix

**Solution**
Prior to this change, the realm used in the `credential` was always the class property. If the realm is unknown, it should be read from the headers. This was happening, but after the `credential` was created.

This change uses the constructed `realm` in the `credential` instead of the class property.

