### PR TITLE
Adding watchosDeviceArm64 support

### DIFF
--- a/buildSrc/src/main/kotlin/NativeUtils.kt
+++ b/buildSrc/src/main/kotlin/NativeUtils.kt
@@ -38,6 +38,7 @@ fun Project.watchosTargets(): List<String> = with(kotlin) {
         watchosArm32(),
         watchosArm64(),
         watchosSimulatorArm64(),
+        watchosDeviceArm64(),
     ).map { it.name }
 }
 

--- a/buildSrc/src/main/kotlin/Publication.kt
+++ b/buildSrc/src/main/kotlin/Publication.kt
@@ -37,6 +37,7 @@ fun isAvailableForPublication(publication: Publication): Boolean {
         "watchosArm32",
         "watchosArm64",
         "watchosSimulatorArm64",
+        "watchosDeviceArm64",
 
         "tvosX64",
         "tvosArm64",


### PR DESCRIPTION
Due to https://youtrack.jetbrains.com/issue/KTOR-6368/Add-watchosDeviceArm64-target, I'm trying to add support for `watchosDeviceArm64` on ktor.

Might be linked to https://github.com/Him188/yamlkt/issues/67 and https://github.com/Him188/yamlkt/pull/72 

EDIT: In case it is not possible to add it on server side due to yamlkt, would it be possible to add it on client side anyway?
EDIT 2: I'm working on adding watchosDeviceArm64 to yamlkt, I'm just waiting for my PR (72 mentioned before) to get merged and released