### PR TITLE
KTOR-6388 WebSocket Connection Failure Due to Lowercase 'upgrade' in 'Connection: upgrade' Header

### DIFF
--- a/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/websocket/WebSocketContent.kt
+++ b/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/websocket/WebSocketContent.kt
@@ -22,7 +22,7 @@ internal class WebSocketContent : ClientUpgradeContent() {
 
     override val headers: Headers = HeadersBuilder().apply {
         append(HttpHeaders.Upgrade, "websocket")
-        append(HttpHeaders.Connection, "upgrade")
+        append(HttpHeaders.Connection, "Upgrade")
 
         append(HttpHeaders.SecWebSocketKey, nonce)
         append(HttpHeaders.SecWebSocketVersion, WEBSOCKET_VERSION)


### PR DESCRIPTION
**Subsystem**
Client

**Motivation**
[KTOR-6388 WebSocket Connection Failure Due to Lowercase 'upgrade' in 'Connection: upgrade' Header](https://youtrack.jetbrains.com/issue/KTOR-6388)

Here are some references that discuss the importance of capitalizing 'Upgrade':
- [GitHub discussion on kubectl port-forward issue](https://github.com/kubernetes/kubernetes/issues/43962)
- [MDN Web Docs - HTTP Upgrade Header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Upgrade)
- [WebSocket example in HAProxy documentation](https://www.haproxy.com/blog/websockets-load-balancing-with-haproxy/)


