### PR TITLE
Fix double actualClose call

### DIFF
--- a/ktor-network/common/src/io/ktor/network/sockets/SocketBase.kt
+++ b/ktor-network/common/src/io/ktor/network/sockets/SocketBase.kt
@@ -16,6 +16,7 @@ internal abstract class SocketBase(
 ) : ReadWriteSocket, SelectableBase(), CoroutineScope {
 
     private val closeFlag = atomic(false)
+    private val actualCloseFlag = atomic(false)
 
     private val readerJob = atomic<ReaderJob?>(null)
 
@@ -92,6 +93,8 @@ internal abstract class SocketBase(
 
     private fun checkChannels() {
         if (closeFlag.value && readerJob.completedOrNotStarted && writerJob.completedOrNotStarted) {
+            if (!actualCloseFlag.compareAndSet(false, true)) return
+
             val e1 = readerJob.exception
             val e2 = writerJob.exception
             val e3 = actualClose()


### PR DESCRIPTION
The actualClose call could be called twice due to race condition when closing. Seems highly unlikely, but this could cause a descriptor to be closed twice, causing errors.

This piece of code was moved from JVM, where a double actualClose call would not have caused an issue (because closing jvm channel twice is ok), but on Native closing a descriptor twice is a serious issue.

Was able to reproduce this issue by adding `runBlocking { delay(1000) }` on line 85 just before `checkChannels()` call