### PR TITLE
Remove unnecessary maxDescriptor + 1; Improve posix call debug information in SelectorManager

### DIFF
--- a/ktor-network/nix/src/io/ktor/network/selector/SelectUtilsNix.kt
+++ b/ktor-network/nix/src/io/ktor/network/selector/SelectUtilsNix.kt
@@ -79,10 +79,7 @@ internal actual class SelectorHelper {
         try {
             while (!interestQueue.isClosed) {
                 watchSet.add(wakeupSignalEvent)
-                var maxDescriptor = fillHandlersOrClose(watchSet, completed, closeSet, readSet, writeSet, errorSet)
-                if (maxDescriptor == 0) continue
-
-                maxDescriptor = max(maxDescriptor + 1, wakeupSignalEvent.descriptor + 1)
+                val maxDescriptor = fillHandlersOrClose(watchSet, completed, closeSet, readSet, writeSet, errorSet)
 
                 try {
                     selector_pselect(maxDescriptor + 1, readSet, writeSet, errorSet).check()

--- a/ktor-network/nix/src/io/ktor/network/selector/SelectUtilsNix.kt
+++ b/ktor-network/nix/src/io/ktor/network/selector/SelectUtilsNix.kt
@@ -82,7 +82,8 @@ internal actual class SelectorHelper {
                 val maxDescriptor = fillHandlersOrClose(watchSet, completed, closeSet, readSet, writeSet, errorSet)
 
                 try {
-                    selector_pselect(maxDescriptor + 1, readSet, writeSet, errorSet).check()
+                    selector_pselect(maxDescriptor + 1, readSet, writeSet, errorSet)
+                        .check(posixFunctionName = "pselect")
                 } catch (_: PosixException.BadFileDescriptorException) {
                     // Thrown if any of the descriptors was closed.
                     // This means the sets are undefined so do not rely on their contents.

--- a/ktor-network/nix/src/io/ktor/network/selector/SignalPoint.kt
+++ b/ktor-network/nix/src/io/ktor/network/selector/SignalPoint.kt
@@ -27,7 +27,7 @@ internal class SignalPoint : Closeable {
     init {
         val (read, write) = memScoped {
             val pipeDescriptors = allocArray<IntVar>(2)
-            pipe(pipeDescriptors).check()
+            pipe(pipeDescriptors).check(posixFunctionName = "pipe")
 
             repeat(2) { index ->
                 makeNonBlocking(pipeDescriptors[index])
@@ -90,7 +90,7 @@ internal class SignalPoint : Closeable {
             do {
                 val result = read(readDescriptor, buffer, 1024.convert()).convert<Int>()
                 if (result < 0) {
-                    when (val error = PosixException.forSocketError()) {
+                    when (val error = PosixException.forSocketError(posixFunctionName = "read")) {
                         is PosixException.TryAgainException -> {}
                         else -> throw error
                     }
@@ -110,6 +110,7 @@ internal class SignalPoint : Closeable {
     }
 
     private fun makeNonBlocking(descriptor: Int) {
-        fcntl(descriptor, F_SETFL, fcntl(descriptor, F_GETFL) or O_NONBLOCK).check()
+        fcntl(descriptor, F_SETFL, fcntl(descriptor, F_GETFL) or O_NONBLOCK)
+            .check(posixFunctionName = "fcntl")
     }
 }

--- a/ktor-network/posix/src/io/ktor/network/util/NativeUtils.kt
+++ b/ktor-network/posix/src/io/ktor/network/util/NativeUtils.kt
@@ -7,10 +7,11 @@ package io.ktor.network.util
 import io.ktor.utils.io.errors.*
 
 internal inline fun Int.check(
+    posixFunctionName: String? = null,
     block: (Int) -> Boolean = { it >= 0 }
 ): Int {
     if (!block(this)) {
-        throw PosixException.forSocketError()
+        throw PosixException.forSocketError(posixFunctionName = posixFunctionName)
     }
 
     return this

--- a/ktor-network/windows/src/io/ktor/network/selector/SelectUtilsWindows.kt
+++ b/ktor-network/windows/src/io/ktor/network/selector/SelectUtilsWindows.kt
@@ -71,7 +71,7 @@ internal actual class SelectorHelper {
                         fWaitAll = 0,
                         dwTimeout = UInt.MAX_VALUE,
                         fAlertable = 0
-                    ).toInt().check()
+                    ).toInt().check(posixFunctionName = "WSAWaitForMultipleEvents")
                 }
 
                 processSelectedEvents(watchSet, completed, index, wsaEvents)
@@ -149,7 +149,7 @@ internal actual class SelectorHelper {
                     WSACreateEvent()
                 }
                 if (wsaEvent == WSA_INVALID_EVENT) {
-                    throw PosixException.forSocketError()
+                    throw PosixException.forSocketError(posixFunctionName = "WSACreateEvent")
                 }
 
                 var lNetworkEvents = events.fold(0) { acc, event ->
@@ -183,7 +183,8 @@ internal actual class SelectorHelper {
 
                 val networkEvents = memScoped {
                     val networkEvents = alloc<WSANETWORKEVENTS>()
-                    WSAEnumNetworkEvents(descriptor.convert(), wsaEvent, networkEvents.ptr).check()
+                    WSAEnumNetworkEvents(descriptor.convert(), wsaEvent, networkEvents.ptr)
+                        .check(posixFunctionName = "WSAEnumNetworkEvents")
                     networkEvents.lNetworkEvents
                 }
 


### PR DESCRIPTION
**Subsystem**
ktor-network

**Motivation**
Received a crash on iOS:
```
          Non-fatal Exception: InvalidArgumentException: EINVAL (22): Invalid argument
0  RemoteGamepad                  0x75237c kfun:io.ktor.utils.io.errors.PosixException.Companion#forErrno(kotlin.Int;kotlin.String?){}io.ktor.utils.io.errors.PosixException + 30 (Throwable.kt:30)
1  RemoteGamepad                  0x15564a0 kfun:io.ktor.network.selector.SelectorHelper.selectionLoop#internal + 163 (SocketUtils.kt:163)
2  RemoteGamepad                  0x1558a84 kfun:io.ktor.network.selector.SelectorHelper.SelectorHelper$start$2.invoke#internal + 53 (SelectUtilsNix.kt:53)
3  RemoteGamepad                  0x328494 kfun:kotlin.coroutines.intrinsics.createCoroutineUnintercepted$$inlined$createCoroutineFromSuspendFunction$2.invokeSuspend#internal (IntrinsicsNative.kt)
4  RemoteGamepad                  0x3260b4 kfun:kotlin.coroutines.native.internal.BaseContinuationImpl#resumeWith(kotlin.Result<kotlin.Any?>){} + 50 (ContinuationImpl.kt:50)
5  RemoteGamepad                  0x47ba48 kfun:kotlinx.coroutines.DispatchedTask#run(){} + 26 (Continuation.kt:26)
6  RemoteGamepad                  0x49b528 kfun:kotlinx.coroutines.MultiWorkerDispatcher.$workerRunLoop$lambda$2COROUTINE$0.invokeSuspend#internal + 12 (Runnable.kt:12)
7  RemoteGamepad                  0x49bf08 kfun:kotlinx.coroutines.MultiWorkerDispatcher.MultiWorkerDispatcher$workerRunLoop$2.invoke#internal + 123 (MultithreadedDispatchers.kt:123)
8  RemoteGamepad                  0x328494 kfun:kotlin.coroutines.intrinsics.createCoroutineUnintercepted$$inlined$createCoroutineFromSuspendFunction$2.invokeSuspend#internal (IntrinsicsNative.kt)
9  RemoteGamepad                  0x3260b4 kfun:kotlin.coroutines.native.internal.BaseContinuationImpl#resumeWith(kotlin.Result<kotlin.Any?>){} + 50 (ContinuationImpl.kt:50)
10 RemoteGamepad                  0x47ba48 kfun:kotlinx.coroutines.DispatchedTask#run(){} + 26 (Continuation.kt:26)
11 RemoteGamepad                  0x42e108 kfun:kotlinx.coroutines.EventLoopImplBase#processNextEvent(){}kotlin.Long + 15 (ObjectiveCUtils.kt:15)
12 RemoteGamepad                  0x492e88 kfun:kotlinx.coroutines#runBlocking(kotlin.coroutines.CoroutineContext;kotlin.coroutines.SuspendFunction1<kotlinx.coroutines.CoroutineScope,0:0>){0§<kotlin.Any?>}0:0 + 49 (EventLoop.common.kt:49)
13 RemoteGamepad                  0x49c1f8 kfun:kotlinx.coroutines.MultiWorkerDispatcher.MultiWorkerDispatcher$1$$inlined$apply$2.$<bridge-DNN>invoke(){}#internal + 123 (MultithreadedDispatchers.kt:123)
14 RemoteGamepad                  0x203dd30 Worker::processQueueElement(bool)
15 RemoteGamepad                  0x203d390 (anonymous namespace)::workerRoutine(void*)
16 libsystem_pthread.dylib        0x637c _pthread_start
17 libsystem_pthread.dylib        0x1494 thread_start
```
Also received some other PosixException crashes on mingw, here is one example:
```
Application Specific Information:
POSIX error 10038: Unknown error (10038)

Thread 0 Crashed:
0   Remote Gamepad.exe              0x7ff7ad4c1e3a      [inlined] kfun:io.ktor.utils.io.errors.PosixException#<T>{}
1   Remote Gamepad.exe              0x7ff7ad4c1e3a      [inlined] kfun:io.ktor.utils.io.errors.PosixException.PosixErrnoException#<T>{} (PosixErrors.kt:71)
2   Remote Gamepad.exe              0x7ff7ad4c1e3a      [inlined] inlined-out:<T> (PosixErrors.kt:122)
3   Remote Gamepad.exe              0x7ff7ad4c1e3a      [inlined] inlined-out:memScoped (Utils.kt:718)
4   Remote Gamepad.exe              0x7ff7ad4c1e3a      [inlined] kfun:io.ktor.utils.io.errors.PosixException.Companion#forErrno{}io.ktor.utils.io.errors.PosixException (PosixErrors.kt:89)
5   Remote Gamepad.exe              0x7ff7ad4c1e3a      [inlined] kfun:io.ktor.network.util#forSocketError__at__io.ktor.utils.io.errors.PosixException.Companion{}io.ktor.utils.io.errors.PosixException (SocketUtils.kt:163)
6   Remote Gamepad.exe              0x7ff7ad4c1e3a      kfun:io.ktor.network.util#forSocketError$default__at__io.ktor.utils.io.errors.PosixException.Companion{}io.ktor.utils.io.errors.PosixException (SocketUtils.kt:160)
7   Remote Gamepad.exe              0x7ff7ad4c6552      [inlined] inlined-out:<T>
8   Remote Gamepad.exe              0x7ff7ad4c6552      [inlined] inlined-out:associateByTo (_Collections.kt:1247)
9   Remote Gamepad.exe              0x7ff7ad4c6552      [inlined] inlined-out:mapValuesTo (Maps.kt:412)
10  Remote Gamepad.exe              0x7ff7ad4c6552      [inlined] inlined-out:mapValues (Maps.kt:462)
11  Remote Gamepad.exe              0x7ff7ad4c6552      [inlined] kfun:io.ktor.network.selector.SelectorHelper.fillHandlersOrClose#internal (SelectUtilsWindows.kt:147)
12  Remote Gamepad.exe              0x7ff7ad4c6552      kfun:io.ktor.network.selector.SelectorHelper.selectionLoop#internal (SelectUtilsWindows.kt:59)
13  Remote Gamepad.exe              0x7ff7ad4c7120      [inlined] kfun:io.ktor.network.selector.SelectorHelper.start$lambda$0#internal (SelectUtilsWindows.kt:34)
14  Remote Gamepad.exe              0x7ff7ad4c7120      kfun:io.ktor.network.selector.SelectorHelper.SelectorHelper$start$2.invoke#internal (SelectUtilsWindows.kt:33)
15  Remote Gamepad.exe              0x7ff7ad28edfa      [inlined] kfun:kotlin.Function2#invoke{}1:2-trampoline ([K][Suspend]Functions:1)
16  Remote Gamepad.exe              0x7ff7ad28edfa      [inlined] inlined-out:startCoroutineUninterceptedOrReturn (IntrinsicsNative.kt:72)
17  Remote Gamepad.exe              0x7ff7ad28edfa      [inlined] inlined-out:<T> (IntrinsicsNative.kt:186)
18  Remote Gamepad.exe              0x7ff7ad28edfa      kfun:kotlin.coroutines.intrinsics.createCoroutineUnintercepted$$inlined$createCoroutineFromSuspendFunction$2.invokeSuspend#internal (IntrinsicsNative.kt:254)
19  Remote Gamepad.exe              0x7ff7ad28d8e0      [inlined] kfun:kotlin.coroutines.native.internal.BaseContinuationImpl#invokeSuspend{}kotlin.Any?-trampoline (ContinuationImpl.kt:50)
20  Remote Gamepad.exe              0x7ff7ad28d8e0      [inlined] inlined-out:<T> (ContinuationImpl.kt:30)
21  Remote Gamepad.exe              0x7ff7ad28d8e0      [inlined] inlined-out:with (Standard.kt:70)
22  Remote Gamepad.exe              0x7ff7ad28d8e0      kfun:kotlin.coroutines.native.internal.BaseContinuationImpl#resumeWith{} (ContinuationImpl.kt:26)
23  Remote Gamepad.exe              0x7ff7ad361b6d      [inlined] kfun:kotlin.coroutines.Continuation#resumeWith{}-trampoline (Continuation.kt:26)
24  Remote Gamepad.exe              0x7ff7ad361b6d      [inlined] inlined-out:resume (Continuation.kt:45)
25  Remote Gamepad.exe              0x7ff7ad361b6d      [inlined] inlined-out:<T> (DispatchedTask.kt:100)
26  Remote Gamepad.exe              0x7ff7ad361b6d      [inlined] inlined-out:withContinuationContext (CoroutineContext.kt:44)
27  Remote Gamepad.exe              0x7ff7ad361b6d      kfun:kotlinx.coroutines.DispatchedTask#run{} (DispatchedTask.kt:82)
28  Remote Gamepad.exe              0x7ff7ad374042      [inlined] kfun:kotlinx.coroutines.Runnable#run{}-trampoline (Runnable.kt:12)
29  Remote Gamepad.exe              0x7ff7ad374042      kfun:kotlinx.coroutines.MultiWorkerDispatcher.$workerRunLoop$lambda$2COROUTINE$0.invokeSuspend#internal (MultithreadedDispatchers.kt:110)
30  Remote Gamepad.exe              0x7ff7ad3748d9      [inlined] kfun:kotlinx.coroutines.MultiWorkerDispatcher.workerRunLoop$lambda$2#internal (MultithreadedDispatchers.kt:102)
31  Remote Gamepad.exe              0x7ff7ad3748d9      kfun:kotlinx.coroutines.MultiWorkerDispatcher.MultiWorkerDispatcher$workerRunLoop$2.invoke#internal (MultithreadedDispatchers.kt:102)
32  Remote Gamepad.exe              0x7ff7ad28edfa      [inlined] kfun:kotlin.Function2#invoke{}1:2-trampoline ([K][Suspend]Functions:1)
33  Remote Gamepad.exe              0x7ff7ad28edfa      [inlined] inlined-out:startCoroutineUninterceptedOrReturn (IntrinsicsNative.kt:72)
34  Remote Gamepad.exe              0x7ff7ad28edfa      [inlined] inlined-out:<T> (IntrinsicsNative.kt:186)
35  Remote Gamepad.exe              0x7ff7ad28edfa      kfun:kotlin.coroutines.intrinsics.createCoroutineUnintercepted$$inlined$createCoroutineFromSuspendFunction$2.invokeSuspend#internal (IntrinsicsNative.kt:254)
36  Remote Gamepad.exe              0x7ff7ad28d8e0      [inlined] kfun:kotlin.coroutines.native.internal.BaseContinuationImpl#invokeSuspend{}kotlin.Any?-trampoline (ContinuationImpl.kt:50)
37  Remote Gamepad.exe              0x7ff7ad28d8e0      [inlined] inlined-out:<T> (ContinuationImpl.kt:30)
38  Remote Gamepad.exe              0x7ff7ad28d8e0      [inlined] inlined-out:with (Standard.kt:70)
39  Remote Gamepad.exe              0x7ff7ad28d8e0      kfun:kotlin.coroutines.native.internal.BaseContinuationImpl#resumeWith{} (ContinuationImpl.kt:26)
40  Remote Gamepad.exe              0x7ff7ad361b6d      [inlined] kfun:kotlin.coroutines.Continuation#resumeWith{}-trampoline (Continuation.kt:26)
41  Remote Gamepad.exe              0x7ff7ad361b6d      [inlined] inlined-out:resume (Continuation.kt:45)
42  Remote Gamepad.exe              0x7ff7ad361b6d      [inlined] inlined-out:<T> (DispatchedTask.kt:100)
43  Remote Gamepad.exe              0x7ff7ad361b6d      [inlined] inlined-out:withContinuationContext (CoroutineContext.kt:44)
44  Remote Gamepad.exe              0x7ff7ad361b6d      kfun:kotlinx.coroutines.DispatchedTask#run{} (DispatchedTask.kt:82)
45  Remote Gamepad.exe              0x7ff7ad337530      [inlined] kfun:kotlinx.coroutines.Runnable#run{}-trampoline (Runnable.kt:12)
46  Remote Gamepad.exe              0x7ff7ad337530      [inlined] inlined-out:<T> (EventLoop.common.kt:263)
47  Remote Gamepad.exe              0x7ff7ad337530      [inlined] inlined-out:platformAutoreleasePool (Dispatchers.kt:31)
48  Remote Gamepad.exe              0x7ff7ad337530      kfun:kotlinx.coroutines.EventLoopImplBase#processNextEvent{}kotlin.Long (EventLoop.common.kt:263)
49  Remote Gamepad.exe              0x7ff7ad36e168      [inlined] kfun:kotlinx.coroutines.EventLoop#processNextEvent{}kotlin.Long-trampoline (EventLoop.common.kt:49)
50  Remote Gamepad.exe              0x7ff7ad36e168      [inlined] kfun:kotlinx.coroutines.BlockingCoroutine.joinBlocking#internal (Builders.kt:130)
51  Remote Gamepad.exe              0x7ff7ad36e168      kfun:kotlinx.coroutines#runBlocking{0§<T>}0:0 (Builders.kt:69)
52  Remote Gamepad.exe              0x7ff7ad374a5e      [inlined] kfun:kotlinx.coroutines#runBlocking$default{0§<T>}0:0 (Builders.kt:45)
53  Remote Gamepad.exe              0x7ff7ad374a5e      [inlined] kfun:kotlinx.coroutines.MultiWorkerDispatcher.workerRunLoop#internal (MultithreadedDispatchers.kt:102)
54  Remote Gamepad.exe              0x7ff7ad374a5e      [inlined] kfun:kotlinx.coroutines.MultiWorkerDispatcher.<T>$lambda$1$lambda$0#internal (MultithreadedDispatchers.kt:86)
55  Remote Gamepad.exe              0x7ff7ad374a5e      [inlined] kfun:kotlinx.coroutines.MultiWorkerDispatcher.MultiWorkerDispatcher$1$$inlined$apply$2.invoke#internal (MultithreadedDispatchers.kt:86)
56  Remote Gamepad.exe              0x7ff7ad374a5e      kfun:kotlinx.coroutines.MultiWorkerDispatcher.MultiWorkerDispatcher$1$$inlined$apply$2.$<T>invoke{}#internal (MultithreadedDispatchers.kt:86)
57  Remote Gamepad.exe              0x7ff7ad574c5d      kfun:io.ktor.client.statement.HttpResponse#<T>{}io.ktor.http.Headers-trampoline (HttpResponse.kt:24)
58  Remote Gamepad.exe              0x7ff7ad574669      kfun:io.ktor.client.statement.HttpResponse#<T>{}io.ktor.http.Headers-trampoline (HttpResponse.kt:24)
59  Remote Gamepad.exe              0x7ff7ad57ea41      kfun:io.ktor.client.statement.HttpResponse#<T>{}io.ktor.http.Headers-trampoline (HttpResponse.kt:24)
60  msvcrt.dll                      0x7ffa948aaf59      callthreadstartex
61  msvcrt.dll                      0x7ffa948ab02b      threadstartex
62  KERNEL32.DLL                    0x7ffa94927373      BaseThreadInitThunk
63  ntdll.dll                       0x7ffa9689cc90      RtlUserThreadStart
```

**Solution**
Found one issue with `maxDescriptor` which is 1 too high, unsure if this could cause issues. The `wakeupSignalEvent` is already added to the `watchSet`, so already included in `maxDescriptor`, and no need to add additional `1` as far as I know. Maybe this caused the EINVAL?

Furthermore, native stack traces often are missing lines / wrong line numbers, so will add more debug information in Ktor. It is unclear at the moment which call in selectionLoop (or nested functions) is actually causing the issue. Added it to all possible functions which could be called from selection code.
