### PR TITLE
Add better description of `TLSConfigBuilder.addCertificateChain()`

### DIFF
--- a/ktor-network/ktor-network-tls/jvm/src/io/ktor/network/tls/TLSConfigBuilder.kt
+++ b/ktor-network/ktor-network-tls/jvm/src/io/ktor/network/tls/TLSConfigBuilder.kt
@@ -16,6 +16,8 @@ import javax.net.ssl.*
 public actual class TLSConfigBuilder {
     /**
      * List of client certificate chains with private keys.
+     *
+     * The Chain will be used only if the first certificate in the chain is issued by server's certificate.
      */
     public val certificates: MutableList<CertificateAndKey> = mutableListOf()
 
@@ -76,6 +78,8 @@ public actual fun TLSConfigBuilder.takeFrom(other: TLSConfigBuilder) {
 
 /**
  * Add client certificate chain to use.
+ *
+ * It will be used only if the first certificate in the chain is issued by server's certificate.
  */
 public fun TLSConfigBuilder.addCertificateChain(chain: Array<X509Certificate>, key: PrivateKey) {
     certificates += CertificateAndKey(chain, key)


### PR DESCRIPTION
**Subsystem**
Client (tls, two-way authentication)

**Motivation**
It is not clear when the client will use the certificate. This description could explain to others why their client does not send the certificate to the server.

**Solution**
Just add better description of it.