### PR TITLE
Prevent double auto-approve

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -2,18 +2,27 @@ name: Auto-Approve
 
 on:
   pull_request_target:
-    types: [opened, labeled]
+    types: [labeled]
 
 jobs:
   auto-approve:
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
-      contents: write
     if: github.actor == 'renovate[bot]' || contains(github.event.pull_request.labels.*.name, '👍 ship!')
     steps:
       - name: Approve
-        run: gh pr review "${{ github.event.pull_request.number }}" --approve --body "Ship it! :shipit:"
+        run: |
+          pr_number=${{ github.event.pull_request.number }}
+          decision=$(gh pr view "$pr_number" --json reviewDecision --jq ".reviewDecision")
+          echo "Current review decision: $decision"
+
+          if [[ "$decision" == "REVIEW_REQUIRED" ]]; then
+            gh pr review "$pr_number" --approve --body "Ship it! :shipit:"
+            echo "Approved!"
+          else
+            echo "Skipped."
+          fi
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository_owner }}/${{ github.event.repository.name }}

--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -26,10 +26,3 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository_owner }}/${{ github.event.repository.name }}
-
-      - name: Enable auto-merge
-        if: contains(github.event.pull_request.labels.*.name, '👍 ship!')
-        run: gh pr merge "${{ github.event.pull_request.number }}" --auto --squash
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GH_REPO: ${{ github.repository_owner }}/${{ github.event.repository.name }}


### PR DESCRIPTION
**Subsystem**
Infrastructure

**Motivation**
The bot approves PRs too zealous:

<img width="534" alt="image" src="https://github.com/user-attachments/assets/04eb9ef7-ce22-4ae7-83e8-145179c96958" />

**Solution**
- Auto-approve PR only if it's current review decision is "REQUIRES_REVIEW".
- Trigger the workflow only on event `labeled` as it is also triggered when PR with label was created.
- Remove "Enable auto-merge" step as it doesn't work with `GITHUB_TOKEN`