### PR TITLE
Fix the annoying warning about the Mocha framework not being used

### DIFF
--- a/build-logic/src/main/kotlin/ktorbuild/targets/JsConfig.kt
+++ b/build-logic/src/main/kotlin/ktorbuild/targets/JsConfig.kt
@@ -10,11 +10,15 @@ import ktorbuild.internal.kotlin
 import ktorbuild.internal.libs
 import org.gradle.api.Project
 import org.gradle.kotlin.dsl.invoke
+import org.jetbrains.kotlin.gradle.plugin.KotlinPlatformType
 import org.jetbrains.kotlin.gradle.targets.js.dsl.KotlinJsSubTargetDsl
 import org.jetbrains.kotlin.gradle.targets.js.dsl.KotlinJsTargetDsl
 
 internal fun KotlinJsTargetDsl.addSubTargets(targets: KtorTargets) {
-    if (targets.isEnabled("${targetName}.nodeJs")) nodejs { useMochaForTests() }
+    if (targets.isEnabled("${targetName}.nodeJs")) nodejs {
+        // Wasm uses a separate test framework. See KotlinWasmNode
+        if (platformType != KotlinPlatformType.wasm) useMochaForTests()
+    }
     if (targets.isEnabled("${targetName}.browser")) browser { useKarmaForTests() }
 }
 


### PR DESCRIPTION
**Subsystem**
Infrastructure

**Motivation**
A lot of weird messages during project sync
> Mocha test framework for Wasm target is not supported. For KotlinWasmNode used

**Solution**
Don't try to configure the Mocha framework for Wasm targets, as [it is unsupported](https://github.com/JetBrains/kotlin/blob/v2.1.20/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/testing/KotlinJsTest.kt#L124).

