### PR TITLE
Renovate: Fix Ktor EAP updates

### DIFF
--- a/build-logic/src/main/kotlin/ktorbuild/internal/Version.kt
+++ b/build-logic/src/main/kotlin/ktorbuild/internal/Version.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2024 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2014-2025 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package ktorbuild.internal
@@ -14,13 +14,13 @@ import org.gradle.api.Project
  * ```
  */
 internal fun Project.resolveVersion(): String {
-    val projectVersion = version.toString().removeSuffix("-SNAPSHOT")
+    val projectVersion = project.version.toString()
     val releaseVersion = findProperty("releaseVersion")?.toString()
     val eapVersion = findProperty("eapVersion")?.toString()
 
     return when {
         releaseVersion != null -> releaseVersion
-        eapVersion != null -> "$projectVersion-eap-$eapVersion"
+        eapVersion != null -> "${projectVersion.removeSuffix("-SNAPSHOT")}-eap-$eapVersion"
         else -> projectVersion
     }
 }

--- a/renovate.json
+++ b/renovate.json
@@ -15,6 +15,10 @@
       "matchPackageNames": [
         "io.ktor:*"
       ],
+      "registryUrls": [
+        "https://maven.pkg.jetbrains.space/public/p/ktor/eap",
+        "https://repo.maven.apache.org/maven2"
+      ],
       "fetchChangeLogs": "off",
       "versioning": "regex:^(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)(?:(?:-.+)?-eap-(?<build>\\d+))?$"
     },


### PR DESCRIPTION
**Subsystem**
Renovate

**Motivation**
Renovate stopped creating PRs with Ktor EAP updates.

**Solution**
Manually specify registries for Ktor.
Also fix a versioning issue when Ktor is built locally. 

