### PR TITLE
Remove leading whitespace in service configuration

### DIFF
--- a/ktor-shared/ktor-serialization/ktor-serialization-kotlinx/ktor-serialization-kotlinx-json/jvm/resources/META-INF/services/io.ktor.serialization.kotlinx.KotlinxSerializationExtensionProvider
+++ b/ktor-shared/ktor-serialization/ktor-serialization-kotlinx/ktor-serialization-kotlinx-json/jvm/resources/META-INF/services/io.ktor.serialization.kotlinx.KotlinxSerializationExtensionProvider
@@ -1,1 +1,1 @@
- io.ktor.serialization.kotlinx.json.KotlinxSerializationJsonExtensionProvider
+io.ktor.serialization.kotlinx.json.KotlinxSerializationJsonExtensionProvider


### PR DESCRIPTION
Fix failed shadowJar ServiceFileTransformer relocation.

**Subsystem**
Client and Server, `kotlinx-serialization-json-jvm`.
Issue from 2.2.4 to 2.3.0 or later migration.

**Motivation**
When using [shadow](https://github.com/johnrengelman/shadow) to shade and relocate Ktor, a runtime `java.util.ServiceConfigurationError` is thrown.

> java.util.ServiceConfigurationError: shaded.io.ktor.serialization.kotlinx.KotlinxSerializationExtensionProvider: Provider io.ktor.serialization.kotlinx.json.KotlinxSerializationJsonExtensionProvider not found

**Solution**
Remove the leading whitespace in the service configuration `io.ktor.serialization.kotlinx.KotlinxSerializationExtensionProvider`. Whitespace causes shadow's [ServiceFileTransformer](https://github.com/johnrengelman/shadow/blob/9c5182d2d9c5f7141e4d2a525ec94d6111283cd9/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/relocation/SimpleRelocator.groovy#L152) to match classes incorrectly.

