### PR TITLE
KTOR-8451: Fix toString for staticContentRoute

### DIFF
--- a/ktor-server/ktor-server-core/jvm/src/io/ktor/server/http/content/StaticContent.kt
+++ b/ktor-server/ktor-server-core/jvm/src/io/ktor/server/http/content/StaticContent.kt
@@ -610,6 +610,8 @@ private fun Route.staticContentRoute(
 ) = createChild(object : RouteSelector() {
     override suspend fun evaluate(context: RoutingResolveContext, segmentIndex: Int): RouteSelectorEvaluation =
         RouteSelectorEvaluation.Success(quality = RouteSelectorEvaluation.qualityTailcard)
+
+    override fun toString() = "(staticContent)"
 }).apply {
     route(remotePath) {
         route("{$pathParameterName...}") {


### PR DESCRIPTION
**Subsystem**
Server, core

**Motivation**
Route rendering is important in several places, for example in metrics collection.
Currently for static files we have metrics like
```
ktor_http_server_requests_seconds_sum{method="GET",route="/io.ktor.server.http.content.StaticContentKt$staticContentRoute$1@70830e08/images/{...}",status="404",
throwable="n/a"} 0.227668303
```

**Solution**
Provide correct toString implementation for anonymous Route subclass, created in `staticContentRoute` method.