### PR TITLE
KTOR-7035: Register MeterFilters before the very first Meter is registered.

### DIFF
--- a/ktor-server/ktor-server-plugins/ktor-server-metrics-micrometer/jvm/src/io/ktor/server/metrics/micrometer/MicrometerMetrics.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-metrics-micrometer/jvm/src/io/ktor/server/metrics/micrometer/MicrometerMetrics.kt
@@ -118,6 +118,12 @@ public val MicrometerMetrics: ApplicationPlugin<MicrometerMetricsConfig> =
         val metricName = pluginConfig.metricName
         val activeRequestsGaugeName = "$metricName.active"
         val registry = pluginConfig.registry
+
+        registry.config().meterFilter(object : MeterFilter {
+            override fun configure(id: Meter.Id, config: DistributionStatisticConfig): DistributionStatisticConfig =
+                if (id.name == metricName) pluginConfig.distributionStatisticConfig.merge(config) else config
+        })
+
         val active = registry.gauge(activeRequestsGaugeName, AtomicInteger(0))
         val measureKey = AttributeKey<CallMeasure>("micrometerMetrics")
 
@@ -136,10 +142,6 @@ public val MicrometerMetrics: ApplicationPlugin<MicrometerMetricsConfig> =
             return this
         }
 
-        registry.config().meterFilter(object : MeterFilter {
-            override fun configure(id: Meter.Id, config: DistributionStatisticConfig): DistributionStatisticConfig =
-                if (id.name == metricName) pluginConfig.distributionStatisticConfig.merge(config) else config
-        })
         pluginConfig.meterBinders.forEach { it.bindTo(pluginConfig.registry) }
 
         @OptIn(InternalAPI::class)

--- a/ktor-server/ktor-server-plugins/ktor-server-metrics-micrometer/jvm/test/io/ktor/server/metrics/micrometer/MicrometerMetricsTests.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-metrics-micrometer/jvm/test/io/ktor/server/metrics/micrometer/MicrometerMetricsTests.kt
@@ -20,6 +20,7 @@ import io.micrometer.core.instrument.binder.system.*
 import io.micrometer.core.instrument.distribution.*
 import io.micrometer.core.instrument.logging.*
 import io.micrometer.core.instrument.simple.*
+import java.io.*
 import kotlin.reflect.*
 import kotlin.test.*
 
@@ -406,6 +407,20 @@ class MicrometerMetricsTests {
 
         startApplication()
         assertTrue(closed)
+    }
+
+    @Test
+    fun `register meter-filter before the very first meter is registered`() {
+        val standardOut = System.out
+        try {
+            val outputStream = ByteArrayOutputStream()
+            System.setOut(PrintStream(outputStream))
+
+            val logs = outputStream.toString()
+            assertFalse(logs.contains("MeterFilter is being configured after a Meter has been registered"))
+        } finally {
+            System.setOut(standardOut)
+        }
     }
 
     private suspend fun ApplicationTestBuilder.metersAreRegistered(


### PR DESCRIPTION
**Subsystem**
Server, plugins, ktor-server-metrics-micrometer

**Motivation**
The PR fixes annoying warning as described in https://youtrack.jetbrains.com/issue/KTOR-7035/

**Solution**
Registration of the MeterFilter is moved up, so that the filter is registered before the gauge meter. Warning message disappears.

