### PR TITLE
Decode URL safe base64 correctly

### DIFF
--- a/ktor-utils/common/src/io/ktor/util/Base64.kt
+++ b/ktor-utils/common/src/io/ktor/util/Base64.kt
@@ -15,6 +15,10 @@ private const val BASE64_PAD = '='
 
 private val BASE64_INVERSE_ALPHABET = IntArray(256) {
     BASE64_ALPHABET.indexOf(it.toChar())
+}.also {
+    // correctly decode URL-safe Base64
+    it['-'.code] = it['+'.code]
+    it['_'.code] = it['/'.code]
 }
 
 /**

--- a/ktor-utils/common/test/io/ktor/util/Base64Test.kt
+++ b/ktor-utils/common/test/io/ktor/util/Base64Test.kt
@@ -51,4 +51,23 @@ class Base64Test {
             assertEquals(text, encodedText.decodeBase64String())
         }
     }
+
+    @Test
+    fun testEncodeDecodeAllCharacters() {
+        val commonChars: List<Char> = ('a'..'z') + ('A'..'Z') + ('0'..'9')
+        val allBase64Chars: String = (commonChars + '+' + '/').joinToString("")
+        val allUrlSafeBase64Chars: String = (commonChars + '-' + '_').joinToString("")
+
+        val expectedBytes: List<Byte> = listOf(
+            105, -73, 29, 121, -8, 33, -118, 57, 37, -102, 122, 41, -86, -69, 45, -70, -4, 49, -53, 48, 1, 8, 49, 5,
+            24, 114, 9, 40, -77, 13, 56, -12, 17, 73, 53, 21, 89, 118, 25, -45, 93, -73, -29, -98, -69, -13, -33, -65,
+        )
+
+        // Check encode
+        assertEquals(allBase64Chars, expectedBytes.toByteArray().encodeBase64())
+        // Check decode
+        assertEquals(expectedBytes, allBase64Chars.decodeBase64Bytes().toList())
+        assertEquals(expectedBytes, allUrlSafeBase64Chars.decodeBase64Bytes().toList())
+
+    }
 }

--- a/ktor-utils/common/test/io/ktor/util/Base64Test.kt
+++ b/ktor-utils/common/test/io/ktor/util/Base64Test.kt
@@ -68,6 +68,5 @@ class Base64Test {
         // Check decode
         assertEquals(expectedBytes, allBase64Chars.decodeBase64Bytes().toList())
         assertEquals(expectedBytes, allUrlSafeBase64Chars.decodeBase64Bytes().toList())
-
     }
 }


### PR DESCRIPTION
**Subsystem**
ktor-utils

**Motivation**
In a unit test for a Ktor project I was encoding and decoding some data with `ByteArray.encodeBase64(): String` and `String.decodeBase64Bytes(): ByteArray` and was wondering why the result was not what I was expecting. After decoding and encoding, the resulting data was very slightly different from what I put in.

Turns out that the issue was, that I was using URL-safe base64 (i.e. same as normal base64, but all `+` characters are replaced by `-` and all `/` replaced by `_`, also no `=` padding at the end).

After looking at the source code, I found that `String.decodeBase64Bytes(): ByteArray` treats every character that is not a valid Base64 character as if it were the character `/`. That's because the decoded character is determined using `indexOf()`, which returns `-1`, so the last character in the alphabet is selected.

So `"_-!A".decodeBase64Bytes()` is decoded to `byteArrayOf(-1, -1, -64)`.

`byteArrayOf(-1, -1, -64).encodeBase64()` will encode to `///A`.

**Solution**
I thought, this could be easily adapted to work with URL-safe base64 as well. Without impacting encoding and decoding of **valid** "normal" Base64. So that's what I did with this PR.

For strings containing non-base64 I was assuming this behaviour was currently undefined (and as far as I can see not documented) behaviour, so I hope it is fine to make this change here.

I also added a test case verifying that a string containing the entire Base64 alphabet (both normal and URL safe) is converted correctly, since several characters were not tested in the previous unit tests.

---

**By the way:** I'm not sure how far along it currently is, but there is now also a `Base64` utility in the stdlib: https://kotlinlang.org/api/core/kotlin-stdlib/kotlin.io.encoding/-base64/ (currently needs opt-in to `@ExperimentalEncodingApi`). Are there any reasons holding ktor back from just using that (besides it still being marked as experimental)?
