### PR TITLE
KTOR-7734 JS: Catch error on channel reader closure

### DIFF
--- a/ktor-client/ktor-client-core/js/src/io/ktor/client/engine/js/browser/BrowserFetch.kt
+++ b/ktor-client/ktor-client-core/js/src/io/ktor/client/engine/js/browser/BrowserFetch.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2014-2025 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package io.ktor.client.engine.js.browser
@@ -7,13 +7,15 @@ package io.ktor.client.engine.js.browser
 import io.ktor.client.engine.js.*
 import io.ktor.client.fetch.*
 import io.ktor.utils.io.*
-import kotlinx.coroutines.*
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.suspendCancellableCoroutine
 import org.khronos.webgl.Uint8Array
 import org.w3c.fetch.Response
-import kotlin.coroutines.*
+import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
 
 internal fun CoroutineScope.readBodyBrowser(response: Response): ByteReadChannel {
-    @Suppress("UNCHECKED_CAST_TO_EXTERNAL_INTERFACE")
+    @Suppress("UnsafeCastFromDynamic")
     val stream: ReadableStream<Uint8Array> = response.body ?: return ByteReadChannel.Empty
     return channelFromStream(stream)
 }
@@ -22,15 +24,15 @@ internal fun CoroutineScope.channelFromStream(
     stream: ReadableStream<Uint8Array>
 ): ByteReadChannel = writer {
     val reader: ReadableStreamDefaultReader<Uint8Array> = stream.getReader()
-    while (true) {
-        try {
+    try {
+        while (true) {
             val chunk = reader.readChunk() ?: break
             channel.writeFully(chunk.asByteArray())
             channel.flush()
-        } catch (cause: Throwable) {
-            reader.cancel(cause)
-            throw cause
         }
+    } catch (cause: Throwable) {
+        reader.cancel(cause)
+        throw cause
     }
 }.channel
 
@@ -39,7 +41,7 @@ internal suspend fun ReadableStreamDefaultReader<Uint8Array>.readChunk(): Uint8A
         read().then {
             val chunk = it.value
             val result = if (it.done) null else chunk
-            continuation.resumeWith(Result.success(result))
+            continuation.resume(result)
         }.catch { cause ->
             continuation.resumeWithException(cause)
         }

--- a/ktor-client/ktor-client-core/js/src/io/ktor/client/engine/js/compatibility/Utils.kt
+++ b/ktor-client/ktor-client-core/js/src/io/ktor/client/engine/js/compatibility/Utils.kt
@@ -13,6 +13,8 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.InternalCoroutinesApi
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
 import kotlin.js.Promise
 
 @OptIn(InternalCoroutinesApi::class)
@@ -39,10 +41,10 @@ internal suspend fun commonFetch(
 
     promise.then(
         onFulfilled = {
-            continuation.resumeWith(Result.success(it))
+            continuation.resume(it)
         },
         onRejected = {
-            continuation.resumeWith(Result.failure(Error("Fail to fetch", it)))
+            continuation.resumeWithException(Error("Fail to fetch", it))
         }
     ).finally { abortOnCallCompletion.dispose() }
 }

--- a/ktor-client/ktor-client-core/js/src/io/ktor/client/engine/js/compatibility/Utils.kt
+++ b/ktor-client/ktor-client-core/js/src/io/ktor/client/engine/js/compatibility/Utils.kt
@@ -27,9 +27,7 @@ internal suspend fun commonFetch(
     val controller = AbortController()
     init.signal = controller.signal
 
-    val abortOnCallCompletion = callJob.invokeOnCompletion(onCancelling = true) {
-        controller.abort()
-    }
+    callJob.invokeOnCompletion(onCancelling = true) { controller.abort() }
 
     val promise: Promise<org.w3c.fetch.Response> = when {
         PlatformUtils.IS_BROWSER -> fetch(input, init)
@@ -46,7 +44,7 @@ internal suspend fun commonFetch(
         onRejected = {
             continuation.resumeWithException(Error("Fail to fetch", it))
         }
-    ).finally { abortOnCallCompletion.dispose() }
+    )
 }
 
 private fun AbortController(): AbortController = js("new AbortController()")

--- a/ktor-client/ktor-client-core/wasmJs/src/io/ktor/client/engine/js/browser/BrowserFetch.kt
+++ b/ktor-client/ktor-client-core/wasmJs/src/io/ktor/client/engine/js/browser/BrowserFetch.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2023 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2014-2025 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package io.ktor.client.engine.js.browser
@@ -8,10 +8,12 @@ import io.ktor.client.engine.js.*
 import io.ktor.client.fetch.*
 import io.ktor.client.utils.*
 import io.ktor.utils.io.*
-import kotlinx.coroutines.*
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.suspendCancellableCoroutine
 import org.khronos.webgl.Uint8Array
 import org.w3c.fetch.Response
-import kotlin.coroutines.*
+import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
 
 internal fun CoroutineScope.readBodyBrowser(response: Response): ByteReadChannel {
     val stream: ReadableStream<Uint8Array?> = response.body?.unsafeCast() ?: return ByteReadChannel.Empty
@@ -22,24 +24,24 @@ internal fun CoroutineScope.channelFromStream(
     stream: ReadableStream<Uint8Array?>
 ): ByteReadChannel = writer {
     val reader: ReadableStreamDefaultReader<Uint8Array?> = stream.getReader()
-    while (true) {
-        try {
+    try {
+        while (true) {
             val chunk = reader.readChunk() ?: break
             channel.writeFully(chunk.asByteArray())
             channel.flush()
-        } catch (cause: Throwable) {
-            reader.cancel(cause.toJsReference())
-            throw cause
         }
+    } catch (cause: Throwable) {
+        reader.cancel(cause.toJsReference())
+        throw cause
     }
 }.channel
 
 internal suspend fun ReadableStreamDefaultReader<Uint8Array?>.readChunk(): Uint8Array? =
-    suspendCancellableCoroutine<Uint8Array?> { continuation ->
+    suspendCancellableCoroutine { continuation ->
         read().then { stream: ReadableStreamReadResult<Uint8Array?> ->
             val chunk = stream.value
             val result = if (stream.done || chunk == null) null else chunk
-            continuation.resumeWith(Result.success(result))
+            continuation.resume(result)
             null
         }.catch { cause: JsAny ->
             continuation.resumeWithException(JsError(cause))

--- a/ktor-client/ktor-client-core/wasmJs/src/io/ktor/client/engine/js/browser/BrowserFetch.kt
+++ b/ktor-client/ktor-client-core/wasmJs/src/io/ktor/client/engine/js/browser/BrowserFetch.kt
@@ -9,11 +9,12 @@ import io.ktor.client.fetch.*
 import io.ktor.client.utils.*
 import io.ktor.utils.io.*
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.await
 import org.khronos.webgl.Uint8Array
 import org.w3c.fetch.Response
 import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
+import kotlin.coroutines.suspendCoroutine
 
 internal fun CoroutineScope.readBodyBrowser(response: Response): ByteReadChannel {
     val stream: ReadableStream<Uint8Array?> = response.body?.unsafeCast() ?: return ByteReadChannel.Empty
@@ -31,13 +32,13 @@ internal fun CoroutineScope.channelFromStream(
             channel.flush()
         }
     } catch (cause: Throwable) {
-        reader.cancel(cause.toJsReference())
+        reader.cancel(cause.toJsReference()).catch { null }.await<Unit>()
         throw cause
     }
 }.channel
 
 internal suspend fun ReadableStreamDefaultReader<Uint8Array?>.readChunk(): Uint8Array? =
-    suspendCancellableCoroutine { continuation ->
+    suspendCoroutine { continuation ->
         read().then { stream: ReadableStreamReadResult<Uint8Array?> ->
             val chunk = stream.value
             val result = if (stream.done || chunk == null) null else chunk

--- a/ktor-client/ktor-client-core/wasmJs/src/io/ktor/client/engine/js/compatibility/Utils.kt
+++ b/ktor-client/ktor-client-core/wasmJs/src/io/ktor/client/engine/js/compatibility/Utils.kt
@@ -28,9 +28,7 @@ internal suspend fun commonFetch(
     val controller = AbortController()
     init.signal = controller.signal
 
-    val abortOnCallCompletion = callJob.invokeOnCompletion(onCancelling = true) {
-        controller.abort()
-    }
+    callJob.invokeOnCompletion(onCancelling = true) { controller.abort() }
 
     val promise: Promise<org.w3c.fetch.Response> = when {
         PlatformUtils.IS_BROWSER -> fetch(input, init)
@@ -54,7 +52,7 @@ internal suspend fun commonFetch(
             continuation.resumeWithException(Error("Fail to fetch", JsError(it)))
             null
         }
-    ).finally { abortOnCallCompletion.dispose() }
+    )
 }
 
 private fun AbortController(): AbortController {

--- a/ktor-client/ktor-client-core/wasmJs/src/io/ktor/client/engine/js/compatibility/Utils.kt
+++ b/ktor-client/ktor-client-core/wasmJs/src/io/ktor/client/engine/js/compatibility/Utils.kt
@@ -14,6 +14,8 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.InternalCoroutinesApi
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
 import kotlin.js.Promise
 
 @OptIn(InternalCoroutinesApi::class)
@@ -45,11 +47,11 @@ internal suspend fun commonFetch(
 
     promise.then(
         onFulfilled = { x: JsAny ->
-            continuation.resumeWith(Result.success(x.unsafeCast()))
+            continuation.resume(x.unsafeCast())
             null
         },
         onRejected = { it: JsAny ->
-            continuation.resumeWith(Result.failure(Error("Fail to fetch", JsError(it))))
+            continuation.resumeWithException(Error("Fail to fetch", JsError(it)))
             null
         }
     ).finally { abortOnCallCompletion.dispose() }


### PR DESCRIPTION
**Subsystem**
Client (JS/WasmJS)

**Motivation**
[KTOR-7734](https://youtrack.jetbrains.com/issue/KTOR-7734) "AbortError: BodyStreamBuffer was aborted" error when canceling parent job

**Solution**
Solution in #4629 wasn’t correct.
The actual root cause of the issue was an uncaught exception thrown inside a `Promise` returned by `reader.cancel()`. Added catching for this exception and reformatted code a bit.

It's better to review these two commits separately.