### PR TITLE
Avoid crashing when TLS TCP socket is closed

### DIFF
--- a/ktor-network/ktor-network-tls/jvm/src/io/ktor/network/tls/TLSClientSessionJvm.kt
+++ b/ktor-network/ktor-network-tls/jvm/src/io/ktor/network/tls/TLSClientSessionJvm.kt
@@ -47,7 +47,6 @@ private class TLSSocket(
             appDataOutputLoop(this.channel)
         }
 
-    @OptIn(ExperimentalCoroutinesApi::class)
     private suspend fun appDataInputLoop(pipe: ByteWriteChannel) {
         try {
             input.consumeEach { record ->
@@ -61,7 +60,7 @@ private class TLSSocket(
                     else -> throw TLSException("Unexpected record ${record.type} ($length bytes)")
                 }
             }
-        } catch (cause: Throwable) {
+        } catch (_: Throwable) {
         } finally {
             pipe.close()
         }
@@ -79,6 +78,8 @@ private class TLSSocket(
                 buffer.flip()
                 output.send(TLSRecord(TLSRecordType.ApplicationData, packet = buildPacket { writeFully(buffer) }))
             }
+        } catch (_: ClosedSendChannelException) {
+            // The socket was already closed, we should ignore that error.
         } finally {
             output.close()
         }

--- a/ktor-network/ktor-network-tls/jvm/test/io/ktor/network/tls/tests/ConnectionTest.kt
+++ b/ktor-network/ktor-network-tls/jvm/test/io/ktor/network/tls/tests/ConnectionTest.kt
@@ -59,23 +59,16 @@ class ConnectionTest {
 
     @Test
     fun tlsWithCloseTest(): Unit = runBlocking {
-        val socketJob = Job()
         val selectorManager = ActorSelectorManager(Dispatchers.IO)
         val socket = aSocket(selectorManager)
             .tcp()
             .connect("www.google.com", port = 443)
-            .tls(Dispatchers.Default + socketJob)
+            .tls(Dispatchers.Default)
 
         val channel = socket.openWriteChannel(autoFlush = true)
         socket.close()
-        channel.writeAvailable(ByteArray(42))
-
-        // We wait for child worker jobs to complete.
-        assertTrue(socketJob.children.count() > 0)
-        socketJob.children.forEach { it.join() }
-        socketJob.children.forEach { assertTrue(it.isCancelled) }
-        // This shouldn't cancel the parent job.
-        assertFalse(socketJob.isCancelled)
+        assertEquals(42, channel.writeAvailable(ByteArray(42)))
+        assertTrue(channel.isClosedForWrite)
     }
 
     @Test


### PR DESCRIPTION
**Subsystem**
Client, TLS over TCP

**Motivation**
When using a plain TCP socket with TLS, two worker jobs are spawned:

- cio-tls-input-loop
- cio-tls-output-loop

These worker jobs live in their own scope, and exceptions they throw can't easily be caught by the caller: the only option is to install a `CoroutineExceptionHandler` for the whole TLS socket, which is quite hacky and may hide bugs.

When the TCP socket is closed, this is only caught when trying to write on the output channel, which throws a `ClosedSendChannelException`.

See the following tickets for that issue:

- https://youtrack.jetbrains.com/issue/KTOR-5178/TLSSocket-cannot-catch-the-exception-thrown-by-appDataOutputLoop
- https://youtrack.jetbrains.com/issue/KTOR-4360/Android-Impossible-to-catch-the-ClosedSendChannelException-when-TLS-connection-socket-is-closed
- https://github.com/ktorio/ktor/issues/3557

**Solution**
We now catch that exception which cleanly stops the background job.

The unit test added fails when we remove the `catch`. It is unfortunately a slightly roundabout way of testing our behavior, because it's the last check (`channel.isClosedForWrite`) that will fail if you comment the `catch`. You'll also see the `ClosedSendChannelException` in the test output if you comment the `catch` block, but it's not sufficient to make the test fail, because the test runner allows exceptions in background threads (but it will crash an android app for example). I'm not sure if there are better ways to test this?