### PR TITLE
Fix exceptions ignored in select code

### DIFF
--- a/ktor-network/jvm/src/io/ktor/network/sockets/DatagramSocketImpl.kt
+++ b/ktor-network/jvm/src/io/ktor/network/sockets/DatagramSocketImpl.kt
@@ -9,7 +9,6 @@ import io.ktor.network.util.*
 import io.ktor.utils.io.core.*
 import kotlinx.coroutines.*
 import kotlinx.coroutines.channels.*
-import kotlinx.io.IOException
 import java.nio.*
 import java.nio.channels.*
 
@@ -52,7 +51,6 @@ internal class DatagramSocketImpl(
                 channel.send(receiveImpl())
             }
         } catch (_: ClosedChannelException) {
-        } catch (cause: IOException) {
         }
     }
 

--- a/ktor-network/jvmAndPosix/test/io/ktor/network/sockets/tests/UDPSocketTest.kt
+++ b/ktor-network/jvmAndPosix/test/io/ktor/network/sockets/tests/UDPSocketTest.kt
@@ -263,11 +263,28 @@ class UDPSocketTest {
             .udp()
             .bind()
 
-        val remoteAddress = InetSocketAddress("127.0.0.1", (server.localAddress as InetSocketAddress).port)
-        val socket = aSocket(selector).udp().connect(remoteAddress)
+        server.use {
+            val remoteAddress = InetSocketAddress("127.0.0.1", (server.localAddress as InetSocketAddress).port)
+            val socket = aSocket(selector).udp().connect(remoteAddress)
 
-        socket.send(Datagram(buildPacket { writeText("hello") }, remoteAddress))
-        assertEquals("hello", server.receive().packet.readText())
+            socket.send(Datagram(buildPacket { writeText("hello") }, remoteAddress))
+            assertEquals("hello", server.receive().packet.readText())
+        }
+    }
+
+    @Test
+    fun testReceiveError() = testSockets { selector ->
+        val socket = aSocket(selector)
+            .udp()
+            .bind()
+
+        socket.use {
+            selector.close()
+            // Receive fails due to closed selector exception
+            assertFails {
+                socket.receive()
+            }
+        }
     }
 }
 

--- a/ktor-network/posix/src/io/ktor/network/sockets/CIOReader.kt
+++ b/ktor-network/posix/src/io/ktor/network/sockets/CIOReader.kt
@@ -10,7 +10,6 @@ import io.ktor.utils.io.*
 import io.ktor.utils.io.errors.*
 import kotlinx.cinterop.*
 import kotlinx.coroutines.*
-import kotlinx.io.IOException
 
 @OptIn(ExperimentalForeignApi::class)
 internal fun CoroutineScope.attachForReadingImpl(
@@ -49,11 +48,7 @@ internal fun CoroutineScope.attachForReadingImpl(
             }
 
             if (count == 0) {
-                try {
-                    selector.select(selectable, SelectInterest.READ)
-                } catch (_: IOException) {
-                    break
-                }
+                selector.select(selectable, SelectInterest.READ)
             }
         }
 

--- a/ktor-network/posix/src/io/ktor/network/sockets/DatagramSocketNative.kt
+++ b/ktor-network/posix/src/io/ktor/network/sockets/DatagramSocketNative.kt
@@ -43,9 +43,7 @@ internal class DatagramSocketNative(
                 val received = readDatagram()
                 channel.send(received)
             }
-        } catch (_: ClosedSendChannelException) {
-        } catch (cause: IOException) {
-        } catch (cause: PosixException) {
+        } catch (_: ClosedSocketException) {
         }
     }
 
@@ -88,7 +86,7 @@ internal class DatagramSocketNative(
             }
 
             when (bytesRead) {
-                0L -> throw IOException("Failed reading from closed socket")
+                0L -> throw ClosedSocketException()
                 -1L -> {
                     val error = getSocketError()
                     if (isWouldBlockError(error)) return null
@@ -106,3 +104,5 @@ internal class DatagramSocketNative(
         }
     }
 }
+
+private class ClosedSocketException : IOException()


### PR DESCRIPTION
Properly pass exceptions so they can be detected when using the sockets. Maybe this will also help find any remaining issues in the selection code.