### PR TITLE
KTOR-3205 KTOR-7270 Naming changes for API, property module references

### DIFF
--- a/ktor-client/ktor-client-android/jvm/test/io/ktor/client/engine/android/AndroidSpecificHttpsTest.kt
+++ b/ktor-client/ktor-client-android/jvm/test/io/ktor/client/engine/android/AndroidSpecificHttpsTest.kt
@@ -27,7 +27,7 @@ import kotlin.test.Test
 class AndroidSpecificHttpsTest : TestWithKtor() {
     override val server: EmbeddedServer<*, *> = embeddedServer(
         Netty,
-        applicationProperties {
+        applicationRuntimeConfig {
             module {
                 routing {
                     get("/") {

--- a/ktor-client/ktor-client-cio/jvm/test/io/ktor/client/engine/cio/CIOSpecificHttpsTest.kt
+++ b/ktor-client/ktor-client-cio/jvm/test/io/ktor/client/engine/cio/CIOSpecificHttpsTest.kt
@@ -6,7 +6,6 @@ package io.ktor.client.engine.cio
 
 import io.ktor.client.call.*
 import io.ktor.client.request.*
-import io.ktor.client.statement.*
 import io.ktor.client.tests.utils.*
 import io.ktor.http.*
 import io.ktor.network.tls.*
@@ -30,7 +29,7 @@ class CIOSpecificHttpsTest : TestWithKtor() {
 
     override val server: EmbeddedServer<*, *> = embeddedServer(
         Netty,
-        applicationProperties {
+        applicationRuntimeConfig {
             module {
                 routing {
                     get("/") {

--- a/ktor-client/ktor-client-cio/jvm/test/io/ktor/client/engine/cio/ConnectErrorsTest.kt
+++ b/ktor-client/ktor-client-cio/jvm/test/io/ktor/client/engine/cio/ConnectErrorsTest.kt
@@ -160,7 +160,7 @@ class ConnectErrorsTest {
             val serverPort = ServerSocket(0).use { it.localPort }
             val server = embeddedServer(
                 Netty,
-                applicationProperties {
+                applicationRuntimeConfig {
                     module {
                         routing {
                             get {

--- a/ktor-client/ktor-client-core/api/ktor-client-core.api
+++ b/ktor-client/ktor-client-core/api/ktor-client-core.api
@@ -740,6 +740,10 @@ public final class io/ktor/client/plugins/cookies/HttpCookiesKt {
 	public static final fun get (Ljava/util/List;Ljava/lang/String;)Lio/ktor/http/Cookie;
 }
 
+public final class io/ktor/client/plugins/internal/SaveBodyAbandonedReadException : java/lang/RuntimeException {
+	public fun <init> ()V
+}
+
 public final class io/ktor/client/plugins/observer/DelegatedCallKt {
 	public static final fun wrap (Lio/ktor/client/call/HttpClientCall;Lio/ktor/utils/io/ByteReadChannel;Lio/ktor/http/Headers;)Lio/ktor/client/call/HttpClientCall;
 	public static final fun wrapWithContent (Lio/ktor/client/call/HttpClientCall;Lio/ktor/utils/io/ByteReadChannel;)Lio/ktor/client/call/HttpClientCall;

--- a/ktor-client/ktor-client-plugins/ktor-client-content-negotiation/ktor-client-content-negotiation-tests/jvm/src/io/ktor/client/plugins/contentnegotiation/tests/JsonContentNegotiationTest.kt
+++ b/ktor-client/ktor-client-plugins/ktor-client-content-negotiation/ktor-client-content-negotiation-tests/jvm/src/io/ktor/client/plugins/contentnegotiation/tests/JsonContentNegotiationTest.kt
@@ -25,7 +25,7 @@ abstract class JsonContentNegotiationTest(val converter: ContentConverter) {
     @Serializable
     data class Wrapper(val value: String)
 
-    fun startServer(testApplicationEngine: Application) {
+    fun startServer(testApplicationEngine: HttpServer) {
         testApplicationEngine.install(ContentNegotiation) {
             register(ContentType.Application.Json, converter)
         }

--- a/ktor-server/ktor-server-cio/jvmAndPosix/src/io/ktor/server/cio/CIO.kt
+++ b/ktor-server/ktor-server-cio/jvmAndPosix/src/io/ktor/server/cio/CIO.kt
@@ -6,6 +6,7 @@ package io.ktor.server.cio
 
 import io.ktor.events.*
 import io.ktor.server.application.*
+import io.ktor.server.application.HttpServer
 import io.ktor.server.engine.*
 
 /**
@@ -24,7 +25,7 @@ public object CIO : ApplicationEngineFactory<CIOApplicationEngine, CIOApplicatio
         monitor: Events,
         developmentMode: Boolean,
         configuration: CIOApplicationEngine.Configuration,
-        applicationProvider: () -> Application
+        applicationProvider: () -> HttpServer
     ): CIOApplicationEngine {
         return CIOApplicationEngine(environment, monitor, developmentMode, configuration, applicationProvider)
     }

--- a/ktor-server/ktor-server-cio/jvmAndPosix/src/io/ktor/server/cio/CIOApplicationCall.kt
+++ b/ktor-server/ktor-server-cio/jvmAndPosix/src/io/ktor/server/cio/CIOApplicationCall.kt
@@ -5,7 +5,7 @@
 package io.ktor.server.cio
 
 import io.ktor.http.cio.*
-import io.ktor.server.application.*
+import io.ktor.server.application.HttpServer
 import io.ktor.server.engine.*
 import io.ktor.util.network.*
 import io.ktor.utils.io.*
@@ -13,7 +13,7 @@ import kotlinx.coroutines.*
 import kotlin.coroutines.*
 
 internal class CIOApplicationCall(
-    application: Application,
+    application: HttpServer,
     _request: Request,
     input: ByteReadChannel,
     output: ByteWriteChannel,

--- a/ktor-server/ktor-server-cio/jvmAndPosix/src/io/ktor/server/cio/CIOApplicationEngine.kt
+++ b/ktor-server/ktor-server-cio/jvmAndPosix/src/io/ktor/server/cio/CIOApplicationEngine.kt
@@ -25,7 +25,7 @@ public class CIOApplicationEngine(
     monitor: Events,
     developmentMode: Boolean,
     public val configuration: Configuration,
-    private val applicationProvider: () -> Application
+    private val applicationProvider: () -> io.ktor.server.application.HttpServer
 ) : BaseApplicationEngine(environment, monitor, developmentMode) {
 
     /**

--- a/ktor-server/ktor-server-cio/jvmAndPosix/src/io/ktor/server/cio/EngineMain.kt
+++ b/ktor-server/ktor-server-cio/jvmAndPosix/src/io/ktor/server/cio/EngineMain.kt
@@ -18,9 +18,9 @@ public object EngineMain {
     @JvmStatic
     public fun main(args: Array<String>) {
         val config = CommandLineConfig(args)
-        val server = EmbeddedServer(config.applicationProperties, CIO) {
+        val server = EmbeddedServer(config.applicationRuntimeConfig, CIO) {
             takeFrom(config.engineConfig)
-            loadConfiguration(config.applicationProperties.environment.config)
+            loadConfiguration(config.applicationRuntimeConfig.environment.config)
         }
         server.start(true)
     }

--- a/ktor-server/ktor-server-core/api/ktor-server-core.api
+++ b/ktor-server/ktor-server-core/api/ktor-server-core.api
@@ -1,15 +1,5 @@
-public final class io/ktor/server/application/Application : io/ktor/server/application/ApplicationCallPipeline, kotlinx/coroutines/CoroutineScope {
-	public final fun dispose ()V
-	public fun getCoroutineContext ()Lkotlin/coroutines/CoroutineContext;
-	public final fun getEngine ()Lio/ktor/server/engine/ApplicationEngine;
-	public final fun getMonitor ()Lio/ktor/events/Events;
-	public final fun getParentCoroutineContext ()Lkotlin/coroutines/CoroutineContext;
-	public final fun getRootPath ()Ljava/lang/String;
-	public final fun setRootPath (Ljava/lang/String;)V
-}
-
 public abstract interface class io/ktor/server/application/ApplicationCall {
-	public abstract fun getApplication ()Lio/ktor/server/application/Application;
+	public abstract fun getApplication ()Lio/ktor/server/application/HttpServer;
 	public abstract fun getAttributes ()Lio/ktor/util/Attributes;
 	public abstract fun getParameters ()Lio/ktor/http/Parameters;
 	public abstract fun getRequest ()Lio/ktor/server/request/ApplicationRequest;
@@ -38,7 +28,7 @@ public final class io/ktor/server/application/ApplicationCallPipeline$Applicatio
 }
 
 public final class io/ktor/server/application/ApplicationCallPipelineKt {
-	public static final fun getApplication (Lio/ktor/util/pipeline/PipelineContext;)Lio/ktor/server/application/Application;
+	public static final fun getApplication (Lio/ktor/util/pipeline/PipelineContext;)Lio/ktor/server/application/HttpServer;
 	public static final fun getCall (Lio/ktor/util/pipeline/PipelineContext;)Lio/ktor/server/application/PipelineCall;
 }
 
@@ -52,12 +42,6 @@ public abstract interface class io/ktor/server/application/ApplicationEnvironmen
 	public abstract fun getConfig ()Lio/ktor/server/config/ApplicationConfig;
 	public abstract fun getLog ()Lorg/slf4j/Logger;
 	public abstract fun getMonitor ()Lio/ktor/events/Events;
-}
-
-public final class io/ktor/server/application/ApplicationKt {
-	public static final fun applicationProperties (Lio/ktor/server/application/ApplicationEnvironment;Lkotlin/jvm/functions/Function1;)Lio/ktor/server/application/ApplicationProperties;
-	public static synthetic fun applicationProperties$default (Lio/ktor/server/application/ApplicationEnvironment;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lio/ktor/server/application/ApplicationProperties;
-	public static final fun getLog (Lio/ktor/server/application/Application;)Lorg/slf4j/Logger;
 }
 
 public abstract interface class io/ktor/server/application/ApplicationPlugin : io/ktor/server/application/BaseApplicationPlugin {
@@ -76,14 +60,14 @@ public final class io/ktor/server/application/ApplicationPluginKt {
 	public static final fun uninstallPlugin (Lio/ktor/util/pipeline/Pipeline;Lio/ktor/util/AttributeKey;)V
 }
 
-public final class io/ktor/server/application/ApplicationProperties {
+public final class io/ktor/server/application/ApplicationRuntimeConfig {
 	public final fun getDevelopmentMode ()Z
 	public final fun getEnvironment ()Lio/ktor/server/application/ApplicationEnvironment;
 	public final fun getParentCoroutineContext ()Lkotlin/coroutines/CoroutineContext;
 	public final fun getRootPath ()Ljava/lang/String;
 }
 
-public final class io/ktor/server/application/ApplicationPropertiesBuilder {
+public final class io/ktor/server/application/ApplicationRuntimeConfigBuilder {
 	public fun <init> (Lio/ktor/server/application/ApplicationEnvironment;)V
 	public final fun getDevelopmentMode ()Z
 	public final fun getEnvironment ()Lio/ktor/server/application/ApplicationEnvironment;
@@ -138,6 +122,22 @@ public abstract interface class io/ktor/server/application/Hook {
 	public abstract fun install (Lio/ktor/server/application/ApplicationCallPipeline;Ljava/lang/Object;)V
 }
 
+public final class io/ktor/server/application/HttpServer : io/ktor/server/application/ApplicationCallPipeline, kotlinx/coroutines/CoroutineScope {
+	public final fun dispose ()V
+	public fun getCoroutineContext ()Lkotlin/coroutines/CoroutineContext;
+	public final fun getEngine ()Lio/ktor/server/engine/ApplicationEngine;
+	public final fun getMonitor ()Lio/ktor/events/Events;
+	public final fun getParentCoroutineContext ()Lkotlin/coroutines/CoroutineContext;
+	public final fun getRootPath ()Ljava/lang/String;
+	public final fun setRootPath (Ljava/lang/String;)V
+}
+
+public final class io/ktor/server/application/HttpServerKt {
+	public static final fun applicationRuntimeConfig (Lio/ktor/server/application/ApplicationEnvironment;Lkotlin/jvm/functions/Function1;)Lio/ktor/server/application/ApplicationRuntimeConfig;
+	public static synthetic fun applicationRuntimeConfig$default (Lio/ktor/server/application/ApplicationEnvironment;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lio/ktor/server/application/ApplicationRuntimeConfig;
+	public static final fun getLog (Lio/ktor/server/application/HttpServer;)Lorg/slf4j/Logger;
+}
+
 public final class io/ktor/server/application/InvalidBodyException : java/lang/Exception {
 	public fun <init> (Ljava/lang/String;)V
 }
@@ -184,7 +184,7 @@ public abstract interface class io/ktor/server/application/Plugin {
 }
 
 public abstract class io/ktor/server/application/PluginBuilder {
-	public abstract fun getApplication ()Lio/ktor/server/application/Application;
+	public abstract fun getApplication ()Lio/ktor/server/application/HttpServer;
 	public final fun getApplicationConfig ()Lio/ktor/server/config/ApplicationConfig;
 	public final fun getEnvironment ()Lio/ktor/server/application/ApplicationEnvironment;
 	public abstract fun getPluginConfig ()Ljava/lang/Object;
@@ -414,8 +414,8 @@ public final class io/ktor/server/engine/ApplicationEnvironmentBuilderKt {
 }
 
 public abstract class io/ktor/server/engine/BaseApplicationCall : io/ktor/server/application/PipelineCall {
-	public fun <init> (Lio/ktor/server/application/Application;)V
-	public final fun getApplication ()Lio/ktor/server/application/Application;
+	public fun <init> (Lio/ktor/server/application/HttpServer;)V
+	public final fun getApplication ()Lio/ktor/server/application/HttpServer;
 	public final fun getAttributes ()Lio/ktor/util/Attributes;
 	public fun getParameters ()Lio/ktor/http/Parameters;
 	public abstract fun getRequest ()Lio/ktor/server/engine/BaseApplicationRequest;
@@ -504,8 +504,8 @@ public final class io/ktor/server/engine/BaseApplicationResponse$ResponseAlready
 }
 
 public final class io/ktor/server/engine/CommandLineConfig {
-	public fun <init> (Lio/ktor/server/application/ApplicationProperties;Lio/ktor/server/engine/BaseApplicationEngine$Configuration;)V
-	public final fun getApplicationProperties ()Lio/ktor/server/application/ApplicationProperties;
+	public fun <init> (Lio/ktor/server/application/ApplicationRuntimeConfig;Lio/ktor/server/engine/BaseApplicationEngine$Configuration;)V
+	public final fun getApplicationRuntimeConfig ()Lio/ktor/server/application/ApplicationRuntimeConfig;
 	public final fun getEngineConfig ()Lio/ktor/server/engine/BaseApplicationEngine$Configuration;
 	public final fun getEnvironment ()Lio/ktor/server/application/ApplicationEnvironment;
 }
@@ -571,9 +571,9 @@ public final class io/ktor/server/engine/DefaultUncaughtExceptionHandler : kotli
 }
 
 public final class io/ktor/server/engine/EmbeddedServer {
-	public fun <init> (Lio/ktor/server/application/ApplicationProperties;Lio/ktor/server/engine/ApplicationEngineFactory;Lkotlin/jvm/functions/Function1;)V
-	public synthetic fun <init> (Lio/ktor/server/application/ApplicationProperties;Lio/ktor/server/engine/ApplicationEngineFactory;Lkotlin/jvm/functions/Function1;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun getApplication ()Lio/ktor/server/application/Application;
+	public fun <init> (Lio/ktor/server/application/ApplicationRuntimeConfig;Lio/ktor/server/engine/ApplicationEngineFactory;Lkotlin/jvm/functions/Function1;)V
+	public synthetic fun <init> (Lio/ktor/server/application/ApplicationRuntimeConfig;Lio/ktor/server/engine/ApplicationEngineFactory;Lkotlin/jvm/functions/Function1;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getApplication ()Lio/ktor/server/application/HttpServer;
 	public final fun getEngine ()Lio/ktor/server/engine/ApplicationEngine;
 	public final fun getEngineConfig ()Lio/ktor/server/engine/ApplicationEngine$Configuration;
 	public final fun getEnvironment ()Lio/ktor/server/application/ApplicationEnvironment;
@@ -589,12 +589,12 @@ public final class io/ktor/server/engine/EmbeddedServer {
 public final class io/ktor/server/engine/EmbeddedServerKt {
 	public static final fun embeddedServer (Lio/ktor/server/engine/ApplicationEngineFactory;ILjava/lang/String;Ljava/util/List;Lkotlin/jvm/functions/Function1;)Lio/ktor/server/engine/EmbeddedServer;
 	public static final fun embeddedServer (Lio/ktor/server/engine/ApplicationEngineFactory;Lio/ktor/server/application/ApplicationEnvironment;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Lio/ktor/server/engine/EmbeddedServer;
-	public static final fun embeddedServer (Lio/ktor/server/engine/ApplicationEngineFactory;Lio/ktor/server/application/ApplicationProperties;Lkotlin/jvm/functions/Function1;)Lio/ktor/server/engine/EmbeddedServer;
+	public static final fun embeddedServer (Lio/ktor/server/engine/ApplicationEngineFactory;Lio/ktor/server/application/ApplicationRuntimeConfig;Lkotlin/jvm/functions/Function1;)Lio/ktor/server/engine/EmbeddedServer;
 	public static final fun embeddedServer (Lkotlinx/coroutines/CoroutineScope;Lio/ktor/server/engine/ApplicationEngineFactory;ILjava/lang/String;Ljava/util/List;Lkotlin/coroutines/CoroutineContext;Lkotlin/jvm/functions/Function1;)Lio/ktor/server/engine/EmbeddedServer;
 	public static final fun embeddedServer (Lkotlinx/coroutines/CoroutineScope;Lio/ktor/server/engine/ApplicationEngineFactory;[Lio/ktor/server/engine/EngineConnectorConfig;Ljava/util/List;Lkotlin/coroutines/CoroutineContext;Lkotlin/jvm/functions/Function1;)Lio/ktor/server/engine/EmbeddedServer;
 	public static synthetic fun embeddedServer$default (Lio/ktor/server/engine/ApplicationEngineFactory;ILjava/lang/String;Ljava/util/List;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lio/ktor/server/engine/EmbeddedServer;
 	public static synthetic fun embeddedServer$default (Lio/ktor/server/engine/ApplicationEngineFactory;Lio/ktor/server/application/ApplicationEnvironment;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lio/ktor/server/engine/EmbeddedServer;
-	public static synthetic fun embeddedServer$default (Lio/ktor/server/engine/ApplicationEngineFactory;Lio/ktor/server/application/ApplicationProperties;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lio/ktor/server/engine/EmbeddedServer;
+	public static synthetic fun embeddedServer$default (Lio/ktor/server/engine/ApplicationEngineFactory;Lio/ktor/server/application/ApplicationRuntimeConfig;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lio/ktor/server/engine/EmbeddedServer;
 	public static synthetic fun embeddedServer$default (Lkotlinx/coroutines/CoroutineScope;Lio/ktor/server/engine/ApplicationEngineFactory;ILjava/lang/String;Ljava/util/List;Lkotlin/coroutines/CoroutineContext;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lio/ktor/server/engine/EmbeddedServer;
 	public static synthetic fun embeddedServer$default (Lkotlinx/coroutines/CoroutineScope;Lio/ktor/server/engine/ApplicationEngineFactory;[Lio/ktor/server/engine/EngineConnectorConfig;Ljava/util/List;Lkotlin/coroutines/CoroutineContext;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lio/ktor/server/engine/EmbeddedServer;
 }
@@ -628,8 +628,8 @@ public final class io/ktor/server/engine/EngineConnectorConfigKt {
 
 public final class io/ktor/server/engine/EngineContextCancellationHelperKt {
 	public static final fun launchOnCancellation (Lkotlinx/coroutines/Job;Lkotlin/jvm/functions/Function1;)Lkotlinx/coroutines/CompletableJob;
-	public static final fun stopServerOnCancellation (Lio/ktor/server/engine/ApplicationEngine;Lio/ktor/server/application/Application;JJ)Lkotlinx/coroutines/CompletableJob;
-	public static synthetic fun stopServerOnCancellation$default (Lio/ktor/server/engine/ApplicationEngine;Lio/ktor/server/application/Application;JJILjava/lang/Object;)Lkotlinx/coroutines/CompletableJob;
+	public static final fun stopServerOnCancellation (Lio/ktor/server/engine/ApplicationEngine;Lio/ktor/server/application/HttpServer;JJ)Lkotlinx/coroutines/CompletableJob;
+	public static synthetic fun stopServerOnCancellation$default (Lio/ktor/server/engine/ApplicationEngine;Lio/ktor/server/application/HttpServer;JJILjava/lang/Object;)Lkotlinx/coroutines/CompletableJob;
 }
 
 public final class io/ktor/server/engine/EnginePipeline : io/ktor/util/pipeline/Pipeline {
@@ -891,7 +891,7 @@ public final class io/ktor/server/http/content/SuppressionAttributeKt {
 }
 
 public final class io/ktor/server/logging/LoggingKt {
-	public static final fun getMdcProvider (Lio/ktor/server/application/Application;)Lio/ktor/server/logging/MDCProvider;
+	public static final fun getMdcProvider (Lio/ktor/server/application/HttpServer;)Lio/ktor/server/logging/MDCProvider;
 	public static final fun toLogString (Lio/ktor/server/request/ApplicationRequest;)Ljava/lang/String;
 }
 
@@ -1627,7 +1627,7 @@ public final class io/ktor/server/routing/RoutingBuilderKt {
 }
 
 public final class io/ktor/server/routing/RoutingCall : io/ktor/server/application/ApplicationCall {
-	public fun getApplication ()Lio/ktor/server/application/Application;
+	public fun getApplication ()Lio/ktor/server/application/HttpServer;
 	public fun getAttributes ()Lio/ktor/util/Attributes;
 	public fun getParameters ()Lio/ktor/http/Parameters;
 	public final fun getPathParameters ()Lio/ktor/http/Parameters;
@@ -1644,7 +1644,7 @@ public final class io/ktor/server/routing/RoutingCall : io/ktor/server/applicati
 
 public final class io/ktor/server/routing/RoutingContext {
 	public fun <init> (Lio/ktor/server/routing/RoutingCall;)V
-	public final fun getApplication ()Lio/ktor/server/application/Application;
+	public final fun getApplication ()Lio/ktor/server/application/HttpServer;
 	public final fun getCall ()Lio/ktor/server/routing/RoutingCall;
 }
 
@@ -1707,7 +1707,7 @@ public final class io/ktor/server/routing/RoutingPathSegmentKind : java/lang/Enu
 
 public final class io/ktor/server/routing/RoutingPipelineCall : io/ktor/server/application/PipelineCall, kotlinx/coroutines/CoroutineScope {
 	public fun <init> (Lio/ktor/server/application/PipelineCall;Lio/ktor/server/routing/RoutingNode;Lkotlin/coroutines/CoroutineContext;Lio/ktor/server/request/ApplicationReceivePipeline;Lio/ktor/server/response/ApplicationSendPipeline;Lio/ktor/http/Parameters;)V
-	public fun getApplication ()Lio/ktor/server/application/Application;
+	public fun getApplication ()Lio/ktor/server/application/HttpServer;
 	public fun getAttributes ()Lio/ktor/util/Attributes;
 	public fun getCoroutineContext ()Lkotlin/coroutines/CoroutineContext;
 	public final fun getEngineCall ()Lio/ktor/server/application/PipelineCall;
@@ -1839,8 +1839,8 @@ public final class io/ktor/server/routing/RoutingResponse : io/ktor/server/respo
 
 public final class io/ktor/server/routing/RoutingRoot : io/ktor/server/routing/RoutingNode, io/ktor/server/routing/Routing {
 	public static final field Plugin Lio/ktor/server/routing/RoutingRoot$Plugin;
-	public fun <init> (Lio/ktor/server/application/Application;)V
-	public final fun getApplication ()Lio/ktor/server/application/Application;
+	public fun <init> (Lio/ktor/server/application/HttpServer;)V
+	public final fun getApplication ()Lio/ktor/server/application/HttpServer;
 	public final fun interceptor (Lio/ktor/util/pipeline/PipelineContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun trace (Lkotlin/jvm/functions/Function1;)V
 }
@@ -1849,14 +1849,14 @@ public final class io/ktor/server/routing/RoutingRoot$Plugin : io/ktor/server/ap
 	public fun getKey ()Lio/ktor/util/AttributeKey;
 	public final fun getRoutingCallFinished ()Lio/ktor/events/EventDefinition;
 	public final fun getRoutingCallStarted ()Lio/ktor/events/EventDefinition;
-	public fun install (Lio/ktor/server/application/Application;Lkotlin/jvm/functions/Function1;)Lio/ktor/server/routing/RoutingRoot;
+	public fun install (Lio/ktor/server/application/HttpServer;Lkotlin/jvm/functions/Function1;)Lio/ktor/server/routing/RoutingRoot;
 	public synthetic fun install (Lio/ktor/util/pipeline/Pipeline;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
 }
 
 public final class io/ktor/server/routing/RoutingRootKt {
-	public static final fun getApplication (Lio/ktor/server/routing/Route;)Lio/ktor/server/application/Application;
+	public static final fun getApplication (Lio/ktor/server/routing/Route;)Lio/ktor/server/application/HttpServer;
 	public static final fun getRoutingFailureStatusCode ()Lio/ktor/util/AttributeKey;
-	public static final fun routing (Lio/ktor/server/application/Application;Lkotlin/jvm/functions/Function1;)Lio/ktor/server/routing/RoutingRoot;
+	public static final fun routing (Lio/ktor/server/application/HttpServer;Lkotlin/jvm/functions/Function1;)Lio/ktor/server/routing/RoutingRoot;
 }
 
 public final class io/ktor/server/routing/TrailingSlashRouteSelector : io/ktor/server/routing/RouteSelector {

--- a/ktor-server/ktor-server-core/common/src/io/ktor/server/application/ApplicationCallPipeline.kt
+++ b/ktor-server/ktor-server-core/common/src/io/ktor/server/application/ApplicationCallPipeline.kt
@@ -81,4 +81,4 @@ public inline val PipelineContext<*, PipelineCall>.call: PipelineCall get() = co
 /**
  * Current application for the context
  */
-public val PipelineContext<*, PipelineCall>.application: Application get() = call.application
+public val PipelineContext<*, PipelineCall>.application: HttpServer get() = call.application

--- a/ktor-server/ktor-server-core/common/src/io/ktor/server/application/ApplicationEvents.kt
+++ b/ktor-server/ktor-server-core/common/src/io/ktor/server/application/ApplicationEvents.kt
@@ -5,7 +5,7 @@
 package io.ktor.server.application
 
 /**
- * Provides events for [Application] lifecycle.
+ * Provides events for [HttpServer] lifecycle.
  */
 @Deprecated(
     "ApplicationEvents has been renamed to Events.",

--- a/ktor-server/ktor-server-core/common/src/io/ktor/server/application/ApplicationPlugin.kt
+++ b/ktor-server/ktor-server-core/common/src/io/ktor/server/application/ApplicationPlugin.kt
@@ -51,7 +51,7 @@ public interface BaseApplicationPlugin<
  * @param TConfiguration is the configuration object type for this Plugin
  */
 public interface ApplicationPlugin<out TConfiguration : Any> :
-    BaseApplicationPlugin<Application, TConfiguration, PluginInstance>
+    BaseApplicationPlugin<HttpServer, TConfiguration, PluginInstance>
 
 internal val pluginRegistryKey = AttributeKey<Attributes>("ApplicationPluginRegistry")
 

--- a/ktor-server/ktor-server-core/common/src/io/ktor/server/application/CommonApplicationEnvironment.kt
+++ b/ktor-server/ktor-server-core/common/src/io/ktor/server/application/CommonApplicationEnvironment.kt
@@ -11,7 +11,7 @@ import io.ktor.util.logging.*
 import kotlin.coroutines.*
 
 /**
- * Represents an environment in which [Application] runs
+ * Represents an environment in which [HttpServer] runs
  */
 public expect interface ApplicationEnvironment {
 
@@ -21,7 +21,7 @@ public expect interface ApplicationEnvironment {
     public val log: Logger
 
     /**
-     * Configuration for the [Application]
+     * Configuration for the [HttpServer]
      */
     public val config: ApplicationConfig
 
@@ -37,7 +37,7 @@ public expect interface ApplicationEnvironment {
 }
 
 internal expect class ApplicationPropertiesBridge(
-    applicationProperties: ApplicationProperties,
+    applicationRuntimeConfig: ApplicationRuntimeConfig,
     parentCoroutineContext: CoroutineContext
 ) {
     internal val parentCoroutineContext: CoroutineContext

--- a/ktor-server/ktor-server-core/common/src/io/ktor/server/application/CreatePluginUtils.kt
+++ b/ktor-server/ktor-server-core/common/src/io/ktor/server/application/CreatePluginUtils.kt
@@ -10,7 +10,7 @@ import io.ktor.util.*
 import io.ktor.util.pipeline.*
 
 /**
- * Creates an [ApplicationPlugin] that can be installed into an [Application].
+ * Creates an [ApplicationPlugin] that can be installed into an [HttpServer].
  *
  * The example below creates a plugin that prints a requested URL each time your application receives a call:
  * ```
@@ -28,9 +28,9 @@ import io.ktor.util.pipeline.*
  * @param name A name of a plugin that is used to get its instance.
  * @param configurationPath is path in configuration file to configuration of this plugin.
  * @param createConfiguration Defines how the initial [PluginConfigT] of your new plugin can be created.
- * Note that it may be modified later when a user of your plugin calls [Application.install].
+ * Note that it may be modified later when a user of your plugin calls [HttpServer.install].
  * @param body Allows you to define handlers ([onCall], [onCallReceive], [onCallRespond] and so on) that
- * can modify the behaviour of an [Application] where your plugin is installed.
+ * can modify the behaviour of an [HttpServer] where your plugin is installed.
  **/
 public fun <PluginConfigT : Any> createApplicationPlugin(
     name: String,
@@ -41,7 +41,7 @@ public fun <PluginConfigT : Any> createApplicationPlugin(
     override val key: AttributeKey<PluginInstance> = AttributeKey(name)
 
     override fun install(
-        pipeline: Application,
+        pipeline: HttpServer,
         configure: PluginConfigT.() -> Unit
     ): PluginInstance {
         val config = try {
@@ -54,7 +54,7 @@ public fun <PluginConfigT : Any> createApplicationPlugin(
 }
 
 /**
- * Creates an [ApplicationPlugin] that can be installed into an [Application].
+ * Creates an [ApplicationPlugin] that can be installed into an [HttpServer].
  *
  * The example below creates a plugin that prints a requested URL each time your application receives a call:
  * ```
@@ -71,9 +71,9 @@ public fun <PluginConfigT : Any> createApplicationPlugin(
  *
  * @param name A name of a plugin that is used to get its instance.
  * @param createConfiguration Defines how the initial [PluginConfigT] of your new plugin can be created.
- * Note that it may be modified later when a user of your plugin calls [Application.install].
+ * Note that it may be modified later when a user of your plugin calls [HttpServer.install].
  * @param body Allows you to define handlers ([onCall], [onCallReceive], [onCallRespond] and so on) that
- * can modify the behaviour of an [Application] where your plugin is installed.
+ * can modify the behaviour of an [HttpServer] where your plugin is installed.
  *
  **/
 public fun <PluginConfigT : Any> createApplicationPlugin(
@@ -84,7 +84,7 @@ public fun <PluginConfigT : Any> createApplicationPlugin(
     override val key: AttributeKey<PluginInstance> = AttributeKey(name)
 
     override fun install(
-        pipeline: Application,
+        pipeline: HttpServer,
         configure: PluginConfigT.() -> Unit
     ): PluginInstance {
         return createPluginInstance(pipeline, pipeline, body, createConfiguration, configure)
@@ -114,7 +114,7 @@ public fun <PluginConfigT : Any> createApplicationPlugin(
  * @param createConfiguration Defines how the initial [PluginConfigT] of your new plugin can be created. Please
  * note that it may be modified later when a user of your plugin calls [install].
  * @param body Allows you to define handlers ([onCall], [onCallReceive], [onCallRespond] and so on) that
- * can modify the behaviour of an [Application] where your plugin is installed.
+ * can modify the behaviour of an [HttpServer] where your plugin is installed.
  **/
 public fun <PluginConfigT : Any> createRouteScopedPlugin(
     name: String,
@@ -130,7 +130,7 @@ public fun <PluginConfigT : Any> createRouteScopedPlugin(
     ): PluginInstance {
         val application = when (pipeline) {
             is RoutingNode -> pipeline.application
-            is Application -> pipeline
+            is HttpServer -> pipeline
             else -> error("Unsupported pipeline type: ${pipeline::class}")
         }
 
@@ -162,7 +162,7 @@ public fun <PluginConfigT : Any> createRouteScopedPlugin(
  * @param createConfiguration Defines how the initial [PluginConfigT] of your new plugin can be created. Please
  * note that it may be modified later when a user of your plugin calls [install].
  * @param body Allows you to define handlers ([onCall], [onCallReceive], [onCallRespond] and so on) that
- * can modify the behaviour of an [Application] where your plugin is installed.
+ * can modify the behaviour of an [HttpServer] where your plugin is installed.
  **/
 public fun <PluginConfigT : Any> createRouteScopedPlugin(
     name: String,
@@ -187,7 +187,7 @@ public fun <PluginConfigT : Any> createRouteScopedPlugin(
 
         val application = when (pipeline) {
             is RoutingNode -> pipeline.application
-            is Application -> pipeline
+            is HttpServer -> pipeline
             else -> error("Unsupported pipeline type: ${pipeline::class}")
         }
 
@@ -196,7 +196,7 @@ public fun <PluginConfigT : Any> createRouteScopedPlugin(
 }
 
 /**
- * Creates an [ApplicationPlugin] that can be installed into an [Application].
+ * Creates an [ApplicationPlugin] that can be installed into an [HttpServer].
  *
  * The example below creates a plugin that prints a requested URL each time your application receives a call:
  * ```
@@ -211,9 +211,9 @@ public fun <PluginConfigT : Any> createRouteScopedPlugin(
  *
  * You can learn more from [Custom plugins](https://ktor.io/docs/custom-plugins.html).
  *
- * @param name A name of a plugin that is used to get an instance of the plugin installed to the [Application].
+ * @param name A name of a plugin that is used to get an instance of the plugin installed to the [HttpServer].
  * @param body Allows you to define handlers ([onCall], [onCallReceive], [onCallRespond] and so on) that
- * can modify the behaviour of an [Application] where your plugin is installed.
+ * can modify the behaviour of an [HttpServer] where your plugin is installed.
  **/
 public fun createApplicationPlugin(
     name: String,
@@ -240,7 +240,7 @@ public fun createApplicationPlugin(
  *
  * @param name A name of a plugin that is used to get an instance of the plugin installed to the [io.ktor.server.routing.RoutingNode].
  * @param body Allows you to define handlers ([onCall], [onCallReceive], [onCallRespond] and so on) that
- * can modify the behaviour of an [Application] where your plugin is installed.
+ * can modify the behaviour of an [HttpServer] where your plugin is installed.
  **/
 public fun createRouteScopedPlugin(
     name: String,
@@ -251,7 +251,7 @@ private fun <
     PipelineT : ApplicationCallPipeline,
     PluginConfigT : Any
     > Plugin<PipelineT, PluginConfigT, PluginInstance>.createPluginInstance(
-    application: Application,
+    application: HttpServer,
     pipeline: ApplicationCallPipeline,
     body: PluginBuilder<PluginConfigT>.() -> Unit,
     createConfiguration: () -> PluginConfigT,
@@ -261,7 +261,7 @@ private fun <
 
     val currentPlugin = this
     val pluginBuilder = object : PluginBuilder<PluginConfigT>(currentPlugin.key) {
-        override val application: Application = application
+        override val application: HttpServer = application
         override val pipeline: ApplicationCallPipeline = pipeline
         override val pluginConfig: PluginConfigT = config
     }
@@ -274,7 +274,7 @@ private fun <
     PipelineT : ApplicationCallPipeline,
     PluginConfigT : Any
     > Plugin<PipelineT, PluginConfigT, PluginInstance>.createRouteScopedPluginInstance(
-    application: Application,
+    application: HttpServer,
     pipeline: ApplicationCallPipeline,
     body: RouteScopedPluginBuilder<PluginConfigT>.() -> Unit,
     createConfiguration: () -> PluginConfigT,
@@ -284,7 +284,7 @@ private fun <
 
     val currentPlugin = this
     val pluginBuilder = object : RouteScopedPluginBuilder<PluginConfigT>(currentPlugin.key) {
-        override val application: Application = application
+        override val application: HttpServer = application
         override val pipeline: ApplicationCallPipeline = pipeline
         override val pluginConfig: PluginConfigT = config
         override val route: RoutingNode? = pipeline as? RoutingNode

--- a/ktor-server/ktor-server-core/common/src/io/ktor/server/application/DefaultApplicationEvents.kt
+++ b/ktor-server/ktor-server-core/common/src/io/ktor/server/application/DefaultApplicationEvents.kt
@@ -7,7 +7,6 @@
 package io.ktor.server.application
 
 import io.ktor.events.EventDefinition
-import kotlin.native.concurrent.*
 
 /**
  * Event definition for Application Starting event
@@ -15,12 +14,12 @@ import kotlin.native.concurrent.*
  * Note, that application itself cannot receive this event because it fires before application is created
  * It is meant to be used by engines.
  */
-public val ApplicationStarting: EventDefinition<Application> = EventDefinition()
+public val ApplicationStarting: EventDefinition<HttpServer> = EventDefinition()
 
 /**
  * Event definition for Application Started event
  */
-public val ApplicationStarted: EventDefinition<Application> = EventDefinition()
+public val ApplicationStarted: EventDefinition<HttpServer> = EventDefinition()
 
 /**
  * Fired when the server is ready to accept connections
@@ -35,9 +34,9 @@ public val ApplicationStopPreparing: EventDefinition<ApplicationEnvironment> = E
 /**
  * Event definition for Application Stopping event
  */
-public val ApplicationStopping: EventDefinition<Application> = EventDefinition()
+public val ApplicationStopping: EventDefinition<HttpServer> = EventDefinition()
 
 /**
  * Event definition for Application Stopped event
  */
-public val ApplicationStopped: EventDefinition<Application> = EventDefinition()
+public val ApplicationStopped: EventDefinition<HttpServer> = EventDefinition()

--- a/ktor-server/ktor-server-core/common/src/io/ktor/server/application/PipelineCall.kt
+++ b/ktor-server/ktor-server-core/common/src/io/ktor/server/application/PipelineCall.kt
@@ -39,7 +39,7 @@ public interface ApplicationCall {
     /**
      * An application being called.
      */
-    public val application: Application
+    public val application: HttpServer
 
     /**
      * Parameters associated with this call.

--- a/ktor-server/ktor-server-core/common/src/io/ktor/server/application/PluginBuilder.kt
+++ b/ktor-server/ktor-server-core/common/src/io/ktor/server/application/PluginBuilder.kt
@@ -24,9 +24,9 @@ public abstract class PluginBuilder<PluginConfig : Any> internal constructor(
 ) {
 
     /**
-     * A reference to the [Application] where the plugin is installed.
+     * A reference to the [HttpServer] where the plugin is installed.
      */
-    public abstract val application: Application
+    public abstract val application: HttpServer
 
     /**
      * A configuration of the current plugin.

--- a/ktor-server/ktor-server-core/common/src/io/ktor/server/application/RouteScopedPluginBuilder.kt
+++ b/ktor-server/ktor-server-core/common/src/io/ktor/server/application/RouteScopedPluginBuilder.kt
@@ -14,7 +14,7 @@ public abstract class RouteScopedPluginBuilder<PluginConfig : Any>(key: Attribut
     PluginBuilder<PluginConfig>(key) {
 
     /**
-     * A [RoutingNode] to which this plugin was installed. Can be `null` if plugin in installed into [Application].
+     * A [RoutingNode] to which this plugin was installed. Can be `null` if plugin in installed into [HttpServer].
      **/
     public abstract val route: RoutingNode?
 }

--- a/ktor-server/ktor-server-core/common/src/io/ktor/server/application/hooks/CommonHooks.kt
+++ b/ktor-server/ktor-server-core/common/src/io/ktor/server/application/hooks/CommonHooks.kt
@@ -53,14 +53,14 @@ public object CallFailed : Hook<suspend (call: ApplicationCall, cause: Throwable
 }
 
 /**
- * A shortcut hook for [Application.monitor] subscription.
+ * A shortcut hook for [HttpServer.monitor] subscription.
  */
 public class MonitoringEvent<Param : Any, Event : EventDefinition<Param>>(
     private val event: Event
 ) : Hook<(Param) -> Unit> {
     override fun install(pipeline: ApplicationCallPipeline, handler: (Param) -> Unit) {
         val application = when (pipeline) {
-            is Application -> pipeline
+            is HttpServer -> pipeline
             is Route -> pipeline.application
             else -> error("Unsupported pipeline: $pipeline")
         }

--- a/ktor-server/ktor-server-core/common/src/io/ktor/server/engine/BaseApplicationCall.kt
+++ b/ktor-server/ktor-server-core/common/src/io/ktor/server/engine/BaseApplicationCall.kt
@@ -11,7 +11,7 @@ import io.ktor.util.*
 /**
  * Base class for implementing an [PipelineCall].
  */
-public abstract class BaseApplicationCall(final override val application: Application) : PipelineCall {
+public abstract class BaseApplicationCall(final override val application: HttpServer) : PipelineCall {
     public final override val attributes: Attributes = Attributes()
     override val parameters: Parameters get() = request.queryParameters
 

--- a/ktor-server/ktor-server-core/common/src/io/ktor/server/engine/BaseApplicationEngine.kt
+++ b/ktor-server/ktor-server-core/common/src/io/ktor/server/engine/BaseApplicationEngine.kt
@@ -89,7 +89,7 @@ private class StartupInfo {
 }
 
 @OptIn(InternalAPI::class)
-private fun Application.installDefaultInterceptors() {
+private fun HttpServer.installDefaultInterceptors() {
     intercept(ApplicationCallPipeline.Fallback) {
         if (call.isHandled) return@intercept
 
@@ -105,7 +105,7 @@ private fun Application.installDefaultInterceptors() {
     }
 }
 
-private fun Application.installDefaultTransformationChecker() {
+private fun HttpServer.installDefaultTransformationChecker() {
     // Respond with "415 Unsupported Media Type" if content cannot be transformed on receive
     intercept(ApplicationCallPipeline.Plugins) {
         try {

--- a/ktor-server/ktor-server-core/common/src/io/ktor/server/engine/CommandLine.kt
+++ b/ktor-server/ktor-server-core/common/src/io/ktor/server/engine/CommandLine.kt
@@ -10,10 +10,10 @@ import io.ktor.util.*
 import io.ktor.util.logging.*
 
 public class CommandLineConfig(
-    public val applicationProperties: ApplicationProperties,
+    public val applicationRuntimeConfig: ApplicationRuntimeConfig,
     public val engineConfig: BaseApplicationEngine.Configuration
 ) {
-    public val environment: ApplicationEnvironment = applicationProperties.environment
+    public val environment: ApplicationEnvironment = applicationRuntimeConfig.environment
 }
 
 public object ConfigKeys {
@@ -50,7 +50,7 @@ public fun CommandLineConfig(args: Array<String>): CommandLineConfig {
         config = configuration
     }
 
-    val applicationProperties = applicationProperties(environment) {
+    val applicationProperties = applicationRuntimeConfig(environment) {
         rootPath = argumentsMap["-path"] ?: configuration.tryGetString(ConfigKeys.rootPathPath) ?: ""
         developmentMode = configuration.tryGetString(ConfigKeys.developmentModeKey)
             ?.let { it.toBoolean() } ?: PlatformUtils.IS_DEVELOPMENT_MODE

--- a/ktor-server/ktor-server-core/common/src/io/ktor/server/engine/EngineContextCancellationHelper.kt
+++ b/ktor-server/ktor-server-core/common/src/io/ktor/server/engine/EngineContextCancellationHelper.kt
@@ -14,7 +14,7 @@ import kotlinx.coroutines.*
  */
 @OptIn(InternalAPI::class)
 public fun ApplicationEngine.stopServerOnCancellation(
-    application: Application,
+    application: HttpServer,
     gracePeriodMillis: Long = 50,
     timeoutMillis: Long = 5000
 ): CompletableJob =

--- a/ktor-server/ktor-server-core/common/src/io/ktor/server/logging/Logging.kt
+++ b/ktor-server/ktor-server-core/common/src/io/ktor/server/logging/Logging.kt
@@ -32,7 +32,7 @@ private object EmptyMDCProvider : MDCProvider {
  * Returns first instance of a plugin that implements [MDCProvider]
  * or default implementation with an empty context
  */
-public val Application.mdcProvider: MDCProvider
+public val HttpServer.mdcProvider: MDCProvider
     @Suppress("UNCHECKED_CAST")
     get() = pluginRegistry.allKeys
         .firstNotNullOfOrNull { pluginRegistry.getOrNull(it as AttributeKey<Any>) as? MDCProvider }

--- a/ktor-server/ktor-server-core/common/src/io/ktor/server/routing/IgnoreTrailingSlash.kt
+++ b/ktor-server/ktor-server-core/common/src/io/ktor/server/routing/IgnoreTrailingSlash.kt
@@ -19,7 +19,7 @@ internal var ApplicationCall.ignoreTrailingSlash: Boolean
 
 /**
  * A plugin that enables ignoring a trailing slash when resolving URLs.
- * @see [Application.routing]
+ * @see [HttpServer.routing]
  */
 public val IgnoreTrailingSlash: ApplicationPlugin<Unit> = createApplicationPlugin("IgnoreTrailingSlash") {
     onCall { call ->

--- a/ktor-server/ktor-server-core/common/src/io/ktor/server/routing/RoutingBuilder.kt
+++ b/ktor-server/ktor-server-core/common/src/io/ktor/server/routing/RoutingBuilder.kt
@@ -14,7 +14,7 @@ import kotlin.jvm.*
 
 /**
  * Builds a route to match the specified [path].
- * @see [Application.routing]
+ * @see [HttpServer.routing]
  */
 @KtorDsl
 public fun Route.route(path: String, build: Route.() -> Unit): Route =
@@ -22,7 +22,7 @@ public fun Route.route(path: String, build: Route.() -> Unit): Route =
 
 /**
  * Builds a route to match the specified HTTP [method] and [path].
- * @see [Application.routing]
+ * @see [HttpServer.routing]
  */
 @KtorDsl
 public fun Route.route(path: String, method: HttpMethod, build: Route.() -> Unit): Route {
@@ -32,7 +32,7 @@ public fun Route.route(path: String, method: HttpMethod, build: Route.() -> Unit
 
 /**
  * Builds a route to match the specified HTTP [method].
- * @see [Application.routing]
+ * @see [HttpServer.routing]
  */
 @KtorDsl
 public fun Route.method(method: HttpMethod, body: Route.() -> Unit): Route {
@@ -42,7 +42,7 @@ public fun Route.method(method: HttpMethod, body: Route.() -> Unit): Route {
 
 /**
  * Builds a route to match a parameter with the specified [name] and [value].
- * @see [Application.routing]
+ * @see [HttpServer.routing]
  */
 @KtorDsl
 public fun Route.param(name: String, value: String, build: Route.() -> Unit): Route {
@@ -52,7 +52,7 @@ public fun Route.param(name: String, value: String, build: Route.() -> Unit): Ro
 
 /**
  * Builds a route to match a parameter with the specified [name] and captures its value.
- * @see [Application.routing]
+ * @see [HttpServer.routing]
  */
 @KtorDsl
 public fun Route.param(name: String, build: Route.() -> Unit): Route {
@@ -62,7 +62,7 @@ public fun Route.param(name: String, build: Route.() -> Unit): Route {
 
 /**
  * Builds a route to capture an optional parameter with specified [name], if it exists.
- * @see [Application.routing]
+ * @see [HttpServer.routing]
  */
 @KtorDsl
 public fun Route.optionalParam(name: String, build: Route.() -> Unit): Route {
@@ -72,7 +72,7 @@ public fun Route.optionalParam(name: String, build: Route.() -> Unit): Route {
 
 /**
  * Builds a route to match a header with the specified [name] and [value].
- * @see [Application.routing]
+ * @see [HttpServer.routing]
  */
 @KtorDsl
 public fun Route.header(name: String, value: String, build: Route.() -> Unit): Route {
@@ -82,7 +82,7 @@ public fun Route.header(name: String, value: String, build: Route.() -> Unit): R
 
 /**
  * Builds a route to match requests with the [HttpHeaders.Accept] header matching any of the specified [contentTypes].
- * @see [Application.routing]
+ * @see [HttpServer.routing]
  */
 @KtorDsl
 public fun Route.accept(vararg contentTypes: ContentType, build: Route.() -> Unit): Route {
@@ -92,7 +92,7 @@ public fun Route.accept(vararg contentTypes: ContentType, build: Route.() -> Uni
 
 /**
  * Builds a route to match requests with the [HttpHeaders.ContentType] header matching the specified [contentType].
- * @see [Application.routing]
+ * @see [HttpServer.routing]
  */
 @KtorDsl
 public fun Route.contentType(contentType: ContentType, build: Route.() -> Unit): Route {
@@ -102,7 +102,7 @@ public fun Route.contentType(contentType: ContentType, build: Route.() -> Unit):
 
 /**
  * Builds a route to match `GET` requests with the specified [path].
- * @see [Application.routing]
+ * @see [HttpServer.routing]
  */
 @KtorDsl
 public fun Route.get(path: String, body: RoutingHandler): Route {
@@ -111,7 +111,7 @@ public fun Route.get(path: String, body: RoutingHandler): Route {
 
 /**
  * Builds a route to match `GET` requests.
- * @see [Application.routing]
+ * @see [HttpServer.routing]
  */
 @KtorDsl
 public fun Route.get(body: RoutingHandler): Route {
@@ -120,7 +120,7 @@ public fun Route.get(body: RoutingHandler): Route {
 
 /**
  * Builds a route to match `POST` requests with the specified [path].
- * @see [Application.routing]
+ * @see [HttpServer.routing]
  */
 @KtorDsl
 public fun Route.post(path: String, body: RoutingHandler): Route {
@@ -129,7 +129,7 @@ public fun Route.post(path: String, body: RoutingHandler): Route {
 
 /**
  * Builds a route to match `POST` requests receiving a request body as content of the [R] type.
- * @see [Application.routing]
+ * @see [HttpServer.routing]
  */
 @KtorDsl
 @JvmName("postTyped")
@@ -141,7 +141,7 @@ public inline fun <reified R : Any> Route.post(
 
 /**
  * Builds a route to match `POST` requests with the specified [path] receiving a request body as content of the [R] type.
- * @see [Application.routing]
+ * @see [HttpServer.routing]
  */
 @KtorDsl
 @JvmName("postTypedPath")
@@ -154,7 +154,7 @@ public inline fun <reified R : Any> Route.post(
 
 /**
  * Builds a route to match `POST` requests.
- * @see [Application.routing]
+ * @see [HttpServer.routing]
  */
 @KtorDsl
 public fun Route.post(body: RoutingHandler): Route {
@@ -163,7 +163,7 @@ public fun Route.post(body: RoutingHandler): Route {
 
 /**
  * Builds a route to match `HEAD` requests with the specified [path].
- * @see [Application.routing]
+ * @see [HttpServer.routing]
  */
 @KtorDsl
 public fun Route.head(path: String, body: RoutingHandler): Route {
@@ -172,7 +172,7 @@ public fun Route.head(path: String, body: RoutingHandler): Route {
 
 /**
  * Builds a route to match `HEAD` requests.
- * @see [Application.routing]
+ * @see [HttpServer.routing]
  */
 @KtorDsl
 public fun Route.head(body: RoutingHandler): Route {
@@ -181,7 +181,7 @@ public fun Route.head(body: RoutingHandler): Route {
 
 /**
  * Builds a route to match `PUT` requests with the specified [path].
- * @see [Application.routing]
+ * @see [HttpServer.routing]
  */
 @KtorDsl
 public fun Route.put(path: String, body: RoutingHandler): Route {
@@ -190,7 +190,7 @@ public fun Route.put(path: String, body: RoutingHandler): Route {
 
 /**
  * Builds a route to match `PUT` requests.
- * @see [Application.routing]
+ * @see [HttpServer.routing]
  */
 @KtorDsl
 public fun Route.put(body: RoutingHandler): Route {
@@ -199,7 +199,7 @@ public fun Route.put(body: RoutingHandler): Route {
 
 /**
  * Builds a route to match `PUT` requests receiving a request body as content of the [R] type.
- * @see [Application.routing]
+ * @see [HttpServer.routing]
  */
 @KtorDsl
 @JvmName("putTyped")
@@ -211,7 +211,7 @@ public inline fun <reified R : Any> Route.put(
 
 /**
  * Builds a route to match `PUT` requests with the specified [path] receiving a request body as content of the [R] type.
- * @see [Application.routing]
+ * @see [HttpServer.routing]
  */
 @KtorDsl
 @JvmName("putTypedPath")
@@ -224,7 +224,7 @@ public inline fun <reified R : Any> Route.put(
 
 /**
  * Builds a route to match `PATCH` requests with the specified [path].
- * @see [Application.routing]
+ * @see [HttpServer.routing]
  */
 @KtorDsl
 public fun Route.patch(path: String, body: RoutingHandler): Route {
@@ -233,7 +233,7 @@ public fun Route.patch(path: String, body: RoutingHandler): Route {
 
 /**
  * Builds a route to match `PATCH` requests.
- * @see [Application.routing]
+ * @see [HttpServer.routing]
  */
 @KtorDsl
 public fun Route.patch(body: RoutingHandler): Route {
@@ -242,7 +242,7 @@ public fun Route.patch(body: RoutingHandler): Route {
 
 /**
  * Builds a route to match `PATCH` requests receiving a request body as content of the [R] type.
- * @see [Application.routing]
+ * @see [HttpServer.routing]
  */
 @KtorDsl
 @JvmName("patchTyped")
@@ -254,7 +254,7 @@ public inline fun <reified R : Any> Route.patch(
 
 /**
  * Builds a route to match `PATCH` requests with the specified [path] receiving a request body as content of the [R] type.
- * @see [Application.routing]
+ * @see [HttpServer.routing]
  */
 @KtorDsl
 @JvmName("patchTypedPath")
@@ -267,7 +267,7 @@ public inline fun <reified R : Any> Route.patch(
 
 /**
  * Builds a route to match `DELETE` requests with the specified [path].
- * @see [Application.routing]
+ * @see [HttpServer.routing]
  */
 @KtorDsl
 public fun Route.delete(path: String, body: RoutingHandler): Route {
@@ -276,7 +276,7 @@ public fun Route.delete(path: String, body: RoutingHandler): Route {
 
 /**
  * Builds a route to match `DELETE` requests.
- * @see [Application.routing]
+ * @see [HttpServer.routing]
  */
 @KtorDsl
 public fun Route.delete(body: RoutingHandler): Route {
@@ -285,7 +285,7 @@ public fun Route.delete(body: RoutingHandler): Route {
 
 /**
  * Builds a route to match `OPTIONS` requests with the specified [path].
- * @see [Application.routing]
+ * @see [HttpServer.routing]
  */
 @KtorDsl
 public fun Route.options(path: String, body: RoutingHandler): Route {
@@ -294,7 +294,7 @@ public fun Route.options(path: String, body: RoutingHandler): Route {
 
 /**
  * Builds a route to match `OPTIONS` requests.
- * @see [Application.routing]
+ * @see [HttpServer.routing]
  */
 @KtorDsl
 public fun Route.options(body: RoutingHandler): Route {

--- a/ktor-server/ktor-server-core/common/src/io/ktor/server/routing/RoutingNode.kt
+++ b/ktor-server/ktor-server-core/common/src/io/ktor/server/routing/RoutingNode.kt
@@ -15,7 +15,7 @@ import io.ktor.utils.io.*
 
 /**
  * Describes a node in a routing tree.
- * @see [Application.routing]
+ * @see [HttpServer.routing]
  *
  * @param parent is a parent node in the tree, or null for root node.
  * @param selector is an instance of [RouteSelector] for this node.
@@ -203,7 +203,7 @@ public class RoutingCall internal constructor(
         internal set
 
     public override val attributes: Attributes = pipelineCall.attributes
-    public override val application: Application = pipelineCall.application
+    public override val application: HttpServer = pipelineCall.application
     public override val parameters: Parameters = pipelineCall.parameters
     public val pathParameters: Parameters = pipelineCall.pathParameters
     public val queryParameters: Parameters = pipelineCall.engineCall.parameters
@@ -222,7 +222,7 @@ public class RoutingCall internal constructor(
 public class RoutingContext(
     public val call: RoutingCall
 ) {
-    public val application: Application
+    public val application: HttpServer
         get() = call.application
 }
 

--- a/ktor-server/ktor-server-core/common/src/io/ktor/server/routing/RoutingPipelineCall.kt
+++ b/ktor-server/ktor-server-core/common/src/io/ktor/server/routing/RoutingPipelineCall.kt
@@ -26,7 +26,7 @@ public class RoutingPipelineCall(
     public val pathParameters: Parameters
 ) : PipelineCall, CoroutineScope {
 
-    override val application: Application get() = engineCall.application
+    override val application: HttpServer get() = engineCall.application
     override val attributes: Attributes get() = engineCall.attributes
 
     override val request: RoutingPipelineRequest =

--- a/ktor-server/ktor-server-core/common/src/io/ktor/server/routing/RoutingRoot.kt
+++ b/ktor-server/ktor-server-core/common/src/io/ktor/server/routing/RoutingRoot.kt
@@ -20,14 +20,14 @@ public val RoutingFailureStatusCode: AttributeKey<HttpStatusCode> = AttributeKey
 internal val LOGGER = KtorSimpleLogger("io.ktor.server.routing.Routing")
 
 /**
- * A root routing node of an [Application].
+ * A root routing node of an [HttpServer].
  * You can learn more about routing in Ktor from [Routing](https://ktor.io/docs/routing-in-ktor.html).
  *
- * @param application is an instance of [Application] for this routing node.
+ * @param application is an instance of [HttpServer] for this routing node.
  */
 @KtorDsl
 public class RoutingRoot(
-    public val application: Application
+    public val application: HttpServer
 ) : RoutingNode(
     parent = null,
     selector = RootRouteSelector(application.rootPath),
@@ -124,7 +124,7 @@ public class RoutingRoot(
      * An installation object of the [RoutingRoot] plugin.
      */
     @Suppress("PublicApiImplicitType")
-    public companion object Plugin : BaseApplicationPlugin<Application, Routing, RoutingRoot> {
+    public companion object Plugin : BaseApplicationPlugin<HttpServer, Routing, RoutingRoot> {
 
         /**
          * A definition for an event that is fired when routing-based call processing starts.
@@ -138,7 +138,7 @@ public class RoutingRoot(
 
         override val key: AttributeKey<RoutingRoot> = AttributeKey("Routing")
 
-        override fun install(pipeline: Application, configure: Routing.() -> Unit): RoutingRoot {
+        override fun install(pipeline: HttpServer, configure: Routing.() -> Unit): RoutingRoot {
             val routingRoot = RoutingRoot(pipeline).apply(configure)
             pipeline.intercept(Call) { routingRoot.interceptor(this) }
             return routingRoot
@@ -147,9 +147,9 @@ public class RoutingRoot(
 }
 
 /**
- * Gets an [Application] for this [RoutingNode] by scanning the hierarchy to the root.
+ * Gets an [HttpServer] for this [RoutingNode] by scanning the hierarchy to the root.
  */
-public val Route.application: Application
+public val Route.application: HttpServer
     get() = when (this) {
         is RoutingRoot -> application
         else -> parent?.application ?: throw UnsupportedOperationException(
@@ -158,9 +158,9 @@ public val Route.application: Application
     }
 
 /**
- * Installs a [RoutingRoot] plugin for the this [Application] and runs a [configuration] script on it.
+ * Installs a [RoutingRoot] plugin for the this [HttpServer] and runs a [configuration] script on it.
  * You can learn more about routing in Ktor from [Routing](https://ktor.io/docs/routing-in-ktor.html).
  */
 @KtorDsl
-public fun Application.routing(configuration: Routing.() -> Unit): RoutingRoot =
+public fun HttpServer.routing(configuration: Routing.() -> Unit): RoutingRoot =
     pluginOrNull(RoutingRoot)?.apply(configuration) ?: install(RoutingRoot, configuration)

--- a/ktor-server/ktor-server-core/common/test/io/ktor/server/logging/MDCProviderTest.kt
+++ b/ktor-server/ktor-server-core/common/test/io/ktor/server/logging/MDCProviderTest.kt
@@ -23,7 +23,7 @@ class MDCProviderTest {
             override fun start(wait: Boolean): ApplicationEngine = TODO("Not yet implemented")
             override fun stop(gracePeriodMillis: Long, timeoutMillis: Long) = TODO("Not yet implemented")
         }
-        val application = Application(environment, false, "/", monitor, EmptyCoroutineContext) { engine }
+        val application = HttpServer(environment, false, "/", monitor, EmptyCoroutineContext) { engine }
         assertNotNull(application.mdcProvider)
     }
 }

--- a/ktor-server/ktor-server-core/jsAndWasmShared/src/io/ktor/server/application/ApplicationEnvironment.jsAndWasmShared.kt
+++ b/ktor-server/ktor-server-core/jsAndWasmShared/src/io/ktor/server/application/ApplicationEnvironment.jsAndWasmShared.kt
@@ -13,7 +13,7 @@ import kotlin.coroutines.*
 public actual interface ApplicationEnvironment {
 
     /**
-     * Configuration for the [Application]
+     * Configuration for the [HttpServer]
      */
     public actual val config: ApplicationConfig
 
@@ -34,6 +34,6 @@ public actual interface ApplicationEnvironment {
 }
 
 internal actual class ApplicationPropertiesBridge actual constructor(
-    applicationProperties: ApplicationProperties,
+    applicationRuntimeConfig: ApplicationRuntimeConfig,
     internal actual val parentCoroutineContext: CoroutineContext,
 )

--- a/ktor-server/ktor-server-core/jvm/src/io/ktor/server/application/ApplicationEnvironment.kt
+++ b/ktor-server/ktor-server-core/jvm/src/io/ktor/server/application/ApplicationEnvironment.kt
@@ -10,7 +10,7 @@ import io.ktor.util.logging.*
 import kotlin.coroutines.*
 
 /**
- * Represents an environment in which [Application] runs
+ * Represents an environment in which [HttpServer] runs
  */
 public actual interface ApplicationEnvironment {
 
@@ -27,7 +27,7 @@ public actual interface ApplicationEnvironment {
     public actual val log: Logger
 
     /**
-     * Configuration for the [Application]
+     * Configuration for the [HttpServer]
      */
     public actual val config: ApplicationConfig
 
@@ -43,11 +43,11 @@ public actual interface ApplicationEnvironment {
 }
 
 internal actual class ApplicationPropertiesBridge actual constructor(
-    applicationProperties: ApplicationProperties,
+    applicationRuntimeConfig: ApplicationRuntimeConfig,
     parentCoroutineContext: CoroutineContext,
 ) {
     actual val parentCoroutineContext: CoroutineContext = when {
-        applicationProperties.developmentMode && applicationProperties.watchPaths.isNotEmpty() ->
+        applicationRuntimeConfig.developmentMode && applicationRuntimeConfig.watchPaths.isNotEmpty() ->
             parentCoroutineContext + ClassLoaderAwareContinuationInterceptor
 
         else -> parentCoroutineContext

--- a/ktor-server/ktor-server-core/jvm/src/io/ktor/server/engine/ShutDownUrl.kt
+++ b/ktor-server/ktor-server-core/jvm/src/io/ktor/server/engine/ShutDownUrl.kt
@@ -91,7 +91,7 @@ public class ShutDownUrl(public val url: String, public val exitCode: Applicatio
         /**
          * An installation object of the [ShutDownUrl] plugin.
          */
-        public val ApplicationCallPlugin: BaseApplicationPlugin<Application, Config, PluginInstance> =
+        public val ApplicationCallPlugin: BaseApplicationPlugin<HttpServer, Config, PluginInstance> =
             createApplicationPlugin("shutdown.url", ::Config) {
                 val plugin = ShutDownUrl(pluginConfig.shutDownUrl, pluginConfig.exitCodeSupplier)
 

--- a/ktor-server/ktor-server-core/jvm/src/io/ktor/server/engine/internal/AutoReloadUtils.kt
+++ b/ktor-server/ktor-server-core/jvm/src/io/ktor/server/engine/internal/AutoReloadUtils.kt
@@ -13,7 +13,7 @@ import kotlin.reflect.jvm.*
 
 internal val currentStartupModules = ThreadLocal<MutableList<String>>()
 internal val ApplicationEnvironmentClassInstance = ApplicationEnvironment::class.java
-internal val ApplicationClassInstance = Application::class.java
+internal val ApplicationClassInstance = HttpServer::class.java
 
 internal fun isApplicationEnvironment(parameter: KParameter): Boolean =
     isParameterOfType(parameter, ApplicationEnvironmentClassInstance)

--- a/ktor-server/ktor-server-core/jvm/src/io/ktor/server/http/content/StaticContent.kt
+++ b/ktor-server/ktor-server-core/jvm/src/io/ktor/server/http/content/StaticContent.kt
@@ -130,7 +130,7 @@ public class StaticContentConfig<Resource : Any> internal constructor() {
 
     /**
      * Configures resources that should not be served.
-     * If this block returns `true` for [Resource], [Application] will respond with [HttpStatusCode.Forbidden].
+     * If this block returns `true` for [Resource], [HttpServer] will respond with [HttpStatusCode.Forbidden].
      * Can be invoked multiple times.
      * For files, [Resource] is a requested [File].
      * For resources, [Resource] is a [URL] to a requested resource.

--- a/ktor-server/ktor-server-core/jvm/src/io/ktor/server/http/content/StaticContentResolution.kt
+++ b/ktor-server/ktor-server-core/jvm/src/io/ktor/server/http/content/StaticContentResolution.kt
@@ -46,7 +46,7 @@ public fun ApplicationCall.resolveResource(
 private val resourceCache by lazy { ConcurrentHashMap<String, URL>() }
 
 @OptIn(InternalAPI::class)
-internal fun Application.resolveResource(
+internal fun HttpServer.resolveResource(
     path: String,
     resourcePackage: String? = null,
     classLoader: ClassLoader = environment.classLoader,

--- a/ktor-server/ktor-server-core/jvm/test-resources/modules/application-module1.conf
+++ b/ktor-server/ktor-server-core/jvm/test-resources/modules/application-module1.conf
@@ -1,0 +1,7 @@
+ktor {
+    application {
+        modules = [
+            "io.ktor.tests.server.engine.ServerModulesConfigTestKt.module1",
+        ]
+    }
+}

--- a/ktor-server/ktor-server-core/jvm/test-resources/modules/application-module2.conf
+++ b/ktor-server/ktor-server-core/jvm/test-resources/modules/application-module2.conf
@@ -1,0 +1,7 @@
+ktor {
+    application {
+        modules = [
+            "io.ktor.tests.server.engine.ServerModulesConfigTestKt.module2",
+        ]
+    }
+}

--- a/ktor-server/ktor-server-core/jvm/test-resources/modules/application-module3.conf
+++ b/ktor-server/ktor-server-core/jvm/test-resources/modules/application-module3.conf
@@ -1,0 +1,7 @@
+ktor {
+    application {
+        modules = [
+            "io.ktor.tests.server.engine.ModuleClass.module3",
+        ]
+    }
+}

--- a/ktor-server/ktor-server-core/jvm/test/io/ktor/tests/hosts/EmbeddedServerReloadingTests.kt
+++ b/ktor-server/ktor-server-core/jvm/test/io/ktor/tests/hosts/EmbeddedServerReloadingTests.kt
@@ -31,12 +31,12 @@ class EmbeddedServerReloadingTests {
                 ConfigFactory.parseMap(
                     mapOf(
                         "ktor.deployment.environment" to "test",
-                        "ktor.application.modules" to listOf(Application::topLevelExtensionFunction.fqName)
+                        "ktor.application.modules" to listOf(HttpServer::topLevelExtensionFunction.fqName)
                     )
                 )
             )
         }
-        val props = applicationProperties(environment) {
+        val props = applicationRuntimeConfig(environment) {
             developmentMode = false
         }
         val server = EmbeddedServer(props, DummyEngineFactory)
@@ -56,13 +56,13 @@ class EmbeddedServerReloadingTests {
                     mapOf(
                         "ktor.deployment.environment" to "test",
                         "ktor.deployment.watch" to listOf("ktor-server-core"),
-                        "ktor.application.modules" to listOf(Application::topLevelExtensionFunction.fqName)
+                        "ktor.application.modules" to listOf(HttpServer::topLevelExtensionFunction.fqName)
                     )
                 )
             )
         }
 
-        val props = applicationProperties(environment)
+        val props = applicationRuntimeConfig(environment)
         val server = EmbeddedServer(props, DummyEngineFactory)
 
         server.start()
@@ -85,7 +85,7 @@ class EmbeddedServerReloadingTests {
                 )
             )
         }
-        val props = applicationProperties(environment) {
+        val props = applicationRuntimeConfig(environment) {
             developmentMode = false
         }
         val server = EmbeddedServer(props, DummyEngineFactory)
@@ -111,7 +111,7 @@ class EmbeddedServerReloadingTests {
                 )
             )
         }
-        val props = applicationProperties(environment) {
+        val props = applicationRuntimeConfig(environment) {
             developmentMode = false
         }
         val server = EmbeddedServer(props, DummyEngineFactory)
@@ -137,7 +137,7 @@ class EmbeddedServerReloadingTests {
                 )
             )
         }
-        val props = applicationProperties(environment) {
+        val props = applicationRuntimeConfig(environment) {
             developmentMode = false
         }
         val server = EmbeddedServer(props, DummyEngineFactory)
@@ -164,7 +164,7 @@ class EmbeddedServerReloadingTests {
                 )
             )
         }
-        val props = applicationProperties(environment) {
+        val props = applicationRuntimeConfig(environment) {
             developmentMode = false
         }
         val server = EmbeddedServer(props, DummyEngineFactory)
@@ -191,7 +191,7 @@ class EmbeddedServerReloadingTests {
                 )
             )
         }
-        val props = applicationProperties(environment) {
+        val props = applicationRuntimeConfig(environment) {
             developmentMode = false
         }
         val server = EmbeddedServer(props, DummyEngineFactory)
@@ -217,7 +217,7 @@ class EmbeddedServerReloadingTests {
                 )
             )
         }
-        val props = applicationProperties(environment) {
+        val props = applicationRuntimeConfig(environment) {
             developmentMode = false
         }
         val server = EmbeddedServer(props, DummyEngineFactory)
@@ -244,7 +244,7 @@ class EmbeddedServerReloadingTests {
                 )
             )
         }
-        val props = applicationProperties(environment) {
+        val props = applicationRuntimeConfig(environment) {
             developmentMode = false
         }
         val server = EmbeddedServer(props, DummyEngineFactory)
@@ -270,7 +270,7 @@ class EmbeddedServerReloadingTests {
                 )
             )
         }
-        val props = applicationProperties(environment) {
+        val props = applicationRuntimeConfig(environment) {
             developmentMode = false
         }
         val server = EmbeddedServer(props, DummyEngineFactory)
@@ -294,7 +294,7 @@ class EmbeddedServerReloadingTests {
                 )
             )
         }
-        val props = applicationProperties(environment) {
+        val props = applicationRuntimeConfig(environment) {
             developmentMode = false
         }
         val server = EmbeddedServer(props, DummyEngineFactory)
@@ -319,7 +319,7 @@ class EmbeddedServerReloadingTests {
                 )
             )
         }
-        val props = applicationProperties(environment) {
+        val props = applicationRuntimeConfig(environment) {
             developmentMode = false
         }
         val server = EmbeddedServer(props, DummyEngineFactory)
@@ -343,7 +343,7 @@ class EmbeddedServerReloadingTests {
                 )
             )
         }
-        val props = applicationProperties(environment) {
+        val props = applicationRuntimeConfig(environment) {
             developmentMode = false
         }
         val server = EmbeddedServer(props, DummyEngineFactory)
@@ -367,7 +367,7 @@ class EmbeddedServerReloadingTests {
                 )
             )
         }
-        val props = applicationProperties(environment) {
+        val props = applicationRuntimeConfig(environment) {
             developmentMode = false
         }
         val server = EmbeddedServer(props, DummyEngineFactory)
@@ -393,7 +393,7 @@ class EmbeddedServerReloadingTests {
                 )
             )
         }
-        val props = applicationProperties(environment) {
+        val props = applicationRuntimeConfig(environment) {
             developmentMode = false
         }
         val server = EmbeddedServer(props, DummyEngineFactory)
@@ -417,7 +417,7 @@ class EmbeddedServerReloadingTests {
                 )
             )
         }
-        val props = applicationProperties(environment) {
+        val props = applicationRuntimeConfig(environment) {
             developmentMode = false
         }
         val server = EmbeddedServer(props, DummyEngineFactory)
@@ -443,7 +443,7 @@ class EmbeddedServerReloadingTests {
                 )
             )
         }
-        val props = applicationProperties(environment) {
+        val props = applicationRuntimeConfig(environment) {
             developmentMode = false
         }
         val server = EmbeddedServer(props, DummyEngineFactory)
@@ -467,7 +467,7 @@ class EmbeddedServerReloadingTests {
         fun main() {
         }
 
-        fun main(app: Application) {
+        fun main(app: HttpServer) {
             app.attributes.put(TestKey, "best function called")
         }
     }
@@ -478,29 +478,29 @@ class EmbeddedServerReloadingTests {
         }
 
         @JvmStatic
-        fun main(app: Application) {
+        fun main(app: HttpServer) {
             app.attributes.put(TestKey, "best function called")
         }
     }
 
     class ClassModuleFunctionHolder {
         @Suppress("UNUSED")
-        fun Application.classExtensionFunction() {
+        fun HttpServer.classExtensionFunction() {
             attributes.put(TestKey, "classExtensionFunction")
         }
 
-        fun classFunction(app: Application) {
+        fun classFunction(app: HttpServer) {
             app.attributes.put(TestKey, "classFunction")
         }
     }
 
     object ObjectModuleFunctionHolder {
         @Suppress("UNUSED")
-        fun Application.objectExtensionFunction() {
+        fun HttpServer.objectExtensionFunction() {
             attributes.put(TestKey, "objectExtensionFunction")
         }
 
-        fun objectFunction(app: Application) {
+        fun objectFunction(app: HttpServer) {
             app.attributes.put(TestKey, "objectFunction")
         }
     }
@@ -514,27 +514,27 @@ class EmbeddedServerReloadingTests {
         private fun KClass<*>.functionFqName(name: String) = "$jvmName.$name"
 
         @Suppress("UNUSED")
-        fun Application.companionObjectExtensionFunction() {
+        fun HttpServer.companionObjectExtensionFunction() {
             attributes.put(TestKey, "companionObjectExtensionFunction")
         }
 
-        fun companionObjectFunction(app: Application) {
+        fun companionObjectFunction(app: HttpServer) {
             app.attributes.put(TestKey, "companionObjectFunction")
         }
 
         @Suppress("UNUSED")
         @JvmStatic
-        fun Application.companionObjectJvmStaticExtensionFunction() {
+        fun HttpServer.companionObjectJvmStaticExtensionFunction() {
             attributes.put(TestKey, "companionObjectJvmStaticExtensionFunction")
         }
 
         @JvmStatic
-        fun companionObjectJvmStaticFunction(app: Application) {
+        fun companionObjectJvmStaticFunction(app: HttpServer) {
             app.attributes.put(TestKey, "companionObjectJvmStaticFunction")
         }
 
         @JvmStatic
-        fun Application.functionWithDefaultArg(test: Boolean = false) {
+        fun HttpServer.functionWithDefaultArg(test: Boolean = false) {
             attributes.put(TestKey, "functionWithDefaultArg")
         }
     }
@@ -542,7 +542,7 @@ class EmbeddedServerReloadingTests {
     @Test
     fun `application is available before environment start`() {
         val env = dummyEnv()
-        val props = applicationProperties(env)
+        val props = applicationRuntimeConfig(env)
         val server = EmbeddedServer(props, DummyEngineFactory)
         val app = server.application
         server.start()
@@ -552,7 +552,7 @@ class EmbeddedServerReloadingTests {
     @Test
     fun `completion handler is invoked when attached before environment start`() {
         val env = dummyEnv()
-        val props = applicationProperties(env)
+        val props = applicationRuntimeConfig(env)
         val server = EmbeddedServer(props, DummyEngineFactory)
         val job = server.application.coroutineContext[Job]!!
 
@@ -571,7 +571,7 @@ class EmbeddedServerReloadingTests {
 
     @Test
     fun `interceptor is invoked when added before environment start`() {
-        val server = EmbeddedServer(applicationProperties(), TestEngine) {}
+        val server = EmbeddedServer(applicationRuntimeConfig(), TestEngine) {}
         val engine = server.engine
         server.application.intercept(ApplicationCallPipeline.Plugins) {
             call.response.header("Custom", "Value")
@@ -613,7 +613,7 @@ class EmbeddedServerReloadingTests {
             monitor: Events,
             developmentMode: Boolean,
             configuration: BaseApplicationEngine.Configuration,
-            applicationProvider: () -> Application
+            applicationProvider: () -> HttpServer
         ): DummyEngine {
             return DummyEngine
         }
@@ -629,11 +629,11 @@ class EmbeddedServerReloadingTests {
 // some weirdness with the compiler ignores default in expect
 fun EmbeddedServer<*, *>.start() = start(wait = false)
 
-fun Application.topLevelExtensionFunction() {
+fun HttpServer.topLevelExtensionFunction() {
     attributes.put(EmbeddedServerReloadingTests.TestKey, "topLevelExtensionFunction")
 }
 
-fun topLevelFunction(app: Application) {
+fun topLevelFunction(app: HttpServer) {
     app.attributes.put(EmbeddedServerReloadingTests.TestKey, "topLevelFunction")
 }
 
@@ -642,11 +642,11 @@ fun topLevelFunction() {
     error("Shouldn't be invoked")
 }
 
-fun Application.topLevelWithDefaultArg(testing: Boolean = false) {
+fun HttpServer.topLevelWithDefaultArg(testing: Boolean = false) {
     attributes.put(EmbeddedServerReloadingTests.TestKey, "topLevelWithDefaultArg")
 }
 
 @JvmOverloads
-fun Application.topLevelWithJvmOverloads(testing: Boolean = false) {
+fun HttpServer.topLevelWithJvmOverloads(testing: Boolean = false) {
     attributes.put(EmbeddedServerReloadingTests.TestKey, "topLevelWithJvmOverloads")
 }

--- a/ktor-server/ktor-server-core/jvm/test/io/ktor/tests/hosts/ReceiveBlockingPrimitiveTest.kt
+++ b/ktor-server/ktor-server-core/jvm/test/io/ktor/tests/hosts/ReceiveBlockingPrimitiveTest.kt
@@ -52,7 +52,7 @@ class ReceiveBlockingPrimitiveTest {
     }
 
     private class TestCall : BaseApplicationCall(
-        Application(
+        HttpServer(
             applicationEnvironment {},
             false,
             "/",

--- a/ktor-server/ktor-server-core/jvm/test/io/ktor/tests/plugins/HttpServerPluginConfigurationTest.kt
+++ b/ktor-server/ktor-server-core/jvm/test/io/ktor/tests/plugins/HttpServerPluginConfigurationTest.kt
@@ -9,7 +9,7 @@ import io.ktor.server.config.*
 import io.ktor.server.testing.*
 import kotlin.test.*
 
-class ApplicationPluginConfigurationTest {
+class HttpServerPluginConfigurationTest {
 
     @Test
     fun testReadPropertyFromFile() = testApplication {

--- a/ktor-server/ktor-server-core/jvm/test/io/ktor/tests/server/engine/ServerModulesConfigTest.kt
+++ b/ktor-server/ktor-server-core/jvm/test/io/ktor/tests/server/engine/ServerModulesConfigTest.kt
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2014-2024 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.tests.server.engine
+
+import io.ktor.client.request.*
+import io.ktor.client.statement.*
+import io.ktor.server.application.*
+import io.ktor.server.config.*
+import io.ktor.server.response.*
+import io.ktor.server.routing.*
+import io.ktor.server.testing.*
+import kotlin.test.*
+
+class ServerModulesConfigTest {
+
+    @Test
+    fun `function reference`() =
+        testModule("module1")
+
+    @Test
+    fun `lambda property reference`() =
+        testModule("module2")
+
+    @Test
+    fun `method reference`() =
+        testModule("module3")
+
+    private fun testModule(moduleName: String) = testApplication {
+        environment {
+            config = HoconConfigLoader().load("modules/application-$moduleName.conf")!!
+        }
+        client.get("/$moduleName").apply {
+            assertEquals("OK", bodyAsText())
+        }
+    }
+
+}
+
+fun HttpServer.module1() {
+    routing {
+        get("/module1") { call.respondText("OK") }
+    }
+}
+
+val module2: HttpServer.() -> Unit = {
+    routing {
+        get("/module2") { call.respondText("OK") }
+    }
+}
+
+class ModuleClass {
+    fun HttpServer.module3() {
+        routing {
+            get("/module3") { call.respondText("OK") }
+        }
+    }
+}

--- a/ktor-server/ktor-server-core/posix/src/io/ktor/server/application/NixApplicationEnvironment.kt
+++ b/ktor-server/ktor-server-core/posix/src/io/ktor/server/application/NixApplicationEnvironment.kt
@@ -13,7 +13,7 @@ import kotlin.coroutines.*
 public actual interface ApplicationEnvironment {
 
     /**
-     * Configuration for the [Application]
+     * Configuration for the [HttpServer]
      */
     public actual val config: ApplicationConfig
 
@@ -34,6 +34,6 @@ public actual interface ApplicationEnvironment {
 }
 
 internal actual class ApplicationPropertiesBridge actual constructor(
-    applicationProperties: ApplicationProperties,
+    applicationRuntimeConfig: ApplicationRuntimeConfig,
     internal actual val parentCoroutineContext: CoroutineContext,
 )

--- a/ktor-server/ktor-server-core/posix/src/io/ktor/server/engine/EmbeddedServerNix.kt
+++ b/ktor-server/ktor-server-core/posix/src/io/ktor/server/engine/EmbeddedServerNix.kt
@@ -15,34 +15,34 @@ public actual class EmbeddedServer<
     TConfiguration : ApplicationEngine.Configuration
     >
 actual constructor(
-    applicationProperties: ApplicationProperties,
+    applicationRuntimeConfig: ApplicationRuntimeConfig,
     engineFactory: ApplicationEngineFactory<TEngine, TConfiguration>,
     engineConfigBlock: TConfiguration.() -> Unit
 ) {
-    public actual val monitor: Events = applicationProperties.environment.monitor
+    public actual val monitor: Events = applicationRuntimeConfig.environment.monitor
 
-    public actual val environment: ApplicationEnvironment = applicationProperties.environment
+    public actual val environment: ApplicationEnvironment = applicationRuntimeConfig.environment
 
     public actual val engineConfig: TConfiguration = engineFactory.configuration(engineConfigBlock)
 
-    public actual val application: Application = Application(
+    public actual val application: HttpServer = HttpServer(
         environment,
-        applicationProperties.developmentMode,
-        applicationProperties.rootPath,
+        applicationRuntimeConfig.developmentMode,
+        applicationRuntimeConfig.rootPath,
         monitor,
-        applicationProperties.parentCoroutineContext,
+        applicationRuntimeConfig.parentCoroutineContext,
         ::engine
     )
 
     public actual val engine: TEngine = engineFactory.create(
         environment,
         monitor,
-        applicationProperties.developmentMode,
+        applicationRuntimeConfig.developmentMode,
         engineConfig,
         ::application
     )
 
-    private val modules = applicationProperties.modules
+    private val modules = applicationRuntimeConfig.modules
 
     public actual fun start(wait: Boolean): EmbeddedServer<TEngine, TConfiguration> {
         safeRaiseEvent(ApplicationStarting, application)
@@ -74,7 +74,7 @@ actual constructor(
         destroy(application)
     }
 
-    private fun destroy(application: Application) {
+    private fun destroy(application: HttpServer) {
         safeRaiseEvent(ApplicationStopping, application)
         try {
             application.dispose()
@@ -84,7 +84,7 @@ actual constructor(
         safeRaiseEvent(ApplicationStopped, application)
     }
 
-    private fun safeRaiseEvent(event: EventDefinition<Application>, application: Application) {
+    private fun safeRaiseEvent(event: EventDefinition<HttpServer>, application: HttpServer) {
         try {
             monitor.raise(event, application)
         } catch (cause: Throwable) {

--- a/ktor-server/ktor-server-jetty-jakarta/api/ktor-server-jetty-jakarta.api
+++ b/ktor-server/ktor-server-jetty-jakarta/api/ktor-server-jetty-jakarta.api
@@ -12,7 +12,7 @@ public final class io/ktor/server/jetty/jakarta/Jetty : io/ktor/server/engine/Ap
 }
 
 public final class io/ktor/server/jetty/jakarta/JettyApplicationCall : io/ktor/server/servlet/jakarta/AsyncServletApplicationCall {
-	public fun <init> (Lio/ktor/server/application/Application;Lorg/eclipse/jetty/server/Request;Ljakarta/servlet/http/HttpServletRequest;Ljakarta/servlet/http/HttpServletResponse;Lkotlin/coroutines/CoroutineContext;Lkotlin/coroutines/CoroutineContext;Lkotlin/coroutines/CoroutineContext;)V
+	public fun <init> (Lio/ktor/server/application/HttpServer;Lorg/eclipse/jetty/server/Request;Ljakarta/servlet/http/HttpServletRequest;Ljakarta/servlet/http/HttpServletResponse;Lkotlin/coroutines/CoroutineContext;Lkotlin/coroutines/CoroutineContext;Lkotlin/coroutines/CoroutineContext;)V
 	public synthetic fun getResponse ()Lio/ktor/server/engine/BaseApplicationResponse;
 	public fun getResponse ()Lio/ktor/server/jetty/jakarta/JettyApplicationResponse;
 	public synthetic fun getResponse ()Lio/ktor/server/response/ApplicationResponse;

--- a/ktor-server/ktor-server-jetty-jakarta/jvm/src/io/ktor/server/jetty/jakarta/Embedded.kt
+++ b/ktor-server/ktor-server-jetty-jakarta/jvm/src/io/ktor/server/jetty/jakarta/Embedded.kt
@@ -25,7 +25,7 @@ public object Jetty : ApplicationEngineFactory<JettyApplicationEngine, JettyAppl
         monitor: Events,
         developmentMode: Boolean,
         configuration: JettyApplicationEngineBase.Configuration,
-        applicationProvider: () -> Application
+        applicationProvider: () -> HttpServer
     ): JettyApplicationEngine {
         return JettyApplicationEngine(environment, monitor, developmentMode, configuration, applicationProvider)
     }

--- a/ktor-server/ktor-server-jetty-jakarta/jvm/src/io/ktor/server/jetty/jakarta/EngineMain.kt
+++ b/ktor-server/ktor-server-jetty-jakarta/jvm/src/io/ktor/server/jetty/jakarta/EngineMain.kt
@@ -18,9 +18,9 @@ public object EngineMain {
     @JvmStatic
     public fun main(args: Array<String>) {
         val config = CommandLineConfig(args)
-        val server = EmbeddedServer(config.applicationProperties, Jetty) {
+        val server = EmbeddedServer(config.applicationRuntimeConfig, Jetty) {
             takeFrom(config.engineConfig)
-            loadConfiguration(config.applicationProperties.environment.config)
+            loadConfiguration(config.applicationRuntimeConfig.environment.config)
         }
         server.start(true)
     }

--- a/ktor-server/ktor-server-jetty-jakarta/jvm/src/io/ktor/server/jetty/jakarta/JettyApplicationCall.kt
+++ b/ktor-server/ktor-server-jetty-jakarta/jvm/src/io/ktor/server/jetty/jakarta/JettyApplicationCall.kt
@@ -14,7 +14,7 @@ import kotlin.coroutines.*
 
 @InternalAPI
 public class JettyApplicationCall(
-    application: Application,
+    application: HttpServer,
     request: Request,
     servletRequest: HttpServletRequest,
     servletResponse: HttpServletResponse,

--- a/ktor-server/ktor-server-jetty-jakarta/jvm/src/io/ktor/server/jetty/jakarta/JettyApplicationEngine.kt
+++ b/ktor-server/ktor-server-jetty-jakarta/jvm/src/io/ktor/server/jetty/jakarta/JettyApplicationEngine.kt
@@ -17,7 +17,7 @@ public class JettyApplicationEngine(
     monitor: Events,
     developmentMode: Boolean,
     configure: Configuration,
-    private val applicationProvider: () -> Application
+    private val applicationProvider: () -> HttpServer
 ) : JettyApplicationEngineBase(environment, monitor, developmentMode, configure, applicationProvider) {
 
     private val dispatcher = server.threadPool.asCoroutineDispatcher()

--- a/ktor-server/ktor-server-jetty-jakarta/jvm/src/io/ktor/server/jetty/jakarta/JettyApplicationEngineBase.kt
+++ b/ktor-server/ktor-server-jetty-jakarta/jvm/src/io/ktor/server/jetty/jakarta/JettyApplicationEngineBase.kt
@@ -23,7 +23,7 @@ public open class JettyApplicationEngineBase(
      * Application engine configuration specifying engine-specific options such as parallelism level.
      */
     public val configuration: Configuration,
-    private val applicationProvider: () -> Application
+    private val applicationProvider: () -> HttpServer
 ) : BaseApplicationEngine(environment, monitor, developmentMode) {
 
     /**

--- a/ktor-server/ktor-server-jetty-jakarta/jvm/src/io/ktor/server/jetty/jakarta/JettyKtorHandler.kt
+++ b/ktor-server/ktor-server-jetty-jakarta/jvm/src/io/ktor/server/jetty/jakarta/JettyKtorHandler.kt
@@ -8,7 +8,6 @@ import io.ktor.http.*
 import io.ktor.server.application.*
 import io.ktor.server.engine.*
 import io.ktor.server.response.*
-import io.ktor.util.*
 import io.ktor.util.cio.*
 import io.ktor.util.pipeline.*
 import io.ktor.utils.io.*
@@ -34,7 +33,7 @@ internal class JettyKtorHandler(
     private val pipeline: () -> EnginePipeline,
     private val engineDispatcher: CoroutineDispatcher,
     configuration: JettyApplicationEngineBase.Configuration,
-    private val applicationProvider: () -> Application
+    private val applicationProvider: () -> HttpServer
 ) : AbstractHandler(), CoroutineScope {
     private val environmentName = configuration.connectors.joinToString("-") { it.port.toString() }
     private val queue: BlockingQueue<Runnable> = LinkedBlockingQueue()

--- a/ktor-server/ktor-server-jetty-jakarta/jvm/test/io/ktor/tests/server/jetty/jakarta/JettyServletApplicationEngine.kt
+++ b/ktor-server/ktor-server-jetty-jakarta/jvm/test/io/ktor/tests/server/jetty/jakarta/JettyServletApplicationEngine.kt
@@ -29,7 +29,7 @@ internal class Servlet(
         monitor: Events,
         developmentMode: Boolean,
         configuration: JettyApplicationEngineBase.Configuration,
-        applicationProvider: () -> Application
+        applicationProvider: () -> HttpServer
     ): JettyServletApplicationEngine {
         return JettyServletApplicationEngine(
             environment,
@@ -47,7 +47,7 @@ internal class JettyServletApplicationEngine(
     monitor: Events,
     developmentMode: Boolean,
     configuration: Configuration,
-    applicationProvider: () -> Application,
+    applicationProvider: () -> HttpServer,
     async: Boolean
 ) : JettyApplicationEngineBase(environment, monitor, developmentMode, configuration, applicationProvider) {
     init {

--- a/ktor-server/ktor-server-jetty-jakarta/jvm/test/io/ktor/tests/server/jetty/jakarta/MultipleDispatchOnTimeout.kt
+++ b/ktor-server/ktor-server-jetty-jakarta/jvm/test/io/ktor/tests/server/jetty/jakarta/MultipleDispatchOnTimeout.kt
@@ -32,7 +32,7 @@ class MultipleDispatchOnTimeout {
         val environment = applicationEnvironment {
             log = LoggerFactory.getLogger("ktor.test")
         }
-        val props = applicationProperties(environment) {
+        val props = applicationRuntimeConfig(environment) {
             module {
                 intercept(ApplicationCallPipeline.Call) {
                     callCount.incrementAndGet()

--- a/ktor-server/ktor-server-jetty-jakarta/ktor-server-jetty-test-http2-jakarta/jvm/test/io/ktor/tests/server/jetty/http2/jakarta/JettyHttp2ServletContainer.kt
+++ b/ktor-server/ktor-server-jetty-jakarta/ktor-server-jetty-test-http2-jakarta/jvm/test/io/ktor/tests/server/jetty/http2/jakarta/JettyHttp2ServletContainer.kt
@@ -28,7 +28,7 @@ internal class Servlet(private val async: Boolean) :
         monitor: Events,
         developmentMode: Boolean,
         configuration: JettyApplicationEngineBase.Configuration,
-        applicationProvider: () -> Application
+        applicationProvider: () -> HttpServer
     ): JettyServletApplicationEngine {
         return JettyServletApplicationEngine(
             environment,
@@ -46,7 +46,7 @@ internal class JettyServletApplicationEngine(
     monitor: Events,
     developmentMode: Boolean,
     configuration: Configuration,
-    applicationProvider: () -> Application,
+    applicationProvider: () -> HttpServer,
     async: Boolean
 ) : JettyApplicationEngineBase(environment, monitor, developmentMode, configuration, applicationProvider) {
     init {

--- a/ktor-server/ktor-server-jetty-jakarta/ktor-server-jetty-test-http2-jakarta/jvm/test/io/ktor/tests/server/jetty/http2/jakarta/MultipleDispatchOnTimeout.kt
+++ b/ktor-server/ktor-server-jetty-jakarta/ktor-server-jetty-test-http2-jakarta/jvm/test/io/ktor/tests/server/jetty/http2/jakarta/MultipleDispatchOnTimeout.kt
@@ -32,7 +32,7 @@ class MultipleDispatchOnTimeout {
         val environment = applicationEnvironment {
             log = LoggerFactory.getLogger("ktor.test")
         }
-        val props = applicationProperties(environment) {
+        val props = applicationRuntimeConfig(environment) {
             module {
                 intercept(ApplicationCallPipeline.Call) {
                     callCount.incrementAndGet()

--- a/ktor-server/ktor-server-jetty/api/ktor-server-jetty.api
+++ b/ktor-server/ktor-server-jetty/api/ktor-server-jetty.api
@@ -12,7 +12,7 @@ public final class io/ktor/server/jetty/Jetty : io/ktor/server/engine/Applicatio
 }
 
 public final class io/ktor/server/jetty/JettyApplicationCall : io/ktor/server/servlet/AsyncServletApplicationCall {
-	public fun <init> (Lio/ktor/server/application/Application;Lorg/eclipse/jetty/server/Request;Ljavax/servlet/http/HttpServletRequest;Ljavax/servlet/http/HttpServletResponse;Lkotlin/coroutines/CoroutineContext;Lkotlin/coroutines/CoroutineContext;Lkotlin/coroutines/CoroutineContext;)V
+	public fun <init> (Lio/ktor/server/application/HttpServer;Lorg/eclipse/jetty/server/Request;Ljavax/servlet/http/HttpServletRequest;Ljavax/servlet/http/HttpServletResponse;Lkotlin/coroutines/CoroutineContext;Lkotlin/coroutines/CoroutineContext;Lkotlin/coroutines/CoroutineContext;)V
 	public synthetic fun getResponse ()Lio/ktor/server/engine/BaseApplicationResponse;
 	public fun getResponse ()Lio/ktor/server/jetty/JettyApplicationResponse;
 	public synthetic fun getResponse ()Lio/ktor/server/response/ApplicationResponse;

--- a/ktor-server/ktor-server-jetty/jvm/src/io/ktor/server/jetty/Embedded.kt
+++ b/ktor-server/ktor-server-jetty/jvm/src/io/ktor/server/jetty/Embedded.kt
@@ -25,7 +25,7 @@ public object Jetty : ApplicationEngineFactory<JettyApplicationEngine, JettyAppl
         monitor: Events,
         developmentMode: Boolean,
         configuration: JettyApplicationEngineBase.Configuration,
-        applicationProvider: () -> Application
+        applicationProvider: () -> HttpServer
     ): JettyApplicationEngine {
         return JettyApplicationEngine(environment, monitor, developmentMode, configuration, applicationProvider)
     }

--- a/ktor-server/ktor-server-jetty/jvm/src/io/ktor/server/jetty/EngineMain.kt
+++ b/ktor-server/ktor-server-jetty/jvm/src/io/ktor/server/jetty/EngineMain.kt
@@ -18,9 +18,9 @@ public object EngineMain {
     @JvmStatic
     public fun main(args: Array<String>) {
         val config = CommandLineConfig(args)
-        val server = EmbeddedServer(config.applicationProperties, Jetty) {
+        val server = EmbeddedServer(config.applicationRuntimeConfig, Jetty) {
             takeFrom(config.engineConfig)
-            loadConfiguration(config.applicationProperties.environment.config)
+            loadConfiguration(config.applicationRuntimeConfig.environment.config)
         }
         server.start(true)
     }

--- a/ktor-server/ktor-server-jetty/jvm/src/io/ktor/server/jetty/JettyApplicationCall.kt
+++ b/ktor-server/ktor-server-jetty/jvm/src/io/ktor/server/jetty/JettyApplicationCall.kt
@@ -14,7 +14,7 @@ import kotlin.coroutines.*
 
 @InternalAPI
 public class JettyApplicationCall(
-    application: Application,
+    application: HttpServer,
     request: Request,
     servletRequest: HttpServletRequest,
     servletResponse: HttpServletResponse,

--- a/ktor-server/ktor-server-jetty/jvm/src/io/ktor/server/jetty/JettyApplicationEngine.kt
+++ b/ktor-server/ktor-server-jetty/jvm/src/io/ktor/server/jetty/JettyApplicationEngine.kt
@@ -17,7 +17,7 @@ public class JettyApplicationEngine(
     monitor: Events,
     developmentMode: Boolean,
     configuration: Configuration,
-    private val applicationProvider: () -> Application
+    private val applicationProvider: () -> HttpServer
 ) : JettyApplicationEngineBase(environment, monitor, developmentMode, configuration, applicationProvider) {
 
     private val dispatcher = server.threadPool.asCoroutineDispatcher()

--- a/ktor-server/ktor-server-jetty/jvm/src/io/ktor/server/jetty/JettyApplicationEngineBase.kt
+++ b/ktor-server/ktor-server-jetty/jvm/src/io/ktor/server/jetty/JettyApplicationEngineBase.kt
@@ -23,7 +23,7 @@ public open class JettyApplicationEngineBase(
      * Application engine configuration specifying engine-specific options such as parallelism level.
      */
     public val configuration: Configuration,
-    private val applicationProvider: () -> Application
+    private val applicationProvider: () -> HttpServer
 ) : BaseApplicationEngine(environment, monitor, developmentMode) {
 
     /**

--- a/ktor-server/ktor-server-jetty/jvm/src/io/ktor/server/jetty/JettyKtorHandler.kt
+++ b/ktor-server/ktor-server-jetty/jvm/src/io/ktor/server/jetty/JettyKtorHandler.kt
@@ -8,7 +8,6 @@ import io.ktor.http.*
 import io.ktor.server.application.*
 import io.ktor.server.engine.*
 import io.ktor.server.response.*
-import io.ktor.util.*
 import io.ktor.util.cio.*
 import io.ktor.util.pipeline.*
 import io.ktor.utils.io.*
@@ -34,7 +33,7 @@ internal class JettyKtorHandler(
     private val pipeline: EnginePipeline,
     private val engineDispatcher: CoroutineDispatcher,
     configuration: JettyApplicationEngineBase.Configuration,
-    private val applicationProvider: () -> Application
+    private val applicationProvider: () -> HttpServer
 ) : AbstractHandler(), CoroutineScope {
     private val environmentName = configuration.connectors.joinToString("-") { it.port.toString() }
     private val queue: BlockingQueue<Runnable> = LinkedBlockingQueue()

--- a/ktor-server/ktor-server-jetty/jvm/test/io/ktor/tests/server/jetty/JettyServletApplicationEngine.kt
+++ b/ktor-server/ktor-server-jetty/jvm/test/io/ktor/tests/server/jetty/JettyServletApplicationEngine.kt
@@ -29,7 +29,7 @@ internal class Servlet(
         monitor: Events,
         developmentMode: Boolean,
         configuration: JettyApplicationEngineBase.Configuration,
-        applicationProvider: () -> Application
+        applicationProvider: () -> HttpServer
     ): JettyServletApplicationEngine {
         return JettyServletApplicationEngine(
             environment,
@@ -47,7 +47,7 @@ internal class JettyServletApplicationEngine(
     monitor: Events,
     developmentMode: Boolean,
     configuration: Configuration,
-    applicationProvider: () -> Application,
+    applicationProvider: () -> HttpServer,
     async: Boolean
 ) : JettyApplicationEngineBase(environment, monitor, developmentMode, configuration, applicationProvider) {
     init {

--- a/ktor-server/ktor-server-jetty/jvm/test/io/ktor/tests/server/jetty/MultipleDispatchOnTimeout.kt
+++ b/ktor-server/ktor-server-jetty/jvm/test/io/ktor/tests/server/jetty/MultipleDispatchOnTimeout.kt
@@ -32,7 +32,7 @@ class MultipleDispatchOnTimeout {
         val environment = applicationEnvironment {
             log = LoggerFactory.getLogger("io.ktor.test")
         }
-        val props = applicationProperties(environment) {
+        val props = applicationRuntimeConfig(environment) {
             module {
                 intercept(ApplicationCallPipeline.Call) {
                     callCount.incrementAndGet()

--- a/ktor-server/ktor-server-jetty/ktor-server-jetty-test-http2/jvm/test/io/ktor/tests/server/jetty/http2/JettyHttp2ServletContainer.kt
+++ b/ktor-server/ktor-server-jetty/ktor-server-jetty-test-http2/jvm/test/io/ktor/tests/server/jetty/http2/JettyHttp2ServletContainer.kt
@@ -28,7 +28,7 @@ internal class Servlet(private val async: Boolean) :
         monitor: Events,
         developmentMode: Boolean,
         configuration: JettyApplicationEngineBase.Configuration,
-        applicationProvider: () -> Application
+        applicationProvider: () -> HttpServer
     ): JettyServletApplicationEngine {
         return JettyServletApplicationEngine(
             environment,
@@ -46,7 +46,7 @@ internal class JettyServletApplicationEngine(
     monitor: Events,
     developmentMode: Boolean,
     configuration: Configuration,
-    applicationProvider: () -> Application,
+    applicationProvider: () -> HttpServer,
     async: Boolean
 ) : JettyApplicationEngineBase(environment, monitor, developmentMode, configuration, applicationProvider) {
     init {

--- a/ktor-server/ktor-server-jetty/ktor-server-jetty-test-http2/jvm/test/io/ktor/tests/server/jetty/http2/MultipleDispatchOnTimeout.kt
+++ b/ktor-server/ktor-server-jetty/ktor-server-jetty-test-http2/jvm/test/io/ktor/tests/server/jetty/http2/MultipleDispatchOnTimeout.kt
@@ -35,7 +35,7 @@ class MultipleDispatchOnTimeout {
 
         val jetty = embeddedServer(
             Jetty,
-            applicationProperties(environment) {
+            applicationRuntimeConfig(environment) {
                 module {
                     intercept(ApplicationCallPipeline.Call) {
                         callCount.incrementAndGet()

--- a/ktor-server/ktor-server-netty/api/ktor-server-netty.api
+++ b/ktor-server/ktor-server-netty/api/ktor-server-netty.api
@@ -62,7 +62,7 @@ public final class io/ktor/server/netty/Netty : io/ktor/server/engine/Applicatio
 }
 
 public abstract class io/ktor/server/netty/NettyApplicationCall : io/ktor/server/engine/BaseApplicationCall {
-	public fun <init> (Lio/ktor/server/application/Application;Lio/netty/channel/ChannelHandlerContext;Ljava/lang/Object;)V
+	public fun <init> (Lio/ktor/server/application/HttpServer;Lio/netty/channel/ChannelHandlerContext;Ljava/lang/Object;)V
 	public final fun getContext ()Lio/netty/channel/ChannelHandlerContext;
 	public abstract fun getRequest ()Lio/ktor/server/netty/NettyApplicationRequest;
 	public abstract fun getResponse ()Lio/ktor/server/netty/NettyApplicationResponse;

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/Embedded.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/Embedded.kt
@@ -25,7 +25,7 @@ public object Netty : ApplicationEngineFactory<NettyApplicationEngine, NettyAppl
         monitor: Events,
         developmentMode: Boolean,
         configuration: NettyApplicationEngine.Configuration,
-        applicationProvider: () -> Application
+        applicationProvider: () -> HttpServer
     ): NettyApplicationEngine {
         return NettyApplicationEngine(environment, monitor, developmentMode, configuration, applicationProvider)
     }

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/EngineMain.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/EngineMain.kt
@@ -18,9 +18,9 @@ public object EngineMain {
     @JvmStatic
     public fun main(args: Array<String>) {
         val config = CommandLineConfig(args)
-        val server = EmbeddedServer(config.applicationProperties, Netty) {
+        val server = EmbeddedServer(config.applicationRuntimeConfig, Netty) {
             takeFrom(config.engineConfig)
-            loadConfiguration(config.applicationProperties.environment.config)
+            loadConfiguration(config.applicationRuntimeConfig.environment.config)
         }
         server.start(true)
     }

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyApplicationCall.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyApplicationCall.kt
@@ -14,7 +14,7 @@ import kotlinx.atomicfu.*
 import kotlinx.coroutines.*
 
 public abstract class NettyApplicationCall(
-    application: Application,
+    application: HttpServer,
     public val context: ChannelHandlerContext,
     private val requestMessage: Any,
 ) : BaseApplicationCall(application) {

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyApplicationEngine.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyApplicationEngine.kt
@@ -31,7 +31,7 @@ public class NettyApplicationEngine(
     monitor: Events,
     developmentMode: Boolean,
     public val configuration: Configuration,
-    private val applicationProvider: () -> Application
+    private val applicationProvider: () -> HttpServer
 ) : BaseApplicationEngine(environment, monitor, developmentMode) {
 
     /**

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyChannelInitializer.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyChannelInitializer.kt
@@ -27,7 +27,7 @@ import kotlin.coroutines.*
  * A [ChannelInitializer] implementation that sets up the default ktor channel pipeline
  */
 public class NettyChannelInitializer(
-    private val applicationProvider: () -> Application,
+    private val applicationProvider: () -> HttpServer,
     private val enginePipeline: EnginePipeline,
     private val environment: ApplicationEnvironment,
     private val callEventGroup: EventExecutorGroup,

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http1/NettyHttp1ApplicationCall.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http1/NettyHttp1ApplicationCall.kt
@@ -13,7 +13,7 @@ import io.netty.handler.codec.http.*
 import kotlin.coroutines.*
 
 internal class NettyHttp1ApplicationCall(
-    application: Application,
+    application: HttpServer,
     context: ChannelHandlerContext,
     httpRequest: HttpRequest,
     requestBodyChannel: ByteReadChannel?,

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http1/NettyHttp1Handler.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http1/NettyHttp1Handler.kt
@@ -18,7 +18,7 @@ import java.io.*
 import kotlin.coroutines.*
 
 internal class NettyHttp1Handler(
-    private val applicationProvider: () -> Application,
+    private val applicationProvider: () -> HttpServer,
     private val enginePipeline: EnginePipeline,
     private val environment: ApplicationEnvironment,
     private val callEventGroup: EventExecutorGroup,

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http2/NettyHttp2ApplicationCall.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http2/NettyHttp2ApplicationCall.kt
@@ -12,7 +12,7 @@ import io.netty.handler.codec.http2.*
 import kotlin.coroutines.*
 
 internal class NettyHttp2ApplicationCall(
-    application: Application,
+    application: HttpServer,
     context: ChannelHandlerContext,
     val headers: Http2Headers,
     handler: NettyHttp2Handler,

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http2/NettyHttp2Handler.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http2/NettyHttp2Handler.kt
@@ -22,7 +22,7 @@ import kotlin.coroutines.*
 @ChannelHandler.Sharable
 internal class NettyHttp2Handler(
     private val enginePipeline: EnginePipeline,
-    private val application: Application,
+    private val application: HttpServer,
     private val callEventGroup: EventExecutorGroup,
     private val userCoroutineContext: CoroutineContext,
     runningLimit: Int

--- a/ktor-server/ktor-server-netty/jvm/test/io/ktor/tests/server/netty/NettyConfigurationTest.kt
+++ b/ktor-server/ktor-server-netty/jvm/test/io/ktor/tests/server/netty/NettyConfigurationTest.kt
@@ -25,7 +25,7 @@ class NettyConfigurationTest {
         val events = Events()
 
         val server = mockk<EmbeddedServer<NettyApplicationEngine, NettyApplicationEngine.Configuration>>()
-        val application = mockk<Application>().apply {
+        val application = mockk<HttpServer>().apply {
             every { coroutineContext } returns Job()
             every { developmentMode } returns false
             every { parentCoroutineContext } returns Dispatchers.Default

--- a/ktor-server/ktor-server-netty/jvm/test/io/ktor/tests/server/netty/NettyHttp2HttpServerResponseTest.kt
+++ b/ktor-server/ktor-server-netty/jvm/test/io/ktor/tests/server/netty/NettyHttp2HttpServerResponseTest.kt
@@ -9,7 +9,7 @@ import io.ktor.server.netty.http2.*
 import io.netty.handler.codec.http2.*
 import kotlin.test.*
 
-class NettyHttp2ApplicationResponseTest {
+class NettyHttp2HttpServerResponseTest {
 
     @Test
     fun testAllHeadersSkipPseudoHeaders() {

--- a/ktor-server/ktor-server-netty/jvm/test/io/ktor/tests/server/netty/NettySpecificTest.kt
+++ b/ktor-server/ktor-server-netty/jvm/test/io/ktor/tests/server/netty/NettySpecificTest.kt
@@ -16,7 +16,7 @@ class NettySpecificTest {
     @Test
     fun testNoLeakWithoutStartAndStop() {
         repeat(100000) {
-            embeddedServer(Netty, applicationProperties { })
+            embeddedServer(Netty, applicationRuntimeConfig { })
         }
     }
 

--- a/ktor-server/ktor-server-plugins/ktor-server-auth-jwt/jvm/test/io/ktor/server/auth/jwt/JWTAuthTest.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-auth-jwt/jvm/test/io/ktor/server/auth/jwt/JWTAuthTest.kt
@@ -477,7 +477,7 @@ class JWTAuthTest {
         }
     }
 
-    private fun Application.configureServerJwk(mock: Boolean = false, challenge: Boolean = false) = configureServer {
+    private fun HttpServer.configureServerJwk(mock: Boolean = false, challenge: Boolean = false) = configureServer {
         jwt {
             this@jwt.realm = this@JWTAuthTest.realm
             if (mock) {
@@ -506,7 +506,7 @@ class JWTAuthTest {
         }
     }
 
-    private fun Application.configureServerJwkNoIssuer(mock: Boolean = false) = configureServer {
+    private fun HttpServer.configureServerJwkNoIssuer(mock: Boolean = false) = configureServer {
         jwt {
             this@jwt.realm = this@JWTAuthTest.realm
             if (mock) {
@@ -524,7 +524,7 @@ class JWTAuthTest {
         }
     }
 
-    private fun Application.configureServerJwtWithLeeway(mock: Boolean = false) = configureServer {
+    private fun HttpServer.configureServerJwtWithLeeway(mock: Boolean = false) = configureServer {
         jwt {
             this@jwt.realm = this@JWTAuthTest.realm
             if (mock) {
@@ -545,7 +545,7 @@ class JWTAuthTest {
         }
     }
 
-    private fun Application.configureServerJwt(extra: JWTAuthenticationProvider.Config.() -> Unit = {}) =
+    private fun HttpServer.configureServerJwt(extra: JWTAuthenticationProvider.Config.() -> Unit = {}) =
         configureServer {
             jwt {
                 this@jwt.realm = this@JWTAuthTest.realm
@@ -560,7 +560,7 @@ class JWTAuthTest {
             }
         }
 
-    private fun Application.configureServer(authBlock: (AuthenticationConfig.() -> Unit)) {
+    private fun HttpServer.configureServer(authBlock: (AuthenticationConfig.() -> Unit)) {
         install(Authentication) {
             authBlock(this)
         }

--- a/ktor-server/ktor-server-plugins/ktor-server-auth/api/ktor-server-auth.api
+++ b/ktor-server/ktor-server-plugins/ktor-server-auth/api/ktor-server-auth.api
@@ -6,7 +6,7 @@ public final class io/ktor/server/auth/Authentication {
 
 public final class io/ktor/server/auth/Authentication$Companion : io/ktor/server/application/BaseApplicationPlugin {
 	public fun getKey ()Lio/ktor/util/AttributeKey;
-	public fun install (Lio/ktor/server/application/Application;Lkotlin/jvm/functions/Function1;)Lio/ktor/server/auth/Authentication;
+	public fun install (Lio/ktor/server/application/HttpServer;Lkotlin/jvm/functions/Function1;)Lio/ktor/server/auth/Authentication;
 	public synthetic fun install (Lio/ktor/util/pipeline/Pipeline;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
 }
 
@@ -76,7 +76,7 @@ public final class io/ktor/server/auth/AuthenticationInterceptorsKt {
 }
 
 public final class io/ktor/server/auth/AuthenticationKt {
-	public static final fun authentication (Lio/ktor/server/application/Application;Lkotlin/jvm/functions/Function1;)V
+	public static final fun authentication (Lio/ktor/server/application/HttpServer;Lkotlin/jvm/functions/Function1;)V
 	public static final fun getAuthentication (Lio/ktor/server/application/ApplicationCall;)Lio/ktor/server/auth/AuthenticationContext;
 }
 

--- a/ktor-server/ktor-server-plugins/ktor-server-auth/common/src/io/ktor/server/auth/Authentication.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-auth/common/src/io/ktor/server/auth/Authentication.kt
@@ -92,10 +92,10 @@ public class Authentication(internal var config: AuthenticationConfig) {
     /**
      * An installation object of the [Authentication] plugin.
      */
-    public companion object : BaseApplicationPlugin<Application, AuthenticationConfig, Authentication> {
+    public companion object : BaseApplicationPlugin<HttpServer, AuthenticationConfig, Authentication> {
         override val key: AttributeKey<Authentication> = AttributeKey("AuthenticationHolder")
 
-        override fun install(pipeline: Application, configure: AuthenticationConfig.() -> Unit): Authentication {
+        override fun install(pipeline: HttpServer, configure: AuthenticationConfig.() -> Unit): Authentication {
             val config = AuthenticationConfig().apply(configure)
             return Authentication(config)
         }
@@ -125,6 +125,6 @@ public inline fun <reified P : Principal> ApplicationCall.principal(provider: St
  * using the [Authentication.configure] function.
  * Changing captured instance of configuration outside of [block] may have no effect or damage application's state.
  */
-public fun Application.authentication(block: AuthenticationConfig.() -> Unit) {
+public fun HttpServer.authentication(block: AuthenticationConfig.() -> Unit) {
     pluginOrNull(Authentication)?.configure(block) ?: install(Authentication, block)
 }

--- a/ktor-server/ktor-server-plugins/ktor-server-auth/common/test/io/ktor/tests/auth/OAuth2Test.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-auth/common/test/io/ktor/tests/auth/OAuth2Test.kt
@@ -154,7 +154,7 @@ class OAuth2Test {
     )
 
     val failures = ArrayList<Throwable>()
-    fun Application.module(settings: OAuthServerSettings.OAuth2ServerSettings = DefaultSettings) {
+    fun HttpServer.module(settings: OAuthServerSettings.OAuth2ServerSettings = DefaultSettings) {
         install(Authentication) {
             oauth("login") {
                 client = testClient
@@ -611,7 +611,7 @@ internal interface OAuth2Server {
 
 internal fun createOAuth2Server(server: OAuth2Server): HttpClient {
     val environment = createTestEnvironment {}
-    val props = applicationProperties(environment) {
+    val props = applicationRuntimeConfig(environment) {
         module {
             routing {
                 route("/oauth/access_token") {

--- a/ktor-server/ktor-server-plugins/ktor-server-auth/jvm/test/io/ktor/tests/auth/DigestTest.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-auth/jvm/test/io/ktor/tests/auth/DigestTest.kt
@@ -178,7 +178,7 @@ class DigestTest {
         assertEquals(HttpStatusCode.OK, responseCorrectAuth.status)
     }
 
-    private fun Application.configureDigestServer(nonceManager: NonceManager = GenerateOnlyNonceManager) {
+    private fun HttpServer.configureDigestServer(nonceManager: NonceManager = GenerateOnlyNonceManager) {
         install(Authentication) {
             digest {
                 val p = "Circle Of Life"

--- a/ktor-server/ktor-server-plugins/ktor-server-auth/jvm/test/io/ktor/tests/auth/OAuth1aTest.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-auth/jvm/test/io/ktor/tests/auth/OAuth1aTest.kt
@@ -285,7 +285,7 @@ class OAuth1aFlowTest {
         }
     }
 
-    private fun Application.configureServer(
+    private fun HttpServer.configureServer(
         redirectUrl: String = "http://localhost/login?redirected=true",
         mutateSettings: OAuthServerSettings.OAuth1aServerSettings.() ->
         OAuthServerSettings.OAuth1aServerSettings = { this }
@@ -347,7 +347,7 @@ private interface TestingOAuthServer {
 
 private fun createOAuthServer(server: TestingOAuthServer): HttpClient {
     val environment = createTestEnvironment {}
-    val props = applicationProperties(environment) {
+    val props = applicationRuntimeConfig(environment) {
         module {
             routing {
                 post("/oauth/request_token") {

--- a/ktor-server/ktor-server-plugins/ktor-server-call-logging/jvm/src/io/ktor/server/plugins/calllogging/CallLogging.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-call-logging/jvm/src/io/ktor/server/plugins/calllogging/CallLogging.kt
@@ -94,10 +94,10 @@ private fun PluginBuilder<CallLoggingConfig>.logCallsWithMDC(logSuccess: (Applic
 }
 
 private fun setupLogging(events: Events, log: (String) -> Unit) {
-    val starting: (Application) -> Unit = { log("Application starting: $it") }
-    val started: (Application) -> Unit = { log("Application started: $it") }
-    val stopping: (Application) -> Unit = { log("Application stopping: $it") }
-    var stopped: (Application) -> Unit = {}
+    val starting: (HttpServer) -> Unit = { log("Application starting: $it") }
+    val started: (HttpServer) -> Unit = { log("Application started: $it") }
+    val stopping: (HttpServer) -> Unit = { log("Application stopping: $it") }
+    var stopped: (HttpServer) -> Unit = {}
 
     stopped = {
         log("Application stopped: $it")

--- a/ktor-server/ktor-server-plugins/ktor-server-freemarker/jvm/test/io/ktor/tests/freemarker/FreeMarkerTest.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-freemarker/jvm/test/io/ktor/tests/freemarker/FreeMarkerTest.kt
@@ -19,7 +19,6 @@ import io.ktor.server.plugins.statuspages.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
 import io.ktor.server.testing.*
-import io.ktor.util.*
 import io.ktor.util.reflect.*
 import io.ktor.utils.io.*
 import io.ktor.utils.io.charsets.*
@@ -189,7 +188,7 @@ class FreeMarkerTest {
         assertEquals("<h1>Bonjour le monde!</h1>", lines[1])
     }
 
-    private fun Application.setUpTestTemplates() {
+    private fun HttpServer.setUpTestTemplates() {
         val bax = "$"
 
         install(FreeMarker) {

--- a/ktor-server/ktor-server-plugins/ktor-server-jte/jvm/test/io/ktor/tests/jte/JteTest.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-jte/jvm/test/io/ktor/tests/jte/JteTest.kt
@@ -20,7 +20,6 @@ import io.ktor.server.plugins.statuspages.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
 import io.ktor.server.testing.*
-import io.ktor.util.*
 import io.ktor.util.reflect.*
 import io.ktor.utils.io.*
 import io.ktor.utils.io.charsets.*
@@ -189,7 +188,7 @@ class JteTest {
         assertEquals("<h1>Bonjour le monde!</h1>", lines[1])
     }
 
-    private fun Application.setUpTestTemplates() {
+    private fun HttpServer.setUpTestTemplates() {
         val bax = "$"
 
         install(Jte) {

--- a/ktor-server/ktor-server-plugins/ktor-server-mustache/jvm/test/io/ktor/server/mustache/MustacheTest.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-mustache/jvm/test/io/ktor/server/mustache/MustacheTest.kt
@@ -186,7 +186,7 @@ class MustacheTest {
         assertEquals("Template", response.bodyAsText().trim())
     }
 
-    private fun Application.setupMustache() {
+    private fun HttpServer.setupMustache() {
         install(Mustache)
     }
 

--- a/ktor-server/ktor-server-plugins/ktor-server-pebble/jvm/test/io/ktor/server/pebble/PebbleTest.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-pebble/jvm/test/io/ktor/server/pebble/PebbleTest.kt
@@ -243,7 +243,7 @@ class PebbleTest {
         assertEquals("<p>Hola, mundo!</p>", response.bodyAsText())
     }
 
-    private fun Application.setupPebble() {
+    private fun HttpServer.setupPebble() {
         install(Pebble) {
             loader(StringLoader())
             availableLanguages = mutableListOf("en", "es")

--- a/ktor-server/ktor-server-plugins/ktor-server-resources/api/ktor-server-resources.api
+++ b/ktor-server/ktor-server-plugins/ktor-server-resources/api/ktor-server-resources.api
@@ -1,7 +1,7 @@
 public final class io/ktor/server/resources/Resources : io/ktor/server/application/BaseApplicationPlugin {
 	public static final field INSTANCE Lio/ktor/server/resources/Resources;
 	public fun getKey ()Lio/ktor/util/AttributeKey;
-	public fun install (Lio/ktor/server/application/Application;Lkotlin/jvm/functions/Function1;)Lio/ktor/resources/Resources;
+	public fun install (Lio/ktor/server/application/HttpServer;Lkotlin/jvm/functions/Function1;)Lio/ktor/resources/Resources;
 	public synthetic fun install (Lio/ktor/util/pipeline/Pipeline;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
 }
 

--- a/ktor-server/ktor-server-plugins/ktor-server-resources/common/src/io/ktor/server/resources/Resources.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-resources/common/src/io/ktor/server/resources/Resources.kt
@@ -44,11 +44,11 @@ import io.ktor.resources.Resources as ResourcesCore
  *
  * @see Resource
  */
-public object Resources : BaseApplicationPlugin<Application, ResourcesCore.Configuration, ResourcesCore> {
+public object Resources : BaseApplicationPlugin<HttpServer, ResourcesCore.Configuration, ResourcesCore> {
 
     override val key: AttributeKey<ResourcesCore> = AttributeKey("Resources")
 
-    override fun install(pipeline: Application, configure: ResourcesCore.Configuration.() -> Unit): ResourcesCore {
+    override fun install(pipeline: HttpServer, configure: ResourcesCore.Configuration.() -> Unit): ResourcesCore {
         val configuration = ResourcesCore.Configuration().apply(configure)
         return ResourcesCore(configuration)
     }
@@ -59,7 +59,7 @@ public object Resources : BaseApplicationPlugin<Application, ResourcesCore.Confi
  *
  * The class of the [resource] instance **must** be annotated with [Resource].
  */
-public inline fun <reified T : Any> Application.href(resource: T): String {
+public inline fun <reified T : Any> HttpServer.href(resource: T): String {
     return href(plugin(Resources).resourcesFormat, resource)
 }
 
@@ -68,6 +68,6 @@ public inline fun <reified T : Any> Application.href(resource: T): String {
  *
  * The class of the [resource] instance **must** be annotated with [Resource].
  */
-public inline fun <reified T : Any> Application.href(resource: T, urlBuilder: URLBuilder) {
+public inline fun <reified T : Any> HttpServer.href(resource: T, urlBuilder: URLBuilder) {
     href(plugin(Resources).resourcesFormat, resource, urlBuilder)
 }

--- a/ktor-server/ktor-server-plugins/ktor-server-thymeleaf/jvm/test/io/ktor/server/thymeleaf/ThymeleafTest.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-thymeleaf/jvm/test/io/ktor/server/thymeleaf/ThymeleafTest.kt
@@ -270,7 +270,7 @@ class ThymeleafTest {
         assertEquals("<div><p>Hello, first fragment</p></div>", response.bodyAsText())
     }
 
-    private fun Application.setUpThymeleafStringTemplate() {
+    private fun HttpServer.setUpThymeleafStringTemplate() {
         install(Thymeleaf) {
             setTemplateResolver(StringTemplateResolver())
         }

--- a/ktor-server/ktor-server-plugins/ktor-server-velocity/jvm/test/io/ktor/tests/velocity/VelocityTest.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-velocity/jvm/test/io/ktor/tests/velocity/VelocityTest.kt
@@ -160,7 +160,7 @@ class VelocityTest {
         assertEquals("<h1>Bonjour le monde!</h1>", lines[1])
     }
 
-    private fun Application.setUpTestTemplates() {
+    private fun HttpServer.setUpTestTemplates() {
         val bax = "$"
 
         install(Velocity) {

--- a/ktor-server/ktor-server-plugins/ktor-server-velocity/jvm/test/io/ktor/tests/velocity/VelocityToolsTest.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-velocity/jvm/test/io/ktor/tests/velocity/VelocityToolsTest.kt
@@ -174,7 +174,7 @@ class VelocityToolsTest {
         }
     }
 
-    private fun Application.setUpTestTemplates(config: EasyFactoryConfiguration.() -> Unit = {}) {
+    private fun HttpServer.setUpTestTemplates(config: EasyFactoryConfiguration.() -> Unit = {}) {
         val bax = "$"
 
         install(VelocityTools) {

--- a/ktor-server/ktor-server-plugins/ktor-server-webjars/jvm/src/io/ktor/server/webjars/Webjars.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-webjars/jvm/src/io/ktor/server/webjars/Webjars.kt
@@ -42,7 +42,7 @@ public class WebjarsConfig {
 
     /**
      * Specifies a value for [HttpHeaders.LastModified] to be used in the response.
-     * By default, it is the time when this [Application] instance started.
+     * By default, it is the time when this [HttpServer] instance started.
      * Return `null` from this block to omit the header.
      *
      * Note: for this property to work, you need to install the [ConditionalHeaders] plugin.

--- a/ktor-server/ktor-server-plugins/ktor-server-websockets/api/ktor-server-websockets.api
+++ b/ktor-server/ktor-server-plugins/ktor-server-websockets/api/ktor-server-websockets.api
@@ -47,7 +47,7 @@ public final class io/ktor/server/websocket/WebSocketServerSession$DefaultImpls 
 }
 
 public final class io/ktor/server/websocket/WebSocketServerSessionKt {
-	public static final fun getApplication (Lio/ktor/server/websocket/WebSocketServerSession;)Lio/ktor/server/application/Application;
+	public static final fun getApplication (Lio/ktor/server/websocket/WebSocketServerSession;)Lio/ktor/server/application/HttpServer;
 	public static final fun getConverter (Lio/ktor/server/websocket/WebSocketServerSession;)Lio/ktor/serialization/WebsocketContentConverter;
 	public static final fun receiveDeserialized (Lio/ktor/server/websocket/WebSocketServerSession;Lio/ktor/util/reflect/TypeInfo;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static final fun sendSerialized (Lio/ktor/server/websocket/WebSocketServerSession;Ljava/lang/Object;Lio/ktor/util/reflect/TypeInfo;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -85,7 +85,7 @@ public final class io/ktor/server/websocket/WebSockets : kotlinx/coroutines/Coro
 public final class io/ktor/server/websocket/WebSockets$Plugin : io/ktor/server/application/BaseApplicationPlugin {
 	public final fun getEXTENSIONS_KEY ()Lio/ktor/util/AttributeKey;
 	public fun getKey ()Lio/ktor/util/AttributeKey;
-	public fun install (Lio/ktor/server/application/Application;Lkotlin/jvm/functions/Function1;)Lio/ktor/server/websocket/WebSockets;
+	public fun install (Lio/ktor/server/application/HttpServer;Lkotlin/jvm/functions/Function1;)Lio/ktor/server/websocket/WebSockets;
 	public synthetic fun install (Lio/ktor/util/pipeline/Pipeline;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
 }
 

--- a/ktor-server/ktor-server-plugins/ktor-server-websockets/common/src/io/ktor/server/websocket/WebSocketServerSession.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-websockets/common/src/io/ktor/server/websocket/WebSocketServerSession.kt
@@ -33,7 +33,7 @@ public interface DefaultWebSocketServerSession : DefaultWebSocketSession, WebSoc
 /**
  * An application that started this web socket session
  */
-public val WebSocketServerSession.application: Application get() = call.application
+public val WebSocketServerSession.application: HttpServer get() = call.application
 
 /**
  * Converter for web socket session

--- a/ktor-server/ktor-server-plugins/ktor-server-websockets/common/src/io/ktor/server/websocket/WebSockets.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-websockets/common/src/io/ktor/server/websocket/WebSockets.kt
@@ -108,7 +108,7 @@ public class WebSockets private constructor(
     /**
      * Plugin installation object.
      */
-    public companion object Plugin : BaseApplicationPlugin<Application, WebSocketOptions, WebSockets> {
+    public companion object Plugin : BaseApplicationPlugin<HttpServer, WebSocketOptions, WebSockets> {
         override val key: AttributeKey<WebSockets> = AttributeKey("WebSockets")
 
         /**
@@ -117,7 +117,7 @@ public class WebSockets private constructor(
         public val EXTENSIONS_KEY: AttributeKey<List<WebSocketExtension<*>>> =
             AttributeKey("WebSocket extensions")
 
-        override fun install(pipeline: Application, configure: WebSocketOptions.() -> Unit): WebSockets {
+        override fun install(pipeline: HttpServer, configure: WebSocketOptions.() -> Unit): WebSockets {
             val config = WebSocketOptions().also(configure)
             with(config) {
                 val webSockets = WebSockets(

--- a/ktor-server/ktor-server-servlet-jakarta/api/ktor-server-servlet-jakarta.api
+++ b/ktor-server/ktor-server-servlet-jakarta/api/ktor-server-servlet-jakarta.api
@@ -1,6 +1,6 @@
 public class io/ktor/server/servlet/jakarta/AsyncServletApplicationCall : io/ktor/server/engine/BaseApplicationCall, kotlinx/coroutines/CoroutineScope {
-	public fun <init> (Lio/ktor/server/application/Application;Ljakarta/servlet/http/HttpServletRequest;Ljakarta/servlet/http/HttpServletResponse;Lkotlin/coroutines/CoroutineContext;Lkotlin/coroutines/CoroutineContext;Lio/ktor/server/servlet/jakarta/ServletUpgrade;Lkotlin/coroutines/CoroutineContext;Ljava/util/Set;)V
-	public synthetic fun <init> (Lio/ktor/server/application/Application;Ljakarta/servlet/http/HttpServletRequest;Ljakarta/servlet/http/HttpServletResponse;Lkotlin/coroutines/CoroutineContext;Lkotlin/coroutines/CoroutineContext;Lio/ktor/server/servlet/jakarta/ServletUpgrade;Lkotlin/coroutines/CoroutineContext;Ljava/util/Set;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lio/ktor/server/application/HttpServer;Ljakarta/servlet/http/HttpServletRequest;Ljakarta/servlet/http/HttpServletResponse;Lkotlin/coroutines/CoroutineContext;Lkotlin/coroutines/CoroutineContext;Lio/ktor/server/servlet/jakarta/ServletUpgrade;Lkotlin/coroutines/CoroutineContext;Ljava/util/Set;)V
+	public synthetic fun <init> (Lio/ktor/server/application/HttpServer;Ljakarta/servlet/http/HttpServletRequest;Ljakarta/servlet/http/HttpServletResponse;Lkotlin/coroutines/CoroutineContext;Lkotlin/coroutines/CoroutineContext;Lio/ktor/server/servlet/jakarta/ServletUpgrade;Lkotlin/coroutines/CoroutineContext;Ljava/util/Set;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun getCoroutineContext ()Lkotlin/coroutines/CoroutineContext;
 	public synthetic fun getRequest ()Lio/ktor/server/engine/BaseApplicationRequest;
 	public synthetic fun getRequest ()Lio/ktor/server/request/ApplicationRequest;
@@ -48,7 +48,7 @@ public final class io/ktor/server/servlet/jakarta/JAASBridgeKt {
 public abstract class io/ktor/server/servlet/jakarta/KtorServlet : jakarta/servlet/http/HttpServlet, kotlinx/coroutines/CoroutineScope {
 	public fun <init> ()V
 	public fun destroy ()V
-	protected abstract fun getApplication ()Lio/ktor/server/application/Application;
+	protected abstract fun getApplication ()Lio/ktor/server/application/HttpServer;
 	public fun getCoroutineContext ()Lkotlin/coroutines/CoroutineContext;
 	protected abstract fun getEnginePipeline ()Lio/ktor/server/engine/EnginePipeline;
 	protected fun getLogger ()Lorg/slf4j/Logger;
@@ -69,7 +69,7 @@ public class io/ktor/server/servlet/jakarta/ServletApplicationEngine : io/ktor/s
 	public static final field EnvironmentAttributeKey Ljava/lang/String;
 	public fun <init> ()V
 	public fun destroy ()V
-	protected fun getApplication ()Lio/ktor/server/application/Application;
+	protected fun getApplication ()Lio/ktor/server/application/HttpServer;
 	public fun getCoroutineContext ()Lkotlin/coroutines/CoroutineContext;
 	protected fun getEnginePipeline ()Lio/ktor/server/engine/EnginePipeline;
 	public final fun getEnvironment ()Lio/ktor/server/application/ApplicationEnvironment;

--- a/ktor-server/ktor-server-servlet-jakarta/jvm/src/io/ktor/server/servlet/jakarta/AsyncServlet.kt
+++ b/ktor-server/ktor-server-servlet-jakarta/jvm/src/io/ktor/server/servlet/jakarta/AsyncServlet.kt
@@ -17,7 +17,7 @@ import java.lang.reflect.*
 import kotlin.coroutines.*
 
 public open class AsyncServletApplicationCall(
-    application: Application,
+    application: HttpServer,
     servletRequest: HttpServletRequest,
     servletResponse: HttpServletResponse,
     engineContext: CoroutineContext,

--- a/ktor-server/ktor-server-servlet-jakarta/jvm/src/io/ktor/server/servlet/jakarta/BlockingServlet.kt
+++ b/ktor-server/ktor-server-servlet-jakarta/jvm/src/io/ktor/server/servlet/jakarta/BlockingServlet.kt
@@ -16,7 +16,7 @@ import kotlinx.coroutines.*
 import kotlin.coroutines.*
 
 internal class BlockingServletApplicationCall(
-    application: Application,
+    application: HttpServer,
     servletRequest: HttpServletRequest,
     servletResponse: HttpServletResponse,
     override val coroutineContext: CoroutineContext,

--- a/ktor-server/ktor-server-servlet-jakarta/jvm/src/io/ktor/server/servlet/jakarta/KtorServlet.kt
+++ b/ktor-server/ktor-server-servlet-jakarta/jvm/src/io/ktor/server/servlet/jakarta/KtorServlet.kt
@@ -28,7 +28,7 @@ public abstract class KtorServlet : HttpServlet(), CoroutineScope {
     /**
      * Current application instance. Could be lazy
      */
-    protected abstract val application: Application
+    protected abstract val application: HttpServer
 
     /**
      * Engine pipeline

--- a/ktor-server/ktor-server-servlet-jakarta/jvm/src/io/ktor/server/servlet/jakarta/ServletApplicationEngine.kt
+++ b/ktor-server/ktor-server-servlet-jakarta/jvm/src/io/ktor/server/servlet/jakarta/ServletApplicationEngine.kt
@@ -61,7 +61,7 @@ public open class ServletApplicationEngine : KtorServlet() {
             log = LoggerFactory.getLogger(applicationId)
             classLoader = servletContext.classLoader
         }
-        val applicationProperties = applicationProperties(environment) {
+        val applicationProperties = applicationRuntimeConfig(environment) {
             rootPath = servletContext.contextPath ?: "/"
         }
         val server = EmbeddedServer(applicationProperties, EmptyEngineFactory)
@@ -80,8 +80,8 @@ public open class ServletApplicationEngine : KtorServlet() {
             ?: embeddedServer!!.environment
 
     @Suppress("UNCHECKED_CAST")
-    override val application: Application
-        get() = servletContext.getAttribute(ApplicationAttributeKey)?.let { it as () -> Application }?.invoke()
+    override val application: HttpServer
+        get() = servletContext.getAttribute(ApplicationAttributeKey)?.let { it as () -> HttpServer }?.invoke()
             ?: embeddedServer!!.application
 
     override val logger: Logger get() = environment.log
@@ -156,7 +156,7 @@ private object EmptyEngineFactory : ApplicationEngineFactory<ApplicationEngine, 
         monitor: Events,
         developmentMode: Boolean,
         configuration: ApplicationEngine.Configuration,
-        applicationProvider: () -> Application
+        applicationProvider: () -> HttpServer
     ): ApplicationEngine {
         return object : ApplicationEngine {
             override val environment: ApplicationEnvironment = environment

--- a/ktor-server/ktor-server-servlet/api/ktor-server-servlet.api
+++ b/ktor-server/ktor-server-servlet/api/ktor-server-servlet.api
@@ -1,6 +1,6 @@
 public class io/ktor/server/servlet/AsyncServletApplicationCall : io/ktor/server/engine/BaseApplicationCall, kotlinx/coroutines/CoroutineScope {
-	public fun <init> (Lio/ktor/server/application/Application;Ljavax/servlet/http/HttpServletRequest;Ljavax/servlet/http/HttpServletResponse;Lkotlin/coroutines/CoroutineContext;Lkotlin/coroutines/CoroutineContext;Lio/ktor/server/servlet/ServletUpgrade;Lkotlin/coroutines/CoroutineContext;Ljava/util/Set;)V
-	public synthetic fun <init> (Lio/ktor/server/application/Application;Ljavax/servlet/http/HttpServletRequest;Ljavax/servlet/http/HttpServletResponse;Lkotlin/coroutines/CoroutineContext;Lkotlin/coroutines/CoroutineContext;Lio/ktor/server/servlet/ServletUpgrade;Lkotlin/coroutines/CoroutineContext;Ljava/util/Set;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lio/ktor/server/application/HttpServer;Ljavax/servlet/http/HttpServletRequest;Ljavax/servlet/http/HttpServletResponse;Lkotlin/coroutines/CoroutineContext;Lkotlin/coroutines/CoroutineContext;Lio/ktor/server/servlet/ServletUpgrade;Lkotlin/coroutines/CoroutineContext;Ljava/util/Set;)V
+	public synthetic fun <init> (Lio/ktor/server/application/HttpServer;Ljavax/servlet/http/HttpServletRequest;Ljavax/servlet/http/HttpServletResponse;Lkotlin/coroutines/CoroutineContext;Lkotlin/coroutines/CoroutineContext;Lio/ktor/server/servlet/ServletUpgrade;Lkotlin/coroutines/CoroutineContext;Ljava/util/Set;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun getCoroutineContext ()Lkotlin/coroutines/CoroutineContext;
 	public synthetic fun getRequest ()Lio/ktor/server/engine/BaseApplicationRequest;
 	public synthetic fun getRequest ()Lio/ktor/server/request/ApplicationRequest;
@@ -48,7 +48,7 @@ public final class io/ktor/server/servlet/JAASBridgeKt {
 public abstract class io/ktor/server/servlet/KtorServlet : javax/servlet/http/HttpServlet, kotlinx/coroutines/CoroutineScope {
 	public fun <init> ()V
 	public fun destroy ()V
-	protected abstract fun getApplication ()Lio/ktor/server/application/Application;
+	protected abstract fun getApplication ()Lio/ktor/server/application/HttpServer;
 	public fun getCoroutineContext ()Lkotlin/coroutines/CoroutineContext;
 	protected abstract fun getEnginePipeline ()Lio/ktor/server/engine/EnginePipeline;
 	protected fun getLogger ()Lorg/slf4j/Logger;
@@ -69,7 +69,7 @@ public class io/ktor/server/servlet/ServletApplicationEngine : io/ktor/server/se
 	public static final field EnvironmentAttributeKey Ljava/lang/String;
 	public fun <init> ()V
 	public fun destroy ()V
-	protected fun getApplication ()Lio/ktor/server/application/Application;
+	protected fun getApplication ()Lio/ktor/server/application/HttpServer;
 	public fun getCoroutineContext ()Lkotlin/coroutines/CoroutineContext;
 	protected fun getEnginePipeline ()Lio/ktor/server/engine/EnginePipeline;
 	public final fun getEnvironment ()Lio/ktor/server/application/ApplicationEnvironment;

--- a/ktor-server/ktor-server-servlet/jvm/src/io/ktor/server/servlet/AsyncServlet.kt
+++ b/ktor-server/ktor-server-servlet/jvm/src/io/ktor/server/servlet/AsyncServlet.kt
@@ -17,7 +17,7 @@ import javax.servlet.http.*
 import kotlin.coroutines.*
 
 public open class AsyncServletApplicationCall(
-    application: Application,
+    application: HttpServer,
     servletRequest: HttpServletRequest,
     servletResponse: HttpServletResponse,
     engineContext: CoroutineContext,

--- a/ktor-server/ktor-server-servlet/jvm/src/io/ktor/server/servlet/BlockingServlet.kt
+++ b/ktor-server/ktor-server-servlet/jvm/src/io/ktor/server/servlet/BlockingServlet.kt
@@ -16,7 +16,7 @@ import javax.servlet.http.*
 import kotlin.coroutines.*
 
 internal class BlockingServletApplicationCall(
-    application: Application,
+    application: HttpServer,
     servletRequest: HttpServletRequest,
     servletResponse: HttpServletResponse,
     override val coroutineContext: CoroutineContext,

--- a/ktor-server/ktor-server-servlet/jvm/src/io/ktor/server/servlet/KtorServlet.kt
+++ b/ktor-server/ktor-server-servlet/jvm/src/io/ktor/server/servlet/KtorServlet.kt
@@ -28,7 +28,7 @@ public abstract class KtorServlet : HttpServlet(), CoroutineScope {
     /**
      * Current application instance. Could be lazy
      */
-    protected abstract val application: Application
+    protected abstract val application: HttpServer
 
     /**
      * Engine pipeline

--- a/ktor-server/ktor-server-servlet/jvm/src/io/ktor/server/servlet/ServletApplicationEngine.kt
+++ b/ktor-server/ktor-server-servlet/jvm/src/io/ktor/server/servlet/ServletApplicationEngine.kt
@@ -61,7 +61,7 @@ public open class ServletApplicationEngine : KtorServlet() {
             log = LoggerFactory.getLogger(applicationId)
             classLoader = servletContext.classLoader
         }
-        val applicationProperties = applicationProperties(environment) {
+        val applicationProperties = applicationRuntimeConfig(environment) {
             rootPath = servletContext.contextPath ?: "/"
         }
         val server = EmbeddedServer(applicationProperties, EmptyEngineFactory)
@@ -80,8 +80,8 @@ public open class ServletApplicationEngine : KtorServlet() {
             ?: embeddedServer!!.environment
 
     @Suppress("UNCHECKED_CAST")
-    override val application: Application
-        get() = servletContext.getAttribute(ApplicationAttributeKey)?.let { it as () -> Application }?.invoke()
+    override val application: HttpServer
+        get() = servletContext.getAttribute(ApplicationAttributeKey)?.let { it as () -> HttpServer }?.invoke()
             ?: embeddedServer!!.application
 
     override val logger: Logger get() = environment.log
@@ -155,7 +155,7 @@ private object EmptyEngineFactory : ApplicationEngineFactory<ApplicationEngine, 
         monitor: Events,
         developmentMode: Boolean,
         configuration: ApplicationEngine.Configuration,
-        applicationProvider: () -> Application
+        applicationProvider: () -> HttpServer
     ): ApplicationEngine {
         return object : ApplicationEngine {
             override val environment: ApplicationEnvironment = environment

--- a/ktor-server/ktor-server-test-base/common/src/io/ktor/server/test/base/EngineTestBase.kt
+++ b/ktor-server/ktor-server-test-base/common/src/io/ktor/server/test/base/EngineTestBase.kt
@@ -41,7 +41,7 @@ expect abstract class EngineTestBase<TEngine : ApplicationEngine, TConfiguration
         routingConfigurer: Route.() -> Unit
     ): EmbeddedServer<TEngine, TConfiguration>
 
-    protected open fun plugins(application: Application, routingConfig: Route.() -> Unit)
+    protected open fun plugins(application: HttpServer, routingConfig: Route.() -> Unit)
 
     protected suspend fun withUrl(
         path: String,

--- a/ktor-server/ktor-server-test-base/jsAndWasmShared/src/io/ktor/server/test/base/EngineTestBase.jsAndWasmShared.kt
+++ b/ktor-server/ktor-server-test-base/jsAndWasmShared/src/io/ktor/server/test/base/EngineTestBase.jsAndWasmShared.kt
@@ -66,7 +66,7 @@ actual constructor(
     protected open fun createServer(
         log: Logger? = null,
         parent: CoroutineContext = EmptyCoroutineContext,
-        module: Application.() -> Unit
+        module: ServerModule
     ): EmbeddedServer<TEngine, TConfiguration> {
         val _port = this.port
         val environment = applicationEnvironment {
@@ -83,7 +83,7 @@ actual constructor(
                 }
             }
         }
-        val properties = applicationProperties(environment) {
+        val properties = applicationRuntimeConfig(environment) {
             this.parentCoroutineContext = parent
             module(module)
         }
@@ -116,7 +116,7 @@ actual constructor(
         }
     }
 
-    protected actual open fun plugins(application: Application, routingConfig: Route.() -> Unit) {
+    protected actual open fun plugins(application: HttpServer, routingConfig: Route.() -> Unit) {
         application.install(RoutingRoot, routingConfig)
     }
 

--- a/ktor-server/ktor-server-test-base/jvm/src/io/ktor/server/test/base/EngineTestBaseJvm.kt
+++ b/ktor-server/ktor-server-test-base/jvm/src/io/ktor/server/test/base/EngineTestBaseJvm.kt
@@ -110,7 +110,7 @@ actual abstract class EngineTestBase<
     protected open fun createServer(
         log: Logger? = null,
         parent: CoroutineContext = EmptyCoroutineContext,
-        module: Application.() -> Unit
+        module: ServerModule
     ): EmbeddedServer<TEngine, TConfiguration> {
         val _port = this.port
         val environment = applicationEnvironment {
@@ -129,7 +129,7 @@ actual abstract class EngineTestBase<
                 }
             }
         }
-        val properties = applicationProperties(environment) {
+        val properties = applicationRuntimeConfig(environment) {
             this.parentCoroutineContext = parent
             module(module)
         }
@@ -158,7 +158,7 @@ actual abstract class EngineTestBase<
         // Empty, intended to be override in derived types when necessary
     }
 
-    protected actual open fun plugins(application: Application, routingConfig: Route.() -> Unit) {
+    protected actual open fun plugins(application: HttpServer, routingConfig: Route.() -> Unit) {
         application.install(CallLogging)
         application.install(RoutingRoot, routingConfig)
     }

--- a/ktor-server/ktor-server-test-base/posix/src/io/ktor/server/test/base/EngineTestBaseNix.kt
+++ b/ktor-server/ktor-server-test-base/posix/src/io/ktor/server/test/base/EngineTestBaseNix.kt
@@ -75,7 +75,7 @@ actual constructor(
     protected open fun createServer(
         log: Logger? = null,
         parent: CoroutineContext = EmptyCoroutineContext,
-        module: Application.() -> Unit
+        module: ServerModule
     ): EmbeddedServer<TEngine, TConfiguration> {
         val _port = this.port
         val environment = applicationEnvironment {
@@ -92,7 +92,7 @@ actual constructor(
                 }
             }
         }
-        val properties = applicationProperties(environment) {
+        val properties = applicationRuntimeConfig(environment) {
             this.parentCoroutineContext = parent
             module(module)
         }
@@ -125,7 +125,7 @@ actual constructor(
         }
     }
 
-    protected actual open fun plugins(application: Application, routingConfig: Route.() -> Unit) {
+    protected actual open fun plugins(application: HttpServer, routingConfig: Route.() -> Unit) {
         application.install(RoutingRoot, routingConfig)
     }
 

--- a/ktor-server/ktor-server-test-host/api/ktor-server-test-host.api
+++ b/ktor-server/ktor-server-test-host/api/ktor-server-test-host.api
@@ -46,8 +46,8 @@ public class io/ktor/server/testing/TestApplicationBuilder {
 }
 
 public final class io/ktor/server/testing/TestApplicationCall : io/ktor/server/engine/BaseApplicationCall, kotlinx/coroutines/CoroutineScope {
-	public fun <init> (Lio/ktor/server/application/Application;ZZLkotlin/coroutines/CoroutineContext;)V
-	public synthetic fun <init> (Lio/ktor/server/application/Application;ZZLkotlin/coroutines/CoroutineContext;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lio/ktor/server/application/HttpServer;ZZLkotlin/coroutines/CoroutineContext;)V
+	public synthetic fun <init> (Lio/ktor/server/application/HttpServer;ZZLkotlin/coroutines/CoroutineContext;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun getCoroutineContext ()Lkotlin/coroutines/CoroutineContext;
 	public synthetic fun getRequest ()Lio/ktor/server/engine/BaseApplicationRequest;
 	public synthetic fun getRequest ()Lio/ktor/server/request/ApplicationRequest;
@@ -65,7 +65,7 @@ public final class io/ktor/server/testing/TestApplicationEngine : io/ktor/server
 	public synthetic fun <init> (Lio/ktor/server/application/ApplicationEnvironment;Lio/ktor/events/Events;ZLkotlin/jvm/functions/Function0;Lio/ktor/server/testing/TestApplicationEngine$Configuration;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun createCall (ZZLkotlin/coroutines/CoroutineContext;Lkotlin/jvm/functions/Function1;)Lio/ktor/server/testing/TestApplicationCall;
 	public static synthetic fun createCall$default (Lio/ktor/server/testing/TestApplicationEngine;ZZLkotlin/coroutines/CoroutineContext;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lio/ktor/server/testing/TestApplicationCall;
-	public final fun getApplication ()Lio/ktor/server/application/Application;
+	public final fun getApplication ()Lio/ktor/server/application/HttpServer;
 	public final fun getCallInterceptor ()Lkotlin/jvm/functions/Function3;
 	public final fun getClient ()Lio/ktor/client/HttpClient;
 	public fun getCoroutineContext ()Lkotlin/coroutines/CoroutineContext;

--- a/ktor-server/ktor-server-test-host/common/src/io/ktor/server/testing/TestApplication.kt
+++ b/ktor-server/ktor-server-test-host/common/src/io/ktor/server/testing/TestApplication.kt
@@ -129,7 +129,7 @@ public class ExternalServicesBuilder internal constructor(private val testApplic
      * @see [testApplication]
      */
     @KtorDsl
-    public fun hosts(vararg hosts: String, block: Application.() -> Unit) {
+    public fun hosts(vararg hosts: String, block: HttpServer.() -> Unit) {
         check(hosts.isNotEmpty()) { "hosts can not be empty" }
 
         hosts.forEach {
@@ -153,10 +153,10 @@ public open class TestApplicationBuilder {
     private var built = false
 
     internal val externalServices = ExternalServicesBuilder(this)
-    internal val applicationModules = mutableListOf<Application.() -> Unit>()
+    internal val applicationModules = mutableListOf<ServerModule>()
     internal var engineConfig: TestApplicationEngine.Configuration.() -> Unit = {}
     internal var environmentBuilder: ApplicationEnvironmentBuilder.() -> Unit = {}
-    internal var applicationProperties: ApplicationPropertiesBuilder.() -> Unit = {}
+    internal var applicationProperties: ApplicationRuntimeConfigBuilder.() -> Unit = {}
     internal val job = Job()
 
     internal val properties by lazy {
@@ -168,7 +168,7 @@ public open class TestApplicationBuilder {
                 config = MapApplicationConfig()
             }
         }
-        applicationProperties(environment) {
+        applicationRuntimeConfig(environment) {
             this@TestApplicationBuilder.applicationModules.forEach { module(it) }
             parentCoroutineContext += this@TestApplicationBuilder.job
             watchPaths = emptyList()
@@ -207,11 +207,11 @@ public open class TestApplicationBuilder {
     }
 
     /**
-     * Adds a configuration block for the [ApplicationProperties].
+     * Adds a configuration block for the [ApplicationRuntimeConfig].
      * @see [testApplication]
      */
     @KtorDsl
-    public fun testApplicationProperties(block: ApplicationPropertiesBuilder.() -> Unit) {
+    public fun testApplicationProperties(block: ApplicationRuntimeConfigBuilder.() -> Unit) {
         checkNotBuilt()
         val oldBuilder = applicationProperties
         applicationProperties = { oldBuilder(); block() }
@@ -233,7 +233,7 @@ public open class TestApplicationBuilder {
      * @see [testApplication]
      */
     @KtorDsl
-    public fun application(block: Application.() -> Unit) {
+    public fun application(block: ServerModule) {
         checkNotBuilt()
         applicationModules.add(block)
     }

--- a/ktor-server/ktor-server-test-host/common/src/io/ktor/server/testing/TestApplicationCall.kt
+++ b/ktor-server/ktor-server-test-host/common/src/io/ktor/server/testing/TestApplicationCall.kt
@@ -13,7 +13,7 @@ import kotlin.coroutines.*
  * A test application call that is used in [withTestApplication] and [handleRequest].
  */
 public class TestApplicationCall(
-    application: Application,
+    application: HttpServer,
     readResponse: Boolean = false,
     closeRequest: Boolean = true,
     override val coroutineContext: CoroutineContext

--- a/ktor-server/ktor-server-test-host/common/src/io/ktor/server/testing/TestApplicationEngine.kt
+++ b/ktor-server/ktor-server-test-host/common/src/io/ktor/server/testing/TestApplicationEngine.kt
@@ -34,7 +34,7 @@ public class TestApplicationEngine(
     environment: ApplicationEnvironment = createTestEnvironment(),
     monitor: Events,
     developmentMode: Boolean = true,
-    private val applicationProvider: () -> Application,
+    private val applicationProvider: () -> HttpServer,
     internal val configuration: Configuration
 ) : BaseApplicationEngine(environment, monitor, developmentMode, EnginePipeline(developmentMode)), CoroutineScope {
 
@@ -44,7 +44,7 @@ public class TestApplicationEngine(
     override val coroutineContext: CoroutineContext =
         applicationProvider().parentCoroutineContext + testEngineJob + configuration.dispatcher
 
-    public val application: Application
+    public val application: HttpServer
         get() = applicationProvider()
 
     /**

--- a/ktor-server/ktor-server-test-host/common/src/io/ktor/server/testing/TestEngine.kt
+++ b/ktor-server/ktor-server-test-host/common/src/io/ktor/server/testing/TestEngine.kt
@@ -47,7 +47,7 @@ public fun <R> withApplication(
     configure: TestApplicationEngine.Configuration.() -> Unit = {},
     test: TestApplicationEngine.() -> R
 ): R {
-    val properties = applicationProperties(environment) {
+    val properties = applicationRuntimeConfig(environment) {
         watchPaths = emptyList()
     }
     val embeddedServer = EmbeddedServer(properties, TestEngine, configure)
@@ -71,7 +71,7 @@ public fun <R> withTestApplication(test: TestApplicationEngine.() -> R): R {
  * Starts a test application engine, passes it to the [test] function, and stops it.
  */
 @Deprecated("Please use new `testApplication` API: https://ktor.io/docs/migrating-2.html#testing-api")
-public fun <R> withTestApplication(moduleFunction: Application.() -> Unit, test: TestApplicationEngine.() -> R): R {
+public fun <R> withTestApplication(moduleFunction: ServerModule, test: TestApplicationEngine.() -> R): R {
     return withApplication(createTestEnvironment()) {
         moduleFunction(application)
         test()
@@ -83,7 +83,7 @@ public fun <R> withTestApplication(moduleFunction: Application.() -> Unit, test:
  */
 @Deprecated("Please use new `testApplication` API: https://ktor.io/docs/migrating-2.html#testing-api")
 public fun <R> withTestApplication(
-    moduleFunction: Application.() -> Unit,
+    moduleFunction: ServerModule,
     configure: TestApplicationEngine.Configuration.() -> Unit = {},
     test: TestApplicationEngine.() -> R
 ): R {
@@ -109,7 +109,7 @@ public object TestEngine : ApplicationEngineFactory<TestApplicationEngine, TestA
         monitor: Events,
         developmentMode: Boolean,
         configuration: TestApplicationEngine.Configuration,
-        applicationProvider: () -> Application
+        applicationProvider: () -> HttpServer
     ): TestApplicationEngine {
         return TestApplicationEngine(environment, monitor, developmentMode, applicationProvider, configuration)
     }

--- a/ktor-server/ktor-server-test-host/jvm/test-resources/application-with-modules.conf
+++ b/ktor-server/ktor-server-test-host/jvm/test-resources/application-with-modules.conf
@@ -1,5 +1,5 @@
 ktor {
     application {
-        modules = [ io.ktor.tests.server.testing.TestApplicationTestJvm.module ]
+        modules = [io.ktor.tests.server.testing.TestHttpServerTestJvm.module]
     }
 }

--- a/ktor-server/ktor-server-test-host/jvm/test/TestHttpServerTestJvm.kt
+++ b/ktor-server/ktor-server-test-host/jvm/test/TestHttpServerTestJvm.kt
@@ -27,7 +27,7 @@ import kotlin.coroutines.*
 import kotlin.test.*
 import io.ktor.client.plugins.websocket.WebSockets as ClientWebSockets
 
-class TestApplicationTestJvm {
+class TestHttpServerTestJvm {
 
     @Test
     fun testDefaultConfigDoesNotLoad() = testApplication {
@@ -288,7 +288,7 @@ class TestApplicationTestJvm {
         override fun toString(): String = "=====$data====="
     }
 
-    fun Application.module() {
+    fun HttpServer.module() {
         routing {
             get { call.respond("OK FROM MODULE") }
         }

--- a/ktor-server/ktor-server-test-suites/jvm/src/io/ktor/server/testing/suites/ConnectionTestSuite.kt
+++ b/ktor-server/ktor-server-test-suites/jvm/src/io/ktor/server/testing/suites/ConnectionTestSuite.kt
@@ -25,7 +25,7 @@ abstract class ConnectionTestSuite(val engine: ApplicationEngineFactory<*, *>) {
     fun testNetworkAddresses() = runBlocking {
         val server = embeddedServer(
             engine,
-            applicationProperties {}
+            applicationRuntimeConfig {}
         ) {
             connector { port = 0 }
             connector { port = ServerSocket(0).use { it.localPort } }
@@ -51,7 +51,7 @@ abstract class ConnectionTestSuite(val engine: ApplicationEngineFactory<*, *>) {
         val serverPort = withContext(Dispatchers.IO) { ServerSocket(0).use { it.localPort } }
         val server = embeddedServer(
             engine,
-            applicationProperties(applicationEnvironment()) {
+            applicationRuntimeConfig(applicationEnvironment()) {
                 module {
                     routing {
                         get("/") {
@@ -88,7 +88,7 @@ abstract class ConnectionTestSuite(val engine: ApplicationEngineFactory<*, *>) {
         val serverPort = withContext(Dispatchers.IO) { ServerSocket(0).use { it.localPort } }
         val server = embeddedServer(
             engine,
-            applicationProperties(applicationEnvironment()) {
+            applicationRuntimeConfig(applicationEnvironment()) {
                 module {
                     routing {
                         get("/") {

--- a/ktor-server/ktor-server-test-suites/jvm/src/io/ktor/server/testing/suites/ServerPluginsTestSuite.kt
+++ b/ktor-server/ktor-server-test-suites/jvm/src/io/ktor/server/testing/suites/ServerPluginsTestSuite.kt
@@ -69,7 +69,7 @@ abstract class ServerPluginsTestSuite<TEngine : ApplicationEngine, TConfiguratio
 
     val expectedEventsForCall = listOf("onCall", "onCallReceive", "onCallRespond")
 
-    override fun plugins(application: Application, routingConfig: Route.() -> Unit) {
+    override fun plugins(application: HttpServer, routingConfig: Route.() -> Unit) {
         super.plugins(application, routingConfig)
 
         application.install(plugin)

--- a/ktor-server/ktor-server-test-suites/jvmAndPosix/src/io/ktor/server/testing/suites/WebSocketEngineSuite.kt
+++ b/ktor-server/ktor-server-test-suites/jvmAndPosix/src/io/ktor/server/testing/suites/WebSocketEngineSuite.kt
@@ -34,7 +34,7 @@ abstract class WebSocketEngineSuite<TEngine : ApplicationEngine, TConfiguration 
     private val errors = mutableListOf<Throwable>()
     override val timeout = 30.seconds
 
-    override fun plugins(application: Application, routingConfig: Route.() -> Unit) {
+    override fun plugins(application: HttpServer, routingConfig: Route.() -> Unit) {
         application.install(WebSockets)
         super.plugins(application, routingConfig)
     }

--- a/ktor-server/ktor-server-tests/common/test/io/ktor/tests/server/plugins/CachingHeadersTest.kt
+++ b/ktor-server/ktor-server-tests/common/test/io/ktor/tests/server/plugins/CachingHeadersTest.kt
@@ -148,7 +148,7 @@ class CachingHeadersTest {
     }
 
     private fun test(
-        configure: Application.() -> Unit,
+        configure: ServerModule,
         test: (HttpResponse) -> Unit
     ) = testApplication {
         application {

--- a/ktor-server/ktor-server-tests/common/test/io/ktor/tests/server/plugins/HSTSTest.kt
+++ b/ktor-server/ktor-server-tests/common/test/io/ktor/tests/server/plugins/HSTSTest.kt
@@ -216,7 +216,7 @@ class HSTSTest {
         }
     }
 
-    private fun Application.testApp(block: HSTSConfig.() -> Unit = {}) {
+    private fun HttpServer.testApp(block: HSTSConfig.() -> Unit = {}) {
         install(XForwardedHeaders)
         install(HSTS) {
             maxAgeInSeconds = 10

--- a/ktor-server/ktor-server-tests/jvm/test/io/ktor/server/http/ApplicationRequestContentTestJvm.kt
+++ b/ktor-server/ktor-server-tests/jvm/test/io/ktor/server/http/ApplicationRequestContentTestJvm.kt
@@ -11,7 +11,7 @@ import io.ktor.server.request.*
 import io.ktor.server.testing.*
 import kotlin.test.*
 
-class ApplicationRequestContentTest {
+class HttpServerRequestContentTest {
 
     @Test
     fun testInputStreamContent() {

--- a/ktor-server/ktor-server-tests/jvm/test/io/ktor/server/http/spa/SinglePageHttpServerTest.kt
+++ b/ktor-server/ktor-server-tests/jvm/test/io/ktor/server/http/spa/SinglePageHttpServerTest.kt
@@ -12,7 +12,7 @@ import io.ktor.server.routing.*
 import io.ktor.server.testing.*
 import kotlin.test.*
 
-class SinglePageApplicationTest {
+class SinglePageHttpServerTest {
     @Test
     fun fullWithFilesTest() = testApplication {
         application {

--- a/ktor-server/ktor-server-tests/jvm/test/io/ktor/server/testing/TestHttpServerEngineTest.kt
+++ b/ktor-server/ktor-server-tests/jvm/test/io/ktor/server/testing/TestHttpServerEngineTest.kt
@@ -25,7 +25,7 @@ import kotlin.system.*
 import kotlin.test.*
 import kotlin.text.Charsets
 
-class TestApplicationEngineTest {
+class TestHttpServerEngineTest {
     @Test
     fun testCustomDispatcher() {
         @OptIn(InternalCoroutinesApi::class)
@@ -154,7 +154,7 @@ class TestApplicationEngineTest {
         val numberOfRequestsProcessed = AtomicInteger(0)
         val numberOfResponsesProcessed = AtomicInteger(0)
 
-        val dummyApplication: Application.() -> Unit = {
+        val dummyApplication: ServerModule = {
             routing {
                 get("/") {
                     call.respond(HttpStatusCode.NoContent)

--- a/ktor-server/ktor-server-tomcat-jakarta/jvm/src/io/ktor/server/tomcat/jakarta/Embedded.kt
+++ b/ktor-server/ktor-server-tomcat-jakarta/jvm/src/io/ktor/server/tomcat/jakarta/Embedded.kt
@@ -25,7 +25,7 @@ public object Tomcat : ApplicationEngineFactory<TomcatApplicationEngine, TomcatA
         monitor: Events,
         developmentMode: Boolean,
         configuration: TomcatApplicationEngine.Configuration,
-        applicationProvider: () -> Application
+        applicationProvider: () -> HttpServer
     ): TomcatApplicationEngine {
         return TomcatApplicationEngine(environment, monitor, developmentMode, configuration, applicationProvider)
     }

--- a/ktor-server/ktor-server-tomcat-jakarta/jvm/src/io/ktor/server/tomcat/jakarta/EngineMain.kt
+++ b/ktor-server/ktor-server-tomcat-jakarta/jvm/src/io/ktor/server/tomcat/jakarta/EngineMain.kt
@@ -18,9 +18,9 @@ public object EngineMain {
     @JvmStatic
     public fun main(args: Array<String>) {
         val config = CommandLineConfig(args)
-        val server = EmbeddedServer(config.applicationProperties, Tomcat) {
+        val server = EmbeddedServer(config.applicationRuntimeConfig, Tomcat) {
             takeFrom(config.engineConfig)
-            loadConfiguration(config.applicationProperties.environment.config)
+            loadConfiguration(config.applicationRuntimeConfig.environment.config)
         }
         server.start(true)
     }

--- a/ktor-server/ktor-server-tomcat-jakarta/jvm/src/io/ktor/server/tomcat/jakarta/TomcatApplicationEngine.kt
+++ b/ktor-server/ktor-server-tomcat-jakarta/jvm/src/io/ktor/server/tomcat/jakarta/TomcatApplicationEngine.kt
@@ -31,7 +31,7 @@ public class TomcatApplicationEngine(
     monitor: Events,
     developmentMode: Boolean,
     public val configuration: Configuration,
-    private val applicationProvider: () -> Application
+    private val applicationProvider: () -> HttpServer
 ) : BaseApplicationEngine(environment, monitor, developmentMode) {
     /**
      * Tomcat engine specific configuration builder
@@ -53,7 +53,7 @@ public class TomcatApplicationEngine(
             get() = setOf(HttpHeaders.TransferEncoding)
         override val enginePipeline: EnginePipeline
             get() = this@TomcatApplicationEngine.pipeline
-        override val application: Application
+        override val application: HttpServer
             get() = this@TomcatApplicationEngine.applicationProvider()
         override val upgrade: ServletUpgrade
             get() = DefaultServletUpgrade

--- a/ktor-server/ktor-server-tomcat/jvm/src/io/ktor/server/tomcat/Embedded.kt
+++ b/ktor-server/ktor-server-tomcat/jvm/src/io/ktor/server/tomcat/Embedded.kt
@@ -25,7 +25,7 @@ public object Tomcat : ApplicationEngineFactory<TomcatApplicationEngine, TomcatA
         monitor: Events,
         developmentMode: Boolean,
         configuration: TomcatApplicationEngine.Configuration,
-        applicationProvider: () -> Application
+        applicationProvider: () -> HttpServer
     ): TomcatApplicationEngine {
         return TomcatApplicationEngine(environment, monitor, developmentMode, configuration, applicationProvider)
     }

--- a/ktor-server/ktor-server-tomcat/jvm/src/io/ktor/server/tomcat/EngineMain.kt
+++ b/ktor-server/ktor-server-tomcat/jvm/src/io/ktor/server/tomcat/EngineMain.kt
@@ -18,9 +18,9 @@ public object EngineMain {
     @JvmStatic
     public fun main(args: Array<String>) {
         val config = CommandLineConfig(args)
-        val server = EmbeddedServer(config.applicationProperties, Tomcat) {
+        val server = EmbeddedServer(config.applicationRuntimeConfig, Tomcat) {
             takeFrom(config.engineConfig)
-            loadConfiguration(config.applicationProperties.environment.config)
+            loadConfiguration(config.applicationRuntimeConfig.environment.config)
         }
         server.start(true)
     }

--- a/ktor-server/ktor-server-tomcat/jvm/src/io/ktor/server/tomcat/TomcatApplicationEngine.kt
+++ b/ktor-server/ktor-server-tomcat/jvm/src/io/ktor/server/tomcat/TomcatApplicationEngine.kt
@@ -31,7 +31,7 @@ public class TomcatApplicationEngine(
     monitor: Events,
     developmentMode: Boolean,
     public val configuration: Configuration,
-    private val applicationProvider: () -> Application
+    private val applicationProvider: () -> HttpServer
 ) : BaseApplicationEngine(environment, monitor, developmentMode) {
     /**
      * Tomcat engine specific configuration builder
@@ -53,7 +53,7 @@ public class TomcatApplicationEngine(
             get() = setOf(HttpHeaders.TransferEncoding)
         override val enginePipeline: EnginePipeline
             get() = this@TomcatApplicationEngine.pipeline
-        override val application: Application
+        override val application: HttpServer
             get() = this@TomcatApplicationEngine.applicationProvider()
         override val upgrade: ServletUpgrade
             get() = DefaultServletUpgrade


### PR DESCRIPTION
**Subsystem**
Server, Core

**Motivation**
- [KTOR-3205](https://youtrack.jetbrains.com/issue/KTOR-3205) Application / Server naming in Ktor, and server entities design
- [KTOR-7270](https://youtrack.jetbrains.com/issue/KTOR-7270) Review naming for ApplicationProperties

**Solution**
This is a much milder version of renaming everything starting with the word `Application`.  Instead, we'll just have `HttpServer` where we previously had `Application`, along with the type alias to avoid breaking anything.

Also renamed the somewhat confusing `ApplicationProperties` and added support for lambda property modules, along with `ServerModule` typealias for `Application.() -> Unit`.
