### PR TITLE
KTOR-7963 Handle ClosedWatchServiceException

### DIFF
--- a/ktor-server/ktor-server-cio/jvm/test/io/ktor/tests/server/cio/CIOEngineTestJvm.kt
+++ b/ktor-server/ktor-server-cio/jvm/test/io/ktor/tests/server/cio/CIOEngineTestJvm.kt
@@ -7,8 +7,10 @@ package io.ktor.tests.server.cio
 import io.ktor.server.cio.*
 import io.ktor.server.engine.*
 import io.ktor.server.testing.suites.*
-import kotlin.system.*
-import kotlin.test.*
+import kotlin.system.measureTimeMillis
+import kotlin.test.Ignore
+import kotlin.test.Test
+import kotlin.test.assertTrue
 
 class CIOCompressionTest : CompressionTestSuite<CIOApplicationEngine, CIOApplicationEngine.Configuration>(CIO) {
     init {


### PR DESCRIPTION
**Subsystem**
Server

**Motivation**
[KTOR-7963](https://youtrack.jetbrains.com/issue/KTOR-7963) Uncaught ClosedWatchServiceException exception thrown by finalizer when closing the server

**Solution**
Catch exceptions from polling.  I was unable to reproduce this reliably in a unit test, it seems to be pretty random with timing.