### PR TITLE
KTOR-7682 Fix TestApplication.stop() doesn't stop the application anymore

### DIFF
--- a/ktor-server/ktor-server-core/common/src/io/ktor/server/engine/EngineContextCancellationHelper.kt
+++ b/ktor-server/ktor-server-core/common/src/io/ktor/server/engine/EngineContextCancellationHelper.kt
@@ -32,7 +32,7 @@ public fun ApplicationEngine.stopServerOnCancellation(
 public fun Job.launchOnCancellation(block: suspend () -> Unit): CompletableJob {
     val completableJob: CompletableJob = Job(parent = this)
 
-    GlobalScope.launch(this + Dispatchers.IOBridge) {
+    GlobalScope.launch(this + Dispatchers.IOBridge + CoroutineName("cancellation-watcher")) {
         var cancelled = false
         try {
             completableJob.join()

--- a/ktor-server/ktor-server-core/common/src/io/ktor/server/engine/EngineContextCancellationHelper.kt
+++ b/ktor-server/ktor-server-core/common/src/io/ktor/server/engine/EngineContextCancellationHelper.kt
@@ -10,7 +10,7 @@ import io.ktor.utils.io.*
 import kotlinx.coroutines.*
 
 /**
- * Stop server on job cancellation. The returned deferred need to be completed or cancelled.
+ * Stop server on job cancellation. The returned [CompletableJob] needs to be completed or cancelled.
  */
 @OptIn(InternalAPI::class)
 public fun ApplicationEngine.stopServerOnCancellation(
@@ -23,27 +23,27 @@ public fun ApplicationEngine.stopServerOnCancellation(
     } ?: Job()
 
 /**
- * Launch a coroutine with [block] body when the parent job is cancelled or a returned deferred is cancelled.
- * It is important to complete or cancel returned deferred
+ * Launch a coroutine with [block] body when either the parent job or the returned job is cancelled.
+ * It is important to complete or cancel the returned [CompletableJob]
  * otherwise the parent job will be unable to complete successfully.
  */
 @OptIn(DelicateCoroutinesApi::class)
 @InternalAPI
 public fun Job.launchOnCancellation(block: suspend () -> Unit): CompletableJob {
-    val deferred: CompletableJob = Job(parent = this)
+    val completableJob: CompletableJob = Job(parent = this)
 
     GlobalScope.launch(this + Dispatchers.IOBridge) {
         var cancelled = false
         try {
-            deferred.join()
+            completableJob.join()
         } catch (_: Throwable) {
             cancelled = true
         }
 
-        if (cancelled || deferred.isCancelled) {
+        if (cancelled || completableJob.isCancelled) {
             block()
         }
     }
 
-    return deferred
+    return completableJob
 }

--- a/ktor-server/ktor-server-jetty-jakarta/jvm/src/io/ktor/server/jetty/jakarta/JettyApplicationEngineBase.kt
+++ b/ktor-server/ktor-server-jetty-jakarta/jvm/src/io/ktor/server/jetty/jakarta/JettyApplicationEngineBase.kt
@@ -7,9 +7,10 @@ package io.ktor.server.jetty.jakarta
 import io.ktor.events.*
 import io.ktor.server.application.*
 import io.ktor.server.engine.*
-import kotlinx.coroutines.*
-import org.eclipse.jetty.server.*
-import kotlin.time.*
+import kotlinx.coroutines.CompletableJob
+import org.eclipse.jetty.server.Server
+import org.eclipse.jetty.server.ServerConnector
+import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
 
 /**
@@ -42,7 +43,7 @@ public open class JettyApplicationEngineBase(
         public var idleTimeout: Duration = 30.seconds
     }
 
-    private var cancellationDeferred: CompletableJob? = null
+    private var cancellationJob: CompletableJob? = null
 
     /**
      * Jetty server instance being configuring and starting
@@ -54,7 +55,7 @@ public open class JettyApplicationEngineBase(
 
     override fun start(wait: Boolean): JettyApplicationEngineBase {
         server.start()
-        cancellationDeferred = stopServerOnCancellation(
+        cancellationJob = stopServerOnCancellation(
             applicationProvider(),
             configuration.shutdownGracePeriod,
             configuration.shutdownTimeout
@@ -74,7 +75,7 @@ public open class JettyApplicationEngineBase(
     }
 
     override fun stop(gracePeriodMillis: Long, timeoutMillis: Long) {
-        cancellationDeferred?.complete()
+        cancellationJob?.complete()
         monitor.raise(ApplicationStopPreparing, environment)
         server.stopTimeout = timeoutMillis
         server.stop()

--- a/ktor-server/ktor-server-jetty/jvm/src/io/ktor/server/jetty/JettyApplicationEngineBase.kt
+++ b/ktor-server/ktor-server-jetty/jvm/src/io/ktor/server/jetty/JettyApplicationEngineBase.kt
@@ -7,9 +7,10 @@ package io.ktor.server.jetty
 import io.ktor.events.*
 import io.ktor.server.application.*
 import io.ktor.server.engine.*
-import kotlinx.coroutines.*
-import org.eclipse.jetty.server.*
-import kotlin.time.*
+import kotlinx.coroutines.CompletableJob
+import org.eclipse.jetty.server.Server
+import org.eclipse.jetty.server.ServerConnector
+import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
 
 /**
@@ -42,7 +43,7 @@ public open class JettyApplicationEngineBase(
         public var idleTimeout: Duration = 30.seconds
     }
 
-    private var cancellationDeferred: CompletableJob? = null
+    private var cancellationJob: CompletableJob? = null
 
     /**
      * Jetty server instance being configuring and starting
@@ -54,7 +55,7 @@ public open class JettyApplicationEngineBase(
 
     override fun start(wait: Boolean): JettyApplicationEngineBase {
         server.start()
-        cancellationDeferred = stopServerOnCancellation(
+        cancellationJob = stopServerOnCancellation(
             applicationProvider(),
             configuration.shutdownGracePeriod,
             configuration.shutdownTimeout
@@ -74,7 +75,7 @@ public open class JettyApplicationEngineBase(
     }
 
     override fun stop(gracePeriodMillis: Long, timeoutMillis: Long) {
-        cancellationDeferred?.complete()
+        cancellationJob?.complete()
         monitor.raise(ApplicationStopPreparing, environment)
         server.stopTimeout = timeoutMillis
         server.stop()

--- a/ktor-server/ktor-server-test-host/common/src/io/ktor/server/testing/TestApplication.kt
+++ b/ktor-server/ktor-server-test-host/common/src/io/ktor/server/testing/TestApplication.kt
@@ -15,10 +15,12 @@ import io.ktor.server.testing.client.*
 import io.ktor.test.dispatcher.*
 import io.ktor.util.pipeline.*
 import io.ktor.utils.io.*
-import kotlinx.atomicfu.*
-import kotlinx.coroutines.*
-import kotlinx.coroutines.test.*
-import kotlin.coroutines.*
+import kotlinx.atomicfu.atomic
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.test.TestResult
+import kotlinx.coroutines.withContext
+import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.EmptyCoroutineContext
 
 /**
  * A client attached to [TestApplication].
@@ -105,10 +107,7 @@ public class TestApplication internal constructor(
 public fun TestApplication(
     block: TestApplicationBuilder.() -> Unit
 ): TestApplication {
-    val builder = ApplicationTestBuilder()
-    val testApplication = TestApplication(builder)
-    builder.block()
-    return testApplication
+    return ApplicationTestBuilder().apply(block).application
 }
 
 /**

--- a/ktor-server/ktor-server-test-host/common/test/TestApplicationTest.kt
+++ b/ktor-server/ktor-server-test-host/common/test/TestApplicationTest.kt
@@ -24,9 +24,11 @@ import io.ktor.util.*
 import io.ktor.utils.io.*
 import io.ktor.utils.io.core.*
 import kotlinx.coroutines.*
-import kotlinx.coroutines.test.*
-import kotlin.coroutines.*
+import kotlinx.coroutines.test.runTest
+import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.coroutineContext
 import kotlin.test.*
+import kotlin.time.Duration.Companion.seconds
 
 class TestApplicationTest {
 
@@ -85,6 +87,19 @@ class TestApplicationTest {
         val response = client.get("a")
         assertEquals("OK", response.bodyAsText())
         assertEquals("value_1", response.headers["response_header"])
+    }
+
+    @Test // KTOR-7682
+    fun testApplicationBlockStartBeforeClientCall() = runTest(timeout = 5.seconds) {
+        val application = TestApplication {
+            serverConfig {
+                parentCoroutineContext = coroutineContext
+            }
+        }
+
+        application.start()
+        application.client.get("/")
+        application.stop()
     }
 
     @Test

--- a/ktor-server/ktor-server-tomcat-jakarta/jvm/src/io/ktor/server/tomcat/jakarta/TomcatApplicationEngine.kt
+++ b/ktor-server/ktor-server-tomcat-jakarta/jvm/src/io/ktor/server/tomcat/jakarta/TomcatApplicationEngine.kt
@@ -9,19 +9,22 @@ import io.ktor.http.*
 import io.ktor.server.application.*
 import io.ktor.server.engine.*
 import io.ktor.server.servlet.jakarta.*
-import jakarta.servlet.*
-import kotlinx.atomicfu.*
-import kotlinx.coroutines.*
-import org.apache.catalina.connector.*
+import jakarta.servlet.MultipartConfigElement
+import kotlinx.atomicfu.atomic
+import kotlinx.coroutines.CompletableJob
+import org.apache.catalina.connector.Connector
 import org.apache.catalina.startup.Tomcat
-import org.apache.coyote.http2.*
-import org.apache.tomcat.jni.*
-import org.apache.tomcat.util.net.*
-import org.apache.tomcat.util.net.jsse.*
-import org.apache.tomcat.util.net.openssl.*
-import org.slf4j.*
-import java.nio.file.*
-import kotlin.coroutines.*
+import org.apache.coyote.http2.Http2Protocol
+import org.apache.tomcat.jni.Library
+import org.apache.tomcat.jni.SSL
+import org.apache.tomcat.util.net.SSLHostConfig
+import org.apache.tomcat.util.net.SSLHostConfigCertificate
+import org.apache.tomcat.util.net.SSLImplementation
+import org.apache.tomcat.util.net.jsse.JSSEImplementation
+import org.apache.tomcat.util.net.openssl.OpenSSLImplementation
+import org.slf4j.Logger
+import java.nio.file.Files
+import kotlin.coroutines.CoroutineContext
 
 /**
  * Tomcat application engine that runs it in embedded mode
@@ -46,7 +49,7 @@ public class TomcatApplicationEngine(
 
     private val tempDirectory by lazy { Files.createTempDirectory("ktor-server-tomcat-jakarta-") }
 
-    private var cancellationDeferred: CompletableJob? = null
+    private var cancellationJob: CompletableJob? = null
 
     private val ktorServlet = object : KtorServlet() {
         override val managedByEngineHeaders: Set<String>
@@ -163,7 +166,7 @@ public class TomcatApplicationEngine(
         resolvedConnectorsDeferred.complete(connectors)
         monitor.raiseCatching(ServerReady, environment, environment.log)
 
-        cancellationDeferred = stopServerOnCancellation(
+        cancellationJob = stopServerOnCancellation(
             applicationProvider(),
             configuration.shutdownGracePeriod,
             configuration.shutdownTimeout
@@ -178,7 +181,7 @@ public class TomcatApplicationEngine(
     override fun stop(gracePeriodMillis: Long, timeoutMillis: Long) {
         if (!stopped.compareAndSet(expect = false, update = true)) return
 
-        cancellationDeferred?.complete()
+        cancellationJob?.complete()
         monitor.raise(ApplicationStopPreparing, environment)
         server.stop()
         server.destroy()

--- a/ktor-server/ktor-server-tomcat/jvm/src/io/ktor/server/tomcat/TomcatApplicationEngine.kt
+++ b/ktor-server/ktor-server-tomcat/jvm/src/io/ktor/server/tomcat/TomcatApplicationEngine.kt
@@ -9,19 +9,20 @@ import io.ktor.http.*
 import io.ktor.server.application.*
 import io.ktor.server.engine.*
 import io.ktor.server.servlet.*
-import kotlinx.atomicfu.*
-import kotlinx.coroutines.*
-import org.apache.catalina.connector.*
+import kotlinx.atomicfu.atomic
+import kotlinx.coroutines.CompletableJob
+import org.apache.catalina.connector.Connector
 import org.apache.catalina.startup.Tomcat
-import org.apache.coyote.http2.*
-import org.apache.tomcat.jni.*
-import org.apache.tomcat.util.net.*
-import org.apache.tomcat.util.net.jsse.*
-import org.apache.tomcat.util.net.openssl.*
-import org.slf4j.*
-import java.nio.file.*
-import javax.servlet.*
-import kotlin.coroutines.*
+import org.apache.coyote.http2.Http2Protocol
+import org.apache.tomcat.jni.Library
+import org.apache.tomcat.jni.SSL
+import org.apache.tomcat.util.net.SSLImplementation
+import org.apache.tomcat.util.net.jsse.JSSEImplementation
+import org.apache.tomcat.util.net.openssl.OpenSSLImplementation
+import org.slf4j.Logger
+import java.nio.file.Files
+import javax.servlet.MultipartConfigElement
+import kotlin.coroutines.CoroutineContext
 
 /**
  * Tomcat application engine that runs it in embedded mode
@@ -46,7 +47,7 @@ public class TomcatApplicationEngine(
 
     private val tempDirectory by lazy { Files.createTempDirectory("ktor-server-tomcat-") }
 
-    private var cancellationDeferred: CompletableJob? = null
+    private var cancellationJob: CompletableJob? = null
 
     private val ktorServlet = object : KtorServlet() {
         override val managedByEngineHeaders: Set<String>
@@ -149,7 +150,7 @@ public class TomcatApplicationEngine(
         resolvedConnectorsDeferred.complete(connectors)
         monitor.raiseCatching(ServerReady, environment, environment.log)
 
-        cancellationDeferred = stopServerOnCancellation(
+        cancellationJob = stopServerOnCancellation(
             applicationProvider(),
             configuration.shutdownGracePeriod,
             configuration.shutdownTimeout
@@ -164,7 +165,7 @@ public class TomcatApplicationEngine(
     override fun stop(gracePeriodMillis: Long, timeoutMillis: Long) {
         if (!stopped.compareAndSet(expect = false, update = true)) return
 
-        cancellationDeferred?.complete()
+        cancellationJob?.complete()
         monitor.raise(ApplicationStopPreparing, environment)
         server.stop()
         server.destroy()


### PR DESCRIPTION
**Subsystem**
Test Infrastructure

**Motivation**
[KTOR-7682 TestApplication.stop() doesn't stop the application anymore](https://youtrack.jetbrains.com/issue/KTOR-7682)

**Solution**
The problem occurs because `TestApplication.client` uses an instance of an application different from the returned by `TestApplication` constructor-like function and calls `start()` on it. `TestApplication.start()` calls `TestApplicationEngine.start()` under the hood which rewrites `cancellationJob`, so coroutine waiting for cancellation never ends.

To fix this problem:
- make `TestApplication` return `application` from builder – the same as used in a client
- remove builder from `TestApplication` constructor to make builder the only way to get `TestApplication` and break circular dependency: `TestApplication` -> `ApplicationTestBuilder` -> `TestApplication`

_It is better to review commit-by-commit_