### PR TITLE
KTOR-829 Support `100 Continue` on server side

### DIFF
--- a/ktor-server/ktor-server-cio/build.gradle.kts
+++ b/ktor-server/ktor-server-cio/build.gradle.kts
@@ -7,7 +7,6 @@ kotlin.sourceSets {
             api(project(":ktor-http:ktor-http-cio"))
             api(project(":ktor-shared:ktor-websockets"))
             api(project(":ktor-network"))
-            implementation(project(":ktor-server:ktor-server-core"))
         }
     }
     jvmAndNixTest {

--- a/ktor-server/ktor-server-cio/build.gradle.kts
+++ b/ktor-server/ktor-server-cio/build.gradle.kts
@@ -7,6 +7,7 @@ kotlin.sourceSets {
             api(project(":ktor-http:ktor-http-cio"))
             api(project(":ktor-shared:ktor-websockets"))
             api(project(":ktor-network"))
+            implementation(project(":ktor-server:ktor-server-core"))
         }
     }
     jvmAndNixTest {

--- a/ktor-server/ktor-server-cio/jvmAndNix/test/io/ktor/tests/server/cio/CIOEngineTest.kt
+++ b/ktor-server/ktor-server-cio/jvmAndNix/test/io/ktor/tests/server/cio/CIOEngineTest.kt
@@ -8,15 +8,20 @@ package io.ktor.tests.server.cio
 import io.ktor.client.statement.*
 import io.ktor.http.*
 import io.ktor.http.content.*
+import io.ktor.network.selector.*
+import io.ktor.network.sockets.*
 import io.ktor.server.application.*
 import io.ktor.server.cio.*
+import io.ktor.server.request.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
 import io.ktor.server.testing.suites.*
 import io.ktor.utils.io.*
+import io.ktor.utils.io.core.*
 import kotlin.test.*
 
 class CIOHttpServerTest : HttpServerCommonTestSuite<CIOApplicationEngine, CIOApplicationEngine.Configuration>(CIO) {
+
     init {
         enableHttp2 = false
         enableSsl = false
@@ -40,5 +45,182 @@ class CIOHttpServerTest : HttpServerCommonTestSuite<CIOApplicationEngine, CIOApp
         withUrl("/") {
             assertEquals("test", bodyAsText())
         }
+    }
+
+    @Test
+    fun testExpectedContinue() = runTest {
+        createAndStartServer {
+            post("/") {
+                val body = call.receiveText()
+                call.respondText(body)
+            }
+        }
+
+        withSocket {
+            val writeChannel = openWriteChannel()
+            val readChannel = openReadChannel()
+            val body = "Hello world"
+
+            writePostHeaders(writeChannel, body.length)
+            val continueResponse = readChannel.readUTF8Line()
+            assertEquals("HTTP/1.1 100 Continue", continueResponse)
+
+            writePostBody(writeChannel, body)
+            val response = readChannel.readRemaining().readText()
+            assertTrue(response.contains("HTTP/1.1 200 OK"))
+            assertTrue(response.contains(body))
+        }
+    }
+
+    @Test
+    fun testExpectedContinueRespondBeforeReadingBody() = runTest {
+        createAndStartServer {
+            post("/") {
+                val length = call.request.headers[HttpHeaders.ContentLength]?.toInt() ?: 0
+                if (length > 5) {
+                    call.respond(HttpStatusCode.BadRequest)
+                    return@post
+                }
+                val body = call.receiveText()
+                call.respondText(body)
+            }
+        }
+
+        withSocket {
+            val writeChannel = openWriteChannel()
+            val readChannel = openReadChannel()
+
+            val longBody = "Hello world"
+            writePostHeaders(writeChannel, longBody.length)
+            val badRequestResponse = readChannel.readUTF8Line()
+            assertEquals("HTTP/1.1 400 Bad Request", badRequestResponse)
+        }
+    }
+
+    @Test
+    fun testExpectedContinueExpectationFailed() = runTest {
+        createAndStartServer {
+            post("/") {
+                val body = call.receiveText()
+                call.respondText(body)
+            }
+        }
+
+        withSocket {
+            val writeChannel = openWriteChannel()
+            val readChannel = openReadChannel()
+
+            val longBody = "Hello world"
+            writePostHeaders(writeChannel, longBody.length, expectedHeader = "invalid-100-continue")
+            val expectationFailedResponse = readChannel.readUTF8Line()
+            assertEquals("HTTP/1.1 417 Expectation Failed", expectationFailedResponse)
+        }
+    }
+
+    @Test
+    fun testExpectedContinueConnection() = runTest {
+        createAndStartServer {
+            post("/") {
+                val body = call.receiveText()
+                call.respond(body)
+            }
+            post("/check-length") {
+                val length = call.request.headers[HttpHeaders.ContentLength]?.toInt() ?: 0
+                if (length == 0) {
+                    call.respond(HttpStatusCode.BadRequest)
+                    return@post
+                }
+                call.respondText("ok")
+            }
+        }
+
+        withSocket {
+            val writeChannel = openWriteChannel()
+            val readChannel = openReadChannel()
+
+            val body = "Hello world"
+            writePostHeaders(writeChannel, body.length)
+            writePostBody(writeChannel, body)
+            val response = readChannel.readRemaining().readText()
+            assertTrue(response.contains("Connection: keep-alive"))
+        }
+
+        withSocket {
+            val writeChannel = openWriteChannel()
+            val readChannel = openReadChannel()
+
+            writePostHeaders(writeChannel, path = "/check-length")
+            val response = readChannel.readRemaining().readText()
+            assertTrue(response.contains("Connection: close"))
+        }
+
+        withSocket {
+            val writeChannel = openWriteChannel()
+            val readChannel = openReadChannel()
+
+            writePostHeaders(writeChannel, expectedHeader = "invalid")
+            val response = readChannel.readRemaining().readText()
+            assertTrue(response.contains("Connection: close"))
+        }
+    }
+
+    @Test
+    fun testExpectedIgnoreHTTP1_0() = runTest {
+        createAndStartServer {
+            post("/") {
+                val body = call.receiveText()
+                call.respond(body)
+            }
+        }
+
+        withSocket {
+            val writeChannel = openWriteChannel()
+            val readChannel = openReadChannel()
+
+            val body = "Hello world"
+            writePostHeaders(writeChannel, body.length, httpVersion = "HTTP/1.0")
+            writePostBody(writeChannel, body)
+            val response = readChannel.readRemaining().readText()
+            assertFalse(response.contains("100 Continue"))
+        }
+    }
+
+    private suspend fun withSocket(block: suspend Socket.() -> Unit) {
+        SelectorManager().use {
+            aSocket(it).tcp().connect(TEST_SERVER_HOST, port).use { socket ->
+                block(socket)
+            }
+        }
+    }
+
+    private suspend fun writePostHeaders(
+        channel: ByteWriteChannel,
+        length: Int = 0,
+        path: String = "/",
+        expectedHeader: String = "100-continue",
+        httpVersion: String = "HTTP/1.1"
+    ) {
+        channel.apply {
+            writeStringUtf8("POST $path $httpVersion\r\n")
+            writeStringUtf8("Host: $TEST_SERVER_HOST\r\n")
+            writeStringUtf8("Content-Type: text/plain\r\n")
+            writeStringUtf8("Content-Length: $length\r\n")
+            writeStringUtf8("Expect: $expectedHeader\r\n")
+            writeStringUtf8("Connection: close\r\n")
+            writeStringUtf8("\r\n")
+            flush()
+        }
+    }
+
+    private suspend fun writePostBody(channel: ByteWriteChannel, body: String) {
+        channel.apply {
+            writeStringUtf8("$body\r\n")
+            writeStringUtf8("\r\n")
+            flush()
+        }
+    }
+
+    companion object {
+        private const val TEST_SERVER_HOST = "127.0.0.1"
     }
 }


### PR DESCRIPTION
Server
[KTOR-829](https://youtrack.jetbrains.com/issue/KTOR-829/Support-100-Continue)
[rfc7231](https://www.rfc-editor.org/rfc/rfc7231#section-5.1.1)


