### PR TITLE
KTOR-6928 Make refresh_token optional according to RFC 6749

### DIFF
--- a/ktor-client/ktor-client-plugins/ktor-client-auth/common/src/io/ktor/client/plugins/auth/providers/BearerAuthProvider.kt
+++ b/ktor-client/ktor-client-plugins/ktor-client-auth/common/src/io/ktor/client/plugins/auth/providers/BearerAuthProvider.kt
@@ -23,7 +23,7 @@ public fun AuthConfig.bearer(block: BearerAuthConfig.() -> Unit) {
 
 public class BearerTokens(
     public val accessToken: String,
-    public val refreshToken: String
+    public val refreshToken: String?
 )
 
 /**


### PR DESCRIPTION
**Subsystem**
Client-Auth

**Motivation**
https://youtrack.jetbrains.com/issue/KTOR-6928/Auth-Make-refreshToken-of-BearerTokens-class-nullable

**Solution**
Make refreshToken nullable. This change is ABI compatible, but not API. On the other hand this parameter isn't used by Ktor, only by users.

Alternative: wait for v3.

