### PR TITLE
KTOR-7397 Migrate ktor-server-auth tests to testApplication DSL

### DIFF
--- a/ktor-server/ktor-server-plugins/ktor-server-auth-ldap/jvm/test/io/ktor/tests/auth/ldap/LDAPServerExtension.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-auth-ldap/jvm/test/io/ktor/tests/auth/ldap/LDAPServerExtension.kt
@@ -1,10 +1,10 @@
 /*
- * Copyright 2014-2023 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2014-2024 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package io.ktor.tests.auth.ldap
 
-import org.apache.directory.api.ldap.codec.api.LdapApiService
+import org.apache.directory.api.ldap.codec.api.*
 import org.apache.directory.api.util.*
 import org.apache.directory.server.annotations.*
 import org.apache.directory.server.core.api.*
@@ -24,7 +24,7 @@ annotation class LDAPServerExtensionTest
  * This is an adaption of the LDAP functionality found in
  * `org.apache.directory.server.core.integ.FrameworkRunner` for JUnit5.
  */
-@CreateLdapServer(transports = [ CreateTransport(protocol = "LDAP") ])
+@CreateLdapServer(transports = [CreateTransport(protocol = "LDAP")])
 class LDAPServerExtension : BeforeAllCallback, AfterAllCallback, ParameterResolver {
 
     private var directoryService: DirectoryService? = null

--- a/ktor-server/ktor-server-plugins/ktor-server-auth-ldap/jvm/test/io/ktor/tests/auth/ldap/LdapAuthTest.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-auth-ldap/jvm/test/io/ktor/tests/auth/ldap/LdapAuthTest.kt
@@ -1,18 +1,19 @@
 /*
- * Copyright 2014-2019 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2014-2024 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package io.ktor.tests.auth.ldap
 
+import io.ktor.client.request.*
+import io.ktor.client.statement.*
 import io.ktor.http.*
 import io.ktor.http.auth.*
-import io.ktor.server.application.*
 import io.ktor.server.auth.*
 import io.ktor.server.auth.ldap.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
 import io.ktor.server.testing.*
-import org.apache.directory.api.ldap.codec.api.LdapApiService
+import org.apache.directory.api.ldap.codec.api.*
 import org.apache.directory.api.ldap.util.*
 import java.net.*
 import java.util.*
@@ -21,154 +22,149 @@ import javax.naming.ldap.*
 import kotlin.test.*
 
 // TODO unauthorized
-
 @LDAPServerExtensionTest
 @Ignore("LdapAuthTest is ignored because it is very slow. Run it explicitly when you need.")
 class LdapAuthTest {
 
     @Test
-    fun testLoginToServer(port: Int) {
-        withTestApplication {
-            application.install(Authentication) {
-                basic {
-                    realm = "realm"
-                    validate { credential ->
-                        ldapAuthenticate(credential, "ldap://$localhost:$port", "uid=%s,ou=system")
-                    }
+    fun testLoginToServer(port: Int) = testApplication {
+        install(Authentication) {
+            basic {
+                realm = "realm"
+                validate { credential ->
+                    ldapAuthenticate(credential, "ldap://$localhost:$port", "uid=%s,ou=system")
                 }
             }
+        }
 
-            application.routing {
-                authenticate {
-                    get("/") {
-                        call.respondText(call.authentication.principal<UserIdPrincipal>()?.name ?: "null")
-                    }
+        routing {
+            authenticate {
+                get("/") {
+                    call.respondText(call.authentication.principal<UserIdPrincipal>()?.name ?: "null")
                 }
             }
+        }
 
-            handleRequest(HttpMethod.Get, "/").let { result ->
-                result.response.headers[HttpHeaders.WWWAuthenticate].let {
-                    assertNotNull(it, "No auth challenge sent")
-                    val challenge = parseAuthorizationHeader(it)
-                    assertNotNull(challenge, "Challenge has incorrect format")
-                    assertEquals("Basic", challenge.authScheme)
-                    assertTrue(challenge is HttpAuthHeader.Parameterized, "It should be parameterized challenge")
-                    assertEquals("realm", challenge.parameter("realm"))
-                    assertEquals("UTF-8", challenge.parameter("charset"))
-                }
-                assertEquals(HttpStatusCode.Unauthorized, result.response.status())
+        client.get("/").let { response ->
+            response.headers[HttpHeaders.WWWAuthenticate].let {
+                assertNotNull(it, "No auth challenge sent")
+                val challenge = parseAuthorizationHeader(it)
+                assertNotNull(challenge, "Challenge has incorrect format")
+                assertEquals("Basic", challenge.authScheme)
+                assertTrue(challenge is HttpAuthHeader.Parameterized, "It should be parameterized challenge")
+                assertEquals("realm", challenge.parameter("realm"))
+                assertEquals("UTF-8", challenge.parameter("charset"))
             }
-            handleRequest(HttpMethod.Get, "/") {
-                addHeader(
-                    HttpHeaders.Authorization,
-                    "Basic " + Base64.getEncoder().encodeToString("admin:secret".toByteArray())
-                )
-            }.let { result ->
-                assertEquals(HttpStatusCode.OK, result.response.status())
-                assertEquals("admin", result.response.content)
-            }
-            handleRequest(HttpMethod.Get, "/") {
-                addHeader(
-                    HttpHeaders.Authorization,
-                    "Basic " + Base64.getEncoder().encodeToString("admin:bad-pass".toByteArray())
-                )
-            }.let { result ->
-                assertEquals(HttpStatusCode.Unauthorized, result.response.status())
-                assertNull(result.response.content)
-            }
-            handleRequest(HttpMethod.Get, "/") {
-                addHeader(
-                    HttpHeaders.Authorization,
-                    "Basic " + Base64.getEncoder().encodeToString("bad-user:bad-pass".toByteArray())
-                )
-            }.let { result ->
-                assertEquals(HttpStatusCode.Unauthorized, result.response.status())
-                assertNull(result.response.content)
-            }
-            handleRequest(HttpMethod.Get, "/") {
-                addHeader(
-                    HttpHeaders.Authorization,
-                    "Basic " + Base64.getEncoder().encodeToString(" \",; \u0419:pass".toByteArray())
-                )
-            }.let { result ->
-                assertEquals(HttpStatusCode.Unauthorized, result.response.status())
-                assertNull(result.response.content)
-            }
+            assertEquals(HttpStatusCode.Unauthorized, response.status)
+        }
+        client.get("/") {
+            header(
+                HttpHeaders.Authorization,
+                "Basic " + Base64.getEncoder().encodeToString("admin:secret".toByteArray())
+            )
+        }.let { response ->
+            assertEquals(HttpStatusCode.OK, response.status)
+            assertEquals("admin", response.bodyAsText())
+        }
+        client.get("/") {
+            header(
+                HttpHeaders.Authorization,
+                "Basic " + Base64.getEncoder().encodeToString("admin:bad-pass".toByteArray())
+            )
+        }.let { response ->
+            assertEquals(HttpStatusCode.Unauthorized, response.status)
+            assertTrue(response.bodyAsText().isEmpty())
+        }
+        client.get("/") {
+            header(
+                HttpHeaders.Authorization,
+                "Basic " + Base64.getEncoder().encodeToString("bad-user:bad-pass".toByteArray())
+            )
+        }.let { response ->
+            assertEquals(HttpStatusCode.Unauthorized, response.status)
+            assertTrue(response.bodyAsText().isEmpty())
+        }
+        client.get("/") {
+            header(
+                HttpHeaders.Authorization,
+                "Basic " + Base64.getEncoder().encodeToString(" \",; \u0419:pass".toByteArray())
+            )
+        }.let { response ->
+            assertEquals(HttpStatusCode.Unauthorized, response.status)
+            assertTrue(response.bodyAsText().isEmpty())
         }
     }
 
     @Test
-    fun testCustomLogin(port: Int) {
-        withTestApplication {
-            application.install(Authentication) {
-                val ldapUrl = "ldap://$localhost:$port"
-                val configure: (MutableMap<String, Any?>) -> Unit = { env ->
-                    env["java.naming.security.principal"] = "uid=admin,ou=system"
-                    env["java.naming.security.credentials"] = "secret"
-                    env["java.naming.security.authentication"] = "simple"
-                }
+    fun testCustomLogin(port: Int) = testApplication {
+        install(Authentication) {
+            val ldapUrl = "ldap://$localhost:$port"
+            val configure: (MutableMap<String, Any?>) -> Unit = { env ->
+                env["java.naming.security.principal"] = "uid=admin,ou=system"
+                env["java.naming.security.credentials"] = "secret"
+                env["java.naming.security.authentication"] = "simple"
+            }
 
-                basic {
-                    validate { credential ->
-                        ldapAuthenticate(credential, ldapUrl, configure) {
-                            val users = (lookup("ou=system") as LdapContext).lookup("ou=users") as LdapContext
-                            val controls = SearchControls().apply {
-                                searchScope = SearchControls.ONELEVEL_SCOPE
-                                returningAttributes = arrayOf("+", "*")
-                            }
-
-                            users.search("", "(uid=user-test)", controls).asSequence().firstOrNull {
-                                val ldapPassword = (it.attributes.get("userPassword")?.get() as ByteArray?)
-                                    ?.toString(Charsets.ISO_8859_1)
-                                ldapPassword == credential.password
-                            }?.let { UserIdPrincipal(credential.name) }
+            basic {
+                validate { credential ->
+                    ldapAuthenticate(credential, ldapUrl, configure) {
+                        val users = (lookup("ou=system") as LdapContext).lookup("ou=users") as LdapContext
+                        val controls = SearchControls().apply {
+                            searchScope = SearchControls.ONELEVEL_SCOPE
+                            returningAttributes = arrayOf("+", "*")
                         }
+
+                        users.search("", "(uid=user-test)", controls).asSequence().firstOrNull {
+                            val ldapPassword = (it.attributes.get("userPassword")?.get() as ByteArray?)
+                                ?.toString(Charsets.ISO_8859_1)
+                            ldapPassword == credential.password
+                        }?.let { UserIdPrincipal(credential.name) }
                     }
                 }
             }
+        }
 
-            application.routing {
-                authenticate {
-                    get("/") {
-                        call.respondText(call.authentication.principal<UserIdPrincipal>()?.name ?: "null")
-                    }
+        routing {
+            authenticate {
+                get("/") {
+                    call.respondText(call.authentication.principal<UserIdPrincipal>()?.name ?: "null")
                 }
             }
+        }
 
-            handleRequest(HttpMethod.Get, "/") {
-                addHeader(
-                    HttpHeaders.Authorization,
-                    "Basic " + Base64.getEncoder().encodeToString("user-test:test".toByteArray())
-                )
-            }.let { result ->
-                assertEquals(HttpStatusCode.OK, result.response.status())
-                assertEquals("user-test", result.response.content)
-            }
-            handleRequest(HttpMethod.Get, "/") {
-                addHeader(
-                    HttpHeaders.Authorization,
-                    "Basic " + Base64.getEncoder().encodeToString("user-test:bad-pass".toByteArray())
-                )
-            }.let { result ->
-                assertEquals(HttpStatusCode.Unauthorized, result.response.status())
-            }
-            handleRequest(HttpMethod.Get, "/") {
-                addHeader(
-                    HttpHeaders.Authorization,
-                    "Basic " + Base64.getEncoder().encodeToString("bad-user:bad-pass".toByteArray())
-                )
-            }.let { result ->
-                assertEquals(HttpStatusCode.Unauthorized, result.response.status())
-            }
-            handleRequest(HttpMethod.Get, "/") {
-                addHeader(
-                    HttpHeaders.Authorization,
-                    "Basic " + Base64.getEncoder().encodeToString(" \",; \u0419:pass".toByteArray())
-                )
-            }.let { result ->
-                assertEquals(HttpStatusCode.Unauthorized, result.response.status())
-                assertNull(result.response.content)
-            }
+        client.get("/") {
+            header(
+                HttpHeaders.Authorization,
+                "Basic " + Base64.getEncoder().encodeToString("user-test:test".toByteArray())
+            )
+        }.let { response ->
+            assertEquals(HttpStatusCode.OK, response.status)
+            assertEquals("user-test", response.bodyAsText())
+        }
+        client.get("/") {
+            header(
+                HttpHeaders.Authorization,
+                "Basic " + Base64.getEncoder().encodeToString("user-test:bad-pass".toByteArray())
+            )
+        }.let { response ->
+            assertEquals(HttpStatusCode.Unauthorized, response.status)
+        }
+        client.get("/") {
+            header(
+                HttpHeaders.Authorization,
+                "Basic " + Base64.getEncoder().encodeToString("bad-user:bad-pass".toByteArray())
+            )
+        }.let { response ->
+            assertEquals(HttpStatusCode.Unauthorized, response.status)
+        }
+        client.get("/") {
+            header(
+                HttpHeaders.Authorization,
+                "Basic " + Base64.getEncoder().encodeToString(" \",; \u0419:pass".toByteArray())
+            )
+        }.let { response ->
+            assertEquals(HttpStatusCode.Unauthorized, response.status)
+            assertTrue(response.bodyAsText().isEmpty())
         }
     }
 

--- a/ktor-server/ktor-server-plugins/ktor-server-auth/jvm/test/io/ktor/tests/auth/DigestTest.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-auth/jvm/test/io/ktor/tests/auth/DigestTest.kt
@@ -1,10 +1,11 @@
 /*
- * Copyright 2014-2019 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2014-2024 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package io.ktor.tests.auth
 
 import io.ktor.client.request.*
+import io.ktor.client.statement.*
 import io.ktor.http.*
 import io.ktor.http.auth.*
 import io.ktor.server.application.*
@@ -13,15 +14,15 @@ import io.ktor.server.response.*
 import io.ktor.server.routing.*
 import io.ktor.server.testing.*
 import io.ktor.util.*
-import kotlinx.coroutines.*
+import kotlinx.coroutines.test.*
 import java.security.*
 import kotlin.test.*
 
 class DigestTest {
     @Test
-    fun createExampleChallengeFromRFC() {
-        withTestApplication {
-            application.intercept(ApplicationCallPipeline.Plugins) {
+    fun createExampleChallengeFromRFC() = testApplication {
+        application {
+            intercept(ApplicationCallPipeline.Plugins) {
                 call.respond(
                     UnauthorizedResponse(
                         HttpAuthHeader.digestAuthChallenge(
@@ -32,73 +33,69 @@ class DigestTest {
                     )
                 )
             }
+        }
 
-            val response = handleRequest {
+        val response = client.request {
+        }
+
+        assertEquals(HttpStatusCode.Unauthorized, response.status)
+        assertEquals(
+            """Digest
+             realm="testrealm@host.com",
+             nonce="dcd98b7102dd2f0e8b11d0f600bfb0c093",
+             opaque="5ccc069c403ebaf9f0171e9517f40e41",
+             algorithm="MD5" """.normalize(),
+            response.headers[HttpHeaders.WWWAuthenticate]
+        )
+    }
+
+    @Test
+    fun testParseDigestExampleFromRFC() = testApplication {
+        val foundDigests = arrayListOf<DigestCredential>()
+
+        install(Authentication) {
+            provider {
+                authenticate { context ->
+                    context.call.digestAuthenticationCredentials()?.let { digest -> foundDigests.add(digest) }
+                }
             }
+        }
 
-            assertEquals(HttpStatusCode.Unauthorized, response.response.status())
-            assertEquals(
-                """Digest
-                 realm="testrealm@host.com",
-                 nonce="dcd98b7102dd2f0e8b11d0f600bfb0c093",
-                 opaque="5ccc069c403ebaf9f0171e9517f40e41",
-                 algorithm="MD5" """.normalize(),
-                response.response.headers[HttpHeaders.WWWAuthenticate]
+        routing {
+            authenticate {
+                get("/") {}
+            }
+        }
+
+        client.request("/") {
+            header(
+                HttpHeaders.Authorization,
+                """Digest username="Mufasa",
+             realm="testrealm@host.com",
+             nonce="dcd98b7102dd2f0e8b11d0f600bfb0c093",
+             uri="/dir/index.html",
+             qop=auth,
+             nc=00000001,
+             cnonce="0a4f113b",
+             response="6629fae49393a05397450978507c4ef1",
+             opaque="5ccc069c403ebaf9f0171e9517f40e41"""".normalize()
             )
         }
+
+        assertEquals(1, foundDigests.size)
+
+        val theOnlyDigest = foundDigests.single()
+
+        assertEquals("testrealm@host.com", theOnlyDigest.realm)
+        assertEquals("dcd98b7102dd2f0e8b11d0f600bfb0c093", theOnlyDigest.nonce)
+        assertEquals("/dir/index.html", theOnlyDigest.digestUri)
+        assertEquals("00000001", theOnlyDigest.nonceCount)
+        assertEquals("6629fae49393a05397450978507c4ef1", theOnlyDigest.response)
+        assertEquals("5ccc069c403ebaf9f0171e9517f40e41", theOnlyDigest.opaque)
     }
 
     @Test
-    fun testParseDigestExampleFromRFC() {
-        withTestApplication {
-            val foundDigests = arrayListOf<DigestCredential>()
-
-            application.install(Authentication) {
-                provider {
-                    authenticate { context ->
-                        context.call.digestAuthenticationCredentials()?.let { digest -> foundDigests.add(digest) }
-                    }
-                }
-            }
-
-            application.routing {
-                authenticate {
-                    get("/") {}
-                }
-            }
-
-            handleRequest {
-                uri = "/"
-
-                addHeader(
-                    HttpHeaders.Authorization,
-                    """Digest username="Mufasa",
-                 realm="testrealm@host.com",
-                 nonce="dcd98b7102dd2f0e8b11d0f600bfb0c093",
-                 uri="/dir/index.html",
-                 qop=auth,
-                 nc=00000001,
-                 cnonce="0a4f113b",
-                 response="6629fae49393a05397450978507c4ef1",
-                 opaque="5ccc069c403ebaf9f0171e9517f40e41"""".normalize()
-                )
-            }
-
-            assertEquals(1, foundDigests.size)
-
-            val theOnlyDigest = foundDigests.single()
-
-            assertEquals("testrealm@host.com", theOnlyDigest.realm)
-            assertEquals("dcd98b7102dd2f0e8b11d0f600bfb0c093", theOnlyDigest.nonce)
-            assertEquals("/dir/index.html", theOnlyDigest.digestUri)
-            assertEquals("00000001", theOnlyDigest.nonceCount)
-            assertEquals("6629fae49393a05397450978507c4ef1", theOnlyDigest.response)
-            assertEquals("5ccc069c403ebaf9f0171e9517f40e41", theOnlyDigest.opaque)
-        }
-    }
-
-    @Test
-    fun testVerify(): Unit = runBlocking {
+    fun testVerify() = runTest {
         val authHeaderContent = """Digest username="Mufasa",
                      realm="testrealm@host.com",
                      nonce="dcd98b7102dd2f0e8b11d0f600bfb0c093",
@@ -177,7 +174,7 @@ class DigestTest {
         assertEquals(HttpStatusCode.OK, responseCorrectAuth.status)
     }
 
-    private fun Application.configureDigestServer(nonceManager: NonceManager = GenerateOnlyNonceManager) {
+    private fun ApplicationTestBuilder.configureDigestServer(nonceManager: NonceManager = GenerateOnlyNonceManager) {
         install(Authentication) {
             digest {
                 val p = "Circle Of Life"
@@ -200,16 +197,13 @@ class DigestTest {
     }
 
     @Test
-    fun testDigestFromRFCExample() {
-        withTestApplication {
-            application.configureDigestServer()
+    fun testDigestFromRFCExample() = testApplication {
+        configureDigestServer()
 
-            val response = handleRequest {
-                uri = "/"
-
-                addHeader(
-                    HttpHeaders.Authorization,
-                    """Digest username="Mufasa",
+        val response = client.request("/") {
+            header(
+                HttpHeaders.Authorization,
+                """Digest username="Mufasa",
                  realm="testrealm@host.com",
                  nonce="dcd98b7102dd2f0e8b11d0f600bfb0c093",
                  uri="/dir/index.html",
@@ -218,25 +212,21 @@ class DigestTest {
                  cnonce="0a4f113b",
                  response="6629fae49393a05397450978507c4ef1",
                  opaque="5ccc069c403ebaf9f0171e9517f40e41"""".normalize()
-                )
-            }
-
-            assertEquals(HttpStatusCode.OK, response.response.status())
-            assertEquals("Secret info", response.response.content)
+            )
         }
+
+        assertEquals(HttpStatusCode.OK, response.status)
+        assertEquals("Secret info", response.bodyAsText())
     }
 
     @Test
-    fun testDigestFromRFCExampleAuthFailedDueToWrongRealm() {
-        withTestApplication {
-            application.configureDigestServer()
+    fun testDigestFromRFCExampleAuthFailedDueToWrongRealm() = testApplication {
+        configureDigestServer()
 
-            val response = handleRequest {
-                uri = "/"
-
-                addHeader(
-                    HttpHeaders.Authorization,
-                    """Digest username="Mufasa",
+        val response = client.request("/") {
+            header(
+                HttpHeaders.Authorization,
+                """Digest username="Mufasa",
                  realm="testrealm@host.com1",
                  nonce="dcd98b7102dd2f0e8b11d0f600bfb0c093",
                  uri="/dir/index.html",
@@ -245,35 +235,29 @@ class DigestTest {
                  cnonce="0a4f113b",
                  response="6629fae49393a05397450978507c4ef1",
                  opaque="5ccc069c403ebaf9f0171e9517f40e41"""".normalize()
-                )
-            }
-
-            assertEquals(HttpStatusCode.Unauthorized, response.response.status())
+            )
         }
+
+        assertEquals(HttpStatusCode.Unauthorized, response.status)
     }
 
     @Test
-    fun testBadRequestOnInvalidHeader() {
-        withTestApplication {
-            application.configureDigestServer()
+    fun testBadRequestOnInvalidHeader() = testApplication {
+        configureDigestServer()
 
-            val call = handleRequest { addHeader(HttpHeaders.Authorization, "D<gest code") }
+        val response = client.request { header(HttpHeaders.Authorization, "D<gest code") }
 
-            assertEquals(HttpStatusCode.BadRequest, call.response.status())
-        }
+        assertEquals(HttpStatusCode.BadRequest, response.status)
     }
 
     @Test
-    fun testDigestFromRFCExampleAuthFailed() {
-        withTestApplication {
-            application.configureDigestServer()
+    fun testDigestFromRFCExampleAuthFailed() = testApplication {
+        configureDigestServer()
 
-            val response = handleRequest {
-                uri = "/"
-
-                addHeader(
-                    HttpHeaders.Authorization,
-                    """Digest username="Mufasa",
+        val response = client.request("/") {
+            header(
+                HttpHeaders.Authorization,
+                """Digest username="Mufasa",
                  realm="testrealm@host.com",
                  nonce="dcd98b7102dd2f0e8b11d0f600bfb0c093",
                  uri="/dir/index.html",
@@ -282,24 +266,20 @@ class DigestTest {
                  cnonce="0a4f113b",
                  response="bad response goes here  507c4ef1",
                  opaque="5ccc069c403ebaf9f0171e9517f40e41"""".normalize()
-                )
-            }
-
-            assertEquals(HttpStatusCode.Unauthorized, response.response.status())
+            )
         }
+
+        assertEquals(HttpStatusCode.Unauthorized, response.status)
     }
 
     @Test
-    fun testDigestFromRFCExampleAuthFailedDueToMissingUser() {
-        withTestApplication {
-            application.configureDigestServer()
+    fun testDigestFromRFCExampleAuthFailedDueToMissingUser() = testApplication {
+        configureDigestServer()
 
-            val response = handleRequest {
-                uri = "/"
-
-                addHeader(
-                    HttpHeaders.Authorization,
-                    """Digest username="missing",
+        val response = client.request("/") {
+            header(
+                HttpHeaders.Authorization,
+                """Digest username="missing",
                  realm="testrealm@host.com",
                  nonce="dcd98b7102dd2f0e8b11d0f600bfb0c093",
                  uri="/dir/index.html",
@@ -308,11 +288,10 @@ class DigestTest {
                  cnonce="0a4f113b",
                  response="6629fae49393a05397450978507c4ef1",
                  opaque="5ccc069c403ebaf9f0171e9517f40e41"""".normalize()
-                )
-            }
-
-            assertEquals(HttpStatusCode.Unauthorized, response.response.status())
+            )
         }
+
+        assertEquals(HttpStatusCode.Unauthorized, response.status)
     }
 
     @Test
@@ -320,17 +299,17 @@ class DigestTest {
         val key = "test".toByteArray()
         val nonceValue = "test-nonce"
 
-        withTestApplication {
-            application.configureDigestServer(
+        testApplication {
+            configureDigestServer(
                 nonceManager = StatelessHmacNonceManager(
                     key,
                     nonceGenerator = { nonceValue }
                 )
             )
 
-            val challenge = handleRequest(HttpMethod.Get, "/").let { call ->
-                assertEquals(HttpStatusCode.Unauthorized, call.response.status())
-                parseAuthorizationHeader(call.response.headers[HttpHeaders.WWWAuthenticate]!!)
+            val challenge = client.get("/").let { response ->
+                assertEquals(HttpStatusCode.Unauthorized, response.status)
+                parseAuthorizationHeader(response.headers[HttpHeaders.WWWAuthenticate]!!)
             }
 
             val nonce = (challenge as? HttpAuthHeader.Parameterized)?.parameter("nonce")
@@ -363,29 +342,25 @@ class DigestTest {
                 userRealmPassDigest
             )
 
-            handleRequest {
-                uri = "/"
-
-                addHeader(
+            client.request("/") {
+                header(
                     HttpHeaders.Authorization,
                     authHeader.withReplacedParameter("response", hex(expectedDigest)).render()
                 )
-            }.let { call ->
-                assertEquals(HttpStatusCode.OK, call.response.status())
+            }.let { response ->
+                assertEquals(HttpStatusCode.OK, response.status)
             }
 
-            handleRequest {
-                uri = "/"
-
-                addHeader(
+            client.request("/") {
+                header(
                     HttpHeaders.Authorization,
                     authHeader.withReplacedParameter("response", hex(expectedDigest)).withReplacedParameter(
                         "nonce",
                         flipLastHexDigit(nonce)
                     ).render()
                 )
-            }.let { call ->
-                assertEquals(HttpStatusCode.Unauthorized, call.response.status())
+            }.let { response ->
+                assertEquals(HttpStatusCode.Unauthorized, response.status)
             }
         }
     }

--- a/ktor-server/ktor-server-plugins/ktor-server-auth/jvm/test/io/ktor/tests/auth/OAuth1aTest.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-auth/jvm/test/io/ktor/tests/auth/OAuth1aTest.kt
@@ -5,6 +5,8 @@
 package io.ktor.tests.auth
 
 import io.ktor.client.*
+import io.ktor.client.request.*
+import io.ktor.client.statement.*
 import io.ktor.http.*
 import io.ktor.http.auth.*
 import io.ktor.server.application.*
@@ -15,7 +17,6 @@ import io.ktor.server.response.*
 import io.ktor.server.routing.*
 import io.ktor.server.testing.*
 import io.ktor.util.*
-import kotlinx.coroutines.*
 import java.time.*
 import java.util.concurrent.*
 import kotlin.math.*
@@ -173,7 +174,6 @@ class OAuth1aFlowTest {
     }
 
     private val executor = Executors.newSingleThreadExecutor()
-    private val dispatcher = executor.asCoroutineDispatcher()
 
     private val settings = OAuthServerSettings.OAuth1aServerSettings(
         name = "oauth1a",
@@ -190,102 +190,88 @@ class OAuth1aFlowTest {
     }
 
     @Test
-    fun testRequestToken() {
-        withTestApplication {
-            application.configureServer("http://localhost/login?redirected=true")
+    fun testRequestToken() = testApplication {
+        configureServer("http://localhost/login?redirected=true")
 
-            val result = handleRequest(HttpMethod.Get, "/login")
+        val response = client.config { followRedirects = false }
+            .get("/login")
 
-            waitExecutor()
+        waitExecutor()
 
-            assertEquals(HttpStatusCode.Found, result.response.status())
-            assertNull(result.response.content)
-            assertEquals(
-                "https://login-server-com/oauth/authorize?oauth_token=token1",
-                result.response.headers[HttpHeaders.Location],
-                "Redirect target location is not valid"
-            )
-        }
+        assertEquals(HttpStatusCode.Found, response.status)
+        assertTrue(response.bodyAsText().isEmpty())
+        assertEquals(
+            "https://login-server-com/oauth/authorize?oauth_token=token1",
+            response.headers[HttpHeaders.Location],
+            "Redirect target location is not valid"
+        )
     }
 
     @Test
-    fun testRequestTokenWrongConsumerKey() {
-        withTestApplication {
-            application.configureServer(
-                "http://localhost/login?redirected=true",
-                mutateSettings = {
-                    OAuthServerSettings.OAuth1aServerSettings(
-                        name,
-                        requestTokenUrl,
-                        authorizeUrl,
-                        accessTokenUrl,
-                        "badConsumerKey",
-                        consumerSecret
-                    )
-                }
-            )
-
-            val result = handleRequest(HttpMethod.Get, "/login")
-
-            waitExecutor()
-
-            assertEquals(HttpStatusCode.Unauthorized, result.response.status())
-        }
-    }
-
-    @Test
-    fun testRequestTokenFailedRedirect() {
-        withTestApplication {
-            application.configureServer("http://localhost/login")
-
-            val result = handleRequest(HttpMethod.Get, "/login")
-
-            waitExecutor()
-
-            assertEquals(HttpStatusCode.Unauthorized, result.response.status())
-        }
-    }
-
-    @Test
-    fun testAccessToken() {
-        withTestApplication {
-            application.configureServer()
-
-            val result = handleRequest(
-                HttpMethod.Get,
-                "/login?redirected=true&oauth_token=token1&oauth_verifier=verifier1"
-            )
-
-            waitExecutor()
-
-            assertEquals(HttpStatusCode.OK, result.response.status())
-            assertTrue { result.response.content!!.startsWith("Ho, ") }
-            assertFalse { result.response.content!!.contains("[]") }
-        }
-    }
-
-    @Test
-    fun testAccessTokenWrongVerifier() {
-        withTestApplication {
-            application.configureServer()
-
-            val result = handleRequest(
-                HttpMethod.Get,
-                "/login?redirected=true&oauth_token=token1&oauth_verifier=verifier2"
-            )
-
-            waitExecutor()
-
-            assertEquals(HttpStatusCode.Found, result.response.status())
-            assertNotNull(result.response.headers[HttpHeaders.Location])
-            assertTrue {
-                result.response.headers[HttpHeaders.Location]!!
-                    .startsWith("https://login-server-com/oauth/authorize")
+    fun testRequestTokenWrongConsumerKey() = testApplication {
+        configureServer(
+            "http://localhost/login?redirected=true",
+            mutateSettings = {
+                OAuthServerSettings.OAuth1aServerSettings(
+                    name,
+                    requestTokenUrl,
+                    authorizeUrl,
+                    accessTokenUrl,
+                    "badConsumerKey",
+                    consumerSecret
+                )
             }
+        )
+
+        val response = client.get("/login")
+
+        waitExecutor()
+
+        assertEquals(HttpStatusCode.Unauthorized, response.status)
+    }
+
+    @Test
+    fun testRequestTokenFailedRedirect() = testApplication {
+        configureServer("http://localhost/login")
+
+        val response = client.get("/login")
+
+        waitExecutor()
+
+        assertEquals(HttpStatusCode.Unauthorized, response.status)
+    }
+
+    @Test
+    fun testAccessToken() = testApplication {
+        configureServer()
+
+        val response = client.get("/login?redirected=true&oauth_token=token1&oauth_verifier=verifier1")
+
+        waitExecutor()
+
+        assertEquals(HttpStatusCode.OK, response.status)
+        assertTrue { response.bodyAsText().startsWith("Ho, ") }
+        assertFalse { response.bodyAsText().contains("[]") }
+    }
+
+    @Test
+    fun testAccessTokenWrongVerifier() = testApplication {
+        configureServer()
+
+        val response = client.config { followRedirects = false }
+            .get("/login?redirected=true&oauth_token=token1&oauth_verifier=verifier2")
+
+        waitExecutor()
+
+        assertEquals(HttpStatusCode.Found, response.status)
+        assertNotNull(response.headers[HttpHeaders.Location])
+        assertTrue {
+            response.headers[HttpHeaders.Location]!!
+                .startsWith("https://login-server-com/oauth/authorize")
         }
     }
 
-    private fun Application.configureServer(
+    private fun ApplicationTestBuilder.configureServer(
         redirectUrl: String = "http://localhost/login?redirected=true",
         mutateSettings: OAuthServerSettings.OAuth1aServerSettings.() ->
         OAuthServerSettings.OAuth1aServerSettings = { this }
@@ -462,7 +448,7 @@ private fun createOAuthServer(server: TestingOAuthServer): HttpClient {
         }
     }
     val embeddedServer = EmbeddedServer(props, TestEngine)
-    embeddedServer.start()
+    embeddedServer.start(wait = false)
     return embeddedServer.engine.client.config {
         expectSuccess = false
     }


### PR DESCRIPTION
**Subsystem**
Server, `ktor-server-auth-*`

**Motivation**
[KTOR-7397](https://youtrack.jetbrains.com/issue/KTOR-7397/) Remove usage of deprecated `withTestApplication` DSL.

**Solution**
Migrated to `testApplication` DSL