### PR TITLE
Update contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,6 +18,11 @@ with some of the [low hanging fruit](https://youtrack.jetbrains.com/issues?q=%23
 
 ### Building the project
 
+> [!IMPORTANT]
+> This project requires JDK 21.
+> Make sure you have JDK 21 installed before attempting to build the project.
+> If you use IntelliJ IDEA, you should also select JDK 21 in **"Project Structure" > "Project" > "SDK"**
+
 Ktor is built with Gradle. Given it is multiplatform, you can build Ktor for the JVM, Native, and JavaScript.
 
 To build the projects and produce the corresponding artifacts, use

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,7 +40,7 @@ Run the following commands to install `libcurl` and `libncurses`:
 
 ```bash
 sudo apt update
-sudo apt install libncurses-dev libtinfo-dev libcurl4-openssl-dev
+sudo apt install libcurl4-openssl-dev libncurses-dev
 ```
 
 **macOS** 
@@ -49,8 +49,7 @@ The easiest way to install `libcurl` and `libncurses` on macOS is to use [Homebr
 Run the following commands:
 
 ```bash
-brew install curl
-brew install ncurses
+brew install curl ncurses
 ```
 
 If targeting macOS and/or iOS, install `Xcode` and `Xcode command line tools` on macOS.


### PR DESCRIPTION
- During a test of our contributing guide on Ubuntu Noble (24.04LTS) I found that `libtinfo-dev` [doesn't exist](https://packages.ubuntu.com/noble/libtinfo-dev) for this Ubuntu version. Actually, we don't need to install it explicitly as it is already included in `libncurses-dev`
- After merging #4500 it is required to have JDK 21 installed to build the project.