### PR TITLE
[kc/dev] Fix compatibility with Clang 16 for C code in nix threadUtils.def

### DIFF
--- a/ktor-utils/nix/interop/threadUtils.def
+++ b/ktor-utils/nix/interop/threadUtils.def
@@ -2,7 +2,7 @@
 #include <execinfo.h>
 #include <signal.h>
 #include <stdatomic.h>
-#include <printf.h>
+#include <stdio.h>
 #include <unistd.h>
  
 void* callstack[256];


### PR DESCRIPTION
ktor-utils/nix/interop/threadUtils.def has some C code which is internally compiled by Clang from the LLVM bundled with K/N.

This C code uses `printf` and includes `printf.h` to get the declaration. Apparently, `printf.h` doesn't declare `printf` function, `stdio.h` does. So, this causes an implicit declaration warning (`-Wimplicit-function-declaration`) with Clang 11 (currently used in K/N).
With updating to Clang 16, this warning becomes an error, so the code no longer compiles.

This commit replaces `printf.h` by `stdio.h` and thus fixes the problem.

KT-49279

**Subsystem**
ktor-utils

**Motivation**
This PR prepares ktor compilation for Kotlin 2.1.0 where we intend to merge the update to LLVM 16.
https://youtrack.jetbrains.com/issue/KT-49279/Kotlin-Native-update-LLVM-from-11.1.0-to-16.0.0-or-newer

**Solution**
See above.

