### PR TITLE
KTOR-6087 s-maxage is not used, even if `HttpCache.Config.isShared` is true

### DIFF
--- a/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/cache/HttpCache.kt
+++ b/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/cache/HttpCache.kt
@@ -280,7 +280,7 @@ public class HttpCache private constructor(
             return null
         }
 
-        return storage.store(response)
+        return storage.store(response, response.varyKeys(), isSharedClient)
     }
 
     private suspend fun findAndRefresh(request: HttpRequest, response: HttpResponse): HttpResponse? {

--- a/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/cache/storage/HttpCacheStorage.kt
+++ b/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/cache/storage/HttpCacheStorage.kt
@@ -95,6 +95,11 @@ public interface CacheStorage {
 /**
  * Store [response] in cache storage.
  */
+@Deprecated(
+    message = "Please use method with `varyKeys` and `isShared` argument",
+    level = DeprecationLevel.WARNING,
+    replaceWith = ReplaceWith("store(response, varyKeys, isShared)")
+)
 public suspend fun CacheStorage.store(response: HttpResponse): CachedResponseData {
     return store(response, response.varyKeys())
 }

--- a/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/cache/storage/HttpCacheStorage.kt
+++ b/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/cache/storage/HttpCacheStorage.kt
@@ -96,9 +96,9 @@ public interface CacheStorage {
  * Store [response] in cache storage.
  */
 @Deprecated(
-    message = "Please use method with `varyKeys` and `isShared` argument",
+    message = "Please use method with `response.varyKeys()` and `isShared` arguments",
     level = DeprecationLevel.WARNING,
-    replaceWith = ReplaceWith("store(response, varyKeys, isShared)")
+    replaceWith = ReplaceWith("store(response, response.varyKeys(), isShared)")
 )
 public suspend fun CacheStorage.store(response: HttpResponse): CachedResponseData {
     return store(response, response.varyKeys())

--- a/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/plugins/CacheTest.kt
+++ b/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/plugins/CacheTest.kt
@@ -423,6 +423,56 @@ class CacheTest : ClientLoader() {
     }
 
     @Test
+    fun testSMaxAgeWhenIsSharedTrue() = testWithEngine(MockEngine) {
+        class FakeResponse {
+            var content: String = ""
+            var status: HttpStatusCode = HttpStatusCode.OK
+        }
+
+        val fakeResponse = FakeResponse()
+        val publicStorage = CacheStorage.Unlimited()
+        val privateStorage = CacheStorage.Unlimited()
+        config {
+            install(HttpCache) {
+                publicStorage(publicStorage)
+                privateStorage(privateStorage)
+
+                isShared = true
+            }
+
+            engine {
+                addHandler {
+                    respond(
+                        content = fakeResponse.content,
+                        status = fakeResponse.status,
+                        headers = buildHeaders {
+                            append(HttpHeaders.ETag, "W/\"ETAG\"")
+                            append(HttpHeaders.CacheControl, "max-age=0,s-maxage=1")
+                        },
+                    )
+                }
+            }
+        }
+
+        test { client ->
+            val url = Url("$TEST_SERVER/cache/vary-s-maxage")
+
+            fakeResponse.content = "First"
+            fakeResponse.status = HttpStatusCode.OK
+            val firstBody = client.get(url).body<String>()
+            assertEquals(firstBody, "First")
+
+            // When isShared = true, s-maxage is in used as expiration.
+            // But this case uses max-age unexpectedly, therefore this response is reflected.
+            fakeResponse.content = "Second"
+            fakeResponse.status = HttpStatusCode.OK
+            val secondBody = client.get(url).body<String>()
+            // They should be the same value because s-maxage doesn't expires yet.
+            assertNotEquals(secondBody, firstBody)
+        }
+    }
+
+    @Test
     fun testOnlyIfCached() = clientTests {
         val publicStorage = CacheStorage.Unlimited()
         val privateStorage = CacheStorage.Unlimited()

--- a/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/plugins/CacheTest.kt
+++ b/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/plugins/CacheTest.kt
@@ -463,12 +463,11 @@ class CacheTest : ClientLoader() {
             assertEquals(firstBody, "First")
 
             // When isShared = true, s-maxage is in used as expiration.
-            // But this case uses max-age unexpectedly, therefore this response is reflected.
+            // s-maxage doesn't expires yet, therefore this response should not be reflected.
             fakeResponse.content = "Second"
             fakeResponse.status = HttpStatusCode.OK
             val secondBody = client.get(url).body<String>()
-            // They should be the same value because s-maxage doesn't expires yet.
-            assertNotEquals(secondBody, firstBody)
+            assertEquals(secondBody, firstBody)
         }
     }
 


### PR DESCRIPTION
**Subsystem**
Client

**Motivation**
[KTOR-6087](https://youtrack.jetbrains.com/issue/KTOR-6087/s-maxage-is-not-used-even-if-HttpCache.Config.isShared-is-true.)

max-age is used unexpectedly instead of s-maxage, even if `HttpCache.Config.isShared` is true.

I've reproduce this issue in Unit Test that requests to server even if s-maxage is not expired. e8d2148ad494a83133b77ed0f916f6c2746bed92

**Solution**
To resolve this issue, passing `isShared` member to a parameter of cache storing function. ec614b4dec94a8b377d418f263b616203fbe22d5

