### PR TITLE
Update Dokka to 1.9.0 and add a workaround for build errors

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -91,7 +91,7 @@ val disabledExplicitApiModeProjects = listOf(
 apply(from = "gradle/compatibility.gradle")
 
 plugins {
-    id("org.jetbrains.dokka") version "1.7.20" apply false
+    id("org.jetbrains.dokka") version "1.9.0" apply false
     id("org.jetbrains.kotlinx.binary-compatibility-validator") version "0.13.2"
     id("kotlinx-atomicfu") version "0.21.0" apply false
     id("com.osacky.doctor") version "0.8.1"
@@ -152,7 +152,7 @@ fun configureDokka() {
 
         val dokkaPlugin by configurations
         dependencies {
-            dokkaPlugin("org.jetbrains.dokka:versioning-plugin:1.7.20")
+            dokkaPlugin("org.jetbrains.dokka:versioning-plugin:1.9.0")
         }
     }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -29,3 +29,7 @@ kotlin.native.ignoreIncorrectDependencies=true
 kotlin.native.binary.memoryModel=experimental
 #kotlinx.atomicfu.enableJvmIrTransformation=true
 #kotlinx.atomicfu.enableJsIrTransformation=true
+
+# dokka
+# workaround for resolving platform dependencies, see https://github.com/Kotlin/dokka/issues/3153
+org.jetbrains.dokka.classpath.useNativeDistributionAccessor=true


### PR DESCRIPTION
**Subsystem**
Infrastructure

**Motivation**
Dokka stopped working after #3662 was merged into `main`. If you run Dokka's tasks now, it will lead to build failures related to the resolution of platform dependencies, likely caused by the combination of Gradle 8 + `kotlin.mpp.enableCInteropCommonization=true`

**Solution**
Update Dokka to 1.9.0 and use the proposed workaround flag, which changes the underlying dependency resolution algorithm.

For more details, see https://github.com/Kotlin/dokka/issues/3153.