### PR TITLE
fixed wrong consumed size

### DIFF
--- a/ktor-network/jvm/src/io/ktor/network/sockets/CIOWriter.kt
+++ b/ktor-network/jvm/src/io/ktor/network/sockets/CIOWriter.kt
@@ -102,19 +102,17 @@ internal fun CoroutineScope.attachForWritingDirectImpl(
                 }
 
                 while (buffer.hasRemaining()) {
-                    var rc = 0
-
                     timeout.withTimeout {
                         do {
-                            rc = nioChannel.write(buffer)
+                            val rc = nioChannel.write(buffer)
                             if (rc == 0) {
                                 selectable.interestOp(SelectInterest.WRITE, true)
                                 selector.select(selectable, SelectInterest.WRITE)
+                                break
                             }
-                        } while (buffer.hasRemaining() && rc == 0)
+                            consumed(rc)
+                        } while (buffer.hasRemaining())
                     }
-
-                    consumed(rc)
                 }
             }
             timeout?.finish()


### PR DESCRIPTION
**Subsystem**
base sockets

**Motivation**
may be there is error in the consumed size in the case if nioChannel.write will not write full buffer in one time

**Solution**
consume bytes after every write iteration

