### PR TITLE
Turned of forcing version update for kotlin native dependencies.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -36,7 +36,10 @@ buildscript {
 
         configurations.classpath {
             resolutionStrategy.eachDependency {
-                if (requested.group == "org.jetbrains.kotlin") {
+                if (requested.group == "org.jetbrains.kotlin"
+                    // on dev environmet k/n has not the same version as KGP. Could be removed after KT-62826 is done.
+                    && requested.name != "kotlin-native"
+                    && requested.name != "kotlin-native-prebuilt") {
                     useVersion(kotlin_version!!)
                 }
             }
@@ -155,7 +158,10 @@ allprojects {
     configurations.configureEach {
         if (isCanBeResolved) {
             resolutionStrategy.eachDependency {
-                if (requested.group == "org.jetbrains.kotlin") {
+                if (requested.group == "org.jetbrains.kotlin"
+                    // on dev environmet k/n has not the same version as KGP. Could be removed after KT-62826 is done.
+                    && requested.name != "kotlin-native"
+                    && requested.name != "kotlin-native-prebuilt") {
                     useVersion(kotlinVersion)
                 }
             }


### PR DESCRIPTION
On CI environment, it is a common situation to have different versions for kotlin-native and Kotlin plugin because we don't push all the Kotlin verisons to the dev repo.

**Subsystem**
build script

**Motivation**
This PR solves problem with different versions for "org.jetbrains.kotlin" dependencies and "org.jetbrains.kotlin:kotlin-native-prebuilt" on CI.

**Solution**
Turned off version alignment

