### PR TITLE
Preparation for NodeJS CIO server

### DIFF
--- a/ktor-client/ktor-client-cio/jvmAndPosix/src/io/ktor/client/engine/cio/ConnectionFactory.kt
+++ b/ktor-client/ktor-client-cio/jvmAndPosix/src/io/ktor/client/engine/cio/ConnectionFactory.kt
@@ -1,6 +1,6 @@
 /*
-* Copyright 2014-2021 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
-*/
+ * Copyright 2014-2024 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
 
 package io.ktor.client.engine.cio
 
@@ -27,7 +27,7 @@ internal class ConnectionFactory(
             addressSemaphore.acquire()
 
             try {
-                aSocket(selector).tcpNoDelay().tcp().connect(address, configuration)
+                aSocket(selector).tcp().connect(address, configuration)
             } catch (cause: Throwable) {
                 // a failure or cancellation
                 addressSemaphore.release()

--- a/ktor-network/api/ktor-network.api
+++ b/ktor-network/api/ktor-network.api
@@ -242,7 +242,6 @@ public final class io/ktor/network/sockets/SocketBuilder : io/ktor/network/socke
 }
 
 public abstract class io/ktor/network/sockets/SocketOptions {
-	public static final field Companion Lio/ktor/network/sockets/SocketOptions$Companion;
 	public synthetic fun <init> (Ljava/util/Map;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	protected fun copyCommon (Lio/ktor/network/sockets/SocketOptions;)V
 	protected final fun getCustomOptions ()Ljava/util/Map;
@@ -258,9 +257,6 @@ public final class io/ktor/network/sockets/SocketOptions$AcceptorOptions : io/kt
 	public synthetic fun copy$ktor_network ()Lio/ktor/network/sockets/SocketOptions;
 	public final fun getBacklogSize ()I
 	public final fun setBacklogSize (I)V
-}
-
-public final class io/ktor/network/sockets/SocketOptions$Companion {
 }
 
 public class io/ktor/network/sockets/SocketOptions$PeerSocketOptions : io/ktor/network/sockets/SocketOptions {
@@ -302,19 +298,20 @@ public final class io/ktor/network/sockets/SocketsKt {
 }
 
 public final class io/ktor/network/sockets/TcpSocketBuilder : io/ktor/network/sockets/Configurable {
-	public fun <init> (Lio/ktor/network/selector/SelectorManager;Lio/ktor/network/sockets/SocketOptions;)V
-	public final fun bind (Lio/ktor/network/sockets/SocketAddress;Lkotlin/jvm/functions/Function1;)Lio/ktor/network/sockets/ServerSocket;
-	public final fun bind (Ljava/lang/String;ILkotlin/jvm/functions/Function1;)Lio/ktor/network/sockets/ServerSocket;
-	public static synthetic fun bind$default (Lio/ktor/network/sockets/TcpSocketBuilder;Lio/ktor/network/sockets/SocketAddress;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lio/ktor/network/sockets/ServerSocket;
-	public static synthetic fun bind$default (Lio/ktor/network/sockets/TcpSocketBuilder;Ljava/lang/String;ILkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lio/ktor/network/sockets/ServerSocket;
+	public final fun bind (Lio/ktor/network/sockets/SocketAddress;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun bind (Ljava/lang/String;ILkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun bind$default (Lio/ktor/network/sockets/TcpSocketBuilder;Lio/ktor/network/sockets/SocketAddress;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun bind$default (Lio/ktor/network/sockets/TcpSocketBuilder;Ljava/lang/String;ILkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public synthetic fun configure (Lkotlin/jvm/functions/Function1;)Lio/ktor/network/sockets/Configurable;
 	public fun configure (Lkotlin/jvm/functions/Function1;)Lio/ktor/network/sockets/TcpSocketBuilder;
 	public final fun connect (Lio/ktor/network/sockets/SocketAddress;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun connect (Ljava/lang/String;ILkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun connect$default (Lio/ktor/network/sockets/TcpSocketBuilder;Lio/ktor/network/sockets/SocketAddress;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public static synthetic fun connect$default (Lio/ktor/network/sockets/TcpSocketBuilder;Ljava/lang/String;ILkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
-	public fun getOptions ()Lio/ktor/network/sockets/SocketOptions;
-	public fun setOptions (Lio/ktor/network/sockets/SocketOptions;)V
+	public fun getOptions ()Lio/ktor/network/sockets/SocketOptions$PeerSocketOptions;
+	public synthetic fun getOptions ()Lio/ktor/network/sockets/SocketOptions;
+	public fun setOptions (Lio/ktor/network/sockets/SocketOptions$PeerSocketOptions;)V
+	public synthetic fun setOptions (Lio/ktor/network/sockets/SocketOptions;)V
 }
 
 public final class io/ktor/network/sockets/TypeOfService {
@@ -343,21 +340,16 @@ public final class io/ktor/network/sockets/TypeOfService$Companion {
 }
 
 public final class io/ktor/network/sockets/UDPSocketBuilder : io/ktor/network/sockets/Configurable {
-	public static final field Companion Lio/ktor/network/sockets/UDPSocketBuilder$Companion;
-	public fun <init> (Lio/ktor/network/selector/SelectorManager;Lio/ktor/network/sockets/SocketOptions$UDPSocketOptions;)V
-	public final fun bind (Lio/ktor/network/sockets/SocketAddress;Lkotlin/jvm/functions/Function1;)Lio/ktor/network/sockets/BoundDatagramSocket;
-	public static synthetic fun bind$default (Lio/ktor/network/sockets/UDPSocketBuilder;Lio/ktor/network/sockets/SocketAddress;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lio/ktor/network/sockets/BoundDatagramSocket;
+	public final fun bind (Lio/ktor/network/sockets/SocketAddress;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun bind$default (Lio/ktor/network/sockets/UDPSocketBuilder;Lio/ktor/network/sockets/SocketAddress;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public synthetic fun configure (Lkotlin/jvm/functions/Function1;)Lio/ktor/network/sockets/Configurable;
 	public fun configure (Lkotlin/jvm/functions/Function1;)Lio/ktor/network/sockets/UDPSocketBuilder;
-	public final fun connect (Lio/ktor/network/sockets/SocketAddress;Lio/ktor/network/sockets/SocketAddress;Lkotlin/jvm/functions/Function1;)Lio/ktor/network/sockets/ConnectedDatagramSocket;
-	public static synthetic fun connect$default (Lio/ktor/network/sockets/UDPSocketBuilder;Lio/ktor/network/sockets/SocketAddress;Lio/ktor/network/sockets/SocketAddress;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lio/ktor/network/sockets/ConnectedDatagramSocket;
+	public final fun connect (Lio/ktor/network/sockets/SocketAddress;Lio/ktor/network/sockets/SocketAddress;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun connect$default (Lio/ktor/network/sockets/UDPSocketBuilder;Lio/ktor/network/sockets/SocketAddress;Lio/ktor/network/sockets/SocketAddress;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public fun getOptions ()Lio/ktor/network/sockets/SocketOptions$UDPSocketOptions;
 	public synthetic fun getOptions ()Lio/ktor/network/sockets/SocketOptions;
 	public fun setOptions (Lio/ktor/network/sockets/SocketOptions$UDPSocketOptions;)V
 	public synthetic fun setOptions (Lio/ktor/network/sockets/SocketOptions;)V
-}
-
-public final class io/ktor/network/sockets/UDPSocketBuilder$Companion {
 }
 
 public final class io/ktor/network/sockets/UnixSocketAddress : io/ktor/network/sockets/SocketAddress {

--- a/ktor-network/api/ktor-network.klib.api
+++ b/ktor-network/api/ktor-network.klib.api
@@ -157,30 +157,24 @@ final class io.ktor.network.sockets/SocketTimeoutException : kotlinx.io/IOExcept
     constructor <init>(kotlin/String, kotlin/Throwable?) // io.ktor.network.sockets/SocketTimeoutException.<init>|<init>(kotlin.String;kotlin.Throwable?){}[0]
 }
 
-final class io.ktor.network.sockets/TcpSocketBuilder : io.ktor.network.sockets/Configurable<io.ktor.network.sockets/TcpSocketBuilder, io.ktor.network.sockets/SocketOptions> { // io.ktor.network.sockets/TcpSocketBuilder|null[0]
-    constructor <init>(io.ktor.network.selector/SelectorManager, io.ktor.network.sockets/SocketOptions) // io.ktor.network.sockets/TcpSocketBuilder.<init>|<init>(io.ktor.network.selector.SelectorManager;io.ktor.network.sockets.SocketOptions){}[0]
-
+final class io.ktor.network.sockets/TcpSocketBuilder : io.ktor.network.sockets/Configurable<io.ktor.network.sockets/TcpSocketBuilder, io.ktor.network.sockets/SocketOptions.PeerSocketOptions> { // io.ktor.network.sockets/TcpSocketBuilder|null[0]
     final var options // io.ktor.network.sockets/TcpSocketBuilder.options|{}options[0]
-        final fun <get-options>(): io.ktor.network.sockets/SocketOptions // io.ktor.network.sockets/TcpSocketBuilder.options.<get-options>|<get-options>(){}[0]
-        final fun <set-options>(io.ktor.network.sockets/SocketOptions) // io.ktor.network.sockets/TcpSocketBuilder.options.<set-options>|<set-options>(io.ktor.network.sockets.SocketOptions){}[0]
+        final fun <get-options>(): io.ktor.network.sockets/SocketOptions.PeerSocketOptions // io.ktor.network.sockets/TcpSocketBuilder.options.<get-options>|<get-options>(){}[0]
+        final fun <set-options>(io.ktor.network.sockets/SocketOptions.PeerSocketOptions) // io.ktor.network.sockets/TcpSocketBuilder.options.<set-options>|<set-options>(io.ktor.network.sockets.SocketOptions.PeerSocketOptions){}[0]
 
-    final fun bind(io.ktor.network.sockets/SocketAddress? = ..., kotlin/Function1<io.ktor.network.sockets/SocketOptions.AcceptorOptions, kotlin/Unit> = ...): io.ktor.network.sockets/ServerSocket // io.ktor.network.sockets/TcpSocketBuilder.bind|bind(io.ktor.network.sockets.SocketAddress?;kotlin.Function1<io.ktor.network.sockets.SocketOptions.AcceptorOptions,kotlin.Unit>){}[0]
-    final fun bind(kotlin/String = ..., kotlin/Int = ..., kotlin/Function1<io.ktor.network.sockets/SocketOptions.AcceptorOptions, kotlin/Unit> = ...): io.ktor.network.sockets/ServerSocket // io.ktor.network.sockets/TcpSocketBuilder.bind|bind(kotlin.String;kotlin.Int;kotlin.Function1<io.ktor.network.sockets.SocketOptions.AcceptorOptions,kotlin.Unit>){}[0]
+    final suspend fun bind(io.ktor.network.sockets/SocketAddress? = ..., kotlin/Function1<io.ktor.network.sockets/SocketOptions.AcceptorOptions, kotlin/Unit> = ...): io.ktor.network.sockets/ServerSocket // io.ktor.network.sockets/TcpSocketBuilder.bind|bind(io.ktor.network.sockets.SocketAddress?;kotlin.Function1<io.ktor.network.sockets.SocketOptions.AcceptorOptions,kotlin.Unit>){}[0]
+    final suspend fun bind(kotlin/String = ..., kotlin/Int = ..., kotlin/Function1<io.ktor.network.sockets/SocketOptions.AcceptorOptions, kotlin/Unit> = ...): io.ktor.network.sockets/ServerSocket // io.ktor.network.sockets/TcpSocketBuilder.bind|bind(kotlin.String;kotlin.Int;kotlin.Function1<io.ktor.network.sockets.SocketOptions.AcceptorOptions,kotlin.Unit>){}[0]
     final suspend fun connect(io.ktor.network.sockets/SocketAddress, kotlin/Function1<io.ktor.network.sockets/SocketOptions.TCPClientSocketOptions, kotlin/Unit> = ...): io.ktor.network.sockets/Socket // io.ktor.network.sockets/TcpSocketBuilder.connect|connect(io.ktor.network.sockets.SocketAddress;kotlin.Function1<io.ktor.network.sockets.SocketOptions.TCPClientSocketOptions,kotlin.Unit>){}[0]
     final suspend fun connect(kotlin/String, kotlin/Int, kotlin/Function1<io.ktor.network.sockets/SocketOptions.TCPClientSocketOptions, kotlin/Unit> = ...): io.ktor.network.sockets/Socket // io.ktor.network.sockets/TcpSocketBuilder.connect|connect(kotlin.String;kotlin.Int;kotlin.Function1<io.ktor.network.sockets.SocketOptions.TCPClientSocketOptions,kotlin.Unit>){}[0]
 }
 
 final class io.ktor.network.sockets/UDPSocketBuilder : io.ktor.network.sockets/Configurable<io.ktor.network.sockets/UDPSocketBuilder, io.ktor.network.sockets/SocketOptions.UDPSocketOptions> { // io.ktor.network.sockets/UDPSocketBuilder|null[0]
-    constructor <init>(io.ktor.network.selector/SelectorManager, io.ktor.network.sockets/SocketOptions.UDPSocketOptions) // io.ktor.network.sockets/UDPSocketBuilder.<init>|<init>(io.ktor.network.selector.SelectorManager;io.ktor.network.sockets.SocketOptions.UDPSocketOptions){}[0]
-
     final var options // io.ktor.network.sockets/UDPSocketBuilder.options|{}options[0]
         final fun <get-options>(): io.ktor.network.sockets/SocketOptions.UDPSocketOptions // io.ktor.network.sockets/UDPSocketBuilder.options.<get-options>|<get-options>(){}[0]
         final fun <set-options>(io.ktor.network.sockets/SocketOptions.UDPSocketOptions) // io.ktor.network.sockets/UDPSocketBuilder.options.<set-options>|<set-options>(io.ktor.network.sockets.SocketOptions.UDPSocketOptions){}[0]
 
-    final fun bind(io.ktor.network.sockets/SocketAddress? = ..., kotlin/Function1<io.ktor.network.sockets/SocketOptions.UDPSocketOptions, kotlin/Unit> = ...): io.ktor.network.sockets/BoundDatagramSocket // io.ktor.network.sockets/UDPSocketBuilder.bind|bind(io.ktor.network.sockets.SocketAddress?;kotlin.Function1<io.ktor.network.sockets.SocketOptions.UDPSocketOptions,kotlin.Unit>){}[0]
-    final fun connect(io.ktor.network.sockets/SocketAddress, io.ktor.network.sockets/SocketAddress? = ..., kotlin/Function1<io.ktor.network.sockets/SocketOptions.UDPSocketOptions, kotlin/Unit> = ...): io.ktor.network.sockets/ConnectedDatagramSocket // io.ktor.network.sockets/UDPSocketBuilder.connect|connect(io.ktor.network.sockets.SocketAddress;io.ktor.network.sockets.SocketAddress?;kotlin.Function1<io.ktor.network.sockets.SocketOptions.UDPSocketOptions,kotlin.Unit>){}[0]
-
-    final object Companion // io.ktor.network.sockets/UDPSocketBuilder.Companion|null[0]
+    final suspend fun bind(io.ktor.network.sockets/SocketAddress? = ..., kotlin/Function1<io.ktor.network.sockets/SocketOptions.UDPSocketOptions, kotlin/Unit> = ...): io.ktor.network.sockets/BoundDatagramSocket // io.ktor.network.sockets/UDPSocketBuilder.bind|bind(io.ktor.network.sockets.SocketAddress?;kotlin.Function1<io.ktor.network.sockets.SocketOptions.UDPSocketOptions,kotlin.Unit>){}[0]
+    final suspend fun connect(io.ktor.network.sockets/SocketAddress, io.ktor.network.sockets/SocketAddress? = ..., kotlin/Function1<io.ktor.network.sockets/SocketOptions.UDPSocketOptions, kotlin/Unit> = ...): io.ktor.network.sockets/ConnectedDatagramSocket // io.ktor.network.sockets/UDPSocketBuilder.connect|connect(io.ktor.network.sockets.SocketAddress;io.ktor.network.sockets.SocketAddress?;kotlin.Function1<io.ktor.network.sockets.SocketOptions.UDPSocketOptions,kotlin.Unit>){}[0]
 }
 
 final class io.ktor.network.sockets/UnixSocketAddress : io.ktor.network.sockets/SocketAddress { // io.ktor.network.sockets/UnixSocketAddress|null[0]
@@ -278,8 +272,6 @@ sealed class io.ktor.network.sockets/SocketOptions { // io.ktor.network.sockets/
 
         open fun copyCommon(io.ktor.network.sockets/SocketOptions) // io.ktor.network.sockets/SocketOptions.PeerSocketOptions.copyCommon|copyCommon(io.ktor.network.sockets.SocketOptions){}[0]
     }
-
-    final object Companion // io.ktor.network.sockets/SocketOptions.Companion|null[0]
 }
 
 final val io.ktor.network.sockets/isClosed // io.ktor.network.sockets/isClosed|@io.ktor.network.sockets.ASocket{}isClosed[0]

--- a/ktor-network/jvm/src/io/ktor/network/sockets/UDPSocketBuilderJvm.kt
+++ b/ktor-network/jvm/src/io/ktor/network/sockets/UDPSocketBuilderJvm.kt
@@ -1,12 +1,12 @@
 /*
- * Copyright 2014-2019 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2014-2024 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package io.ktor.network.sockets
 
 import io.ktor.network.selector.*
 
-internal actual fun UDPSocketBuilder.Companion.connectUDP(
+internal actual fun connectUDP(
     selector: SelectorManager,
     remoteAddress: SocketAddress,
     localAddress: SocketAddress?,
@@ -25,7 +25,7 @@ internal actual fun UDPSocketBuilder.Companion.connectUDP(
     return DatagramSocketImpl(this, selector)
 }
 
-internal actual fun UDPSocketBuilder.Companion.bindUDP(
+internal actual fun bindUDP(
     selector: SelectorManager,
     localAddress: SocketAddress?,
     options: SocketOptions.UDPSocketOptions

--- a/ktor-network/jvmAndPosix/src/io/ktor/network/sockets/Builders.kt
+++ b/ktor-network/jvmAndPosix/src/io/ktor/network/sockets/Builders.kt
@@ -1,6 +1,6 @@
 /*
-* Copyright 2014-2021 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
-*/
+ * Copyright 2014-2024 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
 package io.ktor.network.sockets
 
 import io.ktor.network.selector.*
@@ -32,6 +32,7 @@ public class SocketBuilder internal constructor(
 /**
  * Set TCP_NODELAY socket option to disable the Nagle algorithm.
  */
+@Deprecated("noDelay is true by default", ReplaceWith("this"))
 public fun <T : Configurable<T, *>> T.tcpNoDelay(): T {
     return configure {
         if (this is SocketOptions.TCPClientSocketOptions) {

--- a/ktor-network/jvmAndPosix/src/io/ktor/network/sockets/SocketOptions.kt
+++ b/ktor-network/jvmAndPosix/src/io/ktor/network/sockets/SocketOptions.kt
@@ -1,6 +1,6 @@
 /*
-* Copyright 2014-2021 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
-*/
+ * Copyright 2014-2024 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
 
 package io.ktor.network.sockets
 
@@ -195,7 +195,7 @@ public sealed class SocketOptions(
         }
     }
 
-    public companion object {
+    internal companion object {
         internal fun create(): SocketOptions = GeneralSocketOptions(HashMap())
     }
 }

--- a/ktor-network/jvmAndPosix/src/io/ktor/network/sockets/TcpSocketBuilder.kt
+++ b/ktor-network/jvmAndPosix/src/io/ktor/network/sockets/TcpSocketBuilder.kt
@@ -1,3 +1,7 @@
+/*
+ * Copyright 2014-2024 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
 package io.ktor.network.sockets
 
 import io.ktor.network.selector.*
@@ -5,11 +9,10 @@ import io.ktor.network.selector.*
 /**
  * TCP socket builder
  */
-@Suppress("PublicApiImplicitType")
-public class TcpSocketBuilder(
+public class TcpSocketBuilder internal constructor(
     private val selector: SelectorManager,
-    override var options: SocketOptions
-) : Configurable<TcpSocketBuilder, SocketOptions> {
+    override var options: SocketOptions.PeerSocketOptions
+) : Configurable<TcpSocketBuilder, SocketOptions.PeerSocketOptions> {
     /**
      * Connect to [hostname] and [port].
      */
@@ -22,7 +25,7 @@ public class TcpSocketBuilder(
     /**
      * Bind server socket at [port] to listen to [hostname].
      */
-    public fun bind(
+    public suspend fun bind(
         hostname: String = "0.0.0.0",
         port: Int = 0,
         configure: SocketOptions.AcceptorOptions.() -> Unit = {}
@@ -34,13 +37,13 @@ public class TcpSocketBuilder(
     public suspend fun connect(
         remoteAddress: SocketAddress,
         configure: SocketOptions.TCPClientSocketOptions.() -> Unit = {}
-    ): Socket = connect(selector, remoteAddress, options.peer().tcp().apply(configure))
+    ): Socket = connect(selector, remoteAddress, options.tcp().apply(configure))
 
     /**
      * Bind server socket to listen to [localAddress].
      */
-    public fun bind(
+    public suspend fun bind(
         localAddress: SocketAddress? = null,
         configure: SocketOptions.AcceptorOptions.() -> Unit = {}
-    ): ServerSocket = bind(selector, localAddress, options.peer().acceptor().apply(configure))
+    ): ServerSocket = bind(selector, localAddress, options.acceptor().apply(configure))
 }

--- a/ktor-network/jvmAndPosix/src/io/ktor/network/sockets/UDPSocketBuilder.kt
+++ b/ktor-network/jvmAndPosix/src/io/ktor/network/sockets/UDPSocketBuilder.kt
@@ -1,3 +1,7 @@
+/*
+ * Copyright 2014-2024 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
 package io.ktor.network.sockets
 
 import io.ktor.network.selector.*
@@ -5,14 +9,14 @@ import io.ktor.network.selector.*
 /**
  * UDP socket builder
  */
-public class UDPSocketBuilder(
+public class UDPSocketBuilder internal constructor(
     private val selector: SelectorManager,
     override var options: SocketOptions.UDPSocketOptions
 ) : Configurable<UDPSocketBuilder, SocketOptions.UDPSocketOptions> {
     /**
      * Bind server socket to listen to [localAddress].
      */
-    public fun bind(
+    public suspend fun bind(
         localAddress: SocketAddress? = null,
         configure: SocketOptions.UDPSocketOptions.() -> Unit = {}
     ): BoundDatagramSocket = bindUDP(selector, localAddress, options.udp().apply(configure))
@@ -20,23 +24,21 @@ public class UDPSocketBuilder(
     /**
      * Create a datagram socket to listen datagrams at [localAddress] and set to [remoteAddress].
      */
-    public fun connect(
+    public suspend fun connect(
         remoteAddress: SocketAddress,
         localAddress: SocketAddress? = null,
         configure: SocketOptions.UDPSocketOptions.() -> Unit = {}
     ): ConnectedDatagramSocket = connectUDP(selector, remoteAddress, localAddress, options.udp().apply(configure))
-
-    public companion object
 }
 
-internal expect fun UDPSocketBuilder.Companion.connectUDP(
+internal expect fun connectUDP(
     selector: SelectorManager,
     remoteAddress: SocketAddress,
     localAddress: SocketAddress?,
     options: SocketOptions.UDPSocketOptions
 ): ConnectedDatagramSocket
 
-internal expect fun UDPSocketBuilder.Companion.bindUDP(
+internal expect fun bindUDP(
     selector: SelectorManager,
     localAddress: SocketAddress?,
     options: SocketOptions.UDPSocketOptions

--- a/ktor-network/posix/src/io/ktor/network/sockets/UDPSocketBuilderNative.kt
+++ b/ktor-network/posix/src/io/ktor/network/sockets/UDPSocketBuilderNative.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2014-2024 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package io.ktor.network.sockets
@@ -10,7 +10,7 @@ import kotlinx.cinterop.*
 import platform.posix.*
 
 @OptIn(UnsafeNumber::class, ExperimentalForeignApi::class)
-internal actual fun UDPSocketBuilder.Companion.connectUDP(
+internal actual fun connectUDP(
     selector: SelectorManager,
     remoteAddress: SocketAddress,
     localAddress: SocketAddress?,
@@ -51,7 +51,7 @@ internal actual fun UDPSocketBuilder.Companion.connectUDP(
 }
 
 @OptIn(UnsafeNumber::class, ExperimentalForeignApi::class)
-internal actual fun UDPSocketBuilder.Companion.bindUDP(
+internal actual fun bindUDP(
     selector: SelectorManager,
     localAddress: SocketAddress?,
     options: SocketOptions.UDPSocketOptions

--- a/ktor-server/ktor-server-cio/api/ktor-server-cio.api
+++ b/ktor-server/ktor-server-cio/api/ktor-server-cio.api
@@ -10,7 +10,9 @@ public final class io/ktor/server/cio/CIOApplicationEngine : io/ktor/server/engi
 	public fun <init> (Lio/ktor/server/application/ApplicationEnvironment;Lio/ktor/events/Events;ZLio/ktor/server/cio/CIOApplicationEngine$Configuration;Lkotlin/jvm/functions/Function0;)V
 	public final fun getConfiguration ()Lio/ktor/server/cio/CIOApplicationEngine$Configuration;
 	public fun start (Z)Lio/ktor/server/engine/ApplicationEngine;
+	public fun startSuspend (ZLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun stop (JJ)V
+	public fun stopSuspend (JJLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public final class io/ktor/server/cio/CIOApplicationEngine$Configuration : io/ktor/server/engine/BaseApplicationEngine$Configuration {

--- a/ktor-server/ktor-server-cio/api/ktor-server-cio.klib.api
+++ b/ktor-server/ktor-server-cio/api/ktor-server-cio.klib.api
@@ -44,6 +44,8 @@ final class io.ktor.server.cio/CIOApplicationEngine : io.ktor.server.engine/Base
 
     final fun start(kotlin/Boolean): io.ktor.server.engine/ApplicationEngine // io.ktor.server.cio/CIOApplicationEngine.start|start(kotlin.Boolean){}[0]
     final fun stop(kotlin/Long, kotlin/Long) // io.ktor.server.cio/CIOApplicationEngine.stop|stop(kotlin.Long;kotlin.Long){}[0]
+    final suspend fun startSuspend(kotlin/Boolean): io.ktor.server.engine/ApplicationEngine // io.ktor.server.cio/CIOApplicationEngine.startSuspend|startSuspend(kotlin.Boolean){}[0]
+    final suspend fun stopSuspend(kotlin/Long, kotlin/Long) // io.ktor.server.cio/CIOApplicationEngine.stopSuspend|stopSuspend(kotlin.Long;kotlin.Long){}[0]
 
     final class Configuration : io.ktor.server.engine/BaseApplicationEngine.Configuration { // io.ktor.server.cio/CIOApplicationEngine.Configuration|null[0]
         constructor <init>() // io.ktor.server.cio/CIOApplicationEngine.Configuration.<init>|<init>(){}[0]

--- a/ktor-server/ktor-server-core/api/ktor-server-core.api
+++ b/ktor-server/ktor-server-core/api/ktor-server-core.api
@@ -362,7 +362,9 @@ public abstract interface class io/ktor/server/engine/ApplicationEngine {
 	public abstract fun getEnvironment ()Lio/ktor/server/application/ApplicationEnvironment;
 	public abstract fun resolvedConnectors (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun start (Z)Lio/ktor/server/engine/ApplicationEngine;
+	public abstract fun startSuspend (ZLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun stop (JJ)V
+	public abstract fun stopSuspend (JJLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public class io/ktor/server/engine/ApplicationEngine$Configuration {
@@ -385,7 +387,11 @@ public class io/ktor/server/engine/ApplicationEngine$Configuration {
 
 public final class io/ktor/server/engine/ApplicationEngine$DefaultImpls {
 	public static synthetic fun start$default (Lio/ktor/server/engine/ApplicationEngine;ZILjava/lang/Object;)Lio/ktor/server/engine/ApplicationEngine;
+	public static fun startSuspend (Lio/ktor/server/engine/ApplicationEngine;ZLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun startSuspend$default (Lio/ktor/server/engine/ApplicationEngine;ZLkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public static synthetic fun stop$default (Lio/ktor/server/engine/ApplicationEngine;JJILjava/lang/Object;)V
+	public static fun stopSuspend (Lio/ktor/server/engine/ApplicationEngine;JJLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun stopSuspend$default (Lio/ktor/server/engine/ApplicationEngine;JJLkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 }
 
 public abstract interface class io/ktor/server/engine/ApplicationEngineFactory {
@@ -434,6 +440,8 @@ public abstract class io/ktor/server/engine/BaseApplicationEngine : io/ktor/serv
 	public final fun getPipeline ()Lio/ktor/server/engine/EnginePipeline;
 	protected final fun getResolvedConnectorsDeferred ()Lkotlinx/coroutines/CompletableDeferred;
 	public fun resolvedConnectors (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun startSuspend (ZLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun stopSuspend (JJLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public class io/ktor/server/engine/BaseApplicationEngine$Configuration : io/ktor/server/engine/ApplicationEngine$Configuration {

--- a/ktor-server/ktor-server-core/api/ktor-server-core.klib.api
+++ b/ktor-server/ktor-server-core/api/ktor-server-core.klib.api
@@ -109,6 +109,8 @@ abstract interface io.ktor.server.engine/ApplicationEngine { // io.ktor.server.e
     abstract fun start(kotlin/Boolean = ...): io.ktor.server.engine/ApplicationEngine // io.ktor.server.engine/ApplicationEngine.start|start(kotlin.Boolean){}[0]
     abstract fun stop(kotlin/Long = ..., kotlin/Long = ...) // io.ktor.server.engine/ApplicationEngine.stop|stop(kotlin.Long;kotlin.Long){}[0]
     abstract suspend fun resolvedConnectors(): kotlin.collections/List<io.ktor.server.engine/EngineConnectorConfig> // io.ktor.server.engine/ApplicationEngine.resolvedConnectors|resolvedConnectors(){}[0]
+    open suspend fun startSuspend(kotlin/Boolean = ...): io.ktor.server.engine/ApplicationEngine // io.ktor.server.engine/ApplicationEngine.startSuspend|startSuspend(kotlin.Boolean){}[0]
+    open suspend fun stopSuspend(kotlin/Long = ..., kotlin/Long = ...) // io.ktor.server.engine/ApplicationEngine.stopSuspend|stopSuspend(kotlin.Long;kotlin.Long){}[0]
 
     open class Configuration { // io.ktor.server.engine/ApplicationEngine.Configuration|null[0]
         constructor <init>() // io.ktor.server.engine/ApplicationEngine.Configuration.<init>|<init>(){}[0]

--- a/ktor-server/ktor-server-core/common/src/io/ktor/server/engine/ApplicationEngine.kt
+++ b/ktor-server/ktor-server-core/common/src/io/ktor/server/engine/ApplicationEngine.kt
@@ -6,6 +6,7 @@ package io.ktor.server.engine
 
 import io.ktor.server.application.*
 import io.ktor.server.engine.internal.*
+import kotlinx.coroutines.*
 
 /**
  * An engine which runs an application.
@@ -89,10 +90,32 @@ public interface ApplicationEngine {
     public fun start(wait: Boolean = false): ApplicationEngine
 
     /**
+     * Starts this [ApplicationEngine].
+     *
+     * @param wait if true, then the `start` call blocks a current thread until it finishes its execution.
+     * If you run `start` from the main thread with `wait = false` and nothing else blocking this thread,
+     * then your application will be terminated without handling any requests.
+     * @return returns this instance
+     */
+    public suspend fun startSuspend(wait: Boolean = false): ApplicationEngine {
+        return withContext(Dispatchers.IOBridge) { start(wait) }
+    }
+
+    /**
      * Stops this [ApplicationEngine].
      *
      * @param gracePeriodMillis the maximum amount of time for activity to cool down
      * @param timeoutMillis the maximum amount of time to wait until a server stops gracefully
      */
     public fun stop(gracePeriodMillis: Long = 500, timeoutMillis: Long = 500)
+
+    /**
+     * Stops this [ApplicationEngine].
+     *
+     * @param gracePeriodMillis the maximum amount of time for activity to cool down
+     * @param timeoutMillis the maximum amount of time to wait until a server stops gracefully
+     */
+    public suspend fun stopSuspend(gracePeriodMillis: Long = 500, timeoutMillis: Long = 500) {
+        withContext(Dispatchers.IOBridge) { stop(gracePeriodMillis, timeoutMillis) }
+    }
 }

--- a/ktor-server/ktor-server-test-base/posix/src/io/ktor/server/test/base/EngineTestBaseNix.kt
+++ b/ktor-server/ktor-server-test-base/posix/src/io/ktor/server/test/base/EngineTestBaseNix.kt
@@ -38,9 +38,11 @@ actual constructor(
     @Retention
     protected actual annotation class Http2Only actual constructor()
 
-    protected actual var port: Int = aSocket(TEST_SELECTOR_MANAGER).tcp().bind().use {
-        val inetAddress = it.localAddress as? InetSocketAddress ?: error("Expected inet socket address")
-        inetAddress.port
+    protected actual var port: Int = runBlocking {
+        aSocket(TEST_SELECTOR_MANAGER).tcp().bind().use {
+            val inetAddress = it.localAddress as? InetSocketAddress ?: error("Expected inet socket address")
+            inetAddress.port
+        }
     }
 
     protected actual var sslPort: Int = 0


### PR DESCRIPTION
Note: this is a part of ongoing implementation of client/server support for CIO on JS/WasmJS (https://github.com/ktorio/ktor/compare/main...whyoleg:ktor:common-cio)

NodeJS APIs are asynchronous by default but server-related functions in `ktor` are non-suspend.
This PR has breaking changes which will be needed to allow to implement CIO server via NodeJS for JS/WasmJS in 3.1.
