### PR TITLE
Align Kotlin Serialization plugin version in buildSrc

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
     `kotlin-dsl`
     // Serialization version should be aligned with the Kotlin version embedded in Gradle
     // https://docs.gradle.org/current/userguide/compatibility.html#kotlin
-    kotlin("plugin.serialization") version "1.9.24"
+    kotlin("plugin.serialization") version embeddedKotlinVersion
 }
 
 val buildSnapshotTrain = properties["build_snapshot_train"]?.toString().toBoolean()

--- a/renovate.json
+++ b/renovate.json
@@ -25,16 +25,6 @@
       "enabled": false
     },
     {
-      "description": "Do not update kotlinx.serialization plugin in buildSrc, as it should be updated manually.",
-      "matchDepNames": [
-        "org.jetbrains.kotlin.plugin.serialization"
-      ],
-      "matchFileNames": [
-        "buildSrc/build.gradle.kts"
-      ],
-      "enabled": false
-    },
-    {
       "description": "Do not update Jetty 9.x used in ktor-server-jetty",
       "matchPackageNames": [
         "org.eclipse.jetty*"


### PR DESCRIPTION
Use [`embeddedKotlinVersion`](https://docs.gradle.org/current/kotlin-dsl/gradle/org.gradle.kotlin.dsl/embedded-kotlin-version.html) utility (provided by Gradle) to automatically align `kotlin("plugin.serialization")`

