### PR TITLE
KTOR-7743 Remove redundant configurations for JVM target

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -57,10 +57,6 @@ subprojects {
     configureTargets()
     if (CI) configureTestTasksOnCi()
 
-    configurations {
-        maybeCreate("testOutput")
-    }
-
     kotlin {
         if (!internalProjects.contains(project.name)) explicitApi()
 

--- a/buildSrc/src/main/kotlin/JvmConfig.kt
+++ b/buildSrc/src/main/kotlin/JvmConfig.kt
@@ -46,8 +46,6 @@ fun Project.configureJvm() {
         val testOutput by creating {
             extendsFrom(testCompile)
         }
-        val boot by creating {
-        }
     }
 
     val testJdk = project.testJdk

--- a/buildSrc/src/main/kotlin/JvmConfig.kt
+++ b/buildSrc/src/main/kotlin/JvmConfig.kt
@@ -34,20 +34,6 @@ fun Project.configureJvm() {
         }
     }
 
-    tasks.register<Jar>("jarTest") {
-        dependsOn(tasks.named("jvmTestClasses"))
-        archiveClassifier = "test"
-        from(kotlin.jvm().compilations["test"].output)
-    }
-
-    configurations {
-        val testCompile = findByName("testCompile") ?: return@configurations
-
-        val testOutput by creating {
-            extendsFrom(testCompile)
-        }
-    }
-
     val testJdk = project.testJdk
     val jvmTest = tasks.named<KotlinJvmTest>("jvmTest") {
         maxHeapSize = "2g"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -22,7 +22,6 @@ netty-tcnative = "2.0.69.Final"
 jetty = "9.4.57.v20241219"
 jetty-jakarta = "11.0.24"
 jetty-alpn-api = "1.1.3.v20160715"
-jetty-alpn-boot = "8.1.13.v20181017"
 jetty-alpn-openjdk8 = "9.4.57.v20241219"
 
 tomcat = "9.0.98"
@@ -156,7 +155,6 @@ jetty-alpn-java-server = { module = "org.eclipse.jetty:jetty-alpn-java-server", 
 jetty-alpn-java-client = { module = "org.eclipse.jetty:jetty-alpn-java-client", version.ref = "jetty" }
 
 jetty-alpn-api = { module = "org.eclipse.jetty.alpn:alpn-api", version.ref = "jetty-alpn-api" }
-jetty-alpn-boot = { module = "org.mortbay.jetty.alpn:alpn-boot", version.ref = "jetty-alpn-boot" }
 jetty-alpn-openjdk8-server = { module = "org.eclipse.jetty:jetty-alpn-openjdk8-server", version.ref = "jetty-alpn-openjdk8" }
 jetty-alpn-openjdk8-client = { module = "org.eclipse.jetty:jetty-alpn-openjdk8-client", version.ref = "jetty-alpn-openjdk8" }
 

--- a/ktor-server/build.gradle.kts
+++ b/ktor-server/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2024 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2014-2025 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
 description = "Wrapper for ktor-server-core and base plugins"
@@ -33,8 +33,4 @@ kotlin.sourceSets {
             api(project(":ktor-server:ktor-server-plugins:ktor-server-sessions"))
         }
     }
-}
-
-artifacts {
-    add("testOutput", tasks.named("jarTest"))
 }

--- a/ktor-server/ktor-server-cio/build.gradle.kts
+++ b/ktor-server/ktor-server-cio/build.gradle.kts
@@ -20,10 +20,4 @@ kotlin.sourceSets {
             api(project(":ktor-server:ktor-server-test-base"))
         }
     }
-    jvmTest {
-        dependencies {
-            api(project(":ktor-server:ktor-server-core", configuration = "testOutput"))
-            api(libs.logback.classic)
-        }
-    }
 }

--- a/ktor-server/ktor-server-core/build.gradle.kts
+++ b/ktor-server/ktor-server-core/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2024 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2014-2025 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
 description = ""
@@ -41,14 +41,9 @@ kotlin {
                 implementation(project(":ktor-server:ktor-server-config-yaml"))
                 implementation(project(":ktor-server:ktor-server-test-base"))
                 implementation(project(":ktor-server:ktor-server-test-suites"))
-                
-                api(libs.logback.classic)
+
                 implementation(libs.mockk)
             }
         }
     }
-}
-
-artifacts {
-    add("testOutput", tasks.named("jarTest"))
 }

--- a/ktor-server/ktor-server-jetty-jakarta/build.gradle.kts
+++ b/ktor-server/ktor-server-jetty-jakarta/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2024 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2014-2025 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
 description = ""
@@ -26,8 +26,6 @@ kotlin {
                 api(project(":ktor-server:ktor-server-test-suites"))
 
                 api(libs.jetty.servlet.jakarta)
-                api(project(":ktor-server:ktor-server-core", configuration = "testOutput"))
-                api(libs.logback.classic)
             }
         }
     }

--- a/ktor-server/ktor-server-jetty-jakarta/build.gradle.kts
+++ b/ktor-server/ktor-server-jetty-jakarta/build.gradle.kts
@@ -32,11 +32,3 @@ kotlin {
         }
     }
 }
-
-val jetty_alpn_boot_version: String? by extra
-
-dependencies {
-    if (jetty_alpn_boot_version != null) {
-        add("boot", libs.jetty.alpn.boot)
-    }
-}

--- a/ktor-server/ktor-server-jetty-jakarta/ktor-server-jetty-test-http2-jakarta/build.gradle.kts
+++ b/ktor-server/ktor-server-jetty-jakarta/ktor-server-jetty-test-http2-jakarta/build.gradle.kts
@@ -19,18 +19,6 @@ kotlin.sourceSets {
     }
 }
 
-val jetty_alpn_boot_version: String? by extra
-dependencies {
-    if (jetty_alpn_boot_version != null) {
-        add("boot", libs.jetty.alpn.boot)
-    }
-}
-
 tasks.named<KotlinJvmTest>("jvmTest") {
     systemProperty("enable.http2", "true")
-
-    if (jetty_alpn_boot_version != null && JavaVersion.current() == JavaVersion.VERSION_1_8) {
-        val bootClasspath = configurations.named("boot").get().files
-        jvmArgs(bootClasspath.map { "-Xbootclasspath/p:${it.absolutePath}" }.iterator())
-    }
 }

--- a/ktor-server/ktor-server-jetty-jakarta/ktor-server-jetty-test-http2-jakarta/build.gradle.kts
+++ b/ktor-server/ktor-server-jetty-jakarta/ktor-server-jetty-test-http2-jakarta/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2024 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2014-2025 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
 import org.jetbrains.kotlin.gradle.targets.jvm.tasks.KotlinJvmTest
@@ -12,9 +12,6 @@ kotlin.sourceSets {
             api(libs.jetty.servlet.jakarta)
             api(project(":ktor-server:ktor-server-core"))
             api(project(":ktor-server:ktor-server-jetty-jakarta"))
-            api(project(":ktor-server:ktor-server-core", configuration = "testOutput"))
-
-            api(libs.logback.classic)
         }
     }
 }

--- a/ktor-server/ktor-server-jetty/build.gradle.kts
+++ b/ktor-server/ktor-server-jetty/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2024 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2014-2025 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
 description = ""
@@ -25,8 +25,6 @@ kotlin {
                 api(project(":ktor-server:ktor-server-test-suites"))
 
                 api(libs.jetty.servlet)
-                api(project(":ktor-server:ktor-server-core", configuration = "testOutput"))
-                api(libs.logback.classic)
             }
         }
     }

--- a/ktor-server/ktor-server-jetty/build.gradle.kts
+++ b/ktor-server/ktor-server-jetty/build.gradle.kts
@@ -1,3 +1,7 @@
+/*
+ * Copyright 2014-2024 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
 description = ""
 
 kotlin {
@@ -25,13 +29,5 @@ kotlin {
                 api(libs.logback.classic)
             }
         }
-    }
-}
-
-val jetty_alpn_boot_version: String? by extra
-
-dependencies {
-    if (jetty_alpn_boot_version != null) {
-        add("boot", libs.jetty.alpn.boot)
     }
 }

--- a/ktor-server/ktor-server-jetty/ktor-server-jetty-test-http2/build.gradle.kts
+++ b/ktor-server/ktor-server-jetty/ktor-server-jetty-test-http2/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2024 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2014-2025 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
 import org.jetbrains.kotlin.gradle.targets.jvm.tasks.KotlinJvmTest
@@ -12,9 +12,6 @@ kotlin.sourceSets {
             api(libs.jetty.servlet)
             api(project(":ktor-server:ktor-server-core"))
             api(project(":ktor-server:ktor-server-jetty"))
-            api(project(":ktor-server:ktor-server-core", configuration = "testOutput"))
-
-            api(libs.logback.classic)
         }
     }
 }

--- a/ktor-server/ktor-server-jetty/ktor-server-jetty-test-http2/build.gradle.kts
+++ b/ktor-server/ktor-server-jetty/ktor-server-jetty-test-http2/build.gradle.kts
@@ -19,18 +19,6 @@ kotlin.sourceSets {
     }
 }
 
-val jetty_alpn_boot_version: String? by extra
-dependencies {
-    if (jetty_alpn_boot_version != null) {
-        add("boot", libs.jetty.alpn.boot)
-    }
-}
-
 tasks.named<KotlinJvmTest>("jvmTest") {
     systemProperty("enable.http2", "true")
-
-    if (jetty_alpn_boot_version != null && JavaVersion.current() == JavaVersion.VERSION_1_8) {
-        val bootClasspath = configurations.named("boot").get().files
-        jvmArgs(bootClasspath.map { "-Xbootclasspath/p:${it.absolutePath}" }.iterator())
-    }
 }

--- a/ktor-server/ktor-server-netty/build.gradle.kts
+++ b/ktor-server/ktor-server-netty/build.gradle.kts
@@ -6,8 +6,6 @@ import org.jetbrains.kotlin.gradle.targets.jvm.tasks.KotlinJvmTest
 
 description = ""
 
-val jetty_alpn_api_version: String by extra
-
 val enableAlpnProp = project.hasProperty("enableAlpn")
 val osName = System.getProperty("os.name").lowercase()
 val nativeClassifier: String? = if (enableAlpnProp) {

--- a/ktor-server/ktor-server-netty/build.gradle.kts
+++ b/ktor-server/ktor-server-netty/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2024 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2014-2025 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
 import org.jetbrains.kotlin.gradle.targets.jvm.tasks.KotlinJvmTest
@@ -43,9 +43,6 @@ kotlin.sourceSets {
             api(libs.netty.tcnative)
             api(libs.netty.tcnative.boringssl.static)
             api(libs.mockk)
-            api(libs.logback.classic)
-
-            api(project(":ktor-server:ktor-server-core", configuration = "testOutput"))
         }
     }
 }

--- a/ktor-server/ktor-server-plugins/build.gradle.kts
+++ b/ktor-server/ktor-server-plugins/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2024 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2014-2025 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
 subprojects {
@@ -18,11 +18,7 @@ subprojects {
 
             jvmTest {
                 dependencies {
-                    api(project(":ktor-server:ktor-server-core", configuration = "testOutput"))
-
-                    // Version catalogs aren't accessible directly inside subprojects block
-                    // https://github.com/gradle/gradle/issues/16634#issuecomment-809345790
-                    api(rootProject.libs.logback.classic)
+                    implementation(project(":ktor-server:ktor-server-test-base"))
                 }
             }
         }

--- a/ktor-server/ktor-server-servlet-jakarta/build.gradle.kts
+++ b/ktor-server/ktor-server-servlet-jakarta/build.gradle.kts
@@ -1,3 +1,7 @@
+/*
+ * Copyright 2014-2025 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
 description = ""
 
 kotlin.sourceSets {
@@ -11,7 +15,6 @@ kotlin.sourceSets {
 
     jvmTest {
         dependencies {
-            api(project(":ktor-server:ktor-server-core", configuration = "testOutput"))
             api(project(":ktor-server:ktor-server-config-yaml"))
             implementation(libs.mockk)
             implementation(libs.jakarta.servlet)

--- a/ktor-server/ktor-server-servlet/build.gradle.kts
+++ b/ktor-server/ktor-server-servlet/build.gradle.kts
@@ -1,3 +1,7 @@
+/*
+ * Copyright 2014-2025 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
 description = ""
 
 kotlin.sourceSets {
@@ -10,7 +14,6 @@ kotlin.sourceSets {
 
     jvmTest {
         dependencies {
-            api(project(":ktor-server:ktor-server-core", configuration = "testOutput"))
             api(project(":ktor-server:ktor-server-config-yaml"))
             implementation(libs.mockk)
             implementation(libs.javax.servlet)

--- a/ktor-server/ktor-server-test-base/build.gradle.kts
+++ b/ktor-server/ktor-server-test-base/build.gradle.kts
@@ -4,8 +4,6 @@
 
 description = ""
 
-val jetty_alpn_boot_version: String? by extra
-
 kotlin.sourceSets {
     commonMain {
         dependencies {
@@ -21,10 +19,6 @@ kotlin.sourceSets {
             api(project(":ktor-client:ktor-client-apache"))
             api(project(":ktor-network:ktor-network-tls:ktor-network-tls-certificates"))
             api(project(":ktor-server:ktor-server-plugins:ktor-server-call-logging"))
-
-            if (jetty_alpn_boot_version != null) {
-                api(libs.jetty.alpn.boot)
-            }
         }
     }
 }

--- a/ktor-server/ktor-server-test-base/build.gradle.kts
+++ b/ktor-server/ktor-server-test-base/build.gradle.kts
@@ -19,6 +19,8 @@ kotlin.sourceSets {
             api(project(":ktor-client:ktor-client-apache"))
             api(project(":ktor-network:ktor-network-tls:ktor-network-tls-certificates"))
             api(project(":ktor-server:ktor-server-plugins:ktor-server-call-logging"))
+
+            api(libs.logback.classic)
         }
     }
 }

--- a/ktor-server/ktor-server-test-base/jvm/resources/logback-test.xml
+++ b/ktor-server/ktor-server-test-base/jvm/resources/logback-test.xml
@@ -1,3 +1,7 @@
+<!--
+  ~ Copyright 2014-2025 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+  -->
+
 <configuration>
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>

--- a/ktor-server/ktor-server-test-host/build.gradle.kts
+++ b/ktor-server/ktor-server-test-host/build.gradle.kts
@@ -4,8 +4,6 @@
 
 description = ""
 
-val jetty_alpn_boot_version: String? by extra
-
 kotlin.sourceSets {
     commonMain {
         dependencies {
@@ -27,10 +25,6 @@ kotlin.sourceSets {
             // Not ideal, but prevents an additional artifact, and this is usually just included for testing,
             // so shouldn"t increase the size of the final artifact.
             api(project(":ktor-server:ktor-server-plugins:ktor-server-websockets"))
-
-            if (jetty_alpn_boot_version != null) {
-                api(libs.jetty.alpn.boot)
-            }
 
             api(libs.kotlin.test)
             api(libs.junit)

--- a/ktor-server/ktor-server-test-host/build.gradle.kts
+++ b/ktor-server/ktor-server-test-host/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2024 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2014-2025 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
 description = ""
@@ -34,7 +34,6 @@ kotlin.sourceSets {
 
     jvmTest {
         dependencies {
-            api(project(":ktor-server:ktor-server-core", configuration = "testOutput"))
             api(project(":ktor-server:ktor-server-config-yaml"))
             api(libs.kotlin.test)
         }

--- a/ktor-server/ktor-server-test-suites/build.gradle.kts
+++ b/ktor-server/ktor-server-test-suites/build.gradle.kts
@@ -25,12 +25,4 @@ kotlin.sourceSets {
             implementation(project(":ktor-server:ktor-server-plugins:ktor-server-request-validation"))
         }
     }
-
-    jvmTest {
-        dependencies {
-            api(project(":ktor-server:ktor-server-core", configuration = "testOutput"))
-
-            api(libs.logback.classic)
-        }
-    }
 }

--- a/ktor-server/ktor-server-tests/build.gradle.kts
+++ b/ktor-server/ktor-server-tests/build.gradle.kts
@@ -1,3 +1,7 @@
+/*
+ * Copyright 2014-2025 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
 description = ""
 
 plugins {
@@ -16,8 +20,6 @@ kotlin.sourceSets {
         dependencies {
             implementation(libs.jansi)
             implementation(project(":ktor-client:ktor-client-plugins:ktor-client-encoding"))
-            api(project(":ktor-server:ktor-server-core", configuration = "testOutput"))
-            api(libs.logback.classic)
             api(project(":ktor-server:ktor-server-plugins:ktor-server-sse"))
         }
     }

--- a/ktor-server/ktor-server-tomcat-jakarta/build.gradle.kts
+++ b/ktor-server/ktor-server-tomcat-jakarta/build.gradle.kts
@@ -1,3 +1,7 @@
+/*
+ * Copyright 2014-2025 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
 description = ""
 
 kotlin.sourceSets {
@@ -14,8 +18,6 @@ kotlin.sourceSets {
             api(project(":ktor-server:ktor-server-test-base"))
             api(project(":ktor-server:ktor-server-test-suites"))
             api(project(":ktor-server:ktor-server-core"))
-            api(project(":ktor-server:ktor-server-core", configuration = "testOutput"))
-            api(libs.logback.classic)
         }
     }
 }

--- a/ktor-server/ktor-server-tomcat/build.gradle.kts
+++ b/ktor-server/ktor-server-tomcat/build.gradle.kts
@@ -1,3 +1,7 @@
+/*
+ * Copyright 2014-2025 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
 description = ""
 
 kotlin.sourceSets {
@@ -14,8 +18,6 @@ kotlin.sourceSets {
             api(project(":ktor-server:ktor-server-test-base"))
             api(project(":ktor-server:ktor-server-test-suites"))
             api(project(":ktor-server:ktor-server-core"))
-            api(project(":ktor-server:ktor-server-core", configuration = "testOutput"))
-            api(libs.logback.classic)
         }
     }
 }


### PR DESCRIPTION
**Subsystem**
Infrastructure

**Motivation**
Cleanup before moving JVM target configs to the `build-logic` in [KTOR-7743](https://youtrack.jetbrains.com/issue/KTOR-7743).

**Solution**
- Remove jetty-apln-boot as it is not necessary anymore
- Move test logback config to `ktor-server-test-base` and remove `testOutput` configuration

