### PR TITLE
Build: Store multiple Gradle CC entries

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -45,6 +45,7 @@ org.gradle.caching=true
 org.gradle.parallel=true
 org.gradle.configuration-cache=true
 org.gradle.configuration-cache.parallel=true
+org.gradle.configuration-cache.entries-per-key=100
 org.gradle.kotlin.dsl.allWarningsAsErrors=true
 
 # kotlin


### PR DESCRIPTION
**Subsystem**
Build, Gradle

**Motivation**
Gradle only stores the last CC entry be default. It should store multiple entries to faster switch between tasks, like `test` and `apiDump`.

