### PR TITLE
Ktor 8345: Make VaryHeader check lenient

### DIFF
--- a/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/cache/HttpCache.kt
+++ b/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/cache/HttpCache.kt
@@ -344,7 +344,7 @@ public class HttpCache private constructor(
     ): CachedResponseData? = when {
         varyKeys.isNotEmpty() -> {
             val cache = storage.find(url, varyKeys)
-            if (varyKeys.size != cache.varyKeys.size) {
+            if (cache != null && cache.varyKeys.size != varyKeys.size) {
                 LOGGER.info { "Vary header size differs! This is an issue according to the Vary header specs (https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Vary). " +
                     "However, we will return the best matching cache as it is not your fault. Report the server you communicate with to fix it." }
             }

--- a/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/cache/HttpCache.kt
+++ b/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/cache/HttpCache.kt
@@ -348,7 +348,7 @@ public class HttpCache private constructor(
                 LOGGER.info("Vary header size differs! This is an issue according to the Vary header specs (https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Vary). " +
                     "However, we will return the best matching cache as it is not your fault. Report the server you communicate with to fix it.")
             }
-            return cache
+            cache
         }
 
         else -> {

--- a/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/cache/HttpCache.kt
+++ b/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/cache/HttpCache.kt
@@ -243,9 +243,12 @@ public class HttpCache private constructor(
                     if (responseFromCache.varyKeys().size != response.varyKeys().size) {
                         LOGGER.warn(
                             "Vary header mismatch on cached response for ${response.call.request.url}. " +
-                                "Received 304 Not Modified with Vary: ${response.varyKeys()} but cached response has Vary: ${responseFromCache.varyKeys()}. " +
-                                "According to RFC 7232 §4.1 and RFC 9111 §4.1, the server must include the full Vary header in 304 responses. " +
-                                "Falling back to missing cache logic. Consider reporting this issue to the server maintainers."
+                                "Received 304 Not Modified with Vary: ${response.varyKeys()} " +
+                                "but cached response has Vary: ${responseFromCache.varyKeys()}. " +
+                                "According to RFC 7232 §4.1 and RFC 9111 §4.1, " +
+                                "the server must include the full Vary header in 304 responses. " +
+                                "Falling back to missing cache logic. " +
+                                "Consider reporting this issue to the server maintainers."
                         )
                     }
 

--- a/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/cache/HttpCache.kt
+++ b/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/cache/HttpCache.kt
@@ -343,7 +343,12 @@ public class HttpCache private constructor(
         request: HttpRequest
     ): CachedResponseData? = when {
         varyKeys.isNotEmpty() -> {
-            storage.find(url, varyKeys)
+            val cache = storage.find(url, varyKeys)
+            if (varyKeys.size != cache.varyKeys.size) {
+                LOGGER.info { "Vary header size differs! This is an issue according to the Vary header specs (https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Vary). " +
+                    "However, we will return the best matching cache as it is not your fault. Report the server you communicate with to fix it." }
+            }
+            return cache
         }
 
         else -> {

--- a/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/cache/HttpCache.kt
+++ b/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/cache/HttpCache.kt
@@ -345,8 +345,8 @@ public class HttpCache private constructor(
         varyKeys.isNotEmpty() -> {
             val cache = storage.find(url, varyKeys)
             if (cache != null && cache.varyKeys.size != varyKeys.size) {
-                LOGGER.info { "Vary header size differs! This is an issue according to the Vary header specs (https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Vary). " +
-                    "However, we will return the best matching cache as it is not your fault. Report the server you communicate with to fix it." }
+                LOGGER.info("Vary header size differs! This is an issue according to the Vary header specs (https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Vary). " +
+                    "However, we will return the best matching cache as it is not your fault. Report the server you communicate with to fix it.")
             }
             return cache
         }

--- a/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/cache/HttpCacheLegacy.kt
+++ b/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/cache/HttpCacheLegacy.kt
@@ -73,7 +73,7 @@ internal suspend fun PipelineContext<HttpResponse, Unit>.interceptReceiveLegacy(
                     "but cached response has Vary: ${responseFromCache.varyKeys()}. " +
                     "According to RFC 7232 §4.1 and RFC 9111 §4.1, " +
                     "the server must include the full Vary header in 304 responses. " +
-                    "Falling back to missing cache logic. " +
+                    "Proceeding with cached response despite mismatch. " +
                     "Consider reporting this issue to the server maintainers."
             )
         }

--- a/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/cache/HttpCacheLegacy.kt
+++ b/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/cache/HttpCacheLegacy.kt
@@ -66,6 +66,17 @@ internal suspend fun PipelineContext<HttpResponse, Unit>.interceptReceiveLegacy(
     if (response.status == HttpStatusCode.NotModified) {
         val responseFromCache = plugin.findAndRefresh(response.call.request, response)
             ?: throw InvalidCacheStateException(response.call.request.url)
+        if (responseFromCache.varyKeys().size != response.varyKeys().size) {
+            LOGGER.warn(
+                "Vary header mismatch on cached response for ${response.call.request.url}. " +
+                    "Received 304 Not Modified with Vary: ${response.varyKeys()} " +
+                    "but cached response has Vary: ${responseFromCache.varyKeys()}. " +
+                    "According to RFC 7232 §4.1 and RFC 9111 §4.1, " +
+                    "the server must include the full Vary header in 304 responses. " +
+                    "Falling back to missing cache logic. " +
+                    "Consider reporting this issue to the server maintainers."
+            )
+        }
 
         scope.monitor.raise(HttpCache.HttpResponseFromCache, responseFromCache)
         proceedWith(responseFromCache)
@@ -116,10 +127,11 @@ private fun HttpCache.findAndRefresh(request: HttpRequest, response: HttpRespons
 
     val storage = if (CacheControl.PRIVATE in cacheControl) privateStorage else publicStorage
 
-    val varyKeysFrom304 = response.varyKeys()
-    val cache = findResponse(storage, varyKeysFrom304, url, request) ?: return null
-    val newVaryKeys = varyKeysFrom304.ifEmpty { cache.varyKeys }
-    storage.store(url, HttpCacheEntry(response.cacheExpires(isSharedClient), newVaryKeys, cache.response, cache.body))
+    val cache = findResponse(storage, response.varyKeys(), url, request) ?: return null
+    storage.store(
+        url,
+        HttpCacheEntry(response.cacheExpires(isSharedClient), cache.varyKeys, cache.response, cache.body)
+    )
     return cache.produceResponse()
 }
 

--- a/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/cache/storage/UnlimitedCacheStorage.kt
+++ b/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/cache/storage/UnlimitedCacheStorage.kt
@@ -23,7 +23,7 @@ internal class UnlimitedCacheStorage : HttpCacheStorage() {
     override fun find(url: Url, varyKeys: Map<String, String>): HttpCacheEntry? {
         val data = store.computeIfAbsent(url) { ConcurrentSet() }
         return data.find {
-            varyKeys.all { (key, value) -> it.varyKeys[key] == value } && varyKeys.size == it.varyKeys.size
+            varyKeys.all { (key, value) -> it.varyKeys[key] == value }
         }
     }
 
@@ -45,7 +45,7 @@ internal class UnlimitedStorage : CacheStorage {
     override suspend fun find(url: Url, varyKeys: Map<String, String>): CachedResponseData? {
         val data = store.computeIfAbsent(url) { ConcurrentSet() }
         return data.find {
-            varyKeys.all { (key, value) -> it.varyKeys[key] == value } && varyKeys.size == it.varyKeys.size
+            varyKeys.all { (key, value) -> it.varyKeys[key] == value }
         }
     }
 

--- a/ktor-client/ktor-client-core/jvm/src/io/ktor/client/plugins/cache/storage/FileCacheStorage.kt
+++ b/ktor-client/ktor-client-core/jvm/src/io/ktor/client/plugins/cache/storage/FileCacheStorage.kt
@@ -47,7 +47,7 @@ internal class CachingCacheStorage(
         }
         val data = store.getValue(url)
         return data.find {
-            varyKeys.all { (key, value) -> it.varyKeys[key] == value } && varyKeys.size == it.varyKeys.size
+            varyKeys.all { (key, value) -> it.varyKeys[key] == value }
         }
     }
 
@@ -83,7 +83,7 @@ private class FileCacheStorage(
     override suspend fun find(url: Url, varyKeys: Map<String, String>): CachedResponseData? {
         val data = readCache(key(url))
         return data.find {
-            varyKeys.all { (key, value) -> it.varyKeys[key] == value } && varyKeys.size == it.varyKeys.size
+            varyKeys.all { (key, value) -> it.varyKeys[key] == value }
         }
     }
 

--- a/ktor-client/ktor-client-core/jvm/test/CachingCacheStorageTest.kt
+++ b/ktor-client/ktor-client-core/jvm/test/CachingCacheStorageTest.kt
@@ -99,7 +99,7 @@ private class InMemoryCacheStorage : CacheStorage {
         findCalledCount++
         val cache = store.computeIfAbsent(url) { mutableSetOf() }
         return cache.find {
-            varyKeys.all { (key, value) -> it.varyKeys[key] == value } && varyKeys.size == it.varyKeys.size
+            varyKeys.all { (key, value) -> it.varyKeys[key] == value }
         }
     }
 

--- a/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/plugins/CacheTest.kt
+++ b/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/plugins/CacheTest.kt
@@ -846,15 +846,14 @@ class CacheTest : ClientLoader() {
         }
 
         test { client ->
-            val first = client.get("$TEST_SERVER/cache/different-vary") {
+            val url = "$TEST_SERVER/cache/different-vary"
+            val first = client.get(url) {
                 header("200", "true")
-                header("Set-Vary", "X-Requested-With,Accept-Encoding")
-            }.body<String>()
-            val second = client.get(url) {
-                header("Set-Vary", "X-Requested-With")
-            }.body<String>()
+            }
+            val second = client.get(url)
 
-            assertEquals(first, second)
+            assertEquals(first.bodyAsText(), second.bodyAsText())
+            assertEquals(storage.findAll(Url("$TEST_SERVER/cache/different-vary")).size, 1)
         }
     }
 

--- a/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/plugins/CacheTest.kt
+++ b/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/plugins/CacheTest.kt
@@ -846,15 +846,15 @@ class CacheTest : ClientLoader() {
         }
 
         test { client ->
-            client.get("$TEST_SERVER/cache/different-vary") {
+            val first = client.get("$TEST_SERVER/cache/different-vary") {
                 header("200", "true")
                 header("Set-Vary", "X-Requested-With,Accept-Encoding")
-            }
-            assertFailsWith<InvalidCacheStateException> {
-                client.get("$TEST_SERVER/cache/different-vary") {
-                    header("Set-Vary", "X-Requested-With")
-                }
-            }
+            }.body<String>()
+            val second = client.get(url) {
+                header("Set-Vary", "X-Requested-With")
+            }.body<String>()
+
+            assertEquals(first, second)
         }
     }
 

--- a/ktor-test-server/src/main/kotlin/test/server/tests/Cache.kt
+++ b/ktor-test-server/src/main/kotlin/test/server/tests/Cache.kt
@@ -120,8 +120,8 @@ internal fun Application.cacheTestServer() {
             }
             get("/different-vary") {
                 if (call.request.headers.contains("200")) {
-                    call.response.header("Vary", "X-Requested-With,Accept-Encoding")
-                    call.respond(HttpStatusCode.OK)
+                    call.response.header("Vary", "X-Requested-With, Accept-Encoding")
+                    call.respondText { "Ok" }
                 } else {
                     call.response.header("Vary", "X-Requested-With")
                     call.respond(HttpStatusCode.NotModified)


### PR DESCRIPTION
**Subsystem**
Client, Caching

**Motivation** & **Solution**
This PR fixes https://youtrack.jetbrains.com/issue/KTOR-8345/HttpCache-InvalidCacheStateException-thrown-when-Vary-header-has-different-entries-is-overly-severe

Let me explain:
All starts with [this](https://youtrack.jetbrains.com/issue/KTOR-7104).
Someone requested to update cache in case the Vary header differs.
Actually this violates the Vary header spec.
See https://developer.mozilla.org/de/docs/Web/HTTP/Reference/Headers/Vary
> The same Vary header value should be used on all responses for a given URL, including [304](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Status/304) Not Modified responses and the "default" response.

To make Ktor more compliant with the specs, [this PR](https://github.com/ktorio/ktor/pull/4673) was opened.

The change leads to throwing of an `InvalidCacheStateException` in case the Vary header differs from the original response (200) to the second response (304).
E.g.
GET 200 -> Vary: Accept-Encoding, Language
GET 304 -> Vary: Accept-Encoding --> `InvalidCacheStateException`

**The problem with that approach?**
We (as client developers) can't fix this on ourselves.
We just end up with yelling at our backend team (or even worse, third-party servers) to fix their Vary header.
That is all we can do, sadly.

This PR makes this check more lenient (again).
How it was before❗ 
But instead of running blindly into issues like [KTOR-7104](https://youtrack.jetbrains.com/issue/KTOR-7104), we now log the problem with a clear description that we return "the best matching cache" (which doesn't mean it is the correct one!).
(I'm not sure if this Logging is also propergated to users of the lib, or if its just internal. Let me know if this is wrong and if I have to adjust it.)

---

Honestly, I'm not sure if this is the best-fitting solution.
But I also think that we can't serve both problems - relying on the spec & make client developers happy.
Since the later is IMHO more important, I thought we can relax the ktor client here a bit.

What do you think?


