### PR TITLE
Improved DI for nullables, parameterized types

### DIFF
--- a/ktor-server/ktor-server-plugins/ktor-server-di/api/ktor-server-di.api
+++ b/ktor-server/ktor-server-plugins/ktor-server-di/api/ktor-server-di.api
@@ -1,6 +1,6 @@
 public final class io/ktor/server/plugins/di/AmbiguousCreateFunction : io/ktor/server/plugins/di/DependencyCreateFunction {
+	public static final field Companion Lio/ktor/server/plugins/di/AmbiguousCreateFunction$Companion;
 	public fun <init> (Lio/ktor/server/plugins/di/DependencyKey;Ljava/util/Set;)V
-	public fun <init> (Lio/ktor/server/plugins/di/DependencyKey;[Lio/ktor/server/plugins/di/DependencyCreateFunction;)V
 	public final fun component1 ()Lio/ktor/server/plugins/di/DependencyKey;
 	public final fun component2 ()Ljava/util/Set;
 	public final fun copy (Lio/ktor/server/plugins/di/DependencyKey;Ljava/util/Set;)Lio/ktor/server/plugins/di/AmbiguousCreateFunction;
@@ -11,6 +11,10 @@ public final class io/ktor/server/plugins/di/AmbiguousCreateFunction : io/ktor/s
 	public fun getKey ()Lio/ktor/server/plugins/di/DependencyKey;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/ktor/server/plugins/di/AmbiguousCreateFunction$Companion {
+	public final fun of (Lio/ktor/server/plugins/di/DependencyKey;[Lio/ktor/server/plugins/di/DependencyCreateFunction;)Lio/ktor/server/plugins/di/DependencyCreateFunction;
 }
 
 public final class io/ktor/server/plugins/di/AmbiguousDependencyException : io/ktor/server/plugins/di/DependencyInjectionException {
@@ -124,6 +128,7 @@ public final class io/ktor/server/plugins/di/DependencyInjectionConfig_jvmKt {
 }
 
 public class io/ktor/server/plugins/di/DependencyInjectionException : java/lang/RuntimeException {
+	public fun <init> ()V
 	public fun <init> (Ljava/lang/String;Ljava/lang/Throwable;)V
 	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/Throwable;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 }
@@ -131,6 +136,7 @@ public class io/ktor/server/plugins/di/DependencyInjectionException : java/lang/
 public final class io/ktor/server/plugins/di/DependencyInjectionKt {
 	public static final fun getDI ()Lio/ktor/server/application/ApplicationPlugin;
 	public static final fun getDependencyRegistryKey ()Lio/ktor/util/AttributeKey;
+	public static final fun isNullable (Lio/ktor/server/plugins/di/DependencyKey;)Z
 }
 
 public final class io/ktor/server/plugins/di/DependencyKey {
@@ -150,10 +156,13 @@ public final class io/ktor/server/plugins/di/DependencyKey {
 }
 
 public abstract interface class io/ktor/server/plugins/di/DependencyKeyCovariance {
-	public abstract fun map (Lio/ktor/server/plugins/di/DependencyKey;)Ljava/util/List;
+	public abstract fun map (Lio/ktor/server/plugins/di/DependencyKey;I)Lkotlin/sequences/Sequence;
 }
 
 public final class io/ktor/server/plugins/di/DependencyKeyCovarianceKt {
+	public static final fun getDefaultKeyCovariance ()Lio/ktor/server/plugins/di/DependencyKeyCovariance;
+	public static final fun getNullables ()Lio/ktor/server/plugins/di/DependencyKeyCovariance;
+	public static final fun getOutTypeArgumentsSupertypes ()Lio/ktor/server/plugins/di/DependencyKeyCovariance;
 	public static final fun getSupertypes ()Lio/ktor/server/plugins/di/DependencyKeyCovariance;
 	public static final fun getUnnamed ()Lio/ktor/server/plugins/di/DependencyKeyCovariance;
 	public static final fun plus (Lio/ktor/server/plugins/di/DependencyKeyCovariance;Lio/ktor/server/plugins/di/DependencyKeyCovariance;)Lio/ktor/server/plugins/di/DependencyKeyCovariance;
@@ -263,15 +272,18 @@ public final class io/ktor/server/plugins/di/DuplicateDependencyException : io/k
 public final class io/ktor/server/plugins/di/ExplicitCreateFunction : io/ktor/server/plugins/di/DependencyCreateFunction {
 	public fun <init> (Lio/ktor/server/plugins/di/DependencyKey;Lkotlin/jvm/functions/Function1;)V
 	public fun create (Lio/ktor/server/plugins/di/DependencyResolver;)Ljava/lang/Object;
-	public final fun derived ()Lio/ktor/server/plugins/di/ImplicitCreateFunction;
+	public final fun derived (I)Lio/ktor/server/plugins/di/ImplicitCreateFunction;
 	public fun getKey ()Lio/ktor/server/plugins/di/DependencyKey;
 }
 
 public final class io/ktor/server/plugins/di/ImplicitCreateFunction : io/ktor/server/plugins/di/DependencyCreateFunction {
-	public fun <init> (Lio/ktor/server/plugins/di/ExplicitCreateFunction;)V
+	public fun <init> (Lio/ktor/server/plugins/di/ExplicitCreateFunction;I)V
 	public fun create (Lio/ktor/server/plugins/di/DependencyResolver;)Ljava/lang/Object;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDistance ()I
 	public fun getKey ()Lio/ktor/server/plugins/di/DependencyKey;
 	public final fun getOrigin ()Lio/ktor/server/plugins/di/ExplicitCreateFunction;
+	public fun hashCode ()I
 }
 
 public final class io/ktor/server/plugins/di/InvalidDependencyReferenceException : io/ktor/server/plugins/di/DependencyInjectionException {
@@ -336,6 +348,10 @@ public abstract interface annotation class io/ktor/server/plugins/di/annotations
 }
 
 public final class io/ktor/server/plugins/di/utils/Types_jvmKt {
-	public static final fun hierarchy (Lio/ktor/util/reflect/TypeInfo;)Ljava/util/List;
+	public static final fun hasTypeParameters (Lio/ktor/util/reflect/TypeInfo;Lkotlin/jvm/functions/Function1;)Z
+	public static synthetic fun hasTypeParameters$default (Lio/ktor/util/reflect/TypeInfo;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Z
+	public static final fun hierarchy (Lio/ktor/util/reflect/TypeInfo;)Lkotlin/sequences/Sequence;
+	public static final fun toNullable (Lio/ktor/util/reflect/TypeInfo;)Lio/ktor/util/reflect/TypeInfo;
+	public static final fun typeParametersHierarchy (Lio/ktor/util/reflect/TypeInfo;)Lkotlin/sequences/Sequence;
 }
 

--- a/ktor-server/ktor-server-plugins/ktor-server-di/api/ktor-server-di.klib.api
+++ b/ktor-server/ktor-server-plugins/ktor-server-di/api/ktor-server-di.klib.api
@@ -25,7 +25,7 @@ abstract fun interface io.ktor.server.plugins.di/DependencyConflictPolicy { // i
 }
 
 abstract fun interface io.ktor.server.plugins.di/DependencyKeyCovariance { // io.ktor.server.plugins.di/DependencyKeyCovariance|null[0]
-    abstract fun map(io.ktor.server.plugins.di/DependencyKey): kotlin.collections/List<io.ktor.server.plugins.di/DependencyKey> // io.ktor.server.plugins.di/DependencyKeyCovariance.map|map(io.ktor.server.plugins.di.DependencyKey){}[0]
+    abstract fun map(io.ktor.server.plugins.di/DependencyKey, kotlin/Int): kotlin.sequences/Sequence<kotlin/Pair<io.ktor.server.plugins.di/DependencyKey, kotlin/Int>> // io.ktor.server.plugins.di/DependencyKeyCovariance.map|map(io.ktor.server.plugins.di.DependencyKey;kotlin.Int){}[0]
 }
 
 abstract fun interface io.ktor.server.plugins.di/DependencyResolution { // io.ktor.server.plugins.di/DependencyResolution|null[0]
@@ -33,7 +33,7 @@ abstract fun interface io.ktor.server.plugins.di/DependencyResolution { // io.kt
 }
 
 abstract interface io.ktor.server.plugins.di/DependencyMap { // io.ktor.server.plugins.di/DependencyMap|null[0]
-    abstract fun <#A1: kotlin/Any> get(io.ktor.server.plugins.di/DependencyKey): #A1 // io.ktor.server.plugins.di/DependencyMap.get|get(io.ktor.server.plugins.di.DependencyKey){0§<kotlin.Any>}[0]
+    abstract fun <#A1: kotlin/Any?> get(io.ktor.server.plugins.di/DependencyKey): #A1 // io.ktor.server.plugins.di/DependencyMap.get|get(io.ktor.server.plugins.di.DependencyKey){0§<kotlin.Any?>}[0]
     abstract fun contains(io.ktor.server.plugins.di/DependencyKey): kotlin/Boolean // io.ktor.server.plugins.di/DependencyMap.contains|contains(io.ktor.server.plugins.di.DependencyKey){}[0]
 
     final object Companion { // io.ktor.server.plugins.di/DependencyMap.Companion|null[0]
@@ -64,7 +64,7 @@ abstract interface io.ktor.server.plugins.di/DependencyResolver : io.ktor.server
 }
 
 abstract interface io.ktor.server.plugins.di/MutableDependencyMap : io.ktor.server.plugins.di/DependencyMap { // io.ktor.server.plugins.di/MutableDependencyMap|null[0]
-    abstract fun <#A1: kotlin/Any> getOrPut(io.ktor.server.plugins.di/DependencyKey, kotlin/Function0<#A1>): #A1 // io.ktor.server.plugins.di/MutableDependencyMap.getOrPut|getOrPut(io.ktor.server.plugins.di.DependencyKey;kotlin.Function0<0:0>){0§<kotlin.Any>}[0]
+    abstract fun <#A1: kotlin/Any?> getOrPut(io.ktor.server.plugins.di/DependencyKey, kotlin/Function0<#A1>): #A1 // io.ktor.server.plugins.di/MutableDependencyMap.getOrPut|getOrPut(io.ktor.server.plugins.di.DependencyKey;kotlin.Function0<0:0>){0§<kotlin.Any?>}[0]
 
     final object Companion { // io.ktor.server.plugins.di/MutableDependencyMap.Companion|null[0]
         final fun (io.ktor.server.plugins.di/MutableDependencyMap).asResolver(io.ktor.server.plugins.di/DependencyReflection): io.ktor.server.plugins.di/DependencyResolver // io.ktor.server.plugins.di/MutableDependencyMap.Companion.asResolver|asResolver@io.ktor.server.plugins.di.MutableDependencyMap(io.ktor.server.plugins.di.DependencyReflection){}[0]
@@ -119,7 +119,6 @@ sealed interface io.ktor.server.plugins.di/DependencyCreateFunction { // io.ktor
 
 final class io.ktor.server.plugins.di/AmbiguousCreateFunction : io.ktor.server.plugins.di/DependencyCreateFunction { // io.ktor.server.plugins.di/AmbiguousCreateFunction|null[0]
     constructor <init>(io.ktor.server.plugins.di/DependencyKey, kotlin.collections/Set<io.ktor.server.plugins.di/DependencyCreateFunction>) // io.ktor.server.plugins.di/AmbiguousCreateFunction.<init>|<init>(io.ktor.server.plugins.di.DependencyKey;kotlin.collections.Set<io.ktor.server.plugins.di.DependencyCreateFunction>){}[0]
-    constructor <init>(io.ktor.server.plugins.di/DependencyKey, kotlin/Array<out io.ktor.server.plugins.di/DependencyCreateFunction>...) // io.ktor.server.plugins.di/AmbiguousCreateFunction.<init>|<init>(io.ktor.server.plugins.di.DependencyKey;kotlin.Array<out|io.ktor.server.plugins.di.DependencyCreateFunction>...){}[0]
 
     final val functions // io.ktor.server.plugins.di/AmbiguousCreateFunction.functions|{}functions[0]
         final fun <get-functions>(): kotlin.collections/Set<io.ktor.server.plugins.di/DependencyCreateFunction> // io.ktor.server.plugins.di/AmbiguousCreateFunction.functions.<get-functions>|<get-functions>(){}[0]
@@ -133,6 +132,10 @@ final class io.ktor.server.plugins.di/AmbiguousCreateFunction : io.ktor.server.p
     final fun equals(kotlin/Any?): kotlin/Boolean // io.ktor.server.plugins.di/AmbiguousCreateFunction.equals|equals(kotlin.Any?){}[0]
     final fun hashCode(): kotlin/Int // io.ktor.server.plugins.di/AmbiguousCreateFunction.hashCode|hashCode(){}[0]
     final fun toString(): kotlin/String // io.ktor.server.plugins.di/AmbiguousCreateFunction.toString|toString(){}[0]
+
+    final object Companion { // io.ktor.server.plugins.di/AmbiguousCreateFunction.Companion|null[0]
+        final fun of(io.ktor.server.plugins.di/DependencyKey, kotlin/Array<out io.ktor.server.plugins.di/DependencyCreateFunction>...): io.ktor.server.plugins.di/DependencyCreateFunction // io.ktor.server.plugins.di/AmbiguousCreateFunction.Companion.of|of(io.ktor.server.plugins.di.DependencyKey;kotlin.Array<out|io.ktor.server.plugins.di.DependencyCreateFunction>...){}[0]
+    }
 }
 
 final class io.ktor.server.plugins.di/AmbiguousDependencyException : io.ktor.server.plugins.di/DependencyInjectionException { // io.ktor.server.plugins.di/AmbiguousDependencyException|null[0]
@@ -146,7 +149,7 @@ final class io.ktor.server.plugins.di/CircularDependencyException : io.ktor.serv
 final class io.ktor.server.plugins.di/ConfigurationDependencyMap : io.ktor.server.plugins.di/DependencyMap { // io.ktor.server.plugins.di/ConfigurationDependencyMap|null[0]
     constructor <init>(io.ktor.server.config/ApplicationConfig) // io.ktor.server.plugins.di/ConfigurationDependencyMap.<init>|<init>(io.ktor.server.config.ApplicationConfig){}[0]
 
-    final fun <#A1: kotlin/Any> get(io.ktor.server.plugins.di/DependencyKey): #A1 // io.ktor.server.plugins.di/ConfigurationDependencyMap.get|get(io.ktor.server.plugins.di.DependencyKey){0§<kotlin.Any>}[0]
+    final fun <#A1: kotlin/Any?> get(io.ktor.server.plugins.di/DependencyKey): #A1 // io.ktor.server.plugins.di/ConfigurationDependencyMap.get|get(io.ktor.server.plugins.di.DependencyKey){0§<kotlin.Any?>}[0]
     final fun contains(io.ktor.server.plugins.di/DependencyKey): kotlin/Boolean // io.ktor.server.plugins.di/ConfigurationDependencyMap.contains|contains(io.ktor.server.plugins.di.DependencyKey){}[0]
 }
 
@@ -213,10 +216,10 @@ final class io.ktor.server.plugins.di/DependencyKey { // io.ktor.server.plugins.
 }
 
 final class io.ktor.server.plugins.di/DependencyMapImpl : io.ktor.server.plugins.di/MutableDependencyMap { // io.ktor.server.plugins.di/DependencyMapImpl|null[0]
-    constructor <init>(kotlin.collections/Map<io.ktor.server.plugins.di/DependencyKey, kotlin/Result<kotlin/Any>>, io.ktor.server.plugins.di/DependencyMap = ...) // io.ktor.server.plugins.di/DependencyMapImpl.<init>|<init>(kotlin.collections.Map<io.ktor.server.plugins.di.DependencyKey,kotlin.Result<kotlin.Any>>;io.ktor.server.plugins.di.DependencyMap){}[0]
+    constructor <init>(kotlin.collections/Map<io.ktor.server.plugins.di/DependencyKey, kotlin/Result<*>>, io.ktor.server.plugins.di/DependencyMap = ...) // io.ktor.server.plugins.di/DependencyMapImpl.<init>|<init>(kotlin.collections.Map<io.ktor.server.plugins.di.DependencyKey,kotlin.Result<*>>;io.ktor.server.plugins.di.DependencyMap){}[0]
 
-    final fun <#A1: kotlin/Any> get(io.ktor.server.plugins.di/DependencyKey): #A1 // io.ktor.server.plugins.di/DependencyMapImpl.get|get(io.ktor.server.plugins.di.DependencyKey){0§<kotlin.Any>}[0]
-    final fun <#A1: kotlin/Any> getOrPut(io.ktor.server.plugins.di/DependencyKey, kotlin/Function0<#A1>): #A1 // io.ktor.server.plugins.di/DependencyMapImpl.getOrPut|getOrPut(io.ktor.server.plugins.di.DependencyKey;kotlin.Function0<0:0>){0§<kotlin.Any>}[0]
+    final fun <#A1: kotlin/Any?> get(io.ktor.server.plugins.di/DependencyKey): #A1 // io.ktor.server.plugins.di/DependencyMapImpl.get|get(io.ktor.server.plugins.di.DependencyKey){0§<kotlin.Any?>}[0]
+    final fun <#A1: kotlin/Any?> getOrPut(io.ktor.server.plugins.di/DependencyKey, kotlin/Function0<#A1>): #A1 // io.ktor.server.plugins.di/DependencyMapImpl.getOrPut|getOrPut(io.ktor.server.plugins.di.DependencyKey;kotlin.Function0<0:0>){0§<kotlin.Any?>}[0]
     final fun contains(io.ktor.server.plugins.di/DependencyKey): kotlin/Boolean // io.ktor.server.plugins.di/DependencyMapImpl.contains|contains(io.ktor.server.plugins.di.DependencyKey){}[0]
 }
 
@@ -237,8 +240,8 @@ final class io.ktor.server.plugins.di/DependencyRegistryImpl : io.ktor.server.pl
     final val reflection // io.ktor.server.plugins.di/DependencyRegistryImpl.reflection|{}reflection[0]
         final fun <get-reflection>(): io.ktor.server.plugins.di/DependencyReflection // io.ktor.server.plugins.di/DependencyRegistryImpl.reflection.<get-reflection>|<get-reflection>(){}[0]
 
-    final fun <#A1: kotlin/Any> get(io.ktor.server.plugins.di/DependencyKey): #A1 // io.ktor.server.plugins.di/DependencyRegistryImpl.get|get(io.ktor.server.plugins.di.DependencyKey){0§<kotlin.Any>}[0]
-    final fun <#A1: kotlin/Any> getOrPut(io.ktor.server.plugins.di/DependencyKey, kotlin/Function0<#A1>): #A1 // io.ktor.server.plugins.di/DependencyRegistryImpl.getOrPut|getOrPut(io.ktor.server.plugins.di.DependencyKey;kotlin.Function0<0:0>){0§<kotlin.Any>}[0]
+    final fun <#A1: kotlin/Any?> get(io.ktor.server.plugins.di/DependencyKey): #A1 // io.ktor.server.plugins.di/DependencyRegistryImpl.get|get(io.ktor.server.plugins.di.DependencyKey){0§<kotlin.Any?>}[0]
+    final fun <#A1: kotlin/Any?> getOrPut(io.ktor.server.plugins.di/DependencyKey, kotlin/Function0<#A1>): #A1 // io.ktor.server.plugins.di/DependencyRegistryImpl.getOrPut|getOrPut(io.ktor.server.plugins.di.DependencyKey;kotlin.Function0<0:0>){0§<kotlin.Any?>}[0]
     final fun <#A1: kotlin/Any?> set(io.ktor.server.plugins.di/DependencyKey, kotlin/Function1<io.ktor.server.plugins.di/DependencyResolver, #A1>) // io.ktor.server.plugins.di/DependencyRegistryImpl.set|set(io.ktor.server.plugins.di.DependencyKey;kotlin.Function1<io.ktor.server.plugins.di.DependencyResolver,0:0>){0§<kotlin.Any?>}[0]
     final fun contains(io.ktor.server.plugins.di/DependencyKey): kotlin/Boolean // io.ktor.server.plugins.di/DependencyRegistryImpl.contains|contains(io.ktor.server.plugins.di.DependencyKey){}[0]
     final fun require(io.ktor.server.plugins.di/DependencyKey) // io.ktor.server.plugins.di/DependencyRegistryImpl.require|require(io.ktor.server.plugins.di.DependencyKey){}[0]
@@ -272,18 +275,22 @@ final class io.ktor.server.plugins.di/ExplicitCreateFunction : io.ktor.server.pl
         final fun <get-key>(): io.ktor.server.plugins.di/DependencyKey // io.ktor.server.plugins.di/ExplicitCreateFunction.key.<get-key>|<get-key>(){}[0]
 
     final fun create(io.ktor.server.plugins.di/DependencyResolver): kotlin/Any // io.ktor.server.plugins.di/ExplicitCreateFunction.create|create(io.ktor.server.plugins.di.DependencyResolver){}[0]
-    final fun derived(): io.ktor.server.plugins.di/ImplicitCreateFunction // io.ktor.server.plugins.di/ExplicitCreateFunction.derived|derived(){}[0]
+    final fun derived(kotlin/Int): io.ktor.server.plugins.di/ImplicitCreateFunction // io.ktor.server.plugins.di/ExplicitCreateFunction.derived|derived(kotlin.Int){}[0]
 }
 
 final class io.ktor.server.plugins.di/ImplicitCreateFunction : io.ktor.server.plugins.di/DependencyCreateFunction { // io.ktor.server.plugins.di/ImplicitCreateFunction|null[0]
-    constructor <init>(io.ktor.server.plugins.di/ExplicitCreateFunction) // io.ktor.server.plugins.di/ImplicitCreateFunction.<init>|<init>(io.ktor.server.plugins.di.ExplicitCreateFunction){}[0]
+    constructor <init>(io.ktor.server.plugins.di/ExplicitCreateFunction, kotlin/Int) // io.ktor.server.plugins.di/ImplicitCreateFunction.<init>|<init>(io.ktor.server.plugins.di.ExplicitCreateFunction;kotlin.Int){}[0]
 
+    final val distance // io.ktor.server.plugins.di/ImplicitCreateFunction.distance|{}distance[0]
+        final fun <get-distance>(): kotlin/Int // io.ktor.server.plugins.di/ImplicitCreateFunction.distance.<get-distance>|<get-distance>(){}[0]
     final val key // io.ktor.server.plugins.di/ImplicitCreateFunction.key|{}key[0]
         final fun <get-key>(): io.ktor.server.plugins.di/DependencyKey // io.ktor.server.plugins.di/ImplicitCreateFunction.key.<get-key>|<get-key>(){}[0]
     final val origin // io.ktor.server.plugins.di/ImplicitCreateFunction.origin|{}origin[0]
         final fun <get-origin>(): io.ktor.server.plugins.di/ExplicitCreateFunction // io.ktor.server.plugins.di/ImplicitCreateFunction.origin.<get-origin>|<get-origin>(){}[0]
 
     final fun create(io.ktor.server.plugins.di/DependencyResolver): kotlin/Any // io.ktor.server.plugins.di/ImplicitCreateFunction.create|create(io.ktor.server.plugins.di.DependencyResolver){}[0]
+    final fun equals(kotlin/Any?): kotlin/Boolean // io.ktor.server.plugins.di/ImplicitCreateFunction.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // io.ktor.server.plugins.di/ImplicitCreateFunction.hashCode|hashCode(){}[0]
 }
 
 final class io.ktor.server.plugins.di/InvalidDependencyReferenceException : io.ktor.server.plugins.di/DependencyInjectionException // io.ktor.server.plugins.di/InvalidDependencyReferenceException|null[0]
@@ -302,14 +309,14 @@ final class io.ktor.server.plugins.di/ProcessingDependencyResolver : io.ktor.ser
     final val reflection // io.ktor.server.plugins.di/ProcessingDependencyResolver.reflection|{}reflection[0]
         final fun <get-reflection>(): io.ktor.server.plugins.di/DependencyReflection // io.ktor.server.plugins.di/ProcessingDependencyResolver.reflection.<get-reflection>|<get-reflection>(){}[0]
 
-    final fun <#A1: kotlin/Any> get(io.ktor.server.plugins.di/DependencyKey): #A1 // io.ktor.server.plugins.di/ProcessingDependencyResolver.get|get(io.ktor.server.plugins.di.DependencyKey){0§<kotlin.Any>}[0]
-    final fun <#A1: kotlin/Any> getOrPut(io.ktor.server.plugins.di/DependencyKey, kotlin/Function0<#A1>): #A1 // io.ktor.server.plugins.di/ProcessingDependencyResolver.getOrPut|getOrPut(io.ktor.server.plugins.di.DependencyKey;kotlin.Function0<0:0>){0§<kotlin.Any>}[0]
+    final fun <#A1: kotlin/Any?> get(io.ktor.server.plugins.di/DependencyKey): #A1 // io.ktor.server.plugins.di/ProcessingDependencyResolver.get|get(io.ktor.server.plugins.di.DependencyKey){0§<kotlin.Any?>}[0]
+    final fun <#A1: kotlin/Any?> getOrPut(io.ktor.server.plugins.di/DependencyKey, kotlin/Function0<#A1>): #A1 // io.ktor.server.plugins.di/ProcessingDependencyResolver.getOrPut|getOrPut(io.ktor.server.plugins.di.DependencyKey;kotlin.Function0<0:0>){0§<kotlin.Any?>}[0]
     final fun contains(io.ktor.server.plugins.di/DependencyKey): kotlin/Boolean // io.ktor.server.plugins.di/ProcessingDependencyResolver.contains|contains(io.ktor.server.plugins.di.DependencyKey){}[0]
-    final fun resolveAll(): kotlin.collections/Map<io.ktor.server.plugins.di/DependencyKey, kotlin/Result<kotlin/Any>> // io.ktor.server.plugins.di/ProcessingDependencyResolver.resolveAll|resolveAll(){}[0]
+    final fun resolveAll(): kotlin.collections/Map<io.ktor.server.plugins.di/DependencyKey, kotlin/Result<*>> // io.ktor.server.plugins.di/ProcessingDependencyResolver.resolveAll|resolveAll(){}[0]
 }
 
 open class io.ktor.server.plugins.di/DependencyInjectionException : kotlin/RuntimeException { // io.ktor.server.plugins.di/DependencyInjectionException|null[0]
-    constructor <init>(kotlin/String, kotlin/Throwable? = ...) // io.ktor.server.plugins.di/DependencyInjectionException.<init>|<init>(kotlin.String;kotlin.Throwable?){}[0]
+    constructor <init>(kotlin/String? = ..., kotlin/Throwable? = ...) // io.ktor.server.plugins.di/DependencyInjectionException.<init>|<init>(kotlin.String?;kotlin.Throwable?){}[0]
 }
 
 open class io.ktor.server.plugins.di/MapDependencyProvider : io.ktor.server.plugins.di/DependencyProvider { // io.ktor.server.plugins.di/MapDependencyProvider|null[0]
@@ -343,12 +350,18 @@ final val io.ktor.server.plugins.di/DefaultConflictPolicy // io.ktor.server.plug
     final fun <get-DefaultConflictPolicy>(): io.ktor.server.plugins.di/DependencyConflictPolicy // io.ktor.server.plugins.di/DefaultConflictPolicy.<get-DefaultConflictPolicy>|<get-DefaultConflictPolicy>(){}[0]
 final val io.ktor.server.plugins.di/DefaultDependencyResolution // io.ktor.server.plugins.di/DefaultDependencyResolution|{}DefaultDependencyResolution[0]
     final fun <get-DefaultDependencyResolution>(): io.ktor.server.plugins.di/DependencyResolution // io.ktor.server.plugins.di/DefaultDependencyResolution.<get-DefaultDependencyResolution>|<get-DefaultDependencyResolution>(){}[0]
+final val io.ktor.server.plugins.di/DefaultKeyCovariance // io.ktor.server.plugins.di/DefaultKeyCovariance|{}DefaultKeyCovariance[0]
+    final fun <get-DefaultKeyCovariance>(): io.ktor.server.plugins.di/DependencyKeyCovariance // io.ktor.server.plugins.di/DefaultKeyCovariance.<get-DefaultKeyCovariance>|<get-DefaultKeyCovariance>(){}[0]
 final val io.ktor.server.plugins.di/DefaultReflection // io.ktor.server.plugins.di/DefaultReflection|{}DefaultReflection[0]
     final fun <get-DefaultReflection>(): io.ktor.server.plugins.di/DependencyReflection // io.ktor.server.plugins.di/DefaultReflection.<get-DefaultReflection>|<get-DefaultReflection>(){}[0]
 final val io.ktor.server.plugins.di/DependencyRegistryKey // io.ktor.server.plugins.di/DependencyRegistryKey|{}DependencyRegistryKey[0]
     final fun <get-DependencyRegistryKey>(): io.ktor.util/AttributeKey<io.ktor.server.plugins.di/DependencyRegistry> // io.ktor.server.plugins.di/DependencyRegistryKey.<get-DependencyRegistryKey>|<get-DependencyRegistryKey>(){}[0]
 final val io.ktor.server.plugins.di/LastEntryWinsPolicy // io.ktor.server.plugins.di/LastEntryWinsPolicy|{}LastEntryWinsPolicy[0]
     final fun <get-LastEntryWinsPolicy>(): io.ktor.server.plugins.di/DependencyConflictPolicy // io.ktor.server.plugins.di/LastEntryWinsPolicy.<get-LastEntryWinsPolicy>|<get-LastEntryWinsPolicy>(){}[0]
+final val io.ktor.server.plugins.di/Nullables // io.ktor.server.plugins.di/Nullables|{}Nullables[0]
+    final fun <get-Nullables>(): io.ktor.server.plugins.di/DependencyKeyCovariance // io.ktor.server.plugins.di/Nullables.<get-Nullables>|<get-Nullables>(){}[0]
+final val io.ktor.server.plugins.di/OutTypeArgumentsSupertypes // io.ktor.server.plugins.di/OutTypeArgumentsSupertypes|{}OutTypeArgumentsSupertypes[0]
+    final fun <get-OutTypeArgumentsSupertypes>(): io.ktor.server.plugins.di/DependencyKeyCovariance // io.ktor.server.plugins.di/OutTypeArgumentsSupertypes.<get-OutTypeArgumentsSupertypes>|<get-OutTypeArgumentsSupertypes>(){}[0]
 final val io.ktor.server.plugins.di/Supertypes // io.ktor.server.plugins.di/Supertypes|{}Supertypes[0]
     final fun <get-Supertypes>(): io.ktor.server.plugins.di/DependencyKeyCovariance // io.ktor.server.plugins.di/Supertypes.<get-Supertypes>|<get-Supertypes>(){}[0]
 final val io.ktor.server.plugins.di/Unnamed // io.ktor.server.plugins.di/Unnamed|{}Unnamed[0]
@@ -358,12 +371,15 @@ final var io.ktor.server.plugins.di/dependencies // io.ktor.server.plugins.di/de
     final fun (io.ktor.server.application/Application).<get-dependencies>(): io.ktor.server.plugins.di/DependencyRegistry // io.ktor.server.plugins.di/dependencies.<get-dependencies>|<get-dependencies>@io.ktor.server.application.Application(){}[0]
     final fun (io.ktor.server.application/Application).<set-dependencies>(io.ktor.server.plugins.di/DependencyRegistry) // io.ktor.server.plugins.di/dependencies.<set-dependencies>|<set-dependencies>@io.ktor.server.application.Application(io.ktor.server.plugins.di.DependencyRegistry){}[0]
 
+final fun (io.ktor.server.plugins.di/DependencyKey).io.ktor.server.plugins.di/isNullable(): kotlin/Boolean // io.ktor.server.plugins.di/isNullable|isNullable@io.ktor.server.plugins.di.DependencyKey(){}[0]
 final fun (io.ktor.server.plugins.di/DependencyKeyCovariance).io.ktor.server.plugins.di/plus(io.ktor.server.plugins.di/DependencyKeyCovariance): io.ktor.server.plugins.di/DependencyKeyCovariance // io.ktor.server.plugins.di/plus|plus@io.ktor.server.plugins.di.DependencyKeyCovariance(io.ktor.server.plugins.di.DependencyKeyCovariance){}[0]
 final fun (io.ktor.server.plugins.di/DependencyKeyCovariance).io.ktor.server.plugins.di/times(io.ktor.server.plugins.di/DependencyKeyCovariance): io.ktor.server.plugins.di/DependencyKeyCovariance // io.ktor.server.plugins.di/times|times@io.ktor.server.plugins.di.DependencyKeyCovariance(io.ktor.server.plugins.di.DependencyKeyCovariance){}[0]
 final fun (io.ktor.server.plugins.di/DependencyMap).io.ktor.server.plugins.di/plus(io.ktor.server.plugins.di/DependencyMap): io.ktor.server.plugins.di/DependencyMap // io.ktor.server.plugins.di/plus|plus@io.ktor.server.plugins.di.DependencyMap(io.ktor.server.plugins.di.DependencyMap){}[0]
 final fun (io.ktor.server.plugins.di/DependencyProvider).io.ktor.server.plugins.di/invoke(kotlin/Function1<io.ktor.server.plugins.di/DependencyProviderContext, kotlin/Unit>) // io.ktor.server.plugins.di/invoke|invoke@io.ktor.server.plugins.di.DependencyProvider(kotlin.Function1<io.ktor.server.plugins.di.DependencyProviderContext,kotlin.Unit>){}[0]
 final fun (io.ktor.server.plugins.di/DependencyResolver).io.ktor.server.plugins.di/named(kotlin/String): io.ktor.server.plugins.di/DependencyResolverContext // io.ktor.server.plugins.di/named|named@io.ktor.server.plugins.di.DependencyResolver(kotlin.String){}[0]
-final fun (io.ktor.util.reflect/TypeInfo).io.ktor.server.plugins.di.utils/hierarchy(): kotlin.collections/List<io.ktor.util.reflect/TypeInfo> // io.ktor.server.plugins.di.utils/hierarchy|hierarchy@io.ktor.util.reflect.TypeInfo(){}[0]
+final fun (io.ktor.util.reflect/TypeInfo).io.ktor.server.plugins.di.utils/hierarchy(): kotlin.sequences/Sequence<io.ktor.util.reflect/TypeInfo> // io.ktor.server.plugins.di.utils/hierarchy|hierarchy@io.ktor.util.reflect.TypeInfo(){}[0]
+final fun (io.ktor.util.reflect/TypeInfo).io.ktor.server.plugins.di.utils/toNullable(): io.ktor.util.reflect/TypeInfo? // io.ktor.server.plugins.di.utils/toNullable|toNullable@io.ktor.util.reflect.TypeInfo(){}[0]
+final fun (io.ktor.util.reflect/TypeInfo).io.ktor.server.plugins.di.utils/typeParametersHierarchy(): kotlin.sequences/Sequence<io.ktor.util.reflect/TypeInfo> // io.ktor.server.plugins.di.utils/typeParametersHierarchy|typeParametersHierarchy@io.ktor.util.reflect.TypeInfo(){}[0]
 final fun <#A: kotlin/Any?> (io.ktor.server.plugins.di/DependencyCreateFunction).io.ktor.server.plugins.di/ifImplicit(kotlin/Function1<io.ktor.server.plugins.di/ImplicitCreateFunction, #A>): #A? // io.ktor.server.plugins.di/ifImplicit|ifImplicit@io.ktor.server.plugins.di.DependencyCreateFunction(kotlin.Function1<io.ktor.server.plugins.di.ImplicitCreateFunction,0:0>){0§<kotlin.Any?>}[0]
 final fun <#A: kotlin/Any?> (io.ktor.server.plugins.di/DependencyMap).io.ktor.server.plugins.di/getOrNull(io.ktor.server.plugins.di/DependencyKey): #A? // io.ktor.server.plugins.di/getOrNull|getOrNull@io.ktor.server.plugins.di.DependencyMap(io.ktor.server.plugins.di.DependencyKey){0§<kotlin.Any?>}[0]
 final inline fun <#A: reified kotlin/Any> (io.ktor.server.plugins.di/DependencyProvider).io.ktor.server.plugins.di/provide(kotlin.reflect/KClass<out #A>) // io.ktor.server.plugins.di/provide|provide@io.ktor.server.plugins.di.DependencyProvider(kotlin.reflect.KClass<out|0:0>){0§<kotlin.Any>}[0]

--- a/ktor-server/ktor-server-plugins/ktor-server-di/common/src/io/ktor/server/plugins/di/DependencyInjection.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-di/common/src/io/ktor/server/plugins/di/DependencyInjection.kt
@@ -184,7 +184,7 @@ public class DependencyInjectionConfig {
      *                      By default, this throws a `DuplicateDependencyException`.
      */
     public data class ProviderScope(
-        public var keyMapping: DependencyKeyCovariance = Supertypes,
+        public var keyMapping: DependencyKeyCovariance = Supertypes * Nullables,
         public var conflictPolicy: DependencyConflictPolicy = DefaultConflictPolicy,
         public var onConflict: (DependencyKey) -> Unit = { throw DuplicateDependencyException(it) }
     )

--- a/ktor-server/ktor-server-plugins/ktor-server-di/common/src/io/ktor/server/plugins/di/DependencyInjection.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-di/common/src/io/ktor/server/plugins/di/DependencyInjection.kt
@@ -184,7 +184,7 @@ public class DependencyInjectionConfig {
      *                      By default, this throws a `DuplicateDependencyException`.
      */
     public data class ProviderScope(
-        public var keyMapping: DependencyKeyCovariance = Supertypes * Nullables,
+        public var keyMapping: DependencyKeyCovariance = DefaultKeyCovariance,
         public var conflictPolicy: DependencyConflictPolicy = DefaultConflictPolicy,
         public var onConflict: (DependencyKey) -> Unit = { throw DuplicateDependencyException(it) }
     )
@@ -201,21 +201,25 @@ public data class DependencyKey(
 
     override fun toString(): String = buildString {
         append(type.kotlinType ?: type.type)
-        if (name != null || qualifier != null) {
-            if (name != null) {
-                append("name = \"$name\"")
-            }
-            if (qualifier != null) {
-                append("qualifier = \"$qualifier\"")
-            }
+        if (name != null) {
+            append("(\"$name\")")
         }
     }
 }
 
 /**
+ * Determines if the type associated with a `DependencyKey` is nullable.
+ *
+ * This function checks whether the `kotlinType` property of the `type` in the `DependencyKey`
+ * is marked as nullable. If there is no `kotlinType`, it will return `false`.
+ */
+public fun DependencyKey.isNullable(): Boolean =
+    type.kotlinType?.isMarkedNullable == true
+
+/**
  * Common parent for dependency injection problems.
  */
-public open class DependencyInjectionException(message: String, cause: Throwable? = null) :
+public open class DependencyInjectionException(message: String? = null, cause: Throwable? = null) :
     RuntimeException(message, cause)
 
 /**

--- a/ktor-server/ktor-server-plugins/ktor-server-di/common/src/io/ktor/server/plugins/di/DependencyKeyCovariance.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-di/common/src/io/ktor/server/plugins/di/DependencyKeyCovariance.kt
@@ -5,6 +5,8 @@
 package io.ktor.server.plugins.di
 
 import io.ktor.server.plugins.di.utils.hierarchy
+import io.ktor.server.plugins.di.utils.toNullable
+import io.ktor.util.reflect.TypeInfo
 import io.ktor.utils.io.InternalAPI
 
 /**
@@ -35,6 +37,22 @@ public val Supertypes: DependencyKeyCovariance =
 public val Unnamed: DependencyKeyCovariance =
     DependencyKeyCovariance { key ->
         key.name?.let { listOf(key.copy(name = null)) } ?: emptyList()
+    }
+
+/**
+ * A predefined implementation of [DependencyKeyCovariance] that creates a covariant dependency key
+ * based on the given key. It generates a list containing a single dependency key with a new
+ * [TypeInfo] that retains the same type and Kotlin type as the original key.
+ *
+ * The primary purpose of this value is to facilitate support for nullable types or variant type
+ * mappings within dependency injection.
+ */
+@OptIn(InternalAPI::class)
+public val Nullables: DependencyKeyCovariance =
+    DependencyKeyCovariance { key ->
+        val nullableVariant = key.type.kotlinType?.toNullable()
+            ?: return@DependencyKeyCovariance listOf(key)
+        listOf(key, key.copy(type = TypeInfo(key.type.type, nullableVariant)))
     }
 
 /**

--- a/ktor-server/ktor-server-plugins/ktor-server-di/common/src/io/ktor/server/plugins/di/DependencyProvider.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-di/common/src/io/ktor/server/plugins/di/DependencyProvider.kt
@@ -140,7 +140,7 @@ public fun <T> DependencyCreateFunction.ifImplicit(block: (ImplicitCreateFunctio
  */
 @Suppress("UNCHECKED_CAST")
 public open class MapDependencyProvider(
-    public val keyMapping: DependencyKeyCovariance = Supertypes,
+    public val keyMapping: DependencyKeyCovariance = Supertypes * Nullables,
     public val conflictPolicy: DependencyConflictPolicy = DefaultConflictPolicy,
     public val onConflict: (DependencyKey) -> Unit = { throw DuplicateDependencyException(it) },
     private val log: Logger = KtorSimpleLogger("io.ktor.server.plugins.di.MapDependencyProvider"),

--- a/ktor-server/ktor-server-plugins/ktor-server-di/common/src/io/ktor/server/plugins/di/DependencyRegistry.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-di/common/src/io/ktor/server/plugins/di/DependencyRegistry.kt
@@ -70,10 +70,10 @@ public class DependencyRegistryImpl(
     override fun contains(key: DependencyKey): Boolean =
         resolver.value.contains(key)
 
-    override fun <T : Any> get(key: DependencyKey): T =
+    override fun <T> get(key: DependencyKey): T =
         resolver.value.get(key)
 
-    override fun <T : Any> getOrPut(key: DependencyKey, defaultValue: () -> T): T =
+    override fun <T> getOrPut(key: DependencyKey, defaultValue: () -> T): T =
         resolver.value.getOrPut(key, defaultValue)
 
     override fun require(key: DependencyKey) {
@@ -140,14 +140,14 @@ public class ProcessingDependencyResolver(
     private val provider: DependencyProvider,
     private val external: DependencyMap,
 ) : DependencyResolver {
-    private val resolved = mutableMapOf<DependencyKey, Result<Any>>()
+    private val resolved = mutableMapOf<DependencyKey, Result<*>>()
     private val visited = mutableSetOf<DependencyKey>()
 
-    public fun resolveAll(): Map<DependencyKey, Result<Any>> {
+    public fun resolveAll(): Map<DependencyKey, Result<*>> {
         if (resolved.isNotEmpty()) return resolved.toMap()
 
         for (key in provider.declarations.keys) {
-            get<Any>(key)
+            get<Any?>(key)
         }
         return resolved.toMap()
     }
@@ -155,7 +155,7 @@ public class ProcessingDependencyResolver(
     override fun contains(key: DependencyKey): Boolean =
         resolved.contains(key) || provider.declarations.contains(key) || external.contains(key)
 
-    override fun <T : Any> get(key: DependencyKey): T =
+    override fun <T> get(key: DependencyKey): T =
         resolved.getOrPut(key) {
             if (!visited.add(key)) throw CircularDependencyException(listOf(key))
             try {
@@ -171,7 +171,7 @@ public class ProcessingDependencyResolver(
             }
         }.getOrThrow() as T
 
-    override fun <T : Any> getOrPut(key: DependencyKey, defaultValue: () -> T): T =
+    override fun <T> getOrPut(key: DependencyKey, defaultValue: () -> T): T =
         resolved.getOrPut(key) {
             runCatching {
                 defaultValue()

--- a/ktor-server/ktor-server-plugins/ktor-server-di/common/src/io/ktor/server/plugins/di/utils/Types.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-di/common/src/io/ktor/server/plugins/di/utils/Types.kt
@@ -4,22 +4,33 @@
 
 package io.ktor.server.plugins.di.utils
 
-import io.ktor.server.plugins.di.DependencyKey
-import io.ktor.util.reflect.TypeInfo
-import io.ktor.utils.io.InternalAPI
-import kotlin.reflect.KType
+import io.ktor.util.reflect.*
+import io.ktor.utils.io.*
 
 /**
- * Returns a list of all supertypes and implemented interfaces, recursively iterating up the tree.
+ * Returns all types of the hierarchy, starting with the given type.
  *
- * When type parameters are encountered, they will be automatically substituted with the concrete values supplied to
- * the root [TypeInfo], if available.
+ * When type arguments are encountered, they are included in parent type arguments, so
+ * for example, `Collection<Element>` is included for the root type `ArrayList<Element>`.
  */
 @InternalAPI
-public expect fun TypeInfo.hierarchy(): List<TypeInfo>
+public expect fun TypeInfo.hierarchy(): Sequence<TypeInfo>
 
 /**
- * Provides the nullable version of the provided KType, or null if this is already nullable.
+ * Converts the current [TypeInfo] into a nullable type representation.
+ * If the type is already nullable, returns null.
+ *
+ * @return A new [TypeInfo] instance with a nullable type, or null if the type is already nullable.
  */
 @InternalAPI
-public expect fun KType.toNullable(): KType?
+public expect fun TypeInfo.toNullable(): TypeInfo?
+
+/**
+ * Returns a list of the given base implementation for covariant type arguments.
+ *
+ * For example, supertype bounds with the `out` keyword will return matching supertypes for the type arguments.
+ *
+ * @return A list of [TypeInfo] representing the base type with covariant type arguments.
+ */
+@InternalAPI
+public expect fun TypeInfo.typeParametersHierarchy(): Sequence<TypeInfo>

--- a/ktor-server/ktor-server-plugins/ktor-server-di/common/src/io/ktor/server/plugins/di/utils/Types.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-di/common/src/io/ktor/server/plugins/di/utils/Types.kt
@@ -4,8 +4,10 @@
 
 package io.ktor.server.plugins.di.utils
 
+import io.ktor.server.plugins.di.DependencyKey
 import io.ktor.util.reflect.TypeInfo
 import io.ktor.utils.io.InternalAPI
+import kotlin.reflect.KType
 
 /**
  * Returns a list of all supertypes and implemented interfaces, recursively iterating up the tree.
@@ -15,3 +17,9 @@ import io.ktor.utils.io.InternalAPI
  */
 @InternalAPI
 public expect fun TypeInfo.hierarchy(): List<TypeInfo>
+
+/**
+ * Provides the nullable version of the provided KType, or null if this is already nullable.
+ */
+@InternalAPI
+public expect fun KType.toNullable(): KType?

--- a/ktor-server/ktor-server-plugins/ktor-server-di/common/test/io/ktor/server/plugins/di/DependencyInjectionTest.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-di/common/test/io/ktor/server/plugins/di/DependencyInjectionTest.kt
@@ -229,17 +229,6 @@ class DependencyInjectionTest {
     }
 
     @Test
-    fun nullables() = runTestDI {
-        dependencies {
-            provide<BankTeller?> { null }
-            provide<BankService> { BankServiceImpl() }
-        }
-        assertNull(dependencies.resolve<GreetingService?>())
-        assertNull(dependencies.resolve<BankTeller?>())
-        assertNotNull(dependencies.resolve<BankService?>())
-    }
-
-    @Test
     fun arguments() = runTestDI {
         val expectedStringList = listOf("one", "two")
 

--- a/ktor-server/ktor-server-plugins/ktor-server-di/common/test/io/ktor/server/plugins/di/DependencyInjectionTest.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-di/common/test/io/ktor/server/plugins/di/DependencyInjectionTest.kt
@@ -229,8 +229,19 @@ class DependencyInjectionTest {
     }
 
     @Test
+    fun nullables() = runTestDI {
+        dependencies {
+            provide<BankTeller?> { null }
+            provide<BankService> { BankServiceImpl() }
+        }
+        assertNull(dependencies.resolve<GreetingService?>())
+        assertNull(dependencies.resolve<BankTeller?>())
+        assertNotNull(dependencies.resolve<BankService?>())
+    }
+
+    @Test
     fun arguments() = runTestDI {
-        var expectedStringList = listOf("one", "two")
+        val expectedStringList = listOf("one", "two")
 
         dependencies {
             provide<GreetingService> { GreetingServiceImpl() }
@@ -338,13 +349,14 @@ class DependencyInjectionTest {
         assertEquals(HELLO_CUSTOMER, unnamed.hello())
     }
 
+    @Suppress("UNCHECKED_CAST")
     private fun dependencyMapOf(vararg entries: Pair<DependencyKey, Any>): DependencyMap {
         val map = mapOf(*entries)
         return object : DependencyMap {
             override fun contains(key: DependencyKey): Boolean =
                 map.containsKey(key)
-            override fun <T : Any> get(key: DependencyKey): T =
-                map.get(key) as T
+            override fun <T> get(key: DependencyKey): T =
+                map[key] as T
         }
     }
 

--- a/ktor-server/ktor-server-plugins/ktor-server-di/jvm/src/io/ktor/server/plugins/di/utils/Types.jvm.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-di/jvm/src/io/ktor/server/plugins/di/utils/Types.jvm.kt
@@ -8,29 +8,126 @@ import io.ktor.util.reflect.*
 import io.ktor.utils.io.*
 import kotlin.reflect.KClass
 import kotlin.reflect.KType
+import kotlin.reflect.KTypeParameter
 import kotlin.reflect.KTypeProjection
+import kotlin.reflect.KVariance
 import kotlin.reflect.full.createType
+import kotlin.reflect.full.isSupertypeOf
 
 /**
- * Returns all supertypes and interfaces implemented by the given type, including all
- * found in its hierarchy, such that all covariant types are included.
+ * Returns all types of the hierarchy, starting with the given type.
  *
  * When type arguments are encountered, they are included in parent type arguments, so
  * for example, `Collection<Element>` is included for the root type `ArrayList<Element>`.
  */
 @InternalAPI
-public actual fun TypeInfo.hierarchy(): List<TypeInfo> {
-    val supertypes = kotlinType?.hierarchy() ?: type.supertypes
+public actual fun TypeInfo.hierarchy(): Sequence<TypeInfo> {
+    val supertypes = kotlinType?.hierarchy() ?: type.supertypes.asSequence()
     return supertypes.mapNotNull { it.toTypeInfo() }
 }
 
+/**
+ * Converts the current [TypeInfo] into a nullable type representation.
+ * If the type is already nullable, returns null.
+ *
+ * @return A new [TypeInfo] instance with a nullable type, or null if the type is already nullable.
+ */
 @InternalAPI
-public actual fun KType.toNullable(): KType? =
-    if (isMarkedNullable) null else classifier?.createType(
-        arguments = arguments,
-        nullable = true,
-        annotations = annotations
+public actual fun TypeInfo.toNullable(): TypeInfo? =
+    kotlinType?.takeIf { !it.isMarkedNullable }?.let { kType ->
+        TypeInfo(
+            type,
+            type.createType(
+                arguments = kType.arguments,
+                nullable = true,
+                annotations = kType.annotations
+            )
+        )
+    }
+
+/**
+ * Returns a list of the given base implementation for covariant type arguments.
+ *
+ * For example, supertype bounds with the `out` keyword will return matching supertypes for the type arguments.
+ *
+ * @return A list of [TypeInfo] representing the base type with covariant type arguments.
+ */
+@InternalAPI
+public actual fun TypeInfo.typeParametersHierarchy(): Sequence<TypeInfo> {
+    // Return empty when not applicable
+    if (!hasTypeParameters { it.variance == KVariance.OUT }) {
+        return sequenceOf(this)
+    }
+
+    // Collect all possible supertypes for each OUT parameter
+    val parameterSupertypes: Map<Int, List<KType>> = parameterSupertypes()
+    val parameterIndices = parameterSupertypes.keys.toList()
+
+    // Create a helper function to generate all combinations
+    fun generateCombinations(
+        currentIndex: Int,
+        currentCombination: Map<Int, KType>
+    ): Sequence<TypeInfo> =
+        if (currentIndex >= parameterIndices.size) {
+            // We have a complete combination, create a type with these arguments
+            sequenceOf(this.parameterizedWith(currentCombination))
+        } else {
+            val paramIndex = parameterIndices[currentIndex]
+            // Add each possible supertype for the current parameter to our combinations
+            parameterSupertypes[paramIndex]!!.asSequence().flatMap { paramType ->
+                generateCombinations(
+                    currentIndex + 1,
+                    currentCombination + (paramIndex to paramType)
+                )
+            }
+        }
+
+    // Generate all valid parameterized types from bounds
+    return generateCombinations(0, emptyMap())
+}
+
+@InternalAPI
+public fun TypeInfo.hasTypeParameters(predicate: (KTypeParameter) -> Boolean = { true }): Boolean {
+    val kType = kotlinType ?: return false
+    val typeParams = type.typeParameters
+    if (typeParams.isEmpty()) return false
+    if (typeParams.size != kType.arguments.size) return false
+    return typeParams.any(predicate)
+}
+
+private fun TypeInfo.parameterSupertypes(): Map<Int, List<KType>> {
+    val typeParams = type.typeParameters
+    return buildMap {
+        for ((index, argument) in kotlinType!!.arguments.withIndex()) {
+            val typeParameter = typeParams[index]
+            if (typeParameter.variance != KVariance.OUT) continue
+            val argumentType = argument.type ?: continue
+
+            put(
+                index,
+                argumentType.hierarchy().filter { supertype ->
+                    typeParameter.upperBounds.all {
+                        it == supertype || it.isSupertypeOf(supertype)
+                    }
+                }.toList()
+            )
+        }
+    }
+}
+
+private fun TypeInfo.parameterizedWith(typeArgReplacements: Map<Int, KType>): TypeInfo {
+    val swappedArguments = kotlinType!!.arguments.toMutableList()
+    for ((paramIndex, paramType) in typeArgReplacements) {
+        swappedArguments[paramIndex] = KTypeProjection(KVariance.INVARIANT, paramType)
+    }
+    return TypeInfo(
+        type,
+        type.createType(
+            arguments = swappedArguments,
+            annotations = type.annotations
+        )
     )
+}
 
 private fun KType.toTypeInfo(): TypeInfo? =
     (classifier as? KClass<*>)?.let {
@@ -54,7 +151,7 @@ private val ignoredSupertypes = setOf(
     // Add more general types here as needed
 )
 
-private fun KType.hierarchy(): List<KType> {
+private fun KType.hierarchy(): Sequence<KType> {
     // A helper function to substitute type arguments for supertypes
     fun substituteTypeArguments(supertype: KType, currentType: KType): KType {
         val currentTypeArguments = currentType.arguments
@@ -90,7 +187,7 @@ private fun KType.hierarchy(): List<KType> {
             }
         }
     }
-    return mutableSetOf<KType>().also { set ->
+    return mutableSetOf(this).also { set ->
         collectSupertypes(this, set)
-    }.toList()
+    }.asSequence()
 }

--- a/ktor-server/ktor-server-plugins/ktor-server-di/jvm/src/io/ktor/server/plugins/di/utils/Types.jvm.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-di/jvm/src/io/ktor/server/plugins/di/utils/Types.jvm.kt
@@ -5,7 +5,7 @@
 package io.ktor.server.plugins.di.utils
 
 import io.ktor.util.reflect.*
-import io.ktor.utils.io.InternalAPI
+import io.ktor.utils.io.*
 import kotlin.reflect.KClass
 import kotlin.reflect.KType
 import kotlin.reflect.KTypeProjection
@@ -23,6 +23,14 @@ public actual fun TypeInfo.hierarchy(): List<TypeInfo> {
     val supertypes = kotlinType?.hierarchy() ?: type.supertypes
     return supertypes.mapNotNull { it.toTypeInfo() }
 }
+
+@InternalAPI
+public actual fun KType.toNullable(): KType? =
+    if (isMarkedNullable) null else classifier?.createType(
+        arguments = arguments,
+        nullable = true,
+        annotations = annotations
+    )
 
 private fun KType.toTypeInfo(): TypeInfo? =
     (classifier as? KClass<*>)?.let {

--- a/ktor-server/ktor-server-plugins/ktor-server-di/jvm/test/io/ktor/server/plugins/di/DependencyInjectionJvmTest.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-di/jvm/test/io/ktor/server/plugins/di/DependencyInjectionJvmTest.kt
@@ -11,6 +11,10 @@ import io.ktor.http.*
 import io.ktor.server.application.*
 import io.ktor.server.config.*
 import io.ktor.server.testing.*
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.channels.ReceiveChannel
+import kotlinx.coroutines.channels.SendChannel
+import java.util.function.Consumer
 import kotlin.reflect.KClass
 import kotlin.reflect.KFunction
 import kotlin.reflect.full.IllegalCallableAccessException
@@ -127,7 +131,7 @@ class DependencyInjectionJvmTest {
 
     @Test
     fun `parameterized covariant types`() = testApplication {
-        var mySet = HashSet<String>()
+        val mySet = HashSet<String>()
 
         application {
             dependencies {
@@ -136,6 +140,18 @@ class DependencyInjectionJvmTest {
             assertEquals(mySet, dependencies.resolve())
             assertEquals(mySet, dependencies.resolve<Set<String>>())
             assertEquals(mySet, dependencies.resolve<Collection<String>>())
+            assertNull(dependencies.resolve<List<String>?>())
+        }
+    }
+
+    @Test
+    fun `covariant nullables`() = testApplication {
+        application {
+            dependencies {
+                provide<Int> { 123 }
+            }
+            assertEquals(123, dependencies.resolve<Number?>())
+            assertEquals(null, dependencies.resolve<String?>())
         }
     }
 

--- a/ktor-server/ktor-server-plugins/ktor-server-di/jvm/test/io/ktor/server/plugins/di/utils/TypesTest.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-di/jvm/test/io/ktor/server/plugins/di/utils/TypesTest.kt
@@ -5,39 +5,96 @@
 package io.ktor.server.plugins.di.utils
 
 import io.ktor.util.reflect.*
-import io.ktor.utils.io.InternalAPI
+import io.ktor.utils.io.*
 import kotlin.test.Test
-import kotlin.test.assertContains
-import kotlin.test.assertFalse
+import kotlin.test.assertContentEquals
 
 interface Companion
 interface Pet : Companion
 open class Animal
 class Cat : Animal(), Pet
+interface Groomer<out P : Pet>
 
 @OptIn(InternalAPI::class)
 class TypesTest {
 
     @Test
     fun supertypes() {
-        val supertypes = typeInfo<Cat>().hierarchy()
-        assertContains(supertypes, typeInfo<Animal>())
-        assertContains(supertypes, typeInfo<Pet>())
-        assertContains(supertypes, typeInfo<Companion>())
-        assertFalse("Should not contain Any") { typeInfo<Any>() in supertypes }
+        assertContentEquals(
+            sequenceOf(
+                typeInfo<Cat>(),
+                typeInfo<Animal>(),
+                typeInfo<Pet>(),
+                typeInfo<Companion>()
+            ),
+            typeInfo<Cat>().hierarchy(),
+        )
     }
 
     @Test
-    fun parameterizedSupertypes() {
-        val supertypes = typeInfo<ArrayList<Cat>>().hierarchy()
-        assertContains(supertypes, typeInfo<List<Cat>>())
-        assertContains(supertypes, typeInfo<Collection<Cat>>())
+    fun `parameterized supertypes`() {
+        assertContentEquals(
+            sequenceOf(
+                typeInfo<ArrayList<Cat>>(),
+                typeInfo<java.util.AbstractList<Cat>>(),
+                typeInfo<java.util.AbstractCollection<Cat>>(),
+                typeInfo<Collection<Cat>>(),
+                typeInfo<Iterable<Cat>>(),
+                typeInfo<List<Cat>>(),
+            ),
+            typeInfo<ArrayList<Cat>>().hierarchy().take(6),
+        )
     }
 
     @Test
-    fun multiParameterizedSupertypes() {
-        val supertypes = typeInfo<LinkedHashMap<String, Cat>>().hierarchy()
-        assertContains(supertypes, typeInfo<HashMap<String, Cat>>())
-        assertContains(supertypes, typeInfo<Map<String, Cat>>())
+    fun `multi parameterized supertypes`() {
+        assertContentEquals(
+            sequenceOf(
+                typeInfo<LinkedHashMap<String, Cat>>(),
+                typeInfo<HashMap<String, Cat>>(),
+                typeInfo<java.util.AbstractMap<String, Cat>>(),
+                typeInfo<Map<String, Cat>>(),
+            ),
+            typeInfo<LinkedHashMap<String, Cat>>().hierarchy().take(4),
+        )
+    }
+
+    @Test
+    fun `parameterized arg supertypes`() {
+        assertContentEquals(
+            sequenceOf(
+                typeInfo<List<Cat>>(),
+                typeInfo<List<Animal>>(),
+                typeInfo<List<Pet>>(),
+                typeInfo<List<Companion>>()
+            ),
+            typeInfo<List<Cat>>().typeParametersHierarchy(),
+        )
+    }
+
+    @Test
+    fun `parameterized arg supertypes boundary`() {
+        assertContentEquals(
+            sequenceOf(
+                typeInfo<Groomer<Cat>>(),
+                typeInfo<Groomer<Pet>>(),
+            ),
+            typeInfo<Groomer<Cat>>().typeParametersHierarchy(),
+        )
+    }
+
+    @Test
+    fun `multi parameterized arg supertypes`() {
+        assertContentEquals(
+            sequenceOf(
+                typeInfo<Pair<String, Cat>>(),
+                typeInfo<Pair<String, Animal>>(),
+                typeInfo<Pair<String, Pet>>(),
+                typeInfo<Pair<String, Companion>>(),
+                typeInfo<Pair<CharSequence, Cat>>(),
+                typeInfo<Pair<CharSequence, Animal>>(),
+            ),
+            typeInfo<Pair<String, Cat>>().typeParametersHierarchy().take(6),
+        )
     }
 }

--- a/ktor-server/ktor-server-plugins/ktor-server-di/nonJvm/src/io/ktor/server/plugins/di/utils/Types.nonJvm.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-di/nonJvm/src/io/ktor/server/plugins/di/utils/Types.nonJvm.kt
@@ -13,6 +13,22 @@ import io.ktor.utils.io.InternalAPI
  * For non-JVM platforms, we omit support for resolving covariant types of declared dependencies.
  */
 @InternalAPI
-public actual fun TypeInfo.hierarchy(): List<TypeInfo> =
-    emptyList()
+public actual fun TypeInfo.hierarchy(): Sequence<TypeInfo> =
+    sequenceOf(this)
 
+/**
+ * This kind of reflection is currently only supported for the JVM platform.
+ *
+ * For non-JVM platforms, we omit support for resolving covariant types of declared dependencies.
+ */
+@InternalAPI
+public actual fun TypeInfo.toNullable(): TypeInfo? = null
+
+/**
+ * This kind of reflection is currently only supported for the JVM platform.
+ *
+ * For non-JVM platforms, we omit support for resolving covariant types of declared dependencies.
+ */
+@InternalAPI
+public actual fun TypeInfo.typeParametersHierarchy(): Sequence<TypeInfo> =
+    sequenceOf(this)

--- a/ktor-server/ktor-server-plugins/ktor-server-di/nonJvm/src/io/ktor/server/plugins/di/utils/Types.nonJvm.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-di/nonJvm/src/io/ktor/server/plugins/di/utils/Types.nonJvm.kt
@@ -15,3 +15,4 @@ import io.ktor.utils.io.InternalAPI
 @InternalAPI
 public actual fun TypeInfo.hierarchy(): List<TypeInfo> =
     emptyList()
+


### PR DESCRIPTION
**Subsystem**
Server, DI

**Motivation**
- [KTOR-8305](https://youtrack.jetbrains.com/issue/KTOR-8305) Optional dependencies and nullable type support
- [KTOR-8434](https://youtrack.jetbrains.com/issue/KTOR-8434) Dependency injection - type parameter covariance supertypes

**Solution**
Now, you can optionally resolve dependencies using nullables (like `resolve<Foo?>()`).  This applies only when the dependency is not provided, and will continue to fail if some other exception was thrown when trying to resolve it.

I've also introduced support for resolving covariant type parameter arguments, so declaring `MutableList<String>` will work with resolving `List<CharSequence>` by checking the type bounds on the supertypes.

I discovered during testing that it was very easy to hit ambiguity exceptions from these kinds of inferences, so I introduced a ranking system based on distance to the declared type, so we'll only fail when you have two declarations that are the same distance (like declaring `List<Int>` and `Set<Int>` and attempting to resolve `Collection<Int>`).

There were also a few tweaks to the exception handling so things are easier to debug.