### PR TITLE
KTOR-7254 Fix for IOException on concurrent requests using request body limit

### DIFF
--- a/ktor-server/ktor-server-plugins/ktor-server-body-limit/common/test/io/ktor/server/plugins/bodylimit/RequestBodyLimitTest.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-body-limit/common/test/io/ktor/server/plugins/bodylimit/RequestBodyLimitTest.kt
@@ -1,19 +1,21 @@
 /*
- * Copyright 2014-2023 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2014-2024 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 package io.ktor.server.plugins.bodylimit
 
 import io.ktor.client.request.*
 import io.ktor.client.statement.*
 import io.ktor.http.*
+import io.ktor.server.plugins.*
 import io.ktor.server.request.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
 import io.ktor.server.testing.*
 import io.ktor.utils.io.*
+import kotlinx.coroutines.test.*
 import kotlin.test.*
 
-class BodyLimitTest {
+class RequestBodyLimitTest {
 
     @Test
     fun testBodyLimitPerCall() = testApplication {
@@ -139,4 +141,36 @@ class BodyLimitTest {
         }
         assertEquals(HttpStatusCode.OK, requestCOk.status)
     }
+
+    @Test
+    fun channelApplyLimitTooLarge() = runTest {
+        assertFailsWith<PayloadTooLargeException> {
+            ByteReadChannel("This is too long")
+                .applyLimit(5)
+                .readUTF8Line()
+        }
+    }
+
+    @Test
+    fun channelApplyLimitNormal() = runTest {
+        val expected = "This is OK"
+        val actual = ByteReadChannel(expected)
+            .applyLimit(10)
+            .readUTF8Line()
+        assertEquals(expected, actual)
+    }
+
+    // See KTOR-7254, happens sometimes with many threads
+    @Test
+    fun channelApplyLimitEmptyOnRead() = runTest {
+        val channelThatClosesAfterFirstCheck = object : ByteReadChannel by ByteReadChannel.Empty {
+            var calls = 0
+            override val isClosedForRead get() = calls++ >= 1
+        }
+        val actual = channelThatClosesAfterFirstCheck
+            .applyLimit(10)
+            .readUTF8Line()
+        assertNull(actual)
+    }
+
 }


### PR DESCRIPTION
**Subsystem**
Server, Body Limit

**Motivation**
[KTOR-7254](https://youtrack.jetbrains.com/issue/KTOR-7254) IOException: startIndex (0) > endIndex (-1) when making concurrent requests via thread pool

**Solution**
It's possible for the request to close between the check for `isClosedForRead` and `readAvalailable`, which results in `-1` being returned, which causes the `writeFully` to blow up.

