### PR TITLE
KTOR-7449 Fix for uninitialized request

### DIFF
--- a/ktor-server/ktor-server-core/common/test/io/ktor/server/routing/RouteTest.kt
+++ b/ktor-server/ktor-server-core/common/test/io/ktor/server/routing/RouteTest.kt
@@ -4,10 +4,16 @@
 
 package io.ktor.tests.routing
 
+import io.ktor.client.plugins.api.*
+import io.ktor.client.request.*
 import io.ktor.http.*
+import io.ktor.server.application.*
+import io.ktor.server.request.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
+import io.ktor.server.routing.RoutingRoot.Plugin.RoutingCallStarted
 import io.ktor.server.testing.*
+import io.ktor.util.pipeline.*
 import kotlin.test.*
 
 class RouteTest {
@@ -121,5 +127,19 @@ class RouteTest {
             )
             assertEquals(expected, endpoints.map { it.toString() }.toSet())
         }
+    }
+
+    @Test
+    fun routingInitialization() = testApplication {
+        application {
+            monitor.subscribe(RoutingCallStarted) { call ->
+                assertEquals(HttpMethod.Get, call.request.httpMethod)
+            }
+            routing {
+                get { call.respond(HttpStatusCode.OK) }
+            }
+        }
+
+        assertEquals(HttpStatusCode.OK, client.get("/").status)
     }
 }


### PR DESCRIPTION
**Subsystem**
Server, Routing

**Motivation**
[KTOR-7449](https://youtrack.jetbrains.com/issue/KTOR-7449) UninitializedPropertyAccessException for `request` property when using MonitoringEvent(RoutingCallStarted)

**Solution**
Use lazy delegate over lateinit var.  The previous approach seemed a bit crazy to me.
