### PR TITLE
KTOR-8352: Fix TRACE method handling in AndroidClientEngine

### DIFF
--- a/ktor-client/ktor-client-android/jvm/src/io/ktor/client/engine/android/AndroidClientEngine.kt
+++ b/ktor-client/ktor-client-android/jvm/src/io/ktor/client/engine/android/AndroidClientEngine.kt
@@ -24,8 +24,6 @@ import java.util.*
 import javax.net.ssl.HttpsURLConnection
 import kotlin.coroutines.CoroutineContext
 
-private val METHODS_WITHOUT_BODY = listOf(HttpMethod.Get, HttpMethod.Head)
-
 /**
  * An Android client engine.
  *
@@ -64,7 +62,7 @@ public class AndroidClientEngine(override val config: AndroidEngineConfig) : Htt
 
             config.requestConfig(this)
 
-            if (data.method in METHODS_WITHOUT_BODY) {
+            if (!data.method.supportsRequestBody) {
                 if (outgoingContent.isEmpty()) {
                     return@apply
                 }

--- a/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/HttpMethodTest.kt
+++ b/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/HttpMethodTest.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2014-2025 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.client.tests
+
+import io.ktor.client.*
+import io.ktor.client.request.*
+import io.ktor.client.test.base.*
+import io.ktor.http.*
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class HttpMethodTest : ClientLoader() {
+
+    @Test
+    fun `all HTTP methods should be supported`() = clientTests {
+        test { client ->
+            for (method in client.supportedMethods()) {
+                val response = client.request("$TEST_SERVER/echo/method") { this.method = method }
+                assertEquals(HttpStatusCode.OK, response.status)
+                assertEquals(method.value, response.headers["Http-Method"])
+            }
+        }
+    }
+}
+
+private val allMethods = HttpMethod.DefaultMethods + HttpMethod.Trace
+
+private fun HttpClient.supportedMethods(): List<HttpMethod> = when (engineName) {
+    // PATCH is not supported by HttpURLConnection
+    // https://bugs.openjdk.org/browse/JDK-7016595
+    "AndroidClientEngine" -> allMethods - HttpMethod.Patch
+    // Js engine throws: TypeError: 'TRACE' HTTP method is unsupported.
+    "JsClientEngine" -> allMethods - HttpMethod.Trace
+    else -> allMethods
+}
+
+private val HttpClient.engineName get() = engine::class.simpleName
+private val HttpMethod.Companion.Trace get() = HttpMethod("TRACE")

--- a/ktor-http/common/src/io/ktor/http/HttpMethod.kt
+++ b/ktor-http/common/src/io/ktor/http/HttpMethod.kt
@@ -59,6 +59,7 @@ private val REQUESTS_WITHOUT_BODY = setOf(
     HttpMethod.Get,
     HttpMethod.Head,
     HttpMethod.Options,
+    HttpMethod("TRACE"),
 )
 
 /**

--- a/ktor-test-server/src/main/kotlin/test/server/ClientTestServer.kt
+++ b/ktor-test-server/src/main/kotlin/test/server/ClientTestServer.kt
@@ -31,6 +31,7 @@ internal fun Application.tests() {
     }
 
     authTestServer()
+    echoTest()
     encodingTestServer()
     serializationTestServer()
     cacheTestServer()

--- a/ktor-test-server/src/main/kotlin/test/server/tests/Echo.kt
+++ b/ktor-test-server/src/main/kotlin/test/server/tests/Echo.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2014-2025 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package test.server.tests
+
+import io.ktor.http.*
+import io.ktor.server.application.*
+import io.ktor.server.response.*
+import io.ktor.server.routing.*
+
+internal fun Application.echoTest() {
+    routing {
+        route("/echo") {
+            route("/method") {
+                handle {
+                    val method = call.request.local.method.value
+                    // Some methods don't allow body, so return result in a header
+                    call.response.header("Http-Method", method)
+                    call.response.status(HttpStatusCode.OK)
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
**Subsystem**
Client, Android

**Motivation**
[KTOR-8352](https://youtrack.jetbrains.com/issue/KTOR-8352) Android: "ProtocolException: TRACE does not support writing" when sending TRACE request

**Solution**
Added test checking that all clients are able to send requests with any default HTTP header.
Fixed the Android client by using recently added `!method.supportsRequestBody` instead of checking `METHODS_WITHOUT_BODY` list.
