### PR TITLE
KTOR-7264 Revert migration of monitor property to fix backwards compatibility

### DIFF
--- a/ktor-server/ktor-server-core/api/ktor-server-core.api
+++ b/ktor-server/ktor-server-core/api/ktor-server-core.api
@@ -51,6 +51,7 @@ public abstract interface class io/ktor/server/application/ApplicationEnvironmen
 	public abstract fun getClassLoader ()Ljava/lang/ClassLoader;
 	public abstract fun getConfig ()Lio/ktor/server/config/ApplicationConfig;
 	public abstract fun getLog ()Lorg/slf4j/Logger;
+	public abstract fun getMonitor ()Lio/ktor/events/Events;
 }
 
 public final class io/ktor/server/application/ApplicationKt {

--- a/ktor-server/ktor-server-core/jvm/src/io/ktor/server/application/ApplicationEnvironment.kt
+++ b/ktor-server/ktor-server-core/jvm/src/io/ktor/server/application/ApplicationEnvironment.kt
@@ -4,6 +4,7 @@
 
 package io.ktor.server.application
 
+import io.ktor.events.*
 import io.ktor.server.config.*
 import io.ktor.util.logging.*
 import kotlin.coroutines.*
@@ -29,6 +30,16 @@ public actual interface ApplicationEnvironment {
      * Configuration for the [Application]
      */
     public actual val config: ApplicationConfig
+
+    /**
+     * Provides events on Application lifecycle
+     */
+    @Deprecated(
+        message = "Moved to Application",
+        replaceWith = ReplaceWith("EmbeddedServer.monitor", "io.ktor.server.engine.EmbeddedServer"),
+        level = DeprecationLevel.WARNING,
+    )
+    public actual val monitor: Events
 }
 
 internal actual class ApplicationPropertiesBridge actual constructor(

--- a/ktor-server/ktor-server-core/jvm/src/io/ktor/server/engine/ApplicationEnvironmentJvm.kt
+++ b/ktor-server/ktor-server-core/jvm/src/io/ktor/server/engine/ApplicationEnvironmentJvm.kt
@@ -5,6 +5,7 @@
 
 package io.ktor.server.engine
 
+import io.ktor.events.*
 import io.ktor.server.application.*
 import io.ktor.server.config.*
 import io.ktor.utils.io.*
@@ -43,4 +44,10 @@ internal class ApplicationEnvironmentImplJvm(
     override val classLoader: ClassLoader,
     override val log: Logger,
     override val config: ApplicationConfig,
+    @Deprecated(
+        "Moved to Application",
+        replaceWith = ReplaceWith("EmbeddedServer.monitor", "io.ktor.server.engine.EmbeddedServer"),
+        level = DeprecationLevel.WARNING
+    )
+    override val monitor: Events = Events()
 ) : ApplicationEnvironment

--- a/ktor-server/ktor-server-core/jvm/src/io/ktor/server/engine/EmbeddedServerJvm.kt
+++ b/ktor-server/ktor-server-core/jvm/src/io/ktor/server/engine/EmbeddedServerJvm.kt
@@ -34,7 +34,7 @@ actual constructor(
     engineConfigBlock: TConfiguration.() -> Unit
 ) {
 
-    public actual val monitor: Events = Events()
+    public actual val monitor: Events = applicationProperties.environment.monitor
 
     public actual val environment: ApplicationEnvironment = applicationProperties.environment
 

--- a/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/application/CommonApplicationEnvironment.kt
+++ b/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/application/CommonApplicationEnvironment.kt
@@ -5,6 +5,7 @@
 
 package io.ktor.server.application
 
+import io.ktor.events.*
 import io.ktor.server.config.*
 import io.ktor.util.logging.*
 import kotlin.coroutines.*
@@ -23,6 +24,16 @@ public expect interface ApplicationEnvironment {
      * Configuration for the [Application]
      */
     public val config: ApplicationConfig
+
+    /**
+     * Provides events on Application lifecycle
+     */
+    @Deprecated(
+        message = "Moved to Application",
+        replaceWith = ReplaceWith("EmbeddedServer.monitor", "io.ktor.server.engine.EmbeddedServer"),
+        level = DeprecationLevel.ERROR,
+    )
+    public val monitor: Events
 }
 
 internal expect class ApplicationPropertiesBridge(

--- a/ktor-server/ktor-server-core/nix/src/io/ktor/server/application/NixApplicationEnvironment.kt
+++ b/ktor-server/ktor-server-core/nix/src/io/ktor/server/application/NixApplicationEnvironment.kt
@@ -5,6 +5,7 @@
 
 package io.ktor.server.application
 
+import io.ktor.events.*
 import io.ktor.server.config.*
 import io.ktor.util.logging.*
 import kotlin.coroutines.*
@@ -20,6 +21,16 @@ public actual interface ApplicationEnvironment {
      * Instance of [Logger] to be used for logging.
      */
     public actual val log: Logger
+
+    /**
+     * Provides events on Application lifecycle
+     */
+    @Deprecated(
+        message = "Moved to Application",
+        replaceWith = ReplaceWith("EmbeddedServer.monitor", "io.ktor.server.engine.EmbeddedServer"),
+        level = DeprecationLevel.WARNING,
+    )
+    public actual val monitor: Events
 }
 
 internal actual class ApplicationPropertiesBridge actual constructor(

--- a/ktor-server/ktor-server-core/nix/src/io/ktor/server/engine/ApplicationEngineEnvironmentNix.kt
+++ b/ktor-server/ktor-server-core/nix/src/io/ktor/server/engine/ApplicationEngineEnvironmentNix.kt
@@ -5,6 +5,7 @@
 
 package io.ktor.server.engine
 
+import io.ktor.events.*
 import io.ktor.server.application.*
 import io.ktor.server.config.*
 import io.ktor.util.logging.*
@@ -38,4 +39,10 @@ public actual class ApplicationEnvironmentBuilder {
 public class ApplicationEnvironmentImplNix(
     override val log: Logger,
     override val config: ApplicationConfig,
+    @Deprecated(
+        "Moved to Application",
+        replaceWith = ReplaceWith("EmbeddedServer.monitor", "io.ktor.server.engine.EmbeddedServer"),
+        level = DeprecationLevel.WARNING
+    )
+    override val monitor: Events = Events()
 ) : ApplicationEnvironment

--- a/ktor-server/ktor-server-core/nix/src/io/ktor/server/engine/EmbeddedServerNix.kt
+++ b/ktor-server/ktor-server-core/nix/src/io/ktor/server/engine/EmbeddedServerNix.kt
@@ -19,7 +19,7 @@ actual constructor(
     engineFactory: ApplicationEngineFactory<TEngine, TConfiguration>,
     engineConfigBlock: TConfiguration.() -> Unit
 ) {
-    public actual val monitor: Events = Events()
+    public actual val monitor: Events = applicationProperties.environment.monitor
 
     public actual val environment: ApplicationEnvironment = applicationProperties.environment
 


### PR DESCRIPTION
**Subsystem**
Server

**Motivation**
[KTOR-7264](https://youtrack.jetbrains.com/issue/KTOR-7264) Backwards compatibility for monitor

This change breaks the Koin plugin, and anything else that would have relied on the monitor property. 

**Solution**
Moved monitor back to `ApplicationEnvironment` with a deprecation warning for direct access.

