### PR TITLE
Attributes: Compute if absent, suspend variant

### DIFF
--- a/ktor-utils/common/src/io/ktor/util/Attributes.kt
+++ b/ktor-utils/common/src/io/ktor/util/Attributes.kt
@@ -113,6 +113,11 @@ public interface Attributes {
     public fun <T : Any> computeIfAbsent(key: AttributeKey<T>, block: () -> T): T
 
     /**
+     * Gets a value of the attribute for the specified [key], or calls supplied suspend [block] to compute its value
+     */
+    public suspend fun <T : Any> computeIfAbsentSuspend(key: AttributeKey<T>, block: suspend () -> T): T
+
+    /**
      * Returns [List] of all [AttributeKey] instances in this map
      */
     public val allKeys: List<AttributeKey<*>>

--- a/ktor-utils/common/src/io/ktor/util/collections/ConcurrentMap.kt
+++ b/ktor-utils/common/src/io/ktor/util/collections/ConcurrentMap.kt
@@ -19,6 +19,11 @@ public expect class ConcurrentMap<Key, Value>(
     public fun computeIfAbsent(key: Key, block: () -> Value): Value
 
     /**
+     * Computes [block] and inserts result in map. The [block] will be evaluated at most once.
+     */
+    public suspend fun computeIfAbsentSuspend(key: Key, block: suspend () -> Value): Value
+
+    /**
      * Removes [key] from map if it is mapped to [value].
      */
     public fun remove(key: Key, value: Value): Boolean

--- a/ktor-utils/js/src/io/ktor/util/AttributesJs.kt
+++ b/ktor-utils/js/src/io/ktor/util/AttributesJs.kt
@@ -35,6 +35,14 @@ public class AttributesJs : Attributes {
         }
     }
 
+    @Suppress("UNCHECKED_CAST")
+    override suspend fun <T : Any> computeIfAbsentSuspend(key: AttributeKey<T>, block: suspend () -> T): T {
+        map[key]?.let { return it as T }
+        return block().also { result ->
+            map[key] = result
+        }
+    }
+
     override val allKeys: List<AttributeKey<*>>
         get() = map.keys.toList()
 }

--- a/ktor-utils/js/src/io/ktor/util/collections/ConcurrentMapJs.kt
+++ b/ktor-utils/js/src/io/ktor/util/collections/ConcurrentMapJs.kt
@@ -21,6 +21,16 @@ public actual class ConcurrentMap<Key, Value> public actual constructor(initialC
         return value
     }
 
+    /**
+     * Computes [block] and inserts result in map. The suspend [block] will be evaluated at most once.
+     */
+    public actual suspend fun computeIfAbsentSuspend(key: Key, block: suspend () -> Value): Value {
+        if (delegate.containsKey(key)) return delegate[key]!!
+        val value = block()
+        delegate[key] = value
+        return value
+    }
+
     override val size: Int
         get() = delegate.size
 

--- a/ktor-utils/jvm/src/io/ktor/util/AttributesJvm.kt
+++ b/ktor-utils/jvm/src/io/ktor/util/AttributesJvm.kt
@@ -47,6 +47,15 @@ private class ConcurrentSafeAttributes : AttributesJvmBase() {
         @Suppress("UNCHECKED_CAST")
         return (map.putIfAbsent(key, result) ?: result) as T
     }
+
+    override suspend fun <T : Any> computeIfAbsentSuspend(key: AttributeKey<T>, block: suspend () -> T): T {
+        @Suppress("UNCHECKED_CAST")
+        map[key]?.let { return it as T }
+        val result = block()
+        @Suppress("UNCHECKED_CAST")
+        return (map.putIfAbsent(key, result) ?: result) as T
+    }
+
 }
 
 private class HashMapAttributes : AttributesJvmBase() {
@@ -64,4 +73,13 @@ private class HashMapAttributes : AttributesJvmBase() {
         @Suppress("UNCHECKED_CAST")
         return (map.put(key, result) ?: result) as T
     }
+
+    override suspend fun <T : Any> computeIfAbsentSuspend(key: AttributeKey<T>, block: suspend () -> T): T {
+        @Suppress("UNCHECKED_CAST")
+        map[key]?.let { return it as T }
+        val result = block()
+        @Suppress("UNCHECKED_CAST")
+        return (map.put(key, result) ?: result) as T
+    }
+
 }

--- a/ktor-utils/jvm/src/io/ktor/util/collections/ConcurrentMapJvm.kt
+++ b/ktor-utils/jvm/src/io/ktor/util/collections/ConcurrentMapJvm.kt
@@ -20,6 +20,16 @@ public actual class ConcurrentMap<Key, Value> public actual constructor(initialC
         block()
     }
 
+    /**
+     * Computes [block] and inserts result in map. The suspend [block] will be evaluated at most once.
+     */
+    public actual suspend fun computeIfAbsentSuspend(key: Key, block: suspend () -> Value): Value {
+        if (delegate.containsKey(key)) return delegate[key]!!
+        val value = block()
+        delegate[key] = value
+        return value
+    }
+
     override val size: Int
         get() = delegate.size
 

--- a/ktor-utils/posix/src/io/ktor/util/AttributesNative.kt
+++ b/ktor-utils/posix/src/io/ktor/util/AttributesNative.kt
@@ -36,7 +36,7 @@ private class AttributesNative : Attributes {
 
     @Suppress("UNCHECKED_CAST")
     override suspend fun <T : Any> computeIfAbsentSuspend(key: AttributeKey<T>, block: suspend () -> T): T {
-        return map.computeIfAbsent(key, block) as T
+        return map.computeIfAbsentSuspend(key, block) as T
     }
 
     override val allKeys: List<AttributeKey<*>>

--- a/ktor-utils/posix/src/io/ktor/util/AttributesNative.kt
+++ b/ktor-utils/posix/src/io/ktor/util/AttributesNative.kt
@@ -34,6 +34,11 @@ private class AttributesNative : Attributes {
         return map.computeIfAbsent(key, block) as T
     }
 
+    @Suppress("UNCHECKED_CAST")
+    override suspend fun <T : Any> computeIfAbsentSuspend(key: AttributeKey<T>, block: suspend () -> T): T {
+        return map.computeIfAbsent(key, block) as T
+    }
+
     override val allKeys: List<AttributeKey<*>>
         get() = map.keys.toList()
 }

--- a/ktor-utils/posix/src/io/ktor/util/collections/ConcurrentMapNative.kt
+++ b/ktor-utils/posix/src/io/ktor/util/collections/ConcurrentMapNative.kt
@@ -28,6 +28,16 @@ public actual class ConcurrentMap<Key, Value> public actual constructor(
         return value
     }
 
+    /**
+     * Computes [block] and inserts result in map. The suspend [block] will be evaluated at most once.
+     */
+    public actual suspend fun computeIfAbsentSuspend(key: Key, block: suspend () -> Value): Value {
+        if (delegate.containsKey(key)) return delegate[key]!!
+        val value = block()
+        delegate[key] = value
+        return value
+    }
+
     override val size: Int
         get() = delegate.size
 


### PR DESCRIPTION
**Subsystem**
Ktor utils

**Motivation**
`Attributes` provides a `computeIfAbsent` method, but this method cannot be called with a suspend block. For example, you want to get something from your database on a `call` when handling a request on ktor server and cache it in attributes, you need `computeIfAbsent` to be able to take a suspend block. 

**Solution**
I added a variant to call it with a suspend block.

