### PR TITLE
KTOR-8236: support for 'Vary' header

### DIFF
--- a/ktor-http/common/src/io/ktor/http/content/CompressedContent.kt
+++ b/ktor-http/common/src/io/ktor/http/content/CompressedContent.kt
@@ -46,7 +46,11 @@ private class CompressedReadChannelResponse(
         Headers.build {
             appendFiltered(original.headers) { name, _ -> !name.equals(HttpHeaders.ContentLength, true) }
             append(HttpHeaders.ContentEncoding, encoder.name)
-            append(HttpHeaders.Vary, original.headers[HttpHeaders.Vary]?.plus(", ${HttpHeaders.AcceptEncoding}") ?: HttpHeaders.AcceptEncoding)
+            append(
+                HttpHeaders.Vary,
+                original.headers[HttpHeaders.Vary]?.plus(", ${HttpHeaders.AcceptEncoding}")
+                    ?: HttpHeaders.AcceptEncoding
+            )
         }
     }
 
@@ -68,7 +72,11 @@ private class CompressedWriteChannelResponse(
         Headers.build {
             appendFiltered(original.headers) { name, _ -> !name.equals(HttpHeaders.ContentLength, true) }
             append(HttpHeaders.ContentEncoding, encoder.name)
-            append(HttpHeaders.Vary, original.headers[HttpHeaders.Vary]?.plus(", ${HttpHeaders.AcceptEncoding}") ?: HttpHeaders.AcceptEncoding)
+            append(
+                HttpHeaders.Vary,
+                original.headers[HttpHeaders.Vary]?.plus(", ${HttpHeaders.AcceptEncoding}")
+                    ?: HttpHeaders.AcceptEncoding
+            )
         }
     }
 

--- a/ktor-http/common/src/io/ktor/http/content/CompressedContent.kt
+++ b/ktor-http/common/src/io/ktor/http/content/CompressedContent.kt
@@ -46,6 +46,7 @@ private class CompressedReadChannelResponse(
         Headers.build {
             appendFiltered(original.headers) { name, _ -> !name.equals(HttpHeaders.ContentLength, true) }
             append(HttpHeaders.ContentEncoding, encoder.name)
+            append(HttpHeaders.Vary, original.headers[HttpHeaders.Vary]?.plus(", ${HttpHeaders.AcceptEncoding}") ?: HttpHeaders.AcceptEncoding)
         }
     }
 
@@ -67,6 +68,7 @@ private class CompressedWriteChannelResponse(
         Headers.build {
             appendFiltered(original.headers) { name, _ -> !name.equals(HttpHeaders.ContentLength, true) }
             append(HttpHeaders.ContentEncoding, encoder.name)
+            append(HttpHeaders.Vary, original.headers[HttpHeaders.Vary]?.plus(", ${HttpHeaders.AcceptEncoding}") ?: HttpHeaders.AcceptEncoding)
         }
     }
 

--- a/ktor-server/ktor-server-core/jvm/src/io/ktor/server/http/content/PreCompressed.kt
+++ b/ktor-server/ktor-server-core/jvm/src/io/ktor/server/http/content/PreCompressed.kt
@@ -135,8 +135,10 @@ internal suspend fun ApplicationCall.respondStaticFile(
     suppressCompression()
     val compressedFile = File("${requestedFile.absolutePath}.${bestCompressionFit.extension}")
     if (cacheControlValues.isNotEmpty()) response.header(HttpHeaders.CacheControl, cacheControlValues)
-    response.header(HttpHeaders.Vary,
-        response.headers[HttpHeaders.Vary]?.plus(", ${HttpHeaders.AcceptEncoding}") ?: HttpHeaders.AcceptEncoding)
+    response.header(
+        HttpHeaders.Vary,
+        response.headers[HttpHeaders.Vary]?.plus(", ${HttpHeaders.AcceptEncoding}") ?: HttpHeaders.AcceptEncoding
+    )
     modify(requestedFile, this)
     val localFileContent = LocalFileContent(compressedFile, contentType(requestedFile))
     respond(PreCompressedResponse(localFileContent, bestCompressionFit.encoding))
@@ -197,8 +199,10 @@ internal suspend fun ApplicationCall.respondStaticResource(
         suppressCompression()
         val cacheControlValues = cacheControl(bestCompressionFit.url).joinToString(", ")
         if (cacheControlValues.isNotEmpty()) response.header(HttpHeaders.CacheControl, cacheControlValues)
-        response.header(HttpHeaders.Vary,
-            response.headers[HttpHeaders.Vary]?.plus(", ${HttpHeaders.AcceptEncoding}") ?: HttpHeaders.AcceptEncoding)
+        response.header(
+            HttpHeaders.Vary,
+            response.headers[HttpHeaders.Vary]?.plus(", ${HttpHeaders.AcceptEncoding}") ?: HttpHeaders.AcceptEncoding
+        )
         modifier(bestCompressionFit.url, this)
         respond(PreCompressedResponse(bestCompressionFit.content, bestCompressionFit.compression.encoding))
         return

--- a/ktor-server/ktor-server-core/jvm/src/io/ktor/server/http/content/PreCompressed.kt
+++ b/ktor-server/ktor-server-core/jvm/src/io/ktor/server/http/content/PreCompressed.kt
@@ -135,6 +135,8 @@ internal suspend fun ApplicationCall.respondStaticFile(
     suppressCompression()
     val compressedFile = File("${requestedFile.absolutePath}.${bestCompressionFit.extension}")
     if (cacheControlValues.isNotEmpty()) response.header(HttpHeaders.CacheControl, cacheControlValues)
+    response.header(HttpHeaders.Vary,
+        response.headers[HttpHeaders.Vary]?.plus(", ${HttpHeaders.AcceptEncoding}") ?: HttpHeaders.AcceptEncoding)
     modify(requestedFile, this)
     val localFileContent = LocalFileContent(compressedFile, contentType(requestedFile))
     respond(PreCompressedResponse(localFileContent, bestCompressionFit.encoding))
@@ -195,6 +197,8 @@ internal suspend fun ApplicationCall.respondStaticResource(
         suppressCompression()
         val cacheControlValues = cacheControl(bestCompressionFit.url).joinToString(", ")
         if (cacheControlValues.isNotEmpty()) response.header(HttpHeaders.CacheControl, cacheControlValues)
+        response.header(HttpHeaders.Vary,
+            response.headers[HttpHeaders.Vary]?.plus(", ${HttpHeaders.AcceptEncoding}") ?: HttpHeaders.AcceptEncoding)
         modifier(bestCompressionFit.url, this)
         respond(PreCompressedResponse(bestCompressionFit.content, bestCompressionFit.compression.encoding))
         return

--- a/ktor-server/ktor-server-tests/jvm/test/io/ktor/server/plugins/CompressionTest.kt
+++ b/ktor-server/ktor-server-tests/jvm/test/io/ktor/server/plugins/CompressionTest.kt
@@ -888,7 +888,7 @@ class CompressionTest {
 
         expectedVary?.let {
             assertEquals(response.headers[HttpHeaders.Vary], expectedVary)
-        } ?: assertNull(response.headers[HttpHeaders.Vary])
+        }
 
         return response
     }


### PR DESCRIPTION
**Subsystem**
ktor-http, ktor-server-core

**Motivation**
KTOR-8326. Added support for 'Vary' header in responses.

**Solution**
Append 'Accept-Encoding' header to 'Vary' if response was compressed based on Accept-Encoding values received from client call.

