### PR TITLE
KTOR-7327 Support conversion between byte channel interfaces and kotlinx-io primitives

### DIFF
--- a/ktor-io/api/ktor-io.api
+++ b/ktor-io/api/ktor-io.api
@@ -115,6 +115,10 @@ public final class io/ktor/utils/io/ByteReadChannelOperations_jvmKt {
 	public static final fun skipDelimiter (Lio/ktor/utils/io/ByteReadChannel;Lkotlinx/io/bytestring/ByteString;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
+public final class io/ktor/utils/io/ByteReadChannelSourceKt {
+	public static final fun asSource (Lio/ktor/utils/io/ByteReadChannel;)Lkotlinx/io/RawSource;
+}
+
 public abstract interface class io/ktor/utils/io/ByteWriteChannel {
 	public abstract fun cancel (Ljava/lang/Throwable;)V
 	public abstract fun flush (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -171,6 +175,10 @@ public final class io/ktor/utils/io/ByteWriteChannelOperations_jvmKt {
 	public static synthetic fun writeAvailable$default (Lio/ktor/utils/io/ByteWriteChannel;ILkotlin/jvm/functions/Function1;ILjava/lang/Object;)I
 	public static final fun writeByteBuffer (Lio/ktor/utils/io/ByteWriteChannel;Ljava/nio/ByteBuffer;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static final fun writeFully (Lio/ktor/utils/io/ByteWriteChannel;Ljava/nio/ByteBuffer;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class io/ktor/utils/io/ByteWriteChannelSinkKt {
+	public static final fun asSink (Lio/ktor/utils/io/ByteWriteChannel;)Lkotlinx/io/RawSink;
 }
 
 public abstract interface class io/ktor/utils/io/ChannelJob {
@@ -277,6 +285,10 @@ public final class io/ktor/utils/io/ReaderScope : kotlinx/coroutines/CoroutineSc
 	public fun <init> (Lio/ktor/utils/io/ByteReadChannel;Lkotlin/coroutines/CoroutineContext;)V
 	public final fun getChannel ()Lio/ktor/utils/io/ByteReadChannel;
 	public fun getCoroutineContext ()Lkotlin/coroutines/CoroutineContext;
+}
+
+public final class io/ktor/utils/io/SinkByteWriteChannelKt {
+	public static final fun asByteWriteChannel (Lkotlinx/io/RawSink;)Lio/ktor/utils/io/ByteWriteChannel;
 }
 
 public final class io/ktor/utils/io/WriterJob : io/ktor/utils/io/ChannelJob {
@@ -594,6 +606,7 @@ public abstract class io/ktor/utils/io/pool/SingleInstancePool : io/ktor/utils/i
 }
 
 public final class io/ktor/utils/io/streams/StreamsKt {
+	public static final fun asByteWriteChannel (Ljava/io/OutputStream;)Lio/ktor/utils/io/ByteWriteChannel;
 	public static final fun asInput (Ljava/io/InputStream;)Lkotlinx/io/Source;
 	public static final fun inputStream (Lkotlinx/io/Source;)Ljava/io/InputStream;
 	public static final fun readPacketAtLeast (Ljava/io/InputStream;I)Lkotlinx/io/Source;

--- a/ktor-io/api/ktor-io.klib.api
+++ b/ktor-io/api/ktor-io.klib.api
@@ -385,6 +385,7 @@ final fun (kotlinx.coroutines/CoroutineScope).io.ktor.utils.io/writer(kotlin.cor
 final fun (kotlinx.coroutines/CoroutineScope).io.ktor.utils.io/writer(kotlin.coroutines/CoroutineContext = ..., kotlin/Boolean = ..., kotlin.coroutines/SuspendFunction1<io.ktor.utils.io/WriterScope, kotlin/Unit>): io.ktor.utils.io/WriterJob // io.ktor.utils.io/writer|writer@kotlinx.coroutines.CoroutineScope(kotlin.coroutines.CoroutineContext;kotlin.Boolean;kotlin.coroutines.SuspendFunction1<io.ktor.utils.io.WriterScope,kotlin.Unit>){}[0]
 final fun (kotlinx.io/Buffer).io.ktor.utils.io.core/canRead(): kotlin/Boolean // io.ktor.utils.io.core/canRead|canRead@kotlinx.io.Buffer(){}[0]
 final fun (kotlinx.io/Buffer).io.ktor.utils.io.core/readBytes(kotlin/Int = ...): kotlin/ByteArray // io.ktor.utils.io.core/readBytes|readBytes@kotlinx.io.Buffer(kotlin.Int){}[0]
+final fun (kotlinx.io/RawSink).io.ktor.utils.io/asByteWriteChannel(): io.ktor.utils.io/ByteWriteChannel // io.ktor.utils.io/asByteWriteChannel|asByteWriteChannel@kotlinx.io.RawSink(){}[0]
 final fun (kotlinx.io/Sink).io.ktor.utils.io.core/append(kotlin/CharSequence, kotlin/Int = ..., kotlin/Int = ...) // io.ktor.utils.io.core/append|append@kotlinx.io.Sink(kotlin.CharSequence;kotlin.Int;kotlin.Int){}[0]
 final fun (kotlinx.io/Sink).io.ktor.utils.io.core/build(): kotlinx.io/Source // io.ktor.utils.io.core/build|build@kotlinx.io.Sink(){}[0]
 final fun (kotlinx.io/Sink).io.ktor.utils.io.core/writeFully(kotlin/ByteArray, kotlin/Int = ..., kotlin/Int = ...) // io.ktor.utils.io.core/writeFully|writeFully@kotlinx.io.Sink(kotlin.ByteArray;kotlin.Int;kotlin.Int){}[0]
@@ -603,6 +604,12 @@ sealed class io.ktor.utils.io.errors/PosixException : kotlin/Exception { // io.k
         final fun forErrno(kotlin/Int = ..., kotlin/String? = ...): io.ktor.utils.io.errors/PosixException // io.ktor.utils.io.errors/PosixException.Companion.forErrno|forErrno(kotlin.Int;kotlin.String?){}[0]
     }
 }
+
+// Targets: [native]
+final fun (io.ktor.utils.io/ByteReadChannel).io.ktor.utils.io/asSource(): kotlinx.io/RawSource // io.ktor.utils.io/asSource|asSource@io.ktor.utils.io.ByteReadChannel(){}[0]
+
+// Targets: [native]
+final fun (io.ktor.utils.io/ByteWriteChannel).io.ktor.utils.io/asSink(): kotlinx.io/RawSink // io.ktor.utils.io/asSink|asSink@io.ktor.utils.io.ByteWriteChannel(){}[0]
 
 // Targets: [native]
 final fun (kotlinx.io/Sink).io.ktor.utils.io.core/write(kotlin/Function3<kotlinx.cinterop/CPointer<kotlinx.cinterop/ByteVarOf<kotlin/Byte>>, kotlin/Long, kotlin/Long, kotlin/Long>): kotlin/Long // io.ktor.utils.io.core/write|write@kotlinx.io.Sink(kotlin.Function3<kotlinx.cinterop.CPointer<kotlinx.cinterop.ByteVarOf<kotlin.Byte>>,kotlin.Long,kotlin.Long,kotlin.Long>){}[0]

--- a/ktor-io/common/src/io/ktor/utils/io/CloseToken.kt
+++ b/ktor-io/common/src/io/ktor/utils/io/CloseToken.kt
@@ -4,8 +4,8 @@
 
 package io.ktor.utils.io
 
-import io.ktor.utils.io.errors.*
-import kotlinx.coroutines.*
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CopyableThrowable
 import kotlinx.io.IOException
 
 internal val CLOSED = CloseToken(null)

--- a/ktor-io/common/src/io/ktor/utils/io/SinkByteWriteChannel.kt
+++ b/ktor-io/common/src/io/ktor/utils/io/SinkByteWriteChannel.kt
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2014-2025 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.utils.io
+
+import kotlinx.atomicfu.AtomicRef
+import kotlinx.atomicfu.atomic
+import kotlinx.io.*
+
+/**
+ * Creates a [ByteWriteChannel] that writes to this [Sink].
+ *
+ * Example usage:
+ * ```kotlin
+ * val rawSink: RawSink = Buffer()
+ * val channel: ByteWriteChannel = rawSink.asByteWriteChannel()
+ * channel.writeString("hello, world!")
+ * channel.flushAndClose()
+
+ * (rawSink as Buffer).readString() // "Hello, world"
+ * ```
+ *
+ * Please note that the channel will be buffered even if the sync is not.
+ */
+public fun RawSink.asByteWriteChannel(): ByteWriteChannel = SinkByteWriteChannel(this).apply {
+}
+
+private suspend fun x() {
+    val rawSink: RawSink = Buffer()
+    val channel: ByteWriteChannel = rawSink.asByteWriteChannel()
+    channel.writeString("hello, world!")
+    channel.flushAndClose()
+
+    (rawSink as Buffer).readString() // "Hello, world"
+}
+
+internal class SinkByteWriteChannel(private val origin: RawSink) : ByteWriteChannel {
+    val closed: AtomicRef<CloseToken?> = atomic(null)
+
+    override val isClosedForWrite: Boolean
+        get() = closed.value != null
+
+    override val closedCause: Throwable?
+        get() = closed.value?.cause
+
+    @InternalAPI
+    override val writeBuffer: Sink
+        get() {
+            if (isClosedForWrite) throw closedCause ?: IOException("Channel is closed for write")
+            return origin as? Sink ?: origin.buffered()
+        }
+
+    @OptIn(InternalAPI::class)
+    override suspend fun flush() {
+        writeBuffer.flush()
+    }
+
+    @OptIn(InternalAPI::class)
+    override suspend fun flushAndClose() {
+        if (!closed.compareAndSet(expect = null, update = CLOSED)) return
+        writeBuffer.flush()
+    }
+
+    @OptIn(InternalAPI::class)
+    override fun cancel(cause: Throwable?) {
+        val token = if (cause == null) CLOSED else CloseToken(cause)
+        if (!closed.compareAndSet(expect = null, update = token)) return
+    }
+}

--- a/ktor-io/common/src/io/ktor/utils/io/SinkByteWriteChannel.kt
+++ b/ktor-io/common/src/io/ktor/utils/io/SinkByteWriteChannel.kt
@@ -21,7 +21,7 @@ import kotlinx.io.*
  * (rawSink as Buffer).readString() // "Hello, world"
  * ```
  *
- * Please note that the channel will be buffered even if the sync is not.
+ * Please note that the channel will be buffered even if the sink is not.
  */
 public fun RawSink.asByteWriteChannel(): ByteWriteChannel = SinkByteWriteChannel(this)
 

--- a/ktor-io/common/src/io/ktor/utils/io/SinkByteWriteChannel.kt
+++ b/ktor-io/common/src/io/ktor/utils/io/SinkByteWriteChannel.kt
@@ -23,8 +23,7 @@ import kotlinx.io.*
  *
  * Please note that the channel will be buffered even if the sync is not.
  */
-public fun RawSink.asByteWriteChannel(): ByteWriteChannel = SinkByteWriteChannel(this).apply {
-}
+public fun RawSink.asByteWriteChannel(): ByteWriteChannel = SinkByteWriteChannel(this)
 
 private suspend fun x() {
     val rawSink: RawSink = Buffer()

--- a/ktor-io/common/test/ByteChannelTest.kt
+++ b/ktor-io/common/test/ByteChannelTest.kt
@@ -111,7 +111,7 @@ class ByteChannelTest {
         val deferred1 = async(Dispatchers.Unconfined) {
             try {
                 channel1.writeFully(ByteArray(CHANNEL_MAX_SIZE))
-            } catch (cause: IOException) {
+            } catch (_: IOException) {
                 writerThrows1 = true
             }
         }

--- a/ktor-io/common/test/ByteChannelTest.kt
+++ b/ktor-io/common/test/ByteChannelTest.kt
@@ -23,73 +23,73 @@ class ByteChannelTest {
 
     @Test
     fun testReadFromEmpty() = runTest {
-        val channel1 = ByteChannel()
-        channel1.flushAndClose()
+        val channel = ByteChannel()
+        channel.flushAndClose()
         assertFailsWith<EOFException> {
-            channel1.readByte()
+            channel.readByte()
         }
     }
 
     @Test
     fun testWriteReadByte() = runTest {
-        val channel1 = ByteChannel()
-        channel1.writeByte(42)
-        channel1.flushAndClose()
-        assertEquals(42, channel1.readByte())
+        val channel = ByteChannel()
+        channel.writeByte(42)
+        channel.flushAndClose()
+        assertEquals(42, channel.readByte())
     }
 
     @Test
     fun testCancel() = runTest {
-        val channel1 = ByteChannel()
-        channel1.cancel()
+        val channel = ByteChannel()
+        channel.cancel()
         assertFailsWith<IOException> {
-            channel1.readByte()
+            channel.readByte()
         }
     }
 
     @Test
     fun testWriteInClosedChannel() = runTest {
-        val channel1 = ByteChannel()
-        channel1.flushAndClose()
-        assertTrue(channel1.isClosedForWrite)
+        val channel = ByteChannel()
+        channel.flushAndClose()
+        assertTrue(channel.isClosedForWrite)
         assertFailsWith<ClosedWriteChannelException> {
-            channel1.writeByte(42)
+            channel.writeByte(42)
         }
     }
 
     @Test
     fun testCreateFromArray() = runTest {
-        val array1 = byteArrayOf(1, 2, 3, 4, 5)
-        val channel1 = ByteReadChannel(array1)
-        val result1 = channel1.toByteArray()
-        assertTrue(array1.contentEquals(result1))
+        val array = byteArrayOf(1, 2, 3, 4, 5)
+        val channel = ByteReadChannel(array)
+        val result = channel.toByteArray()
+        assertTrue(array.contentEquals(result))
     }
 
     @Test
     fun testChannelFromString() = runTest {
-        val string1 = "Hello, world!"
-        val channel1 = ByteReadChannel(string1)
-        val result1 = channel1.readRemaining().readText()
-        assertEquals(string1, result1)
+        val string = "Hello, world!"
+        val channel = ByteReadChannel(string)
+        val result = channel.readRemaining().readText()
+        assertEquals(string, result)
     }
 
     @Test
     fun testCancelByteReadChannel() = runTest {
-        val channel1 = ByteReadChannel(byteArrayOf(1, 2, 3, 4, 5))
-        channel1.cancel()
+        val channel = ByteReadChannel(byteArrayOf(1, 2, 3, 4, 5))
+        channel.cancel()
         assertFailsWith<IOException> {
-            channel1.readByte()
+            channel.readByte()
         }
     }
 
     @Test
     fun testCloseAfterAwait() = runTest {
-        val channel1 = ByteChannel()
-        val job1 = launch(start = CoroutineStart.UNDISPATCHED) {
-            channel1.awaitContent()
+        val channel = ByteChannel()
+        val job = launch(start = CoroutineStart.UNDISPATCHED) {
+            channel.awaitContent()
         }
-        channel1.flushAndClose()
-        job1.join()
+        channel.flushAndClose()
+        job.join()
     }
 
     @Test
@@ -106,44 +106,44 @@ class ByteChannelTest {
 
     @Test
     fun testChannelMaxSizeWithException() = runTest {
-        val channel1 = ByteChannel()
+        val channel = ByteChannel()
         var writerThrows1 = false
-        val deferred1 = async(Dispatchers.Unconfined) {
+        val deferred = async(Dispatchers.Unconfined) {
             try {
-                channel1.writeFully(ByteArray(CHANNEL_MAX_SIZE))
+                channel.writeFully(ByteArray(CHANNEL_MAX_SIZE))
             } catch (_: IOException) {
                 writerThrows1 = true
             }
         }
-        assertFalse(deferred1.isCompleted)
-        channel1.cancel()
-        deferred1.await()
+        assertFalse(deferred.isCompleted)
+        channel.cancel()
+        deferred.await()
         assertTrue(writerThrows1)
     }
 
     @Test
     fun testIsCloseForReadAfterCancel() = runTest {
-        val packet1 = buildPacket {
+        val packet = buildPacket {
             writeInt(1)
             writeInt(2)
             writeInt(3)
         }
-        val channel1 = ByteChannel()
-        channel1.writePacket(packet1)
-        channel1.flush()
-        channel1.cancel()
-        assertTrue(channel1.isClosedForRead)
+        val channel = ByteChannel()
+        channel.writePacket(packet)
+        channel.flush()
+        channel.cancel()
+        assertTrue(channel.isClosedForRead)
     }
 
     @Test
     fun testWriteAndFlushResumeReader() = runTest {
-        val channel1 = ByteChannel()
-        val reader1 = async {
-            channel1.readByte()
+        val channel = ByteChannel()
+        val reader = async {
+            channel.readByte()
         }
         yield()
-        channel1.writeByte(42)
-        channel1.flush()
-        assertEquals(42, reader1.await())
+        channel.writeByte(42)
+        channel.flush()
+        assertEquals(42, reader.await())
     }
 }

--- a/ktor-io/common/test/ByteChannelTest.kt
+++ b/ktor-io/common/test/ByteChannelTest.kt
@@ -94,31 +94,31 @@ class ByteChannelTest {
 
     @Test
     fun testChannelMaxSize() = runTest {
-        val channel1 = ByteChannel()
-        val job1 = launch(Dispatchers.Unconfined) {
-            channel1.writeFully(ByteArray(CHANNEL_MAX_SIZE))
+        val channel = ByteChannel()
+        val job = launch(Dispatchers.Unconfined) {
+            channel.writeFully(ByteArray(CHANNEL_MAX_SIZE))
         }
         delay(100)
-        assertFalse(job1.isCompleted)
-        channel1.readByte()
-        job1.join()
+        assertFalse(job.isCompleted)
+        channel.readByte()
+        job.join()
     }
 
     @Test
     fun testChannelMaxSizeWithException() = runTest {
         val channel = ByteChannel()
-        var writerThrows1 = false
+        var writerThrows = false
         val deferred = async(Dispatchers.Unconfined) {
             try {
                 channel.writeFully(ByteArray(CHANNEL_MAX_SIZE))
             } catch (_: IOException) {
-                writerThrows1 = true
+                writerThrows = true
             }
         }
         assertFalse(deferred.isCompleted)
         channel.cancel()
         deferred.await()
-        assertTrue(writerThrows1)
+        assertTrue(writerThrows)
     }
 
     @Test

--- a/ktor-io/common/test/ByteReadChannelOperationsTest.kt
+++ b/ktor-io/common/test/ByteReadChannelOperationsTest.kt
@@ -191,7 +191,7 @@ class ByteReadChannelOperationsTest {
                 With reading so keen, 
                 It stayed ever so lean, 
                 Parsing data in all sorts of lights.
-            """.trimIndent()
+        """.trimIndent()
         val delimiter1 = ", \n".encodeToByteString()
         val input1 = testString1.toByteChannel()
         for (line in testString1.lines()) {

--- a/ktor-io/common/test/ByteReadChannelOperationsTest.kt
+++ b/ktor-io/common/test/ByteReadChannelOperationsTest.kt
@@ -2,214 +2,203 @@
  * Copyright 2014-2024 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
-import io.ktor.test.dispatcher.*
 import io.ktor.utils.io.*
 import io.ktor.utils.io.core.*
-import kotlinx.coroutines.*
+import kotlinx.coroutines.CoroutineName
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.runTest
-import kotlinx.io.*
-import kotlinx.io.bytestring.*
+import kotlinx.io.IOException
+import kotlinx.io.InternalIoApi
+import kotlinx.io.bytestring.ByteString
+import kotlinx.io.bytestring.encodeToByteString
+import kotlinx.io.writeString
 import kotlin.test.*
 import kotlin.time.Duration.Companion.seconds
 
 class ByteReadChannelOperationsTest {
 
     @Test
-    fun testReadPacketBig() = testSuspend {
-        val channel = ByteChannel()
+    fun testReadPacketBig() = runTest {
+        val channel1 = ByteChannel()
         launch {
-            channel.writeByteArray(ByteArray(8192))
-            channel.writeByteArray(ByteArray(8192))
-            channel.flush()
+            channel1.writeByteArray(ByteArray(8192))
+            channel1.writeByteArray(ByteArray(8192))
+            channel1.flush()
         }
-
-        val packet = channel.readPacket(8192 * 2)
-        assertEquals(8192 * 2, packet.remaining)
-        packet.close()
+        val packet1 = channel1.readPacket(8192 * 2)
+        assertEquals(8192 * 2, packet1.remaining)
+        packet1.close()
     }
 
     @Test
-    fun testReadRemaining() = testSuspend {
-        val packet = buildPacket {
+    fun testReadRemaining() = runTest {
+        val packet1 = buildPacket {
             writeInt(1)
             writeInt(2)
             writeInt(3)
         }
-
-        val channel = ByteChannel()
-        channel.writePacket(packet)
-        channel.flushAndClose()
-
-        val first = channel.readRemaining()
-        assertEquals(12, first.remaining)
-        first.close()
-
-        val second = channel.readRemaining()
-        assertEquals(0, second.remaining)
+        val channel1 = ByteChannel()
+        channel1.writePacket(packet1)
+        channel1.flushAndClose()
+        val first1 = channel1.readRemaining()
+        assertEquals(12, first1.remaining)
+        first1.close()
+        val second1 = channel1.readRemaining()
+        assertEquals(0, second1.remaining)
     }
 
     @Test
-    fun testReadRemainingFromCancelled() = testSuspend {
-        val packet = buildPacket {
+    fun testReadRemainingFromCancelled() = runTest {
+        val packet1 = buildPacket {
             writeInt(1)
             writeInt(2)
             writeInt(3)
         }
-
-        val channel = ByteChannel()
-        channel.writePacket(packet)
-        channel.flush()
-        channel.cancel()
-
+        val channel1 = ByteChannel()
+        channel1.writePacket(packet1)
+        channel1.flush()
+        channel1.cancel()
         assertFailsWith<IOException> {
-            channel.readRemaining()
+            channel1.readRemaining()
         }
     }
 
     @Test
-    fun readFully() = testSuspend {
-        val expected = ByteArray(10) { it.toByte() }
-        val actual = ByteArray(10)
-        val channel = ByteChannel()
-        channel.writeFully(expected)
-        channel.flush()
-        channel.readFully(actual)
-        assertContentEquals(expected, actual)
-
-        actual.fill(0)
-        channel.writeFully(expected, 0, 5)
-        channel.flush()
-        channel.readFully(actual, 3, 8)
-        assertContentEquals(ByteArray(3) { 0 }, actual.copyOfRange(0, 3))
-        assertContentEquals(expected.copyOfRange(0, 5), actual.copyOfRange(3, 8))
-        assertContentEquals(ByteArray(2) { 0 }, actual.copyOfRange(8, 10))
+    fun readFully() = runTest {
+        val expected1 = ByteArray(10) { it.toByte() }
+        val actual1 = ByteArray(10)
+        val channel1 = ByteChannel()
+        channel1.writeFully(expected1)
+        channel1.flush()
+        channel1.readFully(actual1)
+        assertContentEquals(expected1, actual1)
+        actual1.fill(0)
+        channel1.writeFully(expected1, 0, 5)
+        channel1.flush()
+        channel1.readFully(actual1, 3, 8)
+        assertContentEquals(ByteArray(3) { 0 }, actual1.copyOfRange(0, 3))
+        assertContentEquals(expected1.copyOfRange(0, 5), actual1.copyOfRange(3, 8))
+        assertContentEquals(ByteArray(2) { 0 }, actual1.copyOfRange(8, 10))
     }
 
     @Test
-    fun skip() = testSuspend {
-        val ch = ByteChannel()
-        ch.writeFully(byteArrayOf(1, 2, 3))
-        ch.close()
-
-        val delimiter = ByteString(byteArrayOf(1, 2))
-        assertTrue(ch.skipIfFound(delimiter))
-        assertEquals(3, ch.readByte())
-        assertTrue(ch.isClosedForRead)
+    fun skip() = runTest {
+        val ch1 = ByteChannel()
+        ch1.writeFully(byteArrayOf(1, 2, 3))
+        ch1.close()
+        val delimiter1 = ByteString(byteArrayOf(1, 2))
+        assertTrue(ch1.skipIfFound(delimiter1))
+        assertEquals(3, ch1.readByte())
+        assertTrue(ch1.isClosedForRead)
     }
 
     @Test
-    fun skipExact() = testSuspend {
-        val ch = ByteChannel()
-        ch.writeFully(byteArrayOf(1, 2))
-        ch.close()
-
-        val delimiter = ByteString(byteArrayOf(1, 2))
-        assertTrue(ch.skipIfFound(delimiter))
-        assertTrue(ch.isClosedForRead)
+    fun skipExact() = runTest {
+        val ch1 = ByteChannel()
+        ch1.writeFully(byteArrayOf(1, 2))
+        ch1.close()
+        val delimiter1 = ByteString(byteArrayOf(1, 2))
+        assertTrue(ch1.skipIfFound(delimiter1))
+        assertTrue(ch1.isClosedForRead)
     }
 
     @Test
-    fun skipInvalid() = testSuspend {
-        val ch = ByteChannel()
-        ch.writeFully(byteArrayOf(9, 1, 2, 3))
-        ch.close()
-
-        val delimiter = ByteString(byteArrayOf(1, 2))
-        assertFalse(ch.skipIfFound(delimiter))
+    fun skipInvalid() = runTest {
+        val ch1 = ByteChannel()
+        ch1.writeFully(byteArrayOf(9, 1, 2, 3))
+        ch1.close()
+        val delimiter1 = ByteString(byteArrayOf(1, 2))
+        assertFalse(ch1.skipIfFound(delimiter1))
     }
 
     @Test
-    fun skipEndOfInput() = testSuspend {
-        val ch = ByteChannel()
-        ch.writeFully(byteArrayOf(1, 2))
-        ch.close()
-
-        val delimiter = ByteString(byteArrayOf(1, 2, 3))
-        assertFalse(ch.skipIfFound(delimiter))
+    fun skipEndOfInput() = runTest {
+        val ch1 = ByteChannel()
+        ch1.writeFully(byteArrayOf(1, 2))
+        ch1.close()
+        val delimiter1 = ByteString(byteArrayOf(1, 2, 3))
+        assertFalse(ch1.skipIfFound(delimiter1))
     }
 
     @Test
-    fun skipDelayed() = testSuspend {
-        val ch = ByteChannel()
-        val writer = launch(CoroutineName("writer"), start = CoroutineStart.LAZY) {
-            ch.writeByte(2)
-            ch.writeByte(3)
-            ch.close()
+    fun skipDelayed() = runTest {
+        val ch1 = ByteChannel()
+        val writer1 = launch(CoroutineName("writer"), start = CoroutineStart.LAZY) {
+            ch1.writeByte(2)
+            ch1.writeByte(3)
+            ch1.close()
         }
-        ch.writeByte(1)
-        ch.flush()
-        writer.start()
-
-        val delimiter = ByteString(byteArrayOf(1, 2))
-        assertTrue(ch.skipIfFound(delimiter))
-        assertEquals(3, ch.readByte())
-        assertTrue(ch.isClosedForRead)
+        ch1.writeByte(1)
+        ch1.flush()
+        writer1.start()
+        val delimiter1 = ByteString(byteArrayOf(1, 2))
+        assertTrue(ch1.skipIfFound(delimiter1))
+        assertEquals(3, ch1.readByte())
+        assertTrue(ch1.isClosedForRead)
     }
 
     @Test
-    fun skipDelayedInvalid() = testSuspend {
-        val ch = ByteChannel()
-        val writer = launch(CoroutineName("writer"), start = CoroutineStart.LAZY) {
-            ch.writeByte(3)
-            ch.writeByte(2)
-            ch.flush()
+    fun skipDelayedInvalid() = runTest {
+        val ch1 = ByteChannel()
+        val writer1 = launch(CoroutineName("writer"), start = CoroutineStart.LAZY) {
+            ch1.writeByte(3)
+            ch1.writeByte(2)
+            ch1.flush()
         }
-        ch.writeByte(1)
-        ch.flush()
-        writer.start()
-
-        val delimiter = ByteString(byteArrayOf(1, 2))
-        assertFalse(ch.skipIfFound(delimiter))
-        assertEquals(1, ch.readByte())
-        ch.close()
+        ch1.writeByte(1)
+        ch1.flush()
+        writer1.start()
+        val delimiter1 = ByteString(byteArrayOf(1, 2))
+        assertFalse(ch1.skipIfFound(delimiter1))
+        assertEquals(1, ch1.readByte())
+        ch1.close()
     }
 
     @Test
-    fun readUntilEmpty() = testSuspend {
+    fun readUntilEmpty() = runTest {
         assertFailsWith<IllegalStateException> {
             "test".toByteChannel().readUntil(ByteString(), ByteChannel())
         }
     }
 
     @Test
-    fun readUntilSingle() = testSuspend {
-        val actual = ByteChannel().also { out ->
+    fun readUntilSingle() = runTest {
+        val actual1 = ByteChannel().also { out ->
             "test some more".toByteChannel().readUntil(ByteString('o'.code.toByte()), out)
             out.close()
         }.readRemaining().readText()
-
-        assertEquals("test s", actual)
+        assertEquals("test s", actual1)
     }
 
     @Test
-    fun readUntilSubstring() = testSuspend {
-        val testString = "This is a test--"
-        val delimiter = "--done"
-        val input = (testString + delimiter).toByteChannel()
-        val output = ByteChannel().also {
-            input.readUntil(delimiter.encodeToByteString(), it)
+    fun readUntilSubstring() = runTest {
+        val testString1 = "This is a test--"
+        val delimiter1 = "--done"
+        val input1 = (testString1 + delimiter1).toByteChannel()
+        val output1 = ByteChannel().also {
+            input1.readUntil(delimiter1.encodeToByteString(), it)
             it.close()
         }
-        assertEquals(testString, output.readRemaining().readText())
+        assertEquals(testString1, output1.readRemaining().readText())
     }
 
     @Test
-    fun readUntil() = testSuspend {
-        val testString = """
-            There once was a stream of bytes, 
-            Flowing through many nights, 
-            With reading so keen, 
-            It stayed ever so lean, 
-            Parsing data in all sorts of lights.
-        """.trimIndent()
-
-        val delimiter = ", \n".encodeToByteString()
-        val input = testString.toByteChannel()
-        for (line in testString.lines()) {
+    fun readUntil() = runTest {
+        val testString1 = """
+                There once was a stream of bytes, 
+                Flowing through many nights, 
+                With reading so keen, 
+                It stayed ever so lean, 
+                Parsing data in all sorts of lights.
+            """.trimIndent()
+        val delimiter1 = ", \n".encodeToByteString()
+        val input1 = testString1.toByteChannel()
+        for (line in testString1.lines()) {
             val expected = line.trimEnd(',', ' ')
             val expectedLength = expected.length.toLong()
             val output = ByteChannel().also { out ->
-                assertEquals(expectedLength, input.readUntil(delimiter, out, ignoreMissing = true))
+                assertEquals(expectedLength, input1.readUntil(delimiter1, out, ignoreMissing = true))
                 out.flushAndClose()
             }
             val actual = output.readRemaining().readText()
@@ -218,38 +207,37 @@ class ByteReadChannelOperationsTest {
     }
 
     @Test
-    fun readUntilStart() = testSuspend {
-        val input = "This is a test".toByteChannel()
-        val actual = writer {
-            input.readUntil("This".encodeToByteString(), channel, limit = 10, ignoreMissing = true)
+    fun readUntilStart() = runTest {
+        val input1 = "This is a test".toByteChannel()
+        val actual1 = writer {
+            input1.readUntil("This".encodeToByteString(), channel, limit = 10, ignoreMissing = true)
         }.channel.readRemaining().readText()
-
-        assertEquals("", actual)
-        assertEquals(" is a test", input.readRemaining().readText())
+        assertEquals("", actual1)
+        assertEquals(" is a test", input1.readRemaining().readText())
     }
 
     @Test
-    fun readUntilLimit() = testSuspend {
-        val input = "This is a test of the readUntil limit".toByteChannel()
+    fun readUntilLimit() = runTest {
+        val input1 = "This is a test of the readUntil limit".toByteChannel()
         assertFailsWith<IOException> {
-            input.readUntil("abc".encodeToByteString(), ByteChannel(), limit = 10, ignoreMissing = true)
+            input1.readUntil("abc".encodeToByteString(), ByteChannel(), limit = 10, ignoreMissing = true)
         }
     }
 
     @Test
-    fun readUntilMissing() = testSuspend {
-        val input = "It's not in here".toByteChannel()
+    fun readUntilMissing() = runTest {
+        val input1 = "It's not in here".toByteChannel()
         assertFailsWith<IOException> {
-            input.readUntil("note".encodeToByteString(), ByteChannel())
+            input1.readUntil("note".encodeToByteString(), ByteChannel())
         }
     }
 
     @Test
-    fun skipIfFound() = testSuspend {
-        val input = "This is a test of the skipIfFound".toByteChannel()
-        assertFalse(input.skipIfFound("Won't find this".encodeToByteString()))
-        assertTrue(input.skipIfFound("This is a test of the ".encodeToByteString()))
-        assertEquals("skipIfFound", input.readUTF8Line())
+    fun skipIfFound() = runTest {
+        val input1 = "This is a test of the skipIfFound".toByteChannel()
+        assertFalse(input1.skipIfFound("Won't find this".encodeToByteString()))
+        assertTrue(input1.skipIfFound("This is a test of the ".encodeToByteString()))
+        assertEquals("skipIfFound", input1.readUTF8Line())
     }
 
     // this test ensures we don't get stuck on awaitContent

--- a/ktor-io/common/test/ByteReadChannelOperationsTest.kt
+++ b/ktor-io/common/test/ByteReadChannelOperationsTest.kt
@@ -20,139 +20,139 @@ class ByteReadChannelOperationsTest {
 
     @Test
     fun testReadPacketBig() = runTest {
-        val channel1 = ByteChannel()
+        val channel = ByteChannel()
         launch {
-            channel1.writeByteArray(ByteArray(8192))
-            channel1.writeByteArray(ByteArray(8192))
-            channel1.flush()
+            channel.writeByteArray(ByteArray(8192))
+            channel.writeByteArray(ByteArray(8192))
+            channel.flush()
         }
-        val packet1 = channel1.readPacket(8192 * 2)
-        assertEquals(8192 * 2, packet1.remaining)
-        packet1.close()
+        val packet = channel.readPacket(8192 * 2)
+        assertEquals(8192 * 2, packet.remaining)
+        packet.close()
     }
 
     @Test
     fun testReadRemaining() = runTest {
-        val packet1 = buildPacket {
+        val packet = buildPacket {
             writeInt(1)
             writeInt(2)
             writeInt(3)
         }
-        val channel1 = ByteChannel()
-        channel1.writePacket(packet1)
-        channel1.flushAndClose()
-        val first1 = channel1.readRemaining()
-        assertEquals(12, first1.remaining)
-        first1.close()
-        val second1 = channel1.readRemaining()
-        assertEquals(0, second1.remaining)
+        val channel = ByteChannel()
+        channel.writePacket(packet)
+        channel.flushAndClose()
+        val first = channel.readRemaining()
+        assertEquals(12, first.remaining)
+        first.close()
+        val second = channel.readRemaining()
+        assertEquals(0, second.remaining)
     }
 
     @Test
     fun testReadRemainingFromCancelled() = runTest {
-        val packet1 = buildPacket {
+        val packet = buildPacket {
             writeInt(1)
             writeInt(2)
             writeInt(3)
         }
-        val channel1 = ByteChannel()
-        channel1.writePacket(packet1)
-        channel1.flush()
-        channel1.cancel()
+        val channel = ByteChannel()
+        channel.writePacket(packet)
+        channel.flush()
+        channel.cancel()
         assertFailsWith<IOException> {
-            channel1.readRemaining()
+            channel.readRemaining()
         }
     }
 
     @Test
     fun readFully() = runTest {
-        val expected1 = ByteArray(10) { it.toByte() }
-        val actual1 = ByteArray(10)
-        val channel1 = ByteChannel()
-        channel1.writeFully(expected1)
-        channel1.flush()
-        channel1.readFully(actual1)
-        assertContentEquals(expected1, actual1)
-        actual1.fill(0)
-        channel1.writeFully(expected1, 0, 5)
-        channel1.flush()
-        channel1.readFully(actual1, 3, 8)
-        assertContentEquals(ByteArray(3) { 0 }, actual1.copyOfRange(0, 3))
-        assertContentEquals(expected1.copyOfRange(0, 5), actual1.copyOfRange(3, 8))
-        assertContentEquals(ByteArray(2) { 0 }, actual1.copyOfRange(8, 10))
+        val expected = ByteArray(10) { it.toByte() }
+        val actual = ByteArray(10)
+        val channel = ByteChannel()
+        channel.writeFully(expected)
+        channel.flush()
+        channel.readFully(actual)
+        assertContentEquals(expected, actual)
+        actual.fill(0)
+        channel.writeFully(expected, 0, 5)
+        channel.flush()
+        channel.readFully(actual, 3, 8)
+        assertContentEquals(ByteArray(3) { 0 }, actual.copyOfRange(0, 3))
+        assertContentEquals(expected.copyOfRange(0, 5), actual.copyOfRange(3, 8))
+        assertContentEquals(ByteArray(2) { 0 }, actual.copyOfRange(8, 10))
     }
 
     @Test
     fun skip() = runTest {
-        val ch1 = ByteChannel()
-        ch1.writeFully(byteArrayOf(1, 2, 3))
-        ch1.close()
-        val delimiter1 = ByteString(byteArrayOf(1, 2))
-        assertTrue(ch1.skipIfFound(delimiter1))
-        assertEquals(3, ch1.readByte())
-        assertTrue(ch1.isClosedForRead)
+        val channel = ByteChannel()
+        channel.writeFully(byteArrayOf(1, 2, 3))
+        channel.close()
+        val delimiter = ByteString(byteArrayOf(1, 2))
+        assertTrue(channel.skipIfFound(delimiter))
+        assertEquals(3, channel.readByte())
+        assertTrue(channel.isClosedForRead)
     }
 
     @Test
     fun skipExact() = runTest {
-        val ch1 = ByteChannel()
-        ch1.writeFully(byteArrayOf(1, 2))
-        ch1.close()
-        val delimiter1 = ByteString(byteArrayOf(1, 2))
-        assertTrue(ch1.skipIfFound(delimiter1))
-        assertTrue(ch1.isClosedForRead)
+        val channel = ByteChannel()
+        channel.writeFully(byteArrayOf(1, 2))
+        channel.close()
+        val delimiter = ByteString(byteArrayOf(1, 2))
+        assertTrue(channel.skipIfFound(delimiter))
+        assertTrue(channel.isClosedForRead)
     }
 
     @Test
     fun skipInvalid() = runTest {
-        val ch1 = ByteChannel()
-        ch1.writeFully(byteArrayOf(9, 1, 2, 3))
-        ch1.close()
-        val delimiter1 = ByteString(byteArrayOf(1, 2))
-        assertFalse(ch1.skipIfFound(delimiter1))
+        val channel = ByteChannel()
+        channel.writeFully(byteArrayOf(9, 1, 2, 3))
+        channel.close()
+        val delimiter = ByteString(byteArrayOf(1, 2))
+        assertFalse(channel.skipIfFound(delimiter))
     }
 
     @Test
     fun skipEndOfInput() = runTest {
-        val ch1 = ByteChannel()
-        ch1.writeFully(byteArrayOf(1, 2))
-        ch1.close()
-        val delimiter1 = ByteString(byteArrayOf(1, 2, 3))
-        assertFalse(ch1.skipIfFound(delimiter1))
+        val channel = ByteChannel()
+        channel.writeFully(byteArrayOf(1, 2))
+        channel.close()
+        val delimiter = ByteString(byteArrayOf(1, 2, 3))
+        assertFalse(channel.skipIfFound(delimiter))
     }
 
     @Test
     fun skipDelayed() = runTest {
-        val ch1 = ByteChannel()
-        val writer1 = launch(CoroutineName("writer"), start = CoroutineStart.LAZY) {
-            ch1.writeByte(2)
-            ch1.writeByte(3)
-            ch1.close()
+        val channel = ByteChannel()
+        val writer = launch(CoroutineName("writer"), start = CoroutineStart.LAZY) {
+            channel.writeByte(2)
+            channel.writeByte(3)
+            channel.close()
         }
-        ch1.writeByte(1)
-        ch1.flush()
-        writer1.start()
+        channel.writeByte(1)
+        channel.flush()
+        writer.start()
         val delimiter1 = ByteString(byteArrayOf(1, 2))
-        assertTrue(ch1.skipIfFound(delimiter1))
-        assertEquals(3, ch1.readByte())
-        assertTrue(ch1.isClosedForRead)
+        assertTrue(channel.skipIfFound(delimiter1))
+        assertEquals(3, channel.readByte())
+        assertTrue(channel.isClosedForRead)
     }
 
     @Test
     fun skipDelayedInvalid() = runTest {
-        val ch1 = ByteChannel()
-        val writer1 = launch(CoroutineName("writer"), start = CoroutineStart.LAZY) {
-            ch1.writeByte(3)
-            ch1.writeByte(2)
-            ch1.flush()
+        val channel = ByteChannel()
+        val writer = launch(CoroutineName("writer"), start = CoroutineStart.LAZY) {
+            channel.writeByte(3)
+            channel.writeByte(2)
+            channel.flush()
         }
-        ch1.writeByte(1)
-        ch1.flush()
-        writer1.start()
-        val delimiter1 = ByteString(byteArrayOf(1, 2))
-        assertFalse(ch1.skipIfFound(delimiter1))
-        assertEquals(1, ch1.readByte())
-        ch1.close()
+        channel.writeByte(1)
+        channel.flush()
+        writer.start()
+        val delimiter = ByteString(byteArrayOf(1, 2))
+        assertFalse(channel.skipIfFound(delimiter))
+        assertEquals(1, channel.readByte())
+        channel.close()
     }
 
     @Test
@@ -164,41 +164,41 @@ class ByteReadChannelOperationsTest {
 
     @Test
     fun readUntilSingle() = runTest {
-        val actual1 = ByteChannel().also { out ->
+        val actual = ByteChannel().also { out ->
             "test some more".toByteChannel().readUntil(ByteString('o'.code.toByte()), out)
             out.close()
         }.readRemaining().readText()
-        assertEquals("test s", actual1)
+        assertEquals("test s", actual)
     }
 
     @Test
     fun readUntilSubstring() = runTest {
-        val testString1 = "This is a test--"
-        val delimiter1 = "--done"
-        val input1 = (testString1 + delimiter1).toByteChannel()
-        val output1 = ByteChannel().also {
-            input1.readUntil(delimiter1.encodeToByteString(), it)
+        val testString = "This is a test--"
+        val delimiter = "--done"
+        val input = (testString + delimiter).toByteChannel()
+        val output = ByteChannel().also {
+            input.readUntil(delimiter.encodeToByteString(), it)
             it.close()
         }
-        assertEquals(testString1, output1.readRemaining().readText())
+        assertEquals(testString, output.readRemaining().readText())
     }
 
     @Test
     fun readUntil() = runTest {
-        val testString1 = """
+        val testString = """
                 There once was a stream of bytes, 
                 Flowing through many nights, 
                 With reading so keen, 
                 It stayed ever so lean, 
                 Parsing data in all sorts of lights.
         """.trimIndent()
-        val delimiter1 = ", \n".encodeToByteString()
-        val input1 = testString1.toByteChannel()
-        for (line in testString1.lines()) {
+        val delimiter = ", \n".encodeToByteString()
+        val input = testString.toByteChannel()
+        for (line in testString.lines()) {
             val expected = line.trimEnd(',', ' ')
             val expectedLength = expected.length.toLong()
             val output = ByteChannel().also { out ->
-                assertEquals(expectedLength, input1.readUntil(delimiter1, out, ignoreMissing = true))
+                assertEquals(expectedLength, input.readUntil(delimiter, out, ignoreMissing = true))
                 out.flushAndClose()
             }
             val actual = output.readRemaining().readText()
@@ -208,36 +208,36 @@ class ByteReadChannelOperationsTest {
 
     @Test
     fun readUntilStart() = runTest {
-        val input1 = "This is a test".toByteChannel()
-        val actual1 = writer {
-            input1.readUntil("This".encodeToByteString(), channel, limit = 10, ignoreMissing = true)
+        val input = "This is a test".toByteChannel()
+        val actual = writer {
+            input.readUntil("This".encodeToByteString(), channel, limit = 10, ignoreMissing = true)
         }.channel.readRemaining().readText()
-        assertEquals("", actual1)
-        assertEquals(" is a test", input1.readRemaining().readText())
+        assertEquals("", actual)
+        assertEquals(" is a test", input.readRemaining().readText())
     }
 
     @Test
     fun readUntilLimit() = runTest {
-        val input1 = "This is a test of the readUntil limit".toByteChannel()
+        val input = "This is a test of the readUntil limit".toByteChannel()
         assertFailsWith<IOException> {
-            input1.readUntil("abc".encodeToByteString(), ByteChannel(), limit = 10, ignoreMissing = true)
+            input.readUntil("abc".encodeToByteString(), ByteChannel(), limit = 10, ignoreMissing = true)
         }
     }
 
     @Test
     fun readUntilMissing() = runTest {
-        val input1 = "It's not in here".toByteChannel()
+        val input = "It's not in here".toByteChannel()
         assertFailsWith<IOException> {
-            input1.readUntil("note".encodeToByteString(), ByteChannel())
+            input.readUntil("note".encodeToByteString(), ByteChannel())
         }
     }
 
     @Test
     fun skipIfFound() = runTest {
-        val input1 = "This is a test of the skipIfFound".toByteChannel()
-        assertFalse(input1.skipIfFound("Won't find this".encodeToByteString()))
-        assertTrue(input1.skipIfFound("This is a test of the ".encodeToByteString()))
-        assertEquals("skipIfFound", input1.readUTF8Line())
+        val input = "This is a test of the skipIfFound".toByteChannel()
+        assertFalse(input.skipIfFound("Won't find this".encodeToByteString()))
+        assertTrue(input.skipIfFound("This is a test of the ".encodeToByteString()))
+        assertEquals("skipIfFound", input.readUTF8Line())
     }
 
     // this test ensures we don't get stuck on awaitContent

--- a/ktor-io/common/test/CoroutinesTest.kt
+++ b/ktor-io/common/test/CoroutinesTest.kt
@@ -5,29 +5,28 @@
 import io.ktor.test.dispatcher.*
 import io.ktor.utils.io.*
 import kotlinx.coroutines.*
+import kotlinx.coroutines.test.runTest
 import kotlin.test.*
 
 class CoroutinesTest {
 
     @OptIn(DelicateCoroutinesApi::class)
     @Test
-    fun testWriterWithExtraFlush() = testSuspend {
-        val channel = GlobalScope.writer {
+    fun testWriterWithExtraFlush() = runTest {
+        val channel1 = GlobalScope.writer {
             channel.writeByte(42)
             delay(100)
         }.channel
-
-        assertEquals(42, channel.readByte())
+        assertEquals(42, channel1.readByte())
     }
 
     @OptIn(DelicateCoroutinesApi::class)
     @Test
-    fun testReader() = testSuspend {
-        val channel = GlobalScope.reader {
+    fun testReader() = runTest {
+        val channel1 = GlobalScope.reader {
             assertEquals(42, channel.readByte())
         }.channel
-
-        channel.writeByte(42)
-        channel.flushAndClose()
+        channel1.writeByte(42)
+        channel1.flushAndClose()
     }
 }

--- a/ktor-io/common/test/CoroutinesTest.kt
+++ b/ktor-io/common/test/CoroutinesTest.kt
@@ -2,7 +2,6 @@
  * Copyright 2014-2024 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
-import io.ktor.test.dispatcher.*
 import io.ktor.utils.io.*
 import kotlinx.coroutines.*
 import kotlinx.coroutines.test.runTest
@@ -13,20 +12,20 @@ class CoroutinesTest {
     @OptIn(DelicateCoroutinesApi::class)
     @Test
     fun testWriterWithExtraFlush() = runTest {
-        val channel1 = GlobalScope.writer {
+        val channel = GlobalScope.writer {
             channel.writeByte(42)
             delay(100)
         }.channel
-        assertEquals(42, channel1.readByte())
+        assertEquals(42, channel.readByte())
     }
 
     @OptIn(DelicateCoroutinesApi::class)
     @Test
     fun testReader() = runTest {
-        val channel1 = GlobalScope.reader {
+        val channel = GlobalScope.reader {
             assertEquals(42, channel.readByte())
         }.channel
-        channel1.writeByte(42)
-        channel1.flushAndClose()
+        channel.writeByte(42)
+        channel.flushAndClose()
     }
 }

--- a/ktor-io/common/test/ReadUtf8LineTest.kt
+++ b/ktor-io/common/test/ReadUtf8LineTest.kt
@@ -14,47 +14,47 @@ class ReadUtf8LineTest {
 
     @Test
     fun testReadUtf8LineWithLongLineWithLimit() = runTest {
-        val lineSize1 = 1024
-        val line1 = "A".repeat(lineSize1)
-        val channel1 = writer {
+        val lineSize = 1024
+        val line = "A".repeat(lineSize)
+        val channel = writer {
             repeat(10) {
-                channel.writeStringUtf8(line1)
+                channel.writeStringUtf8(line)
             }
         }.channel
         assertFailsWith<TooLongLineException> {
-            channel1.readUTF8Line(8 * 1024)
+            channel.readUTF8Line(8 * 1024)
         }
     }
 
     @Test
     fun testNewLineAfterFlush() = runTest {
-        val channel1 = writer {
+        val channel = writer {
             channel.writeStringUtf8("4\r")
             channel.flush()
             delay(100)
             channel.writeStringUtf8("\n2\r\n")
         }.channel
-        val buffer1 = StringBuilder()
-        channel1.readUTF8LineTo(buffer1, 1024)
-        assertEquals("4", buffer1.toString())
-        buffer1.clear()
-        channel1.readUTF8LineTo(buffer1, 1024)
-        assertEquals("2", buffer1.toString())
+        val buffer = StringBuilder()
+        channel.readUTF8LineTo(buffer, 1024)
+        assertEquals("4", buffer.toString())
+        buffer.clear()
+        channel.readUTF8LineTo(buffer, 1024)
+        assertEquals("2", buffer.toString())
     }
 
     @Test
     fun testFlushBeforeNewLine() = runTest {
-        val channel1 = writer {
+        val channel = writer {
             channel.writeStringUtf8("4")
             channel.flush()
             delay(100)
             channel.writeStringUtf8("\r\n2\r\n")
         }.channel
-        val buffer1 = StringBuilder()
-        channel1.readUTF8LineTo(buffer1, 1024)
-        assertEquals("4", buffer1.toString())
-        buffer1.clear()
-        channel1.readUTF8LineTo(buffer1, 1024)
-        assertEquals("2", buffer1.toString())
+        val buffer = StringBuilder()
+        channel.readUTF8LineTo(buffer, 1024)
+        assertEquals("4", buffer.toString())
+        buffer.clear()
+        channel.readUTF8LineTo(buffer, 1024)
+        assertEquals("2", buffer.toString())
     }
 }

--- a/ktor-io/common/test/ReadUtf8LineTest.kt
+++ b/ktor-io/common/test/ReadUtf8LineTest.kt
@@ -2,63 +2,59 @@
  * Copyright 2014-2024 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
-import io.ktor.test.dispatcher.*
 import io.ktor.utils.io.*
 import io.ktor.utils.io.charsets.*
-import kotlinx.coroutines.*
-import kotlin.test.*
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 
 class ReadUtf8LineTest {
 
     @Test
-    fun testReadUtf8LineWithLongLineWithLimit() = testSuspend {
-        val lineSize = 1024
-        val line = "A".repeat(lineSize)
-
-        val channel = writer {
+    fun testReadUtf8LineWithLongLineWithLimit() = runTest {
+        val lineSize1 = 1024
+        val line1 = "A".repeat(lineSize1)
+        val channel1 = writer {
             repeat(10) {
-                channel.writeStringUtf8(line)
+                channel.writeStringUtf8(line1)
             }
         }.channel
-
         assertFailsWith<TooLongLineException> {
-            channel.readUTF8Line(8 * 1024)
+            channel1.readUTF8Line(8 * 1024)
         }
     }
 
     @Test
-    fun testNewLineAfterFlush() = testSuspend {
-        val channel = writer {
+    fun testNewLineAfterFlush() = runTest {
+        val channel1 = writer {
             channel.writeStringUtf8("4\r")
             channel.flush()
             delay(100)
             channel.writeStringUtf8("\n2\r\n")
         }.channel
-
-        val buffer = StringBuilder()
-        channel.readUTF8LineTo(buffer, 1024)
-        assertEquals("4", buffer.toString())
-        buffer.clear()
-
-        channel.readUTF8LineTo(buffer, 1024)
-        assertEquals("2", buffer.toString())
+        val buffer1 = StringBuilder()
+        channel1.readUTF8LineTo(buffer1, 1024)
+        assertEquals("4", buffer1.toString())
+        buffer1.clear()
+        channel1.readUTF8LineTo(buffer1, 1024)
+        assertEquals("2", buffer1.toString())
     }
 
     @Test
-    fun testFlushBeforeNewLine() = testSuspend {
-        val channel = writer {
+    fun testFlushBeforeNewLine() = runTest {
+        val channel1 = writer {
             channel.writeStringUtf8("4")
             channel.flush()
             delay(100)
             channel.writeStringUtf8("\r\n2\r\n")
         }.channel
-
-        val buffer = StringBuilder()
-        channel.readUTF8LineTo(buffer, 1024)
-        assertEquals("4", buffer.toString())
-        buffer.clear()
-
-        channel.readUTF8LineTo(buffer, 1024)
-        assertEquals("2", buffer.toString())
+        val buffer1 = StringBuilder()
+        channel1.readUTF8LineTo(buffer1, 1024)
+        assertEquals("4", buffer1.toString())
+        buffer1.clear()
+        channel1.readUTF8LineTo(buffer1, 1024)
+        assertEquals("2", buffer1.toString())
     }
 }

--- a/ktor-io/common/test/SinkByteWriteChannelTest.kt
+++ b/ktor-io/common/test/SinkByteWriteChannelTest.kt
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2014-2025 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+import io.ktor.utils.io.*
+import kotlinx.coroutines.test.runTest
+import kotlinx.io.Buffer
+import kotlinx.io.IOException
+import kotlinx.io.RawSink
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+import kotlin.test.fail
+
+class SinkByteWriteChannelTest {
+
+    @Test
+    fun testWriteByte() = runTest {
+        val buffer = Buffer()
+        val channel = buffer.asByteWriteChannel()
+        channel.writeByte(42)
+        channel.flushAndClose()
+
+        assertEquals(42, buffer.readByte())
+    }
+
+    @Test
+    fun `raw sink is not closed on channel close`() = runTest {
+        var flushed = false
+        var read = false
+        val sink = object : RawSink {
+            override fun write(source: Buffer, byteCount: Long) {
+                read = true
+                assertEquals(1, byteCount)
+                assertEquals(42, source.readByte())
+            }
+
+            override fun flush() {
+                flushed = true
+            }
+
+            override fun close() {
+                fail()
+            }
+        }
+
+        val channel = sink.asByteWriteChannel()
+        channel.writeByte(42)
+        channel.flushAndClose()
+
+        assertTrue(read, "Read was not called")
+        assertTrue(flushed, "Flush was not called")
+    }
+
+    @Test
+    fun `write after cancel should throw exception`() = runTest {
+        val buffer = Buffer()
+        val channel = buffer.asByteWriteChannel()
+        channel.close(IOException("Test"))
+
+        assertFailsWith<IOException>("Test") {
+            channel.writeByte(42)
+        }
+    }
+
+    @Test
+    fun `write after close should fail`() = runTest {
+        val buffer = Buffer()
+        val channel = buffer.asByteWriteChannel()
+        channel.flushAndClose()
+
+        assertFailsWith<IOException> {
+            channel.writeByte(42)
+        }
+    }
+}
+

--- a/ktor-io/common/test/SinkByteWriteChannelTest.kt
+++ b/ktor-io/common/test/SinkByteWriteChannelTest.kt
@@ -16,8 +16,9 @@ import kotlin.test.fail
 class SinkByteWriteChannelTest {
 
     @Test
-    fun testWriteByte() = runTest {
+    fun `write byte`() = runTest {
         val buffer = Buffer()
+        val sink = object : RawSink by buffer {}
         val channel = buffer.asByteWriteChannel()
         channel.writeByte(42)
         channel.flushAndClose()
@@ -55,8 +56,8 @@ class SinkByteWriteChannelTest {
 
     @Test
     fun `write after cancel should throw exception`() = runTest {
-        val buffer = Buffer()
-        val channel = buffer.asByteWriteChannel()
+        val sink = createSink()
+        val channel = sink.asByteWriteChannel()
         channel.close(IOException("Test"))
 
         assertFailsWith<IOException>("Test") {
@@ -66,13 +67,14 @@ class SinkByteWriteChannelTest {
 
     @Test
     fun `write after close should fail`() = runTest {
-        val buffer = Buffer()
-        val channel = buffer.asByteWriteChannel()
+        val sink = createSink()
+        val channel = sink.asByteWriteChannel()
         channel.flushAndClose()
 
         assertFailsWith<IOException> {
             channel.writeByte(42)
         }
     }
-}
 
+    private fun createSink(): RawSink = object : RawSink by Buffer() {}
+}

--- a/ktor-io/common/test/WriterReaderTest.kt
+++ b/ktor-io/common/test/WriterReaderTest.kt
@@ -6,42 +6,38 @@ import io.ktor.test.dispatcher.*
 import io.ktor.utils.io.*
 import io.ktor.utils.io.CancellationException
 import kotlinx.coroutines.*
+import kotlinx.coroutines.test.runTest
 import kotlin.test.*
 
 class WriterReaderTest {
 
     @OptIn(DelicateCoroutinesApi::class)
     @Test
-    fun testWriterOnCancelled() = testSuspend {
-        val job = Job()
-        job.cancel()
-
-        val writer = GlobalScope.writer(coroutineContext = job) {
+    fun testWriterOnCancelled() = runTest {
+        val job1 = Job()
+        job1.cancel()
+        val writer1 = GlobalScope.writer(coroutineContext = job1) {
         }
-
         assertFailsWith<CancellationException> {
-            writer.channel.readByte()
+            writer1.channel.readByte()
         }
     }
 
     @OptIn(DelicateCoroutinesApi::class)
     @Test
-    fun testReaderOnCancelled() = testSuspend {
-        val job = Job()
-        job.cancel()
-
-        val reader = GlobalScope.reader(coroutineContext = job) {
+    fun testReaderOnCancelled() = runTest {
+        val job1 = Job()
+        job1.cancel()
+        val reader1 = GlobalScope.reader(coroutineContext = job1) {
         }
-
         delay(100L)
-
         assertFailsWith<CancellationException> {
-            reader.channel.writeByte(42)
+            reader1.channel.writeByte(42)
         }
     }
 
     @Test
-    fun testReaderWaitsNestedLaunch() = testSuspend {
+    fun testReaderWaitsNestedLaunch() = runTest {
         val incoming = ByteChannel()
         val out = reader {
             launch {
@@ -57,7 +53,7 @@ class WriterReaderTest {
     }
 
     @Test
-    fun testWriterWaitsNestedLaunch() = testSuspend {
+    fun testWriterWaitsNestedLaunch() = runTest {
         val out = ByteChannel()
 
         val incoming = writer {

--- a/ktor-io/common/test/WriterReaderTest.kt
+++ b/ktor-io/common/test/WriterReaderTest.kt
@@ -2,12 +2,14 @@
  * Copyright 2014-2024 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
-import io.ktor.test.dispatcher.*
+import io.ktor.test.dispatcher.testSuspend
 import io.ktor.utils.io.*
 import io.ktor.utils.io.CancellationException
 import kotlinx.coroutines.*
 import kotlinx.coroutines.test.runTest
-import kotlin.test.*
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 
 class WriterReaderTest {
 
@@ -25,7 +27,7 @@ class WriterReaderTest {
 
     @OptIn(DelicateCoroutinesApi::class)
     @Test
-    fun testReaderOnCancelled() = runTest {
+    fun testReaderOnCancelled() = testSuspend {
         val job1 = Job()
         job1.cancel()
         val reader1 = GlobalScope.reader(coroutineContext = job1) {

--- a/ktor-io/common/test/WriterReaderTest.kt
+++ b/ktor-io/common/test/WriterReaderTest.kt
@@ -2,7 +2,7 @@
  * Copyright 2014-2024 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
-import io.ktor.test.dispatcher.testSuspend
+import io.ktor.test.dispatcher.runTestWithRealTime
 import io.ktor.utils.io.*
 import io.ktor.utils.io.CancellationException
 import kotlinx.coroutines.*
@@ -16,25 +16,25 @@ class WriterReaderTest {
     @OptIn(DelicateCoroutinesApi::class)
     @Test
     fun testWriterOnCancelled() = runTest {
-        val job1 = Job()
-        job1.cancel()
-        val writer1 = GlobalScope.writer(coroutineContext = job1) {
+        val job = Job()
+        job.cancel()
+        val writer = GlobalScope.writer(coroutineContext = job) {
         }
         assertFailsWith<CancellationException> {
-            writer1.channel.readByte()
+            writer.channel.readByte()
         }
     }
 
     @OptIn(DelicateCoroutinesApi::class)
     @Test
-    fun testReaderOnCancelled() = testSuspend {
-        val job1 = Job()
-        job1.cancel()
-        val reader1 = GlobalScope.reader(coroutineContext = job1) {
+    fun testReaderOnCancelled() = runTestWithRealTime {
+        val job = Job()
+        job.cancel()
+        val reader = GlobalScope.reader(coroutineContext = job) {
         }
         delay(100L)
         assertFailsWith<CancellationException> {
-            reader1.channel.writeByte(42)
+            reader.channel.writeByte(42)
         }
     }
 

--- a/ktor-io/jvm/src/io/ktor/utils/io/charsets/CharsetJVM.kt
+++ b/ktor-io/jvm/src/io/ktor/utils/io/charsets/CharsetJVM.kt
@@ -88,7 +88,6 @@ public actual fun CharsetDecoder.decode(input: Source, dst: Appendable, max: Int
 
 public actual typealias Charsets = kotlin.text.Charsets
 
-@Suppress("ACTUAL_WITHOUT_EXPECT")
 public actual open class MalformedInputException
 actual constructor(message: String) : java.nio.charset.MalformedInputException(0) {
     private val _message = message

--- a/ktor-io/jvm/src/io/ktor/utils/io/streams/Streams.kt
+++ b/ktor-io/jvm/src/io/ktor/utils/io/streams/Streams.kt
@@ -4,6 +4,8 @@
 
 package io.ktor.utils.io.streams
 
+import io.ktor.utils.io.ByteWriteChannel
+import io.ktor.utils.io.asByteWriteChannel
 import io.ktor.utils.io.core.*
 import kotlinx.io.*
 import kotlinx.io.Buffer
@@ -35,3 +37,18 @@ public fun InputStream.readPacketAtLeast(min: Int = 1): Source {
 
     return buffer
 }
+
+/**
+ * Converts this [OutputStream] into a [ByteWriteChannel], enabling asynchronous writing of byte sequences.
+ *
+ * ```kotlin
+ * val outputStream: OutputStream = FileOutputStream("file.txt")
+ * val channel: ByteWriteChannel = outputStream.asByteWriteChannel()
+ * channel.writeFully("Hello, World!".toByteArray())
+ * channel.flushAndClose() // Ensure the data is written to the OutputStream
+ * ```
+ *
+ * All operations on the [ByteWriteChannel] are buffered: the underlying [OutputStream] will be receiving bytes
+ * when the [ByteWriteChannel.flush] happens.
+ */
+public fun OutputStream.asByteWriteChannel(): ByteWriteChannel = asSink().asByteWriteChannel()

--- a/ktor-io/jvmAndPosix/src/io/ktor/utils/io/ByteReadChannelSource.kt
+++ b/ktor-io/jvmAndPosix/src/io/ktor/utils/io/ByteReadChannelSource.kt
@@ -10,8 +10,9 @@ import kotlinx.io.RawSource
 
 /**
  * Converts the current `ByteReadChannel` instance into a `RawSource`.
- *
  * This enables the usage of a `ByteReadChannel` as a `RawSource` for reading operations.
+ *
+ * Please note: the [RawSource] produced by this operation uses [runBlocking] to wait for the content to be available.
  *
  * @return a `RawSource` implementation that wraps the `ByteReadChannel`.
  */

--- a/ktor-io/jvmAndPosix/src/io/ktor/utils/io/ByteReadChannelSource.kt
+++ b/ktor-io/jvmAndPosix/src/io/ktor/utils/io/ByteReadChannelSource.kt
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2014-2025 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.utils.io
+
+import kotlinx.coroutines.runBlocking
+import kotlinx.io.Buffer
+import kotlinx.io.RawSource
+
+/**
+ * Converts the current `ByteReadChannel` instance into a `RawSource`.
+ *
+ * This enables the usage of a `ByteReadChannel` as a `RawSource` for reading operations.
+ *
+ * @return a `RawSource` implementation that wraps the `ByteReadChannel`.
+ */
+public fun ByteReadChannel.asSource(): RawSource = ByteReadChannelSource(this)
+
+internal class ByteReadChannelSource(private val origin: ByteReadChannel) : RawSource {
+
+    @OptIn(InternalAPI::class)
+    override fun readAtMostTo(sink: Buffer, byteCount: Long): Long {
+        if (origin.readBuffer.exhausted()) {
+            runBlocking { origin.awaitContent() }
+        }
+
+        if (origin.readBuffer.exhausted()) {
+            return -1
+        }
+
+        return origin.readBuffer.readAtMostTo(sink, byteCount)
+    }
+
+    override fun close() {
+        origin.cancel()
+    }
+}

--- a/ktor-io/jvmAndPosix/src/io/ktor/utils/io/ByteWriteChannelSink.kt
+++ b/ktor-io/jvmAndPosix/src/io/ktor/utils/io/ByteWriteChannelSink.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2014-2025 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.utils.io
+
+import io.ktor.utils.io.core.*
+import kotlinx.coroutines.runBlocking
+import kotlinx.io.Buffer
+import kotlinx.io.RawSink
+
+/**
+ * Converts the current `ByteWriteChannel` instance into a `RawSink`.
+ */
+public fun ByteWriteChannel.asSink(): RawSink = ByteWriteChannelSink(this)
+
+internal class ByteWriteChannelSink(private val origin: ByteWriteChannel) : RawSink {
+
+    @OptIn(InternalAPI::class)
+    override fun write(source: Buffer, byteCount: Long) {
+        origin.rethrowCloseCauseIfNeeded()
+
+        origin.writeBuffer.write(source, byteCount)
+
+        if ((origin as? ByteChannel)?.autoFlush == true || origin.writeBuffer.size >= CHANNEL_MAX_SIZE) {
+            runBlocking {
+                flush()
+            }
+        }
+    }
+
+    @OptIn(InternalAPI::class)
+    override fun flush() = runBlocking {
+        origin.rethrowCloseCauseIfNeeded()
+
+        origin.flush()
+    }
+
+    @OptIn(InternalAPI::class)
+    override fun close() = runBlocking {
+        origin.rethrowCloseCauseIfNeeded()
+
+        origin.flushAndClose()
+    }
+}

--- a/ktor-io/jvmAndPosix/src/io/ktor/utils/io/ByteWriteChannelSink.kt
+++ b/ktor-io/jvmAndPosix/src/io/ktor/utils/io/ByteWriteChannelSink.kt
@@ -11,6 +11,8 @@ import kotlinx.io.RawSink
 
 /**
  * Converts the current `ByteWriteChannel` instance into a `RawSink`.
+ *
+ * Please note: the [RawSink] produced by this operation uses [runBlocking] to flush the content.
  */
 public fun ByteWriteChannel.asSink(): RawSink = ByteWriteChannelSink(this)
 

--- a/ktor-io/jvmAndPosix/test/ByteReadChannelSourceTest.kt
+++ b/ktor-io/jvmAndPosix/test/ByteReadChannelSourceTest.kt
@@ -1,0 +1,78 @@
+import io.ktor.utils.io.ByteReadChannel
+import io.ktor.utils.io.asSource
+import io.ktor.utils.io.writeByte
+import io.ktor.utils.io.writer
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.newCoroutineContext
+import kotlinx.coroutines.test.runTest
+import kotlinx.io.IOException
+import kotlinx.io.buffered
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+/*
+ * Copyright 2014-2025 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+class ByteReadChannelSourceTest {
+
+    @Test
+    fun `read from closed fails`() {
+        val channel = ByteReadChannel(ByteArray(0))
+
+        assertFailsWith<IOException> {
+            channel.asSource().buffered().readByte()
+        }
+    }
+
+    @Test
+    fun `read byte`() {
+        val channel = ByteReadChannel(ByteArray(1) { 42 })
+
+        val source = channel.asSource().buffered()
+        val byte = source.readByte()
+
+        assertEquals(42, byte)
+    }
+
+    @Test
+    fun `resumes after write`() = runTest {
+        val start = Job()
+        val source = writer {
+            start.join()
+            channel.writeByte(42)
+        }.channel.asSource()
+
+        val context = newCoroutineContext(Dispatchers.Default)
+        val result = CompletableDeferred<Byte>()
+        launch(context) {
+            result.complete(source.buffered().readByte())
+        }
+
+        start.complete()
+        assertEquals(42, result.await())
+    }
+
+    @Test
+    fun `cancel is propagating`() = runTest {
+        var cause = CompletableDeferred<Throwable>()
+        val channel = writer {
+            try {
+                while (true) {
+                    channel.writeByte(42)
+                }
+            } catch (e: Throwable) {
+                cause.complete(e)
+            }
+        }.channel
+
+        channel.asSource().close()
+        assertTrue(cause.await() is IOException)
+
+    }
+}

--- a/ktor-io/jvmAndPosix/test/ByteReadChannelSourceTest.kt
+++ b/ktor-io/jvmAndPosix/test/ByteReadChannelSourceTest.kt
@@ -73,6 +73,5 @@ class ByteReadChannelSourceTest {
 
         channel.asSource().close()
         assertTrue(cause.await() is IOException)
-
     }
 }

--- a/ktor-io/jvmAndPosix/test/ByteReadChannelSourceTest.kt
+++ b/ktor-io/jvmAndPosix/test/ByteReadChannelSourceTest.kt
@@ -1,3 +1,6 @@
+/*
+ * Copyright 2014-2025 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
 import io.ktor.utils.io.ByteReadChannel
 import io.ktor.utils.io.asSource
 import io.ktor.utils.io.writeByte
@@ -14,10 +17,6 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
-
-/*
- * Copyright 2014-2025 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
- */
 
 class ByteReadChannelSourceTest {
 

--- a/ktor-io/jvmAndPosix/test/ByteWriteChannelSinkTest.kt
+++ b/ktor-io/jvmAndPosix/test/ByteWriteChannelSinkTest.kt
@@ -1,13 +1,12 @@
+/*
+ * Copyright 2014-2025 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
 import io.ktor.utils.io.*
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.test.runTest
 import kotlinx.io.buffered
 import kotlin.test.Test
 import kotlin.test.assertEquals
-
-/*
- * Copyright 2014-2025 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
- */
 
 class ByteWriteChannelSinkTest {
 

--- a/ktor-io/jvmAndPosix/test/ByteWriteChannelSinkTest.kt
+++ b/ktor-io/jvmAndPosix/test/ByteWriteChannelSinkTest.kt
@@ -1,11 +1,9 @@
 import io.ktor.utils.io.*
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.test.runTest
-import kotlinx.io.IOException
 import kotlinx.io.buffered
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertTrue
 
 /*
  * Copyright 2014-2025 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
@@ -19,7 +17,6 @@ class ByteWriteChannelSinkTest {
         val sink = reader {
             result.complete(channel.readByte())
         }.channel.asSink().buffered()
-
 
         sink.writeByte(42)
         sink.flush()

--- a/ktor-io/jvmAndPosix/test/ByteWriteChannelSinkTest.kt
+++ b/ktor-io/jvmAndPosix/test/ByteWriteChannelSinkTest.kt
@@ -1,0 +1,29 @@
+import io.ktor.utils.io.*
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.test.runTest
+import kotlinx.io.IOException
+import kotlinx.io.buffered
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/*
+ * Copyright 2014-2025 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+class ByteWriteChannelSinkTest {
+
+    @Test
+    fun `write byte`() = runTest {
+        val result = CompletableDeferred<Byte>()
+        val sink = reader {
+            result.complete(channel.readByte())
+        }.channel.asSink().buffered()
+
+
+        sink.writeByte(42)
+        sink.flush()
+
+        assertEquals(42, result.await())
+    }
+}


### PR DESCRIPTION
Fix [KTOR-7327](https://youtrack.jetbrains.com/issue/KTOR-7327) Support conversion between byte channel interfaces and kotlinx-io primitives