### PR TITLE
Test host redirect

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -73,28 +73,15 @@ val configuredVersion: String by extra
 apply(from = "gradle/verifier.gradle")
 
 extra["skipPublish"] = mutableListOf(
-    "ktor-server-test-base",
     "ktor-server-test-suites",
     "ktor-server-tests",
     "ktor-junit",
 )
 
+// Point old artifact to new location
 extra["relocatedArtifacts"] = mapOf(
-    "ktor-auth" to "ktor-server-auth",
-    "ktor-auth-jwt" to "ktor-server-auth-jwt",
-    "ktor-auth-ldap" to "ktor-server-auth-ldap",
-    "ktor-freemarker" to "ktor-server-freemarker",
-    "ktor-metrics" to "ktor-server-metrics",
-    "ktor-metrics-micrometer" to "ktor-server-metrics-micrometer",
-    "ktor-mustache" to "ktor-server-mustache",
-    "ktor-pebble" to "ktor-server-pebble",
-    "ktor-thymeleaf" to "ktor-server-thymeleaf",
-    "ktor-velocity" to "ktor-server-velocity",
-    "ktor-webjars" to "ktor-server-webjars",
-    "ktor-gson" to "ktor-serialization-gson",
-    "ktor-jackson" to "ktor-serialization-jackson",
     "ktor-server-test-base" to "ktor-server-test-host",
-).invert()
+)
 
 extra["nonDefaultProjectStructure"] = mutableListOf(
     "ktor-bom",

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,6 +2,8 @@
  * Copyright 2014-2024 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
+import org.gradle.api.Project
+import org.gradle.internal.extensions.stdlib.*
 import org.jetbrains.dokka.gradle.*
 import org.jetbrains.kotlin.gradle.dsl.*
 import org.jetbrains.kotlin.gradle.tasks.*
@@ -72,8 +74,28 @@ apply(from = "gradle/verifier.gradle")
 
 extra["skipPublish"] = mutableListOf(
     "ktor-server-test-base",
-    "ktor-junit"
+    "ktor-server-test-suites",
+    "ktor-server-tests",
+    "ktor-junit",
 )
+
+extra["relocatedArtifacts"] = mapOf(
+    "ktor-auth" to "ktor-server-auth",
+    "ktor-auth-jwt" to "ktor-server-auth-jwt",
+    "ktor-auth-ldap" to "ktor-server-auth-ldap",
+    "ktor-freemarker" to "ktor-server-freemarker",
+    "ktor-metrics" to "ktor-server-metrics",
+    "ktor-metrics-micrometer" to "ktor-server-metrics-micrometer",
+    "ktor-mustache" to "ktor-server-mustache",
+    "ktor-pebble" to "ktor-server-pebble",
+    "ktor-thymeleaf" to "ktor-server-thymeleaf",
+    "ktor-velocity" to "ktor-server-velocity",
+    "ktor-webjars" to "ktor-server-webjars",
+    "ktor-gson" to "ktor-serialization-gson",
+    "ktor-jackson" to "ktor-serialization-jackson",
+    "ktor-server-test-base" to "ktor-server-test-host",
+).invert()
+
 extra["nonDefaultProjectStructure"] = mutableListOf(
     "ktor-bom",
     "ktor-java-modules-test",

--- a/buildSrc/src/main/kotlin/Publication.kt
+++ b/buildSrc/src/main/kotlin/Publication.kt
@@ -73,6 +73,7 @@ fun Project.configurePublication() {
     val publishLocal: Boolean by rootProject.extra
     val globalM2: String by rootProject.extra
     val nonDefaultProjectStructure: List<String> by rootProject.extra
+    val relocatedArtifacts: Map<String, String> by rootProject.extra
 
     val emptyJar = tasks.register<Jar>("emptyJar") {
         archiveAppendix.set("empty")
@@ -99,34 +100,34 @@ fun Project.configurePublication() {
 
         publications.forEach {
             val publication = it as? MavenPublication ?: return@forEach
-            publication.pom.withXml {
-                val root = asNode()
-                root.appendNode("name", project.name)
-                root.appendNode(
-                    "description",
-                    "Ktor is a framework for quickly creating web applications in Kotlin with minimal effort."
-                )
-                root.appendNode("url", "https://github.com/ktorio/ktor")
-
-                root.appendNode("licenses").apply {
-                    appendNode("license").apply {
-                        appendNode("name", "The Apache Software License, Version 2.0")
-                        appendNode("url", "https://www.apache.org/licenses/LICENSE-2.0.txt")
-                        appendNode("distribution", "repo")
+            publication.pom {
+                name = project.name
+                description = project.description?.takeIf { it.isNotEmpty() } ?: "Ktor is a framework for quickly creating web applications in Kotlin with minimal effort."
+                url = "https://github.com/ktorio/ktor"
+                licenses {
+                    license {
+                        name = "The Apache Software License, Version 2.0"
+                        url = "https://www.apache.org/licenses/LICENSE-2.0.txt"
+                        distribution = "repo"
                     }
                 }
-
-                root.appendNode("developers").apply {
-                    appendNode("developer").apply {
-                        appendNode("id", "JetBrains")
-                        appendNode("name", "JetBrains Team")
-                        appendNode("organization", "JetBrains")
-                        appendNode("organizationUrl", "https://www.jetbrains.com")
+                developers {
+                    developer {
+                        id = "JetBrains"
+                        name = "Jetbrains Team"
+                        organization = "JetBrains"
+                        organizationUrl = "https://www.jetbrains.com"
                     }
                 }
-
-                root.appendNode("scm").apply {
-                    appendNode("url", "https://github.com/ktorio/ktor.git")
+                scm {
+                    url = "https://github.com/ktorio/ktor.git"
+                }
+                relocatedArtifacts[project.name]?.let { oldArtifactId ->
+                    distributionManagement {
+                        relocation {
+                            artifactId = oldArtifactId
+                        }
+                    }
                 }
             }
         }

--- a/buildSrc/src/main/kotlin/Publication.kt
+++ b/buildSrc/src/main/kotlin/Publication.kt
@@ -100,6 +100,7 @@ fun Project.configurePublication() {
 
         publications.forEach {
             val publication = it as? MavenPublication ?: return@forEach
+
             publication.pom {
                 name = project.name
                 description = project.description?.takeIf { it.isNotEmpty() } ?: "Ktor is a framework for quickly creating web applications in Kotlin with minimal effort."
@@ -122,10 +123,10 @@ fun Project.configurePublication() {
                 scm {
                     url = "https://github.com/ktorio/ktor.git"
                 }
-                relocatedArtifacts[project.name]?.let { oldArtifactId ->
+                relocatedArtifacts[project.name]?.let { newArtifactId ->
                     distributionManagement {
                         relocation {
-                            artifactId = oldArtifactId
+                            artifactId = newArtifactId
                         }
                     }
                 }


### PR DESCRIPTION
**Subsystem**
Build system

**Motivation**
- [KTOR-7393](https://youtrack.jetbrains.com/issue/KTOR-7393) Redirect dependencies from ktor-server-test-base

**Solution**
Redirect only the test-base artifact, because it was present in our generator for a long time and will cause issues if used instead of test-host when people upgrade.

I'll avoid trying to add the relocation notes for the 1.* artifacts that were moved, because it would involve creating new publications for each of them, which is very complicated and would be better done with a one-time script.