### PR TITLE
KTOR-6746 Add nullability check for certificates

### DIFF
--- a/ktor-network/ktor-network-tls/build.gradle.kts
+++ b/ktor-network/ktor-network-tls/build.gradle.kts
@@ -10,6 +10,7 @@ kotlin.sourceSets {
         dependencies {
             api(project(":ktor-network:ktor-network-tls:ktor-network-tls-certificates"))
             api(libs.netty.handler)
+            api(libs.mockk)
         }
     }
 }

--- a/ktor-network/ktor-network-tls/jvm/src/io/ktor/network/tls/HostnameUtils.kt
+++ b/ktor-network/ktor-network-tls/jvm/src/io/ktor/network/tls/HostnameUtils.kt
@@ -28,8 +28,8 @@ internal fun verifyHostnameInCertificate(serverName: String, certificate: X509Ce
 
 internal fun verifyIpInCertificate(ipString: String, certificate: X509Certificate) {
     val ips = certificate.subjectAlternativeNames
-        .filter { it[0] as Int == IP_ADDRESS_TYPE }
-        .map { it[1] as String }
+        ?.filter { it[0] as Int == IP_ADDRESS_TYPE }
+        ?.map { it[1] as String } ?: return
 
     if (ips.isEmpty()) return
     if (ips.any { it == ipString }) return

--- a/ktor-network/ktor-network-tls/jvm/test/io/ktor/network/tls/HostnameUtilsTest.kt
+++ b/ktor-network/ktor-network-tls/jvm/test/io/ktor/network/tls/HostnameUtilsTest.kt
@@ -1,8 +1,49 @@
 package io.ktor.network.tls
 
+import io.mockk.*
+import java.security.cert.*
 import kotlin.test.*
 
-class MatchHostnameTest {
+class HostnameUtilsTest {
+
+    @Test
+    fun `verifyIpInCertificate has null certificates`() {
+        val certificate = mockk<X509Certificate> {
+            every { subjectAlternativeNames } returns null
+        }
+
+        verifyIpInCertificate("0.0.0.0", certificate)
+    }
+
+    @Test
+    fun `verifyHostnameInCertificate has null certificates`() {
+        val certificate = mockk<X509Certificate> {
+            every { subjectAlternativeNames } returns null
+        }
+
+        verifyHostnameInCertificate("www.example.com", certificate)
+        verifyHostnameInCertificate("0.0.0.0", certificate)
+    }
+
+    @Test
+    fun `verifyIpInCertificate has empty certificates`() {
+        val certificate = mockk<X509Certificate> {
+            every { subjectAlternativeNames } returns emptyList()
+        }
+
+        verifyIpInCertificate("0.0.0.0", certificate)
+    }
+
+    @Test
+    fun `verifyHostnameInCertificate has empty certificates`() {
+        val certificate = mockk<X509Certificate> {
+            every { subjectAlternativeNames } returns emptyList()
+        }
+
+        verifyHostnameInCertificate("www.example.com", certificate)
+        verifyHostnameInCertificate("0.0.0.0", certificate)
+    }
+
     @Test
     fun testMatchExact() {
         assertTrue(matchHostnameWithCertificate("www.example.com", "www.example.com"))


### PR DESCRIPTION
Fix [KTOR-6746](https://youtrack.jetbrains.com/issue/KTOR-6746) CIO: "getSubjectAlternativeNames(...) must not be null" when IP-addresses are verified and no SAN in the certificate