### PR TITLE
KTOR-7846 Fix running tests against JDK 8

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -131,13 +131,8 @@ fun configureDokka() {
 configureDokka()
 
 fun Project.setupJvmToolchain() {
-    val jdk = when (project.name) {
-        in jdk11Modules -> 11
-        else -> 8
-    }
-
     kotlin {
-        jvmToolchain(jdk)
+        jvmToolchain(project.requiredJdkVersion)
     }
 }
 

--- a/buildSrc/src/main/kotlin/JvmConfig.kt
+++ b/buildSrc/src/main/kotlin/JvmConfig.kt
@@ -11,10 +11,7 @@ import org.gradle.kotlin.dsl.*
 import org.jetbrains.kotlin.gradle.targets.jvm.tasks.*
 
 fun Project.configureJvm() {
-    val compileJdk = when (name) {
-        in jdk11Modules -> 11
-        else -> 8
-    }
+    val compileJdk = project.requiredJdkVersion
 
     kotlin {
         jvm()

--- a/buildSrc/src/main/kotlin/JvmConfig.kt
+++ b/buildSrc/src/main/kotlin/JvmConfig.kt
@@ -2,13 +2,14 @@
  * Copyright 2014-2024 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
-import internal.*
-import org.gradle.api.*
-import org.gradle.api.tasks.testing.*
-import org.gradle.jvm.tasks.*
-import org.gradle.jvm.toolchain.*
+import internal.libs
+import org.gradle.api.Project
+import org.gradle.api.tasks.testing.Test
+import org.gradle.jvm.tasks.Jar
+import org.gradle.jvm.toolchain.JavaLanguageVersion
+import org.gradle.jvm.toolchain.JavaToolchainService
 import org.gradle.kotlin.dsl.*
-import org.jetbrains.kotlin.gradle.targets.jvm.tasks.*
+import org.jetbrains.kotlin.gradle.targets.jvm.tasks.KotlinJvmTest
 
 fun Project.configureJvm() {
     val compileJdk = project.requiredJdkVersion
@@ -87,8 +88,7 @@ fun Project.configureJvm() {
  * On CI use the default JDK.
  */
 private fun Test.configureJavaToolchain(compileJdk: Int) {
-    // JUnit 5 requires JDK 11+
-    val testJdk = (if (CI) currentJdk else compileJdk).coerceAtLeast(11)
+    val testJdk = if (CI) currentJdk else compileJdk
     val javaToolchains = project.the<JavaToolchainService>()
 
     javaLauncher = javaToolchains.launcherFor {

--- a/buildSrc/src/main/kotlin/KtorBuildProperties.kt
+++ b/buildSrc/src/main/kotlin/KtorBuildProperties.kt
@@ -19,7 +19,15 @@ val HOST_NAME = when {
 val currentJdk = JavaVersion.current().majorVersion.toInt()
 
 val Project.requiredJdkVersion: Int
-    get() = if (name in jdk11Modules) 11 else 8
+    get() = when {
+        name in jdk17Modules -> 17
+        name in jdk11Modules -> 11
+        else -> 8
+    }
+
+private val jdk17Modules = setOf(
+    "ktor-server-jte",
+)
 
 private val jdk11Modules = setOf(
     "ktor-client-java",

--- a/buildSrc/src/main/kotlin/KtorBuildProperties.kt
+++ b/buildSrc/src/main/kotlin/KtorBuildProperties.kt
@@ -34,6 +34,7 @@ private val jdk11Modules = setOf(
     "ktor-client-jetty-jakarta",
     "ktor-server-jetty-jakarta",
     "ktor-server-jetty-test-http2-jakarta",
-    "ktor-server-tomcat-jakarta",
+    "ktor-server-openapi",
     "ktor-server-servlet-jakarta",
+    "ktor-server-tomcat-jakarta",
 )

--- a/buildSrc/src/main/kotlin/KtorBuildProperties.kt
+++ b/buildSrc/src/main/kotlin/KtorBuildProperties.kt
@@ -2,7 +2,8 @@
  * Copyright 2014-2024 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
-import org.gradle.api.*
+import org.gradle.api.JavaVersion
+import org.gradle.api.Project
 
 val IDEA_ACTIVE: Boolean = System.getProperty("idea.active") == "true"
 
@@ -17,11 +18,14 @@ val HOST_NAME = when {
 
 val currentJdk = JavaVersion.current().majorVersion.toInt()
 
-val jdk11Modules = listOf(
+val Project.requiredJdkVersion: Int
+    get() = if (name in jdk11Modules) 11 else 8
+
+private val jdk11Modules = setOf(
     "ktor-client-java",
-    "ktor-server-servlet-jakarta",
     "ktor-client-jetty-jakarta",
     "ktor-server-jetty-jakarta",
     "ktor-server-jetty-test-http2-jakarta",
     "ktor-server-tomcat-jakarta",
+    "ktor-server-servlet-jakarta",
 )

--- a/gradle-settings-conventions/src/main/kotlin/conventions-dependency-resolution-management.settings.gradle.kts
+++ b/gradle-settings-conventions/src/main/kotlin/conventions-dependency-resolution-management.settings.gradle.kts
@@ -81,6 +81,14 @@ dependencyResolutionManagement {
             } else if (kotlinVersion != null) {
                 version("kotlin", kotlinVersion)
             }
+
+            downgradeTestDependencies()
         }
     }
+}
+
+fun VersionCatalogBuilder.downgradeTestDependencies() {
+    val testJdk = JavaVersion.current().majorVersion.toInt()
+
+    if (testJdk < 11) version("logback", "1.3.14") // Java 8 support dropped in Logback 1.4.x
 }

--- a/ktor-client/ktor-client-cio/jvm/test/io/ktor/client/engine/cio/CIORequestTest.kt
+++ b/ktor-client/ktor-client-cio/jvm/test/io/ktor/client/engine/cio/CIORequestTest.kt
@@ -12,15 +12,16 @@ import io.ktor.client.statement.*
 import io.ktor.client.tests.utils.*
 import io.ktor.http.*
 import io.ktor.http.content.*
+import io.ktor.junit.coroutines.*
 import io.ktor.server.engine.*
 import io.ktor.server.netty.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
-import io.mockk.*
-import kotlinx.coroutines.*
-import kotlinx.coroutines.debug.junit5.*
-import java.net.*
-import java.nio.channels.*
+import io.mockk.mockkStatic
+import io.mockk.verify
+import kotlinx.coroutines.delay
+import java.net.InetAddress
+import java.nio.channels.UnresolvedAddressException
 import kotlin.test.*
 
 @CoroutinesTimeout(60_000)

--- a/ktor-client/ktor-client-cio/jvm/test/io/ktor/client/engine/cio/ConnectErrorsTest.kt
+++ b/ktor-client/ktor-client-cio/jvm/test/io/ktor/client/engine/cio/ConnectErrorsTest.kt
@@ -11,13 +11,13 @@ import io.ktor.client.plugins.*
 import io.ktor.client.request.*
 import io.ktor.client.statement.*
 import io.ktor.http.*
+import io.ktor.junit.coroutines.*
 import io.ktor.network.tls.certificates.*
 import io.ktor.server.application.*
 import io.ktor.server.engine.*
 import io.ktor.server.netty.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
-import kotlinx.coroutines.debug.junit5.CoroutinesTimeout
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeout
 import java.io.File

--- a/ktor-client/ktor-client-tests/build.gradle.kts
+++ b/ktor-client/ktor-client-tests/build.gradle.kts
@@ -2,7 +2,7 @@
  * Copyright 2014-2024 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
-import test.server.*
+import test.server.TestServerPlugin
 
 description = "Common tests for client"
 
@@ -46,9 +46,8 @@ kotlin.sourceSets {
             api(project(":ktor-server:ktor-server-plugins:ktor-server-auth"))
             api(project(":ktor-server:ktor-server-plugins:ktor-server-websockets"))
             api(project(":ktor-shared:ktor-serialization:ktor-serialization-kotlinx"))
+            api(project(":ktor-shared:ktor-junit"))
             api(libs.logback.classic)
-            api(libs.junit)
-            api(libs.kotlin.test.junit5)
             implementation(libs.kotlinx.coroutines.debug)
         }
     }

--- a/ktor-client/ktor-client-tests/jvm/src/io/ktor/client/tests/utils/TestWithKtor.kt
+++ b/ktor-client/ktor-client-tests/jvm/src/io/ktor/client/tests/utils/TestWithKtor.kt
@@ -1,17 +1,19 @@
 /*
- * Copyright 2014-2022 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2014-2024 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package io.ktor.client.tests.utils
 
-import ch.qos.logback.classic.*
+import ch.qos.logback.classic.Level
 import ch.qos.logback.classic.Logger
+import io.ktor.junit.coroutines.*
 import io.ktor.server.engine.*
-import kotlinx.coroutines.debug.junit5.*
-import org.junit.jupiter.api.*
-import org.slf4j.*
-import java.net.*
-import java.util.concurrent.*
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.slf4j.LoggerFactory
+import java.net.ServerSocket
+import java.net.Socket
+import java.util.concurrent.TimeUnit
 
 @CoroutinesTimeout(5 * 60 * 1000)
 abstract class TestWithKtor {

--- a/ktor-network/jvm/test/io/ktor/network/sockets/tests/ClientSocketTest.kt
+++ b/ktor-network/jvm/test/io/ktor/network/sockets/tests/ClientSocketTest.kt
@@ -1,28 +1,29 @@
 /*
- * Copyright 2014-2019 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2014-2024 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package io.ktor.network.sockets.tests
 
 import io.ktor.junit.*
-import io.ktor.network.*
+import io.ktor.junit.coroutines.*
 import io.ktor.network.selector.*
 import io.ktor.network.sockets.*
-import io.ktor.network.sockets.Socket
-import io.ktor.network.sockets.SocketImpl
 import io.ktor.utils.io.*
 import io.mockk.*
-import kotlinx.coroutines.*
-import kotlinx.coroutines.debug.junit5.*
+import kotlinx.coroutines.asCoroutineDispatcher
+import kotlinx.coroutines.runBlocking
 import java.net.InetSocketAddress
 import java.net.ServerSocket
 import java.net.SocketAddress
-import java.nio.*
-import java.nio.channels.*
-import java.util.concurrent.*
-import kotlin.concurrent.*
-import kotlin.test.*
+import java.nio.ByteBuffer
+import java.nio.channels.ClosedChannelException
+import java.nio.channels.SocketChannel
+import java.util.concurrent.Executors
+import kotlin.concurrent.thread
+import kotlin.test.AfterTest
 import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 
 @CoroutinesTimeout(5 * 60 * 1000)
 @ErrorCollectorTest

--- a/ktor-network/jvm/test/io/ktor/network/sockets/tests/ServerSocketTest.kt
+++ b/ktor-network/jvm/test/io/ktor/network/sockets/tests/ServerSocketTest.kt
@@ -1,22 +1,26 @@
 /*
- * Copyright 2014-2019 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2014-2024 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package io.ktor.network.sockets.tests
 
+import io.ktor.junit.coroutines.*
 import io.ktor.network.selector.*
 import io.ktor.network.sockets.*
 import io.ktor.utils.io.*
 import kotlinx.coroutines.*
-import kotlinx.coroutines.debug.junit5.*
-import java.io.*
-import java.nio.channels.*
-import java.util.concurrent.*
+import java.io.IOException
+import java.nio.channels.CancelledKeyException
+import java.nio.channels.ClosedChannelException
 import java.util.concurrent.CancellationException
-import kotlin.concurrent.*
-import kotlin.coroutines.*
-import kotlin.test.*
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import kotlin.concurrent.Volatile
+import kotlin.concurrent.thread
+import kotlin.coroutines.CoroutineContext
+import kotlin.test.AfterTest
 import kotlin.test.Test
+import kotlin.test.assertEquals
 
 @CoroutinesTimeout(15_000)
 class ServerSocketTest : CoroutineScope {

--- a/ktor-network/ktor-network-tls/build.gradle.kts
+++ b/ktor-network/ktor-network-tls/build.gradle.kts
@@ -1,3 +1,7 @@
+/*
+ * Copyright 2014-2024 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
 kotlin.sourceSets {
     jvmAndPosixMain {
         dependencies {
@@ -8,6 +12,7 @@ kotlin.sourceSets {
     }
     jvmTest {
         dependencies {
+            api(project(":ktor-shared:ktor-junit"))
             api(project(":ktor-network:ktor-network-tls:ktor-network-tls-certificates"))
             api(libs.netty.handler)
             api(libs.mockk)

--- a/ktor-network/ktor-network-tls/jvm/test/io/ktor/network/tls/ConnectionTest.kt
+++ b/ktor-network/ktor-network-tls/jvm/test/io/ktor/network/tls/ConnectionTest.kt
@@ -1,32 +1,37 @@
 /*
- * Copyright 2014-2023 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2014-2024 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
 // ktlint-disable experimental:argument-list-wrapping
 package io.ktor.network.tls
 
+import io.ktor.junit.coroutines.*
 import io.ktor.network.selector.*
 import io.ktor.network.sockets.*
-import io.ktor.network.sockets.InetSocketAddress
 import io.ktor.network.tls.certificates.*
 import io.ktor.util.cio.*
 import io.ktor.utils.io.*
-import io.netty.bootstrap.*
-import io.netty.channel.*
-import io.netty.channel.nio.*
-import io.netty.channel.socket.*
-import io.netty.channel.socket.nio.*
-import io.netty.handler.ssl.*
-import kotlinx.coroutines.*
-import kotlinx.coroutines.debug.junit5.*
-import java.io.*
+import io.netty.bootstrap.ServerBootstrap
+import io.netty.channel.ChannelInitializer
+import io.netty.channel.EventLoopGroup
+import io.netty.channel.nio.NioEventLoopGroup
+import io.netty.channel.socket.SocketChannel
+import io.netty.channel.socket.nio.NioServerSocketChannel
+import io.netty.handler.ssl.SslContextBuilder
+import io.netty.handler.ssl.SslHandler
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.runBlocking
+import java.io.File
+import java.io.IOException
 import java.net.ServerSocket
-import java.security.*
-import java.security.cert.*
-import javax.net.ssl.*
-import kotlin.test.*
+import java.security.KeyStore
+import java.security.PrivateKey
+import java.security.cert.X509Certificate
+import javax.net.ssl.TrustManagerFactory
+import javax.net.ssl.X509TrustManager
 import kotlin.test.Ignore
 import kotlin.test.Test
+import kotlin.test.fail
 
 @Suppress("UNCHECKED_CAST")
 @CoroutinesTimeout(20_000)

--- a/ktor-server/ktor-server-cio/build.gradle.kts
+++ b/ktor-server/ktor-server-cio/build.gradle.kts
@@ -1,3 +1,7 @@
+/*
+ * Copyright 2014-2024 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
 description = ""
 
 kotlin.sourceSets {
@@ -21,6 +25,7 @@ kotlin.sourceSets {
             api(project(":ktor-server:ktor-server-test-base"))
             api(project(":ktor-server:ktor-server-core", configuration = "testOutput"))
             api(libs.logback.classic)
+            implementation(libs.kotlinx.coroutines.debug)
         }
     }
 }

--- a/ktor-server/ktor-server-cio/jvm/test/io/ktor/tests/server/cio/ServerPipelineTest.kt
+++ b/ktor-server/ktor-server-cio/jvm/test/io/ktor/tests/server/cio/ServerPipelineTest.kt
@@ -1,23 +1,25 @@
 /*
- * Copyright 2014-2021 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2014-2024 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package io.ktor.tests.server.cio
 
 import io.ktor.http.*
 import io.ktor.server.cio.backend.*
-import io.ktor.server.cio.internal.*
 import io.ktor.utils.io.*
 import io.ktor.utils.io.core.*
 import kotlinx.coroutines.*
-import kotlinx.coroutines.debug.junit5.*
-import org.junit.jupiter.api.*
-import java.util.concurrent.*
-import java.util.concurrent.atomic.*
-import kotlin.coroutines.*
-import kotlin.test.*
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.TestInfo
+import java.util.concurrent.CountDownLatch
+import kotlin.coroutines.AbstractCoroutineContextElement
+import kotlin.coroutines.CoroutineContext
 import kotlin.test.Test
-import kotlin.time.*
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
 
 @OptIn(InternalAPI::class)

--- a/ktor-server/ktor-server-core/jvm/src/io/ktor/server/http/content/StaticContent.kt
+++ b/ktor-server/ktor-server-core/jvm/src/io/ktor/server/http/content/StaticContent.kt
@@ -4,7 +4,7 @@
 
 package io.ktor.server.http.content
 
-import com.sun.nio.file.*
+import com.sun.nio.file.SensitivityWatchEventModifier
 import io.ktor.http.*
 import io.ktor.http.content.*
 import io.ktor.server.application.*
@@ -13,10 +13,14 @@ import io.ktor.server.http.content.FileSystemPaths.Companion.paths
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
 import io.ktor.util.*
-import java.io.*
-import java.net.*
-import java.nio.file.*
-import kotlin.io.path.*
+import java.io.File
+import java.net.URL
+import java.nio.file.FileSystem
+import java.nio.file.FileSystems
+import java.nio.file.Path
+import java.nio.file.StandardWatchEventKinds
+import kotlin.io.path.isDirectory
+import kotlin.io.path.pathString
 
 /**
  * Attribute to assign the path of a static file served in the response.  The main use of this attribute is to indicate
@@ -616,7 +620,7 @@ private suspend fun ApplicationCall.respondStaticPath(
     defaultPath: String?
 ) {
     val relativePath = parameters.getAll(pathParameterName)?.joinToString(File.separator) ?: return
-    val requestedPath = fileSystem.getPath(basePath ?: "").combineSafe(fileSystem.getPath(relativePath))
+    val requestedPath = fileSystem.getPath(basePath.orEmpty()).combineSafe(fileSystem.getPath(relativePath))
 
     suspend fun checkExclude(path: Path): Boolean {
         if (!exclude(path)) return false

--- a/ktor-server/ktor-server-plugins/ktor-server-i18n/jvm/test/io/ktor/tests/i18n/TranslationTest.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-i18n/jvm/test/io/ktor/tests/i18n/TranslationTest.kt
@@ -11,7 +11,9 @@ import io.ktor.i18n.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
 import io.ktor.server.testing.*
-import kotlin.test.*
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
 
 class TranslationTest {
 
@@ -93,7 +95,7 @@ class TranslationTest {
 
         routing {
             get("/") {
-                val value = i18n("some_key")
+                val value = i18n("some_key").fixJava8Encoding()
                 call.respond(HttpStatusCode.OK, value)
             }
         }
@@ -107,4 +109,19 @@ class TranslationTest {
         val contentAsString = response.bodyAsText()
         assertEquals("Русский Ключ", contentAsString)
     }
+
+    /**
+     * On Java 8 PropertyResourceBundle requires properties to be encoded in ISO-8859-1,
+     * while starting from Java 9 the default encoding is UTF-8.
+     */
+    private fun String.fixJava8Encoding(): String {
+        return if (javaVersion.startsWith("1.8")) {
+            // Encode string in UTF-8 instead of ISO-8859-1
+            this.toByteArray(Charsets.ISO_8859_1).toString(Charsets.UTF_8)
+        } else {
+            this
+        }
+    }
 }
+
+private val javaVersion = System.getProperty("java.version")

--- a/ktor-server/ktor-server-plugins/ktor-server-websockets/build.gradle.kts
+++ b/ktor-server/ktor-server-plugins/ktor-server-websockets/build.gradle.kts
@@ -1,3 +1,7 @@
+/*
+ * Copyright 2014-2024 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
 description = ""
 
 kotlin.sourceSets {
@@ -12,6 +16,12 @@ kotlin.sourceSets {
         dependencies {
             api(project(":ktor-server:ktor-server-plugins:ktor-server-content-negotiation"))
             api(project(":ktor-client:ktor-client-plugins:ktor-client-websockets"))
+        }
+    }
+
+    jvmTest {
+        dependencies {
+            implementation(project(":ktor-shared:ktor-junit"))
         }
     }
 }

--- a/ktor-server/ktor-server-plugins/ktor-server-websockets/jvm/test/io/ktor/tests/websocket/WebSocketTest.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-websockets/jvm/test/io/ktor/tests/websocket/WebSocketTest.kt
@@ -7,6 +7,7 @@ package io.ktor.tests.websocket
 import io.ktor.client.*
 import io.ktor.client.plugins.websocket.*
 import io.ktor.client.plugins.websocket.cio.*
+import io.ktor.junit.coroutines.*
 import io.ktor.serialization.*
 import io.ktor.server.application.*
 import io.ktor.server.testing.*
@@ -18,10 +19,9 @@ import io.ktor.utils.io.charsets.*
 import io.ktor.utils.io.core.*
 import io.ktor.websocket.*
 import kotlinx.coroutines.*
-import kotlinx.coroutines.channels.*
-import kotlinx.coroutines.debug.junit5.*
-import kotlinx.io.*
-import kotlin.random.*
+import kotlinx.coroutines.channels.ClosedReceiveChannelException
+import kotlinx.io.readByteArray
+import kotlin.random.Random
 import kotlin.test.*
 import kotlin.time.Duration.Companion.seconds
 

--- a/ktor-server/ktor-server-test-base/build.gradle.kts
+++ b/ktor-server/ktor-server-test-base/build.gradle.kts
@@ -26,9 +26,6 @@ kotlin.sourceSets {
             if (jetty_alpn_boot_version != null) {
                 api(libs.jetty.alpn.boot)
             }
-
-            api(libs.junit)
-            implementation(libs.kotlinx.coroutines.debug)
         }
     }
 }

--- a/ktor-server/ktor-server-test-base/jvm/src/io/ktor/server/test/base/BaseTestJvm.kt
+++ b/ktor-server/ktor-server-test-base/jvm/src/io/ktor/server/test/base/BaseTestJvm.kt
@@ -6,10 +6,10 @@
 package io.ktor.server.test.base
 
 import io.ktor.junit.*
+import io.ktor.junit.coroutines.*
 import io.ktor.test.dispatcher.*
 import kotlinx.coroutines.CoroutineName
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.debug.junit5.CoroutinesTimeout
 import kotlinx.coroutines.test.TestResult
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.TestInfo

--- a/ktor-server/ktor-server-test-suites/build.gradle.kts
+++ b/ktor-server/ktor-server-test-suites/build.gradle.kts
@@ -23,9 +23,6 @@ kotlin.sourceSets {
             implementation(project(":ktor-server:ktor-server-plugins:ktor-server-conditional-headers"))
             implementation(project(":ktor-server:ktor-server-plugins:ktor-server-default-headers"))
             implementation(project(":ktor-server:ktor-server-plugins:ktor-server-request-validation"))
-
-            implementation(libs.kotlin.test.junit5)
-
             implementation(libs.kotlinx.coroutines.debug)
         }
     }

--- a/ktor-server/ktor-server-test-suites/jvm/src/io/ktor/server/testing/suites/ClientCertTestSuite.kt
+++ b/ktor-server/ktor-server-test-suites/jvm/src/io/ktor/server/testing/suites/ClientCertTestSuite.kt
@@ -8,12 +8,12 @@ import io.ktor.client.*
 import io.ktor.client.call.*
 import io.ktor.client.engine.cio.*
 import io.ktor.client.request.*
+import io.ktor.junit.coroutines.*
 import io.ktor.network.tls.*
 import io.ktor.network.tls.certificates.*
 import io.ktor.server.engine.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
-import kotlinx.coroutines.debug.junit5.CoroutinesTimeout
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlin.test.Test

--- a/ktor-shared/ktor-junit/build.gradle.kts
+++ b/ktor-shared/ktor-junit/build.gradle.kts
@@ -7,8 +7,9 @@ description = "Common extensions for JUnit 5 testing framework"
 kotlin.sourceSets {
     jvmMain {
         dependencies {
-            api(libs.kotlin.test)
             api(libs.kotlin.test.junit5)
+            api(libs.junit)
+            implementation(libs.kotlinx.coroutines.debug)
         }
     }
 }

--- a/ktor-shared/ktor-junit/jvm/src/io/ktor/junit/coroutines/CoroutinesTimeoutExtension.kt
+++ b/ktor-shared/ktor-junit/jvm/src/io/ktor/junit/coroutines/CoroutinesTimeoutExtension.kt
@@ -1,0 +1,444 @@
+/*
+ * Copyright 2014-2024 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+@file:OptIn(ExperimentalCoroutinesApi::class)
+
+package io.ktor.junit.coroutines
+
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.debug.DebugProbes
+import org.junit.jupiter.api.Timeout
+import org.junit.jupiter.api.extension.*
+import org.junit.jupiter.api.parallel.ResourceAccessMode
+import org.junit.jupiter.api.parallel.ResourceLock
+import org.junit.platform.commons.support.AnnotationSupport
+import java.lang.annotation.Inherited
+import java.lang.reflect.Constructor
+import java.lang.reflect.Method
+import java.util.*
+import java.util.concurrent.*
+import java.util.concurrent.atomic.AtomicBoolean
+
+/* ktlint-disable */
+
+//----------------------------------------------------------------------------------------------------------------------
+// The implementation was copied from kotlinx.coroutines with Java 8 compatibility fixes
+// TODO: Remove as soon as https://github.com/Kotlin/kotlinx.coroutines/issues/4278 is fixed
+// Source:
+// https://github.com/Kotlin/kotlinx.coroutines/blob/1.9.0/kotlinx-coroutines-debug/src/junit/junit5/CoroutinesTimeoutExtension.kt
+//----------------------------------------------------------------------------------------------------------------------
+
+/**
+ * Coroutines timeout annotation that is similar to JUnit5's [Timeout] annotation. It allows running test methods in a
+ * separate thread, failing them after the provided time limit and interrupting the thread.
+ *
+ * Additionally, it installs [DebugProbes] and dumps all coroutines at the moment of the timeout. It also cancels
+ * coroutines on timeout if [cancelOnTimeout] set to `true`. The dump contains the coroutine creation stack traces.
+ *
+ * This annotation has an effect on test, test factory, test template, and lifecycle methods and test classes that are
+ * annotated with it.
+ *
+ * Annotating a class is the same as annotating every test, test factory, and test template method (but not lifecycle
+ * methods) of that class and its inner test classes, unless any of them is annotated with [CoroutinesTimeout], in which
+ * case their annotation overrides the one on the containing class.
+ *
+ * Declaring [CoroutinesTimeout] on a test factory checks that it finishes in the specified time, but does not check
+ * whether the methods that it produces obey the timeout as well.
+ *
+ * Example usage:
+ * ```
+ * @CoroutinesTimeout(100)
+ * class CoroutinesTimeoutSimpleTest {
+ *     // does not time out, as the annotation on the method overrides the class-level one
+ *     @CoroutinesTimeout(1000)
+ *     @Test
+ *     fun classTimeoutIsOverridden() {
+ *         runBlocking {
+ *             delay(150)
+ *         }
+ *     }
+ *
+ *     // times out in 100 ms, timeout value is taken from the class-level annotation
+ *     @Test
+ *     fun classTimeoutIsUsed() {
+ *         runBlocking {
+ *             delay(150)
+ *         }
+ *     }
+ * }
+ * ```
+ *
+ * @see Timeout
+ */
+@ExtendWith(CoroutinesTimeoutExtension::class)
+@Inherited
+@MustBeDocumented
+@ResourceLock("coroutines timeout", mode = ResourceAccessMode.READ)
+@Retention(value = AnnotationRetention.RUNTIME)
+@Target(AnnotationTarget.CLASS, AnnotationTarget.FUNCTION)
+annotation class CoroutinesTimeout(
+    val testTimeoutMs: Long,
+    val cancelOnTimeout: Boolean = false
+)
+
+internal class CoroutinesTimeoutException(timeoutMs: Long) : Exception("test timed out after $timeoutMs ms")
+
+/**
+ * This JUnit5 extension allows running test, test factory, test template, and lifecycle methods in a separate thread,
+ * failing them after the provided time limit and interrupting the thread.
+ *
+ * Additionally, it installs [DebugProbes] and dumps all coroutines at the moment of the timeout. It also cancels
+ * coroutines on timeout if [cancelOnTimeout] set to `true`.
+ * [enableCoroutineCreationStackTraces] controls the corresponding [DebugProbes.enableCreationStackTraces] property
+ * and can be optionally enabled if the creation stack traces are necessary.
+ *
+ * Beware that if several tests that use this extension set [enableCoroutineCreationStackTraces] to different values and
+ * execute in parallel, the behavior is ill-defined. In order to avoid conflicts between different instances of this
+ * extension when using JUnit5 in parallel, use [ResourceLock] with resource name `coroutines timeout` on tests that use
+ * it. Note that the tests annotated with [CoroutinesTimeout] already use this [ResourceLock], so there is no need to
+ * annotate them additionally.
+ *
+ * Note that while calls to test factories are verified to finish in the specified time, but the methods that they
+ * produce are not affected by this extension.
+ *
+ * Beware that registering the extension via [CoroutinesTimeout] annotation conflicts with manually registering it on
+ * the same tests via other methods (most notably, [RegisterExtension]) and is prohibited.
+ *
+ * Example of usage:
+ * ```
+ * class HangingTest {
+ *     @JvmField
+ *     @RegisterExtension
+ *     val timeout = CoroutinesTimeoutExtension.seconds(5)
+ *
+ *     @Test
+ *     fun testThatHangs() = runBlocking {
+ *          ...
+ *          delay(Long.MAX_VALUE) // somewhere deep in the stack
+ *          ...
+ *     }
+ * }
+ * ```
+ *
+ * @see [CoroutinesTimeout]
+ * */
+// NB: the constructor is not private so that JUnit is able to call it via reflection.
+internal class CoroutinesTimeoutExtension internal constructor(
+    private val enableCoroutineCreationStackTraces: Boolean = false,
+    private val timeoutMs: Long? = null,
+    private val cancelOnTimeout: Boolean? = null
+) : InvocationInterceptor {
+    /**
+     * Creates the [CoroutinesTimeoutExtension] extension with the given timeout in milliseconds.
+     */
+    constructor(
+        timeoutMs: Long, cancelOnTimeout: Boolean = false,
+        enableCoroutineCreationStackTraces: Boolean = true
+    ) :
+        this(enableCoroutineCreationStackTraces, timeoutMs, cancelOnTimeout)
+
+    companion object {
+        /**
+         * Creates the [CoroutinesTimeoutExtension] extension with the given timeout in seconds.
+         */
+        @JvmOverloads
+        fun seconds(
+            timeout: Int, cancelOnTimeout: Boolean = false,
+            enableCoroutineCreationStackTraces: Boolean = true
+        ): CoroutinesTimeoutExtension =
+            CoroutinesTimeoutExtension(enableCoroutineCreationStackTraces, timeout.toLong() * 1000, cancelOnTimeout)
+    }
+
+    /** @see [initialize] */
+    private val debugProbesOwnershipPassed = AtomicBoolean(false)
+
+    private fun tryPassDebugProbesOwnership() = debugProbesOwnershipPassed.compareAndSet(false, true)
+
+    /* We install the debug probes early so that the coroutines launched from the test constructor are captured as well.
+    However, this is not enough as the same extension instance may be reused several times, even cleaning up its
+    resources from the store. */
+    init {
+        DebugProbes.enableCreationStackTraces = enableCoroutineCreationStackTraces
+        DebugProbes.install()
+    }
+
+    // This is needed so that a class with no tests still successfully passes the ownership of DebugProbes to JUnit5.
+    override fun <T : Any?> interceptTestClassConstructor(
+        invocation: InvocationInterceptor.Invocation<T>,
+        invocationContext: ReflectiveInvocationContext<Constructor<T>>,
+        extensionContext: ExtensionContext
+    ): T {
+        initialize(extensionContext)
+        return invocation.proceed()
+    }
+
+    /**
+     * Initialize this extension instance and/or the extension value store.
+     *
+     * It seems that the only way to reliably have JUnit5 clean up after its extensions is to put an instance of
+     * [ExtensionContext.Store.CloseableResource] into the value store corresponding to the extension instance, which
+     * means that [DebugProbes.uninstall] must be placed into the value store. [debugProbesOwnershipPassed] is `true`
+     * if the call to [DebugProbes.install] performed in the constructor of the extension instance was matched with a
+     * placing of [DebugProbes.uninstall] into the value store. We call the process of placing the cleanup procedure
+     * "passing the ownership", as now JUnit5 (and not our code) has to worry about uninstalling the debug probes.
+     *
+     * However, extension instances can be reused with different value stores, and value stores can be reused across
+     * extension instances. This leads to a tricky scheme of performing [DebugProbes.uninstall]:
+     *
+     * - If neither the ownership of this instance's [DebugProbes] was yet passed nor there is any cleanup procedure
+     *   stored, it means that we can just store our cleanup procedure, passing the ownership.
+     * - If the ownership was not yet passed, but a cleanup procedure is already stored, we can't just replace it with
+     *   another one, as this would lead to imbalance between [DebugProbes.install] and [DebugProbes.uninstall].
+     *   Instead, we know that this extension context will at least outlive this use of this instance, so some debug
+     *   probes other than the ones from our constructor are already installed and won't be uninstalled during our
+     *   operation. We simply uninstall the debug probes that were installed in our constructor.
+     * - If the ownership was passed, but the store is empty, it means that this test instance is reused and, possibly,
+     *   the debug probes installed in its constructor were already uninstalled. This means that we have to install them
+     *   anew and store an uninstaller.
+     */
+    private fun initialize(extensionContext: ExtensionContext) {
+        val store: ExtensionContext.Store = extensionContext.getStore(
+            ExtensionContext.Namespace.create(CoroutinesTimeoutExtension::class, extensionContext.uniqueId)
+        )
+        /** It seems that the JUnit5 documentation does not specify the relationship between the extension instances and
+         * the corresponding [ExtensionContext] (in which the value stores are managed), so it is unclear whether it's
+         * theoretically possible for two extension instances that run concurrently to share an extension context. So,
+         * just in case this risk exists, we synchronize here. */
+        synchronized(store) {
+            if (store["debugProbes"] == null) {
+                if (!tryPassDebugProbesOwnership()) {
+                    /** This means that the [DebugProbes.install] call from the constructor of this extensions has
+                     * already been matched with a corresponding cleanup procedure for JUnit5, but then JUnit5 cleaned
+                     * everything up and later reused the same extension instance for other tests. Therefore, we need to
+                     * install the [DebugProbes] anew. */
+                    DebugProbes.enableCreationStackTraces = enableCoroutineCreationStackTraces
+                    DebugProbes.install()
+                }
+                /** put a fake resource into this extensions's store so that JUnit cleans it up, uninstalling the
+                 * [DebugProbes] after this extension instance is no longer needed. **/
+                store.put("debugProbes", ExtensionContext.Store.CloseableResource { DebugProbes.uninstall() })
+            } else if (!debugProbesOwnershipPassed.get()) {
+                /** This instance shares its store with other ones. Because of this, there was no need to install
+                 * [DebugProbes], they are already installed, and this fact will outlive this use of this instance of
+                 * the extension. */
+                if (tryPassDebugProbesOwnership()) {
+                    // We successfully marked the ownership as passed and now may uninstall the extraneous debug probes.
+                    DebugProbes.uninstall()
+                }
+            }
+        }
+    }
+
+    override fun interceptTestMethod(
+        invocation: InvocationInterceptor.Invocation<Void>,
+        invocationContext: ReflectiveInvocationContext<Method>,
+        extensionContext: ExtensionContext
+    ) {
+        interceptNormalMethod(invocation, invocationContext, extensionContext)
+    }
+
+    override fun interceptAfterAllMethod(
+        invocation: InvocationInterceptor.Invocation<Void>,
+        invocationContext: ReflectiveInvocationContext<Method>,
+        extensionContext: ExtensionContext
+    ) {
+        interceptLifecycleMethod(invocation, invocationContext, extensionContext)
+    }
+
+    override fun interceptAfterEachMethod(
+        invocation: InvocationInterceptor.Invocation<Void>,
+        invocationContext: ReflectiveInvocationContext<Method>,
+        extensionContext: ExtensionContext
+    ) {
+        interceptLifecycleMethod(invocation, invocationContext, extensionContext)
+    }
+
+    override fun interceptBeforeAllMethod(
+        invocation: InvocationInterceptor.Invocation<Void>,
+        invocationContext: ReflectiveInvocationContext<Method>,
+        extensionContext: ExtensionContext
+    ) {
+        interceptLifecycleMethod(invocation, invocationContext, extensionContext)
+    }
+
+    override fun interceptBeforeEachMethod(
+        invocation: InvocationInterceptor.Invocation<Void>,
+        invocationContext: ReflectiveInvocationContext<Method>,
+        extensionContext: ExtensionContext
+    ) {
+        interceptLifecycleMethod(invocation, invocationContext, extensionContext)
+    }
+
+    override fun <T : Any?> interceptTestFactoryMethod(
+        invocation: InvocationInterceptor.Invocation<T>,
+        invocationContext: ReflectiveInvocationContext<Method>,
+        extensionContext: ExtensionContext
+    ): T = interceptNormalMethod(invocation, invocationContext, extensionContext)
+
+    override fun interceptTestTemplateMethod(
+        invocation: InvocationInterceptor.Invocation<Void>,
+        invocationContext: ReflectiveInvocationContext<Method>,
+        extensionContext: ExtensionContext
+    ) {
+        interceptNormalMethod(invocation, invocationContext, extensionContext)
+    }
+
+    private fun <T> Class<T>.coroutinesTimeoutAnnotation(): Optional<CoroutinesTimeout> =
+        AnnotationSupport.findAnnotation(this, CoroutinesTimeout::class.java).let {
+            when {
+                it.isPresent -> it
+                enclosingClass != null -> enclosingClass.coroutinesTimeoutAnnotation()
+                else -> Optional.empty()
+            }
+        }
+
+    private fun <T : Any?> interceptMethod(
+        useClassAnnotation: Boolean,
+        invocation: InvocationInterceptor.Invocation<T>,
+        invocationContext: ReflectiveInvocationContext<Method>,
+        extensionContext: ExtensionContext
+    ): T {
+        initialize(extensionContext)
+        val testAnnotationOptional =
+            AnnotationSupport.findAnnotation(invocationContext.executable, CoroutinesTimeout::class.java)
+        val classAnnotationOptional = extensionContext.testClass.flatMap { it.coroutinesTimeoutAnnotation() }
+        if (timeoutMs != null && cancelOnTimeout != null) {
+            // this means we @RegisterExtension was used in order to register this extension.
+            if (testAnnotationOptional.isPresent && classAnnotationOptional.isPresent) {
+                /* Using annotations creates a separate instance of the extension, which composes in a strange way: both
+                timeouts are applied. This is at odds with the concept that method-level annotations override the outer
+                rules and may lead to unexpected outcomes, so we prohibit this. */
+                throw UnsupportedOperationException("Using CoroutinesTimeout along with instance field-registered CoroutinesTimeout is prohibited; please use either @RegisterExtension or @CoroutinesTimeout, but not both")
+            }
+            return interceptInvocation(invocation, invocationContext.executable.name, timeoutMs, cancelOnTimeout)
+        }
+        /* The extension was registered via an annotation; check that we succeeded in finding the annotation that led to
+        the extension being registered and taking its parameters. */
+        if (!testAnnotationOptional.isPresent && !classAnnotationOptional.isPresent) {
+            throw UnsupportedOperationException("Timeout was registered with a CoroutinesTimeout annotation, but we were unable to find it. Please report this.")
+        }
+        return when {
+            testAnnotationOptional.isPresent -> {
+                val annotation = testAnnotationOptional.get()
+                interceptInvocation(
+                    invocation, invocationContext.executable.name, annotation.testTimeoutMs,
+                    annotation.cancelOnTimeout
+                )
+            }
+
+            useClassAnnotation && classAnnotationOptional.isPresent -> {
+                val annotation = classAnnotationOptional.get()
+                interceptInvocation(
+                    invocation, invocationContext.executable.name, annotation.testTimeoutMs,
+                    annotation.cancelOnTimeout
+                )
+            }
+
+            else -> {
+                invocation.proceed()
+            }
+        }
+    }
+
+    private fun <T> interceptNormalMethod(
+        invocation: InvocationInterceptor.Invocation<T>,
+        invocationContext: ReflectiveInvocationContext<Method>,
+        extensionContext: ExtensionContext
+    ): T = interceptMethod(true, invocation, invocationContext, extensionContext)
+
+    private fun interceptLifecycleMethod(
+        invocation: InvocationInterceptor.Invocation<Void>,
+        invocationContext: ReflectiveInvocationContext<Method>,
+        extensionContext: ExtensionContext
+    ) = interceptMethod(false, invocation, invocationContext, extensionContext)
+
+    private fun <T : Any?> interceptInvocation(
+        invocation: InvocationInterceptor.Invocation<T>,
+        methodName: String,
+        testTimeoutMs: Long,
+        cancelOnTimeout: Boolean
+    ): T =
+        runWithTimeoutDumpingCoroutines(
+            methodName, testTimeoutMs, cancelOnTimeout,
+            { CoroutinesTimeoutException(testTimeoutMs) }, { invocation.proceed() })
+}
+
+
+/**
+ * Run [invocation] in a separate thread with the given timeout in ms, after which the coroutines info is dumped and, if
+ * [cancelOnTimeout] is set, the execution is interrupted.
+ *
+ * Assumes that [DebugProbes] are installed. Does not deinstall them.
+ */
+internal inline fun <T : Any?> runWithTimeoutDumpingCoroutines(
+    methodName: String,
+    testTimeoutMs: Long,
+    cancelOnTimeout: Boolean,
+    initCancellationException: () -> Throwable,
+    crossinline invocation: () -> T
+): T {
+    val testStartedLatch = CountDownLatch(1)
+    val testResult = FutureTask {
+        testStartedLatch.countDown()
+        invocation()
+    }
+    /*
+     * We are using hand-rolled thread instead of single thread executor
+     * in order to be able to safely interrupt thread in the end of a test
+     */
+    val testThread = Thread(testResult, "Timeout test thread").apply { isDaemon = true }
+    try {
+        testThread.start()
+        // Await until test is started to take only test execution time into account
+        testStartedLatch.await()
+        return testResult.get(testTimeoutMs, TimeUnit.MILLISECONDS)
+    } catch (e: TimeoutException) {
+        handleTimeout(testThread, methodName, testTimeoutMs, cancelOnTimeout, initCancellationException())
+    } catch (e: ExecutionException) {
+        throw e.cause ?: e
+    }
+}
+
+private fun handleTimeout(
+    testThread: Thread, methodName: String, testTimeoutMs: Long, cancelOnTimeout: Boolean,
+    cancellationException: Throwable
+): Nothing {
+    val units =
+        if (testTimeoutMs % 1000 == 0L)
+            "${testTimeoutMs / 1000} seconds"
+        else "$testTimeoutMs milliseconds"
+
+    System.err.println("\nTest $methodName timed out after $units\n")
+    System.err.flush()
+
+    DebugProbes.dumpCoroutines()
+    System.out.flush() // Synchronize serr/sout
+
+    /*
+     * Order is important:
+     * 1) Create exception with a stacktrace of hang test
+     * 2) Cancel all coroutines via debug agent API (changing system state!)
+     * 3) Throw created exception
+     */
+    cancellationException.attachStacktraceFrom(testThread)
+    testThread.interrupt()
+    cancelIfNecessary(cancelOnTimeout)
+    // If timed out test throws an exception, we can't do much except ignoring it
+    throw cancellationException
+}
+
+private fun cancelIfNecessary(cancelOnTimeout: Boolean) {
+    if (cancelOnTimeout) {
+        DebugProbes.dumpCoroutinesInfo().forEach {
+            it.job?.cancel()
+        }
+    }
+}
+
+private fun Throwable.attachStacktraceFrom(thread: Thread) {
+    val stackTrace = thread.stackTrace
+    this.stackTrace = stackTrace
+}
+
+/* ktlint-disable */

--- a/ktor-utils/jvm/src/io/ktor/util/NioPath.kt
+++ b/ktor-utils/jvm/src/io/ktor/util/NioPath.kt
@@ -4,8 +4,9 @@
 
 package io.ktor.util
 
-import java.io.*
-import java.nio.file.*
+import java.io.File
+import java.nio.file.InvalidPathException
+import java.nio.file.Path
 
 /**
  * Append a [relativePath] safely that means that adding any extra `..` path elements will not let
@@ -17,6 +18,10 @@ public fun Path.combineSafe(relativePath: Path): Path {
         throw InvalidPathException(relativePath.toString(), "Relative path $relativePath beginning with .. is invalid")
     }
     check(!normalized.isAbsolute) { "Bad relative path $relativePath" }
+
+    // On JVM 8 ZipPath implementation misses this check,
+    // so we have to check the path is not empty to not get an `ArrayIndexOutOfBoundsException`
+    if (nameCount == 0) return normalized
 
     return resolve(normalized)
 }

--- a/ktor-utils/jvm/src/io/ktor/util/reflect/ServiceLoader.kt
+++ b/ktor-utils/jvm/src/io/ktor/util/reflect/ServiceLoader.kt
@@ -12,14 +12,22 @@ import java.util.*
 // See: https://r8.googlesource.com/r8/+/refs/heads/main/src/main/java/com/android/tools/r8/ir/optimize/ServiceLoaderRewriter.java
 
 /**
- * Loads all implementations of the service [T] using [ServiceLoader.load].
- * @see loadServiceOrNull
+ * Loads implementations of the service [T] using [ServiceLoader.load] and returns them as a sequence.
+ * @see loadServices
  */
 @InternalAPI
-public inline fun <reified T : Any> loadServices(): List<T> = ServiceLoader.load(
+public inline fun <reified T : Any> loadServicesAsSequence(): Sequence<T> = ServiceLoader.load(
     T::class.java,
     T::class.java.classLoader,
-).iterator().asSequence().toList()
+).iterator().asSequence()
+
+/**
+ * Loads all implementations of the service [T] using [ServiceLoader.load].
+ * @see loadServiceOrNull
+ * @see loadServicesAsSequence
+ */
+@InternalAPI
+public inline fun <reified T : Any> loadServices(): List<T> = loadServicesAsSequence<T>().toList()
 
 /**
  * Loads single implementation of the service [T] using [ServiceLoader.load]
@@ -27,7 +35,4 @@ public inline fun <reified T : Any> loadServices(): List<T> = ServiceLoader.load
  * @see loadServices
  */
 @InternalAPI
-public inline fun <reified T : Any> loadServiceOrNull(): T? = ServiceLoader.load(
-    T::class.java,
-    T::class.java.classLoader,
-).iterator().asSequence().firstOrNull()
+public inline fun <reified T : Any> loadServiceOrNull(): T? = loadServicesAsSequence<T>().firstOrNull()

--- a/ktor-utils/jvm/test/io/ktor/tests/utils/DeflaterReadChannelTest.kt
+++ b/ktor-utils/jvm/test/io/ktor/tests/utils/DeflaterReadChannelTest.kt
@@ -4,12 +4,12 @@
 
 package io.ktor.tests.utils
 
+import io.ktor.junit.coroutines.*
 import io.ktor.util.*
 import io.ktor.util.cio.*
 import io.ktor.utils.io.*
 import io.ktor.utils.io.jvm.javaio.*
 import kotlinx.coroutines.*
-import kotlinx.coroutines.debug.junit5.CoroutinesTimeout
 import java.io.File
 import java.io.IOException
 import java.io.InputStream


### PR DESCRIPTION
**Subsystem**
Test Infrastructure

**Motivation**
[KTOR-7846](https://youtrack.jetbrains.com/issue/KTOR-7846) Fix running tests against Java 8 on CI

**Solution**
Fix problems making tests incompatible with Java 8 and remove `testJdk.coerceAtLeast(11)` from tests toolchain configuration.

_It is better to review commit-by-commit_