### PR TITLE
KTOR-3159 Allow secure cookie with unencrypted response

### DIFF
--- a/ktor-server/ktor-server-core/api/ktor-server-core.api
+++ b/ktor-server/ktor-server-core/api/ktor-server-core.api
@@ -1177,7 +1177,7 @@ public abstract interface class io/ktor/server/response/PipelineResponse : io/kt
 }
 
 public final class io/ktor/server/response/ResponseCookies {
-	public fun <init> (Lio/ktor/server/response/PipelineResponse;Z)V
+	public fun <init> (Lio/ktor/server/response/PipelineResponse;)V
 	public final fun append (Lio/ktor/http/Cookie;)V
 	public final fun append (Ljava/lang/String;Ljava/lang/String;Lio/ktor/http/CookieEncoding;Ljava/lang/Long;Lio/ktor/util/date/GMTDate;Ljava/lang/String;Ljava/lang/String;ZZLjava/util/Map;)V
 	public static synthetic fun append$default (Lio/ktor/server/response/ResponseCookies;Ljava/lang/String;Ljava/lang/String;Lio/ktor/http/CookieEncoding;Ljava/lang/Long;Lio/ktor/util/date/GMTDate;Ljava/lang/String;Ljava/lang/String;ZZLjava/util/Map;ILjava/lang/Object;)V

--- a/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/engine/BaseApplicationResponse.kt
+++ b/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/engine/BaseApplicationResponse.kt
@@ -30,7 +30,7 @@ public abstract class BaseApplicationResponse(
         private set
 
     override val cookies: ResponseCookies by lazy {
-        ResponseCookies(this, call.request.origin.scheme == "https" || call.request.origin.scheme == "wss")
+        ResponseCookies(this)
     }
 
     override fun status(): HttpStatusCode? = _status

--- a/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/response/ResponseCookies.kt
+++ b/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/response/ResponseCookies.kt
@@ -11,10 +11,7 @@ import io.ktor.util.date.*
  * Server's response cookies.
  * @see [ApplicationResponse.cookies]
  */
-public class ResponseCookies(
-    private val response: PipelineResponse,
-    private val secureTransport: Boolean
-) {
+public class ResponseCookies(private val response: PipelineResponse) {
     /**
      * Gets a cookie from a response's `Set-Cookie` header.
      */
@@ -27,9 +24,6 @@ public class ResponseCookies(
      * Appends a cookie [item] using the `Set-Cookie` response header.
      */
     public fun append(item: Cookie) {
-        if (item.secure && !secureTransport) {
-            throw IllegalArgumentException("You should set secure cookie only via secure transport (HTTPS)")
-        }
         response.headers.append("Set-Cookie", renderSetCookieHeader(item))
     }
 

--- a/ktor-server/ktor-server-tests/jvmAndNix/test/io/ktor/tests/server/plugins/CookiesTest.kt
+++ b/ktor-server/ktor-server-tests/jvmAndNix/test/io/ktor/tests/server/plugins/CookiesTest.kt
@@ -4,6 +4,7 @@
 
 package io.ktor.tests.server.plugins
 
+import io.ktor.client.request.*
 import io.ktor.http.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
@@ -120,36 +121,21 @@ class CookiesTest {
         }
     }
 
+    /*
+     * We do not enforce that Secure flag matches protocol, because we could be behind a proxy.  There are other ways
+     * to ensure that secure cookies are not vulnerable to man-in-the-middle attacks, but we leave this to the
+     * developer.
+     */
     @Test
-    fun testSecureCookieHttp() {
-        withTestApplication {
-            application.routing {
-                get("/*") {
-                    call.response.cookies.append("S", "secret", secure = true)
-                    call.respond("ok")
-                }
-            }
-
-            assertFails {
-                handleRequest(HttpMethod.Get, "/1")
+    fun testSecureCookie() = testApplication {
+        routing {
+            get("/*") {
+                call.response.cookies.append("S", "secret", secure = true)
+                call.respond("ok")
             }
         }
-    }
-
-    @Test
-    fun testSecureCookieHttps() {
-        withTestApplication {
-            application.routing {
-                get("/*") {
-                    call.response.cookies.append("S", "secret", secure = true)
-                    call.respond("ok")
-                }
-            }
-
-            handleRequest(HttpMethod.Get, "/2") {
-                protocol = "https"
-            }
-        }
+        val response = client.get("/cookie-monster")
+        assertEquals("S=secret; Secure", response.headers["Set-Cookie"]?.cutSetCookieHeader())
     }
 
     private fun testSetCookies(expectedHeaderContent: String, block: PipelineResponse.() -> Unit) {


### PR DESCRIPTION
**Subsystem**
Server, Cookies, Security

**Motivation**
- [KTOR-3159](https://youtrack.jetbrains.com/issue/KTOR-3159) Allow to set secure cookie even with http scheme
- [KTOR-6593](https://youtrack.jetbrains.com/issue/KTOR-6593) Allow setting "Secure" flag for cookies on localhost

The general complaint is that we're preventing developers from setting secure cookies when their application is behind a secure proxy.  We assumed that we could still enforce the protocol by relying on the "X-Forwarded-Proto" for this configuration but it doesn't seem to be true for all cases.

**Solution**
This removes the protocol check for responding with the "Secure" flag on the "Set-Cookie" header.  Instead of enforcing the protocol adheres to the "Secure" rule, we rely on the application developer and client (i.e. browsers) to enforce this.