### PR TITLE
KTOR-7868 Gradle: Enable typesafe project accessors

### DIFF
--- a/ktor-client/build.gradle.kts
+++ b/ktor-client/build.gradle.kts
@@ -9,7 +9,7 @@ plugins {
 kotlin {
     sourceSets {
         commonMain.dependencies {
-            api(project(":ktor-client-core"))
+            api(projects.ktorClientCore)
         }
     }
 }

--- a/ktor-client/ktor-client-android/build.gradle.kts
+++ b/ktor-client/ktor-client-android/build.gradle.kts
@@ -12,12 +12,12 @@ plugins {
 kotlin {
     sourceSets {
         jvmMain.dependencies {
-            api(project(":ktor-client-core"))
+            api(projects.ktorClientCore)
         }
         jvmTest.dependencies {
-            api(project(":ktor-client-tests"))
-            api(project(":ktor-network-tls"))
-            api(project(":ktor-network-tls-certificates"))
+            api(projects.ktorClientTests)
+            api(projects.ktorNetworkTls)
+            api(projects.ktorNetworkTlsCertificates)
         }
     }
 }

--- a/ktor-client/ktor-client-apache/build.gradle.kts
+++ b/ktor-client/ktor-client-apache/build.gradle.kts
@@ -12,11 +12,11 @@ plugins {
 kotlin {
     sourceSets {
         jvmMain.dependencies {
-            api(project(":ktor-client-core"))
+            api(projects.ktorClientCore)
             api(libs.apache.httpasyncclient)
         }
         jvmTest.dependencies {
-            api(project(":ktor-client-tests"))
+            api(projects.ktorClientTests)
         }
     }
 }

--- a/ktor-client/ktor-client-apache5/build.gradle.kts
+++ b/ktor-client/ktor-client-apache5/build.gradle.kts
@@ -12,11 +12,11 @@ plugins {
 kotlin {
     sourceSets {
         jvmMain.dependencies {
-            api(project(":ktor-client-core"))
+            api(projects.ktorClientCore)
             api(libs.apache.client5)
         }
         jvmTest.dependencies {
-            api(project(":ktor-client-tests"))
+            api(projects.ktorClientTests)
         }
     }
 }

--- a/ktor-client/ktor-client-cio/build.gradle.kts
+++ b/ktor-client/ktor-client-cio/build.gradle.kts
@@ -12,17 +12,17 @@ plugins {
 kotlin {
     sourceSets {
         commonMain.dependencies {
-            api(project(":ktor-client-core"))
-            api(project(":ktor-http-cio"))
-            api(project(":ktor-websockets"))
-            api(project(":ktor-network-tls"))
+            api(projects.ktorClientCore)
+            api(projects.ktorHttpCio)
+            api(projects.ktorWebsockets)
+            api(projects.ktorNetworkTls)
         }
         commonTest.dependencies {
-            api(project(":ktor-client-tests"))
+            api(projects.ktorClientTests)
         }
         jvmTest.dependencies {
-            api(project(":ktor-network-tls-certificates"))
-            api(project(":ktor-test-base"))
+            api(projects.ktorNetworkTlsCertificates)
+            api(projects.ktorTestBase)
             implementation(libs.mockk)
         }
     }

--- a/ktor-client/ktor-client-core/build.gradle.kts
+++ b/ktor-client/ktor-client-core/build.gradle.kts
@@ -11,11 +11,11 @@ plugins {
 kotlin {
     sourceSets {
         commonMain.dependencies {
-            api(project(":ktor-http"))
-            api(project(":ktor-http-cio"))
-            api(project(":ktor-events"))
-            api(project(":ktor-websocket-serialization"))
-            api(project(":ktor-sse"))
+            api(projects.ktorHttp)
+            api(projects.ktorHttpCio)
+            api(projects.ktorEvents)
+            api(projects.ktorWebsocketSerialization)
+            api(projects.ktorSse)
         }
 
         jvmMain.dependencies {
@@ -31,9 +31,9 @@ kotlin {
         }
 
         commonTest.dependencies {
-            api(project(":ktor-test-dispatcher"))
-            api(project(":ktor-client-mock"))
-            api(project(":ktor-server-test-host"))
+            api(projects.ktorTestDispatcher)
+            api(projects.ktorClientMock)
+            api(projects.ktorServerTestHost)
         }
     }
 }

--- a/ktor-client/ktor-client-curl/build.gradle.kts
+++ b/ktor-client/ktor-client-curl/build.gradle.kts
@@ -18,13 +18,13 @@ kotlin {
 
     sourceSets {
         desktopMain.dependencies {
-            api(project(":ktor-client-core"))
-            api(project(":ktor-http-cio"))
+            api(projects.ktorClientCore)
+            api(projects.ktorHttpCio)
         }
         desktopTest.dependencies {
-            implementation(project(":ktor-client-test-base"))
-            api(project(":ktor-client-logging"))
-            api(project(":ktor-client-json"))
+            implementation(projects.ktorClientTestBase)
+            api(projects.ktorClientLogging)
+            api(projects.ktorClientJson)
             implementation(libs.kotlinx.serialization.json)
         }
     }

--- a/ktor-client/ktor-client-darwin-legacy/build.gradle.kts
+++ b/ktor-client/ktor-client-darwin-legacy/build.gradle.kts
@@ -10,12 +10,12 @@ plugins {
 kotlin {
     sourceSets {
         darwinMain.dependencies {
-            api(project(":ktor-client-core"))
+            api(projects.ktorClientCore)
         }
         darwinTest.dependencies {
-            api(project(":ktor-client-tests"))
-            api(project(":ktor-client-logging"))
-            api(project(":ktor-client-json"))
+            api(projects.ktorClientTests)
+            api(projects.ktorClientLogging)
+            api(projects.ktorClientJson)
         }
     }
 }

--- a/ktor-client/ktor-client-darwin/build.gradle.kts
+++ b/ktor-client/ktor-client-darwin/build.gradle.kts
@@ -10,13 +10,13 @@ plugins {
 kotlin {
     sourceSets {
         darwinMain.dependencies {
-            api(project(":ktor-client-core"))
-            api(project(":ktor-network-tls"))
+            api(projects.ktorClientCore)
+            api(projects.ktorNetworkTls)
         }
         darwinTest.dependencies {
-            api(project(":ktor-client-tests"))
-            api(project(":ktor-client-logging"))
-            api(project(":ktor-client-json"))
+            api(projects.ktorClientTests)
+            api(projects.ktorClientLogging)
+            api(projects.ktorClientJson)
         }
     }
 }

--- a/ktor-client/ktor-client-ios/build.gradle.kts
+++ b/ktor-client/ktor-client-ios/build.gradle.kts
@@ -9,7 +9,7 @@ plugins {
 kotlin {
     sourceSets {
         darwinMain.dependencies {
-            api(project(":ktor-client-darwin"))
+            api(projects.ktorClientDarwin)
         }
     }
 }

--- a/ktor-client/ktor-client-java/build.gradle.kts
+++ b/ktor-client/ktor-client-java/build.gradle.kts
@@ -13,11 +13,11 @@ kotlin {
 
     sourceSets {
         jvmMain.dependencies {
-            api(project(":ktor-client-core"))
+            api(projects.ktorClientCore)
             implementation(libs.kotlinx.coroutines.jdk8)
         }
         jvmTest.dependencies {
-            api(project(":ktor-client-tests"))
+            api(projects.ktorClientTests)
         }
     }
 }

--- a/ktor-client/ktor-client-jetty-jakarta/build.gradle.kts
+++ b/ktor-client/ktor-client-jetty-jakarta/build.gradle.kts
@@ -14,14 +14,14 @@ kotlin {
 
     sourceSets {
         jvmMain.dependencies {
-            api(project(":ktor-client-core"))
+            api(projects.ktorClientCore)
 
             api(libs.jetty.http2.client.jakarta)
             api(libs.jetty.alpn.openjdk8.client)
             api(libs.jetty.alpn.java.client)
         }
         commonTest.dependencies {
-            api(project(":ktor-client-tests"))
+            api(projects.ktorClientTests)
         }
     }
 }

--- a/ktor-client/ktor-client-jetty/build.gradle.kts
+++ b/ktor-client/ktor-client-jetty/build.gradle.kts
@@ -11,14 +11,14 @@ plugins {
 kotlin {
     sourceSets {
         jvmMain.dependencies {
-            api(project(":ktor-client-core"))
+            api(projects.ktorClientCore)
 
             api(libs.jetty.http2.client)
             api(libs.jetty.alpn.openjdk8.client)
             api(libs.jetty.alpn.java.client)
         }
         commonTest.dependencies {
-            api(project(":ktor-client-tests"))
+            api(projects.ktorClientTests)
         }
     }
 }

--- a/ktor-client/ktor-client-js/build.gradle.kts
+++ b/ktor-client/ktor-client-js/build.gradle.kts
@@ -9,11 +9,11 @@ plugins {
 kotlin {
     sourceSets {
         jsMain.dependencies {
-            api(project(":ktor-client-core"))
+            api(projects.ktorClientCore)
         }
 
         wasmJsMain.dependencies {
-            api(project(":ktor-client-core"))
+            api(projects.ktorClientCore)
         }
     }
 }

--- a/ktor-client/ktor-client-mock/build.gradle.kts
+++ b/ktor-client/ktor-client-mock/build.gradle.kts
@@ -10,19 +10,19 @@ plugins {
 kotlin {
     sourceSets {
         commonMain.dependencies {
-            api(project(":ktor-http"))
-            api(project(":ktor-client-core"))
+            api(projects.ktorHttp)
+            api(projects.ktorClientCore)
         }
 
         commonTest.dependencies {
-            api(project(":ktor-test-dispatcher"))
+            api(projects.ktorTestDispatcher)
         }
 
         jvmTest.dependencies {
             api(libs.kotlinx.serialization.core)
-            api(project(":ktor-client-content-negotiation"))
-            api(project(":ktor-serialization-kotlinx"))
-            api(project(":ktor-serialization-kotlinx-json"))
+            api(projects.ktorClientContentNegotiation)
+            api(projects.ktorSerializationKotlinx)
+            api(projects.ktorSerializationKotlinxJson)
         }
     }
 }

--- a/ktor-client/ktor-client-okhttp/build.gradle.kts
+++ b/ktor-client/ktor-client-okhttp/build.gradle.kts
@@ -10,13 +10,13 @@ plugins {
 kotlin {
     sourceSets {
         jvmMain.dependencies {
-            api(project(":ktor-client-core"))
+            api(projects.ktorClientCore)
             api(libs.okhttp)
             api(libs.okhttp.sse)
             api(libs.okio)
         }
         jvmTest.dependencies {
-            api(project(":ktor-client-tests"))
+            api(projects.ktorClientTests)
         }
     }
 }

--- a/ktor-client/ktor-client-plugins/ktor-client-bom-remover/build.gradle.kts
+++ b/ktor-client/ktor-client-plugins/ktor-client-bom-remover/build.gradle.kts
@@ -6,4 +6,5 @@ description = "Ktor client Byte Order Mark support"
 
 plugins {
     id("ktorbuild.project.client-plugin")
+    id("test-server")
 }

--- a/ktor-client/ktor-client-plugins/ktor-client-call-id/build.gradle.kts
+++ b/ktor-client/ktor-client-plugins/ktor-client-call-id/build.gradle.kts
@@ -11,11 +11,11 @@ plugins {
 kotlin {
     sourceSets {
         commonMain.dependencies {
-            api(project(":ktor-call-id"))
+            api(projects.ktorCallId)
         }
         commonTest.dependencies {
-            api(project(":ktor-server-test-host"))
-            api(project(":ktor-server-call-id"))
+            api(projects.ktorServerTestHost)
+            api(projects.ktorServerCallId)
         }
     }
 }

--- a/ktor-client/ktor-client-plugins/ktor-client-content-negotiation/build.gradle.kts
+++ b/ktor-client/ktor-client-plugins/ktor-client-content-negotiation/build.gradle.kts
@@ -12,7 +12,7 @@ plugins {
 kotlin {
     sourceSets {
         commonMain.dependencies {
-            api(project(":ktor-serialization"))
+            api(projects.ktorSerialization)
         }
     }
 }

--- a/ktor-client/ktor-client-plugins/ktor-client-content-negotiation/ktor-client-content-negotiation-tests/build.gradle.kts
+++ b/ktor-client/ktor-client-plugins/ktor-client-content-negotiation/ktor-client-content-negotiation-tests/build.gradle.kts
@@ -13,11 +13,11 @@ kotlin {
     sourceSets {
         jvmMain.dependencies {
             api(libs.kotlin.test.junit5)
-            api(project(":ktor-client-content-negotiation"))
-            api(project(":ktor-server-cio"))
-            api(project(":ktor-client-cio"))
-            api(project(":ktor-client-tests"))
-            api(project(":ktor-server-test-host"))
+            api(projects.ktorClientContentNegotiation)
+            api(projects.ktorServerCio)
+            api(projects.ktorClientCio)
+            api(projects.ktorClientTests)
+            api(projects.ktorServerTestHost)
             api(libs.jackson.annotations)
             api(libs.logback.classic)
         }

--- a/ktor-client/ktor-client-plugins/ktor-client-encoding/build.gradle.kts
+++ b/ktor-client/ktor-client-plugins/ktor-client-encoding/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 kotlin {
     sourceSets {
         jvmTest.dependencies {
-            api(project(":ktor-server-test-host"))
+            api(projects.ktorServerTestHost)
         }
     }
 }

--- a/ktor-client/ktor-client-plugins/ktor-client-json/build.gradle.kts
+++ b/ktor-client/ktor-client-plugins/ktor-client-json/build.gradle.kts
@@ -13,10 +13,10 @@ plugins {
 kotlin {
     sourceSets {
         commonTest.dependencies {
-            api(project(":ktor-client-serialization"))
+            api(projects.ktorClientSerialization)
         }
         jvmTest.dependencies {
-            api(project(":ktor-client-gson"))
+            api(projects.ktorClientGson)
         }
     }
 }

--- a/ktor-client/ktor-client-plugins/ktor-client-json/ktor-client-gson/build.gradle.kts
+++ b/ktor-client/ktor-client-plugins/ktor-client-json/ktor-client-gson/build.gradle.kts
@@ -9,12 +9,12 @@ plugins {
 kotlin {
     sourceSets {
         jvmMain.dependencies {
-            api(project(":ktor-client-json"))
+            api(projects.ktorClientJson)
             api(libs.gson)
         }
         jvmTest.dependencies {
-            api(project(":ktor-client-cio"))
-            api(project(":ktor-serialization-gson"))
+            api(projects.ktorClientCio)
+            api(projects.ktorSerializationGson)
         }
     }
 }

--- a/ktor-client/ktor-client-plugins/ktor-client-json/ktor-client-jackson/build.gradle.kts
+++ b/ktor-client/ktor-client-plugins/ktor-client-json/ktor-client-jackson/build.gradle.kts
@@ -9,14 +9,14 @@ plugins {
 kotlin {
     sourceSets {
         jvmMain.dependencies {
-            api(project(":ktor-client-json"))
+            api(projects.ktorClientJson)
 
             api(libs.jackson.databind)
             api(libs.jackson.module.kotlin)
         }
         jvmTest.dependencies {
-            api(project(":ktor-client-cio"))
-            api(project(":ktor-serialization-gson"))
+            api(projects.ktorClientCio)
+            api(projects.ktorSerializationGson)
         }
     }
 }

--- a/ktor-client/ktor-client-plugins/ktor-client-json/ktor-client-serialization/build.gradle.kts
+++ b/ktor-client/ktor-client-plugins/ktor-client-json/ktor-client-serialization/build.gradle.kts
@@ -11,7 +11,7 @@ kotlin {
     sourceSets {
         commonMain.dependencies {
             api(libs.kotlinx.serialization.json)
-            api(project(":ktor-client-json"))
+            api(projects.ktorClientJson)
         }
     }
 }

--- a/ktor-client/ktor-client-plugins/ktor-client-logging/build.gradle.kts
+++ b/ktor-client/ktor-client-plugins/ktor-client-logging/build.gradle.kts
@@ -13,12 +13,12 @@ kotlin {
             api(libs.kotlinx.coroutines.slf4j)
         }
         commonTest.dependencies {
-            api(project(":ktor-client-mock"))
-            api(project(":ktor-client-content-negotiation"))
+            api(projects.ktorClientMock)
+            api(projects.ktorClientContentNegotiation)
         }
         jvmTest.dependencies {
-            api(project(":ktor-serialization-jackson"))
-            api(project(":ktor-client-encoding"))
+            api(projects.ktorSerializationJackson)
+            api(projects.ktorClientEncoding)
         }
     }
 }

--- a/ktor-client/ktor-client-plugins/ktor-client-resources/build.gradle.kts
+++ b/ktor-client/ktor-client-plugins/ktor-client-resources/build.gradle.kts
@@ -12,7 +12,7 @@ plugins {
 kotlin {
     sourceSets {
         commonMain.dependencies {
-            api(project(":ktor-resources"))
+            api(projects.ktorResources)
             api(libs.kotlinx.serialization.core)
         }
     }

--- a/ktor-client/ktor-client-plugins/ktor-client-tracing/build.gradle.kts
+++ b/ktor-client/ktor-client-plugins/ktor-client-tracing/build.gradle.kts
@@ -9,10 +9,10 @@ plugins {
 kotlin {
     sourceSets {
         commonMain.dependencies {
-            api(project(":ktor-client-core"))
+            api(projects.ktorClientCore)
         }
         jvmTest.dependencies {
-            implementation(project(":ktor-client-cio"))
+            implementation(projects.ktorClientCio)
         }
     }
 }

--- a/ktor-client/ktor-client-plugins/ktor-client-tracing/ktor-client-tracing-stetho/build.gradle.kts
+++ b/ktor-client/ktor-client-plugins/ktor-client-tracing/ktor-client-tracing-stetho/build.gradle.kts
@@ -20,8 +20,8 @@ kotlin {
         val androidMain by getting {
             kotlin.srcDir("android/src")
             dependencies {
-                implementation(project(":ktor-client-tracing"))
-                implementation(project(":ktor-client-core"))
+                implementation(projects.ktorClientTracing)
+                implementation(projects.ktorClientCore)
                 implementation("com.facebook.stetho:stetho:$android_stetho_version")
             }
         }
@@ -29,7 +29,7 @@ kotlin {
         val androidTest by getting {
             kotlin.srcDir("android/test")
             dependencies {
-                implementation(project(":ktor-client-cio"))
+                implementation(projects.ktorClientCio)
                 implementation(libs.kotlin.test.junit5)
                 implementation("org.mockito:mockito-core:5.17.0")
             }

--- a/ktor-client/ktor-client-plugins/ktor-client-websockets/build.gradle.kts
+++ b/ktor-client/ktor-client-plugins/ktor-client-websockets/build.gradle.kts
@@ -4,6 +4,7 @@
 
 plugins {
     id("ktorbuild.project.client-plugin")
+    id("test-server")
 }
 
 kotlin {

--- a/ktor-client/ktor-client-plugins/ktor-client-websockets/build.gradle.kts
+++ b/ktor-client/ktor-client-plugins/ktor-client-websockets/build.gradle.kts
@@ -9,7 +9,7 @@ plugins {
 kotlin {
     sourceSets {
         commonTest.dependencies {
-            api(project(":ktor-client-logging"))
+            api(projects.ktorClientLogging)
         }
     }
 }

--- a/ktor-client/ktor-client-test-base/build.gradle.kts
+++ b/ktor-client/ktor-client-test-base/build.gradle.kts
@@ -11,8 +11,8 @@ plugins {
 kotlin {
     sourceSets {
         commonMain.dependencies {
-            api(project(":ktor-client-core"))
-            api(project(":ktor-test-base"))
+            api(projects.ktorClientCore)
+            api(projects.ktorTestBase)
         }
     }
 }

--- a/ktor-client/ktor-client-tests/build.gradle.kts
+++ b/ktor-client/ktor-client-tests/build.gradle.kts
@@ -13,63 +13,63 @@ plugins {
 kotlin {
     sourceSets {
         commonMain.dependencies {
-            api(project(":ktor-client-test-base"))
-            api(project(":ktor-client-mock"))
+            api(projects.ktorClientTestBase)
+            api(projects.ktorClientMock)
         }
         commonTest.dependencies {
-            api(project(":ktor-client-json"))
-            api(project(":ktor-client-serialization"))
-            api(project(":ktor-client-logging"))
-            api(project(":ktor-client-auth"))
-            api(project(":ktor-client-encoding"))
-            api(project(":ktor-client-content-negotiation"))
-            api(project(":ktor-client-json"))
-            api(project(":ktor-client-serialization"))
-            api(project(":ktor-serialization-kotlinx"))
-            api(project(":ktor-serialization-kotlinx-json"))
+            api(projects.ktorClientJson)
+            api(projects.ktorClientSerialization)
+            api(projects.ktorClientLogging)
+            api(projects.ktorClientAuth)
+            api(projects.ktorClientEncoding)
+            api(projects.ktorClientContentNegotiation)
+            api(projects.ktorClientJson)
+            api(projects.ktorClientSerialization)
+            api(projects.ktorSerializationKotlinx)
+            api(projects.ktorSerializationKotlinxJson)
         }
         jvmMain.dependencies {
             api(libs.kotlinx.serialization.json)
-            api(project(":ktor-network-tls-certificates"))
-            api(project(":ktor-server"))
-            api(project(":ktor-server-cio"))
-            api(project(":ktor-server-netty"))
-            api(project(":ktor-server-auth"))
-            api(project(":ktor-server-websockets"))
-            api(project(":ktor-serialization-kotlinx"))
+            api(projects.ktorNetworkTlsCertificates)
+            api(projects.ktorServer)
+            api(projects.ktorServerCio)
+            api(projects.ktorServerNetty)
+            api(projects.ktorServerAuth)
+            api(projects.ktorServerWebsockets)
+            api(projects.ktorSerializationKotlinx)
             api(libs.logback.classic)
         }
 
         jvmTest.dependencies {
-            api(project(":ktor-client-apache"))
-            api(project(":ktor-client-apache5"))
-            runtimeOnly(project(":ktor-client-android"))
-            runtimeOnly(project(":ktor-client-okhttp"))
-            runtimeOnly(project(":ktor-client-java"))
-            implementation(project(":ktor-client-logging"))
+            api(projects.ktorClientApache)
+            api(projects.ktorClientApache5)
+            runtimeOnly(projects.ktorClientAndroid)
+            runtimeOnly(projects.ktorClientOkhttp)
+            runtimeOnly(projects.ktorClientJava)
+            implementation(projects.ktorClientLogging)
             implementation(libs.kotlinx.coroutines.slf4j)
             implementation(libs.junit)
         }
 
         commonTest.dependencies {
-            api(project(":ktor-client-cio"))
+            api(projects.ktorClientCio)
         }
 
         jsTest.dependencies {
-            api(project(":ktor-client-js"))
+            api(projects.ktorClientJs)
         }
 
         desktopTest.dependencies {
-            api(project(":ktor-client-curl"))
+            api(projects.ktorClientCurl)
         }
 
         darwinTest.dependencies {
-                api(project(":ktor-client-darwin"))
-                api(project(":ktor-client-darwin-legacy"))
+                api(projects.ktorClientDarwin)
+                api(projects.ktorClientDarwinLegacy)
         }
 
         windowsTest.dependencies {
-                api(project(":ktor-client-winhttp"))
+                api(projects.ktorClientWinhttp)
         }
     }
 }

--- a/ktor-client/ktor-client-winhttp/build.gradle.kts
+++ b/ktor-client/ktor-client-winhttp/build.gradle.kts
@@ -15,13 +15,13 @@ kotlin {
 
     sourceSets {
         windowsMain.dependencies {
-            api(project(":ktor-client-core"))
-            api(project(":ktor-http-cio"))
+            api(projects.ktorClientCore)
+            api(projects.ktorHttpCio)
         }
         windowsTest.dependencies {
-            implementation(project(":ktor-client-test-base"))
-            api(project(":ktor-client-logging"))
-            api(project(":ktor-client-json"))
+            implementation(projects.ktorClientTestBase)
+            api(projects.ktorClientLogging)
+            api(projects.ktorClientJson)
         }
     }
 }

--- a/ktor-http/build.gradle.kts
+++ b/ktor-http/build.gradle.kts
@@ -10,13 +10,13 @@ plugins {
 kotlin {
     sourceSets {
         commonMain.dependencies {
-            api(project(":ktor-utils"))
+            api(projects.ktorUtils)
             api(libs.kotlinx.serialization.core)
         }
         jvmTest.dependencies {
-            implementation(project(":ktor-test-base"))
-            implementation(project(":ktor-serialization-kotlinx"))
-            implementation(project(":ktor-serialization-kotlinx-json"))
+            implementation(projects.ktorTestBase)
+            implementation(projects.ktorSerializationKotlinx)
+            implementation(projects.ktorSerializationKotlinxJson)
         }
     }
 }

--- a/ktor-http/ktor-http-cio/build.gradle.kts
+++ b/ktor-http/ktor-http-cio/build.gradle.kts
@@ -11,12 +11,12 @@ plugins {
 kotlin {
     sourceSets {
         commonMain.dependencies {
-            api(project(":ktor-http"))
-            api(project(":ktor-io"))
+            api(projects.ktorHttp)
+            api(projects.ktorIo)
         }
 
         jvmMain.dependencies {
-            api(project(":ktor-network"))
+            api(projects.ktorNetwork)
         }
 
         jvmTest.dependencies {

--- a/ktor-io/build.gradle.kts
+++ b/ktor-io/build.gradle.kts
@@ -17,7 +17,7 @@ kotlin {
             api(libs.kotlinx.io.core)
         }
         commonTest.dependencies {
-            api(project(":ktor-test-dispatcher"))
+            api(projects.ktorTestDispatcher)
         }
     }
 }

--- a/ktor-network/build.gradle.kts
+++ b/ktor-network/build.gradle.kts
@@ -18,15 +18,15 @@ kotlin {
 
     sourceSets {
         commonMain.dependencies {
-            api(project(":ktor-utils"))
+            api(projects.ktorUtils)
         }
 
         commonTest.dependencies {
-            api(project(":ktor-test-dispatcher"))
+            api(projects.ktorTestDispatcher)
         }
 
         jvmTest.dependencies {
-            implementation(project(":ktor-test-base"))
+            implementation(projects.ktorTestBase)
             implementation(libs.mockk)
         }
     }

--- a/ktor-network/ktor-network-tls/build.gradle.kts
+++ b/ktor-network/ktor-network-tls/build.gradle.kts
@@ -9,13 +9,13 @@ plugins {
 kotlin {
     sourceSets {
         commonMain.dependencies {
-            api(project(":ktor-http"))
-            api(project(":ktor-network"))
-            api(project(":ktor-utils"))
+            api(projects.ktorHttp)
+            api(projects.ktorNetwork)
+            api(projects.ktorUtils)
         }
         jvmTest.dependencies {
-            api(project(":ktor-test-base"))
-            api(project(":ktor-network-tls-certificates"))
+            api(projects.ktorTestBase)
+            api(projects.ktorNetworkTlsCertificates)
             api(libs.netty.handler)
             api(libs.mockk)
         }

--- a/ktor-network/ktor-network-tls/ktor-network-tls-certificates/build.gradle.kts
+++ b/ktor-network/ktor-network-tls/ktor-network-tls-certificates/build.gradle.kts
@@ -9,7 +9,7 @@ plugins {
 kotlin {
     sourceSets {
         jvmMain.dependencies {
-            api(project(":ktor-network-tls"))
+            api(projects.ktorNetworkTls)
         }
         jvmTest.dependencies {
             implementation(libs.mockk)

--- a/ktor-server/build.gradle.kts
+++ b/ktor-server/build.gradle.kts
@@ -11,28 +11,28 @@ plugins {
 kotlin {
     sourceSets {
         jvmMain.dependencies {
-            api(project(":ktor-server-call-logging"))
-            api(project(":ktor-server-default-headers"))
-            api(project(":ktor-server-compression"))
+            api(projects.ktorServerCallLogging)
+            api(projects.ktorServerDefaultHeaders)
+            api(projects.ktorServerCompression)
         }
         commonMain.dependencies {
-            api(project(":ktor-server-core"))
-            api(project(":ktor-server-auto-head-response"))
-            api(project(":ktor-server-caching-headers"))
-            api(project(":ktor-server-conditional-headers"))
-            api(project(":ktor-server-content-negotiation"))
-            api(project(":ktor-server-call-id"))
-            api(project(":ktor-server-cors"))
-            api(project(":ktor-server-csrf"))
-            api(project(":ktor-server-data-conversion"))
-            api(project(":ktor-server-double-receive"))
-            api(project(":ktor-server-forwarded-header"))
-            api(project(":ktor-server-hsts"))
-            api(project(":ktor-server-http-redirect"))
-            api(project(":ktor-server-partial-content"))
-            api(project(":ktor-server-status-pages"))
-            api(project(":ktor-server-method-override"))
-            api(project(":ktor-server-sessions"))
+            api(projects.ktorServerCore)
+            api(projects.ktorServerAutoHeadResponse)
+            api(projects.ktorServerCachingHeaders)
+            api(projects.ktorServerConditionalHeaders)
+            api(projects.ktorServerContentNegotiation)
+            api(projects.ktorServerCallId)
+            api(projects.ktorServerCors)
+            api(projects.ktorServerCsrf)
+            api(projects.ktorServerDataConversion)
+            api(projects.ktorServerDoubleReceive)
+            api(projects.ktorServerForwardedHeader)
+            api(projects.ktorServerHsts)
+            api(projects.ktorServerHttpRedirect)
+            api(projects.ktorServerPartialContent)
+            api(projects.ktorServerStatusPages)
+            api(projects.ktorServerMethodOverride)
+            api(projects.ktorServerSessions)
         }
     }
 }

--- a/ktor-server/ktor-server-cio/build.gradle.kts
+++ b/ktor-server/ktor-server-cio/build.gradle.kts
@@ -11,15 +11,15 @@ plugins {
 kotlin {
     sourceSets {
         commonMain.dependencies {
-            api(project(":ktor-server-core"))
-            api(project(":ktor-http-cio"))
-            api(project(":ktor-websockets"))
-            api(project(":ktor-network"))
+            api(projects.ktorServerCore)
+            api(projects.ktorHttpCio)
+            api(projects.ktorWebsockets)
+            api(projects.ktorNetwork)
         }
         commonTest.dependencies {
-            api(project(":ktor-client-cio"))
-            api(project(":ktor-server-test-suites"))
-            api(project(":ktor-server-test-base"))
+            api(projects.ktorClientCio)
+            api(projects.ktorServerTestSuites)
+            api(projects.ktorServerTestBase)
         }
     }
 }

--- a/ktor-server/ktor-server-config-yaml/build.gradle.kts
+++ b/ktor-server/ktor-server-config-yaml/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 kotlin {
     sourceSets {
         commonMain.dependencies {
-            api(project(":ktor-server-core"))
+            api(projects.ktorServerCore)
             // KTOR-8386 Remove in next major release
             api(libs.yamlkt.serialization)
             implementation(libs.kaml.serialization)

--- a/ktor-server/ktor-server-core/build.gradle.kts
+++ b/ktor-server/ktor-server-core/build.gradle.kts
@@ -16,12 +16,12 @@ kotlin {
 
     sourceSets {
         commonMain.dependencies {
-            api(project(":ktor-utils"))
-            api(project(":ktor-http"))
-            api(project(":ktor-serialization"))
-            api(project(":ktor-events"))
-            api(project(":ktor-http-cio"))
-            api(project(":ktor-websockets"))
+            api(projects.ktorUtils)
+            api(projects.ktorHttp)
+            api(projects.ktorSerialization)
+            api(projects.ktorEvents)
+            api(projects.ktorHttpCio)
+            api(projects.ktorWebsockets)
 
             api(libs.kotlin.reflect)
         }
@@ -32,13 +32,13 @@ kotlin {
         }
 
         commonTest.dependencies {
-            api(project(":ktor-server-test-host"))
+            api(projects.ktorServerTestHost)
         }
 
         jvmTest.dependencies {
-            implementation(project(":ktor-server-config-yaml"))
-            implementation(project(":ktor-server-test-base"))
-            implementation(project(":ktor-server-test-suites"))
+            implementation(projects.ktorServerConfigYaml)
+            implementation(projects.ktorServerTestBase)
+            implementation(projects.ktorServerTestSuites)
 
             implementation(libs.mockk)
         }

--- a/ktor-server/ktor-server-host-common/build.gradle.kts
+++ b/ktor-server/ktor-server-host-common/build.gradle.kts
@@ -11,7 +11,7 @@ plugins {
 kotlin {
     sourceSets {
         commonMain.dependencies {
-            api(project(":ktor-server-core"))
+            api(projects.ktorServerCore)
         }
     }
 }

--- a/ktor-server/ktor-server-jetty-jakarta/build.gradle.kts
+++ b/ktor-server/ktor-server-jetty-jakarta/build.gradle.kts
@@ -14,8 +14,8 @@ kotlin {
 
     sourceSets {
         jvmMain.dependencies {
-            api(project(":ktor-server-core"))
-            api(project(":ktor-server-servlet-jakarta"))
+            api(projects.ktorServerCore)
+            api(projects.ktorServerServletJakarta)
             api(libs.jetty.server.jakarta)
             api(libs.jetty.servlets.jakarta)
             api(libs.jetty.alpn.server.jakarta)
@@ -25,9 +25,9 @@ kotlin {
         }
         jvmTest.dependencies {
             api(libs.kotlin.test.junit5)
-            api(project(":ktor-server-core"))
-            api(project(":ktor-server-test-base"))
-            api(project(":ktor-server-test-suites"))
+            api(projects.ktorServerCore)
+            api(projects.ktorServerTestBase)
+            api(projects.ktorServerTestSuites)
 
             api(libs.jetty.servlet.jakarta)
         }

--- a/ktor-server/ktor-server-jetty-jakarta/ktor-server-jetty-test-http2-jakarta/build.gradle.kts
+++ b/ktor-server/ktor-server-jetty-jakarta/ktor-server-jetty-test-http2-jakarta/build.gradle.kts
@@ -14,11 +14,11 @@ kotlin {
 
     sourceSets {
         jvmTest.dependencies {
-            api(project(":ktor-server-test-base"))
-            api(project(":ktor-server-test-suites"))
+            api(projects.ktorServerTestBase)
+            api(projects.ktorServerTestSuites)
             api(libs.jetty.servlet.jakarta)
-            api(project(":ktor-server-core"))
-            api(project(":ktor-server-jetty-jakarta"))
+            api(projects.ktorServerCore)
+            api(projects.ktorServerJettyJakarta)
         }
     }
 }

--- a/ktor-server/ktor-server-jetty/build.gradle.kts
+++ b/ktor-server/ktor-server-jetty/build.gradle.kts
@@ -11,8 +11,8 @@ plugins {
 kotlin {
     sourceSets {
         jvmMain.dependencies {
-            api(project(":ktor-server-core"))
-            api(project(":ktor-server-servlet"))
+            api(projects.ktorServerCore)
+            api(projects.ktorServerServlet)
             api(libs.jetty.server)
             api(libs.jetty.servlets)
             api(libs.jetty.alpn.server)
@@ -21,9 +21,9 @@ kotlin {
             api(libs.jetty.http2.server)
         }
         jvmTest.dependencies {
-            api(project(":ktor-server-core"))
-            api(project(":ktor-server-test-base"))
-            api(project(":ktor-server-test-suites"))
+            api(projects.ktorServerCore)
+            api(projects.ktorServerTestBase)
+            api(projects.ktorServerTestSuites)
 
             api(libs.jetty.servlet)
         }

--- a/ktor-server/ktor-server-jetty/ktor-server-jetty-test-http2/build.gradle.kts
+++ b/ktor-server/ktor-server-jetty/ktor-server-jetty-test-http2/build.gradle.kts
@@ -11,11 +11,11 @@ plugins {
 kotlin {
     sourceSets {
         jvmTest.dependencies {
-            api(project(":ktor-server-test-base"))
-            api(project(":ktor-server-test-suites"))
+            api(projects.ktorServerTestBase)
+            api(projects.ktorServerTestSuites)
             api(libs.jetty.servlet)
-            api(project(":ktor-server-core"))
-            api(project(":ktor-server-jetty"))
+            api(projects.ktorServerCore)
+            api(projects.ktorServerJetty)
         }
     }
 }

--- a/ktor-server/ktor-server-netty/build.gradle.kts
+++ b/ktor-server/ktor-server-netty/build.gradle.kts
@@ -26,7 +26,7 @@ val nativeClassifier: String? = if (enableAlpnProp) {
 kotlin {
     sourceSets {
         jvmMain.dependencies {
-            api(project(":ktor-server-core"))
+            api(projects.ktorServerCore)
 
             api(libs.netty.codec.http2)
             api(libs.jetty.alpn.api)
@@ -38,9 +38,9 @@ kotlin {
             }
         }
         jvmTest.dependencies {
-            api(project(":ktor-server-test-base"))
-            api(project(":ktor-server-test-suites"))
-            api(project(":ktor-server-core"))
+            api(projects.ktorServerTestBase)
+            api(projects.ktorServerTestSuites)
+            api(projects.ktorServerCore)
 
             api(libs.netty.tcnative)
             api(libs.netty.tcnative.boringssl.static)

--- a/ktor-server/ktor-server-plugins/ktor-server-auth-jwt/build.gradle.kts
+++ b/ktor-server/ktor-server-plugins/ktor-server-auth-jwt/build.gradle.kts
@@ -9,7 +9,7 @@ plugins {
 kotlin {
     sourceSets {
         jvmMain.dependencies {
-            api(project(":ktor-server-auth"))
+            api(projects.ktorServerAuth)
             api(libs.java.jwt)
             api(libs.jwks.rsa)
         }

--- a/ktor-server/ktor-server-plugins/ktor-server-auth-ldap/build.gradle.kts
+++ b/ktor-server/ktor-server-plugins/ktor-server-auth-ldap/build.gradle.kts
@@ -9,7 +9,7 @@ plugins {
 kotlin {
     sourceSets {
         jvmMain.dependencies {
-            api(project(":ktor-server-auth"))
+            api(projects.ktorServerAuth)
         }
         jvmTest.dependencies {
             api(libs.apacheds.server)

--- a/ktor-server/ktor-server-plugins/ktor-server-auth/build.gradle.kts
+++ b/ktor-server/ktor-server-plugins/ktor-server-auth/build.gradle.kts
@@ -12,13 +12,13 @@ plugins {
 kotlin {
     sourceSets {
         commonMain.dependencies {
-            api(project(":ktor-client-core"))
-            api(project(":ktor-server-sessions"))
+            api(projects.ktorClientCore)
+            api(projects.ktorServerSessions)
             api(libs.kotlinx.serialization.json)
         }
         jvmTest.dependencies {
-            api(project(":ktor-server-content-negotiation"))
-            api(project(":ktor-serialization-jackson"))
+            api(projects.ktorServerContentNegotiation)
+            api(projects.ktorSerializationJackson)
         }
     }
 }

--- a/ktor-server/ktor-server-plugins/ktor-server-call-id/build.gradle.kts
+++ b/ktor-server/ktor-server-plugins/ktor-server-call-id/build.gradle.kts
@@ -11,10 +11,10 @@ plugins {
 kotlin {
     sourceSets {
         commonMain.dependencies {
-            api(project(":ktor-call-id"))
+            api(projects.ktorCallId)
         }
         jvmMain.dependencies {
-            api(project(":ktor-server-call-logging"))
+            api(projects.ktorServerCallLogging)
         }
     }
 }

--- a/ktor-server/ktor-server-plugins/ktor-server-call-logging/build.gradle.kts
+++ b/ktor-server/ktor-server-plugins/ktor-server-call-logging/build.gradle.kts
@@ -16,8 +16,8 @@ kotlin {
         }
 
         jvmTest.dependencies {
-            implementation(project(":ktor-server-call-id"))
-            implementation(project(":ktor-server-status-pages"))
+            implementation(projects.ktorServerCallId)
+            implementation(projects.ktorServerStatusPages)
         }
     }
 }

--- a/ktor-server/ktor-server-plugins/ktor-server-content-negotiation/build.gradle.kts
+++ b/ktor-server/ktor-server-plugins/ktor-server-content-negotiation/build.gradle.kts
@@ -11,7 +11,7 @@ plugins {
 kotlin {
     sourceSets {
         commonTest.dependencies {
-            implementation(project(":ktor-server-double-receive"))
+            implementation(projects.ktorServerDoubleReceive)
         }
     }
 }

--- a/ktor-server/ktor-server-plugins/ktor-server-freemarker/build.gradle.kts
+++ b/ktor-server/ktor-server-plugins/ktor-server-freemarker/build.gradle.kts
@@ -12,10 +12,10 @@ kotlin {
             api(libs.freemarker)
         }
         jvmTest.dependencies {
-            api(project(":ktor-server-status-pages"))
-            api(project(":ktor-server-compression"))
-            api(project(":ktor-server-conditional-headers"))
-            implementation(project(":ktor-server-content-negotiation"))
+            api(projects.ktorServerStatusPages)
+            api(projects.ktorServerCompression)
+            api(projects.ktorServerConditionalHeaders)
+            implementation(projects.ktorServerContentNegotiation)
         }
     }
 }

--- a/ktor-server/ktor-server-plugins/ktor-server-html-builder/build.gradle.kts
+++ b/ktor-server/ktor-server-plugins/ktor-server-html-builder/build.gradle.kts
@@ -12,7 +12,7 @@ kotlin {
             api(libs.kotlinx.html)
         }
         commonTest.dependencies {
-            api(project(":ktor-server-status-pages"))
+            api(projects.ktorServerStatusPages)
         }
     }
 }

--- a/ktor-server/ktor-server-plugins/ktor-server-htmx/build.gradle.kts
+++ b/ktor-server/ktor-server-plugins/ktor-server-htmx/build.gradle.kts
@@ -9,12 +9,12 @@ plugins {
 kotlin {
     sourceSets {
         commonMain.dependencies {
-            api(project(":ktor-htmx"))
-            implementation(project(":ktor-utils"))
+            api(projects.ktorHtmx)
+            implementation(projects.ktorUtils)
         }
         commonTest.dependencies {
-            implementation(project(":ktor-server-html-builder"))
-            implementation(project(":ktor-htmx-html"))
+            implementation(projects.ktorServerHtmlBuilder)
+            implementation(projects.ktorHtmxHtml)
         }
     }
 }

--- a/ktor-server/ktor-server-plugins/ktor-server-i18n/build.gradle.kts
+++ b/ktor-server/ktor-server-plugins/ktor-server-i18n/build.gradle.kts
@@ -11,7 +11,7 @@ plugins {
 kotlin {
     sourceSets {
         jvmTest.dependencies {
-            implementation(project(":ktor-server-status-pages"))
+            implementation(projects.ktorServerStatusPages)
         }
     }
 }

--- a/ktor-server/ktor-server-plugins/ktor-server-jte/build.gradle.kts
+++ b/ktor-server/ktor-server-plugins/ktor-server-jte/build.gradle.kts
@@ -15,11 +15,11 @@ kotlin {
             api(libs.jte)
         }
         jvmTest.dependencies {
-            api(project(":ktor-server-status-pages"))
-            api(project(":ktor-server-compression"))
-            api(project(":ktor-server-conditional-headers"))
+            api(projects.ktorServerStatusPages)
+            api(projects.ktorServerCompression)
+            api(projects.ktorServerConditionalHeaders)
             api(libs.jte.kotlin)
-            implementation(project(":ktor-server-content-negotiation"))
+            implementation(projects.ktorServerContentNegotiation)
         }
     }
 }

--- a/ktor-server/ktor-server-plugins/ktor-server-metrics-micrometer/build.gradle.kts
+++ b/ktor-server/ktor-server-plugins/ktor-server-metrics-micrometer/build.gradle.kts
@@ -10,11 +10,11 @@ kotlin {
     sourceSets {
         jvmMain.dependencies {
             api(libs.micrometer)
-            implementation(project(":ktor-server-core"))
+            implementation(projects.ktorServerCore)
         }
         jvmTest.dependencies {
-            implementation(project(":ktor-server-metrics"))
-            implementation(project(":ktor-server-auth"))
+            implementation(projects.ktorServerMetrics)
+            implementation(projects.ktorServerAuth)
         }
     }
 }

--- a/ktor-server/ktor-server-plugins/ktor-server-metrics/build.gradle.kts
+++ b/ktor-server/ktor-server-plugins/ktor-server-metrics/build.gradle.kts
@@ -15,9 +15,9 @@ kotlin {
             api(libs.dropwizard.jvm)
         }
         jvmTest.dependencies {
-            api(project(":ktor-server-status-pages"))
-            api(project(":ktor-server-cors"))
-            api(project(":ktor-test-base"))
+            api(projects.ktorServerStatusPages)
+            api(projects.ktorServerCors)
+            api(projects.ktorTestBase)
         }
     }
 }

--- a/ktor-server/ktor-server-plugins/ktor-server-mustache/build.gradle.kts
+++ b/ktor-server/ktor-server-plugins/ktor-server-mustache/build.gradle.kts
@@ -12,9 +12,9 @@ kotlin {
             api(libs.mustache)
         }
         jvmTest.dependencies {
-            api(project(":ktor-server-compression"))
-            api(project(":ktor-server-conditional-headers"))
-            implementation(project(":ktor-server-content-negotiation"))
+            api(projects.ktorServerCompression)
+            api(projects.ktorServerConditionalHeaders)
+            implementation(projects.ktorServerContentNegotiation)
         }
     }
 }

--- a/ktor-server/ktor-server-plugins/ktor-server-openapi/build.gradle.kts
+++ b/ktor-server/ktor-server-plugins/ktor-server-openapi/build.gradle.kts
@@ -12,7 +12,7 @@ kotlin {
 
     sourceSets {
         jvmMain.dependencies {
-            implementation(project(":ktor-server-html-builder"))
+            implementation(projects.ktorServerHtmlBuilder)
 
             implementation(libs.swagger.codegen)
             implementation(libs.swagger.codegen.generators)

--- a/ktor-server/ktor-server-plugins/ktor-server-partial-content/build.gradle.kts
+++ b/ktor-server/ktor-server-plugins/ktor-server-partial-content/build.gradle.kts
@@ -11,7 +11,7 @@ plugins {
 kotlin {
     sourceSets {
         commonMain.dependencies {
-            api(project(":ktor-server-conditional-headers"))
+            api(projects.ktorServerConditionalHeaders)
         }
     }
 }

--- a/ktor-server/ktor-server-plugins/ktor-server-pebble/build.gradle.kts
+++ b/ktor-server/ktor-server-plugins/ktor-server-pebble/build.gradle.kts
@@ -12,9 +12,9 @@ kotlin {
             api(libs.pebble)
         }
         jvmTest.dependencies {
-            api(project(":ktor-server-conditional-headers"))
-            api(project(":ktor-server-compression"))
-            implementation(project(":ktor-server-content-negotiation"))
+            api(projects.ktorServerConditionalHeaders)
+            api(projects.ktorServerCompression)
+            implementation(projects.ktorServerContentNegotiation)
         }
     }
 }

--- a/ktor-server/ktor-server-plugins/ktor-server-request-validation/build.gradle.kts
+++ b/ktor-server/ktor-server-plugins/ktor-server-request-validation/build.gradle.kts
@@ -11,7 +11,7 @@ plugins {
 kotlin {
     sourceSets {
         commonTest.dependencies {
-            implementation(project(":ktor-server-status-pages"))
+            implementation(projects.ktorServerStatusPages)
         }
     }
 }

--- a/ktor-server/ktor-server-plugins/ktor-server-resources/build.gradle.kts
+++ b/ktor-server/ktor-server-plugins/ktor-server-resources/build.gradle.kts
@@ -12,7 +12,7 @@ plugins {
 kotlin {
     sourceSets {
         commonMain.dependencies {
-            api(project(":ktor-resources"))
+            api(projects.ktorResources)
             api(libs.kotlinx.serialization.core)
         }
     }

--- a/ktor-server/ktor-server-plugins/ktor-server-sessions/build.gradle.kts
+++ b/ktor-server/ktor-server-plugins/ktor-server-sessions/build.gradle.kts
@@ -16,7 +16,7 @@ kotlin {
             api(libs.kotlinx.serialization.json)
         }
         jvmTest.dependencies {
-            implementation(project(":ktor-server-netty"))
+            implementation(projects.ktorServerNetty)
         }
     }
 }

--- a/ktor-server/ktor-server-plugins/ktor-server-sse/build.gradle.kts
+++ b/ktor-server/ktor-server-plugins/ktor-server-sse/build.gradle.kts
@@ -12,11 +12,11 @@ plugins {
 kotlin {
     sourceSets {
         commonMain.dependencies {
-            api(project(":ktor-sse"))
+            api(projects.ktorSse)
         }
         commonTest.dependencies {
-            api(project(":ktor-serialization-kotlinx"))
-            api(project(":ktor-serialization-kotlinx-json"))
+            api(projects.ktorSerializationKotlinx)
+            api(projects.ktorSerializationKotlinxJson)
         }
     }
 }

--- a/ktor-server/ktor-server-plugins/ktor-server-status-pages/build.gradle.kts
+++ b/ktor-server/ktor-server-plugins/ktor-server-status-pages/build.gradle.kts
@@ -11,7 +11,7 @@ plugins {
 kotlin {
     sourceSets {
         commonTest.dependencies {
-            implementation(project(":ktor-server-call-id"))
+            implementation(projects.ktorServerCallId)
         }
     }
 }

--- a/ktor-server/ktor-server-plugins/ktor-server-swagger/build.gradle.kts
+++ b/ktor-server/ktor-server-plugins/ktor-server-swagger/build.gradle.kts
@@ -9,7 +9,7 @@ plugins {
 kotlin {
     sourceSets {
         jvmMain.dependencies {
-            implementation(project(":ktor-server-html-builder"))
+            implementation(projects.ktorServerHtmlBuilder)
         }
     }
 }

--- a/ktor-server/ktor-server-plugins/ktor-server-thymeleaf/build.gradle.kts
+++ b/ktor-server/ktor-server-plugins/ktor-server-thymeleaf/build.gradle.kts
@@ -12,9 +12,9 @@ kotlin {
             api(libs.thymeleaf)
         }
         jvmTest.dependencies {
-            api(project(":ktor-server-conditional-headers"))
-            api(project(":ktor-server-compression"))
-            implementation(project(":ktor-server-content-negotiation"))
+            api(projects.ktorServerConditionalHeaders)
+            api(projects.ktorServerCompression)
+            implementation(projects.ktorServerContentNegotiation)
         }
     }
 }

--- a/ktor-server/ktor-server-plugins/ktor-server-velocity/build.gradle.kts
+++ b/ktor-server/ktor-server-plugins/ktor-server-velocity/build.gradle.kts
@@ -13,9 +13,9 @@ kotlin {
             api(libs.velocity.tools)
         }
         jvmTest.dependencies {
-            api(project(":ktor-server-conditional-headers"))
-            api(project(":ktor-server-compression"))
-            implementation(project(":ktor-server-content-negotiation"))
+            api(projects.ktorServerConditionalHeaders)
+            api(projects.ktorServerCompression)
+            implementation(projects.ktorServerContentNegotiation)
         }
     }
 }

--- a/ktor-server/ktor-server-plugins/ktor-server-webjars/build.gradle.kts
+++ b/ktor-server/ktor-server-plugins/ktor-server-webjars/build.gradle.kts
@@ -14,8 +14,8 @@ kotlin {
             api(libs.webjars.locator)
         }
         jvmTest.dependencies {
-            api(project(":ktor-server-conditional-headers"))
-            api(project(":ktor-server-caching-headers"))
+            api(projects.ktorServerConditionalHeaders)
+            api(projects.ktorServerCachingHeaders)
             api(libs.webjars.jquery)
         }
     }

--- a/ktor-server/ktor-server-plugins/ktor-server-websockets/build.gradle.kts
+++ b/ktor-server/ktor-server-plugins/ktor-server-websockets/build.gradle.kts
@@ -11,17 +11,17 @@ plugins {
 kotlin {
     sourceSets {
         commonMain.dependencies {
-            api(project(":ktor-websockets"))
-            api(project(":ktor-websocket-serialization"))
+            api(projects.ktorWebsockets)
+            api(projects.ktorWebsocketSerialization)
         }
 
         commonTest.dependencies {
-            api(project(":ktor-server-content-negotiation"))
-            api(project(":ktor-client-websockets"))
+            api(projects.ktorServerContentNegotiation)
+            api(projects.ktorClientWebsockets)
         }
 
         jvmTest.dependencies {
-            implementation(project(":ktor-test-base"))
+            implementation(projects.ktorTestBase)
         }
     }
 }

--- a/ktor-server/ktor-server-servlet-jakarta/build.gradle.kts
+++ b/ktor-server/ktor-server-servlet-jakarta/build.gradle.kts
@@ -13,13 +13,13 @@ kotlin {
 
     sourceSets {
         jvmMain.dependencies {
-            api(project(":ktor-server-core"))
+            api(projects.ktorServerCore)
 
             compileOnly(libs.jakarta.servlet)
         }
 
         jvmTest.dependencies {
-            api(project(":ktor-server-config-yaml"))
+            api(projects.ktorServerConfigYaml)
             implementation(libs.mockk)
             implementation(libs.jakarta.servlet)
         }

--- a/ktor-server/ktor-server-servlet/build.gradle.kts
+++ b/ktor-server/ktor-server-servlet/build.gradle.kts
@@ -11,12 +11,12 @@ plugins {
 kotlin {
     sourceSets {
         jvmMain.dependencies {
-            api(project(":ktor-server-core"))
+            api(projects.ktorServerCore)
             compileOnly(libs.javax.servlet)
         }
 
         jvmTest.dependencies {
-            api(project(":ktor-server-config-yaml"))
+            api(projects.ktorServerConfigYaml)
             implementation(libs.mockk)
             implementation(libs.javax.servlet)
         }

--- a/ktor-server/ktor-server-test-base/build.gradle.kts
+++ b/ktor-server/ktor-server-test-base/build.gradle.kts
@@ -11,16 +11,16 @@ plugins {
 kotlin {
     sourceSets {
         commonMain.dependencies {
-            api(project(":ktor-server-test-host"))
-            api(project(":ktor-test-base"))
+            api(projects.ktorServerTestHost)
+            api(projects.ktorTestBase)
         }
 
         jvmMain.dependencies {
-            api(project(":ktor-network-tls"))
+            api(projects.ktorNetworkTls)
 
-            api(project(":ktor-client-apache"))
-            api(project(":ktor-network-tls-certificates"))
-            api(project(":ktor-server-call-logging"))
+            api(projects.ktorClientApache)
+            api(projects.ktorNetworkTlsCertificates)
+            api(projects.ktorServerCallLogging)
 
             api(libs.logback.classic)
         }

--- a/ktor-server/ktor-server-test-host/build.gradle.kts
+++ b/ktor-server/ktor-server-test-host/build.gradle.kts
@@ -11,22 +11,22 @@ plugins {
 kotlin {
     sourceSets {
         commonMain.dependencies {
-            api(project(":ktor-client-cio"))
-            api(project(":ktor-server-core"))
-            api(project(":ktor-client-core"))
-            api(project(":ktor-test-dispatcher"))
+            api(projects.ktorClientCio)
+            api(projects.ktorServerCore)
+            api(projects.ktorClientCore)
+            api(projects.ktorTestDispatcher)
         }
 
         jvmMain.dependencies {
-            api(project(":ktor-network-tls"))
+            api(projects.ktorNetworkTls)
 
-            api(project(":ktor-client-apache"))
-            api(project(":ktor-network-tls-certificates"))
-            api(project(":ktor-server-call-logging"))
+            api(projects.ktorClientApache)
+            api(projects.ktorNetworkTlsCertificates)
+            api(projects.ktorServerCallLogging)
 
             // Not ideal, but prevents an additional artifact, and this is usually just included for testing,
             // so shouldn"t increase the size of the final artifact.
-            api(project(":ktor-server-websockets"))
+            api(projects.ktorServerWebsockets)
 
             api(libs.kotlin.test)
             api(libs.junit)
@@ -34,7 +34,7 @@ kotlin {
         }
 
         jvmTest.dependencies {
-            api(project(":ktor-server-config-yaml"))
+            api(projects.ktorServerConfigYaml)
             api(libs.kotlin.test)
         }
     }

--- a/ktor-server/ktor-server-test-suites/build.gradle.kts
+++ b/ktor-server/ktor-server-test-suites/build.gradle.kts
@@ -11,20 +11,20 @@ plugins {
 kotlin {
     sourceSets {
         commonMain.dependencies {
-            implementation(project(":ktor-server-forwarded-header"))
-            implementation(project(":ktor-server-auto-head-response"))
-            implementation(project(":ktor-server-status-pages"))
-            implementation(project(":ktor-server-hsts"))
-            implementation(project(":ktor-server-websockets"))
-            api(project(":ktor-server-test-base"))
+            implementation(projects.ktorServerForwardedHeader)
+            implementation(projects.ktorServerAutoHeadResponse)
+            implementation(projects.ktorServerStatusPages)
+            implementation(projects.ktorServerHsts)
+            implementation(projects.ktorServerWebsockets)
+            api(projects.ktorServerTestBase)
         }
 
         jvmMain.dependencies {
-            implementation(project(":ktor-server-compression"))
-            implementation(project(":ktor-server-partial-content"))
-            implementation(project(":ktor-server-conditional-headers"))
-            implementation(project(":ktor-server-default-headers"))
-            implementation(project(":ktor-server-request-validation"))
+            implementation(projects.ktorServerCompression)
+            implementation(projects.ktorServerPartialContent)
+            implementation(projects.ktorServerConditionalHeaders)
+            implementation(projects.ktorServerDefaultHeaders)
+            implementation(projects.ktorServerRequestValidation)
         }
     }
 }

--- a/ktor-server/ktor-server-tests/build.gradle.kts
+++ b/ktor-server/ktor-server-tests/build.gradle.kts
@@ -12,14 +12,14 @@ plugins {
 kotlin {
     sourceSets {
         commonTest.dependencies {
-            api(project(":ktor-server"))
-            api(project(":ktor-server-rate-limit"))
-            api(project(":ktor-server-test-host"))
+            api(projects.ktorServer)
+            api(projects.ktorServerRateLimit)
+            api(projects.ktorServerTestHost)
         }
         jvmTest.dependencies {
             implementation(libs.jansi)
-            implementation(project(":ktor-client-encoding"))
-            api(project(":ktor-server-sse"))
+            implementation(projects.ktorClientEncoding)
+            api(projects.ktorServerSse)
         }
     }
 }

--- a/ktor-server/ktor-server-tomcat-jakarta/build.gradle.kts
+++ b/ktor-server/ktor-server-tomcat-jakarta/build.gradle.kts
@@ -14,15 +14,15 @@ kotlin {
 
     sourceSets {
         jvmMain.dependencies {
-            api(project(":ktor-server-core"))
-            api(project(":ktor-server-servlet-jakarta"))
+            api(projects.ktorServerCore)
+            api(projects.ktorServerServletJakarta)
             api(libs.tomcat.catalina.jakarta)
             api(libs.tomcat.embed.core.jakarta)
         }
         jvmTest.dependencies {
-            api(project(":ktor-server-test-base"))
-            api(project(":ktor-server-test-suites"))
-            api(project(":ktor-server-core"))
+            api(projects.ktorServerTestBase)
+            api(projects.ktorServerTestSuites)
+            api(projects.ktorServerCore)
         }
     }
 }

--- a/ktor-server/ktor-server-tomcat/build.gradle.kts
+++ b/ktor-server/ktor-server-tomcat/build.gradle.kts
@@ -11,15 +11,15 @@ plugins {
 kotlin {
     sourceSets {
         jvmMain.dependencies {
-            api(project(":ktor-server-core"))
-            api(project(":ktor-server-servlet"))
+            api(projects.ktorServerCore)
+            api(projects.ktorServerServlet)
             api(libs.tomcat.catalina)
             api(libs.tomcat.embed.core)
         }
         jvmTest.dependencies {
-            api(project(":ktor-server-test-base"))
-            api(project(":ktor-server-test-suites"))
-            api(project(":ktor-server-core"))
+            api(projects.ktorServerTestBase)
+            api(projects.ktorServerTestSuites)
+            api(projects.ktorServerCore)
         }
     }
 }

--- a/ktor-shared/ktor-events/build.gradle.kts
+++ b/ktor-shared/ktor-events/build.gradle.kts
@@ -9,7 +9,7 @@ plugins {
 kotlin {
     sourceSets {
         commonMain.dependencies {
-            api(project(":ktor-utils"))
+            api(projects.ktorUtils)
         }
     }
 }

--- a/ktor-shared/ktor-htmx/build.gradle.kts
+++ b/ktor-shared/ktor-htmx/build.gradle.kts
@@ -11,7 +11,7 @@ plugins {
 kotlin {
     sourceSets {
         commonMain.dependencies {
-            api(project(":ktor-utils"))
+            api(projects.ktorUtils)
         }
     }
 }

--- a/ktor-shared/ktor-htmx/ktor-htmx-html/build.gradle.kts
+++ b/ktor-shared/ktor-htmx/ktor-htmx-html/build.gradle.kts
@@ -12,8 +12,8 @@ kotlin {
     sourceSets {
         commonMain.dependencies {
             api(libs.kotlinx.html)
-            api(project(":ktor-htmx"))
-            implementation(project(":ktor-utils"))
+            api(projects.ktorHtmx)
+            implementation(projects.ktorUtils)
         }
     }
 }

--- a/ktor-shared/ktor-resources/build.gradle.kts
+++ b/ktor-shared/ktor-resources/build.gradle.kts
@@ -12,8 +12,8 @@ plugins {
 kotlin {
     sourceSets {
         commonMain.dependencies {
-            api(project(":ktor-http"))
-            api(project(":ktor-utils"))
+            api(projects.ktorHttp)
+            api(projects.ktorUtils)
             api(libs.kotlinx.serialization.core)
         }
     }

--- a/ktor-shared/ktor-serialization/build.gradle.kts
+++ b/ktor-shared/ktor-serialization/build.gradle.kts
@@ -11,7 +11,7 @@ plugins {
 kotlin {
     sourceSets {
         commonMain.dependencies {
-            api(project(":ktor-websockets"))
+            api(projects.ktorWebsockets)
         }
     }
 }

--- a/ktor-shared/ktor-serialization/ktor-serialization-gson/build.gradle.kts
+++ b/ktor-shared/ktor-serialization/ktor-serialization-gson/build.gradle.kts
@@ -11,14 +11,14 @@ plugins {
 kotlin {
     sourceSets {
         jvmMain.dependencies {
-            api(project(":ktor-serialization"))
+            api(projects.ktorSerialization)
             api(libs.gson)
         }
         jvmTest.dependencies {
-            api(project(":ktor-server-test-host"))
-            api(project(":ktor-client-tests"))
-            api(project(":ktor-client-content-negotiation-tests"))
-            api(project(":ktor-serialization-tests"))
+            api(projects.ktorServerTestHost)
+            api(projects.ktorClientTests)
+            api(projects.ktorClientContentNegotiationTests)
+            api(projects.ktorSerializationTests)
 
             api(libs.logback.classic)
         }

--- a/ktor-shared/ktor-serialization/ktor-serialization-jackson/build.gradle.kts
+++ b/ktor-shared/ktor-serialization/ktor-serialization-jackson/build.gradle.kts
@@ -11,15 +11,15 @@ plugins {
 kotlin {
     sourceSets {
         jvmMain.dependencies {
-            api(project(":ktor-serialization"))
+            api(projects.ktorSerialization)
             api(libs.jackson.databind)
             api(libs.jackson.module.kotlin)
         }
         jvmTest.dependencies {
-            api(project(":ktor-server-test-host"))
-            api(project(":ktor-client-tests"))
-            api(project(":ktor-client-content-negotiation-tests"))
-            api(project(":ktor-serialization-tests"))
+            api(projects.ktorServerTestHost)
+            api(projects.ktorClientTests)
+            api(projects.ktorClientContentNegotiationTests)
+            api(projects.ktorSerializationTests)
 
             api(libs.logback.classic)
             api(libs.jackson.dataformat.smile)

--- a/ktor-shared/ktor-serialization/ktor-serialization-kotlinx/build.gradle.kts
+++ b/ktor-shared/ktor-serialization/ktor-serialization-kotlinx/build.gradle.kts
@@ -12,7 +12,7 @@ plugins {
 kotlin {
     sourceSets {
         commonMain.dependencies {
-            api(project(":ktor-serialization"))
+            api(projects.ktorSerialization)
             api(libs.kotlinx.serialization.core)
         }
     }

--- a/ktor-shared/ktor-serialization/ktor-serialization-kotlinx/ktor-serialization-kotlinx-cbor/build.gradle.kts
+++ b/ktor-shared/ktor-serialization/ktor-serialization-kotlinx/ktor-serialization-kotlinx-cbor/build.gradle.kts
@@ -12,12 +12,12 @@ plugins {
 kotlin {
     sourceSets {
         commonMain.dependencies {
-            api(project(":ktor-serialization-kotlinx"))
+            api(projects.ktorSerializationKotlinx)
             api(libs.kotlinx.serialization.cbor)
         }
         commonTest.dependencies {
             api(libs.kotlinx.serialization.json)
-            api(project(":ktor-serialization-kotlinx-tests"))
+            api(projects.ktorSerializationKotlinxTests)
         }
     }
 }

--- a/ktor-shared/ktor-serialization/ktor-serialization-kotlinx/ktor-serialization-kotlinx-json/build.gradle.kts
+++ b/ktor-shared/ktor-serialization/ktor-serialization-kotlinx/ktor-serialization-kotlinx-json/build.gradle.kts
@@ -12,15 +12,15 @@ plugins {
 kotlin {
     sourceSets {
         commonMain.dependencies {
-            api(project(":ktor-serialization-kotlinx"))
+            api(projects.ktorSerializationKotlinx)
             api(libs.kotlinx.serialization.json)
             api(libs.kotlinx.serialization.json.io)
         }
         jvmTest.dependencies {
-            api(project(":ktor-client-content-negotiation-tests"))
+            api(projects.ktorClientContentNegotiationTests)
         }
         commonTest.dependencies {
-            api(project(":ktor-serialization-kotlinx-tests"))
+            api(projects.ktorSerializationKotlinxTests)
         }
     }
 }

--- a/ktor-shared/ktor-serialization/ktor-serialization-kotlinx/ktor-serialization-kotlinx-protobuf/build.gradle.kts
+++ b/ktor-shared/ktor-serialization/ktor-serialization-kotlinx/ktor-serialization-kotlinx-protobuf/build.gradle.kts
@@ -12,14 +12,14 @@ plugins {
 kotlin {
     sourceSets {
         commonMain.dependencies {
-            api(project(":ktor-serialization-kotlinx"))
+            api(projects.ktorSerializationKotlinx)
             api(libs.kotlinx.serialization.protobuf)
         }
         jvmTest.dependencies {
-            api(project(":ktor-client-content-negotiation-tests"))
+            api(projects.ktorClientContentNegotiationTests)
         }
         commonTest.dependencies {
-            api(project(":ktor-serialization-kotlinx-tests"))
+            api(projects.ktorSerializationKotlinxTests)
         }
     }
 }

--- a/ktor-shared/ktor-serialization/ktor-serialization-kotlinx/ktor-serialization-kotlinx-tests/build.gradle.kts
+++ b/ktor-shared/ktor-serialization/ktor-serialization-kotlinx/ktor-serialization-kotlinx-tests/build.gradle.kts
@@ -11,11 +11,11 @@ kotlin {
     sourceSets {
         commonMain.dependencies {
             api(kotlin("test-annotations-common"))
-            api(project(":ktor-serialization-kotlinx"))
-            api(project(":ktor-client-tests"))
+            api(projects.ktorSerializationKotlinx)
+            api(projects.ktorClientTests)
         }
         jvmMain.dependencies {
-            api(project(":ktor-serialization-tests"))
+            api(projects.ktorSerializationTests)
 
             api(libs.logback.classic)
         }

--- a/ktor-shared/ktor-serialization/ktor-serialization-kotlinx/ktor-serialization-kotlinx-xml/build.gradle.kts
+++ b/ktor-shared/ktor-serialization/ktor-serialization-kotlinx/ktor-serialization-kotlinx-xml/build.gradle.kts
@@ -10,14 +10,14 @@ plugins {
 kotlin {
     sourceSets {
         commonMain.dependencies {
-            api(project(":ktor-serialization-kotlinx"))
+            api(projects.ktorSerializationKotlinx)
             api(libs.xmlutil.serialization)
         }
         commonTest.dependencies {
-            implementation(project(":ktor-serialization-kotlinx-tests"))
+            implementation(projects.ktorSerializationKotlinxTests)
         }
         jvmTest.dependencies {
-            implementation(project(":ktor-client-content-negotiation-tests"))
+            implementation(projects.ktorClientContentNegotiationTests)
         }
     }
 }

--- a/ktor-shared/ktor-serialization/ktor-serialization-tests/build.gradle.kts
+++ b/ktor-shared/ktor-serialization/ktor-serialization-tests/build.gradle.kts
@@ -10,8 +10,8 @@ plugins {
 kotlin {
     sourceSets {
         jvmMain.dependencies {
-            api(project(":ktor-server-test-host"))
-            api(project(":ktor-client-content-negotiation-tests"))
+            api(projects.ktorServerTestHost)
+            api(projects.ktorClientContentNegotiationTests)
 
             api(libs.logback.classic)
         }

--- a/ktor-shared/ktor-sse/build.gradle.kts
+++ b/ktor-shared/ktor-sse/build.gradle.kts
@@ -11,7 +11,7 @@ plugins {
 kotlin {
     sourceSets {
         commonMain.dependencies {
-            api(project(":ktor-utils"))
+            api(projects.ktorUtils)
         }
     }
 }

--- a/ktor-shared/ktor-test-base/build.gradle.kts
+++ b/ktor-shared/ktor-test-base/build.gradle.kts
@@ -12,8 +12,8 @@ kotlin {
     sourceSets {
         commonMain.dependencies {
             api(libs.kotlin.test)
-            api(project(":ktor-utils"))
-            api(project(":ktor-test-dispatcher"))
+            api(projects.ktorUtils)
+            api(projects.ktorTestDispatcher)
         }
 
         jvmMain.dependencies {

--- a/ktor-shared/ktor-websocket-serialization/build.gradle.kts
+++ b/ktor-shared/ktor-websocket-serialization/build.gradle.kts
@@ -11,7 +11,7 @@ plugins {
 kotlin {
     sourceSets {
         commonMain.dependencies {
-            api(project(":ktor-serialization"))
+            api(projects.ktorSerialization)
         }
     }
 }

--- a/ktor-shared/ktor-websockets/build.gradle.kts
+++ b/ktor-shared/ktor-websockets/build.gradle.kts
@@ -9,8 +9,8 @@ plugins {
 kotlin {
     sourceSets {
         commonMain.dependencies {
-            api(project(":ktor-utils"))
-            api(project(":ktor-http"))
+            api(projects.ktorUtils)
+            api(projects.ktorHttp)
         }
     }
 }

--- a/ktor-test-dispatcher/build.gradle.kts
+++ b/ktor-test-dispatcher/build.gradle.kts
@@ -12,7 +12,7 @@ kotlin {
             api(libs.kotlinx.coroutines.test)
         }
         posixMain.dependencies {
-            implementation(project(":ktor-utils"))
+            implementation(projects.ktorUtils)
         }
     }
 }

--- a/ktor-utils/build.gradle.kts
+++ b/ktor-utils/build.gradle.kts
@@ -25,14 +25,14 @@ kotlin {
 
     sourceSets {
         commonMain.dependencies {
-            api(project(":ktor-io"))
+            api(projects.ktorIo)
             api(libs.kotlinx.serialization.core)
         }
         commonTest.dependencies {
-            api(project(":ktor-test-dispatcher"))
+            api(projects.ktorTestDispatcher)
         }
         jvmTest.dependencies {
-            implementation(project(":ktor-test-base"))
+            implementation(projects.ktorTestBase)
         }
     }
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -3,6 +3,7 @@
  */
 
 enableFeaturePreview("STABLE_CONFIGURATION_CACHE")
+enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")
 
 pluginManagement {
     includeBuild("build-settings-logic")


### PR DESCRIPTION
**Subsystem**
Infrastructure

**Motivation**
[KTOR-7868](https://youtrack.jetbrains.com/issue/KTOR-7868) Gradle: Enable typesafe project accessors

**Solution**
Enabled type-safe project accessors feature flag and replaced project references using "Replace Structurally" with the following template:

```xml
<replaceConfiguration name="Migrate to typesafe project accessors" text="project(&quot;:$projectPath$&quot;)" recursive="false" type="Kotlin" pattern_context="default" search_injected="false" reformatAccordingToStyle="false" shortenFQN="false" replacement="projects$transformedPath$">
  <constraint name="__context__" within="" contains="" />
  <constraint name="projectPath" within="" contains="" />
  <variableDefinition name="transformedPath" script="&quot;projectPath.text.replace(':', '.').split('[_-]').collect { word -&gt; word.capitalize() }.join('')&quot;" />
</replaceConfiguration>
```

