### PR TITLE
Fixed an issue where canceling the incoming flow of OkHttpSSESession/DefaultClientSSESession failed to disconnect the SSE session.

### DIFF
--- a/ktor-test-server/src/main/kotlin/test/server/tests/ServerSentEvents.kt
+++ b/ktor-test-server/src/main/kotlin/test/server/tests/ServerSentEvents.kt
@@ -25,7 +25,11 @@ internal fun Application.serverSentEvents() {
                 delay(delayMillis)
 
                 val times = call.parameters["times"]?.toInt() ?: 1
+                val interval = call.parameters["interval"]?.toLong() ?: 0
                 repeat(times) {
+                    if (interval > 0 && it > 0) {
+                        delay(interval)
+                    }
                     send("hello\nfrom server", "hello $it", "$it")
                 }
             }


### PR DESCRIPTION
Fixed an issue where canceling the incoming flow of OkHttpSSESession failed to disconnect the SSE session.

**Subsystem**
Client
ktor-client/ktor-client-okhttp

**Motivation**
Refer to a bug/ticket #4692.
In the OkHttpSSESession implementation of SSESession, cancel incoming flow will NOT trigger serverSentEventsSource.cancel(), which will keep SSE still connecting !

**Solution**
- First, ```val incoming: Flow<ServerSentEvent>``` in  OkHttpSSESession should always return the same Flow instance, just as DefaultClientSSESession did.

- Second, cancel ```_incoming.receiveAsFlow()``` will just cancel the Flow but will **NOT** cancel the _incoming Channel, so we should use ```_incoming.consumeAsFlow()``` instead.

- Third, if ```incoming.trySendBlocking(ServerSentEvent(data, type, id))``` fails with a CancellationException, we should rethrow the CancellationException to let ```fun onFailure(eventSource: EventSource, t: Throwable?, response: Response?)``` handle it and close the SSE session.
