### PR TITLE
Add a header to SSE response to address the issue of nginx buffering …

### DIFF
--- a/ktor-server/ktor-server-plugins/ktor-server-sse/jvmAndNix/src/io/ktor/server/sse/Routing.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-sse/jvmAndNix/src/io/ktor/server/sse/Routing.kt
@@ -44,6 +44,7 @@ public fun Route.sse(handler: suspend ServerSSESession.() -> Unit) {
         call.response.header(HttpHeaders.ContentType, ContentType.Text.EventStream.toString())
         call.response.header(HttpHeaders.CacheControl, "no-store")
         call.response.header(HttpHeaders.Connection, "keep-alive")
+        call.response.header("X-Accel-Buffering", "no")
         call.respond(SSEServerContent(call, handler))
     }
 }


### PR DESCRIPTION
Add a header to SSE response to address the issue of nginx buffering causing events to not be timely sending.

[link](https://stackoverflow.com/questions/48506093/nginx-buffering-flask-event-stream-in-docker-image)
