### PR TITLE
KTOR-8035 Refine JVM args

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -33,7 +33,7 @@ version=3.2.0-SNAPSHOT
 # * '-Dkotlin.daemon.options=autoshutdownIdleSeconds=30'
 #   To save some memory, shutting down Kotlin Daemon used for buildSrc compilation after 30 seconds of idle.
 #   See: https://github.com/gradle/gradle/issues/29331
-org.gradle.jvmargs=-Xms2g -Xmx9g -XX:+HeapDumpOnOutOfMemoryError -XX:+UseParallelGC -Dfile.encoding=UTF-8 -Dkotlin.daemon.jvm.options=-Xmx512m,Xms256m,-XX:MaxMetaspaceSize=256m,XX:+HeapDumpOnOutOfMemoryError
+org.gradle.jvmargs=-Xms2g -Xmx9g -XX:+HeapDumpOnOutOfMemoryError -XX:+UseParallelGC -Dfile.encoding=UTF-8 -Dkotlin.daemon.jvm.options="-Xmx512m,Xms256m,-XX:MaxMetaspaceSize=256m,XX:+HeapDumpOnOutOfMemoryError"
 kotlin.daemon.jvmargs=-Xms512m -Xmx2g -XX:MaxMetaspaceSize=256m -XX:+HeapDumpOnOutOfMemoryError
 # Gradle Doctor might increase memory consumption when task monitoring is enabled, so it is disabled by default.
 # Some features can't work without task monitoring:

--- a/gradle.properties
+++ b/gradle.properties
@@ -35,6 +35,7 @@ version=3.2.0-SNAPSHOT
 #   See: https://github.com/gradle/gradle/issues/29331
 org.gradle.jvmargs=-Xms2g -Xmx9g -XX:+HeapDumpOnOutOfMemoryError -XX:+UseParallelGC -Dfile.encoding=UTF-8 -Dkotlin.daemon.jvm.options="-Xmx512m,Xms256m,-XX:MaxMetaspaceSize=256m,XX:+HeapDumpOnOutOfMemoryError"
 kotlin.daemon.jvmargs=-Xms512m -Xmx2g -XX:MaxMetaspaceSize=256m -XX:+HeapDumpOnOutOfMemoryError
+kotlin.native.jvmargs=-Xms512m -Xmx2g -XX:MaxMetaspaceSize=256m -XX:+HeapDumpOnOutOfMemoryError
 # Gradle Doctor might increase memory consumption when task monitoring is enabled, so it is disabled by default.
 # Some features can't work without task monitoring:
 #  doctor-negative-savings, doctor-slow-build-cache-connection, doctor-slow-maven-connection

--- a/gradle.properties
+++ b/gradle.properties
@@ -33,7 +33,7 @@ version=3.2.0-SNAPSHOT
 # * '-Dkotlin.daemon.options=autoshutdownIdleSeconds=30'
 #   To save some memory, shutting down Kotlin Daemon used for buildSrc compilation after 30 seconds of idle.
 #   See: https://github.com/gradle/gradle/issues/29331
-org.gradle.jvmargs=-Xms2g -Xmx9g -XX:+HeapDumpOnOutOfMemoryError -XX:+UseParallelGC -Dfile.encoding=UTF-8 -Dkotlin.daemon.jvm.options="-Xmx512m,Xms256m,-XX:MaxMetaspaceSize=256m,XX:+HeapDumpOnOutOfMemoryError"
+org.gradle.jvmargs=-Xms2g -Xmx9g -XX:+HeapDumpOnOutOfMemoryError -XX:+UseParallelGC -Dfile.encoding=UTF-8 -Dkotlin.daemon.jvm.options="-Xmx512m,Xms256m,-XX:MaxMetaspaceSize=256m,XX:+HeapDumpOnOutOfMemoryError" -Dkotlin.daemon.options="autoshutdownIdleSeconds=1800"
 kotlin.daemon.jvmargs=-Xms512m -Xmx2g -XX:MaxMetaspaceSize=256m -XX:+HeapDumpOnOutOfMemoryError
 kotlin.native.jvmargs=-Xms512m -Xmx2g -XX:MaxMetaspaceSize=256m -XX:+HeapDumpOnOutOfMemoryError
 # Gradle Doctor might increase memory consumption when task monitoring is enabled, so it is disabled by default.

--- a/teamcity.default.properties
+++ b/teamcity.default.properties
@@ -2,4 +2,6 @@
 # Copyright 2014-2025 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
 #
 
-env.GRADLE_OPTS=-Xmx4g -Dkotlin.daemon.options="autoshutdownIdleSeconds=30"
+# Should be in sync with org.gradle.jvmargs from gradle.properties
+# We have to duplicate system properties here because of TW-93433 "TeamCity ignores system properties specified in org.gradle.jvmargs"
+env.GRADLE_OPTS=-Xmx4g -Dkotlin.daemon.options="autoshutdownIdleSeconds=30" -Dkotlin.daemon.jvm.options="-Xmx512m,Xms256m,-XX:MaxMetaspaceSize=256m,XX:+HeapDumpOnOutOfMemoryError"

--- a/teamcity.default.properties
+++ b/teamcity.default.properties
@@ -2,4 +2,4 @@
 # Copyright 2014-2025 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
 #
 
-env.GRADLE_OPTS=-Xmx4g -Dkotlin.daemon.options=autoshutdownIdleSeconds=30
+env.GRADLE_OPTS=-Xmx4g -Dkotlin.daemon.options="autoshutdownIdleSeconds=30"


### PR DESCRIPTION
**Subsystem**
Infrastructure

**Motivation**
[KTOR-8035](https://youtrack.jetbrains.com/issue/KTOR-8035) Investigate CI failures due to insufficient RAM

**Solution**
- Apply a workaround for [TW-93433](https://youtrack.jetbrains.com/issue/TW-93433) "TeamCity ignores system properties specified in org.gradle.jvmargs"
- Limit heap size for K/N utilities
- Reduce the default max idle time for Kotlin Daemons from 3 hours to 30 minutes