### PR TITLE
Introducing Ktor Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
 [![Slack channel](https://img.shields.io/badge/chat-slack-green.svg?logo=slack)](https://kotlinlang.slack.com/messages/ktor/)
 [![GitHub License](https://img.shields.io/badge/license-Apache%20License%202.0-blue.svg?style=flat)](http://www.apache.org/licenses/LICENSE-2.0)
 [![Contribute with Gitpod](https://img.shields.io/badge/Contribute%20with-Gitpod-908a85?logo=gitpod)](https://gitpod.io/#https://github.com/ktorio/ktor)
+[![Gurubase](https://img.shields.io/badge/Gurubase-Ask%20Ktor%20Guru-006BFF)](https://gurubase.io/g/ktor)
 
 Ktor is an asynchronous framework for creating microservices, web applications and more. Written in Kotlin from the
 ground up.


### PR DESCRIPTION
Hello team,

We are the maintainers of [Anteon](https://github.com/getanteon/anteon). Recently, we created Gurubase.io with the mission of building a centralized, open-source, tool-focused knowledge base. Each "guru" in Gurubase is equipped with custom knowledge to answer user questions based on data related to the respective tool.

We’re excited to let you know that [Ktor Guru](https://gurubase.io/g/ktor) has been manually added to Gurubase. Ktor Guru uses the data from this repo and data from the [docs](http://ktor.io) to answer questions by leveraging the LLM.

This PR introduces the "Ktor Guru", showcasing that Ktor now has an AI assistant available to help users with their questions. We’d love to hear your feedback on this contribution.

You also have the option to maintain the "Ktor Guru" by following the instructions in the [Gurubase Repo](https://github.com/getanteon/gurubase?tab=readme-ov-file#how-to-claim-a-guru) and to add an ASK AI widget to the Ktor documentation website as detailed [here](https://github.com/getanteon/gurubase?tab=readme-ov-file#widget).

If you’d prefer us to disable Ktor Guru in Gurubase, just let us know that's totally fine.
