### PR TITLE
KTOR-6695 Add configuration warning when nothing is provided for CSRF

### DIFF
--- a/ktor-server/ktor-server-plugins/ktor-server-csrf/jvmAndNix/src/io/ktor/server/plugins/csrf/CSRF.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-csrf/jvmAndNix/src/io/ktor/server/plugins/csrf/CSRF.kt
@@ -38,6 +38,11 @@ public val CSRF: RouteScopedPlugin<CSRFConfig> = createRouteScopedPlugin("CSRF",
     val headerChecks = pluginConfig.headerChecks
     val onFailure = pluginConfig.handleFailure
 
+    if (!checkHost && allowedOrigins.isEmpty() && headerChecks.isEmpty()) {
+        application.log.warn("No validation options provided for CSRF plugin - requests will not be verified!")
+        return@createRouteScopedPlugin
+    }
+
     onCall { call ->
 
         if (call.request.httpMethod in setOf(HttpMethod.Get, HttpMethod.Head, HttpMethod.Options)) {

--- a/ktor-server/ktor-server-plugins/ktor-server-csrf/jvmAndNix/src/io/ktor/server/plugins/csrf/CSRF.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-csrf/jvmAndNix/src/io/ktor/server/plugins/csrf/CSRF.kt
@@ -39,8 +39,16 @@ public val CSRF: RouteScopedPlugin<CSRFConfig> = createRouteScopedPlugin("CSRF",
     val onFailure = pluginConfig.handleFailure
 
     if (!checkHost && allowedOrigins.isEmpty() && headerChecks.isEmpty()) {
-        application.log.warn("No validation options provided for CSRF plugin - requests will not be verified!")
-        return@createRouteScopedPlugin
+        application.log.info("CSRF configuration is empty; defaulting to allow only local origins")
+        allowedOrigins.addAll(
+            listOf(
+                "localhost",
+                "127.0.0.1",
+                "0.0.0.0",
+            ).map {
+                buildUrl { host = it }
+            }
+        )
     }
 
     onCall { call ->

--- a/ktor-server/ktor-server-plugins/ktor-server-csrf/jvmAndNix/test/io/ktor/server/plugins/csrf/CSRFTest.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-csrf/jvmAndNix/test/io/ktor/server/plugins/csrf/CSRFTest.kt
@@ -10,6 +10,7 @@ import io.ktor.http.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
 import io.ktor.server.testing.*
+import org.slf4j.*
 import kotlin.test.*
 
 class CSRFTest {
@@ -226,6 +227,26 @@ class CSRFTest {
                 assertEquals("success", response.bodyAsText())
             }
         }
+    }
+
+    @Test
+    fun logsWarningWhenMisconfigured() {
+        val warnings = mutableListOf<String>()
+        val testLogger = object : Logger by LoggerFactory.getLogger("") {
+            override fun warn(message: String?) {
+                message?.let(warnings::add)
+            }
+        }
+        testApplication {
+            environment {
+                log = testLogger
+            }
+            install(CSRF)
+        }
+        assertEquals(
+            "No validation options provided for CSRF plugin - requests will not be verified!",
+            warnings.firstOrNull()
+        )
     }
 
     private fun ApplicationTestBuilder.configureCSRF(csrfOptions: CSRFConfig.() -> Unit) {


### PR DESCRIPTION
**Subsystem**
Server, CSRF

**Motivation**
- [KTOR-6695](https://youtrack.jetbrains.com/issue/KTOR-6695) CSRF: The allowOrigin method enables the Origin Header validation

**Solution**
After thinking about how to provide some default behaviour for the CSRF plugin, I am of the opinion that it would be unwise to select one of the mitigations automatically for the user.  Instead, we ought to report an error for when it is an empty configuration.  Personally, I'd rather throw an exception, but logging a warning should be enough.