### PR TITLE
KTOR-7238 Revert naming on route builder types

### DIFF
--- a/ktor-client/ktor-client-plugins/ktor-client-content-negotiation/ktor-client-content-negotiation-tests/jvm/src/io/ktor/client/plugins/contentnegotiation/tests/AbstractClientContentNegotiationTest.kt
+++ b/ktor-client/ktor-client-plugins/ktor-client-content-negotiation/ktor-client-content-negotiation-tests/jvm/src/io/ktor/client/plugins/contentnegotiation/tests/AbstractClientContentNegotiationTest.kt
@@ -81,7 +81,7 @@ abstract class AbstractClientContentNegotiationTest : TestWithKtor() {
         }
     }
 
-    protected open fun createRoutes(routing: Routing): Unit = with(routing) {
+    protected open fun createRoutes(route: Route): Unit = with(route) {
         post("/echo") {
             call.respondWithRequestBody(call.request.contentType())
         }

--- a/ktor-server/ktor-server-core/api/ktor-server-core.api
+++ b/ktor-server/ktor-server-core/api/ktor-server-core.api
@@ -818,8 +818,8 @@ public final class io/ktor/server/http/content/SinglePageApplicationKt {
 	public static final fun ember (Lio/ktor/server/http/content/SPAConfig;Ljava/lang/String;)V
 	public static final fun ignoreFiles (Lio/ktor/server/http/content/SPAConfig;Lkotlin/jvm/functions/Function1;)V
 	public static final fun react (Lio/ktor/server/http/content/SPAConfig;Ljava/lang/String;)V
-	public static final fun singlePageApplication (Lio/ktor/server/routing/Routing;Lkotlin/jvm/functions/Function1;)V
-	public static synthetic fun singlePageApplication$default (Lio/ktor/server/routing/Routing;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+	public static final fun singlePageApplication (Lio/ktor/server/routing/Route;Lkotlin/jvm/functions/Function1;)V
+	public static synthetic fun singlePageApplication$default (Lio/ktor/server/routing/Route;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
 	public static final fun vue (Lio/ktor/server/http/content/SPAConfig;Ljava/lang/String;)V
 }
 
@@ -835,37 +835,37 @@ public final class io/ktor/server/http/content/StaticContentConfig {
 }
 
 public final class io/ktor/server/http/content/StaticContentKt {
-	public static final fun default (Lio/ktor/server/routing/Routing;Ljava/io/File;)V
-	public static final fun default (Lio/ktor/server/routing/Routing;Ljava/lang/String;)V
-	public static final fun defaultResource (Lio/ktor/server/routing/Routing;Ljava/lang/String;Ljava/lang/String;)V
-	public static synthetic fun defaultResource$default (Lio/ktor/server/routing/Routing;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)V
-	public static final fun file (Lio/ktor/server/routing/Routing;Ljava/lang/String;Ljava/io/File;)V
-	public static final fun file (Lio/ktor/server/routing/Routing;Ljava/lang/String;Ljava/lang/String;)V
-	public static synthetic fun file$default (Lio/ktor/server/routing/Routing;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)V
-	public static final fun files (Lio/ktor/server/routing/Routing;Ljava/io/File;)V
-	public static final fun files (Lio/ktor/server/routing/Routing;Ljava/lang/String;)V
-	public static final fun getStaticBasePackage (Lio/ktor/server/routing/Routing;)Ljava/lang/String;
+	public static final fun default (Lio/ktor/server/routing/Route;Ljava/io/File;)V
+	public static final fun default (Lio/ktor/server/routing/Route;Ljava/lang/String;)V
+	public static final fun defaultResource (Lio/ktor/server/routing/Route;Ljava/lang/String;Ljava/lang/String;)V
+	public static synthetic fun defaultResource$default (Lio/ktor/server/routing/Route;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)V
+	public static final fun file (Lio/ktor/server/routing/Route;Ljava/lang/String;Ljava/io/File;)V
+	public static final fun file (Lio/ktor/server/routing/Route;Ljava/lang/String;Ljava/lang/String;)V
+	public static synthetic fun file$default (Lio/ktor/server/routing/Route;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)V
+	public static final fun files (Lio/ktor/server/routing/Route;Ljava/io/File;)V
+	public static final fun files (Lio/ktor/server/routing/Route;Ljava/lang/String;)V
+	public static final fun getStaticBasePackage (Lio/ktor/server/routing/Route;)Ljava/lang/String;
 	public static final fun getStaticFileLocationProperty ()Lio/ktor/util/AttributeKey;
-	public static final fun getStaticRootFolder (Lio/ktor/server/routing/Routing;)Ljava/io/File;
+	public static final fun getStaticRootFolder (Lio/ktor/server/routing/Route;)Ljava/io/File;
 	public static final fun isStaticContent (Lio/ktor/server/application/ApplicationCall;)Z
-	public static final fun preCompressed (Lio/ktor/server/routing/Routing;[Lio/ktor/server/http/content/CompressedFileType;Lkotlin/jvm/functions/Function1;)V
-	public static synthetic fun preCompressed$default (Lio/ktor/server/routing/Routing;[Lio/ktor/server/http/content/CompressedFileType;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
-	public static final fun resource (Lio/ktor/server/routing/Routing;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
-	public static synthetic fun resource$default (Lio/ktor/server/routing/Routing;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)V
-	public static final fun resources (Lio/ktor/server/routing/Routing;Ljava/lang/String;)V
-	public static synthetic fun resources$default (Lio/ktor/server/routing/Routing;Ljava/lang/String;ILjava/lang/Object;)V
-	public static final fun setStaticBasePackage (Lio/ktor/server/routing/Routing;Ljava/lang/String;)V
-	public static final fun setStaticRootFolder (Lio/ktor/server/routing/Routing;Ljava/io/File;)V
-	public static final fun static (Lio/ktor/server/routing/Routing;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Lio/ktor/server/routing/Routing;
-	public static final fun static (Lio/ktor/server/routing/Routing;Lkotlin/jvm/functions/Function1;)Lio/ktor/server/routing/Routing;
-	public static final fun staticFileSystem (Lio/ktor/server/routing/Routing;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/nio/file/FileSystem;Lkotlin/jvm/functions/Function1;)Lio/ktor/server/routing/Routing;
-	public static synthetic fun staticFileSystem$default (Lio/ktor/server/routing/Routing;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/nio/file/FileSystem;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lio/ktor/server/routing/Routing;
-	public static final fun staticFiles (Lio/ktor/server/routing/Routing;Ljava/lang/String;Ljava/io/File;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Lio/ktor/server/routing/Routing;
-	public static synthetic fun staticFiles$default (Lio/ktor/server/routing/Routing;Ljava/lang/String;Ljava/io/File;Ljava/lang/String;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lio/ktor/server/routing/Routing;
-	public static final fun staticResources (Lio/ktor/server/routing/Routing;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Lio/ktor/server/routing/Routing;
-	public static synthetic fun staticResources$default (Lio/ktor/server/routing/Routing;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lio/ktor/server/routing/Routing;
-	public static final fun staticZip (Lio/ktor/server/routing/Routing;Ljava/lang/String;Ljava/lang/String;Ljava/nio/file/Path;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Lio/ktor/server/routing/Routing;
-	public static synthetic fun staticZip$default (Lio/ktor/server/routing/Routing;Ljava/lang/String;Ljava/lang/String;Ljava/nio/file/Path;Ljava/lang/String;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lio/ktor/server/routing/Routing;
+	public static final fun preCompressed (Lio/ktor/server/routing/Route;[Lio/ktor/server/http/content/CompressedFileType;Lkotlin/jvm/functions/Function1;)V
+	public static synthetic fun preCompressed$default (Lio/ktor/server/routing/Route;[Lio/ktor/server/http/content/CompressedFileType;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+	public static final fun resource (Lio/ktor/server/routing/Route;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public static synthetic fun resource$default (Lio/ktor/server/routing/Route;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)V
+	public static final fun resources (Lio/ktor/server/routing/Route;Ljava/lang/String;)V
+	public static synthetic fun resources$default (Lio/ktor/server/routing/Route;Ljava/lang/String;ILjava/lang/Object;)V
+	public static final fun setStaticBasePackage (Lio/ktor/server/routing/Route;Ljava/lang/String;)V
+	public static final fun setStaticRootFolder (Lio/ktor/server/routing/Route;Ljava/io/File;)V
+	public static final fun static (Lio/ktor/server/routing/Route;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Lio/ktor/server/routing/Route;
+	public static final fun static (Lio/ktor/server/routing/Route;Lkotlin/jvm/functions/Function1;)Lio/ktor/server/routing/Route;
+	public static final fun staticFileSystem (Lio/ktor/server/routing/Route;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/nio/file/FileSystem;Lkotlin/jvm/functions/Function1;)Lio/ktor/server/routing/Route;
+	public static synthetic fun staticFileSystem$default (Lio/ktor/server/routing/Route;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/nio/file/FileSystem;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lio/ktor/server/routing/Route;
+	public static final fun staticFiles (Lio/ktor/server/routing/Route;Ljava/lang/String;Ljava/io/File;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Lio/ktor/server/routing/Route;
+	public static synthetic fun staticFiles$default (Lio/ktor/server/routing/Route;Ljava/lang/String;Ljava/io/File;Ljava/lang/String;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lio/ktor/server/routing/Route;
+	public static final fun staticResources (Lio/ktor/server/routing/Route;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Lio/ktor/server/routing/Route;
+	public static synthetic fun staticResources$default (Lio/ktor/server/routing/Route;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lio/ktor/server/routing/Route;
+	public static final fun staticZip (Lio/ktor/server/routing/Route;Ljava/lang/String;Ljava/lang/String;Ljava/nio/file/Path;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Lio/ktor/server/routing/Route;
+	public static synthetic fun staticZip$default (Lio/ktor/server/routing/Route;Ljava/lang/String;Ljava/lang/String;Ljava/nio/file/Path;Ljava/lang/String;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lio/ktor/server/routing/Route;
 }
 
 public final class io/ktor/server/http/content/StaticContentResolutionKt {
@@ -1276,15 +1276,15 @@ public final class io/ktor/server/routing/HostRouteSelector$Companion {
 }
 
 public final class io/ktor/server/routing/HostsRoutingBuilderKt {
-	public static final fun host (Lio/ktor/server/routing/Routing;Ljava/lang/String;ILkotlin/jvm/functions/Function1;)Lio/ktor/server/routing/Routing;
-	public static final fun host (Lio/ktor/server/routing/Routing;Ljava/util/List;Ljava/util/List;Ljava/util/List;Lkotlin/jvm/functions/Function1;)Lio/ktor/server/routing/Routing;
-	public static final fun host (Lio/ktor/server/routing/Routing;Ljava/util/List;Ljava/util/List;Lkotlin/jvm/functions/Function1;)Lio/ktor/server/routing/Routing;
-	public static final fun host (Lio/ktor/server/routing/Routing;Lkotlin/text/Regex;ILkotlin/jvm/functions/Function1;)Lio/ktor/server/routing/Routing;
-	public static synthetic fun host$default (Lio/ktor/server/routing/Routing;Ljava/lang/String;ILkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lio/ktor/server/routing/Routing;
-	public static synthetic fun host$default (Lio/ktor/server/routing/Routing;Ljava/util/List;Ljava/util/List;Ljava/util/List;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lio/ktor/server/routing/Routing;
-	public static synthetic fun host$default (Lio/ktor/server/routing/Routing;Ljava/util/List;Ljava/util/List;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lio/ktor/server/routing/Routing;
-	public static synthetic fun host$default (Lio/ktor/server/routing/Routing;Lkotlin/text/Regex;ILkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lio/ktor/server/routing/Routing;
-	public static final fun port (Lio/ktor/server/routing/Routing;[ILkotlin/jvm/functions/Function1;)Lio/ktor/server/routing/Routing;
+	public static final fun host (Lio/ktor/server/routing/Route;Ljava/lang/String;ILkotlin/jvm/functions/Function1;)Lio/ktor/server/routing/Route;
+	public static final fun host (Lio/ktor/server/routing/Route;Ljava/util/List;Ljava/util/List;Ljava/util/List;Lkotlin/jvm/functions/Function1;)Lio/ktor/server/routing/Route;
+	public static final fun host (Lio/ktor/server/routing/Route;Ljava/util/List;Ljava/util/List;Lkotlin/jvm/functions/Function1;)Lio/ktor/server/routing/Route;
+	public static final fun host (Lio/ktor/server/routing/Route;Lkotlin/text/Regex;ILkotlin/jvm/functions/Function1;)Lio/ktor/server/routing/Route;
+	public static synthetic fun host$default (Lio/ktor/server/routing/Route;Ljava/lang/String;ILkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lio/ktor/server/routing/Route;
+	public static synthetic fun host$default (Lio/ktor/server/routing/Route;Ljava/util/List;Ljava/util/List;Ljava/util/List;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lio/ktor/server/routing/Route;
+	public static synthetic fun host$default (Lio/ktor/server/routing/Route;Ljava/util/List;Ljava/util/List;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lio/ktor/server/routing/Route;
+	public static synthetic fun host$default (Lio/ktor/server/routing/Route;Lkotlin/text/Regex;ILkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lio/ktor/server/routing/Route;
+	public static final fun port (Lio/ktor/server/routing/Route;[ILkotlin/jvm/functions/Function1;)Lio/ktor/server/routing/Route;
 }
 
 public final class io/ktor/server/routing/HttpAcceptRouteSelector : io/ktor/server/routing/RouteSelector {
@@ -1359,7 +1359,7 @@ public final class io/ktor/server/routing/LocalPortRouteSelector$Companion {
 }
 
 public final class io/ktor/server/routing/LocalPortRoutingBuilderKt {
-	public static final fun localPort (Lio/ktor/server/routing/Routing;ILkotlin/jvm/functions/Function1;)Lio/ktor/server/routing/Routing;
+	public static final fun localPort (Lio/ktor/server/routing/Route;ILkotlin/jvm/functions/Function1;)Lio/ktor/server/routing/Route;
 }
 
 public final class io/ktor/server/routing/OptionalParameterRouteSelector : io/ktor/server/routing/RouteSelector {
@@ -1486,15 +1486,15 @@ public final class io/ktor/server/routing/PathSegmentWildcardRouteSelector : io/
 }
 
 public final class io/ktor/server/routing/RegexRoutingKt {
-	public static final fun delete (Lio/ktor/server/routing/Routing;Lkotlin/text/Regex;Lkotlin/jvm/functions/Function2;)Lio/ktor/server/routing/Routing;
-	public static final fun get (Lio/ktor/server/routing/Routing;Lkotlin/text/Regex;Lkotlin/jvm/functions/Function2;)Lio/ktor/server/routing/Routing;
-	public static final fun head (Lio/ktor/server/routing/Routing;Lkotlin/text/Regex;Lkotlin/jvm/functions/Function2;)Lio/ktor/server/routing/Routing;
-	public static final fun options (Lio/ktor/server/routing/Routing;Lkotlin/text/Regex;Lkotlin/jvm/functions/Function2;)Lio/ktor/server/routing/Routing;
-	public static final fun patch (Lio/ktor/server/routing/Routing;Lkotlin/text/Regex;Lkotlin/jvm/functions/Function2;)Lio/ktor/server/routing/Routing;
-	public static final fun post (Lio/ktor/server/routing/Routing;Lkotlin/text/Regex;Lkotlin/jvm/functions/Function2;)Lio/ktor/server/routing/Routing;
-	public static final fun put (Lio/ktor/server/routing/Routing;Lkotlin/text/Regex;Lkotlin/jvm/functions/Function2;)Lio/ktor/server/routing/Routing;
-	public static final fun route (Lio/ktor/server/routing/Routing;Lkotlin/text/Regex;Lio/ktor/http/HttpMethod;Lkotlin/jvm/functions/Function1;)Lio/ktor/server/routing/Routing;
-	public static final fun route (Lio/ktor/server/routing/Routing;Lkotlin/text/Regex;Lkotlin/jvm/functions/Function1;)Lio/ktor/server/routing/Routing;
+	public static final fun delete (Lio/ktor/server/routing/Route;Lkotlin/text/Regex;Lkotlin/jvm/functions/Function2;)Lio/ktor/server/routing/Route;
+	public static final fun get (Lio/ktor/server/routing/Route;Lkotlin/text/Regex;Lkotlin/jvm/functions/Function2;)Lio/ktor/server/routing/Route;
+	public static final fun head (Lio/ktor/server/routing/Route;Lkotlin/text/Regex;Lkotlin/jvm/functions/Function2;)Lio/ktor/server/routing/Route;
+	public static final fun options (Lio/ktor/server/routing/Route;Lkotlin/text/Regex;Lkotlin/jvm/functions/Function2;)Lio/ktor/server/routing/Route;
+	public static final fun patch (Lio/ktor/server/routing/Route;Lkotlin/text/Regex;Lkotlin/jvm/functions/Function2;)Lio/ktor/server/routing/Route;
+	public static final fun post (Lio/ktor/server/routing/Route;Lkotlin/text/Regex;Lkotlin/jvm/functions/Function2;)Lio/ktor/server/routing/Route;
+	public static final fun put (Lio/ktor/server/routing/Route;Lkotlin/text/Regex;Lkotlin/jvm/functions/Function2;)Lio/ktor/server/routing/Route;
+	public static final fun route (Lio/ktor/server/routing/Route;Lkotlin/text/Regex;Lio/ktor/http/HttpMethod;Lkotlin/jvm/functions/Function1;)Lio/ktor/server/routing/Route;
+	public static final fun route (Lio/ktor/server/routing/Route;Lkotlin/text/Regex;Lkotlin/jvm/functions/Function1;)Lio/ktor/server/routing/Route;
 }
 
 public final class io/ktor/server/routing/RootRouteSelector : io/ktor/server/routing/RouteSelector {
@@ -1505,8 +1505,18 @@ public final class io/ktor/server/routing/RootRouteSelector : io/ktor/server/rou
 	public fun toString ()Ljava/lang/String;
 }
 
-public abstract interface class io/ktor/server/routing/RootRouting : io/ktor/server/routing/Routing {
-	public abstract fun trace (Lkotlin/jvm/functions/Function1;)V
+public abstract interface class io/ktor/server/routing/Route {
+	public abstract fun createChild (Lio/ktor/server/routing/RouteSelector;)Lio/ktor/server/routing/Route;
+	public abstract fun getAttributes ()Lio/ktor/util/Attributes;
+	public abstract fun getEnvironment ()Lio/ktor/server/application/ApplicationEnvironment;
+	public abstract fun getParent ()Lio/ktor/server/routing/Route;
+	public abstract fun handle (Lkotlin/jvm/functions/Function2;)V
+	public abstract fun install (Lio/ktor/server/application/Plugin;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+	public abstract fun plugin (Lio/ktor/server/application/Plugin;)Ljava/lang/Object;
+}
+
+public final class io/ktor/server/routing/Route$DefaultImpls {
+	public static synthetic fun install$default (Lio/ktor/server/routing/Route;Lio/ktor/server/application/Plugin;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Ljava/lang/Object;
 }
 
 public abstract class io/ktor/server/routing/RouteSelector {
@@ -1575,45 +1585,35 @@ public final class io/ktor/server/routing/RouteSelectorEvaluation$Success : io/k
 	public fun toString ()Ljava/lang/String;
 }
 
-public abstract interface class io/ktor/server/routing/Routing {
-	public abstract fun createChild (Lio/ktor/server/routing/RouteSelector;)Lio/ktor/server/routing/Routing;
-	public abstract fun getAttributes ()Lio/ktor/util/Attributes;
-	public abstract fun getEnvironment ()Lio/ktor/server/application/ApplicationEnvironment;
-	public abstract fun getParent ()Lio/ktor/server/routing/Routing;
-	public abstract fun handle (Lkotlin/jvm/functions/Function2;)V
-	public abstract fun install (Lio/ktor/server/application/Plugin;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
-	public abstract fun plugin (Lio/ktor/server/application/Plugin;)Ljava/lang/Object;
-}
-
-public final class io/ktor/server/routing/Routing$DefaultImpls {
-	public static synthetic fun install$default (Lio/ktor/server/routing/Routing;Lio/ktor/server/application/Plugin;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Ljava/lang/Object;
+public abstract interface class io/ktor/server/routing/Routing : io/ktor/server/routing/Route {
+	public abstract fun trace (Lkotlin/jvm/functions/Function1;)V
 }
 
 public final class io/ktor/server/routing/RoutingBuilderKt {
-	public static final fun accept (Lio/ktor/server/routing/Routing;[Lio/ktor/http/ContentType;Lkotlin/jvm/functions/Function1;)Lio/ktor/server/routing/Routing;
-	public static final fun contentType (Lio/ktor/server/routing/Routing;Lio/ktor/http/ContentType;Lkotlin/jvm/functions/Function1;)Lio/ktor/server/routing/Routing;
-	public static final fun createRouteFromPath (Lio/ktor/server/routing/Routing;Ljava/lang/String;)Lio/ktor/server/routing/Routing;
-	public static final fun delete (Lio/ktor/server/routing/Routing;Ljava/lang/String;Lkotlin/jvm/functions/Function2;)Lio/ktor/server/routing/Routing;
-	public static final fun delete (Lio/ktor/server/routing/Routing;Lkotlin/jvm/functions/Function2;)Lio/ktor/server/routing/Routing;
-	public static final fun get (Lio/ktor/server/routing/Routing;Ljava/lang/String;Lkotlin/jvm/functions/Function2;)Lio/ktor/server/routing/Routing;
-	public static final fun get (Lio/ktor/server/routing/Routing;Lkotlin/jvm/functions/Function2;)Lio/ktor/server/routing/Routing;
-	public static final fun head (Lio/ktor/server/routing/Routing;Ljava/lang/String;Lkotlin/jvm/functions/Function2;)Lio/ktor/server/routing/Routing;
-	public static final fun head (Lio/ktor/server/routing/Routing;Lkotlin/jvm/functions/Function2;)Lio/ktor/server/routing/Routing;
-	public static final fun header (Lio/ktor/server/routing/Routing;Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Lio/ktor/server/routing/Routing;
-	public static final fun method (Lio/ktor/server/routing/Routing;Lio/ktor/http/HttpMethod;Lkotlin/jvm/functions/Function1;)Lio/ktor/server/routing/Routing;
-	public static final fun optionalParam (Lio/ktor/server/routing/Routing;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Lio/ktor/server/routing/Routing;
-	public static final fun options (Lio/ktor/server/routing/Routing;Ljava/lang/String;Lkotlin/jvm/functions/Function2;)Lio/ktor/server/routing/Routing;
-	public static final fun options (Lio/ktor/server/routing/Routing;Lkotlin/jvm/functions/Function2;)Lio/ktor/server/routing/Routing;
-	public static final fun param (Lio/ktor/server/routing/Routing;Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Lio/ktor/server/routing/Routing;
-	public static final fun param (Lio/ktor/server/routing/Routing;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Lio/ktor/server/routing/Routing;
-	public static final fun patch (Lio/ktor/server/routing/Routing;Ljava/lang/String;Lkotlin/jvm/functions/Function2;)Lio/ktor/server/routing/Routing;
-	public static final fun patch (Lio/ktor/server/routing/Routing;Lkotlin/jvm/functions/Function2;)Lio/ktor/server/routing/Routing;
-	public static final fun post (Lio/ktor/server/routing/Routing;Ljava/lang/String;Lkotlin/jvm/functions/Function2;)Lio/ktor/server/routing/Routing;
-	public static final fun post (Lio/ktor/server/routing/Routing;Lkotlin/jvm/functions/Function2;)Lio/ktor/server/routing/Routing;
-	public static final fun put (Lio/ktor/server/routing/Routing;Ljava/lang/String;Lkotlin/jvm/functions/Function2;)Lio/ktor/server/routing/Routing;
-	public static final fun put (Lio/ktor/server/routing/Routing;Lkotlin/jvm/functions/Function2;)Lio/ktor/server/routing/Routing;
-	public static final fun route (Lio/ktor/server/routing/Routing;Ljava/lang/String;Lio/ktor/http/HttpMethod;Lkotlin/jvm/functions/Function1;)Lio/ktor/server/routing/Routing;
-	public static final fun route (Lio/ktor/server/routing/Routing;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Lio/ktor/server/routing/Routing;
+	public static final fun accept (Lio/ktor/server/routing/Route;[Lio/ktor/http/ContentType;Lkotlin/jvm/functions/Function1;)Lio/ktor/server/routing/Route;
+	public static final fun contentType (Lio/ktor/server/routing/Route;Lio/ktor/http/ContentType;Lkotlin/jvm/functions/Function1;)Lio/ktor/server/routing/Route;
+	public static final fun createRouteFromPath (Lio/ktor/server/routing/Route;Ljava/lang/String;)Lio/ktor/server/routing/Route;
+	public static final fun delete (Lio/ktor/server/routing/Route;Ljava/lang/String;Lkotlin/jvm/functions/Function2;)Lio/ktor/server/routing/Route;
+	public static final fun delete (Lio/ktor/server/routing/Route;Lkotlin/jvm/functions/Function2;)Lio/ktor/server/routing/Route;
+	public static final fun get (Lio/ktor/server/routing/Route;Ljava/lang/String;Lkotlin/jvm/functions/Function2;)Lio/ktor/server/routing/Route;
+	public static final fun get (Lio/ktor/server/routing/Route;Lkotlin/jvm/functions/Function2;)Lio/ktor/server/routing/Route;
+	public static final fun head (Lio/ktor/server/routing/Route;Ljava/lang/String;Lkotlin/jvm/functions/Function2;)Lio/ktor/server/routing/Route;
+	public static final fun head (Lio/ktor/server/routing/Route;Lkotlin/jvm/functions/Function2;)Lio/ktor/server/routing/Route;
+	public static final fun header (Lio/ktor/server/routing/Route;Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Lio/ktor/server/routing/Route;
+	public static final fun method (Lio/ktor/server/routing/Route;Lio/ktor/http/HttpMethod;Lkotlin/jvm/functions/Function1;)Lio/ktor/server/routing/Route;
+	public static final fun optionalParam (Lio/ktor/server/routing/Route;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Lio/ktor/server/routing/Route;
+	public static final fun options (Lio/ktor/server/routing/Route;Ljava/lang/String;Lkotlin/jvm/functions/Function2;)Lio/ktor/server/routing/Route;
+	public static final fun options (Lio/ktor/server/routing/Route;Lkotlin/jvm/functions/Function2;)Lio/ktor/server/routing/Route;
+	public static final fun param (Lio/ktor/server/routing/Route;Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Lio/ktor/server/routing/Route;
+	public static final fun param (Lio/ktor/server/routing/Route;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Lio/ktor/server/routing/Route;
+	public static final fun patch (Lio/ktor/server/routing/Route;Ljava/lang/String;Lkotlin/jvm/functions/Function2;)Lio/ktor/server/routing/Route;
+	public static final fun patch (Lio/ktor/server/routing/Route;Lkotlin/jvm/functions/Function2;)Lio/ktor/server/routing/Route;
+	public static final fun post (Lio/ktor/server/routing/Route;Ljava/lang/String;Lkotlin/jvm/functions/Function2;)Lio/ktor/server/routing/Route;
+	public static final fun post (Lio/ktor/server/routing/Route;Lkotlin/jvm/functions/Function2;)Lio/ktor/server/routing/Route;
+	public static final fun put (Lio/ktor/server/routing/Route;Ljava/lang/String;Lkotlin/jvm/functions/Function2;)Lio/ktor/server/routing/Route;
+	public static final fun put (Lio/ktor/server/routing/Route;Lkotlin/jvm/functions/Function2;)Lio/ktor/server/routing/Route;
+	public static final fun route (Lio/ktor/server/routing/Route;Ljava/lang/String;Lio/ktor/http/HttpMethod;Lkotlin/jvm/functions/Function1;)Lio/ktor/server/routing/Route;
+	public static final fun route (Lio/ktor/server/routing/Route;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Lio/ktor/server/routing/Route;
 }
 
 public final class io/ktor/server/routing/RoutingCall : io/ktor/server/application/ApplicationCall {
@@ -1638,14 +1638,14 @@ public final class io/ktor/server/routing/RoutingContext {
 	public final fun getCall ()Lio/ktor/server/routing/RoutingCall;
 }
 
-public class io/ktor/server/routing/RoutingNode : io/ktor/server/application/ApplicationCallPipeline, io/ktor/server/routing/Routing {
+public class io/ktor/server/routing/RoutingNode : io/ktor/server/application/ApplicationCallPipeline, io/ktor/server/routing/Route {
 	public fun <init> (Lio/ktor/server/routing/RoutingNode;Lio/ktor/server/routing/RouteSelector;ZLio/ktor/server/application/ApplicationEnvironment;)V
 	public synthetic fun <init> (Lio/ktor/server/routing/RoutingNode;Lio/ktor/server/routing/RouteSelector;ZLio/ktor/server/application/ApplicationEnvironment;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun afterIntercepted ()V
-	public synthetic fun createChild (Lio/ktor/server/routing/RouteSelector;)Lio/ktor/server/routing/Routing;
+	public synthetic fun createChild (Lio/ktor/server/routing/RouteSelector;)Lio/ktor/server/routing/Route;
 	public fun createChild (Lio/ktor/server/routing/RouteSelector;)Lio/ktor/server/routing/RoutingNode;
 	public final fun getChildren ()Ljava/util/List;
-	public synthetic fun getParent ()Lio/ktor/server/routing/Routing;
+	public synthetic fun getParent ()Lio/ktor/server/routing/Route;
 	public fun getParent ()Lio/ktor/server/routing/RoutingNode;
 	public final fun getSelector ()Lio/ktor/server/routing/RouteSelector;
 	public fun handle (Lkotlin/jvm/functions/Function2;)V
@@ -1657,9 +1657,9 @@ public class io/ktor/server/routing/RoutingNode : io/ktor/server/application/App
 
 public final class io/ktor/server/routing/RoutingNodeKt {
 	public static final fun getAllRoutes (Lio/ktor/server/routing/RoutingNode;)Ljava/util/List;
-	public static final fun insertPhaseAfter (Lio/ktor/server/routing/Routing;Lio/ktor/util/pipeline/PipelinePhase;Lio/ktor/util/pipeline/PipelinePhase;)V
-	public static final fun insertPhaseBefore (Lio/ktor/server/routing/Routing;Lio/ktor/util/pipeline/PipelinePhase;Lio/ktor/util/pipeline/PipelinePhase;)V
-	public static final fun intercept (Lio/ktor/server/routing/Routing;Lio/ktor/util/pipeline/PipelinePhase;Lkotlin/jvm/functions/Function3;)V
+	public static final fun insertPhaseAfter (Lio/ktor/server/routing/Route;Lio/ktor/util/pipeline/PipelinePhase;Lio/ktor/util/pipeline/PipelinePhase;)V
+	public static final fun insertPhaseBefore (Lio/ktor/server/routing/Route;Lio/ktor/util/pipeline/PipelinePhase;Lio/ktor/util/pipeline/PipelinePhase;)V
+	public static final fun intercept (Lio/ktor/server/routing/Route;Lio/ktor/util/pipeline/PipelinePhase;Lkotlin/jvm/functions/Function3;)V
 }
 
 public final class io/ktor/server/routing/RoutingPath {
@@ -1827,7 +1827,7 @@ public final class io/ktor/server/routing/RoutingResponse : io/ktor/server/respo
 	public fun status (Lio/ktor/http/HttpStatusCode;)V
 }
 
-public final class io/ktor/server/routing/RoutingRoot : io/ktor/server/routing/RoutingNode, io/ktor/server/routing/RootRouting {
+public final class io/ktor/server/routing/RoutingRoot : io/ktor/server/routing/RoutingNode, io/ktor/server/routing/Routing {
 	public static final field Plugin Lio/ktor/server/routing/RoutingRoot$Plugin;
 	public fun <init> (Lio/ktor/server/application/Application;)V
 	public final fun getApplication ()Lio/ktor/server/application/Application;
@@ -1844,7 +1844,7 @@ public final class io/ktor/server/routing/RoutingRoot$Plugin : io/ktor/server/ap
 }
 
 public final class io/ktor/server/routing/RoutingRootKt {
-	public static final fun getApplication (Lio/ktor/server/routing/Routing;)Lio/ktor/server/application/Application;
+	public static final fun getApplication (Lio/ktor/server/routing/Route;)Lio/ktor/server/application/Application;
 	public static final fun getRoutingFailureStatusCode ()Lio/ktor/util/AttributeKey;
 	public static final fun routing (Lio/ktor/server/application/Application;Lkotlin/jvm/functions/Function1;)Lio/ktor/server/routing/RoutingRoot;
 }

--- a/ktor-server/ktor-server-core/jvm/src/io/ktor/server/http/content/PreCompressed.kt
+++ b/ktor-server/ktor-server-core/jvm/src/io/ktor/server/http/content/PreCompressed.kt
@@ -28,7 +28,7 @@ public enum class CompressedFileType(public val extension: String, public val en
 
 internal val compressedKey = AttributeKey<List<CompressedFileType>>("StaticContentCompressed")
 
-internal val Routing.staticContentEncodedTypes: List<CompressedFileType>?
+internal val Route.staticContentEncodedTypes: List<CompressedFileType>?
     get() = attributes.getOrNull(compressedKey) ?: parent?.staticContentEncodedTypes
 
 internal class PreCompressedResponse(

--- a/ktor-server/ktor-server-core/jvm/src/io/ktor/server/http/content/SinglePageApplication.kt
+++ b/ktor-server/ktor-server-core/jvm/src/io/ktor/server/http/content/SinglePageApplication.kt
@@ -26,7 +26,7 @@ import java.io.*
  * }
  * ```
  */
-public fun Routing.singlePageApplication(configBuilder: SPAConfig.() -> Unit = {}) {
+public fun Route.singlePageApplication(configBuilder: SPAConfig.() -> Unit = {}) {
     val config = SPAConfig()
     configBuilder.invoke(config)
 
@@ -52,7 +52,7 @@ public fun Routing.singlePageApplication(configBuilder: SPAConfig.() -> Unit = {
 }
 
 /**
- * Configuration for the [Routing.singlePageApplication] plugin.
+ * Configuration for the [Route.singlePageApplication] plugin.
  */
 public class SPAConfig(
     /**

--- a/ktor-server/ktor-server-core/jvm/src/io/ktor/server/http/content/StaticContent.kt
+++ b/ktor-server/ktor-server-core/jvm/src/io/ktor/server/http/content/StaticContent.kt
@@ -164,12 +164,12 @@ public class StaticContentConfig<Resource : Any> internal constructor() {
  *
  * You can use [block] for additional set up.
  */
-public fun Routing.staticFiles(
+public fun Route.staticFiles(
     remotePath: String,
     dir: File,
     index: String? = "index.html",
     block: StaticContentConfig<File>.() -> Unit = {}
-): Routing {
+): Route {
     val staticRoute = StaticContentConfig<File>().apply(block)
     val autoHead = staticRoute.autoHeadResponse
     val compressedTypes = staticRoute.preCompressedFileTypes
@@ -204,12 +204,12 @@ public fun Routing.staticFiles(
  *
  * You can use [block] for additional set up.
  */
-public fun Routing.staticResources(
+public fun Route.staticResources(
     remotePath: String,
     basePackage: String?,
     index: String? = "index.html",
     block: StaticContentConfig<URL>.() -> Unit = {}
-): Routing {
+): Route {
     val staticRoute = StaticContentConfig<URL>().apply(block)
     val autoHead = staticRoute.autoHeadResponse
     val compressedTypes = staticRoute.preCompressedFileTypes
@@ -244,13 +244,13 @@ public fun Routing.staticResources(
  *
  * You can use [block] for additional set up.
  */
-public fun Routing.staticZip(
+public fun Route.staticZip(
     remotePath: String,
     basePath: String?,
     zip: Path,
     index: String? = "index.html",
     block: StaticContentConfig<Path>.() -> Unit = {}
-): Routing = staticFileSystem(
+): Route = staticFileSystem(
     remotePath = remotePath,
     basePath = basePath,
     index = index,
@@ -268,13 +268,13 @@ public fun Routing.staticZip(
  *
  * You can use [block] for additional set up.
  */
-public fun Routing.staticFileSystem(
+public fun Route.staticFileSystem(
     remotePath: String,
     basePath: String?,
     index: String? = "index.html",
     fileSystem: FileSystem = FileSystems.getDefault(),
     block: StaticContentConfig<Path>.() -> Unit = {}
-): Routing {
+): Route {
     val staticRoute = StaticContentConfig<Path>().apply(block)
     val autoHead = staticRoute.autoHeadResponse
     val compressedTypes = staticRoute.preCompressedFileTypes
@@ -314,9 +314,9 @@ public fun Routing.staticFileSystem(
  *
  * * This can't be disabled in a child route if it was enabled in the root route
  */
-public fun Routing.preCompressed(
+public fun Route.preCompressed(
     vararg types: CompressedFileType = CompressedFileType.entries.toTypedArray(),
-    configure: Routing.() -> Unit
+    configure: Route.() -> Unit
 ) {
     val existing = staticContentEncodedTypes ?: emptyList()
     val mixedTypes = (existing + types.asList()).distinct()
@@ -328,7 +328,7 @@ public fun Routing.preCompressed(
 /**
  * Base folder for relative files calculations for static content
  */
-public var Routing.staticRootFolder: File?
+public var Route.staticRootFolder: File?
     get() = attributes.getOrNull(staticRootFolderKey) ?: parent?.staticRootFolder
     set(value) {
         if (value != null) {
@@ -347,13 +347,13 @@ private fun File?.combine(file: File) = when {
  * Create a block for static content
  */
 @Deprecated("Please use `staticFiles` or `staticResources` instead")
-public fun Routing.static(configure: Routing.() -> Unit): Routing = apply(configure)
+public fun Route.static(configure: Route.() -> Unit): Route = apply(configure)
 
 /**
  * Create a block for static content at specified [remotePath]
  */
 @Deprecated("Please use `staticFiles` or `staticResources` instead")
-public fun Routing.static(remotePath: String, configure: Routing.() -> Unit): Routing =
+public fun Route.static(remotePath: String, configure: Route.() -> Unit): Route =
     route(remotePath, configure)
 
 /**
@@ -361,13 +361,13 @@ public fun Routing.static(remotePath: String, configure: Routing.() -> Unit): Ro
  */
 
 @Deprecated("Please use `staticFiles` instead")
-public fun Routing.default(localPath: String): Unit = default(File(localPath))
+public fun Route.default(localPath: String): Unit = default(File(localPath))
 
 /**
  * Specifies [localPath] as a default file to serve when folder is requested
  */
 @Deprecated("Please use `staticFiles` instead")
-public fun Routing.default(localPath: File) {
+public fun Route.default(localPath: File) {
     val file = staticRootFolder.combine(localPath)
     val compressedTypes = staticContentEncodedTypes
     get {
@@ -380,14 +380,14 @@ public fun Routing.default(localPath: File) {
  */
 
 @Deprecated("Please use `staticFiles` instead")
-public fun Routing.file(remotePath: String, localPath: String = remotePath): Unit =
+public fun Route.file(remotePath: String, localPath: String = remotePath): Unit =
     file(remotePath, File(localPath))
 
 /**
  * Sets up routing to serve [localPath] file as [remotePath]
  */
 @Deprecated("Please use `staticFiles` instead")
-public fun Routing.file(remotePath: String, localPath: File) {
+public fun Route.file(remotePath: String, localPath: File) {
     val file = staticRootFolder.combine(localPath)
     val compressedTypes = staticContentEncodedTypes
     get(remotePath) {
@@ -400,13 +400,13 @@ public fun Routing.file(remotePath: String, localPath: File) {
  */
 
 @Deprecated("Please use `staticFiles` instead")
-public fun Routing.files(folder: String): Unit = files(File(folder))
+public fun Route.files(folder: String): Unit = files(File(folder))
 
 /**
  * Sets up routing to serve all files from [folder]
  */
 @Deprecated("Please use `staticFiles` instead")
-public fun Routing.files(folder: File) {
+public fun Route.files(folder: File) {
     val dir = staticRootFolder.combine(folder)
     val compressedTypes = staticContentEncodedTypes
     get("{$pathParameterName...}") {
@@ -423,7 +423,7 @@ private val staticBasePackageName = AttributeKey<String>("BasePackage")
  */
 
 @Deprecated("Please use `staticResources` instead")
-public var Routing.staticBasePackage: String?
+public var Route.staticBasePackage: String?
     get() = attributes.getOrNull(staticBasePackageName) ?: parent?.staticBasePackage
     set(value) {
         if (value != null) {
@@ -444,7 +444,7 @@ private fun String?.combinePackage(resourcePackage: String?) = when {
  */
 
 @Deprecated("Please use `staticResources` instead")
-public fun Routing.resource(remotePath: String, resource: String = remotePath, resourcePackage: String? = null) {
+public fun Route.resource(remotePath: String, resource: String = remotePath, resourcePackage: String? = null) {
     val compressedTypes = staticContentEncodedTypes
     val packageName = staticBasePackage.combinePackage(resourcePackage)
     get(remotePath) {
@@ -461,7 +461,7 @@ public fun Routing.resource(remotePath: String, resource: String = remotePath, r
  */
 
 @Deprecated("Please use `staticResources` instead")
-public fun Routing.resources(resourcePackage: String? = null) {
+public fun Route.resources(resourcePackage: String? = null) {
     val packageName = staticBasePackage.combinePackage(resourcePackage)
     val compressedTypes = staticContentEncodedTypes
     get("{$pathParameterName...}") {
@@ -479,7 +479,7 @@ public fun Routing.resources(resourcePackage: String? = null) {
  */
 
 @Deprecated("Please use `staticResources` instead")
-public fun Routing.defaultResource(resource: String, resourcePackage: String? = null) {
+public fun Route.defaultResource(resource: String, resourcePackage: String? = null) {
     val packageName = staticBasePackage.combinePackage(resourcePackage)
     val compressedTypes = staticContentEncodedTypes
     get {
@@ -496,7 +496,7 @@ public fun Routing.defaultResource(resource: String, resourcePackage: String? = 
  */
 public fun ApplicationCall.isStaticContent(): Boolean = attributes.contains(StaticFileLocationProperty)
 
-private fun Routing.staticContentRoute(
+private fun Route.staticContentRoute(
     remotePath: String,
     autoHead: Boolean,
     handler: suspend (ApplicationCall).() -> Unit

--- a/ktor-server/ktor-server-core/jvm/test/io/ktor/tests/plugins/RouteRootPluginConfigurationTest.kt
+++ b/ktor-server/ktor-server-core/jvm/test/io/ktor/tests/plugins/RouteRootPluginConfigurationTest.kt
@@ -10,7 +10,7 @@ import io.ktor.server.config.ConfigLoader.Companion.load
 import io.ktor.server.testing.*
 import kotlin.test.*
 
-class RoutingRootPluginConfigurationTest {
+class RouteRootPluginConfigurationTest {
 
     @Test
     fun testReadPropertyFromFile() {

--- a/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/application/hooks/CommonHooks.kt
+++ b/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/application/hooks/CommonHooks.kt
@@ -10,7 +10,6 @@ import io.ktor.server.application.*
 import io.ktor.server.request.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
-import io.ktor.util.*
 import io.ktor.util.pipeline.*
 import io.ktor.util.reflect.*
 import io.ktor.utils.io.*
@@ -62,7 +61,7 @@ public class MonitoringEvent<Param : Any, Event : EventDefinition<Param>>(
     override fun install(pipeline: ApplicationCallPipeline, handler: (Param) -> Unit) {
         val application = when (pipeline) {
             is Application -> pipeline
-            is Routing -> pipeline.application
+            is Route -> pipeline.application
             else -> error("Unsupported pipeline: $pipeline")
         }
         application.monitor.subscribe(event) {

--- a/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/routing/HostsRoutingBuilder.kt
+++ b/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/routing/HostsRoutingBuilder.kt
@@ -18,7 +18,7 @@ import io.ktor.server.plugins.*
  * @param host exact host name that is treated literally
  * @param port to be tested or `0` to pass all ports
  */
-public fun Routing.host(host: String, port: Int = 0, build: Routing.() -> Unit): Routing {
+public fun Route.host(host: String, port: Int = 0, build: Route.() -> Unit): Route {
     return host(listOf(host), emptyList(), if (port > 0) listOf(port) else emptyList(), build)
 }
 
@@ -32,7 +32,7 @@ public fun Routing.host(host: String, port: Int = 0, build: Routing.() -> Unit):
  * @param hostPattern is a  regular expression to match request host
  * @param port to be tested or `0` to pass all ports
  */
-public fun Routing.host(hostPattern: Regex, port: Int = 0, build: Routing.() -> Unit): Routing {
+public fun Route.host(hostPattern: Regex, port: Int = 0, build: Route.() -> Unit): Route {
     return host(emptyList(), listOf(hostPattern), if (port > 0) listOf(port) else emptyList(), build)
 }
 
@@ -48,11 +48,11 @@ public fun Routing.host(hostPattern: Regex, port: Int = 0, build: Routing.() -> 
  *
  * @throws IllegalArgumentException when no constraints were applied in [hosts] and [ports]
  */
-public fun Routing.host(
+public fun Route.host(
     hosts: List<String>,
     ports: List<Int> = emptyList(),
-    build: Routing.() -> Unit
-): Routing {
+    build: Route.() -> Unit
+): Route {
     return host(hosts, emptyList(), ports, build)
 }
 
@@ -69,12 +69,12 @@ public fun Routing.host(
  *
  * @throws IllegalArgumentException when no constraints were applied in [host], [hostPatterns] and [ports]
  */
-public fun Routing.host(
+public fun Route.host(
     hosts: List<String>,
     hostPatterns: List<Regex>,
     ports: List<Int> = emptyList(),
-    build: Routing.() -> Unit
-): Routing {
+    build: Route.() -> Unit
+): Route {
     val selector = HostRouteSelector(hosts, hostPatterns, ports)
     return createChild(selector).apply(build)
 }
@@ -89,7 +89,7 @@ public fun Routing.host(
  *
  * @throws IllegalArgumentException if no ports were specified
  */
-public fun Routing.port(vararg ports: Int, build: Routing.() -> Unit): Routing {
+public fun Route.port(vararg ports: Int, build: Route.() -> Unit): Route {
     require(ports.isNotEmpty()) { "At least one port need to be specified" }
 
     val selector = HostRouteSelector(emptyList(), emptyList(), ports.toList())

--- a/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/routing/LocalPortRoutingBuilder.kt
+++ b/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/routing/LocalPortRoutingBuilder.kt
@@ -21,7 +21,7 @@ import io.ktor.server.application.*
  *
  * @throws IllegalArgumentException if the port is outside the range of TCP/UDP ports
  */
-public fun Routing.localPort(port: Int, build: Routing.() -> Unit): Routing {
+public fun Route.localPort(port: Int, build: Route.() -> Unit): Route {
     require(port in 1..65535) { "Port $port must be a positive number between 1 and 65,535" }
 
     val selector = LocalPortRouteSelector(port)

--- a/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/routing/RegexRouting.kt
+++ b/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/routing/RegexRouting.kt
@@ -25,7 +25,7 @@ import kotlin.jvm.*
  * ```
  */
 @KtorDsl
-public fun Routing.route(path: Regex, build: Routing.() -> Unit): Routing =
+public fun Route.route(path: Regex, build: Route.() -> Unit): Route =
     createRouteFromRegexPath(path).apply(build)
 
 /**
@@ -43,7 +43,7 @@ public fun Routing.route(path: Regex, build: Routing.() -> Unit): Routing =
  * ```
  */
 @KtorDsl
-public fun Routing.route(path: Regex, method: HttpMethod, build: Routing.() -> Unit): Routing {
+public fun Route.route(path: Regex, method: HttpMethod, build: Route.() -> Unit): Route {
     val selector = HttpMethodRouteSelector(method)
     return createRouteFromRegexPath(path).createChild(selector).apply(build)
 }
@@ -61,7 +61,7 @@ public fun Routing.route(path: Regex, method: HttpMethod, build: Routing.() -> U
  * ```
  */
 @KtorDsl
-public fun Routing.get(path: Regex, body: RoutingHandler): Routing {
+public fun Route.get(path: Regex, body: RoutingHandler): Route {
     return route(path, HttpMethod.Get) { handle(body) }
 }
 
@@ -78,7 +78,7 @@ public fun Routing.get(path: Regex, body: RoutingHandler): Routing {
  * ```
  */
 @KtorDsl
-public fun Routing.post(path: Regex, body: RoutingHandler): Routing {
+public fun Route.post(path: Regex, body: RoutingHandler): Route {
     return route(path, HttpMethod.Post) { handle(body) }
 }
 
@@ -96,10 +96,10 @@ public fun Routing.post(path: Regex, body: RoutingHandler): Routing {
  */
 @KtorDsl
 @JvmName("postTypedPath")
-public inline fun <reified R : Any> Routing.post(
+public inline fun <reified R : Any> Route.post(
     path: Regex,
     crossinline body: suspend RoutingContext.(R) -> Unit
-): Routing = post(path) {
+): Route = post(path) {
     body(call.receive())
 }
 
@@ -116,7 +116,7 @@ public inline fun <reified R : Any> Routing.post(
  * ```
  */
 @KtorDsl
-public fun Routing.head(path: Regex, body: RoutingHandler): Routing {
+public fun Route.head(path: Regex, body: RoutingHandler): Route {
     return route(path, HttpMethod.Head) { handle(body) }
 }
 
@@ -133,7 +133,7 @@ public fun Routing.head(path: Regex, body: RoutingHandler): Routing {
  * ```
  */
 @KtorDsl
-public fun Routing.put(path: Regex, body: RoutingHandler): Routing {
+public fun Route.put(path: Regex, body: RoutingHandler): Route {
     return route(path, HttpMethod.Put) { handle(body) }
 }
 
@@ -151,10 +151,10 @@ public fun Routing.put(path: Regex, body: RoutingHandler): Routing {
  */
 @KtorDsl
 @JvmName("putTypedPath")
-public inline fun <reified R : Any> Routing.put(
+public inline fun <reified R : Any> Route.put(
     path: Regex,
     crossinline body: suspend RoutingContext.(R) -> Unit
-): Routing = put(path) {
+): Route = put(path) {
     body(call.receive())
 }
 
@@ -171,7 +171,7 @@ public inline fun <reified R : Any> Routing.put(
  * ```
  */
 @KtorDsl
-public fun Routing.patch(path: Regex, body: RoutingHandler): Routing {
+public fun Route.patch(path: Regex, body: RoutingHandler): Route {
     return route(path, HttpMethod.Patch) { handle(body) }
 }
 
@@ -189,10 +189,10 @@ public fun Routing.patch(path: Regex, body: RoutingHandler): Routing {
  */
 @KtorDsl
 @JvmName("patchTypedPath")
-public inline fun <reified R : Any> Routing.patch(
+public inline fun <reified R : Any> Route.patch(
     path: Regex,
     crossinline body: suspend RoutingContext.(R) -> Unit
-): Routing = patch(path) {
+): Route = patch(path) {
     body(call.receive())
 }
 
@@ -209,7 +209,7 @@ public inline fun <reified R : Any> Routing.patch(
  * ```
  */
 @KtorDsl
-public fun Routing.delete(path: Regex, body: RoutingHandler): Routing {
+public fun Route.delete(path: Regex, body: RoutingHandler): Route {
     return route(path, HttpMethod.Delete) { handle(body) }
 }
 
@@ -226,11 +226,11 @@ public fun Routing.delete(path: Regex, body: RoutingHandler): Routing {
  * ```
  */
 @KtorDsl
-public fun Routing.options(path: Regex, body: RoutingHandler): Routing {
+public fun Route.options(path: Regex, body: RoutingHandler): Route {
     return route(path, HttpMethod.Options) { handle(body) }
 }
 
-private fun Routing.createRouteFromRegexPath(regex: Regex): Routing {
+private fun Route.createRouteFromRegexPath(regex: Regex): Route {
     return createChild(PathSegmentRegexRouteSelector(regex))
 }
 

--- a/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/routing/RoutingBuilder.kt
+++ b/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/routing/RoutingBuilder.kt
@@ -17,7 +17,7 @@ import kotlin.jvm.*
  * @see [Application.routing]
  */
 @KtorDsl
-public fun Routing.route(path: String, build: Routing.() -> Unit): Routing =
+public fun Route.route(path: String, build: Route.() -> Unit): Route =
     createRouteFromPath(path).apply(build)
 
 /**
@@ -25,7 +25,7 @@ public fun Routing.route(path: String, build: Routing.() -> Unit): Routing =
  * @see [Application.routing]
  */
 @KtorDsl
-public fun Routing.route(path: String, method: HttpMethod, build: Routing.() -> Unit): Routing {
+public fun Route.route(path: String, method: HttpMethod, build: Route.() -> Unit): Route {
     val selector = HttpMethodRouteSelector(method)
     return createRouteFromPath(path).createChild(selector).apply(build)
 }
@@ -35,7 +35,7 @@ public fun Routing.route(path: String, method: HttpMethod, build: Routing.() -> 
  * @see [Application.routing]
  */
 @KtorDsl
-public fun Routing.method(method: HttpMethod, body: Routing.() -> Unit): Routing {
+public fun Route.method(method: HttpMethod, body: Route.() -> Unit): Route {
     val selector = HttpMethodRouteSelector(method)
     return createChild(selector).apply(body)
 }
@@ -45,7 +45,7 @@ public fun Routing.method(method: HttpMethod, body: Routing.() -> Unit): Routing
  * @see [Application.routing]
  */
 @KtorDsl
-public fun Routing.param(name: String, value: String, build: Routing.() -> Unit): Routing {
+public fun Route.param(name: String, value: String, build: Route.() -> Unit): Route {
     val selector = ConstantParameterRouteSelector(name, value)
     return createChild(selector).apply(build)
 }
@@ -55,7 +55,7 @@ public fun Routing.param(name: String, value: String, build: Routing.() -> Unit)
  * @see [Application.routing]
  */
 @KtorDsl
-public fun Routing.param(name: String, build: Routing.() -> Unit): Routing {
+public fun Route.param(name: String, build: Route.() -> Unit): Route {
     val selector = ParameterRouteSelector(name)
     return createChild(selector).apply(build)
 }
@@ -65,7 +65,7 @@ public fun Routing.param(name: String, build: Routing.() -> Unit): Routing {
  * @see [Application.routing]
  */
 @KtorDsl
-public fun Routing.optionalParam(name: String, build: Routing.() -> Unit): Routing {
+public fun Route.optionalParam(name: String, build: Route.() -> Unit): Route {
     val selector = OptionalParameterRouteSelector(name)
     return createChild(selector).apply(build)
 }
@@ -75,7 +75,7 @@ public fun Routing.optionalParam(name: String, build: Routing.() -> Unit): Routi
  * @see [Application.routing]
  */
 @KtorDsl
-public fun Routing.header(name: String, value: String, build: Routing.() -> Unit): Routing {
+public fun Route.header(name: String, value: String, build: Route.() -> Unit): Route {
     val selector = HttpHeaderRouteSelector(name, value)
     return createChild(selector).apply(build)
 }
@@ -85,7 +85,7 @@ public fun Routing.header(name: String, value: String, build: Routing.() -> Unit
  * @see [Application.routing]
  */
 @KtorDsl
-public fun Routing.accept(vararg contentTypes: ContentType, build: Routing.() -> Unit): Routing {
+public fun Route.accept(vararg contentTypes: ContentType, build: Route.() -> Unit): Route {
     val selector = HttpMultiAcceptRouteSelector(listOf(*contentTypes))
     return createChild(selector).apply(build)
 }
@@ -95,7 +95,7 @@ public fun Routing.accept(vararg contentTypes: ContentType, build: Routing.() ->
  * @see [Application.routing]
  */
 @KtorDsl
-public fun Routing.contentType(contentType: ContentType, build: Routing.() -> Unit): Routing {
+public fun Route.contentType(contentType: ContentType, build: Route.() -> Unit): Route {
     val selector = ContentTypeHeaderRouteSelector(contentType)
     return createChild(selector).apply(build)
 }
@@ -105,7 +105,7 @@ public fun Routing.contentType(contentType: ContentType, build: Routing.() -> Un
  * @see [Application.routing]
  */
 @KtorDsl
-public fun Routing.get(path: String, body: RoutingHandler): Routing {
+public fun Route.get(path: String, body: RoutingHandler): Route {
     return route(path, HttpMethod.Get) { handle(body) }
 }
 
@@ -114,7 +114,7 @@ public fun Routing.get(path: String, body: RoutingHandler): Routing {
  * @see [Application.routing]
  */
 @KtorDsl
-public fun Routing.get(body: RoutingHandler): Routing {
+public fun Route.get(body: RoutingHandler): Route {
     return method(HttpMethod.Get) { handle(body) }
 }
 
@@ -123,7 +123,7 @@ public fun Routing.get(body: RoutingHandler): Routing {
  * @see [Application.routing]
  */
 @KtorDsl
-public fun Routing.post(path: String, body: RoutingHandler): Routing {
+public fun Route.post(path: String, body: RoutingHandler): Route {
     return route(path, HttpMethod.Post) { handle(body) }
 }
 
@@ -133,9 +133,9 @@ public fun Routing.post(path: String, body: RoutingHandler): Routing {
  */
 @KtorDsl
 @JvmName("postTyped")
-public inline fun <reified R : Any> Routing.post(
+public inline fun <reified R : Any> Route.post(
     crossinline body: suspend RoutingContext.(R) -> Unit
-): Routing = post {
+): Route = post {
     body(call.receive())
 }
 
@@ -145,10 +145,10 @@ public inline fun <reified R : Any> Routing.post(
  */
 @KtorDsl
 @JvmName("postTypedPath")
-public inline fun <reified R : Any> Routing.post(
+public inline fun <reified R : Any> Route.post(
     path: String,
     crossinline body: suspend RoutingContext.(R) -> Unit
-): Routing = post(path) {
+): Route = post(path) {
     body(call.receive())
 }
 
@@ -157,7 +157,7 @@ public inline fun <reified R : Any> Routing.post(
  * @see [Application.routing]
  */
 @KtorDsl
-public fun Routing.post(body: RoutingHandler): Routing {
+public fun Route.post(body: RoutingHandler): Route {
     return method(HttpMethod.Post) { handle(body) }
 }
 
@@ -166,7 +166,7 @@ public fun Routing.post(body: RoutingHandler): Routing {
  * @see [Application.routing]
  */
 @KtorDsl
-public fun Routing.head(path: String, body: RoutingHandler): Routing {
+public fun Route.head(path: String, body: RoutingHandler): Route {
     return route(path, HttpMethod.Head) { handle(body) }
 }
 
@@ -175,7 +175,7 @@ public fun Routing.head(path: String, body: RoutingHandler): Routing {
  * @see [Application.routing]
  */
 @KtorDsl
-public fun Routing.head(body: RoutingHandler): Routing {
+public fun Route.head(body: RoutingHandler): Route {
     return method(HttpMethod.Head) { handle(body) }
 }
 
@@ -184,7 +184,7 @@ public fun Routing.head(body: RoutingHandler): Routing {
  * @see [Application.routing]
  */
 @KtorDsl
-public fun Routing.put(path: String, body: RoutingHandler): Routing {
+public fun Route.put(path: String, body: RoutingHandler): Route {
     return route(path, HttpMethod.Put) { handle(body) }
 }
 
@@ -193,7 +193,7 @@ public fun Routing.put(path: String, body: RoutingHandler): Routing {
  * @see [Application.routing]
  */
 @KtorDsl
-public fun Routing.put(body: RoutingHandler): Routing {
+public fun Route.put(body: RoutingHandler): Route {
     return method(HttpMethod.Put) { handle(body) }
 }
 
@@ -203,9 +203,9 @@ public fun Routing.put(body: RoutingHandler): Routing {
  */
 @KtorDsl
 @JvmName("putTyped")
-public inline fun <reified R : Any> Routing.put(
+public inline fun <reified R : Any> Route.put(
     crossinline body: suspend RoutingContext.(R) -> Unit
-): Routing = put {
+): Route = put {
     body(call.receive())
 }
 
@@ -215,10 +215,10 @@ public inline fun <reified R : Any> Routing.put(
  */
 @KtorDsl
 @JvmName("putTypedPath")
-public inline fun <reified R : Any> Routing.put(
+public inline fun <reified R : Any> Route.put(
     path: String,
     crossinline body: suspend RoutingContext.(R) -> Unit
-): Routing = put(path) {
+): Route = put(path) {
     body(call.receive())
 }
 
@@ -227,7 +227,7 @@ public inline fun <reified R : Any> Routing.put(
  * @see [Application.routing]
  */
 @KtorDsl
-public fun Routing.patch(path: String, body: RoutingHandler): Routing {
+public fun Route.patch(path: String, body: RoutingHandler): Route {
     return route(path, HttpMethod.Patch) { handle(body) }
 }
 
@@ -236,7 +236,7 @@ public fun Routing.patch(path: String, body: RoutingHandler): Routing {
  * @see [Application.routing]
  */
 @KtorDsl
-public fun Routing.patch(body: RoutingHandler): Routing {
+public fun Route.patch(body: RoutingHandler): Route {
     return method(HttpMethod.Patch) { handle(body) }
 }
 
@@ -246,9 +246,9 @@ public fun Routing.patch(body: RoutingHandler): Routing {
  */
 @KtorDsl
 @JvmName("patchTyped")
-public inline fun <reified R : Any> Routing.patch(
+public inline fun <reified R : Any> Route.patch(
     crossinline body: suspend RoutingContext.(R) -> Unit
-): Routing = patch {
+): Route = patch {
     body(call.receive())
 }
 
@@ -258,10 +258,10 @@ public inline fun <reified R : Any> Routing.patch(
  */
 @KtorDsl
 @JvmName("patchTypedPath")
-public inline fun <reified R : Any> Routing.patch(
+public inline fun <reified R : Any> Route.patch(
     path: String,
     crossinline body: suspend RoutingContext.(R) -> Unit
-): Routing = patch(path) {
+): Route = patch(path) {
     body(call.receive())
 }
 
@@ -270,7 +270,7 @@ public inline fun <reified R : Any> Routing.patch(
  * @see [Application.routing]
  */
 @KtorDsl
-public fun Routing.delete(path: String, body: RoutingHandler): Routing {
+public fun Route.delete(path: String, body: RoutingHandler): Route {
     return route(path, HttpMethod.Delete) { handle(body) }
 }
 
@@ -279,7 +279,7 @@ public fun Routing.delete(path: String, body: RoutingHandler): Routing {
  * @see [Application.routing]
  */
 @KtorDsl
-public fun Routing.delete(body: RoutingHandler): Routing {
+public fun Route.delete(body: RoutingHandler): Route {
     return method(HttpMethod.Delete) { handle(body) }
 }
 
@@ -288,7 +288,7 @@ public fun Routing.delete(body: RoutingHandler): Routing {
  * @see [Application.routing]
  */
 @KtorDsl
-public fun Routing.options(path: String, body: RoutingHandler): Routing {
+public fun Route.options(path: String, body: RoutingHandler): Route {
     return route(path, HttpMethod.Options) { handle(body) }
 }
 
@@ -297,16 +297,16 @@ public fun Routing.options(path: String, body: RoutingHandler): Routing {
  * @see [Application.routing]
  */
 @KtorDsl
-public fun Routing.options(body: RoutingHandler): Routing {
+public fun Route.options(body: RoutingHandler): Route {
     return method(HttpMethod.Options) { handle(body) }
 }
 
 /**
  * Creates a routing entry for the specified path.
  */
-public fun Routing.createRouteFromPath(path: String): Routing {
+public fun Route.createRouteFromPath(path: String): Route {
     val parts = RoutingPath.parse(path).parts
-    var current: Routing = this
+    var current: Route = this
     for (index in parts.indices) {
         val (value, kind) = parts[index]
         val selector = when (kind) {

--- a/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/routing/RoutingNode.kt
+++ b/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/routing/RoutingNode.kt
@@ -12,8 +12,6 @@ import io.ktor.util.*
 import io.ktor.util.pipeline.*
 import io.ktor.util.reflect.*
 import io.ktor.utils.io.*
-import kotlinx.coroutines.*
-import kotlin.coroutines.*
 
 /**
  * Describes a node in a routing tree.
@@ -30,7 +28,7 @@ public open class RoutingNode(
     public val selector: RouteSelector,
     developmentMode: Boolean = false,
     environment: ApplicationEnvironment
-) : ApplicationCallPipeline(developmentMode, environment), Routing {
+) : ApplicationCallPipeline(developmentMode, environment), Route {
 
     /**
      * List of child routes for this node.
@@ -236,10 +234,10 @@ public typealias RoutingHandler = suspend RoutingContext.() -> Unit
 /**
  * A builder for a routing tree.
  */
-public interface Routing {
+public interface Route {
     public val environment: ApplicationEnvironment
     public val attributes: Attributes
-    public val parent: Routing?
+    public val parent: Route?
 
     /**
      * Installs a handler into this route which is called when the route is selected for a call.
@@ -249,7 +247,7 @@ public interface Routing {
     /**
      * Creates a child node in this node with a given [selector] or returns an existing one with the same selector.
      */
-    public fun createChild(selector: RouteSelector): Routing
+    public fun createChild(selector: RouteSelector): Route
 
     /**
      * Gets a plugin instance for this pipeline, or fails with [MissingApplicationPluginException]
@@ -273,7 +271,7 @@ public interface Routing {
 /**
  * A builder for a routing tree root.
  */
-public interface RootRouting : Routing {
+public interface Routing : Route {
 
     /**
      * Registers a function used to trace route resolution.
@@ -316,7 +314,7 @@ private fun RoutingNode.getAllRoutes(endpoints: MutableList<RoutingNode>) {
 }
 
 @Deprecated("Please use route scoped plugins instead")
-public fun Routing.intercept(
+public fun Route.intercept(
     phase: PipelinePhase,
     block: suspend PipelineContext<Unit, PipelineCall>.(Unit) -> Unit
 ) {
@@ -324,11 +322,11 @@ public fun Routing.intercept(
 }
 
 @Deprecated("Please use route scoped plugins instead")
-public fun Routing.insertPhaseAfter(reference: PipelinePhase, phase: PipelinePhase) {
+public fun Route.insertPhaseAfter(reference: PipelinePhase, phase: PipelinePhase) {
     (this as RoutingNode).insertPhaseAfter(reference, phase)
 }
 
 @Deprecated("Please use route scoped plugins instead")
-public fun Routing.insertPhaseBefore(reference: PipelinePhase, phase: PipelinePhase) {
+public fun Route.insertPhaseBefore(reference: PipelinePhase, phase: PipelinePhase) {
     (this as RoutingNode).insertPhaseBefore(reference, phase)
 }

--- a/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/routing/RoutingRoot.kt
+++ b/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/routing/RoutingRoot.kt
@@ -34,7 +34,7 @@ public class RoutingRoot(
     application.developmentMode,
     application.environment
 ),
-    RootRouting {
+    Routing {
     private val tracers = mutableListOf<(RoutingResolveTrace) -> Unit>()
 
     init {
@@ -124,7 +124,7 @@ public class RoutingRoot(
      * An installation object of the [RoutingRoot] plugin.
      */
     @Suppress("PublicApiImplicitType")
-    public companion object Plugin : BaseApplicationPlugin<Application, RootRouting, RoutingRoot> {
+    public companion object Plugin : BaseApplicationPlugin<Application, Routing, RoutingRoot> {
 
         /**
          * A definition for an event that is fired when routing-based call processing starts.
@@ -138,7 +138,7 @@ public class RoutingRoot(
 
         override val key: AttributeKey<RoutingRoot> = AttributeKey("Routing")
 
-        override fun install(pipeline: Application, configure: RootRouting.() -> Unit): RoutingRoot {
+        override fun install(pipeline: Application, configure: Routing.() -> Unit): RoutingRoot {
             val routingRoot = RoutingRoot(pipeline).apply(configure)
             pipeline.intercept(Call) { routingRoot.interceptor(this) }
             return routingRoot
@@ -149,7 +149,7 @@ public class RoutingRoot(
 /**
  * Gets an [Application] for this [RoutingNode] by scanning the hierarchy to the root.
  */
-public val Routing.application: Application
+public val Route.application: Application
     get() = when (this) {
         is RoutingRoot -> application
         else -> parent?.application ?: throw UnsupportedOperationException(
@@ -162,5 +162,5 @@ public val Routing.application: Application
  * You can learn more about routing in Ktor from [Routing](https://ktor.io/docs/routing-in-ktor.html).
  */
 @KtorDsl
-public fun Application.routing(configuration: RootRouting.() -> Unit): RoutingRoot =
+public fun Application.routing(configuration: Routing.() -> Unit): RoutingRoot =
     pluginOrNull(RoutingRoot)?.apply(configuration) ?: install(RoutingRoot, configuration)

--- a/ktor-server/ktor-server-plugins/ktor-server-auth/api/ktor-server-auth.api
+++ b/ktor-server/ktor-server-plugins/ktor-server-auth/api/ktor-server-auth.api
@@ -68,10 +68,10 @@ public final class io/ktor/server/auth/AuthenticationFailedCause$NoCredentials :
 }
 
 public final class io/ktor/server/auth/AuthenticationInterceptorsKt {
-	public static final fun authenticate (Lio/ktor/server/routing/Routing;[Ljava/lang/String;Lio/ktor/server/auth/AuthenticationStrategy;Lkotlin/jvm/functions/Function1;)Lio/ktor/server/routing/Routing;
-	public static final fun authenticate (Lio/ktor/server/routing/Routing;[Ljava/lang/String;ZLkotlin/jvm/functions/Function1;)Lio/ktor/server/routing/Routing;
-	public static synthetic fun authenticate$default (Lio/ktor/server/routing/Routing;[Ljava/lang/String;Lio/ktor/server/auth/AuthenticationStrategy;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lio/ktor/server/routing/Routing;
-	public static synthetic fun authenticate$default (Lio/ktor/server/routing/Routing;[Ljava/lang/String;ZLkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lio/ktor/server/routing/Routing;
+	public static final fun authenticate (Lio/ktor/server/routing/Route;[Ljava/lang/String;Lio/ktor/server/auth/AuthenticationStrategy;Lkotlin/jvm/functions/Function1;)Lio/ktor/server/routing/Route;
+	public static final fun authenticate (Lio/ktor/server/routing/Route;[Ljava/lang/String;ZLkotlin/jvm/functions/Function1;)Lio/ktor/server/routing/Route;
+	public static synthetic fun authenticate$default (Lio/ktor/server/routing/Route;[Ljava/lang/String;Lio/ktor/server/auth/AuthenticationStrategy;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lio/ktor/server/routing/Route;
+	public static synthetic fun authenticate$default (Lio/ktor/server/routing/Route;[Ljava/lang/String;ZLkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lio/ktor/server/routing/Route;
 	public static final fun getAuthenticationInterceptors ()Lio/ktor/server/application/RouteScopedPlugin;
 }
 

--- a/ktor-server/ktor-server-plugins/ktor-server-auth/jvmAndNix/src/io/ktor/server/auth/Authentication.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-auth/jvmAndNix/src/io/ktor/server/auth/Authentication.kt
@@ -63,7 +63,7 @@ public class AuthenticationConfig(providers: Map<String?, AuthenticationProvider
  *    }
  *    ```
  *
- * 2. Protect a desired resource using the [io.ktor.server.routing.Routing.authenticate] function
+ * 2. Protect a desired resource using the [io.ktor.server.routing.Route.authenticate] function
  *    that accepts a name of the authentication provider:
  *    ```kotlin
  *    routing {

--- a/ktor-server/ktor-server-plugins/ktor-server-auth/jvmAndNix/src/io/ktor/server/auth/AuthenticationInterceptors.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-auth/jvmAndNix/src/io/ktor/server/auth/AuthenticationInterceptors.kt
@@ -201,11 +201,11 @@ public enum class AuthenticationStrategy { Optional, FirstSuccessful, Required }
  * @throws MissingApplicationPluginException if no [Authentication] plugin installed first.
  * @throws IllegalArgumentException if there are no registered providers referred by [configurations] names.
  */
-public fun Routing.authenticate(
+public fun Route.authenticate(
     vararg configurations: String? = arrayOf<String?>(null),
     optional: Boolean = false,
-    build: Routing.() -> Unit
-): Routing {
+    build: Route.() -> Unit
+): Route {
     return authenticate(
         configurations = configurations,
         strategy = if (optional) AuthenticationStrategy.Optional else AuthenticationStrategy.FirstSuccessful,
@@ -229,11 +229,11 @@ public fun Routing.authenticate(
  * @throws MissingApplicationPluginException if no [Authentication] plugin installed first.
  * @throws IllegalArgumentException if there are no registered providers referred by [configurations] names.
  */
-public fun Routing.authenticate(
+public fun Route.authenticate(
     vararg configurations: String? = arrayOf<String?>(null),
     strategy: AuthenticationStrategy,
-    build: Routing.() -> Unit
-): Routing {
+    build: Route.() -> Unit
+): Route {
     require(configurations.isNotEmpty()) { "At least one configuration name or null for default need to be provided" }
 
     val configurationNames = configurations.distinct().toList()
@@ -265,7 +265,7 @@ public class RouteAuthenticationConfig {
 
 /**
  * An authentication route node that is used by [Authentication] plugin
- * and usually created by the [Routing.authenticate] DSL function,
+ * and usually created by the [Route.authenticate] DSL function,
  * so generally there is no need to instantiate it directly unless you are writing an extension.
  * @param names of authentication providers to be applied to this route.
  */

--- a/ktor-server/ktor-server-plugins/ktor-server-openapi/api/ktor-server-openapi.api
+++ b/ktor-server/ktor-server-plugins/ktor-server-openapi/api/ktor-server-openapi.api
@@ -13,7 +13,7 @@ public final class io/ktor/server/plugins/openapi/OpenAPIConfig {
 }
 
 public final class io/ktor/server/plugins/openapi/OpenAPIKt {
-	public static final fun openAPI (Lio/ktor/server/routing/Routing;Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)V
-	public static synthetic fun openAPI$default (Lio/ktor/server/routing/Routing;Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+	public static final fun openAPI (Lio/ktor/server/routing/Route;Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)V
+	public static synthetic fun openAPI$default (Lio/ktor/server/routing/Route;Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
 }
 

--- a/ktor-server/ktor-server-plugins/ktor-server-openapi/jvm/src/io/ktor/server/plugins/openapi/OpenAPI.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-openapi/jvm/src/io/ktor/server/plugins/openapi/OpenAPI.kt
@@ -19,7 +19,7 @@ import java.io.*
  * The documentation is generated using [StaticHtml2Codegen] by default. It can be customized using config in [block].
  * See [OpenAPIConfig] for more details.
  */
-public fun Routing.openAPI(
+public fun Route.openAPI(
     path: String,
     swaggerFile: String = "openapi/documentation.yaml",
     block: OpenAPIConfig.() -> Unit = {}

--- a/ktor-server/ktor-server-plugins/ktor-server-rate-limit/api/ktor-server-rate-limit.api
+++ b/ktor-server/ktor-server-plugins/ktor-server-rate-limit/api/ktor-server-rate-limit.api
@@ -70,7 +70,7 @@ public final class io/ktor/server/plugins/ratelimit/RateLimiter$State$Exhausted 
 }
 
 public final class io/ktor/server/plugins/ratelimit/RoutingKt {
-	public static final fun rateLimit-TBT8wpQ (Lio/ktor/server/routing/Routing;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Lio/ktor/server/routing/Routing;
-	public static synthetic fun rateLimit-TBT8wpQ$default (Lio/ktor/server/routing/Routing;Ljava/lang/String;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lio/ktor/server/routing/Routing;
+	public static final fun rateLimit-TBT8wpQ (Lio/ktor/server/routing/Route;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Lio/ktor/server/routing/Route;
+	public static synthetic fun rateLimit-TBT8wpQ$default (Lio/ktor/server/routing/Route;Ljava/lang/String;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lio/ktor/server/routing/Route;
 }
 

--- a/ktor-server/ktor-server-plugins/ktor-server-rate-limit/jvmAndNix/src/io/ktor/server/plugins/ratelimit/RateLimitConfig.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-rate-limit/jvmAndNix/src/io/ktor/server/plugins/ratelimit/RateLimitConfig.kt
@@ -24,7 +24,7 @@ public class RateLimitConfig {
     internal var global: RateLimitProvider? = null
 
     /**
-     * Registers the Rate-Limit provider that can be used in sub-routes via the [Routing.rateLimit] function.
+     * Registers the Rate-Limit provider that can be used in sub-routes via the [Route.rateLimit] function.
      */
     public fun register(name: RateLimitName = LIMITER_NAME_EMPTY, block: RateLimitProviderConfig.() -> Unit) {
         if (providers.containsKey(name)) {

--- a/ktor-server/ktor-server-plugins/ktor-server-rate-limit/jvmAndNix/src/io/ktor/server/plugins/ratelimit/Routing.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-rate-limit/jvmAndNix/src/io/ktor/server/plugins/ratelimit/Routing.kt
@@ -15,10 +15,10 @@ import io.ktor.util.*
  * @param configuration names of RateLimit providers defined in the [RateLimit] plugin configuration.
  * @throws IllegalArgumentException if there are no registered providers referred by [configuration] names.
  */
-public fun Routing.rateLimit(
+public fun Route.rateLimit(
     configuration: RateLimitName = LIMITER_NAME_EMPTY,
-    build: Routing.() -> Unit
-): Routing {
+    build: Route.() -> Unit
+): Route {
     val rateLimitRoute = createChild(RateLimitRouteSelector(configuration))
     rateLimitRoute.attributes.put(RateLimitProviderNameKey, configuration)
     val allConfigurations = generateSequence(rateLimitRoute) { it.parent }
@@ -36,7 +36,7 @@ public fun Routing.rateLimit(
 
 /**
  * A rate-limited route node that is used by the [RateLimit] plugin
- * and usually created by the [Routing.rateLimit] DSL function, so generally there is no need to instantiate it directly
+ * and usually created by the [Route.rateLimit] DSL function, so generally there is no need to instantiate it directly
  * unless you are writing an extension.
  * @param name of rate-limit provider to be applied to this route.
  */

--- a/ktor-server/ktor-server-plugins/ktor-server-resources/api/ktor-server-resources.api
+++ b/ktor-server/ktor-server-plugins/ktor-server-resources/api/ktor-server-resources.api
@@ -7,7 +7,7 @@ public final class io/ktor/server/resources/Resources : io/ktor/server/applicati
 
 public final class io/ktor/server/resources/RoutingKt {
 	public static final fun getResourceInstanceKey ()Lio/ktor/util/AttributeKey;
-	public static final fun handle (Lio/ktor/server/routing/Routing;Lkotlinx/serialization/KSerializer;Lkotlin/jvm/functions/Function3;)V
-	public static final fun resource (Lio/ktor/server/routing/Routing;Lkotlinx/serialization/KSerializer;Lkotlin/jvm/functions/Function1;)Lio/ktor/server/routing/Routing;
+	public static final fun handle (Lio/ktor/server/routing/Route;Lkotlinx/serialization/KSerializer;Lkotlin/jvm/functions/Function3;)V
+	public static final fun resource (Lio/ktor/server/routing/Route;Lkotlinx/serialization/KSerializer;Lkotlin/jvm/functions/Function1;)Lio/ktor/server/routing/Route;
 }
 

--- a/ktor-server/ktor-server-plugins/ktor-server-resources/jvmAndNix/src/io/ktor/server/resources/Routing.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-resources/jvmAndNix/src/io/ktor/server/resources/Routing.kt
@@ -17,7 +17,7 @@ import kotlinx.serialization.*
  *
  * A class [T] **must** be annotated with [io.ktor.resources.Resource].
  */
-public inline fun <reified T : Any> Routing.resource(noinline body: Routing.() -> Unit): Routing {
+public inline fun <reified T : Any> Route.resource(noinline body: Route.() -> Unit): Route {
     val serializer = serializer<T>()
     return resource(serializer, body)
 }
@@ -29,16 +29,16 @@ public inline fun <reified T : Any> Routing.resource(noinline body: Routing.() -
  *
  * @param body receives an instance of the typed resource [T] as the first parameter.
  */
-public inline fun <reified T : Any> Routing.get(
+public inline fun <reified T : Any> Route.get(
     noinline body: suspend RoutingContext.(T) -> Unit
-): Routing {
-    lateinit var builtRouting: Routing
+): Route {
+    lateinit var builtRoute: Route
     resource<T> {
-        builtRouting = method(HttpMethod.Get) {
+        builtRoute = method(HttpMethod.Get) {
             handle(body)
         }
     }
-    return builtRouting
+    return builtRoute
 }
 
 /**
@@ -48,16 +48,16 @@ public inline fun <reified T : Any> Routing.get(
  *
  * @param body receives an instance of the typed resource [T] as the first parameter.
  */
-public inline fun <reified T : Any> Routing.options(
+public inline fun <reified T : Any> Route.options(
     noinline body: suspend RoutingContext.(T) -> Unit
-): Routing {
-    lateinit var builtRouting: Routing
+): Route {
+    lateinit var builtRoute: Route
     resource<T> {
-        builtRouting = method(HttpMethod.Options) {
+        builtRoute = method(HttpMethod.Options) {
             handle(body)
         }
     }
-    return builtRouting
+    return builtRoute
 }
 
 /**
@@ -67,16 +67,16 @@ public inline fun <reified T : Any> Routing.options(
  *
  * @param body receives an instance of the typed resource [T] as the first parameter.
  */
-public inline fun <reified T : Any> Routing.head(
+public inline fun <reified T : Any> Route.head(
     noinline body: suspend RoutingContext.(T) -> Unit
-): Routing {
-    lateinit var builtRouting: Routing
+): Route {
+    lateinit var builtRoute: Route
     resource<T> {
-        builtRouting = method(HttpMethod.Head) {
+        builtRoute = method(HttpMethod.Head) {
             handle(body)
         }
     }
-    return builtRouting
+    return builtRoute
 }
 
 /**
@@ -86,16 +86,16 @@ public inline fun <reified T : Any> Routing.head(
  *
  * @param body receives an instance of the typed resource [T] as the first parameter.
  */
-public inline fun <reified T : Any> Routing.post(
+public inline fun <reified T : Any> Route.post(
     noinline body: suspend RoutingContext.(T) -> Unit
-): Routing {
-    lateinit var builtRouting: Routing
+): Route {
+    lateinit var builtRoute: Route
     resource<T> {
-        builtRouting = method(HttpMethod.Post) {
+        builtRoute = method(HttpMethod.Post) {
             handle(body)
         }
     }
-    return builtRouting
+    return builtRoute
 }
 
 /**
@@ -106,9 +106,9 @@ public inline fun <reified T : Any> Routing.post(
  * @param body receives an instance of the typed resource [T] as the first parameter
  * and typed request body [R] as second parameter.
  */
-public inline fun <reified T : Any, reified R : Any> Routing.post(
+public inline fun <reified T : Any, reified R : Any> Route.post(
     noinline body: suspend RoutingContext.(T, R) -> Unit,
-): Routing = post<T> { resource ->
+): Route = post<T> { resource ->
     body(resource, call.receive())
 }
 
@@ -119,16 +119,16 @@ public inline fun <reified T : Any, reified R : Any> Routing.post(
  *
  * @param body receives an instance of the typed resource [T] as the first parameter.
  */
-public inline fun <reified T : Any> Routing.put(
+public inline fun <reified T : Any> Route.put(
     noinline body: suspend RoutingContext.(T) -> Unit
-): Routing {
-    lateinit var builtRouting: Routing
+): Route {
+    lateinit var builtRoute: Route
     resource<T> {
-        builtRouting = method(HttpMethod.Put) {
+        builtRoute = method(HttpMethod.Put) {
             handle(body)
         }
     }
-    return builtRouting
+    return builtRoute
 }
 
 /**
@@ -139,9 +139,9 @@ public inline fun <reified T : Any> Routing.put(
  * @param body receives an instance of the typed resource [T] as the first parameter
  * and typed request body [R] as second parameter.
  */
-public inline fun <reified T : Any, reified R : Any> Routing.put(
+public inline fun <reified T : Any, reified R : Any> Route.put(
     noinline body: suspend RoutingContext.(T, R) -> Unit,
-): Routing = put<T> { resource ->
+): Route = put<T> { resource ->
     body(resource, call.receive())
 }
 
@@ -152,16 +152,16 @@ public inline fun <reified T : Any, reified R : Any> Routing.put(
  *
  * @param body receives an instance of the typed resource [T] as the first parameter.
  */
-public inline fun <reified T : Any> Routing.delete(
+public inline fun <reified T : Any> Route.delete(
     noinline body: suspend RoutingContext.(T) -> Unit
-): Routing {
-    lateinit var builtRouting: Routing
+): Route {
+    lateinit var builtRoute: Route
     resource<T> {
-        builtRouting = method(HttpMethod.Delete) {
+        builtRoute = method(HttpMethod.Delete) {
             handle(body)
         }
     }
-    return builtRouting
+    return builtRoute
 }
 
 /**
@@ -171,16 +171,16 @@ public inline fun <reified T : Any> Routing.delete(
  *
  * @param body receives an instance of the typed resource [T] as the first parameter.
  */
-public inline fun <reified T : Any> Routing.patch(
+public inline fun <reified T : Any> Route.patch(
     noinline body: suspend RoutingContext.(T) -> Unit
-): Routing {
-    lateinit var builtRouting: Routing
+): Route {
+    lateinit var builtRoute: Route
     resource<T> {
-        builtRouting = method(HttpMethod.Patch) {
+        builtRoute = method(HttpMethod.Patch) {
             handle(body)
         }
     }
-    return builtRouting
+    return builtRoute
 }
 
 /**
@@ -191,9 +191,9 @@ public inline fun <reified T : Any> Routing.patch(
  * @param body receives an instance of the typed resource [T] as the first parameter
  * and typed request body [R] as second parameter.
  */
-public inline fun <reified T : Any, reified R : Any> Routing.patch(
+public inline fun <reified T : Any, reified R : Any> Route.patch(
     noinline body: suspend RoutingContext.(T, R) -> Unit,
-): Routing = patch<T> { resource ->
+): Route = patch<T> { resource ->
     body(resource, call.receive())
 }
 
@@ -202,7 +202,7 @@ public inline fun <reified T : Any, reified R : Any> Routing.patch(
  *
  * @param body receives an instance of the typed resource [T] as the first parameter.
  */
-public inline fun <reified T : Any> Routing.handle(
+public inline fun <reified T : Any> Route.handle(
     noinline body: suspend RoutingContext.(T) -> Unit
 ) {
     val serializer = serializer<T>()
@@ -219,10 +219,10 @@ internal val ResourceInstanceKey: AttributeKey<Any> = AttributeKey("ResourceInst
  *
  * A class [T] **must** be annotated with [io.ktor.resources.Resource].
  */
-public fun <T : Any> Routing.resource(
+public fun <T : Any> Route.resource(
     serializer: KSerializer<T>,
-    body: Routing.() -> Unit
-): Routing {
+    body: Route.() -> Unit
+): Route {
     val resources = plugin(Resources)
     val path = resources.resourcesFormat.encodeToPathPattern(serializer)
     val queryParameters = resources.resourcesFormat.encodeToQueryParameters(serializer)
@@ -244,7 +244,7 @@ public fun <T : Any> Routing.resource(
  * @param serializer is used to decode the parameters of the request to an instance of the typed resource [T].
  * @param body receives an instance of the typed resource [T] as the first parameter.
  */
-public fun <T : Any> Routing.handle(
+public fun <T : Any> Route.handle(
     serializer: KSerializer<T>,
     body: suspend RoutingContext.(T) -> Unit
 ) {

--- a/ktor-server/ktor-server-plugins/ktor-server-sse/api/ktor-server-sse.api
+++ b/ktor-server/ktor-server-plugins/ktor-server-sse/api/ktor-server-sse.api
@@ -1,6 +1,6 @@
 public final class io/ktor/server/sse/RoutingKt {
-	public static final fun sse (Lio/ktor/server/routing/Routing;Ljava/lang/String;Lkotlin/jvm/functions/Function2;)V
-	public static final fun sse (Lio/ktor/server/routing/Routing;Lkotlin/jvm/functions/Function2;)V
+	public static final fun sse (Lio/ktor/server/routing/Route;Ljava/lang/String;Lkotlin/jvm/functions/Function2;)V
+	public static final fun sse (Lio/ktor/server/routing/Route;Lkotlin/jvm/functions/Function2;)V
 }
 
 public final class io/ktor/server/sse/SSEKt {

--- a/ktor-server/ktor-server-plugins/ktor-server-sse/jvmAndNix/src/io/ktor/server/sse/Routing.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-sse/jvmAndNix/src/io/ktor/server/sse/Routing.kt
@@ -19,7 +19,7 @@ import io.ktor.server.routing.*
  *
  * @see ServerSSESession
  */
-public fun Routing.sse(path: String, handler: suspend ServerSSESession.() -> Unit) {
+public fun Route.sse(path: String, handler: suspend ServerSSESession.() -> Unit) {
     plugin(SSE)
 
     route(path, HttpMethod.Get) {
@@ -37,7 +37,7 @@ public fun Routing.sse(path: String, handler: suspend ServerSSESession.() -> Uni
  *
  * @see ServerSSESession
  */
-public fun Routing.sse(handler: suspend ServerSSESession.() -> Unit) {
+public fun Route.sse(handler: suspend ServerSSESession.() -> Unit) {
     plugin(SSE)
 
     handle {

--- a/ktor-server/ktor-server-plugins/ktor-server-swagger/api/ktor-server-swagger.api
+++ b/ktor-server/ktor-server-plugins/ktor-server-swagger/api/ktor-server-swagger.api
@@ -8,9 +8,9 @@ public final class io/ktor/server/plugins/swagger/SwaggerConfig {
 }
 
 public final class io/ktor/server/plugins/swagger/SwaggerKt {
-	public static final fun swaggerUI (Lio/ktor/server/routing/Routing;Ljava/lang/String;Ljava/io/File;Lkotlin/jvm/functions/Function1;)V
-	public static final fun swaggerUI (Lio/ktor/server/routing/Routing;Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)V
-	public static synthetic fun swaggerUI$default (Lio/ktor/server/routing/Routing;Ljava/lang/String;Ljava/io/File;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
-	public static synthetic fun swaggerUI$default (Lio/ktor/server/routing/Routing;Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+	public static final fun swaggerUI (Lio/ktor/server/routing/Route;Ljava/lang/String;Ljava/io/File;Lkotlin/jvm/functions/Function1;)V
+	public static final fun swaggerUI (Lio/ktor/server/routing/Route;Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)V
+	public static synthetic fun swaggerUI$default (Lio/ktor/server/routing/Route;Ljava/lang/String;Ljava/io/File;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+	public static synthetic fun swaggerUI$default (Lio/ktor/server/routing/Route;Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
 }
 

--- a/ktor-server/ktor-server-plugins/ktor-server-swagger/jvm/src/io/ktor/server/plugins/swagger/Swagger.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-swagger/jvm/src/io/ktor/server/plugins/swagger/Swagger.kt
@@ -21,7 +21,7 @@ import java.io.*
  * the file system using [java.io.File].
  *
  */
-public fun Routing.swaggerUI(
+public fun Route.swaggerUI(
     path: String,
     swaggerFile: String = "openapi/documentation.yaml",
     block: SwaggerConfig.() -> Unit = {}
@@ -40,7 +40,7 @@ public fun Routing.swaggerUI(
 /**
  * Creates a `get` endpoint with [SwaggerUI] at [path] rendered from the [apiFile].
  */
-public fun Routing.swaggerUI(path: String, apiFile: File, block: SwaggerConfig.() -> Unit = {}) {
+public fun Route.swaggerUI(path: String, apiFile: File, block: SwaggerConfig.() -> Unit = {}) {
     if (!apiFile.exists()) {
         throw FileNotFoundException("Swagger file not found: ${apiFile.absolutePath}")
     }
@@ -49,7 +49,7 @@ public fun Routing.swaggerUI(path: String, apiFile: File, block: SwaggerConfig.(
     swaggerUI(path, apiFile.name, content, block)
 }
 
-internal fun Routing.swaggerUI(
+internal fun Route.swaggerUI(
     path: String,
     apiUrl: String,
     api: String,

--- a/ktor-server/ktor-server-plugins/ktor-server-websockets/api/ktor-server-websockets.api
+++ b/ktor-server/ktor-server-plugins/ktor-server-websockets/api/ktor-server-websockets.api
@@ -24,18 +24,18 @@ public final class io/ktor/server/websocket/KotlinDurationsKt {
 }
 
 public final class io/ktor/server/websocket/RoutingKt {
-	public static final fun webSocket (Lio/ktor/server/routing/Routing;Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function2;)V
-	public static final fun webSocket (Lio/ktor/server/routing/Routing;Ljava/lang/String;Lkotlin/jvm/functions/Function2;)V
-	public static synthetic fun webSocket$default (Lio/ktor/server/routing/Routing;Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function2;ILjava/lang/Object;)V
-	public static synthetic fun webSocket$default (Lio/ktor/server/routing/Routing;Ljava/lang/String;Lkotlin/jvm/functions/Function2;ILjava/lang/Object;)V
-	public static final fun webSocketRaw (Lio/ktor/server/routing/Routing;Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function2;)V
-	public static final fun webSocketRaw (Lio/ktor/server/routing/Routing;Ljava/lang/String;Ljava/lang/String;ZLkotlin/jvm/functions/Function2;)V
-	public static final fun webSocketRaw (Lio/ktor/server/routing/Routing;Ljava/lang/String;Lkotlin/jvm/functions/Function2;)V
-	public static final fun webSocketRaw (Lio/ktor/server/routing/Routing;Ljava/lang/String;ZLkotlin/jvm/functions/Function2;)V
-	public static synthetic fun webSocketRaw$default (Lio/ktor/server/routing/Routing;Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function2;ILjava/lang/Object;)V
-	public static synthetic fun webSocketRaw$default (Lio/ktor/server/routing/Routing;Ljava/lang/String;Ljava/lang/String;ZLkotlin/jvm/functions/Function2;ILjava/lang/Object;)V
-	public static synthetic fun webSocketRaw$default (Lio/ktor/server/routing/Routing;Ljava/lang/String;Lkotlin/jvm/functions/Function2;ILjava/lang/Object;)V
-	public static synthetic fun webSocketRaw$default (Lio/ktor/server/routing/Routing;Ljava/lang/String;ZLkotlin/jvm/functions/Function2;ILjava/lang/Object;)V
+	public static final fun webSocket (Lio/ktor/server/routing/Route;Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function2;)V
+	public static final fun webSocket (Lio/ktor/server/routing/Route;Ljava/lang/String;Lkotlin/jvm/functions/Function2;)V
+	public static synthetic fun webSocket$default (Lio/ktor/server/routing/Route;Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function2;ILjava/lang/Object;)V
+	public static synthetic fun webSocket$default (Lio/ktor/server/routing/Route;Ljava/lang/String;Lkotlin/jvm/functions/Function2;ILjava/lang/Object;)V
+	public static final fun webSocketRaw (Lio/ktor/server/routing/Route;Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function2;)V
+	public static final fun webSocketRaw (Lio/ktor/server/routing/Route;Ljava/lang/String;Ljava/lang/String;ZLkotlin/jvm/functions/Function2;)V
+	public static final fun webSocketRaw (Lio/ktor/server/routing/Route;Ljava/lang/String;Lkotlin/jvm/functions/Function2;)V
+	public static final fun webSocketRaw (Lio/ktor/server/routing/Route;Ljava/lang/String;ZLkotlin/jvm/functions/Function2;)V
+	public static synthetic fun webSocketRaw$default (Lio/ktor/server/routing/Route;Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function2;ILjava/lang/Object;)V
+	public static synthetic fun webSocketRaw$default (Lio/ktor/server/routing/Route;Ljava/lang/String;Ljava/lang/String;ZLkotlin/jvm/functions/Function2;ILjava/lang/Object;)V
+	public static synthetic fun webSocketRaw$default (Lio/ktor/server/routing/Route;Ljava/lang/String;Lkotlin/jvm/functions/Function2;ILjava/lang/Object;)V
+	public static synthetic fun webSocketRaw$default (Lio/ktor/server/routing/Route;Ljava/lang/String;ZLkotlin/jvm/functions/Function2;ILjava/lang/Object;)V
 }
 
 public abstract interface class io/ktor/server/websocket/WebSocketServerSession : io/ktor/websocket/WebSocketSession {

--- a/ktor-server/ktor-server-plugins/ktor-server-websockets/jvmAndNix/src/io/ktor/server/websocket/Routing.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-websockets/jvmAndNix/src/io/ktor/server/websocket/Routing.kt
@@ -27,7 +27,7 @@ import kotlinx.coroutines.CancellationException
  * Once [handler] function returns, the WebSocket connection will be terminated immediately. For RAW WebSockets
  * it is important to perform close sequence properly.
  */
-public fun Routing.webSocketRaw(
+public fun Route.webSocketRaw(
     path: String,
     protocol: String? = null,
     handler: suspend WebSocketServerSession.() -> Unit
@@ -49,7 +49,7 @@ public fun Routing.webSocketRaw(
  *
  * @param negotiateExtensions indicates if the server should negotiate installed WebSocket extensions.
  */
-public fun Routing.webSocketRaw(
+public fun Route.webSocketRaw(
     path: String,
     protocol: String? = null,
     negotiateExtensions: Boolean = false,
@@ -74,7 +74,7 @@ public fun Routing.webSocketRaw(
  * Once [handler] function returns, the WebSocket connection will be terminated immediately. For RAW WebSocket
  * it is important to perform close sequence properly.
  */
-public fun Routing.webSocketRaw(protocol: String? = null, handler: suspend WebSocketServerSession.() -> Unit) {
+public fun Route.webSocketRaw(protocol: String? = null, handler: suspend WebSocketServerSession.() -> Unit) {
     webSocketRaw(protocol, negotiateExtensions = false, handler)
 }
 
@@ -92,7 +92,7 @@ public fun Routing.webSocketRaw(protocol: String? = null, handler: suspend WebSo
  *
  * @param negotiateExtensions indicates if the server should negotiate installed WebSocket extensions.
  */
-public fun Routing.webSocketRaw(
+public fun Route.webSocketRaw(
     protocol: String? = null,
     negotiateExtensions: Boolean = false,
     handler: suspend WebSocketServerSession.() -> Unit
@@ -124,7 +124,7 @@ public fun Routing.webSocketRaw(
  * [DefaultWebSocketSession] anymore. However, WebSocket could live for a while until close sequence completed or
  * a timeout exceeds.
  */
-public fun Routing.webSocket(
+public fun Route.webSocket(
     protocol: String? = null,
     handler: suspend DefaultWebSocketServerSession.() -> Unit
 ) {
@@ -145,7 +145,7 @@ public fun Routing.webSocket(
  * [DefaultWebSocketSession] anymore. However, WebSocket could live for a while until close sequence completed or
  * a timeout exceeds.
  */
-public fun Routing.webSocket(
+public fun Route.webSocket(
     path: String,
     protocol: String? = null,
     handler: suspend DefaultWebSocketServerSession.() -> Unit
@@ -166,7 +166,7 @@ private suspend fun ApplicationCall.respondWebSocketRaw(
     respond(WebSocketUpgrade(this, protocol, negotiateExtensions, handler))
 }
 
-private fun Routing.webSocketProtocol(protocol: String?, block: Routing.() -> Unit) {
+private fun Route.webSocketProtocol(protocol: String?, block: Route.() -> Unit) {
     if (protocol == null) {
         block()
     } else {

--- a/ktor-server/ktor-server-servlet-jakarta/api/ktor-server-servlet-jakarta.api
+++ b/ktor-server/ktor-server-servlet-jakarta/api/ktor-server-servlet-jakarta.api
@@ -156,8 +156,8 @@ public final class io/ktor/server/servlet/jakarta/WebResourcesConfig {
 }
 
 public final class io/ktor/server/servlet/jakarta/WebResourcesKt {
-	public static final fun webResources (Lio/ktor/server/routing/Routing;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)V
-	public static synthetic fun webResources$default (Lio/ktor/server/routing/Routing;Ljava/lang/String;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+	public static final fun webResources (Lio/ktor/server/routing/Route;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)V
+	public static synthetic fun webResources$default (Lio/ktor/server/routing/Route;Ljava/lang/String;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
 }
 
 public final class io/ktor/server/servlet/jakarta/v4/PushKt {

--- a/ktor-server/ktor-server-servlet-jakarta/jvm/src/io/ktor/server/servlet/jakarta/WebResources.kt
+++ b/ktor-server/ktor-server-servlet-jakarta/jvm/src/io/ktor/server/servlet/jakarta/WebResources.kt
@@ -61,7 +61,7 @@ public class WebResourcesConfig internal constructor() {
  * @param subPath slash-delimited web resources root path (relative to webapp directory)
  */
 @OptIn(InternalAPI::class)
-public fun Routing.webResources(subPath: String = "/", configure: WebResourcesConfig.() -> Unit = {}) {
+public fun Route.webResources(subPath: String = "/", configure: WebResourcesConfig.() -> Unit = {}) {
     val config = WebResourcesConfig().apply(configure)
     val pathParameterName = pathParameterName + "_" + Random.nextInt(0, Int.MAX_VALUE)
     val prefix = subPath.split('/', '\\').filter { it.isNotEmpty() }

--- a/ktor-server/ktor-server-servlet/api/ktor-server-servlet.api
+++ b/ktor-server/ktor-server-servlet/api/ktor-server-servlet.api
@@ -156,8 +156,8 @@ public final class io/ktor/server/servlet/WebResourcesConfig {
 }
 
 public final class io/ktor/server/servlet/WebResourcesKt {
-	public static final fun webResources (Lio/ktor/server/routing/Routing;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)V
-	public static synthetic fun webResources$default (Lio/ktor/server/routing/Routing;Ljava/lang/String;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+	public static final fun webResources (Lio/ktor/server/routing/Route;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)V
+	public static synthetic fun webResources$default (Lio/ktor/server/routing/Route;Ljava/lang/String;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
 }
 
 public final class io/ktor/server/servlet/v4/PushKt {

--- a/ktor-server/ktor-server-servlet/jvm/src/io/ktor/server/servlet/WebResources.kt
+++ b/ktor-server/ktor-server-servlet/jvm/src/io/ktor/server/servlet/WebResources.kt
@@ -60,7 +60,7 @@ public class WebResourcesConfig internal constructor() {
  * @param subPath slash-delimited web resources root path (relative to webapp directory)
  */
 @OptIn(InternalAPI::class)
-public fun Routing.webResources(subPath: String = "/", configure: WebResourcesConfig.() -> Unit = {}) {
+public fun Route.webResources(subPath: String = "/", configure: WebResourcesConfig.() -> Unit = {}) {
     val config = WebResourcesConfig().apply(configure)
     val pathParameterName = pathParameterName + "_" + Random.nextInt(0, Int.MAX_VALUE)
     val prefix = subPath.split('/', '\\').filter { it.isNotEmpty() }

--- a/ktor-server/ktor-server-test-base/jvm/src/io/ktor/server/test/base/EngineTestBaseJvm.kt
+++ b/ktor-server/ktor-server-test-base/jvm/src/io/ktor/server/test/base/EngineTestBaseJvm.kt
@@ -158,7 +158,7 @@ actual abstract class EngineTestBase<
         // Empty, intended to be override in derived types when necessary
     }
 
-    protected actual open fun plugins(application: Application, routingConfig: Routing.() -> Unit) {
+    protected actual open fun plugins(application: Application, routingConfig: Route.() -> Unit) {
         application.install(CallLogging)
         application.install(RoutingRoot, routingConfig)
     }
@@ -166,7 +166,7 @@ actual abstract class EngineTestBase<
     protected actual fun createAndStartServer(
         log: Logger?,
         parent: CoroutineContext,
-        routingConfigurer: Routing.() -> Unit
+        routingConfigurer: Route.() -> Unit
     ): EmbeddedServer<TEngine, TConfiguration> {
         var lastFailures = emptyList<Throwable>()
         for (attempt in 1..5) {

--- a/ktor-server/ktor-server-test-base/jvmAndNix/src/io/ktor/server/test/base/EngineTestBase.kt
+++ b/ktor-server/ktor-server-test-base/jvmAndNix/src/io/ktor/server/test/base/EngineTestBase.kt
@@ -38,10 +38,10 @@ expect abstract class EngineTestBase<TEngine : ApplicationEngine, TConfiguration
     protected fun createAndStartServer(
         log: Logger? = null,
         parent: CoroutineContext = EmptyCoroutineContext,
-        routingConfigurer: Routing.() -> Unit
+        routingConfigurer: Route.() -> Unit
     ): EmbeddedServer<TEngine, TConfiguration>
 
-    protected open fun plugins(application: Application, routingConfig: Routing.() -> Unit)
+    protected open fun plugins(application: Application, routingConfig: Route.() -> Unit)
 
     protected fun withUrl(
         path: String,

--- a/ktor-server/ktor-server-test-base/nix/src/io/ktor/server/test/base/EngineTestBaseNix.kt
+++ b/ktor-server/ktor-server-test-base/nix/src/io/ktor/server/test/base/EngineTestBaseNix.kt
@@ -53,7 +53,7 @@ actual constructor(
     protected actual fun createAndStartServer(
         log: Logger?,
         parent: CoroutineContext,
-        routingConfigurer: Routing.() -> Unit
+        routingConfigurer: Route.() -> Unit
     ): EmbeddedServer<TEngine, TConfiguration> {
         var lastFailures = emptyList<Throwable>()
         for (attempt in 1..5) {
@@ -127,7 +127,7 @@ actual constructor(
         }
     }
 
-    protected actual open fun plugins(application: Application, routingConfig: Routing.() -> Unit) {
+    protected actual open fun plugins(application: Application, routingConfig: Route.() -> Unit) {
         application.install(RoutingRoot, routingConfig)
     }
 

--- a/ktor-server/ktor-server-test-host/jvmAndNix/src/io/ktor/server/testing/TestApplication.kt
+++ b/ktor-server/ktor-server-test-host/jvmAndNix/src/io/ktor/server/testing/TestApplication.kt
@@ -253,7 +253,7 @@ public open class TestApplicationBuilder {
      * Installs routing into [TestApplication]
      */
     @KtorDsl
-    public fun routing(configuration: Routing.() -> Unit) {
+    public fun routing(configuration: Route.() -> Unit) {
         checkNotBuilt()
         applicationModules.add { routing(configuration) }
     }

--- a/ktor-server/ktor-server-test-suites/jvm/src/io/ktor/server/testing/suites/ServerPluginsTestSuite.kt
+++ b/ktor-server/ktor-server-test-suites/jvm/src/io/ktor/server/testing/suites/ServerPluginsTestSuite.kt
@@ -10,10 +10,8 @@ import io.ktor.server.request.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
 import io.ktor.server.test.base.*
-import io.ktor.server.testing.*
 import kotlinx.coroutines.*
 import kotlinx.coroutines.sync.*
-import org.junit.jupiter.api.*
 import kotlin.test.*
 import kotlin.test.Test
 
@@ -72,7 +70,7 @@ abstract class ServerPluginsTestSuite<TEngine : ApplicationEngine, TConfiguratio
 
     val expectedEventsForCall = listOf("onCall", "onCallReceive", "onCallRespond")
 
-    override fun plugins(application: Application, routingConfig: Routing.() -> Unit) {
+    override fun plugins(application: Application, routingConfig: Route.() -> Unit) {
         super.plugins(application, routingConfig)
 
         application.install(plugin)

--- a/ktor-server/ktor-server-test-suites/jvmAndNix/src/io/ktor/server/testing/suites/WebSocketEngineSuite.kt
+++ b/ktor-server/ktor-server-test-suites/jvmAndNix/src/io/ktor/server/testing/suites/WebSocketEngineSuite.kt
@@ -34,7 +34,7 @@ abstract class WebSocketEngineSuite<TEngine : ApplicationEngine, TConfiguration 
     private val errors = mutableListOf<Throwable>()
     override val timeout = 30.seconds
 
-    override fun plugins(application: Application, routingConfig: Routing.() -> Unit) {
+    override fun plugins(application: Application, routingConfig: Route.() -> Unit) {
         application.install(WebSockets)
         super.plugins(application, routingConfig)
     }

--- a/ktor-server/ktor-server-tests/jvmAndNix/test/io/ktor/tests/server/routing/RoutingProcessingTest.kt
+++ b/ktor-server/ktor-server-tests/jvmAndNix/test/io/ktor/tests/server/routing/RoutingProcessingTest.kt
@@ -1026,7 +1026,7 @@ class RoutingProcessingTest {
         }
     }
 
-    private fun Routing.transparent(build: Routing.() -> Unit): Routing {
+    private fun Route.transparent(build: Route.() -> Unit): Route {
         val route = createChild(
             object : RouteSelector() {
                 override fun evaluate(context: RoutingResolveContext, segmentIndex: Int): RouteSelectorEvaluation {

--- a/ktor-server/ktor-server-tests/jvmAndNix/test/io/ktor/tests/server/routing/RoutingTracingTest.kt
+++ b/ktor-server/ktor-server-tests/jvmAndNix/test/io/ktor/tests/server/routing/RoutingTracingTest.kt
@@ -303,7 +303,7 @@ class RoutingTracingTest {
         return trace?.buildText()!!
     }
 
-    private fun Routing.testRouting() {
+    private fun Route.testRouting() {
         get("/bar") { call.respond("/bar") }
         get("/baz") { call.respond("/baz") }
         get("/baz/x") { call.respond("/baz/x") }

--- a/ktor-shared/ktor-serialization/ktor-serialization-jackson/jvm/test/ClientJacksonTest.kt
+++ b/ktor-shared/ktor-serialization/ktor-serialization-jackson/jvm/test/ClientJacksonTest.kt
@@ -28,8 +28,8 @@ class ClientJacksonTest : AbstractClientContentNegotiationTest() {
         register(contentType, converter)
     }
 
-    override fun createRoutes(routing: Routing): Unit = with(routing) {
-        super.createRoutes(routing)
+    override fun createRoutes(route: Route): Unit = with(route) {
+        super.createRoutes(route)
 
         post("/jackson") {
             assertEquals("""{"value":"request"}""", call.receive())


### PR DESCRIPTION
**Subsystem**
Server, Routing

**Motivation**
[KTOR-7238](https://youtrack.jetbrains.com/issue/KTOR-7238) Review Routing API changes from 2.* to 3.0

The changes made in 3.0 break backwards compatibility for one of the more common patterns for creating extension functions for routing configuration, which is featured in many of our tutorials and sample code.

**Solution**
This update will return things back to the original names in the builder functions so that extension functions will not need to be renamed with the update to 3.0.

