### PR TITLE
KTOR-4766 Add Unix domain socket support for the CIO server and client engines

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -31,8 +31,8 @@ version=3.2.0-SNAPSHOT
 # * '-Dkotlin.daemon.options=autoshutdownIdleSeconds=30'
 #   To save some memory, shutting down Kotlin Daemon used for buildSrc compilation after 30 seconds of idle.
 #   See: https://github.com/gradle/gradle/issues/29331
-org.gradle.jvmargs=-Xms2g -Xmx8g -XX:+HeapDumpOnOutOfMemoryError -XX:+UseParallelGC -Dfile.encoding=UTF-8 -Dkotlin.daemon.jvm.options=-Xmx512m,Xms256m,-XX:MaxMetaspaceSize=256m,XX:+HeapDumpOnOutOfMemoryError
-kotlin.daemon.jvmargs=-Xms512m -Xmx2g -XX:MaxMetaspaceSize=256m -XX:+HeapDumpOnOutOfMemoryError
+org.gradle.jvmargs=-Xms2g -Xmx10g -XX:+HeapDumpOnOutOfMemoryError -XX:+UseParallelGC -Dfile.encoding=UTF-8 -Dkotlin.daemon.jvm.options=-Xmx512m,Xms256m,-XX:MaxMetaspaceSize=256m,XX:+HeapDumpOnOutOfMemoryError
+kotlin.daemon.jvmargs=-Xms512m -Xmx4g -XX:MaxMetaspaceSize=256m -XX:+HeapDumpOnOutOfMemoryError
 # Gradle Doctor might increase memory consumption when task monitoring is enabled, so it is disabled by default.
 # Some features can't work without task monitoring:
 #  doctor-negative-savings, doctor-slow-build-cache-connection, doctor-slow-maven-connection

--- a/ktor-client/ktor-client-cio/common/src/io/ktor/client/engine/cio/ConnectionFactory.kt
+++ b/ktor-client/ktor-client-cio/common/src/io/ktor/client/engine/cio/ConnectionFactory.kt
@@ -15,10 +15,10 @@ internal class ConnectionFactory(
     private val addressConnectionsLimit: Int
 ) {
     private val limit = Semaphore(connectionsLimit)
-    private val addressLimit = ConcurrentMap<InetSocketAddress, Semaphore>()
+    private val addressLimit = ConcurrentMap<SocketAddress, Semaphore>()
 
     suspend fun connect(
-        address: InetSocketAddress,
+        address: SocketAddress,
         configuration: SocketOptions.TCPClientSocketOptions.() -> Unit = {}
     ): Socket {
         limit.acquire()
@@ -39,8 +39,8 @@ internal class ConnectionFactory(
         }
     }
 
-    fun release(address: InetSocketAddress) {
-        addressLimit[address]!!.release()
+    fun release(address: SocketAddress) {
+        addressLimit[address]?.release()
         limit.release()
     }
 }

--- a/ktor-client/ktor-client-cio/common/src/io/ktor/client/engine/cio/Endpoint.kt
+++ b/ktor-client/ktor-client-cio/common/src/io/ktor/client/engine/cio/Endpoint.kt
@@ -5,7 +5,6 @@
 package io.ktor.client.engine.cio
 
 import io.ktor.client.engine.*
-import io.ktor.client.network.sockets.*
 import io.ktor.client.plugins.*
 import io.ktor.client.request.*
 import io.ktor.client.utils.*
@@ -16,13 +15,15 @@ import io.ktor.util.date.*
 import io.ktor.util.logging.*
 import io.ktor.utils.io.*
 import io.ktor.utils.io.core.*
-import kotlinx.atomicfu.*
+import kotlinx.atomicfu.AtomicInt
+import kotlinx.atomicfu.atomic
 import kotlinx.coroutines.*
-import kotlinx.coroutines.channels.*
-import kotlin.coroutines.*
+import kotlinx.coroutines.channels.Channel
+import kotlin.coroutines.CoroutineContext
 
 private val LOGGER = KtorSimpleLogger("io.ktor.client.engine.cio.Endpoint")
 
+@OptIn(InternalAPI::class)
 internal class Endpoint(
     private val host: String,
     private val port: Int,
@@ -31,7 +32,8 @@ internal class Endpoint(
     private val config: CIOEngineConfig,
     private val connectionFactory: ConnectionFactory,
     override val coroutineContext: CoroutineContext,
-    private val onDone: () -> Unit
+    private val onDone: () -> Unit,
+    private val unixSocket: UnixSocketSettings?,
 ) : CoroutineScope, Closeable {
     private val lastActivity = atomic(getTimeMillis())
     private val connections: AtomicInt = atomic(0)
@@ -194,7 +196,7 @@ internal class Endpoint(
     }
 
     @Suppress("UNUSED_EXPRESSION")
-    private suspend fun connect(requestData: HttpRequestData): Pair<InetSocketAddress, Connection> {
+    private suspend fun connect(requestData: HttpRequestData): Pair<SocketAddress, Connection> {
         val connectAttempts = config.endpoint.connectAttempts
         val (connectTimeout, socketTimeout) = retrieveTimeouts(requestData)
         var timeoutFails = 0
@@ -203,7 +205,11 @@ internal class Endpoint(
 
         try {
             repeat(connectAttempts) {
-                val address = InetSocketAddress(host, port)
+                val address = if (unixSocket != null) {
+                    UnixSocketAddress(unixSocket.path)
+                } else {
+                    InetSocketAddress(host, port)
+                }
 
                 val connect: suspend CoroutineScope.() -> Socket = {
                     connectionFactory.connect(address) {
@@ -230,8 +236,16 @@ internal class Endpoint(
                     if (proxy?.type == ProxyType.HTTP) {
                         startTunnel(requestData, connection.output, connection.input)
                     }
+
+                    if (unixSocket != null) {
+                        throw IllegalArgumentException("TLS over Unix sockets is not supported")
+                    }
+
                     val realAddress = when (proxy) {
-                        null -> address
+                        null ->
+                            address as? InetSocketAddress
+                                ?: throw IllegalArgumentException("Expected InetSocketAddress for TLS connection")
+
                         else -> InetSocketAddress(requestData.url.host, requestData.url.port)
                     }
                     val tlsSocket = connection.tls(coroutineContext) {
@@ -285,7 +299,7 @@ internal class Endpoint(
         return connectTimeout to socketTimeout
     }
 
-    private fun releaseConnection(address: InetSocketAddress) {
+    private fun releaseConnection(address: SocketAddress) {
         connectionFactory.release(address)
         connections.decrementAndGet()
     }

--- a/ktor-client/ktor-client-cio/jvm/test/io/ktor/client/engine/cio/UnixSocketTest.kt
+++ b/ktor-client/ktor-client-cio/jvm/test/io/ktor/client/engine/cio/UnixSocketTest.kt
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2014-2025 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.client.engine.cio
+
+import io.ktor.client.HttpClient
+import io.ktor.client.request.get
+import io.ktor.client.request.unixSocket
+import io.ktor.client.statement.bodyAsText
+import io.ktor.network.sockets.*
+import io.ktor.server.application.*
+import io.ktor.server.cio.*
+import io.ktor.server.cio.CIO
+import io.ktor.server.engine.*
+import io.ktor.server.request.*
+import io.ktor.server.response.*
+import io.ktor.server.routing.*
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class UnixSocketTest {
+
+    @Test
+    fun testUnixSocketClient() = runBlocking {
+        if (!UnixSocketAddress.isSupported()) return@runBlocking
+
+        val server = embeddedServer(
+            CIO,
+            serverConfig {
+                module {
+                    routing {
+                        get("/") {
+                            call.respondText("Hello, Unix socket world!")
+                        }
+                    }
+                }
+            },
+            configure = {
+                unixConnector("/tmp/test-unix-socket-client.sock")
+            }
+        )
+
+        val client = HttpClient(io.ktor.client.engine.cio.CIO)
+        try {
+            server.start(wait = false)
+            delay(1000)
+
+            val response = client.get("http://localhost/") {
+                unixSocket("/tmp/test-unix-socket-client.sock/")
+            }
+            assertEquals(200, response.status.value)
+            assertEquals("Hello, Unix socket world!", response.bodyAsText())
+        } finally {
+            client.close()
+            server.stop()
+        }
+    }
+}

--- a/ktor-client/ktor-client-core/api/ktor-client-core.api
+++ b/ktor-client/ktor-client-core/api/ktor-client-core.api
@@ -1300,6 +1300,22 @@ public final class io/ktor/client/request/SSEClientResponseAdapter : io/ktor/cli
 	public fun adapt (Lio/ktor/client/request/HttpRequestData;Lio/ktor/http/HttpStatusCode;Lio/ktor/http/Headers;Lio/ktor/utils/io/ByteReadChannel;Lio/ktor/http/content/OutgoingContent;Lkotlin/coroutines/CoroutineContext;)Ljava/lang/Object;
 }
 
+public final class io/ktor/client/request/UnixSocketCapability : io/ktor/client/engine/HttpClientEngineCapability {
+	public static final field INSTANCE Lio/ktor/client/request/UnixSocketCapability;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/ktor/client/request/UnixSocketSettings {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun getPath ()Ljava/lang/String;
+}
+
+public final class io/ktor/client/request/UnixSockets_jvmAndPosixKt {
+	public static final fun unixSocket (Lio/ktor/client/request/HttpRequestBuilder;Ljava/lang/String;)V
+}
+
 public final class io/ktor/client/request/UtilsKt {
 	public static final fun accept (Lio/ktor/http/HttpMessageBuilder;Lio/ktor/http/ContentType;)V
 	public static final fun basicAuth (Lio/ktor/http/HttpMessageBuilder;Ljava/lang/String;Ljava/lang/String;)V

--- a/ktor-client/ktor-client-core/api/ktor-client-core.klib.api
+++ b/ktor-client/ktor-client-core/api/ktor-client-core.klib.api
@@ -992,6 +992,13 @@ final class io.ktor.client.request/SSEClientResponseAdapter : io.ktor.client.req
     final fun adapt(io.ktor.client.request/HttpRequestData, io.ktor.http/HttpStatusCode, io.ktor.http/Headers, io.ktor.utils.io/ByteReadChannel, io.ktor.http.content/OutgoingContent, kotlin.coroutines/CoroutineContext): kotlin/Any? // io.ktor.client.request/SSEClientResponseAdapter.adapt|adapt(io.ktor.client.request.HttpRequestData;io.ktor.http.HttpStatusCode;io.ktor.http.Headers;io.ktor.utils.io.ByteReadChannel;io.ktor.http.content.OutgoingContent;kotlin.coroutines.CoroutineContext){}[0]
 }
 
+final class io.ktor.client.request/UnixSocketSettings { // io.ktor.client.request/UnixSocketSettings|null[0]
+    constructor <init>(kotlin/String) // io.ktor.client.request/UnixSocketSettings.<init>|<init>(kotlin.String){}[0]
+
+    final val path // io.ktor.client.request/UnixSocketSettings.path|{}path[0]
+        final fun <get-path>(): kotlin/String // io.ktor.client.request/UnixSocketSettings.path.<get-path>|<get-path>(){}[0]
+}
+
 final class io.ktor.client.statement/DefaultHttpResponse : io.ktor.client.statement/HttpResponse { // io.ktor.client.statement/DefaultHttpResponse|null[0]
     constructor <init>(io.ktor.client.call/HttpClientCall, io.ktor.client.request/HttpResponseData) // io.ktor.client.statement/DefaultHttpResponse.<init>|<init>(io.ktor.client.call.HttpClientCall;io.ktor.client.request.HttpResponseData){}[0]
 
@@ -1256,6 +1263,12 @@ final object io.ktor.client.plugins/HttpTimeoutCapability : io.ktor.client.engin
 
 final object io.ktor.client.plugins/SetupRequestContext : io.ktor.client.plugins.api/ClientHook<kotlin.coroutines/SuspendFunction2<io.ktor.client.request/HttpRequestBuilder, kotlin.coroutines/SuspendFunction0<kotlin/Unit>, kotlin/Unit>> { // io.ktor.client.plugins/SetupRequestContext|null[0]
     final fun install(io.ktor.client/HttpClient, kotlin.coroutines/SuspendFunction2<io.ktor.client.request/HttpRequestBuilder, kotlin.coroutines/SuspendFunction0<kotlin/Unit>, kotlin/Unit>) // io.ktor.client.plugins/SetupRequestContext.install|install(io.ktor.client.HttpClient;kotlin.coroutines.SuspendFunction2<io.ktor.client.request.HttpRequestBuilder,kotlin.coroutines.SuspendFunction0<kotlin.Unit>,kotlin.Unit>){}[0]
+}
+
+final object io.ktor.client.request/UnixSocketCapability : io.ktor.client.engine/HttpClientEngineCapability<io.ktor.client.request/UnixSocketSettings> { // io.ktor.client.request/UnixSocketCapability|null[0]
+    final fun equals(kotlin/Any?): kotlin/Boolean // io.ktor.client.request/UnixSocketCapability.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // io.ktor.client.request/UnixSocketCapability.hashCode|hashCode(){}[0]
+    final fun toString(): kotlin/String // io.ktor.client.request/UnixSocketCapability.toString|toString(){}[0]
 }
 
 final object io.ktor.client.utils/CacheControl { // io.ktor.client.utils/CacheControl|null[0]
@@ -1570,6 +1583,9 @@ final suspend inline fun <#A: reified kotlin/Any?> (io.ktor.client.call/HttpClie
 final suspend inline fun <#A: reified kotlin/Any?> (io.ktor.client.plugins.websocket/DefaultClientWebSocketSession).io.ktor.client.plugins.websocket/receiveDeserialized(): #A // io.ktor.client.plugins.websocket/receiveDeserialized|receiveDeserialized@io.ktor.client.plugins.websocket.DefaultClientWebSocketSession(){0§<kotlin.Any?>}[0]
 final suspend inline fun <#A: reified kotlin/Any?> (io.ktor.client.plugins.websocket/DefaultClientWebSocketSession).io.ktor.client.plugins.websocket/sendSerialized(#A) // io.ktor.client.plugins.websocket/sendSerialized|sendSerialized@io.ktor.client.plugins.websocket.DefaultClientWebSocketSession(0:0){0§<kotlin.Any?>}[0]
 final suspend inline fun <#A: reified kotlin/Any?> (io.ktor.client.statement/HttpResponse).io.ktor.client.call/body(): #A // io.ktor.client.call/body|body@io.ktor.client.statement.HttpResponse(){0§<kotlin.Any?>}[0]
+
+// Targets: [native]
+final fun (io.ktor.client.request/HttpRequestBuilder).io.ktor.client.request/unixSocket(kotlin/String) // io.ktor.client.request/unixSocket|unixSocket@io.ktor.client.request.HttpRequestBuilder(kotlin.String){}[0]
 
 // Targets: [js, wasmJs]
 abstract interface io.ktor.client.fetch/AbortSignal : io.ktor.client.fetch/EventTarget { // io.ktor.client.fetch/AbortSignal|null[0]

--- a/ktor-client/ktor-client-core/common/src/io/ktor/client/request/UnixSockets.kt
+++ b/ktor-client/ktor-client-core/common/src/io/ktor/client/request/UnixSockets.kt
@@ -1,0 +1,13 @@
+/*
+ * Copyright 2014-2025 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+package io.ktor.client.request
+
+import io.ktor.client.engine.*
+import io.ktor.utils.io.InternalAPI
+
+@InternalAPI
+public class UnixSocketSettings(public val path: String)
+
+@OptIn(InternalAPI::class)
+public data object UnixSocketCapability : HttpClientEngineCapability<UnixSocketSettings>

--- a/ktor-client/ktor-client-core/jvmAndPosix/src/UnixSockets.jvmAndPosix.kt
+++ b/ktor-client/ktor-client-core/jvmAndPosix/src/UnixSockets.jvmAndPosix.kt
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2014-2025 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+package io.ktor.client.request
+
+import io.ktor.utils.io.*
+
+/**
+ * Sets the path to the Unix domain socket file.
+ *
+ * ```kotlin
+ * val client = client.get("http://localhost/api") {
+ *    unixSocket("/var/run/docker.sock")
+ * }
+ * ```
+ */
+@OptIn(InternalAPI::class)
+public fun HttpRequestBuilder.unixSocket(path: String) {
+    setCapability(UnixSocketCapability, UnixSocketSettings(path))
+}

--- a/ktor-network/api/ktor-network.api
+++ b/ktor-network/api/ktor-network.api
@@ -360,6 +360,7 @@ public final class io/ktor/network/sockets/UDPSocketBuilder : io/ktor/network/so
 }
 
 public final class io/ktor/network/sockets/UnixSocketAddress : io/ktor/network/sockets/SocketAddress {
+	public static final field Companion Lio/ktor/network/sockets/UnixSocketAddress$Companion;
 	public fun <init> (Ljava/lang/String;)V
 	public final fun component1 ()Ljava/lang/String;
 	public final fun copy (Ljava/lang/String;)Lio/ktor/network/sockets/UnixSocketAddress;
@@ -368,6 +369,10 @@ public final class io/ktor/network/sockets/UnixSocketAddress : io/ktor/network/s
 	public final fun getPath ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/ktor/network/sockets/UnixSocketAddress$Companion {
+	public final fun isSupported ()Z
 }
 
 public final class io/ktor/network/util/PoolsKt {

--- a/ktor-network/api/ktor-network.klib.api
+++ b/ktor-network/api/ktor-network.klib.api
@@ -184,6 +184,10 @@ final class io.ktor.network.sockets/UnixSocketAddress : io.ktor.network.sockets/
     final fun equals(kotlin/Any?): kotlin/Boolean // io.ktor.network.sockets/UnixSocketAddress.equals|equals(kotlin.Any?){}[0]
     final fun hashCode(): kotlin/Int // io.ktor.network.sockets/UnixSocketAddress.hashCode|hashCode(){}[0]
     final fun toString(): kotlin/String // io.ktor.network.sockets/UnixSocketAddress.toString|toString(){}[0]
+
+    final object Companion { // io.ktor.network.sockets/UnixSocketAddress.Companion|null[0]
+        final fun isSupported(): kotlin/Boolean // io.ktor.network.sockets/UnixSocketAddress.Companion.isSupported|isSupported(){}[0]
+    }
 }
 
 final value class io.ktor.network.sockets/TypeOfService { // io.ktor.network.sockets/TypeOfService|null[0]

--- a/ktor-network/common/src/io/ktor/network/sockets/SocketAddress.kt
+++ b/ktor-network/common/src/io/ktor/network/sockets/SocketAddress.kt
@@ -104,4 +104,13 @@ public expect class UnixSocketAddress(
     override fun equals(other: Any?): Boolean
     override fun hashCode(): Int
     override fun toString(): String
+
+    public companion object {
+        /**
+         * Checks if Unix domain sockets are supported on the current platform.
+         *
+         * @return `true` if Unix domain sockets are supported, `false` otherwise.
+         */
+        public fun isSupported(): Boolean
+    }
 }

--- a/ktor-network/common/test/io/ktor/network/sockets/tests/TestUtils.kt
+++ b/ktor-network/common/test/io/ktor/network/sockets/tests/TestUtils.kt
@@ -25,8 +25,6 @@ internal fun testSockets(
     }
 }
 
-internal expect fun Any.supportsUnixDomainSockets(): Boolean
-
 internal expect fun Throwable.isPosixException(): Boolean
 
 @OptIn(ExperimentalUuidApi::class)

--- a/ktor-network/common/test/io/ktor/network/sockets/tests/UnixSocketTest.kt
+++ b/ktor-network/common/test/io/ktor/network/sockets/tests/UnixSocketTest.kt
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2014-2025 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.network.sockets.tests
+
+import io.ktor.network.sockets.*
+import io.ktor.utils.io.*
+import kotlinx.coroutines.async
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class UnixSocketTest {
+
+    @Test
+    fun testEchoOverUnixSockets() = testSockets { selector ->
+        if (!UnixSocketAddress.isSupported()) return@testSockets
+
+        val socketPath = createTempFilePath("ktor-echo-test")
+        try {
+            val tcp = aSocket(selector).tcp()
+            val server = tcp.bind(UnixSocketAddress(socketPath))
+
+            val serverConnectionPromise = async {
+                server.accept()
+            }
+
+            val clientConnection = tcp.connect(UnixSocketAddress(socketPath))
+            val serverConnection = serverConnectionPromise.await()
+
+            val clientOutput = clientConnection.openWriteChannel()
+            try {
+                clientOutput.writeStringUtf8("Hello, world\n")
+                clientOutput.flush()
+            } finally {
+                clientOutput.flushAndClose()
+            }
+
+            val serverInput = serverConnection.openReadChannel()
+            val message = serverInput.readUTF8Line()
+            assertEquals("Hello, world", message)
+
+            val serverOutput = serverConnection.openWriteChannel()
+            try {
+                serverOutput.writeStringUtf8("Hello From Server\n")
+                serverOutput.flush()
+
+                val clientInput = clientConnection.openReadChannel()
+                val echo = clientInput.readUTF8Line()
+
+                assertEquals("Hello From Server", echo)
+            } finally {
+                serverOutput.flushAndClose()
+            }
+
+            serverConnection.close()
+            clientConnection.close()
+
+            server.close()
+        } finally {
+            removeFile(socketPath)
+        }
+    }
+}

--- a/ktor-network/jsAndWasmShared/src/io/ktor/network/sockets/SocketAddress.nonJvm.jsAndWasmShared.kt
+++ b/ktor-network/jsAndWasmShared/src/io/ktor/network/sockets/SocketAddress.nonJvm.jsAndWasmShared.kt
@@ -2,6 +2,6 @@
  * Copyright 2014-2025 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
-package io.ktor.network.sockets.tests
+package io.ktor.network.sockets
 
-internal actual fun Throwable.isPosixException(): Boolean = false
+internal actual fun isUnixSocketSupported(): Boolean = false

--- a/ktor-network/jvm/src/io/ktor/network/sockets/SocketAddressJvm.kt
+++ b/ktor-network/jvm/src/io/ktor/network/sockets/SocketAddressJvm.kt
@@ -103,17 +103,24 @@ public actual class UnixSocketAddress internal constructor(
 
     public actual override fun toString(): String = address.toString()
 
-    private companion object {
+    public actual companion object {
         private val unixDomainSocketAddressClass = try {
             Class.forName(UNIX_DOMAIN_SOCKET_ADDRESS_CLASS)
         } catch (exception: ClassNotFoundException) {
             null
         }
 
-        private fun checkSupportForUnixDomainSockets(): Class<*> {
+        internal fun checkSupportForUnixDomainSockets(): Class<*> {
             return unixDomainSocketAddressClass
                 ?: error("Unix domain sockets are unsupported before Java 16.")
         }
+
+        /**
+         * Checks if Unix domain sockets are supported on the current platform.
+         *
+         * @return `true` if Unix domain sockets are supported, `false` otherwise.
+         */
+        public actual fun isSupported(): Boolean = unixDomainSocketAddressClass != null
     }
 }
 

--- a/ktor-network/jvm/test/io/ktor/network/sockets/tests/TestUtilsJvm.kt
+++ b/ktor-network/jvm/test/io/ktor/network/sockets/tests/TestUtilsJvm.kt
@@ -4,15 +4,4 @@
 
 package io.ktor.network.sockets.tests
 
-private const val UNIX_DOMAIN_SOCKET_ADDRESS_CLASS = "java.net.UnixDomainSocketAddress"
-
-internal actual fun Any.supportsUnixDomainSockets(): Boolean {
-    return try {
-        Class.forName(UNIX_DOMAIN_SOCKET_ADDRESS_CLASS, false, javaClass.classLoader)
-        true
-    } catch (e: ClassNotFoundException) {
-        false
-    }
-}
-
 internal actual fun Throwable.isPosixException(): Boolean = false

--- a/ktor-network/nix/src/io/ktor/network/sockets/SocketAddress.nonJvm.nix.kt
+++ b/ktor-network/nix/src/io/ktor/network/sockets/SocketAddress.nonJvm.nix.kt
@@ -2,6 +2,6 @@
  * Copyright 2014-2025 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
-package io.ktor.network.sockets.tests
+package io.ktor.network.sockets
 
-internal actual fun Throwable.isPosixException(): Boolean = false
+internal actual fun isUnixSocketSupported(): Boolean = true

--- a/ktor-network/nix/test/io/ktor/network/sockets/tests/TestUtils.nix.kt
+++ b/ktor-network/nix/test/io/ktor/network/sockets/tests/TestUtils.nix.kt
@@ -6,6 +6,4 @@ package io.ktor.network.sockets.tests
 
 import io.ktor.utils.io.errors.*
 
-internal actual fun Any.supportsUnixDomainSockets(): Boolean = true
-
 internal actual fun Throwable.isPosixException(): Boolean = this is PosixException

--- a/ktor-network/nonJvm/src/io/ktor/network/sockets/SocketAddress.nonJvm.kt
+++ b/ktor-network/nonJvm/src/io/ktor/network/sockets/SocketAddress.nonJvm.kt
@@ -88,4 +88,15 @@ public actual class UnixSocketAddress actual constructor(
     public actual fun copy(path: String): UnixSocketAddress {
         return UnixSocketAddress(path)
     }
+
+    public actual companion object {
+        /**
+         * Checks if Unix domain sockets are supported on the current platform.
+         *
+         * @return `true` if Unix domain sockets are supported, `false` otherwise.
+         */
+        public actual fun isSupported(): Boolean = isUnixSocketSupported()
+    }
 }
+
+internal expect fun isUnixSocketSupported(): Boolean

--- a/ktor-network/windows/src/io/ktor/network/sockets/SocketAddress.nonJvm.windows.kt
+++ b/ktor-network/windows/src/io/ktor/network/sockets/SocketAddress.nonJvm.windows.kt
@@ -1,0 +1,9 @@
+/*
+ * Copyright 2014-2025 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.network.sockets
+
+import io.ktor.network.util.isAFUnixSupported
+
+internal actual fun isUnixSocketSupported(): Boolean = isAFUnixSupported

--- a/ktor-network/windows/test/io/ktor/network/sockets/tests/TestUtils.windows.kt
+++ b/ktor-network/windows/test/io/ktor/network/sockets/tests/TestUtils.windows.kt
@@ -4,9 +4,6 @@
 
 package io.ktor.network.sockets.tests
 
-import io.ktor.network.util.*
 import io.ktor.utils.io.errors.*
-
-internal actual fun Any.supportsUnixDomainSockets(): Boolean = isAFUnixSupported
 
 internal actual fun Throwable.isPosixException(): Boolean = this is PosixException

--- a/ktor-server/ktor-server-cio/api/ktor-server-cio.api
+++ b/ktor-server/ktor-server-cio/api/ktor-server-cio.api
@@ -55,6 +55,29 @@ public final class io/ktor/server/cio/HttpServerSettings {
 	public fun toString ()Ljava/lang/String;
 }
 
+public final class io/ktor/server/cio/UnixSocketConnectorBuilder : io/ktor/server/engine/EngineConnectorBuilder, io/ktor/server/cio/UnixSocketConnectorConfig {
+	public fun <init> ()V
+	public fun getSocketPath ()Ljava/lang/String;
+	public fun setSocketPath (Ljava/lang/String;)V
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract interface class io/ktor/server/cio/UnixSocketConnectorConfig : io/ktor/server/engine/EngineConnectorConfig {
+	public abstract fun getSocketPath ()Ljava/lang/String;
+}
+
+public final class io/ktor/server/cio/UnixSocketConnectorConfigKt {
+	public static final fun unixConnector (Lio/ktor/server/engine/ApplicationEngine$Configuration;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)V
+	public static synthetic fun unixConnector$default (Lio/ktor/server/engine/ApplicationEngine$Configuration;Ljava/lang/String;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+}
+
+public final class io/ktor/server/cio/UnixSocketServerSettings {
+	public fun <init> (Ljava/lang/String;J)V
+	public synthetic fun <init> (Ljava/lang/String;JILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getConnectionIdleTimeoutSeconds ()J
+	public final fun getSocketPath ()Ljava/lang/String;
+}
+
 public final class io/ktor/server/cio/backend/HttpServerKt {
 	public static final fun httpServer (Lkotlinx/coroutines/CoroutineScope;Lio/ktor/server/cio/HttpServerSettings;Lkotlin/jvm/functions/Function3;)Lio/ktor/server/cio/HttpServer;
 }
@@ -79,5 +102,9 @@ public final class io/ktor/server/cio/backend/ServerRequestScope : kotlinx/corou
 	public final fun getRemoteAddress ()Ljava/net/SocketAddress;
 	public final fun getUpgraded ()Lkotlinx/coroutines/CompletableDeferred;
 	public final fun withContext (Lkotlin/coroutines/CoroutineContext;)Lio/ktor/server/cio/backend/ServerRequestScope;
+}
+
+public final class io/ktor/server/cio/backend/UnixSocketServerKt {
+	public static final fun unixSocketServer (Lkotlinx/coroutines/CoroutineScope;Lio/ktor/server/cio/UnixSocketServerSettings;Lkotlin/jvm/functions/Function3;)Lio/ktor/server/cio/HttpServer;
 }
 

--- a/ktor-server/ktor-server-cio/api/ktor-server-cio.klib.api
+++ b/ktor-server/ktor-server-cio/api/ktor-server-cio.klib.api
@@ -6,6 +6,11 @@
 // - Show declarations: true
 
 // Library unique name: <io.ktor:ktor-server-cio>
+abstract interface io.ktor.server.cio/UnixSocketConnectorConfig : io.ktor.server.engine/EngineConnectorConfig { // io.ktor.server.cio/UnixSocketConnectorConfig|null[0]
+    abstract val socketPath // io.ktor.server.cio/UnixSocketConnectorConfig.socketPath|{}socketPath[0]
+        abstract fun <get-socketPath>(): kotlin/String // io.ktor.server.cio/UnixSocketConnectorConfig.socketPath.<get-socketPath>|<get-socketPath>(){}[0]
+}
+
 final class io.ktor.server.cio.backend/ServerIncomingConnection { // io.ktor.server.cio.backend/ServerIncomingConnection|null[0]
     constructor <init>(io.ktor.utils.io/ByteReadChannel, io.ktor.utils.io/ByteWriteChannel, io.ktor.util.network/NetworkAddress?, io.ktor.util.network/NetworkAddress?) // io.ktor.server.cio.backend/ServerIncomingConnection.<init>|<init>(io.ktor.utils.io.ByteReadChannel;io.ktor.utils.io.ByteWriteChannel;io.ktor.util.network.NetworkAddress?;io.ktor.util.network.NetworkAddress?){}[0]
 
@@ -92,6 +97,25 @@ final class io.ktor.server.cio/HttpServerSettings { // io.ktor.server.cio/HttpSe
     final fun toString(): kotlin/String // io.ktor.server.cio/HttpServerSettings.toString|toString(){}[0]
 }
 
+final class io.ktor.server.cio/UnixSocketConnectorBuilder : io.ktor.server.cio/UnixSocketConnectorConfig, io.ktor.server.engine/EngineConnectorBuilder { // io.ktor.server.cio/UnixSocketConnectorBuilder|null[0]
+    constructor <init>() // io.ktor.server.cio/UnixSocketConnectorBuilder.<init>|<init>(){}[0]
+
+    final var socketPath // io.ktor.server.cio/UnixSocketConnectorBuilder.socketPath|{}socketPath[0]
+        final fun <get-socketPath>(): kotlin/String // io.ktor.server.cio/UnixSocketConnectorBuilder.socketPath.<get-socketPath>|<get-socketPath>(){}[0]
+        final fun <set-socketPath>(kotlin/String) // io.ktor.server.cio/UnixSocketConnectorBuilder.socketPath.<set-socketPath>|<set-socketPath>(kotlin.String){}[0]
+
+    final fun toString(): kotlin/String // io.ktor.server.cio/UnixSocketConnectorBuilder.toString|toString(){}[0]
+}
+
+final class io.ktor.server.cio/UnixSocketServerSettings { // io.ktor.server.cio/UnixSocketServerSettings|null[0]
+    constructor <init>(kotlin/String, kotlin/Long = ...) // io.ktor.server.cio/UnixSocketServerSettings.<init>|<init>(kotlin.String;kotlin.Long){}[0]
+
+    final val connectionIdleTimeoutSeconds // io.ktor.server.cio/UnixSocketServerSettings.connectionIdleTimeoutSeconds|{}connectionIdleTimeoutSeconds[0]
+        final fun <get-connectionIdleTimeoutSeconds>(): kotlin/Long // io.ktor.server.cio/UnixSocketServerSettings.connectionIdleTimeoutSeconds.<get-connectionIdleTimeoutSeconds>|<get-connectionIdleTimeoutSeconds>(){}[0]
+    final val socketPath // io.ktor.server.cio/UnixSocketServerSettings.socketPath|{}socketPath[0]
+        final fun <get-socketPath>(): kotlin/String // io.ktor.server.cio/UnixSocketServerSettings.socketPath.<get-socketPath>|<get-socketPath>(){}[0]
+}
+
 final object io.ktor.server.cio/CIO : io.ktor.server.engine/ApplicationEngineFactory<io.ktor.server.cio/CIOApplicationEngine, io.ktor.server.cio/CIOApplicationEngine.Configuration> { // io.ktor.server.cio/CIO|null[0]
     final fun configuration(kotlin/Function1<io.ktor.server.cio/CIOApplicationEngine.Configuration, kotlin/Unit>): io.ktor.server.cio/CIOApplicationEngine.Configuration // io.ktor.server.cio/CIO.configuration|configuration(kotlin.Function1<io.ktor.server.cio.CIOApplicationEngine.Configuration,kotlin.Unit>){}[0]
     final fun create(io.ktor.server.application/ApplicationEnvironment, io.ktor.events/Events, kotlin/Boolean, io.ktor.server.cio/CIOApplicationEngine.Configuration, kotlin/Function0<io.ktor.server.application/Application>): io.ktor.server.cio/CIOApplicationEngine // io.ktor.server.cio/CIO.create|create(io.ktor.server.application.ApplicationEnvironment;io.ktor.events.Events;kotlin.Boolean;io.ktor.server.cio.CIOApplicationEngine.Configuration;kotlin.Function0<io.ktor.server.application.Application>){}[0]
@@ -102,5 +126,7 @@ final object io.ktor.server.cio/EngineMain { // io.ktor.server.cio/EngineMain|nu
     final fun main(kotlin/Array<kotlin/String>) // io.ktor.server.cio/EngineMain.main|main(kotlin.Array<kotlin.String>){}[0]
 }
 
+final fun (io.ktor.server.engine/ApplicationEngine.Configuration).io.ktor.server.cio/unixConnector(kotlin/String, kotlin/Function1<io.ktor.server.cio/UnixSocketConnectorBuilder, kotlin/Unit> = ...) // io.ktor.server.cio/unixConnector|unixConnector@io.ktor.server.engine.ApplicationEngine.Configuration(kotlin.String;kotlin.Function1<io.ktor.server.cio.UnixSocketConnectorBuilder,kotlin.Unit>){}[0]
 final fun (kotlinx.coroutines/CoroutineScope).io.ktor.server.cio.backend/httpServer(io.ktor.server.cio/HttpServerSettings, kotlin.coroutines/SuspendFunction2<io.ktor.server.cio.backend/ServerRequestScope, io.ktor.http.cio/Request, kotlin/Unit>): io.ktor.server.cio/HttpServer // io.ktor.server.cio.backend/httpServer|httpServer@kotlinx.coroutines.CoroutineScope(io.ktor.server.cio.HttpServerSettings;kotlin.coroutines.SuspendFunction2<io.ktor.server.cio.backend.ServerRequestScope,io.ktor.http.cio.Request,kotlin.Unit>){}[0]
 final fun (kotlinx.coroutines/CoroutineScope).io.ktor.server.cio.backend/startServerConnectionPipeline(io.ktor.server.cio.backend/ServerIncomingConnection, kotlin.time/Duration, kotlin.coroutines/SuspendFunction2<io.ktor.server.cio.backend/ServerRequestScope, io.ktor.http.cio/Request, kotlin/Unit>): kotlinx.coroutines/Job // io.ktor.server.cio.backend/startServerConnectionPipeline|startServerConnectionPipeline@kotlinx.coroutines.CoroutineScope(io.ktor.server.cio.backend.ServerIncomingConnection;kotlin.time.Duration;kotlin.coroutines.SuspendFunction2<io.ktor.server.cio.backend.ServerRequestScope,io.ktor.http.cio.Request,kotlin.Unit>){}[0]
+final fun (kotlinx.coroutines/CoroutineScope).io.ktor.server.cio.backend/unixSocketServer(io.ktor.server.cio/UnixSocketServerSettings, kotlin.coroutines/SuspendFunction2<io.ktor.server.cio.backend/ServerRequestScope, io.ktor.http.cio/Request, kotlin/Unit>): io.ktor.server.cio/HttpServer // io.ktor.server.cio.backend/unixSocketServer|unixSocketServer@kotlinx.coroutines.CoroutineScope(io.ktor.server.cio.UnixSocketServerSettings;kotlin.coroutines.SuspendFunction2<io.ktor.server.cio.backend.ServerRequestScope,io.ktor.http.cio.Request,kotlin.Unit>){}[0]

--- a/ktor-server/ktor-server-cio/common/src/io/ktor/server/cio/CIOApplicationEngine.kt
+++ b/ktor-server/ktor-server-cio/common/src/io/ktor/server/cio/CIOApplicationEngine.kt
@@ -112,7 +112,8 @@ public class CIOApplicationEngine(
         return when (connectorSpec) {
             is UnixSocketConnectorConfig -> {
                 val settings = UnixSocketServerSettings(
-                    socketPath = connectorSpec.socketPath
+                    socketPath = connectorSpec.socketPath,
+                    connectionIdleTimeoutSeconds = configuration.connectionIdleTimeoutSeconds.toLong(),
                 )
 
                 unixSocketServer(settings) { request ->

--- a/ktor-server/ktor-server-cio/common/src/io/ktor/server/cio/HttpServer.kt
+++ b/ktor-server/ktor-server-cio/common/src/io/ktor/server/cio/HttpServer.kt
@@ -5,7 +5,8 @@
 package io.ktor.server.cio
 
 import io.ktor.network.sockets.*
-import kotlinx.coroutines.*
+import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.Job
 
 /**
  * Represents a server instance
@@ -37,4 +38,15 @@ public data class HttpServerSettings(
     val port: Int = 8080,
     val connectionIdleTimeoutSeconds: Long = 45,
     val reuseAddress: Boolean = false
+)
+
+/**
+ * Represents the settings for a Unix-based HTTP server.
+ *
+ * @property connectionIdleTimeoutSeconds time to live for IDLE connections
+ * @property socketPath the path to the Unix domain socket file used for the server communication.
+ */
+public class UnixSocketServerSettings(
+    public val socketPath: String,
+    public val connectionIdleTimeoutSeconds: Long = 45,
 )

--- a/ktor-server/ktor-server-cio/common/src/io/ktor/server/cio/UnixSocketConnectorConfig.kt
+++ b/ktor-server/ktor-server-cio/common/src/io/ktor/server/cio/UnixSocketConnectorConfig.kt
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2014-2025 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.server.cio
+
+import io.ktor.server.engine.ApplicationEngine
+import io.ktor.server.engine.ConnectorType
+import io.ktor.server.engine.EngineConnectorBuilder
+import io.ktor.server.engine.EngineConnectorConfig
+
+/**
+ * Represents a Unix domain socket connector configuration.
+ *
+ * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.server.engine.UnixSocketConnectorConfig)
+ */
+public interface UnixSocketConnectorConfig : EngineConnectorConfig {
+    /**
+     * Path to the Unix domain socket file.
+     *
+     * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.server.engine.UnixSocketConnectorConfig.socketPath)
+     */
+    public val socketPath: String
+}
+
+/**
+ * Mutable implementation of UnixSocketConnectorConfig for building connectors programmatically
+ *
+ * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.server.engine.UnixSocketConnectorBuilder)
+ */
+public class UnixSocketConnectorBuilder : EngineConnectorBuilder(ConnectorType.UNIX), UnixSocketConnectorConfig {
+    /**
+     * Path to the Unix domain socket file.
+     */
+    override var socketPath: String = "/tmp/ktor.sock"
+
+    override fun toString(): String = "${type.name} $socketPath"
+}
+
+/**
+ * Adds a Unix domain socket connector to this engine environment
+ *
+ * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.server.engine.unixConnector)
+ */
+public fun ApplicationEngine.Configuration.unixConnector(
+    socketPath: String,
+    builder: UnixSocketConnectorBuilder.() -> Unit = {}
+) {
+    val element = UnixSocketConnectorBuilder().apply {
+        this.socketPath = socketPath
+        builder()
+    }
+    connectors.add(element)
+}

--- a/ktor-server/ktor-server-cio/common/src/io/ktor/server/cio/backend/ServerPipeline.kt
+++ b/ktor-server/ktor-server-cio/common/src/io/ktor/server/cio/backend/ServerPipeline.kt
@@ -9,6 +9,8 @@ import io.ktor.http.cio.*
 import io.ktor.http.cio.internals.*
 import io.ktor.server.cio.*
 import io.ktor.util.cio.*
+import io.ktor.util.logging.KtorSimpleLogger
+import io.ktor.util.logging.trace
 import io.ktor.utils.io.*
 import io.ktor.utils.io.charsets.*
 import io.ktor.utils.io.core.*
@@ -17,6 +19,8 @@ import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.channels.*
 import kotlinx.io.*
 import kotlin.time.*
+
+private val LOGGER = KtorSimpleLogger("io.ktor.server.cio.backend.ServerPipeline")
 
 /**
  * Start connection HTTP pipeline invoking [handler] for every request.
@@ -67,6 +71,7 @@ public fun CoroutineScope.startServerConnectionPipeline(
             } catch (cancelled: CancellationException) {
                 throw cancelled
             } catch (parseFailed: Throwable) {
+                LOGGER.trace { "Request parsing failed with exception: $parseFailed" }
                 // try to write 400 Bad Request
                 respondBadRequest(actorChannel)
                 break // end pipeline loop

--- a/ktor-server/ktor-server-cio/common/src/io/ktor/server/cio/backend/SocketAddressUtils.kt
+++ b/ktor-server/ktor-server-cio/common/src/io/ktor/server/cio/backend/SocketAddressUtils.kt
@@ -7,10 +7,7 @@ package io.ktor.server.cio.backend
 import io.ktor.network.sockets.*
 import io.ktor.util.network.*
 
-internal val SocketAddress.port: Int
-    get() {
-        val inetAddress = this as? InetSocketAddress ?: error("Expected inet socket address")
-        return inetAddress.port
-    }
+internal val SocketAddress.port: Int?
+    get() = (this as? InetSocketAddress)?.port
 
-internal expect fun SocketAddress.toNetworkAddress(): NetworkAddress
+internal expect fun SocketAddress.toNetworkAddress(): NetworkAddress?

--- a/ktor-server/ktor-server-cio/common/src/io/ktor/server/cio/backend/UnixSocketServer.kt
+++ b/ktor-server/ktor-server-cio/common/src/io/ktor/server/cio/backend/UnixSocketServer.kt
@@ -13,9 +13,11 @@ import io.ktor.util.logging.*
 import io.ktor.utils.io.*
 import kotlinx.coroutines.*
 import kotlinx.io.IOException
+import kotlinx.io.files.Path
+import kotlinx.io.files.SystemFileSystem
 import kotlin.time.Duration.Companion.seconds
 
-private val LOGGER = KtorSimpleLogger("io.ktor.server.cio.HttpServer")
+private val LOGGER = KtorSimpleLogger("io.ktor.server.cio.backend.UnixSocketServer")
 
 /**
  * Start an http server with [settings] invoking [handler] for every request
@@ -23,8 +25,8 @@ private val LOGGER = KtorSimpleLogger("io.ktor.server.cio.HttpServer")
  * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.server.cio.backend.httpServer)
  */
 @OptIn(InternalAPI::class)
-public fun CoroutineScope.httpServer(
-    settings: HttpServerSettings,
+public fun CoroutineScope.unixSocketServer(
+    settings: UnixSocketServerSettings,
     handler: HttpRequestHandler
 ): HttpServer {
     val socket = CompletableDeferred<ServerSocket>()
@@ -42,9 +44,12 @@ public fun CoroutineScope.httpServer(
     val timeout = settings.connectionIdleTimeoutSeconds.seconds
 
     val acceptJob = launch(serverJob + CoroutineName("accept-$settings")) {
-        val serverSocket = aSocket(selector).tcp().bind(settings.host, settings.port) {
-            reuseAddress = settings.reuseAddress
+        val socketFile = Path(settings.socketPath)
+        if (SystemFileSystem.exists(socketFile)) {
+            SystemFileSystem.delete(socketFile)
         }
+
+        val serverSocket = aSocket(selector).tcp().bind(UnixSocketAddress(settings.socketPath))
 
         serverSocket.use { server ->
             socket.complete(server)

--- a/ktor-server/ktor-server-cio/jvm/src/io/ktor/server/cio/backend/SocketAddressUtilsJvm.kt
+++ b/ktor-server/ktor-server-cio/jvm/src/io/ktor/server/cio/backend/SocketAddressUtilsJvm.kt
@@ -7,7 +7,7 @@ package io.ktor.server.cio.backend
 import io.ktor.network.sockets.*
 import io.ktor.util.network.*
 
-internal actual fun SocketAddress.toNetworkAddress(): NetworkAddress {
+internal actual fun SocketAddress.toNetworkAddress(): NetworkAddress? {
     // Do not read the hostname here because that may trigger a name service reverse lookup.
-    return toJavaAddress() as? java.net.InetSocketAddress ?: error("Expected inet socket address")
+    return toJavaAddress() as? java.net.InetSocketAddress
 }

--- a/ktor-server/ktor-server-cio/jvm/test/io/ktor/tests/server/cio/CIOUnixSocketServerTest.kt
+++ b/ktor-server/ktor-server-cio/jvm/test/io/ktor/tests/server/cio/CIOUnixSocketServerTest.kt
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2014-2024 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.tests.server.cio
+
+import io.ktor.network.selector.*
+import io.ktor.network.sockets.UnixSocketAddress
+import io.ktor.network.sockets.aSocket
+import io.ktor.network.sockets.openReadChannel
+import io.ktor.network.sockets.openWriteChannel
+import io.ktor.server.application.*
+import io.ktor.server.cio.*
+import io.ktor.server.engine.*
+import io.ktor.server.request.*
+import io.ktor.server.response.*
+import io.ktor.server.routing.*
+import io.ktor.utils.io.readUTF8Line
+import io.ktor.utils.io.writeStringUtf8
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
+import java.io.File
+import kotlin.io.use
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.use
+
+class CIOUnixSocketServerTest {
+
+    @Test
+    fun testUnixSocketEcho() = runBlocking {
+        if (!UnixSocketAddress.isSupported()) return@runBlocking
+
+        val tempDir = File(System.getProperty("java.io.tmpdir"))
+        val socketFile = File(tempDir, "ktor-unix-socket-test-${System.currentTimeMillis()}.sock")
+        if (socketFile.exists()) {
+            socketFile.delete()
+        }
+        val socketPath = socketFile.absolutePath
+
+        val server = embeddedServer(
+            CIO,
+            serverConfig {
+                module {
+                    routing {
+                        get("/") {
+                            call.respondText("Hello, Unix socket world!")
+                        }
+                        post("/echo") {
+                            val text = call.receiveText()
+                            call.respondText(text)
+                        }
+                    }
+                }
+            },
+            configure = {
+                unixConnector(socketPath)
+            }
+        )
+
+        server.start(wait = false)
+
+        try {
+            delay(1000) // Wait for server to start
+
+            // Create a new selector for this test
+            val testSelector = ActorSelectorManager(Dispatchers.IO)
+            try {
+                // Manual test using raw socket
+                testSelector.use { selector ->
+                    aSocket(selector).tcp().connect(UnixSocketAddress(socketPath)).use { socket ->
+                        val input = socket.openReadChannel()
+                        val output = socket.openWriteChannel()
+
+                        // Simulate HTTP request
+                        output.writeStringUtf8("GET / HTTP/1.1\r\nHost: localhost\r\n\r\n")
+                        output.flush()
+
+                        // Read response
+                        val statusLine = input.readUTF8Line()
+                        assertEquals(true, statusLine?.contains("200 OK"), "Expected HTTP 200 OK, got: $statusLine")
+
+                        // Skip headers
+                        while (true) {
+                            val line = input.readUTF8Line() ?: break
+                            if (line.isEmpty()) break
+                        }
+
+                        // Read body
+                        val responseBody = input.readUTF8Line()
+                        assertEquals("Hello, Unix socket world!", responseBody)
+                    }
+                }
+            } finally {
+                testSelector.close()
+            }
+        } finally {
+            server.stop(1000, 1000)
+            if (socketFile.exists()) {
+                socketFile.delete()
+            }
+        }
+    }
+}

--- a/ktor-server/ktor-server-cio/nonJvm/src/io/ktor/server/cio/backend/SocketAddressUtils.nonJvm.kt
+++ b/ktor-server/ktor-server-cio/nonJvm/src/io/ktor/server/cio/backend/SocketAddressUtils.nonJvm.kt
@@ -7,7 +7,7 @@ package io.ktor.server.cio.backend
 import io.ktor.network.sockets.*
 import io.ktor.util.network.*
 
-internal actual fun SocketAddress.toNetworkAddress(): NetworkAddress {
-    check(this is InetSocketAddress) { "Expected inet socket address" }
+internal actual fun SocketAddress.toNetworkAddress(): NetworkAddress? {
+    if (this !is InetSocketAddress) return null
     return NetworkAddress(hostname, port)
 }

--- a/ktor-server/ktor-server-core/api/ktor-server-core.api
+++ b/ktor-server/ktor-server-core/api/ktor-server-core.api
@@ -568,6 +568,7 @@ public final class io/ktor/server/engine/ConnectorType {
 public final class io/ktor/server/engine/ConnectorType$Companion {
 	public final fun getHTTP ()Lio/ktor/server/engine/ConnectorType;
 	public final fun getHTTPS ()Lio/ktor/server/engine/ConnectorType;
+	public final fun getUNIX ()Lio/ktor/server/engine/ConnectorType;
 }
 
 public final class io/ktor/server/engine/DefaultEnginePipelineKt {

--- a/ktor-server/ktor-server-core/api/ktor-server-core.klib.api
+++ b/ktor-server/ktor-server-core/api/ktor-server-core.klib.api
@@ -582,6 +582,8 @@ final class io.ktor.server.engine/ConnectorType { // io.ktor.server.engine/Conne
             final fun <get-HTTP>(): io.ktor.server.engine/ConnectorType // io.ktor.server.engine/ConnectorType.Companion.HTTP.<get-HTTP>|<get-HTTP>(){}[0]
         final val HTTPS // io.ktor.server.engine/ConnectorType.Companion.HTTPS|{}HTTPS[0]
             final fun <get-HTTPS>(): io.ktor.server.engine/ConnectorType // io.ktor.server.engine/ConnectorType.Companion.HTTPS.<get-HTTPS>|<get-HTTPS>(){}[0]
+        final val UNIX // io.ktor.server.engine/ConnectorType.Companion.UNIX|{}UNIX[0]
+            final fun <get-UNIX>(): io.ktor.server.engine/ConnectorType // io.ktor.server.engine/ConnectorType.Companion.UNIX.<get-UNIX>|<get-UNIX>(){}[0]
     }
 }
 

--- a/ktor-server/ktor-server-core/common/src/io/ktor/server/engine/EngineConnectorConfig.kt
+++ b/ktor-server/ktor-server-core/common/src/io/ktor/server/engine/EngineConnectorConfig.kt
@@ -28,6 +28,13 @@ public data class ConnectorType(val name: String) {
          * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.server.engine.ConnectorType.Companion.HTTPS)
          */
         public val HTTPS: ConnectorType = ConnectorType("HTTPS")
+
+        /**
+         * Unix domain socket connector.
+         *
+         * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.server.engine.ConnectorType.Companion.UNIX)
+         */
+        public val UNIX: ConnectorType = ConnectorType("UNIX")
     }
 }
 

--- a/ktor-server/ktor-server-core/jvm/src/io/ktor/server/engine/EmbeddedServerJvm.kt
+++ b/ktor-server/ktor-server-core/jvm/src/io/ktor/server/engine/EmbeddedServerJvm.kt
@@ -337,7 +337,7 @@ actual constructor(
             engine.resolvedConnectors().forEach {
                 val host = escapeHostname(it.host)
                 environment.log.info(
-                    "Responding at ${it.type.name.lowercase()}://$host:${it.port}"
+                    "Responding at ${it.type.name.lowercase()}:$it"
                 )
             }
         }


### PR DESCRIPTION
Fix [KTOR-4766](https://youtrack.jetbrains.com/issue/KTOR-4766) Unix domain socket support at the Ktor Engine level