### PR TITLE
KTOR-7571 byte read channel cpu lock

### DIFF
--- a/ktor-io/common/src/io/ktor/utils/io/ByteReadChannelOperations.kt
+++ b/ktor-io/common/src/io/ktor/utils/io/ByteReadChannelOperations.kt
@@ -70,7 +70,7 @@ public suspend fun ByteReadChannel.readLong(): Long {
 }
 
 private suspend fun ByteReadChannel.awaitUntilReadable(numberOfBytes: Int) {
-    while (availableForRead < numberOfBytes && awaitContent()) {
+    while (availableForRead < numberOfBytes && awaitContent(numberOfBytes)) {
     }
 
     if (availableForRead < numberOfBytes) throw EOFException("Not enough data available")

--- a/ktor-io/common/src/io/ktor/utils/io/ByteReadChannelOperations.kt
+++ b/ktor-io/common/src/io/ktor/utils/io/ByteReadChannelOperations.kt
@@ -71,6 +71,7 @@ public suspend fun ByteReadChannel.readLong(): Long {
 
 private suspend fun ByteReadChannel.awaitUntilReadable(numberOfBytes: Int) {
     while (availableForRead < numberOfBytes && awaitContent(numberOfBytes)) {
+        yield()
     }
 
     if (availableForRead < numberOfBytes) throw EOFException("Not enough data available")

--- a/ktor-io/common/src/io/ktor/utils/io/ByteReadChannelOperations.kt
+++ b/ktor-io/common/src/io/ktor/utils/io/ByteReadChannelOperations.kt
@@ -53,31 +53,27 @@ public suspend fun ByteReadChannel.readByte(): Byte {
 
 @OptIn(InternalAPI::class)
 public suspend fun ByteReadChannel.readShort(): Short {
-    while (availableForRead < 2 && awaitContent()) {
-    }
-
-    if (availableForRead < 2) throw EOFException("Not enough data available")
-
+    awaitUntilReadable(Short.SIZE_BYTES)
     return readBuffer.readShort()
 }
 
 @OptIn(InternalAPI::class)
 public suspend fun ByteReadChannel.readInt(): Int {
-    while (availableForRead < 4 && awaitContent()) {
-    }
-
-    if (availableForRead < 4) throw EOFException("Not enough data available")
-
+    awaitUntilReadable(Int.SIZE_BYTES)
     return readBuffer.readInt()
 }
 
 @OptIn(InternalAPI::class)
 public suspend fun ByteReadChannel.readLong(): Long {
-    while (availableForRead < 8 && awaitContent()) {
+    awaitUntilReadable(Long.SIZE_BYTES)
+    return readBuffer.readLong()
+}
+
+private suspend fun ByteReadChannel.awaitUntilReadable(numberOfBytes: Int) {
+    while (availableForRead < numberOfBytes && awaitContent()) {
     }
 
-    if (availableForRead < 8) throw EOFException("Not enough data available")
-    return readBuffer.readLong()
+    if (availableForRead < numberOfBytes) throw EOFException("Not enough data available")
 }
 
 @OptIn(InternalAPI::class)

--- a/ktor-io/jvm/test/ByteReadChannelOperationsJvmTest.kt
+++ b/ktor-io/jvm/test/ByteReadChannelOperationsJvmTest.kt
@@ -33,4 +33,46 @@ class ByteReadChannelOperationsJvmTest {
         channel.close()
         assertEquals(-1, channel.readAvailable { buffer -> buffer.remaining() })
     }
+
+    @Test
+    fun testReadShortIsCooperative() = runBlocking {
+        val theAnswerAsBytes: ByteArray = byteArrayOf(0, 42)
+        val channel = ByteChannel()
+        launch {
+            for (byte in theAnswerAsBytes) {
+                delay(10)
+                channel.writeByte(byte)
+                channel.flush()
+            }
+        }
+        assertEquals(42, channel.readShort())
+    }
+
+    @Test
+    fun testReadIntIsCooperative() = runBlocking {
+        val theAnswerAsBytes: ByteArray = byteArrayOf(0, 0, 0, 42)
+        val channel = ByteChannel()
+        launch {
+            for (byte in theAnswerAsBytes) {
+                delay(10)
+                channel.writeByte(byte)
+                channel.flush()
+            }
+        }
+        assertEquals(42, channel.readInt())
+    }
+
+    @Test
+    fun testReadLongIsCooperative() = runBlocking {
+        val theAnswerAsBytes: ByteArray = byteArrayOf(0, 0, 0, 0, 0, 0, 0, 42)
+        val channel = ByteChannel()
+        launch {
+            for (byte in theAnswerAsBytes) {
+                delay(10)
+                channel.writeByte(byte)
+                channel.flush()
+            }
+        }
+        assertEquals(42, channel.readLong())
+    }
 }


### PR DESCRIPTION
**Subsystem**
ktor-io

**Motivation**
See [KTOR-7571](https://youtrack.jetbrains.com/issue/KTOR-7571)

**Solution**
This attempts to solve a cpu-bound endless loop by both passing the number of expected bytes to `awaitContent()` and (in case `awaitContent()` doesn't actually suspend like [`SourceByteReadChannel`](https://github.com/ktorio/ktor/blob/c99356f5ea8a202bfaf022a57ab8de0643354e66/ktor-io/common/src/io/ktor/utils/io/SourceByteReadChannel.kt#L28)) to `yield()` to other coroutines between iterations.

