### PR TITLE
KTOR-7731 Add implementation for the deprecated FileItem.streamProvider

### DIFF
--- a/ktor-http/jvm/src/io/ktor/http/content/MultipartJvm.kt
+++ b/ktor-http/jvm/src/io/ktor/http/content/MultipartJvm.kt
@@ -4,6 +4,7 @@
 
 package io.ktor.http.content
 
+import io.ktor.utils.io.jvm.javaio.*
 import java.io.*
 
 /**
@@ -11,6 +12,6 @@ import java.io.*
  */
 @Suppress("DeprecatedCallableAddReplaceWith")
 @Deprecated("This API uses blocking InputStream. Please use provider() directly.")
-public val PartData.FileItem.streamProvider: () -> InputStream get() = error(
-    "streamProvider is deprecated. Use provider() instead"
-)
+public val PartData.FileItem.streamProvider: () -> InputStream get() = {
+    provider().toInputStream()
+}

--- a/ktor-http/jvm/test/io/ktor/tests/http/content/MultipartJvmTest.kt
+++ b/ktor-http/jvm/test/io/ktor/tests/http/content/MultipartJvmTest.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2014-2024 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.tests.http.content
+
+import io.ktor.http.*
+import io.ktor.http.content.*
+import io.ktor.utils.io.*
+import kotlin.test.*
+
+class MultipartJvmTest {
+
+    @Suppress("DEPRECATION")
+    @Test
+    fun testStreamProvider() {
+        val fileItem = PartData.FileItem({ ByteReadChannel(ByteArray(4097) { 1 }) }, {}, Headers.Empty)
+        val stream = fileItem.streamProvider()
+
+        val buffer = ByteArray(4097)
+        val read = stream.read(buffer)
+        assertEquals(4097, read)
+        assertEquals(ByteArray(4097) { 1 }.toList(), buffer.toList())
+    }
+}


### PR DESCRIPTION
Fix [KTOR-7731](https://youtrack.jetbrains.com/issue/KTOR-7731) `FileItem.streamProvider` is deprecated and doesn't have implementation