### PR TITLE
Revert "fix(deps): update coroutines.version to v1.8.1 (#4028)"

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 kotlin-version = "1.9.22"
 kotlinx-html-version = "0.11.0"
 kotlinx-datetime = "0.5.0"
-coroutines-version = "1.8.1"
+coroutines-version = "1.8.0"
 atomicfu-version = "0.23.2"
 serialization-version = "1.6.1" # Do not upgrade, 1.6.2 breaks maven publishing!
 ktlint-version = "3.15.0"


### PR DESCRIPTION
This reverts commit d96f14697c9371f0efe07e1349b9b65f7d53e646.

All of our common compilation targets have been broken for the last week after this dependency update.  I just noticed today that the allocation tests target on all PRs are failing because of this.