### PR TITLE
KTOR-8291 Fix for coroutines not joined on shutdown

### DIFF
--- a/ktor-server/ktor-server-core/api/ktor-server-core.api
+++ b/ktor-server/ktor-server-core/api/ktor-server-core.api
@@ -1,5 +1,6 @@
 public final class io/ktor/server/application/Application : io/ktor/server/application/ApplicationCallPipeline, kotlinx/coroutines/CoroutineScope {
 	public final fun dispose ()V
+	public final fun disposeAndJoin (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun getCoroutineContext ()Lkotlin/coroutines/CoroutineContext;
 	public final fun getEngine ()Lio/ktor/server/engine/ApplicationEngine;
 	public final fun getMonitor ()Lio/ktor/events/Events;

--- a/ktor-server/ktor-server-core/api/ktor-server-core.klib.api
+++ b/ktor-server/ktor-server-core/api/ktor-server-core.klib.api
@@ -457,6 +457,7 @@ final class io.ktor.server.application/Application : io.ktor.server.application/
         final fun <set-rootPath>(kotlin/String) // io.ktor.server.application/Application.rootPath.<set-rootPath>|<set-rootPath>(kotlin.String){}[0]
 
     final fun dispose() // io.ktor.server.application/Application.dispose|dispose(){}[0]
+    final suspend fun disposeAndJoin() // io.ktor.server.application/Application.disposeAndJoin|disposeAndJoin(){}[0]
 }
 
 final class io.ktor.server.application/DuplicatePluginException : io.ktor.server.application/DuplicateApplicationPluginException { // io.ktor.server.application/DuplicatePluginException|null[0]

--- a/ktor-server/ktor-server-core/common/src/io/ktor/server/application/Application.kt
+++ b/ktor-server/ktor-server-core/common/src/io/ktor/server/application/Application.kt
@@ -12,6 +12,7 @@ import io.ktor.utils.io.*
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancelAndJoin
 import kotlin.coroutines.CoroutineContext
 import kotlin.coroutines.EmptyCoroutineContext
 
@@ -121,13 +122,30 @@ public class Application internal constructor(
     override val coroutineContext: CoroutineContext = parentCoroutineContext + applicationJob
 
     /**
+     * Cancels the application job without waiting for join.
+     *
+     * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.server.application.Application.dispose)
+     */
+    @Deprecated(
+        replaceWith = ReplaceWith("disposeAndJoin()"),
+        level = DeprecationLevel.WARNING,
+        message = "Use disposeAndJoin() instead."
+    )
+    @Suppress("DEPRECATION_ERROR")
+    public fun dispose() {
+        applicationJob.cancel()
+        uninstallAllPlugins()
+    }
+
+    /**
      * Called by [ApplicationEngine] when [Application] is terminated.
      *
      * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.server.application.Application.dispose)
      */
+    @InternalAPI
     @Suppress("DEPRECATION_ERROR")
-    public fun dispose() {
-        applicationJob.cancel()
+    public suspend fun disposeAndJoin() {
+        applicationJob.cancelAndJoin()
         uninstallAllPlugins()
     }
 }

--- a/ktor-server/ktor-server-core/jvm/src/io/ktor/server/engine/ShutDownUrl.kt
+++ b/ktor-server/ktor-server-core/jvm/src/io/ktor/server/engine/ShutDownUrl.kt
@@ -31,6 +31,7 @@ public class ShutDownUrl(public val url: String, public val exitCode: Applicatio
      *
      * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.server.engine.ShutDownUrl.doShutdown)
      */
+    @OptIn(InternalAPI::class)
     public suspend fun doShutdown(call: ApplicationCall) {
         call.application.log.warn("Shutdown URL was called: server is going down")
         val application = call.application
@@ -42,7 +43,7 @@ public class ShutDownUrl(public val url: String, public val exitCode: Applicatio
             latch.join()
 
             application.monitor.raise(ApplicationStopPreparing, environment)
-            application.dispose()
+            application.disposeAndJoin()
 
             exitProcess(exitCode)
         }

--- a/ktor-server/ktor-server-core/posix/src/io/ktor/server/engine/EmbeddedServerNix.kt
+++ b/ktor-server/ktor-server-core/posix/src/io/ktor/server/engine/EmbeddedServerNix.kt
@@ -8,6 +8,7 @@ import io.ktor.events.*
 import io.ktor.events.EventDefinition
 import io.ktor.server.application.*
 import io.ktor.server.engine.internal.*
+import io.ktor.utils.io.InternalAPI
 import kotlinx.coroutines.*
 
 public actual class EmbeddedServer<
@@ -53,7 +54,7 @@ actual constructor(
             monitor.raise(ApplicationStarted, application)
         } catch (cause: Throwable) {
             environment.log.error("Failed to start application.", cause)
-            destroy(application)
+            destroyBlocking(application)
             throw cause
         }
 
@@ -76,18 +77,26 @@ actual constructor(
     }
 
     public actual fun stop(gracePeriodMillis: Long, timeoutMillis: Long) {
+        destroyBlocking(application)
         engine.stop(gracePeriodMillis, timeoutMillis)
-        destroy(application)
     }
 
     public actual suspend fun stopSuspend(gracePeriodMillis: Long, timeoutMillis: Long) {
-        withContext(Dispatchers.IOBridge) { stop(gracePeriodMillis, timeoutMillis) }
+        withContext(Dispatchers.IOBridge) {
+            destroy(application)
+            engine.stop(gracePeriodMillis, timeoutMillis)
+        }
     }
 
-    private fun destroy(application: Application) {
+    private fun destroyBlocking(application: Application) {
+        runBlocking(Dispatchers.IOBridge) { destroy(application) }
+    }
+
+    @OptIn(InternalAPI::class)
+    private suspend fun destroy(application: Application) {
         safeRaiseEvent(ApplicationStopping, application)
         try {
-            application.dispose()
+            application.disposeAndJoin()
         } catch (e: Throwable) {
             environment.log.error("Failed to destroy application instance.", e)
         }

--- a/ktor-server/ktor-server-test-host/api/ktor-server-test-host.api
+++ b/ktor-server/ktor-server-test-host/api/ktor-server-test-host.api
@@ -30,7 +30,7 @@ public final class io/ktor/server/testing/TestApplication : io/ktor/server/testi
 	public fun createClient (Lkotlin/jvm/functions/Function1;)Lio/ktor/client/HttpClient;
 	public fun getClient ()Lio/ktor/client/HttpClient;
 	public final fun start (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun stop ()V
+	public final fun stop (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public class io/ktor/server/testing/TestApplicationBuilder {

--- a/ktor-server/ktor-server-test-host/api/ktor-server-test-host.klib.api
+++ b/ktor-server/ktor-server-test-host/api/ktor-server-test-host.klib.api
@@ -63,8 +63,8 @@ final class io.ktor.server.testing/TestApplication : io.ktor.server.testing/Clie
         final fun <get-client>(): io.ktor.client/HttpClient // io.ktor.server.testing/TestApplication.client.<get-client>|<get-client>(){}[0]
 
     final fun createClient(kotlin/Function1<io.ktor.client/HttpClientConfig<out io.ktor.client.engine/HttpClientEngineConfig>, kotlin/Unit>): io.ktor.client/HttpClient // io.ktor.server.testing/TestApplication.createClient|createClient(kotlin.Function1<io.ktor.client.HttpClientConfig<out|io.ktor.client.engine.HttpClientEngineConfig>,kotlin.Unit>){}[0]
-    final fun stop() // io.ktor.server.testing/TestApplication.stop|stop(){}[0]
     final suspend fun start() // io.ktor.server.testing/TestApplication.start|start(){}[0]
+    final suspend fun stop() // io.ktor.server.testing/TestApplication.stop|stop(){}[0]
 }
 
 final class io.ktor.server.testing/TestApplicationCall : io.ktor.server.engine/BaseApplicationCall, kotlinx.coroutines/CoroutineScope { // io.ktor.server.testing/TestApplicationCall|null[0]

--- a/ktor-server/ktor-server-test-host/common/src/io/ktor/server/testing/TestApplication.kt
+++ b/ktor-server/ktor-server-test-host/common/src/io/ktor/server/testing/TestApplication.kt
@@ -110,9 +110,9 @@ public class TestApplication internal constructor(
      *
      * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.server.testing.TestApplication.stop)
      */
-    public fun stop() {
+    public suspend fun stop() {
         state.value = State.Stopped
-        server.stop()
+        server.stopSuspend()
         externalServices.externalApplications.values.forEach { it.stop() }
         client.close()
     }

--- a/ktor-server/ktor-server-test-suites/jvm/src/io/ktor/server/testing/suites/SustainabilityTestSuite.kt
+++ b/ktor-server/ktor-server-test-suites/jvm/src/io/ktor/server/testing/suites/SustainabilityTestSuite.kt
@@ -11,7 +11,6 @@ import io.ktor.client.statement.*
 import io.ktor.http.*
 import io.ktor.http.cio.*
 import io.ktor.http.content.*
-import io.ktor.network.sockets.*
 import io.ktor.server.application.*
 import io.ktor.server.engine.*
 import io.ktor.server.http.content.*
@@ -244,21 +243,6 @@ abstract class SustainabilityTestSuite<TEngine : ApplicationEngine, TConfigurati
                 call.body<String>()
             }
         }
-    }
-
-    @Test
-    fun testApplicationScopeCancellation() = runTest {
-        var job: Job? = null
-
-        createAndStartServer {
-            job = application.launch {
-                delay(10000000L)
-            }
-        }
-
-        server!!.stop(1, 10, TimeUnit.SECONDS)
-        assertNotNull(job)
-        assertTrue(job!!.isCancelled)
     }
 
     @OptIn(ExperimentalCoroutinesApi::class)
@@ -977,6 +961,53 @@ abstract class SustainabilityTestSuite<TEngine : ApplicationEngine, TConfigurati
             assertNotNull(loggedException)
             loggedException = null
         }
+    }
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    open fun testJobsAreCancelledOnShutdown() = runTest {
+        var applicationJob: Job? = null
+        var routingJob: Job? = null
+        val jobsStartedLatch = CountDownLatch(2)
+
+        suspend fun waitForever() {
+            jobsStartedLatch.countDown()
+            delay(Long.MAX_VALUE) // Hang until canceled
+        }
+
+        val server = createAndStartServer {
+            // Launch a coroutine in the application context
+            applicationJob = application.launch { waitForever() }
+
+            // Configure a route that launches a coroutine in the routing context
+            get("/launch-job") {
+                routingJob = call.launch { waitForever() }
+                call.respondText("Job launched")
+            }
+        }
+
+        // Trigger the route to start the routing job
+        withUrl("/launch-job") {
+            assertEquals("Job launched", call.body<String>())
+        }
+
+        // Wait for both jobs to start
+        assertTrue(jobsStartedLatch.await(5, TimeUnit.SECONDS), "Jobs did not start within timeout")
+
+        // Verify both jobs are active
+        assertNotNull(applicationJob, "Application job should not be null")
+        assertNotNull(routingJob, "Routing job should not be null")
+        assertTrue(applicationJob.isActive, "Application job should be active")
+        assertTrue(routingJob.isActive, "Routing job should be active")
+
+        // Stop the server
+        server.stop(1, 10, TimeUnit.SECONDS)
+
+        // Verify both jobs are canceled
+        assertTrue(applicationJob.isCancelled, "Application job should be canceled")
+
+        // KTOR-8338 Coroutines launched from RoutingContext are not canceled upon server shutdown
+        // assertTrue(routingJob.isCancelled, "Routing job should be canceled")
     }
 }
 


### PR DESCRIPTION
**Subsystem**
Server, Core

**Motivation**
[KTOR-8291](https://youtrack.jetbrains.com/issue/KTOR-8291) Application job is not joined during shutdown

**Solution**
Added a `disposeAndJoin()` internal API function on `Application` which waits for the application job to join after cancelling, then replaced all relevant references.  This is important for properly cleaning up resources when the server is closed or refreshed, because otherwise the process will stop before executing any `onCancelled` hooks are executed.

Note [KTOR-8338](https://youtrack.jetbrains.com/issue/KTOR-8338) will need to wait for 3.2.0, because it will require some more significant changes because only the CIO engine uses the application job as the parent for jobs spawned from the call context.
