### PR TITLE
Add warning to docs to specify all optional parameters on some engines

### DIFF
--- a/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/websocket/builders.kt
+++ b/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/websocket/builders.kt
@@ -57,6 +57,7 @@ public suspend fun HttpClient.webSocketSession(
 
 /**
  * Opens a [DefaultClientWebSocketSession].
+ * WARNING: By not specifying host, port and path it may not work on all engines.
  */
 public suspend fun HttpClient.webSocketSession(
     method: HttpMethod = HttpMethod.Get,
@@ -107,6 +108,7 @@ public suspend fun HttpClient.webSocket(
 
 /**
  * Opens a [block] with [DefaultClientWebSocketSession].
+ * WARNING: By not specifying host, port and path it may not work on all engines
  */
 public suspend fun HttpClient.webSocket(
     method: HttpMethod = HttpMethod.Get,
@@ -152,6 +154,7 @@ public suspend fun HttpClient.webSocket(
 
 /**
  * Opens a [block] with [DefaultClientWebSocketSession].
+ * WARNING: By not specifying host, port and path it may not work on all engines.
  */
 public suspend fun HttpClient.ws(
     method: HttpMethod = HttpMethod.Get,
@@ -211,6 +214,7 @@ public suspend fun HttpClient.wss(
 
 /**
  * Opens a [block] with secure [DefaultClientWebSocketSession].
+ * WARNING: By not specifying host, port and path it may not work on all engines.
  */
 public suspend fun HttpClient.wss(
     method: HttpMethod = HttpMethod.Get,

--- a/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/websocket/builders.kt
+++ b/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/websocket/builders.kt
@@ -218,9 +218,9 @@ public suspend fun HttpClient.wss(
  */
 public suspend fun HttpClient.wss(
     method: HttpMethod = HttpMethod.Get,
-    host: String,
-    port: Int,
-    path: String,
+    host: String? = null,
+    port: Int? = null,
+    path: String? = null,
     request: HttpRequestBuilder.() -> Unit = {},
     block: suspend DefaultClientWebSocketSession.() -> Unit
 ): Unit = webSocket(
@@ -230,7 +230,7 @@ public suspend fun HttpClient.wss(
     path,
     request = {
         url.protocol = URLProtocol.WSS
-        url.port = port
+        if (port != null) url.port = port
 
         request()
     },


### PR DESCRIPTION
**Subsystem**
Client, WebSockets

**Motivation**
I was stuck on making WebSockets work for iOS using `Darwin` engine only to find out these optional fields were required.

**Solution**
Add a warning to the docs to help developers not get stuck where i did.