### PR TITLE
KTOR-7356 Increase multi-part formdata limit

### DIFF
--- a/ktor-http/ktor-http-cio/jvm/src/io/ktor/http/cio/CIOMultipartDataBase.kt
+++ b/ktor-http/ktor-http-cio/jvm/src/io/ktor/http/cio/CIOMultipartDataBase.kt
@@ -7,7 +7,6 @@ package io.ktor.http.cio
 import io.ktor.http.*
 import io.ktor.http.content.*
 import io.ktor.utils.io.*
-import io.ktor.utils.io.core.*
 import kotlinx.coroutines.*
 import kotlinx.coroutines.channels.*
 import kotlin.coroutines.*
@@ -21,7 +20,7 @@ public class CIOMultipartDataBase(
     channel: ByteReadChannel,
     contentType: CharSequence,
     contentLength: Long?,
-    private val formFieldLimit: Long = 65536,
+    formFieldLimit: Long,
 ) : MultiPartData, CoroutineScope {
     private val events: ReceiveChannel<MultipartEvent> =
         parseMultipart(channel, contentType, contentLength, formFieldLimit)

--- a/ktor-http/ktor-http-cio/jvm/src/io/ktor/http/cio/CIOMultipartDataBase.kt
+++ b/ktor-http/ktor-http-cio/jvm/src/io/ktor/http/cio/CIOMultipartDataBase.kt
@@ -20,7 +20,7 @@ public class CIOMultipartDataBase(
     channel: ByteReadChannel,
     contentType: CharSequence,
     contentLength: Long?,
-    formFieldLimit: Long,
+    formFieldLimit: Long = 65536,
 ) : MultiPartData, CoroutineScope {
     private val events: ReceiveChannel<MultipartEvent> =
         parseMultipart(channel, contentType, contentLength, formFieldLimit)

--- a/ktor-http/ktor-http-cio/jvm/src/io/ktor/http/cio/Multipart.kt
+++ b/ktor-http/ktor-http-cio/jvm/src/io/ktor/http/cio/Multipart.kt
@@ -192,7 +192,7 @@ public fun CoroutineScope.parseMultipart(
     input: ByteReadChannel,
     contentType: CharSequence,
     contentLength: Long?,
-    maxPartSize: Long,
+    maxPartSize: Long = Long.MAX_VALUE,
 ): ReceiveChannel<MultipartEvent> {
     if (!contentType.startsWith("multipart/")) {
         throw IOException("Failed to parse multipart: Content-Type should be multipart/* but it is $contentType")

--- a/ktor-http/ktor-http-cio/jvm/src/io/ktor/http/cio/Multipart.kt
+++ b/ktor-http/ktor-http-cio/jvm/src/io/ktor/http/cio/Multipart.kt
@@ -119,9 +119,9 @@ private suspend fun parsePartBodyImpl(
     headers: HttpHeadersMap,
     limit: Long,
 ): Long {
-    val byteCount = when(val contentLength = headers["Content-Length"]?.parseDecLong()) {
+    val byteCount = when (val contentLength = headers["Content-Length"]?.parseDecLong()) {
         null -> copyUntilBoundary("part", boundaryPrefixed, input, { output.writeFully(it) }, limit)
-        in 0L .. limit -> input.copyTo(output, contentLength)
+        in 0L..limit -> input.copyTo(output, contentLength)
         else -> throwLimitExceeded("part", contentLength, limit)
     }
     output.flush()

--- a/ktor-http/ktor-http-cio/jvm/test/io/ktor/tests/http/cio/MultipartTest.kt
+++ b/ktor-http/ktor-http-cio/jvm/test/io/ktor/tests/http/cio/MultipartTest.kt
@@ -409,7 +409,8 @@ class MultipartTest {
             val events = parseMultipart(
                 input,
                 "multipart/form-data; boundary=boundary",
-                body.length.toLong()
+                body.length.toLong(),
+                Long.MAX_VALUE
             ).toList()
 
             assertEquals(1, events.size)

--- a/ktor-server/ktor-server-core/common/src/io/ktor/server/request/ApplicationReceiveFunctions.kt
+++ b/ktor-server/ktor-server-core/common/src/io/ktor/server/request/ApplicationReceiveFunctions.kt
@@ -20,7 +20,7 @@ import kotlin.reflect.*
 private val FORM_FIELD_LIMIT = AttributeKey<Long>("FormFieldLimit")
 
 @PublishedApi
-internal const val DEFAULT_FORM_FIELD_MAX_SIZE: Long = 64 * 1024
+internal const val DEFAULT_FORM_FIELD_MAX_SIZE: Long = 50 * 1024 * 1024
 
 /**
  * A pipeline for processing incoming content.

--- a/ktor-server/ktor-server-tests/common/test/io/ktor/tests/server/http/TestEngineMultipartTest.kt
+++ b/ktor-server/ktor-server-tests/common/test/io/ktor/tests/server/http/TestEngineMultipartTest.kt
@@ -162,34 +162,13 @@ class TestEngineMultipartTest {
     }
 
     @Test
-    fun testMultipartBigger65536Fails() {
+    fun testMultipartBiggerThanLimitFails() {
         if (!PlatformUtils.IS_JVM) return
 
         testApplication {
             routing {
                 post {
-                    val multipart = call.receiveMultipart()
-                    while (true) {
-                        val part = multipart.readPart() ?: break
-                        when (part) {
-                            is PartData.FileItem -> {
-                                part.provider().readRemaining().readText()
-                            }
-
-                            is PartData.FormItem -> {
-                                part.value
-                            }
-
-                            is PartData.BinaryChannelItem -> {
-                                part.provider().readRemaining().readText()
-                            }
-
-                            is PartData.BinaryItem -> {
-                                part.provider().readByteArray()
-                            }
-                        }
-                        part.dispose()
-                    }
+                    call.receiveMultipart(formFieldLimit = 999).readPart()
                 }
             }
 
@@ -198,9 +177,10 @@ class TestEngineMultipartTest {
                     setBody(
                         MultiPartFormDataContent(
                             formData {
-                                append("data", "a".repeat(42 * 1024 * 1024))
+                                append("data", "a".repeat(1000))
                             }
                         )
+
                     )
                 }
             }


### PR DESCRIPTION
**Subsystem**
Server, I/O

**Motivation**
[KTOR-7356](https://youtrack.jetbrains.com/issue/KTOR-7356) Multipart/form-data: Form limit applied for binary and file items

Users having difficulty with the low limit getting triggered during file upload posting in slack recently when trying out the latest build.  The limit here is generally used to avoid DDoS attacks with endless streams, so most other frameworks set this in the megabytes.

**Solution**
Bumped the default limit to 50MB and added some actionable details to the thrown exception.

