### PR TITLE
KTOR-6494 Add https to default allowed schemas for CORS

### DIFF
--- a/ktor-server/ktor-server-plugins/ktor-server-content-negotiation/jvm/test/ContentNegotiationJvmTest.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-content-negotiation/jvm/test/ContentNegotiationJvmTest.kt
@@ -53,6 +53,7 @@ class ContentNegotiationJvmTest {
                 }
                 post("/multipart") {
                     val multipart = call.receiveMultipart()
+
                     @Suppress("DEPRECATION") val parts = multipart.readAllParts()
                     call.respondText("parts: ${parts.map { it.name }}")
                 }

--- a/ktor-server/ktor-server-plugins/ktor-server-cors/jvmAndNix/src/io/ktor/server/plugins/cors/CORSConfig.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-cors/jvmAndNix/src/io/ktor/server/plugins/cors/CORSConfig.kt
@@ -143,8 +143,16 @@ public class CORSConfig {
      * If you specify a wildcard in the host, you cannot add specific subdomains.
      * Otherwise, you can mix wildcard and non-wildcard subdomains as long as
      * the wildcard is always in front of the domain, e.g. `*.sub.domain.com` but not `sub.*.domain.com`.
+     *
+     * @param host host as it appears in the Host header (e.g. localhost:8080)
+     * @param schemes protocols allowed for the origin site; defaults to http and https
+     * @param subDomains additional subdomains for the given host
      */
-    public fun allowHost(host: String, schemes: List<String> = listOf("http"), subDomains: List<String> = emptyList()) {
+    public fun allowHost(
+        host: String,
+        schemes: List<String> = listOf("http", "https"),
+        subDomains: List<String> = emptyList()
+    ) {
         if (host == "*") return anyHost()
 
         require("://" !in host) { "scheme should be specified as a separate parameter schemes" }

--- a/ktor-server/ktor-server-tests/jvmAndNix/test/io/ktor/tests/server/plugins/CORSTest.kt
+++ b/ktor-server/ktor-server-tests/jvmAndNix/test/io/ktor/tests/server/plugins/CORSTest.kt
@@ -258,7 +258,7 @@ class CORSTest {
     fun testSimpleRequestHttps() {
         withTestApplication {
             application.install(CORS) {
-                allowHost("my-host", schemes = listOf("http", "https"))
+                allowHost("my-host")
             }
 
             application.routing {
@@ -1074,16 +1074,20 @@ class CORSTest {
             client.get { headers.append(HttpHeaders.Origin, "http://domain.net") }.status
         )
         assertEquals(
-            HttpStatusCode.Forbidden,
+            HttpStatusCode.OK,
             client.get { headers.append(HttpHeaders.Origin, "https://domain.com") }.status
         )
         assertEquals(
-            HttpStatusCode.Forbidden,
+            HttpStatusCode.OK,
             client.get { headers.append(HttpHeaders.Origin, "https://www.domain.com") }.status
         )
         assertEquals(
             HttpStatusCode.Forbidden,
-            client.get { headers.append(HttpHeaders.Origin, "https://foo.bar.domain.com") }.status
+            client.get { headers.append(HttpHeaders.Origin, "https://domain.net") }.status
+        )
+        assertEquals(
+            HttpStatusCode.Forbidden,
+            client.get { headers.append(HttpHeaders.Origin, "sftp://domain.com") }.status
         )
     }
 


### PR DESCRIPTION
**Subsystem**
CORS (Server)

**Motivation**
[KTOR-6494](https://youtrack.jetbrains.com/issue/KTOR-6494) CORS: `allowHost` without the second argument doesn't allow the secure host

^ This seems like a pretty valid concern, only allowing http by default is quite strange and will inevitably lead to friction when deploying to production.

**Solution**
Simply add https to the default schemas.