### PR TITLE
KTOR-4273 Fix typo in CallLogging plugin package

### DIFF
--- a/ktor-server/ktor-server-plugins/ktor-server-call-id/api/ktor-server-call-id.api
+++ b/ktor-server/ktor-server-plugins/ktor-server-call-id/api/ktor-server-call-id.api
@@ -12,8 +12,8 @@ public final class io/ktor/server/plugins/callid/CallIdConfig {
 }
 
 public final class io/ktor/server/plugins/callid/CallIdJvmKt {
-	public static final fun callIdMdc (Lio/ktor/server/plugins/callloging/CallLoggingConfig;Ljava/lang/String;)V
-	public static synthetic fun callIdMdc$default (Lio/ktor/server/plugins/callloging/CallLoggingConfig;Ljava/lang/String;ILjava/lang/Object;)V
+	public static final fun callIdMdc (Lio/ktor/server/plugins/calllogging/CallLoggingConfig;Ljava/lang/String;)V
+	public static synthetic fun callIdMdc$default (Lio/ktor/server/plugins/calllogging/CallLoggingConfig;Ljava/lang/String;ILjava/lang/Object;)V
 }
 
 public final class io/ktor/server/plugins/callid/CallIdKt {

--- a/ktor-server/ktor-server-plugins/ktor-server-call-id/jvm/src/io/ktor/server/plugins/callid/CallIdJvm.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-call-id/jvm/src/io/ktor/server/plugins/callid/CallIdJvm.kt
@@ -4,7 +4,7 @@
 
 package io.ktor.server.plugins.callid
 
-import io.ktor.server.plugins.callloging.*
+import io.ktor.server.plugins.calllogging.*
 
 /**
  * Put call id into MDC (diagnostic context value) with [name]

--- a/ktor-server/ktor-server-plugins/ktor-server-call-logging/api/ktor-server-call-logging.api
+++ b/ktor-server/ktor-server-plugins/ktor-server-call-logging/api/ktor-server-call-logging.api
@@ -1,4 +1,4 @@
-public final class io/ktor/server/plugins/callloging/CallLoggingConfig {
+public final class io/ktor/server/plugins/calllogging/CallLoggingConfig {
 	public fun <init> ()V
 	public final fun clock (Lkotlin/jvm/functions/Function0;)V
 	public final fun disableDefaultColors ()V
@@ -12,7 +12,7 @@ public final class io/ktor/server/plugins/callloging/CallLoggingConfig {
 	public final fun setLogger (Lorg/slf4j/Logger;)V
 }
 
-public final class io/ktor/server/plugins/callloging/CallLoggingKt {
+public final class io/ktor/server/plugins/calllogging/CallLoggingKt {
 	public static final fun getCallLogging ()Lio/ktor/server/application/ApplicationPlugin;
 	public static final fun processingTimeMillis (Lio/ktor/server/application/ApplicationCall;Lkotlin/jvm/functions/Function0;)J
 	public static synthetic fun processingTimeMillis$default (Lio/ktor/server/application/ApplicationCall;Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)J

--- a/ktor-server/ktor-server-plugins/ktor-server-call-logging/jvm/src/io/ktor/server/plugins/calllogging/CallLogging.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-call-logging/jvm/src/io/ktor/server/plugins/calllogging/CallLogging.kt
@@ -2,7 +2,7 @@
 * Copyright 2014-2021 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
 */
 
-package io.ktor.server.plugins.callloging
+package io.ktor.server.plugins.calllogging
 
 import io.ktor.events.*
 import io.ktor.server.application.*

--- a/ktor-server/ktor-server-plugins/ktor-server-call-logging/jvm/src/io/ktor/server/plugins/calllogging/CallLoggingConfig.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-call-logging/jvm/src/io/ktor/server/plugins/calllogging/CallLoggingConfig.kt
@@ -2,7 +2,7 @@
  * Copyright 2014-2022 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
-package io.ktor.server.plugins.callloging
+package io.ktor.server.plugins.calllogging
 
 import io.ktor.http.*
 import io.ktor.server.application.*

--- a/ktor-server/ktor-server-plugins/ktor-server-call-logging/jvm/src/io/ktor/server/plugins/calllogging/MDCEntryUtils.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-call-logging/jvm/src/io/ktor/server/plugins/calllogging/MDCEntryUtils.kt
@@ -2,7 +2,7 @@
  * Copyright 2014-2022 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
-package io.ktor.server.plugins.callloging
+package io.ktor.server.plugins.calllogging
 
 import io.ktor.server.application.*
 import io.ktor.util.*

--- a/ktor-server/ktor-server-plugins/ktor-server-call-logging/jvm/src/io/ktor/server/plugins/calllogging/MDCHook.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-call-logging/jvm/src/io/ktor/server/plugins/calllogging/MDCHook.kt
@@ -2,7 +2,7 @@
  * Copyright 2014-2022 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
-package io.ktor.server.plugins.callloging
+package io.ktor.server.plugins.calllogging
 
 import io.ktor.server.application.*
 import io.ktor.server.response.*

--- a/ktor-server/ktor-server-plugins/ktor-server-call-logging/jvm/src/io/ktor/server/plugins/calllogging/MDCProvider.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-call-logging/jvm/src/io/ktor/server/plugins/calllogging/MDCProvider.kt
@@ -2,7 +2,7 @@
  * Copyright 2014-2022 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
-package io.ktor.server.plugins.callloging
+package io.ktor.server.plugins.calllogging
 
 import io.ktor.server.application.*
 import io.ktor.server.logging.*

--- a/ktor-server/ktor-server-plugins/ktor-server-call-logging/jvm/test/io/ktor/server/plugins/calllogging/CallLoggingTest.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-call-logging/jvm/test/io/ktor/server/plugins/calllogging/CallLoggingTest.kt
@@ -2,7 +2,7 @@
  * Copyright 2014-2023 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
-package io.ktor.server.plugins.callloging
+package io.ktor.server.plugins.calllogging
 
 import io.ktor.client.request.*
 import io.ktor.client.statement.*
@@ -477,7 +477,7 @@ class CallLoggingTest {
         }
         application {
             routing {
-                staticFiles("/", File("jvm/test/io/ktor/server/plugins/callloging"), index = "CallLoggingTest.kt")
+                staticFiles("/", File("jvm/test/io/ktor/server/plugins/calllogging"), index = "CallLoggingTest.kt")
             }
         }
         val response = client.get("/CallLoggingTest.kt")

--- a/ktor-server/ktor-server-test-base/jvm/src/io/ktor/server/test/base/EngineTestBaseJvm.kt
+++ b/ktor-server/ktor-server-test-base/jvm/src/io/ktor/server/test/base/EngineTestBaseJvm.kt
@@ -15,7 +15,7 @@ import io.ktor.junit.*
 import io.ktor.network.tls.certificates.*
 import io.ktor.server.application.*
 import io.ktor.server.engine.*
-import io.ktor.server.plugins.callloging.*
+import io.ktor.server.plugins.calllogging.*
 import io.ktor.server.routing.*
 import io.ktor.server.testing.*
 import io.ktor.util.*

--- a/ktor-server/ktor-server-tests/jvm/test/io/ktor/server/testing/TestApplicationEngineTest.kt
+++ b/ktor-server/ktor-server-tests/jvm/test/io/ktor/server/testing/TestApplicationEngineTest.kt
@@ -8,7 +8,7 @@ import io.ktor.client.request.*
 import io.ktor.http.*
 import io.ktor.http.content.*
 import io.ktor.server.application.*
-import io.ktor.server.plugins.callloging.*
+import io.ktor.server.plugins.calllogging.*
 import io.ktor.server.request.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*


### PR DESCRIPTION
**Subsystem**
Server

**Motivation**
- [KTOR-4273](https://youtrack.jetbrains.com/issue/KTOR-4273) CallLogging: package is misspelled

**Solution**
Add g.

