### PR TITLE
KTOR-7892 swagger: support OAuth2 authentication flow

### DIFF
--- a/ktor-server/ktor-server-plugins/ktor-server-swagger/api/ktor-server-swagger.api
+++ b/ktor-server/ktor-server-plugins/ktor-server-swagger/api/ktor-server-swagger.api
@@ -7,6 +7,7 @@ public final class io/ktor/server/plugins/swagger/SwaggerConfig : io/ktor/openap
 	public fun getExternalDocs ()Lio/ktor/openapi/ExternalDocs;
 	public final fun getFaviconLocation ()Ljava/lang/String;
 	public fun getInfo ()Lio/ktor/openapi/OpenApiInfo;
+	public final fun getOauth2RedirectUrl ()Ljava/lang/String;
 	public fun getOpenapiVersion ()Ljava/lang/String;
 	public final fun getPackageLocation ()Ljava/lang/String;
 	public final fun getRemotePath ()Ljava/lang/String;
@@ -19,6 +20,7 @@ public final class io/ktor/server/plugins/swagger/SwaggerConfig : io/ktor/openap
 	public fun setExternalDocs (Lio/ktor/openapi/ExternalDocs;)V
 	public final fun setFaviconLocation (Ljava/lang/String;)V
 	public fun setInfo (Lio/ktor/openapi/OpenApiInfo;)V
+	public final fun setOauth2RedirectUrl (Ljava/lang/String;)V
 	public fun setOpenapiVersion (Ljava/lang/String;)V
 	public final fun setPackageLocation (Ljava/lang/String;)V
 	public final fun setRemotePath (Ljava/lang/String;)V

--- a/ktor-server/ktor-server-plugins/ktor-server-swagger/jvm/src/io/ktor/server/plugins/swagger/Swagger.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-swagger/jvm/src/io/ktor/server/plugins/swagger/Swagger.kt
@@ -109,8 +109,18 @@ public fun Route.swaggerUI(
             call.respondText(doc.content, doc.contentType)
         }.hide()
 
+        get("oauth2-redirect.html") {
+            call.respondHtml {
+                body {
+                    script(src = "${config.packageLocation}@${config.version}/oauth2-redirect.js") {}
+                }
+            }
+        }.hide()
+
         get {
             val fullPath = call.request.path()
+            val oauth2RedirectUrlJs = config.oauth2RedirectUrl?.let { "'$it'" }
+                ?: "window.location.origin + '$fullPath/oauth2-redirect.html'"
             val docExpansion = runCatching {
                 call.request.queryParameters.getOrFail<String>("docExpansion")
             }.getOrNull()?.takeIf {
@@ -152,6 +162,7 @@ window.onload = function() {
         url: '$fullPath/$apiUrl',
         dom_id: '#swagger-ui',
         deepLinking: ${config.deepLinking},
+        oauth2RedirectUrl: $oauth2RedirectUrlJs,
         presets: [
             SwaggerUIBundle.presets.apis,
             SwaggerUIStandalonePreset

--- a/ktor-server/ktor-server-plugins/ktor-server-swagger/jvm/src/io/ktor/server/plugins/swagger/SwaggerConfig.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-swagger/jvm/src/io/ktor/server/plugins/swagger/SwaggerConfig.kt
@@ -72,6 +72,17 @@ public class SwaggerConfig private constructor(
     public var deepLinking: Boolean = false
 
     /**
+     * OAuth2 redirect URL passed to Swagger UI as `oauth2RedirectUrl`.
+     *
+     * When `null` (default), Swagger UI uses `window.location.origin + "{swaggerPath}/oauth2-redirect.html"`.
+     *
+     * Set an absolute URL when running behind a reverse proxy or using a custom redirect path.
+     *
+     * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.server.plugins.swagger.SwaggerConfig.oauth2RedirectUrl)
+     */
+    public var oauth2RedirectUrl: String? = null
+
+    /**
      * Swagger favicon location
      *
      * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.server.plugins.swagger.SwaggerConfig.faviconLocation)

--- a/ktor-server/ktor-server-plugins/ktor-server-swagger/jvm/test/io/ktor/server/plugins/swagger/SwaggerTest.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-swagger/jvm/test/io/ktor/server/plugins/swagger/SwaggerTest.kt
@@ -57,6 +57,7 @@ class SwaggerTest {
                     url: '/swagger/documentation.yaml',
                     dom_id: '#swagger-ui',
                     deepLinking: false,
+                    oauth2RedirectUrl: window.location.origin + '/swagger/oauth2-redirect.html',
                     presets: [
                         SwaggerUIBundle.presets.apis,
                         SwaggerUIStandalonePreset
@@ -99,6 +100,7 @@ class SwaggerTest {
                     url: '/swagger/documentation.yaml',
                     dom_id: '#swagger-ui',
                     deepLinking: true,
+                    oauth2RedirectUrl: window.location.origin + '/swagger/oauth2-redirect.html',
                     presets: [
                         SwaggerUIBundle.presets.apis,
                         SwaggerUIStandalonePreset
@@ -141,6 +143,7 @@ class SwaggerTest {
                     url: '/swagger/documentation.yaml',
                     dom_id: '#swagger-ui',
                     deepLinking: false,
+                    oauth2RedirectUrl: window.location.origin + '/swagger/oauth2-redirect.html',
                     presets: [
                         SwaggerUIBundle.presets.apis,
                         SwaggerUIStandalonePreset
@@ -184,6 +187,7 @@ class SwaggerTest {
                     url: '/swagger/documentation.yaml',
                     dom_id: '#swagger-ui',
                     deepLinking: false,
+                    oauth2RedirectUrl: window.location.origin + '/swagger/oauth2-redirect.html',
                     presets: [
                         SwaggerUIBundle.presets.apis,
                         SwaggerUIStandalonePreset
@@ -240,6 +244,7 @@ class SwaggerTest {
                     url: '/swagger/documentation.yaml',
                     dom_id: '#swagger-ui',
                     deepLinking: false,
+                    oauth2RedirectUrl: window.location.origin + '/swagger/oauth2-redirect.html',
                     presets: [
                         SwaggerUIBundle.presets.apis,
                         SwaggerUIStandalonePreset
@@ -320,6 +325,37 @@ class SwaggerTest {
                 assertContains(responseText, description, message = "Response should contain '$description'")
             }
         }
+    }
+
+    @Test
+    fun testSwaggerServesOauthRedirectPage() = testApplication {
+        routing {
+            swaggerUI("swagger")
+        }
+
+        val response = client.get("/swagger/oauth2-redirect.html").bodyAsText()
+        assertEquals(
+            """<!DOCTYPE html>
+<html>
+  <body>
+    <script src="https://unpkg.com/swagger-ui-dist@5.31.0/oauth2-redirect.js"></script>
+  </body>
+</html>
+""",
+            response
+        )
+    }
+
+    @Test
+    fun testSwaggerCustomOauth2RedirectUrl() = testApplication {
+        routing {
+            swaggerUI("swagger") {
+                oauth2RedirectUrl = "https://api.example.com/custom/oauth2-redirect.html"
+            }
+        }
+
+        val response = client.get("/swagger").bodyAsText()
+        assertContains(response, "oauth2RedirectUrl: 'https://api.example.com/custom/oauth2-redirect.html'")
     }
 }
 


### PR DESCRIPTION
**Subsystem**
Server, swagger plugin

**Motivation**
The changes allow to use oauth2 flow in swagger.
[Issue](https://youtrack.jetbrains.com/issue/KTOR-7892/SwaggerUI-Missing-oauth2-redirect.html-support-in-the-plugin)

**Solution**
Expose route serving oauth2-redirect.html to enable OAuth2 authorization redirect handling in Swagger UI.
