### PR TITLE
KTOR-8105 Fix for concurrent flush attempts breaking CIO client (again)

### DIFF
--- a/ktor-client/ktor-client-cio/common/src/io/ktor/client/engine/cio/utils.kt
+++ b/ktor-client/ktor-client-cio/common/src/io/ktor/client/engine/cio/utils.kt
@@ -122,7 +122,7 @@ internal suspend fun writeBody(
     val chunkedJob: EncoderJob? = if (chunked) encodeChunked(output, callContext) else null
     val channel = chunkedJob?.channel ?: output
 
-    val scope = CoroutineScope(callContext + CoroutineName("Request body writer"))
+    val scope = CoroutineScope(callContext + CoroutineName("cio-client-body-writer"))
     scope.launch {
         try {
             processOutgoingContent(request, body, channel)
@@ -194,7 +194,7 @@ internal suspend fun readResponse(
             }
 
             else -> {
-                val coroutineScope = CoroutineScope(callContext + CoroutineName("Response"))
+                val coroutineScope = CoroutineScope(callContext + CoroutineName("cio-client-body-reader"))
                 val httpBodyParser = coroutineScope.writer(autoFlush = true) {
                     parseHttpBody(version, contentLength, transferEncoding, connectionType, input, channel)
                 }

--- a/ktor-network/common/src/io/ktor/network/sockets/SocketBase.kt
+++ b/ktor-network/common/src/io/ktor/network/sockets/SocketBase.kt
@@ -33,6 +33,7 @@ internal abstract class SocketBase(
     override fun close() {
         if (!closeFlag.compareAndSet(false, true)) return
 
+        // TODO this can be dangerous if there is another thread writing to this
         readerJob.value?.channel?.close()
         writerJob.value?.cancel()
         checkChannels()

--- a/ktor-network/ktor-network-tls/jvm/src/io/ktor/network/tls/TLSClientSessionJvm.kt
+++ b/ktor-network/ktor-network-tls/jvm/src/io/ktor/network/tls/TLSClientSessionJvm.kt
@@ -26,7 +26,7 @@ internal actual suspend fun openTLSSession(
     val handshake = TLSClientHandshake(input, output, config, context)
     try {
         handshake.negotiate()
-    } catch (cause: Exception) {
+    } catch (cause: Throwable) {
         runCatching {
             handshake.close().join()
             socket.close()


### PR DESCRIPTION
**Subsystem**
Client, CIO

**Motivation**
Once again fixing these issues:
- [KTOR-8105](https://youtrack.jetbrains.com/issue/KTOR-8105) Race condition when writing to a buffer leads to NPE inside CIOReaderKt.readFrom
- [KTOR-8086](https://youtrack.jetbrains.com/issue/KTOR-8086) NPE in readBuffer
- [KTOR-8096](https://youtrack.jetbrains.com/issue/KTOR-8096) ArrayIndexOutOfBounds kotlinx-io

**Solution**
Previously, I removed a redundant close from the base socket implementation, but it would seem there is some other parts of the code base that rely on this behaviour.  So, I instead defer the close call to after the encoder job is finished closing.  Bonus fix: I noticed we're not encrypting our close records after the handshake is complete.  This is incorrect behaviour, so I fixed that as well.