### PR TITLE
KTOR-8204 Fix for exception on empty chunked body response

### DIFF
--- a/ktor-http/ktor-http-cio/common/src/io/ktor/http/cio/ChunkedTransferEncoding.kt
+++ b/ktor-http/ktor-http-cio/common/src/io/ktor/http/cio/ChunkedTransferEncoding.kt
@@ -69,11 +69,8 @@ public suspend fun decodeChunked(input: ByteReadChannel, out: ByteWriteChannel) 
     var totalBytesCopied = 0L
 
     try {
-        while (true) {
-            chunkSizeBuffer.clear()
-            if (!input.readUTF8LineTo(chunkSizeBuffer, MAX_CHUNK_SIZE_LENGTH, httpLineEndings)) {
-                throw EOFException("Chunked stream has ended unexpectedly: no chunk size")
-            } else if (chunkSizeBuffer.isEmpty()) {
+        while (input.readUTF8LineTo(chunkSizeBuffer, MAX_CHUNK_SIZE_LENGTH, httpLineEndings)) {
+            if (chunkSizeBuffer.isEmpty()) {
                 throw EOFException("Invalid chunk size: empty")
             }
 

--- a/ktor-http/ktor-http-cio/jvm/test/io/ktor/tests/http/cio/ChunkedTest.kt
+++ b/ktor-http/ktor-http-cio/jvm/test/io/ktor/tests/http/cio/ChunkedTest.kt
@@ -25,17 +25,6 @@ import kotlin.test.assertTrue
 class ChunkedTest {
 
     @Test
-    fun testEmptyBroken(): Unit = runBlocking {
-        val bodyText = ""
-        val ch = ByteReadChannel(bodyText.toByteArray())
-        val parsed = ByteChannel()
-
-        assertFailsWith<EOFException> {
-            decodeChunked(ch, parsed)
-        }
-    }
-
-    @Test
     fun testChunkedWithContentLength() = runBlocking {
         val chunkedContent = listOf(
             "3\r\n",
@@ -69,6 +58,16 @@ class ChunkedTest {
         assertFailsWith<EOFException> {
             decodeChunked(ch, parsed)
         }
+    }
+
+    @Test
+    fun testEmptyNoCRLF(): Unit = runBlocking {
+        val bodyText = ""
+        val ch = ByteReadChannel(bodyText.toByteArray())
+        val parsed = ByteChannel()
+
+        decodeChunked(ch, parsed)
+        assertEquals("", parsed.readBuffer().readText())
     }
 
     @Test

--- a/ktor-test-server/src/main/kotlin/test/server/tests/ServerSentEvents.kt
+++ b/ktor-test-server/src/main/kotlin/test/server/tests/ServerSentEvents.kt
@@ -153,6 +153,9 @@ internal fun Application.serverSentEvents() {
             get("no-content") {
                 call.respond(HttpStatusCode.NoContent)
             }
+            get("no-events") {
+                call.respondBytesWriter(ContentType.Text.EventStream) {}
+            }
             get("no-content-after-reconnection") {
                 val count = call.parameters["count"]?.toInt() ?: 0
                 val lastEventId = call.request.header("Last-Event-ID")


### PR DESCRIPTION
**Subsystem**
Client, SSE, I/O

**Motivation**
[KTOR-8204](https://youtrack.jetbrains.com/issue/KTOR-8204) CIO: Exception Chunked stream has ended unexpectedly

**Solution**
It seems to be fairly common to experience connection hangups before events start writing which can lead to this chunked transfer encoding validation error.  Instead of throwing the exception now, we'll just return when there's no chunk size.

Also, I added a catch for closed channels to avoid throwing on normal disconnects when parsing, and I updated the SSE tests a little to shorten up the time they're taking to run.

