### PR TITLE
Add shutdown hook to gracefully stop Netty server

### DIFF
--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/EngineMain.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/EngineMain.kt
@@ -22,6 +22,11 @@ public object EngineMain {
     @JvmStatic
     public fun main(args: Array<String>) {
         val server = createServer(args)
+
+        Runtime.getRuntime().addShutdownHook(Thread {
+            server.stop(gracePeriodMillis = 5000, timeoutMillis = 30000)
+        })
+
         server.start(true)
     }
 


### PR DESCRIPTION
This ensures the server stops cleanly during shutdown by invoking the stop method with a specified grace period and timeout. It improves resource cleanup and prevents abrupt termination.

**Subsystem**
io.ktor.server.netty.EngineMain.kt

**Motivation**
Improvements have been made to respond to exceptions that may occur during server operation and to safely release resources when the server is terminated.

**Solution**
When shutting down the server by registering a Shutdown Hook, the ongoing work has been improved to process and terminate more gracefully.

This ensures the server stops cleanly during shutdown by invoking the stop method with a specified grace period and timeout. It improves resource cleanup and prevents abrupt termination.

