### PR TITLE
Use KotlinHierarchyTemplate for structuring source sets

### DIFF
--- a/buildSrc/src/main/kotlin/TargetsConfig.kt
+++ b/buildSrc/src/main/kotlin/TargetsConfig.kt
@@ -5,7 +5,7 @@
 
 import org.gradle.api.*
 import org.gradle.kotlin.dsl.*
-import org.jetbrains.kotlin.gradle.plugin.*
+import org.jetbrains.kotlin.gradle.*
 import org.jetbrains.kotlin.gradle.targets.js.dsl.*
 import java.io.*
 
@@ -51,228 +51,54 @@ fun Project.configureTargets() {
 
         if (hasPosix || hasLinux || hasDarwin || hasWindows) extra.set("hasNative", true)
 
+        if (hasPosix) { posixTargets() }
+        if (hasDesktop) { desktopTargets() }
+        if (hasNix) { nixTargets() }
+        if (hasLinux) { linuxTargets() }
+        if (hasDarwin) { darwinTargets() }
+        if (hasWindows) { windowsTargets() }
+
+        @OptIn(ExperimentalKotlinGradlePluginApi::class)
+        applyHierarchyTemplate {
+            common {
+                group("nix") {
+                    group("darwin") {
+                        group("macos") { withMacos() }
+                        group("ios") { withIos() }
+                        group("tvos") { withTvos() }
+                        group("watchos") { withWatchos() }
+                    }
+                    group("linux") { withLinux() }
+                }
+
+                withJvm()
+
+                group("jsAndWasmShared") {
+                    withJs()
+                    withWasm()
+                }
+
+                group("posix") {
+                    group("nix")
+                    group("windows") { withMingw() }
+                    group("desktop") {
+                        group("macos")
+                        group("linux")
+                        group("windows")
+                    }
+                }
+
+                group("jvmAndNix") {
+                    group("nix")
+                    withJvm()
+                }
+            }
+        }
+
         sourceSets {
-            if (hasJsAndWasmShared) {
-                val commonMain by getting {}
-                val jsAndWasmSharedMain by creating {
-                    dependsOn(commonMain)
-                }
-                val commonTest by getting {}
-                val jsAndWasmSharedTest by creating {
-                    dependsOn(commonTest)
-                }
-
-                jsMain {
-                    dependsOn(jsAndWasmSharedMain)
-                }
-                jsTest {
-                    dependsOn(jsAndWasmSharedTest)
-                }
-                wasmJsMain {
-                    dependsOn(jsAndWasmSharedMain)
-                }
-                wasmJsTest {
-                    dependsOn(jsAndWasmSharedTest)
-                }
-            }
-
-            if (hasPosix) {
-                val posixMain by creating
-                val posixTest by creating
-            }
-
-            if (hasNix) {
-                val nixMain by creating
-                val nixTest by creating
-            }
-
-            if (hasDarwin) {
-                val darwinMain by creating
-                val darwinTest by creating {
-                    dependencies {
-                        implementation(kotlin("test"))
-                    }
-                }
-
-                val macosMain by creating
-                val macosTest by creating
-
-                val watchosMain by creating
-                val watchosTest by creating
-
-                val tvosMain by creating
-                val tvosTest by creating
-
-                val iosMain by creating
-                val iosTest by creating
-            }
-
-            if (hasDesktop) {
-                val desktopMain by creating
-                val desktopTest by creating {
-                    dependencies {
-                        implementation(kotlin("test"))
-                    }
-                }
-            }
-
-            if (hasLinux) {
-                val linuxMain by creating
-                val linuxTest by creating
-            }
-
-            if (hasWindows) {
-                val windowsMain by creating
-                val windowsTest by creating
-            }
-
-            if (hasJvmAndNix) {
-                val jvmAndNixMain by creating {
-                    findByName("commonMain")?.let { dependsOn(it) }
-                }
-
-                val jvmAndNixTest by creating {
-                    findByName("commonTest")?.let { dependsOn(it) }
-                }
-            }
-
-            if (hasJvm) {
-                val jvmMain by getting {
-                    findByName("jvmAndNixMain")?.let { dependsOn(it) }
-                }
-
-                val jvmTest by getting {
-                    findByName("jvmAndNixTest")?.let { dependsOn(it) }
-                }
-            }
-
-            if (hasPosix) {
-                val posixMain by getting {
-                    findByName("commonMain")?.let { dependsOn(it) }
-                }
-
-                val posixTest by getting {
-                    findByName("commonTest")?.let { dependsOn(it) }
-
-                    dependencies {
-                        implementation(kotlin("test"))
-                    }
-                }
-
-                posixTargets().forEach {
-                    getByName("${it}Main").dependsOn(posixMain)
-                    getByName("${it}Test").dependsOn(posixTest)
-                }
-            }
-
-            if (hasNix) {
-                val nixMain by getting {
-                    findByName("posixMain")?.let { dependsOn(it) }
-                    findByName("jvmAndNixMain")?.let { dependsOn(it) }
-                }
-
-                val nixTest by getting {
-                    findByName("posixTest")?.let { dependsOn(it) }
-                    findByName("jvmAndNixTest")?.let { dependsOn(it) }
-                }
-
-                nixTargets().forEach {
-                    getByName("${it}Main").dependsOn(nixMain)
-                    getByName("${it}Test").dependsOn(nixTest)
-                }
-            }
-
-            if (hasDarwin) {
-                val nixMain: KotlinSourceSet? = findByName("nixMain")
-                val darwinMain by getting
-                val darwinTest by getting
-                val macosMain by getting
-                val macosTest by getting
-                val iosMain by getting
-                val iosTest by getting
-                val watchosMain by getting
-                val watchosTest by getting
-                val tvosMain by getting
-                val tvosTest by getting
-
-                nixMain?.let { darwinMain.dependsOn(it) }
-                macosMain.dependsOn(darwinMain)
-                tvosMain.dependsOn(darwinMain)
-                iosMain.dependsOn(darwinMain)
-                watchosMain.dependsOn(darwinMain)
-
-                macosTargets().forEach {
-                    getByName("${it}Main").dependsOn(macosMain)
-                    getByName("${it}Test").dependsOn(macosTest)
-                }
-
-                iosTargets().forEach {
-                    getByName("${it}Main").dependsOn(iosMain)
-                    getByName("${it}Test").dependsOn(iosTest)
-                }
-
-                watchosTargets().forEach {
-                    getByName("${it}Main").dependsOn(watchosMain)
-                    getByName("${it}Test").dependsOn(watchosTest)
-                }
-
-                tvosTargets().forEach {
-                    getByName("${it}Main").dependsOn(tvosMain)
-                    getByName("${it}Test").dependsOn(tvosTest)
-                }
-
-                darwinTargets().forEach {
-                    getByName("${it}Main").dependsOn(darwinMain)
-                    getByName("${it}Test").dependsOn(darwinTest)
-                }
-            }
-
-            if (hasLinux) {
-                val linuxMain by getting {
-                    findByName("nixMain")?.let { dependsOn(it) }
-                }
-
-                val linuxTest by getting {
-                    findByName("nixTest")?.let { dependsOn(it) }
-
-                    dependencies {
-                        implementation(kotlin("test"))
-                    }
-                }
-
-                linuxTargets().forEach {
-                    getByName("${it}Main").dependsOn(linuxMain)
-                    getByName("${it}Test").dependsOn(linuxTest)
-                }
-            }
-
-            if (hasDesktop) {
-                val desktopMain by getting {
-                    findByName("posixMain")?.let { dependsOn(it) }
-                }
-
-                val desktopTest by getting
-
-                desktopTargets().forEach {
-                    getByName("${it}Main").dependsOn(desktopMain)
-                    getByName("${it}Test").dependsOn(desktopTest)
-                }
-            }
-
-            if (hasWindows) {
-                val windowsMain by getting {
-                    findByName("posixMain")?.let { dependsOn(it) }
-                }
-
-                val windowsTest by getting {
-                    dependencies {
-                        implementation(kotlin("test"))
-                    }
-                }
-
-                windowsTargets().forEach {
-                    getByName("${it}Main").dependsOn(windowsMain)
-                    getByName("${it}Test").dependsOn(windowsTest)
+            commonTest {
+                dependencies {
+                    implementation(kotlin("test"))
                 }
             }
 


### PR DESCRIPTION
KotlinHierarchyTemplate allows writing KMP source set structures with less code and without explicit dependsOn relations.

There is one downside is that all source sets are created now if at least one of the target is declared. i.e. for example if JS target is declared but wasm is not. Then jsAndWasmSharedMain source set will be created anyway.

It also fixes the issue with Kotlin 2.0 
In :ktor-network jvmAndNixTest has an expect that in K1 was actualized in iosTest there was no direct or transitive dependsOn relation from iosTest to jvmAndNixTest and thus in K2 such actualization was prohibited. In this commit Source Set structure is sanitized and now dependsOn relations are in good order.

**Subsystem**
Gradle build

**Motivation**
Depends on relations between Kotlin Source Sets are messed in Ktor project. And Ktor is not to blame here, but Kotlin Multiplatform's dependsOn relations. They are error prone and very verbose. And since K2 Kotlin Compiler requires correctness in Source Set structure. i.e. in K1 due to its compilation model it was possible to violate symbols visibility and expect/actual. A bit more details you can find in related issue: https://youtrack.jetbrains.com/issue/KT-68212/K2-KMP-has-no-corresponding-expected-declaration-with-dependsOn-relationship

This is how SourceSet structure looked like in :ktor-network project. Impossible to read. 
![image](https://github.com/ktorio/ktor/assets/3123432/93a01e7e-e872-4014-965b-d55377daf953)

Same Source Set structure but normalized i.e. redundant depends on edges are removed
![image](https://github.com/ktorio/ktor/assets/3123432/68da0424-9c58-4a18-a3f9-f407bc7db8bc)

But take a look for example at iosTest you can see that it doesn't connect neither to commonTest nor to jvmAndNixTest.
And other source sets are also dongle here and there.

**Solution**
Apply kotlin target hierarchy template.  there is some information on kotlinlang web site https://kotlinlang.org/docs/multiplatform-hierarchy.html#default-hierarchy-template 

After applying the target hierarchy source set structure look much cleaner for both main and test source sets. And it doesn't have to be normalized. It is already in a good shape.
![image](https://github.com/ktorio/ktor/assets/3123432/cfeca71c-af08-441e-ad9a-a1a38937b0f6)

PS: kotlin-community/dev branch also has related PR (!4044)

