### PR TITLE
Upgrade kotlinx-coroutines to 1.7.1

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -32,7 +32,7 @@ kotlin.native.binary.memoryModel=experimental
 #kotlinx.atomicfu.enableJsIrTransformation=true
 
 kotlin_version=1.8.10
-coroutines_version=1.6.4
+coroutines_version=1.7.0
 atomicfu_version=0.20.0
 slf4j_version=1.7.36
 junit_version=4.13.2

--- a/gradle.properties
+++ b/gradle.properties
@@ -32,7 +32,7 @@ kotlin.native.binary.memoryModel=experimental
 #kotlinx.atomicfu.enableJsIrTransformation=true
 
 kotlin_version=1.8.10
-coroutines_version=1.7.0
+coroutines_version=1.7.1
 atomicfu_version=0.20.0
 slf4j_version=1.7.36
 junit_version=4.13.2

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 kotlin-version = "1.8.10"
 kotlinx-html-version = "0.8.1"
-coroutines-version = "1.6.4"
+coroutines-version = "1.7.0"
 atomicfu-version = "0.18.5"
 serialization-version = "1.5.1"
 validator-version = "0.8.0"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 kotlin-version = "1.8.10"
 kotlinx-html-version = "0.8.1"
-coroutines-version = "1.7.0"
+coroutines-version = "1.7.1"
 atomicfu-version = "0.18.5"
 serialization-version = "1.5.1"
 validator-version = "0.8.0"

--- a/ktor-client/ktor-client-cio/jvm/src/io/ktor/client/plugins/websocket/cio/buildersCio.kt
+++ b/ktor-client/ktor-client-cio/jvm/src/io/ktor/client/plugins/websocket/cio/buildersCio.kt
@@ -14,7 +14,6 @@ import kotlinx.coroutines.*
 /**
  * Creates a raw [ClientWebSocketSession]: no ping-pong and other service messages are used.
  */
-@OptIn(ExperimentalCoroutinesApi::class)
 public suspend fun HttpClient.webSocketRawSession(
     method: HttpMethod = HttpMethod.Get,
     host: String? = null,

--- a/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/websocket/builders.kt
+++ b/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/websocket/builders.kt
@@ -23,7 +23,6 @@ public fun HttpClientConfig<*>.WebSockets(config: WebSockets.Config.() -> Unit) 
 /**
  * Opens a [DefaultClientWebSocketSession].
  */
-@OptIn(ExperimentalCoroutinesApi::class)
 public suspend fun HttpClient.webSocketSession(
     block: HttpRequestBuilder.() -> Unit
 ): DefaultClientWebSocketSession {

--- a/ktor-client/ktor-client-curl/desktop/src/io/ktor/client/engine/curl/CurlProcessor.kt
+++ b/ktor-client/ktor-client-curl/desktop/src/io/ktor/client/engine/curl/CurlProcessor.kt
@@ -46,7 +46,7 @@ internal class CurlProcessor(coroutineContext: CoroutineContext) {
         return result.await()
     }
 
-    @OptIn(ExperimentalCoroutinesApi::class)
+    @OptIn(DelicateCoroutinesApi::class)
     private fun runEventLoop() {
         curlScope.launch {
             val api = curlApi!!

--- a/ktor-client/ktor-client-java/jvm/src/io/ktor/client/engine/java/JavaHttpWebSocket.kt
+++ b/ktor-client/ktor-client-java/jvm/src/io/ktor/client/engine/java/JavaHttpWebSocket.kt
@@ -87,7 +87,6 @@ internal class JavaHttpWebSocket(
 
     init {
         launch {
-            @OptIn(ExperimentalCoroutinesApi::class)
             _outgoing.consumeEach { frame ->
                 when (frame.frameType) {
                     FrameType.TEXT -> {

--- a/ktor-http/ktor-http-cio/jvm/test/io/ktor/tests/http/cio/MultipartTest.kt
+++ b/ktor-http/ktor-http-cio/jvm/test/io/ktor/tests/http/cio/MultipartTest.kt
@@ -200,7 +200,6 @@ class MultipartTest {
         val mp = parseMultipart(ch, request.headers)
 
         val allEvents = ArrayList<MultipartEvent>()
-        @OptIn(ExperimentalCoroutinesApi::class)
         mp.consumeEach { allEvents.add(it) }
 
         val parts = allEvents.filterIsInstance<MultipartEvent.MultipartPart>()
@@ -259,7 +258,6 @@ class MultipartTest {
         val mp = GlobalScope.parseMultipart(decoded.channel, request.headers)
 
         val allEvents = ArrayList<MultipartEvent>()
-        @OptIn(ExperimentalCoroutinesApi::class)
         mp.consumeEach { allEvents.add(it) }
 
         assertEquals(7, allEvents.size)

--- a/ktor-http/ktor-http-cio/jvm/test/io/ktor/tests/http/cio/TrySkipDelimiterTest.kt
+++ b/ktor-http/ktor-http-cio/jvm/test/io/ktor/tests/http/cio/TrySkipDelimiterTest.kt
@@ -11,7 +11,6 @@ import kotlinx.coroutines.test.*
 import java.nio.*
 import kotlin.test.*
 
-@OptIn(ExperimentalCoroutinesApi::class)
 class TrySkipDelimiterTest {
     private val ch = ByteChannel()
 

--- a/ktor-network/jvm/src/io/ktor/network/sockets/DatagramSendChannel.kt
+++ b/ktor-network/jvm/src/io/ktor/network/sockets/DatagramSendChannel.kt
@@ -29,7 +29,7 @@ internal class DatagramSendChannel(
     private val closedCause = atomic<Throwable?>(null)
     private val lock = Mutex()
 
-    @ExperimentalCoroutinesApi
+    @DelicateCoroutinesApi
     override val isClosedForSend: Boolean
         get() = socket.isClosed
 

--- a/ktor-network/jvmAndNix/test/io/ktor/network/sockets/tests/UDPSocketTest.kt
+++ b/ktor-network/jvmAndNix/test/io/ktor/network/sockets/tests/UDPSocketTest.kt
@@ -105,7 +105,6 @@ class UDPSocketTest {
         assertTrue(socket.isClosed)
     }
 
-    @OptIn(ExperimentalCoroutinesApi::class)
     @Test
     fun testInvokeOnClose() = testSockets { selector ->
         val socket: BoundDatagramSocket = aSocket(selector)
@@ -130,7 +129,6 @@ class UDPSocketTest {
         assertEquals(1, done.value)
     }
 
-    @OptIn(ExperimentalCoroutinesApi::class)
     @Test
     fun testOutgoingInvokeOnClose() = testSockets { selector ->
         val socket: BoundDatagramSocket = aSocket(selector)
@@ -149,7 +147,6 @@ class UDPSocketTest {
         assertTrue(socket.isClosed)
     }
 
-    @OptIn(ExperimentalCoroutinesApi::class)
     @Test
     fun testOutgoingInvokeOnCloseWithSocketClose() = testSockets { selector ->
         val socket: BoundDatagramSocket = aSocket(selector)
@@ -168,7 +165,6 @@ class UDPSocketTest {
         assertTrue(socket.isClosed)
     }
 
-    @OptIn(ExperimentalCoroutinesApi::class)
     @Test
     fun testOutgoingInvokeOnClosed() = testSockets { selector ->
         val socket: BoundDatagramSocket = aSocket(selector)

--- a/ktor-network/nix/src/io/ktor/network/sockets/DatagramSendChannel.kt
+++ b/ktor-network/nix/src/io/ktor/network/sockets/DatagramSendChannel.kt
@@ -30,7 +30,7 @@ internal class DatagramSendChannel(
     private val closedCause = atomic<Throwable?>(null)
     private val lock = Mutex()
 
-    @ExperimentalCoroutinesApi
+    @DelicateCoroutinesApi
     override val isClosedForSend: Boolean
         get() = socket.isClosed
 

--- a/ktor-server/ktor-server-host-common/jvmAndNix/src/io/ktor/server/engine/EngineContextCancellationHelper.kt
+++ b/ktor-server/ktor-server-host-common/jvmAndNix/src/io/ktor/server/engine/EngineContextCancellationHelper.kt
@@ -30,7 +30,6 @@ public fun ApplicationEngine.stopServerOnCancellation(
 public fun Job.launchOnCancellation(block: suspend () -> Unit): CompletableJob {
     val deferred: CompletableJob = Job(parent = this)
 
-    @OptIn(ExperimentalCoroutinesApi::class)
     GlobalScope.launch(this + Dispatchers.IOBridge) {
         var cancelled = false
         try {

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/cio/RequestBodyHandler.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/cio/RequestBodyHandler.kt
@@ -72,7 +72,7 @@ internal class RequestBodyHandler(
         }
     }
 
-    @OptIn(ExperimentalCoroutinesApi::class)
+    @OptIn(DelicateCoroutinesApi::class)
     fun upgrade(): ByteReadChannel {
         val result = queue.trySend(Upgrade)
         if (result.isSuccess) return newChannel()
@@ -93,7 +93,7 @@ internal class RequestBodyHandler(
         return result
     }
 
-    @OptIn(ExperimentalCoroutinesApi::class)
+    @OptIn(DelicateCoroutinesApi::class)
     private fun tryOfferChannelOrToken(token: Any) {
         val result = queue.trySend(token)
         if (result.isSuccess) return

--- a/ktor-server/ktor-server-plugins/ktor-server-websockets/jvm/test/io/ktor/tests/websocket/WebSocketTest.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-websockets/jvm/test/io/ktor/tests/websocket/WebSocketTest.kt
@@ -29,7 +29,6 @@ import java.util.concurrent.CancellationException
 import kotlin.test.*
 
 @Suppress("DEPRECATION")
-@OptIn(ExperimentalCoroutinesApi::class)
 class WebSocketTest {
     @get:Rule
     val timeout = CoroutinesTimeout.seconds(30)

--- a/ktor-server/ktor-server-plugins/ktor-server-websockets/jvm/test/io/ktor/tests/websocket/WriterTest.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-websockets/jvm/test/io/ktor/tests/websocket/WriterTest.kt
@@ -11,7 +11,7 @@ import kotlinx.coroutines.*
 import java.nio.ByteBuffer
 import kotlin.test.*
 
-@OptIn(ExperimentalCoroutinesApi::class)
+@OptIn(DelicateCoroutinesApi::class)
 class WriterTest {
     @Test
     fun testWriteBigThenClose() = runBlocking {

--- a/ktor-server/ktor-server-plugins/ktor-server-websockets/jvmAndNix/test/io/ktor/tests/websocket/DefaultWebSocketTest.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-websockets/jvmAndNix/test/io/ktor/tests/websocket/DefaultWebSocketTest.kt
@@ -15,7 +15,7 @@ import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.channels.*
 import kotlin.test.*
 
-@OptIn(ExperimentalCoroutinesApi::class)
+@OptIn(DelicateCoroutinesApi::class)
 class DefaultWebSocketTest : BaseTest() {
 
     private lateinit var parent: CompletableJob
@@ -127,7 +127,7 @@ class DefaultWebSocketTest : BaseTest() {
     }
 }
 
-@OptIn(ExperimentalCoroutinesApi::class)
+@OptIn(DelicateCoroutinesApi::class)
 internal suspend fun ensureCompletion(
     parent: CompletableJob,
     client2server: ByteReadChannel,

--- a/ktor-server/ktor-server-plugins/ktor-server-websockets/jvmAndNix/test/io/ktor/tests/websocket/RawWebSocketTest.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-websockets/jvmAndNix/test/io/ktor/tests/websocket/RawWebSocketTest.kt
@@ -16,7 +16,7 @@ import kotlinx.coroutines.channels.*
 import kotlin.reflect.*
 import kotlin.test.*
 
-@OptIn(ExperimentalCoroutinesApi::class)
+@OptIn(DelicateCoroutinesApi::class)
 class RawWebSocketTest : BaseTest() {
     private lateinit var parent: CompletableJob
     private lateinit var client2server: ByteChannel

--- a/ktor-server/ktor-server-servlet-jakarta/jvm/src/io/ktor/server/servlet/jakarta/BlockingServlet.kt
+++ b/ktor-server/ktor-server-servlet-jakarta/jvm/src/io/ktor/server/servlet/jakarta/BlockingServlet.kt
@@ -84,7 +84,6 @@ internal class BlockingServletApplicationResponse(
 /**
  * Never do like this! Very special corner-case.
  */
-@OptIn(ExperimentalCoroutinesApi::class)
 private object UnsafeBlockingTrampoline : CoroutineDispatcher() {
     override fun isDispatchNeeded(context: CoroutineContext): Boolean = true
 

--- a/ktor-server/ktor-server-servlet/jvm/src/io/ktor/server/servlet/BlockingServlet.kt
+++ b/ktor-server/ktor-server-servlet/jvm/src/io/ktor/server/servlet/BlockingServlet.kt
@@ -84,7 +84,6 @@ internal class BlockingServletApplicationResponse(
 /**
  * Never do like this! Very special corner-case.
  */
-@OptIn(ExperimentalCoroutinesApi::class)
 private object UnsafeBlockingTrampoline : CoroutineDispatcher() {
     override fun isDispatchNeeded(context: CoroutineContext): Boolean = true
 

--- a/ktor-server/ktor-server-servlet/jvm/src/io/ktor/server/servlet/ServletUpgrade.kt
+++ b/ktor-server/ktor-server-servlet/jvm/src/io/ktor/server/servlet/ServletUpgrade.kt
@@ -102,7 +102,6 @@ public class ServletUpgradeHandler : HttpUpgradeHandler, CoroutineScope {
 
         val outputChannel = servletWriter(webConnection.outputStream).channel
 
-        @OptIn(ExperimentalCoroutinesApi::class)
         launch(up.userContext + ServletUpgradeCoroutineName, start = CoroutineStart.UNDISPATCHED) {
             val job = up.upgradeMessage.upgrade(
                 inputChannel,

--- a/ktor-server/ktor-server-test-host/jvm/src/io/ktor/server/testing/client/TestEngineWebsocketSession.kt
+++ b/ktor-server/ktor-server-test-host/jvm/src/io/ktor/server/testing/client/TestEngineWebsocketSession.kt
@@ -29,7 +29,6 @@ internal class TestEngineWebsocketSession(
 
     override suspend fun flush() {}
 
-    @OptIn(ExperimentalCoroutinesApi::class)
     suspend fun run() {
         outgoing.invokeOnClose {
             if (it != null) socketJob.completeExceptionally(it)

--- a/ktor-shared/ktor-websockets/common/src/io/ktor/websocket/DefaultWebSocketSession.kt
+++ b/ktor-shared/ktor-websockets/common/src/io/ktor/websocket/DefaultWebSocketSession.kt
@@ -162,7 +162,7 @@ internal class DefaultWebSocketSessionImpl(
         var last: BytePacketBuilder? = null
         var closeFramePresented = false
         try {
-            @OptIn(ExperimentalCoroutinesApi::class)
+            @OptIn(DelicateCoroutinesApi::class)
             raw.incoming.consumeEach { frame ->
                 LOGGER.trace("WebSocketSession($this) receiving frame $frame")
                 when (frame) {


### PR DESCRIPTION
**Subsystem**
Client and Server

**Motivation**
This upgrades `kotlinx-coroutines` to 1.7, which is besides many things a blocker to https://youtrack.jetbrains.com/issue/KTOR-5753

Seems to also be a fix to https://youtrack.jetbrains.com/issue/KTOR-5728, I cannot reproduce the error anymore on my machine after this patch.

**Solution**
Upgrade library and make necessary adjustments.

