### PR TITLE
KTOR-7474 ByteChannel.readUtf8Line() backwards compatibility

### DIFF
--- a/ktor-io/api/ktor-io.api
+++ b/ktor-io/api/ktor-io.api
@@ -82,7 +82,8 @@ public final class io/ktor/utils/io/ByteReadChannelOperationsKt {
 	public static final fun readRemaining (Lio/ktor/utils/io/ByteReadChannel;JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static final fun readRemaining (Lio/ktor/utils/io/ByteReadChannel;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static final fun readShort (Lio/ktor/utils/io/ByteReadChannel;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static final fun readUTF8Line (Lio/ktor/utils/io/ByteReadChannel;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun readUTF8Line (Lio/ktor/utils/io/ByteReadChannel;ILkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun readUTF8Line$default (Lio/ktor/utils/io/ByteReadChannel;ILkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public static final fun readUTF8LineTo (Lio/ktor/utils/io/ByteReadChannel;Ljava/lang/Appendable;ILkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun readUTF8LineTo$default (Lio/ktor/utils/io/ByteReadChannel;Ljava/lang/Appendable;ILkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public static final fun reader (Lkotlinx/coroutines/CoroutineScope;Lkotlin/coroutines/CoroutineContext;Lio/ktor/utils/io/ByteChannel;Lkotlin/jvm/functions/Function2;)Lio/ktor/utils/io/ReaderJob;

--- a/ktor-io/api/ktor-io.klib.api
+++ b/ktor-io/api/ktor-io.klib.api
@@ -434,7 +434,7 @@ final suspend fun (io.ktor.utils.io/ByteReadChannel).io.ktor.utils.io/readPacket
 final suspend fun (io.ktor.utils.io/ByteReadChannel).io.ktor.utils.io/readRemaining(): kotlinx.io/Source // io.ktor.utils.io/readRemaining|readRemaining@io.ktor.utils.io.ByteReadChannel(){}[0]
 final suspend fun (io.ktor.utils.io/ByteReadChannel).io.ktor.utils.io/readRemaining(kotlin/Long): kotlinx.io/Source // io.ktor.utils.io/readRemaining|readRemaining@io.ktor.utils.io.ByteReadChannel(kotlin.Long){}[0]
 final suspend fun (io.ktor.utils.io/ByteReadChannel).io.ktor.utils.io/readShort(): kotlin/Short // io.ktor.utils.io/readShort|readShort@io.ktor.utils.io.ByteReadChannel(){}[0]
-final suspend fun (io.ktor.utils.io/ByteReadChannel).io.ktor.utils.io/readUTF8Line(): kotlin/String? // io.ktor.utils.io/readUTF8Line|readUTF8Line@io.ktor.utils.io.ByteReadChannel(){}[0]
+final suspend fun (io.ktor.utils.io/ByteReadChannel).io.ktor.utils.io/readUTF8Line(kotlin/Int = ...): kotlin/String? // io.ktor.utils.io/readUTF8Line|readUTF8Line@io.ktor.utils.io.ByteReadChannel(kotlin.Int){}[0]
 final suspend fun (io.ktor.utils.io/ByteReadChannel).io.ktor.utils.io/readUTF8LineTo(kotlin.text/Appendable, kotlin/Int = ...): kotlin/Boolean // io.ktor.utils.io/readUTF8LineTo|readUTF8LineTo@io.ktor.utils.io.ByteReadChannel(kotlin.text.Appendable;kotlin.Int){}[0]
 final suspend fun (io.ktor.utils.io/ByteReadChannel).io.ktor.utils.io/toByteArray(): kotlin/ByteArray // io.ktor.utils.io/toByteArray|toByteArray@io.ktor.utils.io.ByteReadChannel(){}[0]
 final suspend fun (io.ktor.utils.io/ByteWriteChannel).io.ktor.utils.io/awaitFreeSpace() // io.ktor.utils.io/awaitFreeSpace|awaitFreeSpace@io.ktor.utils.io.ByteWriteChannel(){}[0]

--- a/ktor-io/common/src/io/ktor/utils/io/ByteReadChannelOperations.kt
+++ b/ktor-io/common/src/io/ktor/utils/io/ByteReadChannelOperations.kt
@@ -6,6 +6,7 @@
 
 package io.ktor.utils.io
 
+import io.ktor.utils.io.charsets.*
 import io.ktor.utils.io.core.*
 import kotlinx.coroutines.*
 import kotlinx.io.*
@@ -129,9 +130,17 @@ public suspend fun ByteReadChannel.copyAndClose(channel: ByteWriteChannel): Long
     return result
 }
 
-public suspend fun ByteReadChannel.readUTF8Line(): String? {
+/**
+ * Reads a line of UTF-8 characters from the `ByteReadChannel`.
+ * It recognizes CR, LF and CRLF as line delimiters.
+ *
+ * @param max the maximum number of characters to read. Default is [Int.MAX_VALUE].
+ * @return a string containing the line read, or null if channel is closed
+ * @throws TooLongLineException if max is reached before encountering a newline or end of input
+ */
+public suspend fun ByteReadChannel.readUTF8Line(max: Int = Int.MAX_VALUE): String? {
     val result = StringBuilder()
-    val completed = readUTF8LineTo(result)
+    val completed = readUTF8LineTo(result, max)
     return if (!completed) null else result.toString()
 }
 
@@ -358,6 +367,7 @@ public suspend fun ByteReadChannel.discard(max: Long = Long.MAX_VALUE): Long {
  * @param max the maximum number of characters to read
  *
  * @return `true` if a new line separator was found or max bytes appended. `false` if no new line separator and no bytes read.
+ * @throws TooLongLineException if max is reached before encountering a newline or end of input
  */
 @OptIn(InternalAPI::class, InternalIoApi::class)
 public suspend fun ByteReadChannel.readUTF8LineTo(out: Appendable, max: Int = Int.MAX_VALUE): Boolean {
@@ -381,7 +391,7 @@ public suspend fun ByteReadChannel.readUTF8LineTo(out: Appendable, max: Int = In
                 consumed += count
                 out.append(readBuffer.readString(count.toLong()))
 
-                if (consumed == max) return true
+                if (consumed == max) throw TooLongLineException("Line exceeds limit of $max characters")
             }
 
             continue

--- a/ktor-io/common/test/ReadUtf8LineTest.kt
+++ b/ktor-io/common/test/ReadUtf8LineTest.kt
@@ -1,5 +1,6 @@
 import io.ktor.test.dispatcher.*
 import io.ktor.utils.io.*
+import io.ktor.utils.io.charsets.*
 import kotlinx.coroutines.*
 import kotlin.test.*
 
@@ -20,10 +21,9 @@ class ReadUtf8LineTest {
             }
         }.channel
 
-        val builder = StringBuilder()
-        channel.readUTF8LineTo(builder, 8 * 1024)
-        assertEquals(8 * 1024, builder.length)
-        assertEquals("A".repeat(8 * 1024), builder.toString())
+        assertFailsWith<TooLongLineException> {
+            channel.readUTF8Line(8 * 1024)
+        }
     }
 
     @Test


### PR DESCRIPTION
**Subsystem**
Client/Server, I/O

**Motivation**
[KTOR-7474](https://youtrack.jetbrains.com/issue/KTOR-7474) ByteChannel.readUtf8Line() backwards compatibility

**Solution**
Re-introduced this function to prevent breaking consumers.  I also noticed that the behaviour changed so that the result is truncated after reaching the max rather than throwing the TooLongLineException, which seems like it could cause some problems, so I restored its use.