### PR TITLE
KTOR-6803 Use last resolved address to release connection

### DIFF
--- a/ktor-client/ktor-client-cio/build.gradle.kts
+++ b/ktor-client/ktor-client-cio/build.gradle.kts
@@ -1,3 +1,7 @@
+/*
+ * Copyright 2014-2024 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
 description = "CIO backend for ktor http client"
 
 apply<test.server.TestServerPlugin>()
@@ -21,6 +25,7 @@ kotlin {
             dependencies {
                 api(project(":ktor-network:ktor-network-tls:ktor-network-tls-certificates"))
                 api(project(":ktor-shared:ktor-junit"))
+                implementation(libs.mockk)
             }
         }
     }

--- a/ktor-client/ktor-client-cio/jvm/test/io/ktor/client/engine/cio/CIORequestTest.kt
+++ b/ktor-client/ktor-client-cio/jvm/test/io/ktor/client/engine/cio/CIORequestTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2014-2024 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package io.ktor.client.engine.cio
@@ -16,12 +16,12 @@ import io.ktor.server.engine.*
 import io.ktor.server.netty.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
+import io.mockk.*
 import kotlinx.coroutines.*
 import kotlinx.coroutines.debug.junit5.*
+import java.net.*
 import java.nio.channels.*
 import kotlin.test.*
-import kotlin.test.Ignore
-import kotlin.test.Test
 
 @CoroutinesTimeout(60_000)
 class CIORequestTest : TestWithKtor() {
@@ -156,6 +156,16 @@ class CIORequestTest : TestWithKtor() {
             assertNotNull(fail)
             if (fail !is ConnectTimeoutException && fail !is UnresolvedAddressException) {
                 fail("Expected ConnectTimeoutException or UnresolvedAddressException, got $fail", fail)
+            }
+        }
+    }
+
+    @Test
+    fun testInetAddressRetrievedOnce() = testWithEngine(CIO) {
+        test { client ->
+            mockkStatic(InetAddress::getByName) {
+                client.prepareGet { url(path = "/echo", port = serverPort) }.execute()
+                verify(exactly = 1) { InetAddress.getByName(any()) }
             }
         }
     }

--- a/ktor-client/ktor-client-cio/jvmAndPosix/src/io/ktor/client/engine/cio/CIOEngine.kt
+++ b/ktor-client/ktor-client-cio/jvmAndPosix/src/io/ktor/client/engine/cio/CIOEngine.kt
@@ -1,6 +1,6 @@
 /*
-* Copyright 2014-2021 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
-*/
+ * Copyright 2014-2024 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
 
 package io.ktor.client.engine.cio
 
@@ -80,7 +80,7 @@ internal class CIOEngine(
 
             try {
                 return endpoint.execute(data, callContext)
-            } catch (cause: ClosedSendChannelException) {
+            } catch (_: ClosedSendChannelException) {
                 continue
             } finally {
                 if (!coroutineContext.isActive) {

--- a/ktor-client/ktor-client-core/common/src/io/ktor/client/engine/HttpClientEngine.kt
+++ b/ktor-client/ktor-client-core/common/src/io/ktor/client/engine/HttpClientEngine.kt
@@ -1,6 +1,6 @@
 /*
-* Copyright 2014-2021 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
-*/
+ * Copyright 2014-2024 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
 
 package io.ktor.client.engine
 
@@ -10,7 +10,6 @@ import io.ktor.client.request.*
 import io.ktor.client.utils.*
 import io.ktor.http.*
 import io.ktor.util.*
-import io.ktor.util.pipeline.*
 import io.ktor.utils.io.*
 import io.ktor.utils.io.core.*
 import kotlinx.coroutines.*


### PR DESCRIPTION
**Subsystem**
Client/Server, related modules

**Motivation**
[KTOR-6803](https://youtrack.jetbrains.com/issue/KTOR-6803) CIO: Requests face connection timeouts when executed on the Android main dispatcher

**Solution**
The problem was caused by a second address resolution performed in `releaseConnection()`. If something happens during this resolution (an exception is thrown or the resolved address differs from the first one), we never release a connection. 

