### PR TITLE
KTOR-8259 Make CurlMultiApiHandler.perform non-blocking

### DIFF
--- a/ktor-client/ktor-client-curl/desktop/src/io/ktor/client/engine/curl/internal/CurlAdapters.kt
+++ b/ktor-client/ktor-client-curl/desktop/src/io/ktor/client/engine/curl/internal/CurlAdapters.kt
@@ -32,15 +32,57 @@ internal val DISALLOWED_WEBSOCKET_HEADERS = setOf(
 @OptIn(ExperimentalForeignApi::class)
 internal fun CURLMcode.verify() {
     if (this != CURLM_OK) {
-        error("Unexpected curl verify: ${curl_multi_strerror(this)?.toKString()}")
+        error("Unexpected curl verify: ${curl_multi_strerror(this)?.toKString()} (${curlMCodeName(this)})")
     }
+}
+
+@OptIn(ExperimentalForeignApi::class)
+private fun curlMCodeName(code: CURLMcode): String = when (code) {
+    CURLM_CALL_MULTI_PERFORM -> "CURLM_CALL_MULTI_PERFORM"
+    CURLM_OK -> "CURLM_OK"
+    CURLM_BAD_HANDLE -> "CURLM_BAD_HANDLE"
+    CURLM_BAD_EASY_HANDLE -> "CURLM_BAD_EASY_HANDLE"
+    CURLM_OUT_OF_MEMORY -> "CURLM_OUT_OF_MEMORY"
+    CURLM_INTERNAL_ERROR -> "CURLM_INTERNAL_ERROR"
+    CURLM_BAD_SOCKET -> "CURLM_BAD_SOCKET"
+    CURLM_UNKNOWN_OPTION -> "CURLM_UNKNOWN_OPTION"
+    CURLM_ADDED_ALREADY -> "CURLM_ADDED_ALREADY"
+    CURLM_RECURSIVE_API_CALL -> "CURLM_RECURSIVE_API_CALL"
+    CURLM_WAKEUP_FAILURE -> "CURLM_WAKEUP_FAILURE"
+    CURLM_BAD_FUNCTION_ARGUMENT -> "CURLM_BAD_FUNCTION_ARGUMENT"
+    CURLM_ABORTED_BY_CALLBACK -> "CURLM_ABORTED_BY_CALLBACK"
+    CURLM_UNRECOVERABLE_POLL -> "CURLM_UNRECOVERABLE_POLL"
+    else -> code.toString()
 }
 
 @OptIn(ExperimentalForeignApi::class)
 internal fun CURLcode.verify() {
     if (this != CURLE_OK) {
-        error("Unexpected curl verify: ${curl_easy_strerror(this)?.toKString()}")
+        error("Unexpected curl verify: ${curl_easy_strerror(this)?.toKString()} (${curlCodeName(this)})")
     }
+}
+
+@OptIn(ExperimentalForeignApi::class)
+private fun curlCodeName(code: CURLcode): String = when (code) {
+    CURLE_OK -> "CURLE_OK"
+    CURLE_UNSUPPORTED_PROTOCOL -> "CURLE_UNSUPPORTED_PROTOCOL"
+    CURLE_FAILED_INIT -> "CURLE_FAILED_INIT"
+    CURLE_URL_MALFORMAT -> "CURLE_URL_MALFORMAT"
+    CURLE_NOT_BUILT_IN -> "CURLE_NOT_BUILT_IN"
+    CURLE_COULDNT_RESOLVE_PROXY -> "CURLE_COULDNT_RESOLVE_PROXY"
+    CURLE_COULDNT_RESOLVE_HOST -> "CURLE_COULDNT_RESOLVE_HOST"
+    CURLE_COULDNT_CONNECT -> "CURLE_COULDNT_CONNECT"
+    CURLE_WEIRD_SERVER_REPLY -> "CURLE_WEIRD_SERVER_REPLY"
+    CURLE_REMOTE_ACCESS_DENIED -> "CURLE_REMOTE_ACCESS_DENIED"
+    CURLE_FTP_ACCEPT_FAILED -> "CURLE_FTP_ACCEPT_FAILED"
+    CURLE_FTP_WEIRD_PASV_REPLY -> "CURLE_FTP_WEIRD_PASV_REPLY"
+    CURLE_FTP_WEIRD_227_FORMAT -> "CURLE_FTP_WEIRD_227_FORMAT"
+    CURLE_FTP_CANT_GET_HOST -> "CURLE_FTP_CANT_GET_HOST"
+    CURLE_HTTP2 -> "CURLE_HTTP2"
+    CURLE_FTP_COULDNT_SET_TYPE -> "CURLE_FTP_COULDNT_SET_TYPE"
+    CURLE_PARTIAL_FILE -> "CURLE_PARTIAL_FILE"
+    CURLE_FTP_COULDNT_RETR_FILE -> "CURLE_FTP_COULDNT_RETR_FILE"
+    else -> code.toString()
 }
 
 @OptIn(ExperimentalForeignApi::class)

--- a/ktor-client/ktor-client-curl/desktop/src/io/ktor/client/engine/curl/internal/CurlMultiApiHandler.kt
+++ b/ktor-client/ktor-client-curl/desktop/src/io/ktor/client/engine/curl/internal/CurlMultiApiHandler.kt
@@ -37,6 +37,7 @@ internal class CurlMultiApiHandler : Closeable {
     private val easyHandlesToUnpause = mutableListOf<EasyHandle>()
 
     override fun close() {
+        if (activeHandles.isNotEmpty()) handleCompleted()
         for ((handle, holder) in activeHandles) {
             cleanupEasyHandle(handle)
             holder.dispose()
@@ -117,7 +118,6 @@ internal class CurlMultiApiHandler : Closeable {
 
     internal fun cancelRequest(easyHandle: EasyHandle, cause: Throwable) {
         cancelledHandles += Pair(easyHandle, cause)
-        curl_multi_remove_handle(multiHandle, easyHandle).verify()
     }
 
     internal fun perform(transfersRunning: IntVarOf<Int>) {

--- a/ktor-client/ktor-client-curl/desktop/src/io/ktor/client/engine/curl/internal/CurlMultiApiHandler.kt
+++ b/ktor-client/ktor-client-curl/desktop/src/io/ktor/client/engine/curl/internal/CurlMultiApiHandler.kt
@@ -13,36 +13,29 @@ import kotlinx.coroutines.CompletableDeferred
 import kotlinx.io.readByteArray
 import libcurl.*
 
-private class RequestHolder @OptIn(ExperimentalForeignApi::class) constructor(
+@OptIn(ExperimentalForeignApi::class)
+private class RequestHolder(
     val responseCompletable: CompletableDeferred<CurlSuccess>,
     val requestWrapper: StableRef<CurlRequestBodyData>,
     val responseWrapper: StableRef<CurlResponseBodyData>,
 ) {
-    @OptIn(ExperimentalForeignApi::class)
     fun dispose() {
         requestWrapper.dispose()
         responseWrapper.dispose()
     }
 }
 
-@OptIn(InternalAPI::class)
+@OptIn(InternalAPI::class, ExperimentalForeignApi::class)
 internal class CurlMultiApiHandler : Closeable {
-    @OptIn(ExperimentalForeignApi::class)
     private val activeHandles = mutableMapOf<EasyHandle, RequestHolder>()
-
-    @OptIn(ExperimentalForeignApi::class)
     private val cancelledHandles = mutableSetOf<Pair<EasyHandle, Throwable>>()
 
-    @OptIn(ExperimentalForeignApi::class)
     private val multiHandle: MultiHandle = curl_multi_init()
         ?: throw RuntimeException("Could not initialize curl multi handle")
 
     private val easyHandlesToUnpauseLock = SynchronizedObject()
-
-    @OptIn(ExperimentalForeignApi::class)
     private val easyHandlesToUnpause = mutableListOf<EasyHandle>()
 
-    @OptIn(ExperimentalForeignApi::class)
     override fun close() {
         for ((handle, holder) in activeHandles) {
             cleanupEasyHandle(handle)
@@ -53,7 +46,6 @@ internal class CurlMultiApiHandler : Closeable {
         curl_multi_cleanup(multiHandle).verify()
     }
 
-    @OptIn(ExperimentalForeignApi::class)
     fun scheduleRequest(request: CurlRequestData, deferred: CompletableDeferred<CurlSuccess>): EasyHandle {
         val easyHandle = curl_easy_init()
             ?: error("Could not initialize an easy handle")
@@ -123,13 +115,11 @@ internal class CurlMultiApiHandler : Closeable {
         return easyHandle
     }
 
-    @OptIn(ExperimentalForeignApi::class)
     internal fun cancelRequest(easyHandle: EasyHandle, cause: Throwable) {
         cancelledHandles += Pair(easyHandle, cause)
         curl_multi_remove_handle(multiHandle, easyHandle).verify()
     }
 
-    @OptIn(ExperimentalForeignApi::class)
     internal fun perform(transfersRunning: IntVarOf<Int>) {
         if (activeHandles.isEmpty()) return
 
@@ -149,10 +139,8 @@ internal class CurlMultiApiHandler : Closeable {
         }
     }
 
-    @OptIn(ExperimentalForeignApi::class)
     internal fun hasHandlers(): Boolean = activeHandles.isNotEmpty()
 
-    @OptIn(ExperimentalForeignApi::class)
     private fun setupMethod(
         easyHandle: EasyHandle,
         method: String,
@@ -176,7 +164,6 @@ internal class CurlMultiApiHandler : Closeable {
         }
     }
 
-    @OptIn(ExperimentalForeignApi::class)
     private fun setupUploadContent(easyHandle: EasyHandle, request: CurlRequestData): COpaquePointer {
         val requestPointer = CurlRequestBodyData(
             body = request.content,
@@ -194,7 +181,6 @@ internal class CurlMultiApiHandler : Closeable {
         return requestPointer
     }
 
-    @OptIn(ExperimentalForeignApi::class)
     private fun handleCompleted() {
         for (cancellation in cancelledHandles) {
             val cancelled = processCancelledEasyHandle(cancellation.first, cancellation.second)
@@ -231,7 +217,6 @@ internal class CurlMultiApiHandler : Closeable {
         }
     }
 
-    @OptIn(ExperimentalForeignApi::class)
     private fun processCancelledEasyHandle(easyHandle: EasyHandle, cause: Throwable): CurlFail = memScoped {
         try {
             val responseDataRef = alloc<COpaquePointerVar>()
@@ -248,7 +233,6 @@ internal class CurlMultiApiHandler : Closeable {
         }
     }
 
-    @OptIn(ExperimentalForeignApi::class)
     private fun processCompletedEasyHandle(
         message: CURLMSG?,
         easyHandle: EasyHandle,
@@ -276,7 +260,6 @@ internal class CurlMultiApiHandler : Closeable {
         }
     }
 
-    @OptIn(ExperimentalForeignApi::class)
     private fun collectFailedResponse(
         message: CURLMSG?,
         request: CurlRequestData,
@@ -314,7 +297,6 @@ internal class CurlMultiApiHandler : Closeable {
         )
     }
 
-    @OptIn(ExperimentalForeignApi::class)
     private fun collectSuccessResponse(easyHandle: EasyHandle): CurlSuccess? = memScoped {
         val responseDataRef = alloc<COpaquePointerVar>()
         val httpProtocolVersion = alloc<LongVar>()
@@ -343,12 +325,10 @@ internal class CurlMultiApiHandler : Closeable {
         }
     }
 
-    @OptIn(ExperimentalForeignApi::class)
     fun wakeup() {
         curl_multi_wakeup(multiHandle)
     }
 
-    @OptIn(ExperimentalForeignApi::class)
     private fun unpauseEasyHandle(easyHandle: EasyHandle) {
         synchronized(easyHandlesToUnpauseLock) {
             easyHandlesToUnpause.add(easyHandle)
@@ -356,7 +336,6 @@ internal class CurlMultiApiHandler : Closeable {
         curl_multi_wakeup(multiHandle)
     }
 
-    @OptIn(ExperimentalForeignApi::class)
     private fun cleanupEasyHandle(easyHandle: EasyHandle) {
         curl_multi_remove_handle(multiHandle, easyHandle).verify()
         curl_easy_cleanup(easyHandle)

--- a/ktor-client/ktor-client-test-base/common/src/io/ktor/client/test/base/ClientLoader.kt
+++ b/ktor-client/ktor-client-test-base/common/src/io/ktor/client/test/base/ClientLoader.kt
@@ -115,6 +115,14 @@ abstract class ClientLoader(private val timeout: Duration = 1.minutes) {
      *
      * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.client.test.base.ClientLoader.except)
      */
+    fun except(engineList: List<String>, vararg engines: String): EngineSelectionRule =
+        except(engineList + engines.asList())
+
+    /**
+     * Excludes the specified [engines] from test execution.
+     *
+     * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.client.test.base.ClientLoader.except)
+     */
     fun except(engines: List<String>): EngineSelectionRule {
         val skipPatterns = engines.map(EnginePattern::parse)
         return EngineSelectionRule { engineName -> skipPatterns.none { it.matches(engineName) } }

--- a/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/HttpTimeoutTest.kt
+++ b/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/HttpTimeoutTest.kt
@@ -20,6 +20,8 @@ import kotlin.test.*
 
 private const val TEST_URL = "$TEST_SERVER/timeout"
 
+// TODO: KTOR-8570 Investigate request timeout behavior in Android engine
+private val ENGINES_WITHOUT_REQUEST_TIMEOUT = listOf("Android")
 private val ENGINES_WITHOUT_SOCKET_TIMEOUT = listOf("Java", "Curl", "Js")
 
 class HttpTimeoutTest : ClientLoader() {
@@ -65,7 +67,7 @@ class HttpTimeoutTest : ClientLoader() {
     }
 
     @Test
-    fun testWithExternalTimeout() = clientTests(except("Android")) {
+    fun testWithExternalTimeout() = clientTests(except(ENGINES_WITHOUT_REQUEST_TIMEOUT)) {
         config {
             install(HttpTimeout)
         }
@@ -101,7 +103,7 @@ class HttpTimeoutTest : ClientLoader() {
     }
 
     @Test
-    fun testHeadWithTimeout() = clientTests {
+    fun testHeadWithTimeout() = clientTests(except(ENGINES_WITHOUT_REQUEST_TIMEOUT)) {
         config {
             install(HttpTimeout) {
                 requestTimeoutMillis = 500
@@ -110,13 +112,13 @@ class HttpTimeoutTest : ClientLoader() {
 
         test { client ->
             assertFailsWith<HttpRequestTimeoutException> {
-                client.head("$TEST_URL/with-delay?delay=1000")
+                client.head("$TEST_URL/with-delay?delay=2000")
             }
         }
     }
 
     @Test
-    fun testGetWithCancellation() = clientTests {
+    fun testGetWithCancellation() = clientTests(except(ENGINES_WITHOUT_REQUEST_TIMEOUT)) {
         config {
             install(HttpTimeout) {
                 requestTimeoutMillis = 1000
@@ -139,7 +141,7 @@ class HttpTimeoutTest : ClientLoader() {
     }
 
     @Test
-    fun testGetRequestTimeout() = clientTests {
+    fun testGetRequestTimeout() = clientTests(except(ENGINES_WITHOUT_REQUEST_TIMEOUT)) {
         config {
             install(HttpTimeout) { requestTimeoutMillis = 10 }
         }
@@ -154,7 +156,7 @@ class HttpTimeoutTest : ClientLoader() {
     }
 
     @Test
-    fun testGetRequestTimeoutPerRequestAttributes() = clientTests {
+    fun testGetRequestTimeoutPerRequestAttributes() = clientTests(except(ENGINES_WITHOUT_REQUEST_TIMEOUT)) {
         config {
             install(HttpTimeout)
         }
@@ -226,7 +228,7 @@ class HttpTimeoutTest : ClientLoader() {
 
     @Test
     fun testGetRequestTimeoutWithSeparateReceivePerRequestAttributes() = clientTests(
-        except("Js", "Darwin", "DarwinLegacy")
+        except(ENGINES_WITHOUT_REQUEST_TIMEOUT, "Js", "Darwin", "DarwinLegacy")
     ) {
         config {
             install(HttpTimeout)
@@ -246,7 +248,7 @@ class HttpTimeoutTest : ClientLoader() {
     }
 
     @Test
-    fun testGetAfterTimeout() = clientTests(except("Js", "Darwin", "DarwinLegacy")) {
+    fun testGetAfterTimeout() = clientTests(except(ENGINES_WITHOUT_REQUEST_TIMEOUT, "Js", "Darwin", "DarwinLegacy")) {
         config {
             install(HttpTimeout)
         }
@@ -267,7 +269,7 @@ class HttpTimeoutTest : ClientLoader() {
     }
 
     @Test
-    fun testGetStream() = clientTests(retries = 10) {
+    fun testGetStream() = clientTests {
         config {
             install(HttpTimeout) { requestTimeoutMillis = 1000 }
         }
@@ -282,7 +284,7 @@ class HttpTimeoutTest : ClientLoader() {
     }
 
     @Test
-    fun testGetStreamRequestTimeout() = clientTests {
+    fun testGetStreamRequestTimeout() = clientTests(except(ENGINES_WITHOUT_REQUEST_TIMEOUT)) {
         config {
             install(HttpTimeout) { requestTimeoutMillis = 1000 }
         }
@@ -349,7 +351,7 @@ class HttpTimeoutTest : ClientLoader() {
     }
 
     @Test
-    fun testRedirectRequestTimeoutOnFirstStep() = clientTests {
+    fun testRedirectRequestTimeoutOnFirstStep() = clientTests(except(ENGINES_WITHOUT_REQUEST_TIMEOUT)) {
         config {
             install(HttpTimeout) { requestTimeoutMillis = 20 }
         }
@@ -357,7 +359,7 @@ class HttpTimeoutTest : ClientLoader() {
         test { client ->
             assertFailsWith<HttpRequestTimeoutException> {
                 client.get("$TEST_URL/with-redirect") {
-                    parameter("delay", 1000)
+                    parameter("delay", 2000)
                     parameter("count", 5)
                 }.body<String>()
             }
@@ -365,7 +367,9 @@ class HttpTimeoutTest : ClientLoader() {
     }
 
     @Test
-    fun testRedirectRequestTimeoutOnFirstStepPerRequestAttributes() = clientTests {
+    fun testRedirectRequestTimeoutOnFirstStepPerRequestAttributes() = clientTests(
+        except(ENGINES_WITHOUT_REQUEST_TIMEOUT)
+    ) {
         config {
             install(HttpTimeout)
         }
@@ -373,7 +377,7 @@ class HttpTimeoutTest : ClientLoader() {
         test { client ->
             assertFailsWith<HttpRequestTimeoutException> {
                 client.get("$TEST_URL/with-redirect") {
-                    parameter("delay", 1000)
+                    parameter("delay", 2000)
                     parameter("count", 5)
 
                     timeout { requestTimeoutMillis = 20 }
@@ -383,7 +387,7 @@ class HttpTimeoutTest : ClientLoader() {
     }
 
     @Test
-    fun testRedirectRequestTimeoutOnSecondStep() = clientTests {
+    fun testRedirectRequestTimeoutOnSecondStep() = clientTests(except(ENGINES_WITHOUT_REQUEST_TIMEOUT)) {
         config {
             install(HttpTimeout) { requestTimeoutMillis = 400 }
         }
@@ -399,7 +403,9 @@ class HttpTimeoutTest : ClientLoader() {
     }
 
     @Test
-    fun testRedirectRequestTimeoutOnSecondStepPerRequestAttributes() = clientTests {
+    fun testRedirectRequestTimeoutOnSecondStepPerRequestAttributes() = clientTests(
+        except(ENGINES_WITHOUT_REQUEST_TIMEOUT)
+    ) {
         config {
             install(HttpTimeout)
         }

--- a/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/HttpTimeoutTest.kt
+++ b/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/HttpTimeoutTest.kt
@@ -17,6 +17,7 @@ import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.withTimeout
 import kotlinx.io.IOException
 import kotlin.test.*
+import kotlin.time.Duration.Companion.seconds
 
 private const val TEST_URL = "$TEST_SERVER/timeout"
 
@@ -24,7 +25,7 @@ private const val TEST_URL = "$TEST_SERVER/timeout"
 private val ENGINES_WITHOUT_REQUEST_TIMEOUT = listOf("Android")
 private val ENGINES_WITHOUT_SOCKET_TIMEOUT = listOf("Java", "Curl", "Js")
 
-class HttpTimeoutTest : ClientLoader() {
+class HttpTimeoutTest : ClientLoader(timeout = 3.seconds) {
     @Test
     fun testGet() = clientTests {
         config {
@@ -239,7 +240,7 @@ class HttpTimeoutTest : ClientLoader() {
                 method = HttpMethod.Get
                 parameter("delay", 10000)
 
-                timeout { requestTimeoutMillis = 2000 }
+                timeout { requestTimeoutMillis = 1000 }
             }.body<ByteReadChannel>()
             assertFailsWith<CancellationException> {
                 response.readUTF8Line()

--- a/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/WebSocketTest.kt
+++ b/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/WebSocketTest.kt
@@ -11,6 +11,7 @@ import io.ktor.client.plugins.auth.*
 import io.ktor.client.plugins.auth.providers.*
 import io.ktor.client.plugins.websocket.*
 import io.ktor.client.request.*
+import io.ktor.client.statement.*
 import io.ktor.client.test.base.*
 import io.ktor.http.*
 import io.ktor.serialization.*
@@ -451,6 +452,23 @@ class WebSocketTest : ClientLoader() {
                 client.webSocket("$TEST_WEBSOCKET_SERVER/auth/websocket") {}
             }
             client.close()
+        }
+    }
+
+    @Test
+    fun testHttpDuringWebSocketConnection() = clientTests(except(ENGINES_WITHOUT_WS)) {
+        config {
+            install(WebSockets)
+        }
+
+        test { client ->
+            client.webSocket("$TEST_WEBSOCKET_SERVER/websockets/echo") {
+                val response = client.get("$TEST_SERVER/content/hello")
+                send(response.bodyAsText())
+
+                val frame = incoming.receive() as Frame.Text
+                assertEquals("hello", frame.readText())
+            }
         }
     }
 }


### PR DESCRIPTION
**Subsystem**
`ktor-client-curl`

**Motivation**
[KTOR-8259](https://youtrack.jetbrains.com/issue/KTOR-8259) Linux curl engine doesn't work for simultaneous websocket and http request

**Solution**
The root cause was in `CurlMultiApiHandler.perform` implementation. It was waiting for `transfersRunning == 0` to exit and for websocket connections it happend only after they're closed. So `drainRequestQueue` was never called again until websocket connection is closed.

Another problem was in `cancelRequest`. It was calling `curl_multi_remove_handle` instead of `handleCompleted` and handle could be removed twice from a `multiHandle`. I removed this call and added `handleCompleted` call in `close` to ensure all completed and cancelled requests are handled.

Also enabled some flaky tests to check if they're still flaky: [KTOR-7847](https://youtrack.jetbrains.com/issue/KTOR-7847), [KTOR-7885](https://youtrack.jetbrains.com/issue/KTOR-7885)

It's better to review commit by commit.