### PR TITLE
KTOR-6826 Include relocation notes for old ktor modules

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -74,7 +74,25 @@ apply(from = "gradle/verifier.gradle")
 
 extra["skipPublish"] = mutableListOf(
     "ktor-server-test-base",
-    "ktor-junit"
+    "ktor-server-test-suites",
+    "ktor-server-tests",
+    "ktor-junit",
+)
+extra["relocatedArtifacts"] = mutableMapOf(
+    "ktor-server-auth" to "ktor-auth",
+    "ktor-server-auth-jwt" to "ktor-auth-jwt",
+    "ktor-server-auth-ldap" to "ktor-auth-ldap",
+    "ktor-server-freemarker" to "ktor-freemarker",
+    "ktor-server-metrics" to "ktor-metrics",
+    "ktor-server-metrics-micrometer" to "ktor-metrics-micrometer",
+    "ktor-server-mustache" to "ktor-mustache",
+    "ktor-server-pebble" to "ktor-pebble",
+    "ktor-server-thymeleaf" to "ktor-thymeleaf",
+    "ktor-server-velocity" to "ktor-velocity",
+    "ktor-server-webjars" to "ktor-webjars",
+    "ktor-serialization-gson" to "ktor-gson",
+    "ktor-serialization-jackson" to "ktor-jackson",
+    "ktor-server-test-host" to "ktor-server-test-base"
 )
 extra["nonDefaultProjectStructure"] = mutableListOf(
     "ktor-bom",
@@ -138,7 +156,7 @@ allprojects {
     }
 
     val skipPublish: List<String> by rootProject.extra
-    if (!skipPublish.contains(project.name)) {
+    if (!skipPublish.contains(project.name) && subprojects.isEmpty()) {
         configurePublication()
     }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -159,7 +159,7 @@ allprojects {
     }
 
     val skipPublish: List<String> by rootProject.extra
-    if (!skipPublish.contains(project.name) && subprojects.isEmpty()) {
+    if (!skipPublish.contains(project.name)) {
         configurePublication()
     }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,6 +3,7 @@
  */
 
 import org.gradle.api.Project
+import org.gradle.internal.extensions.stdlib.*
 import org.jetbrains.dokka.gradle.*
 import org.jetbrains.kotlin.gradle.dsl.*
 import org.jetbrains.kotlin.gradle.tasks.*
@@ -78,22 +79,24 @@ extra["skipPublish"] = mutableListOf(
     "ktor-server-tests",
     "ktor-junit",
 )
-extra["relocatedArtifacts"] = mutableMapOf(
-    "ktor-server-auth" to "ktor-auth",
-    "ktor-server-auth-jwt" to "ktor-auth-jwt",
-    "ktor-server-auth-ldap" to "ktor-auth-ldap",
-    "ktor-server-freemarker" to "ktor-freemarker",
-    "ktor-server-metrics" to "ktor-metrics",
-    "ktor-server-metrics-micrometer" to "ktor-metrics-micrometer",
-    "ktor-server-mustache" to "ktor-mustache",
-    "ktor-server-pebble" to "ktor-pebble",
-    "ktor-server-thymeleaf" to "ktor-thymeleaf",
-    "ktor-server-velocity" to "ktor-velocity",
-    "ktor-server-webjars" to "ktor-webjars",
-    "ktor-serialization-gson" to "ktor-gson",
-    "ktor-serialization-jackson" to "ktor-jackson",
-    "ktor-server-test-host" to "ktor-server-test-base"
-)
+
+extra["relocatedArtifacts"] = mapOf(
+    "ktor-auth" to "ktor-server-auth",
+    "ktor-auth-jwt" to "ktor-server-auth-jwt",
+    "ktor-auth-ldap" to "ktor-server-auth-ldap",
+    "ktor-freemarker" to "ktor-server-freemarker",
+    "ktor-metrics" to "ktor-server-metrics",
+    "ktor-metrics-micrometer" to "ktor-server-metrics-micrometer",
+    "ktor-mustache" to "ktor-server-mustache",
+    "ktor-pebble" to "ktor-server-pebble",
+    "ktor-thymeleaf" to "ktor-server-thymeleaf",
+    "ktor-velocity" to "ktor-server-velocity",
+    "ktor-webjars" to "ktor-server-webjars",
+    "ktor-gson" to "ktor-serialization-gson",
+    "ktor-jackson" to "ktor-serialization-jackson",
+    "ktor-server-test-base" to "ktor-server-test-host",
+).invert()
+
 extra["nonDefaultProjectStructure"] = mutableListOf(
     "ktor-bom",
     "ktor-java-modules-test",

--- a/buildSrc/src/main/kotlin/Publication.kt
+++ b/buildSrc/src/main/kotlin/Publication.kt
@@ -73,6 +73,7 @@ fun Project.configurePublication() {
     val publishLocal: Boolean by rootProject.extra
     val globalM2: String by rootProject.extra
     val nonDefaultProjectStructure: List<String> by rootProject.extra
+    val relocatedArtifacts: Map<String, String> by rootProject.extra
 
     val emptyJar = tasks.register<Jar>("emptyJar") {
         archiveAppendix.set("empty")
@@ -99,34 +100,34 @@ fun Project.configurePublication() {
 
         publications.forEach {
             val publication = it as? MavenPublication ?: return@forEach
-            publication.pom.withXml {
-                val root = asNode()
-                root.appendNode("name", project.name)
-                root.appendNode(
-                    "description",
-                    "Ktor is a framework for quickly creating web applications in Kotlin with minimal effort."
-                )
-                root.appendNode("url", "https://github.com/ktorio/ktor")
-
-                root.appendNode("licenses").apply {
-                    appendNode("license").apply {
-                        appendNode("name", "The Apache Software License, Version 2.0")
-                        appendNode("url", "https://www.apache.org/licenses/LICENSE-2.0.txt")
-                        appendNode("distribution", "repo")
+            publication.pom {
+                name = project.name
+                description = project.description?.takeIf { it.isNotEmpty() } ?: "Ktor is a framework for quickly creating web applications in Kotlin with minimal effort."
+                url = "https://github.com/ktorio/ktor"
+                licenses {
+                    license {
+                        name = "The Apache Software License, Version 2.0"
+                        url = "https://www.apache.org/licenses/LICENSE-2.0.txt"
+                        distribution = "repo"
                     }
                 }
-
-                root.appendNode("developers").apply {
-                    appendNode("developer").apply {
-                        appendNode("id", "JetBrains")
-                        appendNode("name", "JetBrains Team")
-                        appendNode("organization", "JetBrains")
-                        appendNode("organizationUrl", "https://www.jetbrains.com")
+                developers {
+                    developer {
+                        id = "JetBrains"
+                        name = "Jetbrains Team"
+                        organization = "JetBrains"
+                        organizationUrl = "https://www.jetbrains.com"
                     }
                 }
-
-                root.appendNode("scm").apply {
-                    appendNode("url", "https://github.com/ktorio/ktor.git")
+                scm {
+                    url = "https://github.com/ktorio/ktor.git"
+                }
+                relocatedArtifacts[project.name]?.let { oldArtifactId ->
+                    distributionManagement {
+                        relocation {
+                            artifactId = oldArtifactId
+                        }
+                    }
                 }
             }
         }


### PR DESCRIPTION
**Subsystem**
Build System

**Motivation**
- [KTOR-6826](https://youtrack.jetbrains.com/issue/KTOR-6826) Include relocation notes for old Ktor modules
- [KTOR-7393](https://youtrack.jetbrains.com/issue/KTOR-7393) Redirect dependencies from ktor-server-test-base

**Solution**
I added a map for projects that have been moved, so that they can automatically be resolved by maven, and should include a note in the central listing.

I also noticed we have several artifacts that shouldn't have been included in the publications, so I added a couple to the `skipPublish` extension property, and included a clause in the publish condition to skip parent projects (projects without sub-projects, like `ktor-server`).
