### PR TITLE
KTOR-8411 CountedByteWriteChannel: fix autoFlush not working

### DIFF
--- a/ktor-io/api/ktor-io.api
+++ b/ktor-io/api/ktor-io.api
@@ -3,6 +3,10 @@ public abstract interface class io/ktor/utils/io/BufferedByteWriteChannel : io/k
 	public abstract fun flushWriteBuffer ()V
 }
 
+public final class io/ktor/utils/io/BufferedByteWriteChannel$DefaultImpls {
+	public static fun getAutoFlush (Lio/ktor/utils/io/BufferedByteWriteChannel;)Z
+}
+
 public final class io/ktor/utils/io/ByteChannel : io/ktor/utils/io/BufferedByteWriteChannel, io/ktor/utils/io/ByteReadChannel {
 	public fun <init> ()V
 	public fun <init> (Z)V
@@ -13,7 +17,7 @@ public final class io/ktor/utils/io/ByteChannel : io/ktor/utils/io/BufferedByteW
 	public fun flush (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun flushAndClose (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun flushWriteBuffer ()V
-	public final fun getAutoFlush ()Z
+	public fun getAutoFlush ()Z
 	public fun getClosedCause ()Ljava/lang/Throwable;
 	public fun getReadBuffer ()Lkotlinx/io/Source;
 	public fun getWriteBuffer ()Lkotlinx/io/Sink;
@@ -125,9 +129,14 @@ public abstract interface class io/ktor/utils/io/ByteWriteChannel {
 	public abstract fun cancel (Ljava/lang/Throwable;)V
 	public abstract fun flush (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun flushAndClose (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun getAutoFlush ()Z
 	public abstract fun getClosedCause ()Ljava/lang/Throwable;
 	public abstract fun getWriteBuffer ()Lkotlinx/io/Sink;
 	public abstract fun isClosedForWrite ()Z
+}
+
+public final class io/ktor/utils/io/ByteWriteChannel$DefaultImpls {
+	public static fun getAutoFlush (Lio/ktor/utils/io/ByteWriteChannel;)Z
 }
 
 public final class io/ktor/utils/io/ByteWriteChannelKt {
@@ -236,6 +245,7 @@ public final class io/ktor/utils/io/CountedByteWriteChannel : io/ktor/utils/io/B
 	public fun cancel (Ljava/lang/Throwable;)V
 	public fun flush (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun flushAndClose (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getAutoFlush ()Z
 	public fun getClosedCause ()Ljava/lang/Throwable;
 	public final fun getTotalBytesWritten ()J
 	public fun getWriteBuffer ()Lkotlinx/io/Sink;

--- a/ktor-io/api/ktor-io.klib.api
+++ b/ktor-io/api/ktor-io.klib.api
@@ -91,6 +91,8 @@ abstract interface io.ktor.utils.io/ByteWriteChannel { // io.ktor.utils.io/ByteW
         abstract fun <get-isClosedForWrite>(): kotlin/Boolean // io.ktor.utils.io/ByteWriteChannel.isClosedForWrite.<get-isClosedForWrite>|<get-isClosedForWrite>(){}[0]
     abstract val writeBuffer // io.ktor.utils.io/ByteWriteChannel.writeBuffer|{}writeBuffer[0]
         abstract fun <get-writeBuffer>(): kotlinx.io/Sink // io.ktor.utils.io/ByteWriteChannel.writeBuffer.<get-writeBuffer>|<get-writeBuffer>(){}[0]
+    open val autoFlush // io.ktor.utils.io/ByteWriteChannel.autoFlush|{}autoFlush[0]
+        open fun <get-autoFlush>(): kotlin/Boolean // io.ktor.utils.io/ByteWriteChannel.autoFlush.<get-autoFlush>|<get-autoFlush>(){}[0]
 
     abstract fun cancel(kotlin/Throwable?) // io.ktor.utils.io/ByteWriteChannel.cancel|cancel(kotlin.Throwable?){}[0]
     abstract suspend fun flush() // io.ktor.utils.io/ByteWriteChannel.flush|flush(){}[0]
@@ -251,6 +253,8 @@ final class io.ktor.utils.io/CountedByteReadChannel : io.ktor.utils.io/ByteReadC
 final class io.ktor.utils.io/CountedByteWriteChannel : io.ktor.utils.io/ByteWriteChannel { // io.ktor.utils.io/CountedByteWriteChannel|null[0]
     constructor <init>(io.ktor.utils.io/ByteWriteChannel) // io.ktor.utils.io/CountedByteWriteChannel.<init>|<init>(io.ktor.utils.io.ByteWriteChannel){}[0]
 
+    final val autoFlush // io.ktor.utils.io/CountedByteWriteChannel.autoFlush|{}autoFlush[0]
+        final fun <get-autoFlush>(): kotlin/Boolean // io.ktor.utils.io/CountedByteWriteChannel.autoFlush.<get-autoFlush>|<get-autoFlush>(){}[0]
     final val closedCause // io.ktor.utils.io/CountedByteWriteChannel.closedCause|{}closedCause[0]
         final fun <get-closedCause>(): kotlin/Throwable? // io.ktor.utils.io/CountedByteWriteChannel.closedCause.<get-closedCause>|<get-closedCause>(){}[0]
     final val isClosedForWrite // io.ktor.utils.io/CountedByteWriteChannel.isClosedForWrite|{}isClosedForWrite[0]

--- a/ktor-io/common/src/io/ktor/utils/io/ByteChannel.kt
+++ b/ktor-io/common/src/io/ktor/utils/io/ByteChannel.kt
@@ -23,7 +23,7 @@ internal const val CHANNEL_MAX_SIZE: Int = 1024 * 1024
  *
  * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.utils.io.ByteChannel)
  */
-public class ByteChannel(public val autoFlush: Boolean = false) : ByteReadChannel, BufferedByteWriteChannel {
+public class ByteChannel(public override val autoFlush: Boolean = false) : ByteReadChannel, BufferedByteWriteChannel {
     private val flushBuffer: Buffer = Buffer()
 
     @Volatile

--- a/ktor-io/common/src/io/ktor/utils/io/ByteWriteChannel.kt
+++ b/ktor-io/common/src/io/ktor/utils/io/ByteWriteChannel.kt
@@ -18,6 +18,9 @@ import kotlinx.io.*
  */
 public interface ByteWriteChannel {
 
+    public val autoFlush: Boolean
+        get() = false
+
     public val isClosedForWrite: Boolean
 
     public val closedCause: Throwable?
@@ -58,5 +61,5 @@ public fun ByteWriteChannel.cancel() {
 public suspend fun ByteWriteChannel.flushIfNeeded() {
     rethrowCloseCauseIfNeeded()
 
-    if ((this as? ByteChannel)?.autoFlush == true || writeBuffer.size >= CHANNEL_MAX_SIZE) flush()
+    if (this.autoFlush == true || writeBuffer.size >= CHANNEL_MAX_SIZE) flush()
 }

--- a/ktor-io/common/src/io/ktor/utils/io/CloseHookByteWriteChannel.kt
+++ b/ktor-io/common/src/io/ktor/utils/io/CloseHookByteWriteChannel.kt
@@ -20,6 +20,9 @@ internal class CloseHookByteWriteChannel(
     private val delegate: ByteWriteChannel,
     private val onClose: suspend () -> Unit
 ) : ByteWriteChannel by delegate {
+    override val autoFlush: Boolean
+        get() = delegate.autoFlush
+
     override suspend fun flushAndClose() {
         delegate.flushAndClose()
         onClose()

--- a/ktor-io/common/src/io/ktor/utils/io/CountedByteWriteChannel.kt
+++ b/ktor-io/common/src/io/ktor/utils/io/CountedByteWriteChannel.kt
@@ -14,6 +14,9 @@ public class CountedByteWriteChannel(private val delegate: ByteWriteChannel) : B
     private var initial = delegate.writeBuffer.size
     private var flushedCount = 0
 
+    public override val autoFlush: Boolean
+        get() = delegate.autoFlush
+
     @OptIn(InternalAPI::class)
     public val totalBytesWritten: Long get() = (flushedCount + writeBuffer.size - initial).toLong()
 

--- a/ktor-network/common/test/io/ktor/network/sockets/tests/TCPSocketTest.kt
+++ b/ktor-network/common/test/io/ktor/network/sockets/tests/TCPSocketTest.kt
@@ -306,4 +306,28 @@ class TCPSocketTest {
             socket.awaitClosed()
         }
     }
+
+    @Test
+    fun testAutoFlush() = testSockets { selector ->
+        val tcp = aSocket(selector).tcp()
+        val server: ServerSocket = tcp.bind("127.0.0.1", port = 0)
+
+        val serverConnectionPromise = async {
+            server.accept()
+        }
+
+        val clientConnection = tcp.connect("127.0.0.1", port = server.port)
+        val serverConnection = serverConnectionPromise.await()
+        val serverInput = serverConnection.openReadChannel()
+
+        val writeChannel = clientConnection.openWriteChannel(autoFlush = true)
+        writeChannel.writeStringUtf8("Hello, world\n")
+        val message = serverInput.readUTF8Line()
+        assertEquals("Hello, world", message)
+
+        val countedWriteChannel = CountedByteWriteChannel(writeChannel)
+        countedWriteChannel.writeStringUtf8("Hello again\n")
+        val message2 = serverInput.readUTF8Line()
+        assertEquals("Hello again", message2)
+    }
 }


### PR DESCRIPTION
autoFlush of the source channel doesn't make the channel auto flushing

**Subsystem**
ktor-io

**Motivation**
I reported the bug [KTOR-8411](https://youtrack.jetbrains.com/issue/KTOR-8411/CountedByteWriteChannel-autoFlush-of-the-source-channel-doesnt-make-the-channel-auto-flushing) yesterday and took a deeper look to get it fixed, since it looked simple.

**Solution**
I decided to move the `autoFlush` property higher up the hierarchy so that all implementations may actually have access to it and a cast to ByteChannel won't be necessary. The cast fails for some implementations due to the inheritance hierarchy, hence the bug.
