### PR TITLE
JS: Fix origin retrieval on platforms that have window, but no location

### DIFF
--- a/ktor-http/js/src/io/ktor/http/URLBuilderJs.kt
+++ b/ktor-http/js/src/io/ktor/http/URLBuilderJs.kt
@@ -10,17 +10,23 @@ import io.ktor.util.*
  * Hostname of current origin.
  *
  * It uses "localhost" for all platforms except js.
+ *
+ * Note that not all platforms have location set. React Native platofrms expose window without a location.
  */
 public actual val URLBuilder.Companion.origin: String
     get() = when (PlatformUtils.platform) {
         Platform.Browser -> {
             js(
                 """
-                var origin = ""
+                var tmpLocation = null
                 if (typeof window !== 'undefined') {
-                  origin = window.location.origin 
+                  tmpLocation = window.location
                 } else {
-                  origin = self.location.origin 
+                  tmpLocation = self.location
+                }
+                var origin = ""
+                if (tmpLocation) {
+                  origin = location.origin
                 }
                 origin && origin != "null" ? origin : "http://localhost"
                 """


### PR DESCRIPTION
**Subsystem**
Client/HTTP (JS)

**Motivation**
On React Native platforms there is a window object, no node environment, and no location, so URLBuilder was crashing hard.

**Solution**
This improves the safety of the code that retrieves the origin.

https://youtrack.jetbrains.com/issue/KTOR-6576/URLBuilder-crashes-on-React-Native-platforms
