### PR TITLE
KTOR-5456 Fix log level for JS Client DEBUG & TRACE logging

### DIFF
--- a/ktor-utils/js/src/io/ktor/util/logging/KtorSimpleLoggerJs.kt
+++ b/ktor-utils/js/src/io/ktor/util/logging/KtorSimpleLoggerJs.kt
@@ -31,18 +31,18 @@ public actual fun KtorSimpleLogger(name: String): Logger = object : Logger {
     }
 
     override fun debug(message: String) {
-        console.info("DEBUG: $message")
+        console.debug("DEBUG: $message")
     }
 
     override fun debug(message: String, cause: Throwable) {
-        console.info("DEBUG: $message, cause: $cause")
+        console.debug("DEBUG: $message, cause: $cause")
     }
 
     override fun trace(message: String) {
-        console.info("TRACE: $message")
+        console.debug("TRACE: $message")
     }
 
     override fun trace(message: String, cause: Throwable) {
-        console.info("TRACE: $message, cause: $cause")
+        console.debug("TRACE: $message, cause: $cause")
     }
 }

--- a/ktor-utils/js/src/io/ktor/util/logging/KtorSimpleLoggerJs.kt
+++ b/ktor-utils/js/src/io/ktor/util/logging/KtorSimpleLoggerJs.kt
@@ -46,3 +46,14 @@ public actual fun KtorSimpleLogger(name: String): Logger = object : Logger {
         console.debug("TRACE: $message, cause: $cause")
     }
 }
+
+// kotlin Console class doesn't expose `debug` method
+private external interface Console {
+    fun error(vararg o: Any?)
+    fun info(vararg o: Any?)
+    fun log(vararg o: Any?)
+    fun warn(vararg o: Any?)
+    fun debug(vararg o: Any?)
+}
+
+private external val console: Console


### PR DESCRIPTION
**Subsystem**
Client, all modules

**Motivation**
The Ktor JS client is currently very noisy, displays lots of TRACE logs at the "info" level which is typically visible by default (in Chrome).

**Solution**
By using `console.debug()` these TRACE logs will be hidden unless you enable Verbose logging in the JS console.
