### PR TITLE
KTOR-8051 Fix EOFException on retry body check

### DIFF
--- a/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/HttpRequestRetry.kt
+++ b/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/HttpRequestRetry.kt
@@ -235,7 +235,6 @@ public class HttpRequestRetryConfig {
  * }
  * ```
  */
-@OptIn(InternalAPI::class)
 @Suppress("NAME_SHADOWING")
 public val HttpRequestRetry: ClientPlugin<HttpRequestRetryConfig> = createClientPlugin(
     "RetryFeature",
@@ -317,9 +316,7 @@ public val HttpRequestRetry: ClientPlugin<HttpRequestRetryConfig> = createClient
                 call = proceed(subRequest)
                 if (!shouldRetry(retryCount, maxRetries, shouldRetry, call)) {
                     // throws exception if body is corrupt
-                    if (call.response.isSaved && !call.response.rawContent.isClosedForRead) {
-                        call.response.readBytes(0)
-                    }
+                    call.response.throwOnInvalidResponseBody()
                     break
                 }
                 HttpRetryEventData(subRequest, ++retryCount, call.response, null)
@@ -430,4 +427,11 @@ private fun Throwable.isTimeoutException(): Boolean {
     return exception is HttpRequestTimeoutException ||
         exception is ConnectTimeoutException ||
         exception is SocketTimeoutException
+}
+
+@OptIn(InternalAPI::class)
+private suspend fun HttpResponse.throwOnInvalidResponseBody(): Boolean {
+    // wait for saved content to pass through intermediate processing
+    // if the encoding is wrong, then this will throw an exception
+    return isSaved && rawContent.awaitContent()
 }

--- a/ktor-io/common/src/io/ktor/utils/io/ByteReadChannelOperations.kt
+++ b/ktor-io/common/src/io/ktor/utils/io/ByteReadChannelOperations.kt
@@ -460,12 +460,9 @@ public val ByteReadChannel.availableForRead: Int
  */
 @OptIn(InternalAPI::class)
 public suspend fun ByteReadChannel.readFully(out: ByteArray, start: Int = 0, end: Int = out.size) {
-    if (isClosedForRead) throw EOFException("Channel is already closed")
-
     var offset = start
     while (offset < end) {
         if (readBuffer.exhausted()) awaitContent()
-        if (isClosedForRead) throw EOFException("Channel is already closed")
 
         val count = min(end - offset, readBuffer.remaining.toInt())
         readBuffer.readTo(out, offset, offset + count)


### PR DESCRIPTION
**Subsystem**
Client, HttpRequestRetry

**Motivation**
[KTOR-8051](https://youtrack.jetbrains.com/issue/KTOR-8051) HttpRequestRetry: race condition for isClosedForRead leads to EOFException: Channel is already closed

**Solution**
This was actually caused by some unnecessary checks in byte read operations.  When the read buffer is closed, then it should fail through the normal path, throwing a `ClosedReadChannelException`.

