### PR TITLE
KTOR-7797 Remove application lifecycle logs from CallLogging plugin

### DIFF
--- a/ktor-server/ktor-server-plugins/ktor-server-call-logging/jvm/src/io/ktor/server/plugins/calllogging/CallLogging.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-call-logging/jvm/src/io/ktor/server/plugins/calllogging/CallLogging.kt
@@ -1,5 +1,5 @@
 /*
-* Copyright 2014-2024 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+* Copyright 2014-2025 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
 */
 
 package io.ktor.server.plugins.calllogging

--- a/ktor-server/ktor-server-plugins/ktor-server-call-logging/jvm/src/io/ktor/server/plugins/calllogging/CallLogging.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-call-logging/jvm/src/io/ktor/server/plugins/calllogging/CallLogging.kt
@@ -1,10 +1,9 @@
 /*
-* Copyright 2014-2021 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+* Copyright 2014-2024 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
 */
 
 package io.ktor.server.plugins.calllogging
 
-import io.ktor.events.*
 import io.ktor.server.application.*
 import io.ktor.server.application.hooks.*
 import io.ktor.server.http.content.*
@@ -59,7 +58,6 @@ public val CallLogging: ApplicationPlugin<CallLoggingConfig> = createApplication
     }
 
     setupMDCProvider()
-    setupLogging(application.monitor, ::log)
 
     on(CallSetup) { call ->
         call.attributes.put(CALL_START_TIME, clock())
@@ -95,24 +93,4 @@ private fun PluginBuilder<CallLoggingConfig>.logCallsWithMDC(logSuccess: (Applic
             logSuccess(call)
         }
     }
-}
-
-private fun setupLogging(events: Events, log: (String) -> Unit) {
-    val starting: (Application) -> Unit = { log("Application starting: $it") }
-    val started: (Application) -> Unit = { log("Application started: $it") }
-    val stopping: (Application) -> Unit = { log("Application stopping: $it") }
-    var stopped: (Application) -> Unit = {}
-
-    stopped = {
-        log("Application stopped: $it")
-        events.unsubscribe(ApplicationStarting, starting)
-        events.unsubscribe(ApplicationStarted, started)
-        events.unsubscribe(ApplicationStopping, stopping)
-        events.unsubscribe(ApplicationStopped, stopped)
-    }
-
-    events.subscribe(ApplicationStarting, starting)
-    events.subscribe(ApplicationStarted, started)
-    events.subscribe(ApplicationStopping, stopping)
-    events.subscribe(ApplicationStopped, stopped)
 }

--- a/ktor-server/ktor-server-plugins/ktor-server-call-logging/jvm/test/io/ktor/server/plugins/calllogging/CallLoggingTest.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-call-logging/jvm/test/io/ktor/server/plugins/calllogging/CallLoggingTest.kt
@@ -371,7 +371,6 @@ class CallLoggingTest {
                 }
             }
         }
-        lateinit var hash: String
 
         runTestApplication {
             application {
@@ -380,11 +379,11 @@ class CallLoggingTest {
                     clock { 0 }
                 }
             }
-            application { hash = hashCode().toString(radix = 16) }
+            client.get("/")
         }
 
         assertTrue(customMessages.isNotEmpty())
-        assertTrue(customMessages.all { it.startsWith("CUSTOM TRACE:") && it.contains(hash) })
+        assertTrue(customMessages.all { it.startsWith("CUSTOM TRACE:") })
         assertTrue(messages.isEmpty())
     }
 

--- a/ktor-server/ktor-server-plugins/ktor-server-call-logging/jvm/test/io/ktor/server/plugins/calllogging/CallLoggingTest.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-call-logging/jvm/test/io/ktor/server/plugins/calllogging/CallLoggingTest.kt
@@ -64,33 +64,6 @@ class CallLoggingTest {
     }
 
     @Test
-    fun `can log application lifecycle events`() = runTest {
-        var hash: String? = null
-
-        runTestApplication {
-            environment { environment() }
-            application {
-                install(CallLogging) { clock { 0 } }
-                hash = hashCode().toString(radix = 16)
-            }
-        }
-
-        assertTrue(messages.size >= 3, "It should be at least 3 message logged:\n$messages")
-        val startingMessageIndex = messages.indexOfFirst {
-            it == "INFO: Application started: io.ktor.server.application.Application@$hash"
-        }
-        val stoppingMessageIndex = messages.indexOfFirst {
-            it == "INFO: Application stopping: io.ktor.server.application.Application@$hash"
-        }
-        val stoppedMessageIndex = messages.indexOfFirst {
-            it == "INFO: Application stopped: io.ktor.server.application.Application@$hash"
-        }
-        assertTrue { startingMessageIndex >= 0 }
-        assertTrue { startingMessageIndex < stoppingMessageIndex }
-        assertTrue { stoppingMessageIndex < stoppedMessageIndex }
-    }
-
-    @Test
     fun `can log an unhandled get request`() = testApplication {
         environment { environment() }
         install(CallLogging) { clock { 0 } }

--- a/ktor-server/ktor-server-plugins/ktor-server-call-logging/jvm/test/io/ktor/server/plugins/calllogging/CallLoggingTest.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-call-logging/jvm/test/io/ktor/server/plugins/calllogging/CallLoggingTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2024 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2014-2025 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package io.ktor.server.plugins.calllogging


### PR DESCRIPTION
**Subsystem**
Server (CallLogging plugin) 

**Motivation**
UX improvement, as lifecyclke logs are already present even without this plugin
