### PR TITLE
KTOR-7123 Replace Versions values with catalog

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -47,6 +47,8 @@ dependencies {
 
     implementation(libs.kotlinx.serialization.json)
     implementation(libs.logback.classic)
+    implementation(libs.tomlj)
+
 }
 
 kotlin {

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -1,12 +1,26 @@
+import org.tomlj.*
+import org.gradle.kotlin.dsl.*
+import java.nio.file.*
+
 /*
  * Copyright 2014-2023 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
+private val versions by lazy {
+    val tomlFile = Paths.get("gradle/libs.versions.toml")
+    val toml = Toml.parse(tomlFile)
+    object {
+        operator fun get(key: String): String =
+            toml.getString("versions.$key")
+                ?: throw IllegalArgumentException("Version for $key not found in versions catalog $tomlFile")
+    }
+}
+
 object Versions {
-    val kotlin = "1.9.22"
-    val coroutines = "1.8.0"
-    val slf4j = "1.7.36"
-    val junit = "5.10.1"
-    val logback = "1.2.11"
-    val puppeteer = "21.5.0"
+    val kotlin = versions["kotlin-version"]
+    val coroutines = versions["coroutines-version"]
+    val slf4j = versions["slf4j-version"]
+    val junit = versions["junit-version"]
+    val logback = versions["logback-version"]
+    val puppeteer = versions["puppeteer-version"]
 }

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -1,26 +1,45 @@
+import org.gradle.api.*
 import org.tomlj.*
-import org.gradle.kotlin.dsl.*
-import java.nio.file.*
 
 /*
  * Copyright 2014-2023 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
-private val versions by lazy {
-    val tomlFile = Paths.get("gradle/libs.versions.toml")
-    val toml = Toml.parse(tomlFile)
-    object {
-        operator fun get(key: String): String =
-            toml.getString("versions.$key")
-                ?: throw IllegalArgumentException("Version for $key not found in versions catalog $tomlFile")
+/**
+ * A specific set of versions, read from gradle/libs.versions.toml.
+ *
+ * The projectDir is required from the project instance because using the relative path doesn't work on some platforms.
+ */
+val Project.Versions: Versions get() {
+    return localVersions ?: run {
+        val tomlFile = projectDir.toPath()
+            .resolve("gradle/libs.versions.toml")
+        val toml = Toml.parse(tomlFile)
+        val versions = object {
+            operator fun get(key: String): String =
+                toml.getString("versions.$key")
+                    ?: throw IllegalArgumentException("Version for $key not found in versions catalog $tomlFile")
+        }
+        Versions(
+            versions["kotlin-version"],
+            versions["coroutines-version"],
+            versions["slf4j-version"],
+            versions["junit-version"],
+            versions["logback-version"],
+            versions["puppeteer-version"],
+        )
+    }.also {
+        localVersions = it
     }
 }
 
-object Versions {
-    val kotlin = versions["kotlin-version"]
-    val coroutines = versions["coroutines-version"]
-    val slf4j = versions["slf4j-version"]
-    val junit = versions["junit-version"]
-    val logback = versions["logback-version"]
-    val puppeteer = versions["puppeteer-version"]
-}
+private var localVersions: Versions? = null
+
+data class Versions(
+    val kotlin: String,
+    val coroutines: String,
+    val slf4j: String,
+    val junit: String,
+    val logback: String,
+    val puppeteer: String,
+)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -65,6 +65,9 @@ swagger-codegen-version = "3.0.57"
 swagger-codegen-generators-version = "1.0.50"
 swagger-parser-version = "2.1.22"
 
+puppeteer-version = "21.5.0"
+tomlj-version = "1.1.1"
+
 [libraries]
 kotlin-stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib", version.ref = "kotlin-version" }
 kotlin-stdlib-jdk7 = { module = "org.jetbrains.kotlin:kotlin-stdlib-jdk7", version.ref = "kotlin-version" }
@@ -178,3 +181,5 @@ yamlkt-serialization = { module = "net.mamoe.yamlkt:yamlkt", version.ref = "yaml
 swagger-codegen = { module = "io.swagger.codegen.v3:swagger-codegen", version.ref = "swagger-codegen-version" }
 swagger-codegen-generators = { module = "io.swagger.codegen.v3:swagger-codegen-generators", version.ref = "swagger-codegen-generators-version" }
 swagger-parser = { module = "io.swagger.parser.v3:swagger-parser", version.ref = "swagger-parser-version" }
+
+tomlj = { module = "org.tomlj:tomlj", version.ref = "tomlj-version" }

--- a/ktor-server/ktor-server-plugins/build.gradle.kts
+++ b/ktor-server/ktor-server-plugins/build.gradle.kts
@@ -17,7 +17,7 @@ subprojects {
                 dependencies {
                     api(project(":ktor-server:ktor-server-core", configuration = "testOutput"))
 
-                    api("ch.qos.logback:logback-classic:${Versions.logback}")
+                    api("ch.qos.logback:logback-classic:${project.Versions.logback}")
                 }
             }
         }


### PR DESCRIPTION
**Subsystem**
Build

**Motivation**
- [KTOR-7123](https://youtrack.jetbrains.com/issue/KTOR-7123) Some dependency versions not tracked

I noticed today we had an older version of slf4j floating around, which is replaced by the one imported by logback, but I figure it would be best if all our versions are tracked in one place.

**Solution**
Read versions from `libs.versions.toml` rather than using constants.

