### PR TITLE
KTOR-6286 Update xmlutil to 0.86.2

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -57,7 +57,7 @@ jakarta-servlet-version = "5.0.0"
 node-fetch-version = "2.6.7"
 abort-controller-version = "3.0.0"
 ws-version = "8.5.0"
-xmlutil-version = "0.86.1"
+xmlutil-version = "0.86.2"
 yamlkt-version = "0.12.0"
 
 swagger-codegen-version = "3.0.41"


### PR DESCRIPTION
[KTOR-6286](https://youtrack.jetbrains.com/issue/KTOR-6286) We need to update `xmlutil` because in the previous version it was vulnerable to XXE attack 