### PR TITLE
KTOR-7355 Check in usePreconfiguredSession that delegate is set

### DIFF
--- a/ktor-client/ktor-client-darwin/darwin/src/io/ktor/client/engine/darwin/DarwinClientEngineConfig.kt
+++ b/ktor-client/ktor-client-darwin/darwin/src/io/ktor/client/engine/darwin/DarwinClientEngineConfig.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2014-2024 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package io.ktor.client.engine.darwin
@@ -108,9 +108,9 @@ public class DarwinClientEngineConfig : HttpClientEngineConfig() {
      * ```
      * val delegate = KtorNSURLSessionDelegate()
      * val session = NSURLSession.sessionWithConfiguration(
-     *     NSURLSessionConfiguration.defaultSessionConfiguration,
+     *     NSURLSessionConfiguration.defaultSessionConfiguration(),
      *     delegate,
-     *     delegateQueue = NSOperationQueue()
+     *     delegateQueue = null
      * )
      *
      * usePreconfiguredSession(session, delegate)
@@ -119,7 +119,16 @@ public class DarwinClientEngineConfig : HttpClientEngineConfig() {
      * @see [KtorNSURLSessionDelegate] for details.
      */
     public fun usePreconfiguredSession(session: NSURLSession, delegate: KtorNSURLSessionDelegate) {
-        requireNotNull(session.delegate) { "The session must be created with KtorNSURLSessionDelegate as a delegate" }
+        requireNotNull(session.delegate) {
+            """
+                Invalid session: delegate field is null
+                Possible solutions:
+
+                1. Ensure that you set a valid delegate when creating the `session`. For more details, see `KtorNSURLSessionDelegate`.
+
+                2. If you're only modifying session configuration, consider using `configureSession` instead of `usePreconfiguredSession`.
+            """.trimIndent()
+        }
         sessionAndDelegate = session to delegate
     }
 

--- a/ktor-client/ktor-client-darwin/darwin/src/io/ktor/client/engine/darwin/DarwinClientEngineConfig.kt
+++ b/ktor-client/ktor-client-darwin/darwin/src/io/ktor/client/engine/darwin/DarwinClientEngineConfig.kt
@@ -104,9 +104,22 @@ public class DarwinClientEngineConfig : HttpClientEngineConfig() {
      * If the preconfigured session is set, [configureSession] and [handleChallenge] blocks will be ignored.
      *
      * The [session] must be created with [KtorNSURLSessionDelegate] as a delegate.
+     *
+     * ```
+     * val delegate = KtorNSURLSessionDelegate()
+     * val session = NSURLSession.sessionWithConfiguration(
+     *     NSURLSessionConfiguration.defaultSessionConfiguration,
+     *     delegate,
+     *     delegateQueue = NSOperationQueue()
+     * )
+     *
+     * usePreconfiguredSession(session, delegate)
+     * ```
+     *
      * @see [KtorNSURLSessionDelegate] for details.
      */
     public fun usePreconfiguredSession(session: NSURLSession, delegate: KtorNSURLSessionDelegate) {
+        requireNotNull(session.delegate) { "The session must be created with KtorNSURLSessionDelegate as a delegate" }
         sessionAndDelegate = session to delegate
     }
 

--- a/ktor-client/ktor-client-darwin/darwin/test/DarwinEngineTest.kt
+++ b/ktor-client/ktor-client-darwin/darwin/test/DarwinEngineTest.kt
@@ -189,6 +189,29 @@ class DarwinEngineTest {
         }
     }
 
+    // Issue: KTOR-7355
+    @Test
+    fun testOverrideDefaultSessionWithoutDelegate() {
+        val result = runCatching {
+            HttpClient(Darwin) {
+                engine {
+                    usePreconfiguredSession(
+                        session = NSURLSession.sessionWithConfiguration(
+                            NSURLSessionConfiguration.defaultSessionConfiguration()
+                        ),
+                        delegate = KtorNSURLSessionDelegate(),
+                    )
+                }
+            }
+        }
+
+        assertFailsWith<IllegalArgumentException>(
+            "The session must be created with KtorNSURLSessionDelegate as a delegate"
+        ) {
+            result.getOrThrow()
+        }
+    }
+
     @Test
     fun testConfigureRequest(): Unit = runBlocking {
         val client = HttpClient(Darwin) {

--- a/ktor-client/ktor-client-darwin/darwin/test/DarwinEngineTest.kt
+++ b/ktor-client/ktor-client-darwin/darwin/test/DarwinEngineTest.kt
@@ -1,3 +1,7 @@
+/*
+ * Copyright 2014-2024 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
 import io.ktor.client.*
 import io.ktor.client.engine.darwin.*
 import io.ktor.client.engine.darwin.internal.*
@@ -13,10 +17,6 @@ import kotlinx.coroutines.*
 import platform.Foundation.*
 import platform.Foundation.NSHTTPCookieStorage.Companion.sharedHTTPCookieStorage
 import kotlin.test.*
-
-/*
- * Copyright 2014-2022 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
- */
 
 class DarwinEngineTest {
 
@@ -205,9 +205,7 @@ class DarwinEngineTest {
             }
         }
 
-        assertFailsWith<IllegalArgumentException>(
-            "The session must be created with KtorNSURLSessionDelegate as a delegate"
-        ) {
+        assertFailsWith<IllegalArgumentException> {
             result.getOrThrow()
         }
     }


### PR DESCRIPTION
**Subsystem**
Client, `ktor-client-darwin`

**Motivation**
[KTOR-7355](https://youtrack.jetbrains.com/issue/KTOR-7355/) Preconfigured NSURLSession causes requests to hang

**Solution**
It is a valid behavior because the session was created without the delegate.
Nevertheless, it is quite unobvious behavior, so I added check that delegate was specified and example of usage to KDoc.


