### PR TITLE
KTOR-8074 Add deepLinking configuration variable to Swagger plugin (reopen from main)

### DIFF
--- a/ktor-server/ktor-server-plugins/ktor-server-swagger/api/ktor-server-swagger.api
+++ b/ktor-server/ktor-server-plugins/ktor-server-swagger/api/ktor-server-swagger.api
@@ -1,9 +1,11 @@
 public final class io/ktor/server/plugins/swagger/SwaggerConfig {
 	public fun <init> ()V
 	public final fun customStyle (Ljava/lang/String;)V
+	public final fun getDeepLinking ()Z
 	public final fun getFaviconLocation ()Ljava/lang/String;
 	public final fun getPackageLocation ()Ljava/lang/String;
 	public final fun getVersion ()Ljava/lang/String;
+	public final fun setDeepLinking (Z)V
 	public final fun setFaviconLocation (Ljava/lang/String;)V
 	public final fun setPackageLocation (Ljava/lang/String;)V
 	public final fun setVersion (Ljava/lang/String;)V

--- a/ktor-server/ktor-server-plugins/ktor-server-swagger/jvm/src/io/ktor/server/plugins/swagger/Swagger.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-swagger/jvm/src/io/ktor/server/plugins/swagger/Swagger.kt
@@ -110,6 +110,7 @@ window.onload = function() {
     window.ui = SwaggerUIBundle({
         url: '$fullPath/$apiUrl',
         dom_id: '#swagger-ui',
+        deepLinking: ${config.deepLinking},
         presets: [
             SwaggerUIBundle.presets.apis,
             SwaggerUIStandalonePreset

--- a/ktor-server/ktor-server-plugins/ktor-server-swagger/jvm/src/io/ktor/server/plugins/swagger/SwaggerConfig.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-swagger/jvm/src/io/ktor/server/plugins/swagger/SwaggerConfig.kt
@@ -30,7 +30,7 @@ public class SwaggerConfig {
     public var packageLocation: String = "https://unpkg.com/swagger-ui-dist"
 
     /**
-     * Whether to allow deep linking in Swagger UI, as described here: https://swagger.io/docs/open-source-tools/swagger-ui/usage/deep-linking/
+     * Whether to allow [deep linking in Swagger UI](https://swagger.io/docs/open-source-tools/swagger-ui/usage/deep-linking/).
      *
      * Defaults to `false`.
      */

--- a/ktor-server/ktor-server-plugins/ktor-server-swagger/jvm/src/io/ktor/server/plugins/swagger/SwaggerConfig.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-swagger/jvm/src/io/ktor/server/plugins/swagger/SwaggerConfig.kt
@@ -30,6 +30,13 @@ public class SwaggerConfig {
     public var packageLocation: String = "https://unpkg.com/swagger-ui-dist"
 
     /**
+     * Whether to allow deep linking in Swagger UI, as described here: https://swagger.io/docs/open-source-tools/swagger-ui/usage/deep-linking/
+     *
+     * Defaults to `false`.
+     */
+    public var deepLinking: Boolean = false
+
+    /*
      * Swagger favicon location
      */
     public var faviconLocation: String = "https://unpkg.com/swagger-ui-dist@$version/favicon-32x32.png"

--- a/ktor-server/ktor-server-plugins/ktor-server-swagger/jvm/test/io/ktor/server/plugins/swagger/SwaggerTest.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-swagger/jvm/test/io/ktor/server/plugins/swagger/SwaggerTest.kt
@@ -36,6 +36,49 @@ class SwaggerTest {
                 window.ui = SwaggerUIBundle({
                     url: '/swagger/documentation.yaml',
                     dom_id: '#swagger-ui',
+                    deepLinking: false,
+                    presets: [
+                        SwaggerUIBundle.presets.apis,
+                        SwaggerUIStandalonePreset
+                    ],
+                    layout: 'StandaloneLayout'
+                });
+            }</script>
+              </body>
+            </html>
+
+            """.trimIndent(),
+            response
+        )
+    }
+
+    @Test
+    fun testSwaggerAllowDeepLinking() = testApplication {
+        routing {
+            swaggerUI("swagger") {
+                deepLinking = true
+            }
+        }
+
+        val response = client.get("/swagger").bodyAsText()
+        assertEquals(
+            """
+            <!DOCTYPE html>
+            <html>
+              <head>
+                <title>Swagger UI</title>
+                <link href="https://unpkg.com/swagger-ui-dist@5.17.12/swagger-ui.css" rel="stylesheet">
+                <link href="https://unpkg.com/swagger-ui-dist@5.17.12/favicon-32x32.png" rel="icon" type="image/x-icon">
+              </head>
+              <body>
+                <div id="swagger-ui"></div>
+                <script src="https://unpkg.com/swagger-ui-dist@5.17.12/swagger-ui-bundle.js" crossorigin="anonymous"></script>
+                <script src="https://unpkg.com/swagger-ui-dist@5.17.12/swagger-ui-standalone-preset.js" crossorigin="anonymous"></script>
+                <script>window.onload = function() {
+                window.ui = SwaggerUIBundle({
+                    url: '/swagger/documentation.yaml',
+                    dom_id: '#swagger-ui',
+                    deepLinking: true,
                     presets: [
                         SwaggerUIBundle.presets.apis,
                         SwaggerUIStandalonePreset
@@ -77,6 +120,7 @@ class SwaggerTest {
                 window.ui = SwaggerUIBundle({
                     url: '/swagger/documentation.yaml',
                     dom_id: '#swagger-ui',
+                    deepLinking: false,
                     presets: [
                         SwaggerUIBundle.presets.apis,
                         SwaggerUIStandalonePreset
@@ -133,6 +177,7 @@ class SwaggerTest {
                 window.ui = SwaggerUIBundle({
                     url: '/swagger/documentation.yaml',
                     dom_id: '#swagger-ui',
+                    deepLinking: false,
                     presets: [
                         SwaggerUIBundle.presets.apis,
                         SwaggerUIStandalonePreset


### PR DESCRIPTION
**Subsystem**

Ktor server plugin

**Motivation**

Customer asked at work if we could provide deeplinks to the Swagger documentation. Found that it was a setting in Javascriptt (https://swagger.io/docs/open-source-tools/swagger-ui/usage/deep-linking/) that was not exposed by the plugin.

**Solution**

Add a boolean variable to SwaggerConfig to enable deep linking. It defaults to false (which is also the default for SwaggerUI).

