### PR TITLE
KTOR-8145 Add contains operator to ContentType objects

### DIFF
--- a/ktor-client/ktor-client-plugins/ktor-client-content-negotiation/common/src/io/ktor/client/plugins/contentnegotiation/JsonContentTypeMatcher.kt
+++ b/ktor-client/ktor-client-plugins/ktor-client-content-negotiation/common/src/io/ktor/client/plugins/contentnegotiation/JsonContentTypeMatcher.kt
@@ -18,6 +18,6 @@ public object JsonContentTypeMatcher : ContentTypeMatcher {
         }
 
         val value = contentType.withoutParameters().toString()
-        return value.startsWith("application/", ignoreCase = true) && value.endsWith("+json", ignoreCase = true)
+        return value in ContentType.Application && value.endsWith("+json", ignoreCase = true)
     }
 }

--- a/ktor-client/ktor-client-plugins/ktor-client-json/common/src/io/ktor/client/plugins/json/JsonContentTypeMatcher.kt
+++ b/ktor-client/ktor-client-plugins/ktor-client-json/common/src/io/ktor/client/plugins/json/JsonContentTypeMatcher.kt
@@ -13,6 +13,6 @@ internal class JsonContentTypeMatcher : ContentTypeMatcher {
         }
 
         val value = contentType.withoutParameters().toString()
-        return value.startsWith("application/", ignoreCase = true) && value.endsWith("+json", ignoreCase = true)
+        return value in ContentType.Application && value.endsWith("+json", ignoreCase = true)
     }
 }

--- a/ktor-http/api/ktor-http.api
+++ b/ktor-http/api/ktor-http.api
@@ -154,6 +154,9 @@ public final class io/ktor/http/ContentType : io/ktor/http/HeaderValueWithParame
 
 public final class io/ktor/http/ContentType$Application {
 	public static final field INSTANCE Lio/ktor/http/ContentType$Application;
+	public static final field TYPE Ljava/lang/String;
+	public final fun contains (Lio/ktor/http/ContentType;)Z
+	public final fun contains (Ljava/lang/CharSequence;)Z
 	public final fun getAny ()Lio/ktor/http/ContentType;
 	public final fun getAtom ()Lio/ktor/http/ContentType;
 	public final fun getCbor ()Lio/ktor/http/ContentType;
@@ -181,6 +184,9 @@ public final class io/ktor/http/ContentType$Application {
 
 public final class io/ktor/http/ContentType$Audio {
 	public static final field INSTANCE Lio/ktor/http/ContentType$Audio;
+	public static final field TYPE Ljava/lang/String;
+	public final fun contains (Lio/ktor/http/ContentType;)Z
+	public final fun contains (Ljava/lang/CharSequence;)Z
 	public final fun getAny ()Lio/ktor/http/ContentType;
 	public final fun getMP4 ()Lio/ktor/http/ContentType;
 	public final fun getMPEG ()Lio/ktor/http/ContentType;
@@ -194,6 +200,9 @@ public final class io/ktor/http/ContentType$Companion {
 
 public final class io/ktor/http/ContentType$Font {
 	public static final field INSTANCE Lio/ktor/http/ContentType$Font;
+	public static final field TYPE Ljava/lang/String;
+	public final fun contains (Lio/ktor/http/ContentType;)Z
+	public final fun contains (Ljava/lang/CharSequence;)Z
 	public final fun getAny ()Lio/ktor/http/ContentType;
 	public final fun getCollection ()Lio/ktor/http/ContentType;
 	public final fun getOtf ()Lio/ktor/http/ContentType;
@@ -205,6 +214,9 @@ public final class io/ktor/http/ContentType$Font {
 
 public final class io/ktor/http/ContentType$Image {
 	public static final field INSTANCE Lio/ktor/http/ContentType$Image;
+	public static final field TYPE Ljava/lang/String;
+	public final fun contains (Lio/ktor/http/ContentType;)Z
+	public final fun contains (Ljava/lang/String;)Z
 	public final fun getAny ()Lio/ktor/http/ContentType;
 	public final fun getGIF ()Lio/ktor/http/ContentType;
 	public final fun getJPEG ()Lio/ktor/http/ContentType;
@@ -215,12 +227,18 @@ public final class io/ktor/http/ContentType$Image {
 
 public final class io/ktor/http/ContentType$Message {
 	public static final field INSTANCE Lio/ktor/http/ContentType$Message;
+	public static final field TYPE Ljava/lang/String;
+	public final fun contains (Lio/ktor/http/ContentType;)Z
+	public final fun contains (Ljava/lang/String;)Z
 	public final fun getAny ()Lio/ktor/http/ContentType;
 	public final fun getHttp ()Lio/ktor/http/ContentType;
 }
 
 public final class io/ktor/http/ContentType$MultiPart {
 	public static final field INSTANCE Lio/ktor/http/ContentType$MultiPart;
+	public static final field TYPE Ljava/lang/String;
+	public final fun contains (Lio/ktor/http/ContentType;)Z
+	public final fun contains (Ljava/lang/CharSequence;)Z
 	public final fun getAlternative ()Lio/ktor/http/ContentType;
 	public final fun getAny ()Lio/ktor/http/ContentType;
 	public final fun getByteRanges ()Lio/ktor/http/ContentType;
@@ -233,6 +251,9 @@ public final class io/ktor/http/ContentType$MultiPart {
 
 public final class io/ktor/http/ContentType$Text {
 	public static final field INSTANCE Lio/ktor/http/ContentType$Text;
+	public static final field TYPE Ljava/lang/String;
+	public final fun contains (Lio/ktor/http/ContentType;)Z
+	public final fun contains (Ljava/lang/CharSequence;)Z
 	public final fun getAny ()Lio/ktor/http/ContentType;
 	public final fun getCSS ()Lio/ktor/http/ContentType;
 	public final fun getCSV ()Lio/ktor/http/ContentType;
@@ -246,6 +267,9 @@ public final class io/ktor/http/ContentType$Text {
 
 public final class io/ktor/http/ContentType$Video {
 	public static final field INSTANCE Lio/ktor/http/ContentType$Video;
+	public static final field TYPE Ljava/lang/String;
+	public final fun contains (Lio/ktor/http/ContentType;)Z
+	public final fun contains (Ljava/lang/CharSequence;)Z
 	public final fun getAny ()Lio/ktor/http/ContentType;
 	public final fun getMP4 ()Lio/ktor/http/ContentType;
 	public final fun getMPEG ()Lio/ktor/http/ContentType;

--- a/ktor-http/api/ktor-http.klib.api
+++ b/ktor-http/api/ktor-http.klib.api
@@ -416,6 +416,9 @@ final class io.ktor.http/ContentType : io.ktor.http/HeaderValueWithParameters { 
     final fun withoutParameters(): io.ktor.http/ContentType // io.ktor.http/ContentType.withoutParameters|withoutParameters(){}[0]
 
     final object Application { // io.ktor.http/ContentType.Application|null[0]
+        final const val TYPE // io.ktor.http/ContentType.Application.TYPE|{}TYPE[0]
+            final fun <get-TYPE>(): kotlin/String // io.ktor.http/ContentType.Application.TYPE.<get-TYPE>|<get-TYPE>(){}[0]
+
         final val Any // io.ktor.http/ContentType.Application.Any|{}Any[0]
             final fun <get-Any>(): io.ktor.http/ContentType // io.ktor.http/ContentType.Application.Any.<get-Any>|<get-Any>(){}[0]
         final val Atom // io.ktor.http/ContentType.Application.Atom|{}Atom[0]
@@ -462,9 +465,15 @@ final class io.ktor.http/ContentType : io.ktor.http/HeaderValueWithParameters { 
             final fun <get-Yaml>(): io.ktor.http/ContentType // io.ktor.http/ContentType.Application.Yaml.<get-Yaml>|<get-Yaml>(){}[0]
         final val Zip // io.ktor.http/ContentType.Application.Zip|{}Zip[0]
             final fun <get-Zip>(): io.ktor.http/ContentType // io.ktor.http/ContentType.Application.Zip.<get-Zip>|<get-Zip>(){}[0]
+
+        final fun contains(io.ktor.http/ContentType): kotlin/Boolean // io.ktor.http/ContentType.Application.contains|contains(io.ktor.http.ContentType){}[0]
+        final fun contains(kotlin/CharSequence): kotlin/Boolean // io.ktor.http/ContentType.Application.contains|contains(kotlin.CharSequence){}[0]
     }
 
     final object Audio { // io.ktor.http/ContentType.Audio|null[0]
+        final const val TYPE // io.ktor.http/ContentType.Audio.TYPE|{}TYPE[0]
+            final fun <get-TYPE>(): kotlin/String // io.ktor.http/ContentType.Audio.TYPE.<get-TYPE>|<get-TYPE>(){}[0]
+
         final val Any // io.ktor.http/ContentType.Audio.Any|{}Any[0]
             final fun <get-Any>(): io.ktor.http/ContentType // io.ktor.http/ContentType.Audio.Any.<get-Any>|<get-Any>(){}[0]
         final val MP4 // io.ktor.http/ContentType.Audio.MP4|{}MP4[0]
@@ -473,6 +482,9 @@ final class io.ktor.http/ContentType : io.ktor.http/HeaderValueWithParameters { 
             final fun <get-MPEG>(): io.ktor.http/ContentType // io.ktor.http/ContentType.Audio.MPEG.<get-MPEG>|<get-MPEG>(){}[0]
         final val OGG // io.ktor.http/ContentType.Audio.OGG|{}OGG[0]
             final fun <get-OGG>(): io.ktor.http/ContentType // io.ktor.http/ContentType.Audio.OGG.<get-OGG>|<get-OGG>(){}[0]
+
+        final fun contains(io.ktor.http/ContentType): kotlin/Boolean // io.ktor.http/ContentType.Audio.contains|contains(io.ktor.http.ContentType){}[0]
+        final fun contains(kotlin/CharSequence): kotlin/Boolean // io.ktor.http/ContentType.Audio.contains|contains(kotlin.CharSequence){}[0]
     }
 
     final object Companion { // io.ktor.http/ContentType.Companion|null[0]
@@ -483,6 +495,9 @@ final class io.ktor.http/ContentType : io.ktor.http/HeaderValueWithParameters { 
     }
 
     final object Font { // io.ktor.http/ContentType.Font|null[0]
+        final const val TYPE // io.ktor.http/ContentType.Font.TYPE|{}TYPE[0]
+            final fun <get-TYPE>(): kotlin/String // io.ktor.http/ContentType.Font.TYPE.<get-TYPE>|<get-TYPE>(){}[0]
+
         final val Any // io.ktor.http/ContentType.Font.Any|{}Any[0]
             final fun <get-Any>(): io.ktor.http/ContentType // io.ktor.http/ContentType.Font.Any.<get-Any>|<get-Any>(){}[0]
         final val Collection // io.ktor.http/ContentType.Font.Collection|{}Collection[0]
@@ -497,9 +512,15 @@ final class io.ktor.http/ContentType : io.ktor.http/HeaderValueWithParameters { 
             final fun <get-Woff>(): io.ktor.http/ContentType // io.ktor.http/ContentType.Font.Woff.<get-Woff>|<get-Woff>(){}[0]
         final val Woff2 // io.ktor.http/ContentType.Font.Woff2|{}Woff2[0]
             final fun <get-Woff2>(): io.ktor.http/ContentType // io.ktor.http/ContentType.Font.Woff2.<get-Woff2>|<get-Woff2>(){}[0]
+
+        final fun contains(io.ktor.http/ContentType): kotlin/Boolean // io.ktor.http/ContentType.Font.contains|contains(io.ktor.http.ContentType){}[0]
+        final fun contains(kotlin/CharSequence): kotlin/Boolean // io.ktor.http/ContentType.Font.contains|contains(kotlin.CharSequence){}[0]
     }
 
     final object Image { // io.ktor.http/ContentType.Image|null[0]
+        final const val TYPE // io.ktor.http/ContentType.Image.TYPE|{}TYPE[0]
+            final fun <get-TYPE>(): kotlin/String // io.ktor.http/ContentType.Image.TYPE.<get-TYPE>|<get-TYPE>(){}[0]
+
         final val Any // io.ktor.http/ContentType.Image.Any|{}Any[0]
             final fun <get-Any>(): io.ktor.http/ContentType // io.ktor.http/ContentType.Image.Any.<get-Any>|<get-Any>(){}[0]
         final val GIF // io.ktor.http/ContentType.Image.GIF|{}GIF[0]
@@ -512,16 +533,28 @@ final class io.ktor.http/ContentType : io.ktor.http/HeaderValueWithParameters { 
             final fun <get-SVG>(): io.ktor.http/ContentType // io.ktor.http/ContentType.Image.SVG.<get-SVG>|<get-SVG>(){}[0]
         final val XIcon // io.ktor.http/ContentType.Image.XIcon|{}XIcon[0]
             final fun <get-XIcon>(): io.ktor.http/ContentType // io.ktor.http/ContentType.Image.XIcon.<get-XIcon>|<get-XIcon>(){}[0]
+
+        final fun contains(io.ktor.http/ContentType): kotlin/Boolean // io.ktor.http/ContentType.Image.contains|contains(io.ktor.http.ContentType){}[0]
+        final fun contains(kotlin/String): kotlin/Boolean // io.ktor.http/ContentType.Image.contains|contains(kotlin.String){}[0]
     }
 
     final object Message { // io.ktor.http/ContentType.Message|null[0]
+        final const val TYPE // io.ktor.http/ContentType.Message.TYPE|{}TYPE[0]
+            final fun <get-TYPE>(): kotlin/String // io.ktor.http/ContentType.Message.TYPE.<get-TYPE>|<get-TYPE>(){}[0]
+
         final val Any // io.ktor.http/ContentType.Message.Any|{}Any[0]
             final fun <get-Any>(): io.ktor.http/ContentType // io.ktor.http/ContentType.Message.Any.<get-Any>|<get-Any>(){}[0]
         final val Http // io.ktor.http/ContentType.Message.Http|{}Http[0]
             final fun <get-Http>(): io.ktor.http/ContentType // io.ktor.http/ContentType.Message.Http.<get-Http>|<get-Http>(){}[0]
+
+        final fun contains(io.ktor.http/ContentType): kotlin/Boolean // io.ktor.http/ContentType.Message.contains|contains(io.ktor.http.ContentType){}[0]
+        final fun contains(kotlin/String): kotlin/Boolean // io.ktor.http/ContentType.Message.contains|contains(kotlin.String){}[0]
     }
 
     final object MultiPart { // io.ktor.http/ContentType.MultiPart|null[0]
+        final const val TYPE // io.ktor.http/ContentType.MultiPart.TYPE|{}TYPE[0]
+            final fun <get-TYPE>(): kotlin/String // io.ktor.http/ContentType.MultiPart.TYPE.<get-TYPE>|<get-TYPE>(){}[0]
+
         final val Alternative // io.ktor.http/ContentType.MultiPart.Alternative|{}Alternative[0]
             final fun <get-Alternative>(): io.ktor.http/ContentType // io.ktor.http/ContentType.MultiPart.Alternative.<get-Alternative>|<get-Alternative>(){}[0]
         final val Any // io.ktor.http/ContentType.MultiPart.Any|{}Any[0]
@@ -538,9 +571,15 @@ final class io.ktor.http/ContentType : io.ktor.http/HeaderValueWithParameters { 
             final fun <get-Related>(): io.ktor.http/ContentType // io.ktor.http/ContentType.MultiPart.Related.<get-Related>|<get-Related>(){}[0]
         final val Signed // io.ktor.http/ContentType.MultiPart.Signed|{}Signed[0]
             final fun <get-Signed>(): io.ktor.http/ContentType // io.ktor.http/ContentType.MultiPart.Signed.<get-Signed>|<get-Signed>(){}[0]
+
+        final fun contains(io.ktor.http/ContentType): kotlin/Boolean // io.ktor.http/ContentType.MultiPart.contains|contains(io.ktor.http.ContentType){}[0]
+        final fun contains(kotlin/CharSequence): kotlin/Boolean // io.ktor.http/ContentType.MultiPart.contains|contains(kotlin.CharSequence){}[0]
     }
 
     final object Text { // io.ktor.http/ContentType.Text|null[0]
+        final const val TYPE // io.ktor.http/ContentType.Text.TYPE|{}TYPE[0]
+            final fun <get-TYPE>(): kotlin/String // io.ktor.http/ContentType.Text.TYPE.<get-TYPE>|<get-TYPE>(){}[0]
+
         final val Any // io.ktor.http/ContentType.Text.Any|{}Any[0]
             final fun <get-Any>(): io.ktor.http/ContentType // io.ktor.http/ContentType.Text.Any.<get-Any>|<get-Any>(){}[0]
         final val CSS // io.ktor.http/ContentType.Text.CSS|{}CSS[0]
@@ -559,9 +598,15 @@ final class io.ktor.http/ContentType : io.ktor.http/HeaderValueWithParameters { 
             final fun <get-VCard>(): io.ktor.http/ContentType // io.ktor.http/ContentType.Text.VCard.<get-VCard>|<get-VCard>(){}[0]
         final val Xml // io.ktor.http/ContentType.Text.Xml|{}Xml[0]
             final fun <get-Xml>(): io.ktor.http/ContentType // io.ktor.http/ContentType.Text.Xml.<get-Xml>|<get-Xml>(){}[0]
+
+        final fun contains(io.ktor.http/ContentType): kotlin/Boolean // io.ktor.http/ContentType.Text.contains|contains(io.ktor.http.ContentType){}[0]
+        final fun contains(kotlin/CharSequence): kotlin/Boolean // io.ktor.http/ContentType.Text.contains|contains(kotlin.CharSequence){}[0]
     }
 
     final object Video { // io.ktor.http/ContentType.Video|null[0]
+        final const val TYPE // io.ktor.http/ContentType.Video.TYPE|{}TYPE[0]
+            final fun <get-TYPE>(): kotlin/String // io.ktor.http/ContentType.Video.TYPE.<get-TYPE>|<get-TYPE>(){}[0]
+
         final val Any // io.ktor.http/ContentType.Video.Any|{}Any[0]
             final fun <get-Any>(): io.ktor.http/ContentType // io.ktor.http/ContentType.Video.Any.<get-Any>|<get-Any>(){}[0]
         final val MP4 // io.ktor.http/ContentType.Video.MP4|{}MP4[0]
@@ -572,6 +617,9 @@ final class io.ktor.http/ContentType : io.ktor.http/HeaderValueWithParameters { 
             final fun <get-OGG>(): io.ktor.http/ContentType // io.ktor.http/ContentType.Video.OGG.<get-OGG>|<get-OGG>(){}[0]
         final val QuickTime // io.ktor.http/ContentType.Video.QuickTime|{}QuickTime[0]
             final fun <get-QuickTime>(): io.ktor.http/ContentType // io.ktor.http/ContentType.Video.QuickTime.<get-QuickTime>|<get-QuickTime>(){}[0]
+
+        final fun contains(io.ktor.http/ContentType): kotlin/Boolean // io.ktor.http/ContentType.Video.contains|contains(io.ktor.http.ContentType){}[0]
+        final fun contains(kotlin/CharSequence): kotlin/Boolean // io.ktor.http/ContentType.Video.contains|contains(kotlin.CharSequence){}[0]
     }
 }
 

--- a/ktor-http/common/src/io/ktor/http/ContentTypes.kt
+++ b/ktor-http/common/src/io/ktor/http/ContentTypes.kt
@@ -1,6 +1,6 @@
 /*
-* Copyright 2014-2021 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
-*/
+ * Copyright 2014-2024 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
 
 package io.ktor.http
 
@@ -179,46 +179,44 @@ public class ContentType private constructor(
      */
     @Suppress("KDocMissingDocumentation", "unused")
     public object Application {
+        public const val TYPE: String = "application"
+
         /**
          * Represents a pattern `application / *` to match any application content type.
          *
          * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.http.ContentType.Application.Any)
          */
-        public val Any: ContentType = ContentType("application", "*")
-        public val Atom: ContentType = ContentType("application", "atom+xml")
-        public val Cbor: ContentType = ContentType("application", "cbor")
-        public val Json: ContentType = ContentType("application", "json")
-        public val HalJson: ContentType = ContentType("application", "hal+json")
-        public val JavaScript: ContentType = ContentType("application", "javascript")
-        public val OctetStream: ContentType = ContentType("application", "octet-stream")
-        public val Rss: ContentType = ContentType("application", "rss+xml")
-        public val Soap: ContentType = ContentType("application", "soap+xml")
-        public val Xml: ContentType = ContentType("application", "xml")
-        public val Xml_Dtd: ContentType = ContentType("application", "xml-dtd")
-        public val Yaml: ContentType = ContentType("application", "yaml")
-        public val Zip: ContentType = ContentType("application", "zip")
-        public val GZip: ContentType = ContentType("application", "gzip")
+        public val Any: ContentType = ContentType(TYPE, "*")
+        public val Atom: ContentType = ContentType(TYPE, "atom+xml")
+        public val Cbor: ContentType = ContentType(TYPE, "cbor")
+        public val Json: ContentType = ContentType(TYPE, "json")
+        public val HalJson: ContentType = ContentType(TYPE, "hal+json")
+        public val JavaScript: ContentType = ContentType(TYPE, "javascript")
+        public val OctetStream: ContentType = ContentType(TYPE, "octet-stream")
+        public val Rss: ContentType = ContentType(TYPE, "rss+xml")
+        public val Soap: ContentType = ContentType(TYPE, "soap+xml")
+        public val Xml: ContentType = ContentType(TYPE, "xml")
+        public val Xml_Dtd: ContentType = ContentType(TYPE, "xml-dtd")
+        public val Yaml: ContentType = ContentType(TYPE, "yaml")
+        public val Zip: ContentType = ContentType(TYPE, "zip")
+        public val GZip: ContentType = ContentType(TYPE, "gzip")
+        public val FormUrlEncoded: ContentType = ContentType(TYPE, "x-www-form-urlencoded")
+        public val Pdf: ContentType = ContentType(TYPE, "pdf")
+        public val Xlsx: ContentType = ContentType(TYPE, "vnd.openxmlformats-officedocument.spreadsheetml.sheet")
+        public val Docx: ContentType = ContentType(TYPE, "vnd.openxmlformats-officedocument.wordprocessingml.document")
+        public val Pptx: ContentType =
+            ContentType(TYPE, "vnd.openxmlformats-officedocument.presentationml.presentation")
+        public val ProtoBuf: ContentType = ContentType(TYPE, "protobuf")
+        public val Wasm: ContentType = ContentType(TYPE, "wasm")
+        public val ProblemJson: ContentType = ContentType(TYPE, "problem+json")
+        public val ProblemXml: ContentType = ContentType(TYPE, "problem+xml")
 
-        public val FormUrlEncoded: ContentType =
-            ContentType("application", "x-www-form-urlencoded")
+        /** Checks that the given [contentType] has type `application/`. */
+        public operator fun contains(contentType: CharSequence): Boolean =
+            contentType.startsWith("$TYPE/", ignoreCase = true)
 
-        public val Pdf: ContentType = ContentType("application", "pdf")
-        public val Xlsx: ContentType = ContentType(
-            "application",
-            "vnd.openxmlformats-officedocument.spreadsheetml.sheet"
-        )
-        public val Docx: ContentType = ContentType(
-            "application",
-            "vnd.openxmlformats-officedocument.wordprocessingml.document"
-        )
-        public val Pptx: ContentType = ContentType(
-            "application",
-            "vnd.openxmlformats-officedocument.presentationml.presentation"
-        )
-        public val ProtoBuf: ContentType = ContentType("application", "protobuf")
-        public val Wasm: ContentType = ContentType("application", "wasm")
-        public val ProblemJson: ContentType = ContentType("application", "problem+json")
-        public val ProblemXml: ContentType = ContentType("application", "problem+xml")
+        /** Checks that the given [contentType] has type `application/`. */
+        public operator fun contains(contentType: ContentType): Boolean = contentType.match(Any)
     }
 
     /**
@@ -228,10 +226,19 @@ public class ContentType private constructor(
      */
     @Suppress("KDocMissingDocumentation", "unused")
     public object Audio {
-        public val Any: ContentType = ContentType("audio", "*")
-        public val MP4: ContentType = ContentType("audio", "mp4")
-        public val MPEG: ContentType = ContentType("audio", "mpeg")
-        public val OGG: ContentType = ContentType("audio", "ogg")
+        public const val TYPE: String = "audio"
+
+        public val Any: ContentType = ContentType(TYPE, "*")
+        public val MP4: ContentType = ContentType(TYPE, "mp4")
+        public val MPEG: ContentType = ContentType(TYPE, "mpeg")
+        public val OGG: ContentType = ContentType(TYPE, "ogg")
+
+        /** Checks that the given [contentType] has type `audio/`. */
+        public operator fun contains(contentType: CharSequence): Boolean =
+            contentType.startsWith("$TYPE/", ignoreCase = true)
+
+        /** Checks that the given [contentType] has type `audio/`. */
+        public operator fun contains(contentType: ContentType): Boolean = contentType.match(Any)
     }
 
     /**
@@ -241,12 +248,21 @@ public class ContentType private constructor(
      */
     @Suppress("KDocMissingDocumentation", "unused")
     public object Image {
-        public val Any: ContentType = ContentType("image", "*")
-        public val GIF: ContentType = ContentType("image", "gif")
-        public val JPEG: ContentType = ContentType("image", "jpeg")
-        public val PNG: ContentType = ContentType("image", "png")
-        public val SVG: ContentType = ContentType("image", "svg+xml")
-        public val XIcon: ContentType = ContentType("image", "x-icon")
+        public const val TYPE: String = "image"
+
+        public val Any: ContentType = ContentType(TYPE, "*")
+        public val GIF: ContentType = ContentType(TYPE, "gif")
+        public val JPEG: ContentType = ContentType(TYPE, "jpeg")
+        public val PNG: ContentType = ContentType(TYPE, "png")
+        public val SVG: ContentType = ContentType(TYPE, "svg+xml")
+        public val XIcon: ContentType = ContentType(TYPE, "x-icon")
+
+        /** Checks that the given [contentType] has type `image/`. */
+        public operator fun contains(contentSubtype: String): Boolean =
+            contentSubtype.startsWith("$TYPE/", ignoreCase = true)
+
+        /** Checks that the given [contentType] has type `image/`. */
+        public operator fun contains(contentType: ContentType): Boolean = contentType.match(Any)
     }
 
     /**
@@ -256,8 +272,17 @@ public class ContentType private constructor(
      */
     @Suppress("KDocMissingDocumentation", "unused")
     public object Message {
-        public val Any: ContentType = ContentType("message", "*")
-        public val Http: ContentType = ContentType("message", "http")
+        public const val TYPE: String = "message"
+
+        public val Any: ContentType = ContentType(TYPE, "*")
+        public val Http: ContentType = ContentType(TYPE, "http")
+
+        /** Checks that the given [contentType] has type `message/`. */
+        public operator fun contains(contentSubtype: String): Boolean =
+            contentSubtype.startsWith("$TYPE/", ignoreCase = true)
+
+        /** Checks that the given [contentType] has type `message/`. */
+        public operator fun contains(contentType: ContentType): Boolean = contentType.match(Any)
     }
 
     /**
@@ -267,14 +292,23 @@ public class ContentType private constructor(
      */
     @Suppress("KDocMissingDocumentation", "unused")
     public object MultiPart {
-        public val Any: ContentType = ContentType("multipart", "*")
-        public val Mixed: ContentType = ContentType("multipart", "mixed")
-        public val Alternative: ContentType = ContentType("multipart", "alternative")
-        public val Related: ContentType = ContentType("multipart", "related")
-        public val FormData: ContentType = ContentType("multipart", "form-data")
-        public val Signed: ContentType = ContentType("multipart", "signed")
-        public val Encrypted: ContentType = ContentType("multipart", "encrypted")
-        public val ByteRanges: ContentType = ContentType("multipart", "byteranges")
+        public const val TYPE: String = "multipart"
+
+        public val Any: ContentType = ContentType(TYPE, "*")
+        public val Mixed: ContentType = ContentType(TYPE, "mixed")
+        public val Alternative: ContentType = ContentType(TYPE, "alternative")
+        public val Related: ContentType = ContentType(TYPE, "related")
+        public val FormData: ContentType = ContentType(TYPE, "form-data")
+        public val Signed: ContentType = ContentType(TYPE, "signed")
+        public val Encrypted: ContentType = ContentType(TYPE, "encrypted")
+        public val ByteRanges: ContentType = ContentType(TYPE, "byteranges")
+
+        /** Checks that the given [contentType] has type `multipart/`. */
+        public operator fun contains(contentType: CharSequence): Boolean =
+            contentType.startsWith("$TYPE/", ignoreCase = true)
+
+        /** Checks that the given [contentType] has type `multipart/`. */
+        public operator fun contains(contentType: ContentType): Boolean = contentType.match(Any)
     }
 
     /**
@@ -284,15 +318,24 @@ public class ContentType private constructor(
      */
     @Suppress("KDocMissingDocumentation", "unused")
     public object Text {
-        public val Any: ContentType = ContentType("text", "*")
-        public val Plain: ContentType = ContentType("text", "plain")
-        public val CSS: ContentType = ContentType("text", "css")
-        public val CSV: ContentType = ContentType("text", "csv")
-        public val Html: ContentType = ContentType("text", "html")
-        public val JavaScript: ContentType = ContentType("text", "javascript")
-        public val VCard: ContentType = ContentType("text", "vcard")
-        public val Xml: ContentType = ContentType("text", "xml")
-        public val EventStream: ContentType = ContentType("text", "event-stream")
+        public const val TYPE: String = "text"
+
+        public val Any: ContentType = ContentType(TYPE, "*")
+        public val Plain: ContentType = ContentType(TYPE, "plain")
+        public val CSS: ContentType = ContentType(TYPE, "css")
+        public val CSV: ContentType = ContentType(TYPE, "csv")
+        public val Html: ContentType = ContentType(TYPE, "html")
+        public val JavaScript: ContentType = ContentType(TYPE, "javascript")
+        public val VCard: ContentType = ContentType(TYPE, "vcard")
+        public val Xml: ContentType = ContentType(TYPE, "xml")
+        public val EventStream: ContentType = ContentType(TYPE, "event-stream")
+
+        /** Checks that the given [contentType] has type `text/`. */
+        public operator fun contains(contentType: CharSequence): Boolean =
+            contentType.startsWith("$TYPE/", ignoreCase = true)
+
+        /** Checks that the given [contentType] has type `text/`. */
+        public operator fun contains(contentType: ContentType): Boolean = contentType.match(Any)
     }
 
     /**
@@ -302,11 +345,20 @@ public class ContentType private constructor(
      */
     @Suppress("KDocMissingDocumentation", "unused")
     public object Video {
-        public val Any: ContentType = ContentType("video", "*")
-        public val MPEG: ContentType = ContentType("video", "mpeg")
-        public val MP4: ContentType = ContentType("video", "mp4")
-        public val OGG: ContentType = ContentType("video", "ogg")
-        public val QuickTime: ContentType = ContentType("video", "quicktime")
+        public const val TYPE: String = "video"
+
+        public val Any: ContentType = ContentType(TYPE, "*")
+        public val MPEG: ContentType = ContentType(TYPE, "mpeg")
+        public val MP4: ContentType = ContentType(TYPE, "mp4")
+        public val OGG: ContentType = ContentType(TYPE, "ogg")
+        public val QuickTime: ContentType = ContentType(TYPE, "quicktime")
+
+        /** Checks that the given [contentType] has type `video/`. */
+        public operator fun contains(contentType: CharSequence): Boolean =
+            contentType.startsWith("$TYPE/", ignoreCase = true)
+
+        /** Checks that the given [contentType] has type `video/`. */
+        public operator fun contains(contentType: ContentType): Boolean = contentType.match(Any)
     }
 
     /**
@@ -316,13 +368,22 @@ public class ContentType private constructor(
      */
     @Suppress("KDocMissingDocumentation", "unused")
     public object Font {
-        public val Any: ContentType = ContentType("font", "*")
-        public val Collection: ContentType = ContentType("font", "collection")
-        public val Otf: ContentType = ContentType("font", "otf")
-        public val Sfnt: ContentType = ContentType("font", "sfnt")
-        public val Ttf: ContentType = ContentType("font", "ttf")
-        public val Woff: ContentType = ContentType("font", "woff")
-        public val Woff2: ContentType = ContentType("font", "woff2")
+        public const val TYPE: String = "font"
+
+        public val Any: ContentType = ContentType(TYPE, "*")
+        public val Collection: ContentType = ContentType(TYPE, "collection")
+        public val Otf: ContentType = ContentType(TYPE, "otf")
+        public val Sfnt: ContentType = ContentType(TYPE, "sfnt")
+        public val Ttf: ContentType = ContentType(TYPE, "ttf")
+        public val Woff: ContentType = ContentType(TYPE, "woff")
+        public val Woff2: ContentType = ContentType(TYPE, "woff2")
+
+        /** Checks that the given [contentType] has type `font/`. */
+        public operator fun contains(contentType: CharSequence): Boolean =
+            contentType.startsWith("$TYPE/", ignoreCase = true)
+
+        /** Checks that the given [contentType] has type `font/`. */
+        public operator fun contains(contentType: ContentType): Boolean = contentType.match(Any)
     }
 }
 

--- a/ktor-http/ktor-http-cio/common/src/io/ktor/http/cio/Multipart.kt
+++ b/ktor-http/ktor-http-cio/common/src/io/ktor/http/cio/Multipart.kt
@@ -4,6 +4,7 @@
 
 package io.ktor.http.cio
 
+import io.ktor.http.*
 import io.ktor.http.cio.internals.*
 import io.ktor.utils.io.*
 import io.ktor.utils.io.core.*
@@ -177,7 +178,7 @@ public fun CoroutineScope.parseMultipart(
     contentLength: Long?,
     maxPartSize: Long = Long.MAX_VALUE,
 ): ReceiveChannel<MultipartEvent> {
-    if (!contentType.startsWith("multipart/", ignoreCase = true)) {
+    if (contentType !in ContentType.MultiPart) {
         throw UnsupportedMediaTypeExceptionCIO(
             "Failed to parse multipart: Content-Type should be multipart/* but it is $contentType"
         )

--- a/ktor-server/ktor-server-core/common/src/io/ktor/server/request/ApplicationRequestProperties.kt
+++ b/ktor-server/ktor-server-core/common/src/io/ktor/server/request/ApplicationRequestProperties.kt
@@ -1,13 +1,12 @@
 /*
-* Copyright 2014-2021 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
-*/
+ * Copyright 2014-2024 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
 
 @file:Suppress("unused")
 
 package io.ktor.server.request
 
 import io.ktor.http.*
-import io.ktor.server.application.*
 import io.ktor.server.plugins.*
 import io.ktor.utils.io.charsets.*
 
@@ -149,7 +148,7 @@ public fun ApplicationRequest.isChunked(): Boolean =
  *
  * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.server.request.isMultipart)
  */
-public fun ApplicationRequest.isMultipart(): Boolean = contentType().match(ContentType.MultiPart.Any)
+public fun ApplicationRequest.isMultipart(): Boolean = contentType() in ContentType.MultiPart
 
 /**
  * Gets a request's `User-Agent` header value.

--- a/ktor-server/ktor-server-jetty-jakarta/jvm/src/io/ktor/server/jetty/jakarta/JettyKtorHandler.kt
+++ b/ktor-server/ktor-server-jetty-jakarta/jvm/src/io/ktor/server/jetty/jakarta/JettyKtorHandler.kt
@@ -72,7 +72,7 @@ internal class JettyKtorHandler(
     ) {
         try {
             val contentType = request.contentType
-            if (contentType != null && contentType.startsWith("multipart/", ignoreCase = true)) {
+            if (contentType != null && contentType in ContentType.MultiPart) {
                 baseRequest.setAttribute(Request.__MULTIPART_CONFIG_ELEMENT, multipartConfig)
                 // TODO someone reported auto-cleanup issues so we have to check it
             }

--- a/ktor-server/ktor-server-jetty/jvm/src/io/ktor/server/jetty/JettyKtorHandler.kt
+++ b/ktor-server/ktor-server-jetty/jvm/src/io/ktor/server/jetty/JettyKtorHandler.kt
@@ -72,7 +72,7 @@ internal class JettyKtorHandler(
     ) {
         try {
             val contentType = request.contentType
-            if (contentType != null && contentType.startsWith("multipart/", ignoreCase = true)) {
+            if (contentType != null && contentType in ContentType.MultiPart) {
                 baseRequest.setAttribute(Request.MULTIPART_CONFIG_ELEMENT, multipartConfig)
                 // TODO someone reported auto-cleanup issues so we have to check it
             }


### PR DESCRIPTION
**Subsystem**
Core

**Motivation**
[KTOR-8145](https://youtrack.jetbrains.com/issue/KTOR-8145) Add operator contains to ContentType objects
Add a simple way to check if a content type has one of the well-known types. This check should be case-insensitive, that is why it is error-prone to check content type using `contentType.startsWith(...)`

**Solution**
Add an operator `contains` to ContentType objects checking that the content type prefix is equal to the expected type name ignoring its casing.