### PR TITLE
KTOR-5672 Fix erroneous trace log about expired websocket pings

### DIFF
--- a/ktor-shared/ktor-websockets/common/src/io/ktor/websocket/PingPong.kt
+++ b/ktor-shared/ktor-websockets/common/src/io/ktor/websocket/PingPong.kt
@@ -86,13 +86,12 @@ internal fun CoroutineScope.pinger(
                     }
                 }
 
-                LOGGER.trace("WebSocket pinger has timed out")
-
                 if (rc == null) {
                     // timeout
                     // we were unable to send the ping or hadn't got a valid pong message in time,
                     // so we are triggering close sequence (if already started then the following close frame could be ignored)
 
+                    LOGGER.trace("WebSocket pinger has timed out")
                     onTimeout(CloseReason(CloseReason.Codes.INTERNAL_ERROR, "Ping timeout"))
                     break
                 }


### PR DESCRIPTION
**Subsystem**
Server, websocket

**Motivation**
[KTOR-5672](https://youtrack.jetbrains.com/issue/KTOR-5672) The trace log was written even when the `PONG` frame was received in time after the `PING` one.

**Solution**
Shouldn't we put the log in the condition body? Currently, this is confusing.

