### PR TITLE
Better configurability for MockEngine

### DIFF
--- a/ktor-client/ktor-client-mock/api/ktor-client-mock.api
+++ b/ktor-client/ktor-client-mock/api/ktor-client-mock.api
@@ -1,22 +1,28 @@
-public final class io/ktor/client/engine/mock/MockEngine : io/ktor/client/engine/HttpClientEngineBase {
+public class io/ktor/client/engine/mock/MockEngine : io/ktor/client/engine/HttpClientEngineBase {
 	public static final field Companion Lio/ktor/client/engine/mock/MockEngine$Companion;
 	public fun <init> (Lio/ktor/client/engine/mock/MockEngineConfig;)V
-	public fun <init> (Lio/ktor/client/engine/mock/MockEngineConfig;Z)V
 	public fun close ()V
-	public final fun enqueue (Lkotlin/jvm/functions/Function3;)Z
 	public fun execute (Lio/ktor/client/request/HttpRequestData;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public synthetic fun getConfig ()Lio/ktor/client/engine/HttpClientEngineConfig;
 	public fun getConfig ()Lio/ktor/client/engine/mock/MockEngineConfig;
 	public final fun getRequestHistory ()Ljava/util/List;
 	public final fun getResponseHistory ()Ljava/util/List;
 	public fun getSupportedCapabilities ()Ljava/util/Set;
-	public final fun plusAssign (Lkotlin/jvm/functions/Function3;)V
 }
 
 public final class io/ktor/client/engine/mock/MockEngine$Companion : io/ktor/client/engine/HttpClientEngineFactory {
 	public fun create (Lkotlin/jvm/functions/Function1;)Lio/ktor/client/engine/HttpClientEngine;
-	public final fun empty ()Lio/ktor/client/engine/mock/MockEngine;
 	public final fun invoke (Lkotlin/jvm/functions/Function3;)Lio/ktor/client/engine/mock/MockEngine;
+}
+
+public final class io/ktor/client/engine/mock/MockEngine$Queue : io/ktor/client/engine/mock/MockEngine {
+	public fun <init> ()V
+	public fun <init> (Lio/ktor/client/engine/mock/MockEngineConfig;)V
+	public synthetic fun <init> (Lio/ktor/client/engine/mock/MockEngineConfig;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun enqueue (Lkotlin/jvm/functions/Function3;)Z
+	public synthetic fun getConfig ()Lio/ktor/client/engine/HttpClientEngineConfig;
+	public fun getConfig ()Lio/ktor/client/engine/mock/MockEngineConfig;
+	public final fun plusAssign (Lkotlin/jvm/functions/Function3;)V
 }
 
 public final class io/ktor/client/engine/mock/MockEngineConfig : io/ktor/client/engine/HttpClientEngineConfig {

--- a/ktor-client/ktor-client-mock/api/ktor-client-mock.api
+++ b/ktor-client/ktor-client-mock/api/ktor-client-mock.api
@@ -1,17 +1,21 @@
 public final class io/ktor/client/engine/mock/MockEngine : io/ktor/client/engine/HttpClientEngineBase {
 	public static final field Companion Lio/ktor/client/engine/mock/MockEngine$Companion;
 	public fun <init> (Lio/ktor/client/engine/mock/MockEngineConfig;)V
+	public fun <init> (Lio/ktor/client/engine/mock/MockEngineConfig;Z)V
 	public fun close ()V
+	public final fun enqueue (Lkotlin/jvm/functions/Function3;)Z
 	public fun execute (Lio/ktor/client/request/HttpRequestData;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public synthetic fun getConfig ()Lio/ktor/client/engine/HttpClientEngineConfig;
 	public fun getConfig ()Lio/ktor/client/engine/mock/MockEngineConfig;
 	public final fun getRequestHistory ()Ljava/util/List;
 	public final fun getResponseHistory ()Ljava/util/List;
 	public fun getSupportedCapabilities ()Ljava/util/Set;
+	public final fun plusAssign (Lkotlin/jvm/functions/Function3;)V
 }
 
 public final class io/ktor/client/engine/mock/MockEngine$Companion : io/ktor/client/engine/HttpClientEngineFactory {
 	public fun create (Lkotlin/jvm/functions/Function1;)Lio/ktor/client/engine/HttpClientEngine;
+	public final fun empty ()Lio/ktor/client/engine/mock/MockEngine;
 	public final fun invoke (Lkotlin/jvm/functions/Function3;)Lio/ktor/client/engine/mock/MockEngine;
 }
 

--- a/ktor-client/ktor-client-mock/api/ktor-client-mock.klib.api
+++ b/ktor-client/ktor-client-mock/api/ktor-client-mock.klib.api
@@ -6,31 +6,6 @@
 // - Show declarations: true
 
 // Library unique name: <io.ktor:ktor-client-mock>
-final class io.ktor.client.engine.mock/MockEngine : io.ktor.client.engine/HttpClientEngineBase { // io.ktor.client.engine.mock/MockEngine|null[0]
-    constructor <init>(io.ktor.client.engine.mock/MockEngineConfig) // io.ktor.client.engine.mock/MockEngine.<init>|<init>(io.ktor.client.engine.mock.MockEngineConfig){}[0]
-    constructor <init>(io.ktor.client.engine.mock/MockEngineConfig, kotlin/Boolean) // io.ktor.client.engine.mock/MockEngine.<init>|<init>(io.ktor.client.engine.mock.MockEngineConfig;kotlin.Boolean){}[0]
-
-    final val config // io.ktor.client.engine.mock/MockEngine.config|{}config[0]
-        final fun <get-config>(): io.ktor.client.engine.mock/MockEngineConfig // io.ktor.client.engine.mock/MockEngine.config.<get-config>|<get-config>(){}[0]
-    final val requestHistory // io.ktor.client.engine.mock/MockEngine.requestHistory|{}requestHistory[0]
-        final fun <get-requestHistory>(): kotlin.collections/List<io.ktor.client.request/HttpRequestData> // io.ktor.client.engine.mock/MockEngine.requestHistory.<get-requestHistory>|<get-requestHistory>(){}[0]
-    final val responseHistory // io.ktor.client.engine.mock/MockEngine.responseHistory|{}responseHistory[0]
-        final fun <get-responseHistory>(): kotlin.collections/List<io.ktor.client.request/HttpResponseData> // io.ktor.client.engine.mock/MockEngine.responseHistory.<get-responseHistory>|<get-responseHistory>(){}[0]
-    final val supportedCapabilities // io.ktor.client.engine.mock/MockEngine.supportedCapabilities|{}supportedCapabilities[0]
-        final fun <get-supportedCapabilities>(): kotlin.collections/Set<io.ktor.client.engine/HttpClientEngineCapability<out kotlin/Any>> // io.ktor.client.engine.mock/MockEngine.supportedCapabilities.<get-supportedCapabilities>|<get-supportedCapabilities>(){}[0]
-
-    final fun close() // io.ktor.client.engine.mock/MockEngine.close|close(){}[0]
-    final fun enqueue(kotlin.coroutines/SuspendFunction2<io.ktor.client.engine.mock/MockRequestHandleScope, io.ktor.client.request/HttpRequestData, io.ktor.client.request/HttpResponseData>): kotlin/Boolean // io.ktor.client.engine.mock/MockEngine.enqueue|enqueue(kotlin.coroutines.SuspendFunction2<io.ktor.client.engine.mock.MockRequestHandleScope,io.ktor.client.request.HttpRequestData,io.ktor.client.request.HttpResponseData>){}[0]
-    final fun plusAssign(kotlin.coroutines/SuspendFunction2<io.ktor.client.engine.mock/MockRequestHandleScope, io.ktor.client.request/HttpRequestData, io.ktor.client.request/HttpResponseData>) // io.ktor.client.engine.mock/MockEngine.plusAssign|plusAssign(kotlin.coroutines.SuspendFunction2<io.ktor.client.engine.mock.MockRequestHandleScope,io.ktor.client.request.HttpRequestData,io.ktor.client.request.HttpResponseData>){}[0]
-    final suspend fun execute(io.ktor.client.request/HttpRequestData): io.ktor.client.request/HttpResponseData // io.ktor.client.engine.mock/MockEngine.execute|execute(io.ktor.client.request.HttpRequestData){}[0]
-
-    final object Companion : io.ktor.client.engine/HttpClientEngineFactory<io.ktor.client.engine.mock/MockEngineConfig> { // io.ktor.client.engine.mock/MockEngine.Companion|null[0]
-        final fun create(kotlin/Function1<io.ktor.client.engine.mock/MockEngineConfig, kotlin/Unit>): io.ktor.client.engine/HttpClientEngine // io.ktor.client.engine.mock/MockEngine.Companion.create|create(kotlin.Function1<io.ktor.client.engine.mock.MockEngineConfig,kotlin.Unit>){}[0]
-        final fun empty(): io.ktor.client.engine.mock/MockEngine // io.ktor.client.engine.mock/MockEngine.Companion.empty|empty(){}[0]
-        final fun invoke(kotlin.coroutines/SuspendFunction2<io.ktor.client.engine.mock/MockRequestHandleScope, io.ktor.client.request/HttpRequestData, io.ktor.client.request/HttpResponseData>): io.ktor.client.engine.mock/MockEngine // io.ktor.client.engine.mock/MockEngine.Companion.invoke|invoke(kotlin.coroutines.SuspendFunction2<io.ktor.client.engine.mock.MockRequestHandleScope,io.ktor.client.request.HttpRequestData,io.ktor.client.request.HttpResponseData>){}[0]
-    }
-}
-
 final class io.ktor.client.engine.mock/MockEngineConfig : io.ktor.client.engine/HttpClientEngineConfig { // io.ktor.client.engine.mock/MockEngineConfig|null[0]
     constructor <init>() // io.ktor.client.engine.mock/MockEngineConfig.<init>|<init>(){}[0]
 
@@ -46,6 +21,37 @@ final class io.ktor.client.engine.mock/MockEngineConfig : io.ktor.client.engine/
 
 final class io.ktor.client.engine.mock/MockRequestHandleScope { // io.ktor.client.engine.mock/MockRequestHandleScope|null[0]
     constructor <init>(kotlin.coroutines/CoroutineContext) // io.ktor.client.engine.mock/MockRequestHandleScope.<init>|<init>(kotlin.coroutines.CoroutineContext){}[0]
+}
+
+open class io.ktor.client.engine.mock/MockEngine : io.ktor.client.engine/HttpClientEngineBase { // io.ktor.client.engine.mock/MockEngine|null[0]
+    constructor <init>(io.ktor.client.engine.mock/MockEngineConfig) // io.ktor.client.engine.mock/MockEngine.<init>|<init>(io.ktor.client.engine.mock.MockEngineConfig){}[0]
+
+    final val requestHistory // io.ktor.client.engine.mock/MockEngine.requestHistory|{}requestHistory[0]
+        final fun <get-requestHistory>(): kotlin.collections/List<io.ktor.client.request/HttpRequestData> // io.ktor.client.engine.mock/MockEngine.requestHistory.<get-requestHistory>|<get-requestHistory>(){}[0]
+    final val responseHistory // io.ktor.client.engine.mock/MockEngine.responseHistory|{}responseHistory[0]
+        final fun <get-responseHistory>(): kotlin.collections/List<io.ktor.client.request/HttpResponseData> // io.ktor.client.engine.mock/MockEngine.responseHistory.<get-responseHistory>|<get-responseHistory>(){}[0]
+    open val config // io.ktor.client.engine.mock/MockEngine.config|{}config[0]
+        open fun <get-config>(): io.ktor.client.engine.mock/MockEngineConfig // io.ktor.client.engine.mock/MockEngine.config.<get-config>|<get-config>(){}[0]
+    open val supportedCapabilities // io.ktor.client.engine.mock/MockEngine.supportedCapabilities|{}supportedCapabilities[0]
+        open fun <get-supportedCapabilities>(): kotlin.collections/Set<io.ktor.client.engine/HttpClientEngineCapability<out kotlin/Any>> // io.ktor.client.engine.mock/MockEngine.supportedCapabilities.<get-supportedCapabilities>|<get-supportedCapabilities>(){}[0]
+
+    open fun close() // io.ktor.client.engine.mock/MockEngine.close|close(){}[0]
+    open suspend fun execute(io.ktor.client.request/HttpRequestData): io.ktor.client.request/HttpResponseData // io.ktor.client.engine.mock/MockEngine.execute|execute(io.ktor.client.request.HttpRequestData){}[0]
+
+    final class Queue : io.ktor.client.engine.mock/MockEngine { // io.ktor.client.engine.mock/MockEngine.Queue|null[0]
+        constructor <init>(io.ktor.client.engine.mock/MockEngineConfig = ...) // io.ktor.client.engine.mock/MockEngine.Queue.<init>|<init>(io.ktor.client.engine.mock.MockEngineConfig){}[0]
+
+        final val config // io.ktor.client.engine.mock/MockEngine.Queue.config|{}config[0]
+            final fun <get-config>(): io.ktor.client.engine.mock/MockEngineConfig // io.ktor.client.engine.mock/MockEngine.Queue.config.<get-config>|<get-config>(){}[0]
+
+        final fun enqueue(kotlin.coroutines/SuspendFunction2<io.ktor.client.engine.mock/MockRequestHandleScope, io.ktor.client.request/HttpRequestData, io.ktor.client.request/HttpResponseData>): kotlin/Boolean // io.ktor.client.engine.mock/MockEngine.Queue.enqueue|enqueue(kotlin.coroutines.SuspendFunction2<io.ktor.client.engine.mock.MockRequestHandleScope,io.ktor.client.request.HttpRequestData,io.ktor.client.request.HttpResponseData>){}[0]
+        final fun plusAssign(kotlin.coroutines/SuspendFunction2<io.ktor.client.engine.mock/MockRequestHandleScope, io.ktor.client.request/HttpRequestData, io.ktor.client.request/HttpResponseData>) // io.ktor.client.engine.mock/MockEngine.Queue.plusAssign|plusAssign(kotlin.coroutines.SuspendFunction2<io.ktor.client.engine.mock.MockRequestHandleScope,io.ktor.client.request.HttpRequestData,io.ktor.client.request.HttpResponseData>){}[0]
+    }
+
+    final object Companion : io.ktor.client.engine/HttpClientEngineFactory<io.ktor.client.engine.mock/MockEngineConfig> { // io.ktor.client.engine.mock/MockEngine.Companion|null[0]
+        final fun create(kotlin/Function1<io.ktor.client.engine.mock/MockEngineConfig, kotlin/Unit>): io.ktor.client.engine/HttpClientEngine // io.ktor.client.engine.mock/MockEngine.Companion.create|create(kotlin.Function1<io.ktor.client.engine.mock.MockEngineConfig,kotlin.Unit>){}[0]
+        final fun invoke(kotlin.coroutines/SuspendFunction2<io.ktor.client.engine.mock/MockRequestHandleScope, io.ktor.client.request/HttpRequestData, io.ktor.client.request/HttpResponseData>): io.ktor.client.engine.mock/MockEngine // io.ktor.client.engine.mock/MockEngine.Companion.invoke|invoke(kotlin.coroutines.SuspendFunction2<io.ktor.client.engine.mock.MockRequestHandleScope,io.ktor.client.request.HttpRequestData,io.ktor.client.request.HttpResponseData>){}[0]
+    }
 }
 
 final fun (io.ktor.client.engine.mock/MockRequestHandleScope).io.ktor.client.engine.mock/respond(io.ktor.utils.io/ByteReadChannel, io.ktor.http/HttpStatusCode = ..., io.ktor.http/Headers = ...): io.ktor.client.request/HttpResponseData // io.ktor.client.engine.mock/respond|respond@io.ktor.client.engine.mock.MockRequestHandleScope(io.ktor.utils.io.ByteReadChannel;io.ktor.http.HttpStatusCode;io.ktor.http.Headers){}[0]

--- a/ktor-client/ktor-client-mock/api/ktor-client-mock.klib.api
+++ b/ktor-client/ktor-client-mock/api/ktor-client-mock.klib.api
@@ -8,6 +8,7 @@
 // Library unique name: <io.ktor:ktor-client-mock>
 final class io.ktor.client.engine.mock/MockEngine : io.ktor.client.engine/HttpClientEngineBase { // io.ktor.client.engine.mock/MockEngine|null[0]
     constructor <init>(io.ktor.client.engine.mock/MockEngineConfig) // io.ktor.client.engine.mock/MockEngine.<init>|<init>(io.ktor.client.engine.mock.MockEngineConfig){}[0]
+    constructor <init>(io.ktor.client.engine.mock/MockEngineConfig, kotlin/Boolean) // io.ktor.client.engine.mock/MockEngine.<init>|<init>(io.ktor.client.engine.mock.MockEngineConfig;kotlin.Boolean){}[0]
 
     final val config // io.ktor.client.engine.mock/MockEngine.config|{}config[0]
         final fun <get-config>(): io.ktor.client.engine.mock/MockEngineConfig // io.ktor.client.engine.mock/MockEngine.config.<get-config>|<get-config>(){}[0]
@@ -19,10 +20,13 @@ final class io.ktor.client.engine.mock/MockEngine : io.ktor.client.engine/HttpCl
         final fun <get-supportedCapabilities>(): kotlin.collections/Set<io.ktor.client.engine/HttpClientEngineCapability<out kotlin/Any>> // io.ktor.client.engine.mock/MockEngine.supportedCapabilities.<get-supportedCapabilities>|<get-supportedCapabilities>(){}[0]
 
     final fun close() // io.ktor.client.engine.mock/MockEngine.close|close(){}[0]
+    final fun enqueue(kotlin.coroutines/SuspendFunction2<io.ktor.client.engine.mock/MockRequestHandleScope, io.ktor.client.request/HttpRequestData, io.ktor.client.request/HttpResponseData>): kotlin/Boolean // io.ktor.client.engine.mock/MockEngine.enqueue|enqueue(kotlin.coroutines.SuspendFunction2<io.ktor.client.engine.mock.MockRequestHandleScope,io.ktor.client.request.HttpRequestData,io.ktor.client.request.HttpResponseData>){}[0]
+    final fun plusAssign(kotlin.coroutines/SuspendFunction2<io.ktor.client.engine.mock/MockRequestHandleScope, io.ktor.client.request/HttpRequestData, io.ktor.client.request/HttpResponseData>) // io.ktor.client.engine.mock/MockEngine.plusAssign|plusAssign(kotlin.coroutines.SuspendFunction2<io.ktor.client.engine.mock.MockRequestHandleScope,io.ktor.client.request.HttpRequestData,io.ktor.client.request.HttpResponseData>){}[0]
     final suspend fun execute(io.ktor.client.request/HttpRequestData): io.ktor.client.request/HttpResponseData // io.ktor.client.engine.mock/MockEngine.execute|execute(io.ktor.client.request.HttpRequestData){}[0]
 
     final object Companion : io.ktor.client.engine/HttpClientEngineFactory<io.ktor.client.engine.mock/MockEngineConfig> { // io.ktor.client.engine.mock/MockEngine.Companion|null[0]
         final fun create(kotlin/Function1<io.ktor.client.engine.mock/MockEngineConfig, kotlin/Unit>): io.ktor.client.engine/HttpClientEngine // io.ktor.client.engine.mock/MockEngine.Companion.create|create(kotlin.Function1<io.ktor.client.engine.mock.MockEngineConfig,kotlin.Unit>){}[0]
+        final fun empty(): io.ktor.client.engine.mock/MockEngine // io.ktor.client.engine.mock/MockEngine.Companion.empty|empty(){}[0]
         final fun invoke(kotlin.coroutines/SuspendFunction2<io.ktor.client.engine.mock/MockRequestHandleScope, io.ktor.client.request/HttpRequestData, io.ktor.client.request/HttpResponseData>): io.ktor.client.engine.mock/MockEngine // io.ktor.client.engine.mock/MockEngine.Companion.invoke|invoke(kotlin.coroutines.SuspendFunction2<io.ktor.client.engine.mock.MockRequestHandleScope,io.ktor.client.request.HttpRequestData,io.ktor.client.request.HttpResponseData>){}[0]
     }
 }

--- a/ktor-client/ktor-client-mock/common/src/io/ktor/client/engine/mock/MockEngine.kt
+++ b/ktor-client/ktor-client-mock/common/src/io/ktor/client/engine/mock/MockEngine.kt
@@ -116,9 +116,7 @@ public class MockEngine(
          *
          * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.client.engine.mock.MockEngine.Companion.invoke)
          */
-        public operator fun invoke(
-            handler: suspend MockRequestHandleScope.(HttpRequestData) -> HttpResponseData
-        ): MockEngine = MockEngine(
+        public operator fun invoke(handler: MockRequestHandler): MockEngine = MockEngine(
             MockEngineConfig().apply {
                 requestHandlers.add(handler)
             }

--- a/ktor-client/ktor-client-mock/jvm/test/io/ktor/client/tests/mock/MockEngineTests.kt
+++ b/ktor-client/ktor-client-mock/jvm/test/io/ktor/client/tests/mock/MockEngineTests.kt
@@ -74,7 +74,7 @@ class MockEngineTests {
     data class User(val name: String)
 
     @Test
-    fun testWithContentNegotationPlugin() = runBlocking {
+    fun testWithContentNegotiationPlugin() = runBlocking {
         val client = HttpClient(
             MockEngine { request ->
                 val bodyBytes = (request.body as OutgoingContent.ByteArrayContent).bytes()

--- a/ktor-client/ktor-client-mock/jvm/test/io/ktor/client/tests/mock/MockEngineTests.kt
+++ b/ktor-client/ktor-client-mock/jvm/test/io/ktor/client/tests/mock/MockEngineTests.kt
@@ -93,8 +93,8 @@ class MockEngineTests {
     }
 
     @Test
-    fun testEmptyEngineWithManualQueueing(): Unit = runBlocking {
-        val engine = MockEngine.empty()
+    fun testEngineWithManualQueueing(): Unit = runBlocking {
+        val engine = MockEngine.Queue()
         assertTrue(engine.config.requestHandlers.isEmpty())
 
         val client = HttpClient(engine)


### PR DESCRIPTION
**Subsystem**
Client testing

**Motivation**
I recently started using Ktor as a replacement for OkHttp for various reasons, and I came across MockEngine as an apparent replacement for [MockWebServer](https://github.com/square/okhttp/tree/master/mockwebserver). One thing that I did quite a lot with MockWebServer was to:
1. initialise the client in a test's `@Before` block
2. pass it into the rest of the system under test
3. specify HTTP behaviour on a per-test basis
4. make the call
6. verify the behaviour
7. maybe repeat steps 3-6 several times, depending on test complexity

But with MockEngine as it is I need to pass in an initial MockRequestHandler, otherwise an exception is thrown.

**Solution**
This change adds the option to intialise MockEngine without a MockRequestHandler using the `MockEngine.empty()` function - allowing us to enqueue one or more handlers later in the test lifecycle. If no handler exists at the time of a call being made, it still throws `error()` as it did before.

Obviously this isn't going to cover all user's needs so I left the default constructor behaving as it always has, but personally I think this will help people to structure their tests a little better.

CI seems to be failing, but I'm fairly sure(???) that's not the fault of this branch.