### PR TITLE
KTOR-8045 Fix for NPE race condition in dispose

### DIFF
--- a/ktor-server/ktor-server-plugins/ktor-server-double-receive/common/src/io/ktor/server/plugins/doublereceive/ByteArrayCache.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-double-receive/common/src/io/ktor/server/plugins/doublereceive/ByteArrayCache.kt
@@ -53,7 +53,7 @@ internal class MemoryCache(
     override fun dispose() {
         GlobalScope.launch {
             reader.discard()
-            fullBody?.discard()
         }
+        fullBody?.discard()
     }
 }

--- a/ktor-server/ktor-server-tests/jvm/test/io/ktor/server/http/ApplicationRequestContentTestJvm.kt
+++ b/ktor-server/ktor-server-tests/jvm/test/io/ktor/server/http/ApplicationRequestContentTestJvm.kt
@@ -79,5 +79,4 @@ class ApplicationRequestContentTest {
             }
         }.joinAll()
     }
-
 }

--- a/ktor-server/ktor-server-tests/jvm/test/io/ktor/server/http/ApplicationRequestContentTestJvm.kt
+++ b/ktor-server/ktor-server-tests/jvm/test/io/ktor/server/http/ApplicationRequestContentTestJvm.kt
@@ -5,10 +5,17 @@
 package io.ktor.server.http
 
 import io.ktor.client.request.*
+import io.ktor.http.HttpStatusCode
 import io.ktor.server.application.*
 import io.ktor.server.plugins.doublereceive.*
+import io.ktor.server.plugins.statuspages.StatusPages
 import io.ktor.server.request.*
+import io.ktor.server.response.*
+import io.ktor.server.routing.*
 import io.ktor.server.testing.*
+import kotlinx.coroutines.joinAll
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runTest
 import kotlin.test.*
 
 class ApplicationRequestContentTest {
@@ -41,4 +48,36 @@ class ApplicationRequestContentTest {
             setBody("bodyContent")
         }
     }
+
+    @Test
+    fun testDoubleReceiveRaceCondition() = runTest {
+        (1..100).map {
+            launch {
+                testApplication {
+                    application {
+                        install(DoubleReceive) {}
+
+                        install(StatusPages) {
+                            status(HttpStatusCode.BadRequest) { call, status ->
+                                call.respondText(text = "400: Bad Request", status = status)
+                            }
+                        }
+                        routing {
+                            post("/") {
+                                val request = call.receiveText()
+                                call.respond(HttpStatusCode.BadRequest, request)
+                            }
+                        }
+                    }
+
+                    client.post("/") {
+                        setBody("Hello World")
+                    }.also {
+                        assertEquals(HttpStatusCode.BadRequest, it.status)
+                    }
+                }
+            }
+        }.joinAll()
+    }
+
 }


### PR DESCRIPTION
**Subsystem**
Server, DoubleReceive

**Motivation**
[KTOR-8045](https://youtrack.jetbrains.com/issue/KTOR-8045) DoubleReceive: NullPointerException caused by race condition

**Solution**
Moving the body's discard call outside the coroutine avoids the race condition when dispose is called twice.
