### PR TITLE
KTOR-5619 Fix cookie appears twice with DefaultRequest cookie

### DIFF
--- a/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/DefaultRequest.kt
+++ b/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/DefaultRequest.kt
@@ -80,7 +80,10 @@ public class DefaultRequest private constructor(private val block: DefaultReques
                         context.attributes.put(it as AttributeKey<Any>, defaultRequest.attributes[it])
                     }
                 }
-                context.headers.appendMissing(defaultRequest.headers.build())
+
+                context.headers.clear()
+                context.headers.appendAll(defaultRequest.headers.build())
+
                 LOGGER.trace("Applied DefaultRequest to $originalUrlString. New url: ${context.url}")
             }
         }


### PR DESCRIPTION
Fix [KTOR-5619](https://youtrack.jetbrains.com/issue/KTOR-5619/DefaultRequest-a-cookie-appears-twice-in-the-request-header-when-sending-a-request-with-another-cookie)
