### PR TITLE
KTOR-6411 resolve connectors in the test engine

### DIFF
--- a/ktor-server/ktor-server-test-host/jvmAndNix/src/io/ktor/server/testing/TestApplicationEngine.kt
+++ b/ktor-server/ktor-server-test-host/jvmAndNix/src/io/ktor/server/testing/TestApplicationEngine.kt
@@ -143,6 +143,7 @@ class TestApplicationEngine(
             environment.start()
             cancellationDeferred = stopServerOnCancellation()
             applicationStarting.complete()
+            resolvedConnectors.complete(runBlocking { resolvedConnectors() })
             state.value = State.Started
         }
         if (state.value == State.Starting) {

--- a/ktor-server/ktor-server-test-host/jvmAndNix/test/TestApplicationTest.kt
+++ b/ktor-server/ktor-server-test-host/jvmAndNix/test/TestApplicationTest.kt
@@ -375,6 +375,17 @@ class TestApplicationTest {
     }
 
     @Test
+    fun testStartupJobsCompletion() = testApplication {
+        startApplication()
+        val childrenJobsSize = engine.application.coroutineContext.job.children.toList().size
+        assertEquals(
+            expected = 0,
+            actual = childrenJobsSize,
+            message = "all the children jobs should be completed",
+        )
+    }
+
+    @Test
     fun testCanPassCoroutineContextFromOutside() = runBlocking(MyElement("test")) {
         testApplication(coroutineContext) {
             assertEquals("test", coroutineContext[MyElement]!!.data)


### PR DESCRIPTION
**Subsystem**
Server, related modules: ktor-server-test-host

**Motivation**
Test engine does not complete job launched during init (which logs resolved connectors) which makes it hard to detect if all the launch jobs in test are already finished.
Details: https://youtrack.jetbrains.com/issue/KTOR-6411

**Solution**
Complete pending job during the test engine start (like in Netty implementation).

