### PR TITLE
Compression conditions should not be triggered when `OutgoingContent.contentLength` is null

### DIFF
--- a/ktor-server/ktor-server-plugins/ktor-server-compression/jvm/src/io/ktor/server/plugins/compression/Config.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-compression/jvm/src/io/ktor/server/plugins/compression/Config.kt
@@ -167,7 +167,7 @@ public fun ConditionsHolderBuilder.condition(predicate: ApplicationCall.(Outgoin
  * Note that adding a single minimum size condition removes the default configuration.
  */
 public fun ConditionsHolderBuilder.minimumSize(minSize: Long) {
-    condition { content -> content.contentLength?.let { it >= minSize } ?: true }
+    condition { content -> content.contentLength?.let { it >= minSize } ?: false }
 }
 
 /**


### PR DESCRIPTION
Compression conditions should not be triggered when `OutgoingContent.contentLength` is null.