### PR TITLE
Kotlin K2 Migration: Override abstract members explicitly on expect s…

### DIFF
--- a/ktor-client/ktor-client-cio/jvm/src/io/ktor/client/engine/cio/ConnectionPipeline.kt
+++ b/ktor-client/ktor-client-cio/jvm/src/io/ktor/client/engine/cio/ConnectionPipeline.kt
@@ -30,7 +30,7 @@ internal actual class ConnectionPipeline actual constructor(
     tasks: Channel<RequestTask>,
     parentContext: CoroutineContext
 ) : CoroutineScope {
-    override val coroutineContext: CoroutineContext = parentContext + Job()
+    actual override val coroutineContext: CoroutineContext = parentContext + Job()
 
     private val networkInput = connection.input
     private val networkOutput = connection.output

--- a/ktor-client/ktor-client-cio/jvmAndNix/src/io/ktor/client/engine/cio/ConnectionPipelineCommon.kt
+++ b/ktor-client/ktor-client-cio/jvmAndNix/src/io/ktor/client/engine/cio/ConnectionPipelineCommon.kt
@@ -19,4 +19,6 @@ internal expect class ConnectionPipeline(
     parentContext: CoroutineContext
 ) : CoroutineScope {
     val pipelineContext: Job
+
+    override val coroutineContext: CoroutineContext
 }

--- a/ktor-client/ktor-client-cio/nix/src/io/ktor/client/engine/cio/ConnectionPipelineNative.kt
+++ b/ktor-client/ktor-client-cio/nix/src/io/ktor/client/engine/cio/ConnectionPipelineNative.kt
@@ -18,7 +18,7 @@ internal actual class ConnectionPipeline actual constructor(
     tasks: Channel<RequestTask>,
     parentContext: CoroutineContext
 ) : CoroutineScope {
-    override val coroutineContext: CoroutineContext = parentContext
+    actual override val coroutineContext: CoroutineContext = parentContext
 
     init {
         error("Pipelining is not supported in native CIO")

--- a/ktor-io/common/src/io/ktor/utils/io/bits/MemoryFactory.kt
+++ b/ktor-io/common/src/io/ktor/utils/io/bits/MemoryFactory.kt
@@ -1,9 +1,6 @@
 package io.ktor.utils.io.bits
 
-import io.ktor.utils.io.*
 import io.ktor.utils.io.IO_DEPRECATION_MESSAGE
-import io.ktor.utils.io.core.*
-import io.ktor.utils.io.core.internal.*
 import kotlin.contracts.*
 
 // TODO: length default argument should be this.size - offset but it doesn't work due to KT-29920
@@ -59,7 +56,13 @@ public inline fun <R> withMemory(size: Long, block: (Memory) -> R): R {
 }
 
 @PublishedApi
-internal expect object DefaultAllocator : Allocator
+internal expect object DefaultAllocator : Allocator {
+    override fun alloc(size: Int): Memory
+
+    override fun alloc(size: Long): Memory
+
+    override fun free(instance: Memory)
+}
 
 public interface Allocator {
     public fun alloc(size: Int): Memory

--- a/ktor-io/js/src/io/ktor/utils/io/bits/MemoryFactoryJs.kt
+++ b/ktor-io/js/src/io/ktor/utils/io/bits/MemoryFactoryJs.kt
@@ -43,8 +43,10 @@ public fun Memory(view: ArrayBufferView, offset: Int = 0, length: Int = view.byt
 
 @PublishedApi
 internal actual object DefaultAllocator : Allocator {
-    override fun alloc(size: Int): Memory = Memory(DataView(ArrayBuffer(size)))
-    override fun alloc(size: Long): Memory = Memory(DataView(ArrayBuffer(size.toIntOrFail("size"))))
-    override fun free(instance: Memory) {
+    actual override fun alloc(size: Int): Memory = Memory(DataView(ArrayBuffer(size)))
+
+    actual override fun alloc(size: Long): Memory = Memory(DataView(ArrayBuffer(size.toIntOrFail("size"))))
+
+    actual override fun free(instance: Memory) {
     }
 }

--- a/ktor-io/jvm/src/io/ktor/utils/io/bits/MemoryFactoryJvm.kt
+++ b/ktor-io/jvm/src/io/ktor/utils/io/bits/MemoryFactoryJvm.kt
@@ -29,10 +29,10 @@ public inline fun Memory(array: ByteArray, offset: Int = 0, length: Int = array.
 
 @PublishedApi
 internal actual object DefaultAllocator : Allocator {
-    override fun alloc(size: Int): Memory = Memory(ByteBuffer.allocate(size))
+    actual override fun alloc(size: Int): Memory = Memory(ByteBuffer.allocate(size))
 
-    override fun alloc(size: Long): Memory = alloc(size.toIntOrFail("size"))
+    actual override fun alloc(size: Long): Memory = alloc(size.toIntOrFail("size"))
 
-    override fun free(instance: Memory) {
+    actual override fun free(instance: Memory) {
     }
 }

--- a/ktor-utils/common/src/io/ktor/util/ContentEncoder.kt
+++ b/ktor-utils/common/src/io/ktor/util/ContentEncoder.kt
@@ -4,6 +4,9 @@
 
 package io.ktor.util
 
+import io.ktor.utils.io.*
+import kotlin.coroutines.*
+
 /**
  * A request/response content encoder.
  */
@@ -22,12 +25,46 @@ public interface ContentEncoder : Encoder {
 /**
  * Implementation of [ContentEncoder] using gzip algorithm
  */
-public expect object GZipEncoder : ContentEncoder
+public expect object GZipEncoder : ContentEncoder {
+    override val name: String
+
+    override fun encode(
+        source: ByteReadChannel,
+        coroutineContext: CoroutineContext
+    ): ByteReadChannel
+
+    override fun encode(
+        source: ByteWriteChannel,
+        coroutineContext: CoroutineContext
+    ): ByteWriteChannel
+
+    override fun decode(
+        source: ByteReadChannel,
+        coroutineContext: CoroutineContext
+    ): ByteReadChannel
+}
 
 /**
  * Implementation of [ContentEncoder] using deflate algorithm
  */
-public expect object DeflateEncoder : ContentEncoder
+public expect object DeflateEncoder : ContentEncoder {
+    override val name: String
+
+    override fun encode(
+        source: ByteReadChannel,
+        coroutineContext: CoroutineContext
+    ): ByteReadChannel
+
+    override fun encode(
+        source: ByteWriteChannel,
+        coroutineContext: CoroutineContext
+    ): ByteWriteChannel
+
+    override fun decode(
+        source: ByteReadChannel,
+        coroutineContext: CoroutineContext
+    ): ByteReadChannel
+}
 
 /**
  * Implementation of [ContentEncoder] using identity algorithm

--- a/ktor-utils/common/src/io/ktor/util/collections/ConcurrentMap.kt
+++ b/ktor-utils/common/src/io/ktor/util/collections/ConcurrentMap.kt
@@ -22,4 +22,28 @@ public expect class ConcurrentMap<Key, Value>(
      * Removes [key] from map if it is mapped to [value].
      */
     public fun remove(key: Key, value: Value): Boolean
+
+    override fun remove(key: Key): Value?
+
+    override fun clear()
+
+    override fun put(key: Key, value: Value): Value?
+
+    override fun putAll(from: Map<out Key, Value>)
+
+    override val entries: MutableSet<MutableMap.MutableEntry<Key, Value>>
+
+    override val keys: MutableSet<Key>
+
+    override val values: MutableCollection<Value>
+
+    override fun containsKey(key: Key): Boolean
+
+    override fun containsValue(value: Value): Boolean
+
+    override fun get(key: Key): Value?
+
+    override fun isEmpty(): Boolean
+
+    override val size: Int
 }

--- a/ktor-utils/js/src/io/ktor/util/ContentEncodersJs.kt
+++ b/ktor-utils/js/src/io/ktor/util/ContentEncodersJs.kt
@@ -10,12 +10,12 @@ package io.ktor.util
  * Implementation of [ContentEncoder] using gzip algorithm
  */
 public actual object GZipEncoder : ContentEncoder, Encoder by Identity {
-    override val name: String = "gzip"
+    actual override val name: String = "gzip"
 }
 
 /**
  * Implementation of [ContentEncoder] using deflate algorithm
  */
 public actual object DeflateEncoder : ContentEncoder, Encoder by Identity {
-    override val name: String = "deflate"
+    actual override val name: String = "deflate"
 }

--- a/ktor-utils/js/src/io/ktor/util/collections/ConcurrentMapJs.kt
+++ b/ktor-utils/js/src/io/ktor/util/collections/ConcurrentMapJs.kt
@@ -21,37 +21,37 @@ public actual class ConcurrentMap<Key, Value> public actual constructor(initialC
         return value
     }
 
-    override val size: Int
+    actual override val size: Int
         get() = delegate.size
 
-    override fun containsKey(key: Key): Boolean = delegate.containsKey(key)
+    actual override fun containsKey(key: Key): Boolean = delegate.containsKey(key)
 
-    override fun containsValue(value: Value): Boolean = delegate.containsValue(value)
+    actual override fun containsValue(value: Value): Boolean = delegate.containsValue(value)
 
-    override fun get(key: Key): Value? = delegate.get(key)
+    actual override fun get(key: Key): Value? = delegate.get(key)
 
-    override fun isEmpty(): Boolean = delegate.isEmpty()
+    actual override fun isEmpty(): Boolean = delegate.isEmpty()
 
-    override val entries: MutableSet<MutableMap.MutableEntry<Key, Value>>
+    actual override val entries: MutableSet<MutableMap.MutableEntry<Key, Value>>
         get() = delegate.entries
 
-    override val keys: MutableSet<Key>
+    actual override val keys: MutableSet<Key>
         get() = delegate.keys
 
-    override val values: MutableCollection<Value>
+    actual override val values: MutableCollection<Value>
         get() = delegate.values
 
-    override fun clear() {
+    actual override fun clear() {
         delegate.clear()
     }
 
-    override fun put(key: Key, value: Value): Value? = delegate.put(key, value)
+    actual override fun put(key: Key, value: Value): Value? = delegate.put(key, value)
 
-    override fun putAll(from: Map<out Key, Value>) {
+    actual override fun putAll(from: Map<out Key, Value>) {
         delegate.putAll(from)
     }
 
-    override fun remove(key: Key): Value? = delegate.remove(key)
+    actual override fun remove(key: Key): Value? = delegate.remove(key)
 
     public actual fun remove(key: Key, value: Value): Boolean {
         if (delegate[key] != value) return false

--- a/ktor-utils/jvm/src/io/ktor/util/ContentEncodersJvm.kt
+++ b/ktor-utils/jvm/src/io/ktor/util/ContentEncodersJvm.kt
@@ -8,12 +8,12 @@ package io.ktor.util
  * Implementation of [ContentEncoder] using gzip algorithm
  */
 public actual object GZipEncoder : ContentEncoder, Encoder by GZip {
-    override val name: String = "gzip"
+    actual override val name: String = "gzip"
 }
 
 /**
  * Implementation of [ContentEncoder] using deflate algorithm
  */
 public actual object DeflateEncoder : ContentEncoder, Encoder by Deflate {
-    override val name: String = "deflate"
+    actual override val name: String = "deflate"
 }

--- a/ktor-utils/jvm/src/io/ktor/util/collections/ConcurrentMapJvm.kt
+++ b/ktor-utils/jvm/src/io/ktor/util/collections/ConcurrentMapJvm.kt
@@ -20,37 +20,37 @@ public actual class ConcurrentMap<Key, Value> public actual constructor(initialC
         block()
     }
 
-    override val size: Int
+    actual override val size: Int
         get() = delegate.size
 
-    override fun containsKey(key: Key): Boolean = delegate.containsKey(key)
+    actual override fun containsKey(key: Key): Boolean = delegate.containsKey(key)
 
-    override fun containsValue(value: Value): Boolean = delegate.containsValue(value)
+    actual override fun containsValue(value: Value): Boolean = delegate.containsValue(value)
 
-    override fun get(key: Key): Value? = delegate[key]
+    actual override fun get(key: Key): Value? = delegate[key]
 
-    override fun isEmpty(): Boolean = delegate.isEmpty()
+    actual override fun isEmpty(): Boolean = delegate.isEmpty()
 
-    override val entries: MutableSet<MutableMap.MutableEntry<Key, Value>>
+    actual override val entries: MutableSet<MutableMap.MutableEntry<Key, Value>>
         get() = delegate.entries
 
-    override val keys: MutableSet<Key>
+    actual override val keys: MutableSet<Key>
         get() = delegate.keys
 
-    override val values: MutableCollection<Value>
+    actual override val values: MutableCollection<Value>
         get() = delegate.values
 
-    override fun clear() {
+    actual override fun clear() {
         delegate.clear()
     }
 
-    override fun put(key: Key, value: Value): Value? = delegate.put(key, value)
+    actual override fun put(key: Key, value: Value): Value? = delegate.put(key, value)
 
-    override fun putAll(from: Map<out Key, Value>) {
+    actual override fun putAll(from: Map<out Key, Value>) {
         delegate.putAll(from)
     }
 
-    override fun remove(key: Key): Value? = delegate.remove(key)
+    actual override fun remove(key: Key): Value? = delegate.remove(key)
 
     actual override fun remove(key: Key, value: Value): Boolean = delegate.remove(key, value)
 

--- a/ktor-utils/posix/src/io/ktor/util/ContentEncodersNative.kt
+++ b/ktor-utils/posix/src/io/ktor/util/ContentEncodersNative.kt
@@ -8,12 +8,12 @@ package io.ktor.util
  * Implementation of [ContentEncoder] using gzip algorithm
  */
 public actual object GZipEncoder : ContentEncoder, Encoder by Identity {
-    override val name: String = "gzip"
+    actual override val name: String = "gzip"
 }
 
 /**
  * Implementation of [ContentEncoder] using deflate algorithm
  */
 public actual object DeflateEncoder : ContentEncoder, Encoder by Identity {
-    override val name: String = "deflate"
+    actual override val name: String = "deflate"
 }

--- a/ktor-utils/posix/src/io/ktor/util/collections/ConcurrentMapNative.kt
+++ b/ktor-utils/posix/src/io/ktor/util/collections/ConcurrentMapNative.kt
@@ -28,41 +28,41 @@ public actual class ConcurrentMap<Key, Value> public actual constructor(
         return value
     }
 
-    override val size: Int
+    actual override val size: Int
         get() = delegate.size
 
-    override fun containsKey(key: Key): Boolean = synchronized(lock) { delegate.containsKey(key) }
+    actual override fun containsKey(key: Key): Boolean = synchronized(lock) { delegate.containsKey(key) }
 
-    override fun containsValue(value: Value): Boolean = synchronized(lock) { delegate.containsValue(value) }
+    actual override fun containsValue(value: Value): Boolean = synchronized(lock) { delegate.containsValue(value) }
 
-    override fun get(key: Key): Value? = synchronized(lock) { delegate[key] }
+    actual override fun get(key: Key): Value? = synchronized(lock) { delegate[key] }
 
-    override fun isEmpty(): Boolean = delegate.isEmpty()
+    actual override fun isEmpty(): Boolean = delegate.isEmpty()
 
-    override val entries: MutableSet<MutableMap.MutableEntry<Key, Value>>
+    actual override val entries: MutableSet<MutableMap.MutableEntry<Key, Value>>
         get() = synchronized(lock) { delegate.entries }
 
-    override val keys: MutableSet<Key>
+    actual override val keys: MutableSet<Key>
         get() = synchronized(lock) { delegate.keys }
 
-    override val values: MutableCollection<Value>
+    actual override val values: MutableCollection<Value>
         get() = synchronized(lock) { delegate.values }
 
-    override fun clear() {
+    actual override fun clear() {
         synchronized(lock) {
             delegate.clear()
         }
     }
 
-    override fun put(key: Key, value: Value): Value? = synchronized(lock) { delegate.put(key, value) }
+    actual override fun put(key: Key, value: Value): Value? = synchronized(lock) { delegate.put(key, value) }
 
-    override fun putAll(from: Map<out Key, Value>) {
+    actual override fun putAll(from: Map<out Key, Value>) {
         synchronized(lock) {
             delegate.putAll(from)
         }
     }
 
-    override fun remove(key: Key): Value? = synchronized(lock) { delegate.remove(key) }
+    actual override fun remove(key: Key): Value? = synchronized(lock) { delegate.remove(key) }
 
     public actual fun remove(key: Key, value: Value): Boolean = synchronized(lock) {
         if (delegate[key] != value) return false


### PR DESCRIPTION
…ide KT-59739 KT-59887

**Subsystem**
None.

**Motivation**
The Kotlin team checks ktor with the new versions of the K2 compiler. Found problems are investigated and if the problem is not planned to be fixed, migration is added. Branch: `kotlin-community/k2/dev`. To make maintaining the branch easier, we suggest moving migrations to the main branch. 

[KT-59739 ](https://youtrack.jetbrains.com/issue/KT-59739)

**Solution**
In K2, it's required to override abstract members explicitly on expect side.
