### PR TITLE
KTOR-8264 Merge of CHANGELOG.md, README.md and CODE_OF_CONDUCT.md.

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,4 +1,0 @@
-## Code of Conduct
-
-This project and the corresponding community is governed by the [JetBrains Open Source and Community Code of Conduct](https://confluence.jetbrains.com/display/ALL/JetBrains+Open+Source+and+Community+Code+of+Conduct). Please make sure you read it. 
-

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,7 @@ There are multiple ways you can contribute:
 * Community Support
 * Feedback/Issue reports
 
-Independently of how you'd like to contribute, please make sure you read and comply with the [Code of Conduct](CODE_OF_CONDUCT.md).
+Independently of how you'd like to contribute, please make sure you read and comply with the [Code of Conduct](https://confluence.jetbrains.com/display/ALL/JetBrains+Open+Source+and+Community+Code+of+Conduct).
 
 ## Code
 

--- a/README.md
+++ b/README.md
@@ -138,4 +138,4 @@ Kotlin web frameworks such as Wasabi and Kara, which are currently deprecated.
 
 ## Contributing
 
-Please see [the contribution guide](CONTRIBUTING.md) and the [Code of conduct](CODE_OF_CONDUCT.md) before contributing.
+Please see [the contribution guide](CONTRIBUTING.md) and the [Code of conduct](https://confluence.jetbrains.com/display/ALL/JetBrains+Open+Source+and+Community+Code+of+Conduct) before contributing.


### PR DESCRIPTION
**Subsystem**
none

**Motivation**
I thought it would be better to combine each line into one file rather than separate them, and I thought it would be less tiring to move the links once rather than twice.
(Refer to #4713) 

**Solution**
The local `CODE_OF_CONDUCT.md` file was removed, and all references to it were replaced with direct links to the JetBrains Code of Conduct page. This simplifies maintenance

