### PR TITLE
KTOR-6759 Darwin: Throw specific exception for SSL Pinning failure

### DIFF
--- a/ktor-client/ktor-client-darwin/build.gradle.kts
+++ b/ktor-client/ktor-client-darwin/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2024 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2014-2025 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
 plugins {
@@ -12,6 +12,7 @@ kotlin {
         darwinMain {
             dependencies {
                 api(project(":ktor-client:ktor-client-core"))
+                api(project(":ktor-network:ktor-network-tls"))
             }
         }
         darwinTest {

--- a/ktor-client/ktor-client-darwin/darwin/src/io/ktor/client/engine/darwin/DarwinUtils.kt
+++ b/ktor-client/ktor-client-darwin/darwin/src/io/ktor/client/engine/darwin/DarwinUtils.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2014-2024 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package io.ktor.client.engine.darwin
@@ -8,7 +8,6 @@ import io.ktor.client.call.*
 import io.ktor.client.engine.*
 import io.ktor.http.content.*
 import io.ktor.utils.io.*
-import io.ktor.utils.io.errors.*
 import kotlinx.cinterop.*
 import kotlinx.coroutines.*
 import kotlinx.io.IOException

--- a/ktor-client/ktor-client-darwin/darwin/src/io/ktor/client/engine/darwin/certificates/CertificatePinner.kt
+++ b/ktor-client/ktor-client-darwin/darwin/src/io/ktor/client/engine/darwin/certificates/CertificatePinner.kt
@@ -6,8 +6,13 @@ package io.ktor.client.engine.darwin.certificates
 
 import io.ktor.client.engine.darwin.*
 import kotlinx.cinterop.*
-import platform.CoreCrypto.*
-import platform.CoreFoundation.*
+import platform.CoreCrypto.CC_SHA1
+import platform.CoreCrypto.CC_SHA1_DIGEST_LENGTH
+import platform.CoreCrypto.CC_SHA256
+import platform.CoreCrypto.CC_SHA256_DIGEST_LENGTH
+import platform.CoreFoundation.CFDictionaryGetValue
+import platform.CoreFoundation.CFStringCreateWithCString
+import platform.CoreFoundation.kCFStringEncodingUTF8
 import platform.Foundation.*
 import platform.Security.*
 
@@ -248,15 +253,8 @@ public data class CertificatePinner(
      * Returns list of matching certificates' pins for the hostname. Returns an empty list if the
      * hostname does not have pinned certificates.
      */
-    internal fun findMatchingPins(hostname: String): List<PinnedCertificate> {
-        var result: List<PinnedCertificate> = emptyList()
-        for (pin in pinnedCertificates) {
-            if (pin.matches(hostname)) {
-                if (result.isEmpty()) result = mutableListOf()
-                (result as MutableList<PinnedCertificate>).add(pin)
-            }
-        }
-        return result
+    private fun findMatchingPins(hostname: String): List<PinnedCertificate> {
+        return pinnedCertificates.filter { it.matches(hostname) }
     }
 
     /**
@@ -403,7 +401,6 @@ public data class CertificatePinner(
     ) {
         /**
          * Pins certificates for `pattern`.
-         *
          *
          * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.client.engine.darwin.certificates.CertificatePinner.Builder.add)
          *

--- a/ktor-client/ktor-client-darwin/darwin/src/io/ktor/client/engine/darwin/certificates/CertificatePinner.kt
+++ b/ktor-client/ktor-client-darwin/darwin/src/io/ktor/client/engine/darwin/certificates/CertificatePinner.kt
@@ -1,10 +1,12 @@
 /*
-* Copyright 2014-2021 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
-*/
+ * Copyright 2014-2025 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
 
 package io.ktor.client.engine.darwin.certificates
 
 import io.ktor.client.engine.darwin.*
+import io.ktor.network.tls.*
+import io.ktor.util.logging.*
 import kotlinx.cinterop.*
 import platform.CoreCrypto.CC_SHA1
 import platform.CoreCrypto.CC_SHA1_DIGEST_LENGTH
@@ -15,6 +17,8 @@ import platform.CoreFoundation.CFStringCreateWithCString
 import platform.CoreFoundation.kCFStringEncodingUTF8
 import platform.Foundation.*
 import platform.Security.*
+
+private val LOG = KtorSimpleLogger("io.ktor.client.engine.darwin.certificates.CertificatePinner")
 
 /**
  * Constrains which certificates are trusted. Pinning certificates defends against attacks on
@@ -119,36 +123,36 @@ public data class CertificatePinner(
     private val validateTrust: Boolean
 ) : ChallengeHandler {
 
-    @OptIn(ExperimentalForeignApi::class)
     override fun invoke(
         session: NSURLSession,
         task: NSURLSessionTask,
         challenge: NSURLAuthenticationChallenge,
         completionHandler: (NSURLSessionAuthChallengeDisposition, NSURLCredential?) -> Unit
     ) {
+        if (applyPinning(challenge)) {
+            completionHandler(NSURLSessionAuthChallengeUseCredential, challenge.proposedCredential)
+        } else {
+            completionHandler(NSURLSessionAuthChallengePerformDefaultHandling, null)
+        }
+    }
+
+    @OptIn(ExperimentalForeignApi::class)
+    private fun applyPinning(challenge: NSURLAuthenticationChallenge): Boolean {
         val hostname = challenge.protectionSpace.host
         val matchingPins = findMatchingPins(hostname)
 
         if (matchingPins.isEmpty()) {
-            println("CertificatePinner: No pins found for host")
-            completionHandler(NSURLSessionAuthChallengePerformDefaultHandling, null)
-            return
+            LOG.trace { "No pins found for host" }
+            return false
         }
 
-        if (challenge.protectionSpace.authenticationMethod !=
-            NSURLAuthenticationMethodServerTrust
-        ) {
-            println("CertificatePinner: Authentication method not suitable for pinning")
-            completionHandler(NSURLSessionAuthChallengePerformDefaultHandling, null)
-            return
+        if (challenge.protectionSpace.authenticationMethod != NSURLAuthenticationMethodServerTrust) {
+            LOG.trace { "Authentication method not suitable for pinning" }
+            return false
         }
 
         val trust = challenge.protectionSpace.serverTrust
-        if (trust == null) {
-            println("CertificatePinner: Server trust is not available")
-            completionHandler(NSURLSessionAuthChallengeCancelAuthenticationChallenge, null)
-            return
-        }
+            ?: throw TlsPeerUnverifiedException("Server trust is not available")
 
         if (validateTrust) {
             val hostCFString = CFStringCreateWithCString(null, hostname, kCFStringEncodingUTF8)
@@ -157,11 +161,7 @@ public data class CertificatePinner(
                     SecTrustSetPolicies(trust, policy)
                 }
             }
-            if (!trust.trustIsValid()) {
-                println("CertificatePinner: Server trust is invalid")
-                completionHandler(NSURLSessionAuthChallengeCancelAuthenticationChallenge, null)
-                return
-            }
+            if (!trust.trustIsValid()) throw TlsPeerUnverifiedException("Server trust is invalid")
         }
 
         val certCount = SecTrustGetCertificateCount(trust)
@@ -170,19 +170,14 @@ public data class CertificatePinner(
         }
 
         if (certificates.size != certCount.toInt()) {
-            println("CertificatePinner: Unknown certificates")
-            completionHandler(NSURLSessionAuthChallengeCancelAuthenticationChallenge, null)
-            return
+            throw TlsPeerUnverifiedException("Unknown certificates")
         }
 
-        val result = hasOnePinnedCertificate(certificates)
-        if (result) {
-            completionHandler(NSURLSessionAuthChallengeUseCredential, challenge.proposedCredential)
-        } else {
+        if (!hasOnePinnedCertificate(certificates)) {
             val message = buildErrorMessage(certificates, hostname)
-            println(message)
-            completionHandler(NSURLSessionAuthChallengeCancelAuthenticationChallenge, null)
+            throw TlsPeerUnverifiedException(message)
         }
+        return true
     }
 
     /**
@@ -206,6 +201,7 @@ public data class CertificatePinner(
 
                     pin.hash == sha256
                 }
+
                 CertificatesInfo.HASH_ALGORITHM_SHA_1 -> {
                     if (sha1 == null) {
                         sha1 = publicKey.toSha1String()
@@ -213,10 +209,8 @@ public data class CertificatePinner(
 
                     pin.hash == sha1
                 }
-                else -> {
-                    println("CertificatePinner: Unsupported hashAlgorithm: ${pin.hashAlgorithm}")
-                    false
-                }
+
+                else -> throw IllegalArgumentException("Unsupported hashAlgorithm: ${pin.hashAlgorithm}")
             }
         }
     }
@@ -305,7 +299,7 @@ public data class CertificatePinner(
             CFBridgingRelease(publicKeyAttributes)
 
             if (!checkValidKeyType(publicKeyType, publicKeySize)) {
-                println("CertificatePinner: Public Key not supported type or size")
+                LOG.trace { "Public Key not supported type or size" }
                 return null
             }
 

--- a/ktor-client/ktor-client-darwin/darwin/src/io/ktor/client/engine/darwin/internal/DarwinTaskHandler.kt
+++ b/ktor-client/ktor-client-darwin/darwin/src/io/ktor/client/engine/darwin/internal/DarwinTaskHandler.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2022 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2014-2024 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package io.ktor.client.engine.darwin.internal
@@ -25,6 +25,9 @@ internal class DarwinTaskHandler(
 
     private val requestTime: GMTDate = GMTDate()
     private val bodyChunks = Channel<ByteArray>(Channel.UNLIMITED)
+
+    private var pendingFailure: Throwable? = null
+        get() = field?.also { field = null }
 
     private val body: ByteReadChannel = GlobalScope.writer(callContext) {
         try {
@@ -52,9 +55,13 @@ internal class DarwinTaskHandler(
         }
     }
 
+    fun saveFailure(cause: Throwable) {
+        pendingFailure = cause
+    }
+
     fun complete(task: NSURLSessionTask, didCompleteWithError: NSError?) {
         if (didCompleteWithError != null) {
-            val exception = handleNSError(requestData, didCompleteWithError)
+            val exception = pendingFailure ?: handleNSError(requestData, didCompleteWithError)
             bodyChunks.close(exception)
             response.completeExceptionally(exception)
             return

--- a/ktor-client/ktor-client-test-base/common/src/io/ktor/client/test/base/CommonClientTestUtils.kt
+++ b/ktor-client/ktor-client-test-base/common/src/io/ktor/client/test/base/CommonClientTestUtils.kt
@@ -19,6 +19,11 @@ import kotlin.time.Duration.Companion.minutes
 const val TEST_SERVER: String = "http://127.0.0.1:8080"
 
 /**
+ * Web url with TLS for tests.
+ */
+const val TEST_SERVER_TLS: String = "https://127.0.0.1:8089"
+
+/**
  * Websocket server url for tests.
  *
  * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.client.test.base.TEST_WEBSOCKET_SERVER)

--- a/ktor-network/ktor-network-tls/api/ktor-network-tls.api
+++ b/ktor-network/ktor-network-tls/api/ktor-network-tls.api
@@ -222,7 +222,7 @@ public final class io/ktor/network/tls/TLSConfigBuilderKt {
 	public static final fun takeFrom (Lio/ktor/network/tls/TLSConfigBuilder;Lio/ktor/network/tls/TLSConfigBuilder;)V
 }
 
-public final class io/ktor/network/tls/TLSException : java/io/IOException {
+public final class io/ktor/network/tls/TLSException : javax/net/ssl/SSLException {
 	public fun <init> (Ljava/lang/String;Ljava/lang/Throwable;)V
 	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/Throwable;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 }

--- a/ktor-network/ktor-network-tls/api/ktor-network-tls.klib.api
+++ b/ktor-network/ktor-network-tls/api/ktor-network-tls.klib.api
@@ -309,8 +309,17 @@ final class io.ktor.network.tls/TLSConfigBuilder { // io.ktor.network.tls/TLSCon
     final fun build(): io.ktor.network.tls/TLSConfig // io.ktor.network.tls/TLSConfigBuilder.build|build(){}[0]
 }
 
-final class io.ktor.network.tls/TLSException : kotlinx.io/IOException { // io.ktor.network.tls/TLSException|null[0]
+final class io.ktor.network.tls/TLSException : io.ktor.network.tls/TlsException { // io.ktor.network.tls/TLSException|null[0]
     constructor <init>(kotlin/String, kotlin/Throwable? = ...) // io.ktor.network.tls/TLSException.<init>|<init>(kotlin.String;kotlin.Throwable?){}[0]
+}
+
+final class io.ktor.network.tls/TlsPeerUnverifiedException : io.ktor.network.tls/TlsException { // io.ktor.network.tls/TlsPeerUnverifiedException|null[0]
+    constructor <init>(kotlin/String) // io.ktor.network.tls/TlsPeerUnverifiedException.<init>|<init>(kotlin.String){}[0]
+}
+
+open class io.ktor.network.tls/TlsException : kotlinx.io/IOException { // io.ktor.network.tls/TlsException|null[0]
+    constructor <init>(kotlin/String) // io.ktor.network.tls/TlsException.<init>|<init>(kotlin.String){}[0]
+    constructor <init>(kotlin/String, kotlin/Throwable?) // io.ktor.network.tls/TlsException.<init>|<init>(kotlin.String;kotlin.Throwable?){}[0]
 }
 
 final object io.ktor.network.tls/CIOCipherSuites { // io.ktor.network.tls/CIOCipherSuites|null[0]

--- a/ktor-network/ktor-network-tls/common/src/io/ktor/network/tls/CipherSuites.kt
+++ b/ktor-network/ktor-network-tls/common/src/io/ktor/network/tls/CipherSuites.kt
@@ -1,11 +1,11 @@
 /*
- * Copyright 2014-2024 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2014-2025 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package io.ktor.network.tls
 
 import io.ktor.network.tls.extensions.*
-import kotlinx.io.*
+import kotlinx.io.IOException
 
 /**
  * TLS secret key exchange type.
@@ -173,4 +173,27 @@ public object CIOCipherSuites {
 
 internal expect fun CipherSuite.isSupported(): Boolean
 
-public class TLSException(message: String, cause: Throwable? = null) : IOException(message, cause)
+@Deprecated("Use TlsException instead")
+public class TLSException(message: String, cause: Throwable? = null) : TlsException(message, cause)
+
+/**
+ * Represents an exception specific to TLS (Transport Layer Security) operations.
+ *
+ * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.network.tls.TlsException)
+ */
+public expect open class TlsException : IOException {
+    public constructor(message: String)
+    public constructor(message: String, cause: Throwable?)
+}
+
+/**
+ * Indicates that TLS peer can't be verified.
+ *
+ * This exception typically occurs when the identity of the remote peer can't be authenticated
+ * or verified during a TLS handshake. For example, because of mismatched certificates or missing trust anchors.
+ *
+ * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.network.tls.TlsPeerUnverifiedException)
+ *
+ * @param message A message detailing the reason for the verification failure.
+ */
+public expect class TlsPeerUnverifiedException(message: String) : TlsException

--- a/ktor-network/ktor-network-tls/jvm/src/io/ktor/network/tls/CipherSuitesJvm.kt
+++ b/ktor-network/ktor-network-tls/jvm/src/io/ktor/network/tls/CipherSuitesJvm.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2014-2025 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package io.ktor.network.tls
@@ -12,3 +12,6 @@ internal actual fun CipherSuite.isSupported(): Boolean = when (platformVersion.m
     "1.6.0" -> platformVersion.minor >= 181 || keyStrength <= 128
     else -> true
 }
+
+public actual typealias TlsException = javax.net.ssl.SSLException
+public actual typealias TlsPeerUnverifiedException = javax.net.ssl.SSLPeerUnverifiedException

--- a/ktor-network/ktor-network-tls/nonJvm/src/io/ktor/network/tls/CipherSuites.nonJvm.kt
+++ b/ktor-network/ktor-network-tls/nonJvm/src/io/ktor/network/tls/CipherSuites.nonJvm.kt
@@ -1,7 +1,16 @@
 /*
- * Copyright 2014-2019 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2014-2025 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package io.ktor.network.tls
 
+import kotlinx.io.IOException
+
 internal actual fun CipherSuite.isSupported(): Boolean = false
+
+public actual open class TlsException : IOException {
+    public actual constructor(message: String) : super(message)
+    public actual constructor(message: String, cause: Throwable?) : super(message, cause)
+}
+
+public actual class TlsPeerUnverifiedException actual constructor(message: String) : TlsException(message)


### PR DESCRIPTION
**Subsystem**
Client, Darwin

**Motivation**
[KTOR-6759](https://youtrack.jetbrains.com/issue/KTOR-6759) Darwin: Ambiguous DarwinHttpRequestException for SSL Pinning failure

The problem is that we call `completionHandler` with `NSURLSessionAuthChallengePerformDefaultHandling` on SSL pinning failure and then third-party API throws an exception. There are no mechanisms to attach additional data to this exception (or at least I don't know any).
The place where the actual error occurs and the place where `DarwinHttpRequestException` is constructed are two completely different places.

**Solution**
Save actual failure thrown during challenge handling to a`DarwinTaskHandler` and throw it later instead of creating a generic one. Throw specific exception from `CertificatePinner` to make it possible to catch pinning failures specifically:

```kotlin
try {
    client.get("/some-api-with-pinning")
} catch(cause: TLSPeerUnverifiedException) {
    println("SSL pinning failure detected.")
}
```

`TLSPeerUnverifiedException` is a multiplatform exception, and on JVM it is mapped to `SSLPeerUnverifiedException`, so it should be possible to catch pinning failure in common code.