### PR TITLE
Remove additional context from SavedCall

### DIFF
--- a/ktor-client/ktor-client-android/jvm/src/io/ktor/client/engine/android/AndroidClientEngine.kt
+++ b/ktor-client/ktor-client-android/jvm/src/io/ktor/client/engine/android/AndroidClientEngine.kt
@@ -85,7 +85,7 @@ public class AndroidClientEngine(override val config: AndroidEngineConfig) : Htt
             val statusCode = responseMessage?.let { HttpStatusCode(responseCode, it) }
                 ?: HttpStatusCode.fromValue(responseCode)
 
-            val content: ByteReadChannel = current.content(callContext)
+            val content: ByteReadChannel = current.content(responseCode, callContext)
             val headerFields: Map<String, List<String>> = current.headerFields
                 .mapKeys { it.key?.lowercase(Locale.getDefault()) ?: "" }
                 .filter { it.key.isNotBlank() }

--- a/ktor-client/ktor-client-android/jvm/src/io/ktor/client/engine/android/AndroidURLConnectionUtils.kt
+++ b/ktor-client/ktor-client-android/jvm/src/io/ktor/client/engine/android/AndroidURLConnectionUtils.kt
@@ -7,6 +7,7 @@ package io.ktor.client.engine.android
 import io.ktor.client.network.sockets.*
 import io.ktor.client.plugins.*
 import io.ktor.client.request.*
+import io.ktor.http.*
 import io.ktor.util.*
 import io.ktor.util.cio.*
 import io.ktor.utils.io.*
@@ -68,14 +69,20 @@ internal suspend fun <T> HttpURLConnection.timeoutAwareConnection(
 /**
  * Establish connection and return correspondent [ByteReadChannel].
  */
-internal fun HttpURLConnection.content(callContext: CoroutineContext): ByteReadChannel = try {
-    inputStream?.buffered()
-} catch (_: IOException) {
-    errorStream?.buffered()
-}?.toByteReadChannel(
-    context = callContext,
-    pool = KtorDefaultPool
-) ?: ByteReadChannel.Empty
+internal fun HttpURLConnection.content(status: Int, callContext: CoroutineContext): ByteReadChannel {
+    if (status in listOf(HttpStatusCode.NotModified.value, HttpStatusCode.NoContent.value)) {
+        return ByteReadChannel.Empty
+    }
+
+    return try {
+        inputStream?.buffered()
+    } catch (_: IOException) {
+        errorStream?.buffered()
+    }?.toByteReadChannel(
+        context = callContext,
+        pool = KtorDefaultPool
+    ) ?: ByteReadChannel.Empty
+}
 
 /**
  * Checks the exception and identifies timeout exception by it.

--- a/ktor-client/ktor-client-core/common/src/io/ktor/client/call/HttpClientCall.kt
+++ b/ktor-client/ktor-client-core/common/src/io/ktor/client/call/HttpClientCall.kt
@@ -96,8 +96,6 @@ public open class HttpClientCall(
         } catch (cause: Throwable) {
             response.cancel("Receive failed", cause)
             throw cause
-        } finally {
-            response.complete()
         }
     }
 

--- a/ktor-client/ktor-client-core/common/src/io/ktor/client/call/SavedCall.kt
+++ b/ktor-client/ktor-client-core/common/src/io/ktor/client/call/SavedCall.kt
@@ -10,8 +10,6 @@ import io.ktor.client.statement.*
 import io.ktor.http.*
 import io.ktor.util.date.*
 import io.ktor.utils.io.*
-import io.ktor.utils.io.core.*
-import kotlinx.coroutines.*
 import kotlinx.io.*
 import kotlin.coroutines.*
 
@@ -47,8 +45,6 @@ internal class SavedHttpResponse(
     private val body: ByteArray,
     origin: HttpResponse
 ) : HttpResponse() {
-    private val context = Job()
-
     override val status: HttpStatusCode = origin.status
 
     override val version: HttpProtocolVersion = origin.version
@@ -59,7 +55,7 @@ internal class SavedHttpResponse(
 
     override val headers: Headers = origin.headers
 
-    override val coroutineContext: CoroutineContext = origin.coroutineContext + context
+    override val coroutineContext: CoroutineContext = origin.coroutineContext
 
     @OptIn(InternalAPI::class)
     override val content: ByteReadChannel get() = ByteReadChannel(body)

--- a/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/DefaultTransform.kt
+++ b/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/DefaultTransform.kt
@@ -87,7 +87,7 @@ public fun HttpClient.defaultTransformers() {
                 // could be canceled immediately, but it doesn't matter
                 // since the copying job is running under the client job
                 val responseJobHolder = Job(response.coroutineContext[Job])
-                val channel: ByteReadChannel = writer(response.coroutineContext) {
+                val channel: ByteReadChannel = writer(this@defaultTransformers.coroutineContext) {
                     try {
                         body.copyTo(channel, limit = Long.MAX_VALUE)
                     } catch (cause: CancellationException) {

--- a/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/DefaultTransform.kt
+++ b/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/DefaultTransform.kt
@@ -9,7 +9,6 @@ import io.ktor.client.request.*
 import io.ktor.client.statement.*
 import io.ktor.http.*
 import io.ktor.http.content.*
-import io.ktor.util.*
 import io.ktor.util.logging.*
 import io.ktor.utils.io.*
 import io.ktor.utils.io.core.*
@@ -97,8 +96,6 @@ public fun HttpClient.defaultTransformers() {
                     } catch (cause: Throwable) {
                         response.cancel("Receive failed", cause)
                         throw cause
-                    } finally {
-                        response.complete()
                     }
                 }.also { writerJob ->
                     writerJob.invokeOnCompletion {

--- a/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/cache/HttpCache.kt
+++ b/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/cache/HttpCache.kt
@@ -213,7 +213,6 @@ public class HttpCache private constructor(
 
                 if (response.status == HttpStatusCode.NotModified) {
                     LOGGER.trace("Not modified response for ${response.call.request.url}, replying from cache")
-                    response.complete()
                     val responseFromCache = plugin.findAndRefresh(response.call.request, response)
                         ?: throw InvalidCacheStateException(response.call.request.url)
 

--- a/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/cache/HttpCacheEntry.kt
+++ b/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/cache/HttpCacheEntry.kt
@@ -10,14 +10,12 @@ import io.ktor.client.statement.*
 import io.ktor.http.*
 import io.ktor.util.date.*
 import io.ktor.utils.io.*
-import io.ktor.utils.io.core.*
 import kotlinx.io.*
 import kotlin.collections.*
 
 @OptIn(InternalAPI::class)
 internal suspend fun HttpCacheEntry(isShared: Boolean, response: HttpResponse): HttpCacheEntry {
     val body = response.content.readRemaining().readByteArray()
-    response.complete()
     return HttpCacheEntry(response.cacheExpires(isShared), response.varyKeys(), response, body)
 }
 

--- a/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/cache/HttpCacheLegacy.kt
+++ b/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/cache/HttpCacheLegacy.kt
@@ -65,7 +65,6 @@ internal suspend fun PipelineContext<HttpResponse, Unit>.interceptReceiveLegacy(
     }
 
     if (response.status == HttpStatusCode.NotModified) {
-        response.complete()
         val responseFromCache = plugin.findAndRefresh(response.call.request, response)
             ?: throw InvalidCacheStateException(response.call.request.url)
 

--- a/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/cache/storage/HttpCacheStorage.kt
+++ b/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/cache/storage/HttpCacheStorage.kt
@@ -117,7 +117,6 @@ public suspend fun CacheStorage.store(
 ): CachedResponseData {
     val url = response.call.request.url
     val body = response.content.readRemaining().readBytes()
-    response.complete()
     val data = CachedResponseData(
         url = response.call.request.url,
         statusCode = response.status,

--- a/ktor-client/ktor-client-core/jvm/src/io/ktor/client/plugins/DefaultTransformersJvm.kt
+++ b/ktor-client/ktor-client-core/jvm/src/io/ktor/client/plugins/DefaultTransformersJvm.kt
@@ -29,7 +29,6 @@ internal actual fun HttpClient.platformResponseDefaultTransformers() {
                     override fun close() {
                         super.close()
                         stream.close()
-                        context.response.complete()
                     }
                 }
                 proceedWith(HttpResponseContainer(info, response))

--- a/ktor-client/ktor-client-okhttp/jvm/src/io/ktor/client/engine/okhttp/OkHttpEngine.kt
+++ b/ktor-client/ktor-client-okhttp/jvm/src/io/ktor/client/engine/okhttp/OkHttpEngine.kt
@@ -172,7 +172,8 @@ private fun BufferedSource.toChannel(context: CoroutineContext, requestData: Htt
                     lastRead = try {
                         source.read(buffer)
                     } catch (cause: Throwable) {
-                        val cancelOrCloseCause = kotlin.runCatching {  context.job.getCancellationException() }.getOrNull() ?: cause
+                        val cancelOrCloseCause =
+                            kotlin.runCatching { context.job.getCancellationException() }.getOrNull() ?: cause
                         throw mapExceptions(cancelOrCloseCause, requestData)
                     }
                 }
@@ -216,10 +217,12 @@ internal fun OutgoingContent.convertToOkHttpBody(callContext: CoroutineContext):
     is OutgoingContent.ByteArrayContent -> bytes().let {
         it.toRequestBody(contentType.toString().toMediaTypeOrNull(), 0, it.size)
     }
+
     is OutgoingContent.ReadChannelContent -> StreamRequestBody(contentLength) { readFrom() }
     is OutgoingContent.WriteChannelContent -> {
         StreamRequestBody(contentLength) { GlobalScope.writer(callContext) { writeTo(channel) }.channel }
     }
+
     is OutgoingContent.NoContent -> ByteArray(0).toRequestBody(null, 0, 0)
     is OutgoingContent.ContentWrapper -> delegate().convertToOkHttpBody(callContext)
     is OutgoingContent.ProtocolUpgrade -> throw UnsupportedContentTypeException(this)

--- a/ktor-client/ktor-client-plugins/ktor-client-auth/common/test/io/ktor/client/plugins/auth/AuthTest.kt
+++ b/ktor-client/ktor-client-plugins/ktor-client-auth/common/test/io/ktor/client/plugins/auth/AuthTest.kt
@@ -18,6 +18,7 @@ import io.ktor.test.dispatcher.*
 import kotlinx.coroutines.*
 import kotlinx.io.*
 import kotlin.test.*
+import kotlin.test.assertFailsWith
 
 class AuthTest : ClientLoader() {
 

--- a/ktor-client/ktor-client-plugins/ktor-client-bom-remover/common/src/io/ktor/client/plugins/bomremover/BOMRemover.kt
+++ b/ktor-client/ktor-client-plugins/ktor-client-bom-remover/common/src/io/ktor/client/plugins/bomremover/BOMRemover.kt
@@ -9,6 +9,7 @@ import io.ktor.client.call.*
 import io.ktor.client.plugins.api.*
 import io.ktor.client.statement.*
 import io.ktor.utils.io.*
+import kotlinx.coroutines.*
 
 /**
  * BOMRemover plugin that allows you to remove Byte Order Mark from response body.
@@ -38,7 +39,7 @@ public val BOMRemover: ClientPlugin<Unit> = createClientPlugin(
         }
 
         var offset = 0
-        context.writer {
+        GlobalScope.writer {
             for (bom in BOMs) {
                 if (length >= bom.size && bom.indices.all { beginning[it] == bom[it] }) {
                     offset = bom.size

--- a/ktor-client/ktor-client-plugins/ktor-client-logging/jsAndWasmShared/src/io/ktor/client/plugins/logging/KtorMDCContext.jsAndWasmShared.kt
+++ b/ktor-client/ktor-client-plugins/ktor-client-logging/jsAndWasmShared/src/io/ktor/client/plugins/logging/KtorMDCContext.jsAndWasmShared.kt
@@ -7,7 +7,6 @@ package io.ktor.client.plugins.logging
 import io.ktor.utils.io.*
 import kotlin.coroutines.*
 
-
 @InternalAPI
 public actual fun MDCContext(): CoroutineContext.Element = MDCContextElement
 
@@ -17,5 +16,5 @@ internal object MDCContextElement : CoroutineContext.Element {
 
     override fun toString(): String = "MDCContext"
 
-    object MDCContextKey: CoroutineContext.Key<MDCContextElement>
+    object MDCContextKey : CoroutineContext.Key<MDCContextElement>
 }

--- a/ktor-client/ktor-client-plugins/ktor-client-logging/posix/src/io/ktor/client/plugins/logging/KtorMDCContext.posix.kt
+++ b/ktor-client/ktor-client-plugins/ktor-client-logging/posix/src/io/ktor/client/plugins/logging/KtorMDCContext.posix.kt
@@ -16,6 +16,5 @@ internal object MDCContextElement : CoroutineContext.Element {
 
     override fun toString(): String = "MDCContext"
 
-    object MDCContextKey: CoroutineContext.Key<MDCContextElement>
+    object MDCContextKey : CoroutineContext.Key<MDCContextElement>
 }
-

--- a/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/HttpTimeoutTest.kt
+++ b/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/HttpTimeoutTest.kt
@@ -13,10 +13,8 @@ import io.ktor.client.tests.utils.*
 import io.ktor.http.*
 import io.ktor.utils.io.*
 import io.ktor.utils.io.CancellationException
-import io.ktor.utils.io.core.*
-import io.ktor.utils.io.errors.*
 import kotlinx.coroutines.*
-import kotlinx.io.IOException
+import kotlinx.io.*
 import kotlin.test.*
 
 private const val TEST_URL = "$TEST_SERVER/timeout"
@@ -224,26 +222,27 @@ class HttpTimeoutTest : ClientLoader() {
     }
 
     @Test
-    fun testGetRequestTimeoutWithSeparateReceivePerRequestAttributes() = clientTests(listOf("Js")) {
-        config {
-            install(HttpTimeout)
-        }
+    fun testGetRequestTimeoutWithSeparateReceivePerRequestAttributes() =
+        clientTests(listOf("Js", "Curl", "Darwin", "DarwinLegacy")) {
+            config {
+                install(HttpTimeout)
+            }
 
-        test { client ->
-            val response = client.prepareRequest("$TEST_URL/with-stream") {
-                method = HttpMethod.Get
-                parameter("delay", 10000)
+            test { client ->
+                val response = client.prepareRequest("$TEST_URL/with-stream") {
+                    method = HttpMethod.Get
+                    parameter("delay", 10000)
 
-                timeout { requestTimeoutMillis = 1000 }
-            }.body<ByteReadChannel>()
-            assertFailsWith<CancellationException> {
-                response.readUTF8Line()
+                    timeout { requestTimeoutMillis = 1000 }
+                }.body<ByteReadChannel>()
+                assertFailsWith<CancellationException> {
+                    response.readUTF8Line()
+                }
             }
         }
-    }
 
     @Test
-    fun testGetAfterTimeout() = clientTests(listOf("Curl", "Js")) {
+    fun testGetAfterTimeout() = clientTests(listOf("Curl", "Js", "Darwin", "DarwinLegacy")) {
         config {
             install(HttpTimeout)
         }

--- a/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/plugins/ServerSentEventsTest.kt
+++ b/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/plugins/ServerSentEventsTest.kt
@@ -22,6 +22,7 @@ import kotlinx.coroutines.*
 import kotlinx.coroutines.flow.*
 import kotlin.coroutines.*
 import kotlin.test.*
+import kotlin.test.assertFailsWith
 
 class ServerSentEventsTest : ClientLoader(timeoutSeconds = 120) {
 

--- a/ktor-network/ktor-network-tls/ktor-network-tls-certificates/jvm/src/io/ktor/network/tls/certificates/Certificates.kt
+++ b/ktor-network/ktor-network-tls/ktor-network-tls-certificates/jvm/src/io/ktor/network/tls/certificates/Certificates.kt
@@ -7,9 +7,9 @@ package io.ktor.network.tls.certificates
 import io.ktor.network.tls.*
 import io.ktor.network.tls.extensions.*
 import io.ktor.utils.io.core.*
+import kotlinx.io.*
 import kotlinx.io.Sink
 import kotlinx.io.writeUByte
-import kotlinx.io.*
 import java.io.*
 import java.math.*
 import java.net.*

--- a/ktor-network/posix/src/io/ktor/network/sockets/DatagramSendChannel.kt
+++ b/ktor-network/posix/src/io/ktor/network/sockets/DatagramSendChannel.kt
@@ -15,7 +15,6 @@ import kotlinx.coroutines.channels.*
 import kotlinx.coroutines.selects.*
 import kotlinx.coroutines.sync.*
 import kotlinx.io.*
-import kotlinx.io.Buffer
 import kotlinx.io.IOException
 
 private val CLOSED: (Throwable?) -> Unit = {}

--- a/ktor-network/posix/src/io/ktor/network/util/SocketUtils.kt
+++ b/ktor-network/posix/src/io/ktor/network/util/SocketUtils.kt
@@ -148,7 +148,6 @@ internal expect fun ktor_getsockname(
     __len: CPointer<UIntVar>?
 ): Int
 
-
 @OptIn(ExperimentalForeignApi::class)
 internal expect fun ktor_getpeername(
     __fd: Int,

--- a/ktor-server/ktor-server-core/common/test/io/ktor/server/application/ApplicationPluginTest.kt
+++ b/ktor-server/ktor-server-core/common/test/io/ktor/server/application/ApplicationPluginTest.kt
@@ -108,9 +108,12 @@ class ApplicationPluginTest {
                 call.respondText("response")
             }
         }
-        assertEquals("custom data", client.get("/request") {
-            header("F", "custom data")
-        }.bodyAsText())
+        assertEquals(
+            "custom data",
+            client.get("/request") {
+                header("F", "custom data")
+            }.bodyAsText()
+        )
     }
 
     class FConfig {
@@ -267,7 +270,6 @@ class ApplicationPluginTest {
         assertEquals("no route", response2.headers["PATH-1"])
         assertEquals("/a", response2.headers["PATH-2"])
     }
-
 
     @Test
     fun test_side_effect_of_install_called_on_every_installation() = testApplication {

--- a/ktor-server/ktor-server-core/common/test/io/ktor/server/application/HooksTest.kt
+++ b/ktor-server/ktor-server-core/common/test/io/ktor/server/application/HooksTest.kt
@@ -88,7 +88,6 @@ class HooksTest {
             client.get("/")
             assertTrue(state.startCalled)
             assertFalse(state.shutdownCalled)
-
         }
 
         assertTrue(state.shutdownCalled)

--- a/ktor-server/ktor-server-core/jvm/src/io/ktor/server/config/ConfigLoadersJvm.kt
+++ b/ktor-server/ktor-server-core/jvm/src/io/ktor/server/config/ConfigLoadersJvm.kt
@@ -14,7 +14,6 @@ internal actual val CONFIG_PATH: List<String>
         getEnvironmentProperty("config.url"),
     )
 
-
 public actual val configLoaders: List<ConfigLoader> = ConfigLoader::class.java.let {
     ServiceLoader.load(it, it.classLoader).toList()
 }

--- a/ktor-server/ktor-server-core/jvm/test/io/ktor/tests/plugins/ApplicationPluginConfigurationTest.kt
+++ b/ktor-server/ktor-server-core/jvm/test/io/ktor/tests/plugins/ApplicationPluginConfigurationTest.kt
@@ -34,7 +34,6 @@ class ApplicationPluginConfigurationTest {
             lastInstalledValue = pluginConfig.property
         }
 
-
         install(plugin)
         startApplication()
         assertEquals("Default Value", lastInstalledValue)
@@ -46,7 +45,6 @@ class ApplicationPluginConfigurationTest {
         val plugin = createApplicationPlugin("PluginWithProperty", "myplugin", ::ConfigWithProperty) {
             lastInstalledValue = pluginConfig.property
         }
-
 
         install(plugin)
 
@@ -64,7 +62,6 @@ class ApplicationPluginConfigurationTest {
         val plugin = createApplicationPlugin("PluginWithProperty", "db.myplugin", ::ConfigWithProperty) {
             lastInstalledValue = pluginConfig.property
         }
-
 
         environment {
             config = ConfigLoader.load("test-config.yaml")

--- a/ktor-server/ktor-server-core/jvm/test/io/ktor/tests/plugins/RouteRootPluginConfigurationTest.kt
+++ b/ktor-server/ktor-server-core/jvm/test/io/ktor/tests/plugins/RouteRootPluginConfigurationTest.kt
@@ -18,7 +18,6 @@ class RouteRootPluginConfigurationTest {
             lastInstalledValue = pluginConfig.property
         }
 
-
         environment {
             config = load("test-config.yaml")
         }
@@ -49,7 +48,6 @@ class RouteRootPluginConfigurationTest {
             lastInstalledValue = pluginConfig.property
         }
 
-
         install(plugin)
 
         environment {
@@ -66,7 +64,6 @@ class RouteRootPluginConfigurationTest {
         val plugin = createRouteScopedPlugin("PluginWithProperty", "db.myplugin", ::ConfigWithProperty) {
             lastInstalledValue = pluginConfig.property
         }
-
 
         environment {
             config = load("test-config.yaml")

--- a/ktor-server/ktor-server-plugins/ktor-server-auth/common/test/io/ktor/tests/auth/AuthBuildersTest.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-auth/common/test/io/ktor/tests/auth/AuthBuildersTest.kt
@@ -46,7 +46,6 @@ class AuthBuildersTest {
 
     @Test
     fun testMultipleConfigurationsNested() = testApplication {
-
         install(Authentication) {
             form("first") { validate { c -> if (c.name == "first") UserIdPrincipal(c.name) else null } }
             basic("second") { validate { c -> if (c.name == "second") UserIdPrincipal(c.name) else null } }

--- a/ktor-server/ktor-server-plugins/ktor-server-auth/common/test/io/ktor/tests/auth/BasicAuthTest.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-auth/common/test/io/ktor/tests/auth/BasicAuthTest.kt
@@ -35,7 +35,6 @@ class BasicAuthTest {
 
     @Test
     fun testCharsetNull() = testApplication {
-
         install(Authentication) {
             basic {
                 realm = "ktor-test"

--- a/ktor-server/ktor-server-plugins/ktor-server-auth/common/test/io/ktor/tests/auth/OAuth2Test.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-auth/common/test/io/ktor/tests/auth/OAuth2Test.kt
@@ -345,7 +345,11 @@ class OAuth2Test {
         application {
             module()
             intercept(ApplicationCallPipeline.Call) {
-                assertTrue { call.authentication.allFailures.all { it is OAuth2RedirectError && it.error == "access_denied" } }
+                assertTrue {
+                    call.authentication.allFailures.all {
+                        it is OAuth2RedirectError && it.error == "access_denied"
+                    }
+                } // ktlint-disable max-line-length
             }
         }
         val call = noRedirectsClient().get(

--- a/ktor-server/ktor-server-plugins/ktor-server-auth/common/test/io/ktor/tests/auth/SessionAuthTest.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-auth/common/test/io/ktor/tests/auth/SessionAuthTest.kt
@@ -57,7 +57,6 @@ class SessionAuthTest {
             assertEquals(HttpStatusCode.OK, call.status)
         }
 
-
         val cookieStorage = AcceptAllCookiesStorage()
 
         client.config {

--- a/ktor-server/ktor-server-plugins/ktor-server-content-negotiation/common/test/ContentNegotiationTest.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-content-negotiation/common/test/ContentNegotiationTest.kt
@@ -411,7 +411,6 @@ class ContentNegotiationTest {
     fun testMultiple() = testApplication {
         val textContentConverter: ContentConverter = textContentConverter
 
-
         install(ContentNegotiation) {
             // Order here matters. The first registered content type matching the Accept header will be chosen.
             register(customContentType, customContentConverter)

--- a/ktor-server/ktor-server-plugins/ktor-server-content-negotiation/common/test/RequestConverterTest.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-content-negotiation/common/test/RequestConverterTest.kt
@@ -79,7 +79,7 @@ class RequestConverterTest {
 
         try {
             assertEquals(
-                "Cannot transform this request's content to io.ktor.server.plugins.contentnegotiation.NonSerializableClass",
+                "Cannot transform this request's content to io.ktor.server.plugins.contentnegotiation.NonSerializableClass", // ktlint-disable max-line-length
                 responseFoo
             )
         } catch (cause: Throwable) {

--- a/ktor-server/ktor-server-plugins/ktor-server-csrf/common/test/io/ktor/server/plugins/csrf/CSRFTest.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-csrf/common/test/io/ktor/server/plugins/csrf/CSRFTest.kt
@@ -123,7 +123,6 @@ class CSRFTest {
     fun onFailureOverride() = testApplication {
         val customErrorMessage = "Hands off mah cookies!"
 
-
         configureCSRF {
             checkHeader("X-CSRF") { csrfHeader ->
                 request.headers[HttpHeaders.Origin]?.let { origin ->
@@ -174,7 +173,6 @@ class CSRFTest {
     @Test
     fun onFailureDefaultResponse() = testApplication {
         var errorMessageVariable = ""
-
 
         configureCSRF {
             checkHeader("X-CSRF") { csrfHeader ->

--- a/ktor-server/ktor-server-plugins/ktor-server-resources/common/test/io/ktor/tests/resources/ResourcesTest.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-resources/common/test/io/ktor/tests/resources/ResourcesTest.kt
@@ -452,7 +452,6 @@ class ResourcesTest {
             "href = /?text=abc&number=1&longNumber=2 text = abc, number = 1, longNumber = 2"
         )
 
-
         assertEquals(HttpStatusCode.BadRequest, client.get("/?number=1&longNumber=2").status)
         assertEquals(HttpStatusCode.BadRequest, client.get("/?text=abc&number=z&longNumber=2").status)
         assertEquals(

--- a/ktor-server/ktor-server-plugins/ktor-server-sessions/common/test/io/ktor/server/sessions/CacheTest.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-sessions/common/test/io/ktor/server/sessions/CacheTest.kt
@@ -124,20 +124,17 @@ class CacheTest {
         }
         val storage = CacheStorage(memoryStorage, 100)
 
-
         storage.write("id", "123")
         assertEquals("123", storage.read("id"))
 
         assertEquals(2, readCount) // compute + read
         assertEquals(1, writeCount)
 
-
         storage.write("id", "123")
         assertEquals("123", storage.read("id"))
 
         assertEquals(2, readCount) // no additional read
         assertEquals(1, writeCount)
-
 
         storage.write("id", "234")
         assertEquals("234", storage.read("id"))

--- a/ktor-server/ktor-server-plugins/ktor-server-status-pages/common/test/io/ktor/server/plugins/statuspages/StatusPagesTest.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-status-pages/common/test/io/ktor/server/plugins/statuspages/StatusPagesTest.kt
@@ -185,7 +185,6 @@ class StatusPagesTest {
     fun testFailPageDuringInterceptor() = testApplication {
         class O
 
-
         application {
             intercept(ApplicationCallPipeline.Plugins) {
                 call.response.pipeline.intercept(ApplicationSendPipeline.Transform) { message ->
@@ -255,7 +254,6 @@ class StatusPagesTest {
     @Test
     fun testErrorFromExceptionContent() = testApplication {
         class ValidationException(val code: String) : RuntimeException()
-
 
         application {
             install(StatusPages) {
@@ -422,7 +420,6 @@ class StatusPagesTest {
                 throw NotFoundException()
             }
         }
-
 
         var exceptionHandled = false
         var routingHandled = false

--- a/ktor-server/ktor-server-plugins/ktor-server-webjars/jvm/test/io/ktor/server/webjars/WebjarsTest.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-webjars/jvm/test/io/ktor/server/webjars/WebjarsTest.kt
@@ -180,7 +180,6 @@ class WebjarsTest {
             on(alwaysRespondHello, Unit)
         }
 
-
         install(pluginBeforeWebjars)
         install(Webjars)
 

--- a/ktor-server/ktor-server-test-base/jsAndWasmShared/src/io/ktor/server/test/base/BaseTest.jsAndWasmShared.kt
+++ b/ktor-server/ktor-server-test-base/jsAndWasmShared/src/io/ktor/server/test/base/BaseTest.jsAndWasmShared.kt
@@ -41,4 +41,3 @@ actual abstract class BaseTest actual constructor() {
 }
 
 private class UnhandledErrorsException(override val message: String) : Exception()
-

--- a/ktor-server/ktor-server-test-base/posix/src/io/ktor/server/test/base/BaseTestNix.kt
+++ b/ktor-server/ktor-server-test-base/posix/src/io/ktor/server/test/base/BaseTestNix.kt
@@ -49,4 +49,3 @@ actual abstract class BaseTest actual constructor() {
 }
 
 private class UnhandledErrorsException(override val message: String) : Exception()
-

--- a/ktor-server/ktor-server-test-host/common/src/io/ktor/server/testing/client/TestHttpClientEngine.kt
+++ b/ktor-server/ktor-server-test-host/common/src/io/ktor/server/testing/client/TestHttpClientEngine.kt
@@ -37,7 +37,7 @@ public class TestHttpClientEngine(override val config: TestHttpClientConfig) : H
 
     private val clientJob: CompletableJob = Job(app.coroutineContext[Job])
 
-    override val coroutineContext: CoroutineContext = clientJob + dispatcher
+    override val coroutineContext: CoroutineContext = clientJob + dispatcher + CoroutineExceptionHandler { _, _ -> }
 
     @OptIn(InternalAPI::class)
     override suspend fun execute(data: HttpRequestData): HttpResponseData {

--- a/ktor-server/ktor-server-test-suites/jvm/src/io/ktor/server/testing/suites/HttpServerJvmTestSuite.kt
+++ b/ktor-server/ktor-server-test-suites/jvm/src/io/ktor/server/testing/suites/HttpServerJvmTestSuite.kt
@@ -309,7 +309,6 @@ abstract class HttpServerJvmTestSuite<TEngine : ApplicationEngine, TConfiguratio
             inputStream.read(ByteArray(100))
         } // send FIN + RST
 
-
         withTimeout(5000L) {
             completed.join()
         }
@@ -372,7 +371,6 @@ abstract class HttpServerJvmTestSuite<TEngine : ApplicationEngine, TConfiguratio
             }
 
             val ch = ByteChannel(true)
-
 
             launch {
                 val s = inputStream

--- a/ktor-server/ktor-server-test-suites/jvm/src/io/ktor/server/testing/suites/SustainabilityTestSuite.kt
+++ b/ktor-server/ktor-server-test-suites/jvm/src/io/ktor/server/testing/suites/SustainabilityTestSuite.kt
@@ -274,7 +274,6 @@ abstract class SustainabilityTestSuite<TEngine : ApplicationEngine, TConfigurati
 
         parent.cancel()
 
-
         val timeMillis = 15000L
         try {
             withTimeout(timeMillis) {

--- a/ktor-server/ktor-server-test-suites/jvmAndPosix/src/io/ktor/server/testing/suites/WebSocketEngineSuite.kt
+++ b/ktor-server/ktor-server-test-suites/jvmAndPosix/src/io/ktor/server/testing/suites/WebSocketEngineSuite.kt
@@ -70,7 +70,6 @@ abstract class WebSocketEngineSuite<TEngine : ApplicationEngine, TConfiguration 
             }
         }
 
-
         withTimeout(5000) {
             closeReasonJob.join()
             contextJob.join()
@@ -152,7 +151,6 @@ abstract class WebSocketEngineSuite<TEngine : ApplicationEngine, TConfiguration 
             }
         }
 
-
         withTimeout(5000) {
             closeReasonJob.join()
             contextJob.join()
@@ -184,7 +182,6 @@ abstract class WebSocketEngineSuite<TEngine : ApplicationEngine, TConfiguration 
                 delay(1000)
             }
         }
-
 
         withTimeout(5000) {
             contextJob.join()
@@ -219,7 +216,6 @@ abstract class WebSocketEngineSuite<TEngine : ApplicationEngine, TConfiguration 
             }
         }
 
-
         withTimeout(5000) {
             contextJob.join()
         }
@@ -249,7 +245,6 @@ abstract class WebSocketEngineSuite<TEngine : ApplicationEngine, TConfiguration 
                 delay(10000)
             }
         }
-
 
         withTimeout(5000) {
             contextJob.join()

--- a/ktor-server/ktor-server-tests/common/test/io/ktor/tests/server/plugins/ConditionalHeadersTests.kt
+++ b/ktor-server/ktor-server-tests/common/test/io/ktor/tests/server/plugins/ConditionalHeadersTests.kt
@@ -143,7 +143,6 @@ class ETagsTest {
 
     @Test
     fun testIfMatchListConditionAccepted() = withConditionalApplication {
-
         val result = client.get {
             header(HttpHeaders.IfMatch, "tag0,tag1,tag3")
         }

--- a/ktor-server/ktor-server-tests/common/test/io/ktor/tests/server/plugins/PartialContentTest.kt
+++ b/ktor-server/ktor-server-tests/common/test/io/ktor/tests/server/plugins/PartialContentTest.kt
@@ -340,5 +340,4 @@ class PartialContentTest {
         assertContentEquals(expected, bytes)
         assertEquals(expected.size, response.headers[HttpHeaders.ContentLength]!!.toInt())
     }
-
 }

--- a/ktor-server/ktor-server-tests/common/test/io/ktor/tests/server/routing/RoutingTracingTest.kt
+++ b/ktor-server/ktor-server-tests/common/test/io/ktor/tests/server/routing/RoutingTracingTest.kt
@@ -42,7 +42,6 @@ class RoutingTracingTest {
     fun testRoutingBarX() = tracingApplication { trace ->
         assertEquals("/{param}/x", client.get("/bar/x").bodyAsText())
 
-
         assertEquals(
             """
     Trace for [bar, x]
@@ -70,7 +69,6 @@ class RoutingTracingTest {
     @Test
     fun testRoutingBazX() = tracingApplication { trace ->
         assertEquals("/baz/x", client.get("/baz/x").bodyAsText())
-
 
         assertEquals(
             """
@@ -100,7 +98,6 @@ class RoutingTracingTest {
     fun testRoutingBazDoo() = tracingApplication { trace ->
         assertEquals("/baz/{y}", client.get("/baz/doo").bodyAsText())
 
-
         assertEquals(
             """
     Trace for [baz, doo]
@@ -128,7 +125,6 @@ class RoutingTracingTest {
     @Test
     fun testRoutingBazXZ() = tracingApplication { trace ->
         assertEquals("/baz/x/{optional?}", client.get("/baz/x/z").bodyAsText())
-
 
         assertEquals(
             """
@@ -159,7 +155,6 @@ class RoutingTracingTest {
     fun testRoutingBazXValue() = tracingApplication { trace ->
         assertEquals("/baz/x/{optional?}", client.get("/baz/x/value").bodyAsText())
 
-
         assertEquals(
             """
     Trace for [baz, x, value]
@@ -189,7 +184,6 @@ class RoutingTracingTest {
     fun testRoutingP() = tracingApplication { trace ->
         assertEquals("/{param}", client.get("/p").bodyAsText())
 
-
         assertEquals(
             """
     Trace for [p]
@@ -214,7 +208,6 @@ class RoutingTracingTest {
     @Test
     fun testRoutingPX() = tracingApplication { trace ->
         assertEquals("/{param}/x", client.get("/p/x").bodyAsText())
-
 
         assertEquals(
             """
@@ -248,7 +241,6 @@ class RoutingTracingTest {
         }
 
         assertEquals("a", response.bodyAsText())
-
 
         assertEquals(
             """

--- a/ktor-utils/common/src/io/ktor/util/pipeline/Pipeline.kt
+++ b/ktor-utils/common/src/io/ktor/util/pipeline/Pipeline.kt
@@ -11,7 +11,7 @@ import kotlin.coroutines.*
 
 // helper interface for `startInterceptorCoroutineUninterceptedOrReturn`
 internal typealias PipelineInterceptorCoroutine<TSubject, TContext> =
-        (PipelineContext<TSubject, TContext>, TSubject, Continuation<Unit>) -> Any?
+    (PipelineContext<TSubject, TContext>, TSubject, Continuation<Unit>) -> Any?
 
 // Overall, it does the same as `startCoroutineUninterceptedOrReturn` from stdlib.
 // Stdlib even has `(suspend R.(P) -> T).startCoroutineUninterceptedOrReturn`, but it's internal.


### PR DESCRIPTION
**Subsystem**
Client

**Motivation**
`call.coroutineContext.job` should be completed after the creation of `SavedCall`, so `job` is completed after function `public suspend fun execute():  HttpResponse` but not completed in the `block` of function `public suspend fun <T> execute(block: suspend (response: HttpResponse) -> T): T`

**Solution**
1. Remove additional `Job` in `coroutineContext` of `SavedHttpResponse` [commit d555176](https://github.com/ktorio/ktor/pull/4147/commits/d555176d64481868c0dbb235a511b57454672d11)
2. Remove running of reading job if it's not needed in `Android` engine [commit 3543c98](https://github.com/ktorio/ktor/pull/4147/commits/3543c98327928d9266782a5acffe795babdc1ce5)
3. Because after saving of call response completed, we can remove anothers `response.complete()` [commit 7d8cd8b](https://github.com/ktorio/ktor/pull/4147/commits/7d8cd8b83a22e6034ca9141ac356c2c1ae7a70a8)
4. Change `coroutineContext` for writer in `BOMRemover` plugin [commit fe5ddfd](https://github.com/ktorio/ktor/pull/4147/commits/fe5ddfd4982e26b0efee38b82deb043a6ad85a42)
5. Change `coroutineContext` for writer in `DefaultTransform` to run the copying job is running under the client job [commit 61f8e21](https://github.com/ktorio/ktor/pull/4147/commits/61f8e21afaaf0d291f546394a67a09c2d2433a86)
6. Skip streaming `HttpTimeoutTests`, since there is no proper support for streaming engines `Curl` and `Darwin` [commit 47ce132](https://github.com/ktorio/ktor/pull/4147/commits/47ce13248cb42bf6d0e7e12821529bac89255ceb)
7. Add call cancelling when `callContext` cancelled in `OkHttp` engine [commit 9f313c7](https://github.com/ktorio/ktor/pull/4147/commits/9f313c710523f8e5141999e3ec9ac376ccd67451)
8. Add `CoroutineExceptionHandler` in `TestHttpClientEngine` [commit edcbc7c](https://github.com/ktorio/ktor/pull/4147/commits/edcbc7c06cff2633352c5d8c776d4fbcd097f9cd)
