### PR TITLE
KTOR-7323 Drop marker interface requirements in Ktor auth

### DIFF
--- a/ktor-server/ktor-server-jetty-jakarta/ktor-server-jetty-test-http2-jakarta/build.gradle.kts
+++ b/ktor-server/ktor-server-jetty-jakarta/ktor-server-jetty-test-http2-jakarta/build.gradle.kts
@@ -1,4 +1,3 @@
-
 kotlin.sourceSets {
     jvmTest {
         dependencies {

--- a/ktor-server/ktor-server-plugins/ktor-server-auth-jwt/jvm/src/io/ktor/server/auth/jwt/JWTAuth.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-auth-jwt/jvm/src/io/ktor/server/auth/jwt/JWTAuth.kt
@@ -120,14 +120,14 @@ public abstract class JWTPayloadHolder(
  * @param payload JWT
  * @see Payload
  */
-public class JWTCredential(payload: Payload) : Credential, JWTPayloadHolder(payload)
+public class JWTCredential(payload: Payload) : JWTPayloadHolder(payload)
 
 /**
  * A JWT principal that consists of the specified [payload].
  * @param payload JWT
  * @see Payload
  */
-public class JWTPrincipal(payload: Payload) : Principal, JWTPayloadHolder(payload)
+public class JWTPrincipal(payload: Payload) : JWTPayloadHolder(payload)
 
 /**
  * A JWT verifier function used to verify a token format and its signature.
@@ -296,7 +296,7 @@ public class JWTAuthenticationProvider internal constructor(config: Config) : Au
          * Allows you to perform additional validations on the JWT payload.
          * @return a principal (usually an instance of [JWTPrincipal]) or `null`
          */
-        public fun validate(validate: suspend ApplicationCall.(JWTCredential) -> Principal?) {
+        public fun validate(validate: suspend ApplicationCall.(JWTCredential) -> Any?) {
             authenticationFunction = validate
         }
 

--- a/ktor-server/ktor-server-plugins/ktor-server-auth-jwt/jvm/src/io/ktor/server/auth/jwt/JWTUtils.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-auth-jwt/jvm/src/io/ktor/server/auth/jwt/JWTUtils.kt
@@ -89,8 +89,8 @@ internal suspend fun verifyAndValidate(
     jwtVerifier: JWTVerifier?,
     token: HttpAuthHeader,
     schemes: JWTAuthSchemes,
-    validate: suspend ApplicationCall.(JWTCredential) -> Principal?
-): Principal? {
+    validate: suspend ApplicationCall.(JWTCredential) -> Any?
+): Any? {
     val jwt = try {
         token.getBlob(schemes)?.let { jwtVerifier?.verify(it) }
     } catch (cause: JWTVerificationException) {

--- a/ktor-server/ktor-server-plugins/ktor-server-auth-jwt/jvm/test/io/ktor/server/auth/jwt/JWTAuthTest.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-auth-jwt/jvm/test/io/ktor/server/auth/jwt/JWTAuthTest.kt
@@ -11,7 +11,6 @@ import io.ktor.http.*
 import io.ktor.http.auth.*
 import io.ktor.server.application.*
 import io.ktor.server.auth.*
-import io.ktor.server.auth.Principal
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
 import io.ktor.server.testing.*
@@ -75,7 +74,7 @@ class JWTAuthTest {
     @Test
     fun testJwtWithMultipleConfigurations() {
         val validated = mutableSetOf<String>()
-        var currentPrincipal: (JWTCredential) -> Principal? = { null }
+        var currentPrincipal: (JWTCredential) -> Any? = { null }
 
         withApplication {
             application.install(Authentication) {

--- a/ktor-server/ktor-server-plugins/ktor-server-auth-ldap/jvm/src/io/ktor/server/auth/ldap/Ldap.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-auth-ldap/jvm/src/io/ktor/server/auth/ldap/Ldap.kt
@@ -15,7 +15,7 @@ import javax.naming.directory.*
  *
  * To learn more about LDAP authentication in Ktor, see [LDAP](https://ktor.io/docs/ldap.html).
  */
-public fun <K : Credential, P : Any> ldapAuthenticate(
+public fun <K : Any, P : Any> ldapAuthenticate(
     credential: K,
     ldapServerURL: String,
     ldapEnvironmentBuilder: (MutableMap<String, Any?>) -> Unit = {},
@@ -39,7 +39,7 @@ public fun <K : Credential, P : Any> ldapAuthenticate(
  *
  * To learn more about LDAP authentication in Ktor, see [LDAP](https://ktor.io/docs/ldap.html).
  */
-public fun <P : Principal> ldapAuthenticate(
+public fun <P : Any> ldapAuthenticate(
     credential: UserPasswordCredential,
     ldapServerURL: String,
     userDNFormat: String,

--- a/ktor-server/ktor-server-plugins/ktor-server-auth/common/src/io/ktor/server/auth/Authentication.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-auth/common/src/io/ktor/server/auth/Authentication.kt
@@ -109,14 +109,14 @@ public val ApplicationCall.authentication: AuthenticationContext
     get() = AuthenticationContext.from(this)
 
 /**
- * Retrieves an authenticated [Principal] for `this` call.
+ * Retrieves an authenticated [Any] for `this` call.
  */
-public inline fun <reified P : Principal> ApplicationCall.principal(): P? = principal(null)
+public inline fun <reified P : Any> ApplicationCall.principal(): P? = principal(null)
 
 /**
- * Retrieves an authenticated [Principal] for `this` call from provider with name [provider]
+ * Retrieves an authenticated [Any] for `this` call from provider with name [provider]
  */
-public inline fun <reified P : Principal> ApplicationCall.principal(provider: String?): P? =
+public inline fun <reified P : Any> ApplicationCall.principal(provider: String?): P? =
     authentication.principal(provider)
 
 /**

--- a/ktor-server/ktor-server-plugins/ktor-server-auth/common/src/io/ktor/server/auth/Authentication.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-auth/common/src/io/ktor/server/auth/Authentication.kt
@@ -109,12 +109,12 @@ public val ApplicationCall.authentication: AuthenticationContext
     get() = AuthenticationContext.from(this)
 
 /**
- * Retrieves an authenticated [Any] for `this` call.
+ * Retrieves an authenticated principal [Any] for `this` call.
  */
 public inline fun <reified P : Any> ApplicationCall.principal(): P? = principal(null)
 
 /**
- * Retrieves an authenticated [Any] for `this` call from provider with name [provider]
+ * Retrieves an authenticated principal [Any] for `this` call from provider with name [provider]
  */
 public inline fun <reified P : Any> ApplicationCall.principal(provider: String?): P? =
     authentication.principal(provider)

--- a/ktor-server/ktor-server-plugins/ktor-server-auth/common/src/io/ktor/server/auth/AuthenticationContext.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-auth/common/src/io/ktor/server/auth/AuthenticationContext.kt
@@ -25,7 +25,7 @@ public class AuthenticationContext(call: ApplicationCall) {
      * Retrieves an authenticated principal, or returns `null` if a user isn't authenticated.
      */
     @Deprecated("Use accessor methods instead", level = DeprecationLevel.ERROR)
-    public var principal: Principal?
+    public var principal: Any?
         get() = _principal.principals.firstOrNull()?.second
         set(value) {
             check(value != null)
@@ -59,28 +59,28 @@ public class AuthenticationContext(call: ApplicationCall) {
     /**
      * Sets an authenticated principal for this context.
      */
-    public fun principal(principal: Principal) {
+    public fun principal(principal: Any) {
         _principal.add(null, principal)
     }
 
     /**
      * Sets an authenticated principal for this context from provider with name [provider].
      */
-    public fun principal(provider: String? = null, principal: Principal) {
+    public fun principal(provider: String? = null, principal: Any) {
         _principal.add(provider, principal)
     }
 
     /**
      * Retrieves a principal of the type [T] from provider with name [provider], if any.
      */
-    public inline fun <reified T : Principal> principal(provider: String? = null): T? {
+    public inline fun <reified T : Any> principal(provider: String? = null): T? {
         return principal(provider, T::class)
     }
 
     /**
      * Retrieves a principal of the type [T], if any.
      */
-    public fun <T : Principal> principal(provider: String?, klass: KClass<T>): T? {
+    public fun <T : Any> principal(provider: String?, klass: KClass<T>): T? {
         return _principal.get(provider, klass)
     }
 

--- a/ktor-server/ktor-server-plugins/ktor-server-auth/common/src/io/ktor/server/auth/AuthenticationInterceptors.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-auth/common/src/io/ktor/server/auth/AuthenticationInterceptors.kt
@@ -69,7 +69,7 @@ public val AuthenticationInterceptors: RouteScopedPlugin<RouteAuthenticationConf
         if (call.isHandled) return@on
 
         val authenticationContext = AuthenticationContext.from(call)
-        if (authenticationContext.principal<Principal>() != null) return@on
+        if (authenticationContext.principal<Any>() != null) return@on
 
         var count = 0
         for (provider in requiredProviders) {

--- a/ktor-server/ktor-server-plugins/ktor-server-auth/common/src/io/ktor/server/auth/AuthenticationProvider.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-auth/common/src/io/ktor/server/auth/AuthenticationProvider.kt
@@ -14,7 +14,7 @@ public typealias ApplicationCallPredicate = (ApplicationCall) -> Boolean
 /**
  * An authentication function that accepts and verifies credentials and returns a principal when verification is successful.
  */
-public typealias AuthenticationFunction<C> = suspend ApplicationCall.(credentials: C) -> Principal?
+public typealias AuthenticationFunction<C> = suspend ApplicationCall.(credentials: C) -> Any?
 
 /**
  * An authentication provider with the specified name.

--- a/ktor-server/ktor-server-plugins/ktor-server-auth/common/src/io/ktor/server/auth/BasicAuth.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-auth/common/src/io/ktor/server/auth/BasicAuth.kt
@@ -80,7 +80,7 @@ public class BasicAuthenticationProvider internal constructor(
 
         /**
          * Sets a validation function that checks a specified [UserPasswordCredential] instance and
-         * returns [Any] in a case of successful authentication or null if authentication fails.
+         * returns principal [Any] in a case of successful authentication or null if authentication fails.
          */
         public fun validate(body: suspend ApplicationCall.(UserPasswordCredential) -> Any?) {
             authenticationFunction = body

--- a/ktor-server/ktor-server-plugins/ktor-server-auth/common/src/io/ktor/server/auth/BasicAuth.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-auth/common/src/io/ktor/server/auth/BasicAuth.kt
@@ -80,9 +80,9 @@ public class BasicAuthenticationProvider internal constructor(
 
         /**
          * Sets a validation function that checks a specified [UserPasswordCredential] instance and
-         * returns [Principal] in a case of successful authentication or null if authentication fails.
+         * returns [Any] in a case of successful authentication or null if authentication fails.
          */
-        public fun validate(body: suspend ApplicationCall.(UserPasswordCredential) -> Principal?) {
+        public fun validate(body: suspend ApplicationCall.(UserPasswordCredential) -> Any?) {
             authenticationFunction = body
         }
     }

--- a/ktor-server/ktor-server-plugins/ktor-server-auth/common/src/io/ktor/server/auth/BearerAuth.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-auth/common/src/io/ktor/server/auth/BearerAuth.kt
@@ -71,7 +71,7 @@ public class BearerAuthenticationProvider internal constructor(config: Config) :
          * Exchanges the token for a Principal.
          * @return a principal or `null`
          */
-        public fun authenticate(authenticate: suspend ApplicationCall.(BearerTokenCredential) -> Principal?) {
+        public fun authenticate(authenticate: suspend ApplicationCall.(BearerTokenCredential) -> Any?) {
             this.authenticate = authenticate
         }
 

--- a/ktor-server/ktor-server-plugins/ktor-server-auth/common/src/io/ktor/server/auth/FormAuth.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-auth/common/src/io/ktor/server/auth/FormAuth.kt
@@ -96,9 +96,9 @@ public class FormAuthenticationProvider internal constructor(config: Config) : A
 
         /**
          * Sets a validation function that checks a specified [UserPasswordCredential] instance and
-         * returns [Principal] in a case of successful authentication or null if authentication fails.
+         * returns [Any] in a case of successful authentication or null if authentication fails.
          */
-        public fun validate(body: suspend ApplicationCall.(UserPasswordCredential) -> Principal?) {
+        public fun validate(body: suspend ApplicationCall.(UserPasswordCredential) -> Any?) {
             authenticationFunction = body
         }
 

--- a/ktor-server/ktor-server-plugins/ktor-server-auth/common/src/io/ktor/server/auth/FormAuth.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-auth/common/src/io/ktor/server/auth/FormAuth.kt
@@ -96,7 +96,7 @@ public class FormAuthenticationProvider internal constructor(config: Config) : A
 
         /**
          * Sets a validation function that checks a specified [UserPasswordCredential] instance and
-         * returns [Any] in a case of successful authentication or null if authentication fails.
+         * returns principal [Any] in a case of successful authentication or null if authentication fails.
          */
         public fun validate(body: suspend ApplicationCall.(UserPasswordCredential) -> Any?) {
             authenticationFunction = body

--- a/ktor-server/ktor-server-plugins/ktor-server-auth/common/src/io/ktor/server/auth/OAuthCommon.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-auth/common/src/io/ktor/server/auth/OAuthCommon.kt
@@ -110,7 +110,7 @@ public sealed class OAuthCallback {
 /**
  * An OAuth access token acquired from the server.
  */
-public sealed class OAuthAccessTokenResponse : Principal {
+public sealed class OAuthAccessTokenResponse {
     /**
      * OAuth1a access token acquired from the server
      * @property token itself

--- a/ktor-server/ktor-server-plugins/ktor-server-auth/common/src/io/ktor/server/auth/Principal.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-auth/common/src/io/ktor/server/auth/Principal.kt
@@ -9,22 +9,24 @@ import kotlin.reflect.*
 /**
  * A marker interface indicating that a class represents credentials for authentication.
  */
+@Deprecated("This interface can be safely removed")
 public interface Credential
 
 /**
  * A marker interface indicating that a class represents an authenticated principal.
  */
+@Deprecated("This interface can be safely removed")
 public interface Principal
 
-internal class CombinedPrincipal : Principal {
-    val principals: MutableList<Pair<String?, Principal>> = mutableListOf()
+internal class CombinedPrincipal {
+    val principals: MutableList<Pair<String?, Any>> = mutableListOf()
 
-    inline fun <reified T : Principal> get(provider: String?): T? {
+    inline fun <reified T : Any> get(provider: String?): T? {
         return get(provider, T::class)
     }
 
     @Suppress("UNCHECKED_CAST")
-    fun <T : Principal> get(provider: String?, klass: KClass<T>): T? {
+    fun <T : Any> get(provider: String?, klass: KClass<T>): T? {
         return principals
             .firstOrNull { (name, principal) ->
                 if (provider != null) {
@@ -33,7 +35,7 @@ internal class CombinedPrincipal : Principal {
             }?.second as? T
     }
 
-    fun add(provider: String?, principal: Principal) {
+    fun add(provider: String?, principal: Any) {
         principals.add(Pair(provider, principal))
     }
 }

--- a/ktor-server/ktor-server-plugins/ktor-server-auth/common/src/io/ktor/server/auth/SessionAuth.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-auth/common/src/io/ktor/server/auth/SessionAuth.kt
@@ -85,10 +85,10 @@ public class SessionAuthenticationProvider<T : Any> private constructor(
         }
 
         /**
-         * Sets a validation function that checks a given [T] session instance and returns [Principal],
+         * Sets a validation function that checks a given [T] session instance and returns [Any],
          * or null if the session does not correspond to an authenticated principal.
          */
-        public fun validate(block: suspend ApplicationCall.(T) -> Principal?) {
+        public fun validate(block: suspend ApplicationCall.(T) -> Any?) {
             check(validator === UninitializedValidator) { "Only one validator could be registered" }
             validator = block
         }
@@ -107,7 +107,7 @@ public class SessionAuthenticationProvider<T : Any> private constructor(
     }
 
     public companion object {
-        private val UninitializedValidator: suspend ApplicationCall.(Any) -> Principal? = {
+        private val UninitializedValidator: suspend ApplicationCall.(Any) -> Any? = {
             error("It should be a validator supplied to a session auth provider")
         }
     }
@@ -119,7 +119,7 @@ public class SessionAuthenticationProvider<T : Any> private constructor(
  *
  * To learn how to configure the session provider, see [Session authentication](https://ktor.io/docs/session-auth.html).
  */
-public inline fun <reified T : Principal> AuthenticationConfig.session(
+public inline fun <reified T : Any> AuthenticationConfig.session(
     name: String? = null
 ) {
     session(name, T::class)
@@ -131,7 +131,7 @@ public inline fun <reified T : Principal> AuthenticationConfig.session(
  *
  * To learn how to configure the session provider, see [Session authentication](https://ktor.io/docs/session-auth.html).
  */
-public fun <T : Principal> AuthenticationConfig.session(
+public fun <T : Any> AuthenticationConfig.session(
     name: String? = null,
     kClass: KClass<T>
 ) {

--- a/ktor-server/ktor-server-plugins/ktor-server-auth/common/src/io/ktor/server/auth/SessionAuth.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-auth/common/src/io/ktor/server/auth/SessionAuth.kt
@@ -85,7 +85,7 @@ public class SessionAuthenticationProvider<T : Any> private constructor(
         }
 
         /**
-         * Sets a validation function that checks a given [T] session instance and returns [Any],
+         * Sets a validation function that checks a given [T] session instance and returns principal [Any],
          * or null if the session does not correspond to an authenticated principal.
          */
         public fun validate(block: suspend ApplicationCall.(T) -> Any?) {

--- a/ktor-server/ktor-server-plugins/ktor-server-auth/common/src/io/ktor/server/auth/SimpleAuth.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-auth/common/src/io/ktor/server/auth/SimpleAuth.kt
@@ -10,7 +10,7 @@ package io.ktor.server.auth
  * @see [Authentication]
  * @property name of user
  */
-public data class UserIdPrincipal(val name: String) : Principal
+public data class UserIdPrincipal(val name: String)
 
 /**
  * A user's credentials identified by [name] and [password].
@@ -19,9 +19,9 @@ public data class UserIdPrincipal(val name: String) : Principal
  * @property name
  * @property password
  */
-public data class UserPasswordCredential(val name: String, val password: String) : Credential
+public data class UserPasswordCredential(val name: String, val password: String)
 
-public data class BearerTokenCredential(val token: String) : Credential
+public data class BearerTokenCredential(val token: String)
 
 /**
  * An in-memory table that keeps usernames and password hashes.

--- a/ktor-server/ktor-server-plugins/ktor-server-auth/common/test/io/ktor/tests/auth/AuthBuildersTest.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-auth/common/test/io/ktor/tests/auth/AuthBuildersTest.kt
@@ -111,8 +111,8 @@ class AuthBuildersTest {
 
     @Test
     fun testMultipleRequiredConfigurations() = testApplication {
-        class Principal1(val name: String) : Principal
-        class Principal2(val name: String) : Principal
+        class Principal1(val name: String)
+        class Principal2(val name: String)
 
         install(Authentication) {
             form("first") { validate { c -> if (c.name == "first") Principal1(c.name) else null } }
@@ -172,7 +172,7 @@ class AuthBuildersTest {
 
     @Test
     fun testMultipleRequiredConfigurationsAccessByName() = testApplication {
-        class UserNamePrincipal(val name: String) : Principal
+        class UserNamePrincipal(val name: String)
 
         install(Authentication) {
             form("first") { validate { c -> if (c.name == "first") UserNamePrincipal(c.name) else null } }
@@ -233,8 +233,8 @@ class AuthBuildersTest {
 
     @Test
     fun testDefaultConfigurationOverwrittenWithRequired() = testApplication {
-        class Principal1(val name: String) : Principal
-        class Principal2(val name: String) : Principal
+        class Principal1(val name: String)
+        class Principal2(val name: String)
 
         install(Authentication) {
             form("first") { validate { c -> if (c.name == "first") Principal1(c.name) else null } }
@@ -296,8 +296,8 @@ class AuthBuildersTest {
 
     @Test
     fun testRequiredAndDefaultConfigurations() = testApplication {
-        class Principal1(val name: String) : Principal
-        class Principal2(val name: String) : Principal
+        class Principal1(val name: String)
+        class Principal2(val name: String)
 
         install(Authentication) {
             form("first") { validate { c -> if (c.name == "first") Principal1(c.name) else null } }
@@ -358,8 +358,8 @@ class AuthBuildersTest {
 
     @Test
     fun testRequiredAndOptionalConfigurations() = testApplication {
-        class Principal1(val name: String) : Principal
-        class Principal2(val name: String) : Principal
+        class Principal1(val name: String)
+        class Principal2(val name: String)
 
         install(Authentication) {
             form("first") { validate { c -> if (c.name == "first") Principal1(c.name) else null } }
@@ -420,8 +420,8 @@ class AuthBuildersTest {
 
     @Test
     fun testOptionalAndDefaultConfigurations() = testApplication {
-        class Principal1(val name: String) : Principal
-        class Principal2(val name: String) : Principal
+        class Principal1(val name: String)
+        class Principal2(val name: String)
 
         install(Authentication) {
             form("first") { validate { c -> if (c.name == "first") Principal1(c.name) else null } }

--- a/ktor-server/ktor-server-plugins/ktor-server-auth/common/test/io/ktor/tests/auth/BasicAuthTest.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-auth/common/test/io/ktor/tests/auth/BasicAuthTest.kt
@@ -240,7 +240,7 @@ class BasicAuthTest {
     }
 
     private fun ApplicationTestBuilder.configureServer(
-        validate: suspend (UserPasswordCredential) -> Principal? = {
+        validate: suspend (UserPasswordCredential) -> Any? = {
             if (it.name == it.password) UserIdPrincipal(it.name) else null
         }
     ) {

--- a/ktor-server/ktor-server-plugins/ktor-server-auth/common/test/io/ktor/tests/auth/SessionAuthTest.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-auth/common/test/io/ktor/tests/auth/SessionAuthTest.kt
@@ -144,5 +144,5 @@ class SessionAuthTest {
     }
 
     @Serializable
-    data class MySession(val id: Int) : Principal
+    data class MySession(val id: Int)
 }

--- a/ktor-server/ktor-server-plugins/ktor-server-auth/jvm/src/io/ktor/server/auth/DigestAuth.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-auth/jvm/src/io/ktor/server/auth/DigestAuth.kt
@@ -97,7 +97,7 @@ public class DigestAuthenticationProvider internal constructor(
             }
         }
 
-        internal var authenticationFunction: AuthenticationFunction<DigestCredential> = { UserIdPrincipal(it.userName) }
+        internal var authenticationFunction: AuthenticationFunction<DigestCredential> = { UserIdAny(it.userName) }
 
         /**
          * Specifies a realm to be passed in the `WWW-Authenticate` header.
@@ -116,7 +116,7 @@ public class DigestAuthenticationProvider internal constructor(
 
         /**
          * Sets a validation function that checks a specified [DigestCredential] instance and
-         * returns [Principal] in a case of successful authentication or null if authentication fails.
+         * returns [Any] in a case of successful authentication or null if authentication fails.
          */
         public fun validate(body: AuthenticationFunction<DigestCredential>) {
             authenticationFunction = body
@@ -177,7 +177,7 @@ public data class DigestCredential(
     val response: String,
     val cnonce: String?,
     val qop: String?
-) : Credential
+)
 
 /**
  * Retrieves [DigestCredential] for this call.

--- a/ktor-server/ktor-server-plugins/ktor-server-auth/jvm/src/io/ktor/server/auth/DigestAuth.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-auth/jvm/src/io/ktor/server/auth/DigestAuth.kt
@@ -116,7 +116,7 @@ public class DigestAuthenticationProvider internal constructor(
 
         /**
          * Sets a validation function that checks a specified [DigestCredential] instance and
-         * returns [Any] in a case of successful authentication or null if authentication fails.
+         * returns principal [Any] in a case of successful authentication or null if authentication fails.
          */
         public fun validate(body: AuthenticationFunction<DigestCredential>) {
             authenticationFunction = body

--- a/ktor-server/ktor-server-plugins/ktor-server-auth/jvm/src/io/ktor/server/auth/DigestAuth.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-auth/jvm/src/io/ktor/server/auth/DigestAuth.kt
@@ -97,7 +97,7 @@ public class DigestAuthenticationProvider internal constructor(
             }
         }
 
-        internal var authenticationFunction: AuthenticationFunction<DigestCredential> = { UserIdAny(it.userName) }
+        internal var authenticationFunction: AuthenticationFunction<DigestCredential> = { UserIdPrincipal(it.userName) }
 
         /**
          * Specifies a realm to be passed in the `WWW-Authenticate` header.

--- a/ktor-server/ktor-server-plugins/ktor-server-auth/jvm/test/io/ktor/tests/auth/DigestTest.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-auth/jvm/test/io/ktor/tests/auth/DigestTest.kt
@@ -9,7 +9,6 @@ import io.ktor.http.*
 import io.ktor.http.auth.*
 import io.ktor.server.application.*
 import io.ktor.server.auth.*
-import io.ktor.server.auth.Principal
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
 import io.ktor.server.testing.*
@@ -126,7 +125,7 @@ class DigestTest {
 
     @Test
     fun testValidateFunction() = testApplication {
-        class TestPrincipal(val name: String) : Principal
+        class TestPrincipal(val name: String)
         install(Authentication) {
             digest {
                 val p = "Circle Of Life"


### PR DESCRIPTION
**Subsystem**
Server, Authentication

**Motivation**
[KTOR-7323](https://youtrack.jetbrains.com/issue/KTOR-7323) Drop marker interface requirements in Ktor auth

These interfaces don't do anything and they prevent users from using decoupled domain objects for their principal and credential types.

**Solution**
Removed the type boundaries and deprecated the interfaces.

