### PR TITLE
KTOR-6258 Make Cookie class Serializable

### DIFF
--- a/ktor-http/api/ktor-http.api
+++ b/ktor-http/api/ktor-http.api
@@ -263,6 +263,7 @@ public final class io/ktor/http/ContentTypesKt {
 }
 
 public final class io/ktor/http/Cookie {
+	public static final field Companion Lio/ktor/http/Cookie$Companion;
 	public fun <init> (Ljava/lang/String;Ljava/lang/String;Lio/ktor/http/CookieEncoding;Ljava/lang/Integer;Lio/ktor/util/date/GMTDate;Ljava/lang/String;Ljava/lang/String;ZZLjava/util/Map;)V
 	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Lio/ktor/http/CookieEncoding;Ljava/lang/Integer;Lio/ktor/util/date/GMTDate;Ljava/lang/String;Ljava/lang/String;ZZLjava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;
@@ -290,6 +291,21 @@ public final class io/ktor/http/Cookie {
 	public final fun getValue ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
+}
+
+public synthetic class io/ktor/http/Cookie$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/ktor/http/Cookie$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/ktor/http/Cookie;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/ktor/http/Cookie;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/ktor/http/Cookie$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
 public final class io/ktor/http/CookieEncoding : java/lang/Enum {

--- a/ktor-http/api/ktor-http.klib.api
+++ b/ktor-http/api/ktor-http.klib.api
@@ -579,6 +579,21 @@ final class io.ktor.http/Cookie { // io.ktor.http/Cookie|null[0]
     final fun equals(kotlin/Any?): kotlin/Boolean // io.ktor.http/Cookie.equals|equals(kotlin.Any?){}[0]
     final fun hashCode(): kotlin/Int // io.ktor.http/Cookie.hashCode|hashCode(){}[0]
     final fun toString(): kotlin/String // io.ktor.http/Cookie.toString|toString(){}[0]
+
+    final object $serializer : kotlinx.serialization.internal/GeneratedSerializer<io.ktor.http/Cookie> { // io.ktor.http/Cookie.$serializer|null[0]
+        final val descriptor // io.ktor.http/Cookie.$serializer.descriptor|{}descriptor[0]
+            final fun <get-descriptor>(): kotlinx.serialization.descriptors/SerialDescriptor // io.ktor.http/Cookie.$serializer.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+
+        final fun childSerializers(): kotlin/Array<kotlinx.serialization/KSerializer<*>> // io.ktor.http/Cookie.$serializer.childSerializers|childSerializers(){}[0]
+        final fun deserialize(kotlinx.serialization.encoding/Decoder): io.ktor.http/Cookie // io.ktor.http/Cookie.$serializer.deserialize|deserialize(kotlinx.serialization.encoding.Decoder){}[0]
+        final fun serialize(kotlinx.serialization.encoding/Encoder, io.ktor.http/Cookie) // io.ktor.http/Cookie.$serializer.serialize|serialize(kotlinx.serialization.encoding.Encoder;io.ktor.http.Cookie){}[0]
+    }
+
+    final object Companion { // io.ktor.http/Cookie.Companion|null[0]
+        final val $childSerializers // io.ktor.http/Cookie.Companion.$childSerializers|{}$childSerializers[0]
+
+        final fun serializer(): kotlinx.serialization/KSerializer<io.ktor.http/Cookie> // io.ktor.http/Cookie.Companion.serializer|serializer(){}[0]
+    }
 }
 
 final class io.ktor.http/HeaderValue { // io.ktor.http/HeaderValue|null[0]

--- a/ktor-http/build.gradle.kts
+++ b/ktor-http/build.gradle.kts
@@ -1,8 +1,17 @@
+/*
+ * Copyright 2014-2024 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+plugins {
+    id("kotlinx-serialization")
+}
+
 kotlin {
     sourceSets {
         commonMain {
             dependencies {
                 api(project(":ktor-utils"))
+                api(libs.kotlinx.serialization.core)
             }
         }
     }

--- a/ktor-http/common/src/io/ktor/http/Cookie.kt
+++ b/ktor-http/common/src/io/ktor/http/Cookie.kt
@@ -1,11 +1,12 @@
 /*
-* Copyright 2014-2021 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
-*/
+ * Copyright 2014-2024 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
 
 package io.ktor.http
 
 import io.ktor.util.*
 import io.ktor.util.date.*
+import kotlinx.serialization.*
 import kotlin.jvm.*
 
 /**
@@ -23,6 +24,7 @@ import kotlin.jvm.*
  * @property httpOnly only transfer cookie over HTTP, no access from JavaScript
  * @property extensions additional cookie extensions
  */
+@Serializable
 public data class Cookie(
     val name: String,
     val value: String,

--- a/ktor-utils/api/ktor-utils.api
+++ b/ktor-utils/api/ktor-utils.api
@@ -675,8 +675,20 @@ public final class io/ktor/util/date/GMTDate : java/lang/Comparable {
 	public fun toString ()Ljava/lang/String;
 }
 
+public synthetic class io/ktor/util/date/GMTDate$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/ktor/util/date/GMTDate$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/ktor/util/date/GMTDate;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/ktor/util/date/GMTDate;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
 public final class io/ktor/util/date/GMTDate$Companion {
 	public final fun getSTART ()Lio/ktor/util/date/GMTDate;
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
 public final class io/ktor/util/date/GMTDateParser {

--- a/ktor-utils/api/ktor-utils.klib.api
+++ b/ktor-utils/api/ktor-utils.klib.api
@@ -230,11 +230,13 @@ final class <#A: kotlin/Any, #B: kotlin/Any> io.ktor.util.collections/CopyOnWrit
 }
 
 final class <#A: kotlin/Any> io.ktor.util/AttributeKey { // io.ktor.util/AttributeKey|null[0]
-    constructor <init>(kotlin/String, kotlin/String) // io.ktor.util/AttributeKey.<init>|<init>(kotlin.String;kotlin.String){}[0]
+    constructor <init>(kotlin/String, kotlin.reflect/KType = ...) // io.ktor.util/AttributeKey.<init>|<init>(kotlin.String;kotlin.reflect.KType){}[0]
 
     final val name // io.ktor.util/AttributeKey.name|{}name[0]
         final fun <get-name>(): kotlin/String // io.ktor.util/AttributeKey.name.<get-name>|<get-name>(){}[0]
 
+    final fun component1(): kotlin/String // io.ktor.util/AttributeKey.component1|component1(){}[0]
+    final fun copy(kotlin/String = ..., kotlin.reflect/KType = ...): io.ktor.util/AttributeKey<#A> // io.ktor.util/AttributeKey.copy|copy(kotlin.String;kotlin.reflect.KType){}[0]
     final fun equals(kotlin/Any?): kotlin/Boolean // io.ktor.util/AttributeKey.equals|equals(kotlin.Any?){}[0]
     final fun hashCode(): kotlin/Int // io.ktor.util/AttributeKey.hashCode|hashCode(){}[0]
     final fun toString(): kotlin/String // io.ktor.util/AttributeKey.toString|toString(){}[0]
@@ -363,9 +365,21 @@ final class io.ktor.util.date/GMTDate : kotlin/Comparable<io.ktor.util.date/GMTD
     final fun hashCode(): kotlin/Int // io.ktor.util.date/GMTDate.hashCode|hashCode(){}[0]
     final fun toString(): kotlin/String // io.ktor.util.date/GMTDate.toString|toString(){}[0]
 
+    final object $serializer : kotlinx.serialization.internal/GeneratedSerializer<io.ktor.util.date/GMTDate> { // io.ktor.util.date/GMTDate.$serializer|null[0]
+        final val descriptor // io.ktor.util.date/GMTDate.$serializer.descriptor|{}descriptor[0]
+            final fun <get-descriptor>(): kotlinx.serialization.descriptors/SerialDescriptor // io.ktor.util.date/GMTDate.$serializer.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+
+        final fun childSerializers(): kotlin/Array<kotlinx.serialization/KSerializer<*>> // io.ktor.util.date/GMTDate.$serializer.childSerializers|childSerializers(){}[0]
+        final fun deserialize(kotlinx.serialization.encoding/Decoder): io.ktor.util.date/GMTDate // io.ktor.util.date/GMTDate.$serializer.deserialize|deserialize(kotlinx.serialization.encoding.Decoder){}[0]
+        final fun serialize(kotlinx.serialization.encoding/Encoder, io.ktor.util.date/GMTDate) // io.ktor.util.date/GMTDate.$serializer.serialize|serialize(kotlinx.serialization.encoding.Encoder;io.ktor.util.date.GMTDate){}[0]
+    }
+
     final object Companion { // io.ktor.util.date/GMTDate.Companion|null[0]
+        final val $childSerializers // io.ktor.util.date/GMTDate.Companion.$childSerializers|{}$childSerializers[0]
         final val START // io.ktor.util.date/GMTDate.Companion.START|{}START[0]
             final fun <get-START>(): io.ktor.util.date/GMTDate // io.ktor.util.date/GMTDate.Companion.START.<get-START>|<get-START>(){}[0]
+
+        final fun serializer(): kotlinx.serialization/KSerializer<io.ktor.util.date/GMTDate> // io.ktor.util.date/GMTDate.Companion.serializer|serializer(){}[0]
     }
 }
 

--- a/ktor-utils/build.gradle.kts
+++ b/ktor-utils/build.gradle.kts
@@ -1,3 +1,11 @@
+/*
+ * Copyright 2014-2024 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+plugins {
+    id("kotlinx-serialization")
+}
+
 kotlin {
     createCInterop("threadUtils", nixTargets()) {
         definitionFile = File(projectDir, "nix/interop/threadUtils.def")
@@ -7,6 +15,7 @@ kotlin {
         commonMain {
             dependencies {
                 api(project(":ktor-io"))
+                api(libs.kotlinx.serialization.core)
             }
         }
         commonTest {

--- a/ktor-utils/common/src/io/ktor/util/date/Date.kt
+++ b/ktor-utils/common/src/io/ktor/util/date/Date.kt
@@ -1,9 +1,10 @@
 /*
-* Copyright 2014-2021 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
-*/
+ * Copyright 2014-2024 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
 
 package io.ktor.util.date
 
+import kotlinx.serialization.*
 import kotlin.time.*
 
 /**
@@ -84,6 +85,7 @@ public enum class Month(public val value: String) {
  *
  * @property timestamp is a number of epoch milliseconds
  */
+@Serializable
 public data class GMTDate internal constructor(
     val seconds: Int,
     val minutes: Int,


### PR DESCRIPTION
**Subsystem**
`ktor-http`, `ktor-utils`

**Motivation**
https://youtrack.jetbrains.com/issue/KTOR-6258/Make-Cookie-class-Serializable

**Solution**
Added kotlinx.serialization as a dependency to these modules and added `@Serializable` annotation to `Cookie` and `GMTDate` classes.

I wasn't able to use `compileOnly` configuration for kotlinx.serialization dependency as it is supported only on JVM targets. More context: https://youtrack.jetbrains.com/issue/KT-64109/Using-compileOnly-runtimeOnly-dependencies-in-K-N-related-configurations-leads-to-odd-behaviour

Moreover, some tests were failing on JVM target with `NoClassDefFoundError` exception:
```
java.lang.NoClassDefFoundError: kotlinx/serialization/KSerializer
	at io.ktor.util.date.GMTDate.<clinit>(Date.kt:106)
	at io.ktor.util.date.DateJvmKt.toDate(DateJvm.kt:60)
	at io.ktor.util.date.DateJvmKt.GMTDate(DateJvm.kt:38)
	at io.ktor.tests.http.CookieDateParserTest.testCorrectlyMutatesYear(CookieDateParserTest.kt:101)
```