### PR TITLE
KTOR-8201 Add safe close for readerJob

### DIFF
--- a/ktor-io/api/ktor-io.api
+++ b/ktor-io/api/ktor-io.api
@@ -295,6 +295,7 @@ public abstract interface annotation class io/ktor/utils/io/PublicAPICandidate :
 }
 
 public final class io/ktor/utils/io/ReaderJob : io/ktor/utils/io/ChannelJob {
+	public final fun flushAndClose (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun getChannel ()Lio/ktor/utils/io/ByteWriteChannel;
 	public fun getJob ()Lkotlinx/coroutines/Job;
 }

--- a/ktor-io/api/ktor-io.klib.api
+++ b/ktor-io/api/ktor-io.klib.api
@@ -270,6 +270,8 @@ final class io.ktor.utils.io/ReaderJob : io.ktor.utils.io/ChannelJob { // io.kto
         final fun <get-channel>(): io.ktor.utils.io/ByteWriteChannel // io.ktor.utils.io/ReaderJob.channel.<get-channel>|<get-channel>(){}[0]
     final val job // io.ktor.utils.io/ReaderJob.job|{}job[0]
         final fun <get-job>(): kotlinx.coroutines/Job // io.ktor.utils.io/ReaderJob.job.<get-job>|<get-job>(){}[0]
+
+    final suspend fun flushAndClose() // io.ktor.utils.io/ReaderJob.flushAndClose|flushAndClose(){}[0]
 }
 
 final class io.ktor.utils.io/ReaderScope : kotlinx.coroutines/CoroutineScope { // io.ktor.utils.io/ReaderScope|null[0]

--- a/ktor-io/common/src/io/ktor/utils/io/ByteReadChannelOperations.kt
+++ b/ktor-io/common/src/io/ktor/utils/io/ByteReadChannelOperations.kt
@@ -311,7 +311,7 @@ public class ReaderJob internal constructor(
     @InternalAPI
     public suspend fun flushAndClose() {
         job.cancelChildren()
-        job.children.toList().joinAll()
+        job.children.forEach { it.join() }
         channel.flushAndClose()
     }
 }

--- a/ktor-io/common/src/io/ktor/utils/io/ByteReadChannelOperations.kt
+++ b/ktor-io/common/src/io/ktor/utils/io/ByteReadChannelOperations.kt
@@ -303,7 +303,18 @@ public class ReaderScope(
 public class ReaderJob internal constructor(
     public val channel: ByteWriteChannel,
     public override val job: Job
-) : ChannelJob
+) : ChannelJob {
+    /**
+     * To avoid the risk of concurrent write operations, we cancel the nested job before
+     * performing `flushAndClose` on the [ByteWriteChannel].
+     */
+    @InternalAPI
+    public suspend fun flushAndClose() {
+        job.cancelChildren()
+        job.children.toList().joinAll()
+        channel.flushAndClose()
+    }
+}
 
 @Suppress("UNUSED_PARAMETER")
 public fun CoroutineScope.reader(

--- a/ktor-network/common/src/io/ktor/network/sockets/SocketBase.kt
+++ b/ktor-network/common/src/io/ktor/network/sockets/SocketBase.kt
@@ -30,12 +30,15 @@ internal abstract class SocketBase(
         close()
     }
 
+    @OptIn(InternalAPI::class)
     override fun close() {
         if (!closeFlag.compareAndSet(false, true)) return
 
-        readerJob.value?.channel?.close()
-        writerJob.value?.cancel()
-        checkChannels()
+        launch(CoroutineName("socket-close")) {
+            readerJob.value?.flushAndClose()
+            writerJob.value?.cancel()
+            checkChannels()
+        }
     }
 
     final override fun attachForReading(channel: ByteChannel): WriterJob {


### PR DESCRIPTION
**Subsystem**
Core, I/O

**Motivation**
[KTOR-8201](https://youtrack.jetbrains.com/issue/KTOR-8201) Fix socket channel close handling

**Solution**
This introduces a suspending close for reader jobs, which will cancel the nested job, wait for it to join, then perform the flush and close.  This should prevent two coroutines from writing / flushing simultaneously.

