### PR TITLE
KTOR-6574 Fix duplicate headers in ServletApplicationEngine with Tomcat

### DIFF
--- a/ktor-client/ktor-client-core/api/ktor-client-core.api
+++ b/ktor-client/ktor-client-core/api/ktor-client-core.api
@@ -296,16 +296,6 @@ public final class io/ktor/client/plugins/DoubleReceivePluginKt {
 	public static final fun skipSavingBody (Lio/ktor/client/request/HttpRequestBuilder;)V
 }
 
-public final class io/ktor/client/plugins/HttpCalValidatorConfig {
-	public fun <init> ()V
-	public final fun getExpectSuccess ()Z
-	public final fun handleResponseException (Lkotlin/jvm/functions/Function2;)V
-	public final fun handleResponseException (Lkotlin/jvm/functions/Function3;)V
-	public final fun handleResponseExceptionWithRequest (Lkotlin/jvm/functions/Function3;)V
-	public final fun setExpectSuccess (Z)V
-	public final fun validateResponse (Lkotlin/jvm/functions/Function2;)V
-}
-
 public final class io/ktor/client/plugins/HttpCallValidatorConfig {
 	public fun <init> ()V
 	public final fun getExpectSuccess ()Z

--- a/ktor-server/ktor-server-cio/api/ktor-server-cio.api
+++ b/ktor-server/ktor-server-cio/api/ktor-server-cio.api
@@ -78,12 +78,3 @@ public final class io/ktor/server/cio/backend/ServerRequestScope : kotlinx/corou
 	public final fun withContext (Lkotlin/coroutines/CoroutineContext;)Lio/ktor/server/cio/backend/ServerRequestScope;
 }
 
-public final class io/ktor/server/cio/internal/WeakTimeoutQueue {
-	public fun <init> (JLkotlin/jvm/functions/Function0;)V
-	public synthetic fun <init> (JLkotlin/jvm/functions/Function0;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun cancel ()V
-	public final fun getTimeoutMillis ()J
-	public final fun process ()V
-	public final fun withTimeout (Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-}
-

--- a/ktor-server/ktor-server-servlet-jakarta/api/ktor-server-servlet-jakarta.api
+++ b/ktor-server/ktor-server-servlet-jakarta/api/ktor-server-servlet-jakarta.api
@@ -74,6 +74,7 @@ public class io/ktor/server/servlet/jakarta/ServletApplicationEngine : io/ktor/s
 	protected fun getEnginePipeline ()Lio/ktor/server/engine/EnginePipeline;
 	public final fun getEnvironment ()Lio/ktor/server/application/ApplicationEnvironment;
 	protected fun getLogger ()Lorg/slf4j/Logger;
+	protected fun getManagedByEngineHeaders ()Ljava/util/Set;
 	protected fun getUpgrade ()Lio/ktor/server/servlet/jakarta/ServletUpgrade;
 	public fun init ()V
 }

--- a/ktor-server/ktor-server-servlet-jakarta/jvm/src/io/ktor/server/servlet/jakarta/ServletApplicationEngine.kt
+++ b/ktor-server/ktor-server-servlet-jakarta/jvm/src/io/ktor/server/servlet/jakarta/ServletApplicationEngine.kt
@@ -5,6 +5,7 @@
 package io.ktor.server.servlet.jakarta
 
 import io.ktor.events.*
+import io.ktor.http.*
 import io.ktor.server.application.*
 import io.ktor.server.config.*
 import io.ktor.server.config.ConfigLoader.Companion.load
@@ -19,6 +20,20 @@ import kotlin.coroutines.*
  */
 @MultipartConfig
 public open class ServletApplicationEngine : KtorServlet() {
+
+    override val managedByEngineHeaders: Set<String>
+        get() {
+            servletContext.getAttribute(ApplicationAttributeKey)?.let {
+                return emptySet()
+            }
+
+            val servletContext = servletContext
+            return if ("tomcat" in (servletContext.serverInfo?.toLowerCasePreservingASCIIRules() ?: "")) {
+                setOf(HttpHeaders.TransferEncoding, HttpHeaders.Connection)
+            } else {
+                emptySet()
+            }
+        }
 
     private val embeddedServer: EmbeddedServer<ApplicationEngine, ApplicationEngine.Configuration>? by lazy {
         servletContext.getAttribute(ApplicationAttributeKey)?.let {

--- a/ktor-server/ktor-server-servlet-jakarta/jvm/test/io/ktor/tests/servlet/jakarta/ConfigTest.kt
+++ b/ktor-server/ktor-server-servlet-jakarta/jvm/test/io/ktor/tests/servlet/jakarta/ConfigTest.kt
@@ -36,6 +36,7 @@ class ConfigTest {
             every { contextPath } returns "/"
             every { getAttribute(ApplicationAttributeKey) } returns null
             every { getAttribute(EnvironmentAttributeKey) } returns null
+            every { serverInfo } returns ""
         }
 
         val config = mockk<ServletConfig> {
@@ -70,6 +71,7 @@ class ConfigTest {
             every { contextPath } returns "/"
             every { getAttribute(ApplicationAttributeKey) } returns null
             every { getAttribute(EnvironmentAttributeKey) } returns null
+            every { serverInfo } returns ""
         }
 
         val config = mockk<ServletConfig> {

--- a/ktor-server/ktor-server-servlet/api/ktor-server-servlet.api
+++ b/ktor-server/ktor-server-servlet/api/ktor-server-servlet.api
@@ -74,6 +74,7 @@ public class io/ktor/server/servlet/ServletApplicationEngine : io/ktor/server/se
 	protected fun getEnginePipeline ()Lio/ktor/server/engine/EnginePipeline;
 	public final fun getEnvironment ()Lio/ktor/server/application/ApplicationEnvironment;
 	protected fun getLogger ()Lorg/slf4j/Logger;
+	protected fun getManagedByEngineHeaders ()Ljava/util/Set;
 	protected fun getUpgrade ()Lio/ktor/server/servlet/ServletUpgrade;
 	public fun init ()V
 }

--- a/ktor-server/ktor-server-servlet/jvm/src/io/ktor/server/servlet/ServletApplicationEngine.kt
+++ b/ktor-server/ktor-server-servlet/jvm/src/io/ktor/server/servlet/ServletApplicationEngine.kt
@@ -10,8 +10,10 @@ import io.ktor.server.application.*
 import io.ktor.server.config.*
 import io.ktor.server.config.ConfigLoader.Companion.load
 import io.ktor.server.engine.*
+import io.ktor.server.servlet.ServletApplicationEngine.Companion.ApplicationAttributeKey
 import io.ktor.util.*
 import org.slf4j.*
+import javax.servlet.*
 import javax.servlet.annotation.*
 import kotlin.coroutines.*
 
@@ -22,17 +24,10 @@ import kotlin.coroutines.*
 public open class ServletApplicationEngine : KtorServlet() {
 
     override val managedByEngineHeaders: Set<String>
-        get() {
-            servletContext.getAttribute(ApplicationAttributeKey)?.let {
-                return emptySet()
-            }
-
-            val servletContext = servletContext
-            return if ("tomcat" in (servletContext.serverInfo?.toLowerCasePreservingASCIIRules() ?: "")) {
-                setOf(HttpHeaders.TransferEncoding, HttpHeaders.Connection)
-            } else {
-                emptySet()
-            }
+        get() = if (servletContext.isTomcat()) {
+            setOf(HttpHeaders.TransferEncoding, HttpHeaders.Connection)
+        } else {
+            emptySet()
         }
 
     private val embeddedServer: EmbeddedServer<ApplicationEngine, ApplicationEngine.Configuration>? by lazy {
@@ -170,3 +165,6 @@ private object EmptyEngineFactory : ApplicationEngineFactory<ApplicationEngine, 
         }
     }
 }
+
+internal fun ServletContext.isTomcat() =
+    getAttribute(ApplicationAttributeKey) == null && serverInfo.contains("tomcat", ignoreCase = true)

--- a/ktor-server/ktor-server-servlet/jvm/src/io/ktor/server/servlet/ServletApplicationEngine.kt
+++ b/ktor-server/ktor-server-servlet/jvm/src/io/ktor/server/servlet/ServletApplicationEngine.kt
@@ -5,6 +5,7 @@
 package io.ktor.server.servlet
 
 import io.ktor.events.*
+import io.ktor.http.*
 import io.ktor.server.application.*
 import io.ktor.server.config.*
 import io.ktor.server.config.ConfigLoader.Companion.load
@@ -19,6 +20,20 @@ import kotlin.coroutines.*
  */
 @MultipartConfig
 public open class ServletApplicationEngine : KtorServlet() {
+
+    override val managedByEngineHeaders: Set<String>
+        get() {
+            servletContext.getAttribute(ApplicationAttributeKey)?.let {
+                return emptySet()
+            }
+
+            val servletContext = servletContext
+            return if ("tomcat" in (servletContext.serverInfo?.toLowerCasePreservingASCIIRules() ?: "")) {
+                setOf(HttpHeaders.TransferEncoding, HttpHeaders.Connection)
+            } else {
+                emptySet()
+            }
+        }
 
     private val embeddedServer: EmbeddedServer<ApplicationEngine, ApplicationEngine.Configuration>? by lazy {
         servletContext.getAttribute(ApplicationAttributeKey)?.let {

--- a/ktor-server/ktor-server-servlet/jvm/test/io/ktor/tests/servlet/ConfigTest.kt
+++ b/ktor-server/ktor-server-servlet/jvm/test/io/ktor/tests/servlet/ConfigTest.kt
@@ -36,6 +36,7 @@ class ConfigTest {
             every { contextPath } returns "/"
             every { getAttribute(ApplicationAttributeKey) } returns null
             every { getAttribute(EnvironmentAttributeKey) } returns null
+            every { serverInfo } returns ""
         }
 
         val config = mockk<ServletConfig> {
@@ -70,6 +71,7 @@ class ConfigTest {
             every { contextPath } returns "/"
             every { getAttribute(ApplicationAttributeKey) } returns null
             every { getAttribute(EnvironmentAttributeKey) } returns null
+            every { serverInfo } returns ""
         }
 
         val config = mockk<ServletConfig> {


### PR DESCRIPTION
**Subsystem**
Server: ktor-server-servlet, ktor-server-servlet-jakarta

**Motivation**
[KTOR-6574](https://youtrack.jetbrains.com/issue/KTOR-6574/Double-Transfer-Encoding-header-while-using-respondOutputStream-on-Tomcat)
If Ktor project is running as a [WAR](https://ktor.io/docs/war.html) application under the Tomcat application server, a user has duplicate headers `Transfer-Encoding` and `Connection` in response.

**Solution**
The problem is on the `Tomcat` side or `Gretty` + `Tomcat` side because the user doesn't use `Tomcat` from Ktor, only `ServletApplicationEngine` is used. The solution is to configure the `managedByEngineHeaders` property in `ServletApplicationEngine`
Also, I gave in to write test since it's reproducible with gretty and it was hard to run test as WAR under the Tomcat but I tested it locally by publish to maven local and run in side project using gretty plugin.
