### PR TITLE
KTOR-6394 Fix WinHttp websocket empty frame

### DIFF
--- a/ktor-client/ktor-client-winhttp/windows/src/io/ktor/client/engine/winhttp/internal/WinHttpWebSocket.kt
+++ b/ktor-client/ktor-client-winhttp/windows/src/io/ktor/client/engine/winhttp/internal/WinHttpWebSocket.kt
@@ -195,6 +195,8 @@ internal class WinHttpWebSocket @OptIn(ExperimentalForeignApi::class) constructo
                 continuation.resume(Unit)
             }
 
+            if (buffer.get().isEmpty()) return@closeableCoroutine
+
             if (WinHttpWebSocketSend(
                     hWebSocket,
                     type,

--- a/ktor-client/ktor-client-winhttp/windows/src/io/ktor/client/engine/winhttp/internal/WinHttpWebSocket.kt
+++ b/ktor-client/ktor-client-winhttp/windows/src/io/ktor/client/engine/winhttp/internal/WinHttpWebSocket.kt
@@ -104,9 +104,11 @@ internal class WinHttpWebSocket @OptIn(ExperimentalForeignApi::class) constructo
                 }
             }
 
+            val data = if (buffer.get().isEmpty()) null else buffer.addressOf(0)
+
             if (WinHttpWebSocketReceive(
                     hWebSocket,
-                    buffer.addressOf(0),
+                    data,
                     buffer.get().size.convert(),
                     null,
                     null
@@ -195,12 +197,12 @@ internal class WinHttpWebSocket @OptIn(ExperimentalForeignApi::class) constructo
                 continuation.resume(Unit)
             }
 
-            if (buffer.get().isEmpty()) return@closeableCoroutine
+            val data = if (buffer.get().isEmpty()) null else buffer.addressOf(0)
 
             if (WinHttpWebSocketSend(
                     hWebSocket,
                     type,
-                    buffer.addressOf(0),
+                    data,
                     buffer.get().size.convert()
                 ) != 0u
             ) {

--- a/ktor-client/ktor-client-winhttp/windows/test/io/ktor/client/engine/winhttp/WinHttpWebSocketTests.kt
+++ b/ktor-client/ktor-client-winhttp/windows/test/io/ktor/client/engine/winhttp/WinHttpWebSocketTests.kt
@@ -31,4 +31,22 @@ class WinHttpWebSocketTests {
             }
         }
     }
+
+    @Test
+    fun testEmptyFrame() {
+        val client = HttpClient(WinHttp) {
+            install(WebSockets)
+        }
+
+        runBlocking {
+            client.webSocket("$TEST_WEBSOCKET_SERVER/websockets/echo") {
+                send(Frame.Text(""))
+
+                val actual = incoming.receive()
+
+                assertTrue(actual is Frame.Text)
+                assertEquals("", actual.readText())
+            }
+        }
+    }
 }


### PR DESCRIPTION
Fix [KTOR-6394](https://youtrack.jetbrains.com/issue/KTOR-6394/WinHttp-ArrayIndexOutOfBoundsException-when-sending-WS-frame-with-empty-body)