### PR TITLE
Fix percentEncode to use UTF-8

### DIFF
--- a/ktor-http/common/src/io/ktor/http/Codecs.kt
+++ b/ktor-http/common/src/io/ktor/http/Codecs.kt
@@ -130,16 +130,22 @@ internal fun String.percentEncode(allowedSet: Set<Char>): String {
     val encodedCount = count { it !in allowedSet }
     if (encodedCount == 0) return this
 
-    val resultSize = length + encodedCount * 2
+    val content = toByteArray(Charsets.UTF_8)
+
+    val rawCount = length - encodedCount
+    val resultSize = rawCount + (content.size - rawCount) * 3
     val result = CharArray(resultSize)
 
     var writeIndex = 0
-    for (index in 0 until length) {
-        val current = this[index]
-        if (current in allowedSet) {
-            result[writeIndex++] = current
+
+    content.forEach {
+        val char = it.toInt().toChar()
+
+        if (char in allowedSet) {
+            result[writeIndex++] = char
         } else {
-            val code = current.code
+            val code = it.toInt() and 0xff
+
             result[writeIndex++] = '%'
             result[writeIndex++] = hexDigitToChar(code shr 4)
             result[writeIndex++] = hexDigitToChar(code and 0xf)

--- a/ktor-http/common/test/io/ktor/tests/http/ContentDispositionTest.kt
+++ b/ktor-http/common/test/io/ktor/tests/http/ContentDispositionTest.kt
@@ -19,6 +19,16 @@ class ContentDispositionTest {
     }
 
     @Test
+    fun testMultiByteFilename() {
+        val attachment = ContentDisposition.Attachment.withParameter(
+            ContentDisposition.Parameters.FileNameAsterisk,
+            "a©あ𠮷.txt"
+        ).toString()
+
+        assertEquals("attachment; filename*=utf-8''a%C2%A9%E3%81%82%F0%A0%AE%B7.txt", attachment)
+    }
+
+    @Test
     fun testNoEncodeTwice() {
         val value = "UTF-8''%27%27malicious.sh%2500%27normal.txt"
         val attachment = ContentDisposition.Attachment.withParameter(


### PR DESCRIPTION
**Subsystem**
ktor-http

**Motivation**
The Content-Disposition header filename* content does not handle multi byte characters properly.
This is because `percentEncode` function used within `encodeContentDispositionAttribute`, does not encode the string to UTF-8.

**Solution**
Encode the string using UTF-8 representation, and add a test that handles multi byte characters.

