### PR TITLE
KTOR-7584 Moved experimental htmx annotation to a common type

### DIFF
--- a/ktor-io/api/ktor-io.api
+++ b/ktor-io/api/ktor-io.api
@@ -263,6 +263,9 @@ public final class io/ktor/utils/io/DeprecationKt {
 	public static final fun release (Lkotlinx/io/Sink;)V
 }
 
+public abstract interface annotation class io/ktor/utils/io/ExperimentalKtorApi : java/lang/annotation/Annotation {
+}
+
 public abstract interface annotation class io/ktor/utils/io/InternalAPI : java/lang/annotation/Annotation {
 }
 

--- a/ktor-io/api/ktor-io.klib.api
+++ b/ktor-io/api/ktor-io.klib.api
@@ -9,6 +9,10 @@
 // - Show declarations: true
 
 // Library unique name: <io.ktor:ktor-io>
+open annotation class io.ktor.utils.io/ExperimentalKtorApi : kotlin/Annotation { // io.ktor.utils.io/ExperimentalKtorApi|null[0]
+    constructor <init>() // io.ktor.utils.io/ExperimentalKtorApi.<init>|<init>(){}[0]
+}
+
 open annotation class io.ktor.utils.io/InternalAPI : kotlin/Annotation { // io.ktor.utils.io/InternalAPI|null[0]
     constructor <init>() // io.ktor.utils.io/InternalAPI.<init>|<init>(){}[0]
 }

--- a/ktor-io/common/src/io/ktor/utils/io/Annotations.kt
+++ b/ktor-io/common/src/io/ktor/utils/io/Annotations.kt
@@ -25,6 +25,7 @@ package io.ktor.utils.io
     AnnotationTarget.PROPERTY_SETTER,
     AnnotationTarget.PROPERTY_SETTER
 )
+@Retention(AnnotationRetention.BINARY)
 public annotation class InternalAPI
 
 /**
@@ -50,6 +51,25 @@ public annotation class InternalAPI
     level = DeprecationLevel.ERROR
 )
 public annotation class KtorExperimentalAPI
+
+/**
+ * This API may change in a future release depending on feedback.
+ *
+ * If you'd like to provide some feedback regarding the experimental API,
+ * please reach out to us via one of the channels listed here: [https://ktor.io/support/](https://ktor.io/support/)
+ *
+ * Any usage of a declaration annotated with `@ExperimentalKtorApi` must be accepted either by
+ * annotating that usage with the [OptIn] annotation, e.g. `@OptIn(ExperimentalStdlibApi::class)`,
+ * or by using the compiler argument `-opt-in=kotlin.ExperimentalKtorApi`.
+ */
+@RequiresOptIn(
+    level = RequiresOptIn.Level.WARNING,
+    message = "This API is experimental. " +
+        "It could be removed or changed in future releases, or its behaviour may be different."
+)
+@MustBeDocumented
+@Retention(AnnotationRetention.BINARY)
+public annotation class ExperimentalKtorApi
 
 /**
  * API marked with this annotation is intended to become public in the future [version].

--- a/ktor-server/ktor-server-plugins/ktor-server-htmx/common/src/io/ktor/server/htmx/HxHeaders.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-htmx/common/src/io/ktor/server/htmx/HxHeaders.kt
@@ -5,18 +5,18 @@ import io.ktor.http.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
 import io.ktor.util.collections.*
-import io.ktor.utils.io.InternalAPI
+import io.ktor.utils.io.*
 import kotlin.jvm.JvmInline
 
-@ExperimentalHtmxApi
+@ExperimentalKtorApi
 public val RoutingRequest.hx: HXRequestHeaders get() = HXRequestHeaders(headers)
 
-@ExperimentalHtmxApi
+@ExperimentalKtorApi
 public val RoutingResponse.hx: HXResponseHeaders get() = HXResponseHeaders(headers)
 
 public val RoutingRequest.isHtmx: Boolean get() = headers[HxRequestHeaders.Request] == "true"
 
-@ExperimentalHtmxApi
+@ExperimentalKtorApi
 @JvmInline
 public value class HXRequestHeaders(private val headers: Headers) {
 
@@ -42,7 +42,7 @@ public value class HXRequestHeaders(private val headers: Headers) {
     public val triggerName: String? get() = headers[HxRequestHeaders.TriggerName]
 }
 
-@ExperimentalHtmxApi
+@ExperimentalKtorApi
 @OptIn(InternalAPI::class)
 public class HXResponseHeaders(private val headers: ResponseHeaders) : StringMap {
 

--- a/ktor-server/ktor-server-plugins/ktor-server-htmx/common/src/io/ktor/server/htmx/HxRouting.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-htmx/common/src/io/ktor/server/htmx/HxRouting.kt
@@ -12,13 +12,13 @@ import kotlin.jvm.JvmInline
 /**
  * Property for scoping routes to HTMX (e.g., `hx.get { ... }`
  */
-@ExperimentalHtmxApi
+@ExperimentalKtorApi
 public val Route.hx: HxRoute get() = HxRoute.wrap(this)
 
 /**
  * Scope child routes to apply when `HX-Request` header is supplied.
  */
-@ExperimentalHtmxApi
+@ExperimentalKtorApi
 public fun Route.hx(configuration: HxRoute.() -> Unit): Route = with(HxRoute.wrap(this)) {
     header(HxRequestHeaders.Request, "true") {
         configuration()
@@ -28,7 +28,7 @@ public fun Route.hx(configuration: HxRoute.() -> Unit): Route = with(HxRoute.wra
 /**
  * Provides custom routes based on common HTMX headers.
  */
-@ExperimentalHtmxApi
+@ExperimentalKtorApi
 @KtorDsl
 @JvmInline
 public value class HxRoute internal constructor(private val route: Route) : Route by route {

--- a/ktor-server/ktor-server-plugins/ktor-server-htmx/common/test/io/ktor/server/htmx/HxRoutingTest.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-htmx/common/test/io/ktor/server/htmx/HxRoutingTest.kt
@@ -11,6 +11,7 @@ import io.ktor.server.html.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
 import io.ktor.server.testing.*
+import io.ktor.utils.io.ExperimentalKtorApi
 import kotlinx.html.body
 import kotlinx.html.h1
 import kotlin.test.Test
@@ -18,7 +19,7 @@ import kotlin.test.assertEquals
 
 class HxRoutingTest {
 
-    @OptIn(ExperimentalHtmxApi::class)
+    @OptIn(ExperimentalKtorApi::class)
     @Test
     fun routing() = testApplication {
         val responseTemplate: (String) -> String = { header ->

--- a/ktor-shared/ktor-htmx/api/ktor-htmx.api
+++ b/ktor-shared/ktor-htmx/api/ktor-htmx.api
@@ -1,6 +1,3 @@
-public abstract interface annotation class io/ktor/htmx/ExperimentalHtmxApi : java/lang/annotation/Annotation {
-}
-
 public final class io/ktor/htmx/HxAttributeKeys {
 	public static final field Boost Ljava/lang/String;
 	public static final field Confirm Ljava/lang/String;

--- a/ktor-shared/ktor-htmx/api/ktor-htmx.klib.api
+++ b/ktor-shared/ktor-htmx/api/ktor-htmx.klib.api
@@ -6,10 +6,6 @@
 // - Show declarations: true
 
 // Library unique name: <io.ktor:ktor-htmx>
-open annotation class io.ktor.htmx/ExperimentalHtmxApi : kotlin/Annotation { // io.ktor.htmx/ExperimentalHtmxApi|null[0]
-    constructor <init>() // io.ktor.htmx/ExperimentalHtmxApi.<init>|<init>(){}[0]
-}
-
 final object io.ktor.htmx/HxAttributeKeys { // io.ktor.htmx/HxAttributeKeys|null[0]
     final const val Boost // io.ktor.htmx/HxAttributeKeys.Boost|{}Boost[0]
         final fun <get-Boost>(): kotlin/String // io.ktor.htmx/HxAttributeKeys.Boost.<get-Boost>|<get-Boost>(){}[0]

--- a/ktor-shared/ktor-htmx/common/src/io/ktor/htmx/Annotations.kt
+++ b/ktor-shared/ktor-htmx/common/src/io/ktor/htmx/Annotations.kt
@@ -1,8 +1,0 @@
-/*
- * Copyright 2014-2025 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
- */
-
-package io.ktor.htmx
-
-@MustBeDocumented @Retention @RequiresOptIn
-public annotation class ExperimentalHtmxApi

--- a/ktor-shared/ktor-htmx/ktor-htmx-html/common/src/io/ktor/htmx/html/HxAttributes.kt
+++ b/ktor-shared/ktor-htmx/ktor-htmx-html/common/src/io/ktor/htmx/html/HxAttributes.kt
@@ -11,15 +11,15 @@ import kotlinx.html.HtmlTagMarker
 import kotlinx.html.impl.DelegatingMap
 import kotlin.jvm.JvmInline
 
-@ExperimentalHtmxApi
+@ExperimentalKtorApi
 public val DelegatingMap.hx: HxAttributes get() = HxAttributes(this)
 
-@ExperimentalHtmxApi
+@ExperimentalKtorApi
 public inline fun DelegatingMap.hx(block: HxAttributes.() -> Unit) {
     hx.block()
 }
 
-@ExperimentalHtmxApi
+@ExperimentalKtorApi
 @HtmlTagMarker
 @OptIn(InternalAPI::class)
 public class HxAttributes(override val map: DelegatingMap) : StringMapDelegate {

--- a/ktor-shared/ktor-htmx/ktor-htmx-html/common/test/io/ktor/htmx/html/HxAttributesTest.kt
+++ b/ktor-shared/ktor-htmx/ktor-htmx-html/common/test/io/ktor/htmx/html/HxAttributesTest.kt
@@ -4,8 +4,8 @@
 
 package io.ktor.htmx.html
 
-import io.ktor.htmx.ExperimentalHtmxApi
-import io.ktor.htmx.HxSwap
+import io.ktor.htmx.*
+import io.ktor.utils.io.*
 import kotlinx.html.body
 import kotlinx.html.button
 import kotlinx.html.html
@@ -15,7 +15,7 @@ import kotlin.test.assertEquals
 
 class HxAttributesTest {
 
-    @OptIn(ExperimentalHtmxApi::class)
+    @OptIn(ExperimentalKtorApi::class)
     @Test
     fun htmxAttributes() {
         val actual = buildString {


### PR DESCRIPTION
**Subsystem**
Shared, HTMX

**Motivation**
[KTOR-7584](https://youtrack.jetbrains.com/issue/KTOR-7584) First-class HTMX support

I realized having a specific flag doesn't make sense since we can't remove it without breaking the API.

**Solution**
Moved the annotation to a common type so we can mark other things as such when we want to solicit some feedback before committing to a stable API.

