### PR TITLE
KTOR-7008 Fix toMap() to correctly handle nested values in MergedApplicationConfig

### DIFF
--- a/ktor-server/ktor-server-core/common/src/io/ktor/server/config/MergedApplicationConfig.kt
+++ b/ktor-server/ktor-server-core/common/src/io/ktor/server/config/MergedApplicationConfig.kt
@@ -69,5 +69,18 @@ internal class MergedApplicationConfig(
 
     override fun keys(): Set<String> = firstKeys + secondKeys
 
-    override fun toMap(): Map<String, Any?> = second.toMap() + first.toMap()
+    override fun toMap(): Map<String, Any?> = second.toMap().deepMerge(first.toMap())
+
+    @Suppress("UNCHECKED_CAST")
+    private fun Map<String, Any?>.deepMerge(other: Map<String, Any?>): Map<String, Any?> = (this.keys + other.keys).associateWith { key ->
+        val value1 = this[key]
+        val value2 = other[key]
+
+        when {
+            value1 is Map<*, *> && value2 is Map<*, *> -> {
+                (value1 as Map<String, Any?>).deepMerge(value2 as Map<String, Any?>)
+            }
+            else -> value2 ?: value1
+        }
+    } 
 }

--- a/ktor-server/ktor-server-core/common/src/io/ktor/server/config/MergedApplicationConfig.kt
+++ b/ktor-server/ktor-server-core/common/src/io/ktor/server/config/MergedApplicationConfig.kt
@@ -69,18 +69,20 @@ internal class MergedApplicationConfig(
 
     override fun keys(): Set<String> = firstKeys + secondKeys
 
-    override fun toMap(): Map<String, Any?> = second.toMap().deepMerge(first.toMap())
+    override fun toMap(): Map<String, Any?> = second.toMap().merge(first.toMap())
 
     @Suppress("UNCHECKED_CAST")
-    private fun Map<String, Any?>.deepMerge(other: Map<String, Any?>): Map<String, Any?> = (this.keys + other.keys).associateWith { key ->
-        val value1 = this[key]
-        val value2 = other[key]
+    private fun Map<String, Any?>.merge(other: Map<String, Any?>): Map<String, Any?> =
+        (this.keys + other.keys).associateWith { key ->
+            val value1 = this[key]
+            val value2 = other[key]
 
-        when {
-            value1 is Map<*, *> && value2 is Map<*, *> -> {
-                (value1 as Map<String, Any?>).deepMerge(value2 as Map<String, Any?>)
+            when {
+                value1 is Map<*, *> && value2 is Map<*, *> -> {
+                    (value1 as Map<String, Any?>).merge(value2 as Map<String, Any?>)
+                }
+
+                else -> value2 ?: value1
             }
-            else -> value2 ?: value1
         }
-    } 
 }

--- a/ktor-server/ktor-server-core/common/test/io/ktor/server/config/MergedApplicationConfigTest.kt
+++ b/ktor-server/ktor-server-core/common/test/io/ktor/server/config/MergedApplicationConfigTest.kt
@@ -109,10 +109,10 @@ class MergedApplicationConfigTest {
             "nested.nested-value-2" to "value2",
             "nested.nested-value-3" to "value2",
         )
-        val merged = first.mergeWith(second).toMap()
-        assertEquals("value1", (merged["nested"] as Map<*, *>)["nested-value-1"])
-        assertEquals("value2", (merged["nested"] as Map<*, *>)["nested-value-2"])
-        assertEquals("value2", (merged["nested"] as Map<*, *>)["nested-value-3"])
+        val merged = first.mergeWith(second).toMap()["nested"] as Map<*, *>
+        assertEquals("value1", merged["nested-value-1"])
+        assertEquals("value2", merged["nested-value-2"])
+        assertEquals("value2", merged["nested-value-3"])
     }
 
     @Test

--- a/ktor-server/ktor-server-core/common/test/io/ktor/server/config/MergedApplicationConfigTest.kt
+++ b/ktor-server/ktor-server-core/common/test/io/ktor/server/config/MergedApplicationConfigTest.kt
@@ -100,6 +100,22 @@ class MergedApplicationConfigTest {
     }
 
     @Test
+    fun testDeepToMap() {
+        val first = MapApplicationConfig(
+            "nested.nested-value-1" to "value1",
+            "nested.nested-value-2" to "value1",
+        )
+        val second = MapApplicationConfig(
+            "nested.nested-value-2" to "value2",
+            "nested.nested-value-3" to "value2",
+        )
+        val merged = first.mergeWith(second).toMap()
+        assertEquals("value1", (merged["nested"] as Map<*, *>)["nested-value-1"])
+        assertEquals("value2", (merged["nested"] as Map<*, *>)["nested-value-2"])
+        assertEquals("value2", (merged["nested"] as Map<*, *>)["nested-value-3"])
+    }
+
+    @Test
     fun testMergeWith() {
         val first = MapApplicationConfig(
             "value1" to "1",


### PR DESCRIPTION
**Subsystem**
Server

**Motivation**
YouTrack issue link here - [KTOR-7008](https://youtrack.jetbrains.com/issue/KTOR-7008)

**Solution**
Instead of using the default "+" operator on the 2 source maps, deep merge them.

