### PR TITLE
KTOR-8105 Fix concurrent flush attempts corrupting segment pool

### DIFF
--- a/ktor-network/jvm/src/io/ktor/network/sockets/NIOSocketImpl.kt
+++ b/ktor-network/jvm/src/io/ktor/network/sockets/NIOSocketImpl.kt
@@ -62,7 +62,6 @@ internal abstract class NIOSocketImpl<out S>(
     override fun close() {
         if (!closeFlag.compareAndSet(false, true)) return
 
-        readerJob.get()?.channel?.close()
         writerJob.get()?.cancel()
         checkChannels()
     }

--- a/ktor-network/jvm/test/io/ktor/network/sockets/tests/ServerSocketTest.kt
+++ b/ktor-network/jvm/test/io/ktor/network/sockets/tests/ServerSocketTest.kt
@@ -6,6 +6,7 @@ package io.ktor.network.sockets.tests
 
 import io.ktor.network.selector.*
 import io.ktor.network.sockets.*
+import io.ktor.util.cio.*
 import io.ktor.utils.io.*
 import kotlinx.coroutines.*
 import kotlinx.coroutines.debug.junit5.CoroutinesTimeout
@@ -15,7 +16,6 @@ import java.nio.channels.ClosedChannelException
 import java.util.concurrent.CancellationException
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.Executors
-import kotlin.concurrent.Volatile
 import kotlin.concurrent.thread
 import kotlin.coroutines.CoroutineContext
 import kotlin.test.AfterTest
@@ -90,8 +90,9 @@ class ServerSocketTest : CoroutineScope {
     @Test
     fun testWrite() {
         val server = server { client ->
-            val channel = client.openWriteChannel(true)
-            channel.writeStringUtf8("123")
+            client.openWriteChannel(true).use {
+                writeStringUtf8("123")
+            }
         }
 
         client { socket ->


### PR DESCRIPTION
**Subsystem**
Client, CIO

**Motivation**
Should solve all of our concurrency woes:
- [KTOR-8105](https://youtrack.jetbrains.com/issue/KTOR-8105) Race condition when writing to a buffer leads to NPE inside CIOReaderKt.readFrom
- [KTOR-8086](https://youtrack.jetbrains.com/issue/KTOR-8086) NPE in readBuffer
- [KTOR-8096](https://youtrack.jetbrains.com/issue/KTOR-8096) ArrayIndexOutOfBounds kotlinx-io

**Solution**
I found that the NIOSocketImpl is flushing the same channel as the TLS encoder coroutine, which can potentially lead to corruption due to the encoder writing the "close" message, then performing its own flushAndClose.

The stack traces in question:

```
[1318671573] write @ call-context#1025
  io.ktor.utils.io.ByteChannel.flush(ByteChannel.kt:91)
  io.ktor.utils.io.ByteChannel.flushAndClose(ByteChannel.kt:127)
  io.ktor.utils.io.CloseHookByteWriteChannel.flushAndClose(CloseHookByteWriteChannel.kt:21)
  io.ktor.utils.io.ByteWriteChannelKt$close$1.invoke(ByteWriteChannel.kt:39)
  io.ktor.utils.io.ByteWriteChannelKt$close$1.invoke(ByteWriteChannel.kt:39)
  kotlin.coroutines.intrinsics.IntrinsicsKt__IntrinsicsJvmKt$createCoroutineUnintercepted$$inlined$createCoroutineFromSuspendFunction$IntrinsicsKt__IntrinsicsJvmKt$1.invokeSuspend(IntrinsicsJvm.kt:223)
  kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
  kotlinx.coroutines.internal.DispatchedContinuationKt.resumeCancellableWith(DispatchedContinuation.kt:279)
  kotlinx.coroutines.intrinsics.CancellableKt.startCoroutineCancellable(Cancellable.kt:16)
  io.ktor.utils.io.ByteWriteChannelOperationsKt.fireAndForget(ByteWriteChannelOperations.kt:215)
  io.ktor.utils.io.ByteWriteChannelKt.close(ByteWriteChannel.kt:39)
  io.ktor.network.sockets.NIOSocketImpl.close(NIOSocketImpl.kt:65)
  io.ktor.network.tls.TLSCommonKt.tls(TLSCommon.kt:43)
  io.ktor.network.tls.TLSCommonKt$tls$3.invokeSuspend(TLSCommon.kt)
  kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
  kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:98)
  kotlinx.coroutines.internal.LimitedDispatcher$Worker.run(LimitedDispatcher.kt:113)
  kotlinx.coroutines.scheduling.TaskImpl.run(Tasks.kt:89)
  kotlinx.coroutines.scheduling.CoroutineScheduler.runSafely(CoroutineScheduler.kt:586)
  kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.executeTask(CoroutineScheduler.kt:820)
  kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.runWorker(CoroutineScheduler.kt:717)
  kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run(CoroutineScheduler.kt:704)
[1318671573] write @ cio-to-nio-writer#2264
  io.ktor.utils.io.ByteChannel.flush(ByteChannel.kt:91)
  io.ktor.utils.io.ByteChannel.flushAndClose(ByteChannel.kt:127)
  io.ktor.utils.io.ByteReadChannelOperationsKt$reader$job$1.invokeSuspend(ByteReadChannelOperations.kt:319)
  kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
  kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:98)
  kotlinx.coroutines.internal.LimitedDispatcher$Worker.run(LimitedDispatcher.kt:113)
  kotlinx.coroutines.scheduling.TaskImpl.run(Tasks.kt:89)
  kotlinx.coroutines.scheduling.CoroutineScheduler.runSafely(CoroutineScheduler.kt:586)
  kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.executeTask(CoroutineScheduler.kt:820)
  kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.runWorker(CoroutineScheduler.kt:717)
  kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run(CoroutineScheduler.kt:704)
[1318671573] write @ cio-tls-encoder#2326
  io.ktor.utils.io.ByteChannel.getWriteBuffer(ByteChannel.kt:49)
  io.ktor.utils.io.ByteWriteChannelOperationsKt.writeByte(ByteWriteChannelOperations.kt:17)
  io.ktor.network.tls.RenderKt.writeRecord(Render.kt:18)
  io.ktor.network.tls.TLSClientHandshake$output$1.invokeSuspend(TLSClientHandshake.kt:120)
  kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
  kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:100)
  kotlinx.coroutines.internal.LimitedDispatcher$Worker.run(LimitedDispatcher.kt:113)
  kotlinx.coroutines.scheduling.TaskImpl.run(Tasks.kt:89)
  kotlinx.coroutines.scheduling.CoroutineScheduler.runSafely(CoroutineScheduler.kt:586)
  kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.executeTask(CoroutineScheduler.kt:820)
  kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.runWorker(CoroutineScheduler.kt:717)
  kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run(CoroutineScheduler.kt:704)
```
