### PR TITLE
Add handling to propagate error from oauth server to caller

### DIFF
--- a/ktor-server/ktor-server-plugins/ktor-server-auth/api/ktor-server-auth.api
+++ b/ktor-server/ktor-server-plugins/ktor-server-auth/api/ktor-server-auth.api
@@ -299,10 +299,18 @@ public final class io/ktor/server/auth/OAuth2Kt {
 	public static final fun verifyWithOAuth2 (Lio/ktor/server/auth/UserPasswordCredential;Lio/ktor/client/HttpClient;Lio/ktor/server/auth/OAuthServerSettings$OAuth2ServerSettings;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
+public final class io/ktor/server/auth/OAuth2RedirectError : io/ktor/server/auth/AuthenticationFailedCause$Error {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public final fun getError ()Ljava/lang/String;
+	public final fun getErrorDescription ()Ljava/lang/String;
+}
+
 public final class io/ktor/server/auth/OAuth2RequestParameters {
 	public static final field ClientId Ljava/lang/String;
 	public static final field ClientSecret Ljava/lang/String;
 	public static final field Code Ljava/lang/String;
+	public static final field Error Ljava/lang/String;
+	public static final field ErrorDescription Ljava/lang/String;
 	public static final field GrantType Ljava/lang/String;
 	public static final field INSTANCE Lio/ktor/server/auth/OAuth2RequestParameters;
 	public static final field Password Ljava/lang/String;
@@ -382,6 +390,19 @@ public final class io/ktor/server/auth/OAuthAuthenticationProvider$Config : io/k
 }
 
 public abstract class io/ktor/server/auth/OAuthCallback {
+}
+
+public final class io/ktor/server/auth/OAuthCallback$Error : io/ktor/server/auth/OAuthCallback {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;)Lio/ktor/server/auth/OAuthCallback$Error;
+	public static synthetic fun copy$default (Lio/ktor/server/auth/OAuthCallback$Error;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lio/ktor/server/auth/OAuthCallback$Error;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getError ()Ljava/lang/String;
+	public final fun getErrorDescription ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
 }
 
 public final class io/ktor/server/auth/OAuthCallback$TokenPair : io/ktor/server/auth/OAuthCallback {

--- a/ktor-server/ktor-server-plugins/ktor-server-auth/jvmAndNix/src/io/ktor/server/auth/OAuth2.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-auth/jvmAndNix/src/io/ktor/server/auth/OAuth2.kt
@@ -24,15 +24,18 @@ import kotlinx.serialization.json.*
 
 private val Logger: Logger = KtorSimpleLogger("io.ktor.auth.oauth")
 
-internal suspend fun ApplicationCall.oauth2HandleCallback(): OAuthCallback.TokenSingle? {
+internal suspend fun ApplicationCall.oauth2HandleCallback(): OAuthCallback? {
     val params = when (request.contentType()) {
         ContentType.Application.FormUrlEncoded -> receiveParameters()
         else -> parameters
     }
     val code = params[OAuth2RequestParameters.Code]
     val state = params[OAuth2RequestParameters.State]
+    val error = params[OAuth2RequestParameters.Error]
+    val errorDescription = params[OAuth2RequestParameters.ErrorDescription]
 
     return when {
+        error != null -> OAuthCallback.Error(error, errorDescription)
         code != null && state != null -> OAuthCallback.TokenSingle(code, state)
         else -> null
     }
@@ -300,6 +303,8 @@ public object OAuth2RequestParameters {
     public const val ClientSecret: String = "client_secret"
     public const val GrantType: String = "grant_type"
     public const val Code: String = "code"
+    public const val Error: String = "error"
+    public const val ErrorDescription: String = "error_description"
     public const val State: String = "state"
     public const val RedirectUri: String = "redirect_uri"
     public const val ResponseType: String = "response_type"

--- a/ktor-server/ktor-server-plugins/ktor-server-auth/jvmAndNix/src/io/ktor/server/auth/OAuthCommon.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-auth/jvmAndNix/src/io/ktor/server/auth/OAuthCommon.kt
@@ -98,6 +98,13 @@ public sealed class OAuthCallback {
      * @property state passed from a client (ktor server) during authorization startup
      */
     public data class TokenSingle(val token: String, val state: String) : OAuthCallback()
+
+    /**
+     * Oauth2 error callback parameters
+     * @property error the error code passed from the identity provider
+     * @property errorDescription optionally passed, human-readable description of the error code
+     */
+    public data class Error(val error: String, val errorDescription: String?) : OAuthCallback()
 }
 
 /**


### PR DESCRIPTION
**Subsystem**
Ktor-server-auth (oauth2)

**Motivation**
See https://youtrack.jetbrains.com/issue/KTOR-6605 - currently there is no way for user code to see the original error code & description returned from an identity provider. This contains useful information like the fact that the user intentionally cancelled the auth flow etc.

**Solution**
This PR extends the callback response handling to include unhappy path handling. 

It does change the exception type that populates `call.authentication.allFailures` to be a typed descendent of `AuthenticationFailedCause.Error` rather than the `object AuthenticationFailedCause.NoCredentials` that would have (confusingly) been mapped before. This is unlikely to break any userland code, but it could be possible if user code is explicitly checking for `NoCredentials` as a "happy" path, and now it will be `AuthenticationFailedCause.Error` instead.

Due to this, I recommend making it a 3.x.x target.