### PR TITLE
KTOR-6221: Fix reduced concurrent reqs in Apache5

### DIFF
--- a/ktor-client/ktor-client-apache5/jvm/src/io/ktor/client/engine/apache5/Apache5Engine.kt
+++ b/ktor-client/ktor-client-apache5/jvm/src/io/ktor/client/engine/apache5/Apache5Engine.kt
@@ -92,7 +92,7 @@ internal class Apache5Engine(override val config: Apache5EngineConfig) : HttpCli
                 setConnectionManager(
                     PoolingAsyncClientConnectionManagerBuilder.create()
                         .setMaxConnTotal(MAX_CONNECTIONS_COUNT)
-                        .setMaxConnTotal(MAX_CONNECTIONS_COUNT)
+                        .setMaxConnPerRoute(MAX_CONNECTIONS_COUNT)
                         .setTlsStrategy(
                             ClientTlsStrategyBuilder.create()
                                 .setSslContext(config.sslContext ?: SSLContexts.createSystemDefault())


### PR DESCRIPTION
**Subsystem**
Client, Apache5 engine

**Motivation**
When using the Apache5 engine, total concurrent requests to a single route were limited to 5 requests. This causes an unexpected bottleneck when switching engines.

Issue link is https://youtrack.jetbrains.com/issue/KTOR-6221/Apache5-engine-limits-concurrent-requests-to-individual-route-to-5.

**Solution**
This just fixes the type/missing call to `setMaxConnPerRoute` which was intended all along.

