### PR TITLE
KTOR-7483 Allow auth header when client is not shared

### DIFF
--- a/ktor-client/ktor-client-core/api/ktor-client-core.api
+++ b/ktor-client/ktor-client-core/api/ktor-client-core.api
@@ -598,7 +598,7 @@ public final class io/ktor/client/plugins/api/TransformResponseBodyContext {
 
 public final class io/ktor/client/plugins/cache/HttpCache {
 	public static final field Companion Lio/ktor/client/plugins/cache/HttpCache$Companion;
-	public synthetic fun <init> (Lio/ktor/client/plugins/cache/storage/HttpCacheStorage;Lio/ktor/client/plugins/cache/storage/HttpCacheStorage;Lio/ktor/client/plugins/cache/storage/CacheStorage;Lio/ktor/client/plugins/cache/storage/CacheStorage;ZZZLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Lio/ktor/client/plugins/cache/storage/HttpCacheStorage;Lio/ktor/client/plugins/cache/storage/HttpCacheStorage;Lio/ktor/client/plugins/cache/storage/CacheStorage;Lio/ktor/client/plugins/cache/storage/CacheStorage;ZZLkotlin/jvm/internal/DefaultConstructorMarker;)V
 }
 
 public final class io/ktor/client/plugins/cache/HttpCache$Companion : io/ktor/client/plugins/HttpClientPlugin {
@@ -612,13 +612,11 @@ public final class io/ktor/client/plugins/cache/HttpCache$Companion : io/ktor/cl
 
 public final class io/ktor/client/plugins/cache/HttpCache$Config {
 	public fun <init> ()V
-	public final fun getCacheRequestWithAuth ()Z
 	public final fun getPrivateStorage ()Lio/ktor/client/plugins/cache/storage/HttpCacheStorage;
 	public final fun getPublicStorage ()Lio/ktor/client/plugins/cache/storage/HttpCacheStorage;
 	public final fun isShared ()Z
 	public final fun privateStorage (Lio/ktor/client/plugins/cache/storage/CacheStorage;)V
 	public final fun publicStorage (Lio/ktor/client/plugins/cache/storage/CacheStorage;)V
-	public final fun setCacheRequestWithAuth (Z)V
 	public final fun setPrivateStorage (Lio/ktor/client/plugins/cache/storage/HttpCacheStorage;)V
 	public final fun setPublicStorage (Lio/ktor/client/plugins/cache/storage/HttpCacheStorage;)V
 	public final fun setShared (Z)V

--- a/ktor-client/ktor-client-core/api/ktor-client-core.klib.api
+++ b/ktor-client/ktor-client-core/api/ktor-client-core.klib.api
@@ -333,9 +333,6 @@ final class io.ktor.client.plugins.cache/HttpCache { // io.ktor.client.plugins.c
     final class Config { // io.ktor.client.plugins.cache/HttpCache.Config|null[0]
         constructor <init>() // io.ktor.client.plugins.cache/HttpCache.Config.<init>|<init>(){}[0]
 
-        final var cacheRequestWithAuth // io.ktor.client.plugins.cache/HttpCache.Config.cacheRequestWithAuth|{}cacheRequestWithAuth[0]
-            final fun <get-cacheRequestWithAuth>(): kotlin/Boolean // io.ktor.client.plugins.cache/HttpCache.Config.cacheRequestWithAuth.<get-cacheRequestWithAuth>|<get-cacheRequestWithAuth>(){}[0]
-            final fun <set-cacheRequestWithAuth>(kotlin/Boolean) // io.ktor.client.plugins.cache/HttpCache.Config.cacheRequestWithAuth.<set-cacheRequestWithAuth>|<set-cacheRequestWithAuth>(kotlin.Boolean){}[0]
         final var isShared // io.ktor.client.plugins.cache/HttpCache.Config.isShared|{}isShared[0]
             final fun <get-isShared>(): kotlin/Boolean // io.ktor.client.plugins.cache/HttpCache.Config.isShared.<get-isShared>|<get-isShared>(){}[0]
             final fun <set-isShared>(kotlin/Boolean) // io.ktor.client.plugins.cache/HttpCache.Config.isShared.<set-isShared>|<set-isShared>(kotlin.Boolean){}[0]

--- a/ktor-client/ktor-client-core/jvm/test/HttpCacheTest.kt
+++ b/ktor-client/ktor-client-core/jvm/test/HttpCacheTest.kt
@@ -70,7 +70,7 @@ class HttpCacheTest {
     }
 
     @Test
-    fun `should mix ETags when Authorization header is present and flag enabled`() = testApplication {
+    fun `should mix ETags when Authorization header is present and client is not shared`() = testApplication {
         application {
             routing {
                 get("/me") {
@@ -92,11 +92,7 @@ class HttpCacheTest {
         }
 
         val client = createClient {
-            install(HttpCache) {
-                isShared = true
-                @Suppress("DEPRECATION")
-                cacheRequestWithAuth = true
-            }
+            install(HttpCache)
         }
 
         assertEquals(


### PR DESCRIPTION
Fix [KTOR-7483](https://youtrack.jetbrains.com/issue/KTOR-7483) HttpCache: Cache collision in the plugin when Authorization header is used [ZD-6809850]