### PR TITLE
Auto-approve and auto-merge renovate PRs

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -38,3 +38,6 @@ ij_kotlin_name_count_to_use_star_import = 2
 
 [*.properties]
 ij_properties_keep_blank_lines = true
+
+[{*.yml,*.yaml}]
+indent_size = 2

--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -1,0 +1,26 @@
+name: Auto-Approve
+
+on:
+  pull_request_target:
+    types: [opened, labeled]
+
+jobs:
+  auto-approve:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: write
+    if: github.actor == 'renovate[bot]' || contains(github.event.pull_request.labels.*.name, '👍 ship!')
+    steps:
+      - name: Approve
+        run: gh pr review "${{ github.event.pull_request.number }}" --approve --body "Ship it! :shipit:"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository_owner }}/${{ github.event.repository.name }}
+
+      - name: Enable auto-merge
+        if: contains(github.event.pull_request.labels.*.name, '👍 ship!')
+        run: gh pr merge "${{ github.event.pull_request.number }}" --auto --squash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository_owner }}/${{ github.event.repository.name }}

--- a/renovate.json
+++ b/renovate.json
@@ -3,7 +3,8 @@
   "extends": [
     "config:recommended",
     ":semanticCommitsDisabled",
-    ":label(dependencies)"
+    ":label(dependencies)",
+    "schedule:automergeNonOfficeHours"
   ],
   "rebaseWhen": "conflicted",
   "packageRules": [
@@ -20,7 +21,8 @@
         "https://repo.maven.apache.org/maven2"
       ],
       "fetchChangeLogs": "off",
-      "versioning": "regex:^(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)(?:(?:-.+)?-eap-(?<build>\\d+))?$"
+      "versioning": "regex:^(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)(?:(?:-.+)?-eap-(?<build>\\d+))?$",
+      "automerge": true
     },
     {
       "description": "False positive dependency findings.",
@@ -57,6 +59,26 @@
         "com.gradle:develocity-gradle-plugin*"
       ],
       "enabled": false
+    },
+    {
+      "description": "Automerge non-major releases",
+      "matchUpdateTypes": ["patch", "minor"],
+      "automerge": true
+    },
+    {
+      "description": "Automerge test and infrastructure dependencies",
+      "matchDepNames": [
+        "ch.qos.logback:logback-classic",
+        "com.gradle:common-custom-user-data-gradle-plugin",
+        "com.osacky.doctor:doctor-plugin",
+        "gradle",
+        "io.mockk:mockk",
+        "org.jetbrains.kotlinx.kover",
+        "org.jetbrains.kotlinx:binary-compatibility-validator",
+        "org.jmailen.gradle:kotlinter-gradle",
+        "org.junit.jupiter:junit-jupiter"
+      ],
+      "automerge": true
     }
   ]
 }


### PR DESCRIPTION
**Subsystem**
Infrastructure

**Motivation**
1. Make it possible to merge PRs without review (for "Ship" PRs from [Ship/Show/Ask](https://martinfowler.com/articles/ship-show-ask.html))
2. Merge renovate PRs automatically when possible

**Solution**
Automatically approve PRs from Renovate or having label "ship!".
Enable automerge for non-major updates and for test/infrastucture dependencies.

(Added tag "ship" to this PR as a demo)