### PR TITLE
Downgrade to Gradle 8.10

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.10-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
**Motivation**
Gradle 8.10.1 makes builds unstable. For example, it randomly fails to apply `TestServerPlugin`:
```
Failed to apply plugin class 'test.server.TestServerPlugin'.
> Could not create task ':ktor-client:ktor-client-android:checkKotlinGradlePluginConfigurationErrors'.
   > DefaultTaskCollection#configureEach(Action) on task set cannot be executed in the current context.
```
Issue: https://github.com/gradle/gradle/issues/30497

**Solution**
Downgrade to 8.10 and wait for the next version.

