### PR TITLE
KTOR-6417 KTOR-6462 Allow dispatcher customisation

### DIFF
--- a/ktor-client/ktor-client-android/api/ktor-client-android.api
+++ b/ktor-client/ktor-client-android/api/ktor-client-android.api
@@ -8,6 +8,7 @@ public final class io/ktor/client/engine/android/AndroidClientEngine : io/ktor/c
 	public fun execute (Lio/ktor/client/request/HttpRequestData;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public synthetic fun getConfig ()Lio/ktor/client/engine/HttpClientEngineConfig;
 	public fun getConfig ()Lio/ktor/client/engine/android/AndroidEngineConfig;
+	public fun getDispatcher ()Lkotlinx/coroutines/CoroutineDispatcher;
 	public fun getSupportedCapabilities ()Ljava/util/Set;
 }
 

--- a/ktor-client/ktor-client-android/jvm/src/io/ktor/client/engine/android/AndroidClientEngine.kt
+++ b/ktor-client/ktor-client-android/jvm/src/io/ktor/client/engine/android/AndroidClientEngine.kt
@@ -9,6 +9,7 @@ import io.ktor.client.engine.*
 import io.ktor.client.plugins.*
 import io.ktor.client.plugins.sse.*
 import io.ktor.client.request.*
+import io.ktor.client.utils.*
 import io.ktor.http.*
 import io.ktor.http.content.*
 import io.ktor.util.date.*
@@ -28,6 +29,13 @@ private val METHODS_WITHOUT_BODY = listOf(HttpMethod.Get, HttpMethod.Head)
  */
 @OptIn(InternalAPI::class)
 public class AndroidClientEngine(override val config: AndroidEngineConfig) : HttpClientEngineBase("ktor-android") {
+
+    override val dispatcher: CoroutineDispatcher by lazy {
+        Dispatchers.clientDispatcher(
+            config.threadsCount,
+            "ktor-android-dispatcher"
+        )
+    }
 
     override val supportedCapabilities: Set<HttpClientEngineCapability<*>> = setOf(HttpTimeoutCapability, SSECapability)
 

--- a/ktor-client/ktor-client-apache/jvm/src/io/ktor/client/engine/apache/ApacheEngine.kt
+++ b/ktor-client/ktor-client-apache/jvm/src/io/ktor/client/engine/apache/ApacheEngine.kt
@@ -8,6 +8,7 @@ import io.ktor.client.engine.*
 import io.ktor.client.plugins.*
 import io.ktor.client.plugins.sse.*
 import io.ktor.client.request.*
+import io.ktor.client.utils.*
 import io.ktor.utils.io.*
 import kotlinx.coroutines.*
 import org.apache.http.*
@@ -20,6 +21,13 @@ private const val IO_THREAD_COUNT_DEFAULT = 4
 
 @OptIn(InternalAPI::class)
 internal class ApacheEngine(override val config: ApacheEngineConfig) : HttpClientEngineBase("ktor-apache") {
+
+    override val dispatcher by lazy {
+        Dispatchers.clientDispatcher(
+            config.threadsCount,
+            "ktor-apache-dispatcher"
+        )
+    }
 
     override val supportedCapabilities = setOf(HttpTimeoutCapability, SSECapability)
 

--- a/ktor-client/ktor-client-apache5/jvm/src/io/ktor/client/engine/apache5/Apache5Engine.kt
+++ b/ktor-client/ktor-client-apache5/jvm/src/io/ktor/client/engine/apache5/Apache5Engine.kt
@@ -8,6 +8,7 @@ import io.ktor.client.engine.*
 import io.ktor.client.plugins.*
 import io.ktor.client.plugins.sse.*
 import io.ktor.client.request.*
+import io.ktor.client.utils.*
 import io.ktor.utils.io.*
 import kotlinx.coroutines.*
 import org.apache.hc.client5.http.config.*
@@ -28,6 +29,13 @@ private const val IO_THREAD_COUNT_DEFAULT = 4
 
 @OptIn(InternalAPI::class)
 internal class Apache5Engine(override val config: Apache5EngineConfig) : HttpClientEngineBase("ktor-apache") {
+
+    override val dispatcher by lazy {
+        Dispatchers.clientDispatcher(
+            config.threadsCount,
+            "ktor-apache-dispatcher"
+        )
+    }
 
     override val supportedCapabilities = setOf(HttpTimeoutCapability, SSECapability)
 

--- a/ktor-client/ktor-client-cio/jvmAndNix/src/io/ktor/client/engine/cio/CIOEngine.kt
+++ b/ktor-client/ktor-client-cio/jvmAndNix/src/io/ktor/client/engine/cio/CIOEngine.kt
@@ -9,6 +9,7 @@ import io.ktor.client.plugins.*
 import io.ktor.client.plugins.sse.*
 import io.ktor.client.plugins.websocket.*
 import io.ktor.client.request.*
+import io.ktor.client.utils.*
 import io.ktor.http.*
 import io.ktor.network.selector.*
 import io.ktor.util.*
@@ -23,6 +24,9 @@ import kotlin.coroutines.*
 internal class CIOEngine(
     override val config: CIOEngineConfig
 ) : HttpClientEngineBase("ktor-cio") {
+
+    override val dispatcher: CoroutineDispatcher =
+        Dispatchers.clientDispatcher(config.threadsCount, "ktor-cio-dispatcher")
 
     override val supportedCapabilities =
         setOf(HttpTimeoutCapability, WebSocketCapability, WebSocketExtensionsCapability, SSECapability)

--- a/ktor-client/ktor-client-core/api/ktor-client-core.api
+++ b/ktor-client/ktor-client-core/api/ktor-client-core.api
@@ -50,6 +50,10 @@ public final class io/ktor/client/HttpClientKt {
 	public static synthetic fun HttpClient$default (Lio/ktor/client/engine/HttpClientEngineFactory;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lio/ktor/client/HttpClient;
 }
 
+public final class io/ktor/client/call/CompatibilityKt {
+	public static final fun receive (Lio/ktor/client/call/HttpClientCall;Lio/ktor/util/reflect/TypeInfo;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
 public final class io/ktor/client/call/DoubleReceiveException : java/lang/IllegalStateException {
 	public fun <init> (Lio/ktor/client/call/HttpClientCall;)V
 	public fun getMessage ()Ljava/lang/String;
@@ -76,6 +80,7 @@ public class io/ktor/client/call/HttpClientCall : kotlinx/coroutines/CoroutineSc
 }
 
 public final class io/ktor/client/call/HttpClientCall$Companion {
+	public final fun getCustomResponse ()Lio/ktor/util/AttributeKey;
 }
 
 public final class io/ktor/client/call/HttpClientCallKt {
@@ -121,10 +126,6 @@ public final class io/ktor/client/content/LocalFileContentKt {
 	public static synthetic fun LocalFileContent$default (Ljava/io/File;Ljava/lang/String;Lio/ktor/http/ContentType;ILjava/lang/Object;)Lio/ktor/client/content/LocalFileContent;
 }
 
-public abstract interface class io/ktor/client/content/ProgressListener {
-	public abstract fun onProgress (JLjava/lang/Long;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-}
-
 public final class io/ktor/client/engine/ClientEngineClosedException : java/lang/IllegalStateException {
 	public fun <init> ()V
 	public fun <init> (Ljava/lang/Throwable;)V
@@ -149,7 +150,6 @@ public abstract class io/ktor/client/engine/HttpClientEngineBase : io/ktor/clien
 	public fun <init> (Ljava/lang/String;)V
 	public fun close ()V
 	public fun getCoroutineContext ()Lkotlin/coroutines/CoroutineContext;
-	public fun getDispatcher ()Lkotlinx/coroutines/CoroutineDispatcher;
 	public fun getSupportedCapabilities ()Ljava/util/Set;
 	public fun install (Lio/ktor/client/HttpClient;)V
 }
@@ -181,6 +181,16 @@ public final class io/ktor/client/engine/HttpClientEngineFactory$DefaultImpls {
 
 public final class io/ktor/client/engine/HttpClientEngineKt {
 	public static final fun config (Lio/ktor/client/engine/HttpClientEngineFactory;Lkotlin/jvm/functions/Function1;)Lio/ktor/client/engine/HttpClientEngineFactory;
+}
+
+public abstract class io/ktor/client/engine/HttpClientJvmEngine : io/ktor/client/engine/HttpClientEngine {
+	public fun <init> (Ljava/lang/String;)V
+	public fun close ()V
+	protected final fun createCallContext (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getCoroutineContext ()Lkotlin/coroutines/CoroutineContext;
+	public fun getDispatcher ()Lkotlinx/coroutines/CoroutineDispatcher;
+	public fun getSupportedCapabilities ()Ljava/util/Set;
+	public fun install (Lio/ktor/client/HttpClient;)V
 }
 
 public final class io/ktor/client/engine/ProxyBuilder {
@@ -230,13 +240,25 @@ public final class io/ktor/client/network/sockets/TimeoutExceptionsCommonKt {
 	public static final fun mapEngineExceptions (Lkotlinx/coroutines/CoroutineScope;Lio/ktor/utils/io/ByteWriteChannel;Lio/ktor/client/request/HttpRequestData;)Lio/ktor/utils/io/ByteWriteChannel;
 }
 
+public final class io/ktor/client/plugins/BodyProgress {
+	public static final field Plugin Lio/ktor/client/plugins/BodyProgress$Plugin;
+}
+
+public final class io/ktor/client/plugins/BodyProgress$Plugin : io/ktor/client/plugins/HttpClientPlugin {
+	public fun getKey ()Lio/ktor/util/AttributeKey;
+	public fun install (Lio/ktor/client/plugins/BodyProgress;Lio/ktor/client/HttpClient;)V
+	public synthetic fun install (Ljava/lang/Object;Lio/ktor/client/HttpClient;)V
+	public fun prepare (Lkotlin/jvm/functions/Function1;)Lio/ktor/client/plugins/BodyProgress;
+	public synthetic fun prepare (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+}
+
 public final class io/ktor/client/plugins/BodyProgressKt {
-	public static final fun getBodyProgress ()Lio/ktor/client/plugins/api/ClientPlugin;
-	public static final fun onDownload (Lio/ktor/client/request/HttpRequestBuilder;Lio/ktor/client/content/ProgressListener;)V
-	public static final fun onUpload (Lio/ktor/client/request/HttpRequestBuilder;Lio/ktor/client/content/ProgressListener;)V
+	public static final fun onDownload (Lio/ktor/client/request/HttpRequestBuilder;Lkotlin/jvm/functions/Function3;)V
+	public static final fun onUpload (Lio/ktor/client/request/HttpRequestBuilder;Lkotlin/jvm/functions/Function3;)V
 }
 
 public final class io/ktor/client/plugins/ClientRequestException : io/ktor/client/plugins/ResponseException {
+	public fun <init> (Lio/ktor/client/statement/HttpResponse;)V
 	public fun <init> (Lio/ktor/client/statement/HttpResponse;Ljava/lang/String;)V
 	public fun getMessage ()Ljava/lang/String;
 }
@@ -296,11 +318,22 @@ public final class io/ktor/client/plugins/DoubleReceivePluginKt {
 	public static final fun skipSavingBody (Lio/ktor/client/request/HttpRequestBuilder;)V
 }
 
-public final class io/ktor/client/plugins/HttpCallValidatorConfig {
+public final class io/ktor/client/plugins/HttpCallValidator {
+	public static final field Companion Lio/ktor/client/plugins/HttpCallValidator$Companion;
+}
+
+public final class io/ktor/client/plugins/HttpCallValidator$Companion : io/ktor/client/plugins/HttpClientPlugin {
+	public fun getKey ()Lio/ktor/util/AttributeKey;
+	public fun install (Lio/ktor/client/plugins/HttpCallValidator;Lio/ktor/client/HttpClient;)V
+	public synthetic fun install (Ljava/lang/Object;Lio/ktor/client/HttpClient;)V
+	public fun prepare (Lkotlin/jvm/functions/Function1;)Lio/ktor/client/plugins/HttpCallValidator;
+	public synthetic fun prepare (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+}
+
+public final class io/ktor/client/plugins/HttpCallValidator$Config {
 	public fun <init> ()V
 	public final fun getExpectSuccess ()Z
 	public final fun handleResponseException (Lkotlin/jvm/functions/Function2;)V
-	public final fun handleResponseException (Lkotlin/jvm/functions/Function3;)V
 	public final fun handleResponseExceptionWithRequest (Lkotlin/jvm/functions/Function3;)V
 	public final fun setExpectSuccess (Z)V
 	public final fun validateResponse (Lkotlin/jvm/functions/Function2;)V
@@ -309,7 +342,6 @@ public final class io/ktor/client/plugins/HttpCallValidatorConfig {
 public final class io/ktor/client/plugins/HttpCallValidatorKt {
 	public static final fun HttpResponseValidator (Lio/ktor/client/HttpClientConfig;Lkotlin/jvm/functions/Function1;)V
 	public static final fun getExpectSuccess (Lio/ktor/client/request/HttpRequestBuilder;)Z
-	public static final fun getHttpCallValidator ()Lio/ktor/client/plugins/api/ClientPlugin;
 	public static final fun setExpectSuccess (Lio/ktor/client/request/HttpRequestBuilder;Z)V
 }
 
@@ -328,22 +360,38 @@ public final class io/ktor/client/plugins/HttpClientPluginKt {
 	public static final fun pluginOrNull (Lio/ktor/client/HttpClient;Lio/ktor/client/plugins/HttpClientPlugin;)Ljava/lang/Object;
 }
 
-public final class io/ktor/client/plugins/HttpPlainTextConfig {
+public final class io/ktor/client/plugins/HttpPlainText {
+	public static final field Plugin Lio/ktor/client/plugins/HttpPlainText$Plugin;
+}
+
+public final class io/ktor/client/plugins/HttpPlainText$Config {
 	public fun <init> ()V
 	public final fun getResponseCharsetFallback ()Ljava/nio/charset/Charset;
 	public final fun getSendCharset ()Ljava/nio/charset/Charset;
 	public final fun register (Ljava/nio/charset/Charset;Ljava/lang/Float;)V
-	public static synthetic fun register$default (Lio/ktor/client/plugins/HttpPlainTextConfig;Ljava/nio/charset/Charset;Ljava/lang/Float;ILjava/lang/Object;)V
+	public static synthetic fun register$default (Lio/ktor/client/plugins/HttpPlainText$Config;Ljava/nio/charset/Charset;Ljava/lang/Float;ILjava/lang/Object;)V
 	public final fun setResponseCharsetFallback (Ljava/nio/charset/Charset;)V
 	public final fun setSendCharset (Ljava/nio/charset/Charset;)V
 }
 
-public final class io/ktor/client/plugins/HttpPlainTextKt {
-	public static final fun Charsets (Lio/ktor/client/HttpClientConfig;Lkotlin/jvm/functions/Function1;)V
-	public static final fun getHttpPlainText ()Lio/ktor/client/plugins/api/ClientPlugin;
+public final class io/ktor/client/plugins/HttpPlainText$Plugin : io/ktor/client/plugins/HttpClientPlugin {
+	public fun getKey ()Lio/ktor/util/AttributeKey;
+	public fun install (Lio/ktor/client/plugins/HttpPlainText;Lio/ktor/client/HttpClient;)V
+	public synthetic fun install (Ljava/lang/Object;Lio/ktor/client/HttpClient;)V
+	public fun prepare (Lkotlin/jvm/functions/Function1;)Lio/ktor/client/plugins/HttpPlainText;
+	public synthetic fun prepare (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
 }
 
-public final class io/ktor/client/plugins/HttpRedirectConfig {
+public final class io/ktor/client/plugins/HttpPlainTextKt {
+	public static final fun Charsets (Lio/ktor/client/HttpClientConfig;Lkotlin/jvm/functions/Function1;)V
+}
+
+public final class io/ktor/client/plugins/HttpRedirect {
+	public static final field Plugin Lio/ktor/client/plugins/HttpRedirect$Plugin;
+	public synthetic fun <init> (ZZLkotlin/jvm/internal/DefaultConstructorMarker;)V
+}
+
+public final class io/ktor/client/plugins/HttpRedirect$Config {
 	public fun <init> ()V
 	public final fun getAllowHttpsDowngrade ()Z
 	public final fun getCheckHttpMethod ()Z
@@ -351,43 +399,81 @@ public final class io/ktor/client/plugins/HttpRedirectConfig {
 	public final fun setCheckHttpMethod (Z)V
 }
 
-public final class io/ktor/client/plugins/HttpRedirectKt {
-	public static final fun getHttpRedirect ()Lio/ktor/client/plugins/api/ClientPlugin;
-	public static final fun getHttpResponseRedirectEvent ()Lio/ktor/events/EventDefinition;
+public final class io/ktor/client/plugins/HttpRedirect$Plugin : io/ktor/client/plugins/HttpClientPlugin {
+	public final fun getHttpResponseRedirect ()Lio/ktor/events/EventDefinition;
+	public fun getKey ()Lio/ktor/util/AttributeKey;
+	public fun install (Lio/ktor/client/plugins/HttpRedirect;Lio/ktor/client/HttpClient;)V
+	public synthetic fun install (Ljava/lang/Object;Lio/ktor/client/HttpClient;)V
+	public fun prepare (Lkotlin/jvm/functions/Function1;)Lio/ktor/client/plugins/HttpRedirect;
+	public synthetic fun prepare (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
 }
 
-public final class io/ktor/client/plugins/HttpRequestLifecycleKt {
-	public static final fun getHttpRequestLifecycle ()Lio/ktor/client/plugins/api/ClientPlugin;
+public final class io/ktor/client/plugins/HttpRequestRetry {
+	public static final field Plugin Lio/ktor/client/plugins/HttpRequestRetry$Plugin;
 }
 
-public final class io/ktor/client/plugins/HttpRequestRetryConfig {
+public final class io/ktor/client/plugins/HttpRequestRetry$Configuration {
 	public fun <init> ()V
 	public final fun constantDelay (JJZ)V
-	public static synthetic fun constantDelay$default (Lio/ktor/client/plugins/HttpRequestRetryConfig;JJZILjava/lang/Object;)V
+	public static synthetic fun constantDelay$default (Lio/ktor/client/plugins/HttpRequestRetry$Configuration;JJZILjava/lang/Object;)V
 	public final fun delay (Lkotlin/jvm/functions/Function2;)V
 	public final fun delayMillis (ZLkotlin/jvm/functions/Function2;)V
-	public static synthetic fun delayMillis$default (Lio/ktor/client/plugins/HttpRequestRetryConfig;ZLkotlin/jvm/functions/Function2;ILjava/lang/Object;)V
+	public static synthetic fun delayMillis$default (Lio/ktor/client/plugins/HttpRequestRetry$Configuration;ZLkotlin/jvm/functions/Function2;ILjava/lang/Object;)V
 	public final fun exponentialDelay (DJJZ)V
-	public static synthetic fun exponentialDelay$default (Lio/ktor/client/plugins/HttpRequestRetryConfig;DJJZILjava/lang/Object;)V
+	public static synthetic fun exponentialDelay$default (Lio/ktor/client/plugins/HttpRequestRetry$Configuration;DJJZILjava/lang/Object;)V
 	public final fun getMaxRetries ()I
 	public final fun modifyRequest (Lkotlin/jvm/functions/Function2;)V
 	public final fun noRetry ()V
 	public final fun retryIf (ILkotlin/jvm/functions/Function3;)V
-	public static synthetic fun retryIf$default (Lio/ktor/client/plugins/HttpRequestRetryConfig;ILkotlin/jvm/functions/Function3;ILjava/lang/Object;)V
+	public static synthetic fun retryIf$default (Lio/ktor/client/plugins/HttpRequestRetry$Configuration;ILkotlin/jvm/functions/Function3;ILjava/lang/Object;)V
+	public final synthetic fun retryOnException (I)V
 	public final fun retryOnException (IZ)V
-	public static synthetic fun retryOnException$default (Lio/ktor/client/plugins/HttpRequestRetryConfig;IZILjava/lang/Object;)V
+	public static synthetic fun retryOnException$default (Lio/ktor/client/plugins/HttpRequestRetry$Configuration;IILjava/lang/Object;)V
+	public static synthetic fun retryOnException$default (Lio/ktor/client/plugins/HttpRequestRetry$Configuration;IZILjava/lang/Object;)V
 	public final fun retryOnExceptionIf (ILkotlin/jvm/functions/Function3;)V
-	public static synthetic fun retryOnExceptionIf$default (Lio/ktor/client/plugins/HttpRequestRetryConfig;ILkotlin/jvm/functions/Function3;ILjava/lang/Object;)V
+	public static synthetic fun retryOnExceptionIf$default (Lio/ktor/client/plugins/HttpRequestRetry$Configuration;ILkotlin/jvm/functions/Function3;ILjava/lang/Object;)V
 	public final fun retryOnExceptionOrServerErrors (I)V
-	public static synthetic fun retryOnExceptionOrServerErrors$default (Lio/ktor/client/plugins/HttpRequestRetryConfig;IILjava/lang/Object;)V
+	public static synthetic fun retryOnExceptionOrServerErrors$default (Lio/ktor/client/plugins/HttpRequestRetry$Configuration;IILjava/lang/Object;)V
 	public final fun retryOnServerErrors (I)V
-	public static synthetic fun retryOnServerErrors$default (Lio/ktor/client/plugins/HttpRequestRetryConfig;IILjava/lang/Object;)V
+	public static synthetic fun retryOnServerErrors$default (Lio/ktor/client/plugins/HttpRequestRetry$Configuration;IILjava/lang/Object;)V
 	public final fun setMaxRetries (I)V
 }
 
+public final class io/ktor/client/plugins/HttpRequestRetry$DelayContext {
+	public final fun getCause ()Ljava/lang/Throwable;
+	public final fun getRequest ()Lio/ktor/client/request/HttpRequestBuilder;
+	public final fun getResponse ()Lio/ktor/client/statement/HttpResponse;
+}
+
+public final class io/ktor/client/plugins/HttpRequestRetry$ModifyRequestContext {
+	public final fun getCause ()Ljava/lang/Throwable;
+	public final fun getRequest ()Lio/ktor/client/request/HttpRequestBuilder;
+	public final fun getResponse ()Lio/ktor/client/statement/HttpResponse;
+	public final fun getRetryCount ()I
+}
+
+public final class io/ktor/client/plugins/HttpRequestRetry$Plugin : io/ktor/client/plugins/HttpClientPlugin {
+	public final fun getHttpRequestRetryEvent ()Lio/ktor/events/EventDefinition;
+	public fun getKey ()Lio/ktor/util/AttributeKey;
+	public fun install (Lio/ktor/client/plugins/HttpRequestRetry;Lio/ktor/client/HttpClient;)V
+	public synthetic fun install (Ljava/lang/Object;Lio/ktor/client/HttpClient;)V
+	public fun prepare (Lkotlin/jvm/functions/Function1;)Lio/ktor/client/plugins/HttpRequestRetry;
+	public synthetic fun prepare (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+}
+
+public final class io/ktor/client/plugins/HttpRequestRetry$RetryEventData {
+	public final fun getCause ()Ljava/lang/Throwable;
+	public final fun getRequest ()Lio/ktor/client/request/HttpRequestBuilder;
+	public final fun getResponse ()Lio/ktor/client/statement/HttpResponse;
+	public final fun getRetryCount ()I
+}
+
+public final class io/ktor/client/plugins/HttpRequestRetry$ShouldRetryContext {
+	public fun <init> (I)V
+	public final fun getRetryCount ()I
+}
+
 public final class io/ktor/client/plugins/HttpRequestRetryKt {
-	public static final fun getHttpRequestRetry ()Lio/ktor/client/plugins/api/ClientPlugin;
-	public static final fun getHttpRequestRetryEvent ()Lio/ktor/events/EventDefinition;
 	public static final fun retry (Lio/ktor/client/request/HttpRequestBuilder;Lkotlin/jvm/functions/Function1;)V
 }
 
@@ -397,35 +483,11 @@ public final class io/ktor/client/plugins/HttpRequestTimeoutException : java/io/
 	public fun <init> (Ljava/lang/String;Ljava/lang/Long;)V
 }
 
-public final class io/ktor/client/plugins/HttpRetryDelayContext {
-	public final fun getCause ()Ljava/lang/Throwable;
-	public final fun getRequest ()Lio/ktor/client/request/HttpRequestBuilder;
-	public final fun getResponse ()Lio/ktor/client/statement/HttpResponse;
-}
-
-public final class io/ktor/client/plugins/HttpRetryEventData {
-	public final fun getCause ()Ljava/lang/Throwable;
-	public final fun getRequest ()Lio/ktor/client/request/HttpRequestBuilder;
-	public final fun getResponse ()Lio/ktor/client/statement/HttpResponse;
-	public final fun getRetryCount ()I
-}
-
-public final class io/ktor/client/plugins/HttpRetryModifyRequestContext {
-	public final fun getCause ()Ljava/lang/Throwable;
-	public final fun getRequest ()Lio/ktor/client/request/HttpRequestBuilder;
-	public final fun getResponse ()Lio/ktor/client/statement/HttpResponse;
-	public final fun getRetryCount ()I
-}
-
-public final class io/ktor/client/plugins/HttpRetryShouldRetryContext {
-	public fun <init> (I)V
-	public final fun getRetryCount ()I
-}
-
 public final class io/ktor/client/plugins/HttpSend {
 	public static final field Plugin Lio/ktor/client/plugins/HttpSend$Plugin;
 	public synthetic fun <init> (ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun intercept (Lkotlin/jvm/functions/Function3;)V
+	public final fun intercept (Lkotlin/jvm/functions/Function4;)V
 }
 
 public final class io/ktor/client/plugins/HttpSend$Config {
@@ -442,14 +504,14 @@ public final class io/ktor/client/plugins/HttpSend$Plugin : io/ktor/client/plugi
 	public synthetic fun prepare (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
 }
 
-public final class io/ktor/client/plugins/HttpTimeoutCapability : io/ktor/client/engine/HttpClientEngineCapability {
-	public static final field INSTANCE Lio/ktor/client/plugins/HttpTimeoutCapability;
-	public fun toString ()Ljava/lang/String;
+public final class io/ktor/client/plugins/HttpTimeout {
+	public static final field INFINITE_TIMEOUT_MS J
+	public static final field Plugin Lio/ktor/client/plugins/HttpTimeout$Plugin;
+	public synthetic fun <init> (Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 }
 
-public final class io/ktor/client/plugins/HttpTimeoutConfig {
-	public static final field Companion Lio/ktor/client/plugins/HttpTimeoutConfig$Companion;
-	public static final field INFINITE_TIMEOUT_MS J
+public final class io/ktor/client/plugins/HttpTimeout$HttpTimeoutCapabilityConfiguration {
+	public static final field Companion Lio/ktor/client/plugins/HttpTimeout$HttpTimeoutCapabilityConfiguration$Companion;
 	public fun <init> (Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;)V
 	public synthetic fun <init> (Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun equals (Ljava/lang/Object;)Z
@@ -462,8 +524,16 @@ public final class io/ktor/client/plugins/HttpTimeoutConfig {
 	public final fun setSocketTimeoutMillis (Ljava/lang/Long;)V
 }
 
-public final class io/ktor/client/plugins/HttpTimeoutConfig$Companion {
+public final class io/ktor/client/plugins/HttpTimeout$HttpTimeoutCapabilityConfiguration$Companion {
 	public final fun getKey ()Lio/ktor/util/AttributeKey;
+}
+
+public final class io/ktor/client/plugins/HttpTimeout$Plugin : io/ktor/client/engine/HttpClientEngineCapability, io/ktor/client/plugins/HttpClientPlugin {
+	public fun getKey ()Lio/ktor/util/AttributeKey;
+	public fun install (Lio/ktor/client/plugins/HttpTimeout;Lio/ktor/client/HttpClient;)V
+	public synthetic fun install (Ljava/lang/Object;Lio/ktor/client/HttpClient;)V
+	public fun prepare (Lkotlin/jvm/functions/Function1;)Lio/ktor/client/plugins/HttpTimeout;
+	public synthetic fun prepare (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
 }
 
 public final class io/ktor/client/plugins/HttpTimeoutKt {
@@ -475,17 +545,18 @@ public final class io/ktor/client/plugins/HttpTimeoutKt {
 	public static synthetic fun SocketTimeoutException$default (Lio/ktor/client/request/HttpRequestData;Ljava/lang/Throwable;ILjava/lang/Object;)Lio/ktor/client/network/sockets/SocketTimeoutException;
 	public static final fun convertLongTimeoutToIntWithInfiniteAsZero (J)I
 	public static final fun convertLongTimeoutToLongWithInfiniteAsZero (J)J
-	public static final fun getHttpTimeout ()Lio/ktor/client/plugins/api/ClientPlugin;
 	public static final fun timeout (Lio/ktor/client/request/HttpRequestBuilder;Lkotlin/jvm/functions/Function1;)V
 	public static final fun unwrapRequestTimeoutException (Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
 }
 
 public final class io/ktor/client/plugins/RedirectResponseException : io/ktor/client/plugins/ResponseException {
+	public fun <init> (Lio/ktor/client/statement/HttpResponse;)V
 	public fun <init> (Lio/ktor/client/statement/HttpResponse;Ljava/lang/String;)V
 	public fun getMessage ()Ljava/lang/String;
 }
 
 public class io/ktor/client/plugins/ResponseException : java/lang/IllegalStateException {
+	public fun <init> (Lio/ktor/client/statement/HttpResponse;)V
 	public fun <init> (Lio/ktor/client/statement/HttpResponse;Ljava/lang/String;)V
 	public final fun getResponse ()Lio/ktor/client/statement/HttpResponse;
 }
@@ -505,17 +576,18 @@ public abstract interface class io/ktor/client/plugins/Sender {
 }
 
 public final class io/ktor/client/plugins/ServerResponseException : io/ktor/client/plugins/ResponseException {
+	public fun <init> (Lio/ktor/client/statement/HttpResponse;)V
 	public fun <init> (Lio/ktor/client/statement/HttpResponse;Ljava/lang/String;)V
 	public fun getMessage ()Ljava/lang/String;
 }
 
-public final class io/ktor/client/plugins/SetupRequestContext : io/ktor/client/plugins/api/ClientHook {
-	public static final field INSTANCE Lio/ktor/client/plugins/SetupRequestContext;
-	public synthetic fun install (Lio/ktor/client/HttpClient;Ljava/lang/Object;)V
-	public fun install (Lio/ktor/client/HttpClient;Lkotlin/jvm/functions/Function3;)V
+public final class io/ktor/client/plugins/UserAgent {
+	public static final field Plugin Lio/ktor/client/plugins/UserAgent$Plugin;
+	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getAgent ()Ljava/lang/String;
 }
 
-public final class io/ktor/client/plugins/UserAgentConfig {
+public final class io/ktor/client/plugins/UserAgent$Config {
 	public fun <init> ()V
 	public fun <init> (Ljava/lang/String;)V
 	public synthetic fun <init> (Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
@@ -523,10 +595,17 @@ public final class io/ktor/client/plugins/UserAgentConfig {
 	public final fun setAgent (Ljava/lang/String;)V
 }
 
+public final class io/ktor/client/plugins/UserAgent$Plugin : io/ktor/client/plugins/HttpClientPlugin {
+	public fun getKey ()Lio/ktor/util/AttributeKey;
+	public fun install (Lio/ktor/client/plugins/UserAgent;Lio/ktor/client/HttpClient;)V
+	public synthetic fun install (Ljava/lang/Object;Lio/ktor/client/HttpClient;)V
+	public fun prepare (Lkotlin/jvm/functions/Function1;)Lio/ktor/client/plugins/UserAgent;
+	public synthetic fun prepare (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+}
+
 public final class io/ktor/client/plugins/UserAgentKt {
 	public static final fun BrowserUserAgent (Lio/ktor/client/HttpClientConfig;)V
 	public static final fun CurlUserAgent (Lio/ktor/client/HttpClientConfig;)V
-	public static final fun getUserAgent ()Lio/ktor/client/plugins/api/ClientPlugin;
 }
 
 public abstract interface class io/ktor/client/plugins/api/ClientHook {
@@ -575,8 +654,7 @@ public final class io/ktor/client/plugins/api/Send : io/ktor/client/plugins/api/
 	public fun install (Lio/ktor/client/HttpClient;Lkotlin/jvm/functions/Function3;)V
 }
 
-public final class io/ktor/client/plugins/api/Send$Sender : kotlinx/coroutines/CoroutineScope {
-	public fun getCoroutineContext ()Lkotlin/coroutines/CoroutineContext;
+public final class io/ktor/client/plugins/api/Send$Sender {
 	public final fun proceed (Lio/ktor/client/request/HttpRequestBuilder;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
@@ -601,6 +679,8 @@ public final class io/ktor/client/plugins/api/TransformResponseBodyContext {
 public final class io/ktor/client/plugins/cache/HttpCache {
 	public static final field Companion Lio/ktor/client/plugins/cache/HttpCache$Companion;
 	public synthetic fun <init> (Lio/ktor/client/plugins/cache/storage/HttpCacheStorage;Lio/ktor/client/plugins/cache/storage/HttpCacheStorage;Lio/ktor/client/plugins/cache/storage/CacheStorage;Lio/ktor/client/plugins/cache/storage/CacheStorage;ZZLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getPrivateStorage ()Lio/ktor/client/plugins/cache/storage/HttpCacheStorage;
+	public final fun getPublicStorage ()Lio/ktor/client/plugins/cache/storage/HttpCacheStorage;
 }
 
 public final class io/ktor/client/plugins/cache/HttpCache$Companion : io/ktor/client/plugins/HttpClientPlugin {
@@ -683,6 +763,7 @@ public final class io/ktor/client/plugins/cache/storage/HttpCacheStorage$Compani
 }
 
 public final class io/ktor/client/plugins/cache/storage/HttpCacheStorageKt {
+	public static final synthetic fun store (Lio/ktor/client/plugins/cache/storage/CacheStorage;Lio/ktor/client/statement/HttpResponse;Ljava/util/Map;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static final fun store (Lio/ktor/client/plugins/cache/storage/CacheStorage;Lio/ktor/client/statement/HttpResponse;Ljava/util/Map;ZLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static final fun store (Lio/ktor/client/plugins/cache/storage/CacheStorage;Lio/ktor/client/statement/HttpResponse;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun store$default (Lio/ktor/client/plugins/cache/storage/CacheStorage;Lio/ktor/client/statement/HttpResponse;Ljava/util/Map;ZLkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
@@ -745,18 +826,32 @@ public final class io/ktor/client/plugins/cookies/HttpCookiesKt {
 public final class io/ktor/client/plugins/observer/DelegatedCallKt {
 	public static final fun wrap (Lio/ktor/client/call/HttpClientCall;Lio/ktor/utils/io/ByteReadChannel;Lio/ktor/http/Headers;)Lio/ktor/client/call/HttpClientCall;
 	public static final fun wrapWithContent (Lio/ktor/client/call/HttpClientCall;Lio/ktor/utils/io/ByteReadChannel;)Lio/ktor/client/call/HttpClientCall;
+	public static final fun wrapWithContent (Lio/ktor/client/call/HttpClientCall;Lio/ktor/utils/io/ByteReadChannel;Z)Lio/ktor/client/call/HttpClientCall;
 	public static final fun wrapWithContent (Lio/ktor/client/call/HttpClientCall;Lkotlin/jvm/functions/Function0;)Lio/ktor/client/call/HttpClientCall;
 }
 
-public final class io/ktor/client/plugins/observer/ResponseObserverConfig {
+public final class io/ktor/client/plugins/observer/ResponseObserver {
+	public static final field Plugin Lio/ktor/client/plugins/observer/ResponseObserver$Plugin;
+	public fun <init> (Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function1;)V
+	public synthetic fun <init> (Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function1;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+}
+
+public final class io/ktor/client/plugins/observer/ResponseObserver$Config {
 	public fun <init> ()V
 	public final fun filter (Lkotlin/jvm/functions/Function1;)V
 	public final fun onResponse (Lkotlin/jvm/functions/Function2;)V
 }
 
+public final class io/ktor/client/plugins/observer/ResponseObserver$Plugin : io/ktor/client/plugins/HttpClientPlugin {
+	public fun getKey ()Lio/ktor/util/AttributeKey;
+	public fun install (Lio/ktor/client/plugins/observer/ResponseObserver;Lio/ktor/client/HttpClient;)V
+	public synthetic fun install (Ljava/lang/Object;Lio/ktor/client/HttpClient;)V
+	public fun prepare (Lkotlin/jvm/functions/Function1;)Lio/ktor/client/plugins/observer/ResponseObserver;
+	public synthetic fun prepare (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+}
+
 public final class io/ktor/client/plugins/observer/ResponseObserverKt {
 	public static final fun ResponseObserver (Lio/ktor/client/HttpClientConfig;Lkotlin/jvm/functions/Function2;)V
-	public static final fun getResponseObserver ()Lio/ktor/client/plugins/api/ClientPlugin;
 }
 
 public final class io/ktor/client/plugins/sse/BuildersKt {
@@ -787,15 +882,12 @@ public final class io/ktor/client/plugins/sse/BuildersKt {
 	public static synthetic fun sseSession-xEWcMm4$default (Lio/ktor/client/HttpClient;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Lkotlin/time/Duration;Ljava/lang/Boolean;Ljava/lang/Boolean;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 }
 
-public final class io/ktor/client/plugins/sse/ClientSSESession : io/ktor/client/plugins/sse/SSESession {
-	public fun <init> (Lio/ktor/client/call/HttpClientCall;Lio/ktor/client/plugins/sse/SSESession;)V
-	public final fun getCall ()Lio/ktor/client/call/HttpClientCall;
-	public fun getCoroutineContext ()Lkotlin/coroutines/CoroutineContext;
-	public fun getIncoming ()Lkotlinx/coroutines/flow/Flow;
+public abstract interface class io/ktor/client/plugins/sse/ClientSSESession : kotlinx/coroutines/CoroutineScope {
+	public abstract fun getIncoming ()Lkotlinx/coroutines/flow/Flow;
 }
 
-public final class io/ktor/client/plugins/sse/DefaultClientSSESession : io/ktor/client/plugins/sse/SSESession {
-	public fun <init> (Lio/ktor/client/plugins/sse/SSEClientContent;Lio/ktor/utils/io/ByteReadChannel;Lkotlin/coroutines/CoroutineContext;)V
+public final class io/ktor/client/plugins/sse/DefaultClientSSESession : io/ktor/client/plugins/sse/ClientSSESession {
+	public fun <init> (Lio/ktor/client/plugins/sse/SSEClientContent;Lio/ktor/utils/io/ByteReadChannel;Lkotlin/coroutines/CoroutineContext;Lio/ktor/http/HttpStatusCode;Lio/ktor/http/Headers;)V
 	public fun getCoroutineContext ()Lkotlin/coroutines/CoroutineContext;
 	public fun getIncoming ()Lkotlinx/coroutines/flow/Flow;
 }
@@ -805,8 +897,8 @@ public final class io/ktor/client/plugins/sse/SSECapability : io/ktor/client/eng
 	public fun toString ()Ljava/lang/String;
 }
 
-public final class io/ktor/client/plugins/sse/SSEClientContent : io/ktor/http/content/OutgoingContent$ContentWrapper {
-	public synthetic fun <init> (JZZLio/ktor/http/content/OutgoingContent;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+public final class io/ktor/client/plugins/sse/SSEClientContent : io/ktor/http/content/OutgoingContent$NoContent {
+	public synthetic fun <init> (JZZLkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun getHeaders ()Lio/ktor/http/Headers;
 	public final fun getReconnectionTime-UwyO8pc ()J
 	public final fun getShowCommentEvents ()Z
@@ -824,10 +916,6 @@ public final class io/ktor/client/plugins/sse/SSEConfig {
 
 public final class io/ktor/client/plugins/sse/SSEKt {
 	public static final fun getSSE ()Lio/ktor/client/plugins/api/ClientPlugin;
-}
-
-public abstract interface class io/ktor/client/plugins/sse/SSESession : kotlinx/coroutines/CoroutineScope {
-	public abstract fun getIncoming ()Lkotlinx/coroutines/flow/Flow;
 }
 
 public final class io/ktor/client/plugins/websocket/BuildersKt {
@@ -1149,7 +1237,6 @@ public final class io/ktor/client/request/HttpRequestJvmKt {
 }
 
 public final class io/ktor/client/request/HttpRequestKt {
-	public static final fun getResponseAdapterAttributeKey ()Lio/ktor/util/AttributeKey;
 	public static final fun headers (Lio/ktor/http/HttpMessageBuilder;Lkotlin/jvm/functions/Function1;)Lio/ktor/http/HeadersBuilder;
 	public static final fun invoke (Lio/ktor/client/request/HttpRequestBuilder$Companion;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Lio/ktor/client/request/HttpRequestBuilder;
 	public static final fun invoke (Lio/ktor/client/request/HttpRequestBuilder$Companion;Lkotlin/jvm/functions/Function1;)Lio/ktor/client/request/HttpRequestBuilder;
@@ -1210,15 +1297,6 @@ public final class io/ktor/client/request/HttpSendPipeline$Phases {
 
 public final class io/ktor/client/request/RequestBodyKt {
 	public static final fun setBody (Lio/ktor/client/request/HttpRequestBuilder;Ljava/lang/Object;Lio/ktor/util/reflect/TypeInfo;)V
-}
-
-public abstract interface class io/ktor/client/request/ResponseAdapter {
-	public abstract fun adapt (Lio/ktor/client/request/HttpRequestData;Lio/ktor/http/HttpStatusCode;Lio/ktor/http/Headers;Lio/ktor/utils/io/ByteReadChannel;Lio/ktor/http/content/OutgoingContent;Lkotlin/coroutines/CoroutineContext;)Ljava/lang/Object;
-}
-
-public final class io/ktor/client/request/SSEClientResponseAdapter : io/ktor/client/request/ResponseAdapter {
-	public fun <init> ()V
-	public fun adapt (Lio/ktor/client/request/HttpRequestData;Lio/ktor/http/HttpStatusCode;Lio/ktor/http/Headers;Lio/ktor/utils/io/ByteReadChannel;Lio/ktor/http/content/OutgoingContent;Lkotlin/coroutines/CoroutineContext;)Ljava/lang/Object;
 }
 
 public final class io/ktor/client/request/UtilsKt {
@@ -1336,6 +1414,11 @@ public final class io/ktor/client/request/forms/MultiPartFormDataContent : io/kt
 	public fun writeTo (Lio/ktor/utils/io/ByteWriteChannel;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
+public final class io/ktor/client/statement/CompatibilityKt {
+	public static final fun readText (Lio/ktor/client/statement/HttpResponse;Ljava/nio/charset/Charset;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun readText$default (Lio/ktor/client/statement/HttpResponse;Ljava/nio/charset/Charset;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
 public final class io/ktor/client/statement/DefaultHttpResponse : io/ktor/client/statement/HttpResponse {
 	public fun <init> (Lio/ktor/client/call/HttpClientCall;Lio/ktor/client/request/HttpResponseData;)V
 	public fun getCall ()Lio/ktor/client/call/HttpClientCall;
@@ -1425,6 +1508,12 @@ public final class io/ktor/client/statement/ReadersKt {
 	public static final fun discardRemaining (Lio/ktor/client/statement/HttpResponse;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static final fun readBytes (Lio/ktor/client/statement/HttpResponse;ILkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static final fun readBytes (Lio/ktor/client/statement/HttpResponse;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class io/ktor/client/utils/ByteBufferPool : io/ktor/utils/io/pool/DefaultPool {
+	public fun <init> ()V
+	public synthetic fun clearInstance (Ljava/lang/Object;)Ljava/lang/Object;
+	public synthetic fun produceInstance ()Ljava/lang/Object;
 }
 
 public final class io/ktor/client/utils/CIOJvmKt {

--- a/ktor-client/ktor-client-core/common/src/io/ktor/client/engine/HttpClientEngineConfig.kt
+++ b/ktor-client/ktor-client-core/common/src/io/ktor/client/engine/HttpClientEngineConfig.kt
@@ -14,10 +14,6 @@ public open class HttpClientEngineConfig {
     /**
      * Specifies network threads count advice.
      */
-    @Deprecated(
-        "The [threadsCount] property is deprecated. The [Dispatchers.IO] is used by default.",
-        level = DeprecationLevel.ERROR
-    )
     public var threadsCount: Int = 4
 
     /**

--- a/ktor-client/ktor-client-core/js/src/io/ktor/client/engine/js/JsClientEngine.kt
+++ b/ktor-client/ktor-client-core/js/src/io/ktor/client/engine/js/JsClientEngine.kt
@@ -25,6 +25,8 @@ internal class JsClientEngine(
     override val config: JsClientEngineConfig,
 ) : HttpClientEngineBase("ktor-js") {
 
+    override val dispatcher = Dispatchers.Default
+
     override val supportedCapabilities = setOf(HttpTimeoutCapability, WebSocketCapability, SSECapability)
 
     init {

--- a/ktor-client/ktor-client-core/jsAndWasmShared/src/io/ktor/client/engine/HttpClientEngineBase.js.kt
+++ b/ktor-client/ktor-client-core/jsAndWasmShared/src/io/ktor/client/engine/HttpClientEngineBase.js.kt
@@ -1,9 +1,0 @@
-/*
- * Copyright 2014-2023 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
- */
-
-package io.ktor.client.engine
-
-import kotlinx.coroutines.*
-
-internal actual fun ioDispatcher(): CoroutineDispatcher = Dispatchers.Default

--- a/ktor-client/ktor-client-core/jvm/src/io/ktor/client/engine/HttpClientEngineBase.jvm.kt
+++ b/ktor-client/ktor-client-core/jvm/src/io/ktor/client/engine/HttpClientEngineBase.jvm.kt
@@ -1,9 +1,0 @@
-/*
- * Copyright 2014-2023 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
- */
-
-package io.ktor.client.engine
-
-import kotlinx.coroutines.*
-
-internal actual fun ioDispatcher(): CoroutineDispatcher = Dispatchers.IO

--- a/ktor-client/ktor-client-core/jvm/src/io/ktor/client/engine/HttpClientJvmEngine.kt
+++ b/ktor-client/ktor-client-core/jvm/src/io/ktor/client/engine/HttpClientJvmEngine.kt
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2014-2019 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.client.engine
+
+import io.ktor.util.*
+import kotlinx.coroutines.*
+import java.util.concurrent.*
+import kotlin.coroutines.*
+
+/**
+ * Base jvm implementation for [HttpClientEngine]
+ */
+@Suppress("KDocMissingDocumentation")
+@Deprecated(
+    "Use HttpClientEngineBase instead.",
+    replaceWith = ReplaceWith("HttpClientEngineBase"),
+    level = DeprecationLevel.ERROR
+)
+public abstract class HttpClientJvmEngine(engineName: String) : HttpClientEngine {
+    private val clientContext = SilentSupervisor()
+    private val _dispatcher by lazy {
+        Executors.newFixedThreadPool(config.threadsCount) {
+            Thread(it).apply {
+                isDaemon = true
+            }
+        }.asCoroutineDispatcher()
+    }
+
+    @OptIn(InternalCoroutinesApi::class)
+    override val dispatcher: CoroutineDispatcher
+        get() = _dispatcher
+
+    @OptIn(InternalCoroutinesApi::class)
+    override val coroutineContext: CoroutineContext by lazy {
+        _dispatcher + clientContext + CoroutineName("$engineName-context")
+    }
+
+    /**
+     * Create [CoroutineContext] to execute call.
+     */
+    @OptIn(InternalCoroutinesApi::class)
+    protected suspend fun createCallContext(): CoroutineContext {
+        val callJob = Job(clientContext[Job])
+        val callContext = coroutineContext + callJob
+
+        val parentCoroutineJob = currentContext()[Job]
+        val onParentCancelCleanupHandle = parentCoroutineJob?.invokeOnCompletion(
+            onCancelling = true
+        ) { cause ->
+            if (cause != null) callContext.cancel()
+        }
+
+        callJob.invokeOnCompletion {
+            onParentCancelCleanupHandle?.dispose()
+        }
+
+        return callContext
+    }
+
+    override fun close() {
+        val job = clientContext[Job] as CompletableJob
+
+        job.complete()
+        job.invokeOnCompletion {
+            _dispatcher.close()
+        }
+    }
+}
+
+private suspend inline fun currentContext() = coroutineContext

--- a/ktor-client/ktor-client-core/posix/src/io/ktor/client/engine/HttpClientEngineBase.posix.kt
+++ b/ktor-client/ktor-client-core/posix/src/io/ktor/client/engine/HttpClientEngineBase.posix.kt
@@ -1,9 +1,0 @@
-/*
- * Copyright 2014-2023 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
- */
-
-package io.ktor.client.engine
-
-import kotlinx.coroutines.*
-
-internal actual fun ioDispatcher(): CoroutineDispatcher = Dispatchers.IO

--- a/ktor-client/ktor-client-core/wasmJs/src/io/ktor/client/engine/js/JsClientEngine.kt
+++ b/ktor-client/ktor-client-core/wasmJs/src/io/ktor/client/engine/js/JsClientEngine.kt
@@ -16,7 +16,6 @@ import io.ktor.util.*
 import io.ktor.util.date.*
 import io.ktor.utils.io.*
 import kotlinx.coroutines.*
-import kotlinx.coroutines.CancellationException
 import org.w3c.dom.*
 import org.w3c.dom.events.*
 import kotlin.coroutines.*
@@ -37,6 +36,8 @@ private fun createWebSocketNodeJs(
 internal class JsClientEngine(
     override val config: JsClientEngineConfig,
 ) : HttpClientEngineBase("ktor-js") {
+
+    override val dispatcher = Dispatchers.Default
 
     override val supportedCapabilities = setOf(HttpTimeoutCapability, WebSocketCapability, SSECapability)
 

--- a/ktor-client/ktor-client-java/api/ktor-client-java.api
+++ b/ktor-client/ktor-client-java/api/ktor-client-java.api
@@ -15,6 +15,7 @@ public final class io/ktor/client/engine/java/JavaHttpEngine : io/ktor/client/en
 	public fun execute (Lio/ktor/client/request/HttpRequestData;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public synthetic fun getConfig ()Lio/ktor/client/engine/HttpClientEngineConfig;
 	public fun getConfig ()Lio/ktor/client/engine/java/JavaHttpConfig;
+	public fun getDispatcher ()Lkotlinx/coroutines/CoroutineDispatcher;
 	public fun getSupportedCapabilities ()Ljava/util/Set;
 }
 

--- a/ktor-client/ktor-client-java/jvm/test/io/ktor/client/engine/java/JavaEngineTests.kt
+++ b/ktor-client/ktor-client-java/jvm/test/io/ktor/client/engine/java/JavaEngineTests.kt
@@ -13,9 +13,19 @@ import io.ktor.http.*
 import kotlinx.coroutines.*
 import java.net.*
 import java.time.*
+import java.util.concurrent.*
 import kotlin.test.*
 
 class JavaEngineTests {
+    @Test
+    fun testClose() {
+        val engine = JavaHttpEngine(JavaHttpConfig())
+        engine.close()
+
+        assertTrue("Java HTTP dispatcher is not working.") {
+            engine.executor.isShutdown
+        }
+    }
 
     @Test
     fun testProxy() = runBlocking {
@@ -29,6 +39,49 @@ class JavaEngineTests {
             .bodyAsText()
 
         assertEquals("proxy", body)
+    }
+
+    @Test
+    fun testThreadLeak() = runBlocking {
+        System.setProperty("jdk.internal.httpclient.selectorTimeout", "50")
+
+        val initialNumberOfThreads = Thread.getAllStackTraces().size
+        val repeats = 25
+        val executors = ArrayList<ExecutorService>()
+
+        try {
+            repeat(repeats) {
+                HttpClient(Java).use { client ->
+                    val response = client.get("http://www.google.com").body<String>()
+                    assertNotNull(response)
+                    executors += (client.engine as JavaHttpEngine).executor
+                }
+            }
+
+            // When engine is disposed HttpClient's SelectorManager thread remains active
+            // until it realizes that no more reference on HttpClient.
+            // Minimum polling interval SelectorManager thread is 1000ms.
+            var retry = 0
+            do {
+                System.gc()
+                Thread.sleep(1000)
+                System.gc()
+                System.gc()
+            } while (Thread.getAllStackTraces().size >= initialNumberOfThreads && retry++ < 10)
+        } finally {
+            System.clearProperty("jdk.internal.httpclient.selectorTimeout")
+        }
+
+        val totalNumberOfThreads = Thread.getAllStackTraces().size
+        val threadsCreated = totalNumberOfThreads - initialNumberOfThreads
+
+        executors.forEach { pool ->
+            assertTrue(pool.isTerminated)
+        }
+
+        assertTrue("Number of threads should be less $repeats, but was $threadsCreated") {
+            threadsCreated < repeats
+        }
     }
 
     @Test

--- a/ktor-client/ktor-client-jetty/jvm/src/io/ktor/client/engine/jetty/JettyHttp2Engine.kt
+++ b/ktor-client/ktor-client-jetty/jvm/src/io/ktor/client/engine/jetty/JettyHttp2Engine.kt
@@ -7,10 +7,12 @@ package io.ktor.client.engine.jetty
 import io.ktor.client.engine.*
 import io.ktor.client.plugins.*
 import io.ktor.client.request.*
+import io.ktor.client.utils.*
 import io.ktor.util.*
 import io.ktor.utils.io.*
 import kotlinx.coroutines.*
 import org.eclipse.jetty.http2.client.*
+import org.eclipse.jetty.util.thread.*
 
 @OptIn(InternalAPI::class)
 internal class JettyHttp2Engine(
@@ -18,6 +20,14 @@ internal class JettyHttp2Engine(
 ) : HttpClientEngineBase("ktor-jetty") {
 
     override val supportedCapabilities = setOf(HttpTimeoutCapability)
+
+    override val dispatcher: CoroutineDispatcher by lazy {
+        Dispatchers.clientDispatcher(
+            config.threadsCount,
+            "ktor-jetty-dispatcher"
+        )
+    }
+
 
     /**
      * Cache that keeps least recently used [HTTP2Client] instances. Set "0" to avoid caching.

--- a/ktor-client/ktor-client-mock/api/ktor-client-mock.api
+++ b/ktor-client/ktor-client-mock/api/ktor-client-mock.api
@@ -5,6 +5,7 @@ public final class io/ktor/client/engine/mock/MockEngine : io/ktor/client/engine
 	public fun execute (Lio/ktor/client/request/HttpRequestData;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public synthetic fun getConfig ()Lio/ktor/client/engine/HttpClientEngineConfig;
 	public fun getConfig ()Lio/ktor/client/engine/mock/MockEngineConfig;
+	public fun getDispatcher ()Lkotlinx/coroutines/CoroutineDispatcher;
 	public final fun getRequestHistory ()Ljava/util/List;
 	public final fun getResponseHistory ()Ljava/util/List;
 	public fun getSupportedCapabilities ()Ljava/util/Set;

--- a/ktor-client/ktor-client-mock/common/src/io/ktor/client/engine/mock/MockEngine.kt
+++ b/ktor-client/ktor-client-mock/common/src/io/ktor/client/engine/mock/MockEngine.kt
@@ -9,13 +9,16 @@ import io.ktor.client.plugins.*
 import io.ktor.client.plugins.websocket.*
 import io.ktor.client.request.*
 import io.ktor.utils.io.*
-import kotlinx.atomicfu.locks.*
+import io.ktor.utils.io.locks.*
 import kotlinx.coroutines.*
 
 /**
  * [HttpClientEngine] for writing tests without network.
  */
+@OptIn(InternalAPI::class)
 public class MockEngine(override val config: MockEngineConfig) : HttpClientEngineBase("ktor-mock") {
+    override val dispatcher: CoroutineDispatcher = config.dispatcher
+
     override val supportedCapabilities: Set<HttpClientEngineCapability<out Any>> = setOf(
         HttpTimeoutCapability,
         WebSocketCapability,

--- a/ktor-client/ktor-client-mock/common/src/io/ktor/client/engine/mock/MockEngineConfig.kt
+++ b/ktor-client/ktor-client-mock/common/src/io/ktor/client/engine/mock/MockEngineConfig.kt
@@ -40,12 +40,7 @@ public class MockEngineConfig : HttpClientEngineConfig() {
     /**
      * Dispatcher to use with [MockEngine].
      */
-    @Deprecated(
-        "The [dispatcher] is no longer configurable, Dispatchers.IO is used by default",
-        level = DeprecationLevel.ERROR
-    )
-    public var dispatcher: CoroutineDispatcher get() = error("The [dispatcher] is no longer configurable")
-        set(_) = error("The [dispatcher] is no longer configurable")
+    public var dispatcher: CoroutineDispatcher = Dispatchers.Default
 
     /**
      * Add request handler to [MockEngine]

--- a/ktor-client/ktor-client-okhttp/api/ktor-client-okhttp.api
+++ b/ktor-client/ktor-client-okhttp/api/ktor-client-okhttp.api
@@ -23,6 +23,7 @@ public final class io/ktor/client/engine/okhttp/OkHttpEngine : io/ktor/client/en
 	public synthetic fun getConfig ()Lio/ktor/client/engine/HttpClientEngineConfig;
 	public fun getConfig ()Lio/ktor/client/engine/okhttp/OkHttpConfig;
 	public fun getCoroutineContext ()Lkotlin/coroutines/CoroutineContext;
+	public fun getDispatcher ()Lkotlinx/coroutines/CoroutineDispatcher;
 	public fun getSupportedCapabilities ()Ljava/util/Set;
 }
 

--- a/ktor-server/ktor-server-test-host/api/ktor-server-test-host.api
+++ b/ktor-server/ktor-server-test-host/api/ktor-server-test-host.api
@@ -194,6 +194,7 @@ public final class io/ktor/server/testing/client/TestHttpClientEngine : io/ktor/
 	public synthetic fun getConfig ()Lio/ktor/client/engine/HttpClientEngineConfig;
 	public fun getConfig ()Lio/ktor/server/testing/client/TestHttpClientConfig;
 	public fun getCoroutineContext ()Lkotlin/coroutines/CoroutineContext;
+	public fun getDispatcher ()Lkotlinx/coroutines/CoroutineDispatcher;
 	public fun getSupportedCapabilities ()Ljava/util/Set;
 }
 

--- a/ktor-server/ktor-server-test-host/jvmAndNix/src/io/ktor/server/testing/client/DelegatingTestClientEngine.kt
+++ b/ktor-server/ktor-server-test-host/jvmAndNix/src/io/ktor/server/testing/client/DelegatingTestClientEngine.kt
@@ -6,11 +6,11 @@ package io.ktor.server.testing.client
 
 import io.ktor.client.engine.*
 import io.ktor.client.plugins.*
-import io.ktor.client.plugins.sse.*
 import io.ktor.client.plugins.websocket.*
 import io.ktor.client.request.*
 import io.ktor.http.*
 import io.ktor.server.testing.*
+import io.ktor.server.testing.internal.*
 import io.ktor.utils.io.*
 import kotlinx.coroutines.*
 import kotlin.coroutines.*
@@ -18,6 +18,8 @@ import kotlin.coroutines.*
 internal class DelegatingTestClientEngine(
     override val config: DelegatingTestHttpClientConfig
 ) : HttpClientEngineBase("delegating-test-engine") {
+
+    override val dispatcher = Dispatchers.IOBridge
 
     override val supportedCapabilities =
         setOf<HttpClientEngineCapability<*>>(WebSocketCapability, HttpTimeoutCapability, SSECapability)

--- a/ktor-server/ktor-server-test-host/jvmAndNix/src/io/ktor/server/testing/client/TestHttpClientEngine.kt
+++ b/ktor-server/ktor-server-test-host/jvmAndNix/src/io/ktor/server/testing/client/TestHttpClientEngine.kt
@@ -8,6 +8,7 @@ import io.ktor.client.call.*
 import io.ktor.client.engine.*
 import io.ktor.client.plugins.*
 import io.ktor.client.request.*
+import io.ktor.client.utils.*
 import io.ktor.http.*
 import io.ktor.http.content.*
 import io.ktor.server.testing.*
@@ -35,9 +36,12 @@ public class TestHttpClientEngine(override val config: TestHttpClientConfig) : H
 
     override val supportedCapabilities: Set<HttpClientEngineCapability<*>> = bridge.supportedCapabilities
 
+    @OptIn(InternalAPI::class)
+    override val dispatcher: CoroutineDispatcher = Dispatchers.clientDispatcher(config.threadsCount)
+
     private val clientJob: CompletableJob = Job(app.coroutineContext[Job])
 
-    override val coroutineContext: CoroutineContext = clientJob + dispatcher
+    override val coroutineContext: CoroutineContext = dispatcher + clientJob
 
     @OptIn(InternalAPI::class)
     override suspend fun execute(data: HttpRequestData): HttpResponseData {


### PR DESCRIPTION
Fix [KTOR-6417](https://youtrack.jetbrains.com/issue/KTOR-6417) Ktor Client MockEngine dispatcher handle removed

Fix [KTOR-6462](https://youtrack.jetbrains.com/issue/KTOR-6462) Ktor clients and servers should use Dispatchers.IO.limitedParallelism(...) wherever possible