### PR TITLE
KTOR-6400 Add attribute for extending isStaticContent() functionality in Webjars

### DIFF
--- a/ktor-server/ktor-server-core/api/ktor-server-core.api
+++ b/ktor-server/ktor-server-core/api/ktor-server-core.api
@@ -468,6 +468,7 @@ public final class io/ktor/server/http/content/StaticContentKt {
 	public static final fun files (Lio/ktor/server/routing/Route;Ljava/io/File;)V
 	public static final fun files (Lio/ktor/server/routing/Route;Ljava/lang/String;)V
 	public static final fun getStaticBasePackage (Lio/ktor/server/routing/Route;)Ljava/lang/String;
+	public static final fun getStaticFileLocationProperty ()Lio/ktor/util/AttributeKey;
 	public static final fun getStaticRootFolder (Lio/ktor/server/routing/Route;)Ljava/io/File;
 	public static final fun isStaticContent (Lio/ktor/server/application/ApplicationCall;)Z
 	public static final fun preCompressed (Lio/ktor/server/routing/Route;[Lio/ktor/server/http/content/CompressedFileType;Lkotlin/jvm/functions/Function1;)V

--- a/ktor-server/ktor-server-core/jvm/src/io/ktor/server/http/content/PreCompressed.kt
+++ b/ktor-server/ktor-server-core/jvm/src/io/ktor/server/http/content/PreCompressed.kt
@@ -119,6 +119,7 @@ internal suspend fun ApplicationCall.respondStaticFile(
     cacheControl: (File) -> List<CacheControl> = { emptyList() },
     modify: suspend (File, ApplicationCall) -> Unit = { _, _ -> }
 ) {
+    attributes.put(StaticFileLocationProperty, requestedFile.path)
     val bestCompressionFit = bestCompressionFit(requestedFile, request.acceptEncodingItems(), compressedTypes)
     val cacheControlValues = cacheControl(requestedFile).joinToString(", ")
     if (bestCompressionFit == null) {
@@ -145,6 +146,7 @@ internal suspend fun ApplicationCall.respondStaticPath(
     cacheControl: (Path) -> List<CacheControl> = { emptyList() },
     modify: suspend (Path, ApplicationCall) -> Unit = { _, _ -> }
 ) {
+    attributes.put(StaticFileLocationProperty, requestedPath.toString())
     val bestCompressionFit =
         bestCompressionFit(fileSystem, requestedPath, request.acceptEncodingItems(), compressedTypes)
     val cacheControlValues = cacheControl(requestedPath).joinToString(", ")
@@ -173,6 +175,7 @@ internal suspend fun ApplicationCall.respondStaticResource(
     modifier: suspend (URL, ApplicationCall) -> Unit = { _, _ -> },
     exclude: (URL) -> Boolean = { false }
 ) {
+    attributes.put(StaticFileLocationProperty, requestedResource)
     val bestCompressionFit = bestCompressionFit(
         call = this,
         resource = requestedResource,

--- a/ktor-server/ktor-server-core/jvm/src/io/ktor/server/http/content/StaticContent.kt
+++ b/ktor-server/ktor-server-core/jvm/src/io/ktor/server/http/content/StaticContent.kt
@@ -16,6 +16,13 @@ import java.net.*
 import java.nio.file.*
 import kotlin.io.path.*
 
+/**
+ * Attribute to assign the path of a static file served in the response.  The main use of this attribute is to indicate
+ * to subsequent interceptors that a static file was served via the `ApplicationCall.isStaticContent()` extension
+ * function.
+ */
+public val StaticFileLocationProperty: AttributeKey<String> = AttributeKey("StaticFileLocation")
+
 private const val pathParameterName = "static-content-path-parameter"
 
 private val staticRootFolderKey = AttributeKey<File>("BaseFolder")
@@ -487,7 +494,7 @@ public fun Route.defaultResource(resource: String, resourcePackage: String? = nu
 /**
  *  Checks if the application call is requesting static content
  */
-public fun ApplicationCall.isStaticContent(): Boolean = parameters.contains(pathParameterName)
+public fun ApplicationCall.isStaticContent(): Boolean = attributes.contains(StaticFileLocationProperty)
 
 private fun Route.staticContentRoute(
     remotePath: String,

--- a/ktor-server/ktor-server-plugins/ktor-server-webjars/jvm/src/io/ktor/server/webjars/Webjars.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-webjars/jvm/src/io/ktor/server/webjars/Webjars.kt
@@ -3,6 +3,7 @@ package io.ktor.server.webjars
 import io.ktor.http.*
 import io.ktor.http.content.*
 import io.ktor.server.application.*
+import io.ktor.server.http.content.*
 import io.ktor.server.request.*
 import io.ktor.server.response.*
 import io.ktor.util.*
@@ -103,6 +104,7 @@ public val Webjars: ApplicationPlugin<WebjarsConfig> = createApplicationPlugin("
 
         val resourcePath = fullPath.removePrefix(webjarsPrefix)
         try {
+            call.attributes.put(StaticFileLocationProperty, resourcePath)
             val (location, info) = extractWebJar(resourcePath, knownWebJars, locator)
             val stream = WebjarsConfig::class.java.classLoader.getResourceAsStream(location) ?: return@onCall
             val content = InputStreamContent(stream, ContentType.defaultForFilePath(fullPath)).apply {


### PR DESCRIPTION
**Subsystem**
StaticContent, Webjars

**Motivation**
[KTOR-6400](https://youtrack.jetbrains.com/issue/KTOR-6400) Marking files provided by Webjars plugin as static files

**Solution**
Introduced a public attribute for any static file response producer to add the path to the call.  This allows plugins like `Webjars` (or any other) to return true for the `ApplicationCall.isStaticContent()` extension function.  Previously, this function only checked if a path parameter was present from the routing.