### PR TITLE
KTOR-4433 Fix Netty error on CORS trying to set header on committed requests

### DIFF
--- a/ktor-server/ktor-server-plugins/ktor-server-cors/common/src/io/ktor/server/plugins/cors/CORS.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-cors/common/src/io/ktor/server/plugins/cors/CORS.kt
@@ -81,6 +81,8 @@ internal fun PluginBuilder<CORSConfig>.buildPlugin() {
      * a plugin installation.
      */
     onCall { call ->
+        if (call.response.isCommitted) return@onCall
+
         if (!allowsAnyHost || allowCredentials) {
             call.corsVary()
         }

--- a/ktor-server/ktor-server-plugins/ktor-server-cors/common/src/io/ktor/server/plugins/cors/CORS.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-cors/common/src/io/ktor/server/plugins/cors/CORS.kt
@@ -81,7 +81,9 @@ internal fun PluginBuilder<CORSConfig>.buildPlugin() {
      * a plugin installation.
      */
     onCall { call ->
-        if (call.response.isCommitted) return@onCall
+        if (call.response.isCommitted) {
+            return@onCall
+        }
 
         if (!allowsAnyHost || allowCredentials) {
             call.corsVary()

--- a/ktor-server/ktor-server-plugins/ktor-server-csrf/common/src/io/ktor/server/plugins/csrf/CSRF.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-csrf/common/src/io/ktor/server/plugins/csrf/CSRF.kt
@@ -52,6 +52,7 @@ public val CSRF: RouteScopedPlugin<CSRFConfig> = createRouteScopedPlugin("CSRF",
     }
 
     onCall { call ->
+        if (call.response.isCommitted) return@onCall
 
         if (call.request.httpMethod in setOf(HttpMethod.Get, HttpMethod.Head, HttpMethod.Options)) {
             return@onCall

--- a/ktor-server/ktor-server-plugins/ktor-server-csrf/common/src/io/ktor/server/plugins/csrf/CSRF.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-csrf/common/src/io/ktor/server/plugins/csrf/CSRF.kt
@@ -52,7 +52,9 @@ public val CSRF: RouteScopedPlugin<CSRFConfig> = createRouteScopedPlugin("CSRF",
     }
 
     onCall { call ->
-        if (call.response.isCommitted) return@onCall
+        if (call.response.isCommitted) {
+            return@onCall
+        }
 
         if (call.request.httpMethod in setOf(HttpMethod.Get, HttpMethod.Head, HttpMethod.Options)) {
             return@onCall

--- a/ktor-server/ktor-server-plugins/ktor-server-http-redirect/common/src/io/ktor/server/plugins/httpsredirect/HttpsRedirect.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-http-redirect/common/src/io/ktor/server/plugins/httpsredirect/HttpsRedirect.kt
@@ -76,6 +76,8 @@ public val HttpsRedirect: ApplicationPlugin<HttpsRedirectConfig> = createApplica
     ::HttpsRedirectConfig
 ) {
     onCall { call ->
+        if (call.response.isCommitted) return@onCall
+
         if (call.request.origin.scheme == "http" &&
             pluginConfig.excludePredicates.none { predicate -> predicate(call) }
         ) {

--- a/ktor-server/ktor-server-plugins/ktor-server-http-redirect/common/src/io/ktor/server/plugins/httpsredirect/HttpsRedirect.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-http-redirect/common/src/io/ktor/server/plugins/httpsredirect/HttpsRedirect.kt
@@ -76,7 +76,9 @@ public val HttpsRedirect: ApplicationPlugin<HttpsRedirectConfig> = createApplica
     ::HttpsRedirectConfig
 ) {
     onCall { call ->
-        if (call.response.isCommitted) return@onCall
+        if (call.response.isCommitted) {
+            return@onCall
+        }
 
         if (call.request.origin.scheme == "http" &&
             pluginConfig.excludePredicates.none { predicate -> predicate(call) }

--- a/ktor-server/ktor-server-tests/common/test/io/ktor/tests/server/plugins/CORSTest.kt
+++ b/ktor-server/ktor-server-tests/common/test/io/ktor/tests/server/plugins/CORSTest.kt
@@ -1268,9 +1268,11 @@ class CORSTest {
             }
         }
 
-        assertEquals(HttpStatusCode.OK, client.get("/") {
-            header(HttpHeaders.Origin, "http://host.org")
-        }.status)
+        assertEquals(
+            HttpStatusCode.OK,
+            client.get("/") {
+                header(HttpHeaders.Origin, "http://host.org")
+            }.status
+        )
     }
-
 }

--- a/ktor-server/ktor-server-tests/common/test/io/ktor/tests/server/plugins/CORSTest.kt
+++ b/ktor-server/ktor-server-tests/common/test/io/ktor/tests/server/plugins/CORSTest.kt
@@ -8,6 +8,7 @@ import io.ktor.client.request.*
 import io.ktor.client.statement.*
 import io.ktor.http.*
 import io.ktor.server.application.*
+import io.ktor.server.application.hooks.*
 import io.ktor.server.plugins.cors.routing.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
@@ -1247,4 +1248,29 @@ class CORSTest {
             assertEquals("", call.bodyAsText())
         }
     }
+
+    @Test
+    fun ignoredWhenResponseAlreadyCommitted() = testApplication {
+        val RespondPrematurely = createApplicationPlugin("Respond") {
+            on(CallSetup) { call ->
+                call.respondText { "123" }
+            }
+        }
+
+        install(RespondPrematurely)
+        install(CORS) {
+            allowCredentials = true
+        }
+
+        routing {
+            get("/") {
+                call.respond("OK")
+            }
+        }
+
+        assertEquals(HttpStatusCode.OK, client.get("/") {
+            header(HttpHeaders.Origin, "http://host.org")
+        }.status)
+    }
+
 }


### PR DESCRIPTION
**Subsystem**
Server, Netty

**Motivation**
- [KTOR-4433](https://youtrack.jetbrains.com/issue/KTOR-4433) Netty: UnsupportedOperationException is thrown when responding in CallSetup and CORS plugin is installed

**Solution**
Ignore headers after the response is committed.  This aligns the behaviour with the other engines.

Ideally we'd have some mechanism for skipping other interceptors / phases in the application pipeline when you want to respond during the `CallSetup` phase and the like, though from what I can tell there is nothing in the platform for achieving this.