### PR TITLE
KTOR-8136 Introduce ServerSocket.port to simplify port access for the bound server

### DIFF
--- a/ktor-network/api/ktor-network.api
+++ b/ktor-network/api/ktor-network.api
@@ -232,6 +232,10 @@ public final class io/ktor/network/sockets/Socket$DefaultImpls {
 public abstract class io/ktor/network/sockets/SocketAddress {
 }
 
+public final class io/ktor/network/sockets/SocketAddressKt {
+	public static final fun port (Lio/ktor/network/sockets/SocketAddress;)I
+}
+
 public final class io/ktor/network/sockets/SocketBuilder : io/ktor/network/sockets/Configurable {
 	public synthetic fun configure (Lkotlin/jvm/functions/Function1;)Lio/ktor/network/sockets/Configurable;
 	public fun configure (Lkotlin/jvm/functions/Function1;)Lio/ktor/network/sockets/SocketBuilder;
@@ -291,6 +295,7 @@ public final class io/ktor/network/sockets/SocketOptions$UDPSocketOptions : io/k
 public final class io/ktor/network/sockets/SocketsKt {
 	public static final fun awaitClosed (Lio/ktor/network/sockets/ASocket;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static final fun connection (Lio/ktor/network/sockets/Socket;)Lio/ktor/network/sockets/Connection;
+	public static final fun getPort (Lio/ktor/network/sockets/ServerSocket;)I
 	public static final fun isClosed (Lio/ktor/network/sockets/ASocket;)Z
 	public static final fun openReadChannel (Lio/ktor/network/sockets/AReadable;)Lio/ktor/utils/io/ByteReadChannel;
 	public static final fun openWriteChannel (Lio/ktor/network/sockets/AWritable;Z)Lio/ktor/utils/io/ByteWriteChannel;

--- a/ktor-network/api/ktor-network.klib.api
+++ b/ktor-network/api/ktor-network.klib.api
@@ -269,10 +269,13 @@ sealed class io.ktor.network.sockets/SocketOptions { // io.ktor.network.sockets/
 
 final val io.ktor.network.sockets/isClosed // io.ktor.network.sockets/isClosed|@io.ktor.network.sockets.ASocket{}isClosed[0]
     final fun (io.ktor.network.sockets/ASocket).<get-isClosed>(): kotlin/Boolean // io.ktor.network.sockets/isClosed.<get-isClosed>|<get-isClosed>@io.ktor.network.sockets.ASocket(){}[0]
+final val io.ktor.network.sockets/port // io.ktor.network.sockets/port|@io.ktor.network.sockets.ServerSocket{}port[0]
+    final fun (io.ktor.network.sockets/ServerSocket).<get-port>(): kotlin/Int // io.ktor.network.sockets/port.<get-port>|<get-port>@io.ktor.network.sockets.ServerSocket(){}[0]
 
 final fun (io.ktor.network.sockets/AReadable).io.ktor.network.sockets/openReadChannel(): io.ktor.utils.io/ByteReadChannel // io.ktor.network.sockets/openReadChannel|openReadChannel@io.ktor.network.sockets.AReadable(){}[0]
 final fun (io.ktor.network.sockets/AWritable).io.ktor.network.sockets/openWriteChannel(kotlin/Boolean = ...): io.ktor.utils.io/ByteWriteChannel // io.ktor.network.sockets/openWriteChannel|openWriteChannel@io.ktor.network.sockets.AWritable(kotlin.Boolean){}[0]
 final fun (io.ktor.network.sockets/Socket).io.ktor.network.sockets/connection(): io.ktor.network.sockets/Connection // io.ktor.network.sockets/connection|connection@io.ktor.network.sockets.Socket(){}[0]
+final fun (io.ktor.network.sockets/SocketAddress).io.ktor.network.sockets/port(): kotlin/Int // io.ktor.network.sockets/port|port@io.ktor.network.sockets.SocketAddress(){}[0]
 final fun <#A: io.ktor.network.sockets/Configurable<#A, *>> (#A).io.ktor.network.sockets/tcpNoDelay(): #A // io.ktor.network.sockets/tcpNoDelay|tcpNoDelay@0:0(){0§<io.ktor.network.sockets.Configurable<0:0,*>>}[0]
 final fun io.ktor.network.selector/SelectorManager(kotlin.coroutines/CoroutineContext = ...): io.ktor.network.selector/SelectorManager // io.ktor.network.selector/SelectorManager|SelectorManager(kotlin.coroutines.CoroutineContext){}[0]
 final fun io.ktor.network.sockets/aSocket(io.ktor.network.selector/SelectorManager): io.ktor.network.sockets/SocketBuilder // io.ktor.network.sockets/aSocket|aSocket(io.ktor.network.selector.SelectorManager){}[0]

--- a/ktor-network/common/src/io/ktor/network/sockets/SocketAddress.kt
+++ b/ktor-network/common/src/io/ktor/network/sockets/SocketAddress.kt
@@ -4,7 +4,29 @@
 
 package io.ktor.network.sockets
 
+/**
+ * Represents a socket address abstraction.
+ *
+ * This sealed class serves as the base type for different kinds of socket addresses,
+ * such as Internet-specific or other platform-dependent address types.
+ * Implementations of this class are expected to be platform-specific and provide
+ * details necessary to work with socket connections or bindings.
+ */
 public expect sealed class SocketAddress
+
+/**
+ * Retrieves the port number associated with this socket address.
+ *
+ * If the `SocketAddress` instance is of type `InetSocketAddress`, the associated port is returned.
+ * Otherwise, an `UnsupportedOperationException` is thrown, as the provided address type does not support ports.
+ *
+ * @return the port number of the socket address if available.
+ * @throws UnsupportedOperationException if the socket address type does not support a port.
+ */
+public fun SocketAddress.port(): Int = when (this) {
+    is InetSocketAddress -> port
+    else -> throw UnsupportedOperationException("SocketAddress $this does not have a port")
+}
 
 public expect class InetSocketAddress(
     hostname: String,

--- a/ktor-network/common/src/io/ktor/network/sockets/Sockets.kt
+++ b/ktor-network/common/src/io/ktor/network/sockets/Sockets.kt
@@ -166,11 +166,18 @@ public fun AWritable.openWriteChannel(autoFlush: Boolean = false): ByteWriteChan
 public interface Socket : ReadWriteSocket, ABoundSocket, AConnectedSocket, CoroutineScope
 
 /**
- * Represents a server bound socket ready for accepting connections
+ * Represents a server-bound socket ready for accepting connections
  *
  * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.network.sockets.ServerSocket)
  */
 public interface ServerSocket : ASocket, ABoundSocket, Acceptable<Socket>
+
+/**
+ * The port number of the current server.
+ *
+ * @throws UnsupportedOperationException if the local socket address does not support a port.
+ */
+public val ServerSocket.port: Int get() = localAddress.port()
 
 public expect class SocketTimeoutException(message: String) : IOException
 


### PR DESCRIPTION
[KTOR-8136](https://youtrack.jetbrains.com/issue/KTOR-8136) Introduce ServerSocket.port to simplify port access for the bound server