### PR TITLE
KTOR-7543 Fix a couple backwards compatibility issues in 3.0

### DIFF
--- a/ktor-server/ktor-server-core/api/ktor-server-core.api
+++ b/ktor-server/ktor-server-core/api/ktor-server-core.api
@@ -153,6 +153,7 @@ public final class io/ktor/server/application/PipelineCall$DefaultImpls {
 }
 
 public final class io/ktor/server/application/PipelineCallKt {
+	public static final fun getCall (Lio/ktor/util/pipeline/PipelineContext;)Lio/ktor/server/application/ApplicationCall;
 	public static final fun getReceiveType (Lio/ktor/server/application/ApplicationCall;)Lio/ktor/util/reflect/TypeInfo;
 	public static final fun isHandled (Lio/ktor/server/application/ApplicationCall;)Z
 }
@@ -1658,7 +1659,6 @@ public final class io/ktor/server/routing/RoutingCall : io/ktor/server/applicati
 
 public final class io/ktor/server/routing/RoutingContext {
 	public fun <init> (Lio/ktor/server/routing/RoutingCall;)V
-	public final fun getApplication ()Lio/ktor/server/application/Application;
 	public final fun getCall ()Lio/ktor/server/routing/RoutingCall;
 }
 

--- a/ktor-server/ktor-server-core/api/ktor-server-core.klib.api
+++ b/ktor-server/ktor-server-core/api/ktor-server-core.klib.api
@@ -1033,8 +1033,6 @@ final class io.ktor.server.routing/RoutingCall : io.ktor.server.application/Appl
 final class io.ktor.server.routing/RoutingContext { // io.ktor.server.routing/RoutingContext|null[0]
     constructor <init>(io.ktor.server.routing/RoutingCall) // io.ktor.server.routing/RoutingContext.<init>|<init>(io.ktor.server.routing.RoutingCall){}[0]
 
-    final val application // io.ktor.server.routing/RoutingContext.application|{}application[0]
-        final fun <get-application>(): io.ktor.server.application/Application // io.ktor.server.routing/RoutingContext.application.<get-application>|<get-application>(){}[0]
     final val call // io.ktor.server.routing/RoutingContext.call|{}call[0]
         final fun <get-call>(): io.ktor.server.routing/RoutingCall // io.ktor.server.routing/RoutingContext.call.<get-call>|<get-call>(){}[0]
 }
@@ -1619,6 +1617,8 @@ final val io.ktor.server.application/ServerReady // io.ktor.server.application/S
     final fun <get-ServerReady>(): io.ktor.events/EventDefinition<io.ktor.server.application/ApplicationEnvironment> // io.ktor.server.application/ServerReady.<get-ServerReady>|<get-ServerReady>(){}[0]
 final val io.ktor.server.application/application // io.ktor.server.application/application|@io.ktor.util.pipeline.PipelineContext<*,io.ktor.server.application.PipelineCall>{}application[0]
     final fun (io.ktor.util.pipeline/PipelineContext<*, io.ktor.server.application/PipelineCall>).<get-application>(): io.ktor.server.application/Application // io.ktor.server.application/application.<get-application>|<get-application>@io.ktor.util.pipeline.PipelineContext<*,io.ktor.server.application.PipelineCall>(){}[0]
+final val io.ktor.server.application/call // io.ktor.server.application/call|@io.ktor.util.pipeline.PipelineContext<*,0:0>{0§<io.ktor.server.application.ApplicationCall>}call[0]
+    final fun <#A1: io.ktor.server.application/ApplicationCall> (io.ktor.util.pipeline/PipelineContext<*, #A1>).<get-call>(): #A1 // io.ktor.server.application/call.<get-call>|<get-call>@io.ktor.util.pipeline.PipelineContext<*,0:0>(){0§<io.ktor.server.application.ApplicationCall>}[0]
 final val io.ktor.server.application/call // io.ktor.server.application/call|@io.ktor.util.pipeline.PipelineContext<*,io.ktor.server.application.PipelineCall>{}call[0]
     final inline fun (io.ktor.util.pipeline/PipelineContext<*, io.ktor.server.application/PipelineCall>).<get-call>(): io.ktor.server.application/PipelineCall // io.ktor.server.application/call.<get-call>|<get-call>@io.ktor.util.pipeline.PipelineContext<*,io.ktor.server.application.PipelineCall>(){}[0]
 final val io.ktor.server.application/host // io.ktor.server.application/host|@io.ktor.server.config.ApplicationConfig{}host[0]

--- a/ktor-server/ktor-server-core/common/src/io/ktor/server/application/PipelineCall.kt
+++ b/ktor-server/ktor-server-core/common/src/io/ktor/server/application/PipelineCall.kt
@@ -10,6 +10,7 @@ import io.ktor.server.plugins.*
 import io.ktor.server.request.*
 import io.ktor.server.response.*
 import io.ktor.util.*
+import io.ktor.util.pipeline.*
 import io.ktor.util.reflect.*
 import io.ktor.utils.io.*
 import kotlinx.coroutines.*
@@ -119,3 +120,8 @@ public var ApplicationCall.receiveType: TypeInfo
     internal set(value) {
         attributes.put(RECEIVE_TYPE_KEY, value)
     }
+
+/**
+ * Convenience extension property for pipeline interceptors with Application call contexts.
+ */
+public val <C : ApplicationCall> PipelineContext<*, C>.call: C get() = context

--- a/ktor-server/ktor-server-core/common/src/io/ktor/server/routing/RoutingNode.kt
+++ b/ktor-server/ktor-server-core/common/src/io/ktor/server/routing/RoutingNode.kt
@@ -12,6 +12,7 @@ import io.ktor.util.*
 import io.ktor.util.pipeline.*
 import io.ktor.util.reflect.*
 import io.ktor.utils.io.*
+import kotlinx.coroutines.*
 import kotlin.coroutines.*
 
 /**
@@ -234,7 +235,7 @@ public class RoutingCall internal constructor(
  */
 public class RoutingContext(
     public val call: RoutingCall
-) {
+): CoroutineScope by call {
     public val application: Application
         get() = call.application
 }

--- a/ktor-server/ktor-server-core/common/src/io/ktor/server/routing/RoutingNode.kt
+++ b/ktor-server/ktor-server-core/common/src/io/ktor/server/routing/RoutingNode.kt
@@ -235,10 +235,7 @@ public class RoutingCall internal constructor(
  */
 public class RoutingContext(
     public val call: RoutingCall
-): CoroutineScope by call {
-    public val application: Application
-        get() = call.application
-}
+)
 
 /**
  * A function that handles a [RoutingCall].


### PR DESCRIPTION
**Subsystem**
Server, Routing

**Motivation**
[KTOR-7543](https://youtrack.jetbrains.com/issue/KTOR-7543) Common backwards compatibility problems for 3.0

These are a couple of items that are tough to solve with structural replacement, and I've found are very common in projects.

**Solution**
- Added coroutine scope to RoutingContext so that `launch` references don't break.
- Added property alias through an extension for `call`, which is generally always used for interceptors - this only applies to pipeline contexts where the context extends `ApplicationCall`

