### PR TITLE
KTOR-7407 Migrate ktor-server-tests to testApplication DSL

### DIFF
--- a/ktor-server/ktor-server-tests/jvm/test/io/ktor/server/http/ApplicationRequestContentTestJvm.kt
+++ b/ktor-server/ktor-server-tests/jvm/test/io/ktor/server/http/ApplicationRequestContentTestJvm.kt
@@ -1,10 +1,11 @@
-// ktlint-disable filename
 /*
- * Copyright 2014-2022 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2014-2024 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
+
+// ktlint-disable filename
 package io.ktor.server.http
 
-import io.ktor.http.*
+import io.ktor.client.request.*
 import io.ktor.server.application.*
 import io.ktor.server.plugins.doublereceive.*
 import io.ktor.server.request.*
@@ -14,28 +15,30 @@ import kotlin.test.*
 class ApplicationRequestContentTest {
 
     @Test
-    fun testInputStreamContent() {
-        withTestApplication {
-            application.intercept(ApplicationCallPipeline.Call) {
+    fun testInputStreamContent() = testApplication {
+        application {
+            intercept(ApplicationCallPipeline.Call) {
                 assertEquals("bodyContent", call.receiveStream().reader(Charsets.UTF_8).readText())
             }
+        }
 
-            handleRequest(HttpMethod.Get, "") {
-                setBody("bodyContent")
-            }
+        client.get("") {
+            setBody("bodyContent")
         }
     }
 
     @Test
-    fun testDoubleReceiveStreams(): Unit = withTestApplication {
-        application.install(DoubleReceive)
+    fun testDoubleReceiveStreams() = testApplication {
+        install(DoubleReceive)
 
-        application.intercept(ApplicationCallPipeline.Call) {
-            assertEquals(11, call.receiveStream().readBytes().size)
-            assertEquals(11, call.receiveStream().readBytes().size)
+        application {
+            intercept(ApplicationCallPipeline.Call) {
+                assertEquals(11, call.receiveStream().readBytes().size)
+                assertEquals(11, call.receiveStream().readBytes().size)
+            }
         }
 
-        handleRequest(HttpMethod.Get, "") {
+        client.get("") {
             setBody("bodyContent")
         }
     }

--- a/ktor-server/ktor-server-tests/jvm/test/io/ktor/server/http/RespondFunctionsJvmTest.kt
+++ b/ktor-server/ktor-server-tests/jvm/test/io/ktor/server/http/RespondFunctionsJvmTest.kt
@@ -1,9 +1,11 @@
 /*
- * Copyright 2014-2022 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2014-2024 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package io.ktor.server.http
 
+import io.ktor.client.request.*
+import io.ktor.client.statement.*
 import io.ktor.http.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
@@ -12,8 +14,8 @@ import kotlin.test.*
 
 class RespondFunctionsJvmTest {
     @Test
-    fun testRespondBytes(): Unit = withTestApplication {
-        application.routing {
+    fun testRespondBytes() = testApplication {
+        routing {
             get("/output-stream") {
                 call.respondOutputStream(contentLength = 2) { write(1); write(2) }
             }
@@ -22,13 +24,13 @@ class RespondFunctionsJvmTest {
             }
         }
 
-        handleRequest(HttpMethod.Get, "/output-stream").let { call ->
-            assertEquals("1, 2", call.response.byteContent?.joinToString())
-            assertEquals("2", call.response.headers[HttpHeaders.ContentLength])
+        client.get("/output-stream").let { response ->
+            assertEquals("1, 2", response.bodyAsBytes().joinToString())
+            assertEquals("2", response.headers[HttpHeaders.ContentLength])
         }
-        handleRequest(HttpMethod.Get, "/text-writer").let { call ->
-            assertEquals("1, 2", call.response.byteContent?.joinToString())
-            assertEquals("2", call.response.headers[HttpHeaders.ContentLength])
+        client.get("/text-writer").let { response ->
+            assertEquals("1, 2", response.bodyAsBytes().joinToString())
+            assertEquals("2", response.headers[HttpHeaders.ContentLength])
         }
     }
 }

--- a/ktor-server/ktor-server-tests/jvm/test/io/ktor/server/http/RespondWriteTest.kt
+++ b/ktor-server/ktor-server-tests/jvm/test/io/ktor/server/http/RespondWriteTest.kt
@@ -1,10 +1,11 @@
 /*
- * Copyright 2014-2021 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2014-2024 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package io.ktor.server.http
 
-import io.ktor.http.*
+import io.ktor.client.request.*
+import io.ktor.client.statement.*
 import io.ktor.server.application.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
@@ -15,78 +16,71 @@ import kotlin.test.*
 
 class RespondWriteTest {
     @Test
-    fun smoke() {
-        withTestApplication {
-            application.routing {
-                get("/") {
-                    call.respondTextWriter { write("OK") }
-                }
+    fun smoke() = testApplication {
+        routing {
+            get("/") {
+                call.respondTextWriter { write("OK") }
             }
+        }
 
-            handleRequest(HttpMethod.Get, "/").let { call ->
-                assertEquals("OK", call.response.content)
-            }
+        client.get("/").let { response ->
+            assertEquals("OK", response.bodyAsText())
         }
     }
 
     @Test
-    fun testFailureInside() {
-        withTestApplication {
-            application.routing {
-                get("/") {
-                    call.respondTextWriter {
-                        throw IllegalStateException("expected")
-                    }
+    fun testFailureInside() = testApplication {
+        routing {
+            get("/") {
+                call.respondTextWriter {
+                    throw IllegalStateException("expected")
                 }
             }
+        }
 
-            assertFailsWith<IllegalStateException> {
-                handleRequest(HttpMethod.Get, "/")
-            }
+        assertFailsWith<IllegalStateException> {
+            client.get("/")
         }
     }
 
     @Test
-    fun testSuspendInside() {
-        withTestApplication {
-            val executor = Executors.newSingleThreadExecutor()
-            application.monitor.subscribe(ApplicationStopped) { executor.shutdown() }
-            application.routing {
-                get("/") {
-                    call.respondTextWriter {
-                        withContext(executor.asCoroutineDispatcher()) {
-                            write("OK")
-                        }
+    fun testSuspendInside() = testApplication {
+        val executor = Executors.newSingleThreadExecutor()
+        application {
+            monitor.subscribe(ApplicationStopped) { executor.shutdown() }
+        }
+        routing {
+            get("/") {
+                call.respondTextWriter {
+                    withContext(executor.asCoroutineDispatcher()) {
+                        write("OK")
                     }
                 }
             }
+        }
 
-            handleRequest(HttpMethod.Get, "/").let { call ->
-                assertEquals("OK", call.response.content)
-            }
+        client.get("/").let { response ->
+            assertEquals("OK", response.bodyAsText())
         }
     }
 
-    //    @Test
-    @Suppress("UNUSED")
-    fun testFailureInsideUnresolvedCase() {
-        withTestApplication {
-            application.routing {
-                get("/") {
-                    call.respondTextWriter {
-                        close() // after that point the main pipeline is going to continue since the channel is closed
-                        // so we can't simply bypass an exception
-                        // the workaround is to hold pipeline on channel pipe until commit rather than just close
+    @Test
+    fun testFailureInsideUnresolvedCase() = testApplication {
+        routing {
+            get("/") {
+                call.respondTextWriter {
+                    close() // after that point the main pipeline is going to continue since the channel is closed
+                    // so we can't simply bypass an exception
+                    // the workaround is to hold pipeline on channel pipe until commit rather than just close
 
-                        Thread.sleep(1000)
-                        throw IllegalStateException("expected")
-                    }
+                    Thread.sleep(1000)
+                    throw IllegalStateException("expected")
                 }
             }
+        }
 
-            assertFailsWith<IllegalStateException> {
-                handleRequest(HttpMethod.Get, "/")
-            }
+        assertFailsWith<IllegalStateException> {
+            client.get("/")
         }
     }
 }

--- a/ktor-server/ktor-server-tests/jvm/test/io/ktor/server/plugins/AutoHeadResponseJvmTest.kt
+++ b/ktor-server/ktor-server-tests/jvm/test/io/ktor/server/plugins/AutoHeadResponseJvmTest.kt
@@ -1,11 +1,12 @@
 /*
- * Copyright 2014-2019 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2014-2024 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package io.ktor.server.plugins
 
+import io.ktor.client.request.*
+import io.ktor.client.statement.*
 import io.ktor.http.*
-import io.ktor.server.application.*
 import io.ktor.server.plugins.autohead.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
@@ -15,32 +16,25 @@ import kotlin.test.*
 class AutoHeadResponseJvmTest {
 
     @Test
-    fun testTextRespond() {
-        withHeadApplication {
-            application.routing {
-                get("/") {
-                    call.respondTextWriter {
-                        write("Hello")
-                    }
+    fun testTextRespond() = testApplication {
+        install(AutoHeadResponse)
+
+        routing {
+            get("/") {
+                call.respondTextWriter {
+                    write("Hello")
                 }
             }
-
-            handleRequest(HttpMethod.Get, "/").let { call ->
-                assertEquals(HttpStatusCode.OK, call.response.status())
-                assertEquals("Hello", call.response.content)
-            }
-
-            handleRequest(HttpMethod.Head, "/").let { call ->
-                assertEquals(HttpStatusCode.OK, call.response.status())
-                assertNull(call.response.content)
-            }
         }
-    }
 
-    private fun withHeadApplication(block: TestApplicationEngine.() -> Unit) {
-        withTestApplication {
-            application.install(AutoHeadResponse)
-            block()
+        client.get("/").let { response ->
+            assertEquals(HttpStatusCode.OK, response.status)
+            assertEquals("Hello", response.bodyAsText())
+        }
+
+        client.head("/").let { response ->
+            assertEquals(HttpStatusCode.OK, response.status)
+            assertTrue(response.bodyAsText().isEmpty())
         }
     }
 }

--- a/ktor-server/ktor-server-tests/jvm/test/io/ktor/server/plugins/CompressionTest.kt
+++ b/ktor-server/ktor-server-tests/jvm/test/io/ktor/server/plugins/CompressionTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2021 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2014-2024 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package io.ktor.server.plugins
@@ -9,7 +9,6 @@ import io.ktor.client.request.*
 import io.ktor.client.statement.*
 import io.ktor.http.*
 import io.ktor.http.content.*
-import io.ktor.server.application.*
 import io.ktor.server.http.*
 import io.ktor.server.http.content.*
 import io.ktor.server.plugins.cachingheaders.*
@@ -22,6 +21,7 @@ import io.ktor.server.sse.*
 import io.ktor.server.testing.*
 import io.ktor.util.*
 import io.ktor.utils.io.*
+import io.ktor.utils.io.jvm.javaio.*
 import kotlinx.coroutines.*
 import kotlinx.io.*
 import java.time.*
@@ -34,496 +34,452 @@ class CompressionTest {
     private val textToCompressAsBytes = textToCompress.encodeToByteArray()
 
     @Test
-    fun testCompressionNotSpecified() {
-        withTestApplication {
-            application.install(Compression)
-            application.routing {
-                get("/") {
-                    call.respondText(textToCompress)
-                }
+    fun testCompressionNotSpecified() = testApplication {
+        install(Compression)
+        routing {
+            get("/") {
+                call.respondText(textToCompress)
             }
-
-            handleAndAssert("/", null, null, textToCompress)
         }
+
+        handleAndAssert("/", null, null, textToCompress)
     }
 
     @Test
-    fun testCompressionUnknownAcceptedEncodings() {
-        withTestApplication {
-            application.install(Compression)
-            application.routing {
-                get("/") {
-                    call.respondText(textToCompress)
-                }
+    fun testCompressionUnknownAcceptedEncodings() = testApplication {
+        install(Compression)
+        routing {
+            get("/") {
+                call.respondText(textToCompress)
             }
-
-            handleAndAssert("/", "a,b,c", null, textToCompress)
         }
+
+        handleAndAssert("/", "a,b,c", null, textToCompress)
     }
 
     @Test
-    fun testCompressionDefaultDeflate() {
-        withTestApplication {
-            application.install(Compression)
-            application.routing {
-                get("/") {
-                    call.respondText(textToCompress)
-                }
+    fun testCompressionDefaultDeflate() = testApplication {
+        install(Compression)
+        routing {
+            get("/") {
+                call.respondText(textToCompress)
             }
-
-            handleAndAssert("/", "deflate", "deflate", textToCompress)
         }
+
+        handleAndAssert("/", "deflate", "deflate", textToCompress)
     }
 
     @Test
-    fun testCompressionDefaultGzip() {
-        withTestApplication {
-            application.install(Compression)
-            application.routing {
-                get("/") {
-                    call.respondText(textToCompress)
-                }
+    fun testCompressionDefaultGzip() = testApplication {
+        install(Compression)
+        routing {
+            get("/") {
+                call.respondText(textToCompress)
             }
-
-            handleAndAssert("/", "gzip,deflate", "gzip", textToCompress)
         }
+
+        handleAndAssert("/", "gzip,deflate", "gzip", textToCompress)
     }
 
     @Test
-    fun testAcceptStarContentEncodingGzip() {
-        withTestApplication {
-            application.install(Compression) {
-                gzip()
-            }
-
-            application.routing {
-                get("/") {
-                    call.respondText(textToCompress)
-                }
-            }
-
-            handleAndAssert("/", "*", "gzip", textToCompress)
+    fun testAcceptStarContentEncodingGzip() = testApplication {
+        install(Compression) {
+            gzip()
         }
+
+        routing {
+            get("/") {
+                call.respondText(textToCompress)
+            }
+        }
+
+        handleAndAssert("/", "*", "gzip", textToCompress)
     }
 
     @Test
-    fun testShouldNotCompressVideoByDefault() {
-        withTestApplication {
-            application.install(Compression)
+    fun testShouldNotCompressVideoByDefault() = testApplication {
+        install(Compression)
 
-            application.routing {
-                get("/") {
-                    call.respondText(textToCompress, ContentType.Video.MP4)
-                }
+        routing {
+            get("/") {
+                call.respondText(textToCompress, ContentType.Video.MP4)
             }
-
-            handleAndAssert("/", "*", null, textToCompress)
         }
+
+        handleAndAssert("/", "*", null, textToCompress)
     }
 
     @Test
-    fun testGzipShouldNotCompressVideoByDefault() {
-        withTestApplication {
-            application.install(Compression) {
-                gzip()
-            }
-
-            application.routing {
-                get("/") {
-                    call.respondText(textToCompress, ContentType.Video.MP4)
-                }
-            }
-
-            handleAndAssert("/", "*", null, textToCompress)
+    fun testGzipShouldNotCompressVideoByDefault() = testApplication {
+        install(Compression) {
+            gzip()
         }
+
+        routing {
+            get("/") {
+                call.respondText(textToCompress, ContentType.Video.MP4)
+            }
+        }
+
+        handleAndAssert("/", "*", null, textToCompress)
     }
 
     @Test
-    fun testAcceptStarContentEncodingDeflate() {
-        withTestApplication {
-            application.install(Compression) {
-                deflate()
-            }
-
-            application.routing {
-                get("/") {
-                    call.respondText(textToCompress)
-                }
-            }
-
-            handleAndAssert("/", "*", "deflate", textToCompress)
+    fun testAcceptStarContentEncodingDeflate() = testApplication {
+        install(Compression) {
+            deflate()
         }
+
+        routing {
+            get("/") {
+                call.respondText(textToCompress)
+            }
+        }
+
+        handleAndAssert("/", "*", "deflate", textToCompress)
     }
 
     @Test
-    fun testUnknownEncodingListedEncoding() {
-        withTestApplication {
-            application.install(Compression)
-            application.routing {
-                get("/") {
-                    call.respondText(textToCompress)
-                }
+    fun testUnknownEncodingListedEncoding() = testApplication {
+        install(Compression)
+        routing {
+            get("/") {
+                call.respondText(textToCompress)
             }
-
-            handleAndAssert("/", "special,gzip,deflate", "gzip", textToCompress)
         }
+
+        handleAndAssert("/", "special,gzip,deflate", "gzip", textToCompress)
     }
 
     @Test
-    fun testCustomEncoding() {
-        withTestApplication {
-            application.install(Compression) {
-                default()
-                encoder(
-                    object : ContentEncoder {
-                        override val name: String = "special"
+    fun testCustomEncoding() = testApplication {
+        install(Compression) {
+            default()
+            encoder(
+                object : ContentEncoder {
+                    override val name: String = "special"
 
-                        override fun encode(
-                            source: ByteReadChannel,
-                            coroutineContext: CoroutineContext
-                        ) = source
+                    override fun encode(
+                        source: ByteReadChannel,
+                        coroutineContext: CoroutineContext
+                    ) = source
 
-                        override fun encode(
-                            source: ByteWriteChannel,
-                            coroutineContext: CoroutineContext
-                        ) = source
+                    override fun encode(
+                        source: ByteWriteChannel,
+                        coroutineContext: CoroutineContext
+                    ) = source
 
-                        override fun decode(
-                            source: ByteReadChannel,
-                            coroutineContext: CoroutineContext
-                        ): ByteReadChannel = source
+                    override fun decode(
+                        source: ByteReadChannel,
+                        coroutineContext: CoroutineContext
+                    ): ByteReadChannel = source
+                }
+            )
+        }
+        routing {
+            get("/") {
+                call.respondText(textToCompress)
+            }
+        }
+
+        val response = client.get("/") {
+            header(HttpHeaders.AcceptEncoding, "special")
+        }
+        assertEquals(HttpStatusCode.OK, response.status)
+        assertEquals("special", response.headers[HttpHeaders.ContentEncoding])
+        assertEquals(textToCompress, response.bodyAsBytes().toString(Charsets.UTF_8))
+    }
+
+    @Test
+    fun testStatusCode() = testApplication {
+        install(Compression)
+        routing {
+            get("/") {
+                call.respondText(textToCompress, status = HttpStatusCode.Found)
+            }
+        }
+
+        val response = client.config { followRedirects = false }.get("/") {
+            header(HttpHeaders.AcceptEncoding, "*")
+        }
+        assertEquals(HttpStatusCode.Found, response.status)
+        assertEquals(textToCompress, response.bodyAsText())
+    }
+
+    @Test
+    fun testMinSize() = testApplication {
+        install(Compression) {
+            minimumSize(10)
+        }
+
+        routing {
+            get("/small") {
+                call.respondText("0123")
+            }
+            get("/big") {
+                call.respondText("01234567890123456789")
+            }
+            get("/stream") {
+                call.respondText("stream content")
+            }
+        }
+
+        handleAndAssert("/big", "gzip,deflate", "gzip", "01234567890123456789")
+        handleAndAssert("/small", "gzip,deflate", null, "0123")
+        handleAndAssert("/stream", "gzip,deflate", "gzip", "stream content")
+    }
+
+    @Test
+    fun testMinSizeGzip() = testApplication {
+        install(Compression) {
+            gzip()
+            minimumSize(10)
+        }
+
+        routing {
+            get("/small") {
+                call.respondText("0123")
+            }
+            get("/big") {
+                call.respondText("01234567890123456789")
+            }
+            get("/stream") {
+                call.respondText("stream content")
+            }
+        }
+
+        handleAndAssert("/big", "gzip,deflate", "gzip", "01234567890123456789")
+        handleAndAssert("/small", "gzip,deflate", null, "0123")
+        handleAndAssert("/stream", "gzip,deflate", "gzip", "stream content")
+    }
+
+    @Test
+    fun testMimeTypes() = testApplication {
+        install(Compression) {
+            default()
+            matchContentType(ContentType.Text.Any)
+            excludeContentType(ContentType.Text.VCard)
+        }
+
+        routing {
+            get("/") {
+                call.respondText(textToCompress, ContentType.parse(call.parameters["t"]!!))
+            }
+        }
+
+        handleAndAssert("/?t=text/plain", "gzip,deflate", "gzip", textToCompress)
+        handleAndAssert("/?t=text/vcard", "gzip,deflate", null, textToCompress)
+        handleAndAssert("/?t=some/other", "gzip,deflate", null, textToCompress)
+    }
+
+    @Test
+    fun testEncoderLevelCondition() = testApplication {
+        install(Compression) {
+            gzip {
+                condition {
+                    parameters["e"] == "1"
+                }
+            }
+            deflate()
+        }
+
+        routing {
+            get("/") {
+                call.respondText(textToCompress)
+            }
+        }
+
+        handleAndAssert("/?e=1", "gzip", "gzip", textToCompress)
+        handleAndAssert("/?e", "gzip", null, textToCompress)
+        handleAndAssert("/?e", "gzip,deflate", "deflate", textToCompress)
+    }
+
+    @Test
+    fun testEncoderPriority1() = testApplication {
+        install(Compression) {
+            gzip {
+                priority = 10.0
+            }
+            deflate {
+                priority = 1.0
+            }
+        }
+
+        routing {
+            get("/") {
+                call.respondText(textToCompress)
+            }
+        }
+
+        handleAndAssert("/", "gzip", "gzip", textToCompress)
+        handleAndAssert("/", "deflate", "deflate", textToCompress)
+        handleAndAssert("/", "gzip,deflate", "gzip", textToCompress)
+    }
+
+    @Test
+    fun testEncoderPriority2() = testApplication {
+        install(Compression) {
+            gzip {
+                priority = 1.0
+            }
+            deflate {
+                priority = 10.0
+            }
+        }
+
+        routing {
+            get("/") {
+                call.respondText(textToCompress)
+            }
+        }
+
+        handleAndAssert("/", "gzip", "gzip", textToCompress)
+        handleAndAssert("/", "deflate", "deflate", textToCompress)
+        handleAndAssert("/", "gzip,deflate", "deflate", textToCompress)
+    }
+
+    @Test
+    fun testEncoderQuality() = testApplication {
+        install(Compression) {
+            gzip()
+            deflate()
+        }
+
+        routing {
+            get("/") {
+                call.respondText(textToCompress)
+            }
+        }
+
+        handleAndAssert("/", "gzip", "gzip", textToCompress)
+        handleAndAssert("/", "deflate", "deflate", textToCompress)
+        handleAndAssert("/", "gzip;q=1,deflate;q=0.1", "gzip", textToCompress)
+        handleAndAssert("/", "gzip;q=0.1,deflate;q=1", "deflate", textToCompress)
+    }
+
+    @Test
+    fun testCustomCondition() = testApplication {
+        install(Compression) {
+            default()
+            condition {
+                parameters["compress"] == "true"
+            }
+        }
+
+        routing {
+            get("/") {
+                call.respondText(textToCompress)
+            }
+        }
+
+        handleAndAssert("/", "gzip,deflate", null, textToCompress)
+        handleAndAssert("/?compress=true", "gzip,deflate", "gzip", textToCompress)
+    }
+
+    @Test
+    fun testWithConditionalHeaders() = testApplication {
+        val dateTime = ZonedDateTime.now(ZoneId.of("GMT"))
+
+        install(ConditionalHeaders)
+        install(CachingHeaders)
+        install(Compression)
+
+        routing {
+            get("/") {
+                call.respond(
+                    object : OutgoingContent.ReadChannelContent() {
+                        init {
+                            versions += LastModifiedVersion(dateTime)
+                            caching = CachingOptions(
+                                cacheControl = CacheControl.NoCache(CacheControl.Visibility.Public),
+                                expires = dateTime
+                            )
+                        }
+
+                        override val contentType = ContentType.Text.Plain
+                        override val contentLength = textToCompressAsBytes.size.toLong()
+                        override fun readFrom() = ByteReadChannel(textToCompressAsBytes)
                     }
                 )
             }
-            application.routing {
-                get("/") {
-                    call.respondText(textToCompress)
-                }
-            }
+        }
 
-            val result = handleRequest(HttpMethod.Get, "/") {
-                addHeader(HttpHeaders.AcceptEncoding, "special")
-            }
-            assertEquals(HttpStatusCode.OK, result.response.status())
-            assertEquals("special", result.response.headers[HttpHeaders.ContentEncoding])
-            assertEquals(textToCompress, result.response.byteContent!!.toString(Charsets.UTF_8))
+        handleAndAssert("/", "gzip", "gzip", textToCompress).let { response ->
+            assertEquals("text/plain", response.headers[HttpHeaders.ContentType])
+            assertEquals(dateTime.toHttpDateString(), response.headers[HttpHeaders.Expires])
+            assertEquals("no-cache, public", response.headers[HttpHeaders.CacheControl])
+            assertFalse { HttpHeaders.ContentLength in response.headers }
+            assertEquals(dateTime.toHttpDateString(), response.headers[HttpHeaders.LastModified])
+        }
+
+        client.get("/") {
+            header(HttpHeaders.IfModifiedSince, dateTime.toHttpDateString())
+        }.let { response ->
+            assertEquals(HttpStatusCode.NotModified, response.status)
+        }
+
+        client.get("/") {
+            header(HttpHeaders.AcceptEncoding, "gzip")
+            header(HttpHeaders.IfModifiedSince, dateTime.toHttpDateString())
+        }.let { response ->
+            assertEquals(HttpStatusCode.NotModified, response.status)
+        }
+
+        client.get("/") {
+            header(HttpHeaders.AcceptEncoding, "gzip")
+            header(HttpHeaders.IfModifiedSince, dateTime.minusHours(1).toHttpDateString())
+        }.let { response ->
+            assertEquals(HttpStatusCode.OK, response.status)
+            assertEquals("gzip", response.headers[HttpHeaders.ContentEncoding])
+        }
+
+        client.get("/") {
+            header(HttpHeaders.IfModifiedSince, dateTime.minusHours(1).toHttpDateString())
+        }.let { response ->
+            assertEquals(HttpStatusCode.OK, response.status)
+            assertNull(response.headers[HttpHeaders.ContentEncoding])
         }
     }
 
     @Test
-    fun testStatusCode() {
-        withTestApplication {
-            application.install(Compression)
-            application.routing {
-                get("/") {
-                    call.respondText(textToCompress, status = HttpStatusCode.Found)
-                }
-            }
-
-            val result = handleRequest(HttpMethod.Get, "/") {
-                addHeader(HttpHeaders.AcceptEncoding, "*")
-            }
-            assertEquals(HttpStatusCode.Found, result.response.status())
-            assertEquals(textToCompress, result.response.byteContent!!.toString(Charsets.UTF_8))
-        }
-    }
-
-    @Test
-    fun testMinSize() {
-        withTestApplication {
-            application.install(Compression) {
-                minimumSize(10)
-            }
-
-            application.routing {
-                get("/small") {
-                    call.respondText("0123")
-                }
-                get("/big") {
-                    call.respondText("01234567890123456789")
-                }
-                get("/stream") {
-                    call.respondText("stream content")
-                }
-            }
-
-            handleAndAssert("/big", "gzip,deflate", "gzip", "01234567890123456789")
-            handleAndAssert("/small", "gzip,deflate", null, "0123")
-            handleAndAssert("/stream", "gzip,deflate", "gzip", "stream content")
-        }
-    }
-
-    @Test
-    fun testMinSizeGzip() {
-        withTestApplication {
-            application.install(Compression) {
-                gzip()
-                minimumSize(10)
-            }
-
-            application.routing {
-                get("/small") {
-                    call.respondText("0123")
-                }
-                get("/big") {
-                    call.respondText("01234567890123456789")
-                }
-                get("/stream") {
-                    call.respondText("stream content")
-                }
-            }
-
-            handleAndAssert("/big", "gzip,deflate", "gzip", "01234567890123456789")
-            handleAndAssert("/small", "gzip,deflate", null, "0123")
-            handleAndAssert("/stream", "gzip,deflate", "gzip", "stream content")
-        }
-    }
-
-    @Test
-    fun testMimeTypes() {
-        withTestApplication {
-            application.install(Compression) {
-                default()
-                matchContentType(ContentType.Text.Any)
-                excludeContentType(ContentType.Text.VCard)
-            }
-
-            application.routing {
-                get("/") {
-                    call.respondText(textToCompress, ContentType.parse(call.parameters["t"]!!))
-                }
-            }
-
-            handleAndAssert("/?t=text/plain", "gzip,deflate", "gzip", textToCompress)
-            handleAndAssert("/?t=text/vcard", "gzip,deflate", null, textToCompress)
-            handleAndAssert("/?t=some/other", "gzip,deflate", null, textToCompress)
-        }
-    }
-
-    @Test
-    fun testEncoderLevelCondition() {
-        withTestApplication {
-            application.install(Compression) {
-                gzip {
-                    condition {
-                        parameters["e"] == "1"
-                    }
-                }
-                deflate()
-            }
-
-            application.routing {
-                get("/") {
-                    call.respondText(textToCompress)
-                }
-            }
-
-            handleAndAssert("/?e=1", "gzip", "gzip", textToCompress)
-            handleAndAssert("/?e", "gzip", null, textToCompress)
-            handleAndAssert("/?e", "gzip,deflate", "deflate", textToCompress)
-        }
-    }
-
-    @Test
-    fun testEncoderPriority1() {
-        withTestApplication {
-            application.install(Compression) {
-                gzip {
-                    priority = 10.0
-                }
-                deflate {
-                    priority = 1.0
-                }
-            }
-
-            application.routing {
-                get("/") {
-                    call.respondText(textToCompress)
-                }
-            }
-
-            handleAndAssert("/", "gzip", "gzip", textToCompress)
-            handleAndAssert("/", "deflate", "deflate", textToCompress)
-            handleAndAssert("/", "gzip,deflate", "gzip", textToCompress)
-        }
-    }
-
-    @Test
-    fun testEncoderPriority2() {
-        withTestApplication {
-            application.install(Compression) {
-                gzip {
-                    priority = 1.0
-                }
-                deflate {
-                    priority = 10.0
-                }
-            }
-
-            application.routing {
-                get("/") {
-                    call.respondText(textToCompress)
-                }
-            }
-
-            handleAndAssert("/", "gzip", "gzip", textToCompress)
-            handleAndAssert("/", "deflate", "deflate", textToCompress)
-            handleAndAssert("/", "gzip,deflate", "deflate", textToCompress)
-        }
-    }
-
-    @Test
-    fun testEncoderQuality() {
-        withTestApplication {
-            application.install(Compression) {
-                gzip()
-                deflate()
-            }
-
-            application.routing {
-                get("/") {
-                    call.respondText(textToCompress)
-                }
-            }
-
-            handleAndAssert("/", "gzip", "gzip", textToCompress)
-            handleAndAssert("/", "deflate", "deflate", textToCompress)
-            handleAndAssert("/", "gzip;q=1,deflate;q=0.1", "gzip", textToCompress)
-            handleAndAssert("/", "gzip;q=0.1,deflate;q=1", "deflate", textToCompress)
-        }
-    }
-
-    @Test
-    fun testCustomCondition() {
-        withTestApplication {
-            application.install(Compression) {
-                default()
-                condition {
-                    parameters["compress"] == "true"
-                }
-            }
-
-            application.routing {
-                get("/") {
-                    call.respondText(textToCompress)
-                }
-            }
-
-            handleAndAssert("/", "gzip,deflate", null, textToCompress)
-            handleAndAssert("/?compress=true", "gzip,deflate", "gzip", textToCompress)
-        }
-    }
-
-    @Test
-    fun testWithConditionalHeaders() {
-        val dateTime = ZonedDateTime.now(ZoneId.of("GMT"))
-
-        withTestApplication {
-            application.install(ConditionalHeaders)
-            application.install(CachingHeaders)
-            application.install(Compression)
-
-            application.routing {
-                get("/") {
-                    call.respond(
-                        object : OutgoingContent.ReadChannelContent() {
-                            init {
-                                versions += LastModifiedVersion(dateTime)
-                                caching = CachingOptions(
-                                    cacheControl = CacheControl.NoCache(CacheControl.Visibility.Public),
-                                    expires = dateTime
-                                )
-                            }
-
-                            override val contentType = ContentType.Text.Plain
-                            override val contentLength = textToCompressAsBytes.size.toLong()
-                            override fun readFrom() = ByteReadChannel(textToCompressAsBytes)
-                        }
-                    )
-                }
-            }
-
-            handleAndAssert("/", "gzip", "gzip", textToCompress).let { call ->
-                assertEquals("text/plain", call.response.headers[HttpHeaders.ContentType])
-                assertEquals(dateTime.toHttpDateString(), call.response.headers[HttpHeaders.Expires])
-                assertEquals("no-cache, public", call.response.headers[HttpHeaders.CacheControl])
-                assertFalse { HttpHeaders.ContentLength in call.response.headers }
-                assertEquals(dateTime.toHttpDateString(), call.response.headers[HttpHeaders.LastModified])
-            }
-
-            handleRequest(HttpMethod.Get, "/") {
-                addHeader(HttpHeaders.IfModifiedSince, dateTime.toHttpDateString())
-            }.let { call ->
-                assertEquals(HttpStatusCode.NotModified, call.response.status())
-            }
-
-            handleRequest(HttpMethod.Get, "/") {
-                addHeader(HttpHeaders.AcceptEncoding, "gzip")
-                addHeader(HttpHeaders.IfModifiedSince, dateTime.toHttpDateString())
-            }.let { call ->
-                assertEquals(HttpStatusCode.NotModified, call.response.status())
-            }
-
-            handleRequest(HttpMethod.Get, "/") {
-                addHeader(HttpHeaders.AcceptEncoding, "gzip")
-                addHeader(HttpHeaders.IfModifiedSince, dateTime.minusHours(1).toHttpDateString())
-            }.let { call ->
-                assertEquals(HttpStatusCode.OK, call.response.status())
-                assertEquals("gzip", call.response.headers[HttpHeaders.ContentEncoding])
-            }
-
-            handleRequest(HttpMethod.Get, "/") {
-                addHeader(HttpHeaders.IfModifiedSince, dateTime.minusHours(1).toHttpDateString())
-            }.let { call ->
-                assertEquals(HttpStatusCode.OK, call.response.status())
-                assertNull(call.response.headers[HttpHeaders.ContentEncoding])
-            }
-        }
-    }
-
-    @Test
-    fun testLargeContent() {
+    fun testLargeContent() = testApplication {
         val content = buildString {
             for (i in 1..16384) {
                 append("test$i\n".padStart(10, ' '))
             }
         }
 
-        withTestApplication {
-            application.install(Compression)
-            application.routing {
-                get("/") {
-                    call.respondText(content)
-                }
+        install(Compression)
+        routing {
+            get("/") {
+                call.respondText(content)
             }
-
-            handleAndAssert("/", "deflate", "deflate", content)
-            handleAndAssert("/", "gzip", "gzip", content)
         }
+
+        handleAndAssert("/", "deflate", "deflate", content)
+        handleAndAssert("/", "gzip", "gzip", content)
     }
 
     @Test
-    fun testRespondWrite() {
-        withTestApplication {
-            application.install(Compression)
-            application.routing {
-                get("/") {
-                    call.respondTextWriter {
-                        write("test ")
-                        write("me")
-                    }
+    fun testRespondWrite() = testApplication {
+        install(Compression)
+        routing {
+            get("/") {
+                call.respondTextWriter {
+                    write("test ")
+                    write("me")
                 }
             }
-
-            handleAndAssert("/", "gzip", "gzip", "test me")
         }
+
+        handleAndAssert("/", "gzip", "gzip", "test me")
     }
 
     @Test
-    fun testCompressionRespondBytes(): Unit = withTestApplication {
-        application.install(Compression)
+    fun testCompressionRespondBytes() = testApplication {
+        install(Compression)
 
-        application.routing {
+        routing {
             get("/") {
                 call.respond(
                     object : OutgoingContent.WriteChannelContent() {
@@ -539,10 +495,10 @@ class CompressionTest {
     }
 
     @Test
-    fun testIdentityRequested(): Unit = withTestApplication {
-        application.install(Compression)
+    fun testIdentityRequested() = testApplication {
+        install(Compression)
 
-        application.routing {
+        routing {
             get("/text") {
                 call.respondText(textToCompress)
             }
@@ -556,10 +512,10 @@ class CompressionTest {
     }
 
     @Test
-    fun testCompressionRespondObjectWithIdentity(): Unit = withTestApplication {
-        application.install(Compression)
+    fun testCompressionRespondObjectWithIdentity() = testApplication {
+        install(Compression)
 
-        application.routing {
+        routing {
             get("/") {
                 call.respond(
                     object : OutgoingContent.ByteArrayContent() {
@@ -582,10 +538,10 @@ class CompressionTest {
     }
 
     @Test
-    fun testCompressionUpgradeShouldNotBeCompressed(): Unit = withTestApplication {
-        application.install(Compression)
+    fun testCompressionUpgradeShouldNotBeCompressed() = testApplication {
+        install(Compression)
 
-        application.routing {
+        routing {
             get("/") {
                 call.respond(
                     object : OutgoingContent.ProtocolUpgrade() {
@@ -595,8 +551,8 @@ class CompressionTest {
                             engineContext: CoroutineContext,
                             userContext: CoroutineContext
                         ): Job {
-                            return launch {
-                                output.flushAndClose()
+                            return coroutineScope {
+                                launch { output.flushAndClose() }
                             }
                         }
                     }
@@ -604,17 +560,17 @@ class CompressionTest {
             }
         }
 
-        handleRequest(HttpMethod.Get, "/").let { call ->
-            assertEquals(101, call.response.status()?.value)
-            assertNull(call.response.headers[HttpHeaders.ContentEncoding])
+        client.get("/").let { response ->
+            assertEquals(101, response.status.value)
+            assertNull(response.headers[HttpHeaders.ContentEncoding])
         }
     }
 
     @Test
-    fun testCompressionContentTypesShouldNotBeCompressed(): Unit = withTestApplication {
-        application.install(Compression)
+    fun testCompressionContentTypesShouldNotBeCompressed() = testApplication {
+        install(Compression)
 
-        application.routing {
+        routing {
             get("/event-stream") {
                 call.respondText("events", ContentType.Text.EventStream)
             }
@@ -629,28 +585,28 @@ class CompressionTest {
             }
         }
 
-        handleRequest(HttpMethod.Get, "/event-stream").let { call ->
-            assertEquals(200, call.response.status()?.value)
-            assertNull(call.response.headers[HttpHeaders.ContentEncoding])
-            assertEquals("events", call.response.content)
-            assertEquals(ContentType.Text.EventStream, call.response.contentType().withoutParameters())
+        client.get("/event-stream").let { response ->
+            assertEquals(200, response.status.value)
+            assertNull(response.headers[HttpHeaders.ContentEncoding])
+            assertEquals("events", response.bodyAsText())
+            assertEquals(ContentType.Text.EventStream, response.contentType()?.withoutParameters())
         }
-        handleRequest(HttpMethod.Get, "/video").let { call ->
-            assertEquals(200, call.response.status()?.value)
-            assertNull(call.response.headers[HttpHeaders.ContentEncoding])
-            assertEquals("video", call.response.content)
-            assertEquals(ContentType.Video.MPEG, call.response.contentType())
+        client.get("/video").let { response ->
+            assertEquals(200, response.status.value)
+            assertNull(response.headers[HttpHeaders.ContentEncoding])
+            assertEquals("video", response.bodyAsText())
+            assertEquals(ContentType.Video.MPEG, response.contentType())
         }
-        handleRequest(HttpMethod.Get, "/multipart").let { call ->
-            assertEquals(200, call.response.status()?.value)
-            assertNull(call.response.headers[HttpHeaders.ContentEncoding])
-            assertEquals(ContentType.MultiPart.FormData, call.response.contentType().withoutParameters())
+        client.get("/multipart").let { response ->
+            assertEquals(200, response.status.value)
+            assertNull(response.headers[HttpHeaders.ContentEncoding])
+            assertEquals(ContentType.MultiPart.FormData, response.contentType()?.withoutParameters())
         }
     }
 
     @Test
-    fun testSubrouteInstall(): Unit = withTestApplication {
-        application.routing {
+    fun testSubrouteInstall() = testApplication {
+        routing {
             route("1") {
                 install(Compression) {
                     deflate()
@@ -813,51 +769,51 @@ class CompressionTest {
         assertContentEquals(textToCompressAsBytes, response.body<ByteArray>())
     }
 
-    private fun TestApplicationEngine.handleAndAssert(
+    private suspend fun ApplicationTestBuilder.handleAndAssert(
         url: String,
         acceptHeader: String?,
         expectedEncoding: String?,
         expectedContent: String
-    ): TestApplicationCall {
-        val result = handleRequest(HttpMethod.Get, url) {
+    ): HttpResponse {
+        val response = client.get(url) {
             if (acceptHeader != null) {
-                addHeader(HttpHeaders.AcceptEncoding, acceptHeader)
+                header(HttpHeaders.AcceptEncoding, acceptHeader)
             }
         }
 
-        assertEquals(HttpStatusCode.OK, result.response.status())
+        assertEquals(HttpStatusCode.OK, response.status)
         if (expectedEncoding != null) {
-            assertEquals(expectedEncoding, result.response.headers[HttpHeaders.ContentEncoding])
+            assertEquals(expectedEncoding, response.headers[HttpHeaders.ContentEncoding])
             when (expectedEncoding) {
                 "gzip" -> {
-                    assertEquals(expectedContent, result.response.readGzip())
-                    assertNull(result.response.headers[HttpHeaders.ContentLength])
+                    assertEquals(expectedContent, response.readGzip())
+                    assertNull(response.headers[HttpHeaders.ContentLength])
                 }
 
                 "deflate" -> {
-                    assertEquals(expectedContent, result.response.readDeflate())
-                    assertNull(result.response.headers[HttpHeaders.ContentLength])
+                    assertEquals(expectedContent, response.readDeflate())
+                    assertNull(response.headers[HttpHeaders.ContentLength])
                 }
 
                 "identity" -> {
-                    assertEquals(expectedContent, result.response.readIdentity())
-                    assertNotNull(result.response.headers[HttpHeaders.ContentLength])
+                    assertEquals(expectedContent, response.readIdentity())
+                    assertNotNull(response.headers[HttpHeaders.ContentLength])
                 }
 
                 else -> fail("unknown encoding $expectedEncoding")
             }
         } else {
-            assertNull(result.response.headers[HttpHeaders.ContentEncoding], "content shouldn't be compressed")
-            assertEquals(expectedContent, result.response.content)
-            assertNotNull(result.response.headers[HttpHeaders.ContentLength])
+            assertNull(response.headers[HttpHeaders.ContentEncoding], "content shouldn't be compressed")
+            assertEquals(expectedContent, response.bodyAsText())
+            assertNotNull(response.headers[HttpHeaders.ContentLength])
         }
 
-        return result
+        return response
     }
 
-    private fun TestApplicationResponse.readIdentity() = byteContent!!.inputStream().reader().readText()
-    private fun TestApplicationResponse.readDeflate() =
-        InflaterInputStream(byteContent!!.inputStream(), Inflater(true)).reader().readText()
+    private suspend fun HttpResponse.readIdentity() = bodyAsChannel().toInputStream().reader().readText()
+    private suspend fun HttpResponse.readDeflate() =
+        InflaterInputStream(bodyAsChannel().toInputStream(), Inflater(true)).reader().readText()
 
-    private fun TestApplicationResponse.readGzip() = GZIPInputStream(byteContent!!.inputStream()).reader().readText()
+    private suspend fun HttpResponse.readGzip() = GZIPInputStream(bodyAsChannel().toInputStream()).reader().readText()
 }

--- a/ktor-server/ktor-server-tests/jvm/test/io/ktor/server/plugins/CookiesTest.kt
+++ b/ktor-server/ktor-server-tests/jvm/test/io/ktor/server/plugins/CookiesTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2014-2024 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package io.ktor.server.plugins
@@ -8,7 +8,6 @@ import io.ktor.client.plugins.websocket.*
 import io.ktor.client.request.*
 import io.ktor.http.*
 import io.ktor.server.plugins.forwardedheaders.*
-import io.ktor.server.response.*
 import io.ktor.server.routing.*
 import io.ktor.server.sessions.*
 import io.ktor.server.testing.*
@@ -56,17 +55,15 @@ class CookiesTest {
         }
     }
 
-    private fun testSetCookies(expectedHeaderContent: String, block: PipelineResponse.() -> Unit) {
-        withTestApplicationResponse {
-            block()
-            assertEquals(expectedHeaderContent, headers["Set-Cookie"]?.cutSetCookieHeader())
+    private fun testSetCookies(expectedHeaderContent: String, block: RoutingResponse.() -> Unit) = testApplication {
+        routing {
+            get("/set-cookie") {
+                call.response.apply(block)
+            }
         }
-    }
 
-    private fun withTestApplicationResponse(block: TestApplicationResponse.() -> Unit) {
-        withTestApplication {
-            createCall { protocol = "https" }.response.apply(block)
-        }
+        val response = client.get("/set-cookie")
+        assertEquals(expectedHeaderContent, response.headers["Set-Cookie"]?.cutSetCookieHeader())
     }
 
     private fun String.cutSetCookieHeader() = substringBeforeLast("\$x-enc").trimEnd().removeSuffix(";")

--- a/ktor-server/ktor-server-tests/jvm/test/io/ktor/server/plugins/DataConversionTest.kt
+++ b/ktor-server/ktor-server-tests/jvm/test/io/ktor/server/plugins/DataConversionTest.kt
@@ -1,11 +1,10 @@
 /*
- * Copyright 2014-2019 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2014-2024 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package io.ktor.server.plugins
 
-import io.ktor.server.plugins.dataconversion.*
-import io.ktor.server.testing.*
+import io.ktor.util.converters.*
 import io.ktor.util.reflect.*
 import java.math.*
 import kotlin.test.*
@@ -13,14 +12,16 @@ import kotlin.test.*
 class DataConversionTest {
 
     @Test
-    fun testBigNumbers() = withTestApplication {
+    fun testDefaultConversionBigNumbers() {
+        val conversionService = DefaultConversionService
         val expected = "12345678901234567890"
-        val v = application.conversionService.toValues(BigDecimal(expected))
-        assertEquals(expected, v.single())
-        assertEquals(BigDecimal(expected), application.conversionService.fromValues(v, typeInfo<BigDecimal>()))
 
-        val v2 = application.conversionService.toValues(BigInteger(expected))
+        val v = conversionService.toValues(BigDecimal(expected))
+        assertEquals(expected, v.single())
+        assertEquals(BigDecimal(expected), conversionService.fromValues(v, typeInfo<BigDecimal>()))
+
+        val v2 = conversionService.toValues(BigInteger(expected))
         assertEquals(expected, v2.single())
-        assertEquals(BigInteger(expected), application.conversionService.fromValues(v2, typeInfo<BigInteger>()))
+        assertEquals(BigInteger(expected), conversionService.fromValues(v2, typeInfo<BigInteger>()))
     }
 }

--- a/ktor-server/ktor-server-tests/jvm/test/io/ktor/server/plugins/PartialContentTest.kt
+++ b/ktor-server/ktor-server-tests/jvm/test/io/ktor/server/plugins/PartialContentTest.kt
@@ -1,12 +1,13 @@
 /*
- * Copyright 2014-2019 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2014-2024 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package io.ktor.server.plugins
 
+import io.ktor.client.request.*
+import io.ktor.client.statement.*
 import io.ktor.http.*
 import io.ktor.http.content.*
-import io.ktor.server.application.*
 import io.ktor.server.plugins.autohead.*
 import io.ktor.server.plugins.cachingheaders.*
 import io.ktor.server.plugins.conditionalheaders.*
@@ -17,7 +18,7 @@ import io.ktor.server.testing.*
 import io.ktor.util.date.*
 import io.ktor.utils.io.*
 import io.ktor.utils.io.core.*
-import java.io.*
+import kotlinx.io.*
 import kotlin.test.*
 
 class PartialContentTest {
@@ -28,77 +29,79 @@ class PartialContentTest {
     private val content = "test_string".repeat(100).toByteArray()
     private val lastModifiedTime = getTimeMillis()
 
-    private fun withRangeApplication(maxRangeCount: Int? = null, test: TestApplicationEngine.() -> Unit): Unit =
-        withTestApplication {
-            application.install(ConditionalHeaders)
-            application.install(CachingHeaders)
-            application.install(PartialContent) {
-                maxRangeCount?.let { this.maxRangeCount = it }
-            }
-            application.install(AutoHeadResponse)
-            application.routing {
-                route(localPath) {
-                    handle {
-                        val channel = ByteReadChannel(content)
-                        call.respond(
-                            object : OutgoingContent.ReadChannelContent() {
-                                override val contentType: ContentType = ContentType.Application.OctetStream
-                                override val contentLength: Long = content.size.toLong()
-                                override fun readFrom(): ByteReadChannel = channel
-                            }.apply {
-                                versions += LastModifiedVersion(GMTDate(lastModifiedTime))
-                                versions += EntityTagVersion(fileEtag)
-                            }
-                        )
-                    }
+    private fun withRangeApplication(
+        maxRangeCount: Int? = null,
+        test: suspend ApplicationTestBuilder.() -> Unit
+    ) = testApplication {
+        install(ConditionalHeaders)
+        install(CachingHeaders)
+        install(PartialContent) {
+            maxRangeCount?.let { this.maxRangeCount = it }
+        }
+        install(AutoHeadResponse)
+        routing {
+            route(localPath) {
+                handle {
+                    val channel = ByteReadChannel(content)
+                    call.respond(
+                        object : OutgoingContent.ReadChannelContent() {
+                            override val contentType: ContentType = ContentType.Application.OctetStream
+                            override val contentLength: Long = content.size.toLong()
+                            override fun readFrom(): ByteReadChannel = channel
+                        }.apply {
+                            versions += LastModifiedVersion(GMTDate(lastModifiedTime))
+                            versions += EntityTagVersion(fileEtag)
+                        }
+                    )
                 }
             }
-
-            test()
         }
 
+        test()
+    }
+
     @Test
-    fun testCustomMaxRangeCountAcceptedRange(): Unit = withRangeApplication(maxRangeCount = 2) {
-        handleRequest(HttpMethod.Get, localPath) {
-            addHeader(HttpHeaders.Range, "bytes=0-0,2-2")
-        }.let { result ->
-            assertEquals(HttpStatusCode.PartialContent, result.response.status())
-            assertEquals(null, result.response.headers[HttpHeaders.ContentRange])
-            assertNotNull(result.response.headers[HttpHeaders.LastModified])
-            checkContentLength(result)
+    fun testCustomMaxRangeCountAcceptedRange() = withRangeApplication(maxRangeCount = 2) {
+        client.get(localPath) {
+            header(HttpHeaders.Range, "bytes=0-0,2-2")
+        }.let { response ->
+            assertEquals(HttpStatusCode.PartialContent, response.status)
+            assertEquals(null, response.headers[HttpHeaders.ContentRange])
+            assertNotNull(response.headers[HttpHeaders.LastModified])
+            checkContentLength(response)
         }
     }
 
     @Test
-    fun testMultipleRanges(): Unit = withRangeApplication {
+    fun testMultipleRanges() = withRangeApplication {
         // multiple ranges
-        handleRequest(HttpMethod.Get, localPath) {
-            addHeader(HttpHeaders.Range, "bytes=0-0,2-2")
-        }.let { result ->
-            checkContentLength(result)
-            val lines = result.response.content!!.lines()
+        client.get(localPath) {
+            header(HttpHeaders.Range, "bytes=0-0,2-2")
+        }.let { response ->
+            checkContentLength(response)
+            val lines = response.bodyAsText().lines()
             assertTrue(lines[0] == contentType || lines[1] == contentType)
 
-            assertMultipart(result) { parts ->
+            assertMultipart(response) { parts ->
                 assertEquals(listOf("t", "t"), parts)
             }
         }
     }
 
-    private fun assertMultipart(result: TestApplicationCall, block: (List<String>) -> Unit) {
-        assertEquals(HttpStatusCode.PartialContent, result.response.status())
-        assertNotNull(result.response.headers[HttpHeaders.LastModified])
-        val contentType = ContentType.parse(result.response.headers[HttpHeaders.ContentType]!!)
+    private suspend fun assertMultipart(response: HttpResponse, block: (List<String>) -> Unit) {
+        assertEquals(HttpStatusCode.PartialContent, response.status)
+        assertNotNull(response.headers[HttpHeaders.LastModified])
+        val contentType = ContentType.parse(response.headers[HttpHeaders.ContentType]!!)
         assertTrue(contentType.match(ContentType.MultiPart.ByteRanges))
         assertNotNull(contentType.parameter("boundary"))
 
-        val parts = result.response.content!!.reader().buffered().parseMultipart(contentType.parameter("boundary")!!)
+        val parts = response.bodyAsChannel().parseMultipart(contentType.parameter("boundary")!!)
         assertTrue { parts.isNotEmpty() }
 
         block(parts)
     }
 
-    private fun BufferedReader.parseMultipart(boundary: String): List<String> {
+    private suspend fun ByteReadChannel.parseMultipart(boundary: String): List<String> {
         val parts = ArrayList<String>()
         do {
             // according to rfc1341
@@ -121,7 +124,7 @@ class PartialContentTest {
             parts.add(
                 buildString {
                     repeat(length) {
-                        append(read().toChar())
+                        append(readByte().toInt().toChar())
                     }
                 }
             )
@@ -130,16 +133,16 @@ class PartialContentTest {
         return parts
     }
 
-    private fun BufferedReader.findLineWithBoundary(boundary: String): String? {
+    private suspend fun ByteReadChannel.findLineWithBoundary(boundary: String): String? {
         do {
-            val line = readLine() ?: return null
+            val line = readUTF8Line() ?: return null
             if (line.contains(boundary)) return line
         } while (true)
     }
 
-    private fun BufferedReader.scanHeaders() = Headers.build {
+    private suspend fun ByteReadChannel.scanHeaders() = Headers.build {
         do {
-            val line = readLine()
+            val line = readUTF8Line()
             if (line.isNullOrBlank()) break
 
             val (header, value) = line.chomp(":") { throw IOException("Illegal header line $line") }
@@ -173,23 +176,10 @@ class PartialContentTest {
         }
     }
 
-    private fun File.readChars(from: Int, toInclusive: Int = from): String {
-        require(from <= toInclusive)
-
-        val result = CharArray(toInclusive - from + 1)
-        reader().use { input ->
-            if (from > 0) {
-                assertEquals(from.toLong(), input.skip(from.toLong()))
-            }
-            assertEquals(result.size, input.read(result))
-        }
-        return String(result)
-    }
-
-    private fun checkContentLength(result: TestApplicationCall) {
+    private suspend fun checkContentLength(response: HttpResponse) {
         assertEquals(
-            result.response.byteContent!!.size,
-            result.response.headers[HttpHeaders.ContentLength]!!.toInt()
+            response.bodyAsBytes().size,
+            response.headers[HttpHeaders.ContentLength]!!.toInt()
         )
     }
 }

--- a/ktor-server/ktor-server-tests/jvm/test/io/ktor/server/sessions/SessionTestJvm.kt
+++ b/ktor-server/ktor-server-tests/jvm/test/io/ktor/server/sessions/SessionTestJvm.kt
@@ -1,11 +1,12 @@
 /*
- * Copyright 2014-2022 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2014-2024 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package io.ktor.server.sessions
 
+import io.ktor.client.request.*
+import io.ktor.client.statement.*
 import io.ktor.http.*
-import io.ktor.server.application.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
 import io.ktor.server.testing.*
@@ -13,186 +14,179 @@ import io.ktor.util.*
 import kotlin.random.*
 import kotlin.test.*
 
-@Suppress("ReplaceSingleLineLet", "DEPRECATION")
+@Suppress("ComplexRedundantLet")
 class SessionTestJvm {
     private val cookieName = "_S" + Random.nextInt(100)
 
     @Test
-    fun testSessionByValueMac() {
+    fun testSessionByValueMac() = testApplication {
         val key = hex("03515606058610610561058")
-        withTestApplication {
-            application.install(Sessions) {
-                cookie<TestUserSession>(cookieName) {
-                    transform(SessionTransportTransformerMessageAuthentication(key))
-                }
-            }
 
-            commonSignedChecks()
+        install(Sessions) {
+            cookie<TestUserSession>(cookieName) {
+                transform(SessionTransportTransformerMessageAuthentication(key))
+            }
         }
+
+        commonSignedChecks()
     }
 
     @Test
-    fun testSessionEncrypted() {
+    fun testSessionEncrypted() = testApplication {
         val encryptKey = hex("00112233445566778899aabbccddeeff")
         val signKey = hex("02030405060708090a0b0c")
         val forcedIvForTesting = hex("00112233445566778899aabbccddeeff")
 
-        withTestApplication {
-            application.install(Sessions) {
-                cookie<TestUserSession>(cookieName) {
-                    transform(SessionTransportTransformerEncrypt(encryptKey, signKey, { forcedIvForTesting }))
-                }
+        install(Sessions) {
+            cookie<TestUserSession>(cookieName) {
+                transform(SessionTransportTransformerEncrypt(encryptKey, signKey, { forcedIvForTesting }))
             }
+        }
 
-            application.routing {
-                get("/3") {
-                    call.sessions.set(TestUserSession("id2", emptyList()))
-                    call.respondText("ok")
-                }
-                get("/4") {
-                    call.respondText("ok:" + call.sessions.get<TestUserSession>()?.userId)
-                }
+        routing {
+            get("/3") {
+                call.sessions.set(TestUserSession("id2", emptyList()))
+                call.respondText("ok")
             }
-
-            handleRequest(HttpMethod.Get, "/3").let { call ->
-                val sessionCookie = call.response.cookies[cookieName]
-                assertEquals(
-                    "00112233445566778899aabbccddeeff/" +
-                        "9b8cf9900ff0f63849cb7a2ad71ed8a1ac9f0e2735492d2a5129cf278d70ab27:" +
-                        "40af9f393a00034b53d2267251047259005bdf5ff104eede599149e80e6fee13",
-                    sessionCookie!!.value
-                )
+            get("/4") {
+                call.respondText("ok:" + call.sessions.get<TestUserSession>()?.userId)
             }
+        }
 
-            handleRequest(HttpMethod.Get, "/4") {
-                addHeader(HttpHeaders.Cookie, "$cookieName=INVALID")
-            }.let { call ->
-                assertEquals("ok:null", call.response.content)
-            }
+        commonSignedChecks()
 
-            handleRequest(HttpMethod.Get, "/4") {
-                addHeader(HttpHeaders.Cookie, "$cookieName=abc/abc:abc")
-            }.let { call ->
-                assertEquals("ok:null", call.response.content)
-            }
+        client.get("/3").let { response ->
+            val sessionCookie = response.setCookie().find { it.name == cookieName }
+            assertEquals(
+                "00112233445566778899aabbccddeeff/" +
+                    "9b8cf9900ff0f63849cb7a2ad71ed8a1ac9f0e2735492d2a5129cf278d70ab27:" +
+                    "40af9f393a00034b53d2267251047259005bdf5ff104eede599149e80e6fee13",
+                sessionCookie!!.value
+            )
+        }
 
-            commonSignedChecks()
+        client.get("/4") {
+            header(HttpHeaders.Cookie, "$cookieName=INVALID")
+        }.let { response ->
+            assertEquals("ok:null", response.bodyAsText())
+        }
+
+        client.get("/4") {
+            header(HttpHeaders.Cookie, "$cookieName=abc/abc:abc")
+        }.let { response ->
+            assertEquals("ok:null", response.bodyAsText())
         }
     }
 
     @Test
-    fun testSessionEncryptedBackwardCompatible() {
+    fun testSessionEncryptedBackwardCompatible() = testApplication {
         val encryptKey = hex("00112233445566778899aabbccddeeff")
         val signKey = hex("02030405060708090a0b0c")
         val forcedIvForTesting = hex("00112233445566778899aabbccddeeff")
 
-        withTestApplication {
-            application.install(Sessions) {
-                cookie<TestUserSession>(cookieName) {
-                    serializer = reflectionSessionSerializer()
-                    transform(
-                        SessionTransportTransformerEncrypt(
-                            encryptKey,
-                            signKey,
-                            { forcedIvForTesting },
-                            backwardCompatibleRead = true
-                        )
+        install(Sessions) {
+            cookie<TestUserSession>(cookieName) {
+                serializer = reflectionSessionSerializer()
+                transform(
+                    SessionTransportTransformerEncrypt(
+                        encryptKey,
+                        signKey,
+                        { forcedIvForTesting },
+                        backwardCompatibleRead = true
                     )
-                }
-            }
-
-            application.routing {
-                get("/3") {
-                    call.sessions.set(TestUserSession("id2", emptyList()))
-                    call.respondText("ok")
-                }
-                get("/4") {
-                    call.respondText("ok:" + call.sessions.get<TestUserSession>()?.userId)
-                }
-            }
-
-            handleRequest(HttpMethod.Get, "/3").let { call ->
-                val sessionCookie = call.response.cookies[cookieName]
-                assertEquals(
-                    "00112233445566778899aabbccddeeff/" +
-                        "c3850fc1ddc62f71ec5eaad6d393b91fa809fe32a1cf0cb4730788c5a489daef:" +
-                        "65f0bd15bfa7e96b8bd9e134e23a24860b324e361c606e6800af050f5d104b68",
-                    sessionCookie!!.value
                 )
             }
+        }
 
-            handleRequest(HttpMethod.Get, "/4") {
-                addHeader(
-                    HttpHeaders.Cookie,
-                    "$cookieName=" + "00112233445566778899aabbccddeeff/" +
-                        "c3850fc1ddc62f71ec5eaad6d393b91fa809fe32a1cf0cb4730788c5a489daef:" +
-                        "51a5e9fcd1c91418f9a623bafa5022a524348e44244265dc0cab2cebacc28a5d"
-                )
-            }.let { call ->
-                assertEquals("ok:id2", call.response.content)
+        routing {
+            get("/3") {
+                call.sessions.set(TestUserSession("id2", emptyList()))
+                call.respondText("ok")
             }
+            get("/4") {
+                call.respondText("ok:" + call.sessions.get<TestUserSession>()?.userId)
+            }
+        }
 
-            commonSignedChecks()
+        commonSignedChecks()
+
+        client.get("/3").let { response ->
+            val sessionCookie = response.setCookie().find { it.name == cookieName }
+            assertEquals(
+                "00112233445566778899aabbccddeeff/" +
+                    "c3850fc1ddc62f71ec5eaad6d393b91fa809fe32a1cf0cb4730788c5a489daef:" +
+                    "65f0bd15bfa7e96b8bd9e134e23a24860b324e361c606e6800af050f5d104b68",
+                sessionCookie!!.value
+            )
+        }
+
+        client.get("/4") {
+            header(
+                HttpHeaders.Cookie,
+                "$cookieName=" + "00112233445566778899aabbccddeeff/" +
+                    "c3850fc1ddc62f71ec5eaad6d393b91fa809fe32a1cf0cb4730788c5a489daef:" +
+                    "51a5e9fcd1c91418f9a623bafa5022a524348e44244265dc0cab2cebacc28a5d"
+            )
+        }.let { response ->
+            assertEquals("ok:id2", response.bodyAsText())
         }
     }
 
     @Test
-    fun testSessionEncryptedNotBackwardCompatible() {
+    fun testSessionEncryptedNotBackwardCompatible() = testApplication {
         val encryptKey = hex("00112233445566778899aabbccddeeff")
         val signKey = hex("02030405060708090a0b0c")
         val forcedIvForTesting = hex("00112233445566778899aabbccddeeff")
 
-        withTestApplication {
-            application.install(Sessions) {
-                cookie<TestUserSession>(cookieName) {
-                    serializer = reflectionSessionSerializer()
-                    transform(
-                        SessionTransportTransformerEncrypt(
-                            encryptKey,
-                            signKey,
-                            { forcedIvForTesting },
-                        )
+        install(Sessions) {
+            cookie<TestUserSession>(cookieName) {
+                serializer = reflectionSessionSerializer()
+                transform(
+                    SessionTransportTransformerEncrypt(
+                        encryptKey,
+                        signKey,
+                        { forcedIvForTesting },
                     )
-                }
-            }
-
-            application.routing {
-                get("/3") {
-                    call.sessions.set(TestUserSession("id2", emptyList()))
-                    call.respondText("ok")
-                }
-                get("/4") {
-                    call.respondText("ok:" + call.sessions.get<TestUserSession>()?.userId)
-                }
-            }
-
-            handleRequest(HttpMethod.Get, "/3").let { call ->
-                val sessionCookie = call.response.cookies[cookieName]
-                assertEquals(
-                    "00112233445566778899aabbccddeeff/" +
-                        "c3850fc1ddc62f71ec5eaad6d393b91fa809fe32a1cf0cb4730788c5a489daef:" +
-                        "65f0bd15bfa7e96b8bd9e134e23a24860b324e361c606e6800af050f5d104b68",
-                    sessionCookie!!.value
                 )
             }
+        }
 
-            handleRequest(HttpMethod.Get, "/4") {
-                addHeader(
-                    HttpHeaders.Cookie,
-                    "$cookieName=" + "00112233445566778899aabbccddeeff/" +
-                        "c3850fc1ddc62f71ec5eaad6d393b91fa809fe32a1cf0cb4730788c5a489daef:" +
-                        "51a5e9fcd1c91418f9a623bafa5022a524348e44244265dc0cab2cebacc28a5d"
-                )
-            }.let { call ->
-                assertEquals("ok:null", call.response.content)
+        routing {
+            get("/3") {
+                call.sessions.set(TestUserSession("id2", emptyList()))
+                call.respondText("ok")
             }
+            get("/4") {
+                call.respondText("ok:" + call.sessions.get<TestUserSession>()?.userId)
+            }
+        }
 
-            commonSignedChecks()
+        commonSignedChecks()
+
+        client.get("/3").let { response ->
+            val sessionCookie = response.setCookie().find { it.name == cookieName }
+            assertEquals(
+                "00112233445566778899aabbccddeeff/" +
+                    "c3850fc1ddc62f71ec5eaad6d393b91fa809fe32a1cf0cb4730788c5a489daef:" +
+                    "65f0bd15bfa7e96b8bd9e134e23a24860b324e361c606e6800af050f5d104b68",
+                sessionCookie!!.value
+            )
+        }
+
+        client.get("/4") {
+            header(
+                HttpHeaders.Cookie,
+                "$cookieName=" + "00112233445566778899aabbccddeeff/" +
+                    "c3850fc1ddc62f71ec5eaad6d393b91fa809fe32a1cf0cb4730788c5a489daef:" +
+                    "51a5e9fcd1c91418f9a623bafa5022a524348e44244265dc0cab2cebacc28a5d"
+            )
+        }.let { response ->
+            assertEquals("ok:null", response.bodyAsText())
         }
     }
 
-    private fun TestApplicationEngine.commonSignedChecks() {
-        application.routing {
+    private suspend fun ApplicationTestBuilder.commonSignedChecks() {
+        routing {
             get("/1") {
                 call.sessions.set(TestUserSession("id 2", emptyList()))
                 call.respondText("ok")
@@ -204,41 +198,41 @@ class SessionTestJvm {
 
         var sessionId: String
         var sessionHeader: String
-        handleRequest(HttpMethod.Get, "/1").let { call ->
-            val sessionCookie = call.response.cookies[cookieName]
+        client.get("/1").let { response ->
+            val sessionCookie = response.setCookie().find { it.name == cookieName }
             assertNotNull(sessionCookie, "No session cookie found")
             sessionId = sessionCookie.value
-            sessionHeader = call.response.headers[HttpHeaders.SetCookie]!!
+            sessionHeader = response.headers[HttpHeaders.SetCookie]!!
         }
 
-        handleRequest(HttpMethod.Get, "/2") {
-            addHeader(HttpHeaders.Cookie, "$cookieName=${sessionId.encodeURLParameter()}")
-        }.let { call ->
-            assertEquals("ok, id 2", call.response.content)
+        client.get("/2") {
+            header(HttpHeaders.Cookie, "$cookieName=${sessionId.encodeURLParameter()}")
+        }.let { response ->
+            assertEquals("ok, id 2", response.bodyAsText())
         }
 
-        handleRequest(HttpMethod.Get, "/2") {
-            addHeader(HttpHeaders.Cookie, sessionHeader)
-        }.let { call ->
-            assertEquals("ok, id 2", call.response.content)
+        client.get("/2") {
+            header(HttpHeaders.Cookie, sessionHeader)
+        }.let { response ->
+            assertEquals("ok, id 2", response.bodyAsText())
         }
 
-        handleRequest(HttpMethod.Get, "/2").let { call ->
-            assertEquals("ok, null", call.response.content)
+        client.get("/2").let { response ->
+            assertEquals("ok, null", response.bodyAsText())
         }
 
-        handleRequest(HttpMethod.Get, "/2") {
+        client.get("/2") {
             val brokenSession = flipLastHexDigit(sessionId)
-            addHeader(HttpHeaders.Cookie, "$cookieName=${brokenSession.encodeURLParameter()}")
-        }.let { call ->
-            assertEquals("ok, null", call.response.content)
+            header(HttpHeaders.Cookie, "$cookieName=${brokenSession.encodeURLParameter()}")
+        }.let { response ->
+            assertEquals("ok, null", response.bodyAsText())
         }
 
-        handleRequest(HttpMethod.Get, "/2") {
+        client.get("/2") {
             val invalidHex = sessionId.mapIndexed { i, c -> if (i == sessionId.lastIndex) 'x' else c }.joinToString("")
-            addHeader(HttpHeaders.Cookie, "$cookieName=${invalidHex.encodeURLParameter()}")
-        }.let { call ->
-            assertEquals("ok, null", call.response.content)
+            header(HttpHeaders.Cookie, "$cookieName=${invalidHex.encodeURLParameter()}")
+        }.let { response ->
+            assertEquals("ok, null", response.bodyAsText())
         }
     }
 


### PR DESCRIPTION
**Subsystem**
Server, `ktor-server-tests`

**Motivation**
[KTOR-7407](https://youtrack.jetbrains.com/issue/KTOR-7407/) Remove usage of deprecated `withTestApplication` DSL.

**Solution**
Migrated to `testApplication` DSL

