### PR TITLE
KTOR-7540 Turn TypeInfo.reifiedType into an extension-property

### DIFF
--- a/ktor-client/ktor-client-plugins/ktor-client-json/ktor-client-gson/jvm/src/io/ktor/client/plugins/gson/GsonSerializer.kt
+++ b/ktor-client/ktor-client-plugins/ktor-client-json/ktor-client-gson/jvm/src/io/ktor/client/plugins/gson/GsonSerializer.kt
@@ -1,7 +1,7 @@
 /*
  * Copyright 2014-2024 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
-@file:Suppress("DEPRECATION", "DEPRECATION_ERROR")
+@file:Suppress("DEPRECATION_ERROR")
 
 package io.ktor.client.plugins.gson
 

--- a/ktor-server/ktor-server-core/common/src/io/ktor/server/util/Parameters.kt
+++ b/ktor-server/ktor-server-core/common/src/io/ktor/server/util/Parameters.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2021 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2014-2024 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package io.ktor.server.util
@@ -41,12 +41,11 @@ public inline fun Parameters.getOrFail(name: String): String {
 }
 
 /**
- * Get parameters value associated with this [name] converting to type [R] using [DefaultConversionService]
+ * Get parameter value associated with this [name] converting to type [R] using [DefaultConversionService]
  * or fail with [MissingRequestParameterException]
  * @throws MissingRequestParameterException if no values associated with this [name]
  * @throws ParameterConversionException when conversion from String to [R] fails
  */
-@OptIn(ExperimentalStdlibApi::class)
 public inline fun <reified R : Any> Parameters.getOrFail(name: String): R {
     return getOrFailImpl(name, typeInfo<R>())
 }

--- a/ktor-utils/api/ktor-utils.api
+++ b/ktor-utils/api/ktor-utils.api
@@ -1005,9 +1005,9 @@ public final class io/ktor/util/reflect/TypeInfo {
 	public fun <init> (Lkotlin/reflect/KClass;Ljava/lang/reflect/Type;Lkotlin/reflect/KType;)V
 	public synthetic fun <init> (Lkotlin/reflect/KClass;Ljava/lang/reflect/Type;Lkotlin/reflect/KType;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun <init> (Lkotlin/reflect/KClass;Lkotlin/reflect/KType;)V
+	public synthetic fun <init> (Lkotlin/reflect/KClass;Lkotlin/reflect/KType;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getKotlinType ()Lkotlin/reflect/KType;
-	public final fun getReifiedType ()Ljava/lang/reflect/Type;
 	public final fun getType ()Lkotlin/reflect/KClass;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
@@ -1015,6 +1015,7 @@ public final class io/ktor/util/reflect/TypeInfo {
 
 public final class io/ktor/util/reflect/TypeInfoJvmKt {
 	public static final fun getPlatformType (Lkotlin/reflect/KType;)Ljava/lang/reflect/Type;
+	public static final fun getReifiedType (Lio/ktor/util/reflect/TypeInfo;)Ljava/lang/reflect/Type;
 	public static final fun instanceOf (Ljava/lang/Object;Lkotlin/reflect/KClass;)Z
 	public static final fun typeInfoImpl (Ljava/lang/reflect/Type;Lkotlin/reflect/KClass;Lkotlin/reflect/KType;)Lio/ktor/util/reflect/TypeInfo;
 }

--- a/ktor-utils/api/ktor-utils.klib.api
+++ b/ktor-utils/api/ktor-utils.klib.api
@@ -493,16 +493,10 @@ final class io.ktor.util.pipeline/PipelinePhase { // io.ktor.util.pipeline/Pipel
 }
 
 final class io.ktor.util.reflect/TypeInfo { // io.ktor.util.reflect/TypeInfo|null[0]
-    constructor <init>(kotlin.reflect/KClass<*>, kotlin.reflect/KType) // io.ktor.util.reflect/TypeInfo.<init>|<init>(kotlin.reflect.KClass<*>;kotlin.reflect.KType){}[0]
+    constructor <init>(kotlin.reflect/KClass<*>, kotlin.reflect/KType? = ...) // io.ktor.util.reflect/TypeInfo.<init>|<init>(kotlin.reflect.KClass<*>;kotlin.reflect.KType?){}[0]
 
     final val kotlinType // io.ktor.util.reflect/TypeInfo.kotlinType|{}kotlinType[0]
         final fun <get-kotlinType>(): kotlin.reflect/KType? // io.ktor.util.reflect/TypeInfo.kotlinType.<get-kotlinType>|<get-kotlinType>(){}[0]
-    final val reifiedType // io.ktor.util.reflect/TypeInfo.reifiedType|{}reifiedType[0]
-        // Targets: [native]
-        final fun <get-reifiedType>(): kotlin.reflect/KType // io.ktor.util.reflect/TypeInfo.reifiedType.<get-reifiedType>|<get-reifiedType>(){}[0]
-
-        // Targets: [js, wasmJs]
-        final fun <get-reifiedType>(): io.ktor.util.reflect/Type // io.ktor.util.reflect/TypeInfo.reifiedType.<get-reifiedType>|<get-reifiedType>(){}[0]
     final val type // io.ktor.util.reflect/TypeInfo.type|{}type[0]
         final fun <get-type>(): kotlin.reflect/KClass<*> // io.ktor.util.reflect/TypeInfo.type.<get-type>|<get-type>(){}[0]
 

--- a/ktor-utils/common/src/io/ktor/util/reflect/Type.kt
+++ b/ktor-utils/common/src/io/ktor/util/reflect/Type.kt
@@ -9,27 +9,30 @@ import kotlin.reflect.*
 /**
  * Information about type.
  */
+@Deprecated("Not used anymore in common code as it was needed only for JVM target.")
 public expect interface Type
 
+@Suppress("DEPRECATION")
+@Deprecated("Not used anymore in common code as it was needed only for JVM target.")
 public expect val KType.platformType: Type
 
 /**
  * Ktor type information.
  * @property type Source KClass<*>
- * @property reifiedType Type with substituted generics
  * @property kotlinType Kotlin reified type with all generic type parameters.
  */
 public class TypeInfo(
     public val type: KClass<*>,
-    public val reifiedType: Type,
     public val kotlinType: KType? = null
 ) {
 
-    public constructor(type: KClass<*>, kotlinType: KType) : this(
-        type = type,
-        reifiedType = kotlinType.platformType,
-        kotlinType = kotlinType,
-    )
+    @Suppress("UNUSED_PARAMETER", "DEPRECATION")
+    @Deprecated("Use constructor without reifiedType parameter.", ReplaceWith("TypeInfo(type, kotlinType)"))
+    public constructor(
+        type: KClass<*>,
+        reifiedType: Type,
+        kotlinType: KType? = null,
+    ) : this(type, kotlinType)
 
     override fun hashCode(): Int {
         return kotlinType?.hashCode() ?: type.hashCode()
@@ -52,7 +55,7 @@ public class TypeInfo(
 /**
  * Returns [TypeInfo] for the specified type [T]
  */
-public expect inline fun <reified T> typeInfo(): TypeInfo
+public inline fun <reified T> typeInfo(): TypeInfo = TypeInfo(T::class, typeOfOrNull<T>())
 
 /**
  * Check [this] is instance of [type].

--- a/ktor-utils/jsAndWasmShared/src/io/ktor/util/reflect/TypeInfoJs.kt
+++ b/ktor-utils/jsAndWasmShared/src/io/ktor/util/reflect/TypeInfoJs.kt
@@ -6,20 +6,23 @@ package io.ktor.util.reflect
 
 import kotlin.reflect.*
 
+@Deprecated("Not used anymore in common code as it was effective only on JVM target.")
 public actual interface Type
 
+@Suppress("DEPRECATION")
+@Deprecated("Not used anymore in common code as it was effective only on JVM target.")
 public object JsType : Type
 
-public actual inline fun <reified T> typeInfo(): TypeInfo = TypeInfo(T::class, JsType, typeOfOrNull<T>())
-
-@Deprecated("Use TypeInfo constructor instead.", ReplaceWith("TypeInfo(kClass, reifiedType, kType)"))
-public fun typeInfoImpl(reifiedType: Type, kClass: KClass<*>, kType: KType?): TypeInfo =
-    TypeInfo(kClass, reifiedType, kType)
+@Suppress("DEPRECATION")
+@Deprecated("Use TypeInfo constructor instead.", ReplaceWith("TypeInfo(kClass, kType)"))
+public fun typeInfoImpl(reifiedType: Type, kClass: KClass<*>, kType: KType?): TypeInfo = TypeInfo(kClass, kType)
 
 /**
  * Check [this] is instance of [type].
  */
 public actual fun Any.instanceOf(type: KClass<*>): Boolean = type.isInstance(this)
 
+@Suppress("DEPRECATION", "DeprecatedCallableAddReplaceWith")
+@Deprecated("Not used anymore in common code as it was effective only on JVM target.")
 public actual val KType.platformType: Type
     get() = JsType

--- a/ktor-utils/jvm/src/io/ktor/util/reflect/TypeInfoJvm.kt
+++ b/ktor-utils/jvm/src/io/ktor/util/reflect/TypeInfoJvm.kt
@@ -6,30 +6,27 @@ package io.ktor.util.reflect
 
 import kotlin.reflect.*
 
+@Deprecated("Not used anymore in common code as it was needed only for JVM target.")
 public actual typealias Type = java.lang.reflect.Type
 
+/** Type with substituted generics. */
 @OptIn(ExperimentalStdlibApi::class)
-public actual inline fun <reified T> typeInfo(): TypeInfo {
-    val kType = typeOfOrNull<T>()
-    val reifiedType = try {
-        // kType != null always returns false, so we try to get javaType anyway
-        kType!!.javaType
-    } catch (_: NullPointerException) {
-        // Fallback to a type without generics if we can't get KType for the given T
-        T::class.java
-    }
-    return TypeInfo(T::class, reifiedType, kType)
-}
+public val TypeInfo.reifiedType: java.lang.reflect.Type
+    // Fallback to a type without generics if we couldn't get KType.
+    // For example, when class signature was stripped by ProGuard/R8
+    get() = kotlinType?.javaType ?: type.java
 
-@Deprecated("Use TypeInfo constructor instead.", ReplaceWith("TypeInfo(kClass, reifiedType, kType)"))
-public fun typeInfoImpl(reifiedType: Type, kClass: KClass<*>, kType: KType?): TypeInfo =
-    TypeInfo(kClass, reifiedType, kType)
+@Suppress("DEPRECATION")
+@Deprecated("Use TypeInfo constructor instead.", ReplaceWith("TypeInfo(kClass, kType)"))
+public fun typeInfoImpl(reifiedType: Type, kClass: KClass<*>, kType: KType?): TypeInfo = TypeInfo(kClass, kType)
 
 /**
  * Check [this] is instance of [type].
  */
 public actual fun Any.instanceOf(type: KClass<*>): Boolean = type.java.isInstance(this)
 
+@Suppress("DEPRECATION")
+@Deprecated("Use KType.javaType instead.", ReplaceWith("this.javaType", "kotlin.reflect.javaType"))
 @OptIn(ExperimentalStdlibApi::class)
 public actual val KType.platformType: Type
     get() = javaType

--- a/ktor-utils/posix/src/io/ktor/util/reflect/TypeInfoNative.kt
+++ b/ktor-utils/posix/src/io/ktor/util/reflect/TypeInfoNative.kt
@@ -6,19 +6,19 @@ package io.ktor.util.reflect
 
 import kotlin.reflect.*
 
+@Deprecated("Use KType instead.")
 public actual typealias Type = KType
 
-public actual inline fun <reified T> typeInfo(): TypeInfo = TypeInfo(T::class, typeOf<T>())
-
-@Suppress("unused")
+@Suppress("unused", "UNUSED_PARAMETER", "DEPRECATION")
 @Deprecated("Maintained for binary compatibility.", level = DeprecationLevel.HIDDEN)
-internal fun typeInfoImpl(reifiedType: Type, kClass: KClass<*>, kType: KType): TypeInfo =
-    TypeInfo(kClass, reifiedType, kType)
+internal fun typeInfoImpl(reifiedType: Type, kClass: KClass<*>, kType: KType): TypeInfo = TypeInfo(kClass, kType)
 
 /**
  * Check [this] is instance of [type].
  */
 public actual fun Any.instanceOf(type: KClass<*>): Boolean = type.isInstance(this)
 
+@Suppress("DEPRECATION")
+@Deprecated("Use KType directly instead.", ReplaceWith("this"))
 public actual val KType.platformType: Type
     get() = this


### PR DESCRIPTION
**Subsystem**
`ktor-utils`

**Motivation**
[KTOR-7540](https://youtrack.jetbrains.com/issue/KTOR-7540/Remove-reflection-utils-used-only-on-JVM-target-from-common-source-set) - JVM-specific field `reifiedType` has leaked into the common source set

**Solution**
Remove the field from `TypeInfo` and provide an extension property only for the JVM target.