### PR TITLE
KTOR-6701 CSRF match origin on host when default port is included

### DIFF
--- a/ktor-server/ktor-server-plugins/ktor-server-csrf/jvmAndNix/src/io/ktor/server/plugins/csrf/CSRF.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-csrf/jvmAndNix/src/io/ktor/server/plugins/csrf/CSRF.kt
@@ -44,7 +44,7 @@ public val CSRF: RouteScopedPlugin<CSRFConfig> = createRouteScopedPlugin("CSRF",
         if (checkHost) {
             val origin = call.originOrReferrerUrl() ?: return@onCall onFailure(call, "missing \"Origin\" header")
             val host = call.request.headers[HttpHeaders.Host]
-            if (host != origin.hostWithPortIfSpecified) {
+            if (host !in listOf(origin.hostWithPortIfSpecified, origin.hostWithPort)) {
                 return@onCall onFailure(
                     call,
                     "expected \"Origin\" [${origin.host}] host to match \"Host\" [$host] header value"

--- a/ktor-server/ktor-server-plugins/ktor-server-csrf/jvmAndNix/test/io/ktor/server/plugins/csrf/CSRFTest.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-csrf/jvmAndNix/test/io/ktor/server/plugins/csrf/CSRFTest.kt
@@ -173,7 +173,7 @@ class CSRFTest {
                 }
             }
             route("/no-csrf") {
-                post {
+                get {
                     call.respondText("success")
                 }
             }

--- a/ktor-server/ktor-server-plugins/ktor-server-csrf/jvmAndNix/test/io/ktor/server/plugins/csrf/CSRFTest.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-csrf/jvmAndNix/test/io/ktor/server/plugins/csrf/CSRFTest.kt
@@ -142,6 +142,23 @@ class CSRFTest {
         }
     }
 
+    @Test
+    fun worksWithDefaultPort() {
+        testApplication {
+            configureCSRF {
+                originMatchesHost()
+            }
+
+            client.post("/csrf") {
+                header("Host", "localhost:80")
+                header("Origin", "http://localhost:80")
+            }.let { response ->
+                assertEquals(200, response.status.value)
+                assertEquals("success", response.bodyAsText())
+            }
+        }
+    }
+
     private fun ApplicationTestBuilder.configureCSRF(csrfOptions: CSRFConfig.() -> Unit) {
         routing {
             route("/csrf") {
@@ -151,9 +168,12 @@ class CSRFTest {
                 get {
                     call.respondText("success")
                 }
+                post {
+                    call.respondText("success")
+                }
             }
             route("/no-csrf") {
-                get {
+                post {
                     call.respondText("success")
                 }
             }


### PR DESCRIPTION
**Subsystem**
Server, CSRF

**Motivation**
- [KTOR-6701](https://youtrack.jetbrains.com/issue/KTOR-6701) CSRF: false positive originMatchesHost validation when default port is explicitly defined

**Solution**
Always check origin with port in case it's explicitly specified.

