### PR TITLE
Kotlin K2 Migration: Add INVISIBLE_REFERENCE KT-57776

### DIFF
--- a/ktor-utils/common/src/io/ktor/util/pipeline/StackTraceRecover.kt
+++ b/ktor-utils/common/src/io/ktor/util/pipeline/StackTraceRecover.kt
@@ -13,7 +13,7 @@ import kotlin.coroutines.*
  * Notice: This method breaks the [exception] identity.
  */
 internal fun recoverStackTraceBridge(exception: Throwable, continuation: Continuation<*>): Throwable = try {
-    @Suppress("INVISIBLE_MEMBER")
+    @Suppress("INVISIBLE_MEMBER", "INVISIBLE_REFERENCE")
     recoverStackTrace(exception, continuation).withCause(exception.cause)
 } catch (_: Throwable) {
     exception


### PR DESCRIPTION
**Subsystem**
None.

**Motivation**
The Kotlin team checks ktor with the new versions of the K2 compiler. Found problems are investigated and if the problem is not planned to be fixed, migration is added. Branch: kotlin-community/k2/dev. To make maintaining the branch easier, we suggest moving migrations to the main branch.

[KT-57776](https://youtrack.jetbrains.com/issue/KT-57776)
Since we don't have `INVISIBLE_MEMBER` in FIR, libraries should migrate to `@Suppress("INVISIBLE_REFERENCE")`

**Solution**
Added `INVISIBLE_REFERENCE`, kept `INVISIBLE_MEMBER` for compatibility with K1.


