### PR TITLE
KTOR-7243 Support reloading of zip files in StaticContent

### DIFF
--- a/ktor-server/ktor-server-core/api/ktor-server-core.api
+++ b/ktor-server/ktor-server-core/api/ktor-server-core.api
@@ -747,6 +747,15 @@ public final class io/ktor/server/http/content/DefaultTransformKt {
 	public static final fun transformDefaultContent (Lio/ktor/server/application/ApplicationCall;Ljava/lang/Object;)Lio/ktor/http/content/OutgoingContent;
 }
 
+public abstract interface class io/ktor/server/http/content/FileSystemPaths {
+	public static final field Companion Lio/ktor/server/http/content/FileSystemPaths$Companion;
+	public abstract fun getPath (Ljava/lang/String;[Ljava/lang/String;)Ljava/nio/file/Path;
+}
+
+public final class io/ktor/server/http/content/FileSystemPaths$Companion {
+	public final fun paths (Ljava/nio/file/FileSystem;)Lio/ktor/server/http/content/FileSystemPaths;
+}
+
 public final class io/ktor/server/http/content/HttpStatusCodeContent : io/ktor/http/content/OutgoingContent$NoContent {
 	public fun <init> (Lio/ktor/http/HttpStatusCode;)V
 	public fun getStatus ()Lio/ktor/http/HttpStatusCode;
@@ -859,8 +868,8 @@ public final class io/ktor/server/http/content/StaticContentKt {
 	public static final fun setStaticRootFolder (Lio/ktor/server/routing/Route;Ljava/io/File;)V
 	public static final fun static (Lio/ktor/server/routing/Route;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Lio/ktor/server/routing/Route;
 	public static final fun static (Lio/ktor/server/routing/Route;Lkotlin/jvm/functions/Function1;)Lio/ktor/server/routing/Route;
-	public static final fun staticFileSystem (Lio/ktor/server/routing/Route;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/nio/file/FileSystem;Lkotlin/jvm/functions/Function1;)Lio/ktor/server/routing/Route;
-	public static synthetic fun staticFileSystem$default (Lio/ktor/server/routing/Route;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/nio/file/FileSystem;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lio/ktor/server/routing/Route;
+	public static final fun staticFileSystem (Lio/ktor/server/routing/Route;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lio/ktor/server/http/content/FileSystemPaths;Lkotlin/jvm/functions/Function1;)Lio/ktor/server/routing/Route;
+	public static synthetic fun staticFileSystem$default (Lio/ktor/server/routing/Route;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lio/ktor/server/http/content/FileSystemPaths;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lio/ktor/server/routing/Route;
 	public static final fun staticFiles (Lio/ktor/server/routing/Route;Ljava/lang/String;Ljava/io/File;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Lio/ktor/server/routing/Route;
 	public static synthetic fun staticFiles$default (Lio/ktor/server/routing/Route;Ljava/lang/String;Ljava/io/File;Ljava/lang/String;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lio/ktor/server/routing/Route;
 	public static final fun staticResources (Lio/ktor/server/routing/Route;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Lio/ktor/server/routing/Route;

--- a/ktor-server/ktor-server-core/jvm/src/io/ktor/server/http/content/PreCompressed.kt
+++ b/ktor-server/ktor-server-core/jvm/src/io/ktor/server/http/content/PreCompressed.kt
@@ -66,7 +66,7 @@ internal fun bestCompressionFit(
 }
 
 internal fun bestCompressionFit(
-    fileSystem: FileSystem,
+    fileSystem: FileSystemPaths,
     path: Path,
     acceptEncoding: List<HeaderValue>,
     compressedTypes: List<CompressedFileType>?
@@ -139,7 +139,7 @@ internal suspend fun ApplicationCall.respondStaticFile(
 }
 
 internal suspend fun ApplicationCall.respondStaticPath(
-    fileSystem: FileSystem,
+    fileSystem: FileSystemPaths,
     requestedPath: Path,
     compressedTypes: List<CompressedFileType>?,
     contentType: (Path) -> ContentType = { ContentType.defaultForPath(it) },

--- a/ktor-server/ktor-server-core/jvm/src/io/ktor/server/http/content/StaticContent.kt
+++ b/ktor-server/ktor-server-core/jvm/src/io/ktor/server/http/content/StaticContent.kt
@@ -8,6 +8,7 @@ import io.ktor.http.*
 import io.ktor.http.content.*
 import io.ktor.server.application.*
 import io.ktor.server.application.hooks.*
+import io.ktor.server.http.content.FileSystemPaths.Companion.paths
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
 import io.ktor.util.*
@@ -254,7 +255,7 @@ public fun Route.staticZip(
     remotePath = remotePath,
     basePath = basePath,
     index = index,
-    fileSystem = FileSystems.newFileSystem(zip, environment.classLoader),
+    fileSystem = FileSystems.newFileSystem(zip, environment.classLoader).paths(),
     block = block
 )
 
@@ -272,7 +273,7 @@ public fun Route.staticFileSystem(
     remotePath: String,
     basePath: String?,
     index: String? = "index.html",
-    fileSystem: FileSystem = FileSystems.getDefault(),
+    fileSystem: FileSystemPaths = FileSystems.getDefault().paths(),
     block: StaticContentConfig<Path>.() -> Unit = {}
 ): Route {
     val staticRoute = StaticContentConfig<Path>().apply(block)
@@ -559,7 +560,7 @@ private suspend fun ApplicationCall.respondStaticFile(
 }
 
 private suspend fun ApplicationCall.respondStaticPath(
-    fileSystem: FileSystem,
+    fileSystem: FileSystemPaths,
     index: String?,
     basePath: String?,
     compressedTypes: List<CompressedFileType>?,
@@ -665,4 +666,24 @@ private suspend fun ApplicationCall.respondStaticResource(
         cacheControl = cacheControl,
         modifier = modifier
     )
+}
+
+/**
+ * Wrapper on [FileSystem] for more specific delegation since we use only [getPath] method from it.
+ */
+public interface FileSystemPaths {
+    public companion object {
+        /**
+         * Creates a [FileSystemPaths] instance from a [FileSystem].
+         */
+        public fun FileSystem.paths(): FileSystemPaths = object : FileSystemPaths {
+            override fun getPath(first: String, vararg more: String): Path = this@paths.getPath(first, *more)
+        }
+    }
+
+    /**
+     * Converts a path string, or a sequence of strings that when joined form a path string, to a Path.
+     * Equal to [FileSystem.getPath].
+     */
+    public fun getPath(first: String, vararg more: String): Path
 }

--- a/ktor-server/ktor-server-tests/jvm/test/io/ktor/server/plugins/StaticContentTest.kt
+++ b/ktor-server/ktor-server-tests/jvm/test/io/ktor/server/plugins/StaticContentTest.kt
@@ -1316,6 +1316,7 @@ class StaticContentTest {
 
         // Wait for the watch service to detect the change
         testWatchService.take()
+        delay(3000)
 
         val secondResponse = client.get("static/$secondFileName")
         assertEquals(HttpStatusCode.OK, secondResponse.status)


### PR DESCRIPTION
**Subsystem**
Server, StaticContent

**Motivation**
[KTOR-7243](https://youtrack.jetbrains.com/issue/KTOR-7243)

**Solution**
Add a flag `reloadOnRequest`, and if it is set to true, then reload the zip every time a request comes

I was also thinking about [`WatchService`](https://docs.oracle.com/javase%2F8%2Fdocs%2Fapi%2F%2F/java/nio/file/WatchService.html) for `FileSystem`, but it's not really obvious for me, because on request we can try to get and go through incoming `WatchEvents`, we can keep map of  modified/deleted/created `WatchEvents` and reload `file` or entire `zip` if it was changed. But maybe a variant with reloading zip on request is okay to go. It's much simpler and more obvious

