### PR TITLE
Add resource URL cache

### DIFF
--- a/ktor-server/ktor-server-core/jvm/test/io/ktor/tests/http/content/StaticContentResolutionTest.kt
+++ b/ktor-server/ktor-server-core/jvm/test/io/ktor/tests/http/content/StaticContentResolutionTest.kt
@@ -69,4 +69,22 @@ class StaticContentResolutionTest {
         val secretEncoded = client.get("/static/%2e%2e/secret.txt")
         assertEquals(HttpStatusCode.BadRequest, secretEncoded.status)
     }
+
+    @Test
+    fun resourceUrlsAreCached() = testApplication {
+        application {
+            var callCount = 0
+            val countingClassLoader = object : ClassLoader(environment.classLoader) {
+                override fun findResources(name: String?) = super.findResources(name).also {
+                    callCount++
+                }
+            }
+            repeat(5) {
+                resolveResource("test-config.yaml", classLoader = countingClassLoader) {
+                    ContentType.defaultForFileExtension("yaml")
+                }
+            }
+            assertEquals(1, callCount)
+        }
+    }
 }


### PR DESCRIPTION
After playing around with the allocation benchmarks a bit, I found that the `ClassLoader.getResources()` call was the most expensive operation and can be avoided most of the time - resulting in 20-30% improvement by removing ~90 strings allocated from looking through the classpath on each request (which could potentially be much larger on big projects).

The caveat here is that introducing a cache for the resource URLs could create problems for projects that rely on swapping jars at runtime, so I'm thinking it might make sense to introduce this in 3.0.0 with an opt-out option.

I also have a few improvements in `ktor-benchmarks` but I lack the ability to push there atm 🥺 