### PR TITLE
Tweak Gradle flags

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -11,8 +11,8 @@ version=3.0.0-rc-1-SNAPSHOT
 # gradle
 org.gradle.daemon=true
 org.gradle.caching=true
-org.gradle.vfs.watch=true
 org.gradle.jvmargs=-Xmx6g -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8 -XX:+UseParallelGC
+org.gradle.parallel=true
 
 # kotlin
 kotlin.native.ignoreDisabledTargets=true


### PR DESCRIPTION
- Enabling `org.gradle.vfs.watch` is the default from Gradle 7.
- Parallel tasks executing.