### PR TITLE
KTOR-7825 Decrease Gradle memory consumption

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -24,3 +24,6 @@ ktlint_standard_comment-wrapping = disabled
 [*.kts]
 # Always use wildcard imports in scripts
 ij_kotlin_name_count_to_use_star_import = 2
+
+[*.properties]
+ij_properties_keep_blank_lines = true

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,10 +2,10 @@
  * Copyright 2014-2024 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
-import org.jetbrains.dokka.gradle.*
-import org.jetbrains.kotlin.gradle.dsl.*
-import org.jetbrains.kotlin.gradle.tasks.*
-import org.jetbrains.kotlin.konan.target.*
+import org.jetbrains.dokka.gradle.DokkaMultiModuleTask
+import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompilationTask
+import org.jetbrains.kotlin.konan.target.HostManager
 
 val releaseVersion: String? by extra
 val eapVersion: String? by extra
@@ -56,11 +56,7 @@ apply(from = "gradle/compatibility.gradle")
 plugins {
     alias(libs.plugins.dokka) apply false
     alias(libs.plugins.binaryCompatibilityValidator)
-    alias(libs.plugins.doctor)
-}
-
-doctor {
-    enableTestCaching = false
+    conventions.gradleDoctor
 }
 
 subprojects {

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -15,6 +15,7 @@ dependencies {
 
     implementation(libs.kotlinter)
     implementation(libs.develocity)
+    implementation(libs.gradleDoctor)
 
     implementation(libs.ktor.server.default.headers)
     implementation(libs.ktor.server.netty)

--- a/buildSrc/src/main/kotlin/conventions.gradleDoctor.gradle.kts
+++ b/buildSrc/src/main/kotlin/conventions.gradleDoctor.gradle.kts
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2014-2024 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+import org.gradle.api.services.internal.RegisteredBuildServiceProvider
+
+plugins {
+    id("com.osacky.doctor")
+}
+
+doctor {
+    enableTestCaching = false
+}
+
+// Always monitor tasks on CI, but disable it locally by default with providing an option to opt-in.
+// See 'doctor.enableTaskMonitoring' in gradle.properties for details.
+val enableTasksMonitoring = CI ||
+    properties.getOrDefault("doctor.enableTaskMonitoring", "false").toString().toBoolean()
+
+if (!enableTasksMonitoring) {
+    logger.info("Gradle Doctor task monitoring is disabled.")
+    gradle.sharedServices.unregister("listener-service")
+}
+
+fun BuildServiceRegistry.unregister(name: String) {
+    val registration = registrations.getByName(name)
+    registrations.remove(registration)
+    (registration.service as RegisteredBuildServiceProvider<*, *>).maybeStop()
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 #
-# Copyright 2014-2020 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+# Copyright 2014-2024 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
 #
 
 # sytleguide
@@ -8,10 +8,34 @@ kotlin.code.style=official
 # config
 version=3.0.2-SNAPSHOT
 
+## JVM arguments
+#
+# Notes:
+# * You can reduce '-Xmx' downto '6g' or even '4g', but this could lead to OOM on project sync in an IDE
+#   while it might be enough for other tasks.
+# * '-Dkotlin.daemon.jvm.option' is used for the Kotlin Daemon started by Gradle to compile buildSrc as it ignores
+#   the value from 'kotlin.daemon.jvmargs'
+# * We cannot specify default '-XX:MaxMetaspaceSize' value as it could lead to "OutOfMemory: Metaspace" problems
+#   on running BCV tasks. While it is okay to set this value on CI.
+#   See: https://github.com/Kotlin/binary-compatibility-validator/issues/282
+#
+# On CI it is recommended to add the following options:
+# * '-XX:MaxMetaspaceSize=1g'
+#   To prevent Gradle Daemon from being killed due to unbounded usage of metaspace.
+#   See: https://github.com/gradle/gradle/issues/19750
+#   Value '1g' should be enough if you aren't going to run BCV tasks, otherwise use higher value: 2g-4g
+#   The acceptible maximum depends on the number of Gradle workers that are run in parallel. The more workers,
+#   the more metaspace memory is consumed.
+# * '-Dkotlin.daemon.options=autoshutdownIdleSeconds=30'
+#   To save some memory, shutting down Kotlin Daemon used for buildSrc compilation after 30 seconds of idle.
+#   See: https://github.com/gradle/gradle/issues/29331
+#
+org.gradle.jvmargs=-Xms2g -Xmx8g -XX:+HeapDumpOnOutOfMemoryError -XX:+UseParallelGC -Dfile.encoding=UTF-8 -Dkotlin.daemon.jvm.options=-Xmx512m,Xms256m,-XX:MaxMetaspaceSize=256m,XX:+HeapDumpOnOutOfMemoryError
+kotlin.daemon.jvmargs=-Xms512m -Xmx2g -XX:MaxMetaspaceSize=256m -XX:+HeapDumpOnOutOfMemoryError
+
 # gradle
 org.gradle.daemon=true
 org.gradle.caching=true
-org.gradle.jvmargs=-Xmx10g -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8 -XX:+UseParallelGC
 org.gradle.parallel=true
 
 # kotlin
@@ -26,8 +50,6 @@ kotlin.apple.xcodeCompatibility.nowarn=true
 kotlin.suppressGradlePluginWarnings=IncorrectCompileOnlyDependencyWarning
 #kotlinx.atomicfu.enableJvmIrTransformation=true
 #kotlinx.atomicfu.enableNativeIrTransformation=true
-
-kotlin.daemon.jvmargs=-Xmx6g -XX:+HeapDumpOnOutOfMemoryError
 kotlin.daemon.useFallbackStrategy=false
 
 # dokka

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,8 +8,9 @@ kotlin.code.style=official
 # config
 version=3.0.2-SNAPSHOT
 
-## JVM arguments
-#
+## Performance
+
+# JVM arguments used to run Gradle Daemon.
 # Notes:
 # * You can reduce '-Xmx' downto '6g' or even '4g', but this could lead to OOM on project sync in an IDE
 #   while it might be enough for other tasks.
@@ -29,9 +30,13 @@ version=3.0.2-SNAPSHOT
 # * '-Dkotlin.daemon.options=autoshutdownIdleSeconds=30'
 #   To save some memory, shutting down Kotlin Daemon used for buildSrc compilation after 30 seconds of idle.
 #   See: https://github.com/gradle/gradle/issues/29331
-#
 org.gradle.jvmargs=-Xms2g -Xmx8g -XX:+HeapDumpOnOutOfMemoryError -XX:+UseParallelGC -Dfile.encoding=UTF-8 -Dkotlin.daemon.jvm.options=-Xmx512m,Xms256m,-XX:MaxMetaspaceSize=256m,XX:+HeapDumpOnOutOfMemoryError
 kotlin.daemon.jvmargs=-Xms512m -Xmx2g -XX:MaxMetaspaceSize=256m -XX:+HeapDumpOnOutOfMemoryError
+# Gradle Doctor might increase memory consumption when task monitoring is enabled, so it is disabled by default.
+# Some features can't work without task monitoring:
+#  doctor-negative-savings, doctor-slow-build-cache-connection, doctor-slow-maven-connection
+# Issue: https://github.com/runningcode/gradle-doctor/issues/348
+doctor.enableTaskMonitoring=false
 
 # gradle
 org.gradle.daemon=true

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -128,8 +128,6 @@ kotlinx-io-core = { module = "org.jetbrains.kotlinx:kotlinx-io-core", version.re
 
 kotlinx-browser = { module = "org.jetbrains.kotlinx:kotlinx-browser", version.ref = "kotlinx-browser" }
 
-kotlinter = { module = "org.jmailen.gradle:kotlinter-gradle", version.ref = "ktlint" }
-
 dokka-plugin-versioning = { module = "org.jetbrains.dokka:versioning-plugin", version.ref = "dokka" }
 
 netty-handler = { module = "io.netty:netty-handler", version.ref = "netty" }
@@ -229,6 +227,8 @@ tomlj = { module = "org.tomlj:tomlj", version.ref = "tomlj" }
 
 develocity = { module = "com.gradle:develocity-gradle-plugin", version.ref = "develocity" }
 develocity-commonCustomUserData = { module = "com.gradle:common-custom-user-data-gradle-plugin", version.ref = "develocity-commonCustomUserData" }
+kotlinter = { module = "org.jmailen.gradle:kotlinter-gradle", version.ref = "ktlint" }
+gradleDoctor = { module = "com.osacky.doctor:doctor-plugin", version.ref = "gradleDoctor" }
 
 [plugins]
 


### PR DESCRIPTION
**Subsystem**
Build Infrastructure

**Motivation**
It is hard to build the project on machines with less than 16 GB RAM because of high memory consumption.
We have problems on CI when Kotlin Daemon or Gradle Daemon are killed because of high memory pressure.
[KTOR-7825](https://youtrack.jetbrains.com/issue/KTOR-7825) Reduce Gradle memory consumption

**Solution**
- Decrease `Xmx` for Kotlin Daemon (including the one used by Gradle to compile `buildSrc`)
- Decrease `Xmx` for Gradle Daemon
- Add a workaround for Gradle Doctor - https://github.com/runningcode/gradle-doctor/issues/348

It would be great to specify `-XX:MaxMetaspaceSize` to prevent Gradle from being silently killed by OS due to unlimited metaspace consumption (see https://github.com/gradle/gradle/issues/19750) and make memory consumption more predictable. Unfortunately, we can't do it now because of https://github.com/Kotlin/binary-compatibility-validator/issues/282

_This is a WIP PR for those who are interested in trying the new daemon configurations._

**Relates to:**
- https://github.com/ktorio/ktor-build/pull/103