### PR TITLE
Disable automerge in Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,8 +3,7 @@
   "extends": [
     "config:recommended",
     ":semanticCommitsDisabled",
-    ":label(dependencies)",
-    ":automergeStableNonMajor"
+    ":label(dependencies)"
   ],
   "packageRules": [
     {


### PR DESCRIPTION
**Subsystem**
Renovate

**Motivation**
Enabled automerge setting [requires](https://docs.renovatebot.com/updating-rebasing/) all renovate branches to be always updated. It results in a lot of rebases and extra CI runs. Our CI is not prepared for that.

**Solution**
Disable automerge for now.

