### PR TITLE
KTOR-7500 Fix multi-part read lock issue when part is skipped

### DIFF
--- a/ktor-http/common/src/io/ktor/http/content/Multipart.kt
+++ b/ktor-http/common/src/io/ktor/http/content/Multipart.kt
@@ -116,7 +116,7 @@ public suspend fun MultiPartData.forEachPart(partHandler: suspend (PartData) -> 
  * Parse multipart data stream and put all parts into a list.
  * @return a list of [PartData]
  */
-@Deprecated("This method can deadlock on large requests. Use `forEachPart` instead.")
+@Deprecated("This method can deadlock on large requests. Use `forEachPart` instead.", level = DeprecationLevel.ERROR)
 public suspend fun MultiPartData.readAllParts(): List<PartData> {
     var part = readPart() ?: return emptyList()
     val parts = ArrayList<PartData>()

--- a/ktor-http/ktor-http-cio/jvm/src/io/ktor/http/cio/Multipart.kt
+++ b/ktor-http/ktor-http-cio/jvm/src/io/ktor/http/cio/Multipart.kt
@@ -206,6 +206,7 @@ private fun CoroutineScope.parseMultipart(
                     )
                 }
                 parsePartBodyImpl(boundaryPrefixed, countedInput, body, headersMap, maxPartSize)
+                body.close()
             } catch (cause: Throwable) {
                 if (headers.completeExceptionally(cause)) {
                     headersMap?.release()
@@ -213,8 +214,6 @@ private fun CoroutineScope.parseMultipart(
                 body.close(cause)
                 throw cause
             }
-
-            body.close()
         }
 
         // Can be followed by two carriage returns

--- a/ktor-io/common/src/io/ktor/utils/io/SourceByteReadChannel.kt
+++ b/ktor-io/common/src/io/ktor/utils/io/SourceByteReadChannel.kt
@@ -4,6 +4,7 @@
 
 package io.ktor.utils.io
 
+import io.ktor.utils.io.core.*
 import kotlinx.io.*
 import kotlin.concurrent.*
 
@@ -26,7 +27,7 @@ internal class SourceByteReadChannel(private val source: Source) : ByteReadChann
 
     override suspend fun awaitContent(min: Int): Boolean {
         closedCause?.let { throw it }
-        return false
+        return source.remaining >= min
     }
 
     override fun cancel(cause: Throwable?) {

--- a/ktor-server/ktor-server-config-yaml/jvm/test/YamlConfigTestJvm.kt
+++ b/ktor-server/ktor-server-config-yaml/jvm/test/YamlConfigTestJvm.kt
@@ -45,7 +45,7 @@ class YamlConfigTestJvm {
             val content = """
             ktor:
                 property: "${'$'}test.property"
-        """.trimIndent()
+            """.trimIndent()
             val yaml = Yaml.decodeYamlFromString(content)
             val config = YamlConfig(yaml as YamlMap)
             config.checkEnvironmentVariables()

--- a/ktor-server/ktor-server-test-suites/jvm/src/io/ktor/server/testing/suites/ContentTestSuite.kt
+++ b/ktor-server/ktor-server-test-suites/jvm/src/io/ktor/server/testing/suites/ContentTestSuite.kt
@@ -574,12 +574,7 @@ abstract class ContentTestSuite<TEngine : ApplicationEngine, TConfiguration : Ap
         createAndStartServer {
             post("/") {
                 val response = StringBuilder()
-                val parts = mutableListOf<PartData>()
-                call.receiveMultipart().forEachPart {
-                    parts.add(it)
-                }
-
-                parts.sortedBy { it.name }.forEach { part ->
+                call.receiveMultipart().forEachPart { part ->
                     when (part) {
                         is PartData.FormItem -> response.append("${part.name}=${part.value}\n")
                         is PartData.FileItem ->
@@ -592,8 +587,6 @@ abstract class ContentTestSuite<TEngine : ApplicationEngine, TConfiguration : Ap
                         is PartData.BinaryItem -> {}
                         is PartData.BinaryChannelItem -> {}
                     }
-
-                    part.dispose()
                 }
 
                 call.respondText(response.toString())
@@ -773,6 +766,7 @@ abstract class ContentTestSuite<TEngine : ApplicationEngine, TConfiguration : Ap
             {
                 method = HttpMethod.Post
                 headers.append("Content-Length", (Int.MAX_VALUE.toLong() + 1).toString())
+                setBody(ByteArray(1))
             }
         ) {
             assertEquals(200, status.value)

--- a/ktor-server/ktor-server-tests/common/test/io/ktor/tests/server/http/TestEngineMultipartTest.kt
+++ b/ktor-server/ktor-server-tests/common/test/io/ktor/tests/server/http/TestEngineMultipartTest.kt
@@ -62,10 +62,7 @@ class TestEngineMultipartTest {
 
         return testMultiParts({
             assertNotNull(it, "it should be multipart data")
-            val parts = it.readAllParts()
-
-            assertEquals(1, parts.size)
-            val file = parts[0] as PartData.FileItem
+            val file = it.readPart() as PartData.FileItem
 
             assertEquals("fileField", file.name)
             assertEquals("file.bin", file.originalFileName)
@@ -99,7 +96,7 @@ class TestEngineMultipartTest {
         application {
             intercept(ApplicationCallPipeline.Call) {
                 try {
-                    call.receiveMultipart().readAllParts()
+                    call.receiveMultipart().forEachPart { }
                 } catch (error: Throwable) {
                     fail("This pipeline shouldn't finish successfully")
                 }
@@ -210,10 +207,8 @@ class TestEngineMultipartTest {
         extraFileAssertions: suspend (file: PartData.FileItem) -> Unit
     ) = testMultiParts({
         assertNotNull(it, "it should be multipart data")
-        val parts = it.readAllParts()
 
-        assertEquals(1, parts.size)
-        val file = parts[0] as PartData.FileItem
+        val file = it.readPart() as PartData.FileItem
 
         assertEquals("fileField", file.name)
         assertEquals(filename, file.originalFileName)

--- a/ktor-server/ktor-server-tests/jvm/test/io/ktor/server/http/MultipartServerTest.kt
+++ b/ktor-server/ktor-server-tests/jvm/test/io/ktor/server/http/MultipartServerTest.kt
@@ -2,7 +2,7 @@
  * Copyright 2014-2024 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
-package io.ktor.tests.server.http
+package io.ktor.server.http
 
 import io.ktor.client.request.*
 import io.ktor.client.request.forms.*
@@ -13,18 +13,20 @@ import io.ktor.server.request.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
 import io.ktor.server.testing.*
+import io.ktor.tests.server.http.*
 import io.ktor.util.cio.*
 import io.ktor.utils.io.*
-import io.ktor.utils.io.charsets.*
-import kotlinx.coroutines.*
-import kotlinx.io.*
+import io.ktor.utils.io.charsets.Charsets
+import kotlinx.coroutines.withTimeout
+import kotlinx.io.Buffer
+import kotlin.io.use
 import kotlin.test.*
-import kotlin.time.*
 import kotlin.time.Duration.Companion.seconds
+import kotlin.time.measureTime
 
 private const val TEST_FILE_SIZE = 1_000_000
 
-// TODO This does not work with the WASM target
+// TODO Only works in JVM
 class MultipartServerTest {
 
     private val fileDispositionHeaders = Headers.build {
@@ -136,10 +138,13 @@ class MultipartServerTest {
                         when (it) {
                             is PartData.FileItem ->
                                 it.provider().copyTo(this)
+
                             is PartData.BinaryChannelItem ->
                                 it.provider().copyTo(this)
+
                             is PartData.BinaryItem ->
                                 writeBuffer(it.provider())
+
                             is PartData.FormItem ->
                                 writeString(it.value)
                         }

--- a/ktor-server/ktor-server-tests/jvmAndNix/test/io/ktor/tests/server/http/MultipartServerTest.kt
+++ b/ktor-server/ktor-server-tests/jvmAndNix/test/io/ktor/tests/server/http/MultipartServerTest.kt
@@ -95,21 +95,33 @@ class MultipartServerTest {
 
         withTimeout(5.seconds) {
             client.post("/") {
-                setBody(MultiPartFormDataContent(formData {
-                    append("payload", "a".repeat(1000), Headers.build {
-                        append(HttpHeaders.ContentType, ContentType.Application.Json.toString())
-                    })
-                    val provider = ChannelProvider(bytes.size.toLong()) {
-                        ByteReadChannel(bytes)
-                    }
-                    append("file", provider, Headers.build {
-                        append(
-                            HttpHeaders.ContentType,
-                            ContentType.Application.OctetStream.toString()
-                        )
-                        append(HttpHeaders.ContentDisposition, "filename=some.txt")
-                    })
-                }))
+                setBody(
+                    MultiPartFormDataContent(
+                        formData {
+                            append(
+                                "payload",
+                                "a".repeat(1000),
+                                Headers.build {
+                                    append(HttpHeaders.ContentType, ContentType.Application.Json.toString())
+                                }
+                            )
+                            val provider = ChannelProvider(bytes.size.toLong()) {
+                                ByteReadChannel(bytes)
+                            }
+                            append(
+                                "file",
+                                provider,
+                                Headers.build {
+                                    append(
+                                        HttpHeaders.ContentType,
+                                        ContentType.Application.OctetStream.toString()
+                                    )
+                                    append(HttpHeaders.ContentDisposition, "filename=some.txt")
+                                }
+                            )
+                        }
+                    )
+                )
             }
         }
     }


### PR DESCRIPTION
**Subsystem**
Server, I/O

**Motivation**
[KTOR-7500](https://youtrack.jetbrains.com/issue/KTOR-7500) MultiPartData.readPart does not return null when stream ends

**Solution**
Introduce a reference to the previous part to automatically dispose.  This is necessary because of a change in 3.0 to use `ByteReadChannel` for file data, which is required for streaming the body properly.

Note: this will make it so you can't read the parts out of order, though I don't think that makes sense or was officially supported in any way before.