### PR TITLE
KTOR-6698 Skip safe HTTP methods for CSRF

### DIFF
--- a/ktor-server/ktor-server-plugins/ktor-server-csrf/jvmAndNix/src/io/ktor/server/plugins/csrf/CSRF.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-csrf/jvmAndNix/src/io/ktor/server/plugins/csrf/CSRF.kt
@@ -40,6 +40,9 @@ public val CSRF: RouteScopedPlugin<CSRFConfig> = createRouteScopedPlugin("CSRF",
 
     onCall { call ->
 
+        if (call.request.httpMethod in setOf(HttpMethod.Get, HttpMethod.Head, HttpMethod.Options))
+            return@onCall
+
         // Host standard header matches the Origin
         if (checkHost) {
             val origin = call.originOrReferrerUrl() ?: return@onCall onFailure(call, "missing \"Origin\" header")

--- a/ktor-server/ktor-server-plugins/ktor-server-csrf/jvmAndNix/src/io/ktor/server/plugins/csrf/CSRF.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-csrf/jvmAndNix/src/io/ktor/server/plugins/csrf/CSRF.kt
@@ -40,8 +40,9 @@ public val CSRF: RouteScopedPlugin<CSRFConfig> = createRouteScopedPlugin("CSRF",
 
     onCall { call ->
 
-        if (call.request.httpMethod in setOf(HttpMethod.Get, HttpMethod.Head, HttpMethod.Options))
+        if (call.request.httpMethod in setOf(HttpMethod.Get, HttpMethod.Head, HttpMethod.Options)) {
             return@onCall
+        }
 
         // Host standard header matches the Origin
         if (checkHost) {

--- a/ktor-server/ktor-server-plugins/ktor-server-csrf/jvmAndNix/test/io/ktor/server/plugins/csrf/CSRFTest.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-csrf/jvmAndNix/test/io/ktor/server/plugins/csrf/CSRFTest.kt
@@ -21,14 +21,14 @@ class CSRFTest {
                 allowOrigin("https://localhost:8080")
             }
 
-            assertEquals(200, client.get("/no-csrf").status.value)
+            assertEquals(200, client.post("/no-csrf").status.value)
 
-            client.get("/csrf").let { response ->
+            client.post("/csrf").let { response ->
                 assertEquals(400, response.status.value)
                 assertEquals("Cross-site request validation failed; missing \"Origin\" header", response.bodyAsText())
             }
 
-            client.get("/csrf") {
+            client.post("/csrf") {
                 headers[HttpHeaders.Origin] = "https://127.0.0.1:8080"
             }.let { response ->
                 assertEquals(400, response.status.value)
@@ -38,13 +38,13 @@ class CSRFTest {
                 )
             }
 
-            client.get("/csrf") {
+            client.post("/csrf") {
                 headers[HttpHeaders.Origin] = "https://localhost:8080"
             }.let { response ->
                 assertEquals(200, response.status.value)
             }
 
-            client.get("/csrf") {
+            client.post("/csrf") {
                 headers[HttpHeaders.Referrer] = "http://localhost:8080/redirect/from-here"
             }.let { response ->
                 assertEquals(200, response.status.value)
@@ -59,9 +59,9 @@ class CSRFTest {
                 originMatchesHost()
             }
 
-            assertEquals(200, client.get("/no-csrf").status.value)
+            assertEquals(200, client.post("/no-csrf").status.value)
 
-            client.get("/csrf") {
+            client.post("/csrf") {
                 headers[HttpHeaders.Origin] = "http://localhost:8080"
                 headers[HttpHeaders.Host] = "127.0.0.1:8080"
             }.let { response ->
@@ -73,7 +73,7 @@ class CSRFTest {
                 )
             }
 
-            client.get("/csrf") {
+            client.post("/csrf") {
                 headers[HttpHeaders.Origin] = "http://localhost:8080"
                 headers[HttpHeaders.Host] = "localhost:8080"
             }.let { response ->
@@ -89,12 +89,12 @@ class CSRFTest {
                 checkHeader("X-CSRF") { it == "1" }
             }
 
-            client.get("/csrf").let { response ->
+            client.post("/csrf").let { response ->
                 assertEquals(400, response.status.value)
                 assertEquals("Cross-site request validation failed; missing \"X-CSRF\" header", response.bodyAsText())
             }
 
-            client.get("/csrf") {
+            client.post("/csrf") {
                 headers["X-CSRF"] = "0"
             }.let { response ->
                 assertEquals(400, response.status.value)
@@ -104,7 +104,7 @@ class CSRFTest {
                 )
             }
 
-            client.get("/csrf") {
+            client.post("/csrf") {
                 headers["X-CSRF"] = "1"
             }.let { response ->
                 assertEquals(200, response.status.value)
@@ -128,16 +128,41 @@ class CSRFTest {
                 }
             }
 
-            client.get("/csrf") {
+            client.post("/csrf") {
                 headers[HttpHeaders.Origin] = "http://localhost:8080"
                 headers["X-CSRF"] = "http://localhost:8080".hashCode().toString(32)
             }.let { response ->
                 assertEquals(200, response.status.value)
             }
 
-            client.get("/csrf").let { response ->
+            client.post("/csrf").let { response ->
                 assertEquals(403, response.status.value)
                 assertEquals(customErrorMessage, response.bodyAsText())
+            }
+        }
+    }
+
+    @Test
+    fun ignoresSafeMethods() {
+        testApplication {
+            configureCSRF {
+                originMatchesHost()
+            }
+            val safeMethods = listOf(HttpMethod.Get, HttpMethod.Options, HttpMethod.Head)
+            val invalidRequestWithMethod: (HttpMethod) -> HttpRequestBuilder.() -> Unit = { m ->
+                {
+                    method = m
+                    headers[HttpHeaders.Origin] = "http://localhost:8080"
+                    headers[HttpHeaders.Host] = "127.0.0.1:8080"
+                }
+            }
+
+            for (m in HttpMethod.DefaultMethods - safeMethods.toSet()) {
+                assertEquals(400, client.request("/csrf", invalidRequestWithMethod(m)).status.value)
+            }
+
+            for (m in safeMethods) {
+                assertEquals(200, client.request("/csrf", invalidRequestWithMethod(m)).status.value)
             }
         }
     }
@@ -158,14 +183,14 @@ class CSRFTest {
                 }
             }
 
-            client.get("/csrf") {
+            client.post("/csrf") {
                 headers[HttpHeaders.Origin] = "http://localhost:8080"
                 headers["X-CSRF"] = "http://localhost:8080".hashCode().toString(32)
             }.let { response ->
                 assertEquals(200, response.status.value)
             }
 
-            client.get("/csrf").let { response ->
+            client.post("/csrf").let { response ->
                 val expectedMessage = "missing \"X-CSRF\" header"
                 assertEquals(400, response.status.value)
                 assertEquals("Cross-site request validation failed; $expectedMessage", response.bodyAsText())
@@ -197,7 +222,7 @@ class CSRFTest {
                 install(CSRF) {
                     csrfOptions()
                 }
-                get {
+                handle {
                     call.respondText("success")
                 }
                 post {
@@ -205,7 +230,7 @@ class CSRFTest {
                 }
             }
             route("/no-csrf") {
-                get {
+                handle {
                     call.respondText("success")
                 }
             }


### PR DESCRIPTION
**Subsystem**
Server, CSRF

**Motivation**
- [KTOR-6698](https://youtrack.jetbrains.com/issue/KTOR-6698) CSRF: validations probably shouldn't be applied to GET/HEAD/OPTIONS requests

**Solution**
Skips validation for GET, HEAD, and OPTIONS requests.

