### PR TITLE
Fix some ProGuard warnings

### DIFF
--- a/ktor-io/api/ktor-io.api
+++ b/ktor-io/api/ktor-io.api
@@ -142,7 +142,8 @@ public final class io/ktor/utils/io/ByteWriteChannelOperationsKt {
 	public static final fun cancel (Lio/ktor/utils/io/ChannelJob;)V
 	public static final fun close (Lio/ktor/utils/io/ByteWriteChannel;Ljava/lang/Throwable;)V
 	public static final fun getCancellationException (Lio/ktor/utils/io/ChannelJob;)Ljava/util/concurrent/CancellationException;
-	public static final fun invokeOnCompletion (Lio/ktor/utils/io/ChannelJob;Lkotlin/jvm/functions/Function0;)V
+	public static final synthetic fun invokeOnCompletion (Lio/ktor/utils/io/ChannelJob;Lkotlin/jvm/functions/Function0;)V
+	public static final fun invokeOnCompletion (Lio/ktor/utils/io/ChannelJob;Lkotlin/jvm/functions/Function1;)Lkotlinx/coroutines/DisposableHandle;
 	public static final fun isCancelled (Lio/ktor/utils/io/ChannelJob;)Z
 	public static final fun isCompleted (Lio/ktor/utils/io/ChannelJob;)Z
 	public static final fun join (Lio/ktor/utils/io/ChannelJob;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;

--- a/ktor-io/api/ktor-io.klib.api
+++ b/ktor-io/api/ktor-io.klib.api
@@ -402,6 +402,7 @@ final fun (io.ktor.utils.io/ByteWriteChannel).io.ktor.utils.io/rethrowCloseCause
 final fun (io.ktor.utils.io/ChannelJob).io.ktor.utils.io/cancel() // io.ktor.utils.io/cancel|cancel@io.ktor.utils.io.ChannelJob(){}[0]
 final fun (io.ktor.utils.io/ChannelJob).io.ktor.utils.io/getCancellationException(): kotlin.coroutines.cancellation/CancellationException // io.ktor.utils.io/getCancellationException|getCancellationException@io.ktor.utils.io.ChannelJob(){}[0]
 final fun (io.ktor.utils.io/ChannelJob).io.ktor.utils.io/invokeOnCompletion(kotlin/Function0<kotlin/Unit>) // io.ktor.utils.io/invokeOnCompletion|invokeOnCompletion@io.ktor.utils.io.ChannelJob(kotlin.Function0<kotlin.Unit>){}[0]
+final fun (io.ktor.utils.io/ChannelJob).io.ktor.utils.io/invokeOnCompletion(kotlin/Function1<kotlin/Throwable?, kotlin/Unit>): kotlinx.coroutines/DisposableHandle // io.ktor.utils.io/invokeOnCompletion|invokeOnCompletion@io.ktor.utils.io.ChannelJob(kotlin.Function1<kotlin.Throwable?,kotlin.Unit>){}[0]
 final fun (kotlin/ByteArray).io.ktor.utils.io.core/storeIntAt(kotlin/Int, kotlin/Int) // io.ktor.utils.io.core/storeIntAt|storeIntAt@kotlin.ByteArray(kotlin.Int;kotlin.Int){}[0]
 final fun (kotlin/Double).io.ktor.utils.io.bits/reverseByteOrder(): kotlin/Double // io.ktor.utils.io.bits/reverseByteOrder|reverseByteOrder@kotlin.Double(){}[0]
 final fun (kotlin/Float).io.ktor.utils.io.bits/reverseByteOrder(): kotlin/Float // io.ktor.utils.io.bits/reverseByteOrder|reverseByteOrder@kotlin.Float(){}[0]

--- a/ktor-io/common/src/io/ktor/utils/io/ByteWriteChannelOperations.kt
+++ b/ktor-io/common/src/io/ktor/utils/io/ByteWriteChannelOperations.kt
@@ -143,6 +143,10 @@ public val ChannelJob.isCancelled: Boolean get() = job.isCancelled
 @OptIn(InternalCoroutinesApi::class)
 public fun ChannelJob.getCancellationException(): CancellationException = job.getCancellationException()
 
+public fun ChannelJob.invokeOnCompletion(block: (cause: Throwable?) -> Unit): DisposableHandle =
+    job.invokeOnCompletion(block)
+
+@Deprecated("Maintained for binary compatibility", level = DeprecationLevel.HIDDEN)
 public fun ChannelJob.invokeOnCompletion(block: () -> Unit) {
     job.invokeOnCompletion { block() }
 }

--- a/ktor-network/common/src/io/ktor/network/sockets/SocketBase.kt
+++ b/ktor-network/common/src/io/ktor/network/sockets/SocketBase.kt
@@ -22,6 +22,9 @@ internal abstract class SocketBase(
 
     private val writerJob = atomic<WriterJob?>(null)
 
+    // Declare the lambda as a class field because of KTOR-8525
+    private val channelCompletionHandler: (Throwable?) -> Unit = { checkChannels() }
+
     override val socketContext: CompletableJob = Job(parent[Job])
 
     override val coroutineContext: CoroutineContext
@@ -85,9 +88,7 @@ internal abstract class SocketBase(
 
         channel.attachJob(j)
 
-        j.invokeOnCompletion {
-            checkChannels()
-        }
+        j.invokeOnCompletion(channelCompletionHandler)
 
         return j
     }

--- a/ktor-network/common/src/io/ktor/network/sockets/SocketBase.kt
+++ b/ktor-network/common/src/io/ktor/network/sockets/SocketBase.kt
@@ -6,10 +6,11 @@ package io.ktor.network.sockets
 
 import io.ktor.network.selector.*
 import io.ktor.utils.io.*
-import kotlinx.atomicfu.*
+import kotlinx.atomicfu.AtomicRef
+import kotlinx.atomicfu.atomic
 import kotlinx.coroutines.*
-import kotlinx.io.*
-import kotlin.coroutines.*
+import kotlinx.io.IOException
+import kotlin.coroutines.CoroutineContext
 
 internal abstract class SocketBase(
     parent: CoroutineContext
@@ -19,7 +20,6 @@ internal abstract class SocketBase(
     private val actualCloseFlag = atomic(false)
 
     private val readerJob = atomic<ReaderJob?>(null)
-
     private val writerJob = atomic<WriterJob?>(null)
 
     // Declare the lambda as a class field because of KTOR-8525
@@ -36,7 +36,7 @@ internal abstract class SocketBase(
 
     @OptIn(InternalAPI::class)
     override fun close() {
-        if (!closeFlag.compareAndSet(false, true)) return
+        if (!closeFlag.compareAndSet(expect = false, update = true)) return
 
         launch(CoroutineName("socket-close")) {
             readerJob.value?.flushAndClose()
@@ -46,15 +46,11 @@ internal abstract class SocketBase(
     }
 
     final override fun attachForReading(channel: ByteChannel): WriterJob {
-        return attachFor("reading", channel, writerJob) {
-            attachForReadingImpl(channel)
-        }
+        return attachFor("reading", channel, writerJob, ::attachForReadingImpl)
     }
 
     final override fun attachForWriting(channel: ByteChannel): ReaderJob {
-        return attachFor("writing", channel, readerJob) {
-            attachForWritingImpl(channel)
-        }
+        return attachFor("writing", channel, readerJob, ::attachForWritingImpl)
     }
 
     abstract fun attachForReadingImpl(channel: ByteChannel): WriterJob
@@ -64,7 +60,7 @@ internal abstract class SocketBase(
         name: String,
         channel: ByteChannel,
         ref: AtomicRef<J?>,
-        producer: () -> J
+        producer: (ByteChannel) -> J,
     ): J {
         if (closeFlag.value) {
             val e = IOException("Socket closed")
@@ -72,7 +68,7 @@ internal abstract class SocketBase(
             throw e
         }
 
-        val j = producer()
+        val j = producer(channel)
 
         if (!ref.compareAndSet(null, j)) {
             val e = IllegalStateException("$name channel has already been set")
@@ -97,7 +93,7 @@ internal abstract class SocketBase(
 
     private fun checkChannels() {
         if (closeFlag.value && readerJob.completedOrNotStarted && writerJob.completedOrNotStarted) {
-            if (!actualCloseFlag.compareAndSet(false, true)) return
+            if (!actualCloseFlag.compareAndSet(expect = false, update = true)) return
 
             val e1 = readerJob.exception
             val e2 = writerJob.exception

--- a/ktor-server/ktor-server-core/common/src/io/ktor/server/config/MapApplicationConfig.kt
+++ b/ktor-server/ktor-server-core/common/src/io/ktor/server/config/MapApplicationConfig.kt
@@ -4,9 +4,8 @@
 
 package io.ktor.server.config
 
-import io.ktor.util.reflect.TypeInfo
-import io.ktor.util.reflect.serializer
-import io.ktor.utils.io.InternalAPI
+import io.ktor.util.reflect.*
+import io.ktor.utils.io.*
 import kotlin.collections.component1
 import kotlin.collections.component2
 
@@ -92,7 +91,7 @@ public open class MapApplicationConfig : ApplicationConfig {
     public fun put(path: String, values: Iterable<String>) {
         var size = 0
         values.forEachIndexed { i, value ->
-            put(combine(path, i.toString()), value)
+            put(combine(path, i), value)
             size++
         }
         put(combine(path, "size"), size.toString())
@@ -109,7 +108,7 @@ public open class MapApplicationConfig : ApplicationConfig {
         val size = map[combine(key, "size")]
             ?: throw ApplicationConfigurationException("Property $key.size not found.")
         return (0 until size.toInt()).map {
-            MapApplicationConfig(map, combine(key, it.toString()))
+            MapApplicationConfig(map, combine(key, it))
         }
     }
 
@@ -173,7 +172,7 @@ internal class MapApplicationConfigValue(
     override val type: ApplicationConfigValue.Type by lazy {
         when {
             map.containsKey(path) -> ApplicationConfigValue.Type.SINGLE
-            map[combine(path, "size")] != null -> ApplicationConfigValue.Type.LIST
+            map.containsKey(combine(path, "size")) -> ApplicationConfigValue.Type.LIST
             map.containsPrefix(path) -> ApplicationConfigValue.Type.OBJECT
             else -> ApplicationConfigValue.Type.NULL
         }
@@ -182,7 +181,7 @@ internal class MapApplicationConfigValue(
     override fun getList(): List<String> {
         val size =
             map[combine(path, "size")] ?: throw ApplicationConfigurationException("Property $path.size not found.")
-        return (0 until size.toInt()).map { map[combine(path, it.toString())]!! }
+        return (0 until size.toInt()).map { map[combine(path, it)]!! }
     }
 
     override fun getMap(): Map<String, Any?> {
@@ -196,8 +195,8 @@ internal class MapApplicationConfigValue(
     }
 }
 
-private fun combine(root: String, relative: Any): String =
-    if (root.isEmpty()) relative.toString() else "$root.$relative"
+private fun combine(root: String, relative: Int): String = combine(root, relative.toString())
+private fun combine(root: String, relative: String): String = if (root.isEmpty()) relative else "$root.$relative"
 
 private fun findListElements(input: String, listElements: MutableMap<String, Int>) {
     var pointBegin = input.indexOf('.')


### PR DESCRIPTION
**Subsystem**
Client/Server

**Motivation**
[KTOR-8525](https://youtrack.jetbrains.com/issue/KTOR-8525) ktor-network produces ProGuard warning

**Solution**
The warning was caused by a lambda created inside the inline function. I've moved the lambda to the class field.
Also fixed another warning on the recently changed `combine(String, Any)` function