### PR TITLE
KTOR-7043 Explicit testApplication configuration from file

### DIFF
--- a/ktor-server/ktor-server-core/jvm/src/io/ktor/server/config/HoconApplicationConfig.kt
+++ b/ktor-server/ktor-server-core/jvm/src/io/ktor/server/config/HoconApplicationConfig.kt
@@ -5,7 +5,6 @@
 package io.ktor.server.config
 
 import com.typesafe.config.*
-import io.ktor.server.config.ConfigLoader.Companion.load
 import java.io.*
 
 /**

--- a/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/config/ConfigLoaders.kt
+++ b/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/config/ConfigLoaders.kt
@@ -23,7 +23,7 @@ public interface ConfigLoader {
         /**
          * Find and load a configuration file to [ApplicationConfig].
          */
-        public fun ConfigLoader.Companion.load(path: String? = null): ApplicationConfig {
+        public fun load(path: String? = null): ApplicationConfig {
             if (path == null) {
                 val default = loadDefault()
                 if (default != null) return default

--- a/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/engine/CommandLine.kt
+++ b/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/engine/CommandLine.kt
@@ -6,7 +6,6 @@ package io.ktor.server.engine
 
 import io.ktor.server.application.*
 import io.ktor.server.config.*
-import io.ktor.server.config.ConfigLoader.Companion.load
 import io.ktor.util.*
 import io.ktor.util.logging.*
 

--- a/ktor-server/ktor-server-test-host/jvm/src/io/ktor/server/testing/TestEngineJvm.kt
+++ b/ktor-server/ktor-server-test-host/jvm/src/io/ktor/server/testing/TestEngineJvm.kt
@@ -1,9 +1,0 @@
-/*
- * Copyright 2014-2021 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
- */
-
-package io.ktor.server.testing
-
-import io.ktor.server.config.*
-
-internal actual fun DefaultTestConfig(configPath: String?): ApplicationConfig = ApplicationConfig(configPath)

--- a/ktor-server/ktor-server-test-host/jvm/test/TestApplicationTestJvm.kt
+++ b/ktor-server/ktor-server-test-host/jvm/test/TestApplicationTestJvm.kt
@@ -30,18 +30,18 @@ import io.ktor.client.plugins.websocket.WebSockets as ClientWebSockets
 class TestApplicationTestJvm {
 
     @Test
-    fun testDefaultConfig() = testApplication {
+    fun testDefaultConfigDoesNotLoad() = testApplication {
         application {
             val config = environment.config
             routing {
                 get("a") {
-                    call.respond(config.property("ktor.test").getString())
+                    call.respond(config.propertyOrNull("ktor.test").toString())
                 }
             }
         }
 
         val response = client.get("a")
-        assertEquals("test_value", response.bodyAsText())
+        assertEquals("null", response.bodyAsText())
     }
 
     @Test
@@ -95,7 +95,9 @@ class TestApplicationTestJvm {
 
     @Test
     fun testCustomEnvironmentKeepsDefaultProperties() = testApplication {
-        environment { }
+        environment {
+            config = ApplicationConfig("application-custom.conf")
+        }
         routing {
             val config = environment.config
             get("a") {
@@ -104,6 +106,22 @@ class TestApplicationTestJvm {
         }
 
         val response = client.get("a")
+        assertEquals("another_test_value", response.bodyAsText())
+    }
+
+    @Test
+    fun testExplicitDefaultConfig() = testApplication {
+        environment {
+            config = ConfigLoader.load()
+        }
+        routing {
+            val config = environment.config
+            get {
+                call.respond(config.property("ktor.test").getString())
+            }
+        }
+
+        val response = client.get("/")
         assertEquals("test_value", response.bodyAsText())
     }
 

--- a/ktor-server/ktor-server-test-host/jvmAndNix/src/io/ktor/server/testing/TestApplication.kt
+++ b/ktor-server/ktor-server-test-host/jvmAndNix/src/io/ktor/server/testing/TestApplication.kt
@@ -10,6 +10,7 @@ import io.ktor.client.*
 import io.ktor.client.engine.*
 import io.ktor.http.*
 import io.ktor.server.application.*
+import io.ktor.server.config.*
 import io.ktor.server.engine.*
 import io.ktor.server.routing.*
 import io.ktor.server.testing.client.*
@@ -162,7 +163,7 @@ public open class TestApplicationBuilder {
             val oldConfig = config
             this@TestApplicationBuilder.environmentBuilder(this)
             if (config == oldConfig) { // the user did not set config. load the default one
-                config = DefaultTestConfig()
+                config = MapApplicationConfig()
             }
         }
         applicationProperties(environment) {

--- a/ktor-server/ktor-server-test-host/jvmAndNix/src/io/ktor/server/testing/TestEngine.kt
+++ b/ktor-server/ktor-server-test-host/jvmAndNix/src/io/ktor/server/testing/TestEngine.kt
@@ -13,8 +13,6 @@ import io.ktor.server.config.*
 import io.ktor.server.engine.*
 import io.ktor.util.logging.*
 
-internal expect fun DefaultTestConfig(configPath: String? = null): ApplicationConfig
-
 /**
  * Creates an engine environment for a test application.
  */

--- a/ktor-server/ktor-server-test-host/jvmAndNix/test/TestApplicationTest.kt
+++ b/ktor-server/ktor-server-test-host/jvmAndNix/test/TestApplicationTest.kt
@@ -440,6 +440,15 @@ class TestApplicationTest {
         testSocketTimeoutRead(1000, false)
     }
 
+    @Test
+    fun `configuration file is not loaded automatically`() {
+        testApplication {
+            application {
+                assertNull(environment.config.propertyOrNull("test.property"))
+            }
+        }
+    }
+
     class MyElement(val data: String) : CoroutineContext.Element {
         override val key: CoroutineContext.Key<*>
             get() = MyElement

--- a/ktor-server/ktor-server-test-host/nix/src/io/ktor/server/testing/TestEngineNix.kt
+++ b/ktor-server/ktor-server-test-host/nix/src/io/ktor/server/testing/TestEngineNix.kt
@@ -1,9 +1,0 @@
-/*
- * Copyright 2014-2021 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
- */
-
-package io.ktor.server.testing
-
-import io.ktor.server.config.*
-
-internal actual fun DefaultTestConfig(configPath: String?): ApplicationConfig = MapApplicationConfig()


### PR DESCRIPTION
**Subsystem**
Testing

**Motivation**
[KTOR-7043](https://youtrack.jetbrains.com/issue/KTOR-7043) Test Application explicit loading of modules

I noticed this when generating projects with the file configuration options (hocon or yaml), the tests would break due to duplicate modules being loaded.  This seems like a pretty significant design problem with the `testApplication` API, because it makes it so you cannot change your configuration without breaking all of your tests, and it hinders test isolation for checking particular modules.

**Solution**
Removed implicit `DefaultTestConfig` function call for JVM tests, and instead use an empty `MapConfiguration` for all platforms.

The current solution could perhaps be improved with some additional DSL.  If you want to load the file confuration now, you need something like this:

```
environment {
    config = ConfigLoader.load()
}
```

Note, this should only go into 3.0.0.