### PR TITLE
KTOR-8472 Flatten Gradle project hierarchy

### DIFF
--- a/build-logic/src/main/kotlin/ktorbuild.compatibility.gradle.kts
+++ b/build-logic/src/main/kotlin/ktorbuild.compatibility.gradle.kts
@@ -7,51 +7,8 @@ plugins {
 }
 
 apiValidation {
-    val excludeList = setOf(
-        "ktor",
-        "ktor-client-test-base",
-        "ktor-client-tests",
-        "ktor-client-js",
-        "ktor-client-content-negotiation-tests",
-        "ktor-serialization-kotlinx-tests",
-        "ktor-serialization-tests",
-        "ktor-client",
-        "ktor-client-plugins",
-        "ktor-server-test-suites",
-        "ktor-server-test-base",
-        "ktor-test-base",
-    )
-
-    val projects = mutableSetOf<Project>()
-    val queue = arrayDequeOf(
-        project(":ktor-client"),
-        project(":ktor-http"),
-        project(":ktor-network"),
-        project(":ktor-utils"),
-        project(":ktor-io"),
-        project(":ktor-server"),
-        project(":ktor-server:ktor-server-plugins"),
-        project(":ktor-shared"),
-    )
-
-    while (queue.isNotEmpty()) {
-        val currentProject = queue.removeLast()
-        if (projects.add(currentProject)) {
-            queue.addAll(currentProject.childProjects.values)
-        }
-    }
-
-    val projectNames = projects.map { it.name }.toSet()
-
-    ignoredProjects.addAll(excludeList)
-    ignoredProjects.addAll(
-        project.allprojects.map { it.name }.filter { !projectNames.contains(it) }
-    )
-
     @OptIn(kotlinx.validation.ExperimentalBCVApi::class)
     klib {
         enabled = true
     }
 }
-
-fun <T> arrayDequeOf(vararg values: T): ArrayDeque<T> = ArrayDeque(values.asList())

--- a/build-logic/src/main/kotlin/ktorbuild.project.client-plugin.gradle.kts
+++ b/build-logic/src/main/kotlin/ktorbuild.project.client-plugin.gradle.kts
@@ -11,25 +11,25 @@ plugins {
 kotlin {
     sourceSets {
         commonMain.dependencies {
-            api(project(":ktor-client:ktor-client-core"))
+            api(project(":ktor-client-core"))
         }
         commonTest.dependencies {
-            implementation(project(":ktor-client:ktor-client-tests"))
+            implementation(project(":ktor-client-tests"))
         }
 
         if (ktorBuild.targets.hasJvm) {
             jvmTest.dependencies {
-                runtimeOnly(project(":ktor-client:ktor-client-okhttp"))
-                runtimeOnly(project(":ktor-client:ktor-client-apache"))
-                runtimeOnly(project(":ktor-client:ktor-client-cio"))
-                runtimeOnly(project(":ktor-client:ktor-client-android"))
-                runtimeOnly(project(":ktor-client:ktor-client-java"))
+                runtimeOnly(project(":ktor-client-okhttp"))
+                runtimeOnly(project(":ktor-client-apache"))
+                runtimeOnly(project(":ktor-client-cio"))
+                runtimeOnly(project(":ktor-client-android"))
+                runtimeOnly(project(":ktor-client-java"))
             }
         }
 
         if (ktorBuild.targets.hasJs) {
             jsTest.dependencies {
-                runtimeOnly(project(":ktor-client:ktor-client-js"))
+                runtimeOnly(project(":ktor-client-js"))
             }
         }
     }

--- a/build-logic/src/main/kotlin/ktorbuild.project.library.gradle.kts
+++ b/build-logic/src/main/kotlin/ktorbuild.project.library.gradle.kts
@@ -8,6 +8,7 @@ plugins {
     id("ktorbuild.kmp")
     id("ktorbuild.dokka")
     id("ktorbuild.publish")
+    id("ktorbuild.compatibility")
 }
 
 addProjectTag(ProjectTag.Library)

--- a/build-logic/src/main/kotlin/ktorbuild.project.server-plugin.gradle.kts
+++ b/build-logic/src/main/kotlin/ktorbuild.project.server-plugin.gradle.kts
@@ -9,10 +9,10 @@ plugins {
 kotlin {
     sourceSets {
         commonMain.dependencies {
-            api(project(":ktor-server:ktor-server-core"))
+            api(project(":ktor-server-core"))
         }
         commonTest.dependencies {
-            implementation(project(":ktor-server:ktor-server-test-base"))
+            implementation(project(":ktor-server-test-base"))
         }
     }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,7 +4,6 @@
 
 plugins {
     id("ktorbuild.doctor")
-    id("ktorbuild.compatibility")
     id("ktorbuild.publish.verifier")
 }
 

--- a/ktor-client/build.gradle.kts
+++ b/ktor-client/build.gradle.kts
@@ -9,7 +9,7 @@ plugins {
 kotlin {
     sourceSets {
         commonMain.dependencies {
-            api(project(":ktor-client:ktor-client-core"))
+            api(project(":ktor-client-core"))
         }
     }
 }

--- a/ktor-client/ktor-client-android/build.gradle.kts
+++ b/ktor-client/ktor-client-android/build.gradle.kts
@@ -12,12 +12,12 @@ plugins {
 kotlin {
     sourceSets {
         jvmMain.dependencies {
-            api(project(":ktor-client:ktor-client-core"))
+            api(project(":ktor-client-core"))
         }
         jvmTest.dependencies {
-            api(project(":ktor-client:ktor-client-tests"))
-            api(project(":ktor-network:ktor-network-tls"))
-            api(project(":ktor-network:ktor-network-tls:ktor-network-tls-certificates"))
+            api(project(":ktor-client-tests"))
+            api(project(":ktor-network-tls"))
+            api(project(":ktor-network-tls-certificates"))
         }
     }
 }

--- a/ktor-client/ktor-client-apache/build.gradle.kts
+++ b/ktor-client/ktor-client-apache/build.gradle.kts
@@ -12,11 +12,11 @@ plugins {
 kotlin {
     sourceSets {
         jvmMain.dependencies {
-            api(project(":ktor-client:ktor-client-core"))
+            api(project(":ktor-client-core"))
             api(libs.apache.httpasyncclient)
         }
         jvmTest.dependencies {
-            api(project(":ktor-client:ktor-client-tests"))
+            api(project(":ktor-client-tests"))
         }
     }
 }

--- a/ktor-client/ktor-client-apache5/build.gradle.kts
+++ b/ktor-client/ktor-client-apache5/build.gradle.kts
@@ -12,11 +12,11 @@ plugins {
 kotlin {
     sourceSets {
         jvmMain.dependencies {
-            api(project(":ktor-client:ktor-client-core"))
+            api(project(":ktor-client-core"))
             api(libs.apache.client5)
         }
         jvmTest.dependencies {
-            api(project(":ktor-client:ktor-client-tests"))
+            api(project(":ktor-client-tests"))
         }
     }
 }

--- a/ktor-client/ktor-client-cio/build.gradle.kts
+++ b/ktor-client/ktor-client-cio/build.gradle.kts
@@ -12,17 +12,17 @@ plugins {
 kotlin {
     sourceSets {
         commonMain.dependencies {
-            api(project(":ktor-client:ktor-client-core"))
-            api(project(":ktor-http:ktor-http-cio"))
-            api(project(":ktor-shared:ktor-websockets"))
-            api(project(":ktor-network:ktor-network-tls"))
+            api(project(":ktor-client-core"))
+            api(project(":ktor-http-cio"))
+            api(project(":ktor-websockets"))
+            api(project(":ktor-network-tls"))
         }
         commonTest.dependencies {
-            api(project(":ktor-client:ktor-client-tests"))
+            api(project(":ktor-client-tests"))
         }
         jvmTest.dependencies {
-            api(project(":ktor-network:ktor-network-tls:ktor-network-tls-certificates"))
-            api(project(":ktor-shared:ktor-test-base"))
+            api(project(":ktor-network-tls-certificates"))
+            api(project(":ktor-test-base"))
             implementation(libs.mockk)
         }
     }

--- a/ktor-client/ktor-client-core/build.gradle.kts
+++ b/ktor-client/ktor-client-core/build.gradle.kts
@@ -12,10 +12,10 @@ kotlin {
     sourceSets {
         commonMain.dependencies {
             api(project(":ktor-http"))
-            api(project(":ktor-http:ktor-http-cio"))
-            api(project(":ktor-shared:ktor-events"))
-            api(project(":ktor-shared:ktor-websocket-serialization"))
-            api(project(":ktor-shared:ktor-sse"))
+            api(project(":ktor-http-cio"))
+            api(project(":ktor-events"))
+            api(project(":ktor-websocket-serialization"))
+            api(project(":ktor-sse"))
         }
 
         jvmMain.dependencies {
@@ -32,8 +32,8 @@ kotlin {
 
         commonTest.dependencies {
             api(project(":ktor-test-dispatcher"))
-            api(project(":ktor-client:ktor-client-mock"))
-            api(project(":ktor-server:ktor-server-test-host"))
+            api(project(":ktor-client-mock"))
+            api(project(":ktor-server-test-host"))
         }
     }
 }

--- a/ktor-client/ktor-client-curl/build.gradle.kts
+++ b/ktor-client/ktor-client-curl/build.gradle.kts
@@ -18,13 +18,13 @@ kotlin {
 
     sourceSets {
         desktopMain.dependencies {
-            api(project(":ktor-client:ktor-client-core"))
-            api(project(":ktor-http:ktor-http-cio"))
+            api(project(":ktor-client-core"))
+            api(project(":ktor-http-cio"))
         }
         desktopTest.dependencies {
-            implementation(project(":ktor-client:ktor-client-test-base"))
-            api(project(":ktor-client:ktor-client-plugins:ktor-client-logging"))
-            api(project(":ktor-client:ktor-client-plugins:ktor-client-json"))
+            implementation(project(":ktor-client-test-base"))
+            api(project(":ktor-client-logging"))
+            api(project(":ktor-client-json"))
             implementation(libs.kotlinx.serialization.json)
         }
     }

--- a/ktor-client/ktor-client-darwin-legacy/build.gradle.kts
+++ b/ktor-client/ktor-client-darwin-legacy/build.gradle.kts
@@ -10,12 +10,12 @@ plugins {
 kotlin {
     sourceSets {
         darwinMain.dependencies {
-            api(project(":ktor-client:ktor-client-core"))
+            api(project(":ktor-client-core"))
         }
         darwinTest.dependencies {
-            api(project(":ktor-client:ktor-client-tests"))
-            api(project(":ktor-client:ktor-client-plugins:ktor-client-logging"))
-            api(project(":ktor-client:ktor-client-plugins:ktor-client-json"))
+            api(project(":ktor-client-tests"))
+            api(project(":ktor-client-logging"))
+            api(project(":ktor-client-json"))
         }
     }
 }

--- a/ktor-client/ktor-client-darwin/build.gradle.kts
+++ b/ktor-client/ktor-client-darwin/build.gradle.kts
@@ -10,13 +10,13 @@ plugins {
 kotlin {
     sourceSets {
         darwinMain.dependencies {
-            api(project(":ktor-client:ktor-client-core"))
-            api(project(":ktor-network:ktor-network-tls"))
+            api(project(":ktor-client-core"))
+            api(project(":ktor-network-tls"))
         }
         darwinTest.dependencies {
-            api(project(":ktor-client:ktor-client-tests"))
-            api(project(":ktor-client:ktor-client-plugins:ktor-client-logging"))
-            api(project(":ktor-client:ktor-client-plugins:ktor-client-json"))
+            api(project(":ktor-client-tests"))
+            api(project(":ktor-client-logging"))
+            api(project(":ktor-client-json"))
         }
     }
 }

--- a/ktor-client/ktor-client-ios/build.gradle.kts
+++ b/ktor-client/ktor-client-ios/build.gradle.kts
@@ -9,7 +9,7 @@ plugins {
 kotlin {
     sourceSets {
         darwinMain.dependencies {
-            api(project(":ktor-client:ktor-client-darwin"))
+            api(project(":ktor-client-darwin"))
         }
     }
 }

--- a/ktor-client/ktor-client-java/build.gradle.kts
+++ b/ktor-client/ktor-client-java/build.gradle.kts
@@ -13,11 +13,11 @@ kotlin {
 
     sourceSets {
         jvmMain.dependencies {
-            api(project(":ktor-client:ktor-client-core"))
+            api(project(":ktor-client-core"))
             implementation(libs.kotlinx.coroutines.jdk8)
         }
         jvmTest.dependencies {
-            api(project(":ktor-client:ktor-client-tests"))
+            api(project(":ktor-client-tests"))
         }
     }
 }

--- a/ktor-client/ktor-client-jetty-jakarta/build.gradle.kts
+++ b/ktor-client/ktor-client-jetty-jakarta/build.gradle.kts
@@ -14,14 +14,14 @@ kotlin {
 
     sourceSets {
         jvmMain.dependencies {
-            api(project(":ktor-client:ktor-client-core"))
+            api(project(":ktor-client-core"))
 
             api(libs.jetty.http2.client.jakarta)
             api(libs.jetty.alpn.openjdk8.client)
             api(libs.jetty.alpn.java.client)
         }
         commonTest.dependencies {
-            api(project(":ktor-client:ktor-client-tests"))
+            api(project(":ktor-client-tests"))
         }
     }
 }

--- a/ktor-client/ktor-client-jetty/build.gradle.kts
+++ b/ktor-client/ktor-client-jetty/build.gradle.kts
@@ -11,14 +11,14 @@ plugins {
 kotlin {
     sourceSets {
         jvmMain.dependencies {
-            api(project(":ktor-client:ktor-client-core"))
+            api(project(":ktor-client-core"))
 
             api(libs.jetty.http2.client)
             api(libs.jetty.alpn.openjdk8.client)
             api(libs.jetty.alpn.java.client)
         }
         commonTest.dependencies {
-            api(project(":ktor-client:ktor-client-tests"))
+            api(project(":ktor-client-tests"))
         }
     }
 }

--- a/ktor-client/ktor-client-js/build.gradle.kts
+++ b/ktor-client/ktor-client-js/build.gradle.kts
@@ -9,11 +9,11 @@ plugins {
 kotlin {
     sourceSets {
         jsMain.dependencies {
-            api(project(":ktor-client:ktor-client-core"))
+            api(project(":ktor-client-core"))
         }
 
         wasmJsMain.dependencies {
-            api(project(":ktor-client:ktor-client-core"))
+            api(project(":ktor-client-core"))
         }
     }
 }

--- a/ktor-client/ktor-client-mock/build.gradle.kts
+++ b/ktor-client/ktor-client-mock/build.gradle.kts
@@ -11,7 +11,7 @@ kotlin {
     sourceSets {
         commonMain.dependencies {
             api(project(":ktor-http"))
-            api(project(":ktor-client:ktor-client-core"))
+            api(project(":ktor-client-core"))
         }
 
         commonTest.dependencies {
@@ -20,9 +20,9 @@ kotlin {
 
         jvmTest.dependencies {
             api(libs.kotlinx.serialization.core)
-            api(project(":ktor-client:ktor-client-plugins:ktor-client-content-negotiation"))
-            api(project(":ktor-shared:ktor-serialization:ktor-serialization-kotlinx"))
-            api(project(":ktor-shared:ktor-serialization:ktor-serialization-kotlinx:ktor-serialization-kotlinx-json"))
+            api(project(":ktor-client-content-negotiation"))
+            api(project(":ktor-serialization-kotlinx"))
+            api(project(":ktor-serialization-kotlinx-json"))
         }
     }
 }

--- a/ktor-client/ktor-client-okhttp/build.gradle.kts
+++ b/ktor-client/ktor-client-okhttp/build.gradle.kts
@@ -10,13 +10,13 @@ plugins {
 kotlin {
     sourceSets {
         jvmMain.dependencies {
-            api(project(":ktor-client:ktor-client-core"))
+            api(project(":ktor-client-core"))
             api(libs.okhttp)
             api(libs.okhttp.sse)
             api(libs.okio)
         }
         jvmTest.dependencies {
-            api(project(":ktor-client:ktor-client-tests"))
+            api(project(":ktor-client-tests"))
         }
     }
 }

--- a/ktor-client/ktor-client-plugins/ktor-client-call-id/build.gradle.kts
+++ b/ktor-client/ktor-client-plugins/ktor-client-call-id/build.gradle.kts
@@ -11,11 +11,11 @@ plugins {
 kotlin {
     sourceSets {
         commonMain.dependencies {
-            api(project(":ktor-shared:ktor-call-id"))
+            api(project(":ktor-call-id"))
         }
         commonTest.dependencies {
-            api(project(":ktor-server:ktor-server-test-host"))
-            api(project(":ktor-server:ktor-server-plugins:ktor-server-call-id"))
+            api(project(":ktor-server-test-host"))
+            api(project(":ktor-server-call-id"))
         }
     }
 }

--- a/ktor-client/ktor-client-plugins/ktor-client-content-negotiation/build.gradle.kts
+++ b/ktor-client/ktor-client-plugins/ktor-client-content-negotiation/build.gradle.kts
@@ -12,7 +12,7 @@ plugins {
 kotlin {
     sourceSets {
         commonMain.dependencies {
-            api(project(":ktor-shared:ktor-serialization"))
+            api(project(":ktor-serialization"))
         }
     }
 }

--- a/ktor-client/ktor-client-plugins/ktor-client-content-negotiation/ktor-client-content-negotiation-tests/build.gradle.kts
+++ b/ktor-client/ktor-client-plugins/ktor-client-content-negotiation/ktor-client-content-negotiation-tests/build.gradle.kts
@@ -13,11 +13,11 @@ kotlin {
     sourceSets {
         jvmMain.dependencies {
             api(libs.kotlin.test.junit5)
-            api(project(":ktor-client:ktor-client-plugins:ktor-client-content-negotiation"))
-            api(project(":ktor-server:ktor-server-cio"))
-            api(project(":ktor-client:ktor-client-cio"))
-            api(project(":ktor-client:ktor-client-tests"))
-            api(project(":ktor-server:ktor-server-test-host"))
+            api(project(":ktor-client-content-negotiation"))
+            api(project(":ktor-server-cio"))
+            api(project(":ktor-client-cio"))
+            api(project(":ktor-client-tests"))
+            api(project(":ktor-server-test-host"))
             api(libs.jackson.annotations)
             api(libs.logback.classic)
         }

--- a/ktor-client/ktor-client-plugins/ktor-client-encoding/build.gradle.kts
+++ b/ktor-client/ktor-client-plugins/ktor-client-encoding/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 kotlin {
     sourceSets {
         jvmTest.dependencies {
-            api(project(":ktor-server:ktor-server-test-host"))
+            api(project(":ktor-server-test-host"))
         }
     }
 }

--- a/ktor-client/ktor-client-plugins/ktor-client-json/build.gradle.kts
+++ b/ktor-client/ktor-client-plugins/ktor-client-json/build.gradle.kts
@@ -13,10 +13,10 @@ plugins {
 kotlin {
     sourceSets {
         commonTest.dependencies {
-            api(project(":ktor-client:ktor-client-plugins:ktor-client-json:ktor-client-serialization"))
+            api(project(":ktor-client-serialization"))
         }
         jvmTest.dependencies {
-            api(project(":ktor-client:ktor-client-plugins:ktor-client-json:ktor-client-gson"))
+            api(project(":ktor-client-gson"))
         }
     }
 }

--- a/ktor-client/ktor-client-plugins/ktor-client-json/ktor-client-gson/build.gradle.kts
+++ b/ktor-client/ktor-client-plugins/ktor-client-json/ktor-client-gson/build.gradle.kts
@@ -9,12 +9,12 @@ plugins {
 kotlin {
     sourceSets {
         jvmMain.dependencies {
-            api(project(":ktor-client:ktor-client-plugins:ktor-client-json"))
+            api(project(":ktor-client-json"))
             api(libs.gson)
         }
         jvmTest.dependencies {
-            api(project(":ktor-client:ktor-client-cio"))
-            api(project(":ktor-shared:ktor-serialization:ktor-serialization-gson"))
+            api(project(":ktor-client-cio"))
+            api(project(":ktor-serialization-gson"))
         }
     }
 }

--- a/ktor-client/ktor-client-plugins/ktor-client-json/ktor-client-jackson/build.gradle.kts
+++ b/ktor-client/ktor-client-plugins/ktor-client-json/ktor-client-jackson/build.gradle.kts
@@ -9,14 +9,14 @@ plugins {
 kotlin {
     sourceSets {
         jvmMain.dependencies {
-            api(project(":ktor-client:ktor-client-plugins:ktor-client-json"))
+            api(project(":ktor-client-json"))
 
             api(libs.jackson.databind)
             api(libs.jackson.module.kotlin)
         }
         jvmTest.dependencies {
-            api(project(":ktor-client:ktor-client-cio"))
-            api(project(":ktor-shared:ktor-serialization:ktor-serialization-gson"))
+            api(project(":ktor-client-cio"))
+            api(project(":ktor-serialization-gson"))
         }
     }
 }

--- a/ktor-client/ktor-client-plugins/ktor-client-json/ktor-client-serialization/build.gradle.kts
+++ b/ktor-client/ktor-client-plugins/ktor-client-json/ktor-client-serialization/build.gradle.kts
@@ -11,7 +11,7 @@ kotlin {
     sourceSets {
         commonMain.dependencies {
             api(libs.kotlinx.serialization.json)
-            api(project(":ktor-client:ktor-client-plugins:ktor-client-json"))
+            api(project(":ktor-client-json"))
         }
     }
 }

--- a/ktor-client/ktor-client-plugins/ktor-client-logging/build.gradle.kts
+++ b/ktor-client/ktor-client-plugins/ktor-client-logging/build.gradle.kts
@@ -13,12 +13,12 @@ kotlin {
             api(libs.kotlinx.coroutines.slf4j)
         }
         commonTest.dependencies {
-            api(project(":ktor-client:ktor-client-mock"))
-            api(project(":ktor-client:ktor-client-plugins:ktor-client-content-negotiation"))
+            api(project(":ktor-client-mock"))
+            api(project(":ktor-client-content-negotiation"))
         }
         jvmTest.dependencies {
-            api(project(":ktor-shared:ktor-serialization:ktor-serialization-jackson"))
-            api(project(":ktor-client:ktor-client-plugins:ktor-client-encoding"))
+            api(project(":ktor-serialization-jackson"))
+            api(project(":ktor-client-encoding"))
         }
     }
 }

--- a/ktor-client/ktor-client-plugins/ktor-client-resources/build.gradle.kts
+++ b/ktor-client/ktor-client-plugins/ktor-client-resources/build.gradle.kts
@@ -12,7 +12,7 @@ plugins {
 kotlin {
     sourceSets {
         commonMain.dependencies {
-            api(project(":ktor-shared:ktor-resources"))
+            api(project(":ktor-resources"))
             api(libs.kotlinx.serialization.core)
         }
     }

--- a/ktor-client/ktor-client-plugins/ktor-client-tracing/build.gradle.kts
+++ b/ktor-client/ktor-client-plugins/ktor-client-tracing/build.gradle.kts
@@ -9,10 +9,10 @@ plugins {
 kotlin {
     sourceSets {
         commonMain.dependencies {
-            api(project(":ktor-client:ktor-client-core"))
+            api(project(":ktor-client-core"))
         }
         jvmTest.dependencies {
-            implementation(project(":ktor-client:ktor-client-cio"))
+            implementation(project(":ktor-client-cio"))
         }
     }
 }

--- a/ktor-client/ktor-client-plugins/ktor-client-tracing/ktor-client-tracing-stetho/build.gradle.kts
+++ b/ktor-client/ktor-client-plugins/ktor-client-tracing/ktor-client-tracing-stetho/build.gradle.kts
@@ -20,8 +20,8 @@ kotlin {
         val androidMain by getting {
             kotlin.srcDir("android/src")
             dependencies {
-                implementation(project(":ktor-client:ktor-client-plugins:ktor-client-tracing"))
-                implementation(project(":ktor-client:ktor-client-core"))
+                implementation(project(":ktor-client-tracing"))
+                implementation(project(":ktor-client-core"))
                 implementation("com.facebook.stetho:stetho:$android_stetho_version")
             }
         }
@@ -29,7 +29,7 @@ kotlin {
         val androidTest by getting {
             kotlin.srcDir("android/test")
             dependencies {
-                implementation(project(":ktor-client:ktor-client-cio"))
+                implementation(project(":ktor-client-cio"))
                 implementation(libs.kotlin.test.junit5)
                 implementation("org.mockito:mockito-core:5.17.0")
             }

--- a/ktor-client/ktor-client-plugins/ktor-client-websockets/build.gradle.kts
+++ b/ktor-client/ktor-client-plugins/ktor-client-websockets/build.gradle.kts
@@ -9,7 +9,7 @@ plugins {
 kotlin {
     sourceSets {
         commonTest.dependencies {
-            api(project(":ktor-client:ktor-client-plugins:ktor-client-logging"))
+            api(project(":ktor-client-logging"))
         }
     }
 }

--- a/ktor-client/ktor-client-test-base/build.gradle.kts
+++ b/ktor-client/ktor-client-test-base/build.gradle.kts
@@ -11,8 +11,8 @@ plugins {
 kotlin {
     sourceSets {
         commonMain.dependencies {
-            api(project(":ktor-client:ktor-client-core"))
-            api(project(":ktor-shared:ktor-test-base"))
+            api(project(":ktor-client-core"))
+            api(project(":ktor-test-base"))
         }
     }
 }

--- a/ktor-client/ktor-client-tests/build.gradle.kts
+++ b/ktor-client/ktor-client-tests/build.gradle.kts
@@ -13,63 +13,63 @@ plugins {
 kotlin {
     sourceSets {
         commonMain.dependencies {
-            api(project(":ktor-client:ktor-client-test-base"))
-            api(project(":ktor-client:ktor-client-mock"))
+            api(project(":ktor-client-test-base"))
+            api(project(":ktor-client-mock"))
         }
         commonTest.dependencies {
-            api(project(":ktor-client:ktor-client-plugins:ktor-client-json"))
-            api(project(":ktor-client:ktor-client-plugins:ktor-client-json:ktor-client-serialization"))
-            api(project(":ktor-client:ktor-client-plugins:ktor-client-logging"))
-            api(project(":ktor-client:ktor-client-plugins:ktor-client-auth"))
-            api(project(":ktor-client:ktor-client-plugins:ktor-client-encoding"))
-            api(project(":ktor-client:ktor-client-plugins:ktor-client-content-negotiation"))
-            api(project(":ktor-client:ktor-client-plugins:ktor-client-json"))
-            api(project(":ktor-client:ktor-client-plugins:ktor-client-json:ktor-client-serialization"))
-            api(project(":ktor-shared:ktor-serialization:ktor-serialization-kotlinx"))
-            api(project(":ktor-shared:ktor-serialization:ktor-serialization-kotlinx:ktor-serialization-kotlinx-json"))
+            api(project(":ktor-client-json"))
+            api(project(":ktor-client-serialization"))
+            api(project(":ktor-client-logging"))
+            api(project(":ktor-client-auth"))
+            api(project(":ktor-client-encoding"))
+            api(project(":ktor-client-content-negotiation"))
+            api(project(":ktor-client-json"))
+            api(project(":ktor-client-serialization"))
+            api(project(":ktor-serialization-kotlinx"))
+            api(project(":ktor-serialization-kotlinx-json"))
         }
         jvmMain.dependencies {
             api(libs.kotlinx.serialization.json)
-            api(project(":ktor-network:ktor-network-tls:ktor-network-tls-certificates"))
+            api(project(":ktor-network-tls-certificates"))
             api(project(":ktor-server"))
-            api(project(":ktor-server:ktor-server-cio"))
-            api(project(":ktor-server:ktor-server-netty"))
-            api(project(":ktor-server:ktor-server-plugins:ktor-server-auth"))
-            api(project(":ktor-server:ktor-server-plugins:ktor-server-websockets"))
-            api(project(":ktor-shared:ktor-serialization:ktor-serialization-kotlinx"))
+            api(project(":ktor-server-cio"))
+            api(project(":ktor-server-netty"))
+            api(project(":ktor-server-auth"))
+            api(project(":ktor-server-websockets"))
+            api(project(":ktor-serialization-kotlinx"))
             api(libs.logback.classic)
         }
 
         jvmTest.dependencies {
-            api(project(":ktor-client:ktor-client-apache"))
-            api(project(":ktor-client:ktor-client-apache5"))
-            runtimeOnly(project(":ktor-client:ktor-client-android"))
-            runtimeOnly(project(":ktor-client:ktor-client-okhttp"))
-            runtimeOnly(project(":ktor-client:ktor-client-java"))
-            implementation(project(":ktor-client:ktor-client-plugins:ktor-client-logging"))
+            api(project(":ktor-client-apache"))
+            api(project(":ktor-client-apache5"))
+            runtimeOnly(project(":ktor-client-android"))
+            runtimeOnly(project(":ktor-client-okhttp"))
+            runtimeOnly(project(":ktor-client-java"))
+            implementation(project(":ktor-client-logging"))
             implementation(libs.kotlinx.coroutines.slf4j)
             implementation(libs.junit)
         }
 
         commonTest.dependencies {
-            api(project(":ktor-client:ktor-client-cio"))
+            api(project(":ktor-client-cio"))
         }
 
         jsTest.dependencies {
-            api(project(":ktor-client:ktor-client-js"))
+            api(project(":ktor-client-js"))
         }
 
         desktopTest.dependencies {
-            api(project(":ktor-client:ktor-client-curl"))
+            api(project(":ktor-client-curl"))
         }
 
         darwinTest.dependencies {
-                api(project(":ktor-client:ktor-client-darwin"))
-                api(project(":ktor-client:ktor-client-darwin-legacy"))
+                api(project(":ktor-client-darwin"))
+                api(project(":ktor-client-darwin-legacy"))
         }
 
         windowsTest.dependencies {
-                api(project(":ktor-client:ktor-client-winhttp"))
+                api(project(":ktor-client-winhttp"))
         }
     }
 }

--- a/ktor-client/ktor-client-winhttp/build.gradle.kts
+++ b/ktor-client/ktor-client-winhttp/build.gradle.kts
@@ -15,13 +15,13 @@ kotlin {
 
     sourceSets {
         windowsMain.dependencies {
-            api(project(":ktor-client:ktor-client-core"))
-            api(project(":ktor-http:ktor-http-cio"))
+            api(project(":ktor-client-core"))
+            api(project(":ktor-http-cio"))
         }
         windowsTest.dependencies {
-            implementation(project(":ktor-client:ktor-client-test-base"))
-            api(project(":ktor-client:ktor-client-plugins:ktor-client-logging"))
-            api(project(":ktor-client:ktor-client-plugins:ktor-client-json"))
+            implementation(project(":ktor-client-test-base"))
+            api(project(":ktor-client-logging"))
+            api(project(":ktor-client-json"))
         }
     }
 }

--- a/ktor-http/build.gradle.kts
+++ b/ktor-http/build.gradle.kts
@@ -14,9 +14,9 @@ kotlin {
             api(libs.kotlinx.serialization.core)
         }
         jvmTest.dependencies {
-            implementation(project(":ktor-shared:ktor-test-base"))
-            implementation(project(":ktor-shared:ktor-serialization:ktor-serialization-kotlinx"))
-            implementation(project(":ktor-shared:ktor-serialization:ktor-serialization-kotlinx:ktor-serialization-kotlinx-json"))
+            implementation(project(":ktor-test-base"))
+            implementation(project(":ktor-serialization-kotlinx"))
+            implementation(project(":ktor-serialization-kotlinx-json"))
         }
     }
 }

--- a/ktor-network/build.gradle.kts
+++ b/ktor-network/build.gradle.kts
@@ -26,7 +26,7 @@ kotlin {
         }
 
         jvmTest.dependencies {
-            implementation(project(":ktor-shared:ktor-test-base"))
+            implementation(project(":ktor-test-base"))
             implementation(libs.mockk)
         }
     }

--- a/ktor-network/ktor-network-tls/build.gradle.kts
+++ b/ktor-network/ktor-network-tls/build.gradle.kts
@@ -14,8 +14,8 @@ kotlin {
             api(project(":ktor-utils"))
         }
         jvmTest.dependencies {
-            api(project(":ktor-shared:ktor-test-base"))
-            api(project(":ktor-network:ktor-network-tls:ktor-network-tls-certificates"))
+            api(project(":ktor-test-base"))
+            api(project(":ktor-network-tls-certificates"))
             api(libs.netty.handler)
             api(libs.mockk)
         }

--- a/ktor-network/ktor-network-tls/ktor-network-tls-certificates/build.gradle.kts
+++ b/ktor-network/ktor-network-tls/ktor-network-tls-certificates/build.gradle.kts
@@ -9,7 +9,7 @@ plugins {
 kotlin {
     sourceSets {
         jvmMain.dependencies {
-            api(project(":ktor-network:ktor-network-tls"))
+            api(project(":ktor-network-tls"))
         }
         jvmTest.dependencies {
             implementation(libs.mockk)

--- a/ktor-server/build.gradle.kts
+++ b/ktor-server/build.gradle.kts
@@ -11,28 +11,28 @@ plugins {
 kotlin {
     sourceSets {
         jvmMain.dependencies {
-            api(project(":ktor-server:ktor-server-plugins:ktor-server-call-logging"))
-            api(project(":ktor-server:ktor-server-plugins:ktor-server-default-headers"))
-            api(project(":ktor-server:ktor-server-plugins:ktor-server-compression"))
+            api(project(":ktor-server-call-logging"))
+            api(project(":ktor-server-default-headers"))
+            api(project(":ktor-server-compression"))
         }
         commonMain.dependencies {
-            api(project(":ktor-server:ktor-server-core"))
-            api(project(":ktor-server:ktor-server-plugins:ktor-server-auto-head-response"))
-            api(project(":ktor-server:ktor-server-plugins:ktor-server-caching-headers"))
-            api(project(":ktor-server:ktor-server-plugins:ktor-server-conditional-headers"))
-            api(project(":ktor-server:ktor-server-plugins:ktor-server-content-negotiation"))
-            api(project(":ktor-server:ktor-server-plugins:ktor-server-call-id"))
-            api(project(":ktor-server:ktor-server-plugins:ktor-server-cors"))
-            api(project(":ktor-server:ktor-server-plugins:ktor-server-csrf"))
-            api(project(":ktor-server:ktor-server-plugins:ktor-server-data-conversion"))
-            api(project(":ktor-server:ktor-server-plugins:ktor-server-double-receive"))
-            api(project(":ktor-server:ktor-server-plugins:ktor-server-forwarded-header"))
-            api(project(":ktor-server:ktor-server-plugins:ktor-server-hsts"))
-            api(project(":ktor-server:ktor-server-plugins:ktor-server-http-redirect"))
-            api(project(":ktor-server:ktor-server-plugins:ktor-server-partial-content"))
-            api(project(":ktor-server:ktor-server-plugins:ktor-server-status-pages"))
-            api(project(":ktor-server:ktor-server-plugins:ktor-server-method-override"))
-            api(project(":ktor-server:ktor-server-plugins:ktor-server-sessions"))
+            api(project(":ktor-server-core"))
+            api(project(":ktor-server-auto-head-response"))
+            api(project(":ktor-server-caching-headers"))
+            api(project(":ktor-server-conditional-headers"))
+            api(project(":ktor-server-content-negotiation"))
+            api(project(":ktor-server-call-id"))
+            api(project(":ktor-server-cors"))
+            api(project(":ktor-server-csrf"))
+            api(project(":ktor-server-data-conversion"))
+            api(project(":ktor-server-double-receive"))
+            api(project(":ktor-server-forwarded-header"))
+            api(project(":ktor-server-hsts"))
+            api(project(":ktor-server-http-redirect"))
+            api(project(":ktor-server-partial-content"))
+            api(project(":ktor-server-status-pages"))
+            api(project(":ktor-server-method-override"))
+            api(project(":ktor-server-sessions"))
         }
     }
 }

--- a/ktor-server/ktor-server-cio/build.gradle.kts
+++ b/ktor-server/ktor-server-cio/build.gradle.kts
@@ -11,15 +11,15 @@ plugins {
 kotlin {
     sourceSets {
         commonMain.dependencies {
-            api(project(":ktor-server:ktor-server-core"))
-            api(project(":ktor-http:ktor-http-cio"))
-            api(project(":ktor-shared:ktor-websockets"))
+            api(project(":ktor-server-core"))
+            api(project(":ktor-http-cio"))
+            api(project(":ktor-websockets"))
             api(project(":ktor-network"))
         }
         commonTest.dependencies {
-            api(project(":ktor-client:ktor-client-cio"))
-            api(project(":ktor-server:ktor-server-test-suites"))
-            api(project(":ktor-server:ktor-server-test-base"))
+            api(project(":ktor-client-cio"))
+            api(project(":ktor-server-test-suites"))
+            api(project(":ktor-server-test-base"))
         }
     }
 }

--- a/ktor-server/ktor-server-config-yaml/build.gradle.kts
+++ b/ktor-server/ktor-server-config-yaml/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 kotlin {
     sourceSets {
         commonMain.dependencies {
-            api(project(":ktor-server:ktor-server-core"))
+            api(project(":ktor-server-core"))
             // KTOR-8386 Remove in next major release
             api(libs.yamlkt.serialization)
             implementation(libs.kaml.serialization)

--- a/ktor-server/ktor-server-core/build.gradle.kts
+++ b/ktor-server/ktor-server-core/build.gradle.kts
@@ -18,10 +18,10 @@ kotlin {
         commonMain.dependencies {
             api(project(":ktor-utils"))
             api(project(":ktor-http"))
-            api(project(":ktor-shared:ktor-serialization"))
-            api(project(":ktor-shared:ktor-events"))
-            api(project(":ktor-http:ktor-http-cio"))
-            api(project(":ktor-shared:ktor-websockets"))
+            api(project(":ktor-serialization"))
+            api(project(":ktor-events"))
+            api(project(":ktor-http-cio"))
+            api(project(":ktor-websockets"))
 
             api(libs.kotlin.reflect)
         }
@@ -32,13 +32,13 @@ kotlin {
         }
 
         commonTest.dependencies {
-            api(project(":ktor-server:ktor-server-test-host"))
+            api(project(":ktor-server-test-host"))
         }
 
         jvmTest.dependencies {
-            implementation(project(":ktor-server:ktor-server-config-yaml"))
-            implementation(project(":ktor-server:ktor-server-test-base"))
-            implementation(project(":ktor-server:ktor-server-test-suites"))
+            implementation(project(":ktor-server-config-yaml"))
+            implementation(project(":ktor-server-test-base"))
+            implementation(project(":ktor-server-test-suites"))
 
             implementation(libs.mockk)
         }

--- a/ktor-server/ktor-server-host-common/build.gradle.kts
+++ b/ktor-server/ktor-server-host-common/build.gradle.kts
@@ -11,7 +11,7 @@ plugins {
 kotlin {
     sourceSets {
         commonMain.dependencies {
-            api(project(":ktor-server:ktor-server-core"))
+            api(project(":ktor-server-core"))
         }
     }
 }

--- a/ktor-server/ktor-server-jetty-jakarta/build.gradle.kts
+++ b/ktor-server/ktor-server-jetty-jakarta/build.gradle.kts
@@ -14,8 +14,8 @@ kotlin {
 
     sourceSets {
         jvmMain.dependencies {
-            api(project(":ktor-server:ktor-server-core"))
-            api(project(":ktor-server:ktor-server-servlet-jakarta"))
+            api(project(":ktor-server-core"))
+            api(project(":ktor-server-servlet-jakarta"))
             api(libs.jetty.server.jakarta)
             api(libs.jetty.servlets.jakarta)
             api(libs.jetty.alpn.server.jakarta)
@@ -25,9 +25,9 @@ kotlin {
         }
         jvmTest.dependencies {
             api(libs.kotlin.test.junit5)
-            api(project(":ktor-server:ktor-server-core"))
-            api(project(":ktor-server:ktor-server-test-base"))
-            api(project(":ktor-server:ktor-server-test-suites"))
+            api(project(":ktor-server-core"))
+            api(project(":ktor-server-test-base"))
+            api(project(":ktor-server-test-suites"))
 
             api(libs.jetty.servlet.jakarta)
         }

--- a/ktor-server/ktor-server-jetty-jakarta/ktor-server-jetty-test-http2-jakarta/build.gradle.kts
+++ b/ktor-server/ktor-server-jetty-jakarta/ktor-server-jetty-test-http2-jakarta/build.gradle.kts
@@ -14,11 +14,11 @@ kotlin {
 
     sourceSets {
         jvmTest.dependencies {
-            api(project(":ktor-server:ktor-server-test-base"))
-            api(project(":ktor-server:ktor-server-test-suites"))
+            api(project(":ktor-server-test-base"))
+            api(project(":ktor-server-test-suites"))
             api(libs.jetty.servlet.jakarta)
-            api(project(":ktor-server:ktor-server-core"))
-            api(project(":ktor-server:ktor-server-jetty-jakarta"))
+            api(project(":ktor-server-core"))
+            api(project(":ktor-server-jetty-jakarta"))
         }
     }
 }

--- a/ktor-server/ktor-server-jetty/build.gradle.kts
+++ b/ktor-server/ktor-server-jetty/build.gradle.kts
@@ -11,8 +11,8 @@ plugins {
 kotlin {
     sourceSets {
         jvmMain.dependencies {
-            api(project(":ktor-server:ktor-server-core"))
-            api(project(":ktor-server:ktor-server-servlet"))
+            api(project(":ktor-server-core"))
+            api(project(":ktor-server-servlet"))
             api(libs.jetty.server)
             api(libs.jetty.servlets)
             api(libs.jetty.alpn.server)
@@ -21,9 +21,9 @@ kotlin {
             api(libs.jetty.http2.server)
         }
         jvmTest.dependencies {
-            api(project(":ktor-server:ktor-server-core"))
-            api(project(":ktor-server:ktor-server-test-base"))
-            api(project(":ktor-server:ktor-server-test-suites"))
+            api(project(":ktor-server-core"))
+            api(project(":ktor-server-test-base"))
+            api(project(":ktor-server-test-suites"))
 
             api(libs.jetty.servlet)
         }

--- a/ktor-server/ktor-server-jetty/ktor-server-jetty-test-http2/build.gradle.kts
+++ b/ktor-server/ktor-server-jetty/ktor-server-jetty-test-http2/build.gradle.kts
@@ -11,11 +11,11 @@ plugins {
 kotlin {
     sourceSets {
         jvmTest.dependencies {
-            api(project(":ktor-server:ktor-server-test-base"))
-            api(project(":ktor-server:ktor-server-test-suites"))
+            api(project(":ktor-server-test-base"))
+            api(project(":ktor-server-test-suites"))
             api(libs.jetty.servlet)
-            api(project(":ktor-server:ktor-server-core"))
-            api(project(":ktor-server:ktor-server-jetty"))
+            api(project(":ktor-server-core"))
+            api(project(":ktor-server-jetty"))
         }
     }
 }

--- a/ktor-server/ktor-server-netty/build.gradle.kts
+++ b/ktor-server/ktor-server-netty/build.gradle.kts
@@ -26,7 +26,7 @@ val nativeClassifier: String? = if (enableAlpnProp) {
 kotlin {
     sourceSets {
         jvmMain.dependencies {
-            api(project(":ktor-server:ktor-server-core"))
+            api(project(":ktor-server-core"))
 
             api(libs.netty.codec.http2)
             api(libs.jetty.alpn.api)
@@ -38,9 +38,9 @@ kotlin {
             }
         }
         jvmTest.dependencies {
-            api(project(":ktor-server:ktor-server-test-base"))
-            api(project(":ktor-server:ktor-server-test-suites"))
-            api(project(":ktor-server:ktor-server-core"))
+            api(project(":ktor-server-test-base"))
+            api(project(":ktor-server-test-suites"))
+            api(project(":ktor-server-core"))
 
             api(libs.netty.tcnative)
             api(libs.netty.tcnative.boringssl.static)

--- a/ktor-server/ktor-server-plugins/ktor-server-auth-jwt/build.gradle.kts
+++ b/ktor-server/ktor-server-plugins/ktor-server-auth-jwt/build.gradle.kts
@@ -9,7 +9,7 @@ plugins {
 kotlin {
     sourceSets {
         jvmMain.dependencies {
-            api(project(":ktor-server:ktor-server-plugins:ktor-server-auth"))
+            api(project(":ktor-server-auth"))
             api(libs.java.jwt)
             api(libs.jwks.rsa)
         }

--- a/ktor-server/ktor-server-plugins/ktor-server-auth-ldap/build.gradle.kts
+++ b/ktor-server/ktor-server-plugins/ktor-server-auth-ldap/build.gradle.kts
@@ -9,7 +9,7 @@ plugins {
 kotlin {
     sourceSets {
         jvmMain.dependencies {
-            api(project(":ktor-server:ktor-server-plugins:ktor-server-auth"))
+            api(project(":ktor-server-auth"))
         }
         jvmTest.dependencies {
             api(libs.apacheds.server)

--- a/ktor-server/ktor-server-plugins/ktor-server-auth/build.gradle.kts
+++ b/ktor-server/ktor-server-plugins/ktor-server-auth/build.gradle.kts
@@ -12,13 +12,13 @@ plugins {
 kotlin {
     sourceSets {
         commonMain.dependencies {
-            api(project(":ktor-client:ktor-client-core"))
-            api(project(":ktor-server:ktor-server-plugins:ktor-server-sessions"))
+            api(project(":ktor-client-core"))
+            api(project(":ktor-server-sessions"))
             api(libs.kotlinx.serialization.json)
         }
         jvmTest.dependencies {
-            api(project(":ktor-server:ktor-server-plugins:ktor-server-content-negotiation"))
-            api(project(":ktor-shared:ktor-serialization:ktor-serialization-jackson"))
+            api(project(":ktor-server-content-negotiation"))
+            api(project(":ktor-serialization-jackson"))
         }
     }
 }

--- a/ktor-server/ktor-server-plugins/ktor-server-call-id/build.gradle.kts
+++ b/ktor-server/ktor-server-plugins/ktor-server-call-id/build.gradle.kts
@@ -11,10 +11,10 @@ plugins {
 kotlin {
     sourceSets {
         commonMain.dependencies {
-            api(project(":ktor-shared:ktor-call-id"))
+            api(project(":ktor-call-id"))
         }
         jvmMain.dependencies {
-            api(project(":ktor-server:ktor-server-plugins:ktor-server-call-logging"))
+            api(project(":ktor-server-call-logging"))
         }
     }
 }

--- a/ktor-server/ktor-server-plugins/ktor-server-call-logging/build.gradle.kts
+++ b/ktor-server/ktor-server-plugins/ktor-server-call-logging/build.gradle.kts
@@ -16,8 +16,8 @@ kotlin {
         }
 
         jvmTest.dependencies {
-            implementation(project(":ktor-server:ktor-server-plugins:ktor-server-call-id"))
-            implementation(project(":ktor-server:ktor-server-plugins:ktor-server-status-pages"))
+            implementation(project(":ktor-server-call-id"))
+            implementation(project(":ktor-server-status-pages"))
         }
     }
 }

--- a/ktor-server/ktor-server-plugins/ktor-server-content-negotiation/build.gradle.kts
+++ b/ktor-server/ktor-server-plugins/ktor-server-content-negotiation/build.gradle.kts
@@ -11,7 +11,7 @@ plugins {
 kotlin {
     sourceSets {
         commonTest.dependencies {
-            implementation(project(":ktor-server:ktor-server-plugins:ktor-server-double-receive"))
+            implementation(project(":ktor-server-double-receive"))
         }
     }
 }

--- a/ktor-server/ktor-server-plugins/ktor-server-freemarker/build.gradle.kts
+++ b/ktor-server/ktor-server-plugins/ktor-server-freemarker/build.gradle.kts
@@ -12,10 +12,10 @@ kotlin {
             api(libs.freemarker)
         }
         jvmTest.dependencies {
-            api(project(":ktor-server:ktor-server-plugins:ktor-server-status-pages"))
-            api(project(":ktor-server:ktor-server-plugins:ktor-server-compression"))
-            api(project(":ktor-server:ktor-server-plugins:ktor-server-conditional-headers"))
-            implementation(project(":ktor-server:ktor-server-plugins:ktor-server-content-negotiation"))
+            api(project(":ktor-server-status-pages"))
+            api(project(":ktor-server-compression"))
+            api(project(":ktor-server-conditional-headers"))
+            implementation(project(":ktor-server-content-negotiation"))
         }
     }
 }

--- a/ktor-server/ktor-server-plugins/ktor-server-html-builder/build.gradle.kts
+++ b/ktor-server/ktor-server-plugins/ktor-server-html-builder/build.gradle.kts
@@ -12,7 +12,7 @@ kotlin {
             api(libs.kotlinx.html)
         }
         commonTest.dependencies {
-            api(project(":ktor-server:ktor-server-plugins:ktor-server-status-pages"))
+            api(project(":ktor-server-status-pages"))
         }
     }
 }

--- a/ktor-server/ktor-server-plugins/ktor-server-htmx/build.gradle.kts
+++ b/ktor-server/ktor-server-plugins/ktor-server-htmx/build.gradle.kts
@@ -9,12 +9,12 @@ plugins {
 kotlin {
     sourceSets {
         commonMain.dependencies {
-            api(project(":ktor-shared:ktor-htmx"))
+            api(project(":ktor-htmx"))
             implementation(project(":ktor-utils"))
         }
         commonTest.dependencies {
-            implementation(project(":ktor-server:ktor-server-plugins:ktor-server-html-builder"))
-            implementation(project(":ktor-shared:ktor-htmx:ktor-htmx-html"))
+            implementation(project(":ktor-server-html-builder"))
+            implementation(project(":ktor-htmx-html"))
         }
     }
 }

--- a/ktor-server/ktor-server-plugins/ktor-server-i18n/build.gradle.kts
+++ b/ktor-server/ktor-server-plugins/ktor-server-i18n/build.gradle.kts
@@ -10,10 +10,8 @@ plugins {
 
 kotlin {
     sourceSets {
-        jvmTest {
-            dependencies {
-                implementation(project(":ktor-server:ktor-server-plugins:ktor-server-status-pages"))
-            }
+        jvmTest.dependencies {
+            implementation(project(":ktor-server-status-pages"))
         }
     }
 }

--- a/ktor-server/ktor-server-plugins/ktor-server-jte/build.gradle.kts
+++ b/ktor-server/ktor-server-plugins/ktor-server-jte/build.gradle.kts
@@ -15,11 +15,11 @@ kotlin {
             api(libs.jte)
         }
         jvmTest.dependencies {
-            api(project(":ktor-server:ktor-server-plugins:ktor-server-status-pages"))
-            api(project(":ktor-server:ktor-server-plugins:ktor-server-compression"))
-            api(project(":ktor-server:ktor-server-plugins:ktor-server-conditional-headers"))
+            api(project(":ktor-server-status-pages"))
+            api(project(":ktor-server-compression"))
+            api(project(":ktor-server-conditional-headers"))
             api(libs.jte.kotlin)
-            implementation(project(":ktor-server:ktor-server-plugins:ktor-server-content-negotiation"))
+            implementation(project(":ktor-server-content-negotiation"))
         }
     }
 }

--- a/ktor-server/ktor-server-plugins/ktor-server-metrics-micrometer/build.gradle.kts
+++ b/ktor-server/ktor-server-plugins/ktor-server-metrics-micrometer/build.gradle.kts
@@ -10,11 +10,11 @@ kotlin {
     sourceSets {
         jvmMain.dependencies {
             api(libs.micrometer)
-            implementation(project(":ktor-server:ktor-server-core"))
+            implementation(project(":ktor-server-core"))
         }
         jvmTest.dependencies {
-            implementation(project(":ktor-server:ktor-server-plugins:ktor-server-metrics"))
-            implementation(project(":ktor-server:ktor-server-plugins:ktor-server-auth"))
+            implementation(project(":ktor-server-metrics"))
+            implementation(project(":ktor-server-auth"))
         }
     }
 }

--- a/ktor-server/ktor-server-plugins/ktor-server-metrics/build.gradle.kts
+++ b/ktor-server/ktor-server-plugins/ktor-server-metrics/build.gradle.kts
@@ -15,9 +15,9 @@ kotlin {
             api(libs.dropwizard.jvm)
         }
         jvmTest.dependencies {
-            api(project(":ktor-server:ktor-server-plugins:ktor-server-status-pages"))
-            api(project(":ktor-server:ktor-server-plugins:ktor-server-cors"))
-            api(project(":ktor-shared:ktor-test-base"))
+            api(project(":ktor-server-status-pages"))
+            api(project(":ktor-server-cors"))
+            api(project(":ktor-test-base"))
         }
     }
 }

--- a/ktor-server/ktor-server-plugins/ktor-server-mustache/build.gradle.kts
+++ b/ktor-server/ktor-server-plugins/ktor-server-mustache/build.gradle.kts
@@ -12,9 +12,9 @@ kotlin {
             api(libs.mustache)
         }
         jvmTest.dependencies {
-            api(project(":ktor-server:ktor-server-plugins:ktor-server-compression"))
-            api(project(":ktor-server:ktor-server-plugins:ktor-server-conditional-headers"))
-            implementation(project(":ktor-server:ktor-server-plugins:ktor-server-content-negotiation"))
+            api(project(":ktor-server-compression"))
+            api(project(":ktor-server-conditional-headers"))
+            implementation(project(":ktor-server-content-negotiation"))
         }
     }
 }

--- a/ktor-server/ktor-server-plugins/ktor-server-openapi/build.gradle.kts
+++ b/ktor-server/ktor-server-plugins/ktor-server-openapi/build.gradle.kts
@@ -12,7 +12,7 @@ kotlin {
 
     sourceSets {
         jvmMain.dependencies {
-            implementation(project(":ktor-server:ktor-server-plugins:ktor-server-html-builder"))
+            implementation(project(":ktor-server-html-builder"))
 
             implementation(libs.swagger.codegen)
             implementation(libs.swagger.codegen.generators)

--- a/ktor-server/ktor-server-plugins/ktor-server-partial-content/build.gradle.kts
+++ b/ktor-server/ktor-server-plugins/ktor-server-partial-content/build.gradle.kts
@@ -11,7 +11,7 @@ plugins {
 kotlin {
     sourceSets {
         commonMain.dependencies {
-            api(project(":ktor-server:ktor-server-plugins:ktor-server-conditional-headers"))
+            api(project(":ktor-server-conditional-headers"))
         }
     }
 }

--- a/ktor-server/ktor-server-plugins/ktor-server-pebble/build.gradle.kts
+++ b/ktor-server/ktor-server-plugins/ktor-server-pebble/build.gradle.kts
@@ -12,9 +12,9 @@ kotlin {
             api(libs.pebble)
         }
         jvmTest.dependencies {
-            api(project(":ktor-server:ktor-server-plugins:ktor-server-conditional-headers"))
-            api(project(":ktor-server:ktor-server-plugins:ktor-server-compression"))
-            implementation(project(":ktor-server:ktor-server-plugins:ktor-server-content-negotiation"))
+            api(project(":ktor-server-conditional-headers"))
+            api(project(":ktor-server-compression"))
+            implementation(project(":ktor-server-content-negotiation"))
         }
     }
 }

--- a/ktor-server/ktor-server-plugins/ktor-server-request-validation/build.gradle.kts
+++ b/ktor-server/ktor-server-plugins/ktor-server-request-validation/build.gradle.kts
@@ -11,7 +11,7 @@ plugins {
 kotlin {
     sourceSets {
         commonTest.dependencies {
-            implementation(project(":ktor-server:ktor-server-plugins:ktor-server-status-pages"))
+            implementation(project(":ktor-server-status-pages"))
         }
     }
 }

--- a/ktor-server/ktor-server-plugins/ktor-server-resources/build.gradle.kts
+++ b/ktor-server/ktor-server-plugins/ktor-server-resources/build.gradle.kts
@@ -12,7 +12,7 @@ plugins {
 kotlin {
     sourceSets {
         commonMain.dependencies {
-            api(project(":ktor-shared:ktor-resources"))
+            api(project(":ktor-resources"))
             api(libs.kotlinx.serialization.core)
         }
     }

--- a/ktor-server/ktor-server-plugins/ktor-server-sessions/build.gradle.kts
+++ b/ktor-server/ktor-server-plugins/ktor-server-sessions/build.gradle.kts
@@ -16,7 +16,7 @@ kotlin {
             api(libs.kotlinx.serialization.json)
         }
         jvmTest.dependencies {
-            implementation(project(":ktor-server:ktor-server-netty"))
+            implementation(project(":ktor-server-netty"))
         }
     }
 }

--- a/ktor-server/ktor-server-plugins/ktor-server-sse/build.gradle.kts
+++ b/ktor-server/ktor-server-plugins/ktor-server-sse/build.gradle.kts
@@ -12,11 +12,11 @@ plugins {
 kotlin {
     sourceSets {
         commonMain.dependencies {
-            api(project(":ktor-shared:ktor-sse"))
+            api(project(":ktor-sse"))
         }
         commonTest.dependencies {
-            api(project(":ktor-shared:ktor-serialization:ktor-serialization-kotlinx"))
-            api(project(":ktor-shared:ktor-serialization:ktor-serialization-kotlinx:ktor-serialization-kotlinx-json"))
+            api(project(":ktor-serialization-kotlinx"))
+            api(project(":ktor-serialization-kotlinx-json"))
         }
     }
 }

--- a/ktor-server/ktor-server-plugins/ktor-server-status-pages/build.gradle.kts
+++ b/ktor-server/ktor-server-plugins/ktor-server-status-pages/build.gradle.kts
@@ -11,7 +11,7 @@ plugins {
 kotlin {
     sourceSets {
         commonTest.dependencies {
-            implementation(project(":ktor-server:ktor-server-plugins:ktor-server-call-id"))
+            implementation(project(":ktor-server-call-id"))
         }
     }
 }

--- a/ktor-server/ktor-server-plugins/ktor-server-swagger/build.gradle.kts
+++ b/ktor-server/ktor-server-plugins/ktor-server-swagger/build.gradle.kts
@@ -9,7 +9,7 @@ plugins {
 kotlin {
     sourceSets {
         jvmMain.dependencies {
-            implementation(project(":ktor-server:ktor-server-plugins:ktor-server-html-builder"))
+            implementation(project(":ktor-server-html-builder"))
         }
     }
 }

--- a/ktor-server/ktor-server-plugins/ktor-server-thymeleaf/build.gradle.kts
+++ b/ktor-server/ktor-server-plugins/ktor-server-thymeleaf/build.gradle.kts
@@ -12,9 +12,9 @@ kotlin {
             api(libs.thymeleaf)
         }
         jvmTest.dependencies {
-            api(project(":ktor-server:ktor-server-plugins:ktor-server-conditional-headers"))
-            api(project(":ktor-server:ktor-server-plugins:ktor-server-compression"))
-            implementation(project(":ktor-server:ktor-server-plugins:ktor-server-content-negotiation"))
+            api(project(":ktor-server-conditional-headers"))
+            api(project(":ktor-server-compression"))
+            implementation(project(":ktor-server-content-negotiation"))
         }
     }
 }

--- a/ktor-server/ktor-server-plugins/ktor-server-velocity/build.gradle.kts
+++ b/ktor-server/ktor-server-plugins/ktor-server-velocity/build.gradle.kts
@@ -13,9 +13,9 @@ kotlin {
             api(libs.velocity.tools)
         }
         jvmTest.dependencies {
-            api(project(":ktor-server:ktor-server-plugins:ktor-server-conditional-headers"))
-            api(project(":ktor-server:ktor-server-plugins:ktor-server-compression"))
-            implementation(project(":ktor-server:ktor-server-plugins:ktor-server-content-negotiation"))
+            api(project(":ktor-server-conditional-headers"))
+            api(project(":ktor-server-compression"))
+            implementation(project(":ktor-server-content-negotiation"))
         }
     }
 }

--- a/ktor-server/ktor-server-plugins/ktor-server-webjars/build.gradle.kts
+++ b/ktor-server/ktor-server-plugins/ktor-server-webjars/build.gradle.kts
@@ -14,8 +14,8 @@ kotlin {
             api(libs.webjars.locator)
         }
         jvmTest.dependencies {
-            api(project(":ktor-server:ktor-server-plugins:ktor-server-conditional-headers"))
-            api(project(":ktor-server:ktor-server-plugins:ktor-server-caching-headers"))
+            api(project(":ktor-server-conditional-headers"))
+            api(project(":ktor-server-caching-headers"))
             api(libs.webjars.jquery)
         }
     }

--- a/ktor-server/ktor-server-plugins/ktor-server-websockets/build.gradle.kts
+++ b/ktor-server/ktor-server-plugins/ktor-server-websockets/build.gradle.kts
@@ -11,17 +11,17 @@ plugins {
 kotlin {
     sourceSets {
         commonMain.dependencies {
-            api(project(":ktor-shared:ktor-websockets"))
-            api(project(":ktor-shared:ktor-websocket-serialization"))
+            api(project(":ktor-websockets"))
+            api(project(":ktor-websocket-serialization"))
         }
 
         commonTest.dependencies {
-            api(project(":ktor-server:ktor-server-plugins:ktor-server-content-negotiation"))
-            api(project(":ktor-client:ktor-client-plugins:ktor-client-websockets"))
+            api(project(":ktor-server-content-negotiation"))
+            api(project(":ktor-client-websockets"))
         }
 
         jvmTest.dependencies {
-            implementation(project(":ktor-shared:ktor-test-base"))
+            implementation(project(":ktor-test-base"))
         }
     }
 }

--- a/ktor-server/ktor-server-servlet-jakarta/build.gradle.kts
+++ b/ktor-server/ktor-server-servlet-jakarta/build.gradle.kts
@@ -13,13 +13,13 @@ kotlin {
 
     sourceSets {
         jvmMain.dependencies {
-            api(project(":ktor-server:ktor-server-core"))
+            api(project(":ktor-server-core"))
 
             compileOnly(libs.jakarta.servlet)
         }
 
         jvmTest.dependencies {
-            api(project(":ktor-server:ktor-server-config-yaml"))
+            api(project(":ktor-server-config-yaml"))
             implementation(libs.mockk)
             implementation(libs.jakarta.servlet)
         }

--- a/ktor-server/ktor-server-servlet/build.gradle.kts
+++ b/ktor-server/ktor-server-servlet/build.gradle.kts
@@ -11,12 +11,12 @@ plugins {
 kotlin {
     sourceSets {
         jvmMain.dependencies {
-            api(project(":ktor-server:ktor-server-core"))
+            api(project(":ktor-server-core"))
             compileOnly(libs.javax.servlet)
         }
 
         jvmTest.dependencies {
-            api(project(":ktor-server:ktor-server-config-yaml"))
+            api(project(":ktor-server-config-yaml"))
             implementation(libs.mockk)
             implementation(libs.javax.servlet)
         }

--- a/ktor-server/ktor-server-test-base/build.gradle.kts
+++ b/ktor-server/ktor-server-test-base/build.gradle.kts
@@ -11,16 +11,16 @@ plugins {
 kotlin {
     sourceSets {
         commonMain.dependencies {
-            api(project(":ktor-server:ktor-server-test-host"))
-            api(project(":ktor-shared:ktor-test-base"))
+            api(project(":ktor-server-test-host"))
+            api(project(":ktor-test-base"))
         }
 
         jvmMain.dependencies {
-            api(project(":ktor-network:ktor-network-tls"))
+            api(project(":ktor-network-tls"))
 
-            api(project(":ktor-client:ktor-client-apache"))
-            api(project(":ktor-network:ktor-network-tls:ktor-network-tls-certificates"))
-            api(project(":ktor-server:ktor-server-plugins:ktor-server-call-logging"))
+            api(project(":ktor-client-apache"))
+            api(project(":ktor-network-tls-certificates"))
+            api(project(":ktor-server-call-logging"))
 
             api(libs.logback.classic)
         }

--- a/ktor-server/ktor-server-test-host/build.gradle.kts
+++ b/ktor-server/ktor-server-test-host/build.gradle.kts
@@ -11,22 +11,22 @@ plugins {
 kotlin {
     sourceSets {
         commonMain.dependencies {
-            api(project(":ktor-client:ktor-client-cio"))
-            api(project(":ktor-server:ktor-server-core"))
-            api(project(":ktor-client:ktor-client-core"))
+            api(project(":ktor-client-cio"))
+            api(project(":ktor-server-core"))
+            api(project(":ktor-client-core"))
             api(project(":ktor-test-dispatcher"))
         }
 
         jvmMain.dependencies {
-            api(project(":ktor-network:ktor-network-tls"))
+            api(project(":ktor-network-tls"))
 
-            api(project(":ktor-client:ktor-client-apache"))
-            api(project(":ktor-network:ktor-network-tls:ktor-network-tls-certificates"))
-            api(project(":ktor-server:ktor-server-plugins:ktor-server-call-logging"))
+            api(project(":ktor-client-apache"))
+            api(project(":ktor-network-tls-certificates"))
+            api(project(":ktor-server-call-logging"))
 
             // Not ideal, but prevents an additional artifact, and this is usually just included for testing,
             // so shouldn"t increase the size of the final artifact.
-            api(project(":ktor-server:ktor-server-plugins:ktor-server-websockets"))
+            api(project(":ktor-server-websockets"))
 
             api(libs.kotlin.test)
             api(libs.junit)
@@ -34,7 +34,7 @@ kotlin {
         }
 
         jvmTest.dependencies {
-            api(project(":ktor-server:ktor-server-config-yaml"))
+            api(project(":ktor-server-config-yaml"))
             api(libs.kotlin.test)
         }
     }

--- a/ktor-server/ktor-server-test-suites/build.gradle.kts
+++ b/ktor-server/ktor-server-test-suites/build.gradle.kts
@@ -11,20 +11,20 @@ plugins {
 kotlin {
     sourceSets {
         commonMain.dependencies {
-            implementation(project(":ktor-server:ktor-server-plugins:ktor-server-forwarded-header"))
-            implementation(project(":ktor-server:ktor-server-plugins:ktor-server-auto-head-response"))
-            implementation(project(":ktor-server:ktor-server-plugins:ktor-server-status-pages"))
-            implementation(project(":ktor-server:ktor-server-plugins:ktor-server-hsts"))
-            implementation(project(":ktor-server:ktor-server-plugins:ktor-server-websockets"))
-            api(project(":ktor-server:ktor-server-test-base"))
+            implementation(project(":ktor-server-forwarded-header"))
+            implementation(project(":ktor-server-auto-head-response"))
+            implementation(project(":ktor-server-status-pages"))
+            implementation(project(":ktor-server-hsts"))
+            implementation(project(":ktor-server-websockets"))
+            api(project(":ktor-server-test-base"))
         }
 
         jvmMain.dependencies {
-            implementation(project(":ktor-server:ktor-server-plugins:ktor-server-compression"))
-            implementation(project(":ktor-server:ktor-server-plugins:ktor-server-partial-content"))
-            implementation(project(":ktor-server:ktor-server-plugins:ktor-server-conditional-headers"))
-            implementation(project(":ktor-server:ktor-server-plugins:ktor-server-default-headers"))
-            implementation(project(":ktor-server:ktor-server-plugins:ktor-server-request-validation"))
+            implementation(project(":ktor-server-compression"))
+            implementation(project(":ktor-server-partial-content"))
+            implementation(project(":ktor-server-conditional-headers"))
+            implementation(project(":ktor-server-default-headers"))
+            implementation(project(":ktor-server-request-validation"))
         }
     }
 }

--- a/ktor-server/ktor-server-tests/build.gradle.kts
+++ b/ktor-server/ktor-server-tests/build.gradle.kts
@@ -13,13 +13,13 @@ kotlin {
     sourceSets {
         commonTest.dependencies {
             api(project(":ktor-server"))
-            api(project(":ktor-server:ktor-server-plugins:ktor-server-rate-limit"))
-            api(project(":ktor-server:ktor-server-test-host"))
+            api(project(":ktor-server-rate-limit"))
+            api(project(":ktor-server-test-host"))
         }
         jvmTest.dependencies {
             implementation(libs.jansi)
-            implementation(project(":ktor-client:ktor-client-plugins:ktor-client-encoding"))
-            api(project(":ktor-server:ktor-server-plugins:ktor-server-sse"))
+            implementation(project(":ktor-client-encoding"))
+            api(project(":ktor-server-sse"))
         }
     }
 }

--- a/ktor-server/ktor-server-tomcat-jakarta/build.gradle.kts
+++ b/ktor-server/ktor-server-tomcat-jakarta/build.gradle.kts
@@ -14,15 +14,15 @@ kotlin {
 
     sourceSets {
         jvmMain.dependencies {
-            api(project(":ktor-server:ktor-server-core"))
-            api(project(":ktor-server:ktor-server-servlet-jakarta"))
+            api(project(":ktor-server-core"))
+            api(project(":ktor-server-servlet-jakarta"))
             api(libs.tomcat.catalina.jakarta)
             api(libs.tomcat.embed.core.jakarta)
         }
         jvmTest.dependencies {
-            api(project(":ktor-server:ktor-server-test-base"))
-            api(project(":ktor-server:ktor-server-test-suites"))
-            api(project(":ktor-server:ktor-server-core"))
+            api(project(":ktor-server-test-base"))
+            api(project(":ktor-server-test-suites"))
+            api(project(":ktor-server-core"))
         }
     }
 }

--- a/ktor-server/ktor-server-tomcat/build.gradle.kts
+++ b/ktor-server/ktor-server-tomcat/build.gradle.kts
@@ -11,15 +11,15 @@ plugins {
 kotlin {
     sourceSets {
         jvmMain.dependencies {
-            api(project(":ktor-server:ktor-server-core"))
-            api(project(":ktor-server:ktor-server-servlet"))
+            api(project(":ktor-server-core"))
+            api(project(":ktor-server-servlet"))
             api(libs.tomcat.catalina)
             api(libs.tomcat.embed.core)
         }
         jvmTest.dependencies {
-            api(project(":ktor-server:ktor-server-test-base"))
-            api(project(":ktor-server:ktor-server-test-suites"))
-            api(project(":ktor-server:ktor-server-core"))
+            api(project(":ktor-server-test-base"))
+            api(project(":ktor-server-test-suites"))
+            api(project(":ktor-server-core"))
         }
     }
 }

--- a/ktor-shared/ktor-htmx/ktor-htmx-html/build.gradle.kts
+++ b/ktor-shared/ktor-htmx/ktor-htmx-html/build.gradle.kts
@@ -12,7 +12,7 @@ kotlin {
     sourceSets {
         commonMain.dependencies {
             api(libs.kotlinx.html)
-            api(project(":ktor-shared:ktor-htmx"))
+            api(project(":ktor-htmx"))
             implementation(project(":ktor-utils"))
         }
     }

--- a/ktor-shared/ktor-serialization/build.gradle.kts
+++ b/ktor-shared/ktor-serialization/build.gradle.kts
@@ -11,7 +11,7 @@ plugins {
 kotlin {
     sourceSets {
         commonMain.dependencies {
-            api(project(":ktor-shared:ktor-websockets"))
+            api(project(":ktor-websockets"))
         }
     }
 }

--- a/ktor-shared/ktor-serialization/ktor-serialization-gson/build.gradle.kts
+++ b/ktor-shared/ktor-serialization/ktor-serialization-gson/build.gradle.kts
@@ -11,14 +11,14 @@ plugins {
 kotlin {
     sourceSets {
         jvmMain.dependencies {
-            api(project(":ktor-shared:ktor-serialization"))
+            api(project(":ktor-serialization"))
             api(libs.gson)
         }
         jvmTest.dependencies {
-            api(project(":ktor-server:ktor-server-test-host"))
-            api(project(":ktor-client:ktor-client-tests"))
-            api(project(":ktor-client:ktor-client-plugins:ktor-client-content-negotiation:ktor-client-content-negotiation-tests"))
-            api(project(":ktor-shared:ktor-serialization:ktor-serialization-tests"))
+            api(project(":ktor-server-test-host"))
+            api(project(":ktor-client-tests"))
+            api(project(":ktor-client-content-negotiation-tests"))
+            api(project(":ktor-serialization-tests"))
 
             api(libs.logback.classic)
         }

--- a/ktor-shared/ktor-serialization/ktor-serialization-jackson/build.gradle.kts
+++ b/ktor-shared/ktor-serialization/ktor-serialization-jackson/build.gradle.kts
@@ -11,15 +11,15 @@ plugins {
 kotlin {
     sourceSets {
         jvmMain.dependencies {
-            api(project(":ktor-shared:ktor-serialization"))
+            api(project(":ktor-serialization"))
             api(libs.jackson.databind)
             api(libs.jackson.module.kotlin)
         }
         jvmTest.dependencies {
-            api(project(":ktor-server:ktor-server-test-host"))
-            api(project(":ktor-client:ktor-client-tests"))
-            api(project(":ktor-client:ktor-client-plugins:ktor-client-content-negotiation:ktor-client-content-negotiation-tests"))
-            api(project(":ktor-shared:ktor-serialization:ktor-serialization-tests"))
+            api(project(":ktor-server-test-host"))
+            api(project(":ktor-client-tests"))
+            api(project(":ktor-client-content-negotiation-tests"))
+            api(project(":ktor-serialization-tests"))
 
             api(libs.logback.classic)
             api(libs.jackson.dataformat.smile)

--- a/ktor-shared/ktor-serialization/ktor-serialization-kotlinx/build.gradle.kts
+++ b/ktor-shared/ktor-serialization/ktor-serialization-kotlinx/build.gradle.kts
@@ -12,7 +12,7 @@ plugins {
 kotlin {
     sourceSets {
         commonMain.dependencies {
-            api(project(":ktor-shared:ktor-serialization"))
+            api(project(":ktor-serialization"))
             api(libs.kotlinx.serialization.core)
         }
     }

--- a/ktor-shared/ktor-serialization/ktor-serialization-kotlinx/ktor-serialization-kotlinx-cbor/build.gradle.kts
+++ b/ktor-shared/ktor-serialization/ktor-serialization-kotlinx/ktor-serialization-kotlinx-cbor/build.gradle.kts
@@ -12,12 +12,12 @@ plugins {
 kotlin {
     sourceSets {
         commonMain.dependencies {
-            api(project(":ktor-shared:ktor-serialization:ktor-serialization-kotlinx"))
+            api(project(":ktor-serialization-kotlinx"))
             api(libs.kotlinx.serialization.cbor)
         }
         commonTest.dependencies {
             api(libs.kotlinx.serialization.json)
-            api(project(":ktor-shared:ktor-serialization:ktor-serialization-kotlinx:ktor-serialization-kotlinx-tests"))
+            api(project(":ktor-serialization-kotlinx-tests"))
         }
     }
 }

--- a/ktor-shared/ktor-serialization/ktor-serialization-kotlinx/ktor-serialization-kotlinx-json/build.gradle.kts
+++ b/ktor-shared/ktor-serialization/ktor-serialization-kotlinx/ktor-serialization-kotlinx-json/build.gradle.kts
@@ -12,20 +12,15 @@ plugins {
 kotlin {
     sourceSets {
         commonMain.dependencies {
-            api(project(":ktor-shared:ktor-serialization:ktor-serialization-kotlinx"))
+            api(project(":ktor-serialization-kotlinx"))
             api(libs.kotlinx.serialization.json)
             api(libs.kotlinx.serialization.json.io)
         }
         jvmTest.dependencies {
-            @Suppress("ktlint:standard:max-line-length")
-            api(
-                project(
-                    ":ktor-client:ktor-client-plugins:ktor-client-content-negotiation:ktor-client-content-negotiation-tests"
-                )
-            )
+            api(project(":ktor-client-content-negotiation-tests"))
         }
         commonTest.dependencies {
-            api(project(":ktor-shared:ktor-serialization:ktor-serialization-kotlinx:ktor-serialization-kotlinx-tests"))
+            api(project(":ktor-serialization-kotlinx-tests"))
         }
     }
 }

--- a/ktor-shared/ktor-serialization/ktor-serialization-kotlinx/ktor-serialization-kotlinx-protobuf/build.gradle.kts
+++ b/ktor-shared/ktor-serialization/ktor-serialization-kotlinx/ktor-serialization-kotlinx-protobuf/build.gradle.kts
@@ -12,14 +12,14 @@ plugins {
 kotlin {
     sourceSets {
         commonMain.dependencies {
-            api(project(":ktor-shared:ktor-serialization:ktor-serialization-kotlinx"))
+            api(project(":ktor-serialization-kotlinx"))
             api(libs.kotlinx.serialization.protobuf)
         }
         jvmTest.dependencies {
-            api(project(":ktor-client:ktor-client-plugins:ktor-client-content-negotiation:ktor-client-content-negotiation-tests"))
+            api(project(":ktor-client-content-negotiation-tests"))
         }
         commonTest.dependencies {
-            api(project(":ktor-shared:ktor-serialization:ktor-serialization-kotlinx:ktor-serialization-kotlinx-tests"))
+            api(project(":ktor-serialization-kotlinx-tests"))
         }
     }
 }

--- a/ktor-shared/ktor-serialization/ktor-serialization-kotlinx/ktor-serialization-kotlinx-tests/build.gradle.kts
+++ b/ktor-shared/ktor-serialization/ktor-serialization-kotlinx/ktor-serialization-kotlinx-tests/build.gradle.kts
@@ -11,11 +11,11 @@ kotlin {
     sourceSets {
         commonMain.dependencies {
             api(kotlin("test-annotations-common"))
-            api(project(":ktor-shared:ktor-serialization:ktor-serialization-kotlinx"))
-            api(project(":ktor-client:ktor-client-tests"))
+            api(project(":ktor-serialization-kotlinx"))
+            api(project(":ktor-client-tests"))
         }
         jvmMain.dependencies {
-            api(project(":ktor-shared:ktor-serialization:ktor-serialization-tests"))
+            api(project(":ktor-serialization-tests"))
 
             api(libs.logback.classic)
         }

--- a/ktor-shared/ktor-serialization/ktor-serialization-kotlinx/ktor-serialization-kotlinx-xml/build.gradle.kts
+++ b/ktor-shared/ktor-serialization/ktor-serialization-kotlinx/ktor-serialization-kotlinx-xml/build.gradle.kts
@@ -10,14 +10,14 @@ plugins {
 kotlin {
     sourceSets {
         commonMain.dependencies {
-            api(project(":ktor-shared:ktor-serialization:ktor-serialization-kotlinx"))
+            api(project(":ktor-serialization-kotlinx"))
             api(libs.xmlutil.serialization)
         }
         commonTest.dependencies {
-            implementation(project(":ktor-shared:ktor-serialization:ktor-serialization-kotlinx:ktor-serialization-kotlinx-tests"))
+            implementation(project(":ktor-serialization-kotlinx-tests"))
         }
         jvmTest.dependencies {
-            implementation(project(":ktor-client:ktor-client-plugins:ktor-client-content-negotiation:ktor-client-content-negotiation-tests"))
+            implementation(project(":ktor-client-content-negotiation-tests"))
         }
     }
 }

--- a/ktor-shared/ktor-serialization/ktor-serialization-tests/build.gradle.kts
+++ b/ktor-shared/ktor-serialization/ktor-serialization-tests/build.gradle.kts
@@ -10,8 +10,8 @@ plugins {
 kotlin {
     sourceSets {
         jvmMain.dependencies {
-            api(project(":ktor-server:ktor-server-test-host"))
-            api(project(":ktor-client:ktor-client-plugins:ktor-client-content-negotiation:ktor-client-content-negotiation-tests"))
+            api(project(":ktor-server-test-host"))
+            api(project(":ktor-client-content-negotiation-tests"))
 
             api(libs.logback.classic)
         }

--- a/ktor-shared/ktor-websocket-serialization/build.gradle.kts
+++ b/ktor-shared/ktor-websocket-serialization/build.gradle.kts
@@ -11,7 +11,7 @@ plugins {
 kotlin {
     sourceSets {
         commonMain.dependencies {
-            api(project(":ktor-shared:ktor-serialization"))
+            api(project(":ktor-serialization"))
         }
     }
 }

--- a/ktor-test-dispatcher/api/ktor-test-dispatcher.api
+++ b/ktor-test-dispatcher/api/ktor-test-dispatcher.api
@@ -1,0 +1,10 @@
+public final class io/ktor/test/dispatcher/TestCommonKt {
+	public static final fun runTestWithRealTime-8Mi8wO0 (Lkotlin/coroutines/CoroutineContext;JLkotlin/jvm/functions/Function2;)V
+	public static synthetic fun runTestWithRealTime-8Mi8wO0$default (Lkotlin/coroutines/CoroutineContext;JLkotlin/jvm/functions/Function2;ILjava/lang/Object;)V
+}
+
+public final class io/ktor/test/dispatcher/TestJvmKt {
+	public static final fun testSuspend (Lkotlin/coroutines/CoroutineContext;JLkotlin/jvm/functions/Function2;)V
+	public static synthetic fun testSuspend$default (Lkotlin/coroutines/CoroutineContext;JLkotlin/jvm/functions/Function2;ILjava/lang/Object;)V
+}
+

--- a/ktor-test-dispatcher/api/ktor-test-dispatcher.klib.api
+++ b/ktor-test-dispatcher/api/ktor-test-dispatcher.klib.api
@@ -1,0 +1,20 @@
+// Klib ABI Dump
+// Targets: [androidNativeArm32, androidNativeArm64, androidNativeX64, androidNativeX86, iosArm64, iosSimulatorArm64, iosX64, js, linuxArm64, linuxX64, macosArm64, macosX64, mingwX64, tvosArm64, tvosSimulatorArm64, tvosX64, wasmJs, watchosArm32, watchosArm64, watchosDeviceArm64, watchosSimulatorArm64, watchosX64]
+// Alias: native => [androidNativeArm32, androidNativeArm64, androidNativeX64, androidNativeX86, iosArm64, iosSimulatorArm64, iosX64, linuxArm64, linuxX64, macosArm64, macosX64, mingwX64, tvosArm64, tvosSimulatorArm64, tvosX64, watchosArm32, watchosArm64, watchosDeviceArm64, watchosSimulatorArm64, watchosX64]
+// Rendering settings:
+// - Signature version: 2
+// - Show manifest properties: true
+// - Show declarations: true
+
+// Library unique name: <io.ktor:ktor-test-dispatcher>
+// Targets: [native]
+final fun io.ktor.test.dispatcher/runTestWithRealTime(kotlin.coroutines/CoroutineContext = ..., kotlin.time/Duration = ..., kotlin.coroutines/SuspendFunction1<kotlinx.coroutines/CoroutineScope, kotlin/Unit>) // io.ktor.test.dispatcher/runTestWithRealTime|runTestWithRealTime(kotlin.coroutines.CoroutineContext;kotlin.time.Duration;kotlin.coroutines.SuspendFunction1<kotlinx.coroutines.CoroutineScope,kotlin.Unit>){}[0]
+
+// Targets: [native]
+final fun io.ktor.test.dispatcher/testSuspend(kotlin.coroutines/CoroutineContext = ..., kotlin/Long = ..., kotlin.coroutines/SuspendFunction1<kotlinx.coroutines/CoroutineScope, kotlin/Unit>) // io.ktor.test.dispatcher/testSuspend|testSuspend(kotlin.coroutines.CoroutineContext;kotlin.Long;kotlin.coroutines.SuspendFunction1<kotlinx.coroutines.CoroutineScope,kotlin.Unit>){}[0]
+
+// Targets: [js, wasmJs]
+final fun io.ktor.test.dispatcher/runTestWithRealTime(kotlin.coroutines/CoroutineContext = ..., kotlin.time/Duration = ..., kotlin.coroutines/SuspendFunction1<kotlinx.coroutines/CoroutineScope, kotlin/Unit>): kotlinx.coroutines.test.internal/JsPromiseInterfaceForTesting // io.ktor.test.dispatcher/runTestWithRealTime|runTestWithRealTime(kotlin.coroutines.CoroutineContext;kotlin.time.Duration;kotlin.coroutines.SuspendFunction1<kotlinx.coroutines.CoroutineScope,kotlin.Unit>){}[0]
+
+// Targets: [js, wasmJs]
+final fun io.ktor.test.dispatcher/testSuspend(kotlin.coroutines/CoroutineContext = ..., kotlin/Long = ..., kotlin.coroutines/SuspendFunction1<kotlinx.coroutines/CoroutineScope, kotlin/Unit>): kotlinx.coroutines.test.internal/JsPromiseInterfaceForTesting // io.ktor.test.dispatcher/testSuspend|testSuspend(kotlin.coroutines.CoroutineContext;kotlin.Long;kotlin.coroutines.SuspendFunction1<kotlinx.coroutines.CoroutineScope,kotlin.Unit>){}[0]

--- a/ktor-utils/build.gradle.kts
+++ b/ktor-utils/build.gradle.kts
@@ -32,7 +32,7 @@ kotlin {
             api(project(":ktor-test-dispatcher"))
         }
         jvmTest.dependencies {
-            implementation(project(":ktor-shared:ktor-test-base"))
+            implementation(project(":ktor-test-base"))
         }
     }
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -20,126 +20,218 @@ rootProject.name = "ktor"
 includeBuild("build-logic")
 includeBuild("ktor-test-server")
 
-include(":ktor-server")
-include(":ktor-server:ktor-server-core")
-include(":ktor-server:ktor-server-config-yaml")
-include(":ktor-server:ktor-server-tests")
-include(":ktor-server:ktor-server-host-common")
-include(":ktor-server:ktor-server-test-host")
-include(":ktor-server:ktor-server-test-base")
-include(":ktor-server:ktor-server-test-suites")
-include(":ktor-server:ktor-server-jetty")
-include(":ktor-server:ktor-server-jetty:ktor-server-jetty-test-http2")
-include(":ktor-server:ktor-server-jetty-jakarta")
-include(":ktor-server:ktor-server-jetty-jakarta:ktor-server-jetty-test-http2-jakarta")
-include(":ktor-server:ktor-server-servlet")
-include(":ktor-server:ktor-server-servlet-jakarta")
-include(":ktor-server:ktor-server-tomcat")
-include(":ktor-server:ktor-server-tomcat-jakarta")
-include(":ktor-server:ktor-server-netty")
-include(":ktor-server:ktor-server-cio")
-include(":ktor-client")
-include(":ktor-client:ktor-client-core")
-include(":ktor-client:ktor-client-test-base")
-include(":ktor-client:ktor-client-tests")
-include(":ktor-client:ktor-client-apache")
-include(":ktor-client:ktor-client-apache5")
-include(":ktor-client:ktor-client-android")
-include(":ktor-client:ktor-client-cio")
-include(":ktor-client:ktor-client-curl")
-include(":ktor-client:ktor-client-ios")
-include(":ktor-client:ktor-client-darwin")
-include(":ktor-client:ktor-client-darwin-legacy")
-include(":ktor-client:ktor-client-winhttp")
-include(":ktor-client:ktor-client-java")
-include(":ktor-client:ktor-client-jetty")
-include(":ktor-client:ktor-client-jetty-jakarta")
-include(":ktor-client:ktor-client-js")
-include(":ktor-client:ktor-client-mock")
-include(":ktor-client:ktor-client-okhttp")
-include(":ktor-client:ktor-client-plugins:ktor-client-json")
-include(":ktor-client:ktor-client-plugins:ktor-client-json:ktor-client-gson")
-include(":ktor-client:ktor-client-plugins:ktor-client-json:ktor-client-jackson")
-include(":ktor-client:ktor-client-plugins:ktor-client-json:ktor-client-serialization")
-include(":ktor-client:ktor-client-plugins:ktor-client-auth")
-include(":ktor-client:ktor-client-plugins:ktor-client-call-id")
-include(":ktor-client:ktor-client-plugins:ktor-client-logging")
-include(":ktor-client:ktor-client-plugins:ktor-client-encoding")
-include(":ktor-client:ktor-client-plugins:ktor-client-websockets")
-include(":ktor-client:ktor-client-plugins:ktor-client-content-negotiation")
-include(":ktor-client:ktor-client-plugins:ktor-client-content-negotiation:ktor-client-content-negotiation-tests")
-include(":ktor-client:ktor-client-plugins:ktor-client-resources")
-include(":ktor-client:ktor-client-plugins:ktor-client-bom-remover")
-include(":ktor-server:ktor-server-plugins:ktor-server-auth")
-include(":ktor-server:ktor-server-plugins:ktor-server-auth-jwt")
-include(":ktor-server:ktor-server-plugins:ktor-server-auth-ldap")
-include(":ktor-server:ktor-server-plugins:ktor-server-auto-head-response")
-include(":ktor-server:ktor-server-plugins:ktor-server-body-limit")
-include(":ktor-server:ktor-server-plugins:ktor-server-caching-headers")
-include(":ktor-server:ktor-server-plugins:ktor-server-call-id")
-include(":ktor-server:ktor-server-plugins:ktor-server-call-logging")
-include(":ktor-server:ktor-server-plugins:ktor-server-compression")
-include(":ktor-server:ktor-server-plugins:ktor-server-conditional-headers")
-include(":ktor-server:ktor-server-plugins:ktor-server-content-negotiation")
-include(":ktor-server:ktor-server-plugins:ktor-server-cors")
-include(":ktor-server:ktor-server-plugins:ktor-server-csrf")
-include(":ktor-server:ktor-server-plugins:ktor-server-data-conversion")
-include(":ktor-server:ktor-server-plugins:ktor-server-default-headers")
-include(":ktor-server:ktor-server-plugins:ktor-server-di")
-include(":ktor-server:ktor-server-plugins:ktor-server-double-receive")
-include(":ktor-server:ktor-server-plugins:ktor-server-forwarded-header")
-include(":ktor-server:ktor-server-plugins:ktor-server-freemarker")
-include(":ktor-server:ktor-server-plugins:ktor-server-hsts")
-include(":ktor-server:ktor-server-plugins:ktor-server-html-builder")
-include(":ktor-server:ktor-server-plugins:ktor-server-htmx")
-include(":ktor-server:ktor-server-plugins:ktor-server-http-redirect")
-include(":ktor-server:ktor-server-plugins:ktor-server-jte")
-include(":ktor-server:ktor-server-plugins:ktor-server-metrics")
-include(":ktor-server:ktor-server-plugins:ktor-server-metrics-micrometer")
-include(":ktor-server:ktor-server-plugins:ktor-server-mustache")
-include(":ktor-server:ktor-server-plugins:ktor-server-partial-content")
-include(":ktor-server:ktor-server-plugins:ktor-server-pebble")
-include(":ktor-server:ktor-server-plugins:ktor-server-rate-limit")
-include(":ktor-server:ktor-server-plugins:ktor-server-request-validation")
-include(":ktor-server:ktor-server-plugins:ktor-server-resources")
-include(":ktor-server:ktor-server-plugins:ktor-server-sessions")
-include(":ktor-server:ktor-server-plugins:ktor-server-status-pages")
-include(":ktor-server:ktor-server-plugins:ktor-server-thymeleaf")
-include(":ktor-server:ktor-server-plugins:ktor-server-velocity")
-include(":ktor-server:ktor-server-plugins:ktor-server-webjars")
-include(":ktor-server:ktor-server-plugins:ktor-server-websockets")
-include(":ktor-server:ktor-server-plugins:ktor-server-method-override")
-include(":ktor-server:ktor-server-plugins:ktor-server-openapi")
-include(":ktor-server:ktor-server-plugins:ktor-server-swagger")
-include(":ktor-server:ktor-server-plugins:ktor-server-sse")
-include(":ktor-server:ktor-server-plugins:ktor-server-i18n")
-include(":ktor-http")
-include(":ktor-http:ktor-http-cio")
-include(":ktor-io")
-include(":ktor-utils")
-include(":ktor-network")
-include(":ktor-network:ktor-network-tls")
-include(":ktor-network:ktor-network-tls:ktor-network-tls-certificates")
-include(":ktor-bom")
-include(":ktor-test-dispatcher")
-include(":ktor-shared:ktor-call-id")
-include(":ktor-shared:ktor-resources")
-include(":ktor-shared:ktor-serialization")
-include(":ktor-shared:ktor-serialization:ktor-serialization-kotlinx")
-include(":ktor-shared:ktor-serialization:ktor-serialization-kotlinx:ktor-serialization-kotlinx-tests")
-include(":ktor-shared:ktor-serialization:ktor-serialization-kotlinx:ktor-serialization-kotlinx-json")
-include(":ktor-shared:ktor-serialization:ktor-serialization-kotlinx:ktor-serialization-kotlinx-cbor")
-include(":ktor-shared:ktor-serialization:ktor-serialization-kotlinx:ktor-serialization-kotlinx-xml")
-include(":ktor-shared:ktor-serialization:ktor-serialization-kotlinx:ktor-serialization-kotlinx-protobuf")
-include(":ktor-shared:ktor-serialization:ktor-serialization-gson")
-include(":ktor-shared:ktor-serialization:ktor-serialization-jackson")
-include(":ktor-shared:ktor-serialization:ktor-serialization-tests")
-include(":ktor-shared:ktor-events")
-include(":ktor-shared:ktor-websocket-serialization")
-include(":ktor-shared:ktor-websockets")
-include(":ktor-shared:ktor-sse")
-include(":ktor-shared:ktor-htmx")
-include(":ktor-shared:ktor-htmx:ktor-htmx-html")
-include(":ktor-shared:ktor-test-base")
-include(":ktor-java-modules-test")
-include(":ktor-dokka")
+// Project declarations go here.
+// We use custom DSL instead of the default `include(":project:path")` function.
+// - Use 'unaryPlus' operator to declare a project
+// - Use 'including' keyword to declare nested projects
+// - Declare projects in 'server', 'client' or 'shared' blocks when possible
+projects {
+    server {
+        +"ktor-server-core"
+        +"ktor-server-config-yaml"
+        +"ktor-server-host-common"
+        +"ktor-server-jetty" including {
+            +"ktor-server-jetty-test-http2"
+        }
+        +"ktor-server-jetty-jakarta" including {
+            +"ktor-server-jetty-test-http2-jakarta"
+        }
+        +"ktor-server-servlet"
+        +"ktor-server-servlet-jakarta"
+        +"ktor-server-tomcat"
+        +"ktor-server-tomcat-jakarta"
+        +"ktor-server-netty"
+        +"ktor-server-cio"
+
+        +"ktor-server-test-host"
+        +"ktor-server-test-base"
+        +"ktor-server-test-suites"
+        +"ktor-server-tests"
+
+        nested("ktor-server-plugins") {
+            +"ktor-server-auth"
+            +"ktor-server-auth-jwt"
+            +"ktor-server-auth-ldap"
+            +"ktor-server-auto-head-response"
+            +"ktor-server-body-limit"
+            +"ktor-server-caching-headers"
+            +"ktor-server-call-id"
+            +"ktor-server-call-logging"
+            +"ktor-server-compression"
+            +"ktor-server-conditional-headers"
+            +"ktor-server-content-negotiation"
+            +"ktor-server-cors"
+            +"ktor-server-csrf"
+            +"ktor-server-data-conversion"
+            +"ktor-server-default-headers"
+            +"ktor-server-di"
+            +"ktor-server-double-receive"
+            +"ktor-server-forwarded-header"
+            +"ktor-server-freemarker"
+            +"ktor-server-hsts"
+            +"ktor-server-html-builder"
+            +"ktor-server-htmx"
+            +"ktor-server-http-redirect"
+            +"ktor-server-i18n"
+            +"ktor-server-jte"
+            +"ktor-server-method-override"
+            +"ktor-server-metrics"
+            +"ktor-server-metrics-micrometer"
+            +"ktor-server-mustache"
+            +"ktor-server-openapi"
+            +"ktor-server-partial-content"
+            +"ktor-server-pebble"
+            +"ktor-server-rate-limit"
+            +"ktor-server-request-validation"
+            +"ktor-server-resources"
+            +"ktor-server-sessions"
+            +"ktor-server-sse"
+            +"ktor-server-status-pages"
+            +"ktor-server-swagger"
+            +"ktor-server-thymeleaf"
+            +"ktor-server-velocity"
+            +"ktor-server-webjars"
+            +"ktor-server-websockets"
+        }
+    }
+
+    client {
+        +"ktor-client-core"
+        +"ktor-client-apache"
+        +"ktor-client-apache5"
+        +"ktor-client-android"
+        +"ktor-client-cio"
+        +"ktor-client-curl"
+        +"ktor-client-ios"
+        +"ktor-client-darwin"
+        +"ktor-client-darwin-legacy"
+        +"ktor-client-winhttp"
+        +"ktor-client-java"
+        +"ktor-client-jetty"
+        +"ktor-client-jetty-jakarta"
+        +"ktor-client-js"
+        +"ktor-client-mock"
+        +"ktor-client-okhttp"
+
+        +"ktor-client-test-base"
+        +"ktor-client-tests"
+
+        nested("ktor-client-plugins") {
+            +"ktor-client-auth"
+            +"ktor-client-bom-remover"
+            +"ktor-client-call-id"
+            +"ktor-client-content-negotiation" including {
+                +"ktor-client-content-negotiation-tests"
+            }
+            +"ktor-client-encoding"
+            +"ktor-client-json" including {
+                +"ktor-client-gson"
+                +"ktor-client-jackson"
+                +"ktor-client-serialization"
+            }
+            +"ktor-client-logging"
+            +"ktor-client-resources"
+            +"ktor-client-websockets"
+        }
+    }
+
+    shared {
+        +"ktor-call-id"
+        +"ktor-events"
+        +"ktor-resources"
+        +"ktor-serialization" including {
+            +"ktor-serialization-kotlinx" including {
+                +"ktor-serialization-kotlinx-json"
+                +"ktor-serialization-kotlinx-cbor"
+                +"ktor-serialization-kotlinx-xml"
+                +"ktor-serialization-kotlinx-protobuf"
+                +"ktor-serialization-kotlinx-tests"
+            }
+            +"ktor-serialization-gson"
+            +"ktor-serialization-jackson"
+            +"ktor-serialization-tests"
+        }
+        +"ktor-sse"
+        +"ktor-htmx" including {
+            +"ktor-htmx-html"
+        }
+        +"ktor-websocket-serialization"
+        +"ktor-websockets"
+        +"ktor-test-base"
+    }
+
+    +"ktor-network" including {
+        +"ktor-network-tls" including {
+            +"ktor-network-tls-certificates"
+        }
+    }
+
+    +"ktor-http" including {
+        +"ktor-http-cio"
+    }
+
+    +"ktor-io"
+    +"ktor-utils"
+    +"ktor-bom"
+    +"ktor-test-dispatcher"
+    +"ktor-java-modules-test"
+    +"ktor-dokka"
+}
+
+// region Project hierarchy DSL
+@DslMarker
+annotation class ProjectDsl
+
+@ProjectDsl
+sealed class ProjectScope(private val settings: Settings) {
+
+    /** Declares subproject in the current project scope. */
+    operator fun String.unaryPlus(): ProjectScope {
+        val projectName = this@unaryPlus
+        val projectPath = subprojectPath(projectName)
+
+        settings.include(projectName)
+        settings.project(":$projectName").projectDir = settings.settingsDir.resolve(projectPath)
+        return NestedProjectScope(settings, projectPath)
+    }
+
+    /**
+     * Adds one more level of nesting to the projects declared in the [nested] lambda.
+     * The group directory is not considered as a Gradle project.
+     */
+    fun nested(groupName: String, nested: ProjectScope.() -> Unit) {
+        NestedProjectScope(settings, subprojectPath(groupName)).nested()
+    }
+
+    abstract fun subprojectPath(projectName: String): String
+}
+
+class RootProjectScope(settings: Settings) : ProjectScope(settings) {
+    override fun subprojectPath(projectName: String) = projectName
+}
+
+class NestedProjectScope(settings: Settings, private val basePath: String) : ProjectScope(settings) {
+    override fun subprojectPath(projectName: String): String = "$basePath/$projectName"
+}
+
+/**
+ * Adds projects declared in the [nested] function to [this] project scope.
+ * Should be used in combination with functions returning [ProjectScope].
+ * For example:
+ * ```
+ * projects {
+ *     +"foo" including {
+ *         +"bar"
+ *     }
+ * }
+ * ```
+ */
+infix fun ProjectScope.including(nested: ProjectScope.() -> Unit) = nested()
+
+fun Settings.projects(nested: RootProjectScope.() -> Unit) = RootProjectScope(this).nested()
+
+/** Declares projects related to server implementation. */
+fun RootProjectScope.server(nested: ProjectScope.() -> Unit) = +"ktor-server" including nested
+fun RootProjectScope.client(nested: ProjectScope.() -> Unit) = +"ktor-client" including nested
+fun RootProjectScope.shared(nested: ProjectScope.() -> Unit) = nested("ktor-shared", nested)
+// endregion


### PR DESCRIPTION
**Subsystem**
Build Infrastructure

**Motivation**
[KTOR-8472](https://youtrack.jetbrains.com/issue/KTOR-8472) Flatten Gradle projects hierarchy

**Solution**
Created a small DSL to declare hierarchical subprojects while keeping the Gradle project structure flat.
Now it should be simpler to run tasks for nested projects and we can use fuzzy-matching. 
For example:
```
./gradlew kCTB:jvmTest
```
this command runs `:ktor-client-test-base:jvmTest`

_It makes sense to review only the first two commits. The third one has been made using the "Search and replace" action._