### PR TITLE
Remove deprecated Kotlin/Native targets.

### DIFF
--- a/buildSrc/src/main/kotlin/NativeUtils.kt
+++ b/buildSrc/src/main/kotlin/NativeUtils.kt
@@ -37,7 +37,6 @@ fun Project.iosTargets(): List<String> = fastOr {
         listOf(
             iosX64(),
             iosArm64(),
-            iosArm32(),
             iosSimulatorArm64(),
         ).map { it.name }
     }
@@ -46,7 +45,6 @@ fun Project.iosTargets(): List<String> = fastOr {
 fun Project.watchosTargets(): List<String> = fastOr {
     with(kotlin) {
         listOf(
-            watchosX86(),
             watchosX64(),
             watchosArm32(),
             watchosArm64(),

--- a/buildSrc/src/main/kotlin/Publication.kt
+++ b/buildSrc/src/main/kotlin/Publication.kt
@@ -30,10 +30,8 @@ fun isAvailableForPublication(publication: Publication): Boolean {
     val macPublications = setOf(
         "iosX64",
         "iosArm64",
-        "iosArm32",
         "iosSimulatorArm64",
 
-        "watchosX86",
         "watchosX64",
         "watchosArm32",
         "watchosArm64",


### PR DESCRIPTION
`iosArm32` and `watchosX86` were deprecated in Kotlin 1.8.20 and will be removed in Kotlin 1.9.20.
See https://kotl.in/native-targets-tiers for details.

