### PR TITLE
KTOR-5699 Fix reading response of HEAD request

### DIFF
--- a/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/DefaultTransform.kt
+++ b/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/DefaultTransform.kt
@@ -82,7 +82,10 @@ public fun HttpClient.defaultTransformers() {
 
                 val contentLength = response.contentLength()
                 val notEncoded = !PlatformUtils.IS_BROWSER && response.headers[HttpHeaders.ContentEncoding] == null
-                if (notEncoded && contentLength != null && contentLength > 0) {
+                // HEAD requests could have a non-zero Content-Length
+                // See https://www.rfc-editor.org/rfc/rfc9110.html#section-9.3.2-2
+                val notHead = context.request.method != HttpMethod.Head
+                if (notEncoded && notHead && contentLength != null && contentLength > 0) {
                     check(bytes.size == contentLength.toInt()) { "Expected $contentLength, actual ${bytes.size}" }
                 }
                 proceedWith(HttpResponseContainer(info, bytes))


### PR DESCRIPTION
**Subsystem**
client

**Motivation**
A lot of code has the same implementation handling all HTTP requests and this includes reading the body of a response. In the case of a HEAD request this can break when the Content-Length header has a non-zero value

**Solution**
Do not check the response length matches the Content-Length header for HEAD requests

