### PR TITLE
KTOR-5289 Change TCP connect on native to non-blocking and cancellable

### DIFF
--- a/ktor-network/jvmAndNix/test/io/ktor/network/sockets/tests/TCPSocketTest.kt
+++ b/ktor-network/jvmAndNix/test/io/ktor/network/sockets/tests/TCPSocketTest.kt
@@ -9,6 +9,7 @@ import io.ktor.utils.io.*
 import io.ktor.utils.io.CancellationException
 import io.ktor.utils.io.core.*
 import kotlinx.coroutines.*
+import kotlinx.io.*
 import kotlin.test.*
 
 class TCPSocketTest {
@@ -130,7 +131,7 @@ class TCPSocketTest {
 
     @Test
     fun testConnectToNonExistingSocket() = testSockets { selector ->
-        assertFailsWith<IllegalStateException> {
+        assertFailsWith<IOException> {
             aSocket(selector)
                 .tcp()
                 .connect("localhost", 8001) // there should be no server active on this port

--- a/ktor-network/jvmAndNix/test/io/ktor/network/sockets/tests/TCPSocketTest.kt
+++ b/ktor-network/jvmAndNix/test/io/ktor/network/sockets/tests/TCPSocketTest.kt
@@ -8,7 +8,6 @@ import io.ktor.network.sockets.*
 import io.ktor.utils.io.*
 import io.ktor.utils.io.CancellationException
 import io.ktor.utils.io.core.*
-import io.ktor.utils.io.errors.*
 import kotlinx.coroutines.*
 import kotlin.test.*
 
@@ -126,6 +125,15 @@ class TCPSocketTest {
             assertFailsWith<CancellationException> {
                 readChannel.readByte()
             }
+        }
+    }
+
+    @Test
+    fun testConnectToNonExistingSocket() = testSockets { selector ->
+        assertFailsWith<IllegalStateException> {
+            aSocket(selector)
+                .tcp()
+                .connect("localhost", 8001) // there should be no server active on this port
         }
     }
 }

--- a/ktor-network/nix/src/io/ktor/network/selector/SelectUtils.kt
+++ b/ktor-network/nix/src/io/ktor/network/selector/SelectUtils.kt
@@ -204,7 +204,7 @@ internal class SelectorHelper {
         SelectInterest.READ -> readSet
         SelectInterest.WRITE -> writeSet
         SelectInterest.ACCEPT -> readSet
-        else -> error("Unsupported interest ${event.interest}.")
+        SelectInterest.CONNECT -> writeSet
     }
 }
 

--- a/ktor-network/nix/src/io/ktor/network/sockets/ConnectUtilsNative.kt
+++ b/ktor-network/nix/src/io/ktor/network/sockets/ConnectUtilsNative.kt
@@ -6,6 +6,7 @@ package io.ktor.network.sockets
 
 import io.ktor.network.selector.*
 import io.ktor.network.util.*
+import io.ktor.utils.io.errors.*
 import kotlinx.cinterop.*
 import platform.posix.*
 
@@ -21,18 +22,40 @@ internal actual suspend fun connect(
         try {
             val descriptor: Int = socket(remote.family.convert(), SOCK_STREAM, 0).check()
 
-            remote.nativeAddress { address, size ->
-                connect(descriptor, address, size).check()
-            }
-
             assignOptions(descriptor, socketOptions)
             nonBlocking(descriptor)
+
+            val selectable = SelectableNative(descriptor)
+
+            var connectResult = -1
+            remote.nativeAddress { address, size ->
+                connectResult = connect(descriptor, address, size)
+            }
+
+            if (connectResult < 0 && errno == EINPROGRESS) {
+                while (true) {
+                    selector.select(selectable, SelectInterest.CONNECT)
+                    val result = alloc<IntVar>()
+                    val size = alloc<socklen_tVar> {
+                        value = sizeOf<IntVar>().convert()
+                    }
+                    getsockopt(descriptor, SOL_SOCKET, SO_ERROR, result.ptr, size.ptr).check()
+                    when (result.value) {
+                        0 -> break // connected
+                        EINPROGRESS -> continue
+                        else -> throw PosixException.forErrno(errno = result.value)
+                    }
+                }
+            } else {
+                connectResult.check()
+            }
 
             val localAddress = getLocalAddress(descriptor)
 
             return TCPSocketNative(
                 descriptor,
                 selector,
+                selectable,
                 remoteAddress = remote.toSocketAddress(),
                 localAddress = localAddress.toSocketAddress()
             )

--- a/ktor-network/nix/src/io/ktor/network/sockets/ConnectUtilsNative.kt
+++ b/ktor-network/nix/src/io/ktor/network/sockets/ConnectUtilsNative.kt
@@ -8,6 +8,7 @@ import io.ktor.network.selector.*
 import io.ktor.network.util.*
 import io.ktor.utils.io.errors.*
 import kotlinx.cinterop.*
+import kotlinx.io.IOException
 import platform.posix.*
 
 private const val DEFAULT_BACKLOG_SIZE = 50
@@ -63,7 +64,7 @@ internal actual suspend fun connect(
         }
     }
 
-    error("Failed to connect to $remoteAddress.")
+    throw IOException("Failed to connect to $remoteAddress.")
 }
 
 @OptIn(UnsafeNumber::class, ExperimentalForeignApi::class)

--- a/ktor-network/nix/src/io/ktor/network/sockets/TCPServerSocketNative.kt
+++ b/ktor-network/nix/src/io/ktor/network/sockets/TCPServerSocketNative.kt
@@ -68,6 +68,7 @@ internal class TCPServerSocketNative(
         TCPSocketNative(
             clientDescriptor,
             selectorManager,
+            SelectableNative(clientDescriptor),
             remoteAddress = remoteAddress.toSocketAddress(),
             localAddress = localAddress.toSocketAddress(),
             parent = selfContext() + coroutineContext

--- a/ktor-network/nix/src/io/ktor/network/sockets/TCPSocketNative.kt
+++ b/ktor-network/nix/src/io/ktor/network/sockets/TCPSocketNative.kt
@@ -13,12 +13,12 @@ import kotlin.coroutines.*
 internal class TCPSocketNative(
     private val descriptor: Int,
     private val selector: SelectorManager,
+    private val selectable: SelectableNative,
     override val remoteAddress: SocketAddress,
     override val localAddress: SocketAddress,
     parent: CoroutineContext = EmptyCoroutineContext
 ) : Socket, CoroutineScope {
     private val _context: CompletableJob = Job(parent[Job])
-    private val selectable: SelectableNative = SelectableNative(descriptor)
 
     override val coroutineContext: CoroutineContext = parent + Dispatchers.Unconfined + _context
 


### PR DESCRIPTION
[KTOR-5289](https://youtrack.jetbrains.com/issue/KTOR-5289) withTimeout doesn't cancel socket connection on native

This PR changes the connect call to not block. That means connect is now cancellable and works with timeouts. Furthermore, I noticed that in some conditions connect can block for very long (on iOS), which is now also resolved as it can be cancelled.

On JVM the connect call is already non-blocking, so no changes needed there.

My second commit changes the exception type from `IllegalStateException` to `IOException`, as I think this is better . You can revert it if needed as it is a separate commit.