### PR TITLE
Fix ExperimentalWasmDsl usages

### DIFF
--- a/buildSrc/src/main/kotlin/TargetsConfig.kt
+++ b/buildSrc/src/main/kotlin/TargetsConfig.kt
@@ -6,8 +6,6 @@
 import org.gradle.api.*
 import org.gradle.kotlin.dsl.*
 import org.jetbrains.kotlin.gradle.*
-import org.jetbrains.kotlin.gradle.plugin.*
-import org.jetbrains.kotlin.gradle.targets.js.dsl.*
 import java.io.*
 
 val Project.files: Array<File> get() = project.projectDir.listFiles() ?: emptyArray()

--- a/buildSrc/src/main/kotlin/WasmConfig.kt
+++ b/buildSrc/src/main/kotlin/WasmConfig.kt
@@ -4,7 +4,7 @@
 
 import org.gradle.api.*
 import org.gradle.kotlin.dsl.*
-import org.jetbrains.kotlin.gradle.targets.js.dsl.*
+import org.jetbrains.kotlin.gradle.ExperimentalWasmDsl
 import java.io.*
 
 fun Project.configureWasm() {


### PR DESCRIPTION
In Kotlin 2.0.20-Beta2 it was moved to another package
