### PR TITLE
KTOR-7775 BasicAuth: Add clearToken method

### DIFF
--- a/ktor-client/ktor-client-plugins/ktor-client-auth/api/ktor-client-auth.api
+++ b/ktor-client/ktor-client-plugins/ktor-client-auth/api/ktor-client-auth.api
@@ -121,6 +121,7 @@ public final class io/ktor/client/plugins/auth/providers/DigestAuthProvider : io
 	public fun <init> (Lkotlin/jvm/functions/Function1;Ljava/lang/String;Ljava/lang/String;)V
 	public synthetic fun <init> (Lkotlin/jvm/functions/Function1;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun addRequestHeaders (Lio/ktor/client/request/HttpRequestBuilder;Lio/ktor/http/auth/HttpAuthHeader;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun clearToken ()V
 	public final fun getAlgorithmName ()Ljava/lang/String;
 	public final fun getRealm ()Ljava/lang/String;
 	public fun getSendWithoutRequest ()Z

--- a/ktor-client/ktor-client-plugins/ktor-client-auth/api/ktor-client-auth.api
+++ b/ktor-client/ktor-client-plugins/ktor-client-auth/api/ktor-client-auth.api
@@ -55,6 +55,7 @@ public final class io/ktor/client/plugins/auth/providers/BasicAuthProvider : io/
 	public fun <init> (Lkotlin/jvm/functions/Function1;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)V
 	public synthetic fun <init> (Lkotlin/jvm/functions/Function1;Ljava/lang/String;Lkotlin/jvm/functions/Function1;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun addRequestHeaders (Lio/ktor/client/request/HttpRequestBuilder;Lio/ktor/http/auth/HttpAuthHeader;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun clearToken ()V
 	public fun getSendWithoutRequest ()Z
 	public fun isApplicable (Lio/ktor/http/auth/HttpAuthHeader;)Z
 	public fun refreshToken (Lio/ktor/client/statement/HttpResponse;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;

--- a/ktor-client/ktor-client-plugins/ktor-client-auth/api/ktor-client-auth.klib.api
+++ b/ktor-client/ktor-client-plugins/ktor-client-auth/api/ktor-client-auth.klib.api
@@ -132,6 +132,7 @@ final class io.ktor.client.plugins.auth.providers/DigestAuthProvider : io.ktor.c
     final val sendWithoutRequest // io.ktor.client.plugins.auth.providers/DigestAuthProvider.sendWithoutRequest|{}sendWithoutRequest[0]
         final fun <get-sendWithoutRequest>(): kotlin/Boolean // io.ktor.client.plugins.auth.providers/DigestAuthProvider.sendWithoutRequest.<get-sendWithoutRequest>|<get-sendWithoutRequest>(){}[0]
 
+    final fun clearToken() // io.ktor.client.plugins.auth.providers/DigestAuthProvider.clearToken|clearToken(){}[0]
     final fun isApplicable(io.ktor.http.auth/HttpAuthHeader): kotlin/Boolean // io.ktor.client.plugins.auth.providers/DigestAuthProvider.isApplicable|isApplicable(io.ktor.http.auth.HttpAuthHeader){}[0]
     final fun sendWithoutRequest(io.ktor.client.request/HttpRequestBuilder): kotlin/Boolean // io.ktor.client.plugins.auth.providers/DigestAuthProvider.sendWithoutRequest|sendWithoutRequest(io.ktor.client.request.HttpRequestBuilder){}[0]
     final suspend fun addRequestHeaders(io.ktor.client.request/HttpRequestBuilder, io.ktor.http.auth/HttpAuthHeader?) // io.ktor.client.plugins.auth.providers/DigestAuthProvider.addRequestHeaders|addRequestHeaders(io.ktor.client.request.HttpRequestBuilder;io.ktor.http.auth.HttpAuthHeader?){}[0]

--- a/ktor-client/ktor-client-plugins/ktor-client-auth/api/ktor-client-auth.klib.api
+++ b/ktor-client/ktor-client-plugins/ktor-client-auth/api/ktor-client-auth.klib.api
@@ -52,6 +52,7 @@ final class io.ktor.client.plugins.auth.providers/BasicAuthProvider : io.ktor.cl
     final val sendWithoutRequest // io.ktor.client.plugins.auth.providers/BasicAuthProvider.sendWithoutRequest|{}sendWithoutRequest[0]
         final fun <get-sendWithoutRequest>(): kotlin/Boolean // io.ktor.client.plugins.auth.providers/BasicAuthProvider.sendWithoutRequest.<get-sendWithoutRequest>|<get-sendWithoutRequest>(){}[0]
 
+    final fun clearToken() // io.ktor.client.plugins.auth.providers/BasicAuthProvider.clearToken|clearToken(){}[0]
     final fun isApplicable(io.ktor.http.auth/HttpAuthHeader): kotlin/Boolean // io.ktor.client.plugins.auth.providers/BasicAuthProvider.isApplicable|isApplicable(io.ktor.http.auth.HttpAuthHeader){}[0]
     final fun sendWithoutRequest(io.ktor.client.request/HttpRequestBuilder): kotlin/Boolean // io.ktor.client.plugins.auth.providers/BasicAuthProvider.sendWithoutRequest|sendWithoutRequest(io.ktor.client.request.HttpRequestBuilder){}[0]
     final suspend fun addRequestHeaders(io.ktor.client.request/HttpRequestBuilder, io.ktor.http.auth/HttpAuthHeader?) // io.ktor.client.plugins.auth.providers/BasicAuthProvider.addRequestHeaders|addRequestHeaders(io.ktor.client.request.HttpRequestBuilder;io.ktor.http.auth.HttpAuthHeader?){}[0]

--- a/ktor-client/ktor-client-plugins/ktor-client-auth/common/src/io/ktor/client/plugins/auth/providers/BasicAuthProvider.kt
+++ b/ktor-client/ktor-client-plugins/ktor-client-auth/common/src/io/ktor/client/plugins/auth/providers/BasicAuthProvider.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2024 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2014-2025 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package io.ktor.client.plugins.auth.providers
@@ -161,6 +161,10 @@ public class BasicAuthProvider(
     override suspend fun refreshToken(response: HttpResponse): Boolean {
         tokensHolder.setToken(credentials)
         return true
+    }
+
+    public fun clearToken() {
+        tokensHolder.clearToken()
     }
 }
 

--- a/ktor-client/ktor-client-plugins/ktor-client-auth/common/src/io/ktor/client/plugins/auth/providers/BasicAuthProvider.kt
+++ b/ktor-client/ktor-client-plugins/ktor-client-auth/common/src/io/ktor/client/plugins/auth/providers/BasicAuthProvider.kt
@@ -163,6 +163,19 @@ public class BasicAuthProvider(
         return true
     }
 
+    /**
+     * Clears the currently stored authentication tokens from the cache.
+     *
+     * This method should be called in the following cases:
+     * - When the credentials have been updated and need to take effect
+     * - When you want to force re-authentication
+     * - When you want to clear sensitive authentication data
+     *
+     * Note: The result of [credentials] invocation is cached internally.
+     * Calling this method will force the next authentication attempt to fetch fresh credentials.
+     *
+     * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.client.plugins.auth.providers.BasicAuthProvider.clearToken)
+     */
     public fun clearToken() {
         tokensHolder.clearToken()
     }

--- a/ktor-client/ktor-client-plugins/ktor-client-auth/common/src/io/ktor/client/plugins/auth/providers/BasicAuthProvider.kt
+++ b/ktor-client/ktor-client-plugins/ktor-client-auth/common/src/io/ktor/client/plugins/auth/providers/BasicAuthProvider.kt
@@ -176,6 +176,7 @@ public class BasicAuthProvider(
      *
      * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.client.plugins.auth.providers.BasicAuthProvider.clearToken)
      */
+    @InternalAPI // TODO KTOR-8180: Provide control over tokens to user code
     public fun clearToken() {
         tokensHolder.clearToken()
     }

--- a/ktor-client/ktor-client-plugins/ktor-client-auth/common/src/io/ktor/client/plugins/auth/providers/BearerAuthProvider.kt
+++ b/ktor-client/ktor-client-plugins/ktor-client-auth/common/src/io/ktor/client/plugins/auth/providers/BearerAuthProvider.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2024 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2014-2025 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package io.ktor.client.plugins.auth.providers
@@ -162,6 +162,19 @@ public class BearerAuthProvider(
         return newToken != null
     }
 
+    /**
+     * Clears the currently stored authentication tokens from the cache.
+     *
+     * This method should be called in the following cases:
+     * - When access or refresh tokens have been updated externally
+     * - When you want to clear sensitive token data (for example, during logout)
+     *
+     * Note: The result of `loadTokens` invocation is cached internally.
+     * Calling this method will force the next authentication attempt to fetch fresh tokens
+     * through the configured `loadTokens` function.
+     *
+     * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.client.plugins.auth.providers.BearerAuthProvider.clearToken)
+     */
     public fun clearToken() {
         tokensHolder.clearToken()
     }

--- a/ktor-client/ktor-client-plugins/ktor-client-auth/common/src/io/ktor/client/plugins/auth/providers/DigestAuthProvider.kt
+++ b/ktor-client/ktor-client-plugins/ktor-client-auth/common/src/io/ktor/client/plugins/auth/providers/DigestAuthProvider.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2024 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2014-2025 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package io.ktor.client.plugins.auth.providers
@@ -13,7 +13,7 @@ import io.ktor.util.*
 import io.ktor.utils.io.*
 import io.ktor.utils.io.charsets.*
 import io.ktor.utils.io.core.*
-import kotlinx.atomicfu.*
+import kotlinx.atomicfu.atomic
 
 /**
  * Installs the client's [DigestAuthProvider].
@@ -217,5 +217,21 @@ public class DigestAuthProvider(
     private suspend fun makeDigest(data: String): ByteArray {
         val digest = Digest(algorithmName)
         return digest.build(data.toByteArray(Charsets.UTF_8))
+    }
+
+    /**
+     * Clears the currently stored authentication tokens from the cache.
+     *
+     * This method should be called in the following cases:
+     * - When the credentials have been updated and need to take effect
+     * - When you want to clear sensitive authentication data
+     *
+     * Note: The result of [credentials] invocation is cached internally.
+     * Calling this method will force the next authentication attempt to fetch fresh credentials.
+     *
+     * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.client.plugins.auth.providers.DigestAuthProvider.clearToken)
+     */
+    public fun clearToken() {
+        tokenHolder.clearToken()
     }
 }

--- a/ktor-client/ktor-client-plugins/ktor-client-auth/common/src/io/ktor/client/plugins/auth/providers/DigestAuthProvider.kt
+++ b/ktor-client/ktor-client-plugins/ktor-client-auth/common/src/io/ktor/client/plugins/auth/providers/DigestAuthProvider.kt
@@ -231,6 +231,7 @@ public class DigestAuthProvider(
      *
      * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.client.plugins.auth.providers.DigestAuthProvider.clearToken)
      */
+    @InternalAPI // TODO KTOR-8180: Provide control over tokens to user code
     public fun clearToken() {
         tokenHolder.clearToken()
     }

--- a/ktor-client/ktor-client-plugins/ktor-client-auth/common/test/io/ktor/client/plugins/auth/BasicProviderTest.kt
+++ b/ktor-client/ktor-client-plugins/ktor-client-auth/common/test/io/ktor/client/plugins/auth/BasicProviderTest.kt
@@ -8,6 +8,7 @@ import io.ktor.client.plugins.auth.providers.*
 import io.ktor.client.request.*
 import io.ktor.http.*
 import io.ktor.http.auth.*
+import io.ktor.utils.io.*
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -50,6 +51,7 @@ class BasicProviderTest {
         assertTrue(provider.isApplicable(header), "Provider with capitalized scheme should be applicable")
     }
 
+    @OptIn(InternalAPI::class)
     @Test
     fun `update credentials after clearToken`() = runTest {
         var credentials = BasicAuthCredentials("admin", "admin")


### PR DESCRIPTION
**Subsystem**
Client, Basic Auth

**Motivation**
[KTOR-7775](https://youtrack.jetbrains.com/issue/KTOR-7775) Auth: BasicAuthProvider caches credentials until process death

**Solution**
Add `BasicAuthProvider.clearToken` similarly to `BearerAuthProvider`. So now the token can be cleared the following way:
```kotlin
import io.ktor.client.plugins.auth.authProvider

client.authProvider<BasicAuthProvider>()?.clearToken()
```

Probably, we should come up with a common solution for clearing authorization tokens, but unlikely in 3.1.0.
