### PR TITLE
KTOR-6697 CSRF: confusing error message when Host has no port and hosts match

### DIFF
--- a/ktor-client/ktor-client-cio/jvmAndNix/src/io/ktor/client/engine/cio/utils.kt
+++ b/ktor-client/ktor-client-cio/jvmAndNix/src/io/ktor/client/engine/cio/utils.kt
@@ -142,7 +142,11 @@ internal suspend fun writeBody(
     }
 }
 
-private suspend fun processOutgoingContent(request: HttpRequestData, body: OutgoingContent, channel: ByteWriteChannel): Boolean {
+private suspend fun processOutgoingContent(
+    request: HttpRequestData,
+    body: OutgoingContent,
+    channel: ByteWriteChannel
+): Boolean {
     when (body) {
         is OutgoingContent.NoContent -> return false
         is OutgoingContent.ByteArrayContent -> channel.writeFully(body.bytes())

--- a/ktor-server/ktor-server-plugins/ktor-server-csrf/jvmAndNix/src/io/ktor/server/plugins/csrf/CSRF.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-csrf/jvmAndNix/src/io/ktor/server/plugins/csrf/CSRF.kt
@@ -51,7 +51,7 @@ public val CSRF: RouteScopedPlugin<CSRFConfig> = createRouteScopedPlugin("CSRF",
             if (host !in listOf(origin.hostWithPortIfSpecified, origin.hostWithPort)) {
                 return@onCall onFailure(
                     call,
-                    "expected \"Origin\" [${origin.host}] host to match \"Host\" [$host] header value"
+                    "expected \"Origin\" [${origin.hostWithPortIfSpecified}] host to match \"Host\" [$host] header value"
                 )
             }
         }

--- a/ktor-server/ktor-server-plugins/ktor-server-csrf/jvmAndNix/src/io/ktor/server/plugins/csrf/CSRF.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-csrf/jvmAndNix/src/io/ktor/server/plugins/csrf/CSRF.kt
@@ -51,7 +51,8 @@ public val CSRF: RouteScopedPlugin<CSRFConfig> = createRouteScopedPlugin("CSRF",
             if (host !in listOf(origin.hostWithPortIfSpecified, origin.hostWithPort)) {
                 return@onCall onFailure(
                     call,
-                    "expected \"Origin\" [${origin.hostWithPortIfSpecified}] host to match \"Host\" [$host] header value"
+                    "expected \"Origin\" [${origin.hostWithPortIfSpecified}] host " +
+                        "to match \"Host\" [$host] header value"
                 )
             }
         }

--- a/ktor-server/ktor-server-plugins/ktor-server-csrf/jvmAndNix/test/io/ktor/server/plugins/csrf/CSRFTest.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-csrf/jvmAndNix/test/io/ktor/server/plugins/csrf/CSRFTest.kt
@@ -68,7 +68,19 @@ class CSRFTest {
                 assertEquals(400, response.status.value)
                 assertEquals(
                     "Cross-site request validation failed; " +
-                        "expected \"Origin\" [localhost] host to match \"Host\" [127.0.0.1:8080] header value",
+                        "expected \"Origin\" [localhost:8080] host to match \"Host\" [127.0.0.1:8080] header value",
+                    response.bodyAsText()
+                )
+            }
+
+            client.post("/csrf") {
+                headers[HttpHeaders.Origin] = "http://localhost:8080"
+                headers[HttpHeaders.Host] = "localhost"
+            }.let { response ->
+                assertEquals(400, response.status.value)
+                assertEquals(
+                    "Cross-site request validation failed; " +
+                        "expected \"Origin\" [localhost:8080] host to match \"Host\" [localhost] header value",
                     response.bodyAsText()
                 )
             }


### PR DESCRIPTION
**Subsystem**
Server, CSRF

**Motivation**
- [KTOR-6697](https://youtrack.jetbrains.com/issue/KTOR-6697) CSRF: confusing error message when Host has no port and the hosts match

**Solution**
Error message origin includes port when specified.

