### PR TITLE
KTOR-7596 Make multipart Content-Type check case-insensitive

### DIFF
--- a/ktor-client/ktor-client-plugins/ktor-client-content-negotiation/common/src/io/ktor/client/plugins/contentnegotiation/JsonContentTypeMatcher.kt
+++ b/ktor-client/ktor-client-plugins/ktor-client-content-negotiation/common/src/io/ktor/client/plugins/contentnegotiation/JsonContentTypeMatcher.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2022 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2014-2024 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package io.ktor.client.plugins.contentnegotiation
@@ -16,6 +16,6 @@ public object JsonContentTypeMatcher : ContentTypeMatcher {
         }
 
         val value = contentType.withoutParameters().toString()
-        return value.startsWith("application/") && value.endsWith("+json")
+        return value.startsWith("application/", ignoreCase = true) && value.endsWith("+json", ignoreCase = true)
     }
 }

--- a/ktor-client/ktor-client-plugins/ktor-client-json/common/src/io/ktor/client/plugins/json/JsonContentTypeMatcher.kt
+++ b/ktor-client/ktor-client-plugins/ktor-client-json/common/src/io/ktor/client/plugins/json/JsonContentTypeMatcher.kt
@@ -1,6 +1,6 @@
 /*
-* Copyright 2014-2021 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
-*/
+ * Copyright 2014-2024 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
 
 package io.ktor.client.plugins.json
 
@@ -13,6 +13,6 @@ internal class JsonContentTypeMatcher : ContentTypeMatcher {
         }
 
         val value = contentType.withoutParameters().toString()
-        return value.startsWith("application/") && value.endsWith("+json")
+        return value.startsWith("application/", ignoreCase = true) && value.endsWith("+json", ignoreCase = true)
     }
 }

--- a/ktor-http/ktor-http-cio/jvm/src/io/ktor/http/cio/Multipart.kt
+++ b/ktor-http/ktor-http-cio/jvm/src/io/ktor/http/cio/Multipart.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2021 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2014-2024 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package io.ktor.http.cio
@@ -11,7 +11,6 @@ import io.ktor.utils.io.core.*
 import kotlinx.coroutines.*
 import kotlinx.coroutines.channels.*
 import kotlinx.io.*
-import kotlinx.io.IOException
 import kotlinx.io.bytestring.*
 import java.io.EOFException
 import java.nio.*
@@ -148,14 +147,13 @@ public fun CoroutineScope.parseMultipart(
 /**
  * Starts a multipart parser coroutine producing multipart events
  */
-@Suppress("DEPRECATION_ERROR")
 public fun CoroutineScope.parseMultipart(
     input: ByteReadChannel,
     contentType: CharSequence,
     contentLength: Long?,
     maxPartSize: Long = Long.MAX_VALUE,
 ): ReceiveChannel<MultipartEvent> {
-    if (!contentType.startsWith("multipart/")) {
+    if (!contentType.startsWith("multipart/", ignoreCase = true)) {
         throw IOException("Failed to parse multipart: Content-Type should be multipart/* but it is $contentType")
     }
     val boundaryByteBuffer = parseBoundaryInternal(contentType)

--- a/ktor-http/ktor-http-cio/jvm/test/io/ktor/tests/http/cio/MultipartTest.kt
+++ b/ktor-http/ktor-http-cio/jvm/test/io/ktor/tests/http/cio/MultipartTest.kt
@@ -1,6 +1,6 @@
 /*
-* Copyright 2014-2021 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
-*/
+ * Copyright 2014-2024 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
 
 package io.ktor.tests.http.cio
 
@@ -8,6 +8,8 @@ import io.ktor.http.cio.*
 import io.ktor.utils.io.*
 import kotlinx.coroutines.*
 import kotlinx.coroutines.channels.*
+import kotlinx.coroutines.test.*
+import kotlinx.io.*
 import kotlin.test.*
 
 @OptIn(DelicateCoroutinesApi::class)
@@ -333,6 +335,17 @@ class MultipartTest {
         assertFails {
             parseBoundaryInternal("multipart/mixed; boundary= \"\" ")
         }
+    }
+
+    @Test
+    fun testParseContentType() = runTest {
+        fun testContentType(contentType: String) {
+            parseMultipart(ByteReadChannel.Empty, "$contentType; boundary=A", 0L)
+        }
+
+        testContentType("multipart/mixed")
+        testContentType("Multipart/mixed")
+        assertFailsWith<IOException> { testContentType("multi-part/mixed") }
     }
 
     @OptIn(DelicateCoroutinesApi::class)

--- a/ktor-server/ktor-server-jetty-jakarta/jvm/src/io/ktor/server/jetty/jakarta/JettyKtorHandler.kt
+++ b/ktor-server/ktor-server-jetty-jakarta/jvm/src/io/ktor/server/jetty/jakarta/JettyKtorHandler.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2023 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2014-2024 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package io.ktor.server.jetty.jakarta
@@ -8,7 +8,6 @@ import io.ktor.http.*
 import io.ktor.server.application.*
 import io.ktor.server.engine.*
 import io.ktor.server.response.*
-import io.ktor.util.*
 import io.ktor.util.cio.*
 import io.ktor.util.pipeline.*
 import io.ktor.utils.io.*
@@ -72,7 +71,7 @@ internal class JettyKtorHandler(
     ) {
         try {
             val contentType = request.contentType
-            if (contentType != null && contentType.startsWith("multipart/")) {
+            if (contentType != null && contentType.startsWith("multipart/", ignoreCase = true)) {
                 baseRequest.setAttribute(Request.__MULTIPART_CONFIG_ELEMENT, multipartConfig)
                 // TODO someone reported auto-cleanup issues so we have to check it
             }

--- a/ktor-server/ktor-server-jetty/jvm/src/io/ktor/server/jetty/JettyKtorHandler.kt
+++ b/ktor-server/ktor-server-jetty/jvm/src/io/ktor/server/jetty/JettyKtorHandler.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2014-2024 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package io.ktor.server.jetty
@@ -8,7 +8,6 @@ import io.ktor.http.*
 import io.ktor.server.application.*
 import io.ktor.server.engine.*
 import io.ktor.server.response.*
-import io.ktor.util.*
 import io.ktor.util.cio.*
 import io.ktor.util.pipeline.*
 import io.ktor.utils.io.*
@@ -72,7 +71,7 @@ internal class JettyKtorHandler(
     ) {
         try {
             val contentType = request.contentType
-            if (contentType != null && contentType.startsWith("multipart/")) {
+            if (contentType != null && contentType.startsWith("multipart/", ignoreCase = true)) {
                 baseRequest.setAttribute(Request.MULTIPART_CONFIG_ELEMENT, multipartConfig)
                 // TODO someone reported auto-cleanup issues so we have to check it
             }


### PR DESCRIPTION
**Subsystem**
Server, `ktor-http-cio`

**Motivation**
[KTOR-7596](https://youtrack.jetbrains.com/issue/KTOR-7596) receiveMultipart fails with "IOException: Failed to parse multipart" when content-type is capitalized

**Solution**
Use case-insensitive check for multipart content-type 

