### PR TITLE
KTOR-8172 Fix issue in JVM byte channel read function

### DIFF
--- a/ktor-io/jvm/test/ByteReadChannelOperationsJvmTest.kt
+++ b/ktor-io/jvm/test/ByteReadChannelOperationsJvmTest.kt
@@ -4,7 +4,11 @@
 
 import io.ktor.utils.io.*
 import kotlinx.coroutines.*
+import kotlinx.coroutines.test.runTest
+import kotlinx.io.EOFException
+import org.junit.jupiter.api.assertThrows
 import kotlin.test.*
+import kotlin.test.Test
 import kotlin.time.Duration.Companion.seconds
 import kotlin.time.measureTime
 
@@ -99,5 +103,17 @@ class ByteReadChannelOperationsJvmTest {
         assertEquals(numberOfLines, count)
         assertTrue(time < 5.seconds, "Expected I/O to be complete in a reasonable time, but it took $time")
         assertEquals(2_088_890, out.length)
+    }
+
+    @Test
+    fun readWithGreaterMinThrows() = runTest {
+        val channel = ByteChannel()
+        channel.writeByte(1)
+        channel.close()
+        assertThrows<EOFException> {
+            channel.read(2) {
+                fail("There is only one byte in the channel")
+            }
+        }
     }
 }


### PR DESCRIPTION
**Subsystem**
Core, I/O

**Motivation**
[KTOR-8172](https://youtrack.jetbrains.com/issue/KTOR-8172) ByteChannel read issue on min > 1

I found this problem when looking through the code for potential infinite loops.  There were no references to the function where min > 1 so it's not causing problems internally, but it's part of our public API so it seems important to fix.

**Solution**
When the min is supplied, we ought to use this as an argument for the `awaitContent()` function and throw EOF accordingly when said content is unavailable.