### PR TITLE
KTOR-8164 Bump tiny header limit in CIO engine

### DIFF
--- a/ktor-http/ktor-http-cio/common/src/io/ktor/http/cio/HttpHeadersMap.kt
+++ b/ktor-http/ktor-http-cio/common/src/io/ktor/http/cio/HttpHeadersMap.kt
@@ -7,7 +7,7 @@ package io.ktor.http.cio
 import io.ktor.http.cio.internals.*
 import io.ktor.utils.io.pool.*
 
-private const val EXPECTED_HEADERS_QTY = 64
+private const val EXPECTED_HEADERS_QTY = 512
 
 /*
  * index array structure

--- a/ktor-server/ktor-server-cio/common/test/io/ktor/tests/server/cio/CIOEngineTest.kt
+++ b/ktor-server/ktor-server-cio/common/test/io/ktor/tests/server/cio/CIOEngineTest.kt
@@ -4,6 +4,7 @@
 
 package io.ktor.tests.server.cio
 
+import io.ktor.client.request.header
 import io.ktor.client.statement.*
 import io.ktor.http.*
 import io.ktor.http.content.*
@@ -168,6 +169,26 @@ class CIOHttpServerTest : HttpServerCommonTestSuite<CIOApplicationEngine, CIOApp
             writePostBody(writeChannel, body)
             val response = readAvailable(readChannel)
             assertFalse(response.contains("100 Continue"))
+        }
+    }
+
+    @Test
+    fun testLotsOfHeaders() = runTest {
+        val count = 500
+        val implicitHeadersCount = 4
+
+        createAndStartServer {
+            get("/headers") {
+                call.respond("${call.request.headers.entries().size} headers received")
+            }
+        }
+        withUrl("/headers", {
+            repeat(count) {
+                header("HeaderName$it", "HeaderContent$it")
+            }
+        }) {
+            assertEquals(HttpStatusCode.OK, status)
+            assertEquals("${count + implicitHeadersCount} headers received", bodyAsText())
         }
     }
 


### PR DESCRIPTION
**Subsystem**
Server, CIO

**Motivation**
[KTOR-8164](https://youtrack.jetbrains.com/issue/KTOR-8164) CIO Server Engine fails for requests with more than 64 headers

**Solution**
Increased the header limit for now.  This dictates the size of elements in a common int array pool, so it shouldn't really adversely effect the memory consumption.