### PR TITLE
Remove assumption "JKS" is always available.

### DIFF
--- a/ktor-network/ktor-network-tls/ktor-network-tls-certificates/jvm/src/io/ktor/network/tls/certificates/Certificates.kt
+++ b/ktor-network/ktor-network-tls/ktor-network-tls-certificates/jvm/src/io/ktor/network/tls/certificates/Certificates.kt
@@ -175,7 +175,7 @@ public fun KeyStore.generateCertificate(
  *  If [file] is set, all certificates are stored in a JKS keystore in [file] with [password].
  */
 public fun KeyStore.trustStore(file: File? = null, password: CharArray = "changeit".toCharArray()): KeyStore {
-    val trustStore = KeyStore.getInstance("JKS")!!
+    val trustStore = KeyStore.getInstance(KeyStore.getDefaultType())!!
     trustStore.load(null, null)
     aliases().toList().forEach { alias ->
         val cert: Certificate = getCertificate(alias)

--- a/ktor-network/ktor-network-tls/ktor-network-tls-certificates/jvm/src/io/ktor/network/tls/certificates/builders.kt
+++ b/ktor-network/ktor-network-tls/ktor-network-tls-certificates/jvm/src/io/ktor/network/tls/certificates/builders.kt
@@ -157,7 +157,7 @@ public class KeyStoreBuilder internal constructor() {
     }
 
     internal fun build(): KeyStore {
-        val store = KeyStore.getInstance("JKS")!!
+        val store = KeyStore.getInstance(KeyStore.getDefaultType())!!
         store.load(null, null)
 
         certificates.forEach { (alias, info) ->

--- a/ktor-server/ktor-server-core/jvm/src/io/ktor/server/engine/EnvironmentUtilsJvm.kt
+++ b/ktor-server/ktor-server-core/jvm/src/io/ktor/server/engine/EnvironmentUtilsJvm.kt
@@ -38,7 +38,7 @@ internal actual fun ApplicationEngine.Configuration.configureSSLConnectors(
     val keyStoreFile = File(sslKeyStorePath).let { file ->
         if (file.exists() || file.isAbsolute) file else File(".", sslKeyStorePath).absoluteFile
     }
-    val keyStore = KeyStore.getInstance("JKS").apply {
+    val keyStore = KeyStore.getInstance(KeyStore.getDefaultType()).apply {
         FileInputStream(keyStoreFile).use {
             load(it, sslKeyStorePassword.toCharArray())
         }

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyChannelInitializer.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyChannelInitializer.kt
@@ -161,7 +161,7 @@ public class NettyChannelInitializer(
     private fun EngineSSLConnectorConfig.trustManagerFactory(): TrustManagerFactory? {
         val trustStore = trustStore ?: trustStorePath?.let { file ->
             FileInputStream(file).use { fis ->
-                KeyStore.getInstance("JKS").also { it.load(fis, null) }
+                KeyStore.getInstance(KeyStore.getDefaultType()).also { it.load(fis, null) }
             }
         }
         return trustStore?.let { store ->


### PR DESCRIPTION
On some platforms (e.g. Android) Java KeyStore (JKS) support is not available. Using the default platform keystore ensures that keys can still be stored on those platforms.

**Subsystem**
Server and Network

**Motivation**
Attempting to use the keystore related code results in an error on Android, switching the assumption that "JKS" is always available to using the platform provided default resolves this.

**Solution**
Change hard coded "JKS" to use of `getDefaultType()` which provides the keystore format available on the system. On Android this is "BKS" (ref: https://cs.android.com/android/platform/superproject/main/+/main:libcore/luni/src/main/java/java/security/security.properties;l=50)
