### PR TITLE
KTOR-7220 Fix reading from empty Buffer

### DIFF
--- a/ktor-io/jvm/src/io/ktor/utils/io/ByteReadChannelOperations.jvm.kt
+++ b/ktor-io/jvm/src/io/ktor/utils/io/ByteReadChannelOperations.jvm.kt
@@ -204,7 +204,7 @@ public fun ByteReadChannel.readAvailable(block: (ByteBuffer) -> Int): Int {
 @OptIn(InternalAPI::class)
 public suspend inline fun ByteReadChannel.read(min: Int = 1, noinline consumer: (ByteBuffer) -> Unit) {
     require(min >= 0) { "min should be positive or zero" }
-    if (availableForRead >= min) {
+    if (availableForRead > 0 && availableForRead >= min) {
         readBuffer.read(consumer)
         return
     }
@@ -214,5 +214,5 @@ public suspend inline fun ByteReadChannel.read(min: Int = 1, noinline consumer: 
         throw EOFException("Not enough bytes available: required $min but $availableForRead available")
     }
 
-    readBuffer.read(consumer)
+    if (availableForRead > 0) readBuffer.read(consumer)
 }

--- a/ktor-io/jvm/test/ByteReadChannelReadTest.jvm.kt
+++ b/ktor-io/jvm/test/ByteReadChannelReadTest.jvm.kt
@@ -1,0 +1,21 @@
+import io.ktor.utils.io.*
+import kotlinx.coroutines.*
+import kotlinx.coroutines.test.*
+import java.nio.*
+import kotlin.test.*
+
+/*
+ * Copyright 2014-2024 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+class ByteReadChannelReadTest {
+
+    @Test
+    fun testReadAvailableFromEmpty() = runTest {
+        val channel = ByteReadChannel(ByteArray(0))
+
+        channel.read(0) { buffer: ByteBuffer ->
+            fail()
+        }
+    }
+}


### PR DESCRIPTION
[KTOR-7220](https://youtrack.jetbrains.com/issue/KTOR-7220) ByteReadChannel.copyTo sometimes throws "IllegalArgumentException: Buffer is empty"