### PR TITLE
KTOR-7209: fix Text.chomp values separator

### DIFF
--- a/ktor-utils/common/src/io/ktor/util/Text.kt
+++ b/ktor-utils/common/src/io/ktor/util/Text.kt
@@ -38,7 +38,7 @@ public inline fun String.chomp(
     val idx = indexOf(separator)
     return when (idx) {
         -1 -> onMissingDelimiter()
-        else -> substring(0, idx) to substring(idx + 1)
+        else -> substring(0, idx) to substring(idx + separator.length)
     }
 }
 


### PR DESCRIPTION
**Subsystem**
ktor-utils

**Motivation**
issue: [KTOR-7209](https://youtrack.jetbrains.com/issue/KTOR-7209/io.ktor.util.TextKt.chomp-doesnt-work-on-strings-with-more-than-one-character)
`chomp` assumes the input string is exactly one character, however it is expected to work with any non-empty separator

**Solution**
Fixed offset in substring from `1` to `separator.length`

