### PR TITLE
KTOR-7012 Deprecate `InputStream.toByteReadChannel` with fallback to ktor-io module

### DIFF
--- a/ktor-server/ktor-server-core/jvm/src/io/ktor/server/http/content/JarFileContent.kt
+++ b/ktor-server/ktor-server-core/jvm/src/io/ktor/server/http/content/JarFileContent.kt
@@ -8,6 +8,7 @@ import io.ktor.http.*
 import io.ktor.http.content.*
 import io.ktor.util.cio.*
 import io.ktor.utils.io.*
+import io.ktor.utils.io.jvm.javaio.*
 import java.io.*
 import java.nio.file.*
 import java.util.jar.*

--- a/ktor-utils/jvm/src/io/ktor/util/cio/InputStreamAdapters.kt
+++ b/ktor-utils/jvm/src/io/ktor/util/cio/InputStreamAdapters.kt
@@ -10,33 +10,22 @@ import kotlinx.coroutines.*
 import java.io.*
 import java.nio.*
 import kotlin.coroutines.*
+import io.ktor.utils.io.jvm.javaio.toByteReadChannel as toByteReadChannelImpl
 
 /**
  * Open a channel and launch a coroutine to copy bytes from the input stream to the channel.
  * Please note that it may block your async code when started on [Dispatchers.Unconfined]
  * since [InputStream] is blocking on it's nature
  */
+@Deprecated(
+    "Use variant from 'ktor-io' module instead",
+    replaceWith = ReplaceWith(
+        "this.toByteReadChannel(context + parent, pool)",
+        "io.ktor.utils.io.jvm.javaio.toByteReadChannel",
+    )
+)
 public fun InputStream.toByteReadChannel(
     pool: ObjectPool<ByteBuffer> = KtorDefaultPool,
     context: CoroutineContext = Dispatchers.Unconfined,
     parent: Job = Job()
-): ByteReadChannel = CoroutineScope(context).writer(parent, autoFlush = true) {
-    val buffer = pool.borrow()
-    try {
-        while (true) {
-            buffer.clear()
-            val readCount = read(buffer.array(), buffer.arrayOffset() + buffer.position(), buffer.remaining())
-            if (readCount < 0) break
-            if (readCount == 0) continue
-
-            buffer.position(buffer.position() + readCount)
-            buffer.flip()
-            channel.writeFully(buffer)
-        }
-    } catch (cause: Throwable) {
-        channel.close(cause)
-    } finally {
-        pool.recycle(buffer)
-        close()
-    }
-}.channel
+): ByteReadChannel = toByteReadChannelImpl(context + parent, pool)


### PR DESCRIPTION
**Subsystem**
Server, `ktor-core`

**Motivation**
[KTOR-7012](https://youtrack.jetbrains.com/issue/KTOR-7012/) `InputStream.toByteReadChannel` creates an unattached job

**Solution**
Deprecate this extension in favor of the variant from `ktor-io` which doesn't suffer from this problem.

