### PR TITLE
KTOR-8183 Add a simplified route string

### DIFF
--- a/ktor-server/ktor-server-core/api/ktor-server-core.api
+++ b/ktor-server/ktor-server-core/api/ktor-server-core.api
@@ -1687,6 +1687,7 @@ public class io/ktor/server/routing/RoutingNode : io/ktor/server/application/App
 
 public final class io/ktor/server/routing/RoutingNodeKt {
 	public static final fun getAllRoutes (Lio/ktor/server/routing/RoutingNode;)Ljava/util/List;
+	public static final fun getPath (Lio/ktor/server/routing/RoutingNode;)Ljava/lang/String;
 	public static final fun insertPhaseAfter (Lio/ktor/server/routing/Route;Lio/ktor/util/pipeline/PipelinePhase;Lio/ktor/util/pipeline/PipelinePhase;)V
 	public static final fun insertPhaseBefore (Lio/ktor/server/routing/Route;Lio/ktor/util/pipeline/PipelinePhase;Lio/ktor/util/pipeline/PipelinePhase;)V
 	public static final fun intercept (Lio/ktor/server/routing/Route;Lio/ktor/util/pipeline/PipelinePhase;Lkotlin/jvm/functions/Function3;)V

--- a/ktor-server/ktor-server-core/api/ktor-server-core.klib.api
+++ b/ktor-server/ktor-server-core/api/ktor-server-core.klib.api
@@ -1660,6 +1660,8 @@ final val io.ktor.server.routing/RoutingFailureStatusCode // io.ktor.server.rout
     final fun <get-RoutingFailureStatusCode>(): io.ktor.util/AttributeKey<io.ktor.http/HttpStatusCode> // io.ktor.server.routing/RoutingFailureStatusCode.<get-RoutingFailureStatusCode>|<get-RoutingFailureStatusCode>(){}[0]
 final val io.ktor.server.routing/application // io.ktor.server.routing/application|@io.ktor.server.routing.Route{}application[0]
     final fun (io.ktor.server.routing/Route).<get-application>(): io.ktor.server.application/Application // io.ktor.server.routing/application.<get-application>|<get-application>@io.ktor.server.routing.Route(){}[0]
+final val io.ktor.server.routing/path // io.ktor.server.routing/path|@io.ktor.server.routing.RoutingNode{}path[0]
+    final fun (io.ktor.server.routing/RoutingNode).<get-path>(): kotlin/String // io.ktor.server.routing/path.<get-path>|<get-path>@io.ktor.server.routing.RoutingNode(){}[0]
 
 final var io.ktor.server.application/receiveType // io.ktor.server.application/receiveType|@io.ktor.server.application.ApplicationCall{}receiveType[0]
     final fun (io.ktor.server.application/ApplicationCall).<get-receiveType>(): io.ktor.util.reflect/TypeInfo // io.ktor.server.application/receiveType.<get-receiveType>|<get-receiveType>@io.ktor.server.application.ApplicationCall(){}[0]

--- a/ktor-server/ktor-server-core/common/src/io/ktor/server/routing/RoutingNode.kt
+++ b/ktor-server/ktor-server-core/common/src/io/ktor/server/routing/RoutingNode.kt
@@ -369,7 +369,6 @@ private fun RoutingNode.path(): String {
 }
 
 private fun RouteSelector.toPathElement(): String = when (this) {
-
     is PathSegmentConstantRouteSelector,
     is PathSegmentParameterRouteSelector,
     is PathSegmentOptionalParameterRouteSelector,

--- a/ktor-server/ktor-server-core/common/src/io/ktor/server/routing/RoutingNode.kt
+++ b/ktor-server/ktor-server-core/common/src/io/ktor/server/routing/RoutingNode.kt
@@ -352,7 +352,7 @@ private fun RoutingNode.getAllRoutes(endpoints: MutableList<RoutingNode>) {
 /**
  * String representation of the path matched by this route.
  *
- * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.server.routing.path)
+ * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.server.routing.RoutingNode.path)
  */
 public val RoutingNode.path: String
     get() = path()

--- a/ktor-server/ktor-server-core/common/src/io/ktor/server/routing/RoutingNode.kt
+++ b/ktor-server/ktor-server-core/common/src/io/ktor/server/routing/RoutingNode.kt
@@ -12,7 +12,6 @@ import io.ktor.util.*
 import io.ktor.util.pipeline.*
 import io.ktor.util.reflect.*
 import io.ktor.utils.io.*
-import kotlinx.coroutines.*
 import kotlin.coroutines.*
 
 /**
@@ -348,6 +347,39 @@ private fun RoutingNode.getAllRoutes(endpoints: MutableList<RoutingNode>) {
         endpoints.add(this)
     }
     children.forEach { it.getAllRoutes(endpoints) }
+}
+
+/**
+ * String representation of the path matched by this route.
+ *
+ * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.server.routing.path)
+ */
+public val RoutingNode.path: String
+    get() = path()
+
+private fun RoutingNode.path(): String {
+    val parentPath = parent?.path()
+    val selectorElement = selector.toPathElement()
+    return when {
+        parentPath == null -> selectorElement
+        selectorElement.isEmpty() -> parentPath
+        parentPath.endsWith('/') || selectorElement.startsWith('/') -> "$parentPath$selectorElement"
+        else -> "$parentPath/$selectorElement"
+    }
+}
+
+private fun RouteSelector.toPathElement(): String = when (this) {
+
+    is PathSegmentConstantRouteSelector,
+    is PathSegmentParameterRouteSelector,
+    is PathSegmentOptionalParameterRouteSelector,
+    is PathSegmentTailcardRouteSelector,
+    is PathSegmentWildcardRouteSelector,
+    is PathSegmentRegexRouteSelector -> toString()
+
+    is TrailingSlashRouteSelector -> "/"
+
+    else -> ""
 }
 
 @Deprecated("Please use route scoped plugins instead")

--- a/ktor-server/ktor-server-core/common/test/io/ktor/server/routing/RouteTest.kt
+++ b/ktor-server/ktor-server-core/common/test/io/ktor/server/routing/RouteTest.kt
@@ -155,7 +155,7 @@ class RouteTest {
                 // Routing nodes not related to path
                 route("omitted") {
                     contentType(ContentType.Text.CSV) {
-                        post("contentType"){}
+                        post("contentType") {}
                     }
                     param("order", "asc") {
                         post("param") {}

--- a/ktor-server/ktor-server-core/common/test/io/ktor/server/routing/RouteTest.kt
+++ b/ktor-server/ktor-server-core/common/test/io/ktor/server/routing/RouteTest.kt
@@ -138,4 +138,36 @@ class RouteTest {
 
         assertEquals(HttpStatusCode.OK, client.get("/").status)
     }
+
+    @Test
+    fun testPathProperty() = testApplication {
+        application {
+            val root = routing {
+                get {}
+                get("/") {}
+                get("/trailing/slash/") {}
+                get("/parameter/{mandatory}/{optional?}") {}
+                get("/wildcard/*") {}
+                get("/tailcard/{...}") {}
+                get("/parameter/tailcard/{path...}") {}
+                get(Regex("/.+regex")) {}
+            }
+
+            val paths = root.getAllRoutes()
+                .map { it.path }
+                .toSet()
+
+            val expected = setOf(
+                "",
+                "/",
+                "/trailing/slash/",
+                "/parameter/{mandatory}/{optional?}",
+                "/wildcard/*",
+                "/tailcard/{...}",
+                "/parameter/tailcard/{...}",
+                "/Regex(/.+regex)",
+            )
+            assertEquals(expected, paths)
+        }
+    }
 }

--- a/ktor-server/ktor-server-core/common/test/io/ktor/server/routing/RouteTest.kt
+++ b/ktor-server/ktor-server-core/common/test/io/ktor/server/routing/RouteTest.kt
@@ -151,6 +151,19 @@ class RouteTest {
                 get("/tailcard/{...}") {}
                 get("/parameter/tailcard/{path...}") {}
                 get(Regex("/.+regex")) {}
+
+                // Routing nodes not related to path
+                route("omitted") {
+                    contentType(ContentType.Text.CSV) {
+                        post("contentType"){}
+                    }
+                    param("order", "asc") {
+                        post("param") {}
+                    }
+                    header("Accept-Language", "en-US,en;q=0.5") {
+                        get("header") {}
+                    }
+                }
             }
 
             val paths = root.getAllRoutes()
@@ -166,6 +179,11 @@ class RouteTest {
                 "/tailcard/{...}",
                 "/parameter/tailcard/{...}",
                 "/Regex(/.+regex)",
+
+                // contentType, param and header RouteSelectors should be omitted
+                "/omitted/contentType",
+                "/omitted/param",
+                "/omitted/header",
             )
             assertEquals(expected, paths)
         }

--- a/ktor-server/ktor-server-plugins/ktor-server-metrics-micrometer/api/ktor-server-metrics-micrometer.api
+++ b/ktor-server/ktor-server-plugins/ktor-server-metrics-micrometer/api/ktor-server-metrics-micrometer.api
@@ -11,6 +11,7 @@ public final class io/ktor/server/metrics/micrometer/MicrometerMetricsConfig {
 	public final fun setMetricName (Ljava/lang/String;)V
 	public final fun setRegistry (Lio/micrometer/core/instrument/MeterRegistry;)V
 	public final fun timers (Lkotlin/jvm/functions/Function3;)V
+	public final fun transformRoute (Lkotlin/jvm/functions/Function1;)V
 }
 
 public final class io/ktor/server/metrics/micrometer/MicrometerMetricsKt {

--- a/ktor-server/ktor-server-plugins/ktor-server-metrics-micrometer/build.gradle.kts
+++ b/ktor-server/ktor-server-plugins/ktor-server-metrics-micrometer/build.gradle.kts
@@ -9,6 +9,7 @@ kotlin {
         jvmTest {
             dependencies{
                 implementation(project(":ktor-server:ktor-server-plugins:ktor-server-metrics"))
+                api(project(":ktor-server:ktor-server-plugins:ktor-server-auth"))
             }
         }
     }

--- a/ktor-server/ktor-server-plugins/ktor-server-metrics-micrometer/jvm/src/io/ktor/server/metrics/micrometer/MicrometerMetrics.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-metrics-micrometer/jvm/src/io/ktor/server/metrics/micrometer/MicrometerMetrics.kt
@@ -222,9 +222,7 @@ public val MicrometerMetrics: ApplicationPlugin<MicrometerMetricsConfig> =
 
         application.monitor.subscribe(RoutingRoot.RoutingCallStarted) { call ->
             call.attributes.getOrNull(measureKey)?.let { measure ->
-                measure.route = call.route.let { route ->
-                    pluginConfig.transformRoute(route)
-                }
+                measure.route = pluginConfig.transformRoute(call.route)
             }
         }
     }

--- a/ktor-server/ktor-server-plugins/ktor-server-metrics-micrometer/jvm/src/io/ktor/server/metrics/micrometer/MicrometerMetrics.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-metrics-micrometer/jvm/src/io/ktor/server/metrics/micrometer/MicrometerMetrics.kt
@@ -120,7 +120,7 @@ public class MicrometerMetricsConfig {
         timerBuilder = block
     }
 
-    internal var transformRoute: RoutingNode.() -> String = { path }
+    internal var transformRoute: (RoutingNode) -> String = { it.path }
 
     /**
      * Configures mapping function for the route label string of the [CallMeasure].
@@ -131,20 +131,20 @@ public class MicrometerMetricsConfig {
      * Use the toString() function of the RoutingNode:
      * ```kotlin
      * transformRoute {
-     *    toString()
+     *    it.toString()
      * }
      * ```
      *
      * Remove a prefix from the path:
      * ```kotlin
      * transformRoute {
-     *     path.removePrefix("/path/prefix")
+     *     it.path.removePrefix("/path/prefix")
      * }
      * ```
      *
      * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.server.metrics.micrometer.MicrometerMetricsConfig.transformRoute)
      */
-    public fun transformRoute(block : RoutingNode.() -> String) {
+    public fun transformRoute(block: (RoutingNode) -> String) {
         transformRoute = block
     }
 }

--- a/ktor-server/ktor-server-plugins/ktor-server-metrics-micrometer/jvm/test/io/ktor/server/metrics/micrometer/MicrometerMetricsTests.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-metrics-micrometer/jvm/test/io/ktor/server/metrics/micrometer/MicrometerMetricsTests.kt
@@ -8,6 +8,7 @@ import io.ktor.client.request.*
 import io.ktor.client.statement.*
 import io.ktor.http.*
 import io.ktor.server.application.*
+import io.ktor.server.auth.*
 import io.ktor.server.metrics.dropwizard.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
@@ -398,6 +399,63 @@ class MicrometerMetricsTests {
             val gauge = find(activeRequestsGaugeName).gauge()
             val configurableGauge = find(activeRequestsGaugeName).gauge()
             assertEquals(gauge, configurableGauge)
+        }
+    }
+
+    @Test
+    fun `route transformation can be configured`() = testApplication {
+        val testRegistry = SimpleMeterRegistry()
+
+        install(MicrometerMetrics) {
+            registry = testRegistry
+            transformRoute {
+                "/prefix$path"
+            }
+        }
+
+        routing {
+            get("/uri") {
+                call.respond("some response")
+            }
+        }
+
+        client.request("/uri")
+
+        with(testRegistry.find(requestTimeTimerName).timers()) {
+            assertEquals(1, size)
+            this.first().run {
+                assertTag("route", "/prefix/uri")
+            }
+        }
+    }
+
+    @Test
+    fun `route with auth plugin should not include authentication provider`() = testApplication {
+        val testRegistry = SimpleMeterRegistry()
+
+        install(MicrometerMetrics) {
+            registry = testRegistry
+        }
+
+        install(Authentication) {
+            bearer { }
+        }
+
+        routing {
+            authenticate {
+                    get("/uri") {
+                        call.respond("some response")
+                    }
+            }
+        }
+
+        client.request("/uri")
+
+        with(testRegistry.find(requestTimeTimerName).timers()) {
+            assertEquals(1, size)
+            this.first().run {
+                assertTag("route", "/uri")
+            }
         }
     }
 

--- a/ktor-server/ktor-server-plugins/ktor-server-metrics-micrometer/jvm/test/io/ktor/server/metrics/micrometer/MicrometerMetricsTests.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-metrics-micrometer/jvm/test/io/ktor/server/metrics/micrometer/MicrometerMetricsTests.kt
@@ -409,7 +409,7 @@ class MicrometerMetricsTests {
         install(MicrometerMetrics) {
             registry = testRegistry
             transformRoute {
-                "/prefix$path"
+                "/prefix${it.path}"
             }
         }
 

--- a/ktor-server/ktor-server-plugins/ktor-server-metrics-micrometer/jvm/test/io/ktor/server/metrics/micrometer/MicrometerMetricsTests.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-metrics-micrometer/jvm/test/io/ktor/server/metrics/micrometer/MicrometerMetricsTests.kt
@@ -443,9 +443,9 @@ class MicrometerMetricsTests {
 
         routing {
             authenticate {
-                    get("/uri") {
-                        call.respond("some response")
-                    }
+                get("/uri") {
+                    call.respond("some response")
+                }
             }
         }
 


### PR DESCRIPTION
**Subsystem**
Server, server-core & metrics-micrometer

**Motivation**
[KTOR-8183](https://youtrack.jetbrains.com/issue/KTOR-8183) Add a simplified route string

**Solution**
Add `path` extension property to RoutingNode. It returns a String representation of the path matched by the route. RoutingNodes not related to the path, i.e. from the authorization plugin or the http method are ommited here.

Make the route label string of micrometer metrics configurable with the `transformRoute` function in `MicrometerMetricsConfig` and use `RoutingNode.path` as default.

This fixes the issue of unwanted path elements, like `/(authenticate "default")/uri`, in the metrics route label.
The original behaviour can be configured by setting
```kotlin
transformRoute { 
    parent.toString() 
}
```
in the `MicrometerMetricsConfig`.