### PR TITLE
use encoded nonceCount to create response token

### DIFF
--- a/ktor-client/ktor-client-plugins/ktor-client-auth/common/src/io/ktor/client/plugins/auth/providers/DigestAuthProvider.kt
+++ b/ktor-client/ktor-client-plugins/ktor-client-auth/common/src/io/ktor/client/plugins/auth/providers/DigestAuthProvider.kt
@@ -143,7 +143,7 @@ public class DigestAuthProvider(
     }
 
     override suspend fun addRequestHeaders(request: HttpRequestBuilder, authHeader: HttpAuthHeader?) {
-        val nonceCount = requestCounter.incrementAndGet()
+        val nonceCount = requestCounter.incrementAndGet().toString(radix = 16).padStart(length = 8, padChar = '0')
         val methodName = request.method.value.uppercase()
         val url = URLBuilder().takeFrom(request.url).build()
 
@@ -180,7 +180,7 @@ public class DigestAuthProvider(
                 this["response"] = hex(token).quote()
                 this["uri"] = url.fullPath.quote()
                 actualQop?.let { this["qop"] = it }
-                this["nc"] = nonceCount.toString(radix = 16).padStart(length = 8, padChar = '0')
+                this["nc"] = nonceCount
                 @Suppress("DEPRECATION_ERROR")
                 this["algorithm"] = algorithmName
             },


### PR DESCRIPTION
**Subsystem**
Client Auth Plugin

**Motivation**
Fixes https://youtrack.jetbrains.com/issue/KTOR-7681

**Solution**
The "response" token was being generated with "nc" encoded as a decimal string, when in Ktor 3.0.1, it was changes to be an 8 digit hex string. Passing the properly encoded "nc" into the token fixes the breakage.

