### PR TITLE
KTOR-3290 Add SSE support for test engine

### DIFF
--- a/ktor-server/ktor-server-plugins/ktor-server-sse/build.gradle.kts
+++ b/ktor-server/ktor-server-plugins/ktor-server-sse/build.gradle.kts
@@ -6,4 +6,10 @@ kotlin.sourceSets {
             api(project(":ktor-shared:ktor-sse"))
         }
     }
+
+    jvmAndNixTest {
+        dependencies {
+            api(project(":ktor-client:ktor-client-core"))
+        }
+    }
 }

--- a/ktor-server/ktor-server-plugins/ktor-server-thymeleaf/jvm/src/io/ktor/server/thymeleaf/RespondTemplate.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-thymeleaf/jvm/src/io/ktor/server/thymeleaf/RespondTemplate.kt
@@ -18,5 +18,5 @@ public suspend fun ApplicationCall.respondTemplate(
     etag: String? = null,
     contentType: ContentType = ContentType.Text.Html.withCharset(Charsets.UTF_8),
     locale: Locale = Locale.getDefault(),
-    status: HttpStatusCode = HttpStatusCode.OK    
+    status: HttpStatusCode = HttpStatusCode.OK
 ): Unit = respond(status, ThymeleafContent(template, model, etag, contentType, locale))

--- a/ktor-server/ktor-server-test-host/jvmAndNix/src/io/ktor/server/testing/client/DelegatingTestClientEngine.kt
+++ b/ktor-server/ktor-server-test-host/jvmAndNix/src/io/ktor/server/testing/client/DelegatingTestClientEngine.kt
@@ -6,6 +6,7 @@ package io.ktor.server.testing.client
 
 import io.ktor.client.engine.*
 import io.ktor.client.plugins.*
+import io.ktor.client.plugins.sse.*
 import io.ktor.client.plugins.websocket.*
 import io.ktor.client.request.*
 import io.ktor.http.*
@@ -19,7 +20,7 @@ internal class DelegatingTestClientEngine(
 ) : HttpClientEngineBase("delegating-test-engine") {
 
     override val supportedCapabilities =
-        setOf<HttpClientEngineCapability<*>>(WebSocketCapability, HttpTimeoutCapability)
+        setOf<HttpClientEngineCapability<*>>(WebSocketCapability, HttpTimeoutCapability, SSECapability)
 
     private val appEngine by lazy { config.testApplicationProvder().server.engine }
     private val externalEngines by lazy {

--- a/ktor-server/ktor-server-test-host/jvmAndNix/src/io/ktor/server/testing/client/TestHttpClientEngine.kt
+++ b/ktor-server/ktor-server-test-host/jvmAndNix/src/io/ktor/server/testing/client/TestHttpClientEngine.kt
@@ -78,7 +78,6 @@ class TestHttpClientEngine(override val config: TestHttpClientConfig) : HttpClie
             responseBody,
             callContext
         )
-
     }
 
     private suspend fun runRequest(

--- a/ktor-server/ktor-server-test-host/jvmAndNix/src/io/ktor/server/testing/client/TestHttpClientEngine.kt
+++ b/ktor-server/ktor-server-test-host/jvmAndNix/src/io/ktor/server/testing/client/TestHttpClientEngine.kt
@@ -6,6 +6,7 @@ package io.ktor.server.testing.client
 
 import io.ktor.client.call.*
 import io.ktor.client.engine.*
+import io.ktor.client.plugins.sse.*
 import io.ktor.client.request.*
 import io.ktor.http.*
 import io.ktor.http.content.*
@@ -40,9 +41,10 @@ class TestHttpClientEngine(override val config: TestHttpClientConfig) : HttpClie
 
     @OptIn(InternalAPI::class)
     override suspend fun execute(data: HttpRequestData): HttpResponseData {
+        val callContext = callContext()
         if (data.isUpgradeRequest()) {
             val (testServerCall, session) = with(data) {
-                bridge.runWebSocketRequest(url.fullPath, headers, body, callContext())
+                bridge.runWebSocketRequest(url.fullPath, headers, body, callContext)
             }
             return with(testServerCall.response) {
                 httpResponseData(session)
@@ -52,10 +54,31 @@ class TestHttpClientEngine(override val config: TestHttpClientConfig) : HttpClie
         val testServerCall = with(data) {
             runRequest(method, url, headers, body, url.protocol)
         }
+        val response = testServerCall.response
+        val status = response.statusOrNotFound()
+        val headers = response.headers.allValues().takeUnless { it.isEmpty() } ?: Headers
+            .build { append(HttpHeaders.ContentLength, "0") }
+        val body = ByteReadChannel(response.byteContent ?: byteArrayOf())
 
-        return with(testServerCall.response) {
-            httpResponseData(ByteReadChannel(byteContent ?: byteArrayOf()))
+        val responseBody: Any = if (needToProcessSSE(data, status, headers)) {
+            DefaultClientSSESession(
+                data.body as SSEClientContent,
+                body,
+                callContext
+            )
+        } else {
+            body
         }
+
+        return HttpResponseData(
+            status,
+            GMTDate(),
+            headers,
+            HttpProtocolVersion.HTTP_1_1,
+            responseBody,
+            callContext
+        )
+
     }
 
     private suspend fun runRequest(
@@ -80,7 +103,7 @@ class TestHttpClientEngine(override val config: TestHttpClientConfig) : HttpClie
 
     @OptIn(InternalAPI::class)
     private suspend fun TestApplicationResponse.httpResponseData(body: Any) = HttpResponseData(
-        status() ?: HttpStatusCode.NotFound,
+        statusOrNotFound(),
         GMTDate(),
         headers.allValues().takeUnless { it.isEmpty() } ?: Headers
             .build { append(HttpHeaders.ContentLength, "0") },
@@ -120,4 +143,6 @@ class TestHttpClientEngine(override val config: TestHttpClientConfig) : HttpClie
 
         is OutgoingContent.ProtocolUpgrade -> throw UnsupportedContentTypeException(this)
     }
+
+    private fun TestApplicationResponse.statusOrNotFound() = status() ?: HttpStatusCode.NotFound
 }

--- a/ktor-shared/ktor-junit/jvm/src/io/ktor/junit/RetrySupport.kt
+++ b/ktor-shared/ktor-junit/jvm/src/io/ktor/junit/RetrySupport.kt
@@ -20,7 +20,9 @@ class RetrySupport : TestTemplateInvocationContextProvider {
         return context.testMethod.isPresent && context.testMethod.get().isAnnotationPresent(RetryableTest::class.java)
     }
 
-    override fun provideTestTemplateInvocationContexts(context: ExtensionContext): Stream<TestTemplateInvocationContext> {
+    override fun provideTestTemplateInvocationContexts(
+        context: ExtensionContext
+    ): Stream<TestTemplateInvocationContext> {
         val testMethod = context.testMethod.get()
         val annotation = testMethod.getAnnotation(RetryableTest::class.java)
 


### PR DESCRIPTION
**Subsystem**
Server sse

**Motivation**
We have an old ticket [KTOR-3290](https://youtrack.jetbrains.com/issue/KTOR-3290) with [PR](https://github.com/ktorio/ktor/pull/2659). However, it became outdated because we have SSE support now, so we can just add a support for test to engine to have simple way to test


