### PR TITLE
Use "import on demand" only for Ktor modules

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -11,8 +11,7 @@ indent_size = 2
 
 [*.{kt,kts}]
 ij_kotlin_code_style_defaults = KOTLIN_OFFICIAL
-ij_kotlin_name_count_to_use_star_import = 1
-ij_kotlin_name_count_to_use_star_import_for_members = 1
+ij_kotlin_packages_to_use_import_on_demand = java.util.*, io.ktor.**
 
 ktlint_standard_no-wildcard-imports = disabled
 ktlint_standard_trailing-comma-on-call-site = disabled
@@ -21,3 +20,7 @@ ktlint_standard_filename = disabled
 ktlint_standard_class-naming = disabled
 ktlint_standard_annotation = disabled
 ktlint_standard_comment-wrapping = disabled
+
+[*.kts]
+# Always use wildcard imports in scripts
+ij_kotlin_name_count_to_use_star_import = 2

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ build
 .gradle
 .gradletasknamecache
 .idea/*
+!.idea/externalDependencies.xml
 !.idea/runConfigurations
 !.idea/runConfigurations/*
 !.idea/vcs.xml

--- a/.idea/externalDependencies.xml
+++ b/.idea/externalDependencies.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ExternalDependencies">
+    <plugin id="org.editorconfig.editorconfigjetbrains" />
+  </component>
+</project>

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -98,13 +98,14 @@ A few things to remember:
 
 * Your code should conform to
   the official [Kotlin code style guide](https://kotlinlang.org/docs/reference/coding-conventions.html)
-  except that star imports should be always enabled
-  (ensure Preferences | Editor | Code Style | Kotlin, tab **Imports**, both `Use import with '*'` should be checked).
+  except that star imports should always be used for `io.ktor.*` packages.
+  Code style is managed by [EditorConfig](https://www.jetbrains.com/help/idea/editorconfig.html),
+  so make sure the EditorConfig plugin is enabled in the IDE.
 * Every new source file should have a copyright header.
 * Every public API (including functions, classes, objects and so on) should be documented,
   every parameter, property, return types and exceptions should be described properly.
-* A questionable and new API should be marked with the `@KtorExperimentalAPI` annotation.
-* A Public API that is not intended to be used by end-users that couldn't be made private/internal due to technical reasons,
+* A Public API which is not intended to be used by end-users that couldn't be made private/internal due to technical
+  reasons,
   should be marked with `@InternalAPI` annotation.
 
 ### Commit messages

--- a/ktor-http/ktor-http-cio/jvm/src/io/ktor/http/cio/Multipart.kt
+++ b/ktor-http/ktor-http-cio/jvm/src/io/ktor/http/cio/Multipart.kt
@@ -6,14 +6,15 @@ package io.ktor.http.cio
 
 import io.ktor.http.cio.internals.*
 import io.ktor.utils.io.*
-import io.ktor.utils.io.ByteString
 import io.ktor.utils.io.core.*
 import kotlinx.coroutines.*
-import kotlinx.coroutines.channels.*
-import kotlinx.io.*
-import kotlinx.io.bytestring.*
+import kotlinx.coroutines.channels.ReceiveChannel
+import kotlinx.coroutines.channels.produce
+import kotlinx.io.IOException
+import kotlinx.io.Source
+import kotlinx.io.bytestring.ByteString
 import java.io.EOFException
-import java.nio.*
+import java.nio.ByteBuffer
 
 /**
  * Represents a multipart content starting event. Every part need to be completely consumed or released via [release]

--- a/ktor-http/ktor-http-cio/jvm/src/io/ktor/http/cio/RequestResponseBuilder.kt
+++ b/ktor-http/ktor-http-cio/jvm/src/io/ktor/http/cio/RequestResponseBuilder.kt
@@ -1,14 +1,13 @@
 /*
- * Copyright 2014-2019 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2014-2024 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package io.ktor.http.cio
 
 import io.ktor.http.*
-import io.ktor.utils.io.*
 import io.ktor.utils.io.core.*
-import kotlinx.io.*
-import java.nio.*
+import kotlinx.io.Source
+import java.nio.ByteBuffer
 
 /**
  * Builds an HTTP request or response


### PR DESCRIPTION
**Subsystem**
Code Style

**Motivation**
We need wildcard imports to be used only for packages with DSLs, for third-party libraries it is better to use regular imports.

**Solution**
Use `ij_kotlin_packages_to_use_import_on_demand` option instead of `ij_kotlin_name_count_to_use_star_import` in `.editorconfig`.

