### PR TITLE
Don't update develocity plugin automatically

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -55,8 +55,9 @@
     },
     {
       "description": "Do not update Develocity as server may not support a newer version",
-      "matchPackageNames": [
-        "com.gradle:develocity-gradle-plugin*"
+      "matchDepNames": [
+        "com.gradle.develocity",
+        "com.gradle:develocity-gradle-plugin"
       ],
       "enabled": false
     },


### PR DESCRIPTION
Added Develocity plugin id to the list of exceptions. It is required because of https://github.com/ktorio/ktor/commit/8a8b1867a503bdd539348cb10b03976fa719635f