### PR TITLE
Bump http-version to 4.1.101.Final

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,7 +7,7 @@ atomicfu-version = "0.20.2"
 serialization-version = "1.5.1"
 ktlint-version = "3.15.0"
 
-netty-version = "4.1.97.Final"
+netty-version = "4.1.101.Final"
 netty-tcnative-version = "2.0.61.Final"
 
 jetty-version = "9.4.53.v20231009"


### PR DESCRIPTION
**Subsystem**
ktor-server-netty

**Motivation**
We're getting security warnings from dependabot in a project that uses `ktor` that versions of `netty-codec-http2 < 4.1.100.Final` are affected by [CVE-2023-44487](https://www.cve.org/CVERecord?id=CVE-2023-44487).

**Solution**
Just bumped the version to the latest patch.
