### PR TITLE
KTOR-8299_Add Japanese documentation ()

### DIFF
--- a/docs/ja/CODE_OF_CONDUCT.md
+++ b/docs/ja/CODE_OF_CONDUCT.md
@@ -1,0 +1,3 @@
+## 行動規範
+
+このプロジェクトおよび関連するコミュニティは、[JetBrains オープンソースおよびコミュニティ行動規範](https://confluence.jetbrains.com/display/ALL/JetBrains+Open+Source+and+Community+Code+of+Conduct) に基づいて運営されています。必ず内容を確認してください。

--- a/docs/ja/CONTRIBUTING.md
+++ b/docs/ja/CONTRIBUTING.md
@@ -1,0 +1,113 @@
+## 貢献方法
+
+まず初めに、Ktor への貢献を検討していただきありがとうございます！
+
+貢献にはさまざまな方法があります：
+
+- コードの提供
+- ドキュメントの改善
+- コミュニティサポート
+- フィードバックやバグ報告
+
+どの方法で貢献する場合でも、必ず[行動規範](CODE_OF_CONDUCT.md)を確認し、遵守してください。
+
+### コードの貢献
+
+Ktor のバックログには、多くのバグ修正や新機能の実装タスクがあります。自由に選択できますが、まずは[取り組みやすいタスク](https://youtrack.jetbrains.com/issues?q=%23Ktor%20%20%20%23%7BUp%20For%20Grabs%7D%20%20%23Unresolved%20)から始めることを推奨します。
+
+#### プロジェクトのビルド
+
+> **重要**
+> このプロジェクトは JDK 21 を必要とします。JDK 21 をインストールしたうえでビルドを実行してください。
+> IntelliJ IDEA を使用する場合は、**「プロジェクト構造」>「プロジェクト」>「SDK」** で JDK 21 を選択してください。
+
+Ktor は Gradle を使用してビルドされます。Ktor はマルチプラットフォーム対応のため、JVM、ネイティブ、JavaScript 用にビルドできます。
+
+プロジェクトをビルドし、対応するアーティファクトを作成するには、以下のコマンドを実行してください。
+
+```sh
+./gradlew assemble
+```
+
+テストを実行するには、以下のコマンドを使用します。
+
+```sh
+./gradlew jvmTest
+```
+
+JVM 上のすべてのテストを実行します。最低限これを実行してください。他のプラットフォーム向けのコードを記述する場合は、それに対応するテストも実行する必要があります。
+
+利用可能なタスクを確認するには、以下のコマンドを実行してください。
+
+```sh
+./gradlew tasks
+```
+
+#### 開発環境のセットアップ
+
+開発に使用する OS に応じて、追加のライブラリやツールのインストールが必要です。
+
+**Linux**
+
+以下のコマンドを実行して `libcurl` および `libncurses` をインストールしてください。
+
+```sh
+sudo apt update
+sudo apt install libcurl4-openssl-dev libncurses-dev
+```
+
+**macOS**
+
+[Homebrew](https://brew.sh) を使用して `libcurl` および `libncurses` をインストールできます。
+
+```sh
+brew install curl ncurses
+```
+
+macOS または iOS をターゲットとする場合は、Xcode および Xcode コマンドラインツールのインストールが必要です。
+
+**Windows**
+
+Windows での開発には [Cygwin](http://cygwin.com/) の使用を推奨します。これにより `libncurses` などの必要なライブラリが提供されます。
+
+#### IntelliJ IDEA でのプロジェクトのインポート
+
+Ktor のプロジェクトフォルダを開くだけで、IntelliJ IDEA が Gradle プロジェクトとして自動検出し、インポートします。すべてのビルドやテストの操作を Gradle に委任するよう、[Gradle 設定](https://www.jetbrains.com/help/idea/gradle-settings.html) を確認してください。
+
+### プルリクエスト（PR）
+
+貢献は GitHub の[プルリクエスト](https://help.github.com/en/articles/about-pull-requests)を通じて行います。
+
+1. Ktor リポジトリをフォークし、フォーク先で作業してください。
+2. [新しい PR を作成](https://github.com/ktorio/ktor/compare)し、**main ブランチ** にマージをリクエストしてください。
+3. 説明を明確にし、関連するチケットやバグ報告がある場合は KTOR-{NUM} の形式で記載してください。
+4. 新機能を追加する場合、その価値やユースケースを説明し、Ktor フレームワークに適した変更である理由を明示してください。
+5. ドキュメントの更新が必要な場合は、[YouTrack](https://youtrack.jetbrains.com/issues/KTOR) に新しいチケットを作成してください。
+6. すべてのコード変更にはテストを含め、既存のテストを破壊しないようにしてください。
+
+### スタイルガイド
+
+- コードは公式の[Kotlin コーディング規約](https://kotlinlang.org/docs/reference/coding-conventions.html)に従うこと。
+- `io.ktor.*` のパッケージでは、常にワイルドカードインポートを使用すること。
+- すべての新しいソースファイルには著作権ヘッダーを記述すること。
+- すべてのパブリック API（関数、クラス、オブジェクトなど）には適切なドキュメントを追加すること。
+- 非公開にすべきだが技術的制約で公開されている API には `@InternalAPI` を付与すること。
+
+### コミットメッセージ
+
+- 英語で記述すること。
+- 現在形・命令形で記述すること（例：「Fix」ではなく「Fixes」）。
+- バグ修正のコミットには `KTOR-{NUM}` の形式で YouTrack のバグ番号を付けること。
+
+### ドキュメントへの貢献
+
+Ktor の公式ドキュメントは、[ktor-documentation](https://github.com/ktorio/ktor-documentation) リポジトリにあります。[貢献ガイド](https://github.com/ktorio/ktor-documentation#contributing)を確認してください。
+
+### コミュニティサポート
+
+[Ktor のサポートチャネル](https://ktor.io/support) に参加し、他の開発者を助けることで貢献できます。これは学習にも最適です。
+
+### フィードバック・バグ報告
+
+バグ報告や機能リクエストは [YouTrack](https://youtrack.jetbrains.com/issues/KTOR) で行ってください。
+

--- a/docs/ja/README.md
+++ b/docs/ja/README.md
@@ -1,0 +1,117 @@
+<div align="center">
+
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/ktorio/ktor/main/.github/images/ktor-logo-for-dark.svg">
+    <img alt="Ktor ロゴ" src="https://raw.githubusercontent.com/ktorio/ktor/main/.github/images/ktor-logo-for-light.svg">
+  </picture>
+
+</div>
+
+[![JetBrains公式プロジェクト](http://jb.gg/badges/official.svg)](https://confluence.jetbrains.com/display/ALL/JetBrains+on+GitHub)
+[![Maven Central](https://img.shields.io/maven-central/v/io.ktor/ktor-server)](https://central.sonatype.com/search?namespace=io.ktor)
+[![Kotlin](https://img.shields.io/badge/kotlin-2.1.10-blue.svg?logo=kotlin)](http://kotlinlang.org)
+[![Slackチャンネル](https://img.shields.io/badge/chat-slack-green.svg?logo=slack)](https://kotlinlang.slack.com/messages/ktor/)
+[![GitHubライセンス](https://img.shields.io/badge/license-Apache%20License%202.0-blue.svg?style=flat)](http://www.apache.org/licenses/LICENSE-2.0)
+[![Gitpodで貢献](https://img.shields.io/badge/Contribute%20with-Gitpod-908a85?logo=gitpod)](https://gitpod.io/#https://github.com/ktorio/ktor)
+
+Ktorは、Kotlinでゼロから開発された非同期フレームワークであり、マイクロサービスやWebアプリケーションの作成などに適しています。
+
+## 依存関係の追加
+プロジェクトに以下の依存関係を追加してください：
+
+```kotlin
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    implementation("io.ktor:ktor-server-netty:$ktor_version")
+}
+```
+
+## アプリケーションの作成と機能のインストール
+
+```kotlin
+import io.ktor.server.netty.*
+import io.ktor.server.routing.*
+import io.ktor.server.application.*
+import io.ktor.http.*
+import io.ktor.server.response.*
+import io.ktor.server.engine.*
+
+fun main(args: Array<String>) {
+    embeddedServer(Netty, 8080) {
+        routing {
+            get("/") {
+                call.respondText("Hello, world!", ContentType.Text.Html)
+            }
+        }
+    }.start(wait = true)
+}
+```
+
+また、[Ktor Gradle Plugin](https://github.com/ktorio/ktor-build-plugins) を使用すると、BOMの設定、タスクの実行、デプロイの管理が可能です。
+
+```kotlin
+plugins {
+    id("io.ktor.plugin") version "3.0.0"
+}
+
+dependencies {
+    implementation("io.ktor:ktor-server-netty")
+}
+```
+
+## アプリケーションの実行
+
+```shell
+./gradlew run
+```
+
+* `localhost:8080` で組み込みWebサーバーが起動
+* ルーティングを設定し、ルートパスへのGETリクエストに `Hello, world!` を返す
+
+## Ktorの使用開始
+
+Ktorを使ってKotlinのHTTPまたはRESTfulアプリケーションを開発：[start.ktor.io](https://start.ktor.io)
+
+## Ktorの特徴
+
+### 柔軟な設計
+
+Ktorフレームワークは、ロギング、テンプレート、メッセージング、永続化、シリアライズ、依存性注入などに関して厳格な制約を課しません。必要に応じて、簡単なインターフェースを実装するだけで拡張できます。
+
+### 非同期処理
+
+KtorのパイプラインとAPIは、Kotlinのコルーチンを活用しており、スレッドブロックを防ぎつつ、シンプルな非同期プログラミングモデルを提供します。
+
+### テストの容易さ
+
+Ktorアプリケーションは、実際のネットワーク通信を行わない特別なテスト環境でホスト可能であり、統合テストも簡単に実行できます。
+
+## JetBrains製品
+
+Ktorは公式の[JetBrains](https://jetbrains.com)製品であり、JetBrainsのチームを中心に開発されています。
+
+## ドキュメント
+
+詳細な説明やクイックスタートガイドについては、公式サイト[ktor.io](http://ktor.io)をご覧ください。
+
+* [Gradleでの導入](https://ktor.io/docs/gradle.html)
+* [Mavenでの導入](https://ktor.io/docs/maven.html)
+* [IntelliJ IDEAでの導入](https://ktor.io/docs/intellij-idea.html)
+
+## 問題報告 / サポート
+
+バグ報告や機能リクエストは[こちらのIssue Tracker](https://youtrack.jetbrains.com/issues/KTOR)へ。
+質問は[StackOverflow](https://stackoverflow.com/questions/tagged/ktor)で受け付けています。
+また、[Kotlin Slack Ktorチャンネル](https://app.slack.com/client/T09229ZC6/C0A974TJ9)でもコミュニティサポートを提供しています。
+
+## セキュリティ脆弱性の報告
+
+Ktorのセキュリティ上の問題を発見した場合は、[JetBrainsの責任ある開示プロセス](https://www.jetbrains.com/legal/terms/responsible-disclosure.html)を通じて報告してください。
+
+## 貢献
+
+貢献する前に、[コントリビューションガイド](CONTRIBUTING.md)および[行動規範](CODE_OF_CONDUCT.md)をご確認ください。
+


### PR DESCRIPTION
This PR adds Japanese documentation to Ktor, including:
- `docs/ja/README.md` (Project overview in Japanese)
- `docs/ja/CONTRIBUTING.md` (Contribution guidelines in Japanese)
- `docs/ja/CODE_OF_CONDUCT.md` (Code of Conduct in Japanese)

Related YouTrack ticket: [KTOR-8299](https://youtrack.jetbrains.com/issue/KTOR-8299/Add-Japanese-Documentation-for-Ktor)
