### PR TITLE
KTOR-5699 Fix reading response of HEAD request

### DIFF
--- a/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/DefaultTransform.kt
+++ b/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/DefaultTransform.kt
@@ -82,8 +82,6 @@ public fun HttpClient.defaultTransformers() {
 
                 val contentLength = response.contentLength()
                 val notEncoded = !PlatformUtils.IS_BROWSER && response.headers[HttpHeaders.ContentEncoding] == null
-                // HEAD requests could have a non-zero Content-Length
-                // See https://www.rfc-editor.org/rfc/rfc9110.html#section-9.3.2-2
                 val notHead = context.request.method != HttpMethod.Head
                 if (notEncoded && notHead && contentLength != null && contentLength > 0) {
                     check(bytes.size == contentLength.toInt()) { "Expected $contentLength, actual ${bytes.size}" }

--- a/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/DefaultTransform.kt
+++ b/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/DefaultTransform.kt
@@ -82,7 +82,10 @@ public fun HttpClient.defaultTransformers() {
 
                 val contentLength = response.contentLength()
                 val notEncoded = !PlatformUtils.IS_BROWSER && response.headers[HttpHeaders.ContentEncoding] == null
-                if (notEncoded && contentLength != null && contentLength > 0) {
+                // HEAD requests could have a non-zero Content-Length
+                // See https://www.rfc-editor.org/rfc/rfc9110.html#section-9.3.2-2
+                val notHead = context.request.method != HttpMethod.Head
+                if (notEncoded && notHead && contentLength != null && contentLength > 0) {
                     check(bytes.size == contentLength.toInt()) { "Expected $contentLength, actual ${bytes.size}" }
                 }
                 proceedWith(HttpResponseContainer(info, bytes))

--- a/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/DefaultTransformTest.kt
+++ b/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/DefaultTransformTest.kt
@@ -8,15 +8,17 @@ import io.ktor.client.*
 import io.ktor.client.call.*
 import io.ktor.client.engine.mock.*
 import io.ktor.client.request.*
-import io.ktor.client.tests.utils.*
 import io.ktor.http.*
 import io.ktor.test.dispatcher.*
+import io.ktor.util.*
 import kotlin.test.*
 
 class DefaultTransformTest {
 
     @Test
     fun testVerifyByteArrayLength() = testSuspend {
+        if (PlatformUtils.IS_BROWSER) return@testSuspend
+
         val httpClient = HttpClient(MockEngine) {
             engine {
                 addHandler { _ ->
@@ -28,5 +30,18 @@ class DefaultTransformTest {
         assertFailsWith<IllegalStateException> {
             httpClient.get("http://host/path").body<ByteArray>()
         }
+    }
+
+    @Test
+    fun testReadingHeadResponseAsByteArray() = testSuspend {
+        val httpClient = HttpClient(MockEngine) {
+            engine {
+                addHandler { _ ->
+                    respond("", headers = headersOf(HttpHeaders.ContentLength, "123"))
+                }
+            }
+        }
+
+        httpClient.head("http://host/path").body<ByteArray>()
     }
 }


### PR DESCRIPTION
A lot of code has the same implementation for handling all HTTP requests, and this includes reading the body of a response. In the case of a HEAD request, this can break when the Content-Length header has a non-zero
value

Original PR https://github.com/ktorio/ktor/pull/3438