### PR TITLE
KTOR-6396 Skip certificate hostname check if no hostnames provided

### DIFF
--- a/ktor-http/common/src/io/ktor/http/IpParser.kt
+++ b/ktor-http/common/src/io/ktor/http/IpParser.kt
@@ -6,7 +6,6 @@ package io.ktor.http
 
 import io.ktor.http.parsing.*
 import io.ktor.http.parsing.regex.*
-import kotlin.native.concurrent.*
 
 /**
  * Check if [host] is IPv4 or IPv6 address.

--- a/ktor-network/ktor-network-tls/jvm/src/io/ktor/network/tls/HostnameUtils.kt
+++ b/ktor-network/ktor-network-tls/jvm/src/io/ktor/network/tls/HostnameUtils.kt
@@ -17,6 +17,7 @@ internal fun verifyHostnameInCertificate(serverName: String, certificate: X509Ce
     }
 
     val hosts = certificate.hosts()
+    if (hosts.isEmpty()) return
     if (hosts.any { matchHostnameWithCertificate(serverName, it) }) return
 
     throw TLSException(
@@ -30,6 +31,7 @@ internal fun verifyIpInCertificate(ipString: String, certificate: X509Certificat
         .filter { it[0] as Int == IP_ADDRESS_TYPE }
         .map { it[1] as String }
 
+    if (ips.isEmpty()) return
     if (ips.any { it == ipString }) return
 
     throw TLSException(
@@ -90,9 +92,11 @@ internal fun matchHostnameWithCertificate(serverName: String, certificateHost: S
 }
 
 private fun X509Certificate.hosts(): List<String> = subjectAlternativeNames
-    .filter { it[0] as Int == DNS_NAME_TYPE }
-    .map { it[1] as String }
+    ?.filter { it[0] as Int == DNS_NAME_TYPE }
+    ?.map { it[1] as String }
+    ?: emptyList()
 
 private fun X509Certificate.ips(): List<String> = subjectAlternativeNames
-    .filter { it[0] as Int == IP_ADDRESS_TYPE }
-    .map { it[1] as String }
+    ?.filter { it[0] as Int == IP_ADDRESS_TYPE }
+    ?.map { it[1] as String }
+    ?: emptyList()


### PR DESCRIPTION
Fix [KTOR-6396](https://youtrack.jetbrains.com/issue/KTOR-6396) CIO: "getSubjectAlternativeNames(...) must not be null" error on Android when using CA without SAN since 2.3.5