### PR TITLE
KTOR-7723 Improve clientTests DX

### DIFF
--- a/ktor-client/ktor-client-cio/jvm/test/io/ktor/client/engine/cio/ConnectErrorsTest.kt
+++ b/ktor-client/ktor-client-cio/jvm/test/io/ktor/client/engine/cio/ConnectErrorsTest.kt
@@ -11,13 +11,13 @@ import io.ktor.client.plugins.*
 import io.ktor.client.request.*
 import io.ktor.client.statement.*
 import io.ktor.http.*
-import io.ktor.test.junit.coroutines.*
 import io.ktor.network.tls.certificates.*
 import io.ktor.server.application.*
 import io.ktor.server.engine.*
 import io.ktor.server.netty.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
+import io.ktor.test.junit.coroutines.*
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeout
 import java.io.File

--- a/ktor-client/ktor-client-plugins/ktor-client-auth/common/test/io/ktor/client/plugins/auth/AuthTest.kt
+++ b/ktor-client/ktor-client-plugins/ktor-client-auth/common/test/io/ktor/client/plugins/auth/AuthTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2014-2024 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package io.ktor.client.plugins.auth
@@ -23,7 +23,7 @@ import kotlin.test.assertFailsWith
 class AuthTest : ClientLoader() {
 
     @Test
-    fun testDigestAuthLegacy() = clientTests(listOf("Js", "native:*")) {
+    fun testDigestAuthLegacy() = clientTests(except("Js", "native:*")) {
         config {
             install(Auth) {
                 digest {
@@ -43,7 +43,7 @@ class AuthTest : ClientLoader() {
     }
 
     @Test
-    fun testDigestAuth() = clientTests(listOf("Js", "native:*")) {
+    fun testDigestAuth() = clientTests(except("Js", "native:*")) {
         config {
             install(Auth) {
                 digest {
@@ -60,7 +60,7 @@ class AuthTest : ClientLoader() {
     }
 
     @Test
-    fun testDigestAuthPerRealm() = clientTests(listOf("Js", "native:*")) {
+    fun testDigestAuthPerRealm() = clientTests(except("Js", "native:*")) {
         config {
             install(Auth) {
                 digest {
@@ -84,7 +84,7 @@ class AuthTest : ClientLoader() {
     }
 
     @Test
-    fun testDigestAuthSHA256() = clientTests(listOf("Js", "native:*")) {
+    fun testDigestAuthSHA256() = clientTests(except("Js", "native:*")) {
         config {
             install(Auth) {
                 digest {
@@ -101,7 +101,7 @@ class AuthTest : ClientLoader() {
 
     @Suppress("DEPRECATION_ERROR")
     @Test
-    fun testBasicAuthLegacy() = clientTests(listOf("Js")) {
+    fun testBasicAuthLegacy() = clientTests(except("Js")) {
         config {
             install(Auth) {
                 basic {
@@ -117,7 +117,7 @@ class AuthTest : ClientLoader() {
     }
 
     @Test
-    fun testBasicAuth() = clientTests(listOf("Js")) {
+    fun testBasicAuth() = clientTests(except("Js")) {
         config {
             install(Auth) {
                 basic {
@@ -202,7 +202,7 @@ class AuthTest : ClientLoader() {
 
     @Suppress("DEPRECATION_ERROR")
     @Test
-    fun testUnauthorizedBasicAuthLegacy() = clientTests(listOf("Js")) {
+    fun testUnauthorizedBasicAuthLegacy() = clientTests(except("Js")) {
         config {
             install(Auth) {
                 basic {
@@ -221,7 +221,7 @@ class AuthTest : ClientLoader() {
     }
 
     @Test
-    fun testUnauthorizedBasicAuth() = clientTests(listOf("Js")) {
+    fun testUnauthorizedBasicAuth() = clientTests(except("Js")) {
         config {
             install(Auth) {
                 basic {
@@ -238,7 +238,7 @@ class AuthTest : ClientLoader() {
     }
 
     @Test
-    fun testBasicAuthMultiple() = clientTests(listOf("Js")) {
+    fun testBasicAuthMultiple() = clientTests(except("Js")) {
         config {
             install(Auth) {
                 basic {
@@ -261,7 +261,7 @@ class AuthTest : ClientLoader() {
     }
 
     @Test
-    fun testBasicAuthMultipleNotSendWithoutRequest() = clientTests(listOf("Js")) {
+    fun testBasicAuthMultipleNotSendWithoutRequest() = clientTests(except("Js")) {
         config {
             install(Auth) {
                 basic {
@@ -284,7 +284,7 @@ class AuthTest : ClientLoader() {
     }
 
     @Test
-    fun testBasicAuthPerRealm() = clientTests(listOf("Js")) {
+    fun testBasicAuthPerRealm() = clientTests(except("Js")) {
         config {
             install(Auth) {
                 basic {
@@ -729,7 +729,7 @@ class AuthTest : ClientLoader() {
     }
 
     @Test
-    fun testMultipleChallengesInMultipleHeadersUnauthorized() = clientTests(listOf("Js")) {
+    fun testMultipleChallengesInMultipleHeadersUnauthorized() = clientTests(except("Js")) {
         test { client ->
             val response = client.get("$TEST_SERVER/auth/multiple/headers")
             assertEquals(HttpStatusCode.Unauthorized, response.status)

--- a/ktor-client/ktor-client-plugins/ktor-client-encoding/common/test/ContentEncodingTest.kt
+++ b/ktor-client/ktor-client-plugins/ktor-client-encoding/common/test/ContentEncodingTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2014-2024 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package io.ktor.client.plugins.compression
@@ -36,7 +36,7 @@ class ContentEncodingTest : ClientLoader() {
 
     // Note: JS is decompressed before hitting the client, so the response does not appear compressed
     @Test
-    fun testDeflate() = clientTests(listOf("native:CIO", "js")) {
+    fun testDeflate() = clientTests(except("native:CIO", "Js")) {
         config {
             ContentEncoding {
                 deflate()
@@ -52,7 +52,7 @@ class ContentEncodingTest : ClientLoader() {
     }
 
     @Test
-    fun testGZip() = clientTests(listOf("native:CIO", "js")) {
+    fun testGZip() = clientTests(except("native:CIO", "Js")) {
         config {
             ContentEncoding {
                 gzip()
@@ -68,7 +68,7 @@ class ContentEncodingTest : ClientLoader() {
     }
 
     @Test
-    fun testGZipEmpty() = clientTests(listOf("js")) {
+    fun testGZipEmpty() = clientTests(except("Js")) {
         config {
             ContentEncoding {
                 gzip()
@@ -83,7 +83,7 @@ class ContentEncodingTest : ClientLoader() {
     }
 
     @Test
-    fun testGzipByteArray() = clientTests(listOf("js")) {
+    fun testGzipByteArray() = clientTests(except("Js")) {
         config {
             ContentEncoding {
                 gzip()
@@ -100,7 +100,7 @@ class ContentEncodingTest : ClientLoader() {
     }
 
     @Test
-    fun testDisableDecompression() = clientTests(listOf("OkHttp", "Js")) {
+    fun testDisableDecompression() = clientTests(except("OkHttp", "Js")) {
         config {
             ContentEncoding(mode = ContentEncodingConfig.Mode.CompressRequest) {
                 gzip()
@@ -115,7 +115,7 @@ class ContentEncodingTest : ClientLoader() {
     }
 
     @Test
-    fun testNoEncoding() = clientTests(listOf("OkHttp")) {
+    fun testNoEncoding() = clientTests(except("OkHttp")) {
         config {
             install(ContentEncoding)
         }

--- a/ktor-client/ktor-client-plugins/ktor-client-websockets/common/test/io/ktor/client/tests/plugins/WebSocketRemoteTest.kt
+++ b/ktor-client/ktor-client-plugins/ktor-client-websockets/common/test/io/ktor/client/tests/plugins/WebSocketRemoteTest.kt
@@ -19,7 +19,7 @@ class WebSocketRemoteTest : ClientLoader() {
     private val skipEngines = listOf("Android", "Apache", "Curl")
 
     @Test
-    fun testRemotePingPong() = clientTests(skipEngines) {
+    fun testRemotePingPong() = clientTests(except(skipEngines)) {
         config {
             install(WebSockets)
         }
@@ -35,7 +35,7 @@ class WebSocketRemoteTest : ClientLoader() {
 
     @Test
     @Ignore
-    fun testSecureRemotePingPong() = clientTests(skipEngines) {
+    fun testSecureRemotePingPong() = clientTests(except(skipEngines)) {
         config {
             install(WebSockets)
         }
@@ -50,7 +50,7 @@ class WebSocketRemoteTest : ClientLoader() {
     }
 
     @Test
-    fun testWithLogging() = clientTests(skipEngines) {
+    fun testWithLogging() = clientTests(except(skipEngines)) {
         config {
             install(Logging) {
                 level = LogLevel.ALL
@@ -67,7 +67,7 @@ class WebSocketRemoteTest : ClientLoader() {
     }
 
     @Test
-    fun testSessionClose() = clientTests(skipEngines) {
+    fun testSessionClose() = clientTests(except(skipEngines)) {
         config {
             install(WebSockets)
         }
@@ -80,7 +80,7 @@ class WebSocketRemoteTest : ClientLoader() {
     }
 
     @Test
-    fun testSessionTermination() = clientTests(skipEngines) {
+    fun testSessionTermination() = clientTests(except(skipEngines)) {
         config {
             install(WebSockets)
         }
@@ -93,7 +93,7 @@ class WebSocketRemoteTest : ClientLoader() {
     }
 
     @Test
-    fun testBadCloseReason() = clientTests(skipEngines) {
+    fun testBadCloseReason() = clientTests(except(skipEngines)) {
         config {
             install(WebSockets)
         }
@@ -106,7 +106,7 @@ class WebSocketRemoteTest : ClientLoader() {
     }
 
     @Test
-    fun testNotFound() = clientTests(skipEngines) {
+    fun testNotFound() = clientTests(except(skipEngines)) {
         config {
             install(WebSockets)
             expectSuccess = true
@@ -146,7 +146,7 @@ class WebSocketRemoteTest : ClientLoader() {
     private class CustomException : Exception()
 
     @Test
-    fun testErrorHandling() = clientTests(skipEngines) {
+    fun testErrorHandling() = clientTests(except(skipEngines)) {
         config {
             install(WebSockets)
         }

--- a/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/ClientHeadersTest.kt
+++ b/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/ClientHeadersTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2014-2024 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package io.ktor.client.tests
@@ -15,7 +15,7 @@ class ClientHeadersTest : ClientLoader() {
 
     @Test
     fun testHeadersReturnNullWhenMissing() = clientTests(
-        listOf("Java", "Curl", "Js", "Darwin", "DarwinLegacy", "WinHttp")
+        except("Java", "Curl", "Js", "Darwin", "DarwinLegacy", "WinHttp")
     ) {
         test { client ->
             client.get("$TEST_SERVER/headers").let {
@@ -29,7 +29,7 @@ class ClientHeadersTest : ClientLoader() {
     }
 
     @Test
-    fun testContentNegotiationMediaType() = clientTests(listOf("Java", "Curl", "Js", "Darwin", "DarwinLegacy")) {
+    fun testContentNegotiationMediaType() = clientTests(except("Java", "Curl", "Js", "Darwin", "DarwinLegacy")) {
         test { client ->
             client.preparePost("$TEST_SERVER/content-type") {
                 contentType(ContentType.Application.Json)
@@ -42,7 +42,7 @@ class ClientHeadersTest : ClientLoader() {
     }
 
     @Test
-    fun testHeadersMerge() = clientTests(listOf("Js")) {
+    fun testHeadersMerge() = clientTests(except("Js")) {
         test { client ->
             client.get("$TEST_SERVER/headers-merge") {
                 accept(ContentType.Text.Html)
@@ -64,7 +64,7 @@ class ClientHeadersTest : ClientLoader() {
     }
 
     @Test
-    fun testAcceptMerge() = clientTests(listOf("Js")) {
+    fun testAcceptMerge() = clientTests(except("Js")) {
         test { client ->
             val lines = client.get("$TCP_SERVER/headers-merge") {
                 accept(ContentType.Application.Xml)
@@ -77,7 +77,7 @@ class ClientHeadersTest : ClientLoader() {
     }
 
     @Test
-    fun testSingleHostHeader() = clientTests(listOf("Js", "Android", "Java")) {
+    fun testSingleHostHeader() = clientTests(except("Js", "Android", "Java")) {
         test { client ->
             client.get("$TEST_SERVER/headers/host") {
                 header(HttpHeaders.Host, "CustomHost")
@@ -108,7 +108,7 @@ class ClientHeadersTest : ClientLoader() {
     }
 
     @Test
-    fun testRequestHasContentLength() = clientTests(listOf("Java", "Curl", "Js", "Darwin", "DarwinLegacy", "WinHttp")) {
+    fun testRequestHasContentLength() = clientTests(except("Java", "Curl", "Js", "Darwin", "DarwinLegacy", "WinHttp")) {
         test { client ->
             val get = client.get("$TEST_SERVER/headers").bodyAsText()
             assertEquals("", get)

--- a/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/ContentTest.kt
+++ b/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/ContentTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2014-2024 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package io.ktor.client.tests
@@ -99,7 +99,7 @@ class ContentTest : ClientLoader() {
     }
 
     @Test
-    fun testSendByteReadChannel() = clientTests(listOf("Js")) {
+    fun testSendByteReadChannel() = clientTests(except("Js")) {
         config {
             install(HttpTimeout) {
                 socketTimeoutMillis = 1.minutes.inWholeMilliseconds
@@ -120,7 +120,7 @@ class ContentTest : ClientLoader() {
     }
 
     @Test
-    fun testSendByteWriteChannel() = clientTests(listOf("Js")) {
+    fun testSendByteWriteChannel() = clientTests(except("Js")) {
         config {
             install(HttpTimeout) {
                 socketTimeoutMillis = 1.minutes.inWholeMilliseconds
@@ -146,7 +146,7 @@ class ContentTest : ClientLoader() {
     }
 
     @Test
-    fun testString() = clientTests(listOf("Darwin", "CIO", "DarwinLegacy"), retries = 10) {
+    fun testString() = clientTests(except("Darwin", "CIO", "DarwinLegacy"), retries = 10) {
         test { client ->
             testStrings.forEach { content ->
                 val requestWithBody = client.echo<String>(content)
@@ -176,7 +176,7 @@ class ContentTest : ClientLoader() {
     }
 
     @Test
-    fun testTextContent() = clientTests(listOf("Darwin", "CIO", "DarwinLegacy")) {
+    fun testTextContent() = clientTests(except("Darwin", "CIO", "DarwinLegacy")) {
         test { client ->
             testStrings.forEach { content ->
                 val response = client.echo<String>(TextContent(content, ContentType.Text.Plain))
@@ -348,7 +348,7 @@ class ContentTest : ClientLoader() {
     }
 
     @Test
-    fun testDownloadStreamResponseWithClose() = clientTests(onlyWithEngine = "CIO") {
+    fun testDownloadStreamResponseWithClose() = clientTests(only("CIO")) {
         test { client ->
             client.prepareGet("$TEST_SERVER/content/stream").execute {
             }
@@ -357,7 +357,7 @@ class ContentTest : ClientLoader() {
 
     // NSUrlSession buffers first 512 bytes
     @Test
-    fun testDownloadStream() = clientTests(listOf("Darwin", "DarwinLegacy")) {
+    fun testDownloadStream() = clientTests(except("Darwin", "DarwinLegacy")) {
         test { client ->
             client.prepareGet("$TEST_SERVER/content/stream?delay=100").execute {
                 val channel = it.bodyAsChannel()

--- a/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/EventsTest.kt
+++ b/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/EventsTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2021 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2014-2024 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package io.ktor.client.tests
@@ -74,7 +74,7 @@ class EventsTest : ClientLoader() {
     }
 
     @Test
-    fun testRedirectEvent() = clientTests(listOf("Js")) {
+    fun testRedirectEvent() = clientTests(except("Js")) {
         test { client ->
             counter.value = 0
             client.monitor.subscribe(HttpResponseRedirectEvent) {

--- a/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/ExceptionsTest.kt
+++ b/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/ExceptionsTest.kt
@@ -1,6 +1,6 @@
 /*
-* Copyright 2014-2021 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
-*/
+ * Copyright 2014-2024 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
 
 package io.ktor.client.tests
 
@@ -130,7 +130,7 @@ class ExceptionsTest : ClientLoader() {
     }
 
     @Test
-    fun testErrorOnResponseCoroutine() = clientTests(listOf("Curl", "CIO", "Darwin", "DarwinLegacy")) {
+    fun testErrorOnResponseCoroutine() = clientTests(except("Curl", "CIO", "Darwin", "DarwinLegacy")) {
         test { client ->
             val requestBuilder = HttpRequestBuilder()
             requestBuilder.url.takeFrom("$TEST_SERVER/download/infinite")

--- a/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/FullFormTest.kt
+++ b/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/FullFormTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2014-2024 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package io.ktor.client.tests
@@ -68,7 +68,7 @@ class FullFormTest : ClientLoader() {
 
     @Test
     @Ignore
-    fun testCustomUrls() = clientTests(listOf("Darwin", "native:CIO", "DarwinLegacy")) {
+    fun testCustomUrls() = clientTests(except("Darwin", "native:CIO", "DarwinLegacy")) {
         val urls = listOf(
             "https://google.com",
             "https://kotlinlang.org/"

--- a/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/HttpRedirectTest.kt
+++ b/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/HttpRedirectTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2014-2024 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package io.ktor.client.tests
@@ -59,7 +59,7 @@ class HttpRedirectTest : ClientLoader() {
     }
 
     @Test
-    fun testRedirectWithCookies() = clientTests(listOf("Js")) {
+    fun testRedirectWithCookies() = clientTests(except("Js")) {
         config {
             install(HttpCookies)
             install(HttpRedirect)
@@ -76,7 +76,7 @@ class HttpRedirectTest : ClientLoader() {
 
     @Test
     @Ignore
-    fun testCustomUrls() = clientTests(listOf("Darwin", "DarwinLegacy")) {
+    fun testCustomUrls() = clientTests(except("Darwin", "DarwinLegacy")) {
         val urls = listOf(
             "https://files.forgecdn.net/files/2574/880/BiblioCraft[v2.4.5][MC1.12.2].jar",
             "https://files.forgecdn.net/files/2611/560/Botania r1.10-356.jar",
@@ -125,7 +125,7 @@ class HttpRedirectTest : ClientLoader() {
     }
 
     @Test
-    fun testRedirectHostAbsolute() = clientTests(listOf("Js")) {
+    fun testRedirectHostAbsolute() = clientTests(except("Js")) {
         test { client ->
             client.prepareGet("$TEST_URL_BASE/directory/hostAbsoluteRedirect").execute {
                 assertEquals("OK", it.bodyAsText())

--- a/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/HttpStatementTest.kt
+++ b/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/HttpStatementTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2014-2024 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package io.ktor.client.tests
@@ -38,7 +38,7 @@ class HttpStatementTest : ClientLoader() {
     }
 
     @Test
-    fun testGZipFromSavedResponse() = clientTests(listOf("native:CIO")) {
+    fun testGZipFromSavedResponse() = clientTests(except("native:CIO")) {
         config {
             ContentEncoding {
                 gzip()

--- a/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/HttpTimeoutTest.kt
+++ b/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/HttpTimeoutTest.kt
@@ -63,7 +63,7 @@ class HttpTimeoutTest : ClientLoader() {
     }
 
     @Test
-    fun testWithExternalTimeout() = clientTests(listOf("Android")) {
+    fun testWithExternalTimeout() = clientTests(except("Android")) {
         config {
             install(HttpTimeout)
         }
@@ -211,7 +211,7 @@ class HttpTimeoutTest : ClientLoader() {
     }
 
     @Test
-    fun testGetRequestTimeoutWithSeparateReceive() = clientTests(listOf("Js"), retries = 5) {
+    fun testGetRequestTimeoutWithSeparateReceive() = clientTests(except("Js"), retries = 5) {
 //      https://youtrack.jetbrains.com/issue/KTOR-7847/Investigate-Flaky-timeout-tests-on-linuxX64
         if (PlatformUtils.IS_NATIVE) return@clientTests
 
@@ -233,7 +233,7 @@ class HttpTimeoutTest : ClientLoader() {
 
     @Test
     fun testGetRequestTimeoutWithSeparateReceivePerRequestAttributes() = clientTests(
-        listOf("Js", "Curl", "Darwin", "DarwinLegacy")
+        except("Js", "Curl", "Darwin", "DarwinLegacy")
     ) {
         config {
             install(HttpTimeout)
@@ -253,7 +253,7 @@ class HttpTimeoutTest : ClientLoader() {
     }
 
     @Test
-    fun testGetAfterTimeout() = clientTests(listOf("Curl", "Js", "Darwin", "DarwinLegacy")) {
+    fun testGetAfterTimeout() = clientTests(except("Curl", "Js", "Darwin", "DarwinLegacy")) {
         config {
             install(HttpTimeout)
         }
@@ -327,7 +327,7 @@ class HttpTimeoutTest : ClientLoader() {
     // Fix https://youtrack.jetbrains.com/issue/KTOR-7885
     @Ignore
     @Test
-    fun testRedirect() = clientTests(listOf("Js"), retries = 5) {
+    fun testRedirect() = clientTests(except("Js"), retries = 5) {
         config {
             install(HttpTimeout) { requestTimeoutMillis = 10000 }
         }
@@ -344,7 +344,7 @@ class HttpTimeoutTest : ClientLoader() {
 
     // Js can't configure test timeout in browser
     @Test
-    fun testRedirectPerRequestAttributes() = clientTests(listOf("Js")) {
+    fun testRedirectPerRequestAttributes() = clientTests(except("Js")) {
         config {
             install(HttpTimeout)
         }
@@ -429,7 +429,7 @@ class HttpTimeoutTest : ClientLoader() {
     }
 
     @Test
-    fun testConnectionRefusedException() = clientTests(listOf("Js", "native:*", "jvm/win:*")) {
+    fun testConnectionRefusedException() = clientTests(except("Js", "native:*", "jvm/win:*")) {
         config {
             install(HttpTimeout) { connectTimeoutMillis = 1000 }
         }
@@ -445,7 +445,7 @@ class HttpTimeoutTest : ClientLoader() {
     }
 
     @Test
-    fun testSocketTimeoutRead() = clientTests(listOf("Js", "native:CIO", "Curl", "Java")) {
+    fun testSocketTimeoutRead() = clientTests(except("Js", "native:CIO", "Curl", "Java")) {
         config {
             install(HttpTimeout) { socketTimeoutMillis = 1000 }
         }
@@ -461,7 +461,7 @@ class HttpTimeoutTest : ClientLoader() {
 
     @Test
     fun testSocketTimeoutReadPerRequestAttributes() = clientTests(
-        listOf("Js", "native:CIO", "Curl", "Java", "Apache5")
+        except("Js", "native:CIO", "Curl", "Java", "Apache5")
     ) {
         config {
             install(HttpTimeout)
@@ -479,7 +479,7 @@ class HttpTimeoutTest : ClientLoader() {
     }
 
     @Test
-    fun testSocketTimeoutWriteFailOnWrite() = clientTests(listOf("Js", "Android", "native:CIO", "Curl", "Java")) {
+    fun testSocketTimeoutWriteFailOnWrite() = clientTests(except("Js", "Android", "native:CIO", "Curl", "Java")) {
         config {
             install(HttpTimeout) { socketTimeoutMillis = 500 }
         }
@@ -493,7 +493,7 @@ class HttpTimeoutTest : ClientLoader() {
 
     @Test
     fun testSocketTimeoutWriteFailOnWritePerRequestAttributes() = clientTests(
-        listOf("Js", "Android", "Apache5", "native:CIO", "Curl", "Java")
+        except("Js", "Android", "Apache5", "native:CIO", "Curl", "Java")
     ) {
         config {
             install(HttpTimeout)

--- a/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/JsonTest.kt
+++ b/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/JsonTest.kt
@@ -1,6 +1,6 @@
 /*
-* Copyright 2014-2021 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
-*/
+ * Copyright 2014-2024 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
 
 package io.ktor.client.tests
 
@@ -21,7 +21,7 @@ class JsonTest : ClientLoader() {
     data class Result<T>(val message: String, val data: T)
 
     @Test
-    fun testUserGenerics() = clientTests(listOf("Js")) {
+    fun testUserGenerics() = clientTests(except("Js")) {
         config {
             install(ContentNegotiation) { json() }
         }

--- a/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/LoggingTest.kt
+++ b/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/LoggingTest.kt
@@ -52,7 +52,7 @@ class LoggingTest : ClientLoader() {
     }
 
     @Test
-    fun testLoggingLevelBody() = clientTests(listOf("native:CIO")) {
+    fun testLoggingLevelBody() = clientTests(except("native:CIO")) {
         val logger = TestLogger(
             "REQUEST: http://localhost:8080/logging",
             "METHOD: HttpMethod(value=GET)",
@@ -72,7 +72,7 @@ class LoggingTest : ClientLoader() {
     }
 
     @Test
-    fun testLogLevelAll() = clientTests(listOf("native:CIO")) {
+    fun testLogLevelAll() = clientTests(except("native:CIO")) {
         val logger = TestLogger(
             "REQUEST: http://localhost:8080/logging",
             "METHOD: HttpMethod(value=GET)",
@@ -142,7 +142,7 @@ class LoggingTest : ClientLoader() {
     }
 
     @Test
-    fun testLogPostBody() = clientTests(listOf("native:CIO")) {
+    fun testLogPostBody() = clientTests(except("native:CIO")) {
         val testLogger = TestLogger(
             "REQUEST: http://localhost:8080/logging",
             "METHOD: HttpMethod(value=POST)",
@@ -198,7 +198,7 @@ class LoggingTest : ClientLoader() {
     }
 
     @Test
-    fun testLogPostMalformedUtf8Body() = clientTests(listOf("native:CIO")) {
+    fun testLogPostMalformedUtf8Body() = clientTests(except("native:CIO")) {
         val testLogger = TestLogger(
             "REQUEST: http://localhost:8080/logging/non-utf",
             "METHOD: HttpMethod(value=POST)",
@@ -254,7 +254,7 @@ class LoggingTest : ClientLoader() {
     }
 
     @Test
-    fun testRequestAndResponseBody() = clientTests(listOf("native:CIO")) {
+    fun testRequestAndResponseBody() = clientTests(except("native:CIO")) {
         val testLogger = TestLogger(
             "REQUEST: http://127.0.0.1:8080/content/echo",
             "METHOD: HttpMethod(value=POST)",
@@ -304,7 +304,7 @@ class LoggingTest : ClientLoader() {
     }
 
     @Test
-    fun testRequestContentTypeInLog() = clientTests(listOf("Darwin", "native:CIO", "DarwinLegacy")) {
+    fun testRequestContentTypeInLog() = clientTests(except("Darwin", "native:CIO", "DarwinLegacy")) {
         val testLogger = TestLogger(
             "REQUEST: http://127.0.0.1:8080/content/echo",
             "METHOD: HttpMethod(value=POST)",
@@ -356,7 +356,7 @@ class LoggingTest : ClientLoader() {
     }
 
     @Test
-    fun testLoggingWithCompression() = clientTests(listOf("Darwin", "DarwinLegacy", "native:CIO")) {
+    fun testLoggingWithCompression() = clientTests(except("Darwin", "DarwinLegacy", "native:CIO")) {
         val testLogger = TestLogger(
             "REQUEST: http://127.0.0.1:8080/compression/deflate",
             "METHOD: HttpMethod(value=GET)",

--- a/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/LoggingTest.kt
+++ b/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/LoggingTest.kt
@@ -11,7 +11,6 @@ import io.ktor.client.plugins.logging.*
 import io.ktor.client.request.*
 import io.ktor.client.request.forms.*
 import io.ktor.client.statement.*
-import io.ktor.client.statement.readRawBytes
 import io.ktor.client.tests.utils.*
 import io.ktor.http.*
 import io.ktor.serialization.kotlinx.json.*

--- a/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/MultiPartFormDataTest.kt
+++ b/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/MultiPartFormDataTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2014-2024 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package io.ktor.client.tests
@@ -25,7 +25,7 @@ class MultiPartFormDataTest : ClientLoader() {
     }
 
     @Test
-    fun testMultiPartFormData() = clientTests(listOf("native:*")) {
+    fun testMultiPartFormData() = clientTests(except("native:*")) {
         test { client ->
             val result = client.preparePost("$TEST_SERVER/multipart") {
                 setBody(

--- a/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/PluginsTest.kt
+++ b/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/PluginsTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2014-2024 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package io.ktor.client.tests
@@ -43,7 +43,7 @@ class PluginsTest : ClientLoader() {
 
     @OptIn(InternalAPI::class)
     @Test
-    fun testBodyObserver() = clientTests(listOf("CIO")) {
+    fun testBodyObserver() = clientTests(except("CIO")) {
         val body = "Hello, world"
         val task = Job()
         config {

--- a/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/PostTest.kt
+++ b/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/PostTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2014-2024 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package io.ktor.client.tests
@@ -17,21 +17,21 @@ import kotlin.time.Duration.Companion.minutes
 
 class PostTest : ClientLoader() {
     @Test
-    fun testPostString() = clientTests(listOf("Js")) {
+    fun testPostString() = clientTests(except("Js")) {
         test { client ->
             client.postHelper(makeString(777))
         }
     }
 
     @Test
-    fun testHugePost() = clientTests(listOf("Js", "Darwin", "CIO", "Curl", "DarwinLegacy", "WinHttp")) {
+    fun testHugePost() = clientTests(except("Js", "Darwin", "CIO", "Curl", "DarwinLegacy", "WinHttp")) {
         test { client ->
             client.postHelper(makeString(32 * 1024 * 1024))
         }
     }
 
     @Test
-    fun testWithPause() = clientTests(listOf("Js", "Darwin", "CIO", "DarwinLegacy")) {
+    fun testWithPause() = clientTests(except("Js", "Darwin", "CIO", "DarwinLegacy")) {
         config {
             install(HttpTimeout) {
                 socketTimeoutMillis = 1.minutes.inWholeMilliseconds

--- a/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/ProxyTest.kt
+++ b/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/ProxyTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2014-2024 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package io.ktor.client.tests
@@ -19,7 +19,7 @@ data class ProxyResponse(val status: String)
 class ProxyTest : ClientLoader() {
 
     @Test
-    fun testHttpProxy() = clientTests(listOf("Js")) {
+    fun testHttpProxy() = clientTests(except("Js")) {
         config {
             engine {
                 proxy = ProxyBuilder.http(TCP_SERVER)
@@ -33,7 +33,7 @@ class ProxyTest : ClientLoader() {
     }
 
     @Test
-    fun testProxyWithSerialization() = clientTests(listOf("Js")) {
+    fun testProxyWithSerialization() = clientTests(except("Js")) {
         config {
             engine {
                 proxy = ProxyBuilder.http(TCP_SERVER)

--- a/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/UploadTest.kt
+++ b/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/UploadTest.kt
@@ -1,6 +1,6 @@
 /*
-* Copyright 2014-2021 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
-*/
+ * Copyright 2014-2024 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
 
 package io.ktor.client.tests
 
@@ -14,7 +14,7 @@ import kotlin.test.*
 class UploadTest : ClientLoader() {
 
     @Test
-    fun testUploadWithByteArrayContent() = clientTests(listOf("Android", "Curl", "Darwin", "DarwinLegacy")) {
+    fun testUploadWithByteArrayContent() = clientTests(except("Android", "Curl", "Darwin", "DarwinLegacy")) {
         test { client ->
             val result = client.post("$TEST_SERVER/upload/content") {
                 setBody(ByteArrayContent(ByteArray(1024)))

--- a/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/WebSocketTest.kt
+++ b/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/WebSocketTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2022 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2014-2024 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package io.ktor.client.tests
@@ -70,7 +70,7 @@ class WebSocketTest : ClientLoader() {
     }
 
     @Test
-    fun testWebsocketSession() = clientTests(ENGINES_WITHOUT_WS) {
+    fun testWebsocketSession() = clientTests(except(ENGINES_WITHOUT_WS)) {
         config {
             install(WebSockets)
         }
@@ -85,7 +85,7 @@ class WebSocketTest : ClientLoader() {
     }
 
     @Test
-    fun testParallelWebsocketSessions() = clientTests(ENGINES_WITHOUT_WS) {
+    fun testParallelWebsocketSessions() = clientTests(except(ENGINES_WITHOUT_WS)) {
         config {
             install(WebSockets)
         }
@@ -115,7 +115,7 @@ class WebSocketTest : ClientLoader() {
     }
 
     @Test
-    fun testWebsocketWithDefaultRequest() = clientTests(ENGINES_WITHOUT_WS + "Js") {
+    fun testWebsocketWithDefaultRequest() = clientTests(except(ENGINES_WITHOUT_WS + "Js")) {
         config {
             install(WebSockets)
             defaultRequest {
@@ -135,7 +135,7 @@ class WebSocketTest : ClientLoader() {
     }
 
     @Test
-    fun testWebsocketSessionWithError() = clientTests(ENGINES_WITHOUT_WS) {
+    fun testWebsocketSessionWithError() = clientTests(except(ENGINES_WITHOUT_WS)) {
         config {
             install(WebSockets)
         }
@@ -146,7 +146,7 @@ class WebSocketTest : ClientLoader() {
     }
 
     @Test
-    fun testExceptionWss() = clientTests(ENGINES_WITHOUT_WS + "Js") {
+    fun testExceptionWss() = clientTests(except(ENGINES_WITHOUT_WS + "Js")) {
         config {
             install(WebSockets)
         }
@@ -161,7 +161,7 @@ class WebSocketTest : ClientLoader() {
     }
 
     @Test
-    fun testWebSocketSerialization() = clientTests(ENGINES_WITHOUT_WS) {
+    fun testWebSocketSerialization() = clientTests(except(ENGINES_WITHOUT_WS)) {
         config {
             WebSockets {
                 contentConverter = customContentConverter
@@ -181,7 +181,7 @@ class WebSocketTest : ClientLoader() {
     }
 
     @Test
-    fun testWebSocketSerializationWithExplicitTypeInfo() = clientTests(ENGINES_WITHOUT_WS) {
+    fun testWebSocketSerializationWithExplicitTypeInfo() = clientTests(except(ENGINES_WITHOUT_WS)) {
         config {
             WebSockets {
                 contentConverter = customContentConverter
@@ -201,7 +201,7 @@ class WebSocketTest : ClientLoader() {
     }
 
     @Test
-    fun testSerializationWithNoConverter() = clientTests(ENGINES_WITHOUT_WS) {
+    fun testSerializationWithNoConverter() = clientTests(except(ENGINES_WITHOUT_WS)) {
         config {
             WebSockets {
             }
@@ -223,7 +223,7 @@ class WebSocketTest : ClientLoader() {
     }
 
     @Test
-    fun testRequestTimeoutIsNotApplied() = clientTests(ENGINES_WITHOUT_WS) {
+    fun testRequestTimeoutIsNotApplied() = clientTests(except(ENGINES_WITHOUT_WS)) {
         config {
             install(WebSockets)
 
@@ -244,7 +244,7 @@ class WebSocketTest : ClientLoader() {
     }
 
     @Test
-    fun testCountPong() = clientTests(ENGINES_WITHOUT_WS + "Js") {
+    fun testCountPong() = clientTests(except(ENGINES_WITHOUT_WS + "Js")) {
         config {
             install(WebSockets)
         }
@@ -260,7 +260,7 @@ class WebSocketTest : ClientLoader() {
     }
 
     @Test
-    fun testCancellingScope() = clientTests(ENGINES_WITHOUT_WS) {
+    fun testCancellingScope() = clientTests(except(ENGINES_WITHOUT_WS)) {
         config {
             install(WebSockets)
         }
@@ -277,7 +277,7 @@ class WebSocketTest : ClientLoader() {
     }
 
     @Test
-    fun testWebsocketRequiringSubProtocolWithSubProtocol() = clientTests(ENGINES_WITHOUT_WS) {
+    fun testWebsocketRequiringSubProtocolWithSubProtocol() = clientTests(except(ENGINES_WITHOUT_WS)) {
         config {
             install(WebSockets)
         }
@@ -297,7 +297,7 @@ class WebSocketTest : ClientLoader() {
     }
 
     @Test
-    fun testWebsocketRequiringSubProtocolWithoutSubProtocol() = clientTests(ENGINES_WITHOUT_WS) {
+    fun testWebsocketRequiringSubProtocolWithoutSubProtocol() = clientTests(except(ENGINES_WITHOUT_WS)) {
         config {
             install(WebSockets)
         }
@@ -312,7 +312,7 @@ class WebSocketTest : ClientLoader() {
     }
 
     @Test
-    fun testIncomingOverflow() = clientTests(ENGINES_WITHOUT_WS) {
+    fun testIncomingOverflow() = clientTests(except(ENGINES_WITHOUT_WS)) {
         config {
             install(WebSockets)
         }
@@ -329,7 +329,7 @@ class WebSocketTest : ClientLoader() {
     @Ignore // TODO KTOR-7088
     @Test
     fun testImmediateReceiveAfterConnect() = clientTests(
-        ENGINES_WITHOUT_WS + "Darwin" + "Js" // TODO KTOR-7088
+        except(ENGINES_WITHOUT_WS + "Darwin" + "Js") // TODO KTOR-7088
     ) {
         config {
             install(WebSockets)
@@ -354,7 +354,7 @@ class WebSocketTest : ClientLoader() {
     }
 
     @Test
-    fun testAuthenticationWithValidRefreshToken() = clientTests(ENGINES_WITHOUT_WS + "Js") {
+    fun testAuthenticationWithValidRefreshToken() = clientTests(except(ENGINES_WITHOUT_WS + "Js")) {
         config {
             install(WebSockets)
 
@@ -376,7 +376,10 @@ class WebSocketTest : ClientLoader() {
     }
 
     @Test
-    fun testAuthenticationWithValidInitialToken() = clientTests(ENGINES_WITHOUT_WS + "Js" + "Darwin", retries = 5) {
+    fun testAuthenticationWithValidInitialToken() = clientTests(
+        except(ENGINES_WITHOUT_WS + "Js" + "Darwin"),
+        retries = 5
+    ) {
         config {
             install(WebSockets)
 
@@ -397,7 +400,7 @@ class WebSocketTest : ClientLoader() {
     }
 
     @Test
-    fun testAuthenticationWithInvalidToken() = clientTests(ENGINES_WITHOUT_WS + "Js") {
+    fun testAuthenticationWithInvalidToken() = clientTests(except(ENGINES_WITHOUT_WS + "Js")) {
         config {
             install(WebSockets)
 

--- a/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/plugins/CacheLegacyStorageTest.kt
+++ b/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/plugins/CacheLegacyStorageTest.kt
@@ -1,6 +1,6 @@
 /*
-* Copyright 2014-2021 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
-*/
+ * Copyright 2014-2024 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
 
 package io.ktor.client.tests.plugins
 
@@ -75,7 +75,7 @@ class CacheLegacyStorageTest : ClientLoader() {
     }
 
     @Test
-    fun testETagCache() = clientTests(listOf("Js")) {
+    fun testETagCache() = clientTests(except("Js")) {
         val publicStorage = HttpCacheStorage.Unlimited()
         val privateStorage = HttpCacheStorage.Unlimited()
         config {
@@ -99,7 +99,7 @@ class CacheLegacyStorageTest : ClientLoader() {
     }
 
     @Test
-    fun testLastModified() = clientTests(listOf("Js")) {
+    fun testLastModified() = clientTests(except("Js")) {
         val publicStorage = HttpCacheStorage.Unlimited()
         val privateStorage = HttpCacheStorage.Unlimited()
         config {
@@ -123,7 +123,7 @@ class CacheLegacyStorageTest : ClientLoader() {
     }
 
     @Test
-    fun testVary() = clientTests(listOf("Js")) {
+    fun testVary() = clientTests(except("Js")) {
         val publicStorage = HttpCacheStorage.Unlimited()
         val privateStorage = HttpCacheStorage.Unlimited()
         config {
@@ -180,7 +180,7 @@ class CacheLegacyStorageTest : ClientLoader() {
     }
 
     @Test
-    fun testVaryStale() = clientTests(listOf("Js")) {
+    fun testVaryStale() = clientTests(except("Js")) {
         val publicStorage = HttpCacheStorage.Unlimited()
         val privateStorage = HttpCacheStorage.Unlimited()
         config {
@@ -238,7 +238,7 @@ class CacheLegacyStorageTest : ClientLoader() {
 
     @OptIn(InternalAPI::class)
     @Test
-    fun testNoVaryIn304() = clientTests(listOf("Js")) {
+    fun testNoVaryIn304() = clientTests(except("Js")) {
         val publicStorage = HttpCacheStorage.Unlimited()
         val privateStorage = HttpCacheStorage.Unlimited()
         config {
@@ -418,7 +418,7 @@ class CacheLegacyStorageTest : ClientLoader() {
     }
 
     @Test
-    fun testNoStoreRequest() = clientTests(listOf("Js")) {
+    fun testNoStoreRequest() = clientTests(except("Js")) {
         val publicStorage = HttpCacheStorage.Unlimited()
         val privateStorage = HttpCacheStorage.Unlimited()
         config {
@@ -444,7 +444,7 @@ class CacheLegacyStorageTest : ClientLoader() {
     }
 
     @Test
-    fun testNoCacheRequest() = clientTests(listOf("Js")) {
+    fun testNoCacheRequest() = clientTests(except("Js")) {
         val publicStorage = HttpCacheStorage.Unlimited()
         val privateStorage = HttpCacheStorage.Unlimited()
         config {
@@ -476,7 +476,7 @@ class CacheLegacyStorageTest : ClientLoader() {
     }
 
     @Test
-    fun testRequestWithMaxAge0() = clientTests(listOf("Js")) {
+    fun testRequestWithMaxAge0() = clientTests(except("Js")) {
         val publicStorage = HttpCacheStorage.Unlimited()
         val privateStorage = HttpCacheStorage.Unlimited()
         config {
@@ -569,7 +569,7 @@ class CacheLegacyStorageTest : ClientLoader() {
     }
 
     @Test
-    fun testPublicAndPrivateCache() = clientTests(listOf("native:*")) {
+    fun testPublicAndPrivateCache() = clientTests(except("native:*")) {
         val publicStorage = HttpCacheStorage.Unlimited()
         val privateStorage = HttpCacheStorage.Unlimited()
         config {

--- a/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/plugins/CacheTest.kt
+++ b/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/plugins/CacheTest.kt
@@ -75,7 +75,7 @@ class CacheTest : ClientLoader() {
     }
 
     @Test
-    fun testETagCache() = clientTests(listOf("Js")) {
+    fun testETagCache() = clientTests(except("Js")) {
         val publicStorage = CacheStorage.Unlimited()
         val privateStorage = CacheStorage.Unlimited()
         config {
@@ -99,7 +99,7 @@ class CacheTest : ClientLoader() {
     }
 
     @Test
-    fun testReuseCacheStorage() = clientTests(listOf("Js")) {
+    fun testReuseCacheStorage() = clientTests(except("Js")) {
         val publicStorage = CacheStorage.Unlimited()
         val privateStorage = CacheStorage.Unlimited()
         config {
@@ -124,7 +124,7 @@ class CacheTest : ClientLoader() {
     }
 
     @Test
-    fun testLastModified() = clientTests(listOf("Js")) {
+    fun testLastModified() = clientTests(except("Js")) {
         val publicStorage = CacheStorage.Unlimited()
         val privateStorage = CacheStorage.Unlimited()
         config {
@@ -148,7 +148,7 @@ class CacheTest : ClientLoader() {
     }
 
     @Test
-    fun testVary() = clientTests(listOf("Js")) {
+    fun testVary() = clientTests(except("Js")) {
         val publicStorage = CacheStorage.Unlimited()
         val privateStorage = CacheStorage.Unlimited()
         config {
@@ -205,7 +205,7 @@ class CacheTest : ClientLoader() {
     }
 
     @Test
-    fun testVaryStale() = clientTests(listOf("Js")) {
+    fun testVaryStale() = clientTests(except("Js")) {
         val publicStorage = CacheStorage.Unlimited()
         val privateStorage = CacheStorage.Unlimited()
         config {
@@ -263,7 +263,7 @@ class CacheTest : ClientLoader() {
 
     @OptIn(InternalAPI::class)
     @Test
-    fun testNoVaryIn304() = clientTests(listOf("Js")) {
+    fun testNoVaryIn304() = clientTests(except("Js")) {
         val publicStorage = CacheStorage.Unlimited()
         val privateStorage = CacheStorage.Unlimited()
         config {
@@ -545,7 +545,7 @@ class CacheTest : ClientLoader() {
     }
 
     @Test
-    fun testNoStoreRequest() = clientTests(listOf("Js")) {
+    fun testNoStoreRequest() = clientTests(except("Js")) {
         val publicStorage = CacheStorage.Unlimited()
         val privateStorage = CacheStorage.Unlimited()
         config {
@@ -571,7 +571,7 @@ class CacheTest : ClientLoader() {
     }
 
     @Test
-    fun testNoCacheRequest() = clientTests(listOf("Js")) {
+    fun testNoCacheRequest() = clientTests(except("Js")) {
         val publicStorage = CacheStorage.Unlimited()
         val privateStorage = CacheStorage.Unlimited()
         config {
@@ -603,7 +603,7 @@ class CacheTest : ClientLoader() {
     }
 
     @Test
-    fun testRequestWithMaxAge0() = clientTests(listOf("Js")) {
+    fun testRequestWithMaxAge0() = clientTests(except("Js")) {
         val publicStorage = CacheStorage.Unlimited()
         val privateStorage = CacheStorage.Unlimited()
         config {

--- a/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/plugins/CookiesIntegrationTests.kt
+++ b/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/plugins/CookiesIntegrationTests.kt
@@ -20,7 +20,7 @@ class CookiesIntegrationTests : ClientLoader() {
     private val domain = "127.0.0.1"
 
     @Test
-    fun testAccept() = clientTests(listOf("Js")) {
+    fun testAccept() = clientTests(except("Js")) {
         config {
             install(HttpCookies)
         }
@@ -35,7 +35,7 @@ class CookiesIntegrationTests : ClientLoader() {
     }
 
     @Test
-    fun testUpdate() = clientTests(listOf("Js")) {
+    fun testUpdate() = clientTests(except("Js")) {
         config {
             install(HttpCookies) {
                 default {
@@ -55,7 +55,7 @@ class CookiesIntegrationTests : ClientLoader() {
     }
 
     @Test
-    fun testExpiration() = clientTests(listOf("Js")) {
+    fun testExpiration() = clientTests(except("Js")) {
         config {
             install(HttpCookies) {
                 default {
@@ -72,7 +72,7 @@ class CookiesIntegrationTests : ClientLoader() {
     }
 
     @Test
-    fun testConstant() = clientTests(listOf("Js")) {
+    fun testConstant() = clientTests(except("Js")) {
         config {
             install(HttpCookies) {
                 storage = ConstantCookiesStorage(Cookie("id", "1", domain = domain))
@@ -89,7 +89,7 @@ class CookiesIntegrationTests : ClientLoader() {
     }
 
     @Test
-    fun testMultipleCookies() = clientTests(listOf("Js")) {
+    fun testMultipleCookies() = clientTests(except("Js")) {
         config {
             install(HttpCookies) {
                 default {
@@ -106,7 +106,7 @@ class CookiesIntegrationTests : ClientLoader() {
     }
 
     @Test
-    fun testPath() = clientTests(listOf("Js")) {
+    fun testPath() = clientTests(except("Js")) {
         config {
             install(HttpCookies)
         }
@@ -118,7 +118,7 @@ class CookiesIntegrationTests : ClientLoader() {
     }
 
     @Test
-    fun caseSensitive() = clientTests(listOf("Js", "Darwin", "DarwinLegacy")) {
+    fun caseSensitive() = clientTests(except("Js", "Darwin", "DarwinLegacy")) {
         config {
             install(HttpCookies)
         }
@@ -134,7 +134,7 @@ class CookiesIntegrationTests : ClientLoader() {
     }
 
     @Test
-    fun testMultipleCookiesWithComma() = clientTests(listOf("Js")) {
+    fun testMultipleCookiesWithComma() = clientTests(except("Js")) {
         config {
             install(HttpCookies) {
                 default {
@@ -157,7 +157,7 @@ class CookiesIntegrationTests : ClientLoader() {
     }
 
     @Test
-    fun testCookiesEncodedWithRespectiveEncoding() = clientTests(listOf("Js")) {
+    fun testCookiesEncodedWithRespectiveEncoding() = clientTests(except("Js")) {
         val cookies = listOf(
             Cookie("uri", "first, cookie", domain = domain, encoding = CookieEncoding.URI_ENCODING),
             Cookie("raw", "first%2C+cookie", domain = domain, encoding = CookieEncoding.RAW),
@@ -186,7 +186,7 @@ class CookiesIntegrationTests : ClientLoader() {
     }
 
     @Test
-    fun testCookiesWithWrongValue() = clientTests(listOf("Js", "Darwin", "DarwinLegacy", "WinHttp", "Java", "Curl")) {
+    fun testCookiesWithWrongValue() = clientTests(except("Js", "Darwin", "DarwinLegacy", "WinHttp", "Java", "Curl")) {
         config {
             install(HttpCookies)
         }
@@ -209,7 +209,7 @@ class CookiesIntegrationTests : ClientLoader() {
     }
 
     @Test
-    fun testRequestBuilderSingleCookie() = clientTests(listOf("Js")) {
+    fun testRequestBuilderSingleCookie() = clientTests(except("Js")) {
         test { client ->
             val result = client.get("$TEST_HOST/respond-single-cookie") {
                 cookie("single", value = "abacaba")
@@ -219,7 +219,7 @@ class CookiesIntegrationTests : ClientLoader() {
     }
 
     @Test
-    fun testRequestBuilderMultipleCookies() = clientTests(listOf("Js")) {
+    fun testRequestBuilderMultipleCookies() = clientTests(except("Js")) {
         test { client ->
             val result = client.get("$TEST_HOST/respond-a-minus-b") {
                 cookie("a", value = "10")
@@ -230,7 +230,7 @@ class CookiesIntegrationTests : ClientLoader() {
     }
 
     @Test
-    fun testSeparatedBySemicolon() = clientTests(listOf("Js")) {
+    fun testSeparatedBySemicolon() = clientTests(except("Js")) {
         test { client ->
             client.get("$TEST_HOST/encoded") {
                 cookie("firstCookie", "first")

--- a/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/plugins/SerializationTest.kt
+++ b/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/plugins/SerializationTest.kt
@@ -1,6 +1,6 @@
 /*
-* Copyright 2014-2021 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
-*/
+ * Copyright 2014-2024 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
 
 package io.ktor.client.tests.plugins
 
@@ -18,7 +18,7 @@ class MyCustomObject(val message: String)
 
 class SerializationTest : ClientLoader() {
     @Test
-    fun testSendCustomObject() = clientTests(listOf("native:CIO")) {
+    fun testSendCustomObject() = clientTests(except("native:CIO")) {
         config {
             install(ContentNegotiation) { json() }
         }
@@ -35,7 +35,7 @@ class SerializationTest : ClientLoader() {
     }
 
     @Test
-    fun testSendStringWithSerialization() = clientTests(listOf("native:CIO")) {
+    fun testSendStringWithSerialization() = clientTests(except("native:CIO")) {
         config {
             install(ContentNegotiation) { json() }
         }
@@ -52,7 +52,7 @@ class SerializationTest : ClientLoader() {
     }
 
     @Test
-    fun testSendStringWithSerializationIgnoring() = clientTests(listOf("native:CIO")) {
+    fun testSendStringWithSerializationIgnoring() = clientTests(except("native:CIO")) {
         config {
             install(ContentNegotiation) {
                 clearIgnoredTypes()

--- a/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/plugins/ServerSentEventsTest.kt
+++ b/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/plugins/ServerSentEventsTest.kt
@@ -193,7 +193,7 @@ class ServerSentEventsTest : ClientLoader() {
     }
 
     @Test
-    fun testShowComments() = clientTests(listOf("OkHttp")) {
+    fun testShowComments() = clientTests(except("OkHttp")) {
         config {
             install(SSE) {
                 showCommentEvents()
@@ -217,7 +217,7 @@ class ServerSentEventsTest : ClientLoader() {
     }
 
     @Test
-    fun testDifferentConfigs() = clientTests(listOf("OkHttp")) {
+    fun testDifferentConfigs() = clientTests(except("OkHttp")) {
         config {
             install(SSE) {
                 showCommentEvents()
@@ -347,7 +347,7 @@ class ServerSentEventsTest : ClientLoader() {
     // Android, Darwin and Js engines don't support request body in GET request
     // SSE in OkHttp and Curl doesn't send a request body for GET request
     @Test
-    fun testRequestBody() = clientTests(listOf("Android", "Darwin", "DarwinLegacy", "Js", "OkHttp", "Curl")) {
+    fun testRequestBody() = clientTests(except("Android", "Darwin", "DarwinLegacy", "Js", "OkHttp", "Curl")) {
         config {
             install(SSE)
         }
@@ -367,7 +367,7 @@ class ServerSentEventsTest : ClientLoader() {
     }
 
     @Test
-    fun testErrorForProtocolUpgradeRequestBody() = clientTests(listOf("OkHttp")) {
+    fun testErrorForProtocolUpgradeRequestBody() = clientTests(except("OkHttp")) {
         config {
             install(SSE)
         }

--- a/ktor-client/ktor-client-tests/jvm/test/io/ktor/client/tests/FileCacheTest.kt
+++ b/ktor-client/ktor-client-tests/jvm/test/io/ktor/client/tests/FileCacheTest.kt
@@ -19,7 +19,7 @@ class FileCacheTest : ClientLoader() {
     private val privateStorage = FileStorage(Files.createTempDirectory("cache-test-private").toFile())
 
     @Test
-    fun testVaryHeader() = clientTests(listOf("Js")) {
+    fun testVaryHeader() = clientTests(except("Js")) {
         config {
             install(HttpCache) {
                 publicStorage(this@FileCacheTest.publicStorage)
@@ -77,7 +77,7 @@ class FileCacheTest : ClientLoader() {
     }
 
     @Test
-    fun testReuseCacheStorage() = clientTests(listOf("Js")) {
+    fun testReuseCacheStorage() = clientTests(except("Js")) {
         config {
             install(HttpCache) {
                 publicStorage(this@FileCacheTest.publicStorage)

--- a/ktor-client/ktor-client-tests/jvm/test/io/ktor/client/tests/LoggingTestJvm.kt
+++ b/ktor-client/ktor-client-tests/jvm/test/io/ktor/client/tests/LoggingTestJvm.kt
@@ -31,7 +31,7 @@ class LoggingTestJvm : ClientLoader() {
 
     @OptIn(InternalAPI::class)
     @Test
-    fun testMdc() = clientTests(listOf("native:CIO")) {
+    fun testMdc() = clientTests(except("native:CIO")) {
         val testLogger = LoggerWithMdc()
 
         config {

--- a/ktor-client/ktor-client-tests/jvm/test/io/ktor/client/tests/WebSocketJvmTest.kt
+++ b/ktor-client/ktor-client-tests/jvm/test/io/ktor/client/tests/WebSocketJvmTest.kt
@@ -1,6 +1,6 @@
 /*
-* Copyright 2014-2021 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
-*/
+ * Copyright 2014-2024 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
 
 package io.ktor.client.tests
 
@@ -15,7 +15,7 @@ private const val TEST_SIZE: Int = 100
 class WebSocketJvmTest : ClientLoader(100000.seconds) {
 
     @Test
-    fun testWebSocketDeflateBinary() = clientTests(listOf("Android", "Apache", "Apache5")) {
+    fun testWebSocketDeflateBinary() = clientTests(except("Android", "Apache", "Apache5")) {
         config {
             WebSockets {
                 extensions {
@@ -39,7 +39,7 @@ class WebSocketJvmTest : ClientLoader(100000.seconds) {
     }
 
     @Test
-    fun testWebSocketDeflateNoContextTakeover() = clientTests(listOf("Android", "Apache", "Apache5")) {
+    fun testWebSocketDeflateNoContextTakeover() = clientTests(except("Android", "Apache", "Apache5")) {
         config {
             WebSockets {
                 extensions {

--- a/ktor-shared/ktor-test-base/common/test/io/ktor/test/RunTestWithDataTest.kt
+++ b/ktor-shared/ktor-test-base/common/test/io/ktor/test/RunTestWithDataTest.kt
@@ -36,7 +36,7 @@ class RunTestWithDataTest {
     fun testEmptyTestCases() = runTestWithData(
         testCases = emptyList<Int>(),
         test = { fail("Should not be called") },
-        afterEach = { _, _ -> fail("Should not be called") },
+        afterEach = { fail("Should not be called") },
         handleFailures = { fail("Should not be called") },
     )
     //endregion
@@ -128,7 +128,7 @@ class RunTestWithDataTest {
             },
             handleFailures = {
                 assertEquals(1, it.size)
-                assertEquals(1, it.single().data)
+                assertEquals(1, it.single().testCase.data)
                 assertEquals(2, successfulItem)
             },
         )
@@ -142,9 +142,9 @@ class RunTestWithDataTest {
             testCases = 1..3,
             retries = 1,
             timeout = 15.milliseconds,
-            afterEach = { (id, retry), error ->
-                val status = if (error == null) "succeeded" else "failed: ${error.message}"
-                executionLog.add("Test $id: attempt $retry $status")
+            afterEach = { result ->
+                val status = if (result is TestFailure) "failed: ${result.cause.message}" else "succeeded"
+                executionLog.add("Test ${result.testCase.data}: attempt ${result.testCase.retry} $status")
             },
             test = { (id, retry) ->
                 println("${id}x$retry")


### PR DESCRIPTION
**Subsystem**
Test Infrastructure

**Motivation**
1. [KTOR-7723](https://youtrack.jetbrains.com/issue/KTOR-7723) Engine exclusion from clientTests is confusing
2. Test execution time reported by Gradle is not true. On JVM it counts time spent on the whole test including all engines and retries, on JS it counts Promise creation time.

**Solution**
- Changed syntax to exclude engines from tests
- Added test status reporting for each try with test duration

<img width="838" alt="image" src="https://github.com/user-attachments/assets/992c2334-c043-43cd-8448-1aa38c0e25a6" />
