### PR TITLE
KTOR-7726 Support binary (Smile) encoding in JacksonConverter

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -148,6 +148,7 @@ json-simple = { module = "com.googlecode.json-simple:json-simple", version.ref =
 gson = { module = "com.google.code.gson:gson", version.ref = "gson" }
 jackson-databind = { module = "com.fasterxml.jackson.core:jackson-databind", version.ref = "jackson" }
 jackson-module-kotlin = { module = "com.fasterxml.jackson.module:jackson-module-kotlin", version.ref = "jackson" }
+jackson-dataformat-smile = { module = "com.fasterxml.jackson.dataformat:jackson-dataformat-smile", version.ref = "jackson" }
 jackson-annotations = { module = "com.fasterxml.jackson.core:jackson-annotations", version.ref = "jackson" }
 
 jansi = { module = "org.fusesource.jansi:jansi", version.ref = "jansi" }

--- a/ktor-shared/ktor-serialization/ktor-serialization-jackson/build.gradle.kts
+++ b/ktor-shared/ktor-serialization/ktor-serialization-jackson/build.gradle.kts
@@ -21,6 +21,7 @@ kotlin {
                 api(project(":ktor-shared:ktor-serialization:ktor-serialization-tests"))
                 
                 api(libs.logback.classic)
+                api(libs.jackson.dataformat.smile)
             }
         }
     }

--- a/ktor-shared/ktor-serialization/ktor-serialization-jackson/jvm/src/JacksonConverter.kt
+++ b/ktor-shared/ktor-serialization/ktor-serialization-jackson/jvm/src/JacksonConverter.kt
@@ -1,6 +1,6 @@
 /*
-* Copyright 2014-2021 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
-*/
+ * Copyright 2014-2024 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
 
 package io.ktor.serialization.jackson
 
@@ -107,9 +107,9 @@ public class JacksonConverter(
         }
 
         private fun isUnicode(charset: Charset): Boolean {
-            return jacksonEncodings.contains(charset.name())
-                || charset == Charsets.UTF_16
-                || charset == Charsets.UTF_32
+            return jacksonEncodings.contains(charset.name()) ||
+                charset == Charsets.UTF_16 ||
+                charset == Charsets.UTF_32
         }
     }
 

--- a/ktor-shared/ktor-serialization/ktor-serialization-jackson/jvm/src/JacksonConverter.kt
+++ b/ktor-shared/ktor-serialization/ktor-serialization-jackson/jvm/src/JacksonConverter.kt
@@ -11,7 +11,6 @@ import com.fasterxml.jackson.module.kotlin.*
 import io.ktor.http.*
 import io.ktor.http.content.*
 import io.ktor.serialization.*
-import io.ktor.util.*
 import io.ktor.util.reflect.*
 import io.ktor.utils.io.*
 import io.ktor.utils.io.charsets.*
@@ -103,13 +102,13 @@ public class JacksonConverter(
     }
 
     private companion object {
-        private val encodings = buildMap<String, JsonEncoding> {
-            JsonEncoding.entries.forEach { put(it.javaName, it) }
-            put("US-ASCII", JsonEncoding.UTF8) // Jackson automatically unescapes Unicode characters
+        private val jacksonEncodings = buildSet<String> {
+            JsonEncoding.entries.forEach { add(it.javaName) }
+            add("US-ASCII") // Jackson automatically unescapes Unicode characters
         }
 
         private fun isUnicode(charset: Charset): Boolean {
-            return encodings.containsKey(charset.name())
+            return jacksonEncodings.contains(charset.name())
                 || charset == Charsets.UTF_16
                 || charset == Charsets.UTF_32
         }

--- a/ktor-shared/ktor-serialization/ktor-serialization-jackson/jvm/test/ClientJacksonTest.kt
+++ b/ktor-shared/ktor-serialization/ktor-serialization-jackson/jvm/test/ClientJacksonTest.kt
@@ -3,6 +3,10 @@
  */
 
 import com.fasterxml.jackson.annotation.*
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.dataformat.smile.SmileFactory
+import com.fasterxml.jackson.module.kotlin.jacksonTypeRef
+import com.fasterxml.jackson.module.kotlin.registerKotlinModule
 import io.ktor.client.call.*
 import io.ktor.client.engine.cio.*
 import io.ktor.client.plugins.contentnegotiation.*
@@ -24,6 +28,8 @@ class ClientJacksonTest : AbstractClientContentNegotiationTest() {
     override val customContentType: ContentType = ContentType.parse("application/x-json")
     override val webSocketsConverter: WebsocketContentConverter = JacksonWebsocketContentConverter()
 
+    private val smileContentType = ContentType.parse("application/x-jackson-smile")
+
     override fun ContentNegotiationConfig.configureContentNegotiation(contentType: ContentType) {
         register(contentType, converter)
     }
@@ -44,6 +50,20 @@ class ClientJacksonTest : AbstractClientContentNegotiationTest() {
                     ":" +
                     "${call.request.headers[HttpHeaders.ContentLength]}"
             )
+        }
+        post("/smile") {
+            val input = call.receiveStream()
+
+            val mapper = ObjectMapper(SmileFactory())
+            val data = mapper.readValue(input, jacksonTypeRef<Map<*, *>>())
+            assertEquals(mapOf("value" to "request"), data)
+
+            val response = mapOf(
+                "ok" to true,
+                "result" to listOf(mapOf("value" to "response", "ignoredValue" to "not_ignored"))
+            )
+
+            call.respondBytes(mapper.writeValueAsBytes(response), smileContentType)
         }
     }
 
@@ -100,6 +120,33 @@ class ClientJacksonTest : AbstractClientContentNegotiationTest() {
             }.body<String>()
 
             assertEquals("null:19", response)
+        }
+    }
+
+    @Test
+    fun testSmileEncoding() = testWithEngine(CIO) {
+        val smileMapper = ObjectMapper(SmileFactory()).apply {
+            registerKotlinModule()
+        }
+
+        config {
+            install(ContentNegotiation) {
+                register(smileContentType, JacksonConverter(smileMapper))
+            }
+        }
+
+        test { client ->
+            val response = client.post {
+                url(port = serverPort, path = "smile")
+                setBody(Jackson("request", "ignored"))
+                contentType(smileContentType)
+                accept(smileContentType)
+            }.body<Response<List<Jackson>>>()
+
+            assertTrue(response.ok)
+            val list = response.result!!
+            assertEquals(1, list.size)
+            assertEquals(Jackson("response", null), list[0]) // encoded with GsonConverter
         }
     }
 

--- a/ktor-shared/ktor-serialization/ktor-serialization-jackson/jvm/test/ClientJacksonTest.kt
+++ b/ktor-shared/ktor-serialization/ktor-serialization-jackson/jvm/test/ClientJacksonTest.kt
@@ -3,10 +3,9 @@
  */
 
 import com.fasterxml.jackson.annotation.*
-import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.dataformat.smile.SmileFactory
-import com.fasterxml.jackson.module.kotlin.jacksonTypeRef
-import com.fasterxml.jackson.module.kotlin.registerKotlinModule
+import com.fasterxml.jackson.databind.*
+import com.fasterxml.jackson.dataformat.smile.*
+import com.fasterxml.jackson.module.kotlin.*
 import io.ktor.client.call.*
 import io.ktor.client.engine.cio.*
 import io.ktor.client.plugins.contentnegotiation.*

--- a/ktor-shared/ktor-serialization/ktor-serialization-jackson/jvm/test/ServerJacksonTest.kt
+++ b/ktor-shared/ktor-serialization/ktor-serialization-jackson/jvm/test/ServerJacksonTest.kt
@@ -3,7 +3,7 @@
  */
 
 import com.fasterxml.jackson.databind.*
-import com.fasterxml.jackson.dataformat.smile.SmileFactory
+import com.fasterxml.jackson.dataformat.smile.*
 import com.fasterxml.jackson.module.kotlin.*
 import io.ktor.client.request.*
 import io.ktor.client.statement.*

--- a/ktor-shared/ktor-serialization/ktor-serialization-jackson/jvm/test/ServerJacksonTest.kt
+++ b/ktor-shared/ktor-serialization/ktor-serialization-jackson/jvm/test/ServerJacksonTest.kt
@@ -15,6 +15,7 @@ import io.ktor.server.request.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
 import io.ktor.server.testing.*
+import kotlinx.coroutines.flow.flowOf
 import java.nio.charset.*
 import kotlin.test.*
 
@@ -163,6 +164,37 @@ class ServerJacksonTest : AbstractServerSerializationTest() {
         }.let { response ->
             assertEquals(HttpStatusCode.OK, response.status)
             assertEquals("""id=1, title=Hello, World!, unicode=$uc""", response.bodyAsText())
+        }
+    }
+
+    @Test
+    fun testStreamingSmileEncoding() = testApplication {
+        val smileContentType = ContentType.parse("application/x-jackson-smile")
+        val smileMapper = ObjectMapper(SmileFactory()).apply {
+            registerKotlinModule()
+        }
+
+        install(ContentNegotiation) {
+            register(smileContentType, JacksonConverter(smileMapper))
+        }
+        routing {
+            get("/smile-stream") {
+                val testEntities = flowOf(
+                    MyEntity(111, "ൠ", listOf(ChildEntity("item1", 1), ChildEntity("item2", 2))),
+                    MyEntity(222, "ൠ1", listOf(ChildEntity("item3", 3), ChildEntity("item4", 5)))
+                )
+
+                call.respond(testEntities)
+            }
+        }
+
+        client.get("/smile-stream") {
+            header(HttpHeaders.Accept, smileContentType)
+        }.let { response ->
+            assertEquals(HttpStatusCode.OK, response.status)
+            val bytes = response.bodyAsBytes()
+            val entities = smileMapper.readValue<List<MyEntity>>(bytes)
+            assertEquals(2, entities.size)
         }
     }
 }

--- a/ktor-shared/ktor-serialization/ktor-serialization-jackson/jvm/test/ServerJacksonTest.kt
+++ b/ktor-shared/ktor-serialization/ktor-serialization-jackson/jvm/test/ServerJacksonTest.kt
@@ -15,7 +15,7 @@ import io.ktor.server.request.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
 import io.ktor.server.testing.*
-import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.*
 import java.nio.charset.*
 import kotlin.test.*
 


### PR DESCRIPTION
**Subsystem**
ContentNegociation: Server, Client: `JacksonConverter`.

**Motivation**
Allows usage of non-textual Smile JSON factory with Jackson, which is used for binary encoding of JSON.

Fixes https://youtrack.jetbrains.com/issue/KTOR-7726

**Solution**
When reading input, `JacksonConverter` creates a character stream, using the request `Charset` (default `UTF-8`). This approach is not compatible with the binary format, the [Smile encoding](https://github.com/FasterXML/smile-format-specification).

When attempting to read the binary encoded JSON structure with `JacksonConverter`, Jackson fails with an initialization error (or sometimes `JsonParseException`):

```Can not create parser for character-based (not byte-based) source
java.lang.UnsupportedOperationException: Can not create parser for character-based (not byte-based) source
```

In order to fix this problem, Jackson should operate over a byte-stream and not a character stream like it does today in `JsonConverter#deserialize`.