### PR TITLE
Prioritize explicit headers

### DIFF
--- a/ktor-client/ktor-client-core/common/src/io/ktor/client/engine/Utils.kt
+++ b/ktor-client/ktor-client-core/common/src/io/ktor/client/engine/Utils.kt
@@ -36,8 +36,8 @@ public fun mergeHeaders(
     block: (key: String, value: String) -> Unit
 ) {
     buildHeaders {
-        appendAll(requestHeaders)
         appendAll(content.headers)
+        appendAll(requestHeaders) 
     }.forEach { key, values ->
         if (HttpHeaders.ContentLength == key) return@forEach // set later
         if (HttpHeaders.ContentType == key) return@forEach // set later
@@ -58,12 +58,12 @@ public fun mergeHeaders(
         block(HttpHeaders.UserAgent, KTOR_DEFAULT_USER_AGENT)
     }
 
-    val type = content.contentType?.toString()
-        ?: content.headers[HttpHeaders.ContentType]
+    val type = content.headers[HttpHeaders.ContentType]
+        ?: content.contentType?.toString()
         ?: requestHeaders[HttpHeaders.ContentType]
 
-    val length = content.contentLength?.toString()
-        ?: content.headers[HttpHeaders.ContentLength]
+    val length = content.headers[HttpHeaders.ContentLength]
+        ?: content.contentLength?.toString()
         ?: requestHeaders[HttpHeaders.ContentLength]
 
     type?.let { block(HttpHeaders.ContentType, it) }


### PR DESCRIPTION
**Subsystem**
Client common engine

**Motivation**
I've had an issue sending HTTP request with form data. A server was rejecting the request based on content-type. It was expecting `application/x-www-form-urlencoded` but [FormDataContent](https://github.com/ktorio/ktor/blob/80b68afb5a5133e1909299fc4d1bf81645dd3bd4/ktor-client/ktor-client-core/common/src/io/ktor/client/request/forms/FormDataContent.kt#L30) adds also an encoding. 

**Solution**
Explicitly provided headers should have higher priority then calculated.
