### PR TITLE
KTOR-6666 Fix Ktor build problem; cannot compile native targets

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,7 +4,7 @@ kotlinx-html-version = "0.11.0"
 kotlinx-datetime = "0.5.0"
 coroutines-version = "1.7.3"
 atomicfu-version = "0.23.2"
-serialization-version = "1.6.2"
+serialization-version = "1.6.1" # Do not upgrade, 1.6.2 breaks maven publishing!
 ktlint-version = "3.15.0"
 
 netty-version = "4.1.106.Final"


### PR DESCRIPTION
**Subsystem**
Server, build

**Motivation**
- [KTOR-6666](https://youtrack.jetbrains.com/issue/KTOR-6666)

**Solution**
Looks like the serialization lib got updated again, this will fix the maven publishing / allocation tests.  I'll try to find a solution that allows us to upgrade this.

