### PR TITLE
KTOR-7586 Fix MimesTest doesn't compile on JS target

### DIFF
--- a/ktor-http/common/test/io/ktor/tests/http/MimesTest.kt
+++ b/ktor-http/common/test/io/ktor/tests/http/MimesTest.kt
@@ -10,7 +10,7 @@ import kotlin.test.*
 class MimesTest {
 
     @Test
-    fun `test mime with multiple extensions`() {
+    fun testMimeWithMultipleExtensions() {
         val textPlain = "text/plain".toContentType()
         val textMime = "text" to textPlain
         val txtMime = "txt" to textPlain
@@ -19,14 +19,14 @@ class MimesTest {
     }
 
     @Test
-    fun `test mime with single extension`() {
+    fun testMimeWithSingleExtension() {
         val acad = "application/acad".toContentType()
         val dwgMime = "dwg" to acad
         assertTrue(mimes.contains(dwgMime))
     }
 
     @Test
-    fun `test mimes size matches preallocated list size`() {
+    fun testMimesSizeMatchesPreallocatedListSize() {
         assertEquals(INITIAL_MIMES_LIST_SIZE, mimes.size)
     }
 }


### PR DESCRIPTION
The problem was introduced with #4410

Build fails with an error because of spaces in test names
```
e: file:///mnt/agent/work/8d547b974a7be21f/ktor-http/common/test/io/ktor/tests/http/MimesTest.kt:12:5 Name contains illegal chars that cannot appear in JavaScript identifier.
e: file:///mnt/agent/work/8d547b974a7be21f/ktor-http/common/test/io/ktor/tests/http/MimesTest.kt:21:5 Name contains illegal chars that cannot appear in JavaScript identifier.
e: file:///mnt/agent/work/8d547b974a7be21f/ktor-http/common/test/io/ktor/tests/http/MimesTest.kt:28:5 Name contains illegal chars that cannot appear in JavaScript identifier.
```