### PR TITLE
KTOR-5652 Add proper cause to WebSocketException in Java engine

### DIFF
--- a/ktor-client/ktor-client-core/api/ktor-client-core.api
+++ b/ktor-client/ktor-client-core/api/ktor-client-core.api
@@ -900,6 +900,7 @@ public final class io/ktor/client/plugins/websocket/WebSocketCapability : io/kto
 
 public final class io/ktor/client/plugins/websocket/WebSocketException : java/lang/IllegalStateException {
 	public fun <init> (Ljava/lang/String;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/Throwable;)V
 }
 
 public final class io/ktor/client/plugins/websocket/WebSocketExtensionsCapability : io/ktor/client/engine/HttpClientEngineCapability {

--- a/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/websocket/WebSockets.kt
+++ b/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/websocket/WebSockets.kt
@@ -201,4 +201,7 @@ public class WebSockets internal constructor(
 }
 
 @Suppress("KDocMissingDocumentation")
-public class WebSocketException(message: String) : IllegalStateException(message)
+public class WebSocketException(message: String, cause: Throwable?) : IllegalStateException(message, cause) {
+    // required for backwards binary compatibility
+    public constructor(message: String) : this(message, cause = null)
+}

--- a/ktor-client/ktor-client-java/jvm/src/io/ktor/client/engine/java/JavaHttpWebSocket.kt
+++ b/ktor-client/ktor-client-java/jvm/src/io/ktor/client/engine/java/JavaHttpWebSocket.kt
@@ -183,7 +183,7 @@ internal class JavaHttpWebSocket(
     }.asCompletableFuture()
 
     override fun onError(webSocket: WebSocket, error: Throwable) {
-        val cause = WebSocketException("${error.message}")
+        val cause = WebSocketException(error.message ?: "web socket failed", error)
         _incoming.close(cause)
         _outgoing.cancel()
         socketJob.complete()


### PR DESCRIPTION
**Subsystem**
Client, Web Sockets

**Motivation**
The web socket client throws `WebSocketException` without cause in `onError` in the Java engine.
See https://youtrack.jetbrains.com/issue/KTOR-5652/Missing-cause-for-WebSocketException-in-JavaHttpWebSocket

**Solution**
Add the cause to the exception, so the stacktraces can show the underlying problem when the message is not sufficient (or absent).

