### PR TITLE
Add extension to discovery routing root node

### DIFF
--- a/ktor-server/ktor-server-core/api/ktor-server-core.api
+++ b/ktor-server/ktor-server-core/api/ktor-server-core.api
@@ -1698,6 +1698,10 @@ public final class io/ktor/server/routing/RoutingContext {
 	public final fun getCall ()Lio/ktor/server/routing/RoutingCall;
 }
 
+public final class io/ktor/server/routing/RoutingIntrospectionKt {
+	public static final fun getRoutingRoot (Lio/ktor/server/application/Application;)Lio/ktor/server/routing/RoutingNode;
+}
+
 public class io/ktor/server/routing/RoutingNode : io/ktor/server/application/ApplicationCallPipeline, io/ktor/server/routing/Route {
 	public fun <init> (Lio/ktor/server/routing/RoutingNode;Lio/ktor/server/routing/RouteSelector;ZLio/ktor/server/application/ApplicationEnvironment;)V
 	public synthetic fun <init> (Lio/ktor/server/routing/RoutingNode;Lio/ktor/server/routing/RouteSelector;ZLio/ktor/server/application/ApplicationEnvironment;ILkotlin/jvm/internal/DefaultConstructorMarker;)V

--- a/ktor-server/ktor-server-core/api/ktor-server-core.klib.api
+++ b/ktor-server/ktor-server-core/api/ktor-server-core.klib.api
@@ -1679,6 +1679,8 @@ final val io.ktor.server.routing/application // io.ktor.server.routing/applicati
     final fun (io.ktor.server.routing/Route).<get-application>(): io.ktor.server.application/Application // io.ktor.server.routing/application.<get-application>|<get-application>@io.ktor.server.routing.Route(){}[0]
 final val io.ktor.server.routing/path // io.ktor.server.routing/path|@io.ktor.server.routing.RoutingNode{}path[0]
     final fun (io.ktor.server.routing/RoutingNode).<get-path>(): kotlin/String // io.ktor.server.routing/path.<get-path>|<get-path>@io.ktor.server.routing.RoutingNode(){}[0]
+final val io.ktor.server.routing/routingRoot // io.ktor.server.routing/routingRoot|@io.ktor.server.application.Application{}routingRoot[0]
+    final fun (io.ktor.server.application/Application).<get-routingRoot>(): io.ktor.server.routing/RoutingNode // io.ktor.server.routing/routingRoot.<get-routingRoot>|<get-routingRoot>@io.ktor.server.application.Application(){}[0]
 
 final var io.ktor.server.application/receiveType // io.ktor.server.application/receiveType|@io.ktor.server.application.ApplicationCall{}receiveType[0]
     final fun (io.ktor.server.application/ApplicationCall).<get-receiveType>(): io.ktor.util.reflect/TypeInfo // io.ktor.server.application/receiveType.<get-receiveType>|<get-receiveType>@io.ktor.server.application.ApplicationCall(){}[0]

--- a/ktor-server/ktor-server-core/common/src/io/ktor/server/routing/RoutingIntrospection.kt
+++ b/ktor-server/ktor-server-core/common/src/io/ktor/server/routing/RoutingIntrospection.kt
@@ -1,0 +1,13 @@
+/*
+ * Copyright 2014-2025 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.server.routing
+
+import io.ktor.server.application.*
+
+/**
+ * Gets the root of the routing block.
+ */
+public val Application.routingRoot: RoutingNode
+    get() = pluginOrNull(RoutingRoot) ?: throw IllegalStateException("Routing plugin is not installed")


### PR DESCRIPTION
The routing root node is hardly discoverable, so navigating over existing API endpoints is complicated