### PR TITLE
KTOR-7427 Re-introduce readFully byte channel operation

### DIFF
--- a/ktor-io/common/src/io/ktor/utils/io/ByteReadChannelOperations.kt
+++ b/ktor-io/common/src/io/ktor/utils/io/ByteReadChannelOperations.kt
@@ -446,16 +446,20 @@ public val ByteReadChannel.availableForRead: Int
  * Reads all [length] bytes to [dst] buffer or fails if channel has been closed.
  * Suspends if not enough bytes available.
  */
-@OptIn(InternalAPI::class)
 public suspend fun ByteReadChannel.readFully(out: ByteArray) {
+    readFully(out, 0, out.size)
+}
+
+@OptIn(InternalAPI::class)
+public suspend fun ByteReadChannel.readFully(out: ByteArray, start: Int, end: Int) {
     if (isClosedForRead) throw EOFException("Channel is already closed")
 
-    var offset = 0
-    while (offset < out.size) {
+    var offset = start
+    while (offset < end) {
         if (readBuffer.exhausted()) awaitContent()
         if (isClosedForRead) throw EOFException("Channel is already closed")
 
-        val count = min(out.size - offset, readBuffer.remaining.toInt())
+        val count = min(end - offset, readBuffer.remaining.toInt())
         readBuffer.readTo(out, offset, offset + count)
         offset += count
     }

--- a/ktor-io/common/test/ByteReadChannelOperationsTest.kt
+++ b/ktor-io/common/test/ByteReadChannelOperationsTest.kt
@@ -63,4 +63,24 @@ class ByteReadChannelOperationsTest {
             channel.readRemaining()
         }
     }
+
+    @Test
+    fun readFully() = testSuspend {
+        val expected = ByteArray(10) { it.toByte() }
+        val actual = ByteArray(10)
+        val channel = ByteChannel()
+        channel.writeFully(expected)
+        channel.flush()
+        channel.readFully(actual)
+        assertContentEquals(expected, actual)
+
+        actual.fill(0)
+        channel.writeFully(expected, 0, 5)
+        channel.flush()
+        channel.readFully(actual, 3, 8)
+        assertContentEquals(ByteArray(3) { 0 }, actual.copyOfRange(0, 3))
+        assertContentEquals(expected.copyOfRange(0, 5), actual.copyOfRange(3, 8))
+        assertContentEquals(ByteArray(2) { 0 }, actual.copyOfRange(8, 10))
+    }
+
 }


### PR DESCRIPTION
**Subsystem**
Server, I/O

**Motivation**
[KTOR-7427](https://youtrack.jetbrains.com/issue/KTOR-7427) `ByteReadChannel.readFully(dst: ByteArray, offset: Int, length: Int)` is missing since 3.0.0-beta-2

**Solution**
Re-introduce the extension function.