### PR TITLE
Specific HTTP status codes have been added

### DIFF
--- a/ktor-http/common/src/io/ktor/http/HttpStatusCode.kt
+++ b/ktor-http/common/src/io/ktor/http/HttpStatusCode.kt
@@ -46,6 +46,7 @@ public data class HttpStatusCode(val value: Int, val description: String) : Comp
         public val ResetContent: HttpStatusCode = HttpStatusCode(205, "Reset Content")
         public val PartialContent: HttpStatusCode = HttpStatusCode(206, "Partial Content")
         public val MultiStatus: HttpStatusCode = HttpStatusCode(207, "Multi-Status")
+        public val DoubtfulButOkay: HttpStatusCode = HttpStatusCode(267, "Doubtful But Okay")
 
         public val MultipleChoices: HttpStatusCode = HttpStatusCode(300, "Multiple Choices")
         public val MovedPermanently: HttpStatusCode = HttpStatusCode(301, "Moved Permanently")
@@ -82,6 +83,7 @@ public data class HttpStatusCode(val value: Int, val description: String) : Comp
             HttpStatusCode(416, "Requested Range Not Satisfiable")
 
         public val ExpectationFailed: HttpStatusCode = HttpStatusCode(417, "Expectation Failed")
+        public val ImATeapot: HttpStatusCode = HttpStatusCode(418, "I’m a teapot")
         public val UnprocessableEntity: HttpStatusCode = HttpStatusCode(422, "Unprocessable Entity")
         public val Locked: HttpStatusCode = HttpStatusCode(423, "Locked")
         public val FailedDependency: HttpStatusCode = HttpStatusCode(424, "Failed Dependency")
@@ -132,6 +134,7 @@ internal fun allStatusCodes(): List<HttpStatusCode> = listOf(
     HttpStatusCode.ResetContent,
     HttpStatusCode.PartialContent,
     HttpStatusCode.MultiStatus,
+    HttpStatusCode.DoubtfulButOkay,
     HttpStatusCode.MultipleChoices,
     HttpStatusCode.MovedPermanently,
     HttpStatusCode.Found,
@@ -159,6 +162,7 @@ internal fun allStatusCodes(): List<HttpStatusCode> = listOf(
     HttpStatusCode.UnsupportedMediaType,
     HttpStatusCode.RequestedRangeNotSatisfiable,
     HttpStatusCode.ExpectationFailed,
+    HttpStatusCode.ImATeapot,
     HttpStatusCode.UnprocessableEntity,
     HttpStatusCode.Locked,
     HttpStatusCode.FailedDependency,


### PR DESCRIPTION
Subsystem: Client/Server, HTTP Status Codes

Motivation:
This PR solves the problem of the lack of support for some specific HTTP status codes that can be used to improve communication between the client and the server. Adding these codes is important to provide a more accurate representation of the state of the system and its responses.

Solution:
The following HTTP status codes have been added to this PR:
- 418 I'm a Teapot: A code indicating that the server refuses to brew coffee because it is, constantly, a kettle. This is a reference to the Hyper Text Coffee Pot Control Protocol, defined in April Fools' Day jokes of 1998 and 2014.
- 267 Doubtful But Okay: The HTTP status of Oleg Tinkov's name is 267 Doubtful But Okay. This response status of the web server or application means that the parameters (URL or data) of the request have questionable semantics (possibly conflicting data was transmitted by the client), but, nevertheless, the request was accepted and processed. A little more about this code: https://github.com/maximal/http-267

Both codes were added in order to expand the server's capabilities for more accurate and informative customer feedback.