### PR TITLE
KTOR-6664 Cancel pending incoming messages if the session is closing

### DIFF
--- a/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/websocket/builders.kt
+++ b/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/websocket/builders.kt
@@ -101,6 +101,7 @@ public suspend fun HttpClient.webSocket(
             block(it)
         } finally {
             it.close()
+            it.incoming.cancel()
         }
     }
 }

--- a/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/WebSocketTest.kt
+++ b/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/WebSocketTest.kt
@@ -307,4 +307,19 @@ class WebSocketTest : ClientLoader() {
             }
         }
     }
+
+    @Test
+    fun testIncomingOverflow() = clientTests(ENGINES_WITHOUT_WS) {
+        config {
+            install(WebSockets)
+        }
+
+        test { client ->
+            client.webSocket("$TEST_WEBSOCKET_SERVER/websockets/echo") {
+                repeat(1000) {
+                    send("test")
+                }
+            }
+        }
+    }
 }

--- a/ktor-client/ktor-client-tests/jvm/src/io/ktor/client/tests/utils/ClientLoaderJvm.kt
+++ b/ktor-client/ktor-client-tests/jvm/src/io/ktor/client/tests/utils/ClientLoaderJvm.kt
@@ -64,7 +64,7 @@ actual abstract class ClientLoader actual constructor(val timeoutSeconds: Int) {
         )
         val notOnlyEngine = onlyWithEngine != null && engineName.lowercase(locale) != onlyWithEngine.lowercase(locale)
 
-        return platformShouldBeSkipped || engineShouldBeSkipped || notOnlyEngine
+        return (engineShouldBeSkipped && platformShouldBeSkipped) || notOnlyEngine
     }
 
     @OptIn(ExperimentalCoroutinesApi::class)


### PR DESCRIPTION
[KTOR-6664](https://youtrack.jetbrains.com/issue/KTOR-6664) WebSocket doesn't get terminated when runBlocking is used