### PR TITLE
Remove space from default user agent

### DIFF
--- a/ktor-client/ktor-client-core/common/src/io/ktor/client/engine/Utils.kt
+++ b/ktor-client/ktor-client-core/common/src/io/ktor/client/engine/Utils.kt
@@ -16,7 +16,7 @@ import kotlin.coroutines.*
  * Default user agent to use in ktor client.
  */
 @InternalAPI
-public val KTOR_DEFAULT_USER_AGENT: String = "Ktor client"
+public val KTOR_DEFAULT_USER_AGENT: String = "ktor-client"
 
 private val DATE_HEADERS = setOf(
     HttpHeaders.Date,


### PR DESCRIPTION
**Subsystem**
Client

**Motivation**
The product identifier in a user agent should not contain spaces.

https://httpwg.org/specs/rfc9110.html#field.user-agent

**Solution**
Make it kebab-case.

