### PR TITLE
Change kotlinx-coroutines-test dependency to API

### DIFF
--- a/ktor-test-dispatcher/build.gradle.kts
+++ b/ktor-test-dispatcher/build.gradle.kts
@@ -6,7 +6,7 @@ kotlin {
     sourceSets {
         commonMain {
             dependencies {
-                implementation(libs.kotlinx.coroutines.test)
+                api(libs.kotlinx.coroutines.test)
             }
         }
         posixMain {


### PR DESCRIPTION
**Subsystem**
N/A

**Motivation**
K2 IDE quality gates for multiplatform project

**Solution**
The `TestResult` class from `kotlinx-coroutines-test` is used as the return type in the `testSuspend` function from the `ktor-test-dispatcher:commonMain`. So the library is an API dependency for the module. Changing `implementation`
dependency to `api` fixes the K2 `MISSING_DEPENDENCY_CLASS` diagnostics in common tests, which were false negatives in the K1. Example: `io.ktor.utils.io.ByteChannelTest`.

CLI compilations don't report the error: there are no compilations for common test source sets that would've missed the dependency. Platform test compilations use the `actual` versions, which are type aliases with RHS types from stdlib. Stdlib is an implicit dependency, so there's no error either.

See [KT-68589](https://youtrack.jetbrains.com/issue/KT-68589)