### PR TITLE
Add kotlinx.browser dependency to WasmJs target

### DIFF
--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -27,6 +27,7 @@ val Project.Versions: Versions get() {
             versions["junit-version"],
             versions["logback-version"],
             versions["puppeteer-version"],
+            versions["kotlinx-browser-version"],
         )
     }.also {
         localVersions = it
@@ -42,4 +43,5 @@ data class Versions(
     val junit: String,
     val logback: String,
     val puppeteer: String,
+    val browser: String,
 )

--- a/buildSrc/src/main/kotlin/WasmConfig.kt
+++ b/buildSrc/src/main/kotlin/WasmConfig.kt
@@ -12,6 +12,11 @@ fun Project.configureWasm() {
 
     kotlin {
         sourceSets {
+            val wasmJsMain by getting {
+                dependencies {
+                    implementation("org.jetbrains.kotlinx:kotlinx-browser:${Versions.browser}")
+                }
+            }
             val wasmJsTest by getting {
                 dependencies {
                     implementation(npm("puppeteer", Versions.puppeteer))

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,6 +7,7 @@ coroutines-version = "1.8.1"
 atomicfu-version = "0.25.0"
 serialization-version = "1.7.1"
 ktlint-version = "3.15.0"
+kotlinx-browser-version = "0.1"
 
 netty-version = "4.1.112.Final"
 netty-tcnative-version = "2.0.65.Final"


### PR DESCRIPTION
**Subsystem**
All WasmJs target modules

**Motivation**
The browser declarations are [going to be moved](https://youtrack.jetbrains.com/issue/KT-54299/Extract-org.w3c-declarations-to-separate-library-from-K-Wasm-Stdlib) from the wasmJs stdlib to a separate [artifact](https://central.sonatype.com/artifact/org.jetbrains.kotlinx/kotlinx-browser).

**Solution**
Add a new dependency to wasmJs target.