### PR TITLE
KTOR-7761 Use Dispatchers.IO for IOBridge (cherry-pick to main branch)

### DIFF
--- a/ktor-server/ktor-server-cio/posix/src/io/ktor/server/cio/internal/CoroutineUtilsNix.kt
+++ b/ktor-server/ktor-server-cio/posix/src/io/ktor/server/cio/internal/CoroutineUtilsNix.kt
@@ -7,4 +7,4 @@ package io.ktor.server.cio.internal
 import kotlinx.coroutines.*
 
 internal actual val Dispatchers.IOBridge: CoroutineDispatcher
-    get() = Default
+    get() = IO

--- a/ktor-server/ktor-server-core/posix/src/io/ktor/server/engine/internal/ApplicationUtilsNix.kt
+++ b/ktor-server/ktor-server-core/posix/src/io/ktor/server/engine/internal/ApplicationUtilsNix.kt
@@ -9,10 +9,12 @@ import io.ktor.server.engine.*
 import kotlinx.cinterop.*
 import kotlinx.coroutines.*
 import platform.posix.*
+import kotlin.experimental.*
 
-internal actual fun availableProcessorsBridge(): Int = 1
+@OptIn(ExperimentalNativeApi::class)
+internal actual fun availableProcessorsBridge(): Int = Platform.getAvailableProcessors()
 
-internal actual val Dispatchers.IOBridge: CoroutineDispatcher get() = Default
+internal actual val Dispatchers.IOBridge: CoroutineDispatcher get() = IO
 
 @OptIn(ExperimentalForeignApi::class)
 internal actual fun printError(message: Any?) {

--- a/ktor-server/ktor-server-test-host/posix/src/io/ktor/server/testing/internal/CoroutineUtilsNix.kt
+++ b/ktor-server/ktor-server-test-host/posix/src/io/ktor/server/testing/internal/CoroutineUtilsNix.kt
@@ -6,6 +6,6 @@ package io.ktor.server.testing.internal
 
 import kotlinx.coroutines.*
 
-internal actual val Dispatchers.IOBridge: CoroutineDispatcher get() = Default
+internal actual val Dispatchers.IOBridge: CoroutineDispatcher get() = IO
 
 internal actual fun <T> maybeRunBlocking(block: suspend CoroutineScope.() -> T): T = runBlocking(block = block)


### PR DESCRIPTION
**Subsystem**
Server

**Motivation**
Fixes https://youtrack.jetbrains.com/issue/KTOR-7761/Use-Dispatchers.IO-for-native-in-server-IOBridge

**Original PR:** https://github.com/ktorio/ktor/pull/4478