### PR TITLE
KTOR-6614 Fix SSE client breaking non-SSE requests

### DIFF
--- a/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/sse/SSE.kt
+++ b/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/sse/SSE.kt
@@ -49,6 +49,10 @@ public val SSE: ClientPlugin<SSEConfig> = createClientPlugin(
         LOGGER.trace("Sending SSE request ${request.url}")
         request.setCapability(SSECapability, Unit)
 
+        if (getAttributeValue(request, sseRequestAttr) != true) {
+            return@transformRequestBody null
+        }
+
         val localReconnectionTime = getAttributeValue(request, reconnectionTimeAttr)
         val localShowCommentEvents = getAttributeValue(request, showCommentEventsAttr)
         val localShowRetryEvents = getAttributeValue(request, showRetryEventsAttr)

--- a/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/sse/SSE.kt
+++ b/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/sse/SSE.kt
@@ -46,12 +46,11 @@ public val SSE: ClientPlugin<SSEConfig> = createClientPlugin(
     val showRetryEvents = pluginConfig.showRetryEvents
 
     transformRequestBody { request, _, _ ->
-        LOGGER.trace("Sending SSE request ${request.url}")
-        request.setCapability(SSECapability, Unit)
-
         if (getAttributeValue(request, sseRequestAttr) != true) {
             return@transformRequestBody null
         }
+        LOGGER.trace("Sending SSE request ${request.url}")
+        request.setCapability(SSECapability, Unit)
 
         val localReconnectionTime = getAttributeValue(request, reconnectionTimeAttr)
         val localShowCommentEvents = getAttributeValue(request, showCommentEventsAttr)

--- a/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/sse/builders.kt
+++ b/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/sse/builders.kt
@@ -13,6 +13,7 @@ import io.ktor.util.*
 import kotlinx.coroutines.*
 import kotlin.time.*
 
+internal val sseRequestAttr = AttributeKey<Boolean>("SSERequestFlag")
 internal val reconnectionTimeAttr = AttributeKey<Duration>("SSEReconnectionTime")
 internal val showCommentEventsAttr = AttributeKey<Boolean>("SSEShowCommentEvents")
 internal val showRetryEventsAttr = AttributeKey<Boolean>("SSEShowRetryEvents")
@@ -40,6 +41,7 @@ public suspend fun HttpClient.serverSentEventsSession(
     val sessionDeferred = CompletableDeferred<ClientSSESession>()
     val statement = prepareRequest {
         block()
+        addAttribute(sseRequestAttr, true)
         addAttribute(reconnectionTimeAttr, reconnectionTime)
         addAttribute(showCommentEventsAttr, showCommentEvents)
         addAttribute(showRetryEventsAttr, showRetryEvents)

--- a/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/plugins/ServerSentEventsTest.kt
+++ b/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/plugins/ServerSentEventsTest.kt
@@ -9,6 +9,8 @@ import io.ktor.client.plugins.*
 import io.ktor.client.plugins.auth.*
 import io.ktor.client.plugins.auth.providers.*
 import io.ktor.client.plugins.sse.*
+import io.ktor.client.request.*
+import io.ktor.client.statement.*
 import io.ktor.client.tests.utils.*
 import io.ktor.http.*
 import io.ktor.sse.*
@@ -32,6 +34,20 @@ class ServerSentEventsTest : ClientLoader(timeoutSeconds = 120) {
             client.serverSentEvents {}
         }.let {
             kotlin.test.assertContains(it.message!!, SSE.key.name)
+        }
+    }
+
+    @Test
+    fun normalRequestsWorkWithSSEInstalled() = clientTests {
+        config {
+            install(SSE)
+        }
+
+        test { client ->
+            val response = client.post("$TEST_SERVER/content/echo") {
+                setBody("Hello")
+            }
+            assertEquals("Hello", response.bodyAsText())
         }
     }
 


### PR DESCRIPTION
**Subsystem**
Client, SSE

**Motivation**
- [KTOR-6614](https://youtrack.jetbrains.com/issue/KTOR-6614) Installing SSE breaks GET/POST functionality

**Solution**
Added an attribute flag to enable SSE transform; previously it would apply to all requests.

