### PR TITLE
KTOR-2932 Fix cancelled and failed JS websockets not closing

### DIFF
--- a/ktor-client/ktor-client-core/js/src/io/ktor/client/plugins/websocket/JsWebSocketSession.kt
+++ b/ktor-client/ktor-client-core/js/src/io/ktor/client/plugins/websocket/JsWebSocketSession.kt
@@ -127,7 +127,9 @@ internal class JsWebSocketSession(
             if (cause == null) {
                 websocket.close()
             } else {
-                websocket.close(CloseReason.Codes.INTERNAL_ERROR.code, "Client failed")
+                // We cannot use INTERNAL_ERROR similarly to other WebSocketSession implementations here
+                // as sending it is not supported by browsers.
+                websocket.close(CloseReason.Codes.NORMAL.code, "Client failed")
             }
         }
     }

--- a/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/WebSocketTest.kt
+++ b/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/WebSocketTest.kt
@@ -253,4 +253,21 @@ class WebSocketTest : ClientLoader() {
             }
         }
     }
+
+    @Test
+    fun testCancellingScope() = clientTests(ENGINES_WITHOUT_WS) {
+        config {
+            install(WebSockets)
+        }
+
+        test { client ->
+            val session = client.webSocketSession("$TEST_WEBSOCKET_SERVER/websockets/echo")
+            session.send("test")
+            val result = session.incoming.receive() as Frame.Text
+            assertEquals("test", result.readText())
+
+            client.coroutineContext[Job]!!.cancel("test", IllegalStateException("test"))
+            assertNotNull(session.closeReason.await())
+        }
+    }
 }


### PR DESCRIPTION
**Subsystem**
Client, JS, Websockets

**Motivation**
Currently, websockets opened by the JS implementation in the browser do not get properly closed in case of cancellation or failure.

This is caused by browser `websocket.close()` throwing `InvalidAccessError` with codes that are not 1000 or 3000-4999 (see documentation [here](https://developer.mozilla.org/en-US/docs/Web/API/WebSocket/close#exceptions)), the implementation used 1011.

This is also mentioned in KTOR-2932. This PR does not change the meaning of cancellations which is the main focus of KTOR-2932, it only addresses the major bug.

The websockets staying open can cause critical performance issues (and has caused them for us, exhausting websockets in nginx).

**Solution**
Use 1000 as the closing reason code in the JS implementation, it is likely the only reasonable option as using something from the 3000-4999 range would be unexpected.