### PR TITLE
KTOR-8343 Fix: Store client header cookies with RAW encoding to preve…

### DIFF
--- a/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/cookies/HttpCookies.kt
+++ b/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/cookies/HttpCookies.kt
@@ -53,7 +53,9 @@ public class HttpCookies internal constructor(
             val url = builder.url.clone().build()
             val cookies = headers[HttpHeaders.Cookie]?.let { cookieHeader ->
                 LOGGER.trace("Saving cookie $cookieHeader for ${builder.url}")
-                parseClientCookiesHeader(cookieHeader).map { (name, encodedValue) -> Cookie(name, encodedValue) }
+                parseClientCookiesHeader(cookieHeader).map { (name, encodedValue) ->
+                    Cookie(name, encodedValue, encoding = CookieEncoding.RAW)
+                }
             }
             cookies?.forEach { storage.addCookie(url, it) }
         }

--- a/ktor-client/ktor-client-core/common/test/CookiesTest.kt
+++ b/ktor-client/ktor-client-core/common/test/CookiesTest.kt
@@ -96,4 +96,22 @@ class CookiesTest {
 
         assertNull(builder.headers[HttpHeaders.Cookie])
     }
+
+    @Test
+    fun testCapturedHeaderCookiesStoredAsRawPreserveOriginalHeader() = testSuspend {
+        val feature = HttpCookies(AcceptAllCookiesStorage(), emptyList())
+        val builder = HttpRequestBuilder()
+        val defaultEncodingCookie = Cookie("default", "&%?#=$")
+        val rawEncodingCookie = Cookie("raw", "&%?#=$", encoding = CookieEncoding.RAW)
+        val base64EncodingCookie = Cookie("base64", "&%?#=$", encoding = CookieEncoding.BASE64_ENCODING)
+        val dquotesEncodingCookie = Cookie("dquotes", "&%?#=$", encoding = CookieEncoding.DQUOTES)
+        val cookies = listOf(defaultEncodingCookie, rawEncodingCookie, base64EncodingCookie, dquotesEncodingCookie)
+            .joinToString("; ", transform = ::renderCookieHeader)
+
+        builder.header(HttpHeaders.Cookie, cookies)
+        feature.captureHeaderCookies(builder)
+        feature.sendCookiesWith(builder)
+
+        assertEquals(cookies, builder.headers[HttpHeaders.Cookie])
+    }
 }


### PR DESCRIPTION
…nt value alteration

**Subsystem**
Client, HttpCookies

**Motivation**
[KTOR-8343 HttpCookies: Encoding of request cookies is not preserved in CookiesStorage](https://youtrack.jetbrains.com/issue/KTOR-8343/HttpCookies-Encoding-of-request-cookies-is-not-preserved-in-CookiesStorage)
Currently, when `HttpCookies` captures cookies from the `Cookie` request header, it doesn't explicitly specify an encoding for storage. This can lead to unintended alteration of cookie values if the `CookiesStorage` later retrieves them assuming a different encoding (e.g., `URI_ENCODING` by default).
This is problematic because the original cookie value, as sent by the client, might not be preserved, potentially leading to unexpected behavior in applications that rely on exact cookie values.

**Solution**
This PR modifies `HttpCookies` to explicitly store cookies captured from the `Cookie` request header with `CookieEncoding.RAW`.
By doing so, we ensure that the cookie value is preserved in its original form as received in the header, regardless of any default encoding assumptions by the `CookiesStorage`.

A new test case, `testCapturedHeaderCookiesStoredAsRawPreserveOriginalHeader`, has been added to `CookiesTest.kt` to verify that cookies captured from the header are indeed stored and retrieved with their original values intact, even when they contain characters that might be altered by other encodings.
