### PR TITLE
Disable testGzipWithContentLengthWithoutPlugin for non-JVM clients

### DIFF
--- a/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/ContentEncodingIntegrationTest.kt
+++ b/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/ContentEncodingIntegrationTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2024 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2014-2025 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package io.ktor.client.tests
@@ -18,16 +18,15 @@ private const val TEST_URL = "$TEST_SERVER/compression"
 
 class ContentEncodingIntegrationTest : ClientLoader() {
 
+    // GZipEncoder is implemented only on JVM.
     @Test
-    fun testGzipWithContentLengthWithoutPlugin() = clientTests {
+    fun testGzipWithContentLengthWithoutPlugin() = clientTests(only("jvm:*")) {
         test { client ->
             val response = client.get("$TEST_URL/gzip-with-content-length")
-            val byteContent = response.bodyAsBytes()
-
             val content = if (response.headers[HttpHeaders.ContentEncoding] == "gzip") {
-                GZipEncoder.decode(ByteReadChannel(byteContent)).readRemaining().readString()
+                GZipEncoder.decode(response.bodyAsChannel()).readRemaining().readString()
             } else {
-                byteContent.decodeToString()
+                response.bodyAsText()
             }
 
             assertEquals("Hello, world", content)


### PR DESCRIPTION
**Subsystem**
Test Infrastructure

**Motivation**
This test is always failing on non-JVM targets as `GZipEncoder` is implemented only on JVM.

**Solution**
Make `clientTests(only(...))` use `EnginePattern` and specify pattern `jvm:*` for this test.
Alternatively, we could move this test into the JVM source-set, but I decided to keep it here since it doesn't use any JVM-specific API.

