### PR TITLE
KTOR-7583 Enable missing native targets in ktor-serialization-kotlinx-xml

### DIFF
--- a/buildSrc/src/main/kotlin/NativeUtils.kt
+++ b/buildSrc/src/main/kotlin/NativeUtils.kt
@@ -48,8 +48,7 @@ fun Project.watchosTargets(): List<String> = with(kotlin) {
         watchosArm64(),
         watchosSimulatorArm64(),
         // ktor-server-config-yaml: because of dependency on YAML library: https://github.com/Him188/yamlkt/issues/67
-        // ktor-serialization-kotlinx-xml: because of dependency on xmlutil library: https://repo.maven.apache.org/maven2/io/github/pdvrieze/xmlutil/ // ktlint-disable max-line-length
-        if ((project.name != "ktor-server-config-yaml") && (project.name != "ktor-serialization-kotlinx-xml")) {
+        if (project.name != "ktor-server-config-yaml") {
             watchosDeviceArm64()
         } else {
             null

--- a/ktor-shared/ktor-serialization/ktor-serialization-kotlinx/ktor-serialization-kotlinx-xml/api/ktor-serialization-kotlinx-xml.klib.api
+++ b/ktor-shared/ktor-serialization/ktor-serialization-kotlinx/ktor-serialization-kotlinx-xml/api/ktor-serialization-kotlinx-xml.klib.api
@@ -1,5 +1,5 @@
 // Klib ABI Dump
-// Targets: [iosArm64, iosSimulatorArm64, iosX64, js, linuxArm64, linuxX64, macosArm64, macosX64, mingwX64, tvosArm64, tvosSimulatorArm64, tvosX64, wasmJs, watchosArm32, watchosArm64, watchosSimulatorArm64, watchosX64]
+// Targets: [androidNativeArm32, androidNativeArm64, androidNativeX64, androidNativeX86, iosArm64, iosSimulatorArm64, iosX64, js, linuxArm64, linuxX64, macosArm64, macosX64, mingwX64, tvosArm64, tvosSimulatorArm64, tvosX64, wasmJs, watchosArm32, watchosArm64, watchosDeviceArm64, watchosSimulatorArm64, watchosX64]
 // Rendering settings:
 // - Signature version: 2
 // - Show manifest properties: true

--- a/ktor-shared/ktor-serialization/ktor-serialization-kotlinx/ktor-serialization-kotlinx-xml/gradle.properties
+++ b/ktor-shared/ktor-serialization/ktor-serialization-kotlinx/ktor-serialization-kotlinx-xml/gradle.properties
@@ -5,6 +5,3 @@
 # xmlutil uses DOM API under the hood so it doesn't support Node.js.
 # Issue: https://github.com/pdvrieze/xmlutil/issues/83
 target.js.nodeJs=false
-# xmlutil doesn't provide android native targets
-# Issue: https://github.com/pdvrieze/xmlutil/issues/240
-target.androidNative=false


### PR DESCRIPTION
**Subsystem**
Client/Server, `ktor-serialization-kotlinx-xml`

**Motivation**
[KTOR-7583](https://youtrack.jetbrains.com/issue/KTOR-7583) Support missing native targets in ktor-serialization-kotlinx-xml

**Solution**
Enable native targets as we’ve updated xmlutil (https://github.com/ktorio/ktor/pull/4402)
