### PR TITLE
Improve Jetty server initializing for customization

### DIFF
--- a/ktor-server/ktor-server-jetty/jvm/src/io/ktor/server/jetty/JettyApplicationEngineBase.kt
+++ b/ktor-server/ktor-server-jetty/jvm/src/io/ktor/server/jetty/JettyApplicationEngineBase.kt
@@ -48,8 +48,8 @@ public open class JettyApplicationEngineBase(
      * Jetty server instance being configuring and starting
      */
     protected val server: Server = Server().apply {
-        configuration.configureServer(this)
         initializeServer(configuration)
+        configuration.configureServer(this)
     }
 
     override fun start(wait: Boolean): JettyApplicationEngineBase {


### PR DESCRIPTION
Improve the ordering of the Jetty server initization so the configureServer step can configure the connections added by the server initializer

**Subsystem**
Ktor Server, Jetty Engine

**Motivation**
There is currently only limited means to customise the server created by the ktor server initializer.
Any logic in the `configuration.configureServer` block will always see 0 connections on the server. Whilst this is fine for adding custom connections it does not give any capacity to refine the configuration of the Jetty server connections created by Ktor.

It is possible to get the configured connections on the Jetty server, if the configure server block is executed after `initializeServer()`.

**Solution**
Switch the ordering of the `configuration.configureServer` invocation so the ktor created connections are visible.

