### PR TITLE
KTOR-6081  Cache returns null when vary header set different ways whatever it has same values

### DIFF
--- a/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/plugins/CacheTest.kt
+++ b/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/plugins/CacheTest.kt
@@ -389,12 +389,8 @@ class CacheTest : ClientLoader() {
             fakeResponse.content = ""
             fakeResponse.status = HttpStatusCode.NotModified
             fakeResponse.headers = headersOf(HttpHeaders.Vary, vary.joinToString(","))
-            try {
-                client.get(url)
-                fail("Must be caused an Exception")
-            } catch (e: Exception) {
-                assertTrue(e is InvalidCacheStateException)
-            }
+            val notModifiedBody = client.get(url).body<String>()
+            assertEquals(notModifiedBody, okBody)
         }
     }
 

--- a/ktor-http/common/src/io/ktor/http/HttpMessageProperties.kt
+++ b/ktor-http/common/src/io/ktor/http/HttpMessageProperties.kt
@@ -61,7 +61,9 @@ public fun HttpMessageBuilder.etag(): String? = headers[HttpHeaders.ETag]
 /**
  * Parse `Vary` header value.
  */
-public fun HttpMessageBuilder.vary(): List<String>? = headers[HttpHeaders.Vary]?.split(",")?.map { it.trim() }
+public fun HttpMessageBuilder.vary(): List<String>? = headers.getAll(HttpHeaders.Vary)?.flatMap { varyKeys ->
+    varyKeys.split(",").map { it.trim() }
+}
 
 /**
  * Parse `Content-Length` header value.
@@ -86,7 +88,9 @@ public fun HttpMessage.etag(): String? = headers[HttpHeaders.ETag]
 /**
  * Parse `Vary` header value.
  */
-public fun HttpMessage.vary(): List<String>? = headers[HttpHeaders.Vary]?.split(",")?.map { it.trim() }
+public fun HttpMessage.vary(): List<String>? = headers.getAll(HttpHeaders.Vary)?.flatMap { varyKeys ->
+    varyKeys.split(",").map { it.trim() }
+}
 
 /**
  * Parse `Content-Length` header value.


### PR DESCRIPTION
**Subsystem**
Client

**Motivation**
[HttpMessage.vary()](https://github.com/ktorio/ktor/blob/15a0cc73fe2ad9cb1f664d9495f480524cdbb62f/ktor-http/common/src/io/ktor/http/HttpMessageProperties.kt#L89) returns `listOf("Origin")` if vary header is configured twice like below.

```
vary: Origin
vary: Accept
```

On the other hand, [HttpMessage.vary()](https://github.com/ktorio/ktor/blob/15a0cc73fe2ad9cb1f664d9495f480524cdbb62f/ktor-http/common/src/io/ktor/http/HttpMessageProperties.kt#L89) returns `listOf("Origin", "Accept")` if vary header is configured once with comma separated values.

```
vary: Origin,Accept
```

Those are same vary keys, but HttpCache plugin doesn't regard as same vary keys in [this line](https://github.com/ktorio/ktor/blob/15a0cc73fe2ad9cb1f664d9495f480524cdbb62f/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/cache/storage/UnlimitedCacheStorage.kt#L45-L50).

Therefore, it causes `InvalidCacheStateException` in [this line](https://github.com/ktorio/ktor/blob/15a0cc73fe2ad9cb1f664d9495f480524cdbb62f/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/cache/HttpCache.kt#L206-L207).

I've reproduced this issue in Unit Tests, before fixed it. 98a77421614b10d0891cbd325744aeda871248fa

**Solution**

[HttpMessage.vary()](https://github.com/ktorio/ktor/blob/15a0cc73fe2ad9cb1f664d9495f480524cdbb62f/ktor-http/common/src/io/ktor/http/HttpMessageProperties.kt#L89) needs to return `listOf("Origin", "Accept")` even if vary header is configured twice.

I've fixed [HttpMessage.vary()](https://github.com/ktorio/ktor/blob/15a0cc73fe2ad9cb1f664d9495f480524cdbb62f/ktor-http/common/src/io/ktor/http/HttpMessageProperties.kt#L89) like below.

```kotlin
fun HttpMessage.vary(): List<String>? = headers.getAll(HttpHeaders.Vary)?.flatMap { varyKeys ->
    varyKeys.split(",").map { it.trim() }
}
```

And this fixing pass the unit tests. 1ca46fc02e5b0fd39c0954281504ac745b30f05d

