### PR TITLE
KTOR-8338 Fix for call context coroutines not being cancelled

### DIFF
--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyApplicationEngine.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyApplicationEngine.kt
@@ -23,7 +23,6 @@ import io.netty.channel.socket.nio.NioServerSocketChannel
 import io.netty.handler.codec.http.HttpObjectDecoder
 import io.netty.handler.codec.http.HttpServerCodec
 import kotlinx.coroutines.CompletableJob
-import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.asCoroutineDispatcher
 import java.net.BindException
 import java.util.concurrent.TimeUnit

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyApplicationEngine.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyApplicationEngine.kt
@@ -185,10 +185,6 @@ public class NettyApplicationEngine(
         }
     }
 
-    private val nettyDispatcher: CoroutineDispatcher by lazy {
-        NettyDispatcher
-    }
-
     private val workerDispatcher by lazy {
         workerEventGroup.asCoroutineDispatcher()
     }
@@ -200,11 +196,6 @@ public class NettyApplicationEngine(
         configuration.connectors.map(::createBootstrap)
     }
 
-    private val userContext = applicationProvider().parentCoroutineContext +
-        nettyDispatcher +
-        NettyApplicationCallHandler.CallHandlerCoroutineName +
-        DefaultUncaughtExceptionHandler(environment.log)
-
     private fun createBootstrap(connector: EngineConnectorConfig): ServerBootstrap {
         return customBootstrap.clone().apply {
             if (config().group() == null && config().childGroup() == null) {
@@ -214,6 +205,10 @@ public class NettyApplicationEngine(
             if (config().channelFactory() == null) {
                 channel(getChannelClass().java)
             }
+
+            val userContext = applicationProvider().coroutineContext +
+                NettyApplicationCallHandler.CallHandlerCoroutineName +
+                DefaultUncaughtExceptionHandler(environment.log)
 
             childHandler(
                 NettyChannelInitializer(

--- a/ktor-server/ktor-server-test-suites/jvm/src/io/ktor/server/testing/suites/SustainabilityTestSuite.kt
+++ b/ktor-server/ktor-server-test-suites/jvm/src/io/ktor/server/testing/suites/SustainabilityTestSuite.kt
@@ -1005,9 +1005,7 @@ abstract class SustainabilityTestSuite<TEngine : ApplicationEngine, TConfigurati
 
         // Verify both jobs are canceled
         assertTrue(applicationJob.isCancelled, "Application job should be canceled")
-
-        // KTOR-8338 Coroutines launched from RoutingContext are not canceled upon server shutdown
-        // assertTrue(routingJob.isCancelled, "Routing job should be canceled")
+        assertTrue(routingJob.isCancelled, "Routing job should be canceled")
     }
 }
 


### PR DESCRIPTION
**Subsystem**
Server, Netty

**Motivation**
[KTOR-8338](https://youtrack.jetbrains.com/issue/KTOR-8338) Coroutines launched from RoutingContext are not cancelled upon server shutdown

**Solution**
This avoids using the netty dispatcher for the user context within routing calls.  Previously, the underlying executor for the netty dispatcher would get closed, then `onComplete` would fail to trigger because of the missing executor.  Now, the netty dispatcher will only be used for handling the calls themselves, and not other coroutines launched from the call.