### PR TITLE
KTOR-7667: Enable Gradle configuration cache

### DIFF
--- a/build-logic/src/main/kotlin/ktorbuild.kmp.gradle.kts
+++ b/build-logic/src/main/kotlin/ktorbuild.kmp.gradle.kts
@@ -58,13 +58,16 @@ if (targets.hasJsOrWasmJs) {
 @Suppress("UnstableApiUsage")
 if (targets.hasNative) {
     tasks.maybeNamed("linkDebugTestLinuxX64") {
-        onlyIf("run only on Linux") { ktorBuild.os.get().isLinux }
+        val os = ktorBuild.os.get()
+        onlyIf("run only on Linux") { os.isLinux }
     }
     tasks.maybeNamed("linkDebugTestLinuxArm64") {
-        onlyIf("run only on Linux") { ktorBuild.os.get().isLinux }
+        val os = ktorBuild.os.get()
+        onlyIf("run only on Linux") { os.isLinux }
     }
     tasks.maybeNamed("linkDebugTestMingwX64") {
-        onlyIf("run only on Windows") { ktorBuild.os.get().isWindows }
+        val os = ktorBuild.os.get()
+        onlyIf("run only on Windows") { os.isWindows }
     }
 }
 

--- a/build-logic/src/main/kotlin/ktorbuild.publish.gradle.kts
+++ b/build-logic/src/main/kotlin/ktorbuild.publish.gradle.kts
@@ -57,7 +57,8 @@ configureSigning()
 
 plugins.withId("ktorbuild.kmp") {
     tasks.withType<AbstractPublishToMaven>().configureEach {
-        onlyIf { isAvailableForPublication(ktorBuild.os.get()) }
+        val os = ktorBuild.os.get()
+        onlyIf { isAvailableForPublication(os) }
     }
 
     registerTargetsPublishTasks(ktorBuild.targets)

--- a/build-logic/src/main/kotlin/ktorbuild/CInterop.kt
+++ b/build-logic/src/main/kotlin/ktorbuild/CInterop.kt
@@ -8,9 +8,11 @@ import ktorbuild.targets.KtorTargets
 import org.gradle.kotlin.dsl.assign
 import org.gradle.kotlin.dsl.getValue
 import org.gradle.kotlin.dsl.provideDelegate
+import org.gradle.kotlin.dsl.withType
 import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
 import org.jetbrains.kotlin.gradle.plugin.mpp.DefaultCInteropSettings
 import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget
+import org.jetbrains.kotlin.gradle.tasks.KotlinNativeCompile
 
 /**
  * Creates a CInterop configuration for all Native targets using the given [sourceSet]
@@ -62,4 +64,9 @@ fun KotlinMultiplatformExtension.createCInterop(
                 configure(targetName)
             }
         }
+
+    // Disable configuration cache for compile[target]MainKotlinMetadata tasks
+    project.tasks.withType<KotlinNativeCompile>()
+        .named { it.endsWith("MainKotlinMetadata") }
+        .configureEach { notCompatibleWithConfigurationCache("Workaround for KT-76147") }
 }

--- a/build-settings-logic/src/main/kotlin/ConfigurationCacheWorkarounds.kt
+++ b/build-settings-logic/src/main/kotlin/ConfigurationCacheWorkarounds.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2014-2025 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+import sun.misc.Unsafe
+import java.lang.reflect.Field
+
+@Suppress("UNCHECKED_CAST")
+internal object ConfigurationCacheWorkarounds {
+    private val ignoreBeanFieldsField = Class.forName("org.gradle.internal.serialize.beans.services.Workarounds")
+        .getDeclaredField("ignoredBeanFields")
+        .apply { isAccessible = true }
+
+    private val unsafe = runCatching {
+        Unsafe::class.java.getDeclaredField("theUnsafe")
+            .apply { isAccessible = true }
+            .get(null) as Unsafe
+    }.getOrNull()
+
+    private var ignoreBeanFields = ignoreBeanFieldsField.get(null) as Array<Pair<String, String>>
+        set(value) {
+            val isSet = runCatching { unsafe?.setFinalStatic(ignoreBeanFieldsField, value) }.getOrNull() != null
+            if (isSet) {
+                field = value
+            } else {
+                // If we can't set a new array to the field, fallback to replacing array's content with new values
+                for (i in 0..minOf(field.lastIndex, value.lastIndex)) field[i] = value[i]
+            }
+        }
+
+    /** Registers fields that should be excluded from configuration cache. */
+    fun addIgnoredBeanFields(vararg fields: Pair<String, String>) {
+        ignoreBeanFields = fields as Array<Pair<String, String>> + ignoreBeanFields
+    }
+}
+
+@Suppress("DEPRECATION")
+private fun Unsafe.setFinalStatic(field: Field, value: Any) {
+    val fieldBase = staticFieldBase(field)
+    val fieldOffset = staticFieldOffset(field)
+
+    putObject(fieldBase, fieldOffset, value)
+}

--- a/build-settings-logic/src/main/kotlin/ktorbuild.configuration-cache.settings.gradle.kts
+++ b/build-settings-logic/src/main/kotlin/ktorbuild.configuration-cache.settings.gradle.kts
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2014-2025 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+import org.gradle.kotlin.dsl.support.serviceOf
+
+val features = serviceOf<BuildFeatures>()
+
+if (features.configurationCache.requested.get()) {
+    // KT-72933: Storing these fields leads to OOM
+    ConfigurationCacheWorkarounds.addIgnoredBeanFields(
+        "transformationParameters" to "org.jetbrains.kotlin.gradle.plugin.mpp.MetadataDependencyTransformationTask",
+        "parameters" to "org.jetbrains.kotlin.gradle.targets.native.internal.CInteropMetadataDependencyTransformationTask",
+    )
+
+    // Mark these tasks as incompatible with configuration cache as we partially exclude their state from CC
+    gradle.beforeProject {
+        tasks.matching { it::class.java.simpleName.contains("MetadataDependencyTransformationTask") }
+            .configureEach { notCompatibleWithConfigurationCache("Workaround for KT-72933") }
+    }
+
+    println("Configuration Cache: Workaround for KT-72933 was applied")
+}

--- a/build-settings-logic/src/main/kotlin/ktorbuild.develocity.settings.gradle.kts
+++ b/build-settings-logic/src/main/kotlin/ktorbuild.develocity.settings.gradle.kts
@@ -18,6 +18,9 @@ develocity {
     // Should be in sync with settings.gradle.kts
     server = "https://ge.jetbrains.com"
 
+    // Copy the value to the local variable for compatibility with configuration cache
+    val isCIRun = isCIRun
+
     buildScan {
         uploadInBackground = !isCIRun
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -43,6 +43,8 @@ doctor.enableTaskMonitoring=false
 org.gradle.daemon=true
 org.gradle.caching=true
 org.gradle.parallel=true
+org.gradle.configuration-cache=true
+org.gradle.configuration-cache.parallel=true
 org.gradle.kotlin.dsl.allWarningsAsErrors=true
 
 # kotlin

--- a/gradle.properties
+++ b/gradle.properties
@@ -56,6 +56,9 @@ kotlin.mpp.applyDefaultHierarchyTemplate=false
 kotlin.apple.xcodeCompatibility.nowarn=true
 kotlin.suppressGradlePluginWarnings=IncorrectCompileOnlyDependencyWarning
 kotlin.daemon.useFallbackStrategy=false
+# Enable new project model to be prepared for enabling isolated projects
+# TODO: Remove when we enable isolated projects in Gradle
+kotlin.kmp.isolated-projects.support=enable
 
 # dokka
 # workaround for resolving platform dependencies, see https://github.com/Kotlin/dokka/issues/3153

--- a/ktor-test-server/src/main/kotlin/test-server.gradle.kts
+++ b/ktor-test-server/src/main/kotlin/test-server.gradle.kts
@@ -4,9 +4,8 @@
 
 import test.server.TestServerService
 
-val testServerService = TestServerService.registerIfAbsent(project)
-
 tasks.withType<AbstractTestTask>().configureEach {
+    val testServerService = TestServerService.registerIfAbsent(project)
     usesService(testServerService)
     // Trigger server start if it is not started yet
     doFirst("start test server") { testServerService.get() }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -12,6 +12,7 @@ plugins {
     id("org.gradle.toolchains.foojay-resolver-convention") version "0.9.0"
     id("conventions-dependency-resolution-management")
     id("ktorbuild.develocity")
+    id("ktorbuild.configuration-cache")
 }
 
 rootProject.name = "ktor"

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -2,6 +2,8 @@
  * Copyright 2014-2025 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
+enableFeaturePreview("STABLE_CONFIGURATION_CACHE")
+
 pluginManagement {
     includeBuild("build-settings-logic")
 }


### PR DESCRIPTION
**Subsystem**
Infrastructure

**Motivation**
[KTOR-7667](https://youtrack.jetbrains.com/issue/KTOR-7667) Enable Gradle configuration cache

**Solution**
Finally, I've found a hackaround for [KT-72933](https://youtrack.jetbrains.com/issue/KT-72933), and we can enable configuration cache 🎉 
It will work only for tasks not involving `MetadataDependencyTransformationTask`.

Some benchmark results for scenario "Rerun `:ktor-client:ktor-client-core:jvmTest` after a change in JVM source set."
<img width="1424" alt="image" src="https://github.com/user-attachments/assets/493fc602-417b-4c24-9ce5-accf5a4899de" />
_default_ - optimizations disabled
_COD_ - configuration on demand enabled
_CC_ - configuration cache enabled

Scenarios `default` and `COD` represent the case when there is no configuration cache that could be reused, let's call it "initial configuration".
Results show that configuration on demand significantly improves initial configuration configuration times and slightly improves storing and loading of configuration cache (because of smaller cache size)

**Next steps:**
- [KTOR-8332](https://youtrack.jetbrains.com/issue/KTOR-8332) Enable Gradle configuration cache for native tasks (as soon as KT-72933 is fixed)