### PR TITLE
KTOR-8133 Fix concurrent flush and close

### DIFF
--- a/ktor-io/common/src/io/ktor/utils/io/ByteReadChannelOperations.kt
+++ b/ktor-io/common/src/io/ktor/utils/io/ByteReadChannelOperations.kt
@@ -332,7 +332,6 @@ public fun CoroutineScope.reader(
             channel.close(cause)
         } finally {
             nested.join()
-            runCatching { channel.flushAndClose() }
         }
     }.apply {
         invokeOnCompletion {


### PR DESCRIPTION
**Subsystem**
Core, I/O

**Motivation**
[KTOR-8133](https://youtrack.jetbrains.com/issue/KTOR-8133) Audit Ktor codebase for potential byte channel race conditions

**Solution**
This extra close can lead to two concurrent writes.  Normally, the consumer closes the channel, which finishes this job.

Note: This is the last sketchy looking spot I've found in the core code.  I'll keep combing through the rest of the project, but with a lower priority.