### PR TITLE
Removed star imports of java.util.concurrent.atomic.* package.

### DIFF
--- a/ktor-server/ktor-server-test-base/jvm/src/io/ktor/server/test/base/HighLoadHttpGenerator.kt
+++ b/ktor-server/ktor-server-test-base/jvm/src/io/ktor/server/test/base/HighLoadHttpGenerator.kt
@@ -13,7 +13,7 @@ import java.nio.ByteOrder
 import java.nio.channels.*
 import java.nio.channels.spi.*
 import java.util.concurrent.*
-import java.util.concurrent.atomic.*
+import java.util.concurrent.atomic.AtomicLong
 import kotlin.concurrent.*
 import kotlin.io.use
 import kotlin.text.toByteArray

--- a/ktor-utils/jvm/test/io/ktor/tests/utils/CacheTest.kt
+++ b/ktor-utils/jvm/test/io/ktor/tests/utils/CacheTest.kt
@@ -6,7 +6,7 @@ package io.ktor.tests.utils
 
 import io.ktor.util.*
 import java.util.*
-import java.util.concurrent.atomic.*
+import java.util.concurrent.atomic.AtomicInteger
 import kotlin.concurrent.*
 import kotlin.test.*
 


### PR DESCRIPTION
Since 2.1.0-Beta1 Atomic types are introduced in `kotlin.concurrent` package, `AtomicLong` and `AtomicBoolean` types have the same names in both `kotlin.concurrent` and `java.util.concurrent.atomic` packages, which causes resolution ambiguity in case when both packages are star imported.

