### PR TITLE
KTOR-8015 CIO: Do not accept CR as line delimiter in requests

### DIFF
--- a/ktor-http/ktor-http-cio/common/src/io/ktor/http/cio/HttpParser.kt
+++ b/ktor-http/ktor-http-cio/common/src/io/ktor/http/cio/HttpParser.kt
@@ -21,6 +21,16 @@ private const val HTTP_STATUS_CODE_MAX_RANGE = 999
 private val hostForbiddenSymbols = setOf('/', '?', '#', '@')
 
 /**
+ * Line endings allowed as a separator for HTTP fields and start line.
+ *
+ * "Although the line terminator for the start-line and fields is the sequence CRLF,
+ * a recipient MAY recognize a single LF as a line terminator and ignore any preceding CR."
+ * https://datatracker.ietf.org/doc/html/rfc9112#section-2.2-3
+ */
+@OptIn(InternalAPI::class)
+internal val httpLineEndings: LineEndingMode = LineEndingMode.CRLF + LineEndingMode.LF
+
+/**
  * Parse an HTTP request line and headers
  *
  * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.http.cio.parseRequest)

--- a/ktor-http/ktor-http-cio/common/src/io/ktor/http/cio/HttpParser.kt
+++ b/ktor-http/ktor-http-cio/common/src/io/ktor/http/cio/HttpParser.kt
@@ -1,6 +1,6 @@
 /*
-* Copyright 2014-2021 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
-*/
+ * Copyright 2014-2025 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
 
 package io.ktor.http.cio
 
@@ -35,13 +35,14 @@ internal val httpLineEndings: LineEndingMode = LineEndingMode.CRLF + LineEndingM
  *
  * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.http.cio.parseRequest)
  */
+@OptIn(InternalAPI::class)
 public suspend fun parseRequest(input: ByteReadChannel): Request? {
     val builder = CharArrayBuilder()
     val range = MutableRange(0, 0)
 
     try {
         while (true) {
-            if (!input.readUTF8LineTo(builder, HTTP_LINE_LIMIT)) return null
+            if (!input.readUTF8LineTo(builder, HTTP_LINE_LIMIT, httpLineEndings)) return null
             range.end = builder.length
             if (range.start == range.end) continue
 
@@ -71,12 +72,13 @@ public suspend fun parseRequest(input: ByteReadChannel): Request? {
  *
  * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.http.cio.parseResponse)
  */
+@OptIn(InternalAPI::class)
 public suspend fun parseResponse(input: ByteReadChannel): Response? {
     val builder = CharArrayBuilder()
     val range = MutableRange(0, 0)
 
     try {
-        if (!input.readUTF8LineTo(builder, HTTP_LINE_LIMIT)) return null
+        if (!input.readUTF8LineTo(builder, HTTP_LINE_LIMIT, httpLineEndings)) return null
         range.end = builder.length
 
         val version = parseVersion(builder, range)
@@ -107,6 +109,7 @@ public suspend fun parseHeaders(input: ByteReadChannel): HttpHeadersMap {
 /**
  * Parse HTTP headers. Not applicable to request and response status lines.
  */
+@OptIn(InternalAPI::class)
 internal suspend fun parseHeaders(
     input: ByteReadChannel,
     builder: CharArrayBuilder,
@@ -116,7 +119,7 @@ internal suspend fun parseHeaders(
 
     try {
         while (true) {
-            if (!input.readUTF8LineTo(builder, HTTP_LINE_LIMIT)) {
+            if (!input.readUTF8LineTo(builder, HTTP_LINE_LIMIT, httpLineEndings)) {
                 headers.release()
                 return null
             }

--- a/ktor-io/api/ktor-io.api
+++ b/ktor-io/api/ktor-io.api
@@ -89,6 +89,8 @@ public final class io/ktor/utils/io/ByteReadChannelOperationsKt {
 	public static synthetic fun readUTF8Line$default (Lio/ktor/utils/io/ByteReadChannel;ILkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public static final fun readUTF8LineTo (Lio/ktor/utils/io/ByteReadChannel;Ljava/lang/Appendable;ILkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun readUTF8LineTo$default (Lio/ktor/utils/io/ByteReadChannel;Ljava/lang/Appendable;ILkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static final fun readUTF8LineTo-RRvyBJ8 (Lio/ktor/utils/io/ByteReadChannel;Ljava/lang/Appendable;IILkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun readUTF8LineTo-RRvyBJ8$default (Lio/ktor/utils/io/ByteReadChannel;Ljava/lang/Appendable;IILkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public static final fun readUntil (Lio/ktor/utils/io/ByteReadChannel;Lkotlinx/io/bytestring/ByteString;Lio/ktor/utils/io/ByteWriteChannel;JZLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun readUntil$default (Lio/ktor/utils/io/ByteReadChannel;Lkotlinx/io/bytestring/ByteString;Lio/ktor/utils/io/ByteWriteChannel;JZLkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public static final fun reader (Lkotlinx/coroutines/CoroutineScope;Lkotlin/coroutines/CoroutineContext;Lio/ktor/utils/io/ByteChannel;Lkotlin/jvm/functions/Function2;)Lio/ktor/utils/io/ReaderJob;
@@ -276,6 +278,28 @@ public abstract interface annotation class io/ktor/utils/io/KtorDsl : java/lang/
 }
 
 public abstract interface annotation class io/ktor/utils/io/KtorExperimentalAPI : java/lang/annotation/Annotation {
+}
+
+public final class io/ktor/utils/io/LineEndingMode {
+	public static final field Companion Lio/ktor/utils/io/LineEndingMode$Companion;
+	public static final synthetic fun box-impl (I)Lio/ktor/utils/io/LineEndingMode;
+	public static final fun contains-lTjpP64 (II)Z
+	public fun equals (Ljava/lang/Object;)Z
+	public static fun equals-impl (ILjava/lang/Object;)Z
+	public static final fun equals-impl0 (II)Z
+	public fun hashCode ()I
+	public static fun hashCode-impl (I)I
+	public static final fun plus-1Ter-O4 (II)I
+	public fun toString ()Ljava/lang/String;
+	public static fun toString-impl (I)Ljava/lang/String;
+	public final synthetic fun unbox-impl ()I
+}
+
+public final class io/ktor/utils/io/LineEndingMode$Companion {
+	public final fun getAny-f0jXZW8 ()I
+	public final fun getCR-f0jXZW8 ()I
+	public final fun getCRLF-f0jXZW8 ()I
+	public final fun getLF-f0jXZW8 ()I
 }
 
 public final class io/ktor/utils/io/LookAheadSessionKt {

--- a/ktor-io/api/ktor-io.klib.api
+++ b/ktor-io/api/ktor-io.klib.api
@@ -297,6 +297,25 @@ final class io.ktor.utils.io/WriterScope : kotlinx.coroutines/CoroutineScope { /
         final fun <get-coroutineContext>(): kotlin.coroutines/CoroutineContext // io.ktor.utils.io/WriterScope.coroutineContext.<get-coroutineContext>|<get-coroutineContext>(){}[0]
 }
 
+final value class io.ktor.utils.io/LineEndingMode { // io.ktor.utils.io/LineEndingMode|null[0]
+    final fun contains(io.ktor.utils.io/LineEndingMode): kotlin/Boolean // io.ktor.utils.io/LineEndingMode.contains|contains(io.ktor.utils.io.LineEndingMode){}[0]
+    final fun equals(kotlin/Any?): kotlin/Boolean // io.ktor.utils.io/LineEndingMode.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // io.ktor.utils.io/LineEndingMode.hashCode|hashCode(){}[0]
+    final fun plus(io.ktor.utils.io/LineEndingMode): io.ktor.utils.io/LineEndingMode // io.ktor.utils.io/LineEndingMode.plus|plus(io.ktor.utils.io.LineEndingMode){}[0]
+    final fun toString(): kotlin/String // io.ktor.utils.io/LineEndingMode.toString|toString(){}[0]
+
+    final object Companion { // io.ktor.utils.io/LineEndingMode.Companion|null[0]
+        final val Any // io.ktor.utils.io/LineEndingMode.Companion.Any|{}Any[0]
+            final fun <get-Any>(): io.ktor.utils.io/LineEndingMode // io.ktor.utils.io/LineEndingMode.Companion.Any.<get-Any>|<get-Any>(){}[0]
+        final val CR // io.ktor.utils.io/LineEndingMode.Companion.CR|{}CR[0]
+            final fun <get-CR>(): io.ktor.utils.io/LineEndingMode // io.ktor.utils.io/LineEndingMode.Companion.CR.<get-CR>|<get-CR>(){}[0]
+        final val CRLF // io.ktor.utils.io/LineEndingMode.Companion.CRLF|{}CRLF[0]
+            final fun <get-CRLF>(): io.ktor.utils.io/LineEndingMode // io.ktor.utils.io/LineEndingMode.Companion.CRLF.<get-CRLF>|<get-CRLF>(){}[0]
+        final val LF // io.ktor.utils.io/LineEndingMode.Companion.LF|{}LF[0]
+            final fun <get-LF>(): io.ktor.utils.io/LineEndingMode // io.ktor.utils.io/LineEndingMode.Companion.LF.<get-LF>|<get-LF>(){}[0]
+    }
+}
+
 open class io.ktor.utils.io.charsets/MalformedInputException : kotlinx.io/IOException { // io.ktor.utils.io.charsets/MalformedInputException|null[0]
     constructor <init>(kotlin/String) // io.ktor.utils.io.charsets/MalformedInputException.<init>|<init>(kotlin.String){}[0]
 }
@@ -461,6 +480,7 @@ final suspend fun (io.ktor.utils.io/ByteReadChannel).io.ktor.utils.io/readRemain
 final suspend fun (io.ktor.utils.io/ByteReadChannel).io.ktor.utils.io/readShort(): kotlin/Short // io.ktor.utils.io/readShort|readShort@io.ktor.utils.io.ByteReadChannel(){}[0]
 final suspend fun (io.ktor.utils.io/ByteReadChannel).io.ktor.utils.io/readUTF8Line(kotlin/Int = ...): kotlin/String? // io.ktor.utils.io/readUTF8Line|readUTF8Line@io.ktor.utils.io.ByteReadChannel(kotlin.Int){}[0]
 final suspend fun (io.ktor.utils.io/ByteReadChannel).io.ktor.utils.io/readUTF8LineTo(kotlin.text/Appendable, kotlin/Int = ...): kotlin/Boolean // io.ktor.utils.io/readUTF8LineTo|readUTF8LineTo@io.ktor.utils.io.ByteReadChannel(kotlin.text.Appendable;kotlin.Int){}[0]
+final suspend fun (io.ktor.utils.io/ByteReadChannel).io.ktor.utils.io/readUTF8LineTo(kotlin.text/Appendable, kotlin/Int = ..., io.ktor.utils.io/LineEndingMode = ...): kotlin/Boolean // io.ktor.utils.io/readUTF8LineTo|readUTF8LineTo@io.ktor.utils.io.ByteReadChannel(kotlin.text.Appendable;kotlin.Int;io.ktor.utils.io.LineEndingMode){}[0]
 final suspend fun (io.ktor.utils.io/ByteReadChannel).io.ktor.utils.io/readUntil(kotlinx.io.bytestring/ByteString, io.ktor.utils.io/ByteWriteChannel, kotlin/Long = ..., kotlin/Boolean = ...): kotlin/Long // io.ktor.utils.io/readUntil|readUntil@io.ktor.utils.io.ByteReadChannel(kotlinx.io.bytestring.ByteString;io.ktor.utils.io.ByteWriteChannel;kotlin.Long;kotlin.Boolean){}[0]
 final suspend fun (io.ktor.utils.io/ByteReadChannel).io.ktor.utils.io/skipIfFound(kotlinx.io.bytestring/ByteString): kotlin/Boolean // io.ktor.utils.io/skipIfFound|skipIfFound@io.ktor.utils.io.ByteReadChannel(kotlinx.io.bytestring.ByteString){}[0]
 final suspend fun (io.ktor.utils.io/ByteReadChannel).io.ktor.utils.io/toByteArray(): kotlin/ByteArray // io.ktor.utils.io/toByteArray|toByteArray@io.ktor.utils.io.ByteReadChannel(){}[0]

--- a/ktor-io/common/src/io/ktor/utils/io/CloseToken.kt
+++ b/ktor-io/common/src/io/ktor/utils/io/CloseToken.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2024 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2014-2025 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package io.ktor.utils.io
@@ -13,7 +13,7 @@ internal val CLOSED = CloseToken(null)
 @OptIn(ExperimentalCoroutinesApi::class)
 internal class CloseToken(private val origin: Throwable?) {
 
-    fun wrapCause(wrap: (Throwable?) -> Throwable = ::ClosedByteChannelException): Throwable? {
+    fun wrapCause(wrap: (Throwable) -> Throwable = ::ClosedByteChannelException): Throwable? {
         return when (origin) {
             null -> null
             is CopyableThrowable<*> -> origin.createCopy()
@@ -22,6 +22,6 @@ internal class CloseToken(private val origin: Throwable?) {
         }
     }
 
-    fun throwOrNull(wrap: (Throwable?) -> Throwable): Unit? =
+    fun throwOrNull(wrap: (Throwable) -> Throwable): Unit? =
         wrapCause(wrap)?.let { throw it }
 }

--- a/ktor-io/common/src/io/ktor/utils/io/LineEndingMode.kt
+++ b/ktor-io/common/src/io/ktor/utils/io/LineEndingMode.kt
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2014-2025 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.utils.io
+
+import kotlin.jvm.JvmInline
+
+/**
+ * Represents different line ending modes and provides operations to work with them.
+ * The class uses a bitmask internally to represent different line ending combinations.
+ *
+ * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.utils.io.LineEndingMode)
+ */
+@InternalAPI
+@JvmInline
+public value class LineEndingMode private constructor(private val mode: Int) {
+
+    /**
+     * Checks if this line ending mode includes another mode.
+     *
+     * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.utils.io.LineEndingMode.contains)
+     */
+    public operator fun contains(other: LineEndingMode): Boolean =
+        mode or other.mode == mode
+
+    /**
+     * Combines this line ending mode with another mode.
+     * The resulting mode will accept both line endings.
+     *
+     * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.utils.io.LineEndingMode.plus)
+     */
+    public operator fun plus(other: LineEndingMode): LineEndingMode =
+        LineEndingMode(mode or other.mode)
+
+    override fun toString(): String = when (this) {
+        CR -> "CR"
+        LF -> "LF"
+        CRLF -> "CRLF"
+        else -> values.filter { it in this }.toString()
+    }
+
+    public companion object {
+        /**
+         * Represents Carriage Return (\r) line ending.
+         *
+         * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.utils.io.LineEndingMode.CR)
+         */
+        public val CR: LineEndingMode = LineEndingMode(0b001)
+
+        /**
+         * Represents Line Feed (\n) line ending.
+         *
+         * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.utils.io.LineEndingMode.LF)
+         */
+        public val LF: LineEndingMode = LineEndingMode(0b010)
+
+        /**
+         * Represents Carriage Return + Line Feed (\r\n) line ending.
+         *
+         * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.utils.io.LineEndingMode.CRLF)
+         */
+        public val CRLF: LineEndingMode = LineEndingMode(0b100)
+
+        /**
+         * Represents a mode that accepts any line ending ([CR], [LF], or [CRLF]).
+         *
+         * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.utils.io.LineEndingMode.Any)
+         */
+        public val Any: LineEndingMode = LineEndingMode(0b111)
+
+        private val values = listOf(CR, LF, CRLF)
+    }
+}

--- a/ktor-io/common/src/io/ktor/utils/io/SinkByteWriteChannel.kt
+++ b/ktor-io/common/src/io/ktor/utils/io/SinkByteWriteChannel.kt
@@ -6,7 +6,10 @@ package io.ktor.utils.io
 
 import kotlinx.atomicfu.AtomicRef
 import kotlinx.atomicfu.atomic
-import kotlinx.io.*
+import kotlinx.io.IOException
+import kotlinx.io.RawSink
+import kotlinx.io.Sink
+import kotlinx.io.buffered
 
 /**
  * Creates a [ByteWriteChannel] that writes to this [Sink].
@@ -58,7 +61,6 @@ internal class SinkByteWriteChannel(origin: RawSink) : ByteWriteChannel {
         if (!closed.compareAndSet(expect = null, update = CLOSED)) return
     }
 
-    @OptIn(InternalAPI::class)
     override fun cancel(cause: Throwable?) {
         val token = if (cause == null) CLOSED else CloseToken(cause)
         if (!closed.compareAndSet(expect = null, update = token)) return

--- a/ktor-server/ktor-server-test-suites/jvm/src/io/ktor/server/testing/suites/SustainabilityTestSuite.kt
+++ b/ktor-server/ktor-server-test-suites/jvm/src/io/ktor/server/testing/suites/SustainabilityTestSuite.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2024 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2014-2025 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package io.ktor.server.testing.suites
@@ -11,6 +11,7 @@ import io.ktor.client.statement.*
 import io.ktor.http.*
 import io.ktor.http.cio.*
 import io.ktor.http.content.*
+import io.ktor.network.sockets.*
 import io.ktor.server.application.*
 import io.ktor.server.engine.*
 import io.ktor.server.http.content.*


### PR DESCRIPTION
**Subsystem**
Server (CIO)

**Motivation**
[KTOR-8015](https://youtrack.jetbrains.com/issue/KTOR-8015) Server accepts \r without a following \n as a valid line terminator in chunked transfer encoding

**Solution**
Add a parameter `lineEnding` to `readUTF8Line` to make it possible to ensure that a proper line ending is used.