### PR TITLE
KTOR-8163 WasmJS: Add callbacks before awaiting connection

### DIFF
--- a/ktor-client/ktor-client-core/js/src/io/ktor/client/engine/js/JsClientEngine.kt
+++ b/ktor-client/ktor-client-core/js/src/io/ktor/client/engine/js/JsClientEngine.kt
@@ -98,7 +98,6 @@ internal class JsClientEngine(
 
         val urlString = request.url.toString()
         val socket: WebSocket = createWebSocket(urlString, request.headers)
-
         val session = JsWebSocketSession(callContext, socket)
 
         try {

--- a/ktor-client/ktor-client-core/wasmJs/src/io/ktor/client/engine/js/WasmJsClientEngine.kt
+++ b/ktor-client/ktor-client-core/wasmJs/src/io/ktor/client/engine/js/WasmJsClientEngine.kt
@@ -106,6 +106,7 @@ internal class JsClientEngine(
 
         val urlString = request.url.toString()
         val socket: WebSocket = createWebSocket(urlString, request.headers)
+        val session = JsWebSocketSession(callContext, socket)
 
         try {
             socket.awaitConnection()
@@ -113,8 +114,6 @@ internal class JsClientEngine(
             callContext.cancel(CancellationException("Failed to connect to $urlString", cause))
             throw cause
         }
-
-        val session = JsWebSocketSession(callContext, socket)
 
         val protocol = socket.protocol.takeIf { it.isNotEmpty() }
         val headers = if (protocol != null) headersOf(HttpHeaders.SecWebSocketProtocol, protocol) else Headers.Empty

--- a/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/WebSocketTest.kt
+++ b/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/WebSocketTest.kt
@@ -345,29 +345,26 @@ class WebSocketTest : ClientLoader() {
         }
     }
 
-    @Ignore // TODO KTOR-7088
     @Test
     fun testImmediateReceiveAfterConnect() = clientTests(
-        except(ENGINES_WITHOUT_WS + "Darwin" + "Js") // TODO KTOR-7088
+        except(ENGINES_WITHOUT_WS + "Darwin"), // TODO KTOR-7088
     ) {
         config {
             install(WebSockets)
         }
 
         test { client ->
-            withTimeout(10_000) {
-                coroutineScope {
-                    val defs = (1..100).map {
-                        async {
-                            client.webSocket("$TEST_WEBSOCKET_SERVER/websockets/headers") {
-                                val frame = withTimeoutOrNull(1.seconds) { incoming.receive() }
-                                assertNotNull(frame)
-                                assertIs<Frame.Text>(frame)
-                            }
+            coroutineScope {
+                val defs = (1..100).map {
+                    async {
+                        client.webSocket("$TEST_WEBSOCKET_SERVER/websockets/headers") {
+                            val frame = withTimeoutOrNull(1.seconds) { incoming.receive() }
+                            assertNotNull(frame)
+                            assertIs<Frame.Text>(frame)
                         }
                     }
-                    defs.awaitAll()
                 }
+                defs.awaitAll()
             }
         }
     }


### PR DESCRIPTION
**Subsystem**
Client (WasmJS)

**Motivation**
[KTOR-8163](https://youtrack.jetbrains.com/issue/KTOR-8163) WasmJS WebSocket client sometimes drops a frame received immediately after handshake

**Solution**
Cherry-pick fix made for JS engine: #4012

