### PR TITLE
Add `watchosDeviceArm64` target with yaml workaround

### DIFF
--- a/buildSrc/src/main/kotlin/NativeUtils.kt
+++ b/buildSrc/src/main/kotlin/NativeUtils.kt
@@ -33,11 +33,13 @@ fun Project.iosTargets(): List<String> = with(kotlin) {
 }
 
 fun Project.watchosTargets(): List<String> = with(kotlin) {
-    listOf(
+    listOfNotNull(
         watchosX64(),
         watchosArm32(),
         watchosArm64(),
         watchosSimulatorArm64(),
+        // because of dependency on YAML library: https://github.com/Him188/yamlkt/issues/67
+        if (project.name != "ktor-server-config-yaml") watchosDeviceArm64() else null,
     ).map { it.name }
 }
 

--- a/buildSrc/src/main/kotlin/Publication.kt
+++ b/buildSrc/src/main/kotlin/Publication.kt
@@ -37,6 +37,7 @@ fun isAvailableForPublication(publication: Publication): Boolean {
         "watchosArm32",
         "watchosArm64",
         "watchosSimulatorArm64",
+        "watchosDeviceArm64",
 
         "tvosX64",
         "tvosArm64",

--- a/ktor-server/ktor-server-core/build.gradle.kts
+++ b/ktor-server/ktor-server-core/build.gradle.kts
@@ -43,7 +43,6 @@ kotlin {
                 implementation(project(":ktor-server:ktor-server-config-yaml"))
                 implementation(project(":ktor-server:ktor-server-test-base"))
                 implementation(project(":ktor-server:ktor-server-test-suites"))
-                implementation(project(":ktor-server:ktor-server-config-yaml"))
                 
                 api(libs.logback.classic)
                 implementation(libs.mockk)

--- a/ktor-server/ktor-server-test-base/build.gradle.kts
+++ b/ktor-server/ktor-server-test-base/build.gradle.kts
@@ -34,10 +34,4 @@ kotlin.sourceSets {
             api(kotlin("test"))
         }
     }
-
-    jvmAndPosixTest {
-        dependencies {
-            api(project(":ktor-server:ktor-server-config-yaml"))
-        }
-    }
 }

--- a/ktor-server/ktor-server-test-host/build.gradle.kts
+++ b/ktor-server/ktor-server-test-host/build.gradle.kts
@@ -37,13 +37,8 @@ kotlin.sourceSets {
     jvmTest {
         dependencies {
             api(project(":ktor-server:ktor-server-core", configuration = "testOutput"))
-            api(kotlin("test"))
-        }
-    }
-
-    jvmAndPosixTest {
-        dependencies {
             api(project(":ktor-server:ktor-server-config-yaml"))
+            api(kotlin("test"))
         }
     }
 }


### PR DESCRIPTION
fixes [KTOR-6368](https://youtrack.jetbrains.com/issue/KTOR-6368/Add-watchosDeviceArm64-target) by adding workaround for `yaml` module and removing unnecessary dependencies on that module in tests.

[yamlkt](https://github.com/Him188/yamlkt/issues/67) doesn't support the target yet. There is an open [PR](https://github.com/Him188/yamlkt/pull/72), but there are some problems with integration.

After that PR will be merged, dependency could be updated and hack in `NativeUtils` could be removed.
