### PR TITLE
KTOR-7406 Migrate ktor-server-plugins tests to testApplication DSL

### DIFF
--- a/ktor-server/ktor-server-plugins/ktor-server-mustache/jvm/test/io/ktor/server/mustache/MustacheTest.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-mustache/jvm/test/io/ktor/server/mustache/MustacheTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2021 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2014-2024 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package io.ktor.server.mustache
@@ -9,7 +9,6 @@ import io.ktor.client.statement.*
 import io.ktor.http.*
 import io.ktor.http.content.*
 import io.ktor.serialization.*
-import io.ktor.server.application.*
 import io.ktor.server.plugins.compression.*
 import io.ktor.server.plugins.conditionalheaders.*
 import io.ktor.server.plugins.contentnegotiation.*
@@ -19,6 +18,7 @@ import io.ktor.server.testing.*
 import io.ktor.util.reflect.*
 import io.ktor.utils.io.*
 import io.ktor.utils.io.charsets.*
+import io.ktor.utils.io.jvm.javaio.*
 import java.util.zip.*
 import kotlin.test.*
 import kotlin.text.Charsets
@@ -26,159 +26,144 @@ import kotlin.text.Charsets
 class MustacheTest {
 
     @Test
-    fun `Fill template and expect correct rendered content`() {
-        withTestApplication {
-            application.setupMustache()
-            application.install(ConditionalHeaders)
+    fun `Fill template and expect correct rendered content`() = testApplication {
+        setupMustache()
+        install(ConditionalHeaders)
 
-            application.routing {
-                get("/") {
-                    call.respond(MustacheContent(TemplateWithPlaceholder, DefaultModel, "e"))
-                }
+        routing {
+            get("/") {
+                call.respond(MustacheContent(TemplateWithPlaceholder, DefaultModel, "e"))
             }
+        }
 
-            handleRequest(HttpMethod.Get, "/").response.let { response ->
+        client.get("/").let { response ->
+            val lines = response.bodyAsText().lines()
 
-                val lines = response.content!!.lines()
-
-                assertEquals("<p>Hello, 1</p>", lines[0])
-                assertEquals("<h1>Hello World!</h1>", lines[1])
-            }
+            assertEquals("<p>Hello, 1</p>", lines[0])
+            assertEquals("<h1>Hello World!</h1>", lines[1])
         }
     }
 
     @Test
-    fun `Fill template and expect correct default content type`() {
-        withTestApplication {
-            application.setupMustache()
-            application.install(ConditionalHeaders)
+    fun `Fill template and expect correct default content type`() = testApplication {
+        setupMustache()
+        install(ConditionalHeaders)
 
-            application.routing {
-                get("/") {
-                    call.respond(MustacheContent(TemplateWithPlaceholder, DefaultModel, "e"))
-                }
+        routing {
+            get("/") {
+                call.respond(MustacheContent(TemplateWithPlaceholder, DefaultModel, "e"))
             }
+        }
 
-            handleRequest(HttpMethod.Get, "/").response.let { response ->
+        client.get("/").let { response ->
 
-                val contentTypeText = assertNotNull(response.headers[HttpHeaders.ContentType])
-                assertEquals(ContentType.Text.Html.withCharset(Charsets.UTF_8), ContentType.parse(contentTypeText))
-            }
+            val contentTypeText = assertNotNull(response.headers[HttpHeaders.ContentType])
+            assertEquals(ContentType.Text.Html.withCharset(Charsets.UTF_8), ContentType.parse(contentTypeText))
         }
     }
 
     @Test
-    fun `Fill template and expect eTag set when it is provided`() {
-        withTestApplication {
-            application.setupMustache()
-            application.install(ConditionalHeaders)
+    fun `Fill template and expect eTag set when it is provided`() = testApplication {
+        setupMustache()
+        install(ConditionalHeaders)
 
-            application.routing {
-                get("/") {
-                    call.respond(MustacheContent(TemplateWithPlaceholder, DefaultModel, "e"))
-                }
+        routing {
+            get("/") {
+                call.respond(MustacheContent(TemplateWithPlaceholder, DefaultModel, "e"))
             }
+        }
 
-            assertEquals("\"e\"", handleRequest(HttpMethod.Get, "/").response.headers[HttpHeaders.ETag])
+        assertEquals("\"e\"", client.get("/").headers[HttpHeaders.ETag])
+    }
+
+    @Test
+    fun `Render empty model`() = testApplication {
+        setupMustache()
+        install(ConditionalHeaders)
+
+        routing {
+            get("/") {
+                call.respond(MustacheContent(TemplateWithoutPlaceholder, null, "e"))
+            }
+        }
+
+        client.get("/").let { response ->
+
+            val lines = response.bodyAsText().lines()
+
+            assertEquals("<p>Hello, Anonymous</p>", lines[0])
+            assertEquals("<h1>Hi!</h1>", lines[1])
         }
     }
 
     @Test
-    fun `Render empty model`() {
-        withTestApplication {
-            application.setupMustache()
-            application.install(ConditionalHeaders)
+    fun `Render template compressed with GZIP`() = testApplication {
+        setupMustache()
+        install(Compression) {
+            gzip { minimumSize(10) }
+        }
+        install(ConditionalHeaders)
 
-            application.routing {
-                get("/") {
-                    call.respond(MustacheContent(TemplateWithoutPlaceholder, null, "e"))
-                }
+        routing {
+            get("/") {
+                call.respondTemplate(TemplateWithPlaceholder, DefaultModel, "e")
             }
+        }
 
-            handleRequest(HttpMethod.Get, "/").response.let { response ->
+        client.get("/") {
+            header(HttpHeaders.AcceptEncoding, "gzip")
+        }.let { response ->
+            val content = GZIPInputStream(response.bodyAsChannel().toInputStream()).reader().readText()
 
-                val lines = response.content!!.lines()
+            val lines = content.lines()
 
-                assertEquals("<p>Hello, Anonymous</p>", lines[0])
-                assertEquals("<h1>Hi!</h1>", lines[1])
-            }
+            assertEquals("<p>Hello, 1</p>", lines[0])
+            assertEquals("<h1>Hello World!</h1>", lines[1])
         }
     }
 
     @Test
-    fun `Render template compressed with GZIP`() {
-        withTestApplication {
-            application.setupMustache()
-            application.install(Compression) {
-                gzip { minimumSize(10) }
-            }
-            application.install(ConditionalHeaders)
+    fun `Render template without eTag`() = testApplication {
+        setupMustache()
+        install(ConditionalHeaders)
 
-            application.routing {
-                get("/") {
-                    call.respondTemplate(TemplateWithPlaceholder, DefaultModel, "e")
-                }
-            }
-
-            handleRequest(HttpMethod.Get, "/") {
-                addHeader(HttpHeaders.AcceptEncoding, "gzip")
-            }.response.let { response ->
-                val content = GZIPInputStream(response.byteContent!!.inputStream()).reader().readText()
-
-                val lines = content.lines()
-
-                assertEquals("<p>Hello, 1</p>", lines[0])
-                assertEquals("<h1>Hello World!</h1>", lines[1])
+        routing {
+            get("/") {
+                call.respond(MustacheContent(TemplateWithPlaceholder, DefaultModel))
             }
         }
-    }
 
-    @Test
-    fun `Render template without eTag`() {
-        withTestApplication {
-            application.setupMustache()
-            application.install(ConditionalHeaders)
-
-            application.routing {
-                get("/") {
-                    call.respond(MustacheContent(TemplateWithPlaceholder, DefaultModel))
-                }
-            }
-
-            assertEquals(null, handleRequest(HttpMethod.Get, "/").response.headers[HttpHeaders.ETag])
-        }
+        assertEquals(null, client.get("/").headers[HttpHeaders.ETag])
     }
 
     @Test
     fun `Content Negotiation invoked after`() = testApplication {
-        application {
-            install(ContentNegotiation) {
-                val alwaysFailingConverter = object : ContentConverter {
-                    override suspend fun serialize(
-                        contentType: ContentType,
-                        charset: Charset,
-                        typeInfo: TypeInfo,
-                        value: Any?
-                    ): OutgoingContent? {
-                        fail("This converter should be never started for send")
-                    }
-
-                    override suspend fun deserialize(
-                        charset: Charset,
-                        typeInfo: TypeInfo,
-                        content: ByteReadChannel
-                    ): Any? {
-                        fail("This converter should be never started for receive")
-                    }
+        install(ContentNegotiation) {
+            val alwaysFailingConverter = object : ContentConverter {
+                override suspend fun serialize(
+                    contentType: ContentType,
+                    charset: Charset,
+                    typeInfo: TypeInfo,
+                    value: Any?
+                ): OutgoingContent? {
+                    fail("This converter should be never started for send")
                 }
-                register(ContentType.Application.Json, alwaysFailingConverter)
+
+                override suspend fun deserialize(
+                    charset: Charset,
+                    typeInfo: TypeInfo,
+                    content: ByteReadChannel
+                ): Any? {
+                    fail("This converter should be never started for receive")
+                }
             }
-            setupMustache()
+            register(ContentType.Application.Json, alwaysFailingConverter)
+        }
+        setupMustache()
 
-            routing {
-                get("/") {
-                    call.respond(MustacheContent("index.hbs", mapOf<String, String>()))
-                }
+        routing {
+            get("/") {
+                call.respond(MustacheContent("index.hbs", mapOf<String, String>()))
             }
         }
 
@@ -186,7 +171,7 @@ class MustacheTest {
         assertEquals("Template", response.bodyAsText().trim())
     }
 
-    private fun Application.setupMustache() {
+    private fun ApplicationTestBuilder.setupMustache() {
         install(Mustache)
     }
 

--- a/ktor-server/ktor-server-plugins/ktor-server-velocity/jvm/test/io/ktor/tests/velocity/VelocityTest.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-velocity/jvm/test/io/ktor/tests/velocity/VelocityTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2014-2024 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package io.ktor.tests.velocity
@@ -9,7 +9,6 @@ import io.ktor.client.statement.*
 import io.ktor.http.*
 import io.ktor.http.content.*
 import io.ktor.serialization.*
-import io.ktor.server.application.*
 import io.ktor.server.plugins.compression.*
 import io.ktor.server.plugins.conditionalheaders.*
 import io.ktor.server.plugins.contentnegotiation.*
@@ -20,6 +19,7 @@ import io.ktor.server.velocity.*
 import io.ktor.util.reflect.*
 import io.ktor.utils.io.*
 import io.ktor.utils.io.charsets.*
+import io.ktor.utils.io.jvm.javaio.*
 import org.apache.velocity.runtime.resource.loader.*
 import org.apache.velocity.runtime.resource.util.*
 import java.util.zip.*
@@ -28,130 +28,116 @@ import kotlin.text.Charsets
 
 class VelocityTest {
     @Test
-    fun testName() {
-        withTestApplication {
-            application.setUpTestTemplates()
-            application.install(ConditionalHeaders)
-            application.routing {
-                val model = mapOf("id" to 1, "title" to "Hello, World!")
+    fun testName() = testApplication {
+        setUpTestTemplates()
+        install(ConditionalHeaders)
+        routing {
+            val model = mapOf("id" to 1, "title" to "Hello, World!")
 
-                get("/") {
-                    call.respond(VelocityContent("test.vl", model, "e"))
-                }
+            get("/") {
+                call.respond(VelocityContent("test.vl", model, "e"))
             }
+        }
 
-            handleRequest(HttpMethod.Get, "/").response.let { response ->
-                assertNotNull(response.content)
-                val expectedContent = listOf("<p>Hello, 1</p>", "<h1>Hello, World!</h1>")
-                assertEquals(expectedContent, response.content!!.lines())
+        client.get("/").let { response ->
+            val expectedContent = listOf("<p>Hello, 1</p>", "<h1>Hello, World!</h1>")
+            assertEquals(expectedContent, response.bodyAsText().lines())
 
-                val contentTypeText = assertNotNull(response.headers[HttpHeaders.ContentType])
-                assertEquals(ContentType.Text.Html.withCharset(Charsets.UTF_8), ContentType.parse(contentTypeText))
-                assertEquals("\"e\"", response.headers[HttpHeaders.ETag])
-            }
+            val contentTypeText = assertNotNull(response.headers[HttpHeaders.ContentType])
+            assertEquals(ContentType.Text.Html.withCharset(Charsets.UTF_8), ContentType.parse(contentTypeText))
+            assertEquals("\"e\"", response.headers[HttpHeaders.ETag])
         }
     }
 
     @Test
-    fun testCompression() {
-        withTestApplication {
-            application.setUpTestTemplates()
-            application.install(Compression) {
-                gzip { minimumSize(10) }
+    fun testCompression() = testApplication {
+        setUpTestTemplates()
+        install(Compression) {
+            gzip { minimumSize(10) }
+        }
+        install(ConditionalHeaders)
+
+        routing {
+            val model = mapOf("id" to 1, "title" to "Hello, World!")
+
+            get("/") {
+                call.respond(VelocityContent("test.vl", model, "e"))
             }
-            application.install(ConditionalHeaders)
+        }
 
-            application.routing {
-                val model = mapOf("id" to 1, "title" to "Hello, World!")
+        client.get("/") {
+            header(HttpHeaders.AcceptEncoding, "gzip")
+        }.let { response ->
+            val content = GZIPInputStream(response.bodyAsChannel().toInputStream()).reader().readText()
+            val expectedContent = listOf("<p>Hello, 1</p>", "<h1>Hello, World!</h1>")
+            assertEquals(expectedContent, content.lines())
 
-                get("/") {
-                    call.respond(VelocityContent("test.vl", model, "e"))
-                }
-            }
-
-            handleRequest(HttpMethod.Get, "/") {
-                addHeader(HttpHeaders.AcceptEncoding, "gzip")
-            }.response.let { response ->
-                val content = GZIPInputStream(response.byteContent!!.inputStream()).reader().readText()
-                val expectedContent = listOf("<p>Hello, 1</p>", "<h1>Hello, World!</h1>")
-                assertEquals(expectedContent, content.lines())
-
-                val contentTypeText = assertNotNull(response.headers[HttpHeaders.ContentType])
-                assertEquals(ContentType.Text.Html.withCharset(Charsets.UTF_8), ContentType.parse(contentTypeText))
-                assertEquals("\"e\"", response.headers[HttpHeaders.ETag])
-            }
+            val contentTypeText = assertNotNull(response.headers[HttpHeaders.ContentType])
+            assertEquals(ContentType.Text.Html.withCharset(Charsets.UTF_8), ContentType.parse(contentTypeText))
+            assertEquals("\"e\"", response.headers[HttpHeaders.ETag])
         }
     }
 
     @Test
-    fun testWithoutEtag() {
-        withTestApplication {
-            application.setUpTestTemplates()
-            application.install(ConditionalHeaders)
+    fun testWithoutEtag() = testApplication {
+        setUpTestTemplates()
+        install(ConditionalHeaders)
 
-            application.routing {
-                val model = mapOf("id" to 1, "title" to "Hello, World!")
+        routing {
+            val model = mapOf("id" to 1, "title" to "Hello, World!")
 
-                get("/") {
-                    call.respond(VelocityContent("test.vl", model))
-                }
+            get("/") {
+                call.respond(VelocityContent("test.vl", model))
             }
+        }
 
-            handleRequest(HttpMethod.Get, "/").response.let { response ->
-                val content = response.content
-                assertNotNull(content)
-                val expectedContent = listOf("<p>Hello, 1</p>", "<h1>Hello, World!</h1>")
-                assertEquals(expectedContent, content.lines())
+        client.get("/").let { response ->
+            val content = response.bodyAsText()
+            val expectedContent = listOf("<p>Hello, 1</p>", "<h1>Hello, World!</h1>")
+            assertEquals(expectedContent, content.lines())
 
-                val contentTypeText = assertNotNull(response.headers[HttpHeaders.ContentType])
-                assertEquals(ContentType.Text.Html.withCharset(Charsets.UTF_8), ContentType.parse(contentTypeText))
-                assertEquals(null, response.headers[HttpHeaders.ETag])
-            }
+            val contentTypeText = assertNotNull(response.headers[HttpHeaders.ContentType])
+            assertEquals(ContentType.Text.Html.withCharset(Charsets.UTF_8), ContentType.parse(contentTypeText))
+            assertEquals(null, response.headers[HttpHeaders.ETag])
         }
     }
 
     @Test
-    fun canRespondAppropriately() {
-        withTestApplication {
-            application.setUpTestTemplates()
-            application.install(ConditionalHeaders)
+    fun canRespondAppropriately() = testApplication {
+        setUpTestTemplates()
+        install(ConditionalHeaders)
 
-            application.routing {
-                val model = mapOf("id" to 1, "title" to "Bonjour le monde!")
+        routing {
+            val model = mapOf("id" to 1, "title" to "Bonjour le monde!")
 
-                get("/") {
-                    call.respondTemplate("test.vl", model)
-                }
+            get("/") {
+                call.respondTemplate("test.vl", model)
             }
+        }
 
-            val call = handleRequest(HttpMethod.Get, "/")
+        val response = client.get("/")
 
-            with(call.response) {
-                assertNotNull(content)
+        with(response) {
+            val lines = bodyAsText().lines()
 
-                val lines = content!!.lines()
-
-                assertEquals("<p>Hello, 1</p>", lines[0])
-                assertEquals("<h1>Bonjour le monde!</h1>", lines[1])
-            }
+            assertEquals("<p>Hello, 1</p>", lines[0])
+            assertEquals("<h1>Bonjour le monde!</h1>", lines[1])
         }
     }
 
     @Test
     fun testContentNegotiationInvokedAfter() = testApplication {
-        application {
-            install(ContentNegotiation) {
-                register(ContentType.Application.Json, alwaysFailingConverter)
-            }
-            setUpTestTemplates()
-            install(ConditionalHeaders)
+        install(ContentNegotiation) {
+            register(ContentType.Application.Json, alwaysFailingConverter)
+        }
+        setUpTestTemplates()
+        install(ConditionalHeaders)
 
-            routing {
-                val model = mapOf("id" to 1, "title" to "Bonjour le monde!")
+        routing {
+            val model = mapOf("id" to 1, "title" to "Bonjour le monde!")
 
-                get("/") {
-                    call.respondTemplate("test.vl", model)
-                }
+            get("/") {
+                call.respondTemplate("test.vl", model)
             }
         }
 
@@ -160,7 +146,7 @@ class VelocityTest {
         assertEquals("<h1>Bonjour le monde!</h1>", lines[1])
     }
 
-    private fun Application.setUpTestTemplates() {
+    private fun TestApplicationBuilder.setUpTestTemplates() {
         val bax = "$"
 
         install(Velocity) {

--- a/ktor-server/ktor-server-plugins/ktor-server-velocity/jvm/test/io/ktor/tests/velocity/VelocityToolsTest.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-velocity/jvm/test/io/ktor/tests/velocity/VelocityToolsTest.kt
@@ -1,13 +1,13 @@
 /*
- * Copyright 2014-2019 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2014-2024 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
 @file:Suppress("unused", "UNUSED_PARAMETER")
 
 package io.ktor.tests.velocity
 
-import io.ktor.http.*
-import io.ktor.server.application.*
+import io.ktor.client.request.*
+import io.ktor.client.statement.*
 import io.ktor.server.plugins.conditionalheaders.*
 import io.ktor.server.routing.*
 import io.ktor.server.testing.*
@@ -21,160 +21,140 @@ import kotlin.test.*
 class VelocityToolsTest {
 
     @Test
-    fun testBareVelocity() {
-        withTestApplication {
-            application.setUpTestTemplates()
-            application.install(ConditionalHeaders)
+    fun testBareVelocity() = testApplication {
+        setUpTestTemplates()
+        install(ConditionalHeaders)
 
-            application.routing {
-                val model = mapOf("id" to 1, "title" to "Bonjour le monde!")
+        routing {
+            val model = mapOf("id" to 1, "title" to "Bonjour le monde!")
 
-                get("/") {
-                    call.respondTemplate("test.vl", model)
-                }
+            get("/") {
+                call.respondTemplate("test.vl", model)
             }
+        }
 
-            val call = handleRequest(HttpMethod.Get, "/")
+        val response = client.get("/")
 
-            with(call.response) {
-                assertNotNull(content)
+        with(response) {
+            val lines = bodyAsText().lines()
 
-                val lines = content!!.lines()
-
-                assertEquals("<p>Hello, 1</p>", lines[0])
-                assertEquals("<h1>Bonjour le monde!</h1>", lines[1])
-                assertEquals("<i></i>", lines[2])
-            }
+            assertEquals("<p>Hello, 1</p>", lines[0])
+            assertEquals("<h1>Bonjour le monde!</h1>", lines[1])
+            assertEquals("<i></i>", lines[2])
         }
     }
 
     @Test
-    fun testStandardTools() {
-        withTestApplication {
-            application.setUpTestTemplates {
-                addDefaultTools()
-                setProperty("locale", "en_US")
+    fun testStandardTools() = testApplication {
+        setUpTestTemplates {
+            addDefaultTools()
+            setProperty("locale", "en_US")
+        }
+        install(ConditionalHeaders)
+
+        routing {
+            val model = mapOf("id" to 1, "title" to "Bonjour le monde!")
+
+            get("/") {
+                call.respondTemplate("test.vl", model)
             }
-            application.install(ConditionalHeaders)
+        }
 
-            application.routing {
-                val model = mapOf("id" to 1, "title" to "Bonjour le monde!")
+        val response = client.get("/")
 
-                get("/") {
-                    call.respondTemplate("test.vl", model)
-                }
-            }
+        with(response) {
+            val lines = bodyAsText().lines()
 
-            val call = handleRequest(HttpMethod.Get, "/")
-
-            with(call.response) {
-                assertNotNull(content)
-
-                val lines = content!!.lines()
-
-                assertEquals("<p>Hello, 1</p>", lines[0])
-                assertEquals("<h1>Bonjour le monde!</h1>", lines[1])
-                assertEquals("<i>October</i>", lines[2])
-            }
+            assertEquals("<p>Hello, 1</p>", lines[0])
+            assertEquals("<h1>Bonjour le monde!</h1>", lines[1])
+            assertEquals("<i>October</i>", lines[2])
         }
     }
 
     class DateTool {
-        fun toDate(vararg Any: Any): Date? = null
-        fun format(vararg Any: Any) = "today"
+        fun toDate(vararg any: Any): Date? = null
+        fun format(vararg any: Any) = "today"
     }
 
     @Test
-    fun testCustomTool() {
-        withTestApplication {
-            application.setUpTestTemplates {
-                tool(DateTool::class.java)
+    fun testCustomTool() = testApplication {
+        setUpTestTemplates {
+            tool(DateTool::class.java)
+        }
+        install(ConditionalHeaders)
+
+        routing {
+            val model = mapOf("id" to 1, "title" to "Bonjour le monde!")
+
+            get("/") {
+                call.respondTemplate("test.vl", model)
             }
-            application.install(ConditionalHeaders)
+        }
 
-            application.routing {
-                val model = mapOf("id" to 1, "title" to "Bonjour le monde!")
+        val response = client.get("/")
 
-                get("/") {
-                    call.respondTemplate("test.vl", model)
-                }
-            }
+        with(response) {
+            val lines = bodyAsText().lines()
 
-            val call = handleRequest(HttpMethod.Get, "/")
-
-            with(call.response) {
-                assertNotNull(content)
-
-                val lines = content!!.lines()
-
-                assertEquals("<p>Hello, 1</p>", lines[0])
-                assertEquals("<h1>Bonjour le monde!</h1>", lines[1])
-                assertEquals("<i>today</i>", lines[2])
-            }
+            assertEquals("<p>Hello, 1</p>", lines[0])
+            assertEquals("<h1>Bonjour le monde!</h1>", lines[1])
+            assertEquals("<i>today</i>", lines[2])
         }
     }
 
     @Test
-    fun testConfigureLocale() {
-        withTestApplication {
-            application.setUpTestTemplates {
-                addDefaultTools()
-                setProperty("locale", "fr_FR")
+    fun testConfigureLocale() = testApplication {
+        setUpTestTemplates {
+            addDefaultTools()
+            setProperty("locale", "fr_FR")
+        }
+        install(ConditionalHeaders)
+
+        routing {
+            val model = mapOf("id" to 1, "title" to "Bonjour le monde!")
+
+            get("/") {
+                call.respondTemplate("test.vl", model)
             }
-            application.install(ConditionalHeaders)
+        }
 
-            application.routing {
-                val model = mapOf("id" to 1, "title" to "Bonjour le monde!")
+        val response = client.get("/")
 
-                get("/") {
-                    call.respondTemplate("test.vl", model)
-                }
-            }
+        with(response) {
+            val lines = bodyAsText().lines()
 
-            val call = handleRequest(HttpMethod.Get, "/")
-
-            with(call.response) {
-                assertNotNull(content)
-
-                val lines = content!!.lines()
-
-                assertEquals("<p>Hello, 1</p>", lines[0])
-                assertEquals("<h1>Bonjour le monde!</h1>", lines[1])
-                assertEquals("<i>octobre</i>", lines[2])
-            }
+            assertEquals("<p>Hello, 1</p>", lines[0])
+            assertEquals("<h1>Bonjour le monde!</h1>", lines[1])
+            assertEquals("<i>octobre</i>", lines[2])
         }
     }
 
     @Test
-    fun testNoVelocityConfig() {
-        withTestApplication {
-            application.install(VelocityTools)
+    fun testNoVelocityConfig() = testApplication {
+        install(VelocityTools)
 
-            application.routing {
-                val model = mapOf("id" to 1, "title" to "Bonjour le monde!")
+        routing {
+            val model = mapOf("id" to 1, "title" to "Bonjour le monde!")
 
-                get("/") {
-                    // default engine resource loader is 'file',
-                    // default test working directory is ktor-velocity project root
-                    call.respondTemplate("jvm/test/resources/test-template.vhtml", model)
-                }
+            get("/") {
+                // default engine resource loader is 'file',
+                // default test working directory is ktor-velocity project root
+                call.respondTemplate("jvm/test/resources/test-template.vhtml", model)
             }
+        }
 
-            val call = handleRequest(HttpMethod.Get, "/")
+        val response = client.get("/")
 
-            with(call.response) {
-                assertNotNull(content)
+        with(response) {
+            val lines = bodyAsText().lines()
 
-                val lines = content!!.lines()
-
-                assertEquals("<p>Hello, 1</p>", lines[0])
-                assertEquals("<h1>Bonjour le monde!</h1>", lines[1])
-                assertEquals("<i></i>", lines[2])
-            }
+            assertEquals("<p>Hello, 1</p>", lines[0])
+            assertEquals("<h1>Bonjour le monde!</h1>", lines[1])
+            assertEquals("<i></i>", lines[2])
         }
     }
 
-    private fun Application.setUpTestTemplates(config: EasyFactoryConfiguration.() -> Unit = {}) {
+    private fun ApplicationTestBuilder.setUpTestTemplates(config: EasyFactoryConfiguration.() -> Unit = {}) {
         val bax = "$"
 
         install(VelocityTools) {


### PR DESCRIPTION
**Subsystem**
Server, `ktor-server-mustache`, `ktor-server-pebble`, `ktor-server-velocity`

**Motivation**
[KTOR-7406](https://youtrack.jetbrains.com/issue/KTOR-7406/) Remove usage of deprecated `withTestApplication` DSL.

**Solution**
Migrated to `testApplication` DSL

