### PR TITLE
Lift test dependency to the source set that uses it

### DIFF
--- a/ktor-server/ktor-server-cio/build.gradle.kts
+++ b/ktor-server/ktor-server-cio/build.gradle.kts
@@ -14,11 +14,11 @@ kotlin.sourceSets {
             api(project(":ktor-server:ktor-server-core"))
             api(project(":ktor-client:ktor-client-cio"))
             api(project(":ktor-server:ktor-server-test-suites"))
+            api(project(":ktor-server:ktor-server-test-base"))
         }
     }
     jvmTest {
         dependencies {
-            api(project(":ktor-server:ktor-server-test-base"))
             api(project(":ktor-server:ktor-server-core", configuration = "testOutput"))
             api(libs.logback.classic)
         }


### PR DESCRIPTION
CIOHttpServerTest extends from the base class
HttpServerCommonTestSuite. It in turn extends EngineTestBase declared in :ktor-server:ktor-server-test-base. Dependency on this module is declared for jvmTest instead of the shared jvmAndNixTest that contains CIOHttpServerTest. The missing dependency on a transitive module with the grandparent class results in a MISSING_DEPENDENCY_SUPERCLASS in K2 IDE.

KTIJ-28250

**Subsystem**
Build configuration

**Motivation**

KTOR is one of the quality gate projects for K2 IDE.
Relates to https://youtrack.jetbrains.com/issue/KTIJ-28250.
We think that this particular problem might be a misconfiguration in KTOR itself rather then a resolution issue.

**Solution**
Update the build config.