### PR TITLE
KTOR-2121 Update trailcard logic for handling trailing slashes

### DIFF
--- a/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/routing/RouteSelector.kt
+++ b/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/routing/RouteSelector.kt
@@ -431,18 +431,15 @@ public data class PathSegmentTailcardRouteSelector(
                 }
             )
         }
-        return when {
-            segmentIndex < segments.size ->
-                RouteSelectorEvaluation.Success(
-                    RouteSelectorEvaluation.qualityTailcard,
-                    values,
-                    segmentIncrement = segments.size - segmentIndex
-                )
-            else -> RouteSelectorEvaluation.Failure(
-                RouteSelectorEvaluation.qualityMissing,
-                HttpStatusCode.NotFound
-            )
+        val quality = when {
+            segmentIndex < segments.size -> RouteSelectorEvaluation.qualityTailcard
+            else -> RouteSelectorEvaluation.qualityMissing
         }
+        return RouteSelectorEvaluation.Success(
+            quality,
+            values,
+            segmentIncrement = segments.size - segmentIndex
+        )
     }
 
     override fun toString(): String = "{...}"

--- a/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/routing/RouteSelector.kt
+++ b/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/routing/RouteSelector.kt
@@ -410,7 +410,7 @@ public data class PathSegmentTailcardRouteSelector(
     }
 
     override fun evaluate(context: RoutingResolveContext, segmentIndex: Int): RouteSelectorEvaluation {
-        val segments = context.segments.dropLastWhile { it.isEmpty() } // remove extra segment from trailing slash
+        val segments = context.segments
         if (prefix.isNotEmpty()) {
             val segmentText = segments.getOrNull(segmentIndex)
             if (segmentText == null || !segmentText.startsWith(prefix)) {
@@ -431,15 +431,18 @@ public data class PathSegmentTailcardRouteSelector(
                 }
             )
         }
-        val quality = when {
-            segmentIndex < segments.size -> RouteSelectorEvaluation.qualityTailcard
-            else -> RouteSelectorEvaluation.qualityMissing
+        return when {
+            segmentIndex < segments.size ->
+                RouteSelectorEvaluation.Success(
+                    RouteSelectorEvaluation.qualityTailcard,
+                    values,
+                    segmentIncrement = segments.size - segmentIndex
+                )
+            else -> RouteSelectorEvaluation.Failure(
+                RouteSelectorEvaluation.qualityMissing,
+                HttpStatusCode.NotFound
+            )
         }
-        return RouteSelectorEvaluation.Success(
-            quality,
-            values,
-            segmentIncrement = segments.size - segmentIndex
-        )
     }
 
     override fun toString(): String = "{...}"

--- a/ktor-server/ktor-server-tests/jvmAndNix/test/io/ktor/tests/server/routing/RoutingResolveTest.kt
+++ b/ktor-server/ktor-server-tests/jvmAndNix/test/io/ktor/tests/server/routing/RoutingResolveTest.kt
@@ -21,8 +21,7 @@ fun resolve(
     routing: RouteNode,
     path: String,
     parameters: Parameters = Parameters.Empty,
-    headers: Headers = Headers.Empty,
-    tracers: List<(RoutingResolveTrace) -> Unit> = emptyList(),
+    headers: Headers = Headers.Empty
 ): RoutingResolveResult {
     return withTestApplication {
         RoutingResolveContext(
@@ -37,7 +36,7 @@ fun resolve(
                 }
                 headers.flattenForEach { name, value -> request.addHeader(name, value) }
             },
-            tracers
+            emptyList()
         ).resolve()
     }
 }
@@ -453,8 +452,8 @@ class RoutingResolveTest {
             }
         }
 
-        on("resolving /foo/") {
-            val result = resolve(root, "/foo/")
+        on("resolving /foo") {
+            val result = resolve(root, "/foo")
 
             it("should successfully resolve") {
                 assertTrue(result is RoutingResolveResult.Success)
@@ -463,7 +462,7 @@ class RoutingResolveTest {
                 assertEquals(paramEntry, result.route)
             }
             it("should have empty parameter") {
-                assertEquals("", result.parameters["items"])
+                assertNull(result.parameters["items"])
             }
         }
 
@@ -747,29 +746,17 @@ class RoutingResolveTest {
         val prefixChild = routing.route("/foo/{param...}") {
             handle {}
         }
-
-        assertTrue(resolve(routing, "/foo") is RoutingResolveResult.Failure)
-
-        resolve(routing, "/foo/").let { result ->
+        fun String.assertResolvedTo(vararg segments: String) {
+            val result = resolve(routing, this)
             assertTrue(result is RoutingResolveResult.Success)
             assertSame(prefixChild, result.route)
-            assertEquals("", result.parameters["param"])
+            assertEquals(listOf(*segments), result.parameters.getAll("param"))
         }
-        resolve(routing, "/foo/bar/").let { result ->
-            assertTrue(result is RoutingResolveResult.Success)
-            assertSame(prefixChild, result.route)
-            assertEquals(listOf("bar", ""), result.parameters.getAll("param"))
-        }
-        resolve(routing, "/foo/bar/baz").let { result ->
-            assertTrue(result is RoutingResolveResult.Success)
-            assertSame(prefixChild, result.route)
-            assertEquals(listOf("bar", "baz"), result.parameters.getAll("param"))
-        }
-        resolve(routing, "/foo/bar/baz/").let { result ->
-            assertTrue(result is RoutingResolveResult.Success)
-            assertSame(prefixChild, result.route)
-            assertEquals(listOf("bar", "baz", ""), result.parameters.getAll("param"))
-        }
+        "/foo".assertResolvedTo()
+        "/foo/".assertResolvedTo("")
+        "/foo/bar/".assertResolvedTo("bar", "")
+        "/foo/bar/baz".assertResolvedTo("bar", "baz")
+        "/foo/bar/baz/".assertResolvedTo("bar", "baz", "")
     }
 
     @Test


### PR DESCRIPTION
**Subsystem**
Routing

**Motivation**
[KTOR-2121](https://youtrack.jetbrains.com/issue/KTOR-2121) {...} (tailcard) does not match URLs ending with '/'

**Solution**
Made it so the tailcard selector treats empty segments the same as others, and allowed failures for when there is no segment.

This is a pretty significant change to the routing logic, and could break some people if they rely on routes like `/foo/{...}` to match on `/foo`.  I was thinking maybe we ought to include some flag to opt in or out of this behaviour, wdyt?

There were also some intentional tests for the opposite behaviour than described in the bug, although the logic there is inconsistent:

1. Routes like `/foo/{...}/` should be considered invalid because the wildcard here is described as "the rest of the URL path" in the documentation.
2. There's no reason why `/foo` should match on `/foo/{...}`, it ought to be matched as `/foo{...}`.

Edit: change (2) was reverted, we rely too much on this behaviour and it would be too disruptive