### PR TITLE
KTOR-7334 Fix for AttributeKey byte code incompatibility

### DIFF
--- a/ktor-server/ktor-server-plugins/ktor-server-conditional-headers/common/src/io/ktor/server/plugins/conditionalheaders/ConditionalHeaders.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-conditional-headers/common/src/io/ktor/server/plugins/conditionalheaders/ConditionalHeaders.kt
@@ -11,6 +11,7 @@ import io.ktor.server.application.hooks.*
 import io.ktor.server.http.content.*
 import io.ktor.util.*
 import io.ktor.utils.io.*
+import kotlin.reflect.*
 
 /**
  * A configuration for the [ConditionalHeaders] plugin.
@@ -38,7 +39,7 @@ public class ConditionalHeadersConfig {
 }
 
 internal val VersionProvidersKey: AttributeKey<List<suspend (ApplicationCall, OutgoingContent) -> List<Version>>> =
-    AttributeKey("ConditionalHeadersKey")
+    AttributeKey("ConditionalHeadersKey", typeOf<List<*>>())
 
 /**
  * Retrieves versions such as [LastModifiedVersion] or [EntityTagVersion] for a given content.

--- a/ktor-utils/common/src/io/ktor/util/Attributes.kt
+++ b/ktor-utils/common/src/io/ktor/util/Attributes.kt
@@ -4,6 +4,7 @@
 
 package io.ktor.util
 
+import kotlin.jvm.*
 import kotlin.reflect.*
 
 /**
@@ -11,17 +12,18 @@ import kotlin.reflect.*
  * @param T is a type of the value stored in the attribute
  * @param name is a name of the attribute for diagnostic purposes. Can't be blank
  */
+@JvmSynthetic
 public inline fun <reified T : Any> AttributeKey(name: String): AttributeKey<T> =
-    AttributeKey(name, T::class.toString())
+    AttributeKey(name, typeOf<T>())
 
 /**
  * Specifies a key for an attribute in [Attributes]
  * @param T is a type of the value stored in the attribute
  * @param name is a name of the attribute for diagnostic purposes. Can't be blank
  */
-public class AttributeKey<T : Any> @PublishedApi internal constructor(
+public data class AttributeKey<T : Any> @JvmOverloads constructor(
     public val name: String,
-    private val type: String
+    private val type: KType = typeOf<Any>(),
 ) {
     init {
         if (name.isEmpty()) {
@@ -30,17 +32,6 @@ public class AttributeKey<T : Any> @PublishedApi internal constructor(
     }
 
     override fun toString(): String = "AttributeKey: $name"
-
-    override fun equals(other: Any?): Boolean {
-        if (this === other) return true
-        if (other == null || other !is AttributeKey<*>) return false
-
-        return name == other.name && type == other.type
-    }
-
-    override fun hashCode(): Int {
-        return name.hashCode()
-    }
 }
 
 /**

--- a/ktor-utils/common/test/io/ktor/util/AttributesTest.kt
+++ b/ktor-utils/common/test/io/ktor/util/AttributesTest.kt
@@ -7,19 +7,25 @@ package io.ktor.util
 import kotlin.test.*
 
 class AttributesTest {
-    object Foo
-    object Bar
+    data object Foo
+    data object Bar
 
     @Test
     fun testAttributesTypeSafety() {
         val foo = AttributeKey<Foo>("example")
         val bar = AttributeKey<Bar>("example")
+        val fooList = AttributeKey<List<Foo>>("example")
+        val barList = AttributeKey<List<Bar>>("example")
         with(Attributes()) {
             put(foo, Foo)
             put(bar, Bar)
+            put(fooList, listOf(Foo))
+            put(barList, listOf(Bar))
 
             assertEquals(Foo, get(foo))
             assertEquals(Bar, get(bar))
+            assertEquals(listOf(Foo), get(fooList))
+            assertEquals(listOf(Bar), get(barList))
         }
     }
 }


### PR DESCRIPTION
**Subsystem**
Client/Server, Utils

**Motivation**
[KTOR-7334](https://youtrack.jetbrains.com/issue/KTOR-7334) Bytecode incompatibility in AttributeKey

I encountered this when testing with Koin and the latest 3.0 EAP.  Turns out replacing the original constructor with a function of the same name doesn't produce the correct bytecode for backwards compatibility, which will break any external plugins using the `AttributeKey` class.

**Solution**
1. Added some crafty annotations to maintain backwards compatibility.
2. Updated the class to allow support for generics.

There is the caveat that external plugins using `AttributeKey` won't be able to take advantage of the type differentiation until the upgrade to 3.0.  BUT they won't blow up from a `NoSuchMethodFoundException` 😄 
