### PR TITLE
KTOR-6098 Netty: Allow listening only for HTTP/1.1 protocol SSL connections

### DIFF
--- a/ktor-server/ktor-server-netty/api/ktor-server-netty.api
+++ b/ktor-server/ktor-server-netty/api/ktor-server-netty.api
@@ -80,11 +80,11 @@ public final class io/ktor/server/netty/NettyApplicationEngine$Configuration : i
 	public fun <init> ()V
 	public final fun getChannelPipelineConfig ()Lkotlin/jvm/functions/Function1;
 	public final fun getConfigureBootstrap ()Lkotlin/jvm/functions/Function1;
+	public final fun getEnableHttp2 ()Z
 	public final fun getHttpServerCodec ()Lkotlin/jvm/functions/Function0;
 	public final fun getMaxChunkSize ()I
 	public final fun getMaxHeaderSize ()I
 	public final fun getMaxInitialLineLength ()I
-	public final fun getRequestQueueLimit ()I
 	public final fun getRequestReadTimeoutSeconds ()I
 	public final fun getResponseWriteTimeoutSeconds ()I
 	public final fun getRunningLimit ()I
@@ -92,11 +92,11 @@ public final class io/ktor/server/netty/NettyApplicationEngine$Configuration : i
 	public final fun getTcpKeepAlive ()Z
 	public final fun setChannelPipelineConfig (Lkotlin/jvm/functions/Function1;)V
 	public final fun setConfigureBootstrap (Lkotlin/jvm/functions/Function1;)V
+	public final fun setEnableHttp2 (Z)V
 	public final fun setHttpServerCodec (Lkotlin/jvm/functions/Function0;)V
 	public final fun setMaxChunkSize (I)V
 	public final fun setMaxHeaderSize (I)V
 	public final fun setMaxInitialLineLength (I)V
-	public final fun setRequestQueueLimit (I)V
 	public final fun setRequestReadTimeoutSeconds (I)V
 	public final fun setResponseWriteTimeoutSeconds (I)V
 	public final fun setRunningLimit (I)V
@@ -155,7 +155,7 @@ public final class io/ktor/server/netty/NettyApplicationResponse$Companion {
 
 public final class io/ktor/server/netty/NettyChannelInitializer : io/netty/channel/ChannelInitializer {
 	public static final field Companion Lio/ktor/server/netty/NettyChannelInitializer$Companion;
-	public fun <init> (Lio/ktor/server/engine/EnginePipeline;Lio/ktor/server/engine/ApplicationEngineEnvironment;Lio/netty/util/concurrent/EventExecutorGroup;Lkotlin/coroutines/CoroutineContext;Lkotlin/coroutines/CoroutineContext;Lio/ktor/server/engine/EngineConnectorConfig;IIIILkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;)V
+	public fun <init> (Lio/ktor/server/engine/EnginePipeline;Lio/ktor/server/engine/ApplicationEngineEnvironment;Lio/netty/util/concurrent/EventExecutorGroup;Lkotlin/coroutines/CoroutineContext;Lkotlin/coroutines/CoroutineContext;Lio/ktor/server/engine/EngineConnectorConfig;IIILkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;Z)V
 	public synthetic fun initChannel (Lio/netty/channel/Channel;)V
 }
 

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/EngineMain.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/EngineMain.kt
@@ -26,9 +26,6 @@ public object EngineMain {
     internal fun NettyApplicationEngine.Configuration.loadConfiguration(config: ApplicationConfig) {
         val deploymentConfig = config.config("ktor.deployment")
         loadCommonConfiguration(deploymentConfig)
-        deploymentConfig.propertyOrNull("requestQueueLimit")?.getString()?.toInt()?.let {
-            requestQueueLimit = it
-        }
         deploymentConfig.propertyOrNull("runningLimit")?.getString()?.toInt()?.let {
             runningLimit = it
         }

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyApplicationEngine.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyApplicationEngine.kt
@@ -36,10 +36,6 @@ public class NettyApplicationEngine(
      * Configuration for the [NettyApplicationEngine]
      */
     public class Configuration : BaseApplicationEngine.Configuration() {
-        /**
-         * Size of the queue to store [ApplicationCall] instances that cannot be immediately processed
-         */
-        public var requestQueueLimit: Int = 16
 
         /**
          * Number of concurrently running requests from the same http pipeline
@@ -89,6 +85,11 @@ public class NettyApplicationEngine(
          * The maximum length of the content or each chunk
          */
         public var maxChunkSize: Int = HttpObjectDecoder.DEFAULT_MAX_CHUNK_SIZE
+
+        /**
+         * If set to `true`, enables HTTP/2 protocol for Netty engine
+         */
+        public var enableHttp2: Boolean = true
 
         /**
          * User-provided function to configure Netty's [HttpServerCodec]
@@ -186,12 +187,12 @@ public class NettyApplicationEngine(
                     workerDispatcher,
                     userContext,
                     connector,
-                    configuration.requestQueueLimit,
                     configuration.runningLimit,
                     configuration.responseWriteTimeoutSeconds,
                     configuration.requestReadTimeoutSeconds,
                     configuration.httpServerCodec,
-                    configuration.channelPipelineConfig
+                    configuration.channelPipelineConfig,
+                    configuration.enableHttp2
                 )
             )
             if (configuration.tcpKeepAlive) {


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KTOR-6098

