### PR TITLE
KTOR-7645 Use BuildService API to start the test server

### DIFF
--- a/buildSrc/src/main/kotlin/test/server/TestServerPlugin.kt
+++ b/buildSrc/src/main/kotlin/test/server/TestServerPlugin.kt
@@ -5,33 +5,46 @@
 package test.server
 
 import org.gradle.api.*
-import test.server.*
-import test.server.startServer
+import org.gradle.api.logging.*
+import org.gradle.api.provider.Provider
+import org.gradle.api.services.*
+import org.gradle.api.tasks.testing.*
+import org.gradle.kotlin.dsl.*
 import java.io.*
-import java.util.concurrent.atomic.AtomicInteger
 
 class TestServerPlugin : Plugin<Project> {
-    private var server: Closeable? = null
-    private val activeTasks = AtomicInteger(0)
-
-    fun start() {
-        val count = activeTasks.incrementAndGet()
-        if (count == 1) {
-            server = startServer()
-        }
-    }
-
-    fun stop() {
-        val count = activeTasks.decrementAndGet()
-        if (count == 0) {
-            server!!.close()
-            server = null
-        }
-    }
 
     override fun apply(target: Project) {
-        target.tasks.configureEach {
-            doFirst { start() }
+        val testServerService = TestServerService.registerIfAbsent(target)
+
+        target.tasks.withType<AbstractTestTask>().configureEach {
+            usesService(testServerService)
+            // Trigger server start if it is not started yet
+            doFirst("start test server") { testServerService.get() }
+        }
+    }
+}
+
+private abstract class TestServerService : BuildService<BuildServiceParameters.None>, AutoCloseable {
+
+    private val logger = Logging.getLogger("TestServerService")
+    private val server: Closeable
+
+    init {
+        logger.lifecycle("Starting test server...")
+        server = startServer()
+        logger.lifecycle("Test server started.")
+    }
+
+    override fun close() {
+        logger.lifecycle("Stopping test server...")
+        server.close()
+        logger.lifecycle("Test server stopped.")
+    }
+
+    companion object {
+        fun registerIfAbsent(project: Project): Provider<TestServerService> {
+            return project.gradle.sharedServices.registerIfAbsent("testServer", TestServerService::class)
         }
     }
 }


### PR DESCRIPTION
**Subsystem**
Test infrastructure

**Motivation**
[KTOR-7645](https://youtrack.jetbrains.com/issue/KTOR-7645) Use BuildService API to start the test server

**Solution**
Refactor `TestServerPlugin` to use `BuildService` API and run the test server only before test tasks.
