### PR TITLE
KTOR-7965 Fix for connection leak in Netty websockets

### DIFF
--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http1/NettyHttp1ApplicationResponse.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http1/NettyHttp1ApplicationResponse.kt
@@ -100,18 +100,22 @@ internal class NettyHttp1ApplicationResponse(
             }
         }
 
-        val job = upgrade.upgrade(upgradedReadChannel, upgradedWriteChannel, engineContext, userAppContext)
+        val job = upgrade.upgrade(
+            upgradedReadChannel,
+            upgradedWriteChannel,
+            engineContext,
+            userAppContext
+        )
 
         job.invokeOnCompletion {
             upgradedWriteChannel.close()
             bodyHandler.close()
             upgradedReadChannel.cancel(it)
+            context.channel().close()
         }
 
         (call as NettyApplicationCall).responseWriteJob.join()
         job.join()
-
-        context.channel().close()
     }
 
     private fun setChunked(message: HttpResponse) {

--- a/ktor-server/ktor-server-test-suites/common/src/io/ktor/server/testing/suites/WebSocketEngineSuite.kt
+++ b/ktor-server/ktor-server-test-suites/common/src/io/ktor/server/testing/suites/WebSocketEngineSuite.kt
@@ -12,7 +12,6 @@ import io.ktor.server.engine.*
 import io.ktor.server.routing.*
 import io.ktor.server.test.base.*
 import io.ktor.server.websocket.*
-import io.ktor.test.dispatcher.runTestWithRealTime
 import io.ktor.util.*
 import io.ktor.utils.io.*
 import io.ktor.utils.io.charsets.*
@@ -572,7 +571,7 @@ abstract class WebSocketEngineSuite<TEngine : ApplicationEngine, TConfiguration 
     }
 
     @Test
-    open fun testClientClosingFirst() = runTest {
+    open fun testClientClosingFirst() = runTest(retries = 3) {
         val deferred = CompletableDeferred<Unit>()
 
         createAndStartServer {
@@ -654,13 +653,14 @@ abstract class WebSocketEngineSuite<TEngine : ApplicationEngine, TConfiguration 
     }
 
     @Test
-    fun testCorruptFrameWithBadOpcode() = runTestWithRealTime {
+    fun testCorruptFrameWithBadOpcode() = runTest {
         createAndStartServer {
             application.routing {
                 webSocket("/") {
-                    for (frame in incoming) {
-                        // Echo frames back
-                        outgoing.send(frame)
+                    runCatching {
+                        for (frame in incoming) {
+                            outgoing.send(frame)
+                        }
                     }
                 }
             }

--- a/ktor-shared/ktor-websockets/common/src/io/ktor/websocket/RawWebSocketCommon.kt
+++ b/ktor-shared/ktor-websockets/common/src/io/ktor/websocket/RawWebSocketCommon.kt
@@ -231,7 +231,7 @@ public suspend fun ByteReadChannel.readFrame(maxFrameSize: Long, lastOpcode: Int
         throw ProtocolViolationException("Can't continue finished frames")
     }
     val opcode = if (rawOpcode == 0) lastOpcode else rawOpcode
-    val frameType = FrameType[opcode] ?: throw IllegalStateException("Unsupported opcode: $opcode")
+    val frameType = FrameType[opcode] ?: throw ProtocolViolationException("Unsupported opcode: $opcode")
     if (rawOpcode != 0 && lastOpcode != 0 && !frameType.controlFrame) {
         // trying to intermix data frames
         throw ProtocolViolationException("Can't start new data frame before finishing previous one")

--- a/ktor-shared/ktor-websockets/jvm/src/io/ktor/websocket/FrameParser.kt
+++ b/ktor-shared/ktor-websockets/jvm/src/io/ktor/websocket/FrameParser.kt
@@ -37,7 +37,8 @@ public class FrameParser {
         private set
 
     public val frameType: FrameType
-        get() = FrameType[opcode] ?: throw IllegalStateException("Unsupported opcode ${Integer.toHexString(opcode)}")
+        get() = FrameType[opcode]
+            ?: throw ProtocolViolationException("Unsupported opcode ${Integer.toHexString(opcode)}")
 
     public enum class State {
         HEADER0,

--- a/ktor-shared/ktor-websockets/jvm/src/io/ktor/websocket/RawWebSocketJvm.kt
+++ b/ktor-shared/ktor-websockets/jvm/src/io/ktor/websocket/RawWebSocketJvm.kt
@@ -71,10 +71,10 @@ internal class RawWebSocketJvm(
                     filtered.send(frame)
                 }
             } catch (cause: FrameTooBigException) {
-                outgoing.send(Frame.Close(CloseReason(CloseReason.Codes.TOO_BIG, cause.message)))
+                outgoing.trySend(Frame.Close(CloseReason(CloseReason.Codes.TOO_BIG, cause.message)))
                 filtered.close(cause)
             } catch (cause: ProtocolViolationException) {
-                outgoing.send(Frame.Close(CloseReason(CloseReason.Codes.PROTOCOL_ERROR, cause.message)))
+                outgoing.trySend(Frame.Close(CloseReason(CloseReason.Codes.PROTOCOL_ERROR, cause.message)))
                 filtered.close(cause)
             } catch (cause: CancellationException) {
                 reader.incoming.cancel(cause)


### PR DESCRIPTION
**Subsystem**
Server, Netty, Websockets

**Motivation**
[KTOR-7965](https://youtrack.jetbrains.com/issue/KTOR-7965) Netty/Websockets: server processes hanging in CLOSE_WAIT state after many concurrent requests

**Solution**
This was caused by an invalid client frame header causing an exception in the server that would miss closing the underlying Netty channel, which would leak socket connections.

We'd also have some uncaught coroutine exceptions from this due to using `IllegalArgumentException` for invalid opcodes.  There was also a problem with exceptions thrown from trying to send the error close frame after the client has hung up.

