### PR TITLE
KTOR-6122 Add type to AttributeKey equals

### DIFF
--- a/ktor-utils/api/ktor-utils.api
+++ b/ktor-utils/api/ktor-utils.api
@@ -5,7 +5,7 @@ public final class io/ktor/util/AlwaysFailNonceManager : io/ktor/util/NonceManag
 }
 
 public final class io/ktor/util/AttributeKey {
-	public fun <init> (Ljava/lang/String;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getName ()Ljava/lang/String;
 	public fun hashCode ()I

--- a/ktor-utils/common/src/io/ktor/util/Attributes.kt
+++ b/ktor-utils/common/src/io/ktor/util/Attributes.kt
@@ -4,13 +4,15 @@
 
 package io.ktor.util
 
+import kotlin.reflect.*
+
 /**
  * Specifies a key for an attribute in [Attributes]
  * @param T is a type of the value stored in the attribute
  * @param name is a name of the attribute for diagnostic purposes. Can't be blank
  */
 public inline fun <reified T : Any> AttributeKey(name: String): AttributeKey<T> =
-    AttributeKey(name, T::class.qualifiedName ?: T::class.toString())
+    AttributeKey(name, T::class.toString())
 
 /**
  * Specifies a key for an attribute in [Attributes]

--- a/ktor-utils/common/src/io/ktor/util/Attributes.kt
+++ b/ktor-utils/common/src/io/ktor/util/Attributes.kt
@@ -9,7 +9,19 @@ package io.ktor.util
  * @param T is a type of the value stored in the attribute
  * @param name is a name of the attribute for diagnostic purposes. Can't be blank
  */
-public class AttributeKey<T : Any>(public val name: String) {
+public inline fun <reified T : Any> AttributeKey(name: String): AttributeKey<T> =
+    AttributeKey(name, T::class.qualifiedName ?: T::class.toString())
+
+/**
+ * Specifies a key for an attribute in [Attributes]
+ * @param T is a type of the value stored in the attribute
+ * @param name is a name of the attribute for diagnostic purposes. Can't be blank
+ */
+
+public class AttributeKey<T : Any> @PublishedApi internal constructor(
+    public val name: String,
+    private val type: String
+) {
     init {
         if (name.isEmpty()) {
             throw IllegalStateException("Name can't be blank")
@@ -20,13 +32,9 @@ public class AttributeKey<T : Any>(public val name: String) {
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
-        if (other == null || this::class != other::class) return false
+        if (other == null || other !is AttributeKey<*>) return false
 
-        other as AttributeKey<*>
-
-        if (name != other.name) return false
-
-        return true
+        return name == other.name && type == other.type
     }
 
     override fun hashCode(): Int {

--- a/ktor-utils/common/test/io/ktor/util/AttributesTest.kt
+++ b/ktor-utils/common/test/io/ktor/util/AttributesTest.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2014-2023 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.util
+
+import kotlin.test.*
+
+class AttributesTest {
+    object Foo
+    object Bar
+
+    @Test
+    fun testAttributesTypeSafety() {
+        val foo = AttributeKey<Foo>("example")
+        val bar = AttributeKey<Bar>("example")
+        with(Attributes()) {
+            put(foo, Foo)
+            put(bar, Bar)
+
+            assertEquals(Foo, get(foo))
+            assertEquals(Bar, get(bar))
+        }
+    }
+}


### PR DESCRIPTION
Fix [KTOR-6122](https://youtrack.jetbrains.com/issue/KTOR-6122/AttributeKey-equality-comparison-breaks-type-safety)