### PR TITLE
KTOR-8061 MicrometerMetricsConfig add UptimeMetrics to standard meterBinders

### DIFF
--- a/ktor-server/ktor-server-plugins/ktor-server-metrics-micrometer/jvm/src/io/ktor/server/metrics/micrometer/MicrometerMetrics.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-metrics-micrometer/jvm/src/io/ktor/server/metrics/micrometer/MicrometerMetrics.kt
@@ -77,7 +77,8 @@ public class MicrometerMetricsConfig {
         JvmGcMetrics(),
         ProcessorMetrics(),
         JvmThreadMetrics(),
-        FileDescriptorMetrics()
+        FileDescriptorMetrics(),
+        UptimeMetrics(),
     )
 
     /**


### PR DESCRIPTION
**Subsystem**
Server - Plugin Micrometer

**Motivation**
Lots of standard dashboards include the JVM process uptime / start time. The default Ktor Micrometer Plugin doesn't include this metric, causing panels referencing it to be empty.

**Solution**
Add the incredibly simple [UptimeMetrics](https://github.com/micrometer-metrics/micrometer/blob/main/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/system/UptimeMetrics.java) MeterBinder. It adds the `process.uptime` and `process.start.time` metrics.

