### PR TITLE
Allow renovate to rebase only on conflicts

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,6 +5,7 @@
     ":semanticCommitsDisabled",
     ":label(dependencies)"
   ],
+  "rebaseWhen": "conflicted",
   "packageRules": [
     {
       "description": "Allow EAPs for Ktor dependencies and use custom versioning to detect a build number",


### PR DESCRIPTION
**Subsystem**
Renovate

**Motivation**
Renovate is still rebasing its PRs, producing noise

**Solution**
Explicitly specify that rebase is allowed only on conflicts