### PR TITLE
KTOR-7303 Remove read/write channels for UDP sockets

### DIFF
--- a/ktor-network/api/ktor-network.api
+++ b/ktor-network/api/ktor-network.api
@@ -89,7 +89,7 @@ public abstract interface class io/ktor/network/sockets/ABoundSocket {
 	public abstract fun getLocalAddress ()Lio/ktor/network/sockets/SocketAddress;
 }
 
-public abstract interface class io/ktor/network/sockets/AConnectedSocket : io/ktor/network/sockets/AWritable {
+public abstract interface class io/ktor/network/sockets/AConnectedSocket {
 	public abstract fun getRemoteAddress ()Lio/ktor/network/sockets/SocketAddress;
 }
 
@@ -118,7 +118,7 @@ public final class io/ktor/network/sockets/Acceptable$DefaultImpls {
 	public static fun dispose (Lio/ktor/network/sockets/Acceptable;)V
 }
 
-public abstract interface class io/ktor/network/sockets/BoundDatagramSocket : io/ktor/network/sockets/ABoundSocket, io/ktor/network/sockets/AReadable, io/ktor/network/sockets/ASocket, io/ktor/network/sockets/DatagramReadWriteChannel {
+public abstract interface class io/ktor/network/sockets/BoundDatagramSocket : io/ktor/network/sockets/ABoundSocket, io/ktor/network/sockets/ASocket, io/ktor/network/sockets/DatagramReadWriteChannel {
 }
 
 public final class io/ktor/network/sockets/BoundDatagramSocket$DefaultImpls {
@@ -142,7 +142,7 @@ public final class io/ktor/network/sockets/Configurable$DefaultImpls {
 	public static fun configure (Lio/ktor/network/sockets/Configurable;Lkotlin/jvm/functions/Function1;)Lio/ktor/network/sockets/Configurable;
 }
 
-public abstract interface class io/ktor/network/sockets/ConnectedDatagramSocket : io/ktor/network/sockets/ABoundSocket, io/ktor/network/sockets/AConnectedSocket, io/ktor/network/sockets/ASocket, io/ktor/network/sockets/DatagramReadWriteChannel, io/ktor/network/sockets/ReadWriteSocket {
+public abstract interface class io/ktor/network/sockets/ConnectedDatagramSocket : io/ktor/network/sockets/ABoundSocket, io/ktor/network/sockets/AConnectedSocket, io/ktor/network/sockets/ASocket, io/ktor/network/sockets/DatagramReadWriteChannel {
 }
 
 public final class io/ktor/network/sockets/ConnectedDatagramSocket$DefaultImpls {

--- a/ktor-network/jvmAndPosix/src/io/ktor/network/sockets/Datagram.kt
+++ b/ktor-network/jvmAndPosix/src/io/ktor/network/sockets/Datagram.kt
@@ -66,10 +66,10 @@ public interface DatagramReadWriteChannel : DatagramReadChannel, DatagramWriteCh
 /**
  * Represents a bound datagram socket
  */
-public interface BoundDatagramSocket : ASocket, ABoundSocket, AReadable, DatagramReadWriteChannel
+public interface BoundDatagramSocket : ASocket, ABoundSocket, DatagramReadWriteChannel
 
 /**
  * Represents a connected datagram socket.
  */
 public interface ConnectedDatagramSocket :
-    ASocket, ABoundSocket, AConnectedSocket, ReadWriteSocket, DatagramReadWriteChannel
+    ASocket, ABoundSocket, AConnectedSocket, DatagramReadWriteChannel

--- a/ktor-network/jvmAndPosix/src/io/ktor/network/sockets/Sockets.kt
+++ b/ktor-network/jvmAndPosix/src/io/ktor/network/sockets/Sockets.kt
@@ -44,7 +44,7 @@ public suspend fun ASocket.awaitClosed() {
 /**
  * Represent a connected socket
  */
-public interface AConnectedSocket : AWritable {
+public interface AConnectedSocket {
     /**
      * Remote socket address. Could throw an exception if the peer is not yet connected or already disconnected.
      */

--- a/ktor-network/posix/src/io/ktor/network/sockets/DatagramSocketNative.kt
+++ b/ktor-network/posix/src/io/ktor/network/sockets/DatagramSocketNative.kt
@@ -6,7 +6,6 @@ package io.ktor.network.sockets
 
 import io.ktor.network.selector.*
 import io.ktor.network.util.*
-import io.ktor.utils.io.*
 import io.ktor.utils.io.core.*
 import io.ktor.utils.io.errors.*
 import kotlinx.cinterop.*
@@ -22,7 +21,7 @@ internal class DatagramSocketNative(
     val selectable: Selectable,
     private val remote: SocketAddress?,
     parent: CoroutineContext = EmptyCoroutineContext
-) : BoundDatagramSocket, ConnectedDatagramSocket, Socket, CoroutineScope {
+) : BoundDatagramSocket, ConnectedDatagramSocket, CoroutineScope {
     private val _context: CompletableJob = Job(parent[Job])
 
     override val coroutineContext: CoroutineContext = parent + Dispatchers.Unconfined + _context
@@ -69,12 +68,6 @@ internal class DatagramSocketNative(
         }
         sender.close()
     }
-
-    override fun attachForReading(channel: ByteChannel): WriterJob =
-        attachForReadingImpl(channel, descriptor, selectable, selector)
-
-    override fun attachForWriting(channel: ByteChannel): ReaderJob =
-        attachForWritingImpl(channel, descriptor, selectable, selector)
 
     private suspend fun readDatagram(): Datagram {
         while (true) {


### PR DESCRIPTION
[KTOR-7303](https://youtrack.jetbrains.com/issue/KTOR-7303) Remove read/write channels for UDP sockets

I didn't remove the `attachForReading`/`attachForWriting` functions from the internal NIOSocketImpl. Is that alright or should they be moved to `SocketImpl`?