### PR TITLE
Fixed develocity version

### DIFF
--- a/gradle-settings-conventions/build.gradle.kts
+++ b/gradle-settings-conventions/build.gradle.kts
@@ -12,6 +12,6 @@ repositories {
 }
 
 dependencies {
-    implementation("com.gradle:develocity-gradle-plugin:3.18.1")
+    implementation("com.gradle:develocity-gradle-plugin:3.17")
     implementation("com.gradle:common-custom-user-data-gradle-plugin:2.0.2")
 }

--- a/renovate.json
+++ b/renovate.json
@@ -45,6 +45,13 @@
         "major"
       ],
       "enabled": false
+    },
+    {
+      "description": "Do not update Develocity as server may not support a newer version",
+      "matchPackageNames": [
+        "com.gradle:develocity-gradle-plugin*"
+      ],
+      "enabled": false
     }
   ]
 }


### PR DESCRIPTION
**Subsystem**
Gradle

**Motivation**
Develocity auto-update broke scans publication.
Our develocity server does not support versions other than 3.17

**Solution**
Disable auto update

