### PR TITLE
Disable failing https test

### DIFF
--- a/ktor-client/ktor-client-cio/jvm/test/io/ktor/client/engine/cio/CIOSpecificHttpsTest.kt
+++ b/ktor-client/ktor-client-cio/jvm/test/io/ktor/client/engine/cio/CIOSpecificHttpsTest.kt
@@ -147,6 +147,7 @@ class CIOSpecificHttpsTest : TestWithKtor() {
         }
     }
 
+    @Ignore
     @Test
     fun testGetServerTrusted() {
         testWithEngine(CIO) {


### PR DESCRIPTION
This test just recently started failing because the server started responding with 401's.

I don't know what exactly it's testing, or why were making calls to npay.eu in our test... I'm thinking maybe we should just delete it?