### PR TITLE
KTOR-8206 Apply socket and connect timeouts to WS and SSE

### DIFF
--- a/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/WebSocketTest.kt
+++ b/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/WebSocketTest.kt
@@ -6,6 +6,7 @@ package io.ktor.client.tests
 
 import io.ktor.client.*
 import io.ktor.client.plugins.*
+import io.ktor.client.plugins.api.*
 import io.ktor.client.plugins.auth.*
 import io.ktor.client.plugins.auth.providers.*
 import io.ktor.client.plugins.websocket.*
@@ -13,11 +14,11 @@ import io.ktor.client.request.*
 import io.ktor.client.test.base.*
 import io.ktor.http.*
 import io.ktor.serialization.*
-import io.ktor.test.dispatcher.*
 import io.ktor.util.reflect.*
 import io.ktor.utils.io.charsets.*
 import io.ktor.websocket.*
 import kotlinx.coroutines.*
+import kotlinx.coroutines.test.runTest
 import kotlin.test.*
 import kotlin.time.Duration.Companion.seconds
 
@@ -55,7 +56,7 @@ class WebSocketTest : ClientLoader() {
     }
 
     @Test
-    fun testExceptionIfWebsocketIsNotInstalled() = testSuspend {
+    fun testExceptionIfWebsocketIsNotInstalled() = runTest {
         val client = HttpClient()
         assertFailsWith<IllegalStateException> {
             client.webSocketSession()
@@ -223,13 +224,25 @@ class WebSocketTest : ClientLoader() {
     }
 
     @Test
-    fun testRequestTimeoutIsNotApplied() = clientTests(except(ENGINES_WITHOUT_WS)) {
+    fun testTimeoutCapabilityIsSetIgnoringRequestTimeout() = clientTests(except(ENGINES_WITHOUT_WS)) {
+        var requestTimeouts: HttpTimeoutConfig? = null
+        val timeoutsInterceptor = createClientPlugin("TimeoutsInterceptor") {
+            on(Send) { request ->
+                requestTimeouts = request.getCapabilityOrNull(HttpTimeoutCapability)
+                proceed(request)
+            }
+        }
+
         config {
             install(WebSockets)
 
             install(HttpTimeout) {
                 requestTimeoutMillis = 10
+                connectTimeoutMillis = 1001
+                socketTimeoutMillis = 1002
             }
+
+            install(timeoutsInterceptor)
         }
 
         test { client ->
@@ -240,6 +253,11 @@ class WebSocketTest : ClientLoader() {
                 val result = incoming.receive() as Frame.Text
                 assertEquals("test", result.readText())
             }
+
+            val timeouts = assertNotNull(requestTimeouts, "Timeouts capability should be installed")
+            assertNull(timeouts.requestTimeoutMillis, "Request timeout should be ignored")
+            assertEquals(1001, timeouts.connectTimeoutMillis, "Connect timeout should be set")
+            assertEquals(1002, timeouts.socketTimeoutMillis, "Socket timeout should be set")
         }
     }
 


### PR DESCRIPTION
**Subsystem**
Client

**Motivation**
[KTOR-8206](https://youtrack.jetbrains.com/issue/KTOR-8206) WebSocket and SSE don't respect connection timeout set in the HttpTimeout plugin

**Solution**
Previously all timeout settings were ignored for WS and SSE requests. I've changed this behavior to ignore only request timeout.

