### PR TITLE
Revert "KTOR-6826 Include relocation notes for old ktor modules (#4276)"

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,8 +2,6 @@
  * Copyright 2014-2024 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
-import org.gradle.api.Project
-import org.gradle.internal.extensions.stdlib.*
 import org.jetbrains.dokka.gradle.*
 import org.jetbrains.kotlin.gradle.dsl.*
 import org.jetbrains.kotlin.gradle.tasks.*
@@ -74,28 +72,8 @@ apply(from = "gradle/verifier.gradle")
 
 extra["skipPublish"] = mutableListOf(
     "ktor-server-test-base",
-    "ktor-server-test-suites",
-    "ktor-server-tests",
-    "ktor-junit",
+    "ktor-junit"
 )
-
-extra["relocatedArtifacts"] = mapOf(
-    "ktor-auth" to "ktor-server-auth",
-    "ktor-auth-jwt" to "ktor-server-auth-jwt",
-    "ktor-auth-ldap" to "ktor-server-auth-ldap",
-    "ktor-freemarker" to "ktor-server-freemarker",
-    "ktor-metrics" to "ktor-server-metrics",
-    "ktor-metrics-micrometer" to "ktor-server-metrics-micrometer",
-    "ktor-mustache" to "ktor-server-mustache",
-    "ktor-pebble" to "ktor-server-pebble",
-    "ktor-thymeleaf" to "ktor-server-thymeleaf",
-    "ktor-velocity" to "ktor-server-velocity",
-    "ktor-webjars" to "ktor-server-webjars",
-    "ktor-gson" to "ktor-serialization-gson",
-    "ktor-jackson" to "ktor-serialization-jackson",
-    "ktor-server-test-base" to "ktor-server-test-host",
-).invert()
-
 extra["nonDefaultProjectStructure"] = mutableListOf(
     "ktor-bom",
     "ktor-java-modules-test",

--- a/buildSrc/src/main/kotlin/Publication.kt
+++ b/buildSrc/src/main/kotlin/Publication.kt
@@ -73,7 +73,6 @@ fun Project.configurePublication() {
     val publishLocal: Boolean by rootProject.extra
     val globalM2: String by rootProject.extra
     val nonDefaultProjectStructure: List<String> by rootProject.extra
-    val relocatedArtifacts: Map<String, String> by rootProject.extra
 
     val emptyJar = tasks.register<Jar>("emptyJar") {
         archiveAppendix.set("empty")
@@ -100,34 +99,34 @@ fun Project.configurePublication() {
 
         publications.forEach {
             val publication = it as? MavenPublication ?: return@forEach
-            publication.pom {
-                name = project.name
-                description = project.description?.takeIf { it.isNotEmpty() } ?: "Ktor is a framework for quickly creating web applications in Kotlin with minimal effort."
-                url = "https://github.com/ktorio/ktor"
-                licenses {
-                    license {
-                        name = "The Apache Software License, Version 2.0"
-                        url = "https://www.apache.org/licenses/LICENSE-2.0.txt"
-                        distribution = "repo"
+            publication.pom.withXml {
+                val root = asNode()
+                root.appendNode("name", project.name)
+                root.appendNode(
+                    "description",
+                    "Ktor is a framework for quickly creating web applications in Kotlin with minimal effort."
+                )
+                root.appendNode("url", "https://github.com/ktorio/ktor")
+
+                root.appendNode("licenses").apply {
+                    appendNode("license").apply {
+                        appendNode("name", "The Apache Software License, Version 2.0")
+                        appendNode("url", "https://www.apache.org/licenses/LICENSE-2.0.txt")
+                        appendNode("distribution", "repo")
                     }
                 }
-                developers {
-                    developer {
-                        id = "JetBrains"
-                        name = "Jetbrains Team"
-                        organization = "JetBrains"
-                        organizationUrl = "https://www.jetbrains.com"
+
+                root.appendNode("developers").apply {
+                    appendNode("developer").apply {
+                        appendNode("id", "JetBrains")
+                        appendNode("name", "JetBrains Team")
+                        appendNode("organization", "JetBrains")
+                        appendNode("organizationUrl", "https://www.jetbrains.com")
                     }
                 }
-                scm {
-                    url = "https://github.com/ktorio/ktor.git"
-                }
-                relocatedArtifacts[project.name]?.let { oldArtifactId ->
-                    distributionManagement {
-                        relocation {
-                            artifactId = oldArtifactId
-                        }
-                    }
+
+                root.appendNode("scm").apply {
+                    appendNode("url", "https://github.com/ktorio/ktor.git")
                 }
             }
         }


### PR DESCRIPTION
This reverts commit 3da1214e1f66a45be57b1ff9e00f1db233fbd7c5.

**Subsystem**
Published artifacts

**Motivation**
Links to old artifacts actually goes the other way, so now maven will always try to use the old artifacts.

- [KTOR-7425](https://youtrack.jetbrains.com/issue/KTOR-7425) Maven builds not working

**Solution**
Reverts changes linking to old artifacts.

