### PR TITLE
KTOR-7359 Implement a suspending version of EmbeddedServer.start and EmbeddedServer.stop

### DIFF
--- a/ktor-server/ktor-server-core/api/ktor-server-core.api
+++ b/ktor-server/ktor-server-core/api/ktor-server-core.api
@@ -590,9 +590,13 @@ public final class io/ktor/server/engine/EmbeddedServer {
 	public final fun reload ()V
 	public final fun start (Z)Lio/ktor/server/engine/EmbeddedServer;
 	public static synthetic fun start$default (Lio/ktor/server/engine/EmbeddedServer;ZILjava/lang/Object;)Lio/ktor/server/engine/EmbeddedServer;
+	public final fun startSuspend (ZLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun startSuspend$default (Lio/ktor/server/engine/EmbeddedServer;ZLkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public final fun stop (JJ)V
 	public final fun stop (JJLjava/util/concurrent/TimeUnit;)V
 	public static synthetic fun stop$default (Lio/ktor/server/engine/EmbeddedServer;JJILjava/lang/Object;)V
+	public final fun stopSuspend (JJLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun stopSuspend$default (Lio/ktor/server/engine/EmbeddedServer;JJLkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 }
 
 public final class io/ktor/server/engine/EmbeddedServerKt {

--- a/ktor-server/ktor-server-core/api/ktor-server-core.klib.api
+++ b/ktor-server/ktor-server-core/api/ktor-server-core.klib.api
@@ -416,6 +416,8 @@ final class <#A: io.ktor.server.engine/ApplicationEngine, #B: io.ktor.server.eng
 
     final fun start(kotlin/Boolean = ...): io.ktor.server.engine/EmbeddedServer<#A, #B> // io.ktor.server.engine/EmbeddedServer.start|start(kotlin.Boolean){}[0]
     final fun stop(kotlin/Long = ..., kotlin/Long = ...) // io.ktor.server.engine/EmbeddedServer.stop|stop(kotlin.Long;kotlin.Long){}[0]
+    final suspend fun startSuspend(kotlin/Boolean = ...): io.ktor.server.engine/EmbeddedServer<#A, #B> // io.ktor.server.engine/EmbeddedServer.startSuspend|startSuspend(kotlin.Boolean){}[0]
+    final suspend fun stopSuspend(kotlin/Long = ..., kotlin/Long = ...) // io.ktor.server.engine/EmbeddedServer.stopSuspend|stopSuspend(kotlin.Long;kotlin.Long){}[0]
 }
 
 final class <#A: kotlin/Any, #B: io.ktor.events/EventDefinition<#A>> io.ktor.server.application.hooks/MonitoringEvent : io.ktor.server.application/Hook<kotlin/Function1<#A, kotlin/Unit>> { // io.ktor.server.application.hooks/MonitoringEvent|null[0]

--- a/ktor-server/ktor-server-core/common/src/io/ktor/server/engine/EmbeddedServer.kt
+++ b/ktor-server/ktor-server-core/common/src/io/ktor/server/engine/EmbeddedServer.kt
@@ -6,6 +6,7 @@ package io.ktor.server.engine
 
 import io.ktor.events.*
 import io.ktor.server.application.*
+import io.ktor.server.engine.internal.*
 import io.ktor.util.logging.*
 import kotlinx.coroutines.*
 import kotlin.coroutines.*
@@ -34,7 +35,14 @@ public expect class EmbeddedServer<TEngine : ApplicationEngine, TConfiguration :
 
     public fun start(wait: Boolean = false): EmbeddedServer<TEngine, TConfiguration>
 
+    public suspend fun startSuspend(wait: Boolean = false): EmbeddedServer<TEngine, TConfiguration>
+
     public fun stop(
+        gracePeriodMillis: Long = engineConfig.shutdownGracePeriod,
+        timeoutMillis: Long = engineConfig.shutdownGracePeriod
+    )
+
+    public suspend fun stopSuspend(
         gracePeriodMillis: Long = engineConfig.shutdownGracePeriod,
         timeoutMillis: Long = engineConfig.shutdownGracePeriod
     )

--- a/ktor-server/ktor-server-core/jvm/src/io/ktor/server/engine/EmbeddedServerJvm.kt
+++ b/ktor-server/ktor-server-core/jvm/src/io/ktor/server/engine/EmbeddedServerJvm.kt
@@ -294,6 +294,10 @@ actual constructor(
         return this
     }
 
+    public actual suspend fun startSuspend(wait: Boolean): EmbeddedServer<TEngine, TConfiguration> {
+        return withContext(Dispatchers.IOBridge) { start(wait) }
+    }
+
     public fun stop(shutdownGracePeriod: Long, shutdownTimeout: Long, timeUnit: TimeUnit) {
         try {
             engine.stop(timeUnit.toMillis(shutdownGracePeriod), timeUnit.toMillis(shutdownTimeout))
@@ -310,6 +314,10 @@ actual constructor(
 
     public actual fun stop(gracePeriodMillis: Long, timeoutMillis: Long) {
         stop(gracePeriodMillis, timeoutMillis, TimeUnit.MILLISECONDS)
+    }
+
+    public actual suspend fun stopSuspend(gracePeriodMillis: Long, timeoutMillis: Long) {
+        withContext(Dispatchers.IOBridge) { stop(gracePeriodMillis, timeoutMillis) }
     }
 
     private fun instantiateAndConfigureApplication(currentClassLoader: ClassLoader): Application {

--- a/ktor-server/ktor-server-core/posix/src/io/ktor/server/engine/EmbeddedServerNix.kt
+++ b/ktor-server/ktor-server-core/posix/src/io/ktor/server/engine/EmbeddedServerNix.kt
@@ -71,9 +71,17 @@ actual constructor(
         return this
     }
 
+    public actual suspend fun startSuspend(wait: Boolean): EmbeddedServer<TEngine, TConfiguration> {
+        return withContext(Dispatchers.IOBridge) { start(wait) }
+    }
+
     public actual fun stop(gracePeriodMillis: Long, timeoutMillis: Long) {
         engine.stop(gracePeriodMillis, timeoutMillis)
         destroy(application)
+    }
+
+    public actual suspend fun stopSuspend(gracePeriodMillis: Long, timeoutMillis: Long) {
+        withContext(Dispatchers.IOBridge) { stop(gracePeriodMillis, timeoutMillis) }
     }
 
     private fun destroy(application: Application) {

--- a/ktor-server/ktor-server-test-base/jsAndWasmShared/src/io/ktor/server/test/base/EngineTestBase.jsAndWasmShared.kt
+++ b/ktor-server/ktor-server-test-base/jsAndWasmShared/src/io/ktor/server/test/base/EngineTestBase.jsAndWasmShared.kt
@@ -53,7 +53,7 @@ actual constructor(
     @OptIn(DelicateCoroutinesApi::class)
     @AfterTest
     fun tearDownBase() {
-        GlobalScope.launch { server?.stopSuspend(0, 500) }
+        GlobalScope.launch { server?.stopSuspend(gracePeriodMillis = 0, timeoutMillis = 500) }
     }
 
     protected actual suspend fun createAndStartServer(

--- a/ktor-server/ktor-server-test-base/jsAndWasmShared/src/io/ktor/server/test/base/EngineTestBase.jsAndWasmShared.kt
+++ b/ktor-server/ktor-server-test-base/jsAndWasmShared/src/io/ktor/server/test/base/EngineTestBase.jsAndWasmShared.kt
@@ -19,6 +19,9 @@ import kotlin.coroutines.*
 import kotlin.test.*
 import kotlin.time.Duration.Companion.seconds
 
+private const val UNINITIALIZED_PORT = -1
+private const val DEFAULT_PORT = 0
+
 actual abstract class EngineTestBase<
     TEngine : ApplicationEngine,
     TConfiguration : ApplicationEngine.Configuration
@@ -39,10 +42,10 @@ actual constructor(
      * That's why we assign port after the server is started in [startServer]
      * Note: this means, that [port] can be used only after calling [createAndStartServer] or [startServer].
      */
-    private var _port: Int = 0
+    private var _port: Int = UNINITIALIZED_PORT
     protected actual var port: Int
         get() {
-            check(_port != 0) { "Port is not initialized" }
+            check(_port != UNINITIALIZED_PORT) { "Port is not initialized" }
             return _port
         }
         set(_) {
@@ -110,8 +113,8 @@ actual constructor(
 
         return embeddedServer(applicationEngineFactory, properties) {
             connector {
-                // port is zero, so that it will be automatically assigned when the server is started.
-                port = 0
+                // the default port is zero, so that it will be automatically assigned when the server is started.
+                port = DEFAULT_PORT
             }
             shutdownGracePeriod = 1000
             shutdownTimeout = 1000

--- a/ktor-server/ktor-server-test-base/jsAndWasmShared/src/io/ktor/server/test/base/EngineTestBase.jsAndWasmShared.kt
+++ b/ktor-server/ktor-server-test-base/jsAndWasmShared/src/io/ktor/server/test/base/EngineTestBase.jsAndWasmShared.kt
@@ -33,6 +33,12 @@ actual constructor(
     @Retention
     protected actual annotation class Http2Only actual constructor()
 
+    /**
+     * It's not possible to find a free port during test setup,
+     * as on JS (Node.js) all APIs are non-blocking (suspend).
+     * That's why we assign port after the server is started in [startServer]
+     * Note: this means, that [port] can be used only after calling [createAndStartServer] or [startServer].
+     */
     private var _port: Int = 0
     protected actual var port: Int
         get() {

--- a/ktor-server/ktor-server-test-base/jsAndWasmShared/src/io/ktor/server/test/base/EngineTestBase.jsAndWasmShared.kt
+++ b/ktor-server/ktor-server-test-base/jsAndWasmShared/src/io/ktor/server/test/base/EngineTestBase.jsAndWasmShared.kt
@@ -109,7 +109,10 @@ actual constructor(
         }
 
         return embeddedServer(applicationEngineFactory, properties) {
-            connector { port = 0 }
+            connector {
+                // port is zero, so that it will be automatically assigned when the server is started.
+                port = 0
+            }
             shutdownGracePeriod = 1000
             shutdownTimeout = 1000
         }


### PR DESCRIPTION
**Subsystem**
Server

**Motivation**
* fixes https://youtrack.jetbrains.com/issue/KTOR-7459
* alternative to https://youtrack.jetbrains.com/issue/KTOR-2939
* prerequisite for https://github.com/ktorio/ktor/pull/4466

**Solution**

Only `startSuspend` and `stopSuspend` functions were added with minimal bridge for JVM and Native implementations.
That was done like this, because in most cases users will anyway call `start` and `stop`, and it's not clear, which engines could support `suspend` start/stop (e.g CIO can, for sure, but for others it's not that clear).
That's why minimally invasive changes were implemented to support wasm-js and js case, where `runBlocking` is not available.

PR also contains changes to `EngineTestBase` for js and wasm-js as this is the main consumer for those new APIs.

Note: probably some commonization is possible for both `EmbeddedServer` and `EngineTestBase`, it should be investigated.