### PR TITLE
Fix log level doc comment typo

### DIFF
--- a/ktor-client/ktor-client-plugins/ktor-client-logging/common/src/io/ktor/client/plugins/logging/Logging.kt
+++ b/ktor-client/ktor-client-plugins/ktor-client-logging/common/src/io/ktor/client/plugins/logging/Logging.kt
@@ -50,7 +50,7 @@ public class Logging private constructor(
             }
 
         /**
-         * Specifies the log level.
+         * Specifies the logging level.
          */
         public var level: LogLevel = LogLevel.HEADERS
 

--- a/ktor-client/ktor-client-plugins/ktor-client-logging/common/src/io/ktor/client/plugins/logging/Logging.kt
+++ b/ktor-client/ktor-client-plugins/ktor-client-logging/common/src/io/ktor/client/plugins/logging/Logging.kt
@@ -50,7 +50,7 @@ public class Logging private constructor(
             }
 
         /**
-         * Specifies the log the logging level.
+         * Specifies the log level.
          */
         public var level: LogLevel = LogLevel.HEADERS
 


### PR DESCRIPTION
**Subsystem**
Client, Logging plugin

**Motivation**
Original doc comment for `logLevel` property in `Logging.Config` is `Specifies the log the logging level.`

**Solution**
Change the doc comment to `Specifies the logging level.`

