### PR TITLE
Update Develocity plugin to 3.18.2

### DIFF
--- a/build-settings-logic/settings.gradle.kts
+++ b/build-settings-logic/settings.gradle.kts
@@ -3,7 +3,8 @@
  */
 
 plugins {
-    id("com.gradle.develocity") version "3.17.6"
+    // Keep it in sync with libs.versions.toml
+    id("com.gradle.develocity") version "3.18.2"
 }
 
 dependencyResolutionManagement {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -76,8 +76,9 @@ swagger-parser = "2.1.26"
 puppeteer = "21.5.0"
 tomlj = "1.1.1"
 
-develocity = "3.17.6" # Should be compatible with our server: ge.jetbrains.com
-develocity-commonCustomUserData = "2.1"
+# Keep it in sync with build-settings-logic/settings.gradle.kts
+develocity = "3.18.2" # Should be compatible with our server: ge.jetbrains.com
+develocity-commonCustomUserData = "2.2.1"
 gradleDoctor = "0.10.0"
 
 [libraries]

--- a/renovate.json
+++ b/renovate.json
@@ -59,11 +59,18 @@
         "com.gradle.develocity",
         "com.gradle:develocity-gradle-plugin"
       ],
+      "matchUpdateTypes": [
+        "major",
+        "minor"
+      ],
       "enabled": false
     },
     {
       "description": "Automerge non-major releases",
-      "matchUpdateTypes": ["patch", "minor"],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
       "automerge": true
     },
     {


### PR DESCRIPTION
**Subsystem**
Infrastructure

As soon as our Develocity server has been updated to 2024.2, we can use Develocity v3.18.*