### PR TITLE
KTOR-8091 Fix ktor-client-curl publishing

### DIFF
--- a/buildSrc/src/main/kotlin/TargetsConfig.kt
+++ b/buildSrc/src/main/kotlin/TargetsConfig.kt
@@ -13,11 +13,12 @@ val Project.hasCommon: Boolean get() = files.any { it.name == "common" }
 val Project.hasNonJvm: Boolean get() = files.any { it.name == "nonJvm" }
 val Project.hasJvmAndPosix: Boolean get() = hasCommon || files.any { it.name == "jvmAndPosix" }
 val Project.hasPosix: Boolean get() = hasCommon || hasNonJvm || hasJvmAndPosix || files.any { it.name == "posix" }
+val Project.hasDesktop: Boolean get() = hasPosix || files.any { it.name == "desktop" }
 val Project.hasNix: Boolean get() = hasPosix || files.any { it.name == "nix" }
-val Project.hasLinux: Boolean get() = hasNix || files.any { it.name == "linux" }
-val Project.hasDarwin: Boolean get() = hasNix || files.any { it.name == "darwin" }
+val Project.hasLinux: Boolean get() = hasNix || hasDesktop || files.any { it.name == "linux" }
+val Project.hasDarwin: Boolean get() = hasNix || hasDesktop || files.any { it.name == "darwin" }
 val Project.hasAndroidNative: Boolean get() = hasPosix || files.any { it.name == "androidNative" }
-val Project.hasWindows: Boolean get() = hasPosix || files.any { it.name == "windows" }
+val Project.hasWindows: Boolean get() = hasPosix || hasDesktop || files.any { it.name == "windows" }
 val Project.hasJsAndWasmShared: Boolean get() = hasCommon || hasNonJvm || files.any { it.name == "jsAndWasmShared" }
 val Project.hasJs: Boolean get() = hasJsAndWasmShared || files.any { it.name == "js" }
 val Project.hasWasmJs: Boolean get() = hasJsAndWasmShared || files.any { it.name == "wasmJs" }


### PR DESCRIPTION
**Subsystem**
Infrastructure

**Motivation**
[KTOR-8091](https://youtrack.jetbrains.com/issue/KTOR-8091) ktor-client-curl artifacts aren’t published after EAP 1146

**Solution**
Aggregating tasks relay on the flags declared in `TargetsConfig`. Unfortunately, these flags were out of sync a bit (#4616 should fix this problem) and this caused `ktor-client-curl` not to be published.
```kotlin
private fun Project.configureAggregatingTasks() {
    // ...
    // These three were false if only "desktop" source-set is present.
    if (hasLinux) registerAggregatingTask("Linux", linuxTargets)
    if (hasWindows) registerAggregatingTask("Windows", windowsTargets)
    if (hasDarwin) registerAggregatingTask("Darwin", darwinTargets)
    // ...
}
```