### PR TITLE
KTOR-829 Support `100 Continue` on client side

### DIFF
--- a/ktor-client/ktor-client-cio/jvmAndNix/src/io/ktor/client/engine/cio/Endpoint.kt
+++ b/ktor-client/ktor-client-cio/jvmAndNix/src/io/ktor/client/engine/cio/Endpoint.kt
@@ -10,10 +10,12 @@ import io.ktor.client.plugins.*
 import io.ktor.client.request.*
 import io.ktor.client.utils.*
 import io.ktor.http.*
+import io.ktor.http.content.*
 import io.ktor.network.sockets.*
 import io.ktor.network.tls.*
 import io.ktor.util.*
 import io.ktor.util.date.*
+import io.ktor.utils.io.*
 import io.ktor.utils.io.core.*
 import kotlinx.atomicfu.*
 import kotlinx.coroutines.*
@@ -119,11 +121,66 @@ internal class Endpoint(
             setupTimeout(callContext, request, timeout)
 
             val requestTime = GMTDate()
-            writeRequest(request, output, callContext, proxy != null)
-            return readResponse(requestTime, request, input, originOutput, callContext)
+            val overProxy = proxy != null
+
+            return if (expectContinue(request.headers[HttpHeaders.Expect], request.body)) {
+                processExpectContinue(request, input, output, originOutput, callContext, requestTime, overProxy)
+            } else {
+                writeRequest(request, output, callContext, overProxy)
+                readResponse(requestTime, request, input, originOutput, callContext)
+            }
         } catch (cause: Throwable) {
             throw cause.mapToKtor(request)
         }
+    }
+
+    @OptIn(InternalCoroutinesApi::class)
+    private suspend fun processExpectContinue(
+        request: HttpRequestData,
+        input: ByteReadChannel,
+        output: ByteWriteChannel,
+        originOutput: ByteWriteChannel,
+        callContext: CoroutineContext,
+        requestTime: GMTDate,
+        overProxy: Boolean,
+    ) = withContext(callContext) {
+        writeHeaders(request, output, overProxy, closeChannel = false)
+
+        val response = withTimeoutOrNull(CONTINUE_RESPONSE_TIMEOUT_MILLIS) {
+            val job = Job()
+            coroutineContext.job.invokeOnCompletion(onCancelling = true) {
+                if (it == null) job.complete()
+                else job.completeExceptionally(it)
+            }
+            callContext.job.invokeOnCompletion {
+                if (it == null) job.complete()
+                else job.completeExceptionally(it)
+            }
+
+            readResponse(requestTime, request, input, originOutput, callContext + job)
+        }
+
+        if (response != null) {
+            when (response.statusCode) {
+                HttpStatusCode.ExpectationFailed -> {
+                    val newRequest = HttpRequestBuilder().apply {
+                        takeFrom(request)
+                        headers.remove(HttpHeaders.Expect)
+                    }.build()
+                    writeRequest(newRequest, output, callContext, overProxy)
+                }
+
+                HttpStatusCode.Continue -> {
+                    writeBody(request, output, callContext)
+                }
+
+                else -> return@withContext response
+            }
+        } else {
+            writeBody(request, output, callContext)
+        }
+
+        return@withContext readResponse(requestTime, request, input, originOutput, callContext)
     }
 
     private suspend fun createPipeline(request: HttpRequestData) {
@@ -240,6 +297,10 @@ internal class Endpoint(
 
     override fun close() {
         timeout.cancel()
+    }
+
+    companion object {
+        const val CONTINUE_RESPONSE_TIMEOUT_MILLIS = 1000L
     }
 }
 

--- a/ktor-client/ktor-client-cio/jvmAndNix/src/io/ktor/client/engine/cio/Endpoint.kt
+++ b/ktor-client/ktor-client-cio/jvmAndNix/src/io/ktor/client/engine/cio/Endpoint.kt
@@ -216,7 +216,7 @@ internal class Endpoint(
                 }
 
                 val socket = when (connectTimeout) {
-                    HttpTimeout.INFINITE_TIMEOUT_MS -> connect()
+                    HttpTimeout.INFINITE_TIMEOUT_MS -> coroutineScope { connect() }
                     else -> {
                         val connection = withTimeoutOrNull(connectTimeout, connect)
                         if (connection == null) {

--- a/ktor-client/ktor-client-cio/jvmAndNix/src/io/ktor/client/engine/cio/Endpoint.kt
+++ b/ktor-client/ktor-client-cio/jvmAndNix/src/io/ktor/client/engine/cio/Endpoint.kt
@@ -192,6 +192,7 @@ internal class Endpoint(
         pipeline.pipelineContext.invokeOnCompletion { releaseConnection() }
     }
 
+    @Suppress("UNUSED_EXPRESSION")
     private suspend fun connect(requestData: HttpRequestData): Connection {
         val connectAttempts = config.endpoint.connectAttempts
         val (connectTimeout, socketTimeout) = retrieveTimeouts(requestData)
@@ -210,7 +211,7 @@ internal class Endpoint(
                 }
 
                 val socket = when (connectTimeout) {
-                    HttpTimeout.INFINITE_TIMEOUT_MS -> coroutineScope { connect() }
+                    HttpTimeout.INFINITE_TIMEOUT_MS -> connect()
                     else -> {
                         val connection = withTimeoutOrNull(connectTimeout, connect)
                         if (connection == null) {

--- a/ktor-client/ktor-client-cio/jvmAndNix/src/io/ktor/client/engine/cio/Endpoint.kt
+++ b/ktor-client/ktor-client-cio/jvmAndNix/src/io/ktor/client/engine/cio/Endpoint.kt
@@ -144,7 +144,7 @@ internal class Endpoint(
         requestTime: GMTDate,
         overProxy: Boolean,
     ) = withContext(callContext) {
-        writeHeaders(request, output, overProxy, closeChannel = false)
+        writeHeaders(request, output, overProxy)
 
         val response = withTimeoutOrNull(CONTINUE_RESPONSE_TIMEOUT_MILLIS) {
             val job = Job()

--- a/ktor-client/ktor-client-cio/jvmAndNix/src/io/ktor/client/engine/cio/Endpoint.kt
+++ b/ktor-client/ktor-client-cio/jvmAndNix/src/io/ktor/client/engine/cio/Endpoint.kt
@@ -174,7 +174,10 @@ internal class Endpoint(
                     writeBody(request, output, callContext)
                 }
 
-                else -> return@withContext response
+                else -> {
+                    output.close()
+                    return@withContext response
+                }
             }
         } else {
             writeBody(request, output, callContext)

--- a/ktor-client/ktor-client-cio/jvmAndNix/src/io/ktor/client/engine/cio/utils.kt
+++ b/ktor-client/ktor-client-cio/jvmAndNix/src/io/ktor/client/engine/cio/utils.kt
@@ -39,7 +39,7 @@ internal suspend fun writeHeaders(
     request: HttpRequestData,
     output: ByteWriteChannel,
     overProxy: Boolean,
-    closeChannel: Boolean
+    closeChannel: Boolean = true
 ) {
     val builder = RequestResponseBuilder()
 

--- a/ktor-client/ktor-client-cio/jvmAndNix/src/io/ktor/client/engine/cio/utils.kt
+++ b/ktor-client/ktor-client-cio/jvmAndNix/src/io/ktor/client/engine/cio/utils.kt
@@ -176,7 +176,7 @@ internal suspend fun readResponse(
 
         val body = when {
             request.method == HttpMethod.Head ||
-                status in listOf(HttpStatusCode.NotModified, HttpStatusCode.NoContent, HttpStatusCode.Continue) ||
+                status in listOf(HttpStatusCode.NotModified, HttpStatusCode.NoContent) ||
                 status.isInformational() -> {
                 ByteReadChannel.Empty
             }

--- a/ktor-client/ktor-client-cio/jvmAndNix/src/io/ktor/client/engine/cio/utils.kt
+++ b/ktor-client/ktor-client-cio/jvmAndNix/src/io/ktor/client/engine/cio/utils.kt
@@ -30,6 +30,17 @@ internal suspend fun writeRequest(
     overProxy: Boolean,
     closeChannel: Boolean = true
 ) = withContext(callContext) {
+    writeHeaders(request, output, overProxy, closeChannel)
+    writeBody(request, output, callContext)
+}
+
+@OptIn(InternalAPI::class)
+internal suspend fun writeHeaders(
+    request: HttpRequestData,
+    output: ByteWriteChannel,
+    overProxy: Boolean,
+    closeChannel: Boolean
+) {
     val builder = RequestResponseBuilder()
 
     val method = request.method
@@ -40,7 +51,8 @@ internal suspend fun writeRequest(
     val contentLength = headers[HttpHeaders.ContentLength] ?: body.contentLength?.toString()
     val contentEncoding = headers[HttpHeaders.TransferEncoding]
     val responseEncoding = body.headers[HttpHeaders.TransferEncoding]
-    val chunked = contentLength == null || responseEncoding == "chunked" || contentEncoding == "chunked"
+    val chunked = isChunked(contentLength, responseEncoding, contentEncoding)
+    val expected = headers[HttpHeaders.Expect]
 
     try {
         val normalizedUrl = if (url.pathSegments.isEmpty()) URLBuilder(url).apply { encodedPath = "/" }.build() else url
@@ -64,13 +76,17 @@ internal suspend fun writeRequest(
         }
 
         mergeHeaders(headers, body) { key, value ->
-            if (key == HttpHeaders.ContentLength) return@mergeHeaders
+            if (key == HttpHeaders.ContentLength || key == HttpHeaders.Expect) return@mergeHeaders
 
             builder.headerLine(key, value)
         }
 
         if (chunked && contentEncoding == null && responseEncoding == null && body !is OutgoingContent.NoContent) {
             builder.headerLine(HttpHeaders.TransferEncoding, "chunked")
+        }
+
+        if (expectContinue(expected, body)) {
+            builder.headerLine(HttpHeaders.Expect, expected!!)
         }
 
         builder.emptyLine()
@@ -84,11 +100,23 @@ internal suspend fun writeRequest(
     } finally {
         builder.release()
     }
+}
 
-    if (body is OutgoingContent.NoContent) {
+internal suspend fun writeBody(
+    request: HttpRequestData,
+    output: ByteWriteChannel,
+    callContext: CoroutineContext,
+    closeChannel: Boolean = true
+) {
+    if (request.body is OutgoingContent.NoContent) {
         if (closeChannel) output.close()
-        return@withContext
+        return
     }
+
+    val contentLength = request.headers[HttpHeaders.ContentLength] ?: request.body.contentLength?.toString()
+    val contentEncoding = request.headers[HttpHeaders.TransferEncoding]
+    val responseEncoding = request.body.headers[HttpHeaders.TransferEncoding]
+    val chunked = isChunked(contentLength, responseEncoding, contentEncoding)
 
     val chunkedJob: EncoderJob? = if (chunked) encodeChunked(output, callContext) else null
     val channel = chunkedJob?.channel ?: output
@@ -96,7 +124,7 @@ internal suspend fun writeRequest(
     val scope = CoroutineScope(callContext + CoroutineName("Request body writer"))
     scope.launch {
         try {
-            when (body) {
+            when (val body = request.body) {
                 is OutgoingContent.NoContent -> return@launch
                 is OutgoingContent.ByteArrayContent -> channel.writeFully(body.bytes())
                 is OutgoingContent.ReadChannelContent -> body.readFrom().copyAndClose(channel)
@@ -148,10 +176,11 @@ internal suspend fun readResponse(
 
         val body = when {
             request.method == HttpMethod.Head ||
-                status in listOf(HttpStatusCode.NotModified, HttpStatusCode.NoContent) ||
+                status in listOf(HttpStatusCode.NotModified, HttpStatusCode.NoContent, HttpStatusCode.Continue) ||
                 status.isInformational() -> {
                 ByteReadChannel.Empty
             }
+
             else -> {
                 val coroutineScope = CoroutineScope(callContext + CoroutineName("Response"))
                 val httpBodyParser = coroutineScope.writer(autoFlush = true) {
@@ -252,3 +281,12 @@ internal fun ByteWriteChannel.handleHalfClosed(
     coroutineContext: CoroutineContext,
     propagateClose: Boolean
 ): ByteWriteChannel = if (propagateClose) this else withoutClosePropagation(coroutineContext)
+
+internal fun isChunked(
+    contentLength: String?,
+    responseEncoding: String?,
+    contentEncoding: String?
+) = contentLength == null || responseEncoding == "chunked" || contentEncoding == "chunked"
+
+internal fun expectContinue(expectHeader: String?, body: OutgoingContent) =
+    expectHeader != null && body !is OutgoingContent.NoContent


### PR DESCRIPTION
Client
[KTOR-829](https://youtrack.jetbrains.com/issue/KTOR-829/Support-100-Continue)
[rfc7231 section-5.1.1](https://www.rfc-editor.org/rfc/rfc7231#section-5.1.1)
