### PR TITLE
Fix UDP/TCP receive on Windows

### DIFF
--- a/ktor-network/posix/src/io/ktor/network/sockets/CIOReader.kt
+++ b/ktor-network/posix/src/io/ktor/network/sockets/CIOReader.kt
@@ -31,8 +31,10 @@ internal fun CoroutineScope.attachForReadingImpl(
                     when (bytesRead) {
                         0 -> close = true
                         -1 -> {
-                            if (isWouldBlockError(getSocketError())) return@write 0
-                            throw PosixException.forSocketError()
+                            val error = getSocketError()
+                            if (isWouldBlockError(error)) return@write 0
+                            if (error == 0) return@write 0
+                            throw PosixException.forSocketError(error)
                         }
                     }
 

--- a/ktor-network/posix/src/io/ktor/network/sockets/DatagramSocketNative.kt
+++ b/ktor-network/posix/src/io/ktor/network/sockets/DatagramSocketNative.kt
@@ -99,8 +99,10 @@ internal class DatagramSocketNative(
             when (bytesRead) {
                 0L -> throw IOException("Failed reading from closed socket")
                 -1L -> {
-                    if (isWouldBlockError(getSocketError())) return null
-                    throw PosixException.forSocketError()
+                    val error = getSocketError()
+                    if (isWouldBlockError(error)) return null
+                    if (error == 0) return null
+                    throw PosixException.forSocketError(error)
                 }
             }
 


### PR DESCRIPTION
**Subsystem**
ktor-network on mingwX64

**Motivation**
The recvfrom call can fail with `-1L`, which means there is an error. On Windows, the `WSAGetLastError()` function is called to retrieve the error, but for some reason this can return `0` (which means NO error). This does not happen that often, but when receiving UDP messages continually, this does occur about once per minute for me.

**Solution**
Solution is to just ignore the error as `0` means no error. Why this happens, no idea. UDP receive still works after this strange error and packets can be received. Not sure how to reproduce this in a test.

