### PR TITLE
KTOR-7934 Apply fix for Js target

### DIFF
--- a/ktor-client/ktor-client-core/js/src/io/ktor/client/engine/js/JsClientEngine.kt
+++ b/ktor-client/ktor-client-core/js/src/io/ktor/client/engine/js/JsClientEngine.kt
@@ -156,7 +156,11 @@ private fun org.w3c.fetch.Headers.mapToKtor(method: HttpMethod, attributes: Attr
         append(key, value)
     }
 
-    dropCompressionHeaders(method, attributes)
+    dropCompressionHeaders(
+        method,
+        attributes,
+        alwaysRemove = PlatformUtils.IS_BROWSER
+    )
 }
 
 /**

--- a/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/ContentEncodingIntegrationTest.kt
+++ b/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/ContentEncodingIntegrationTest.kt
@@ -13,20 +13,27 @@ import io.ktor.utils.io.*
 import kotlinx.io.readString
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNull
 
 private const val TEST_URL = "$TEST_SERVER/compression"
 
 class ContentEncodingIntegrationTest : ClientLoader() {
 
-    // GZipEncoder is implemented only on JVM.
+    // GZipEncoder is implemented only on JVM; implicitly decoded for browser
     @Test
     fun testGzipWithContentLengthWithoutPlugin() = clientTests(only("jvm:*", "web:Js")) {
         test { client ->
             val response = client.get("$TEST_URL/gzip-with-content-length")
-            val content = if (response.headers[HttpHeaders.ContentEncoding] == "gzip") {
-                GZipEncoder.decode(response.bodyAsChannel()).readRemaining().readString()
-            } else {
-                response.bodyAsText()
+            val content = when (response.headers[HttpHeaders.ContentEncoding]) {
+                "gzip" -> GZipEncoder.decode(response.bodyAsChannel()).readRemaining().readString()
+                null -> {
+                    // Content-Length should be removed for browser
+                    if (PlatformUtils.IS_BROWSER) {
+                        assertNull(response.headers[HttpHeaders.ContentLength])
+                    }
+                    response.bodyAsText()
+                }
+                else -> error("Unexpected content encoding: ${response.headers[HttpHeaders.ContentEncoding]}")
             }
 
             assertEquals("Hello, world", content)


### PR DESCRIPTION
**Subsystem**
Client, Browser / JS

**Motivation**
[KTOR-7934](https://youtrack.jetbrains.com/issue/KTOR-7934) JS/WASM fails with "IllegalStateException: Content-Length mismatch" on requesting gzipped content

**Solution**
Update the JS compile target as well.  I had only updated wasmJs last time.

