### PR TITLE
KTOR-8135 Socket accept not throwing error on socket close on native

### DIFF
--- a/ktor-network/common/test/io/ktor/network/sockets/tests/TCPSocketTest.kt
+++ b/ktor-network/common/test/io/ktor/network/sockets/tests/TCPSocketTest.kt
@@ -168,4 +168,20 @@ class TCPSocketTest {
         serverConnection.close()
         server.close()
     }
+
+    @Test
+    fun testAcceptErrorOnSocketClose() = testSockets { selector ->
+        val socket = aSocket(selector)
+            .tcp()
+            .bind(InetSocketAddress("127.0.0.1", 0))
+
+        launch {
+            assertFailsWith<IOException> {
+                socket.accept()
+            }
+        }
+        delay(100) // Make sure socket is awaiting connection using ACCEPT
+
+        socket.close()
+    }
 }

--- a/ktor-network/jsAndWasmShared/src/io/ktor/network/sockets/ServerSocketContext.kt
+++ b/ktor-network/jsAndWasmShared/src/io/ktor/network/sockets/ServerSocketContext.kt
@@ -55,7 +55,7 @@ internal class ServerSocketContext(
 private class ServerSocketImpl(
     override val localAddress: SocketAddress,
     override val socketContext: Job,
-    private val incoming: ReceiveChannel<Socket>,
+    private val incoming: Channel<Socket>,
     private val server: Server
 ) : ServerSocket {
     override suspend fun accept(): Socket = incoming.receive()
@@ -68,6 +68,7 @@ private class ServerSocketImpl(
     }
 
     override fun close() {
+        incoming.close(IOException("Server socket closed"))
         socketContext.cancel("Server socket closed")
     }
 }

--- a/ktor-network/nix/src/io/ktor/network/selector/SelectUtilsNix.kt
+++ b/ktor-network/nix/src/io/ktor/network/selector/SelectUtilsNix.kt
@@ -200,6 +200,7 @@ internal actual class SelectorHelper {
         for (event in watchSet) {
             if (event.descriptor in closeSet) {
                 completed.add(event)
+                event.fail(IOException("Selectable closed"))
                 continue
             }
 

--- a/ktor-network/windows/src/io/ktor/network/selector/SelectUtilsWindows.kt
+++ b/ktor-network/windows/src/io/ktor/network/selector/SelectUtilsWindows.kt
@@ -10,6 +10,7 @@ import io.ktor.utils.io.*
 import io.ktor.utils.io.errors.*
 import kotlinx.cinterop.*
 import kotlinx.coroutines.*
+import kotlinx.io.IOException
 import platform.posix.*
 import kotlin.coroutines.cancellation.CancellationException
 
@@ -152,6 +153,7 @@ internal actual class SelectorHelper {
         watchSet.forEach { event ->
             if (event.descriptor in closeSet) {
                 completed.add(event)
+                event.fail(IOException("Selectable closed"))
                 return@forEach
             }
             val wsaEvent = wsaEvents.getValue(event.descriptor)


### PR DESCRIPTION
[KTOR-8135](https://youtrack.jetbrains.com/issue/KTOR-8135) Socket accept not throwing error on socket close on native

Test failed before on native macosArm64 but was successful on JVM, so native specific bug