### PR TITLE
KTOR-7193 RoutingRoot: remove preemptive tracing check

### DIFF
--- a/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/routing/RoutingRoot.kt
+++ b/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/routing/RoutingRoot.kt
@@ -42,8 +42,6 @@ public class RoutingRoot(
     }
 
     private fun addDefaultTracing() {
-        if (!LOGGER.isTraceEnabled) return
-
         tracers.add {
             LOGGER.trace(it.buildText())
         }

--- a/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/routing/RoutingRoot.kt
+++ b/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/routing/RoutingRoot.kt
@@ -43,7 +43,9 @@ public class RoutingRoot(
 
     private fun addDefaultTracing() {
         tracers.add {
-            LOGGER.trace(it.buildText())
+            if (LOGGER.isTraceEnabled) {
+                LOGGER.trace(it.buildText())
+            }
         }
     }
 


### PR DESCRIPTION
**Subsystem**
Server Core

**Motivation**
The check prevented users from changing the log level of the `LOGGER` at a later point as the interceptor responsible isn't added.
See [KTOR-7193](https://youtrack.jetbrains.com/issue/KTOR-7193/Tracing-allow-changing-log-level-at-runtime) for an extensive rationale.

**Solution**
Remove the check. The SLF4j implementation will do it prior to every log anyway. The performance impact should be absolutely neglectable.
