### PR TITLE
Fix flaky testErrorForProtocolUpgradeRequestBody 

### DIFF
--- a/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/plugins/ServerSentEventsTest.kt
+++ b/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/plugins/ServerSentEventsTest.kt
@@ -351,28 +351,30 @@ class ServerSentEventsTest : ClientLoader(timeoutSeconds = 120) {
     }
 
     @Test
-    fun testErrorForProtocolUpgradeRequestBody() = clientTests(listOf("OkHttp")) {
-        config {
-            install(SSE)
-        }
-
-        val body = object : OutgoingContent.ProtocolUpgrade() {
-            override suspend fun upgrade(
-                input: ByteReadChannel,
-                output: ByteWriteChannel,
-                engineContext: CoroutineContext,
-                userContext: CoroutineContext
-            ): Job {
-                output.close()
-                return Job()
+    fun testErrorForProtocolUpgradeRequestBody() = repeat(10000) {
+        clientTests(listOf("OkHttp")) {
+            config {
+                install(SSE)
             }
-        }
-        test { client ->
-            kotlin.test.assertFailsWith<SSEException> {
-                client.sse({
-                    url("$TEST_SERVER/sse/echo")
-                    setBody(body)
-                }) {}
+
+            val body = object : OutgoingContent.ProtocolUpgrade() {
+                override suspend fun upgrade(
+                    input: ByteReadChannel,
+                    output: ByteWriteChannel,
+                    engineContext: CoroutineContext,
+                    userContext: CoroutineContext
+                ): Job {
+                    output.close()
+                    return Job()
+                }
+            }
+            test { client ->
+                kotlin.test.assertFailsWith<SSEException> {
+                    client.sse({
+                        url("$TEST_SERVER/sse/echo")
+                        setBody(body)
+                    }) {}
+                }
             }
         }
     }

--- a/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/plugins/ServerSentEventsTest.kt
+++ b/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/plugins/ServerSentEventsTest.kt
@@ -351,30 +351,28 @@ class ServerSentEventsTest : ClientLoader(timeoutSeconds = 120) {
     }
 
     @Test
-    fun testErrorForProtocolUpgradeRequestBody() = repeat(10000) {
-        clientTests(listOf("OkHttp")) {
-            config {
-                install(SSE)
-            }
+    fun testErrorForProtocolUpgradeRequestBody() = clientTests(listOf("OkHttp")) {
+        config {
+            install(SSE)
+        }
 
-            val body = object : OutgoingContent.ProtocolUpgrade() {
-                override suspend fun upgrade(
-                    input: ByteReadChannel,
-                    output: ByteWriteChannel,
-                    engineContext: CoroutineContext,
-                    userContext: CoroutineContext
-                ): Job {
-                    output.close()
-                    return Job()
-                }
+        val body = object : OutgoingContent.ProtocolUpgrade() {
+            override suspend fun upgrade(
+                input: ByteReadChannel,
+                output: ByteWriteChannel,
+                engineContext: CoroutineContext,
+                userContext: CoroutineContext
+            ): Job {
+                output.close()
+                return Job()
             }
-            test { client ->
-                kotlin.test.assertFailsWith<SSEException> {
-                    client.sse({
-                        url("$TEST_SERVER/sse/echo")
-                        setBody(body)
-                    }) {}
-                }
+        }
+        test { client ->
+            kotlin.test.assertFailsWith<SSEException> {
+                client.sse({
+                    url("$TEST_SERVER/sse/echo")
+                    setBody(body)
+                }) {}
             }
         }
     }

--- a/ktor-http/common/src/io/ktor/http/content/OutgoingContent.kt
+++ b/ktor-http/common/src/io/ktor/http/content/OutgoingContent.kt
@@ -160,7 +160,7 @@ public sealed class OutgoingContent {
 }
 
 /**
- * Check if current [OutgoingContent] doesn't contains content
+ * Check if current [OutgoingContent] doesn't contain content
  */
 @InternalAPI
 public fun OutgoingContent.isEmpty(): Boolean = when (this) {

--- a/ktor-http/common/src/io/ktor/http/content/OutgoingContent.kt
+++ b/ktor-http/common/src/io/ktor/http/content/OutgoingContent.kt
@@ -165,7 +165,6 @@ public sealed class OutgoingContent {
 @InternalAPI
 public fun OutgoingContent.isEmpty(): Boolean = when (this) {
     is OutgoingContent.NoContent -> true
-    is OutgoingContent.ProtocolUpgrade -> true
     is OutgoingContent.ContentWrapper -> delegate().isEmpty()
     else -> false
 }

--- a/ktor-http/common/src/io/ktor/http/content/OutgoingContent.kt
+++ b/ktor-http/common/src/io/ktor/http/content/OutgoingContent.kt
@@ -162,8 +162,10 @@ public sealed class OutgoingContent {
 /**
  * Check if current [OutgoingContent] doesn't contains content
  */
+@InternalAPI
 public fun OutgoingContent.isEmpty(): Boolean = when (this) {
     is OutgoingContent.NoContent -> true
+    is OutgoingContent.ProtocolUpgrade -> true
     is OutgoingContent.ContentWrapper -> delegate().isEmpty()
     else -> false
 }


### PR DESCRIPTION
**Subsystem**
Client, CIO, SSE

**Solution**
Extract check of needing processing content from `launch`. Because otherwise, we have the following situation:
``` kotlin
fun makeDedicatedRequest(...) {
       try {
                writeRequest(...)
                readResponse(...)
        } catch (cause: Throwable) {
            // error must be caught here
            throw cause.mapToKtor(request)
        }
}

fun writeRequest(...) = withContext(callContext) {
    writeBody(...)
}

fun writeBody(...) {
    val scope = CoroutineScope(callContext + CoroutineName("Request body writer"))
    scope.launch {
        try {
            processOutgoingContent(...) // error is throwing here
        }
    }
}
```
So where is a race and a case when because of `launch` in `writeBody`, `readResponse` starts and finishes earlier than the error is throwing in `launch`, and the error isn't caught 

Proposed solution: Extract check before `launch`, so because it's in `withContext` `readResponse` will starts after it
