### PR TITLE
Replace ReentrantLock with shared service with limited parallelism

### DIFF
--- a/build-logic/src/main/kotlin/ktorbuild.publish.gradle.kts
+++ b/build-logic/src/main/kotlin/ktorbuild.publish.gradle.kts
@@ -3,11 +3,10 @@
  */
 
 import ktorbuild.*
+import ktorbuild.internal.*
 import ktorbuild.internal.gradle.findByName
-import ktorbuild.internal.ktorBuild
 import ktorbuild.internal.publish.*
 import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
-import java.util.concurrent.locks.ReentrantLock
 
 plugins {
     id("maven-publish")
@@ -76,11 +75,9 @@ private fun Project.configureSigning() {
         sign(publishing.publications)
     }
 
-    val gpgAgentLock: ReentrantLock by rootProject.extra { ReentrantLock() }
-
+    // Workaround for https://github.com/gradle/gradle/issues/12167
     tasks.withType<Sign>().configureEach {
-        doFirst { gpgAgentLock.lock() }
-        doLast { gpgAgentLock.unlock() }
+        withLimitedParallelism("gpg-agent", maxParallelTasks = 1)
     }
 }
 

--- a/build-logic/src/main/kotlin/ktorbuild/internal/LimitedParallelismService.kt
+++ b/build-logic/src/main/kotlin/ktorbuild/internal/LimitedParallelismService.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2014-2025 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package ktorbuild.internal
+
+import org.gradle.api.Project
+import org.gradle.api.Task
+import org.gradle.api.provider.Provider
+import org.gradle.api.services.BuildService
+import org.gradle.api.services.BuildServiceParameters
+import org.gradle.kotlin.dsl.assign
+import org.gradle.kotlin.dsl.registerIfAbsent
+
+private abstract class LimitedParallelismService : BuildService<BuildServiceParameters.None> {
+
+    companion object {
+        fun registerIfAbsent(project: Project, name: String, maxParallel: Int): Provider<LimitedParallelismService> {
+            return project.gradle.sharedServices.registerIfAbsent(name, LimitedParallelismService::class) {
+                maxParallelUsages = maxParallel
+            }
+        }
+    }
+}
+
+/** Limits parallelism for the tasks with the same [ruleName]. */
+internal fun Task.withLimitedParallelism(ruleName: String, maxParallelTasks: Int = 1) {
+    val service = LimitedParallelismService.registerIfAbsent(project, ruleName, maxParallelTasks)
+
+    usesService(service)
+    doFirst { service.get() }
+}


### PR DESCRIPTION
**Subsystem**
Publishing Infrastructure

**Reason**
Publishing fails as `gpgAgentLock` is stored in the root project's `extra`

**Solution**
Remove usage of `rootProject.extra`. Use shared build service instead.

