### PR TITLE
KTOR-7299 Fix close race condition causing descriptor to be closed while select is still busy

### DIFF
--- a/ktor-network/nix/src/io/ktor/network/selector/SelectUtilsNix.kt
+++ b/ktor-network/nix/src/io/ktor/network/selector/SelectUtilsNix.kt
@@ -62,11 +62,11 @@ internal actual class SelectorHelper {
 
     actual fun requestTermination() {
         interestQueue.close()
-        closeQueue.close()
         wakeupSignal.signal()
     }
 
     private fun cleanup() {
+        closeQueue.close()
         while (true) {
             val event = closeQueue.removeFirstOrNull() ?: break
             closeDescriptor(event)

--- a/ktor-network/windows/src/io/ktor/network/selector/SelectUtilsWindows.kt
+++ b/ktor-network/windows/src/io/ktor/network/selector/SelectUtilsWindows.kt
@@ -43,11 +43,11 @@ internal actual class SelectorHelper {
 
     actual fun requestTermination() {
         interestQueue.close()
-        closeQueue.close()
         wakeupSignal.signal()
     }
 
     private fun cleanup() {
+        closeQueue.close()
         while (true) {
             val event = closeQueue.removeFirstOrNull() ?: break
             closeDescriptor(event)


### PR DESCRIPTION
[KTOR-7299](https://youtrack.jetbrains.com/issue/KTOR-7299) IOException: Fail to select descriptor for ACCEPT

Unfortunately it does not resolve my specific issue, but I noticed this race condition when investigating the issue. 
I cannot consistently reproduce this in a test so I did not add it, but I was able to reproduce it sometimes throwing `kotlinx.io.IOException: Bad descriptor 5 for ACCEPT`. This means the descriptor was closed multiple times, which should never happen. With the changes in this PR (and after #4637 is merged which I discovered due to this issue) it will throw `kotlinx.io.IOException: Selectable closed` instead. This is in line with JVM which throws ClosedChannelException (so IOException).

Explanation of race condition before this PR:
1. Closing selectormanager closes the closeQueue: https://github.com/ktorio/ktor/blob/e4fd251825d741350746c474881f8243b843d0d6/ktor-network/nix/src/io/ktor/network/selector/SelectUtilsNix.kt#L65
2. any further calls to notifyClosed will call closeDescriptor because closeQueue is already closed: https://github.com/ktorio/ktor/blob/e4fd251825d741350746c474881f8243b843d0d6/ktor-network/nix/src/io/ktor/network/selector/SelectUtilsNix.kt#L77-L83
3. the above could happen while the selectionLoop is still active (because wakeupSignal.signal() could take some time). That means the descriptor is closed while select is still busy!

Fixed the above issue by moving `closeQueue.close()` to after the selection loop has finished so descriptors are not closed while select is still busy.
