### PR TITLE
Fix for gradle doctor error when publishing native targets

### DIFF
--- a/buildSrc/src/main/kotlin/TargetsConfig.kt
+++ b/buildSrc/src/main/kotlin/TargetsConfig.kt
@@ -6,6 +6,7 @@
 import org.gradle.api.*
 import org.gradle.kotlin.dsl.*
 import org.jetbrains.kotlin.gradle.plugin.*
+import org.jetbrains.kotlin.gradle.plugin.mpp.*
 import java.io.*
 
 val Project.files: Array<File> get() = project.projectDir.listFiles() ?: emptyArray()
@@ -245,6 +246,11 @@ fun Project.configureTargets() {
                 tasks.findByName("linkDebugTestLinuxX64")?.onlyIf { HOST_NAME == "linux" }
                 tasks.findByName("linkDebugTestLinuxArm64")?.onlyIf { HOST_NAME == "linux" }
                 tasks.findByName("linkDebugTestMingwX64")?.onlyIf { HOST_NAME == "windows" }
+
+                // slower to cache, gradle gets angry
+                tasks.findByName("compileCommonMainKotlinMetadata")?.let { task ->
+                    task.outputs.cacheIf { false }
+                }
             }
         }
     }

--- a/ktor-client/ktor-client-mock/build.gradle.kts
+++ b/ktor-client/ktor-client-mock/build.gradle.kts
@@ -7,6 +7,7 @@ kotlin.sourceSets {
         dependencies {
             api(project(":ktor-http"))
             api(project(":ktor-client:ktor-client-core"))
+            api(libs.kotlin.stdlib)
         }
     }
 


### PR DESCRIPTION
**Subsystem**
Build

**Motivation**
Consistent failures in "Allocation Tests" due to a gradle cache issue when publishing native targets.

**Solution**
Disable build cache on select tasks where they are considered faster than caching (make gradle happy)

