### PR TITLE
KTOR-360: add parseUrl function

### DIFF
--- a/ktor-http/api/ktor-http.api
+++ b/ktor-http/api/ktor-http.api
@@ -1001,6 +1001,7 @@ public final class io/ktor/http/URLUtilsKt {
 	public static final fun isAbsolutePath (Lio/ktor/http/Url;)Z
 	public static final fun isRelativePath (Lio/ktor/http/URLBuilder;)Z
 	public static final fun isRelativePath (Lio/ktor/http/Url;)Z
+	public static final fun parseUrl (Ljava/lang/String;)Lio/ktor/http/Url;
 	public static final fun takeFrom (Lio/ktor/http/URLBuilder;Lio/ktor/http/URLBuilder;)Lio/ktor/http/URLBuilder;
 	public static final fun takeFrom (Lio/ktor/http/URLBuilder;Lio/ktor/http/Url;)Lio/ktor/http/URLBuilder;
 }

--- a/ktor-http/common/src/io/ktor/http/URLUtils.kt
+++ b/ktor-http/common/src/io/ktor/http/URLUtils.kt
@@ -24,6 +24,20 @@ public fun Url(builder: URLBuilder): Url = URLBuilder().takeFrom(builder).build(
 public fun buildUrl(block: URLBuilder.() -> Unit): Url = URLBuilder().apply(block).build()
 
 /**
+ * Parses the given URL string and returns a [Url] object if valid, otherwise, it returns `null`.
+ *
+ * @param urlString The URL string to be parsed.
+ * @return A [Url] object if the URL is valid or `null` otherwise.
+ */
+public fun parseUrl(urlString: String): Url? {
+    return try {
+        URLBuilder(urlString).takeIf { it.host.isNotEmpty() }?.build()
+    } catch (cause: URLParserException) {
+        null
+    }
+}
+
+/**
  * Construct [URLBuilder] from [urlString].
  */
 @Suppress("FunctionName")

--- a/ktor-http/common/test/io/ktor/tests/http/UrlTest.kt
+++ b/ktor-http/common/test/io/ktor/tests/http/UrlTest.kt
@@ -316,4 +316,15 @@ class UrlTest {
         assertTrue(Url("").isRelativePath)
         assertTrue(Url("hello/world").isRelativePath)
     }
+
+    @Test
+    fun testParseUrl() {
+        val url = parseUrl("https://ktor.io/docs")
+        assertNotNull(url)
+        assertEquals("https", url.protocol.name)
+        assertEquals("ktor.io", url.host)
+
+        assertEquals(null, parseUrl("incorrecturl"))
+        assertEquals(null, parseUrl("http://localhost:7000Value"))
+    }
 }


### PR DESCRIPTION
**Subsystem**
ktor-http

**Motivation**
issue https://github.com/ktorio/ktor/issues/1903. 
Currently URL parsing returns a valid URL when an invalid URL is passed in (for "bogus" it returns "http://localhost/bogus"). Also there is no method that would return null instead of an exception if url parsing fails.

**Solution**
added `parseUrl` function to the `URLUtils.kt`, it tries to parse the URL using the passed string and, if unsuccessful, returns null

