### PR TITLE
KTOR-7746 Fix infinite loop issue with eager buffer shifting

### DIFF
--- a/ktor-io/common/src/io/ktor/utils/io/ByteChannel.kt
+++ b/ktor-io/common/src/io/ktor/utils/io/ByteChannel.kt
@@ -64,7 +64,7 @@ public class ByteChannel(public val autoFlush: Boolean = false) : ByteReadChanne
     @OptIn(InternalAPI::class)
     override suspend fun awaitContent(min: Int): Boolean {
         rethrowCloseCauseIfNeeded()
-        if (flushBufferSize + _readBuffer.size >= min) return true
+        if (_readBuffer.size >= min) return true
 
         sleepWhile(Slot::Read) {
             flushBufferSize + _readBuffer.size < min && _closedCause.value == null


### PR DESCRIPTION
**Subsystem**
Core

**Motivation**
[KTOR-7746](https://youtrack.jetbrains.com/issue/KTOR-7746) ByteReadChannel.{readShort/readInt/readLong} leads to infinite loop when required bytes distributed in flush and read buffers

**Solution**
This fixes the condition where we have partial content in the read buffer and the flush buffer is never transferred because it is waiting for the condition of `_readBuffer.exhausted` in the accessor, and it is skipped in `awaitContent`.

Now, when flushBuffer + readBuffer size is greater than min, then `sleepWhile` will exit immediately without any synchronization then the flush will happen.

