### PR TITLE
Add ',' to parameter quoting terminals in HttpHeaderValueParser

### DIFF
--- a/ktor-http/common/src/io/ktor/http/HttpHeaderValueParser.kt
+++ b/ktor-http/common/src/io/ktor/http/HttpHeaderValueParser.kt
@@ -213,7 +213,7 @@ private fun parseHeaderValueParameterValueQuoted(value: String, start: Int): Pai
         val currentChar = value[position]
 
         when {
-            currentChar == '"' && value.nextIsSemicolonOrEnd(position) -> {
+            currentChar == '"' && value.nextIsDelimiterOrEnd(position) -> {
                 return position + 1 to builder.toString()
             }
 
@@ -232,7 +232,7 @@ private fun parseHeaderValueParameterValueQuoted(value: String, start: Int): Pai
     return position to '"' + builder.toString()
 }
 
-private fun String.nextIsSemicolonOrEnd(start: Int): Boolean {
+private fun String.nextIsDelimiterOrEnd(start: Int): Boolean {
     var position = start + 1
     loop@ while (position < length && get(position) == ' ') {
         position += 1

--- a/ktor-http/common/src/io/ktor/http/HttpHeaderValueParser.kt
+++ b/ktor-http/common/src/io/ktor/http/HttpHeaderValueParser.kt
@@ -238,5 +238,5 @@ private fun String.nextIsSemicolonOrEnd(start: Int): Boolean {
         position += 1
     }
 
-    return position == length || get(position) == ';'
+    return position == length || get(position) == ';' || get(position) == ','
 }

--- a/ktor-http/common/test/io/ktor/tests/http/CommonHeadersTest.kt
+++ b/ktor-http/common/test/io/ktor/tests/http/CommonHeadersTest.kt
@@ -200,6 +200,23 @@ class CommonHeadersTest {
     }
 
     @Test
+    fun parsingQuotedParamsWorks() {
+        assertEquals(
+            listOf(
+                HeaderValue("", listOf(HeaderValueParam("k", "v"), HeaderValueParam("k2", "v2"))),
+            ),
+            parseHeaderValue("k=\"v\";k2=\"v2\"", parametersOnly = true)
+        )
+        assertEquals(
+            listOf(
+                HeaderValue("", listOf(HeaderValueParam("k", "v"))),
+                HeaderValue("", listOf(HeaderValueParam("k2", "v2")))
+            ),
+            parseHeaderValue("k=\"v\",k2=\"v2\"", parametersOnly = true)
+        )
+    }
+
+    @Test
     fun testRenderSimple() {
         assertEquals("file", ContentDisposition.File.toString())
     }


### PR DESCRIPTION
**Subsystem**
HTTP - header parsing

**Motivation**
I want to replace HTTP Header parsing within Intellij Platform (specifically collab tools subsystems) with Ktor parsing.
Sadly, we are currently blocked by this bug: parsing a header value with parameters surrounded by double-annotation marks, immediately followed by a comma fails. Ex: `k: "v", k2: "v2"` does not correctly parse after the first `"`.

**Solution**
Add the comma exception to the list of characters that can follow `"`

