### PR TITLE
KTOR-7016 Lazy initialize iconv charsets

### DIFF
--- a/ktor-io/linux/src/CharsetLinux.kt
+++ b/ktor-io/linux/src/CharsetLinux.kt
@@ -10,9 +10,9 @@ import platform.iconv.*
 import platform.posix.*
 
 public actual object Charsets {
-    public actual val UTF_8: Charset = CharsetIconv("UTF-8")
-    public actual val ISO_8859_1: Charset = CharsetIconv("ISO-8859-1")
-    internal val UTF_16: Charset = CharsetIconv(platformUtf16)
+    public actual val UTF_8: Charset by lazy { CharsetIconv("UTF-8") }
+    public actual val ISO_8859_1: Charset by lazy { CharsetIconv("ISO-8859-1") }
+    internal val UTF_16: Charset by lazy { CharsetIconv(platformUtf16) }
 }
 
 internal actual fun findCharset(name: String): Charset {

--- a/ktor-io/mingwX64/src/CharsetMingw.kt
+++ b/ktor-io/mingwX64/src/CharsetMingw.kt
@@ -10,9 +10,9 @@ import platform.iconv.*
 import platform.posix.*
 
 public actual object Charsets {
-    public actual val UTF_8: Charset = CharsetIconv("UTF-8")
-    public actual val ISO_8859_1: Charset = CharsetIconv("ISO-8859-1")
-    internal val UTF_16: Charset = CharsetIconv(platformUtf16)
+    public actual val UTF_8: Charset by lazy { CharsetIconv("UTF-8") }
+    public actual val ISO_8859_1: Charset by lazy { CharsetIconv("ISO-8859-1") }
+    internal val UTF_16: Charset by lazy { CharsetIconv(platformUtf16) }
 }
 
 @OptIn(ExperimentalForeignApi::class)


### PR DESCRIPTION
Fix [KTOR-7016](https://youtrack.jetbrains.com/issue/KTOR-7016) Embedded Linux device without iso-8859-1 and UTF-16 cannot use ktor-network