### PR TITLE
KTOR-6384 Fix Websocket Extension negotiation -

### DIFF
--- a/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/websocket/WebSockets.kt
+++ b/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/websocket/WebSockets.kt
@@ -96,7 +96,7 @@ public class WebSockets internal constructor(
     private fun addNegotiatedProtocols(context: HttpRequestBuilder, protocols: List<WebSocketExtensionHeader>) {
         if (protocols.isEmpty()) return
 
-        val headerValue = protocols.joinToString(";")
+        val headerValue = protocols.joinToString(",")
         context.header(HttpHeaders.SecWebSocketExtensions, headerValue)
     }
 

--- a/ktor-server/ktor-server-plugins/ktor-server-websockets/common/src/io/ktor/server/websocket/WebSocketUpgrade.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-websockets/common/src/io/ktor/server/websocket/WebSocketUpgrade.kt
@@ -131,7 +131,7 @@ public class WebSocketUpgrade(
         }
 
         if (extensionHeaders.isNotEmpty()) {
-            append(HttpHeaders.SecWebSocketExtensions, extensionHeaders.joinToString(";"))
+            append(HttpHeaders.SecWebSocketExtensions, extensionHeaders.joinToString(","))
         }
 
         return extensionsToUse

--- a/ktor-shared/ktor-websockets/common/src/io/ktor/websocket/WebSocketExtensionHeader.kt
+++ b/ktor-shared/ktor-websockets/common/src/io/ktor/websocket/WebSocketExtensionHeader.kt
@@ -33,7 +33,7 @@ public class WebSocketExtensionHeader(public val name: String, public val parame
     override fun toString(): String = "$name ${parametersToString()}"
 
     private fun parametersToString(): String =
-        if (parameters.isEmpty()) "" else ", ${parameters.joinToString(",")}"
+        if (parameters.isEmpty()) "" else "; ${parameters.joinToString(";")}"
 }
 
 /**


### PR DESCRIPTION
According to RFC 6455 protocols are delimited by comma and arguments by semicolon, not the other way around

https://datatracker.ietf.org/doc/html/rfc6455#page-48

**Subsystem**
Client/Server, Websocket extension

**Motivation**
Fixes a bug KTOR-6384

**Solution**
Just swap the delimeters for protocols and their arguments.
