### PR TITLE
Fix flaky test WebSocketTest.testFragmentationMaxSize

### DIFF
--- a/ktor-server/ktor-server-plugins/ktor-server-websockets/jvm/test/io/ktor/tests/websocket/WebSocketTest.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-websockets/jvm/test/io/ktor/tests/websocket/WebSocketTest.kt
@@ -318,13 +318,11 @@ class WebSocketTest {
             maxFrameSize = 1025
         }
 
-        var exception: Throwable? = null
+        val result = DeferredResult()
         routing {
             webSocket("/") {
-                try {
+                withDeferredResult(result) {
                     incoming.receive()
-                } catch (cause: Throwable) {
-                    exception = cause
                 }
             }
         }
@@ -340,6 +338,7 @@ class WebSocketTest {
             clientClosedProperly = true
         }
 
+        val exception = result.await().exceptionOrNull()
         assertTrue(clientClosedProperly, "Client wasn't closed properly")
         assertTrue("Expected FrameTooBigException, but found $exception") {
             exception is FrameTooBigException


### PR DESCRIPTION
**Subsystem**
Tests

**Motivation**
[Test history](https://ktor.teamcity.com/test/8431731462014885548?currentProjectId=Ktor_ProjectKtorCore)

**Solution**
Await for server finish before assertions
