### PR TITLE
KTOR-7442 Sessions: custom SessionSerializer is no longer supported

### DIFF
--- a/ktor-server/ktor-server-plugins/ktor-server-sessions/common/src/io/ktor/server/sessions/SessionsBuilder.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-sessions/common/src/io/ktor/server/sessions/SessionsBuilder.kt
@@ -71,7 +71,11 @@ public fun <S : Any> SessionsConfig.cookie(
     @Suppress("UNCHECKED_CAST")
     val sessionType = typeInfo.type as KClass<S>
 
-    val builder = CookieIdSessionBuilder(sessionType, typeInfo.kotlinType!!).apply(block)
+    val builder = CookieIdSessionBuilder(sessionType, typeInfo.kotlinType!!)
+        .apply {
+            block()
+            init()
+        }
     cookie(name, builder, sessionType, storage)
 }
 
@@ -209,7 +213,11 @@ public fun <S : Any> SessionsConfig.cookie(
     @Suppress("UNCHECKED_CAST")
     val sessionType = typeInfo.type as KClass<S>
 
-    val builder = CookieSessionBuilder(sessionType, typeInfo.kotlinType!!).apply(block)
+    val builder = CookieSessionBuilder(sessionType, typeInfo.kotlinType!!)
+        .apply {
+            block()
+            init()
+        }
     cookie(name, sessionType, builder)
 }
 
@@ -316,14 +324,10 @@ internal constructor(
     public val type: KClass<S>,
     public val typeInfo: KType
 ) {
-    private var _serializer: SessionSerializer<S>? = null
-
     /**
      * Specifies a serializer used to serialize session data.
      */
-    public var serializer: SessionSerializer<S>
-        set(value) { _serializer = value }
-        get() = _serializer ?: defaultSessionSerializer(typeInfo)
+    public lateinit var serializer: SessionSerializer<S>
 
     private val _transformers = mutableListOf<SessionTransportTransformer>()
 
@@ -343,6 +347,15 @@ internal constructor(
      * Gets a configuration used to specify additional cookie attributes for [Sessions].
      */
     public val cookie: CookieConfiguration = CookieConfiguration()
+
+    /**
+     * Ensures fields are initialized properly.
+     */
+    internal fun init() {
+        if (!this::serializer.isInitialized) {
+            serializer = defaultSessionSerializer(typeInfo)
+        }
+    }
 }
 
 /**

--- a/ktor-server/ktor-server-plugins/ktor-server-sessions/common/src/io/ktor/server/sessions/SessionsBuilder.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-sessions/common/src/io/ktor/server/sessions/SessionsBuilder.kt
@@ -316,11 +316,14 @@ internal constructor(
     public val type: KClass<S>,
     public val typeInfo: KType
 ) {
+    private var _serializer: SessionSerializer<S>? = null
 
     /**
      * Specifies a serializer used to serialize session data.
      */
-    public var serializer: SessionSerializer<S> = defaultSessionSerializer(typeInfo)
+    public var serializer: SessionSerializer<S>
+        set(value) { _serializer = value }
+        get() = _serializer ?: defaultSessionSerializer(typeInfo)
 
     private val _transformers = mutableListOf<SessionTransportTransformer>()
 

--- a/ktor-server/ktor-server-test-host/api/ktor-server-test-host.api
+++ b/ktor-server/ktor-server-test-host/api/ktor-server-test-host.api
@@ -122,10 +122,6 @@ public final class io/ktor/server/testing/TestApplicationResponse : io/ktor/serv
 	public final fun websocketChannel ()Lio/ktor/utils/io/ByteReadChannel;
 }
 
-public final class io/ktor/server/testing/TestApplicationResponseJvmKt {
-	public static final fun awaitWebSocket (Lio/ktor/server/testing/TestApplicationResponse;Ljava/time/Duration;)V
-}
-
 public final class io/ktor/server/testing/TestEngine : io/ktor/server/engine/ApplicationEngineFactory {
 	public static final field INSTANCE Lio/ktor/server/testing/TestEngine;
 	public synthetic fun configuration (Lkotlin/jvm/functions/Function1;)Lio/ktor/server/engine/ApplicationEngine$Configuration;

--- a/ktor-server/ktor-server-test-host/api/ktor-server-test-host.api
+++ b/ktor-server/ktor-server-test-host/api/ktor-server-test-host.api
@@ -122,6 +122,10 @@ public final class io/ktor/server/testing/TestApplicationResponse : io/ktor/serv
 	public final fun websocketChannel ()Lio/ktor/utils/io/ByteReadChannel;
 }
 
+public final class io/ktor/server/testing/TestApplicationResponseJvmKt {
+	public static final fun awaitWebSocket (Lio/ktor/server/testing/TestApplicationResponse;Ljava/time/Duration;)V
+}
+
 public final class io/ktor/server/testing/TestEngine : io/ktor/server/engine/ApplicationEngineFactory {
 	public static final field INSTANCE Lio/ktor/server/testing/TestEngine;
 	public synthetic fun configuration (Lkotlin/jvm/functions/Function1;)Lio/ktor/server/engine/ApplicationEngine$Configuration;


### PR DESCRIPTION
**Subsystem**
Client/Server, related modules

**Motivation**
[KTOR-7442](https://youtrack.jetbrains.com/issue/KTOR-7442) Sessions: custom SessionSerializer is no longer supported

**Solution**
Removed the implicit call to initialize the kotlinx serializer when constructing the cookie session builder.

