### PR TITLE
KTOR-7461 Fix for OutputStream response writing full contents to memory

### DIFF
--- a/ktor-io/jvm/src/io/ktor/utils/io/jvm/javaio/Blocking.kt
+++ b/ktor-io/jvm/src/io/ktor/utils/io/jvm/javaio/Blocking.kt
@@ -50,14 +50,13 @@ public fun ByteReadChannel.toInputStream(parent: Job? = null): InputStream = obj
  * Create blocking [java.io.OutputStream] for this channel that does block every time the channel suspends at write
  * Similar to do reading in [runBlocking] however you can pass it to regular blocking API
  */
-@OptIn(InternalAPI::class)
 public fun ByteWriteChannel.toOutputStream(): OutputStream = object : OutputStream() {
     override fun write(b: Int) {
-        writeBuffer.writeByte(b.toByte())
+        runBlocking { this@toOutputStream.writeByte(b.toByte()) }
     }
 
     override fun write(b: ByteArray, off: Int, len: Int) {
-        writeBuffer.write(b, off, off + len)
+        runBlocking { this@toOutputStream.writeFully(b, off, off + len) }
     }
 
     override fun flush() {

--- a/ktor-server/ktor-server-test-suites/jvm/src/io/ktor/server/testing/suites/ContentTestSuite.kt
+++ b/ktor-server/ktor-server-test-suites/jvm/src/io/ktor/server/testing/suites/ContentTestSuite.kt
@@ -4,6 +4,7 @@
 
 package io.ktor.server.testing.suites
 
+import io.ktor.client.call.*
 import io.ktor.client.request.*
 import io.ktor.client.statement.*
 import io.ktor.http.*
@@ -791,6 +792,38 @@ abstract class ContentTestSuite<TEngine : ApplicationEngine, TConfiguration : Ap
             assertEquals("", bodyAsText())
         }
     }
+
+    @Test
+    fun outputStreamIsStreamedToConsumer() = runTest {
+        var readingStarted = false
+
+        createAndStartServer {
+            handle {
+                call.respondOutputStream {
+                    var count = 0
+                    while(!readingStarted) {
+                        write(++count)
+                        assertFalse(count > 10_000_000)
+                    }
+                }
+            }
+        }
+
+        withUrl("/") {
+            assertEquals(200, status.value)
+            assertEquals(ContentType.Application.OctetStream, contentType())
+
+            val input: InputStream = body()
+            var count = 0
+            var byte = 0
+            do {
+                assertEquals((count++).toByte(), byte.toByte())
+                byte = input.read()
+                readingStarted = true
+            } while(byte >= 0)
+        }
+    }
+
 
     companion object {
         const val classesDir: String = "build/classes/"

--- a/ktor-server/ktor-server-test-suites/jvm/src/io/ktor/server/testing/suites/ContentTestSuite.kt
+++ b/ktor-server/ktor-server-test-suites/jvm/src/io/ktor/server/testing/suites/ContentTestSuite.kt
@@ -801,7 +801,7 @@ abstract class ContentTestSuite<TEngine : ApplicationEngine, TConfiguration : Ap
             handle {
                 call.respondOutputStream {
                     var count = 0
-                    while(!readingStarted) {
+                    while (!readingStarted) {
                         write(++count)
                         assertFalse(count > 10_000_000)
                     }
@@ -820,10 +820,9 @@ abstract class ContentTestSuite<TEngine : ApplicationEngine, TConfiguration : Ap
                 assertEquals((count++).toByte(), byte.toByte())
                 byte = input.read()
                 readingStarted = true
-            } while(byte >= 0)
+            } while (byte >= 0)
         }
     }
-
 
     companion object {
         const val classesDir: String = "build/classes/"


### PR DESCRIPTION
**Subsystem**
Server, I/O

**Motivation**
[KTOR-7461](https://youtrack.jetbrains.com/issue/KTOR-7461) respondOutputStream reads entire contents into memory before returning response

**Solution**
The `OutputStream` adapter for `ByteChannel` was writing directly to the `writeBuffer` without ever flushing, which would cause the entire contents to be put into memory before being written to the socket.

