### PR TITLE
KTOR-6709 Fix URLParserException on minimal file url

### DIFF
--- a/ktor-http/common/src/io/ktor/http/URLParser.kt
+++ b/ktor-http/common/src/io/ktor/http/URLParser.kt
@@ -136,6 +136,10 @@ internal fun URLBuilder.takeFromUnsafe(urlString: String): URLBuilder {
 
 private fun URLBuilder.parseFile(urlString: String, startIndex: Int, endIndex: Int, slashCount: Int) {
     when (slashCount) {
+        1 -> {
+            host = ""
+            encodedPath = urlString.substring(startIndex, endIndex)
+        }
         2 -> {
             val nextSlash = urlString.indexOf('/', startIndex)
             if (nextSlash == -1 || nextSlash == endIndex) {

--- a/ktor-http/common/test/io/ktor/tests/http/UrlTest.kt
+++ b/ktor-http/common/test/io/ktor/tests/http/UrlTest.kt
@@ -265,6 +265,15 @@ class UrlTest {
     }
 
     @Test
+    fun testForFileProtocolMinimalRepresentation() {
+        val result = Url("file:/var/www")
+        assertEquals("file", result.protocol.name)
+        assertEquals("", result.host)
+        assertEquals(listOf("var", "www"), result.rawSegments)
+        assertEquals("file:///var/www", result.toString())
+    }
+
+    @Test
     fun testForMailProtocol() {
         val expectedUrl = "mailto:abc@xyz.io"
         val resultUrl = Url(expectedUrl)


### PR DESCRIPTION
**Subsystem**
Core, ktor-http

**Motivation**
Resolves [KTOR-6709](https://youtrack.jetbrains.com/issue/KTOR-6709) Fail to parse url: file:/path/to/file.txt. URLParser does not support file urls with a single leading `/`.

**Solution**
Add when clause to `URLBuilder.parseFilefor` extension function to match a single leading slash. 
It sets the host to empty string and the rest of the url as encodedPath.

Does **not** modify how URLBuilders `toString()` is implemented. Leading to `Url("file:/var/www").toString()` returning `"file:///var/www"`.

