### PR TITLE
Support  Websocket Subprotocols For JS Clients (KTOR-4001)

### DIFF
--- a/buildSrc/src/main/kotlin/test/server/tests/WebSockets.kt
+++ b/buildSrc/src/main/kotlin/test/server/tests/WebSockets.kt
@@ -52,6 +52,18 @@ internal fun Application.webSockets() {
                     }
                 }
             }
+            webSocket("sub-protocol", protocol = "test-protocol") {
+                for (frame in incoming) {
+                    when (frame) {
+                        is Frame.Text -> {
+                            val text = frame.readText()
+                            send(Frame.Text(text))
+                        }
+                        is Frame.Binary -> send(Frame.Binary(fin = true, frame.data))
+                        else -> error("Unsupported frame type: ${frame.frameType}.")
+                    }
+                }
+            }
         }
     }
 }

--- a/ktor-client/ktor-client-core/js/src/io/ktor/client/engine/js/JsClientEngine.kt
+++ b/ktor-client/ktor-client-core/js/src/io/ktor/client/engine/js/JsClientEngine.kt
@@ -66,8 +66,8 @@ internal class JsClientEngine(
         urlString_capturingHack: String,
         headers: Headers
     ): WebSocket {
-        val (protocolHeaderNames, otherHeaderNames) = headers.names().partition {
-            it.equals("sec-websocket-protocol", true)
+        val protocolHeaderNames = headers.names().filter { headerName ->
+            headerName.equals("sec-websocket-protocol", true)
         }
         val protocols = protocolHeaderNames.mapNotNull { headers.getAll(it) }.flatten().toTypedArray()
         return when (PlatformUtils.platform) {

--- a/ktor-client/ktor-client-core/js/src/io/ktor/client/engine/js/JsClientEngine.kt
+++ b/ktor-client/ktor-client-core/js/src/io/ktor/client/engine/js/JsClientEngine.kt
@@ -70,12 +70,18 @@ internal class JsClientEngine(
         else -> {
             val ws_capturingHack = js("eval('require')('ws')")
             val headers_capturingHack: dynamic = object {}
+            val subProtocolHeaderValues = mutableListOf<String>()
             headers.forEach { name, values ->
+                // Capture any and all websocket subprotocol headers to pass to the WebSocket constructor
+                if (name.equals("sec-websocket-protocol", true)) {
+                    subProtocolHeaderValues.addAll(values)
+                }
                 headers_capturingHack[name] = values.joinToString(",")
             }
-            js("new ws_capturingHack(urlString_capturingHack, { headers: headers_capturingHack })")
+            val subprotocols_capturingHack = subProtocolHeaderValues.toTypedArray()
+            js("new ws_capturingHack(urlString_capturingHack, subprotocols_capturingHack, { headers: headers_capturingHack })")
         }
-    }
+        }
 
     private suspend fun executeWebSocketRequest(
         request: HttpRequestData,

--- a/ktor-client/ktor-client-core/js/src/io/ktor/client/engine/js/JsClientEngine.kt
+++ b/ktor-client/ktor-client-core/js/src/io/ktor/client/engine/js/JsClientEngine.kt
@@ -66,7 +66,9 @@ internal class JsClientEngine(
         urlString_capturingHack: String,
         headers: Headers
     ): WebSocket {
-        val (protocolHeaderNames, otherHeaderNames) = headers.names().partition { it.equals("sec-websocket-protocol", true) }
+        val (protocolHeaderNames, otherHeaderNames) = headers.names().partition {
+            it.equals("sec-websocket-protocol", true)
+        }
         val protocols = protocolHeaderNames.mapNotNull { headers.getAll(it) }.flatten().toTypedArray()
         return when (PlatformUtils.platform) {
             Platform.Browser -> js("new WebSocket(urlString_capturingHack, protocols)")

--- a/ktor-client/ktor-client-java/jvm/src/io/ktor/client/engine/java/JavaHttpWebSocket.kt
+++ b/ktor-client/ktor-client-java/jvm/src/io/ktor/client/engine/java/JavaHttpWebSocket.kt
@@ -143,6 +143,14 @@ internal class JavaHttpWebSocket(
                     header(key, value)
                 }
             }
+
+            requestData.headers.getAll(HttpHeaders.SecWebSocketProtocol)?.toTypedArray()?.let {
+                if (it.isNotEmpty()) {
+                    val mostPreferred = it.first()
+                    val leastPreferred = it.sliceArray(1..<it.size)
+                    subprotocols(mostPreferred, *leastPreferred)
+                }
+            }
         }
 
         webSocket = builder.buildAsync(requestData.url.toURI(), this).await()

--- a/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/WebSocketTest.kt
+++ b/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/WebSocketTest.kt
@@ -292,6 +292,7 @@ class WebSocketTest : ClientLoader() {
             }
         }
     }
+
     @Test
     fun testWebsocketRequiringSubProtocolWithoutSubProtocol() = clientTests(ENGINES_WITHOUT_WS) {
         config {

--- a/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/WebSocketTest.kt
+++ b/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/WebSocketTest.kt
@@ -7,6 +7,7 @@ package io.ktor.client.tests
 import io.ktor.client.*
 import io.ktor.client.plugins.*
 import io.ktor.client.plugins.websocket.*
+import io.ktor.client.request.*
 import io.ktor.client.tests.utils.*
 import io.ktor.http.*
 import io.ktor.serialization.*
@@ -269,6 +270,35 @@ class WebSocketTest : ClientLoader() {
 
             client.coroutineContext[Job]!!.cancel("test", IllegalStateException("test"))
             assertNotNull(session.closeReason.await())
+        }
+    }
+
+    @Test
+    fun testWebsocketRequiringSubProtocolWithSubProtocol() = clientTests(ENGINES_WITHOUT_WS) {
+        config {
+            install(WebSockets)
+        }
+
+        test { client ->
+            client.webSocket("$TEST_WEBSOCKET_SERVER/websockets/sub-protocol", request = { header(HttpHeaders.SecWebSocketProtocol, "test-protocol")}) {
+                send(Frame.Text("test"))
+                val result = incoming.receive() as Frame.Text
+                assertEquals("test", result.readText())
+            }
+        }
+    }
+    @Test
+    fun testWebsocketRequiringSubProtocolWithoutSubProtocol() = clientTests(ENGINES_WITHOUT_WS) {
+        config {
+            install(WebSockets)
+        }
+
+        test { client ->
+            assertFailsWith<WebSocketException> {
+                client.webSocket("$TEST_WEBSOCKET_SERVER/websockets/sub-protocol") {
+                    send(Frame.Text("test"))
+                }
+            }
         }
     }
 }

--- a/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/WebSocketTest.kt
+++ b/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/WebSocketTest.kt
@@ -282,7 +282,7 @@ class WebSocketTest : ClientLoader() {
         test { client ->
             client.webSocket(
                 "$TEST_WEBSOCKET_SERVER/websockets/sub-protocol",
-                request = { 
+                request = {
                     header(HttpHeaders.SecWebSocketProtocol, "test-protocol")
                 }
             ) {

--- a/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/WebSocketTest.kt
+++ b/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/WebSocketTest.kt
@@ -299,7 +299,7 @@ class WebSocketTest : ClientLoader() {
         }
 
         test { client ->
-            assertFailsWith<WebSocketException> {
+            assertFailsWith<Exception> {
                 client.webSocket("$TEST_WEBSOCKET_SERVER/websockets/sub-protocol") {
                     send(Frame.Text("test"))
                 }

--- a/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/WebSocketTest.kt
+++ b/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/WebSocketTest.kt
@@ -280,7 +280,12 @@ class WebSocketTest : ClientLoader() {
         }
 
         test { client ->
-            client.webSocket("$TEST_WEBSOCKET_SERVER/websockets/sub-protocol", request = { header(HttpHeaders.SecWebSocketProtocol, "test-protocol")}) {
+            client.webSocket(
+                "$TEST_WEBSOCKET_SERVER/websockets/sub-protocol",
+                request = { 
+                    header(HttpHeaders.SecWebSocketProtocol, "test-protocol")
+                }
+            ) {
                 send(Frame.Text("test"))
                 val result = incoming.receive() as Frame.Text
                 assertEquals("test", result.readText())


### PR DESCRIPTION
**Subsystem**
JS Engines Websockets
Java Engine Websockets

**Motivation**
Fixes KTOR-4001

There needs to be a way to set the subprotocols the websocket supports/requires (See [KTOR-4001](https://youtrack.jetbrains.com/issue/KTOR-4001/Server-sent-a-subprotocol-but-none-was-requested-when-using-Node-WebSockets#focus=Comments-27-5866649.0-0)) because certain server implementations will reject connections that do not specify the correct subprotocols, or [being important for handler resolution](https://developer.mozilla.org/en-US/docs/Web/API/WebSocket/WebSocket#parameters). Currently, [apollographql/apollo-kotlin](https://github.com/apollographql/apollo-kotlin) (a downstream consumer of KTOR) has implemented a work around because the `createWebSocket` method provided by KTOR does not allow for passing the protocols directly, nor does it support consuming from the [standard protocol upgrade header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Protocol_upgrade_mechanism#sec-websocket-protocol) `sec-websocket-protocol`.


**Solution**
This implementation is based off the the [downstream workaround in apollo-kotlin](https://github.com/apollographql/apollo-kotlin/blob/3c429280d290ec885512497cf34f57181b667a7e/libraries/apollo-runtime/src/jsMain/kotlin/com/apollographql/apollo3/network/ws/JsWebSocketEngine.kt#L84).

Another option is that KTOR could expose a `protocols` parameter to `createWebSocket` rather than relying solely on the headers, though one would likely want also define/document how any conflicts would be resolved if that parameter were to be exposed.

------------------------------
[Initial Discovery of issue](https://github.com/apollographql/apollo-kotlin/pull/3913#issuecomment-1065745594)
[Another case of server rejecting WS connection](https://github.com/apollographql/apollo-kotlin/pull/4445#issue-1400572611)

