### PR TITLE
KTOR-8306 Dependency injection tooling for tests

### DIFF
--- a/ktor-server/ktor-server-plugins/ktor-server-di/api/ktor-server-di.api
+++ b/ktor-server/ktor-server-plugins/ktor-server-di/api/ktor-server-di.api
@@ -31,6 +31,7 @@ public abstract interface class io/ktor/server/plugins/di/DependencyConflictPoli
 
 public final class io/ktor/server/plugins/di/DependencyConflictPolicyKt {
 	public static final fun getDefaultConflictPolicy ()Lio/ktor/server/plugins/di/DependencyConflictPolicy;
+	public static final fun getLastEntryWinsPolicy ()Lio/ktor/server/plugins/di/DependencyConflictPolicy;
 }
 
 public abstract interface class io/ktor/server/plugins/di/DependencyConflictResult {

--- a/ktor-server/ktor-server-plugins/ktor-server-di/api/ktor-server-di.api
+++ b/ktor-server/ktor-server-plugins/ktor-server-di/api/ktor-server-di.api
@@ -39,23 +39,41 @@ public abstract interface class io/ktor/server/plugins/di/DependencyConflictResu
 
 public final class io/ktor/server/plugins/di/DependencyConflictResult$Ambiguous : io/ktor/server/plugins/di/DependencyConflictResult {
 	public static final field INSTANCE Lio/ktor/server/plugins/di/DependencyConflictResult$Ambiguous;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
 }
 
 public final class io/ktor/server/plugins/di/DependencyConflictResult$Conflict : io/ktor/server/plugins/di/DependencyConflictResult {
 	public static final field INSTANCE Lio/ktor/server/plugins/di/DependencyConflictResult$Conflict;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
 }
 
 public final class io/ktor/server/plugins/di/DependencyConflictResult$KeepNew : io/ktor/server/plugins/di/DependencyConflictResult {
 	public static final field INSTANCE Lio/ktor/server/plugins/di/DependencyConflictResult$KeepNew;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
 }
 
 public final class io/ktor/server/plugins/di/DependencyConflictResult$KeepPrevious : io/ktor/server/plugins/di/DependencyConflictResult {
 	public static final field INSTANCE Lio/ktor/server/plugins/di/DependencyConflictResult$KeepPrevious;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
 }
 
 public final class io/ktor/server/plugins/di/DependencyConflictResult$Replace : io/ktor/server/plugins/di/DependencyConflictResult {
 	public fun <init> (Lio/ktor/server/plugins/di/DependencyCreateFunction;)V
+	public final fun component1 ()Lio/ktor/server/plugins/di/DependencyCreateFunction;
+	public final fun copy (Lio/ktor/server/plugins/di/DependencyCreateFunction;)Lio/ktor/server/plugins/di/DependencyConflictResult$Replace;
+	public static synthetic fun copy$default (Lio/ktor/server/plugins/di/DependencyConflictResult$Replace;Lio/ktor/server/plugins/di/DependencyCreateFunction;ILjava/lang/Object;)Lio/ktor/server/plugins/di/DependencyConflictResult$Replace;
+	public fun equals (Ljava/lang/Object;)Z
 	public final fun getFunction ()Lio/ktor/server/plugins/di/DependencyCreateFunction;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
 }
 
 public class io/ktor/server/plugins/di/DependencyConstructionException : java/lang/IllegalArgumentException {
@@ -237,8 +255,8 @@ public final class io/ktor/server/plugins/di/InvalidDependencyReferenceException
 
 public class io/ktor/server/plugins/di/MapDependencyProvider : io/ktor/server/plugins/di/DependencyProvider {
 	public fun <init> ()V
-	public fun <init> (Lio/ktor/server/plugins/di/DependencyKeyCovariance;Lio/ktor/server/plugins/di/DependencyConflictPolicy;Lkotlin/jvm/functions/Function1;)V
-	public synthetic fun <init> (Lio/ktor/server/plugins/di/DependencyKeyCovariance;Lio/ktor/server/plugins/di/DependencyConflictPolicy;Lkotlin/jvm/functions/Function1;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lio/ktor/server/plugins/di/DependencyKeyCovariance;Lio/ktor/server/plugins/di/DependencyConflictPolicy;Lkotlin/jvm/functions/Function1;Lorg/slf4j/Logger;)V
+	public synthetic fun <init> (Lio/ktor/server/plugins/di/DependencyKeyCovariance;Lio/ktor/server/plugins/di/DependencyConflictPolicy;Lkotlin/jvm/functions/Function1;Lorg/slf4j/Logger;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getConflictPolicy ()Lio/ktor/server/plugins/di/DependencyConflictPolicy;
 	public fun getDeclarations ()Ljava/util/Map;
 	public final fun getKeyMapping ()Lio/ktor/server/plugins/di/DependencyKeyCovariance;

--- a/ktor-server/ktor-server-plugins/ktor-server-di/api/ktor-server-di.klib.api
+++ b/ktor-server/ktor-server-plugins/ktor-server-di/api/ktor-server-di.klib.api
@@ -280,6 +280,8 @@ final val io.ktor.server.plugins.di/DefaultReflection // io.ktor.server.plugins.
     final fun <get-DefaultReflection>(): io.ktor.server.plugins.di/DependencyReflection // io.ktor.server.plugins.di/DefaultReflection.<get-DefaultReflection>|<get-DefaultReflection>(){}[0]
 final val io.ktor.server.plugins.di/DependencyRegistryKey // io.ktor.server.plugins.di/DependencyRegistryKey|{}DependencyRegistryKey[0]
     final fun <get-DependencyRegistryKey>(): io.ktor.util/AttributeKey<io.ktor.server.plugins.di/DependencyRegistry> // io.ktor.server.plugins.di/DependencyRegistryKey.<get-DependencyRegistryKey>|<get-DependencyRegistryKey>(){}[0]
+final val io.ktor.server.plugins.di/LastEntryWinsPolicy // io.ktor.server.plugins.di/LastEntryWinsPolicy|{}LastEntryWinsPolicy[0]
+    final fun <get-LastEntryWinsPolicy>(): io.ktor.server.plugins.di/DependencyConflictPolicy // io.ktor.server.plugins.di/LastEntryWinsPolicy.<get-LastEntryWinsPolicy>|<get-LastEntryWinsPolicy>(){}[0]
 final val io.ktor.server.plugins.di/Supertypes // io.ktor.server.plugins.di/Supertypes|{}Supertypes[0]
     final fun <get-Supertypes>(): io.ktor.server.plugins.di/DependencyKeyCovariance // io.ktor.server.plugins.di/Supertypes.<get-Supertypes>|<get-Supertypes>(){}[0]
 final val io.ktor.server.plugins.di/Unnamed // io.ktor.server.plugins.di/Unnamed|{}Unnamed[0]

--- a/ktor-server/ktor-server-plugins/ktor-server-di/api/ktor-server-di.klib.api
+++ b/ktor-server/ktor-server-plugins/ktor-server-di/api/ktor-server-di.klib.api
@@ -47,15 +47,37 @@ sealed interface io.ktor.server.plugins.di/DependencyConflictResult { // io.ktor
 
         final val function // io.ktor.server.plugins.di/DependencyConflictResult.Replace.function|{}function[0]
             final fun <get-function>(): io.ktor.server.plugins.di/DependencyCreateFunction // io.ktor.server.plugins.di/DependencyConflictResult.Replace.function.<get-function>|<get-function>(){}[0]
+
+        final fun component1(): io.ktor.server.plugins.di/DependencyCreateFunction // io.ktor.server.plugins.di/DependencyConflictResult.Replace.component1|component1(){}[0]
+        final fun copy(io.ktor.server.plugins.di/DependencyCreateFunction = ...): io.ktor.server.plugins.di/DependencyConflictResult.Replace // io.ktor.server.plugins.di/DependencyConflictResult.Replace.copy|copy(io.ktor.server.plugins.di.DependencyCreateFunction){}[0]
+        final fun equals(kotlin/Any?): kotlin/Boolean // io.ktor.server.plugins.di/DependencyConflictResult.Replace.equals|equals(kotlin.Any?){}[0]
+        final fun hashCode(): kotlin/Int // io.ktor.server.plugins.di/DependencyConflictResult.Replace.hashCode|hashCode(){}[0]
+        final fun toString(): kotlin/String // io.ktor.server.plugins.di/DependencyConflictResult.Replace.toString|toString(){}[0]
     }
 
-    final object Ambiguous : io.ktor.server.plugins.di/DependencyConflictResult // io.ktor.server.plugins.di/DependencyConflictResult.Ambiguous|null[0]
+    final object Ambiguous : io.ktor.server.plugins.di/DependencyConflictResult { // io.ktor.server.plugins.di/DependencyConflictResult.Ambiguous|null[0]
+        final fun equals(kotlin/Any?): kotlin/Boolean // io.ktor.server.plugins.di/DependencyConflictResult.Ambiguous.equals|equals(kotlin.Any?){}[0]
+        final fun hashCode(): kotlin/Int // io.ktor.server.plugins.di/DependencyConflictResult.Ambiguous.hashCode|hashCode(){}[0]
+        final fun toString(): kotlin/String // io.ktor.server.plugins.di/DependencyConflictResult.Ambiguous.toString|toString(){}[0]
+    }
 
-    final object Conflict : io.ktor.server.plugins.di/DependencyConflictResult // io.ktor.server.plugins.di/DependencyConflictResult.Conflict|null[0]
+    final object Conflict : io.ktor.server.plugins.di/DependencyConflictResult { // io.ktor.server.plugins.di/DependencyConflictResult.Conflict|null[0]
+        final fun equals(kotlin/Any?): kotlin/Boolean // io.ktor.server.plugins.di/DependencyConflictResult.Conflict.equals|equals(kotlin.Any?){}[0]
+        final fun hashCode(): kotlin/Int // io.ktor.server.plugins.di/DependencyConflictResult.Conflict.hashCode|hashCode(){}[0]
+        final fun toString(): kotlin/String // io.ktor.server.plugins.di/DependencyConflictResult.Conflict.toString|toString(){}[0]
+    }
 
-    final object KeepNew : io.ktor.server.plugins.di/DependencyConflictResult // io.ktor.server.plugins.di/DependencyConflictResult.KeepNew|null[0]
+    final object KeepNew : io.ktor.server.plugins.di/DependencyConflictResult { // io.ktor.server.plugins.di/DependencyConflictResult.KeepNew|null[0]
+        final fun equals(kotlin/Any?): kotlin/Boolean // io.ktor.server.plugins.di/DependencyConflictResult.KeepNew.equals|equals(kotlin.Any?){}[0]
+        final fun hashCode(): kotlin/Int // io.ktor.server.plugins.di/DependencyConflictResult.KeepNew.hashCode|hashCode(){}[0]
+        final fun toString(): kotlin/String // io.ktor.server.plugins.di/DependencyConflictResult.KeepNew.toString|toString(){}[0]
+    }
 
-    final object KeepPrevious : io.ktor.server.plugins.di/DependencyConflictResult // io.ktor.server.plugins.di/DependencyConflictResult.KeepPrevious|null[0]
+    final object KeepPrevious : io.ktor.server.plugins.di/DependencyConflictResult { // io.ktor.server.plugins.di/DependencyConflictResult.KeepPrevious|null[0]
+        final fun equals(kotlin/Any?): kotlin/Boolean // io.ktor.server.plugins.di/DependencyConflictResult.KeepPrevious.equals|equals(kotlin.Any?){}[0]
+        final fun hashCode(): kotlin/Int // io.ktor.server.plugins.di/DependencyConflictResult.KeepPrevious.hashCode|hashCode(){}[0]
+        final fun toString(): kotlin/String // io.ktor.server.plugins.di/DependencyConflictResult.KeepPrevious.toString|toString(){}[0]
+    }
 }
 
 sealed interface io.ktor.server.plugins.di/DependencyCreateFunction { // io.ktor.server.plugins.di/DependencyCreateFunction|null[0]
@@ -252,7 +274,7 @@ open class io.ktor.server.plugins.di/DependencyReflectionDisabledException : io.
 }
 
 open class io.ktor.server.plugins.di/MapDependencyProvider : io.ktor.server.plugins.di/DependencyProvider { // io.ktor.server.plugins.di/MapDependencyProvider|null[0]
-    constructor <init>(io.ktor.server.plugins.di/DependencyKeyCovariance = ..., io.ktor.server.plugins.di/DependencyConflictPolicy = ..., kotlin/Function1<io.ktor.server.plugins.di/DependencyKey, kotlin/Unit> = ...) // io.ktor.server.plugins.di/MapDependencyProvider.<init>|<init>(io.ktor.server.plugins.di.DependencyKeyCovariance;io.ktor.server.plugins.di.DependencyConflictPolicy;kotlin.Function1<io.ktor.server.plugins.di.DependencyKey,kotlin.Unit>){}[0]
+    constructor <init>(io.ktor.server.plugins.di/DependencyKeyCovariance = ..., io.ktor.server.plugins.di/DependencyConflictPolicy = ..., kotlin/Function1<io.ktor.server.plugins.di/DependencyKey, kotlin/Unit> = ..., io.ktor.util.logging/Logger = ...) // io.ktor.server.plugins.di/MapDependencyProvider.<init>|<init>(io.ktor.server.plugins.di.DependencyKeyCovariance;io.ktor.server.plugins.di.DependencyConflictPolicy;kotlin.Function1<io.ktor.server.plugins.di.DependencyKey,kotlin.Unit>;io.ktor.util.logging.Logger){}[0]
 
     final val conflictPolicy // io.ktor.server.plugins.di/MapDependencyProvider.conflictPolicy|{}conflictPolicy[0]
         final fun <get-conflictPolicy>(): io.ktor.server.plugins.di/DependencyConflictPolicy // io.ktor.server.plugins.di/MapDependencyProvider.conflictPolicy.<get-conflictPolicy>|<get-conflictPolicy>(){}[0]

--- a/ktor-server/ktor-server-plugins/ktor-server-di/common/src/io/ktor/server/plugins/di/DependencyConflictPolicy.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-di/common/src/io/ktor/server/plugins/di/DependencyConflictPolicy.kt
@@ -68,3 +68,16 @@ public val DefaultConflictPolicy: DependencyConflictPolicy = DependencyConflictP
         is ExplicitCreateFunction -> current.ifImplicit { KeepPrevious } ?: Conflict
     }
 }
+
+/**
+ * During testing, we simply override previously declared values.
+ * This allows for replacing base implementations with mock values.
+ */
+public val LastEntryWinsPolicy: DependencyConflictPolicy = DependencyConflictPolicy { prev, current ->
+    require(current !is AmbiguousCreateFunction) { "Unexpected ambiguous function supplied" }
+    when (prev) {
+        is AmbiguousCreateFunction,
+        is ImplicitCreateFunction -> KeepNew
+        is ExplicitCreateFunction -> current.ifImplicit { KeepPrevious } ?: KeepNew
+    }
+}

--- a/ktor-server/ktor-server-plugins/ktor-server-di/common/src/io/ktor/server/plugins/di/DependencyConflictPolicy.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-di/common/src/io/ktor/server/plugins/di/DependencyConflictPolicy.kt
@@ -47,11 +47,11 @@ public fun interface DependencyConflictPolicy {
  * - `Replace`: Replace the existing dependency with a specific creation function.
  */
 public sealed interface DependencyConflictResult {
-    public object KeepPrevious : DependencyConflictResult
-    public object KeepNew : DependencyConflictResult
-    public object Ambiguous : DependencyConflictResult
-    public object Conflict : DependencyConflictResult
-    public class Replace(public val function: DependencyCreateFunction) : DependencyConflictResult
+    public data object KeepPrevious : DependencyConflictResult
+    public data object KeepNew : DependencyConflictResult
+    public data object Ambiguous : DependencyConflictResult
+    public data object Conflict : DependencyConflictResult
+    public data class Replace(public val function: DependencyCreateFunction) : DependencyConflictResult
 }
 
 /**

--- a/ktor-server/ktor-server-plugins/ktor-server-di/common/src/io/ktor/server/plugins/di/DependencyInjection.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-di/common/src/io/ktor/server/plugins/di/DependencyInjection.kt
@@ -5,6 +5,7 @@
 package io.ktor.server.plugins.di
 
 import io.ktor.server.application.ApplicationPlugin
+import io.ktor.server.application.PluginBuilder
 import io.ktor.server.application.createApplicationPlugin
 import io.ktor.server.plugins.di.utils.ClasspathReference
 import io.ktor.server.plugins.di.utils.installReference
@@ -61,10 +62,16 @@ public val DI: ApplicationPlugin<DependencyInjectionConfig> =
                 ?.map { ClasspathReference(it) }
                 .orEmpty()
 
+        val provider = if (isTestEngine() && !pluginConfig.providerChanged) {
+            MapDependencyProvider(conflictPolicy = LastEntryWinsPolicy)
+        } else {
+            pluginConfig.provider
+        }
+
         application.attributes.put(
             DependencyRegistryKey,
             DependencyRegistryImpl(
-                pluginConfig.provider,
+                provider,
                 pluginConfig.resolution,
                 pluginConfig.reflection,
             ).also { registry ->
@@ -74,6 +81,9 @@ public val DI: ApplicationPlugin<DependencyInjectionConfig> =
             }
         )
     }
+
+private fun PluginBuilder<*>.isTestEngine(): Boolean =
+    application.engine::class.simpleName == "TestApplicationEngine"
 
 public val DependencyRegistryKey: AttributeKey<DependencyRegistry> =
     AttributeKey<DependencyRegistry>("DependencyRegistry")
@@ -111,8 +121,13 @@ public object NoReflection : DependencyReflection {
  * @see MapDependencyProvider
  */
 public class DependencyInjectionConfig {
+    internal var providerChanged = false
     public var reflection: DependencyReflection = DefaultReflection
     public var provider: DependencyProvider = MapDependencyProvider()
+        set(value) {
+            field = value
+            providerChanged = true
+        }
     public var resolution: DependencyResolution = DefaultDependencyResolution
 
     /**

--- a/ktor-server/ktor-server-plugins/ktor-server-di/common/test/io/ktor/server/plugins/di/DependencyInjectionTest.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-di/common/test/io/ktor/server/plugins/di/DependencyInjectionTest.kt
@@ -4,6 +4,7 @@
 
 package io.ktor.server.plugins.di
 
+import io.ktor.server.application.*
 import io.ktor.server.testing.*
 import io.ktor.util.reflect.*
 import kotlin.reflect.KClass
@@ -53,155 +54,146 @@ data class PaidWork(val requiredExperience: WorkExperience)
 class DependencyInjectionTest {
 
     @Test
-    fun missing() = testApplication {
+    fun missing() = testDI {
+        assertFailsWith<MissingDependencyException> {
+            val service: GreetingService by dependencies
+            fail("Should fail but found $service")
+        }
+    }
+
+    @Test
+    fun `resolution out of order`() = testDI {
+        assertFailsWith<OutOfOrderDependencyException> {
+            dependencies { provide<GreetingService> { GreetingServiceImpl() } }
+            assertNotNull(dependencies.resolve<GreetingService>())
+            dependencies { provide<String> { "Hello" } }
+        }
+    }
+
+    @Test
+    fun `conflicting declarations`() = testDI {
+        assertFailsWith<DuplicateDependencyException> {
+            dependencies { provide<GreetingService> { GreetingServiceImpl() } }
+            dependencies { provide<GreetingService> { BankGreetingService() } }
+        }
+    }
+
+    @Test
+    fun `last entry wins for tests`() = testApplication {
         application {
+            dependencies { provide<GreetingService> { GreetingServiceImpl() } }
+            dependencies { provide<GreetingService> { BankGreetingService() } }
+
+            val service: GreetingService by dependencies
+            assertEquals(HELLO_CUSTOMER, service.hello())
+        }
+    }
+
+    @Test
+    fun `circular dependencies`() = testDI {
+        assertFailsWith<CircularDependencyException> {
+            dependencies {
+                provide<WorkExperience> { WorkExperience(resolve()) }
+                provide<PaidWork> { PaidWork(resolve()) }
+                provide<List<PaidWork>> { listOf(resolve()) }
+            }
+            val eligibleJobs: List<PaidWork> by dependencies
+            fail("This should fail but returned $eligibleJobs")
+        }
+    }
+
+    @Test
+    fun basic() = testDI {
+        dependencies {
+            provide<GreetingService> { GreetingServiceImpl() }
+        }
+
+        val service: GreetingService by dependencies
+        assertEquals(HELLO, service.hello())
+    }
+
+    @Test
+    fun caching() = testDI {
+        var callCount = 0
+        dependencies {
+            provide<GreetingService> {
+                callCount++
+                GreetingServiceImpl()
+            }
+        }
+
+        val delegatedService: GreetingService by dependencies
+        assertEquals(0, callCount, "Delegated properties should be lazily resolved")
+        assertEquals(HELLO, delegatedService.hello())
+        assertEquals(1, callCount)
+        assertEquals(HELLO, dependencies.resolve<GreetingService>().hello())
+        assertEquals(HELLO, dependencies.resolve<GreetingService>().hello())
+        assertEquals(1, callCount)
+    }
+
+    @Test
+    fun `basic with qualifier`() = testDI {
+        dependencies {
+            provide<GreetingService>(name = "test") { GreetingServiceImpl() }
+        }
+
+        val service: GreetingService by dependencies.named("test")
+        assertEquals(HELLO, service.hello())
+    }
+
+    @Test
+    fun lambdas() = testDI {
+        dependencies {
+            provide<() -> GreetingService> { { GreetingServiceImpl() } }
+        }
+
+        val service: () -> GreetingService by dependencies
+        assertEquals(HELLO, service().hello())
+    }
+
+    @Test
+    fun parameterized() = testDI {
+        dependencies {
+            provide<GreetingService> { GreetingServiceImpl() }
+            provide<List<GreetingService>> { listOf(resolve(), resolve()) }
+        }
+
+        val services: List<GreetingService> by dependencies
+        for (service in services) {
+            assertEquals(HELLO, service.hello())
             assertFailsWith<MissingDependencyException> {
-                val service: GreetingService by dependencies
-                fail("Should fail but found $service")
+                dependencies.resolve<List<BankService>>()
             }
         }
     }
 
     @Test
-    fun `resolution out of order`() = testApplication {
-        application {
-            assertFailsWith<OutOfOrderDependencyException> {
-                dependencies { provide<GreetingService> { GreetingServiceImpl() } }
-                assertNotNull(dependencies.resolve<GreetingService>())
-                dependencies { provide<String> { "Hello" } }
+    fun arguments() = testDI {
+        var expectedStringList = listOf("one", "two")
+
+        dependencies {
+            provide<GreetingService> { GreetingServiceImpl() }
+            provide<List<String>>("my-strings") {
+                expectedStringList
+            }
+            provide<List<Any>>("my-list") {
+                listOf(
+                    resolve<GreetingService>(),
+                    resolve<List<String>>("my-strings"),
+                )
             }
         }
-    }
 
-    @Test
-    fun `conflicting declarations`() = testApplication {
-        application {
-            assertFailsWith<DuplicateDependencyException> {
-                dependencies { provide<GreetingService> { GreetingServiceImpl() } }
-                dependencies { provide<GreetingService> { BankGreetingService() } }
-            }
-        }
-    }
+        val service: GreetingService by dependencies
+        val stringList: List<String> by dependencies.named("my-strings")
+        val anyList: List<Any> by dependencies.named("my-list")
 
-    @Test
-    fun `circular dependencies`() = testApplication {
-        application {
-            assertFailsWith<CircularDependencyException> {
-                dependencies {
-                    provide<WorkExperience> { WorkExperience(resolve()) }
-                    provide<PaidWork> { PaidWork(resolve()) }
-                    provide<List<PaidWork>> { listOf(resolve()) }
-                }
-                val eligibleJobs: List<PaidWork> by dependencies
-                fail("This should fail but returned $eligibleJobs")
-            }
-        }
-    }
-
-    @Test
-    fun basic() = testApplication {
-        application {
-            dependencies {
-                provide<GreetingService> { GreetingServiceImpl() }
-            }
-
-            val service: GreetingService by dependencies
-            assertEquals(HELLO, service.hello())
-        }
-    }
-
-    @Test
-    fun caching() = testApplication {
-        application {
-            var callCount = 0
-            dependencies {
-                provide<GreetingService> {
-                    callCount++
-                    GreetingServiceImpl()
-                }
-            }
-
-            val delegatedService: GreetingService by dependencies
-            assertEquals(0, callCount, "Delegated properties should be lazily resolved")
-            assertEquals(HELLO, delegatedService.hello())
-            assertEquals(1, callCount)
-            assertEquals(HELLO, dependencies.resolve<GreetingService>().hello())
-            assertEquals(HELLO, dependencies.resolve<GreetingService>().hello())
-            assertEquals(1, callCount)
-        }
-    }
-
-    @Test
-    fun `basic with qualifier`() = testApplication {
-        application {
-            dependencies {
-                provide<GreetingService>(name = "test") { GreetingServiceImpl() }
-            }
-
-            val service: GreetingService by dependencies.named("test")
-            assertEquals(HELLO, service.hello())
-        }
-    }
-
-    @Test
-    fun lambdas() = testApplication {
-        application {
-            dependencies {
-                provide<() -> GreetingService> { { GreetingServiceImpl() } }
-            }
-
-            val service: () -> GreetingService by dependencies
-            assertEquals(HELLO, service().hello())
-        }
-    }
-
-    @Test
-    fun parameterized() = testApplication {
-        application {
-            dependencies {
-                provide<GreetingService> { GreetingServiceImpl() }
-                provide<List<GreetingService>> { listOf(resolve(), resolve()) }
-            }
-
-            val services: List<GreetingService> by dependencies
-            for (service in services) {
-                assertEquals(HELLO, service.hello())
-                assertFailsWith<MissingDependencyException> {
-                    dependencies.resolve<List<BankService>>()
-                }
-            }
-        }
-    }
-
-    @Test
-    fun arguments() = testApplication {
-        application {
-            var expectedStringList = listOf("one", "two")
-
-            dependencies {
-                provide<GreetingService> { GreetingServiceImpl() }
-                provide<List<String>>("my-strings") {
-                    expectedStringList
-                }
-                provide<List<Any>>("my-list") {
-                    listOf(
-                        resolve<GreetingService>(),
-                        resolve<List<String>>("my-strings"),
-                    )
-                }
-            }
-
-            val service: GreetingService by dependencies
-            val stringList: List<String> by dependencies.named("my-strings")
-            val anyList: List<Any> by dependencies.named("my-list")
-
-            assertEquals(HELLO, service.hello())
-            assertEquals(expectedStringList, stringList)
-            val (first, second) = anyList
-            assertIs<GreetingService>(first)
-            assertEquals(HELLO, first.hello())
-            assertEquals(expectedStringList, second)
-        }
+        assertEquals(HELLO, service.hello())
+        assertEquals(expectedStringList, stringList)
+        val (first, second) = anyList
+        assertIs<GreetingService>(first)
+        assertEquals(HELLO, first.hello())
+        assertEquals(expectedStringList, second)
     }
 
     @Test
@@ -229,39 +221,49 @@ class DependencyInjectionTest {
 
     @Suppress("UNCHECKED_CAST")
     @Test
-    fun `custom reflection`() = testApplication {
-        install(DI) {
-            reflection = object : DependencyReflection {
-                override fun <T : Any> create(
-                    kClass: KClass<T>,
-                    init: (DependencyKey) -> Any
-                ): T = when (kClass) {
-                    GreetingService::class -> GreetingServiceImpl() as T
-                    else -> fail("Unexpected class $kClass")
-                }
+    fun `custom reflection`() = testDI({
+        reflection = object : DependencyReflection {
+            override fun <T : Any> create(
+                kClass: KClass<T>,
+                init: (DependencyKey) -> Any
+            ): T = when (kClass) {
+                GreetingService::class -> GreetingServiceImpl() as T
+                else -> fail("Unexpected class $kClass")
             }
         }
-        application {
-            val service: GreetingService = dependencies.create()
-            assertEquals(HELLO, service.hello())
-        }
+    }) {
+        val service: GreetingService = dependencies.create()
+        assertEquals(HELLO, service.hello())
     }
 
     @Test
-    fun `unnamed key mapping`() = testApplication {
+    fun `unnamed key mapping`() = testDI({
+        provider {
+            keyMapping = Unnamed
+        }
+    }) {
+        dependencies {
+            provide<GreetingService>("bank") { BankGreetingService() }
+        }
+        val named: GreetingService by dependencies.named("bank")
+        val unnamed: GreetingService by dependencies
+        assertEquals(HELLO_CUSTOMER, named.hello())
+        assertEquals(HELLO_CUSTOMER, unnamed.hello())
+    }
+
+    // Use default DI configuration (not test mode)
+    private fun testDI(
+        pluginInstall: DependencyInjectionConfig.() -> Unit = {},
+        block: Application.() -> Unit
+    ) = testApplication {
         install(DI) {
-            provider {
-                keyMapping = Unnamed
+            pluginInstall()
+            if (!providerChanged) {
+                provider = MapDependencyProvider()
             }
         }
         application {
-            dependencies {
-                provide<GreetingService>("bank") { BankGreetingService() }
-            }
-            val named: GreetingService by dependencies.named("bank")
-            val unnamed: GreetingService by dependencies
-            assertEquals(HELLO_CUSTOMER, named.hello())
-            assertEquals(HELLO_CUSTOMER, unnamed.hello())
+            block()
         }
     }
 }

--- a/ktor-server/ktor-server-plugins/ktor-server-di/jvm/test/io/ktor/server/plugins/di/DependencyInjectionJvmTest.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-di/jvm/test/io/ktor/server/plugins/di/DependencyInjectionJvmTest.kt
@@ -109,6 +109,9 @@ class DependencyInjectionJvmTest {
 
     @Test
     fun `covariant ambiguity`() = testApplication {
+        install(DI) {
+            provider = MapDependencyProvider()
+        }
         application {
             dependencies {
                 provide(GreetingServiceImpl::class)


### PR DESCRIPTION
**Subsystem**
Server, DI

**Motivation**
[KTOR-8306](https://youtrack.jetbrains.com/issue/KTOR-8306) Dependency injection tooling for tests

This was requested in the design doc review as a possible improvement for test tooling.

**Solution**
Now, when the DI plugin is installed from the test engine, it will use a custom conflict policy that allows overriding implementations.

When writing tests, you can now do something like:

```kotlin
fun test() = testApplication {
    // 1. Install modules as they'd normally appear
    installProductionTypes()
    
    // 2. Replace specific implementations with mocks
    dependencies {
        provide<Database> { MockDatabaseInstance() }
    }
    
    // 3. Run tests
}
```