### PR TITLE
KTOR-8339: Set a reasonable default for `caPath` in Curl client

### DIFF
--- a/ktor-client/ktor-client-curl/desktop/src/io/ktor/client/engine/curl/CurlClientEngineConfig.kt
+++ b/ktor-client/ktor-client-curl/desktop/src/io/ktor/client/engine/curl/CurlClientEngineConfig.kt
@@ -22,7 +22,7 @@ public class CurlClientEngineConfig : HttpClientEngineConfig() {
      *
      * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.client.engine.curl.CurlClientEngineConfig.caInfo)
      */
-    public var caInfo: String? = null
+    public var caInfo: String? = "/etc/ssl/certs"
 
     /**
      * Sets directory that holds Certificate Authority (CA) certificates using `CURLOPT_CAPATH`.


### PR DESCRIPTION
**Subsystem**
`ktor-client-curl`

**Motivation**
The following code passes on Linux X64, but fails on Linux Arm64 with a SSL error:

```kotlin
val client = HttpClient(Curl) { }
val res = client.get("https://kotlinlang.org/")
println("status=${res.status} bytes=${res.bodyAsBytes().size}")
// X64: status=200 OK bytes=115427
// Arm64: SSL peer certificate or SSH remote key was not OK
client.close()
```

It can be worked around by manually setting `caPath`, but this creates unnecessary boilerplate in multiplatform projects because the client configuration becomes platform specific.

```kotlin
val client = HttpClient(Curl) {
    engine {
        caPath = "/etc/ssl/certs"
    }
}
```

The root cause is that [CURLINFO_CAPATH](https://curl.se/libcurl/c/CURLINFO_CAPATH.html) is set to `/etc/ssl/certs` in the `libcurl.a` compiled for X64, but set to null in the `libcurl.a` compiled for ARM64. Those libs, last updated in https://github.com/ktorio/ktor/pull/4445, must have been built in an inconsistent manner (not sure how! cc @whyoleg). This can be verified with:

```c
#include <stdio.h>
#include "curl.h"

int main(void)
{
  CURL *curl = curl_easy_init();
  if(curl) {
    char *capath = NULL;
    curl_easy_getinfo(curl, CURLINFO_CAPATH, &capath);
    if(capath) {
      printf("default ca path: %s\n", capath);
    }
    curl_easy_cleanup(curl);
  }
}
```

**Solution**

The easiest way would be to set `caPath = "/etc/ssl/certs"` by default, which is a sane default and should work out of the box for most distribs.

Alternatively, we could make sure that `CURLINFO_CAPATH` is set next time we update `libcurl.a`.

