### PR TITLE
CI: Update gradle-wrapper-validation action to v4

### DIFF
--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -1,5 +1,5 @@
 name: "Validate Gradle Wrapper"
-on: [push, pull_request]
+on: [ push, pull_request ]
 
 permissions:
   contents: read #  to fetch code (actions/checkout)
@@ -10,4 +10,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: gradle/wrapper-validation-action@v3
+      - uses: gradle/actions/wrapper-validation@v4


### PR DESCRIPTION
**Subsystem**
CI

**Motivation**
The coordinate changed to gradle/actions/wrapper-validation, that's why renovatebot was unable to bump this dependency.

**Solution**
Use new coordinates.

