### PR TITLE
Release buildPacket on success

### DIFF
--- a/ktor-io/common/src/io/ktor/utils/io/core/Builder.kt
+++ b/ktor-io/common/src/io/ktor/utils/io/core/Builder.kt
@@ -17,9 +17,8 @@ public inline fun buildPacket(block: BytePacketBuilder.() -> Unit): ByteReadPack
     try {
         block(builder)
         return builder.build()
-    } catch (t: Throwable) {
+    } finally {
         builder.release()
-        throw t
     }
 }
 


### PR DESCRIPTION
**Subsystem**
`io.ktor.utils.io.core`

**Motivation**
The function `buildPacket` is useful, but it has a try-catch to catch exceptions in building a packet, and releases the resources of the `BytePacketBuilder` _only_ if an exception is caught. If the packet builds successfully, the resources do not get released.

**Solution**
Replace the `catch` with a `finally`, which will run and release resources regardless of whether the packet is built successfully.

