### PR TITLE
KTOR-6491 Make the internal Route.swaggerUI method public

### DIFF
--- a/ktor-server/ktor-server-plugins/ktor-server-swagger/api/ktor-server-swagger.api
+++ b/ktor-server/ktor-server-plugins/ktor-server-swagger/api/ktor-server-swagger.api
@@ -9,8 +9,10 @@ public final class io/ktor/server/plugins/swagger/SwaggerConfig {
 
 public final class io/ktor/server/plugins/swagger/SwaggerKt {
 	public static final fun swaggerUI (Lio/ktor/server/routing/Route;Ljava/lang/String;Ljava/io/File;Lkotlin/jvm/functions/Function1;)V
+	public static final fun swaggerUI (Lio/ktor/server/routing/Route;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)V
 	public static final fun swaggerUI (Lio/ktor/server/routing/Route;Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)V
 	public static synthetic fun swaggerUI$default (Lio/ktor/server/routing/Route;Ljava/lang/String;Ljava/io/File;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+	public static synthetic fun swaggerUI$default (Lio/ktor/server/routing/Route;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
 	public static synthetic fun swaggerUI$default (Lio/ktor/server/routing/Route;Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
 }
 

--- a/ktor-server/ktor-server-plugins/ktor-server-swagger/jvm/src/io/ktor/server/plugins/swagger/Swagger.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-swagger/jvm/src/io/ktor/server/plugins/swagger/Swagger.kt
@@ -49,7 +49,17 @@ public fun Route.swaggerUI(path: String, apiFile: File, block: SwaggerConfig.() 
     swaggerUI(path, apiFile.name, content, block)
 }
 
-internal fun Route.swaggerUI(
+/**
+ * Configures a route to serve Swagger UI and its corresponding API specification.
+ *
+ * This function sets up a given path to serve a Swagger UI interface based on the provided API specification.
+ *
+ * @param path The base path where the Swagger UI will be accessible.
+ * @param apiUrl The relative URL for the Swagger API JSON file.
+ * @param api The content of the Swagger API specification.
+ * @param block A configuration block to apply additional Swagger configuration settings.
+ */
+public fun Route.swaggerUI(
     path: String,
     apiUrl: String,
     api: String,


### PR DESCRIPTION
Fix [KTOR-6491](https://youtrack.jetbrains.com/issue/KTOR-6491) Make the internal Route.swaggerUI method public
