### PR TITLE
KTOR-7469 Fix IllegalArgumentException in HttpCookies when server returns a raw cookie with not allowed characters

### DIFF
--- a/ktor-http/common/src/io/ktor/http/Cookie.kt
+++ b/ktor-http/common/src/io/ktor/http/Cookie.kt
@@ -168,14 +168,7 @@ public fun renderSetCookieHeader(
  * Encode cookie value using the specified [encoding]
  */
 public fun encodeCookieValue(value: String, encoding: CookieEncoding): String = when (encoding) {
-    CookieEncoding.RAW -> when {
-        value.any { it.shouldEscapeInCookies() } ->
-            throw IllegalArgumentException(
-                "The cookie value contains characters that cannot be encoded in RAW format. " +
-                    " Consider URL_ENCODING mode"
-            )
-        else -> value
-    }
+    CookieEncoding.RAW -> value
     CookieEncoding.DQUOTES -> when {
         value.contains('"') -> throw IllegalArgumentException(
             "The cookie value contains characters that cannot be encoded in DQUOTES format. " +

--- a/ktor-http/common/test/io/ktor/tests/http/RenderSetCookieTest.kt
+++ b/ktor-http/common/test/io/ktor/tests/http/RenderSetCookieTest.kt
@@ -22,16 +22,15 @@ class RenderSetCookieTest {
     }
 
     @Test
-    fun renderCookieThrowsOnNotEncodedExtensions() {
+    fun renderCookieExtensionsWithNotRecommendedSymbols() {
         val cookie = Cookie(
             "name",
             "value",
             encoding = CookieEncoding.BASE64_ENCODING,
             extensions = mapOf("foo" to "b,ar")
         )
-        assertFailsWith<IllegalArgumentException> {
-            renderSetCookieHeader(cookie)
-        }
+        val rendered = renderSetCookieHeader(cookie)
+        assertEquals("name=dmFsdWU=; foo=b,ar; \$x-enc=BASE64_ENCODING", rendered)
     }
 
     @Test


### PR DESCRIPTION
**Subsystem**
Client, HttpCookies plugin

**Motivation**
[KTOR-7469](https://youtrack.jetbrains.com/issue/KTOR-7469)

**Solution**
The exception is thrown if a cookie with Raw encoding contains an invalid character such as:
```kotlin
isWhitespace() || this < ' ' || this in setOf(';', ',', '"')
```
Some servers send cookies to clients that contain these characters, however, the documentation does not support it. The solution is to remove this check because it doesn't break [Security Considerations](https://datatracker.ietf.org/doc/html/rfc6265#section-8)

