### PR TITLE
KTOR-6417 Allow changing dispatcher in the client

### DIFF
--- a/ktor-client/ktor-client-core/api/ktor-client-core.api
+++ b/ktor-client/ktor-client-core/api/ktor-client-core.api
@@ -163,9 +163,11 @@ public final class io/ktor/client/engine/HttpClientEngineCapabilityKt {
 
 public class io/ktor/client/engine/HttpClientEngineConfig {
 	public fun <init> ()V
+	public final fun getDispatcher ()Lkotlinx/coroutines/CoroutineDispatcher;
 	public final fun getPipelining ()Z
 	public final fun getProxy ()Ljava/net/Proxy;
 	public final fun getThreadsCount ()I
+	public final fun setDispatcher (Lkotlinx/coroutines/CoroutineDispatcher;)V
 	public final fun setPipelining (Z)V
 	public final fun setProxy (Ljava/net/Proxy;)V
 	public final fun setThreadsCount (I)V

--- a/ktor-client/ktor-client-core/common/src/io/ktor/client/engine/HttpClientEngineBase.kt
+++ b/ktor-client/ktor-client-core/common/src/io/ktor/client/engine/HttpClientEngineBase.kt
@@ -18,7 +18,7 @@ import kotlin.coroutines.*
 public abstract class HttpClientEngineBase(private val engineName: String) : HttpClientEngine {
     private val closed = atomic(false)
 
-    override val dispatcher: CoroutineDispatcher = ioDispatcher()
+    override val dispatcher: CoroutineDispatcher by lazy { config.dispatcher ?: ioDispatcher() }
 
     override val coroutineContext: CoroutineContext by lazy {
         SilentSupervisor() + dispatcher + CoroutineName("$engineName-context")

--- a/ktor-client/ktor-client-core/common/src/io/ktor/client/engine/HttpClientEngineConfig.kt
+++ b/ktor-client/ktor-client-core/common/src/io/ktor/client/engine/HttpClientEngineConfig.kt
@@ -5,6 +5,7 @@
 package io.ktor.client.engine
 
 import io.ktor.utils.io.*
+import kotlinx.coroutines.*
 
 /**
  * Base configuration for [HttpClientEngine].
@@ -15,10 +16,15 @@ public open class HttpClientEngineConfig {
      * Specifies network threads count advice.
      */
     @Deprecated(
-        "The [threadsCount] property is deprecated. The [Dispatchers.IO] is used by default.",
+        "The [threadsCount] property is deprecated. Consider setting [dispatcher] instead.",
         level = DeprecationLevel.ERROR
     )
     public var threadsCount: Int = 4
+
+    /**
+     * Allow specifying the coroutine dispatcher to use for IO operations.
+     */
+    public var dispatcher: CoroutineDispatcher? = null
 
     /**
      * Enables HTTP pipelining advice.

--- a/ktor-client/ktor-client-mock/api/ktor-client-mock.api
+++ b/ktor-client/ktor-client-mock/api/ktor-client-mock.api
@@ -18,10 +18,8 @@ public final class io/ktor/client/engine/mock/MockEngine$Companion : io/ktor/cli
 public final class io/ktor/client/engine/mock/MockEngineConfig : io/ktor/client/engine/HttpClientEngineConfig {
 	public fun <init> ()V
 	public final fun addHandler (Lkotlin/jvm/functions/Function3;)V
-	public final fun getDispatcher ()Lkotlinx/coroutines/CoroutineDispatcher;
 	public final fun getRequestHandlers ()Ljava/util/List;
 	public final fun getReuseHandlers ()Z
-	public final fun setDispatcher (Lkotlinx/coroutines/CoroutineDispatcher;)V
 	public final fun setReuseHandlers (Z)V
 }
 

--- a/ktor-client/ktor-client-mock/common/src/io/ktor/client/engine/mock/MockEngine.kt
+++ b/ktor-client/ktor-client-mock/common/src/io/ktor/client/engine/mock/MockEngine.kt
@@ -62,7 +62,9 @@ public class MockEngine(override val config: MockEngineConfig) : HttpClientEngin
             handler
         }
 
-        val response = handler(MockRequestHandleScope(callContext), data)
+        val response = withContext(dispatcher + callContext) {
+            handler(MockRequestHandleScope(callContext), data)
+        }
 
         synchronized(mutex) {
             _requestsHistory.add(data)

--- a/ktor-client/ktor-client-mock/common/src/io/ktor/client/engine/mock/MockEngineConfig.kt
+++ b/ktor-client/ktor-client-mock/common/src/io/ktor/client/engine/mock/MockEngineConfig.kt
@@ -38,16 +38,6 @@ public class MockEngineConfig : HttpClientEngineConfig() {
     public var reuseHandlers: Boolean = true
 
     /**
-     * Dispatcher to use with [MockEngine].
-     */
-    @Deprecated(
-        "The [dispatcher] is no longer configurable, Dispatchers.IO is used by default",
-        level = DeprecationLevel.ERROR
-    )
-    public var dispatcher: CoroutineDispatcher get() = error("The [dispatcher] is no longer configurable")
-        set(_) = error("The [dispatcher] is no longer configurable")
-
-    /**
      * Add request handler to [MockEngine]
      */
     public fun addHandler(handler: MockRequestHandler) {


### PR DESCRIPTION
Fix [KTOR-6417](https://youtrack.jetbrains.com/issue/KTOR-6417) Ktor Client MockEngine dispatcher handle removed
[KTOR-6462](https://youtrack.jetbrains.com/issue/KTOR-6462) Ktor clients and servers should use Dispatchers.IO.limitedParallelism(...) wherever possible

We need the possibility to set custom dispatchers to enable users to reuse dispatchers and configure test-specific dispatchers in tests.