### PR TITLE
KTOR-7410: add about URL parsing

### DIFF
--- a/ktor-http/common/src/io/ktor/http/URLBuilder.kt
+++ b/ktor-http/common/src/io/ktor/http/URLBuilder.kt
@@ -143,6 +143,11 @@ private fun <A : Appendable> URLBuilder.appendTo(out: A): A {
             out.appendMailto(encodedUserAndPassword, host)
             return out
         }
+
+        "about" -> {
+            out.appendAbout(host)
+            return out
+        }
     }
 
     out.append("://")
@@ -171,6 +176,11 @@ private fun Appendable.appendFile(host: String, encodedPath: String) {
         append('/')
     }
     append(encodedPath)
+}
+
+private fun Appendable.appendAbout(host: String) {
+    append(":")
+    append(host)
 }
 
 /**

--- a/ktor-http/common/src/io/ktor/http/URLParser.kt
+++ b/ktor-http/common/src/io/ktor/http/URLParser.kt
@@ -57,6 +57,12 @@ internal fun URLBuilder.takeFromUnsafe(urlString: String): URLBuilder {
         return this
     }
 
+    if (protocol.name == "about") {
+        require(slashCount == 0)
+        host = urlString.substring(startIndex, endIndex)
+        return this
+    }
+
     if (slashCount >= 2) {
         loop@ while (true) {
             val delimiter = urlString.indexOfAny("@/\\?#".toCharArray(), startIndex).takeIf { it > 0 } ?: endIndex

--- a/ktor-http/common/test/io/ktor/tests/http/UrlTest.kt
+++ b/ktor-http/common/test/io/ktor/tests/http/UrlTest.kt
@@ -359,6 +359,8 @@ class UrlTest {
         assertEquals("version", aboutVersionUrl.host)
 
         val urlHttp = Url("about")
-        assertEquals("http://localhost/about", urlHttp.toString())
+        assertEquals("localhost", urlHttp.host)
+        assertEquals(URLProtocol.HTTP, urlHttp.protocol)
+        assertTrue(urlHttp.rawSegments.contains("about"))
     }
 }

--- a/ktor-http/common/test/io/ktor/tests/http/UrlTest.kt
+++ b/ktor-http/common/test/io/ktor/tests/http/UrlTest.kt
@@ -345,4 +345,20 @@ class UrlTest {
         assertEquals(null, parseUrl("incorrecturl"))
         assertEquals(null, parseUrl("http://localhost:7000Value"))
     }
+
+    @Test
+    fun testAboutUrl() {
+        val aboutBlankUrl = Url("about:blank")
+        assertEquals("about:blank", aboutBlankUrl.toString())
+        assertEquals("about", aboutBlankUrl.protocol.name)
+        assertEquals("blank", aboutBlankUrl.host)
+
+        val aboutVersionUrl = Url("about:version")
+        assertEquals("about:version", aboutVersionUrl.toString())
+        assertEquals("about", aboutVersionUrl.protocol.name)
+        assertEquals("version", aboutVersionUrl.host)
+
+        val urlHttp = Url("about")
+        assertEquals("http://localhost/about", urlHttp.toString())
+    }
 }


### PR DESCRIPTION
**Subsystem**
ktor-http

**Motivation**
https://youtrack.jetbrains.com/issue/KTOR-7410

**Solution**
Added processing of `about:blank` and other `about:` urls

