### PR TITLE
Enable linuxX64 caches back after update to Kotlin 2.1.0 with llvm 16

### DIFF
--- a/ktor-client/ktor-client-curl/gradle.properties
+++ b/ktor-client/ktor-client-curl/gradle.properties
@@ -1,5 +1,0 @@
-#
-# Copyright 2014-2024 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
-#
-
-kotlin.native.cacheKind.linuxX64=none


### PR DESCRIPTION
**Subsystem**
ktor-client-curl

**Motivation**
During curl static setup there was an issue with K/N caches (https://github.com/ktorio/ktor/pull/4445#issuecomment-2462084904) for linuxX64 target, but with Kotlin 2.1.0 and LLVM 16 (instead of 11 previously) it should work fine. 

**Solution**
drop flag, To be tested by linux CI agent, as the issue reproduces only on linux machine