### PR TITLE
KTOR-7265 Fix for ContentEncoding deadlock

### DIFF
--- a/buildSrc/src/main/kotlin/test/server/tests/Content.kt
+++ b/buildSrc/src/main/kotlin/test/server/tests/Content.kt
@@ -61,6 +61,14 @@ internal fun Application.contentTestServer() {
 
                 call.respond("100")
             }
+            get("/big-plain-text") {
+                call.respondText {
+                    buildString {
+                        for (i in 1..10_000)
+                            appendLine("I will not introduce deadlocks.")
+                    }
+                }
+            }
             post("/sign") {
                 val form = call.receiveParameters()
 

--- a/buildSrc/src/main/kotlin/test/server/tests/Encoding.kt
+++ b/buildSrc/src/main/kotlin/test/server/tests/Encoding.kt
@@ -63,6 +63,16 @@ internal fun Application.encodingTestServer() {
                 }
                 setCompressionEndpoints()
             }
+            route("/big-plain-text") {
+                get {
+                    call.respondText {
+                        buildString {
+                            for (i in 1..10_000)
+                                appendLine("I will not introduce deadlocks.")
+                        }
+                    }
+                }
+            }
         }
     }
 }

--- a/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/internal/ByteChannelReplay.kt
+++ b/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/internal/ByteChannelReplay.kt
@@ -11,7 +11,7 @@ import kotlinx.coroutines.*
 import kotlinx.io.*
 
 internal class ByteChannelReplay(private val origin: ByteReadChannel) {
-    private val content: AtomicRef<CompletableDeferred<ByteArray>?> = atomic(null)
+    private val content: AtomicRef<CopyFromSourceTask?> = atomic(null)
 
     @OptIn(DelicateCoroutinesApi::class)
     fun replay(): ByteReadChannel {
@@ -19,43 +19,76 @@ internal class ByteChannelReplay(private val origin: ByteReadChannel) {
             throw origin.closedCause!!
         }
 
-        var deferred: CompletableDeferred<ByteArray>? = content.value
-        if (deferred == null) {
-            deferred = CompletableDeferred()
-            if (!content.compareAndSet(null, deferred)) {
-                deferred = content.value
+        var copyTask: CopyFromSourceTask? = content.value
+        if (copyTask == null) {
+            copyTask = CopyFromSourceTask()
+            if (!content.compareAndSet(null, copyTask)) {
+                copyTask = content.value
             } else {
-                return receiveBody(deferred)
+                return copyTask.start()
             }
         }
 
         return GlobalScope.writer {
-            val body = deferred!!.await()
+            val body = copyTask!!.awaitImpatiently()
             channel.writeFully(body)
         }.channel
     }
 
-    @OptIn(DelicateCoroutinesApi::class)
-    fun receiveBody(
-        result: CompletableDeferred<ByteArray>
-    ): ByteReadChannel = GlobalScope.writer(Dispatchers.Unconfined) {
-        val body = BytePacketBuilder()
-        try {
-            while (!origin.isClosedForRead) {
-                if (origin.availableForRead == 0) origin.awaitContent()
-                val packet = origin.readPacket(origin.availableForRead)
+    /**
+     * The first caller to get the body will stream from the origin, while copying packets to the saved body.
+     *
+     * This can be interrupted by the next caller if the first is taking too long to read. This still waits for the
+     * origin to be copied to memory.
+     */
+    private inner class CopyFromSourceTask(
+        val savedResponse: CompletableDeferred<ByteArray> = CompletableDeferred()
+    ) {
+        lateinit var writerJob: WriterJob
 
-                body.writePacket(packet.copy())
-                channel.writePacket(packet)
-                channel.flush()
-            }
-
-            origin.closedCause?.let { throw it }
-            result.complete(body.build().readByteArray())
-        } catch (cause: Throwable) {
-            body.close()
-            result.completeExceptionally(cause)
-            throw cause
+        fun start(): ByteReadChannel {
+            writerJob = receiveBody()
+            return writerJob.channel
         }
-    }.channel
+
+        @OptIn(DelicateCoroutinesApi::class)
+        fun receiveBody(): WriterJob = GlobalScope.writer(Dispatchers.Unconfined) {
+            val body = BytePacketBuilder()
+            try {
+                while (!origin.isClosedForRead) {
+                    if (origin.availableForRead == 0) origin.awaitContent()
+                    val packet = origin.readPacket(origin.availableForRead)
+
+                    try {
+                        if (!channel.isClosedForWrite) {
+                            channel.writePacket(packet.peek())
+                            channel.flush()
+                        }
+                    } catch (_: Exception) {
+                        // the reader may have abandoned this channel
+                        // but we still want to write to the saved response
+                    }
+                    body.writePacket(packet)
+                }
+
+                origin.closedCause?.let { throw it }
+                savedResponse.complete(body.build().readByteArray())
+            } catch (cause: Throwable) {
+                body.close()
+                savedResponse.completeExceptionally(cause)
+                throw cause
+            }
+        }
+
+        suspend fun awaitImpatiently(): ByteArray {
+            if (!writerJob.isCompleted)
+                writerJob.channel.cancel(SaveBodyAbandonedReadException())
+            return savedResponse.await()
+        }
+    }
 }
+
+/**
+ * Thrown when a second attempt to read the body is made while the first call is blocked.
+ */
+public class SaveBodyAbandonedReadException: RuntimeException("Save body abandoned")

--- a/ktor-client/ktor-client-plugins/ktor-client-encoding/common/src/ContentEncoding.kt
+++ b/ktor-client/ktor-client-plugins/ktor-client-encoding/common/src/ContentEncoding.kt
@@ -108,7 +108,7 @@ public val ContentEncoding: ClientPlugin<ContentEncodingConfig> =
             }
         }
 
-        fun CoroutineScope.decode(response: HttpResponse, content: ByteReadChannel): HttpResponse {
+        fun CoroutineScope.decode(response: HttpResponse): HttpResponse {
             val encodings = response.headers[HttpHeaders.ContentEncoding]?.split(",")?.map { it.trim().lowercase() }
                 ?: run {
                     LOGGER.trace(
@@ -118,7 +118,7 @@ public val ContentEncoding: ClientPlugin<ContentEncodingConfig> =
                     return response
                 }
 
-            var current = content
+            var current = response.content
             for (encoding in encodings.reversed()) {
                 val encoder: Encoder = encoders[encoding] ?: throw UnsupportedContentEncodingException(encoding)
 
@@ -177,7 +177,7 @@ public val ContentEncoding: ClientPlugin<ContentEncodingConfig> =
             if (contentLength == 0L) return@on null
             if (contentLength == null && method == HttpMethod.Head) return@on null
 
-            return@on response.call.decode(response, response.content)
+            return@on response.call.decode(response)
         }
     }
 

--- a/ktor-client/ktor-client-plugins/ktor-client-encoding/common/test/ContentEncodingTest.kt
+++ b/ktor-client/ktor-client-plugins/ktor-client-encoding/common/test/ContentEncodingTest.kt
@@ -109,4 +109,16 @@ class ContentEncodingTest : ClientLoader() {
             assertEquals("gzip", response.headers[HttpHeaders.ContentEncoding])
         }
     }
+
+    @Test
+    fun testNoEncoding() = clientTests(listOf("OkHttp")) {
+        config {
+            install(ContentEncoding)
+        }
+
+        test { client ->
+            val response = client.get("$TEST_URL/big-plain-text")
+            assertEquals(HttpStatusCode.OK, response.status)
+        }
+    }
 }


### PR DESCRIPTION
**Subsystem**
Client, ContentEncoding, SaveBody

**Motivation**
- [KTOR-7265](https://youtrack.jetbrains.com/issue/KTOR-7265) ContentEncoding: request hangs when using 3.0.0-beta-2

**Solution**
The problem would arise when the `SaveBody` plugin's `ByteChannelReplay` would be called by two consumers and the first wouldn't read the full response.  This would cause the 
deferred result to never complete, which would make subsequent calls hang indefinitely.

The simplest solution here is to just cancel the writer on the first caller when the second tries to read.  This allows the stream to finish copying without relying on being read by the first caller.

This solution has the caveat that you can run into problems when you try accessing the response with multiple threads.  I attempted to do a much more extensive change to always do the copying up-front so we can rely on some thread safety, but this causes some other problems where streaming is expected, so I'll defer that work for a later time.