### PR TITLE
KTOR-8107 Don't add auth header for requests with AuthCircuitBreaker

### DIFF
--- a/ktor-client/ktor-client-plugins/ktor-client-auth/common/src/io/ktor/client/plugins/auth/providers/BearerAuthProvider.kt
+++ b/ktor-client/ktor-client-plugins/ktor-client-auth/common/src/io/ktor/client/plugins/auth/providers/BearerAuthProvider.kt
@@ -151,7 +151,9 @@ public class BearerAuthProvider(
             if (contains(HttpHeaders.Authorization)) {
                 remove(HttpHeaders.Authorization)
             }
-            append(HttpHeaders.Authorization, tokenValue)
+            if (request.attributes.contains(AuthCircuitBreaker).not()) {
+                append(HttpHeaders.Authorization, tokenValue)
+            }
         }
     }
 


### PR DESCRIPTION
**Subsystem**
Client BearerAuthProvider

**Motivation**
This PR fixes [KTOR-8107](https://youtrack.jetbrains.com/issue/KTOR-8107/Dont-send-Authorization-header-for-requests-marked-with-markAsRefreshTokenRequest)

**Solution**
When AuthCircuitBreaker attribute is found on request, Authorization header is not appended.

