### PR TITLE
Add the resource to client requests when using the `Resources` Plugin.

### DIFF
--- a/ktor-client/ktor-client-plugins/ktor-client-resources/api/ktor-client-resources.api
+++ b/ktor-client/ktor-client-plugins/ktor-client-resources/api/ktor-client-resources.api
@@ -1,4 +1,5 @@
 public final class io/ktor/client/plugins/resources/BuildersKt {
+	public static final fun getRESOURCE ()Lio/ktor/util/AttributeKey;
 	public static final fun resources (Lio/ktor/client/HttpClient;)Lio/ktor/resources/Resources;
 }
 

--- a/ktor-client/ktor-client-plugins/ktor-client-resources/api/ktor-client-resources.klib.api
+++ b/ktor-client/ktor-client-plugins/ktor-client-resources/api/ktor-client-resources.klib.api
@@ -14,6 +14,9 @@ final object io.ktor.client.plugins.resources/Resources : io.ktor.client.plugins
     final fun prepare(kotlin/Function1<io.ktor.resources/Resources.Configuration, kotlin/Unit>): io.ktor.resources/Resources // io.ktor.client.plugins.resources/Resources.prepare|prepare(kotlin.Function1<io.ktor.resources.Resources.Configuration,kotlin.Unit>){}[0]
 }
 
+final val io.ktor.client.plugins.resources/RESOURCE // io.ktor.client.plugins.resources/RESOURCE|{}RESOURCE[0]
+    final fun <get-RESOURCE>(): io.ktor.util/AttributeKey<kotlin/Any> // io.ktor.client.plugins.resources/RESOURCE.<get-RESOURCE>|<get-RESOURCE>(){}[0]
+
 final fun (io.ktor.client/HttpClient).io.ktor.client.plugins.resources/resources(): io.ktor.resources/Resources // io.ktor.client.plugins.resources/resources|resources@io.ktor.client.HttpClient(){}[0]
 final inline fun <#A: reified kotlin/Any> (io.ktor.client/HttpClient).io.ktor.client.plugins.resources/href(#A): kotlin/String // io.ktor.client.plugins.resources/href|href@io.ktor.client.HttpClient(0:0){0§<kotlin.Any>}[0]
 final inline fun <#A: reified kotlin/Any> (io.ktor.client/HttpClient).io.ktor.client.plugins.resources/href(#A, io.ktor.http/URLBuilder) // io.ktor.client.plugins.resources/href|href@io.ktor.client.HttpClient(0:0;io.ktor.http.URLBuilder){0§<kotlin.Any>}[0]

--- a/ktor-client/ktor-client-plugins/ktor-client-resources/common/src/io/ktor/client/plugins/resources/builders.kt
+++ b/ktor-client/ktor-client-plugins/ktor-client-resources/common/src/io/ktor/client/plugins/resources/builders.kt
@@ -11,6 +11,7 @@ import io.ktor.client.statement.*
 import io.ktor.resources.*
 import io.ktor.resources.serialization.ResourcesFormat
 import io.ktor.util.AttributeKey
+import io.ktor.util.Attributes
 import kotlinx.serialization.*
 import io.ktor.client.request.delete as deleteBuilder
 import io.ktor.client.request.get as getBuilder
@@ -40,7 +41,7 @@ public suspend inline fun <reified T : Any> HttpClient.get(
 ): HttpResponse {
     val resources = resources()
     return getBuilder {
-        includeUrlTemplate(resources.resourcesFormat, serializer<T>())
+        attributes.putUrlTemplate(resources.resourcesFormat, serializer<T>())
         href(resources.resourcesFormat, resource, url)
         builder()
     }
@@ -57,7 +58,7 @@ public suspend inline fun <reified T : Any> HttpClient.post(
 ): HttpResponse {
     val resources = resources()
     return postBuilder {
-        includeUrlTemplate(resources.resourcesFormat, serializer<T>())
+        attributes.attributes.putUrlTemplate(resources.resourcesFormat, serializer<T>())
         href(resources.resourcesFormat, resource, url)
         builder()
     }
@@ -74,7 +75,7 @@ public suspend inline fun <reified T : Any> HttpClient.put(
 ): HttpResponse {
     val resources = resources()
     return putBuilder {
-        includeUrlTemplate(resources.resourcesFormat, serializer<T>())
+        attributes.putUrlTemplate(resources.resourcesFormat, serializer<T>())
         href(resources.resourcesFormat, resource, url)
         builder()
     }
@@ -91,7 +92,7 @@ public suspend inline fun <reified T : Any> HttpClient.delete(
 ): HttpResponse {
     val resources = resources()
     return deleteBuilder {
-        includeUrlTemplate(resources.resourcesFormat, serializer<T>())
+        attributes.putUrlTemplate(resources.resourcesFormat, serializer<T>())
         href(resources.resourcesFormat, resource, url)
         builder()
     }
@@ -108,7 +109,7 @@ public suspend inline fun <reified T : Any> HttpClient.patch(
 ): HttpResponse {
     val resources = resources()
     return patchBuilder {
-        includeUrlTemplate(resources.resourcesFormat, serializer<T>())
+        attributes.putUrlTemplate(resources.resourcesFormat, serializer<T>())
         href(resources.resourcesFormat, resource, url)
         builder()
     }
@@ -125,7 +126,7 @@ public suspend inline fun <reified T : Any> HttpClient.options(
 ): HttpResponse {
     val resources = resources()
     return optionsBuilder {
-        includeUrlTemplate(resources.resourcesFormat, serializer<T>())
+        attributes.putUrlTemplate(resources.resourcesFormat, serializer<T>())
         href(resources.resourcesFormat, resource, url)
         builder()
     }
@@ -142,7 +143,7 @@ public suspend inline fun <reified T : Any> HttpClient.head(
 ): HttpResponse {
     val resources = resources()
     return headBuilder {
-        includeUrlTemplate(resources.resourcesFormat, serializer<T>())
+        attributes.putUrlTemplate(resources.resourcesFormat, serializer<T>())
         href(resources.resourcesFormat, resource, url)
         builder()
     }
@@ -159,7 +160,7 @@ public suspend inline fun <reified T : Any> HttpClient.request(
 ): HttpResponse {
     val resources = resources()
     return requestBuilder {
-        includeUrlTemplate(resources.resourcesFormat, serializer<T>())
+        attributes.putUrlTemplate(resources.resourcesFormat, serializer<T>())
         href(resources.resourcesFormat, resource, url)
         builder()
     }
@@ -176,7 +177,7 @@ public suspend inline fun <reified T : Any> HttpClient.prepareGet(
 ): HttpStatement {
     val resources = resources()
     return prepareGetBuilder {
-        includeUrlTemplate(resources.resourcesFormat, serializer<T>())
+        attributes.putUrlTemplate(resources.resourcesFormat, serializer<T>())
         href(resources.resourcesFormat, resource, url)
         builder()
     }
@@ -193,7 +194,7 @@ public suspend inline fun <reified T : Any> HttpClient.preparePost(
 ): HttpStatement {
     val resources = resources()
     return preparePostBuilder {
-        includeUrlTemplate(resources.resourcesFormat, serializer<T>())
+        attributes.putUrlTemplate(resources.resourcesFormat, serializer<T>())
         href(resources.resourcesFormat, resource, url)
         builder()
     }
@@ -210,7 +211,7 @@ public suspend inline fun <reified T : Any> HttpClient.preparePut(
 ): HttpStatement {
     val resources = resources()
     return preparePutBuilder {
-        includeUrlTemplate(resources.resourcesFormat, serializer<T>())
+        attributes.putUrlTemplate(resources.resourcesFormat, serializer<T>())
         href(resources.resourcesFormat, resource, url)
         builder()
     }
@@ -227,7 +228,7 @@ public suspend inline fun <reified T : Any> HttpClient.prepareDelete(
 ): HttpStatement {
     val resources = resources()
     return prepareDeleteBuilder {
-        includeUrlTemplate(resources.resourcesFormat, serializer<T>())
+        attributes.putUrlTemplate(resources.resourcesFormat, serializer<T>())
         href(resources.resourcesFormat, resource, url)
         builder()
     }
@@ -244,7 +245,7 @@ public suspend inline fun <reified T : Any> HttpClient.preparePatch(
 ): HttpStatement {
     val resources = resources()
     return preparePatchBuilder {
-        includeUrlTemplate(resources.resourcesFormat, serializer<T>())
+        attributes.putUrlTemplate(resources.resourcesFormat, serializer<T>())
         href(resources.resourcesFormat, resource, url)
         builder()
     }
@@ -261,7 +262,7 @@ public suspend inline fun <reified T : Any> HttpClient.prepareOptions(
 ): HttpStatement {
     val resources = resources()
     return prepareOptionsBuilder {
-        includeUrlTemplate(resources.resourcesFormat, serializer<T>())
+        attributes.putUrlTemplate(resources.resourcesFormat, serializer<T>())
         href(resources.resourcesFormat, resource, url)
         builder()
     }
@@ -278,7 +279,7 @@ public suspend inline fun <reified T : Any> HttpClient.prepareHead(
 ): HttpStatement {
     val resources = resources()
     return prepareHeadBuilder {
-        includeUrlTemplate(resources.resourcesFormat, serializer<T>())
+        attributes.putUrlTemplate(resources.resourcesFormat, serializer<T>())
         href(resources.resourcesFormat, resource, url)
         builder()
     }
@@ -295,7 +296,7 @@ public suspend inline fun <reified T : Any> HttpClient.prepareRequest(
 ): HttpStatement {
     val resources = resources()
     return prepareRequestBuilder {
-        includeUrlTemplate(resources.resourcesFormat, serializer<T>())
+        attributes.putUrlTemplate(resources.resourcesFormat, serializer<T>())
         href(resources.resourcesFormat, resource, url)
         builder()
     }
@@ -303,11 +304,11 @@ public suspend inline fun <reified T : Any> HttpClient.prepareRequest(
 
 public val URL_TEMPLATE: AttributeKey<String> = AttributeKey<String>("URL_TEMPLATE")
 
-public fun <T : Any> HttpRequestBuilder.includeUrlTemplate(
+public fun <T : Any> Attributes.putUrlTemplate(
     format: ResourcesFormat,
     serializer: KSerializer<T>,
 ) {
-    attributes.put(URL_TEMPLATE, urlTemplate(format, serializer))
+    put(URL_TEMPLATE, urlTemplate(format, serializer))
 }
 
 internal fun <T> urlTemplate(

--- a/ktor-client/ktor-client-plugins/ktor-client-resources/common/src/io/ktor/client/plugins/resources/builders.kt
+++ b/ktor-client/ktor-client-plugins/ktor-client-resources/common/src/io/ktor/client/plugins/resources/builders.kt
@@ -9,10 +9,7 @@ import io.ktor.client.plugins.*
 import io.ktor.client.request.*
 import io.ktor.client.statement.*
 import io.ktor.resources.*
-import io.ktor.resources.serialization.ResourcesFormat
 import io.ktor.util.AttributeKey
-import io.ktor.util.Attributes
-import kotlinx.serialization.*
 import io.ktor.client.request.delete as deleteBuilder
 import io.ktor.client.request.get as getBuilder
 import io.ktor.client.request.head as headBuilder

--- a/ktor-client/ktor-client-plugins/ktor-client-resources/common/src/io/ktor/client/plugins/resources/builders.kt
+++ b/ktor-client/ktor-client-plugins/ktor-client-resources/common/src/io/ktor/client/plugins/resources/builders.kt
@@ -9,6 +9,9 @@ import io.ktor.client.plugins.*
 import io.ktor.client.request.*
 import io.ktor.client.statement.*
 import io.ktor.resources.*
+import io.ktor.resources.serialization.ResourcesFormat
+import io.ktor.util.AttributeKey
+import kotlinx.serialization.*
 import io.ktor.client.request.delete as deleteBuilder
 import io.ktor.client.request.get as getBuilder
 import io.ktor.client.request.head as headBuilder
@@ -37,6 +40,7 @@ public suspend inline fun <reified T : Any> HttpClient.get(
 ): HttpResponse {
     val resources = resources()
     return getBuilder {
+        includeUrlTemplate(resources.resourcesFormat, serializer<T>())
         href(resources.resourcesFormat, resource, url)
         builder()
     }
@@ -53,6 +57,7 @@ public suspend inline fun <reified T : Any> HttpClient.post(
 ): HttpResponse {
     val resources = resources()
     return postBuilder {
+        includeUrlTemplate(resources.resourcesFormat, serializer<T>())
         href(resources.resourcesFormat, resource, url)
         builder()
     }
@@ -69,6 +74,7 @@ public suspend inline fun <reified T : Any> HttpClient.put(
 ): HttpResponse {
     val resources = resources()
     return putBuilder {
+        includeUrlTemplate(resources.resourcesFormat, serializer<T>())
         href(resources.resourcesFormat, resource, url)
         builder()
     }
@@ -85,6 +91,7 @@ public suspend inline fun <reified T : Any> HttpClient.delete(
 ): HttpResponse {
     val resources = resources()
     return deleteBuilder {
+        includeUrlTemplate(resources.resourcesFormat, serializer<T>())
         href(resources.resourcesFormat, resource, url)
         builder()
     }
@@ -101,6 +108,7 @@ public suspend inline fun <reified T : Any> HttpClient.patch(
 ): HttpResponse {
     val resources = resources()
     return patchBuilder {
+        includeUrlTemplate(resources.resourcesFormat, serializer<T>())
         href(resources.resourcesFormat, resource, url)
         builder()
     }
@@ -117,6 +125,7 @@ public suspend inline fun <reified T : Any> HttpClient.options(
 ): HttpResponse {
     val resources = resources()
     return optionsBuilder {
+        includeUrlTemplate(resources.resourcesFormat, serializer<T>())
         href(resources.resourcesFormat, resource, url)
         builder()
     }
@@ -133,6 +142,7 @@ public suspend inline fun <reified T : Any> HttpClient.head(
 ): HttpResponse {
     val resources = resources()
     return headBuilder {
+        includeUrlTemplate(resources.resourcesFormat, serializer<T>())
         href(resources.resourcesFormat, resource, url)
         builder()
     }
@@ -149,6 +159,7 @@ public suspend inline fun <reified T : Any> HttpClient.request(
 ): HttpResponse {
     val resources = resources()
     return requestBuilder {
+        includeUrlTemplate(resources.resourcesFormat, serializer<T>())
         href(resources.resourcesFormat, resource, url)
         builder()
     }
@@ -165,6 +176,7 @@ public suspend inline fun <reified T : Any> HttpClient.prepareGet(
 ): HttpStatement {
     val resources = resources()
     return prepareGetBuilder {
+        includeUrlTemplate(resources.resourcesFormat, serializer<T>())
         href(resources.resourcesFormat, resource, url)
         builder()
     }
@@ -181,6 +193,7 @@ public suspend inline fun <reified T : Any> HttpClient.preparePost(
 ): HttpStatement {
     val resources = resources()
     return preparePostBuilder {
+        includeUrlTemplate(resources.resourcesFormat, serializer<T>())
         href(resources.resourcesFormat, resource, url)
         builder()
     }
@@ -197,6 +210,7 @@ public suspend inline fun <reified T : Any> HttpClient.preparePut(
 ): HttpStatement {
     val resources = resources()
     return preparePutBuilder {
+        includeUrlTemplate(resources.resourcesFormat, serializer<T>())
         href(resources.resourcesFormat, resource, url)
         builder()
     }
@@ -213,6 +227,7 @@ public suspend inline fun <reified T : Any> HttpClient.prepareDelete(
 ): HttpStatement {
     val resources = resources()
     return prepareDeleteBuilder {
+        includeUrlTemplate(resources.resourcesFormat, serializer<T>())
         href(resources.resourcesFormat, resource, url)
         builder()
     }
@@ -229,6 +244,7 @@ public suspend inline fun <reified T : Any> HttpClient.preparePatch(
 ): HttpStatement {
     val resources = resources()
     return preparePatchBuilder {
+        includeUrlTemplate(resources.resourcesFormat, serializer<T>())
         href(resources.resourcesFormat, resource, url)
         builder()
     }
@@ -245,6 +261,7 @@ public suspend inline fun <reified T : Any> HttpClient.prepareOptions(
 ): HttpStatement {
     val resources = resources()
     return prepareOptionsBuilder {
+        includeUrlTemplate(resources.resourcesFormat, serializer<T>())
         href(resources.resourcesFormat, resource, url)
         builder()
     }
@@ -261,6 +278,7 @@ public suspend inline fun <reified T : Any> HttpClient.prepareHead(
 ): HttpStatement {
     val resources = resources()
     return prepareHeadBuilder {
+        includeUrlTemplate(resources.resourcesFormat, serializer<T>())
         href(resources.resourcesFormat, resource, url)
         builder()
     }
@@ -277,8 +295,39 @@ public suspend inline fun <reified T : Any> HttpClient.prepareRequest(
 ): HttpStatement {
     val resources = resources()
     return prepareRequestBuilder {
+        includeUrlTemplate(resources.resourcesFormat, serializer<T>())
         href(resources.resourcesFormat, resource, url)
         builder()
+    }
+}
+
+public val URL_TEMPLATE: AttributeKey<String> = AttributeKey<String>("URL_TEMPLATE")
+
+public fun <T : Any> HttpRequestBuilder.includeUrlTemplate(
+    format: ResourcesFormat,
+    serializer: KSerializer<T>,
+) {
+    attributes.put(URL_TEMPLATE, urlTemplate(format, serializer))
+}
+
+internal fun <T> urlTemplate(
+    format: ResourcesFormat,
+    serializer: KSerializer<T>,
+): String {
+    val path = format.encodeToPathPattern(serializer)
+    val query = format.encodeToQueryParameters(serializer)
+    return buildString {
+        append(path)
+        for ((i, parameter) in query.withIndex()) {
+            append(if (i == 0) '?' else '&')
+            append(parameter.name)
+            append("={")
+            append(parameter.name)
+            if (parameter.isOptional) {
+                append('?')
+            }
+            append('}')
+        }
     }
 }
 

--- a/ktor-client/ktor-client-plugins/ktor-client-resources/common/src/io/ktor/client/plugins/resources/builders.kt
+++ b/ktor-client/ktor-client-plugins/ktor-client-resources/common/src/io/ktor/client/plugins/resources/builders.kt
@@ -41,7 +41,7 @@ public suspend inline fun <reified T : Any> HttpClient.get(
 ): HttpResponse {
     val resources = resources()
     return getBuilder {
-        attributes.putUrlTemplate(resources.resourcesFormat, serializer<T>())
+        attributes.put(RESOURCE, resource)
         href(resources.resourcesFormat, resource, url)
         builder()
     }
@@ -58,7 +58,7 @@ public suspend inline fun <reified T : Any> HttpClient.post(
 ): HttpResponse {
     val resources = resources()
     return postBuilder {
-        attributes.putUrlTemplate(resources.resourcesFormat, serializer<T>())
+        attributes.put(RESOURCE, resource)
         href(resources.resourcesFormat, resource, url)
         builder()
     }
@@ -75,7 +75,7 @@ public suspend inline fun <reified T : Any> HttpClient.put(
 ): HttpResponse {
     val resources = resources()
     return putBuilder {
-        attributes.putUrlTemplate(resources.resourcesFormat, serializer<T>())
+        attributes.put(RESOURCE, resource)
         href(resources.resourcesFormat, resource, url)
         builder()
     }
@@ -92,7 +92,7 @@ public suspend inline fun <reified T : Any> HttpClient.delete(
 ): HttpResponse {
     val resources = resources()
     return deleteBuilder {
-        attributes.putUrlTemplate(resources.resourcesFormat, serializer<T>())
+        attributes.put(RESOURCE, resource)
         href(resources.resourcesFormat, resource, url)
         builder()
     }
@@ -109,7 +109,7 @@ public suspend inline fun <reified T : Any> HttpClient.patch(
 ): HttpResponse {
     val resources = resources()
     return patchBuilder {
-        attributes.putUrlTemplate(resources.resourcesFormat, serializer<T>())
+        attributes.put(RESOURCE, resource)
         href(resources.resourcesFormat, resource, url)
         builder()
     }
@@ -126,7 +126,7 @@ public suspend inline fun <reified T : Any> HttpClient.options(
 ): HttpResponse {
     val resources = resources()
     return optionsBuilder {
-        attributes.putUrlTemplate(resources.resourcesFormat, serializer<T>())
+        attributes.put(RESOURCE, resource)
         href(resources.resourcesFormat, resource, url)
         builder()
     }
@@ -143,7 +143,7 @@ public suspend inline fun <reified T : Any> HttpClient.head(
 ): HttpResponse {
     val resources = resources()
     return headBuilder {
-        attributes.putUrlTemplate(resources.resourcesFormat, serializer<T>())
+        attributes.put(RESOURCE, resource)
         href(resources.resourcesFormat, resource, url)
         builder()
     }
@@ -160,7 +160,7 @@ public suspend inline fun <reified T : Any> HttpClient.request(
 ): HttpResponse {
     val resources = resources()
     return requestBuilder {
-        attributes.putUrlTemplate(resources.resourcesFormat, serializer<T>())
+        attributes.put(RESOURCE, resource)
         href(resources.resourcesFormat, resource, url)
         builder()
     }
@@ -177,7 +177,7 @@ public suspend inline fun <reified T : Any> HttpClient.prepareGet(
 ): HttpStatement {
     val resources = resources()
     return prepareGetBuilder {
-        attributes.putUrlTemplate(resources.resourcesFormat, serializer<T>())
+        attributes.put(RESOURCE, resource)
         href(resources.resourcesFormat, resource, url)
         builder()
     }
@@ -194,7 +194,7 @@ public suspend inline fun <reified T : Any> HttpClient.preparePost(
 ): HttpStatement {
     val resources = resources()
     return preparePostBuilder {
-        attributes.putUrlTemplate(resources.resourcesFormat, serializer<T>())
+        attributes.put(RESOURCE, resource)
         href(resources.resourcesFormat, resource, url)
         builder()
     }
@@ -211,7 +211,7 @@ public suspend inline fun <reified T : Any> HttpClient.preparePut(
 ): HttpStatement {
     val resources = resources()
     return preparePutBuilder {
-        attributes.putUrlTemplate(resources.resourcesFormat, serializer<T>())
+        attributes.put(RESOURCE, resource)
         href(resources.resourcesFormat, resource, url)
         builder()
     }
@@ -228,7 +228,7 @@ public suspend inline fun <reified T : Any> HttpClient.prepareDelete(
 ): HttpStatement {
     val resources = resources()
     return prepareDeleteBuilder {
-        attributes.putUrlTemplate(resources.resourcesFormat, serializer<T>())
+        attributes.put(RESOURCE, resource)
         href(resources.resourcesFormat, resource, url)
         builder()
     }
@@ -245,7 +245,7 @@ public suspend inline fun <reified T : Any> HttpClient.preparePatch(
 ): HttpStatement {
     val resources = resources()
     return preparePatchBuilder {
-        attributes.putUrlTemplate(resources.resourcesFormat, serializer<T>())
+        attributes.put(RESOURCE, resource)
         href(resources.resourcesFormat, resource, url)
         builder()
     }
@@ -262,7 +262,7 @@ public suspend inline fun <reified T : Any> HttpClient.prepareOptions(
 ): HttpStatement {
     val resources = resources()
     return prepareOptionsBuilder {
-        attributes.putUrlTemplate(resources.resourcesFormat, serializer<T>())
+        attributes.put(RESOURCE, resource)
         href(resources.resourcesFormat, resource, url)
         builder()
     }
@@ -279,7 +279,7 @@ public suspend inline fun <reified T : Any> HttpClient.prepareHead(
 ): HttpStatement {
     val resources = resources()
     return prepareHeadBuilder {
-        attributes.putUrlTemplate(resources.resourcesFormat, serializer<T>())
+        attributes.put(RESOURCE, resource)
         href(resources.resourcesFormat, resource, url)
         builder()
     }
@@ -296,41 +296,17 @@ public suspend inline fun <reified T : Any> HttpClient.prepareRequest(
 ): HttpStatement {
     val resources = resources()
     return prepareRequestBuilder {
-        attributes.putUrlTemplate(resources.resourcesFormat, serializer<T>())
+        attributes.put(RESOURCE, resource)
         href(resources.resourcesFormat, resource, url)
         builder()
     }
 }
 
-public val URL_TEMPLATE: AttributeKey<String> = AttributeKey<String>("URL_TEMPLATE")
-
-public fun <T : Any> Attributes.putUrlTemplate(
-    format: ResourcesFormat,
-    serializer: KSerializer<T>,
-) {
-    put(URL_TEMPLATE, urlTemplate(format, serializer))
-}
-
-internal fun <T> urlTemplate(
-    format: ResourcesFormat,
-    serializer: KSerializer<T>,
-): String {
-    val path = format.encodeToPathPattern(serializer)
-    val query = format.encodeToQueryParameters(serializer)
-    return buildString {
-        append(path)
-        for ((i, parameter) in query.withIndex()) {
-            append(if (i == 0) '?' else '&')
-            append(parameter.name)
-            append("={")
-            append(parameter.name)
-            if (parameter.isOptional) {
-                append('?')
-            }
-            append('}')
-        }
-    }
-}
+/**
+ * The instance of the [Resource] annotated class used to for a request.
+ * Plugins may want to utilize this for monitoring.
+ */
+public val RESOURCE: AttributeKey<Any> = AttributeKey<Any>("RESOURCE")
 
 @PublishedApi
 internal fun HttpClient.resources(): io.ktor.resources.Resources {

--- a/ktor-client/ktor-client-plugins/ktor-client-resources/common/src/io/ktor/client/plugins/resources/builders.kt
+++ b/ktor-client/ktor-client-plugins/ktor-client-resources/common/src/io/ktor/client/plugins/resources/builders.kt
@@ -58,7 +58,7 @@ public suspend inline fun <reified T : Any> HttpClient.post(
 ): HttpResponse {
     val resources = resources()
     return postBuilder {
-        attributes.attributes.putUrlTemplate(resources.resourcesFormat, serializer<T>())
+        attributes.putUrlTemplate(resources.resourcesFormat, serializer<T>())
         href(resources.resourcesFormat, resource, url)
         builder()
     }

--- a/ktor-client/ktor-client-plugins/ktor-client-resources/common/src/io/ktor/client/plugins/resources/builders.kt
+++ b/ktor-client/ktor-client-plugins/ktor-client-resources/common/src/io/ktor/client/plugins/resources/builders.kt
@@ -303,7 +303,7 @@ public suspend inline fun <reified T : Any> HttpClient.prepareRequest(
  * The instance of the [Resource] annotated class used to for a request.
  * Plugins may want to utilize this for monitoring.
  */
-public val RESOURCE: AttributeKey<Any> = AttributeKey<Any>("RESOURCE")
+public val RESOURCE: AttributeKey<Any> = AttributeKey<Any>("Resource")
 
 @PublishedApi
 internal fun HttpClient.resources(): io.ktor.resources.Resources {

--- a/ktor-client/ktor-client-plugins/ktor-client-resources/common/test/ResourcesTest.kt
+++ b/ktor-client/ktor-client-plugins/ktor-client-resources/common/test/ResourcesTest.kt
@@ -11,10 +11,9 @@ import io.ktor.client.statement.*
 import io.ktor.client.test.base.*
 import io.ktor.http.*
 import io.ktor.resources.*
-import io.ktor.resources.serialization.ResourcesFormat
-import kotlinx.serialization.serializer
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertSame
 
 class ResourcesTest {
 
@@ -167,34 +166,17 @@ class ResourcesTest {
             }
         }
         test { client ->
+            val resource = PathWithOptionalQueryParameter(10, "clyde")
             val clientWithAssertions = client.config {
-                install(createClientPlugin("check attribute is set") {
+                install(createClientPlugin("check resource attribute is set") {
                     onRequest { call, _ ->
-                        assertEquals(
-                            call.attributes[URL_TEMPLATE],
-                            urlTemplate(ResourcesFormat(), serializer<PathWithOptionalQueryParameter>())
-                        )
+                        assertSame(resource, call.attributes[RESOURCE])
                     }
                 })
             }
-            val response = clientWithAssertions.get(PathWithOptionalQueryParameter(10, "clyde"))
+
+            val response = clientWithAssertions.get(resource)
             assertEquals(response.status, HttpStatusCode.OK)
         }
-    }
-
-    @Test
-    fun testUrlTemplateFromResources() {
-        assertEquals(
-            urlTemplate(ResourcesFormat(), serializer<Path.Child>()),
-            "path/{id}/{method}/child/{path?}?query={query}"
-        )
-    }
-
-    @Test
-    fun testUrlTemplateFromResourcesWithOptionalQueryParameters() {
-        assertEquals(
-            urlTemplate(ResourcesFormat(), serializer<PathWithOptionalQueryParameter>()),
-            "path/{id}?query={query?}"
-        )
     }
 }

--- a/ktor-client/ktor-client-plugins/ktor-client-resources/common/test/ResourcesTest.kt
+++ b/ktor-client/ktor-client-plugins/ktor-client-resources/common/test/ResourcesTest.kt
@@ -168,11 +168,13 @@ class ResourcesTest {
         test { client ->
             val resource = PathWithOptionalQueryParameter(10, "clyde")
             val clientWithAssertions = client.config {
-                install(createClientPlugin("check resource attribute is set") {
-                    onRequest { call, _ ->
-                        assertSame(resource, call.attributes[RESOURCE])
+                install(
+                    createClientPlugin("check resource attribute is set") {
+                        onRequest { call, _ ->
+                            assertSame(resource, call.attributes[RESOURCE])
+                        }
                     }
-                })
+                )
             }
 
             val response = clientWithAssertions.get(resource)


### PR DESCRIPTION
**Subsystem**
Client, Resources

**Motivation**
This PR allows downstream plugins to introspect the resource used to create the request URL. 

The motivating use case for this is to allow spans to be named `GET api/user/{id}?query={query}` instead of `GET`, which is the best downstream telemetry can do right now.

This would result in a huge quality of life improvement around aggregating client requests to the same endpoint. Currently I'm writing regex against the full URL which is both slow, error prone and has to be done for each endpoint.

**Solution**
I've added a `RESOURCE` attribute to the request when the resources plugin is used.

~~I've made a seperate PR to opentelemetry-java-instrumentation to use this attribute to populate `url.template`  https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/13572~~

I will make a PR to opentelemetry-java-instrumentation once this is merged so I can test on that side. (as requested by their maintainers)

**Alternatives**

- Don't do anything. This is out of scope of KTOR. Application should be handling things like this.