### PR TITLE
[QUIC] Packets retransmission 1

### DIFF
--- a/ktor-network/ktor-network-quic/jvm/src/io/ktor/network/quic/tls/CryptoKeys.kt
+++ b/ktor-network/ktor-network-quic/jvm/src/io/ktor/network/quic/tls/CryptoKeys.kt
@@ -13,7 +13,7 @@ import java.nio.charset.*
 import javax.crypto.*
 import javax.crypto.spec.*
 
-internal class CryptoKeys(secret: ByteArray, version: UInt32, private val debugLabel: String? = null) {
+internal class CryptoKeys(secret: ByteArray, version: UInt32, val debugLabel: String? = null) {
     private val key: ByteArray
     val iv: ByteArray
     private val hp: ByteArray

--- a/ktor-network/ktor-network-quic/jvm/test/io/ktor/network/quic/integration/TestKwikClient.kt
+++ b/ktor-network/ktor-network-quic/jvm/test/io/ktor/network/quic/integration/TestKwikClient.kt
@@ -9,7 +9,6 @@ import net.luminis.quic.*
 import net.luminis.quic.log.*
 import java.io.*
 import java.net.*
-import java.nio.charset.*
 import kotlin.test.*
 
 class TestKwikClient(serverPort: Int) {

--- a/ktor-network/ktor-network-quic/jvmAndNix/src/io/ktor/network/quic/bytes/PayloadSize.kt
+++ b/ktor-network/ktor-network-quic/jvmAndNix/src/io/ktor/network/quic/bytes/PayloadSize.kt
@@ -16,7 +16,6 @@ import io.ktor.network.quic.util.POW_2_62
  */
 internal object PayloadSize {
     const val FRAME_TYPE_SIZE = 1
-    const val APP_ERROR_SIZE = 8
     const val PATH_CHALLENGE_DATA = 8
     const val STATELESS_RESET_TOKEN = 16
 
@@ -65,7 +64,7 @@ internal object PayloadSize {
     inline fun ofByteArray(byteArray: ByteArray): Int = byteArray.size
 
     @Suppress("NOTHING_TO_INLINE")
-    inline fun ofByteArrayWithLength(byteArray: ByteArray): Int = ofVarInt(byteArray.size) + byteArray.size
+    inline fun ofByteArrayWithLength(byteArray: ByteArray): Int = ofVarInt(byteArray.size) + ofByteArray(byteArray)
 
     @Suppress("NOTHING_TO_INLINE")
     inline fun ofByteArrayWithLength(byteArraySize: Int): Int = ofVarInt(byteArraySize) + byteArraySize

--- a/ktor-network/ktor-network-quic/jvmAndNix/src/io/ktor/network/quic/bytes/PayloadSize.kt
+++ b/ktor-network/ktor-network-quic/jvmAndNix/src/io/ktor/network/quic/bytes/PayloadSize.kt
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2014-2023 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.network.quic.bytes
+
+import io.ktor.network.quic.connections.QUICConnectionID
+import io.ktor.network.quic.errors.QUICTransportError
+import io.ktor.network.quic.util.POW_2_06
+import io.ktor.network.quic.util.POW_2_14
+import io.ktor.network.quic.util.POW_2_30
+import io.ktor.network.quic.util.POW_2_62
+
+/**
+ * Object that holding maximum sizes for parameters of frames
+ */
+internal object PayloadSize {
+    const val FRAME_TYPE_SIZE = 1
+    const val APP_ERROR_SIZE = 8
+    const val PATH_CHALLENGE_DATA = 8
+    const val STATELESS_RESET_TOKEN = 16
+
+    const val LONG_SIZE = 8
+
+    const val RETRY_PACKET_INTEGRITY_TAG_LENGTH = 16
+
+    /**
+     * Length of sample ciphertext used for header protection
+     */
+    const val HP_SAMPLE_LENGTH = 16
+
+    /**
+     * Length of the header that gets appended during encryption
+     */
+    const val ENCRYPTION_HEADER_LENGTH = 16
+
+    const val HEADER_FLAGS_LENGTH = 1
+    const val LONG_HEADER_LENGTH_FIELD_MAX_LENGTH = 4
+    const val HEADER_PACKET_NUMBER_MAX_LENGTH = 4
+    const val LONG_HEADER_VERSION_LENGTH = 4
+
+    fun ofVarInt(varInt: Long): Int {
+        return when {
+            varInt < POW_2_06 -> 1
+            varInt < POW_2_14 -> 2
+            varInt < POW_2_30 -> 4
+            varInt < POW_2_62 -> 8
+            else -> error("Var int can not be greater than $POW_2_62")
+        }
+    }
+
+    fun ofVarInt(varInt: Int): Int {
+        return when {
+            varInt < POW_2_06 -> 1
+            varInt < POW_2_14 -> 2
+            varInt < POW_2_30 -> 4
+            else -> 8
+        }
+    }
+
+    @Suppress("NOTHING_TO_INLINE")
+    inline fun ofError(error: QUICTransportError) = error.expectedSize
+
+    @Suppress("NOTHING_TO_INLINE")
+    inline fun ofByteArray(byteArray: ByteArray): Int = byteArray.size
+
+    @Suppress("NOTHING_TO_INLINE")
+    inline fun ofByteArrayWithLength(byteArray: ByteArray): Int = ofVarInt(byteArray.size) + byteArray.size
+
+    @Suppress("NOTHING_TO_INLINE")
+    inline fun ofByteArrayWithLength(byteArraySize: Int): Int = ofVarInt(byteArraySize) + byteArraySize
+
+    fun ofConnectionID(id: QUICConnectionID): Int = ofVarInt(id.size) + ofByteArray(id.value)
+}

--- a/ktor-network/ktor-network-quic/jvmAndNix/src/io/ktor/network/quic/connections/PacketSendHandler.kt
+++ b/ktor-network/ktor-network-quic/jvmAndNix/src/io/ktor/network/quic/connections/PacketSendHandler.kt
@@ -107,7 +107,7 @@ internal sealed class PacketSendHandlerImpl<ReadyHandler : ReadyPacketHandler>(
     }
 
     class Initial(
-        private val tlsComponent: TLSComponent,
+        private val packetWriter: PacketWriter,
         packetHandler: ReadyPacketHandler.Initial,
         role: ConnectionRole,
     ) : PacketSendHandlerImpl<ReadyPacketHandler.Initial>(packetHandler, EncryptionLevel.Initial, role) {
@@ -124,8 +124,7 @@ internal sealed class PacketSendHandlerImpl<ReadyHandler : ReadyPacketHandler>(
         }
 
         override suspend fun sendPacket(datagramBuilder: BytePacketBuilder, payload: ByteArray, packetNumber: Long) {
-            PacketWriter.writeInitialPacket(
-                tlsComponent = tlsComponent,
+            packetWriter.writeInitialPacket(
                 largestAcknowledged = packetHandler.getLargestAcknowledged(encryptionLevel),
                 packetBuilder = datagramBuilder,
                 version = QUICVersion.V1,
@@ -139,7 +138,7 @@ internal sealed class PacketSendHandlerImpl<ReadyHandler : ReadyPacketHandler>(
     }
 
     class Handshake(
-        private val tlsComponent: TLSComponent,
+        private val packetWriter: PacketWriter,
         packetHandler: ReadyPacketHandler,
         role: ConnectionRole,
     ) : PacketSendHandlerImpl<ReadyPacketHandler>(packetHandler, EncryptionLevel.Handshake, role) {
@@ -155,8 +154,7 @@ internal sealed class PacketSendHandlerImpl<ReadyHandler : ReadyPacketHandler>(
         }
 
         override suspend fun sendPacket(datagramBuilder: BytePacketBuilder, payload: ByteArray, packetNumber: Long) {
-            PacketWriter.writeHandshakePacket(
-                tlsComponent = tlsComponent,
+            packetWriter.writeHandshakePacket(
                 largestAcknowledged = packetHandler.getLargestAcknowledged(encryptionLevel),
                 packetBuilder = datagramBuilder,
                 version = QUICVersion.V1,
@@ -169,7 +167,7 @@ internal sealed class PacketSendHandlerImpl<ReadyHandler : ReadyPacketHandler>(
     }
 
     class OneRTT(
-        private val tlsComponent: TLSComponent,
+        private val packetWriter: PacketWriter,
         packetHandler: ReadyPacketHandler.OneRTT,
         role: ConnectionRole,
     ) : PacketSendHandlerImpl<ReadyPacketHandler.OneRTT>(packetHandler, EncryptionLevel.AppData, role) {
@@ -182,8 +180,7 @@ internal sealed class PacketSendHandlerImpl<ReadyHandler : ReadyPacketHandler>(
         }
 
         override suspend fun sendPacket(datagramBuilder: BytePacketBuilder, payload: ByteArray, packetNumber: Long) {
-            PacketWriter.writeOneRTTPacket(
-                tlsComponent = tlsComponent,
+            packetWriter.writeOneRTTPacket(
                 largestAcknowledged = packetHandler.getLargestAcknowledged(encryptionLevel),
                 packetBuilder = datagramBuilder,
                 spinBit = packetHandler.spinBit,

--- a/ktor-network/ktor-network-quic/jvmAndNix/src/io/ktor/network/quic/connections/QUICConnection.kt
+++ b/ktor-network/ktor-network-quic/jvmAndNix/src/io/ktor/network/quic/connections/QUICConnection.kt
@@ -193,18 +193,20 @@ internal class QUICConnection(
 
     private val readyPacketHandler = ReadyPacketHandlerImpl(outgoingDatagramHandler)
 
+    private val packetWriter = PacketWriterImpl(tlsComponent)
+
     private val initialPacketHandler = PacketSendHandlerImpl.Initial(
-        tlsComponent = tlsComponent,
+        packetWriter = packetWriter,
         packetHandler = readyPacketHandler,
         role = ConnectionRole.SERVER,
     )
     private val handshakePacketHandler = PacketSendHandlerImpl.Handshake(
-        tlsComponent = tlsComponent,
+        packetWriter = packetWriter,
         packetHandler = readyPacketHandler,
         role = ConnectionRole.SERVER,
     )
     private val oneRTTPacketHandler = PacketSendHandlerImpl.OneRTT(
-        tlsComponent = tlsComponent,
+        packetWriter = packetWriter,
         packetHandler = readyPacketHandler,
         role = ConnectionRole.SERVER,
     )

--- a/ktor-network/ktor-network-quic/jvmAndNix/src/io/ktor/network/quic/errors/QUICTransportError.kt
+++ b/ktor-network/ktor-network-quic/jvmAndNix/src/io/ktor/network/quic/errors/QUICTransportError.kt
@@ -42,6 +42,11 @@ internal value class AppError(val intCode: Long) {
 internal sealed interface QUICTransportError {
     fun writeToFrame(packetBuilder: BytePacketBuilder)
 
+    /**
+     * Expected size in bytes of this error in a frame
+     */
+    val expectedSize: Int
+
     fun toDebugString(): String
 
     companion object {
@@ -86,6 +91,8 @@ internal enum class QUICProtocolTransportError(val intCode: UInt8) : QUICTranspo
         packetBuilder.writeUInt8(intCode)
     }
 
+    override val expectedSize: Int = 1
+
     override fun toDebugString(): String {
         return "Transport Error $name, code: $intCode"
     }
@@ -108,6 +115,8 @@ internal class QUICCryptoHandshakeTransportError(val tlsAlertCode: UInt8) : QUIC
         packetBuilder.writeUInt8(tlsAlertCode)
     }
 
+    override val expectedSize: Int = 2
+
     override fun toDebugString(): String {
         return "Crypto Handshake Error: $tlsAlertCode"
     }
@@ -120,6 +129,8 @@ internal class QUICReasonedTransportError(
     override fun writeToFrame(packetBuilder: BytePacketBuilder) {
         error.writeToFrame(packetBuilder)
     }
+
+    override val expectedSize: Int = error.expectedSize
 
     override fun toDebugString(): String {
         return "Error: ${error.toDebugString()}, reason: ${String(reasonPhrase)}"

--- a/ktor-network/ktor-network-quic/jvmAndNix/src/io/ktor/network/quic/frames/FrameProcessor.kt
+++ b/ktor-network/ktor-network-quic/jvmAndNix/src/io/ktor/network/quic/frames/FrameProcessor.kt
@@ -22,7 +22,7 @@ internal interface FrameProcessor {
     suspend fun acceptACK(
         packet: QUICPacket,
         ackDelay: Long,
-        ackRanges: LongArray,
+        ackRanges: List<Long>,
     ): QUICTransportError?
 
     /**
@@ -34,7 +34,7 @@ internal interface FrameProcessor {
     suspend fun acceptACKWithECN(
         packet: QUICPacket,
         ackDelay: Long,
-        ackRanges: LongArray,
+        ackRanges: List<Long>,
         ect0: Long,
         ect1: Long,
         ectCE: Long,

--- a/ktor-network/ktor-network-quic/jvmAndNix/src/io/ktor/network/quic/frames/FrameReader.kt
+++ b/ktor-network/ktor-network-quic/jvmAndNix/src/io/ktor/network/quic/frames/FrameReader.kt
@@ -123,7 +123,7 @@ internal object FrameReader {
         val ackRangeCount = payload.readVarIntOrElse { return FRAME_ENCODING_ERROR }
         val firstAckRange = payload.readVarIntOrElse { return FRAME_ENCODING_ERROR }
 
-        val ackRanges = LongArray((ackRangeCount * 2 + 2).toInt())
+        val ackRanges = MutableList<Long>((ackRangeCount * 2 + 2).toInt()) { 0 }
         ackRanges[0] = largestAcknowledged
         var previousSmallest = largestAcknowledged - firstAckRange
         ackRanges[1] = previousSmallest

--- a/ktor-network/ktor-network-quic/jvmAndNix/src/io/ktor/network/quic/packets/Consts.kt
+++ b/ktor-network/ktor-network-quic/jvmAndNix/src/io/ktor/network/quic/packets/Consts.kt
@@ -6,29 +6,12 @@ package io.ktor.network.quic.packets
 
 import io.ktor.network.quic.bytes.*
 
-internal object PktConst {
+internal object Consts {
     const val LONG_HEADER_PACKET_TYPE_INITIAL: UInt8 = 0x00u
     const val LONG_HEADER_PACKET_TYPE_0_RTT: UInt8 = 0x10u
     const val LONG_HEADER_PACKET_TYPE_HANDSHAKE: UInt8 = 0x20u
     const val LONG_HEADER_PACKET_TYPE_RETRY: UInt8 = 0x30u
 
-    const val RETRY_PACKET_INTEGRITY_TAG_LENGTH = 16
-
-    /**
-     * Length of sample ciphertext used for header protection
-     */
-    const val HP_SAMPLE_LENGTH = 16
-
-    /**
-     * Length of the header that gets appended during encryption
-     */
-    const val ENCRYPTION_HEADER_LENGTH = 16
-
     const val SHORT_HEADER_SPIN_BIT: UInt8 = 0x20u
     const val SHORT_HEADER_KEY_PHASE: UInt8 = 0x04u
-
-    const val HEADER_FLAGS_LENGTH = 1
-    const val LONG_HEADER_LENGTH_FIELD_MAX_LENGTH = 4
-    const val HEADER_PACKET_NUMBER_MAX_LENGTH = 4
-    const val LONG_HEADER_VERSION_LENGTH = 4
 }

--- a/ktor-network/ktor-network-quic/jvmAndNix/src/io/ktor/network/quic/packets/PacketNumberSpace.kt
+++ b/ktor-network/ktor-network-quic/jvmAndNix/src/io/ktor/network/quic/packets/PacketNumberSpace.kt
@@ -14,6 +14,7 @@ import kotlinx.atomicfu.*
  */
 internal class PacketNumberSpace {
     private val logger = logger()
+
     private val increment = atomic(0L)
     private val _largestAcknowledged = atomic(-1L) // -1 for no acknowledgements yet
 
@@ -79,8 +80,7 @@ internal class PacketNumberSpace {
 
     fun registerSentRanges(ranges: List<Long>, packetNumber: Long) {
         sentAckPackets[packetNumber]?.let {
-            // programmer's error
-            error("Each packet should have one ack frame, number: $packetNumber, old numbers: ${ranges.joinToString()}")
+            logger.warn("Each packet should have one ack frame, number: $packetNumber, old numbers: ${ranges.joinToString()}. Will overwrite") // ktlint-disable max-line-length argument-list-wrapping
         }
         sentAckPackets[packetNumber] = ranges
     }

--- a/ktor-network/ktor-network-quic/jvmAndNix/src/io/ktor/network/quic/packets/PacketNumberSpace.kt
+++ b/ktor-network/ktor-network-quic/jvmAndNix/src/io/ktor/network/quic/packets/PacketNumberSpace.kt
@@ -20,7 +20,7 @@ internal class PacketNumberSpace {
     private val unacknowledgedLocalPacketNumbers = mutableSetOf<Long>()
     private val unacknowledgedPeerPacketNumbers = mutableSetOf<Long>()
 
-    private val sentAckPackets = mutableMapOf<Long, MutableSet<Long>>()
+    private val sentAckPackets = mutableMapOf<Long, List<Long>>()
 
     val largestPacketNumber: Long get() = increment.getAndAdd(0)
     val largestAcknowledged: Long get() = _largestAcknowledged.getAndAdd(0)
@@ -36,15 +36,13 @@ internal class PacketNumberSpace {
     /**
      * @param ackRanges from [io.ktor.network.quic.frames.FrameProcessor.acceptACK]
      */
-    fun processAcknowledgements(ackRanges: LongArray) {
+    fun processAcknowledgements(ackRanges: List<Long>) {
         if (ackRanges.isEmpty()) return // todo error?
 
-        for (i in ackRanges.indices step 2) {
-            for (packetNumber in ackRanges[i] downTo ackRanges[i + 1]) { // full loop
-                unacknowledgedLocalPacketNumbers.remove(packetNumber)
-                sentAckPackets.remove(packetNumber)?.let { numbers ->
-                    unacknowledgedPeerPacketNumbers.removeAll(numbers)
-                }
+        ackRanges.rangesToNumbers().forEach { packetNumber ->
+            unacknowledgedLocalPacketNumbers.remove(packetNumber)
+            sentAckPackets.remove(packetNumber)?.let { ranges ->
+                unacknowledgedPeerPacketNumbers.removeAll(ranges.rangesToNumbers().toSet())
             }
         }
 
@@ -57,7 +55,7 @@ internal class PacketNumberSpace {
      *
      * Null if everything is acknowledged
      */
-    fun getAckRanges(): Pair<LongArray, (Long) -> Unit>? {
+    fun getAckRanges(): List<Long>? {
         if (unacknowledgedPeerPacketNumbers.isEmpty()) return null
 
         val sorted = unacknowledgedPeerPacketNumbers.sortedDescending()
@@ -76,12 +74,15 @@ internal class PacketNumberSpace {
 
         logger.info("generated ACK ranges array: (${result.joinToString()}) from (${unacknowledgedPeerPacketNumbers.joinToString()})") // ktlint-disable max-line-length argument-list-wrapping
 
-        return result.toLongArray() to { packetNumber ->
-            // is the first case possible?
-            sentAckPackets[packetNumber]?.addAll(sorted) ?: run {
-                sentAckPackets[packetNumber] = sorted.toMutableSet()
-            }
+        return result
+    }
+
+    fun registerSentRanges(ranges: List<Long>, packetNumber: Long) {
+        sentAckPackets[packetNumber]?.let {
+            // programmer's error
+            error("Each packet should have one ack frame, number: $packetNumber, old numbers: ${ranges.joinToString()}")
         }
+        sentAckPackets[packetNumber] = ranges
     }
 
     /**
@@ -90,6 +91,10 @@ internal class PacketNumberSpace {
     @Suppress("unused")
     fun getUnacknowledgedLocalPacketNumbers(): Set<Long> {
         return unacknowledgedLocalPacketNumbers
+    }
+
+    private fun List<Long>.rangesToNumbers(): List<Long> {
+        return chunked(2) { (start, end) -> (start downTo end) }.flatten()
     }
 
     class Pool {

--- a/ktor-network/ktor-network-quic/jvmAndNix/src/io/ktor/network/quic/packets/PacketWriter.kt
+++ b/ktor-network/ktor-network-quic/jvmAndNix/src/io/ktor/network/quic/packets/PacketWriter.kt
@@ -43,7 +43,6 @@ internal object PacketWriter {
      */
     private const val SHORT_HEADER_FIRST_BYTE_TEMPLATE: UInt8 = 0x40u
 
-
     /**
      * Writes a Version Negotiation packet to [packetBuilder] according to specification.
      * If it is QUIC version 1, sets second bit to 1.
@@ -149,7 +148,7 @@ internal object PacketWriter {
             encryptionLevel = EncryptionLevel.Initial,
             largestAcknowledged = largestAcknowledged,
             packetBuilder = packetBuilder,
-            packetType = PktConst.LONG_HEADER_PACKET_TYPE_INITIAL,
+            packetType = Consts.LONG_HEADER_PACKET_TYPE_INITIAL,
             version = version,
             destinationConnectionID = destinationConnectionID,
             sourceConnectionID = sourceConnectionID,
@@ -191,7 +190,7 @@ internal object PacketWriter {
             encryptionLevel = EncryptionLevel.Handshake,
             largestAcknowledged = largestAcknowledged,
             packetBuilder = packetBuilder,
-            packetType = PktConst.LONG_HEADER_PACKET_TYPE_HANDSHAKE,
+            packetType = Consts.LONG_HEADER_PACKET_TYPE_HANDSHAKE,
             version = version,
             destinationConnectionID = destinationConnectionID,
             sourceConnectionID = sourceConnectionID,
@@ -229,7 +228,7 @@ internal object PacketWriter {
             encryptionLevel = EncryptionLevel.AppData,
             largestAcknowledged = largestAcknowledged,
             packetBuilder = packetBuilder,
-            packetType = PktConst.LONG_HEADER_PACKET_TYPE_0_RTT,
+            packetType = Consts.LONG_HEADER_PACKET_TYPE_0_RTT,
             version = version,
             destinationConnectionID = destinationConnectionID,
             sourceConnectionID = sourceConnectionID,
@@ -262,7 +261,7 @@ internal object PacketWriter {
             writeConnectionID(destinationConnectionID)
             writeConnectionID(sourceConnectionID)
             writeBeforeLength()
-            writeVarInt(payload.size + packetNumberLength.toInt() + PktConst.ENCRYPTION_HEADER_LENGTH)
+            writeVarInt(payload.size + packetNumberLength.toInt() + PayloadSize.ENCRYPTION_HEADER_LENGTH)
             writeRawPacketNumber(this, packetNumberLength.toUInt32(), packetNumber.toUInt())
         }.readBytes()
 
@@ -313,15 +312,15 @@ internal object PacketWriter {
 
         val packetNumberLength: UInt8 = getPacketNumberLength(packetNumber, largestAcknowledged)
 
-        val spinBitValue: UInt8 = if (spinBit) PktConst.SHORT_HEADER_SPIN_BIT else 0x00u
-        val keyPhaseValue: UInt8 = if (keyPhase) PktConst.SHORT_HEADER_KEY_PHASE else 0x00u
+        val spinBitValue: UInt8 = if (spinBit) Consts.SHORT_HEADER_SPIN_BIT else 0x00u
+        val keyPhaseValue: UInt8 = if (keyPhase) Consts.SHORT_HEADER_KEY_PHASE else 0x00u
 
         val flags: UInt8 = SHORT_HEADER_FIRST_BYTE_TEMPLATE or
             spinBitValue or
             keyPhaseValue or
             (packetNumberLength - 1u).toUInt8()
 
-        val unencryptedHeader = buildPacket {
+        val unencryptedHeader: ByteArray = buildPacket {
             writeUInt8(flags)
             writeFully(destinationConnectionID.value)
             writeRawPacketNumber(this, packetNumberLength.toUInt32(), packetNumber.toUInt())
@@ -385,7 +384,7 @@ internal object PacketWriter {
         )
 
         val offset: Int = 4 - packetNumberLength
-        val sample: ByteArray = encryptedPayload.copyOfRange(offset, offset + PktConst.HP_SAMPLE_LENGTH)
+        val sample: ByteArray = encryptedPayload.copyOfRange(offset, offset + PayloadSize.HP_SAMPLE_LENGTH)
         val headerProtectionMask: Long = tlsComponent.headerProtectionMask(sample, level, isDecrypting = false)
 
         return body(encryptedPayload, headerProtectionMask)

--- a/ktor-network/ktor-network-quic/jvmAndNix/src/io/ktor/network/quic/packets/PacketWriter.kt
+++ b/ktor-network/ktor-network-quic/jvmAndNix/src/io/ktor/network/quic/packets/PacketWriter.kt
@@ -80,7 +80,7 @@ internal interface PacketWriter {
     )
 }
 
-internal class PacketWriterImpl(private val tlsComponent: TLSComponent): PacketWriter {
+internal class PacketWriterImpl(private val tlsComponent: TLSComponent) : PacketWriter {
     companion object {
         /**
          * header form = 0b1 (long header)

--- a/ktor-network/ktor-network-quic/jvmAndNix/test/io/ktor/network/quic/frames/FrameExpectedSizeTest.kt
+++ b/ktor-network/ktor-network-quic/jvmAndNix/test/io/ktor/network/quic/frames/FrameExpectedSizeTest.kt
@@ -1,0 +1,260 @@
+/*
+ * Copyright 2014-2023 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.network.quic.frames
+
+import io.ktor.network.quic.connections.*
+import io.ktor.network.quic.errors.*
+import io.ktor.network.quic.util.*
+import io.ktor.utils.io.core.*
+import kotlinx.coroutines.*
+import kotlin.test.*
+
+class FrameExpectedSizeTest {
+    @Test
+    fun padding() = sizeTest {
+        assertExpectedSize(1, "Padding frame") {
+            writePadding()
+        }
+    }
+
+    @Test
+    fun ping() = sizeTest {
+        assertExpectedSize(1, "Ping frame") {
+            writePadding()
+        }
+    }
+
+    @Test
+    fun ack() = sizeTest {
+        assertExpectedSize(23, "Ack frame") {
+            writeACK(
+                ackDelay = 4100,
+                ack_delay_exponent = 5,
+                ackRanges = listOf(67, 15, 12, 3),
+            )
+        }
+
+        assertExpectedSize(21 + (POW_2_14 / 2 - 1) * 16, "Ack frame 2") {
+            writeACK(
+                ackDelay = 4100,
+                ack_delay_exponent = 5,
+                ackRanges = List(POW_2_14.toInt()) { (it * POW_2_30) }.reversed(),
+            )
+        }
+
+        assertExpectedSize(26, "Ack frame ect") {
+            writeACKWithECN(
+                ackDelay = 4100,
+                ack_delay_exponent = 5,
+                ackRanges = listOf(67, 15, 12, 3),
+                ect0 = 1,
+                ect1 = 1,
+                ectCE = 1,
+            )
+        }
+    }
+
+    @Test
+    fun resetStream() = sizeTest {
+        assertExpectedSize(5, "ResetStream frame") {
+            writeResetStream(4, AppError(1), 100)
+        }
+
+        assertExpectedSize(15, "ResetStream frame 2") {
+            writeResetStream(POW_2_30, AppError(100), POW_2_14)
+        }
+    }
+
+    @Test
+    fun stopSending() = sizeTest {
+        assertExpectedSize(3, "StopSending frame") {
+            writeStopSending(4, AppError(1))
+        }
+
+        assertExpectedSize(17, "StopSending frame 2") {
+            writeStopSending(POW_2_30, AppError(POW_2_30))
+        }
+    }
+
+    @Test
+    fun crypto() = sizeTest {
+        assertExpectedSize(6, "Crypto frame") {
+            writeCrypto(1, ByteArray(3) { 0x00 })
+        }
+
+        assertExpectedSize(6 + POW_2_14, "Crypto frame 2") {
+            writeCrypto(1, ByteArray((POW_2_14).toInt()) { 0x00 })
+        }
+    }
+
+    @Test
+    fun newToken() = sizeTest {
+        assertExpectedSize(3, "NewToken frame") {
+            writeNewToken(byteArrayOf(0x00))
+        }
+    }
+
+    @Test
+    fun stream() = sizeTest {
+        assertExpectedSize(5, "Stream frame") {
+            writeStream(1, 1, specifyLength = true, fin = true, data = byteArrayOf(0x00))
+        }
+
+        assertExpectedSize(4, "Stream frame 2") {
+            writeStream(1, null, specifyLength = true, fin = true, data = byteArrayOf(0x00))
+        }
+
+        assertExpectedSize(3, "Stream frame 3") {
+            writeStream(1, null, specifyLength = false, fin = true, data = byteArrayOf(0x00))
+        }
+    }
+
+    @Test
+    fun maxData() = sizeTest {
+        assertExpectedSize(2, "MaxData frame") {
+            writeMaxData(1)
+        }
+    }
+
+    @Test
+    fun maxStreamData() = sizeTest {
+        assertExpectedSize(3, "MaxStreamData frame") {
+            writeMaxStreamData(1, 1)
+        }
+    }
+
+    @Test
+    fun maxStreams() = sizeTest {
+        assertExpectedSize(5, "MaxStreams bi frame") {
+            writeMaxStreamsBidirectional(POW_2_14)
+        }
+
+        assertExpectedSize(9, "MaxStreams uni frame") {
+            writeMaxStreamsUnidirectional(POW_2_30)
+        }
+    }
+
+    @Test
+    fun dataBlocked() = sizeTest {
+        assertExpectedSize(3, "dataBlocked frame") {
+            writeDataBlocked(POW_2_06)
+        }
+    }
+
+    @Test
+    fun streamDataBlocked() = sizeTest {
+        assertExpectedSize(7, "StreamDataBlocked frame") {
+            writeStreamDataBlocked(POW_2_06, POW_2_14)
+        }
+    }
+
+    @Test
+    fun streamsBlocked() = sizeTest {
+        assertExpectedSize(3, "StreamsBlocked bi frame") {
+            writeStreamsBlockedBidirectional(POW_2_06)
+        }
+
+        assertExpectedSize(5, "StreamsBlocked uni frame") {
+            writeStreamsBlockedUnidirectional(POW_2_14)
+        }
+    }
+
+    @Test
+    fun newConnectionId() = sizeTest {
+        assertExpectedSize(21, "NewConnectionId frame") {
+            writeNewConnectionId(1, 1, QUICConnectionID(byteArrayOf(0x00)), ByteArray(16) { 0x00 })
+        }
+
+        assertExpectedSize(26, "NewConnectionId frame 2") {
+            writeNewConnectionId(POW_2_14, POW_2_06, QUICConnectionID(byteArrayOf(0x00, 0x00)), ByteArray(16) { 0x00 })
+        }
+    }
+
+    @Test
+    fun retireConnectionId() = sizeTest {
+        assertExpectedSize(5, "RetireConnectionId frame") {
+            writeRetireConnectionId(POW_2_14)
+        }
+    }
+
+    @Test
+    fun pathChallenge() = sizeTest {
+        assertExpectedSize(9, "PathChallenge frame") {
+            writePathChallenge(ByteArray(8) { 0x00 })
+        }
+    }
+
+    @Test
+    fun pathResponse() = sizeTest {
+        assertExpectedSize(9, "PathResponse frame") {
+            writePathResponse(ByteArray(8) { 0x00 })
+        }
+    }
+
+    @Test
+    fun connectionClose() = sizeTest {
+        assertExpectedSize(23, "ConnectionClose app frame") {
+            writeConnectionCloseWithAppError(AppError(POW_2_14), ByteArray(17) { 0x00 })
+        }
+
+        assertExpectedSize(147, "ConnectionClose transport frame") {
+            writeConnectionCloseWithTransportError(QUICProtocolTransportError.FRAME_ENCODING_ERROR, null, ByteArray(142) { 0x00 }) // ktlint-disable max-line-length
+        }
+
+        assertExpectedSize(148, "ConnectionClose transport frame") {
+            writeConnectionCloseWithTransportError(QUICCryptoHandshakeTransportError(0x00u), QUICFrameType.CRYPTO, ByteArray(142) { 0x00 }) // ktlint-disable max-line-length
+        }
+    }
+
+    @Test
+    fun handshakeDone() = sizeTest {
+        assertExpectedSize(1, "HandshakeDone frame") {
+            writeHandshakeDone()
+        }
+    }
+
+    private fun sizeTest(body: suspend SizeTest.() -> Unit) = runBlocking {
+        SizeTest().body()
+    }
+
+    private class SizeTest : PacketSendHandler {
+        private var expectedExpectedSizeValue: Int = -1
+        private var testMessage: String = ""
+        private var invoked = 0
+
+        private val writer by lazy { FrameWriterImpl(this) }
+
+        suspend fun assertExpectedSize(expectedValue: Long, message: String, body: suspend FrameWriter.() -> Unit) {
+            assertExpectedSize(expectedValue.toInt(), message, body)
+        }
+
+        suspend fun assertExpectedSize(expectedValue: Int, message: String, body: suspend FrameWriter.() -> Unit) {
+            expectedExpectedSizeValue = expectedValue
+            testMessage = message
+            invoked = 0
+
+            writer.body()
+
+            if (invoked != 1) {
+                fail("writeFrame method was not invoked or invoked more than once, $testMessage")
+            }
+        }
+
+        override suspend fun writeFrame(expectedFrameSize: Int, handler: BytePacketBuilder.() -> Unit): Long {
+            assertEquals(
+                expectedExpectedSizeValue,
+                expectedFrameSize,
+                "Wrong expectedFrameSize value: $testMessage"
+            ) // ktlint-disable max-line-length
+
+            val actualFrameSize = buildPacket(handler).remaining
+            assertTrue("Actual size must not be greater than expectedFrameSize value, $testMessage: expectedFrameSize: $expectedFrameSize, actual: $actualFrameSize") { actualFrameSize <= expectedFrameSize } // ktlint-disable max-line-length
+
+            invoked++
+
+            return 0
+        }
+    }
+}

--- a/ktor-network/ktor-network-quic/jvmAndNix/test/io/ktor/network/quic/frames/FrameExpectedSizeTest.kt
+++ b/ktor-network/ktor-network-quic/jvmAndNix/test/io/ktor/network/quic/frames/FrameExpectedSizeTest.kt
@@ -81,33 +81,33 @@ class FrameExpectedSizeTest {
     @Test
     fun crypto() = sizeTest {
         assertExpectedSize(6, "Crypto frame") {
-            writeCrypto(1, ByteArray(3) { 0x00 })
+            writeCrypto(1, zeroByteArray(3))
         }
 
         assertExpectedSize(6 + POW_2_14, "Crypto frame 2") {
-            writeCrypto(1, ByteArray((POW_2_14).toInt()) { 0x00 })
+            writeCrypto(1, zeroByteArray(POW_2_14))
         }
     }
 
     @Test
     fun newToken() = sizeTest {
         assertExpectedSize(3, "NewToken frame") {
-            writeNewToken(byteArrayOf(0x00))
+            writeNewToken(zeroByteArray(1))
         }
     }
 
     @Test
     fun stream() = sizeTest {
         assertExpectedSize(5, "Stream frame") {
-            writeStream(1, 1, specifyLength = true, fin = true, data = byteArrayOf(0x00))
+            writeStream(1, 1, specifyLength = true, fin = true, data = zeroByteArray(1))
         }
 
         assertExpectedSize(4, "Stream frame 2") {
-            writeStream(1, null, specifyLength = true, fin = true, data = byteArrayOf(0x00))
+            writeStream(1, null, specifyLength = true, fin = true, data = zeroByteArray(1))
         }
 
         assertExpectedSize(3, "Stream frame 3") {
-            writeStream(1, null, specifyLength = false, fin = true, data = byteArrayOf(0x00))
+            writeStream(1, null, specifyLength = false, fin = true, data = zeroByteArray(1))
         }
     }
 
@@ -164,11 +164,11 @@ class FrameExpectedSizeTest {
     @Test
     fun newConnectionId() = sizeTest {
         assertExpectedSize(21, "NewConnectionId frame") {
-            writeNewConnectionId(1, 1, QUICConnectionID(byteArrayOf(0x00)), ByteArray(16) { 0x00 })
+            writeNewConnectionId(1, 1, zeroByteArray(1).asCID(), zeroByteArray(16))
         }
 
         assertExpectedSize(26, "NewConnectionId frame 2") {
-            writeNewConnectionId(POW_2_14, POW_2_06, QUICConnectionID(byteArrayOf(0x00, 0x00)), ByteArray(16) { 0x00 })
+            writeNewConnectionId(POW_2_14, POW_2_06, zeroByteArray(2).asCID(), zeroByteArray(16))
         }
     }
 
@@ -182,29 +182,29 @@ class FrameExpectedSizeTest {
     @Test
     fun pathChallenge() = sizeTest {
         assertExpectedSize(9, "PathChallenge frame") {
-            writePathChallenge(ByteArray(8) { 0x00 })
+            writePathChallenge(zeroByteArray(8))
         }
     }
 
     @Test
     fun pathResponse() = sizeTest {
         assertExpectedSize(9, "PathResponse frame") {
-            writePathResponse(ByteArray(8) { 0x00 })
+            writePathResponse(zeroByteArray(8))
         }
     }
 
     @Test
     fun connectionClose() = sizeTest {
         assertExpectedSize(23, "ConnectionClose app frame") {
-            writeConnectionCloseWithAppError(AppError(POW_2_14), ByteArray(17) { 0x00 })
+            writeConnectionCloseWithAppError(AppError(POW_2_14), zeroByteArray(17))
         }
 
         assertExpectedSize(147, "ConnectionClose transport frame") {
-            writeConnectionCloseWithTransportError(QUICProtocolTransportError.FRAME_ENCODING_ERROR, null, ByteArray(142) { 0x00 }) // ktlint-disable max-line-length
+            writeConnectionCloseWithTransportError(QUICProtocolTransportError.FRAME_ENCODING_ERROR, null, zeroByteArray(142)) // ktlint-disable max-line-length
         }
 
         assertExpectedSize(148, "ConnectionClose transport frame") {
-            writeConnectionCloseWithTransportError(QUICCryptoHandshakeTransportError(0x00u), QUICFrameType.CRYPTO, ByteArray(142) { 0x00 }) // ktlint-disable max-line-length
+            writeConnectionCloseWithTransportError(QUICCryptoHandshakeTransportError(0x00u), QUICFrameType.CRYPTO, zeroByteArray(142)) // ktlint-disable max-line-length
         }
     }
 

--- a/ktor-network/ktor-network-quic/jvmAndNix/test/io/ktor/network/quic/frames/FrameExpectedSizeTest.kt
+++ b/ktor-network/ktor-network-quic/jvmAndNix/test/io/ktor/network/quic/frames/FrameExpectedSizeTest.kt
@@ -200,11 +200,11 @@ class FrameExpectedSizeTest {
         }
 
         assertExpectedSize(147, "ConnectionClose transport frame") {
-            writeConnectionCloseWithTransportError(QUICProtocolTransportError.FRAME_ENCODING_ERROR, null, zeroByteArray(142)) // ktlint-disable max-line-length
+            writeConnectionCloseWithTransportError(QUICProtocolTransportError.FRAME_ENCODING_ERROR, null, zeroByteArray(142)) // ktlint-disable max-line-length argument-list-wrapping
         }
 
         assertExpectedSize(148, "ConnectionClose transport frame") {
-            writeConnectionCloseWithTransportError(QUICCryptoHandshakeTransportError(0x00u), QUICFrameType.CRYPTO, zeroByteArray(142)) // ktlint-disable max-line-length
+            writeConnectionCloseWithTransportError(QUICCryptoHandshakeTransportError(0x00u), QUICFrameType.CRYPTO, zeroByteArray(142)) // ktlint-disable max-line-length argument-list-wrapping
         }
     }
 
@@ -250,7 +250,9 @@ class FrameExpectedSizeTest {
             ) // ktlint-disable max-line-length
 
             val actualFrameSize = buildPacket(handler).remaining
-            assertTrue("Actual size must not be greater than expectedFrameSize value, $testMessage: expectedFrameSize: $expectedFrameSize, actual: $actualFrameSize") { actualFrameSize <= expectedFrameSize } // ktlint-disable max-line-length
+            assertTrue("Actual size must not be greater than expectedFrameSize value, $testMessage: expectedFrameSize: $expectedFrameSize, actual: $actualFrameSize") { // ktlint-disable max-line-length argument-list-wrapping
+                actualFrameSize <= expectedFrameSize
+            }
 
             invoked++
 

--- a/ktor-network/ktor-network-quic/jvmAndNix/test/io/ktor/network/quic/frames/base/TestFrameProcessor.kt
+++ b/ktor-network/ktor-network-quic/jvmAndNix/test/io/ktor/network/quic/frames/base/TestFrameProcessor.kt
@@ -25,7 +25,7 @@ internal class TestFrameProcessor(
     override suspend fun acceptACK(
         packet: QUICPacket,
         ackDelay: Long,
-        ackRanges: LongArray,
+        ackRanges: List<Long>,
     ) = testAccept(QUICFrameType.ACK) {
         listACKValidators[it](ackDelay, ackRanges)
     }
@@ -33,7 +33,7 @@ internal class TestFrameProcessor(
     override suspend fun acceptACKWithECN(
         packet: QUICPacket,
         ackDelay: Long,
-        ackRanges: LongArray,
+        ackRanges: List<Long>,
         ect0: Long,
         ect1: Long,
         ectCE: Long,
@@ -218,12 +218,12 @@ internal class TestFrameProcessor(
 internal class ReadFramesValidator {
     val listACKValidators = mutableListOf<(
         ackDelay: Long,
-        ackRanges: LongArray,
+        ackRanges: List<Long>,
     ) -> Unit>()
 
     val listACKWithECNValidators = mutableListOf<(
         ackDelay: Long,
-        ackRanges: LongArray,
+        ackRanges: List<Long>,
         ect0: Long,
         ect1: Long,
         ectCE: Long,
@@ -320,11 +320,11 @@ internal class ReadFramesValidator {
         reasonPhrase: ByteArray,
     ) -> Unit>()
 
-    fun validateACK(body: (ackDelay: Long, ackRanges: LongArray) -> Unit) {
+    fun validateACK(body: (ackDelay: Long, ackRanges: List<Long>) -> Unit) {
         listACKValidators.add(body)
     }
 
-    fun validateACKWithECN(body: (ackDelay: Long, ackRanges: LongArray, ect0: Long, ect1: Long, ectCE: Long) -> Unit) {
+    fun validateACKWithECN(body: (ackDelay: Long, ackRanges: List<Long>, ect0: Long, ect1: Long, ectCE: Long) -> Unit) {
         listACKWithECNValidators.add(body)
     }
 

--- a/ktor-network/ktor-network-quic/jvmAndNix/test/io/ktor/network/quic/frames/base/TestFrameWriter.kt
+++ b/ktor-network/ktor-network-quic/jvmAndNix/test/io/ktor/network/quic/frames/base/TestFrameWriter.kt
@@ -2,6 +2,8 @@
  * Copyright 2014-2023 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
+@file:Suppress("LocalVariableName")
+
 package io.ktor.network.quic.frames.base
 
 import io.ktor.network.quic.connections.*
@@ -9,216 +11,207 @@ import io.ktor.network.quic.errors.*
 import io.ktor.network.quic.frames.*
 import io.ktor.utils.io.core.*
 
-internal class TestFrameWriter : FrameWriter {
+internal class TestFrameWriter(handler: TestPacketSendHandler) : FrameWriter {
     private val _expectedFrames = mutableListOf<QUICFrameType>()
     val expectedFrames: List<QUICFrameType> = _expectedFrames
     var writtenFramesCnt: Int = 0
         private set
 
+    private val frameWriter = FrameWriterImpl(handler)
+
     @OptIn(ExperimentalUnsignedTypes::class)
-    fun writeCustomFrame(
+    suspend fun writeCustomFrame(
         packetBuilder: BytePacketBuilder,
         typeV1: QUICFrameType,
         shouldFailOnRead: Boolean,
         body: BytePacketBuilder.() -> Unit,
-    ) = withLog(typeV1, shouldFailOnRead) {
+    ): Long = withLog(typeV1, shouldFailOnRead) {
         packetBuilder.writeUByte(typeV1.typeValue)
         packetBuilder.body()
+        0 // packet number, not needed for these tests
     }
 
-    override fun writePadding(
-        packetBuilder: BytePacketBuilder,
-    ) = withLog(QUICFrameType.PADDING) {
-        writePadding(packetBuilder)
+    override suspend fun writePadding(): Long {
+        return withLog(QUICFrameType.PADDING) {
+            writePadding()
+        }
     }
 
-    override fun writePing(
-        packetBuilder: BytePacketBuilder,
-    ) = withLog(QUICFrameType.PING) {
-        writePing(packetBuilder)
+    override suspend fun writePing(): Long {
+        return withLog(QUICFrameType.PING) {
+            writePing()
+        }
     }
 
-    override fun writeACK(
-        packetBuilder: BytePacketBuilder,
+    override suspend fun writeACK(ackDelay: Long, ack_delay_exponent: Int, ackRanges: List<Long>): Long {
+        return withLog(QUICFrameType.ACK) {
+            writeACK(ackDelay, ack_delay_exponent, ackRanges)
+        }
+    }
+
+    override suspend fun writeACKWithECN(
         ackDelay: Long,
         ack_delay_exponent: Int,
-        ackRanges: LongArray,
-    ) = withLog(QUICFrameType.ACK) {
-        writeACK(packetBuilder, ackDelay, ack_delay_exponent, ackRanges)
-    }
-
-    override fun writeACKWithECN(
-        packetBuilder: BytePacketBuilder,
-        ackDelay: Long,
-        ack_delay_exponent: Int,
-        ackRanges: LongArray,
+        ackRanges: List<Long>,
         ect0: Long,
         ect1: Long,
         ectCE: Long,
-    ) = withLog(QUICFrameType.ACK_ECN) {
-        writeACKWithECN(packetBuilder, ackDelay, ack_delay_exponent, ackRanges, ect0, ect1, ectCE)
+    ): Long = withLog(QUICFrameType.ACK_ECN) {
+        writeACKWithECN(ackDelay, ack_delay_exponent, ackRanges, ect0, ect1, ectCE)
     }
 
-    override fun writeResetStream(
-        packetBuilder: BytePacketBuilder,
+    override suspend fun writeResetStream(
         streamId: Long,
         applicationProtocolErrorCode: AppError,
         finaSize: Long,
-    ) = withLog(QUICFrameType.RESET_STREAM) {
-        writeResetStream(packetBuilder, streamId, applicationProtocolErrorCode, finaSize)
+    ): Long = withLog(QUICFrameType.RESET_STREAM) {
+        writeResetStream(streamId, applicationProtocolErrorCode, finaSize)
     }
 
-    override fun writeStopSending(
-        packetBuilder: BytePacketBuilder,
-        streamId: Long,
-        applicationProtocolErrorCode: AppError,
-    ) = withLog(QUICFrameType.STOP_SENDING) {
-        writeStopSending(packetBuilder, streamId, applicationProtocolErrorCode)
+    override suspend fun writeStopSending(streamId: Long, applicationProtocolErrorCode: AppError): Long {
+        return withLog(QUICFrameType.STOP_SENDING) {
+            writeStopSending(streamId, applicationProtocolErrorCode)
+        }
     }
 
-    override fun writeCrypto(
-        packetBuilder: BytePacketBuilder,
-        offset: Long,
-        data: ByteArray,
-    ) = withLog(QUICFrameType.CRYPTO) {
-        writeCrypto(packetBuilder, offset, data)
+    override suspend fun writeCrypto(offset: Long, data: ByteArray): Long {
+        return withLog(QUICFrameType.CRYPTO) {
+            writeCrypto(offset, data)
+        }
     }
 
-    override fun writeNewToken(
-        packetBuilder: BytePacketBuilder,
-        token: ByteArray,
-    ) = withLog(QUICFrameType.NEW_TOKEN) {
-        writeNewToken(packetBuilder, token)
+    override suspend fun writeNewToken(token: ByteArray): Long {
+        return withLog(QUICFrameType.NEW_TOKEN) {
+            writeNewToken(token)
+        }
     }
 
-    override fun writeStream(
-        packetBuilder: BytePacketBuilder,
+    override suspend fun writeStream(
         streamId: Long,
         offset: Long?,
         specifyLength: Boolean,
         fin: Boolean,
         data: ByteArray,
-    ) = withLog(QUICFrameType.STREAM) {
-        writeStream(packetBuilder, streamId, offset, specifyLength, fin, data)
+    ): Long = withLog(QUICFrameType.STREAM) {
+        writeStream(streamId, offset, specifyLength, fin, data)
     }
 
-    override fun writeMaxData(
-        packetBuilder: BytePacketBuilder,
-        maximumData: Long,
-    ) = withLog(QUICFrameType.MAX_DATA) {
-        writeMaxData(packetBuilder, maximumData)
+    override suspend fun writeMaxData(maximumData: Long): Long {
+        return withLog(QUICFrameType.MAX_DATA) {
+            writeMaxData(maximumData)
+        }
     }
 
-    override fun writeMaxStreamData(
-        packetBuilder: BytePacketBuilder,
-        streamId: Long,
-        maximumStreamData: Long,
-    ) = withLog(QUICFrameType.MAX_STREAM_DATA) {
-        writeMaxStreamData(packetBuilder, streamId, maximumStreamData)
+    override suspend fun writeMaxStreamData(streamId: Long, maximumStreamData: Long): Long {
+        return withLog(QUICFrameType.MAX_STREAM_DATA) {
+            writeMaxStreamData(streamId, maximumStreamData)
+        }
     }
 
-    override fun writeMaxStreamsBidirectional(
-        packetBuilder: BytePacketBuilder,
-        maximumStreams: Long,
-    ) = withLog(QUICFrameType.MAX_STREAMS_BIDIRECTIONAL) {
-        writeMaxStreamsBidirectional(packetBuilder, maximumStreams)
+    override suspend fun writeMaxStreamsBidirectional(maximumStreams: Long): Long {
+        return withLog(QUICFrameType.MAX_STREAMS_BIDIRECTIONAL) {
+            writeMaxStreamsBidirectional(maximumStreams)
+        }
     }
 
-    override fun writeMaxStreamsUnidirectional(
-        packetBuilder: BytePacketBuilder,
-        maximumStreams: Long,
-    ) = withLog(QUICFrameType.MAX_STREAMS_UNIDIRECTIONAL) {
-        writeMaxStreamsUnidirectional(packetBuilder, maximumStreams)
+    override suspend fun writeMaxStreamsUnidirectional(maximumStreams: Long): Long {
+        return withLog(QUICFrameType.MAX_STREAMS_UNIDIRECTIONAL) {
+            writeMaxStreamsUnidirectional(maximumStreams)
+        }
     }
 
-    override fun writeDataBlocked(
-        packetBuilder: BytePacketBuilder,
-        maximumData: Long,
-    ) = withLog(QUICFrameType.DATA_BLOCKED) {
-        writeDataBlocked(packetBuilder, maximumData)
+    override suspend fun writeDataBlocked(maximumData: Long): Long {
+        return withLog(QUICFrameType.DATA_BLOCKED) {
+            writeDataBlocked(maximumData)
+        }
     }
 
-    override fun writeStreamDataBlocked(
-        packetBuilder: BytePacketBuilder,
-        streamId: Long,
-        maximumStreamData: Long,
-    ) = withLog(QUICFrameType.STREAM_DATA_BLOCKED) {
-        writeStreamDataBlocked(packetBuilder, streamId, maximumStreamData)
+    override suspend fun writeStreamDataBlocked(streamId: Long, maximumStreamData: Long): Long {
+        return withLog(QUICFrameType.STREAM_DATA_BLOCKED) {
+            writeStreamDataBlocked(streamId, maximumStreamData)
+        }
     }
 
-    override fun writeStreamsBlockedBidirectional(
-        packetBuilder: BytePacketBuilder,
-        maximumStreams: Long,
-    ) = withLog(QUICFrameType.STREAMS_BLOCKED_BIDIRECTIONAL) {
-        writeStreamsBlockedBidirectional(packetBuilder, maximumStreams)
+    override suspend fun writeStreamsBlockedBidirectional(maximumStreams: Long): Long {
+        return withLog(QUICFrameType.STREAMS_BLOCKED_BIDIRECTIONAL) {
+            writeStreamsBlockedBidirectional(maximumStreams)
+        }
     }
 
-    override fun writeStreamsBlockedUnidirectional(
-        packetBuilder: BytePacketBuilder,
-        maximumStreams: Long,
-    ) = withLog(QUICFrameType.STREAMS_BLOCKED_UNIDIRECTIONAL) {
-        writeStreamsBlockedUnidirectional(packetBuilder, maximumStreams)
+    override suspend fun writeStreamsBlockedUnidirectional(maximumStreams: Long): Long {
+        return withLog(QUICFrameType.STREAMS_BLOCKED_UNIDIRECTIONAL) {
+            writeStreamsBlockedUnidirectional(maximumStreams)
+        }
     }
 
-    override fun writeNewConnectionId(
-        packetBuilder: BytePacketBuilder,
+    override suspend fun writeNewConnectionId(
         sequenceNumber: Long,
         retirePriorTo: Long,
         connectionID: QUICConnectionID,
         statelessResetToken: ByteArray,
-    ) = withLog(QUICFrameType.NEW_CONNECTION_ID) {
-        writeNewConnectionId(packetBuilder, sequenceNumber, retirePriorTo, connectionID, statelessResetToken)
+    ): Long = withLog(QUICFrameType.NEW_CONNECTION_ID) {
+        writeNewConnectionId(sequenceNumber, retirePriorTo, connectionID, statelessResetToken)
     }
 
-    override fun writeRetireConnectionId(
-        packetBuilder: BytePacketBuilder,
-        sequenceNumber: Long,
-    ) = withLog(QUICFrameType.RETIRE_CONNECTION_ID) {
-        writeRetireConnectionId(packetBuilder, sequenceNumber)
+    override suspend fun writeRetireConnectionId(sequenceNumber: Long): Long {
+        return withLog(QUICFrameType.RETIRE_CONNECTION_ID) {
+            writeRetireConnectionId(sequenceNumber)
+        }
     }
 
-    override fun writePathChallenge(
-        packetBuilder: BytePacketBuilder,
-        data: ByteArray,
-    ) = withLog(QUICFrameType.PATH_CHALLENGE) {
-        writePathChallenge(packetBuilder, data)
+    override suspend fun writePathChallenge(data: ByteArray): Long {
+        return withLog(QUICFrameType.PATH_CHALLENGE) {
+            writePathChallenge(data)
+        }
     }
 
-    override fun writePathResponse(
-        packetBuilder: BytePacketBuilder,
-        data: ByteArray,
-    ) = withLog(QUICFrameType.PATH_RESPONSE) {
-        writePathResponse(packetBuilder, data)
+    override suspend fun writePathResponse(data: ByteArray): Long {
+        return withLog(QUICFrameType.PATH_RESPONSE) {
+            writePathResponse(data)
+        }
     }
 
-    override fun writeConnectionCloseWithTransportError(
-        packetBuilder: BytePacketBuilder,
+    override suspend fun writeConnectionCloseWithTransportError(
         errorCode: QUICTransportError,
         frameTypeV1: QUICFrameType?,
         reasonPhrase: ByteArray,
-    ) = withLog(QUICFrameType.CONNECTION_CLOSE_TRANSPORT_ERR) {
-        writeConnectionCloseWithTransportError(packetBuilder, errorCode, frameTypeV1, reasonPhrase)
+    ): Long = withLog(QUICFrameType.CONNECTION_CLOSE_TRANSPORT_ERR) {
+        writeConnectionCloseWithTransportError(errorCode, frameTypeV1, reasonPhrase)
     }
 
-    override fun writeConnectionCloseWithAppError(
-        packetBuilder: BytePacketBuilder,
-        errorCode: AppError,
+    override suspend fun writeConnectionCloseWithAppError(
+        applicationProtocolErrorCode: AppError,
         reasonPhrase: ByteArray,
-    ) = withLog(QUICFrameType.CONNECTION_CLOSE_APP_ERR) {
-        writeConnectionCloseWithAppError(packetBuilder, errorCode, reasonPhrase)
+    ): Long = withLog(QUICFrameType.CONNECTION_CLOSE_APP_ERR) {
+        writeConnectionCloseWithAppError(applicationProtocolErrorCode, reasonPhrase)
     }
 
-    override fun writeHandshakeDone(
-        packetBuilder: BytePacketBuilder,
-    ) = withLog(QUICFrameType.HANDSHAKE_DONE) {
-        writeHandshakeDone(packetBuilder)
+    override suspend fun writeHandshakeDone(): Long {
+        return withLog(QUICFrameType.HANDSHAKE_DONE) {
+            writeHandshakeDone()
+        }
     }
 
-    private fun withLog(typeV1: QUICFrameType, shouldFailOnRead: Boolean = false, body: FrameWriter.() -> Unit) {
-        FrameWriterImpl.body()
+    private suspend fun withLog(
+        typeV1: QUICFrameType,
+        shouldFailOnRead: Boolean = false,
+        body: suspend FrameWriter.() -> Long,
+    ): Long {
+        val packetNumber = frameWriter.body()
+
         if (!shouldFailOnRead) {
             _expectedFrames.add(typeV1)
         }
         writtenFramesCnt++
+
+        return packetNumber
+    }
+}
+
+internal class TestPacketSendHandler(private val builder: BytePacketBuilder) : PacketSendHandler {
+    override suspend fun writeFrame(expectedFrameSize: Int, handler: BytePacketBuilder.() -> Unit): Long {
+        builder.handler()
+
+        return 0
     }
 }

--- a/ktor-network/ktor-network-quic/jvmAndNix/test/io/ktor/network/quic/frames/base/TestFrameWriter.kt
+++ b/ktor-network/ktor-network-quic/jvmAndNix/test/io/ktor/network/quic/frames/base/TestFrameWriter.kt
@@ -63,9 +63,9 @@ internal class TestFrameWriter(handler: TestPacketSendHandler) : FrameWriter {
     override suspend fun writeResetStream(
         streamId: Long,
         applicationProtocolErrorCode: AppError,
-        finaSize: Long,
+        finalSize: Long,
     ): Long = withLog(QUICFrameType.RESET_STREAM) {
-        writeResetStream(streamId, applicationProtocolErrorCode, finaSize)
+        writeResetStream(streamId, applicationProtocolErrorCode, finalSize)
     }
 
     override suspend fun writeStopSending(streamId: Long, applicationProtocolErrorCode: AppError): Long {

--- a/ktor-network/ktor-network-quic/jvmAndNix/test/io/ktor/network/quic/other/VarIntCodingTest.kt
+++ b/ktor-network/ktor-network-quic/jvmAndNix/test/io/ktor/network/quic/other/VarIntCodingTest.kt
@@ -13,7 +13,7 @@ import kotlin.test.*
 @ExperimentalUnsignedTypes
 class VarIntCodingTest {
     @Test
-    fun testEncodeVarint() {
+    fun testEncodeVarInt() {
         val builder = BytePacketBuilder()
         with(builder) {
             writeVarInt(0)

--- a/ktor-network/ktor-network-quic/jvmAndNix/test/io/ktor/network/quic/packets/PacketNumberSpaceTest.kt
+++ b/ktor-network/ktor-network-quic/jvmAndNix/test/io/ktor/network/quic/packets/PacketNumberSpaceTest.kt
@@ -30,17 +30,17 @@ class PacketNumberSpaceTest {
         pns.receivePacket(3)
         pns.receivePacket(6)
 
-        val (ranges, setFunction) = pns.getAckRanges() ?: fail("Expected ack ranges")
+        val ranges = pns.getAckRanges() ?: fail("Expected ack ranges")
 
-        assertContentEquals(longArrayOf(6, 6, 3, 2), ranges, "Ack ranges")
+        assertContentEquals(listOf(6, 6, 3, 2), ranges, "Ack ranges")
 
-        setFunction(pns.next())
+        pns.registerSentRanges(ranges, pns.next())
 
         pns.receivePacket(0)
         pns.receivePacket(1)
         pns.receivePacket(4)
 
-        pns.processAcknowledgements(longArrayOf(3, 3, 1, 1))
+        pns.processAcknowledgements(listOf(3, 3, 1, 1))
 
         assertEquals(
             expected = setOf<Long>(0, 2, 4),
@@ -54,17 +54,17 @@ class PacketNumberSpaceTest {
         pns.receivePacket(14)
         pns.receivePacket(15)
 
-        pns.processAcknowledgements(longArrayOf(4, 4))
+        pns.processAcknowledgements(listOf(4, 4))
 
         assertEquals(4, pns.largestAcknowledged, "Largest acknowledged 2")
 
-        val (ranges2, setFunction2) = pns.getAckRanges() ?: fail("Expected ack ranges 2")
+        val ranges2 = pns.getAckRanges() ?: fail("Expected ack ranges 2")
 
-        assertContentEquals(longArrayOf(15, 13, 10, 9, 4, 4, 1, 0), ranges2, "Ack ranges 2")
+        assertContentEquals(listOf(15, 13, 10, 9, 4, 4, 1, 0), ranges2, "Ack ranges 2")
 
-        setFunction2(pns.next())
+        pns.registerSentRanges(ranges2, pns.next())
 
-        pns.processAcknowledgements(longArrayOf(5, 5, 2, 2, 0, 0))
+        pns.processAcknowledgements(listOf(5, 5, 2, 2, 0, 0))
 
         assertTrue(
             actual = pns.getUnacknowledgedLocalPacketNumbers().isEmpty(),

--- a/ktor-network/ktor-network-quic/jvmAndNix/test/io/ktor/network/quic/packets/PacketSendHandlerTest.kt
+++ b/ktor-network/ktor-network-quic/jvmAndNix/test/io/ktor/network/quic/packets/PacketSendHandlerTest.kt
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2014-2023 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.network.quic.packets
+
+import io.ktor.network.quic.bytes.*
+import io.ktor.network.quic.connections.*
+import io.ktor.network.quic.consts.*
+import io.ktor.network.quic.tls.*
+import io.ktor.network.quic.util.*
+import io.ktor.utils.io.core.*
+import kotlinx.coroutines.*
+import kotlin.test.*
+
+class PacketSendHandlerTest {
+    @Test
+    fun initial() = handlerTest<ReadyPacketHandler.Initial>(overhead = 43) { writer, handler ->
+        PacketSendHandlerImpl.Initial(writer, handler, ConnectionRole.SERVER)
+    }
+
+    @Test
+    fun handshake() = handlerTest<ReadyPacketHandler>(overhead = 39) { writer, handler ->
+        PacketSendHandlerImpl.Handshake(writer, handler, ConnectionRole.SERVER)
+    }
+
+    @Test
+    fun oneRTT() = handlerTest<ReadyPacketHandler.OneRTT>(overhead = 25) { writer, handler ->
+        PacketSendHandlerImpl.OneRTT(writer, handler, ConnectionRole.SERVER)
+    }
+
+    private suspend fun test(overhead: Int, handler: PacketSendHandlerImpl<*>) {
+        val pn1 = handler.writeFrame(TEST_DATAGRAM_MAX_SIZE / 2) {
+            writeFully(zeroByteArray(TEST_DATAGRAM_MAX_SIZE / 2))
+        }
+
+        assertEquals(0, pn1, "First packet, first frame")
+
+        val nextPacketSize = TEST_DATAGRAM_MAX_SIZE - TEST_DATAGRAM_MAX_SIZE / 2 - overhead
+
+        val pn2 = handler.writeFrame(nextPacketSize) { writeFully(zeroByteArray(nextPacketSize)) }
+
+        assertEquals(0, pn2, "First packet, second frame")
+
+        val pn3 = handler.writeFrame(1) { writeFully(zeroByteArray(1)) }
+
+        assertEquals(1, pn3, "Second packet, first frame")
+
+        val pn4 = handler.writeFrame(TEST_DATAGRAM_MAX_SIZE / 2) {
+            writeFully(zeroByteArray(TEST_DATAGRAM_MAX_SIZE / 2))
+        }
+
+        assertEquals(1, pn4, "Second packet, second frame")
+
+        handler.finish()
+
+        val pn5 = handler.writeFrame(TEST_DATAGRAM_MAX_SIZE / 2 - 1 - overhead) {
+            writeFully(zeroByteArray(TEST_DATAGRAM_MAX_SIZE / 2 - 1 - overhead))
+        }
+
+        assertEquals(2, pn5, "Third packet, first frame")
+
+        val pn6 = handler.writeFrame(1) { writeFully(zeroByteArray(1)) }
+
+        assertEquals(3, pn6, "Fourth packet, first frame")
+    }
+
+    private fun <H : ReadyPacketHandler> handlerTest(
+        overhead: Int,
+        getHandler: (PacketWriter, H) -> PacketSendHandlerImpl<H>
+    ) = runBlocking {
+        val buffer = BytePacketBuilder()
+
+        @Suppress("UNCHECKED_CAST")
+        val handler = getHandler(TestPacketWriter(buffer), TestReadyPacketHandler(buffer) as H)
+
+        test(overhead, handler)
+    }
+
+    companion object {
+        internal const val TEST_DATAGRAM_MAX_SIZE = 200
+    }
+}
+
+private class TestPacketWriter(private val buffer: BytePacketBuilder) : PacketWriter {
+    override fun writeVersionNegotiationPacket(packetBuilder: BytePacketBuilder, version: UInt32, destinationConnectionID: QUICConnectionID, sourceConnectionID: QUICConnectionID, supportedVersions: Array<UInt32>) { } // ktlint-disable max-line-length
+
+    override fun writeRetryPacket(packetBuilder: BytePacketBuilder, originalDestinationConnectionID: QUICConnectionID, version: UInt32, destinationConnectionID: QUICConnectionID, sourceConnectionID: QUICConnectionID, retryToken: ByteArray) { } // ktlint-disable max-line-length
+
+    override suspend fun writeInitialPacket(largestAcknowledged: Long, packetBuilder: BytePacketBuilder, version: UInt32, destinationConnectionID: QUICConnectionID, sourceConnectionID: QUICConnectionID, token: ByteArray, packetNumber: Long, payload: ByteArray) { // ktlint-disable max-line-length
+        buffer.writeFully(payload)
+    }
+
+    override suspend fun writeHandshakePacket(largestAcknowledged: Long, packetBuilder: BytePacketBuilder, version: UInt32, destinationConnectionID: QUICConnectionID, sourceConnectionID: QUICConnectionID, packetNumber: Long, payload: ByteArray) { // ktlint-disable max-line-length
+        buffer.writeFully(payload)
+    }
+
+    override suspend fun writeZeroRTTPacket(largestAcknowledged: Long, packetBuilder: BytePacketBuilder, version: UInt32, destinationConnectionID: QUICConnectionID, sourceConnectionID: QUICConnectionID, packetNumber: Long, payload: ByteArray) { // ktlint-disable max-line-length
+        buffer.writeFully(payload)
+    }
+
+    override suspend fun writeOneRTTPacket(largestAcknowledged: Long, packetBuilder: BytePacketBuilder, spinBit: Boolean, keyPhase: Boolean, destinationConnectionID: QUICConnectionID, packetNumber: Long, payload: ByteArray) { // ktlint-disable max-line-length
+        buffer.writeFully(payload)
+    }
+}
+
+private class TestReadyPacketHandler(private val buffer: BytePacketBuilder) :
+    ReadyPacketHandler.Initial,
+    ReadyPacketHandler.OneRTT,
+    ReadyPacketHandler.Retry,
+    ReadyPacketHandler.VersionNegotiation {
+
+    override val destinationConnectionID: QUICConnectionID = zeroByteArray(4).asCID()
+    override val destinationConnectionIDSize: Int = 4
+    override val sourceConnectionID: QUICConnectionID = zeroByteArray(4).asCID()
+    override val sourceConnectionIDSize: Int = 4
+    override val token: ByteArray = zeroByteArray(3)
+    override val originalDestinationConnectionID: QUICConnectionID = zeroByteArray(4).asCID()
+    override val retryToken: ByteArray = zeroByteArray(4)
+    override val spinBit: Boolean = false
+    override val keyPhase: Boolean = false
+    override val supportedVersions: Array<UInt32> = arrayOf(QUICVersion.V1)
+
+    override fun getLargestAcknowledged(encryptionLevel: EncryptionLevel): Long = 0
+
+    var pn = 0L
+    override fun getPacketNumber(encryptionLevel: EncryptionLevel): Long = pn++
+
+    override val maxUdpPayloadSize: Int = PacketSendHandlerTest.TEST_DATAGRAM_MAX_SIZE
+
+    override val usedDatagramSize: Int get() = buffer.size
+
+    override suspend fun forceEndDatagram() {
+        buffer.reset()
+    }
+
+    override suspend fun withDatagramBuilder(body: suspend (BytePacketBuilder) -> Unit) {
+        body(buffer)
+    }
+}

--- a/ktor-network/ktor-network-quic/jvmAndNix/test/io/ktor/network/quic/packets/PacketSendHandlerTest.kt
+++ b/ktor-network/ktor-network-quic/jvmAndNix/test/io/ktor/network/quic/packets/PacketSendHandlerTest.kt
@@ -83,23 +83,23 @@ class PacketSendHandlerTest {
 }
 
 private class TestPacketWriter(private val buffer: BytePacketBuilder) : PacketWriter {
-    override fun writeVersionNegotiationPacket(packetBuilder: BytePacketBuilder, version: UInt32, destinationConnectionID: QUICConnectionID, sourceConnectionID: QUICConnectionID, supportedVersions: Array<UInt32>) { } // ktlint-disable max-line-length
+    override fun writeVersionNegotiationPacket(packetBuilder: BytePacketBuilder, version: UInt32, destinationConnectionID: QUICConnectionID, sourceConnectionID: QUICConnectionID, supportedVersions: Array<UInt32>) { } // ktlint-disable max-line-length parameter-list-wrapping
 
-    override fun writeRetryPacket(packetBuilder: BytePacketBuilder, originalDestinationConnectionID: QUICConnectionID, version: UInt32, destinationConnectionID: QUICConnectionID, sourceConnectionID: QUICConnectionID, retryToken: ByteArray) { } // ktlint-disable max-line-length
+    override fun writeRetryPacket(packetBuilder: BytePacketBuilder, originalDestinationConnectionID: QUICConnectionID, version: UInt32, destinationConnectionID: QUICConnectionID, sourceConnectionID: QUICConnectionID, retryToken: ByteArray) { } // ktlint-disable max-line-length parameter-list-wrapping
 
-    override suspend fun writeInitialPacket(largestAcknowledged: Long, packetBuilder: BytePacketBuilder, version: UInt32, destinationConnectionID: QUICConnectionID, sourceConnectionID: QUICConnectionID, token: ByteArray, packetNumber: Long, payload: ByteArray) { // ktlint-disable max-line-length
+    override suspend fun writeInitialPacket(largestAcknowledged: Long, packetBuilder: BytePacketBuilder, version: UInt32, destinationConnectionID: QUICConnectionID, sourceConnectionID: QUICConnectionID, token: ByteArray, packetNumber: Long, payload: ByteArray) { // ktlint-disable max-line-length parameter-list-wrapping
         buffer.writeFully(payload)
     }
 
-    override suspend fun writeHandshakePacket(largestAcknowledged: Long, packetBuilder: BytePacketBuilder, version: UInt32, destinationConnectionID: QUICConnectionID, sourceConnectionID: QUICConnectionID, packetNumber: Long, payload: ByteArray) { // ktlint-disable max-line-length
+    override suspend fun writeHandshakePacket(largestAcknowledged: Long, packetBuilder: BytePacketBuilder, version: UInt32, destinationConnectionID: QUICConnectionID, sourceConnectionID: QUICConnectionID, packetNumber: Long, payload: ByteArray) { // ktlint-disable max-line-length parameter-list-wrapping
         buffer.writeFully(payload)
     }
 
-    override suspend fun writeZeroRTTPacket(largestAcknowledged: Long, packetBuilder: BytePacketBuilder, version: UInt32, destinationConnectionID: QUICConnectionID, sourceConnectionID: QUICConnectionID, packetNumber: Long, payload: ByteArray) { // ktlint-disable max-line-length
+    override suspend fun writeZeroRTTPacket(largestAcknowledged: Long, packetBuilder: BytePacketBuilder, version: UInt32, destinationConnectionID: QUICConnectionID, sourceConnectionID: QUICConnectionID, packetNumber: Long, payload: ByteArray) { // ktlint-disable max-line-length parameter-list-wrapping
         buffer.writeFully(payload)
     }
 
-    override suspend fun writeOneRTTPacket(largestAcknowledged: Long, packetBuilder: BytePacketBuilder, spinBit: Boolean, keyPhase: Boolean, destinationConnectionID: QUICConnectionID, packetNumber: Long, payload: ByteArray) { // ktlint-disable max-line-length
+    override suspend fun writeOneRTTPacket(largestAcknowledged: Long, packetBuilder: BytePacketBuilder, spinBit: Boolean, keyPhase: Boolean, destinationConnectionID: QUICConnectionID, packetNumber: Long, payload: ByteArray) { // ktlint-disable max-line-length parameter-list-wrapping
         buffer.writeFully(payload)
     }
 }

--- a/ktor-network/ktor-network-quic/jvmAndNix/test/io/ktor/network/quic/util/TestUtils.kt
+++ b/ktor-network/ktor-network-quic/jvmAndNix/test/io/ktor/network/quic/util/TestUtils.kt
@@ -1,0 +1,9 @@
+/*
+ * Copyright 2014-2023 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.network.quic.util
+
+fun zeroByteArray(size: Int): ByteArray = ByteArray(size) { 0x00 }
+
+fun zeroByteArray(size: Long): ByteArray = ByteArray(size.toInt()) { 0x00 }


### PR DESCRIPTION
**Subsystem**
ktor-network

**Motivation**
QUIC packet retransmission requires caching individual frames, which in current solution is hard

**Solution**
Refactor frames and packets writing operations to allow to introduce recovery module

