### PR TITLE
Fix for publications build

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,7 +4,7 @@ kotlinx-html-version = "0.10.1"
 kotlinx-datetime = "0.5.0"
 coroutines-version = "1.7.3"
 atomicfu-version = "0.23.1"
-serialization-version = "1.6.2"
+serialization-version = "1.6.1"
 ktlint-version = "3.15.0"
 
 netty-version = "4.1.105.Final"


### PR DESCRIPTION
I noticed the allocation tests have been broken for the last few days due to a compilation issue in :ktor-client:ktor-client-mock:compileCommonMainKotlinMetadata.  After a bit of digging I narrowed it down to this commit 8891c452403530123b484a76a242344baff03ebd for upgrading the serialization version.  Reverting this for now until we can figure out why upgrading the serialization version is causing the common compilation to fail with missing stdlib references.