### PR TITLE
KTOR-6182 Throw UnknownServiceException if cleartext traffic is not permitted

### DIFF
--- a/ktor-client/ktor-client-core/api/ktor-client-core.api
+++ b/ktor-client/ktor-client-core/api/ktor-client-core.api
@@ -240,6 +240,10 @@ public final class io/ktor/client/plugins/BodyProgressKt {
 	public static final fun onUpload (Lio/ktor/client/request/HttpRequestBuilder;Lio/ktor/client/content/ProgressListener;)V
 }
 
+public final class io/ktor/client/plugins/CleartextTrafficKt {
+	public static final fun getCleartextTraffic ()Lio/ktor/client/plugins/api/ClientPlugin;
+}
+
 public final class io/ktor/client/plugins/ClientRequestException : io/ktor/client/plugins/ResponseException {
 	public fun <init> (Lio/ktor/client/statement/HttpResponse;Ljava/lang/String;)V
 	public fun getMessage ()Ljava/lang/String;

--- a/ktor-client/ktor-client-core/api/ktor-client-core.klib.api
+++ b/ktor-client/ktor-client-core/api/ktor-client-core.klib.api
@@ -1400,6 +1400,8 @@ final val io.ktor.client.plugins.websocket/pingInterval // io.ktor.client.plugin
     final inline fun (io.ktor.client.plugins.websocket/WebSockets).<get-pingInterval>(): kotlin.time/Duration? // io.ktor.client.plugins.websocket/pingInterval.<get-pingInterval>|<get-pingInterval>@io.ktor.client.plugins.websocket.WebSockets(){}[0]
 final val io.ktor.client.plugins/BodyProgress // io.ktor.client.plugins/BodyProgress|{}BodyProgress[0]
     final fun <get-BodyProgress>(): io.ktor.client.plugins.api/ClientPlugin<kotlin/Unit> // io.ktor.client.plugins/BodyProgress.<get-BodyProgress>|<get-BodyProgress>(){}[0]
+final val io.ktor.client.plugins/CleartextTraffic // io.ktor.client.plugins/CleartextTraffic|{}CleartextTraffic[0]
+    final fun <get-CleartextTraffic>(): io.ktor.client.plugins.api/ClientPlugin<kotlin/Unit> // io.ktor.client.plugins/CleartextTraffic.<get-CleartextTraffic>|<get-CleartextTraffic>(){}[0]
 final val io.ktor.client.plugins/HttpCallValidator // io.ktor.client.plugins/HttpCallValidator|{}HttpCallValidator[0]
     final fun <get-HttpCallValidator>(): io.ktor.client.plugins.api/ClientPlugin<io.ktor.client.plugins/HttpCallValidatorConfig> // io.ktor.client.plugins/HttpCallValidator.<get-HttpCallValidator>|<get-HttpCallValidator>(){}[0]
 final val io.ktor.client.plugins/HttpPlainText // io.ktor.client.plugins/HttpPlainText|{}HttpPlainText[0]

--- a/ktor-client/ktor-client-core/common/src/io/ktor/client/HttpClient.kt
+++ b/ktor-client/ktor-client-core/common/src/io/ktor/client/HttpClient.kt
@@ -1373,6 +1373,7 @@ public class HttpClient(
             config.install(HttpRequestLifecycle)
             config.install(BodyProgress)
             config.install(SaveBody)
+            config.install(CleartextTraffic)
 
             if (useDefaultTransformers) {
                 config.install("DefaultTransformers") { defaultTransformers() }

--- a/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/CleartextTraffic.kt
+++ b/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/CleartextTraffic.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2014-2025 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.client.plugins
+
+import io.ktor.client.plugins.api.ClientPlugin
+import io.ktor.client.plugins.api.createClientPlugin
+import io.ktor.utils.io.errors.UnknownServiceException
+
+/**
+ * Returns whether cleartext network traffic (e.g. HTTP, FTP, XMPP, IMAP, SMTP -- without TLS or STARTTLS) is permitted
+ * for communicating with hostname for this process.
+ *
+ * See [NetworkSecurityPolicy#isCleartextTrafficPermitted](https://developer.android.com/reference/android/security/NetworkSecurityPolicy#isCleartextTrafficPermitted(java.lang.String)).
+ */
+internal expect fun isCleartextTrafficPermitted(hostname: String): Boolean
+
+/**
+ * Used by Android to determine whether cleartext network traffic is permitted for all network communication from this
+ * process.
+ */
+public val CleartextTraffic: ClientPlugin<Unit> = createClientPlugin("CleartextTraffic") {
+    onRequest { request, _ ->
+        val host = request.url.host
+        if (!isCleartextTrafficPermitted(host)) {
+            throw UnknownServiceException("CLEARTEXT communication to $host not permitted by network security policy")
+        }
+    }
+}

--- a/ktor-client/ktor-client-core/jvm/src/io/ktor/client/plugins/CleartextTraffic.jvm.kt
+++ b/ktor-client/ktor-client-core/jvm/src/io/ktor/client/plugins/CleartextTraffic.jvm.kt
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2014-2025 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.client.plugins
+
+import java.lang.reflect.InvocationTargetException
+
+/**
+ * This explicit check avoids activating in Android Studio with Android specific classes available when running plugins inside the IDE.
+ */
+private val isAndroid: Boolean = System.getProperty("java.vm.name") == "Dalvik"
+
+internal actual fun isCleartextTrafficPermitted(hostname: String): Boolean {
+    if (!isAndroid) return true
+
+    // Stolen from https://github.com/square/okhttp/blob/65624f5f5b3dd3084b88e4608eaa55cd69d02e07/okhttp/src/main/kotlin/okhttp3/internal/platform/AndroidPlatform.kt#L105-L122
+    return try {
+        val networkPolicyClass = Class.forName("android.security.NetworkSecurityPolicy")
+        val getInstanceMethod = networkPolicyClass.getMethod("getInstance").apply { isAccessible = true }
+        val networkSecurityPolicy = getInstanceMethod(null)
+        api24IsCleartextTrafficPermitted(hostname, networkPolicyClass, networkSecurityPolicy)
+    } catch (_: ClassNotFoundException) {
+        true
+    } catch (_: NoSuchMethodException) {
+        true
+    } catch (e: IllegalAccessException) {
+        throw AssertionError("unable to determine cleartext support", e)
+    } catch (e: IllegalArgumentException) {
+        throw AssertionError("unable to determine cleartext support", e)
+    } catch (e: InvocationTargetException) {
+        throw AssertionError("unable to determine cleartext support", e)
+    }
+}
+
+@Throws(InvocationTargetException::class, IllegalAccessException::class)
+private fun api24IsCleartextTrafficPermitted(
+    hostname: String,
+    networkPolicyClass: Class<*>,
+    networkSecurityPolicy: Any
+): Boolean = try {
+    val isCleartextTrafficPermittedMethod = networkPolicyClass
+        .getMethod("isCleartextTrafficPermitted", String::class.java)
+        .apply { isAccessible = true }
+    isCleartextTrafficPermittedMethod(networkSecurityPolicy, hostname) as Boolean
+} catch (_: NoSuchMethodException) {
+    api23IsCleartextTrafficPermitted(networkPolicyClass, networkSecurityPolicy)
+}
+
+@Throws(InvocationTargetException::class, IllegalAccessException::class)
+private fun api23IsCleartextTrafficPermitted(
+    networkPolicyClass: Class<*>,
+    networkSecurityPolicy: Any
+): Boolean = try {
+    val isCleartextTrafficPermittedMethod = networkPolicyClass
+        .getMethod("isCleartextTrafficPermitted")
+        .apply { isAccessible = true }
+    isCleartextTrafficPermittedMethod(networkSecurityPolicy) as Boolean
+} catch (_: NoSuchMethodException) {
+    true
+}

--- a/ktor-client/ktor-client-core/nonJvm/src/io/ktor/client/plugins/CleartextTraffic.nonJvm.kt
+++ b/ktor-client/ktor-client-core/nonJvm/src/io/ktor/client/plugins/CleartextTraffic.nonJvm.kt
@@ -1,0 +1,10 @@
+/*
+ * Copyright 2014-2025 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.client.plugins
+
+/**
+ * Non-JVM platforms are assumed to permit cleartext traffic.
+ */
+internal actual fun isCleartextTrafficPermitted(hostname: String): Boolean = true

--- a/ktor-io/api/ktor-io.klib.api
+++ b/ktor-io/api/ktor-io.klib.api
@@ -334,6 +334,10 @@ open class io.ktor.utils.io.charsets/MalformedInputException : kotlinx.io/IOExce
     constructor <init>(kotlin/String) // io.ktor.utils.io.charsets/MalformedInputException.<init>|<init>(kotlin.String){}[0]
 }
 
+open class io.ktor.utils.io.errors/UnknownServiceException : kotlinx.io/IOException { // io.ktor.utils.io.errors/UnknownServiceException|null[0]
+    constructor <init>(kotlin/String) // io.ktor.utils.io.errors/UnknownServiceException.<init>|<init>(kotlin.String){}[0]
+}
+
 open class io.ktor.utils.io/ClosedByteChannelException : kotlinx.io/IOException { // io.ktor.utils.io/ClosedByteChannelException|null[0]
     constructor <init>(kotlin/Throwable? = ...) // io.ktor.utils.io/ClosedByteChannelException.<init>|<init>(kotlin.Throwable?){}[0]
 }

--- a/ktor-io/common/src/io/ktor/utils/io/errors/Exceptions.kt
+++ b/ktor-io/common/src/io/ktor/utils/io/errors/Exceptions.kt
@@ -9,3 +9,5 @@ public typealias IOException = kotlinx.io.IOException
 
 @Deprecated("Use kotlinx.io.EOFException instead", ReplaceWith("kotlinx.io.EOFException"))
 public typealias EOFException = kotlinx.io.EOFException
+
+public expect open class UnknownServiceException(message: String) : kotlinx.io.IOException

--- a/ktor-io/jvm/src/io/ktor/utils/io/errors/Exceptions.jvm.kt
+++ b/ktor-io/jvm/src/io/ktor/utils/io/errors/Exceptions.jvm.kt
@@ -1,0 +1,7 @@
+/*
+ * Copyright 2014-2024 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.utils.io.errors
+
+public actual typealias UnknownServiceException = java.net.UnknownServiceException

--- a/ktor-io/nonJvm/src/io/ktor/utils/io/errors/Exceptions.nonjvm.kt
+++ b/ktor-io/nonJvm/src/io/ktor/utils/io/errors/Exceptions.nonjvm.kt
@@ -1,0 +1,7 @@
+/*
+ * Copyright 2014-2024 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.utils.io.errors
+
+public actual open class UnknownServiceException actual constructor(message: String) : kotlinx.io.IOException()


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KTOR-6182

This part had been implemented in Okhttp & HttpURLConnection, we just need to patch it for CIO.

Staled some code from:
https://github.com/square/okhttp/blob/735ed1a6e5a15042f6d7e8f100fb3c8376f6aa27/okhttp/src/jvmMain/kotlin/okhttp3/internal/connection/RealRoutePlanner.kt#L205-L208
https://github.com/square/okhttp/blob/550cc11989e5117ed3d8afaf20c7b6c419b5351f/okhttp/src/main/kotlin/okhttp3/internal/platform/AndroidPlatform.kt#L105-L148