### PR TITLE
add buildUrl

### DIFF
--- a/ktor-http/api/ktor-http.api
+++ b/ktor-http/api/ktor-http.api
@@ -992,6 +992,7 @@ public final class io/ktor/http/URLUtilsKt {
 	public static final fun Url (Lio/ktor/http/URLBuilder;)Lio/ktor/http/Url;
 	public static final fun Url (Ljava/lang/String;)Lio/ktor/http/Url;
 	public static final fun appendUrlFullPath (Ljava/lang/Appendable;Ljava/lang/String;Lio/ktor/http/ParametersBuilder;Z)V
+	public static final fun buildUrl (Lkotlin/jvm/functions/Function1;)Lio/ktor/http/Url;
 	public static final fun getFullPath (Lio/ktor/http/Url;)Ljava/lang/String;
 	public static final fun getHostWithPort (Lio/ktor/http/Url;)Ljava/lang/String;
 	public static final fun getHostWithPortIfSpecified (Lio/ktor/http/Url;)Ljava/lang/String;

--- a/ktor-http/common/src/io/ktor/http/URLUtils.kt
+++ b/ktor-http/common/src/io/ktor/http/URLUtils.kt
@@ -19,6 +19,12 @@ public fun Url(urlString: String): Url = URLBuilder(urlString).build()
 public fun Url(builder: URLBuilder): Url = URLBuilder().takeFrom(builder).build()
 
 /**
+ * Construct a [Url] by applying [block] an empty [UrlBuilder].
+ */
+public fun buildUrl(block: URLBuilder.() -> Unit): Url = URLBuilder().apply(block).build()
+
+
+/**
  * Construct [URLBuilder] from [urlString].
  */
 @Suppress("FunctionName")


### PR DESCRIPTION
like `buildString` but for URL's

**Subsystem**
http

**Motivation**
I dislike calling 
```kotlin
UrlBuilder().apply {
    // ...
}.build()
```
and yet seem to do it every-time I construct a URL.

**Solution**
```kotlin
public fun buildUrl(block: URLBuilder.() -> Unit): Url = URLBuilder().apply(block).build()
```

**Some examples**

with no `url`
```kotlin
fun issuer(region: String, userPoolId: String) = buildUrl {
    protocol = URLProtocol.HTTPS
    host = "cognito-idp.$region.amazonaws.com"
    appendPathSegments(userPoolId)
}
```

with `url`
```kotlin 
fun domain(region: String, userPoolId: String): Url = buildUrl {
    takeFrom(issuer(region, userPoolId))
    appendPathSegments(".well-known", ".jwks.json")
}
```

