### PR TITLE
KTOR-8051 Revert EOFException change

### DIFF
--- a/ktor-io/common/src/io/ktor/utils/io/ByteReadChannelOperations.kt
+++ b/ktor-io/common/src/io/ktor/utils/io/ByteReadChannelOperations.kt
@@ -460,9 +460,11 @@ public val ByteReadChannel.availableForRead: Int
  */
 @OptIn(InternalAPI::class)
 public suspend fun ByteReadChannel.readFully(out: ByteArray, start: Int = 0, end: Int = out.size) {
+    if (end > start && isClosedForRead) throw EOFException("Channel is already closed")
     var offset = start
     while (offset < end) {
         if (readBuffer.exhausted()) awaitContent()
+        if (isClosedForRead) throw EOFException("Channel is already closed")
 
         val count = min(end - offset, readBuffer.remaining.toInt())
         readBuffer.readTo(out, offset, offset + count)


### PR DESCRIPTION
**Subsystem**
Core, I/O

**Motivation**
Reverts the change in https://github.com/ktorio/ktor/pull/4619 that removes these exceptions.  My original assumption is that the closed channel exception would make more sense to throw since it's consistent with the rest of the library and contains some more context, but I found some websocket client code that relies on this behaviour, so it'd be best to keep this as is.

**Solution**
Rolled back this change, but with an extra check to ensure readFully with empty bounds is a no-op.

