### PR TITLE
WA: Disable JS legacy transformation manually until it is completely removed from the atomicfu plugin.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -102,7 +102,6 @@ apply(from = "gradle/compatibility.gradle")
 plugins {
     id("org.jetbrains.dokka") version "1.9.20" apply false
     id("org.jetbrains.kotlinx.binary-compatibility-validator") version "0.16.3"
-    //id("org.jetbrains.kotlinx.atomicfu") version "0.25.0" apply false
     id("com.osacky.doctor") version "0.10.0"
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -102,7 +102,7 @@ apply(from = "gradle/compatibility.gradle")
 plugins {
     id("org.jetbrains.dokka") version "1.9.20" apply false
     id("org.jetbrains.kotlinx.binary-compatibility-validator") version "0.16.3"
-    id("org.jetbrains.kotlinx.atomicfu") version "0.25.0" apply false
+    //id("org.jetbrains.kotlinx.atomicfu") version "0.25.0" apply false
     id("com.osacky.doctor") version "0.10.0"
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -128,7 +128,7 @@ allprojects {
     if (nonDefaultProjectStructure.contains(project.name)) return@allprojects
 
     apply(plugin = "kotlin-multiplatform")
-    apply(plugin = "org.jetbrains.kotlinx.atomicfu")
+    apply(plugin = "atomicfu-conventions")
 
     configureTargets()
 

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -48,6 +48,7 @@ dependencies {
     implementation(libs.kotlinx.serialization.json)
     implementation(libs.logback.classic)
     implementation(libs.tomlj)
+    implementation("org.jetbrains.kotlinx:atomicfu-gradle-plugin:${libs.versions.atomicfu.version.get()}")
 }
 
 kotlin {

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -48,7 +48,7 @@ dependencies {
     implementation(libs.kotlinx.serialization.json)
     implementation(libs.logback.classic)
     implementation(libs.tomlj)
-    implementation("org.jetbrains.kotlinx:atomicfu-gradle-plugin:${libs.versions.atomicfu.version.get()}")
+    implementation("org.jetbrains.kotlinx:atomicfu-gradle-plugin:${libs.versions.atomicfu.get()}")
 }
 
 kotlin {

--- a/buildSrc/src/main/kotlin/atomicfu-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/atomicfu-conventions.gradle.kts
@@ -1,0 +1,12 @@
+/*
+ * Copyright 2014-2024 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+plugins {
+    id("org.jetbrains.kotlinx.atomicfu")
+}
+
+// Workaround for KT-71203. Can be removed after https://github.com/Kotlin/kotlinx-atomicfu/issues/431
+atomicfu {
+    transformJs = false
+}


### PR DESCRIPTION
This change fixes this [train failure](https://buildserver.labs.intellij.net/buildConfiguration/Kotlin_KotlinDev_KotlinxTrainKtorK2/565822720). 

```
e: KLIB resolver: The same 'unique_name=io.ktor:ktor-io' found in more than one library: /mnt/agent/work/1edc2f021dd239f7/project.ktor/ktor-io/build/classes/atomicfu/js/main, /mnt/agent/work/1edc2f021dd239f7/project.ktor/ktor-io/build/classes/kotlin/js/main
Please file an issue to https://kotl.in/issue and meanwhile use CLI flag `-Xklib-duplicated-unique-name-strategy` with one of the following values:
allow-all-with-warning: Use all KLIB dependencies, even when they have same `unique_name` property.
allow-first-with-warning: Use the first KLIB dependency with clashing `unique_name` property. No order guarantees are given though.
deny: Fail a compilation with the error.
```

Through an oversight `atomicfu-gradle-plugin` kept tranformJs option (corresponding to the legacy JS transformation) enabled by default, and with no *.js files to transform it just copied the compileJs output directory.

Here is the similar fix merged into kotlinx.coroutines: https://github.com/Kotlin/kotlinx.coroutines/pull/4223
