### PR TITLE
KTOR-4673 Add '425 Too Early' http status code

### DIFF
--- a/ktor-http/api/ktor-http.api
+++ b/ktor-http/api/ktor-http.api
@@ -706,6 +706,7 @@ public final class io/ktor/http/HttpStatusCode$Companion {
 	public final fun getSwitchProxy ()Lio/ktor/http/HttpStatusCode;
 	public final fun getSwitchingProtocols ()Lio/ktor/http/HttpStatusCode;
 	public final fun getTemporaryRedirect ()Lio/ktor/http/HttpStatusCode;
+	public final fun getTooEarly ()Lio/ktor/http/HttpStatusCode;
 	public final fun getTooManyRequests ()Lio/ktor/http/HttpStatusCode;
 	public final fun getUnauthorized ()Lio/ktor/http/HttpStatusCode;
 	public final fun getUnprocessableEntity ()Lio/ktor/http/HttpStatusCode;

--- a/ktor-http/common/src/io/ktor/http/HttpStatusCode.kt
+++ b/ktor-http/common/src/io/ktor/http/HttpStatusCode.kt
@@ -85,6 +85,7 @@ public data class HttpStatusCode(val value: Int, val description: String) : Comp
         public val UnprocessableEntity: HttpStatusCode = HttpStatusCode(422, "Unprocessable Entity")
         public val Locked: HttpStatusCode = HttpStatusCode(423, "Locked")
         public val FailedDependency: HttpStatusCode = HttpStatusCode(424, "Failed Dependency")
+        public val TooEarly: HttpStatusCode = HttpStatusCode(425, "Too Early")
         public val UpgradeRequired: HttpStatusCode = HttpStatusCode(426, "Upgrade Required")
         public val TooManyRequests: HttpStatusCode = HttpStatusCode(429, "Too Many Requests")
 
@@ -170,6 +171,7 @@ internal fun allStatusCodes(): List<HttpStatusCode> = listOf(
     HttpStatusCode.UnprocessableEntity,
     HttpStatusCode.Locked,
     HttpStatusCode.FailedDependency,
+    HttpStatusCode.TooEarly,
     HttpStatusCode.UpgradeRequired,
     HttpStatusCode.TooManyRequests,
     HttpStatusCode.RequestHeaderFieldTooLarge,

--- a/ktor-http/common/test/io/ktor/tests/http/HttpStatusCodeTest.kt
+++ b/ktor-http/common/test/io/ktor/tests/http/HttpStatusCodeTest.kt
@@ -10,7 +10,7 @@ import kotlin.test.*
 class HttpStatusCodeTest {
     @Test
     fun HttpStatusCodeAll() {
-        assertEquals(52, HttpStatusCode.allStatusCodes.size)
+        assertEquals(53, HttpStatusCode.allStatusCodes.size)
     }
 
     @Test


### PR DESCRIPTION
[KTOR-4673](https://youtrack.jetbrains.com/issue/KTOR-4673) The '425 Too Early' status code is missing in the HttpStatusCode

