### PR TITLE
KTOR-6625 Fix HttpCallValidatorConfig name

### DIFF
--- a/ktor-client/ktor-client-core/api/ktor-client-core.api
+++ b/ktor-client/ktor-client-core/api/ktor-client-core.api
@@ -306,6 +306,16 @@ public final class io/ktor/client/plugins/HttpCalValidatorConfig {
 	public final fun validateResponse (Lkotlin/jvm/functions/Function2;)V
 }
 
+public final class io/ktor/client/plugins/HttpCallValidatorConfig {
+	public fun <init> ()V
+	public final fun getExpectSuccess ()Z
+	public final fun handleResponseException (Lkotlin/jvm/functions/Function2;)V
+	public final fun handleResponseException (Lkotlin/jvm/functions/Function3;)V
+	public final fun handleResponseExceptionWithRequest (Lkotlin/jvm/functions/Function3;)V
+	public final fun setExpectSuccess (Z)V
+	public final fun validateResponse (Lkotlin/jvm/functions/Function2;)V
+}
+
 public final class io/ktor/client/plugins/HttpCallValidatorKt {
 	public static final fun HttpResponseValidator (Lio/ktor/client/HttpClientConfig;Lkotlin/jvm/functions/Function1;)V
 	public static final fun getExpectSuccess (Lio/ktor/client/request/HttpRequestBuilder;)Z

--- a/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/HttpCallValidator.kt
+++ b/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/HttpCallValidator.kt
@@ -23,7 +23,7 @@ private val LOGGER = KtorSimpleLogger("io.ktor.client.plugins.HttpCallValidator"
  * [HttpCallValidator] configuration.
  */
 @KtorDsl
-public class HttpCalValidatorConfig {
+public class HttpCallValidatorConfig {
     internal val responseValidators: MutableList<ResponseValidator> = mutableListOf()
     internal val responseExceptionHandlers: MutableList<HandlerWrapper> = mutableListOf()
 
@@ -96,9 +96,9 @@ public typealias CallRequestExceptionHandler = suspend (cause: Throwable, reques
  *
  * See also [Config] for additional details.
  */
-public val HttpCallValidator: ClientPlugin<HttpCalValidatorConfig> = createClientPlugin(
+public val HttpCallValidator: ClientPlugin<HttpCallValidatorConfig> = createClientPlugin(
     "HttpResponseValidator",
-    ::HttpCalValidatorConfig
+    ::HttpCallValidatorConfig
 ) {
 
     val responseValidators: List<ResponseValidator> = pluginConfig.responseValidators.reversed()
@@ -186,7 +186,7 @@ private fun HttpRequest(builder: HttpRequestBuilder) = object : HttpRequest {
 /**
  * Install [HttpCallValidator] with [block] configuration.
  */
-public fun HttpClientConfig<*>.HttpResponseValidator(block: HttpCalValidatorConfig.() -> Unit) {
+public fun HttpClientConfig<*>.HttpResponseValidator(block: HttpCallValidatorConfig.() -> Unit) {
     install(HttpCallValidator, block)
 }
 


### PR DESCRIPTION
Fix [KTOR-6625](https://youtrack.jetbrains.com/issue/KTOR-6625) HttpCalValidatorConfig class name is misspelled