### PR TITLE
KTOR-7294: allow for exp. retry delays of below 2 seconds

### DIFF
--- a/ktor-client/ktor-client-core/api/ktor-client-core.api
+++ b/ktor-client/ktor-client-core/api/ktor-client-core.api
@@ -364,8 +364,8 @@ public final class io/ktor/client/plugins/HttpRequestRetryConfig {
 	public final fun delay (Lkotlin/jvm/functions/Function2;)V
 	public final fun delayMillis (ZLkotlin/jvm/functions/Function2;)V
 	public static synthetic fun delayMillis$default (Lio/ktor/client/plugins/HttpRequestRetryConfig;ZLkotlin/jvm/functions/Function2;ILjava/lang/Object;)V
-	public final fun exponentialDelay (DJJZ)V
-	public static synthetic fun exponentialDelay$default (Lio/ktor/client/plugins/HttpRequestRetryConfig;DJJZILjava/lang/Object;)V
+	public final fun exponentialDelay (DJJJZ)V
+	public static synthetic fun exponentialDelay$default (Lio/ktor/client/plugins/HttpRequestRetryConfig;DJJJZILjava/lang/Object;)V
 	public final fun getMaxRetries ()I
 	public final fun modifyRequest (Lkotlin/jvm/functions/Function2;)V
 	public final fun noRetry ()V

--- a/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/HttpRequestRetry.kt
+++ b/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/HttpRequestRetry.kt
@@ -163,20 +163,25 @@ public class HttpRequestRetryConfig {
 
     /**
      * Specifies an exponential delay between retries, which is calculated using the Exponential backoff algorithm.
-     * This delay equals to `base ^ retryCount * 1000 + [0..randomizationMs]`
+     * This delay equals to `(base ^ retryCount-1) * baseDelayMs + [0..randomizationMs]`.
+     *
+     * For the defaults (base delay 1000ms, base 2), this results in 1000ms, 2000ms, 4000ms, 8000ms ... plus a random
+     * value up to 1000ms.
      */
     public fun exponentialDelay(
         base: Double = 2.0,
+        baseDelayMs: Long = 1000,
         maxDelayMs: Long = 60000,
         randomizationMs: Long = 1000,
         respectRetryAfterHeader: Boolean = true
     ) {
         check(base > 0)
+        check(baseDelayMs > 0)
         check(maxDelayMs > 0)
         check(randomizationMs >= 0)
 
         delayMillis(respectRetryAfterHeader) { retry ->
-            val delay = minOf(base.pow(retry).toLong() * 1000L, maxDelayMs)
+            val delay = minOf((base.pow(retry - 1) * baseDelayMs).toLong(), maxDelayMs)
             delay + randomMs(randomizationMs)
         }
     }

--- a/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/HttpRequestRetryTest.kt
+++ b/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/HttpRequestRetryTest.kt
@@ -34,13 +34,13 @@ class HttpRequestRetryTest {
 
         test { client ->
             client.get { }
-            assertTrue(
-                delays
-                    .foldIndexed(true) { index, acc, delay ->
-                        val expectedDelay = (2.0.pow(index + 1) * 1000).toLong()
-                        acc && delay in expectedDelay..expectedDelay + 1000
-                    }
-            )
+
+            val expectedDelays = listOf(1000L, 2000L, 4000L)
+            assertEquals(expectedDelays.size, delays.size)
+
+            expectedDelays.zip(delays).forEach { (expected, actual) ->
+                assertTrue { actual in expected..expected + 1000 }
+            }
         }
     }
 
@@ -99,7 +99,7 @@ class HttpRequestRetryTest {
     }
 
     @Test
-    fun testExponentialDelay() = testWithEngine(MockEngine) {
+    fun testExponentialDelayDefaults() = testWithEngine(MockEngine) {
         val delays = mutableListOf<Long>()
         config {
             engine {
@@ -117,7 +117,53 @@ class HttpRequestRetryTest {
 
         test { client ->
             client.get { }
-            assertEquals(listOf(2000L, 4000L, 8000L), delays)
+            assertEquals(listOf(1000L, 2000L, 4000L), delays)
+        }
+    }
+
+    @Test
+    fun testExponentialDelayExplicitBaseDelay() = testWithEngine(MockEngine) {
+        val delays = mutableListOf<Long>()
+        config {
+            engine {
+                addHandler { respondError(HttpStatusCode.InternalServerError) }
+                addHandler { respondError(HttpStatusCode.InternalServerError) }
+                addHandler { respondError(HttpStatusCode.InternalServerError) }
+                addHandler { respondOk() }
+            }
+            install(HttpRequestRetry) {
+                retryOnServerErrors(3)
+                exponentialDelay(randomizationMs = 0, baseDelayMs = 200)
+                delay { delays.add(it) }
+            }
+        }
+
+        test { client ->
+            client.get { }
+            assertEquals(listOf(200L, 400L, 800L), delays)
+        }
+    }
+
+    @Test
+    fun testExponentialDelayExplicitBase() = testWithEngine(MockEngine) {
+        val delays = mutableListOf<Long>()
+        config {
+            engine {
+                addHandler { respondError(HttpStatusCode.InternalServerError) }
+                addHandler { respondError(HttpStatusCode.InternalServerError) }
+                addHandler { respondError(HttpStatusCode.InternalServerError) }
+                addHandler { respondOk() }
+            }
+            install(HttpRequestRetry) {
+                retryOnServerErrors(3)
+                exponentialDelay(randomizationMs = 0, base = 1.1)
+                delay { delays.add(it) }
+            }
+        }
+
+        test { client ->
+            client.get { }
+            assertEquals(listOf(1000L, 1100L, 1210L), delays)
         }
     }
 


### PR DESCRIPTION
**Subsystem**
Http Client, retries with exponential backoff

**Motivation**
The exponential backoff has two issues

- The "base delay" multiplier is fixed to 1 second
- The initial delay is already `base^1 * 1 second`, resulting in 2 seconds for the first delay with the default base of 2.0

While you could set a non-default base of e.g. 1.1, this flattens mainly the exponential increase, and still does not allow a initial delay < 1 second. Setting the base to `0 < delay < 1` would even lead to decreasing delays. This is at least counter-intutive. 

**Solution**

- Allow the delay multiplier to be set to arbitrary millisecond values
- Fix the initial delay to not be `base ^ retry`, but `base ^(retry - 1)`

Examples: 

`base = 2, baseDelay = 1000` produces delays of 1000, 2000, 4000, 8000 ... ms
`base = 2, baseDelay = 100` produces delays of 100, 200, 400, 800 ... ms
`base = 1.1, baseDelay = 100` produces delays of 100, 110, 121, 133.1 ... ms

