### PR TITLE
KTOR-6344 Fix content length range in AndroidClientEngine

### DIFF
--- a/ktor-client/ktor-client-android/jvm/src/io/ktor/client/engine/android/AndroidClientEngine.kt
+++ b/ktor-client/ktor-client-android/jvm/src/io/ktor/client/engine/android/AndroidClientEngine.kt
@@ -11,7 +11,6 @@ import io.ktor.client.plugins.sse.*
 import io.ktor.client.request.*
 import io.ktor.http.*
 import io.ktor.http.content.*
-import io.ktor.util.*
 import io.ktor.util.date.*
 import io.ktor.utils.io.*
 import io.ktor.utils.io.jvm.javaio.*
@@ -74,7 +73,7 @@ public class AndroidClientEngine(override val config: AndroidEngineConfig) : Htt
                 addRequestProperty(HttpHeaders.TransferEncoding, "chunked")
             }
 
-            contentLength?.let { setFixedLengthStreamingMode(it.toInt()) } ?: setChunkedStreamingMode(0)
+            contentLength?.let { setFixedLengthStreamingMode(it) } ?: setChunkedStreamingMode(0)
             doOutput = true
 
             outgoingContent.writeTo(outputStream, callContext)


### PR DESCRIPTION
[KTOR-6344](https://youtrack.jetbrains.com/issue/KTOR-6344) 
Invoke `setFixedLengthStreamingMode(long contentLength)` instead of `setFixedLengthStreamingMode(int contentLength)` because `contentLength` is `Long?`