### PR TITLE
Remove unused `NettyApplicationRequest#newDecoder`

### DIFF
--- a/ktor-server/ktor-server-netty/api/ktor-server-netty.api
+++ b/ktor-server/ktor-server-netty/api/ktor-server-netty.api
@@ -114,7 +114,6 @@ public abstract class io/ktor/server/netty/NettyApplicationRequest : io/ktor/ser
 	public final fun getQueryParameters ()Lio/ktor/http/Parameters;
 	public fun getRawQueryParameters ()Lio/ktor/http/Parameters;
 	protected final fun getUri ()Ljava/lang/String;
-	protected abstract fun newDecoder ()Lio/netty/handler/codec/http/multipart/HttpPostMultipartRequestDecoder;
 }
 
 public final class io/ktor/server/netty/NettyApplicationRequestHeaders : io/ktor/http/Headers {

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyApplicationRequest.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyApplicationRequest.kt
@@ -11,7 +11,6 @@ import io.ktor.server.request.*
 import io.ktor.utils.io.*
 import io.netty.channel.*
 import io.netty.handler.codec.http.*
-import io.netty.handler.codec.http.multipart.*
 import kotlinx.coroutines.*
 import kotlin.coroutines.*
 
@@ -41,8 +40,6 @@ public abstract class NettyApplicationRequest(
     override val cookies: RequestCookies = NettyApplicationRequestCookies(this)
 
     override val engineReceiveChannel: ByteReadChannel = requestBodyChannel
-
-    protected abstract fun newDecoder(): HttpPostMultipartRequestDecoder
 
     public fun close() {}
 }

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http1/NettyHttp1ApplicationRequest.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http1/NettyHttp1ApplicationRequest.kt
@@ -10,7 +10,6 @@ import io.ktor.server.netty.*
 import io.ktor.utils.io.*
 import io.netty.channel.*
 import io.netty.handler.codec.http.*
-import io.netty.handler.codec.http.multipart.*
 import kotlin.coroutines.*
 
 internal class NettyHttp1ApplicationRequest(
@@ -30,7 +29,4 @@ internal class NettyHttp1ApplicationRequest(
     override val local = NettyConnectionPoint(httpRequest, context)
 
     override val engineHeaders: Headers = NettyApplicationRequestHeaders(httpRequest)
-    override fun newDecoder(): HttpPostMultipartRequestDecoder {
-        return HttpPostMultipartRequestDecoder(httpRequest)
-    }
 }

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http2/NettyHttp2ApplicationRequest.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http2/NettyHttp2ApplicationRequest.kt
@@ -11,9 +11,6 @@ import io.ktor.server.request.*
 import io.ktor.util.*
 import io.ktor.utils.io.*
 import io.netty.channel.*
-import io.netty.handler.codec.http.*
-import io.netty.handler.codec.http.HttpMethod
-import io.netty.handler.codec.http.multipart.*
 import io.netty.handler.codec.http2.*
 import kotlinx.coroutines.*
 import kotlinx.coroutines.channels.*
@@ -64,14 +61,4 @@ internal class NettyHttp2ApplicationRequest(
     )
 
     override val cookies: RequestCookies = NettyApplicationRequestCookies(this)
-
-    override fun newDecoder(): HttpPostMultipartRequestDecoder {
-        val hh = DefaultHttpHeaders(false)
-        for ((name, value) in nettyHeaders) {
-            hh.add(name, value)
-        }
-
-        val request = DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST, uri, hh)
-        return HttpPostMultipartRequestDecoder(request)
-    }
 }


### PR DESCRIPTION
These methods aren't used anywhere, and weren't part of the public API.

Also, `DefaultHttpHeaders(false)` is an indicator of a potential vulnerability,
due to disabling HTTP header validation.
Removing this code removes the potential for this vulnerability being present.

Signed-off-by: Jonathan Leitschuh <Jonathan.Leitschuh@gmail.com>

**Subsystem**

Server: `ktor-server-netty`

**Motivation**

Potential risk of HTTP request/reponse splitting through the use of `DefaultHttpHeaders(false)`.

**Solution**

Completely remove the unused method.

