### PR TITLE
android webrtc engine + introduced Android-KMP gradle plugin

### DIFF
--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -15,6 +15,7 @@ dependencies {
     implementation(libs.develocity)
     implementation(libs.gradleDoctor)
     implementation(libs.kotlinter)
+    implementation(libs.android.kmp.library)
 
     // A hack to make version catalogs accessible from buildSrc sources
     // https://github.com/gradle/gradle/issues/15383#issuecomment-779893192

--- a/build-logic/settings.gradle.kts
+++ b/build-logic/settings.gradle.kts
@@ -5,6 +5,7 @@
 pluginManagement {
     // Add repositories required for build-settings-logic
     repositories {
+        google()
         gradlePluginPortal()
 
         // Should be in sync with ktorsettings.kotlin-user-project

--- a/build-logic/src/main/kotlin/ktorbuild.kmp.gradle.kts
+++ b/build-logic/src/main/kotlin/ktorbuild.kmp.gradle.kts
@@ -14,8 +14,15 @@ import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
 plugins {
     id("ktorbuild.base")
     kotlin("multiplatform")
-    id("org.jetbrains.kotlinx.atomicfu")
     id("ktorbuild.codestyle")
+}
+
+// atomicfu gradle plugin is not compatible with Android KMP plugin
+// see https://github.com/Kotlin/kotlinx-atomicfu/issues/511
+if (!project.hasAndroidPlugin()) {
+    plugins {
+        id("org.jetbrains.kotlinx.atomicfu")
+    }
 }
 
 kotlin {
@@ -30,7 +37,7 @@ kotlin {
     }
 
     applyHierarchyTemplate(KtorTargets.hierarchyTemplate)
-    addTargets(ktorBuild.targets)
+    addTargets(ktorBuild.targets, ktorBuild.isCI.get())
 }
 
 val targets = ktorBuild.targets
@@ -39,6 +46,7 @@ configureCommon()
 if (targets.hasJvm) configureJvm()
 if (targets.hasJs) configureJs()
 if (targets.hasWasmJs) configureWasmJs()
+if (targets.hasAndroidJvm && project.hasAndroidPlugin()) configureAndroidJvm()
 
 if (targets.hasJsOrWasmJs) {
     tasks.configureEach {

--- a/build-logic/src/main/kotlin/ktorbuild/targets/AndroidConfig.kt
+++ b/build-logic/src/main/kotlin/ktorbuild/targets/AndroidConfig.kt
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2014-2025 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package ktorbuild.targets
+
+import com.android.build.api.dsl.KotlinMultiplatformAndroidLibraryTarget
+import org.gradle.api.Project
+import ktorbuild.internal.kotlin
+import org.gradle.kotlin.dsl.invoke
+import ktorbuild.internal.libs
+
+internal fun Project.hasAndroidPlugin(): Boolean {
+    return plugins.hasPlugin("com.android.kotlin.multiplatform.library")
+}
+
+@Suppress("UnstableApiUsage")
+internal fun KotlinMultiplatformAndroidLibraryTarget.addTests(targets: KtorTargets, allowDeviceTest: Boolean) {
+    if (targets.isEnabled("android.unitTest")) {
+        withHostTest {}
+    }
+    if (allowDeviceTest && targets.isEnabled("android.deviceTest")) {
+        withDeviceTestBuilder {
+            // make it depend on a commonTest
+            sourceSetTreeName = "test"
+        }.configure {
+            // androidx.test.runner should be installed
+            instrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+        }
+    }
+}
+
+internal fun Project.configureAndroidJvm() {
+    kotlin {
+        sourceSets {
+            androidMain {
+                // should be added automatically, but fails with the new Android KMP plugin
+                dependsOn(commonMain.get())
+            }
+
+            this.findByName("androidDeviceTest")?.apply {
+                // should be added automatically, but fails with the new Android KMP plugin
+                dependsOn(commonTest.get())
+                dependencies {
+                    implementation(libs.androidx.core)
+                    implementation(libs.androidx.runner)
+                }
+            }
+        }
+    }
+}

--- a/build-settings-logic/build.gradle.kts
+++ b/build-settings-logic/build.gradle.kts
@@ -14,6 +14,7 @@ plugins {
 
 dependencies {
     implementation(libs.kotlin.gradlePlugin)
+    implementation(libs.android.kmp.library)
     implementation(libs.develocity)
     implementation(libs.develocity.commonCustomUserData)
 }

--- a/build-settings-logic/settings.gradle.kts
+++ b/build-settings-logic/settings.gradle.kts
@@ -21,6 +21,7 @@ dependencyResolutionManagement {
     }
 
     repositories {
+        google()
         gradlePluginPortal()
 
         // Should be in sync with ktorsettings.kotlin-user-project

--- a/build-settings-logic/src/main/kotlin/ktorsettings.dependency-resolution-management.settings.gradle.kts
+++ b/build-settings-logic/src/main/kotlin/ktorsettings.dependency-resolution-management.settings.gradle.kts
@@ -30,6 +30,7 @@ dependencyResolutionManagement {
 private fun RepositoryHandler.configureRepositories() {
     google {
         content {
+            includeGroupAndSubgroups("androidx")
             includeGroupAndSubgroups("com.google")
             includeGroupAndSubgroups("com.android")
         }

--- a/gradle.properties
+++ b/gradle.properties
@@ -68,6 +68,9 @@ kotlin.daemon.useFallbackStrategy=false
 # TODO: Remove when we enable isolated projects in Gradle
 kotlin.kmp.isolated-projects.support=enable
 
+# Android
+android.useAndroidX=true
+
 # dokka
 # workaround for resolving platform dependencies, see https://github.com/Kotlin/dokka/issues/3153
 org.jetbrains.dokka.classpath.useNativeDistributionAccessor=true

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,7 @@
 [versions]
 
+android-kmp-plugin = "8.9.2"
+androidx = "1.6.1"
 kotlin = "2.1.21"
 kotlinx-html = "0.12.0"
 kotlinx-datetime = "0.6.2"
@@ -26,6 +28,8 @@ jetty-alpn-openjdk8 = "9.4.57.v20241219"
 
 tomcat = "9.0.105"
 tomcat-jakarta = "10.1.40"
+
+stream-webrtc-android = "1.3.8"
 
 apache = "4.1.5"
 apache5 = "5.4.4"
@@ -83,6 +87,10 @@ develocity-commonCustomUserData = "2.2.1"
 gradleDoctor = "0.10.0"
 
 [libraries]
+
+android-kmp-library = { module = "com.android.kotlin.multiplatform.library:com.android.kotlin.multiplatform.library.gradle.plugin", version.ref = "android-kmp-plugin" }
+androidx-core = { module = "androidx.test:core", version.ref = "androidx" }
+androidx-runner = { module = "androidx.test:runner", version.ref = "androidx" }
 
 kotlin-gradlePlugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
 kotlin-reflect = { module = "org.jetbrains.kotlin:kotlin-reflect", version.ref = "kotlin" }
@@ -142,6 +150,7 @@ netty-transport-native-epoll = { module = "io.netty:netty-transport-native-epoll
 netty-tcnative = { module = "io.netty:netty-tcnative", version.ref = "netty-tcnative" }
 netty-tcnative-boringssl-static = { module = "io.netty:netty-tcnative-boringssl-static", version.ref = "netty-tcnative" }
 
+stream-webrtc-android = { module = "io.getstream:stream-webrtc-android", version.ref = "stream-webrtc-android" }
 tomcat-catalina = { module = "org.apache.tomcat:tomcat-catalina", version.ref = "tomcat" }
 tomcat-embed-core = { module = "org.apache.tomcat.embed:tomcat-embed-core", version.ref = "tomcat" }
 

--- a/ktor-client/ktor-client-webrtc/android/src/io/ktor/client/webrtc/LibAndroid.kt
+++ b/ktor-client/ktor-client-webrtc/android/src/io/ktor/client/webrtc/LibAndroid.kt
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2014-2025 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.client.webrtc
+
+import org.webrtc.DtmfSender
+import org.webrtc.MediaStreamTrack
+import org.webrtc.RtpParameters
+import org.webrtc.RtpSender
+
+/**
+ * Wrapper for org.webrtc.MediaStreamTrack.
+ **/
+public abstract class AndroidMediaTrack(
+    public val nativeTrack: MediaStreamTrack,
+    private val onDispose: (() -> Unit)?
+) : WebRTCMedia.Track {
+    public override val id: String = nativeTrack.id()
+
+    public override val kind: WebRTCMedia.TrackType = kindOf(nativeTrack)
+
+    public override val enabled: Boolean
+        get() = nativeTrack.enabled()
+
+    override fun enable(enabled: Boolean) {
+        nativeTrack.setEnabled(enabled)
+    }
+
+    override fun getNative(): Any = nativeTrack
+
+    override fun close() {
+        onDispose?.invoke()
+        nativeTrack.dispose()
+    }
+
+    public companion object {
+        private fun kindOf(nativeTrack: MediaStreamTrack): WebRTCMedia.TrackType {
+            return when (nativeTrack.kind()) {
+                "audio" -> WebRTCMedia.TrackType.AUDIO
+                "video" -> WebRTCMedia.TrackType.VIDEO
+                else -> error("Unknown media track kind: ${nativeTrack.kind()}")
+            }
+        }
+
+        public fun from(nativeTrack: MediaStreamTrack): AndroidMediaTrack = when (kindOf(nativeTrack)) {
+            WebRTCMedia.TrackType.AUDIO -> AndroidAudioTrack(nativeTrack)
+            WebRTCMedia.TrackType.VIDEO -> AndroidVideoTrack(nativeTrack)
+        }
+    }
+}
+
+public class AndroidAudioTrack(nativeTrack: MediaStreamTrack, onDispose: (() -> Unit)? = null) : WebRTCMedia.AudioTrack,
+    AndroidMediaTrack(nativeTrack, onDispose)
+
+public class AndroidVideoTrack(nativeTrack: MediaStreamTrack, onDispose: (() -> Unit)? = null) : WebRTCMedia.VideoTrack,
+    AndroidMediaTrack(nativeTrack, onDispose)
+
+public class AndroidRtpSender(public val nativeRtpSender: RtpSender) : WebRTC.RtpSender {
+    override val dtmf: WebRTC.DtmfSender?
+        get() = nativeRtpSender.dtmf()?.let { AndroidDtmfServer(it) }
+
+    override val track: WebRTCMedia.Track?
+        get() = nativeRtpSender.track()?.let { AndroidMediaTrack.from(it) }
+
+    override fun getNative(): Any = nativeRtpSender
+
+    override suspend fun replaceTrack(withTrack: WebRTCMedia.Track?) {
+        nativeRtpSender.setTrack((withTrack as? AndroidMediaTrack)?.nativeTrack, false)
+    }
+
+    override suspend fun getParameters(): WebRTC.RtpParameters {
+        return AndroidRtpParameters(nativeRtpSender.parameters)
+    }
+
+    override suspend fun setParameters(parameters: WebRTC.RtpParameters) {
+        nativeRtpSender.parameters = (parameters as? AndroidRtpParameters)?.nativeRtpParameters
+    }
+}
+
+public class AndroidDtmfServer(private val nativeRtpSender: DtmfSender) : WebRTC.DtmfSender {
+    override val toneBuffer: String
+        get() = nativeRtpSender.tones()
+
+    override val canInsertDTMF: Boolean
+        get() = nativeRtpSender.canInsertDtmf()
+
+    override fun getNative(): Any = nativeRtpSender
+
+    override fun insertDTMF(tones: String, duration: Int, interToneGap: Int) {
+        nativeRtpSender.insertDtmf(tones, duration, interToneGap)
+    }
+}
+
+public class AndroidRtpParameters(public val nativeRtpParameters: RtpParameters) : WebRTC.RtpParameters {
+    override val transactionId: String = nativeRtpParameters.transactionId
+    override val encodings: List<RtpParameters.Encoding> = nativeRtpParameters.encodings
+    override val codecs: List<RtpParameters.Codec> = nativeRtpParameters.codecs
+    override val rtcp: Any = nativeRtpParameters.rtcp
+
+    override val headerExtensions: List<WebRTC.RtpHeaderExtensionParameters>
+        get() = nativeRtpParameters.headerExtensions.map {
+            WebRTC.RtpHeaderExtensionParameters(
+                it.id,
+                it.uri,
+                it.encrypted
+            )
+        }
+
+    override val degradationPreference: WebRTC.DegradationPreference
+        get() = when (nativeRtpParameters.degradationPreference) {
+            RtpParameters.DegradationPreference.MAINTAIN_RESOLUTION -> WebRTC.DegradationPreference.MAINTAIN_RESOLUTION
+            RtpParameters.DegradationPreference.MAINTAIN_FRAMERATE -> WebRTC.DegradationPreference.MAINTAIN_FRAMERATE
+            RtpParameters.DegradationPreference.BALANCED -> WebRTC.DegradationPreference.BALANCED
+            else -> WebRTC.DegradationPreference.DISABLED
+        }
+}

--- a/ktor-client/ktor-client-webrtc/android/src/io/ktor/client/webrtc/MediaDevices.kt
+++ b/ktor-client/ktor-client-webrtc/android/src/io/ktor/client/webrtc/MediaDevices.kt
@@ -1,0 +1,198 @@
+/*
+ * Copyright 2014-2025 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.client.webrtc
+
+import android.Manifest
+import android.content.Context
+import android.content.pm.PackageManager
+import android.os.Build
+import kotlinx.coroutines.suspendCancellableCoroutine
+import org.webrtc.Camera2Enumerator
+import org.webrtc.CameraVideoCapturer.CameraEventsHandler
+import org.webrtc.DefaultVideoDecoderFactory
+import org.webrtc.DefaultVideoEncoderFactory
+import org.webrtc.EglBase
+import org.webrtc.MediaConstraints
+import org.webrtc.PeerConnectionFactory
+import org.webrtc.SurfaceTextureHelper
+import org.webrtc.VideoSource
+import org.webrtc.audio.JavaAudioDeviceModule
+import java.util.*
+import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
+import kotlin.math.min
+
+/**
+ * MediaDevicesFactory based on the org.webrtc, which uses Android Camera2 API
+ **/
+public class AndroidMediaDevices(
+    private val context: Context,
+    eglBase: EglBase = EglBase.create()
+) : MediaTrackFactory {
+
+    private val eglBaseContext: EglBase.Context = eglBase.eglBaseContext
+
+    private val videoDecoderFactory by lazy {
+        DefaultVideoDecoderFactory(eglBaseContext)
+    }
+    private val videoEncoderFactory by lazy {
+        DefaultVideoEncoderFactory(eglBaseContext, true, true)
+    }
+
+    private val cameraEnumerator = Camera2Enumerator(context)
+
+    private fun findCameraId(constraints: WebRTCMedia.VideoTrackConstraints): String? {
+        val targetFrontCamera = constraints.facingMode != WebRTCMedia.FacingMode.ENVIRONMENT
+        return cameraEnumerator.deviceNames.firstOrNull { id ->
+            if (targetFrontCamera) {
+                cameraEnumerator.isFrontFacing(id)
+            } else {
+                cameraEnumerator.isBackFacing(id)
+            }
+        }
+    }
+
+    private val audioDeviceModule = JavaAudioDeviceModule.builder(context)
+        .setUseHardwareAcousticEchoCanceler(Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q)
+        .setUseHardwareNoiseSuppressor(Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q)
+        .createAudioDeviceModule().also {
+            it.setMicrophoneMute(false)
+            it.setSpeakerMute(false)
+        }
+
+    public val peerConnectionFactory: PeerConnectionFactory by lazy {
+        PeerConnectionFactory
+            .builder()
+            .setVideoDecoderFactory(videoDecoderFactory)
+            .setVideoEncoderFactory(videoEncoderFactory)
+            .setAudioDeviceModule(audioDeviceModule)
+            .createPeerConnectionFactory()
+    }
+
+    init {
+        PeerConnectionFactory.initialize(
+            PeerConnectionFactory.InitializationOptions
+                .builder(context)
+                .createInitializationOptions()
+        )
+    }
+
+    private fun assertPermission(permission: String) {
+        val status = context.checkCallingOrSelfPermission(permission)
+        if (status != PackageManager.PERMISSION_GRANTED) {
+            throw WebRTCMedia.PermissionException(permission)
+        }
+    }
+
+    override suspend fun createAudioTrack(constraints: WebRTCMedia.AudioTrackConstraints): WebRTCMedia.AudioTrack {
+        if (constraints.latency != null) {
+            throw NotImplementedError(
+                "Latency is not supported yet for Android. You can provide custom MediaTrackFactory"
+            )
+        }
+        if (constraints.channelCount != null) {
+            throw NotImplementedError(
+                "Channel count is not supported yet for Android. You can provide custom MediaTrackFactory"
+            )
+        }
+        if (constraints.sampleSize != null) {
+            throw NotImplementedError(
+                "Sample size is not supported yet for Android. You can provide custom MediaTrackFactory"
+            )
+        }
+        assertPermission(Manifest.permission.RECORD_AUDIO)
+
+        val mc = arrayListOf<Pair<String, Boolean>>()
+        mc.add("googEchoCancellation" to (constraints.echoCancellation ?: true))
+        mc.add("googAutoGainControl" to (constraints.autoGainControl ?: true))
+        mc.add("googNoiseSuppression" to (constraints.noiseSuppression ?: true))
+
+        val mediaConstraints = MediaConstraints().apply {
+            mandatory.addAll(
+                mc.map {
+                    MediaConstraints.KeyValuePair(
+                        it.first,
+                        it.second.toString()
+                    )
+                }
+            )
+            optional.add(MediaConstraints.KeyValuePair("DtlsSrtpKeyAgreement", "true"))
+        }
+        val id = "android-webrtc-audio-${UUID.randomUUID()}"
+        val src = peerConnectionFactory.createAudioSource(mediaConstraints)
+        val nativeTrack = peerConnectionFactory.createAudioTrack(id, src).apply {
+            setVolume(constraints.volume ?: 1.0)
+        }
+        return AndroidAudioTrack(nativeTrack) {
+            src.dispose()
+        }
+    }
+
+    private suspend fun makeVideoSource(constraints: WebRTCMedia.VideoTrackConstraints): Pair<VideoSource, () -> Unit> {
+        val cameraId = findCameraId(constraints) ?: error("No camera found for such constraints")
+        val format = cameraEnumerator.getSupportedFormats(cameraId)!![0]
+
+        val videoWidth = constraints.width ?: format.width
+        val videoHeight = constraints.height ?: format.height
+        val videoFrameRate = constraints.frameRate ?: min(format.framerate.max, 60)
+
+        return suspendCancellableCoroutine { cont ->
+            var videoSource: VideoSource? = null
+            var onDispose = {}
+            val eventsHandler = object : CameraEventsHandler {
+                override fun onCameraError(err: String?) {
+                    onDispose()
+                    if (cont.isActive) cont.resumeWithException(WebRTCMedia.DeviceException(err ?: "Camera error"))
+                }
+
+                override fun onCameraDisconnected() {
+                    onDispose()
+                    if (cont.isActive) cont.resumeWithException(WebRTCMedia.DeviceException("Camera disconnected"))
+                }
+
+                override fun onCameraClosed() {
+                    if (cont.isActive) cont.resumeWithException(WebRTCMedia.DeviceException("Camera closed"))
+                }
+
+                override fun onFirstFrameAvailable() {
+                    if (cont.isActive) cont.resume(requireNotNull(videoSource) to onDispose)
+                }
+
+                override fun onCameraOpening(cameraId: String?) = Unit
+                override fun onCameraFreezed(p0: String?) = Unit
+            }
+            val videoCapturer = cameraEnumerator.createCapturer(cameraId, eventsHandler)
+            val surfaceTextureHelper = SurfaceTextureHelper.create(
+                "SurfaceTextureHelperThread",
+                eglBaseContext
+            )
+            onDispose = {
+                videoCapturer.stopCapture()
+                videoCapturer.dispose()
+                surfaceTextureHelper.dispose()
+                videoSource?.dispose()
+            }
+            // video source will be ready or throw an error (if the configuration is wrong) later
+            videoSource = peerConnectionFactory.createVideoSource(false).apply {
+                videoCapturer.initialize(surfaceTextureHelper, context, capturerObserver)
+                videoCapturer.startCapture(videoWidth, videoHeight, videoFrameRate)
+            }
+        }
+    }
+
+    override suspend fun createVideoTrack(constraints: WebRTCMedia.VideoTrackConstraints): WebRTCMedia.VideoTrack {
+        if (constraints.resizeMode != null) {
+            throw NotImplementedError(
+                "Resize mode is not supported yet for Android. You can provide custom MediaTrackFactory"
+            )
+        }
+        assertPermission(Manifest.permission.CAMERA)
+
+        val (src, onDispose) = makeVideoSource(constraints)
+        val id = "android-webrtc-video-${UUID.randomUUID()}"
+        val nativeTrack = peerConnectionFactory.createVideoTrack(id, src)
+        return AndroidVideoTrack(nativeTrack) { onDispose() }
+    }
+}

--- a/ktor-client/ktor-client-webrtc/android/src/io/ktor/client/webrtc/Utils.kt
+++ b/ktor-client/ktor-client-webrtc/android/src/io/ktor/client/webrtc/Utils.kt
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2014-2025 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.client.webrtc
+
+import org.webrtc.IceCandidate
+import org.webrtc.PeerConnection
+import org.webrtc.RTCStatsReport
+import org.webrtc.SdpObserver
+import org.webrtc.SessionDescription
+import kotlin.coroutines.Continuation
+import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
+
+public fun WebRTC.SessionDescription.toNative(): SessionDescription {
+    return SessionDescription(
+        when (type) {
+            WebRTC.SessionDescriptionType.OFFER -> SessionDescription.Type.OFFER
+            WebRTC.SessionDescriptionType.ANSWER -> SessionDescription.Type.ANSWER
+            WebRTC.SessionDescriptionType.ROLLBACK -> SessionDescription.Type.ROLLBACK
+            WebRTC.SessionDescriptionType.PROVISIONAL_ANSWER -> SessionDescription.Type.PRANSWER
+        },
+        sdp
+    )
+}
+
+public fun WebRTC.BundlePolicy.toNative(): PeerConnection.BundlePolicy = when (this) {
+    WebRTC.BundlePolicy.BALANCED -> PeerConnection.BundlePolicy.BALANCED
+    WebRTC.BundlePolicy.MAX_BUNDLE -> PeerConnection.BundlePolicy.MAXBUNDLE
+    WebRTC.BundlePolicy.MAX_COMPAT -> PeerConnection.BundlePolicy.MAXCOMPAT
+}
+
+public fun WebRTC.IceTransportPolicy.toNative(): PeerConnection.IceTransportsType = when (this) {
+    WebRTC.IceTransportPolicy.ALL -> PeerConnection.IceTransportsType.ALL
+    WebRTC.IceTransportPolicy.RELAY -> PeerConnection.IceTransportsType.RELAY
+}
+
+public fun WebRTC.RTCPMuxPolicy.toNative(): PeerConnection.RtcpMuxPolicy = when (this) {
+    WebRTC.RTCPMuxPolicy.NEGOTIATE -> PeerConnection.RtcpMuxPolicy.NEGOTIATE
+    WebRTC.RTCPMuxPolicy.REQUIRE -> PeerConnection.RtcpMuxPolicy.REQUIRE
+}
+
+public fun PeerConnection.IceConnectionState?.toCommon(): WebRTC.IceConnectionState? = when (this) {
+    PeerConnection.IceConnectionState.NEW -> WebRTC.IceConnectionState.NEW
+    PeerConnection.IceConnectionState.FAILED -> WebRTC.IceConnectionState.FAILED
+    PeerConnection.IceConnectionState.CLOSED -> WebRTC.IceConnectionState.CLOSED
+    PeerConnection.IceConnectionState.CHECKING -> WebRTC.IceConnectionState.CHECKING
+    PeerConnection.IceConnectionState.CONNECTED -> WebRTC.IceConnectionState.CONNECTED
+    PeerConnection.IceConnectionState.COMPLETED -> WebRTC.IceConnectionState.COMPLETED
+    PeerConnection.IceConnectionState.DISCONNECTED -> WebRTC.IceConnectionState.DISCONNECTED
+    else -> null
+}
+
+public fun PeerConnection.PeerConnectionState?.toCommon(): WebRTC.ConnectionState? = when (this) {
+    PeerConnection.PeerConnectionState.NEW -> WebRTC.ConnectionState.NEW
+    PeerConnection.PeerConnectionState.CLOSED -> WebRTC.ConnectionState.CLOSED
+    PeerConnection.PeerConnectionState.CONNECTED -> WebRTC.ConnectionState.CONNECTED
+    PeerConnection.PeerConnectionState.DISCONNECTED -> WebRTC.ConnectionState.DISCONNECTED
+    PeerConnection.PeerConnectionState.FAILED -> WebRTC.ConnectionState.FAILED
+    PeerConnection.PeerConnectionState.CONNECTING -> WebRTC.ConnectionState.CONNECTING
+    else -> null
+}
+
+public fun PeerConnection.SignalingState?.toCommon(): WebRTC.SignalingState? = when (this) {
+    PeerConnection.SignalingState.STABLE -> WebRTC.SignalingState.STABLE
+    PeerConnection.SignalingState.CLOSED -> WebRTC.SignalingState.CLOSED
+    PeerConnection.SignalingState.HAVE_LOCAL_OFFER -> WebRTC.SignalingState.HAVE_LOCAL_OFFER
+    PeerConnection.SignalingState.HAVE_LOCAL_PRANSWER -> WebRTC.SignalingState.HAVE_LOCAL_PROVISIONAL_ANSWER
+    PeerConnection.SignalingState.HAVE_REMOTE_OFFER -> WebRTC.SignalingState.HAVE_REMOTE_OFFER
+    PeerConnection.SignalingState.HAVE_REMOTE_PRANSWER -> WebRTC.SignalingState.HAVE_REMOTE_PROVISIONAL_ANSWER
+    else -> null
+}
+
+public fun PeerConnection.IceGatheringState?.toCommon(): WebRTC.IceGatheringState? = when (this) {
+    PeerConnection.IceGatheringState.NEW -> WebRTC.IceGatheringState.NEW
+    PeerConnection.IceGatheringState.COMPLETE -> WebRTC.IceGatheringState.COMPLETE
+    PeerConnection.IceGatheringState.GATHERING -> WebRTC.IceGatheringState.GATHERING
+    else -> null
+}
+
+public fun SessionDescription.toCommon(): WebRTC.SessionDescription {
+    return WebRTC.SessionDescription(
+        when (requireNotNull(type)) {
+            SessionDescription.Type.OFFER -> WebRTC.SessionDescriptionType.OFFER
+            SessionDescription.Type.ANSWER -> WebRTC.SessionDescriptionType.ANSWER
+            SessionDescription.Type.ROLLBACK -> WebRTC.SessionDescriptionType.ROLLBACK
+            SessionDescription.Type.PRANSWER -> WebRTC.SessionDescriptionType.PROVISIONAL_ANSWER
+        },
+        description
+    )
+}
+
+public fun RTCStatsReport.toCommon(): List<WebRTC.Stats> = statsMap.values.map {
+    WebRTC.Stats(
+        it.id,
+        it.type,
+        it.timestampUs.toLong(),
+        it.members
+    )
+}
+
+public fun IceCandidate.toCommon(): WebRTC.IceCandidate = WebRTC.IceCandidate(
+    candidate = sdp,
+    sdpMid = sdpMid,
+    sdpMLineIndex = sdpMLineIndex
+)
+
+public fun Continuation<SessionDescription>.resumeAfterSdpCreate(): SdpObserver {
+    return object : SdpObserver {
+        override fun onCreateSuccess(sdp: SessionDescription?) = resume(requireNotNull(sdp))
+        override fun onCreateFailure(error: String?) = resumeWithException(WebRTC.SdpException(error))
+        override fun onSetSuccess() = Unit
+        override fun onSetFailure(error: String?) = Unit
+    }
+}
+
+public fun Continuation<Unit>.resumeAfterSdpSet(): SdpObserver {
+    return object : SdpObserver {
+        override fun onCreateSuccess(sdp: SessionDescription?) {}
+        override fun onCreateFailure(error: String?) {}
+        override fun onSetSuccess() = resume(Unit)
+        override fun onSetFailure(error: String?) = resumeWithException(WebRTC.SdpException(error))
+    }
+}

--- a/ktor-client/ktor-client-webrtc/android/src/io/ktor/client/webrtc/WebRTCEngine.android.kt
+++ b/ktor-client/ktor-client-webrtc/android/src/io/ktor/client/webrtc/WebRTCEngine.android.kt
@@ -1,0 +1,259 @@
+/*
+ * Copyright 2014-2025 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.client.webrtc
+
+import android.content.Context
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import org.webrtc.AddIceObserver
+import org.webrtc.DataChannel
+import org.webrtc.IceCandidate
+import org.webrtc.MediaConstraints
+import org.webrtc.MediaStream
+import org.webrtc.PeerConnection
+import org.webrtc.PeerConnection.Observer
+import org.webrtc.PeerConnection.RTCConfiguration
+import org.webrtc.PeerConnectionFactory
+import org.webrtc.RtpReceiver
+import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
+import kotlin.coroutines.suspendCoroutine
+
+internal actual fun ioDispatcher(): CoroutineDispatcher = Dispatchers.IO
+
+public class AndroidWebRTCEngineConfig : WebRTCConfig() {
+    /**
+     * Android application context needed to create media tracks.
+     * */
+    public lateinit var context: Context
+
+    /**
+     * In Android WebRTC implementation PeerConnectionFactory is coupled with the MediaTrackFactory, so if you provide a
+     * custom MediaTrackFactory, you should specify PeerConnectionFactory to initialize a PeerConnection.
+     * */
+    public var rtcFactory: PeerConnectionFactory? = null
+}
+
+public class AndroidWebRTCEngine(
+    override val config: AndroidWebRTCEngineConfig,
+    private val mediaTrackFactory: MediaTrackFactory = config.mediaTrackFactory ?: AndroidMediaDevices(config.context)
+) : WebRTCEngineBase("android-webrtc"), MediaTrackFactory by mediaTrackFactory {
+
+    private fun getLocalFactory(): PeerConnectionFactory {
+        val factory = config.rtcFactory ?: (mediaTrackFactory as? AndroidMediaDevices)?.peerConnectionFactory
+        if (factory == null) {
+            error("Please specify custom rtcFactory for custom MediaTrackFactory")
+        }
+        return factory
+    }
+
+    private fun WebRTC.IceServer.toNative(): PeerConnection.IceServer {
+        return PeerConnection.IceServer
+            .builder(urls)
+            .setUsername(username ?: "") // will throw if null
+            .setPassword(credential ?: "") // will throw if null
+            .createIceServer()
+    }
+
+    override suspend fun createPeerConnection(): WebRtcPeerConnection {
+        val iceServers = (config.iceServers + config.turnServers).map { it.toNative() }
+        val rtcConfig = RTCConfiguration(iceServers).apply {
+            bundlePolicy = config.bundlePolicy.toNative()
+            rtcpMuxPolicy = config.rtcpMuxPolicy.toNative()
+            iceCandidatePoolSize = config.iceCandidatePoolSize
+            sdpSemantics = PeerConnection.SdpSemantics.UNIFIED_PLAN
+            iceTransportsType = config.iceTransportPolicy.toNative()
+        }
+        return AndroidWebRtcPeerConnection(
+            coroutineContext,
+            config.statsRefreshRate,
+            config.iceCandidatesReplay,
+            config.remoteTracksReplay
+        ).initialize { observer ->
+            getLocalFactory().createPeerConnection(rtcConfig, observer)
+        }
+    }
+}
+
+public class AndroidWebRtcPeerConnection(
+    override val coroutineContext: CoroutineContext,
+    private val statsRefreshRate: Long,
+    iceCandidatesReplay: Int,
+    remoteTracksReplay: Int
+) : CoroutineScope, WebRtcPeerConnection(iceCandidatesReplay, remoteTracksReplay) {
+    private lateinit var peerConnection: PeerConnection
+
+    // remember RTP senders because method PeerConnection.getSenders() disposes all returned senders
+    private val rtpSenders = arrayListOf<AndroidRtpSender>()
+
+    // helper method to break a dependency cycle (PeerConnection -> PeerConnectionFactory -> Observer)
+    public fun initialize(block: (Observer) -> PeerConnection?): AndroidWebRtcPeerConnection {
+        peerConnection = requireNotNull(block(createObserver()))
+
+        // Set up statistics collection
+        if (statsRefreshRate > 0) {
+            launch {
+                while (true) {
+                    delay(statsRefreshRate)
+                    val stats = suspendCoroutine { cont ->
+                        peerConnection.getStats { cont.resume(it.toCommon()) }
+                    }
+                    currentStats.emit(stats)
+                }
+            }
+        }
+
+        return this
+    }
+
+    private val hasVideo get() = rtpSenders.any { it.track?.kind == WebRTCMedia.TrackType.VIDEO }
+    private val hasAudio get() = rtpSenders.any { it.track?.kind == WebRTCMedia.TrackType.AUDIO }
+
+    private fun offerConstraints() = MediaConstraints().apply {
+        if (hasAudio) mandatory.add(MediaConstraints.KeyValuePair("OfferToReceiveAudio", "true"))
+        if (hasVideo) mandatory.add(MediaConstraints.KeyValuePair("OfferToReceiveVideo", "true"))
+    }
+
+    private fun createObserver() = object : Observer {
+        override fun onIceCandidate(candidate: IceCandidate?) {
+            if (candidate == null) return
+            launch {
+                iceCandidates.emit(candidate.toCommon())
+            }
+        }
+
+        override fun onIceCandidatesRemoved(candidates: Array<out IceCandidate>?) = Unit
+
+        override fun onAddTrack(receiver: RtpReceiver?, mediaStreams: Array<out MediaStream>?) {
+            if (receiver == null) return
+            launch {
+                receiver.track()?.let { remoteTracks.emit(Add(AndroidMediaTrack.from(it))) }
+            }
+        }
+
+        override fun onRemoveTrack(receiver: RtpReceiver?) {
+            if (receiver == null) return
+            launch {
+                receiver.track()?.let { remoteTracks.emit(Remove(AndroidMediaTrack.from(it))) }
+            }
+        }
+
+        override fun onIceConnectionChange(newState: PeerConnection.IceConnectionState?) {
+            val commonState = newState.toCommon() ?: return
+            launch { currentIceConnectionState.emit(commonState) }
+        }
+
+        override fun onConnectionChange(newState: PeerConnection.PeerConnectionState?) {
+            val commonState = newState.toCommon() ?: return
+            launch { currentConnectionState.emit(commonState) }
+        }
+
+        override fun onSignalingChange(newState: PeerConnection.SignalingState?) {
+            val commonState = newState.toCommon() ?: return
+            launch { currentSignalingState.emit(commonState) }
+        }
+
+        override fun onIceGatheringChange(newState: PeerConnection.IceGatheringState?) {
+            val commonState = newState.toCommon() ?: return
+            launch { currentIceGatheringState.emit(commonState) }
+        }
+
+        override fun onIceConnectionReceivingChange(receiving: Boolean) = Unit
+        override fun onRenegotiationNeeded(): Unit = negotiationNeededCallback()
+
+        // we omit streams and operate with tracks instead
+        override fun onAddStream(p0: MediaStream?) = Unit
+        override fun onRemoveStream(p0: MediaStream?) = Unit
+
+        // #TODO: implement data channels
+        override fun onDataChannel(dataChannel: DataChannel?) = Unit
+    }
+
+    override val localDescription: WebRTC.SessionDescription?
+        get() = peerConnection.localDescription?.toCommon()
+
+    override val remoteDescription: WebRTC.SessionDescription?
+        get() = peerConnection.remoteDescription?.toCommon()
+
+    override suspend fun createOffer(): WebRTC.SessionDescription {
+        val offer = suspendCoroutine { cont ->
+            peerConnection.createOffer(cont.resumeAfterSdpCreate(), offerConstraints())
+        }
+        return offer.toCommon()
+    }
+
+    override suspend fun createAnswer(): WebRTC.SessionDescription {
+        val answer = suspendCoroutine { cont ->
+            peerConnection.createAnswer(cont.resumeAfterSdpCreate(), offerConstraints())
+        }
+        return answer.toCommon()
+    }
+
+    override suspend fun setLocalDescription(description: WebRTC.SessionDescription) {
+        suspendCoroutine { cont ->
+            peerConnection.setLocalDescription(cont.resumeAfterSdpSet(), description.toNative())
+        }
+    }
+
+    override suspend fun setRemoteDescription(description: WebRTC.SessionDescription) {
+        suspendCoroutine { cont ->
+            peerConnection.setRemoteDescription(cont.resumeAfterSdpSet(), description.toNative())
+        }
+    }
+
+    override suspend fun addIceCandidate(candidate: WebRTC.IceCandidate) {
+        val iceCandidate = IceCandidate(
+            candidate.sdpMid,
+            candidate.sdpMLineIndex,
+            candidate.candidate,
+        )
+        suspendCoroutine { cont ->
+            peerConnection.addIceCandidate(
+                iceCandidate,
+                object : AddIceObserver {
+                    override fun onAddSuccess() = cont.resume(Unit)
+                    override fun onAddFailure(error: String?) = cont.resumeWithException(WebRTC.IceException(error))
+                }
+            )
+        }
+    }
+
+    override suspend fun addTrack(track: WebRTCMedia.Track): WebRTC.RtpSender {
+        val mediaTrack = track as? AndroidMediaTrack ?: error("Track should extend AndroidMediaTrack")
+        val newSender = AndroidRtpSender(peerConnection.addTrack(mediaTrack.nativeTrack))
+        rtpSenders.add(newSender)
+        return newSender
+    }
+
+    override suspend fun removeTrack(track: WebRTCMedia.Track) {
+        val mediaTrack = track as? AndroidMediaTrack ?: error("Track should extend AndroidMediaTrack")
+        val sender = rtpSenders.firstOrNull { it.track?.id == mediaTrack.id } ?: return
+        peerConnection.removeTrack(sender.nativeRtpSender)
+    }
+
+    override suspend fun removeTrack(sender: WebRTC.RtpSender) {
+        val rtpSender = sender as? AndroidRtpSender ?: error("Sender should extend AndroidRtpSender")
+        peerConnection.removeTrack(rtpSender.nativeRtpSender)
+    }
+
+    override fun restartIce() {
+        peerConnection.restartIce()
+    }
+
+    override fun close() {
+        peerConnection.close()
+    }
+
+    override fun getNativeConnection(): Any = peerConnection
+}
+
+public object AndroidWebRTC : WebRTCClientEngineFactory<AndroidWebRTCEngineConfig> {
+    override fun create(block: AndroidWebRTCEngineConfig.() -> Unit): WebRTCEngine =
+        AndroidWebRTCEngine(AndroidWebRTCEngineConfig().apply(block))
+}

--- a/ktor-client/ktor-client-webrtc/androidDevice/test/io/ktor/client/webrtc/WebRTCEngineTest.android.kt
+++ b/ktor-client/ktor-client-webrtc/androidDevice/test/io/ktor/client/webrtc/WebRTCEngineTest.android.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2014-2025 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.client.webrtc
+
+import android.Manifest
+import android.content.Context
+import androidx.test.platform.app.InstrumentationRegistry
+
+private val ctx: Context get() = InstrumentationRegistry.getInstrumentation().targetContext
+
+actual fun createTestWebRTCClient(): WebRTCClient {
+    return WebRTCClient(AndroidWebRTC) {
+        iceServers = listOf()
+        turnServers = listOf()
+        statsRefreshRate = 100 // 100 ms refresh rate
+        mediaTrackFactory = AndroidMediaDevices(ctx)
+    }
+}
+
+actual fun grantPermissions(audio: Boolean, video: Boolean) {
+    val automation = InstrumentationRegistry.getInstrumentation().uiAutomation
+    if (audio) {
+        automation.grantRuntimePermission(ctx.packageName, Manifest.permission.RECORD_AUDIO)
+    } else {
+        automation.revokeRuntimePermission(ctx.packageName, Manifest.permission.RECORD_AUDIO)
+    }
+    if (video) {
+        automation.grantRuntimePermission(ctx.packageName, Manifest.permission.CAMERA)
+    } else {
+        automation.revokeRuntimePermission(ctx.packageName, Manifest.permission.CAMERA)
+    }
+}

--- a/ktor-client/ktor-client-webrtc/api/ktor-client-webrtc.api
+++ b/ktor-client/ktor-client-webrtc/api/ktor-client-webrtc.api
@@ -1,0 +1,594 @@
+public final class io/ktor/client/webrtc/Add : io/ktor/client/webrtc/Operation {
+	public fun <init> (Ljava/lang/Object;)V
+}
+
+public final class io/ktor/client/webrtc/AndroidAudioTrack : io/ktor/client/webrtc/AndroidMediaTrack, io/ktor/client/webrtc/WebRTCMedia$AudioTrack {
+	public fun <init> (Lorg/webrtc/MediaStreamTrack;Lkotlin/jvm/functions/Function0;)V
+	public synthetic fun <init> (Lorg/webrtc/MediaStreamTrack;Lkotlin/jvm/functions/Function0;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+}
+
+public final class io/ktor/client/webrtc/AndroidDtmfServer : io/ktor/client/webrtc/WebRTC$DtmfSender {
+	public fun <init> (Lorg/webrtc/DtmfSender;)V
+	public fun getCanInsertDTMF ()Z
+	public fun getNative ()Ljava/lang/Object;
+	public fun getToneBuffer ()Ljava/lang/String;
+	public fun insertDTMF (Ljava/lang/String;II)V
+}
+
+public final class io/ktor/client/webrtc/AndroidMediaDevices : io/ktor/client/webrtc/MediaTrackFactory {
+	public fun <init> (Landroid/content/Context;Lorg/webrtc/EglBase;)V
+	public synthetic fun <init> (Landroid/content/Context;Lorg/webrtc/EglBase;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun createAudioTrack (Lio/ktor/client/webrtc/WebRTCMedia$AudioTrackConstraints;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun createVideoTrack (Lio/ktor/client/webrtc/WebRTCMedia$VideoTrackConstraints;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getPeerConnectionFactory ()Lorg/webrtc/PeerConnectionFactory;
+}
+
+public abstract class io/ktor/client/webrtc/AndroidMediaTrack : io/ktor/client/webrtc/WebRTCMedia$Track {
+	public static final field Companion Lio/ktor/client/webrtc/AndroidMediaTrack$Companion;
+	public fun <init> (Lorg/webrtc/MediaStreamTrack;Lkotlin/jvm/functions/Function0;)V
+	public fun close ()V
+	public fun enable (Z)V
+	public fun getEnabled ()Z
+	public fun getId ()Ljava/lang/String;
+	public fun getKind ()Lio/ktor/client/webrtc/WebRTCMedia$TrackType;
+	public fun getNative ()Ljava/lang/Object;
+	public final fun getNativeTrack ()Lorg/webrtc/MediaStreamTrack;
+}
+
+public final class io/ktor/client/webrtc/AndroidMediaTrack$Companion {
+	public final fun from (Lorg/webrtc/MediaStreamTrack;)Lio/ktor/client/webrtc/AndroidMediaTrack;
+}
+
+public final class io/ktor/client/webrtc/AndroidRtpParameters : io/ktor/client/webrtc/WebRTC$RtpParameters {
+	public fun <init> (Lorg/webrtc/RtpParameters;)V
+	public synthetic fun getCodecs ()Ljava/lang/Iterable;
+	public fun getCodecs ()Ljava/util/List;
+	public fun getDegradationPreference ()Lio/ktor/client/webrtc/WebRTC$DegradationPreference;
+	public synthetic fun getEncodings ()Ljava/lang/Iterable;
+	public fun getEncodings ()Ljava/util/List;
+	public synthetic fun getHeaderExtensions ()Ljava/lang/Iterable;
+	public fun getHeaderExtensions ()Ljava/util/List;
+	public final fun getNativeRtpParameters ()Lorg/webrtc/RtpParameters;
+	public fun getRtcp ()Ljava/lang/Object;
+	public fun getTransactionId ()Ljava/lang/String;
+}
+
+public final class io/ktor/client/webrtc/AndroidRtpSender : io/ktor/client/webrtc/WebRTC$RtpSender {
+	public fun <init> (Lorg/webrtc/RtpSender;)V
+	public fun getDtmf ()Lio/ktor/client/webrtc/WebRTC$DtmfSender;
+	public fun getNative ()Ljava/lang/Object;
+	public final fun getNativeRtpSender ()Lorg/webrtc/RtpSender;
+	public fun getParameters (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getTrack ()Lio/ktor/client/webrtc/WebRTCMedia$Track;
+	public fun replaceTrack (Lio/ktor/client/webrtc/WebRTCMedia$Track;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun setParameters (Lio/ktor/client/webrtc/WebRTC$RtpParameters;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class io/ktor/client/webrtc/AndroidVideoTrack : io/ktor/client/webrtc/AndroidMediaTrack, io/ktor/client/webrtc/WebRTCMedia$VideoTrack {
+	public fun <init> (Lorg/webrtc/MediaStreamTrack;Lkotlin/jvm/functions/Function0;)V
+	public synthetic fun <init> (Lorg/webrtc/MediaStreamTrack;Lkotlin/jvm/functions/Function0;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+}
+
+public final class io/ktor/client/webrtc/AndroidWebRTC : io/ktor/client/webrtc/WebRTCClientEngineFactory {
+	public static final field INSTANCE Lio/ktor/client/webrtc/AndroidWebRTC;
+	public fun create (Lkotlin/jvm/functions/Function1;)Lio/ktor/client/webrtc/WebRTCEngine;
+}
+
+public final class io/ktor/client/webrtc/AndroidWebRTCEngine : io/ktor/client/webrtc/WebRTCEngineBase, io/ktor/client/webrtc/MediaTrackFactory {
+	public fun <init> (Lio/ktor/client/webrtc/AndroidWebRTCEngineConfig;Lio/ktor/client/webrtc/MediaTrackFactory;)V
+	public synthetic fun <init> (Lio/ktor/client/webrtc/AndroidWebRTCEngineConfig;Lio/ktor/client/webrtc/MediaTrackFactory;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun createAudioTrack (Lio/ktor/client/webrtc/WebRTCMedia$AudioTrackConstraints;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun createPeerConnection (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun createVideoTrack (Lio/ktor/client/webrtc/WebRTCMedia$VideoTrackConstraints;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getConfig ()Lio/ktor/client/webrtc/AndroidWebRTCEngineConfig;
+	public synthetic fun getConfig ()Lio/ktor/client/webrtc/WebRTCConfig;
+}
+
+public final class io/ktor/client/webrtc/AndroidWebRTCEngineConfig : io/ktor/client/webrtc/WebRTCConfig {
+	public field context Landroid/content/Context;
+	public fun <init> ()V
+	public final fun getContext ()Landroid/content/Context;
+	public final fun getRtcFactory ()Lorg/webrtc/PeerConnectionFactory;
+	public final fun setContext (Landroid/content/Context;)V
+	public final fun setRtcFactory (Lorg/webrtc/PeerConnectionFactory;)V
+}
+
+public final class io/ktor/client/webrtc/AndroidWebRtcPeerConnection : io/ktor/client/webrtc/WebRtcPeerConnection, kotlinx/coroutines/CoroutineScope {
+	public fun <init> (Lkotlin/coroutines/CoroutineContext;JII)V
+	public fun addIceCandidate (Lio/ktor/client/webrtc/WebRTC$IceCandidate;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun addTrack (Lio/ktor/client/webrtc/WebRTCMedia$Track;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun close ()V
+	public fun createAnswer (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun createOffer (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getCoroutineContext ()Lkotlin/coroutines/CoroutineContext;
+	public fun getLocalDescription ()Lio/ktor/client/webrtc/WebRTC$SessionDescription;
+	public fun getNativeConnection ()Ljava/lang/Object;
+	public fun getRemoteDescription ()Lio/ktor/client/webrtc/WebRTC$SessionDescription;
+	public final fun initialize (Lkotlin/jvm/functions/Function1;)Lio/ktor/client/webrtc/AndroidWebRtcPeerConnection;
+	public fun removeTrack (Lio/ktor/client/webrtc/WebRTC$RtpSender;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun removeTrack (Lio/ktor/client/webrtc/WebRTCMedia$Track;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun restartIce ()V
+	public fun setLocalDescription (Lio/ktor/client/webrtc/WebRTC$SessionDescription;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun setRemoteDescription (Lio/ktor/client/webrtc/WebRTC$SessionDescription;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public abstract interface class io/ktor/client/webrtc/MediaTrackFactory {
+	public abstract fun createAudioTrack (Lio/ktor/client/webrtc/WebRTCMedia$AudioTrackConstraints;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun createVideoTrack (Lio/ktor/client/webrtc/WebRTCMedia$VideoTrackConstraints;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public abstract class io/ktor/client/webrtc/Operation {
+	public synthetic fun <init> (Ljava/lang/Object;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getItem ()Ljava/lang/Object;
+}
+
+public final class io/ktor/client/webrtc/Remove : io/ktor/client/webrtc/Operation {
+	public fun <init> (Ljava/lang/Object;)V
+}
+
+public final class io/ktor/client/webrtc/UtilsKt {
+	public static final fun resumeAfterSdpCreate (Lkotlin/coroutines/Continuation;)Lorg/webrtc/SdpObserver;
+	public static final fun resumeAfterSdpSet (Lkotlin/coroutines/Continuation;)Lorg/webrtc/SdpObserver;
+	public static final fun toCommon (Lorg/webrtc/IceCandidate;)Lio/ktor/client/webrtc/WebRTC$IceCandidate;
+	public static final fun toCommon (Lorg/webrtc/PeerConnection$IceConnectionState;)Lio/ktor/client/webrtc/WebRTC$IceConnectionState;
+	public static final fun toCommon (Lorg/webrtc/PeerConnection$IceGatheringState;)Lio/ktor/client/webrtc/WebRTC$IceGatheringState;
+	public static final fun toCommon (Lorg/webrtc/PeerConnection$PeerConnectionState;)Lio/ktor/client/webrtc/WebRTC$ConnectionState;
+	public static final fun toCommon (Lorg/webrtc/PeerConnection$SignalingState;)Lio/ktor/client/webrtc/WebRTC$SignalingState;
+	public static final fun toCommon (Lorg/webrtc/RTCStatsReport;)Ljava/util/List;
+	public static final fun toCommon (Lorg/webrtc/SessionDescription;)Lio/ktor/client/webrtc/WebRTC$SessionDescription;
+	public static final fun toNative (Lio/ktor/client/webrtc/WebRTC$BundlePolicy;)Lorg/webrtc/PeerConnection$BundlePolicy;
+	public static final fun toNative (Lio/ktor/client/webrtc/WebRTC$IceTransportPolicy;)Lorg/webrtc/PeerConnection$IceTransportsType;
+	public static final fun toNative (Lio/ktor/client/webrtc/WebRTC$RTCPMuxPolicy;)Lorg/webrtc/PeerConnection$RtcpMuxPolicy;
+	public static final fun toNative (Lio/ktor/client/webrtc/WebRTC$SessionDescription;)Lorg/webrtc/SessionDescription;
+}
+
+public final class io/ktor/client/webrtc/WebRTC {
+	public static final field INSTANCE Lio/ktor/client/webrtc/WebRTC;
+}
+
+public final class io/ktor/client/webrtc/WebRTC$BundlePolicy : java/lang/Enum {
+	public static final field BALANCED Lio/ktor/client/webrtc/WebRTC$BundlePolicy;
+	public static final field MAX_BUNDLE Lio/ktor/client/webrtc/WebRTC$BundlePolicy;
+	public static final field MAX_COMPAT Lio/ktor/client/webrtc/WebRTC$BundlePolicy;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lio/ktor/client/webrtc/WebRTC$BundlePolicy;
+	public static fun values ()[Lio/ktor/client/webrtc/WebRTC$BundlePolicy;
+}
+
+public final class io/ktor/client/webrtc/WebRTC$ConnectionState : java/lang/Enum {
+	public static final field CLOSED Lio/ktor/client/webrtc/WebRTC$ConnectionState;
+	public static final field CONNECTED Lio/ktor/client/webrtc/WebRTC$ConnectionState;
+	public static final field CONNECTING Lio/ktor/client/webrtc/WebRTC$ConnectionState;
+	public static final field DISCONNECTED Lio/ktor/client/webrtc/WebRTC$ConnectionState;
+	public static final field FAILED Lio/ktor/client/webrtc/WebRTC$ConnectionState;
+	public static final field NEW Lio/ktor/client/webrtc/WebRTC$ConnectionState;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lio/ktor/client/webrtc/WebRTC$ConnectionState;
+	public static fun values ()[Lio/ktor/client/webrtc/WebRTC$ConnectionState;
+}
+
+public final class io/ktor/client/webrtc/WebRTC$DegradationPreference : java/lang/Enum {
+	public static final field BALANCED Lio/ktor/client/webrtc/WebRTC$DegradationPreference;
+	public static final field DISABLED Lio/ktor/client/webrtc/WebRTC$DegradationPreference;
+	public static final field MAINTAIN_FRAMERATE Lio/ktor/client/webrtc/WebRTC$DegradationPreference;
+	public static final field MAINTAIN_RESOLUTION Lio/ktor/client/webrtc/WebRTC$DegradationPreference;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lio/ktor/client/webrtc/WebRTC$DegradationPreference;
+	public static fun values ()[Lio/ktor/client/webrtc/WebRTC$DegradationPreference;
+}
+
+public abstract interface class io/ktor/client/webrtc/WebRTC$DtmfSender {
+	public abstract fun getCanInsertDTMF ()Z
+	public abstract fun getNative ()Ljava/lang/Object;
+	public abstract fun getToneBuffer ()Ljava/lang/String;
+	public abstract fun insertDTMF (Ljava/lang/String;II)V
+}
+
+public final class io/ktor/client/webrtc/WebRTC$IceCandidate {
+	public static final field Companion Lio/ktor/client/webrtc/WebRTC$IceCandidate$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;I)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()I
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;I)Lio/ktor/client/webrtc/WebRTC$IceCandidate;
+	public static synthetic fun copy$default (Lio/ktor/client/webrtc/WebRTC$IceCandidate;Ljava/lang/String;Ljava/lang/String;IILjava/lang/Object;)Lio/ktor/client/webrtc/WebRTC$IceCandidate;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCandidate ()Ljava/lang/String;
+	public final fun getSdpMLineIndex ()I
+	public final fun getSdpMid ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public synthetic class io/ktor/client/webrtc/WebRTC$IceCandidate$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/ktor/client/webrtc/WebRTC$IceCandidate$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/ktor/client/webrtc/WebRTC$IceCandidate;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/ktor/client/webrtc/WebRTC$IceCandidate;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+}
+
+public final class io/ktor/client/webrtc/WebRTC$IceCandidate$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/ktor/client/webrtc/WebRTC$IceConnectionState : java/lang/Enum {
+	public static final field CHECKING Lio/ktor/client/webrtc/WebRTC$IceConnectionState;
+	public static final field CLOSED Lio/ktor/client/webrtc/WebRTC$IceConnectionState;
+	public static final field COMPLETED Lio/ktor/client/webrtc/WebRTC$IceConnectionState;
+	public static final field CONNECTED Lio/ktor/client/webrtc/WebRTC$IceConnectionState;
+	public static final field DISCONNECTED Lio/ktor/client/webrtc/WebRTC$IceConnectionState;
+	public static final field FAILED Lio/ktor/client/webrtc/WebRTC$IceConnectionState;
+	public static final field NEW Lio/ktor/client/webrtc/WebRTC$IceConnectionState;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public final fun isSuccessful ()Z
+	public static fun valueOf (Ljava/lang/String;)Lio/ktor/client/webrtc/WebRTC$IceConnectionState;
+	public static fun values ()[Lio/ktor/client/webrtc/WebRTC$IceConnectionState;
+}
+
+public final class io/ktor/client/webrtc/WebRTC$IceException : java/lang/RuntimeException {
+	public fun <init> (Ljava/lang/String;Ljava/lang/Throwable;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/Throwable;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+}
+
+public final class io/ktor/client/webrtc/WebRTC$IceGatheringState : java/lang/Enum {
+	public static final field COMPLETE Lio/ktor/client/webrtc/WebRTC$IceGatheringState;
+	public static final field GATHERING Lio/ktor/client/webrtc/WebRTC$IceGatheringState;
+	public static final field NEW Lio/ktor/client/webrtc/WebRTC$IceGatheringState;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lio/ktor/client/webrtc/WebRTC$IceGatheringState;
+	public static fun values ()[Lio/ktor/client/webrtc/WebRTC$IceGatheringState;
+}
+
+public final class io/ktor/client/webrtc/WebRTC$IceServer {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lio/ktor/client/webrtc/WebRTC$IceServer;
+	public static synthetic fun copy$default (Lio/ktor/client/webrtc/WebRTC$IceServer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lio/ktor/client/webrtc/WebRTC$IceServer;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCredential ()Ljava/lang/String;
+	public final fun getUrls ()Ljava/lang/String;
+	public final fun getUsername ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/ktor/client/webrtc/WebRTC$IceTransportPolicy : java/lang/Enum {
+	public static final field ALL Lio/ktor/client/webrtc/WebRTC$IceTransportPolicy;
+	public static final field RELAY Lio/ktor/client/webrtc/WebRTC$IceTransportPolicy;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lio/ktor/client/webrtc/WebRTC$IceTransportPolicy;
+	public static fun values ()[Lio/ktor/client/webrtc/WebRTC$IceTransportPolicy;
+}
+
+public final class io/ktor/client/webrtc/WebRTC$RTCPMuxPolicy : java/lang/Enum {
+	public static final field NEGOTIATE Lio/ktor/client/webrtc/WebRTC$RTCPMuxPolicy;
+	public static final field REQUIRE Lio/ktor/client/webrtc/WebRTC$RTCPMuxPolicy;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lio/ktor/client/webrtc/WebRTC$RTCPMuxPolicy;
+	public static fun values ()[Lio/ktor/client/webrtc/WebRTC$RTCPMuxPolicy;
+}
+
+public final class io/ktor/client/webrtc/WebRTC$RtpHeaderExtensionParameters {
+	public fun <init> (ILjava/lang/String;Z)V
+	public final fun component1 ()I
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Z
+	public final fun copy (ILjava/lang/String;Z)Lio/ktor/client/webrtc/WebRTC$RtpHeaderExtensionParameters;
+	public static synthetic fun copy$default (Lio/ktor/client/webrtc/WebRTC$RtpHeaderExtensionParameters;ILjava/lang/String;ZILjava/lang/Object;)Lio/ktor/client/webrtc/WebRTC$RtpHeaderExtensionParameters;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getEncrypted ()Z
+	public final fun getId ()I
+	public final fun getUri ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract interface class io/ktor/client/webrtc/WebRTC$RtpParameters {
+	public abstract fun getCodecs ()Ljava/lang/Iterable;
+	public abstract fun getDegradationPreference ()Lio/ktor/client/webrtc/WebRTC$DegradationPreference;
+	public abstract fun getEncodings ()Ljava/lang/Iterable;
+	public abstract fun getHeaderExtensions ()Ljava/lang/Iterable;
+	public abstract fun getRtcp ()Ljava/lang/Object;
+	public abstract fun getTransactionId ()Ljava/lang/String;
+}
+
+public abstract interface class io/ktor/client/webrtc/WebRTC$RtpSender {
+	public abstract fun getDtmf ()Lio/ktor/client/webrtc/WebRTC$DtmfSender;
+	public abstract fun getNative ()Ljava/lang/Object;
+	public abstract fun getParameters (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun getTrack ()Lio/ktor/client/webrtc/WebRTCMedia$Track;
+	public abstract fun replaceTrack (Lio/ktor/client/webrtc/WebRTCMedia$Track;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun setParameters (Lio/ktor/client/webrtc/WebRTC$RtpParameters;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class io/ktor/client/webrtc/WebRTC$SdpException : java/lang/RuntimeException {
+	public fun <init> (Ljava/lang/String;Ljava/lang/Throwable;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/Throwable;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+}
+
+public final class io/ktor/client/webrtc/WebRTC$SessionDescription {
+	public static final field Companion Lio/ktor/client/webrtc/WebRTC$SessionDescription$Companion;
+	public fun <init> (Lio/ktor/client/webrtc/WebRTC$SessionDescriptionType;Ljava/lang/String;)V
+	public final fun component1 ()Lio/ktor/client/webrtc/WebRTC$SessionDescriptionType;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (Lio/ktor/client/webrtc/WebRTC$SessionDescriptionType;Ljava/lang/String;)Lio/ktor/client/webrtc/WebRTC$SessionDescription;
+	public static synthetic fun copy$default (Lio/ktor/client/webrtc/WebRTC$SessionDescription;Lio/ktor/client/webrtc/WebRTC$SessionDescriptionType;Ljava/lang/String;ILjava/lang/Object;)Lio/ktor/client/webrtc/WebRTC$SessionDescription;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getSdp ()Ljava/lang/String;
+	public final fun getType ()Lio/ktor/client/webrtc/WebRTC$SessionDescriptionType;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public synthetic class io/ktor/client/webrtc/WebRTC$SessionDescription$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/ktor/client/webrtc/WebRTC$SessionDescription$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/ktor/client/webrtc/WebRTC$SessionDescription;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/ktor/client/webrtc/WebRTC$SessionDescription;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+}
+
+public final class io/ktor/client/webrtc/WebRTC$SessionDescription$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/ktor/client/webrtc/WebRTC$SessionDescriptionType : java/lang/Enum {
+	public static final field ANSWER Lio/ktor/client/webrtc/WebRTC$SessionDescriptionType;
+	public static final field Companion Lio/ktor/client/webrtc/WebRTC$SessionDescriptionType$Companion;
+	public static final field OFFER Lio/ktor/client/webrtc/WebRTC$SessionDescriptionType;
+	public static final field PROVISIONAL_ANSWER Lio/ktor/client/webrtc/WebRTC$SessionDescriptionType;
+	public static final field ROLLBACK Lio/ktor/client/webrtc/WebRTC$SessionDescriptionType;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lio/ktor/client/webrtc/WebRTC$SessionDescriptionType;
+	public static fun values ()[Lio/ktor/client/webrtc/WebRTC$SessionDescriptionType;
+}
+
+public final class io/ktor/client/webrtc/WebRTC$SessionDescriptionType$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/ktor/client/webrtc/WebRTC$SignalingState : java/lang/Enum {
+	public static final field CLOSED Lio/ktor/client/webrtc/WebRTC$SignalingState;
+	public static final field HAVE_LOCAL_OFFER Lio/ktor/client/webrtc/WebRTC$SignalingState;
+	public static final field HAVE_LOCAL_PROVISIONAL_ANSWER Lio/ktor/client/webrtc/WebRTC$SignalingState;
+	public static final field HAVE_REMOTE_OFFER Lio/ktor/client/webrtc/WebRTC$SignalingState;
+	public static final field HAVE_REMOTE_PROVISIONAL_ANSWER Lio/ktor/client/webrtc/WebRTC$SignalingState;
+	public static final field STABLE Lio/ktor/client/webrtc/WebRTC$SignalingState;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lio/ktor/client/webrtc/WebRTC$SignalingState;
+	public static fun values ()[Lio/ktor/client/webrtc/WebRTC$SignalingState;
+}
+
+public final class io/ktor/client/webrtc/WebRTC$Stats {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;JLjava/util/Map;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()J
+	public final fun component4 ()Ljava/util/Map;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;JLjava/util/Map;)Lio/ktor/client/webrtc/WebRTC$Stats;
+	public static synthetic fun copy$default (Lio/ktor/client/webrtc/WebRTC$Stats;Ljava/lang/String;Ljava/lang/String;JLjava/util/Map;ILjava/lang/Object;)Lio/ktor/client/webrtc/WebRTC$Stats;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getId ()Ljava/lang/String;
+	public final fun getProps ()Ljava/util/Map;
+	public final fun getTimestamp ()J
+	public final fun getType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/ktor/client/webrtc/WebRTCClient : io/ktor/client/webrtc/WebRTCEngine {
+	public fun <init> (Lio/ktor/client/webrtc/WebRTCEngine;)V
+	public fun close ()V
+	public fun createAudioTrack (Lio/ktor/client/webrtc/WebRTCMedia$AudioTrackConstraints;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun createPeerConnection (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun createVideoTrack (Lio/ktor/client/webrtc/WebRTCMedia$VideoTrackConstraints;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getConfig ()Lio/ktor/client/webrtc/WebRTCConfig;
+	public fun getCoroutineContext ()Lkotlin/coroutines/CoroutineContext;
+	public fun getDispatcher ()Lkotlinx/coroutines/CoroutineDispatcher;
+	public final fun getEngine ()Lio/ktor/client/webrtc/WebRTCEngine;
+}
+
+public abstract interface class io/ktor/client/webrtc/WebRTCClientEngineFactory {
+	public abstract fun create (Lkotlin/jvm/functions/Function1;)Lio/ktor/client/webrtc/WebRTCEngine;
+}
+
+public final class io/ktor/client/webrtc/WebRTCClientEngineFactory$DefaultImpls {
+	public static synthetic fun create$default (Lio/ktor/client/webrtc/WebRTCClientEngineFactory;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lio/ktor/client/webrtc/WebRTCEngine;
+}
+
+public final class io/ktor/client/webrtc/WebRTCClientKt {
+	public static final fun WebRTCClient (Lio/ktor/client/webrtc/WebRTCClientEngineFactory;Lkotlin/jvm/functions/Function1;)Lio/ktor/client/webrtc/WebRTCClient;
+	public static synthetic fun WebRTCClient$default (Lio/ktor/client/webrtc/WebRTCClientEngineFactory;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lio/ktor/client/webrtc/WebRTCClient;
+}
+
+public class io/ktor/client/webrtc/WebRTCConfig {
+	public fun <init> ()V
+	public final fun getBundlePolicy ()Lio/ktor/client/webrtc/WebRTC$BundlePolicy;
+	public final fun getDispatcher ()Lkotlinx/coroutines/CoroutineDispatcher;
+	public final fun getIceCandidatePoolSize ()I
+	public final fun getIceCandidatesReplay ()I
+	public final fun getIceServers ()Ljava/util/List;
+	public final fun getIceTransportPolicy ()Lio/ktor/client/webrtc/WebRTC$IceTransportPolicy;
+	public final fun getMediaTrackFactory ()Lio/ktor/client/webrtc/MediaTrackFactory;
+	public final fun getRemoteTracksReplay ()I
+	public final fun getRtcpMuxPolicy ()Lio/ktor/client/webrtc/WebRTC$RTCPMuxPolicy;
+	public final fun getStatsRefreshRate ()J
+	public final fun getTurnServers ()Ljava/util/List;
+	public final fun setBundlePolicy (Lio/ktor/client/webrtc/WebRTC$BundlePolicy;)V
+	public final fun setDispatcher (Lkotlinx/coroutines/CoroutineDispatcher;)V
+	public final fun setIceCandidatePoolSize (I)V
+	public final fun setIceCandidatesReplay (I)V
+	public final fun setIceServers (Ljava/util/List;)V
+	public final fun setIceTransportPolicy (Lio/ktor/client/webrtc/WebRTC$IceTransportPolicy;)V
+	public final fun setMediaTrackFactory (Lio/ktor/client/webrtc/MediaTrackFactory;)V
+	public final fun setRemoteTracksReplay (I)V
+	public final fun setRtcpMuxPolicy (Lio/ktor/client/webrtc/WebRTC$RTCPMuxPolicy;)V
+	public final fun setStatsRefreshRate (J)V
+	public final fun setTurnServers (Ljava/util/List;)V
+}
+
+public abstract interface class io/ktor/client/webrtc/WebRTCEngine : io/ktor/client/webrtc/MediaTrackFactory, java/io/Closeable, kotlinx/coroutines/CoroutineScope {
+	public abstract fun createPeerConnection (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun getConfig ()Lio/ktor/client/webrtc/WebRTCConfig;
+	public abstract fun getDispatcher ()Lkotlinx/coroutines/CoroutineDispatcher;
+}
+
+public abstract class io/ktor/client/webrtc/WebRTCEngineBase : io/ktor/client/webrtc/WebRTCEngine {
+	public fun <init> (Ljava/lang/String;)V
+	public fun close ()V
+	public fun getCoroutineContext ()Lkotlin/coroutines/CoroutineContext;
+	public fun getDispatcher ()Lkotlinx/coroutines/CoroutineDispatcher;
+}
+
+public final class io/ktor/client/webrtc/WebRTCMedia {
+	public static final field INSTANCE Lio/ktor/client/webrtc/WebRTCMedia;
+}
+
+public abstract interface class io/ktor/client/webrtc/WebRTCMedia$AudioTrack : io/ktor/client/webrtc/WebRTCMedia$Track {
+}
+
+public final class io/ktor/client/webrtc/WebRTCMedia$AudioTrackConstraints {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/Double;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Double;Ljava/lang/Integer;)V
+	public synthetic fun <init> (Ljava/lang/Double;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Double;Ljava/lang/Integer;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/Double;
+	public final fun component2 ()Ljava/lang/Integer;
+	public final fun component3 ()Ljava/lang/Integer;
+	public final fun component4 ()Ljava/lang/Boolean;
+	public final fun component5 ()Ljava/lang/Boolean;
+	public final fun component6 ()Ljava/lang/Boolean;
+	public final fun component7 ()Ljava/lang/Double;
+	public final fun component8 ()Ljava/lang/Integer;
+	public final fun copy (Ljava/lang/Double;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Double;Ljava/lang/Integer;)Lio/ktor/client/webrtc/WebRTCMedia$AudioTrackConstraints;
+	public static synthetic fun copy$default (Lio/ktor/client/webrtc/WebRTCMedia$AudioTrackConstraints;Ljava/lang/Double;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Double;Ljava/lang/Integer;ILjava/lang/Object;)Lio/ktor/client/webrtc/WebRTCMedia$AudioTrackConstraints;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAutoGainControl ()Ljava/lang/Boolean;
+	public final fun getChannelCount ()Ljava/lang/Integer;
+	public final fun getEchoCancellation ()Ljava/lang/Boolean;
+	public final fun getLatency ()Ljava/lang/Double;
+	public final fun getNoiseSuppression ()Ljava/lang/Boolean;
+	public final fun getSampleRate ()Ljava/lang/Integer;
+	public final fun getSampleSize ()Ljava/lang/Integer;
+	public final fun getVolume ()Ljava/lang/Double;
+	public fun hashCode ()I
+	public final fun setAutoGainControl (Ljava/lang/Boolean;)V
+	public final fun setChannelCount (Ljava/lang/Integer;)V
+	public final fun setEchoCancellation (Ljava/lang/Boolean;)V
+	public final fun setLatency (Ljava/lang/Double;)V
+	public final fun setNoiseSuppression (Ljava/lang/Boolean;)V
+	public final fun setSampleRate (Ljava/lang/Integer;)V
+	public final fun setSampleSize (Ljava/lang/Integer;)V
+	public final fun setVolume (Ljava/lang/Double;)V
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/ktor/client/webrtc/WebRTCMedia$DeviceException : java/lang/RuntimeException {
+	public fun <init> (Ljava/lang/String;Ljava/lang/Throwable;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/Throwable;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+}
+
+public final class io/ktor/client/webrtc/WebRTCMedia$FacingMode : java/lang/Enum {
+	public static final field ENVIRONMENT Lio/ktor/client/webrtc/WebRTCMedia$FacingMode;
+	public static final field LEFT Lio/ktor/client/webrtc/WebRTCMedia$FacingMode;
+	public static final field RIGHT Lio/ktor/client/webrtc/WebRTCMedia$FacingMode;
+	public static final field USER Lio/ktor/client/webrtc/WebRTCMedia$FacingMode;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lio/ktor/client/webrtc/WebRTCMedia$FacingMode;
+	public static fun values ()[Lio/ktor/client/webrtc/WebRTCMedia$FacingMode;
+}
+
+public final class io/ktor/client/webrtc/WebRTCMedia$PermissionException : java/lang/RuntimeException {
+	public fun <init> (Ljava/lang/String;)V
+}
+
+public final class io/ktor/client/webrtc/WebRTCMedia$ResizeMode : java/lang/Enum {
+	public static final field CROP_AND_SCALE Lio/ktor/client/webrtc/WebRTCMedia$ResizeMode;
+	public static final field NONE Lio/ktor/client/webrtc/WebRTCMedia$ResizeMode;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lio/ktor/client/webrtc/WebRTCMedia$ResizeMode;
+	public static fun values ()[Lio/ktor/client/webrtc/WebRTCMedia$ResizeMode;
+}
+
+public abstract interface class io/ktor/client/webrtc/WebRTCMedia$Track : java/lang/AutoCloseable {
+	public abstract fun enable (Z)V
+	public abstract fun getEnabled ()Z
+	public abstract fun getId ()Ljava/lang/String;
+	public abstract fun getKind ()Lio/ktor/client/webrtc/WebRTCMedia$TrackType;
+	public abstract fun getNative ()Ljava/lang/Object;
+}
+
+public final class io/ktor/client/webrtc/WebRTCMedia$TrackType : java/lang/Enum {
+	public static final field AUDIO Lio/ktor/client/webrtc/WebRTCMedia$TrackType;
+	public static final field VIDEO Lio/ktor/client/webrtc/WebRTCMedia$TrackType;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lio/ktor/client/webrtc/WebRTCMedia$TrackType;
+	public static fun values ()[Lio/ktor/client/webrtc/WebRTCMedia$TrackType;
+}
+
+public abstract interface class io/ktor/client/webrtc/WebRTCMedia$VideoTrack : io/ktor/client/webrtc/WebRTCMedia$Track {
+}
+
+public final class io/ktor/client/webrtc/WebRTCMedia$VideoTrackConstraints {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Double;Lio/ktor/client/webrtc/WebRTCMedia$FacingMode;Lio/ktor/client/webrtc/WebRTCMedia$ResizeMode;)V
+	public synthetic fun <init> (Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Double;Lio/ktor/client/webrtc/WebRTCMedia$FacingMode;Lio/ktor/client/webrtc/WebRTCMedia$ResizeMode;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/Integer;
+	public final fun component2 ()Ljava/lang/Integer;
+	public final fun component3 ()Ljava/lang/Integer;
+	public final fun component4 ()Ljava/lang/Double;
+	public final fun component5 ()Lio/ktor/client/webrtc/WebRTCMedia$FacingMode;
+	public final fun component6 ()Lio/ktor/client/webrtc/WebRTCMedia$ResizeMode;
+	public final fun copy (Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Double;Lio/ktor/client/webrtc/WebRTCMedia$FacingMode;Lio/ktor/client/webrtc/WebRTCMedia$ResizeMode;)Lio/ktor/client/webrtc/WebRTCMedia$VideoTrackConstraints;
+	public static synthetic fun copy$default (Lio/ktor/client/webrtc/WebRTCMedia$VideoTrackConstraints;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Double;Lio/ktor/client/webrtc/WebRTCMedia$FacingMode;Lio/ktor/client/webrtc/WebRTCMedia$ResizeMode;ILjava/lang/Object;)Lio/ktor/client/webrtc/WebRTCMedia$VideoTrackConstraints;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAspectRatio ()Ljava/lang/Double;
+	public final fun getFacingMode ()Lio/ktor/client/webrtc/WebRTCMedia$FacingMode;
+	public final fun getFrameRate ()Ljava/lang/Integer;
+	public final fun getHeight ()Ljava/lang/Integer;
+	public final fun getResizeMode ()Lio/ktor/client/webrtc/WebRTCMedia$ResizeMode;
+	public final fun getWidth ()Ljava/lang/Integer;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract class io/ktor/client/webrtc/WebRtcPeerConnection : java/io/Closeable {
+	public fun <init> (II)V
+	public abstract fun addIceCandidate (Lio/ktor/client/webrtc/WebRTC$IceCandidate;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun addTrack (Lio/ktor/client/webrtc/WebRTCMedia$Track;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun createAnswer (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun createOffer (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getConnectionStateFlow ()Lkotlinx/coroutines/flow/StateFlow;
+	protected final fun getCurrentConnectionState ()Lkotlinx/coroutines/flow/MutableStateFlow;
+	protected final fun getCurrentIceConnectionState ()Lkotlinx/coroutines/flow/MutableStateFlow;
+	protected final fun getCurrentIceGatheringState ()Lkotlinx/coroutines/flow/MutableStateFlow;
+	protected final fun getCurrentSignalingState ()Lkotlinx/coroutines/flow/MutableStateFlow;
+	protected final fun getCurrentStats ()Lkotlinx/coroutines/flow/MutableStateFlow;
+	public final fun getIceCandidateFlow ()Lkotlinx/coroutines/flow/SharedFlow;
+	protected final fun getIceCandidates ()Lkotlinx/coroutines/flow/MutableSharedFlow;
+	public final fun getIceConnectionStateFlow ()Lkotlinx/coroutines/flow/StateFlow;
+	public final fun getIceGatheringStateFlow ()Lkotlinx/coroutines/flow/StateFlow;
+	public abstract fun getLocalDescription ()Lio/ktor/client/webrtc/WebRTC$SessionDescription;
+	public abstract fun getNativeConnection ()Ljava/lang/Object;
+	protected final fun getNegotiationNeededCallback ()Lkotlin/jvm/functions/Function0;
+	public abstract fun getRemoteDescription ()Lio/ktor/client/webrtc/WebRTC$SessionDescription;
+	protected final fun getRemoteTracks ()Lkotlinx/coroutines/flow/MutableSharedFlow;
+	public final fun getRemoteTracksFlow ()Lkotlinx/coroutines/flow/SharedFlow;
+	public final fun getSignalingStateFlow ()Lkotlinx/coroutines/flow/StateFlow;
+	public final fun getStatsFlow ()Lkotlinx/coroutines/flow/StateFlow;
+	public final fun onNegotiationNeeded (Lkotlin/jvm/functions/Function0;)V
+	public abstract fun removeTrack (Lio/ktor/client/webrtc/WebRTC$RtpSender;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun removeTrack (Lio/ktor/client/webrtc/WebRTCMedia$Track;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun restartIce ()V
+	public abstract fun setLocalDescription (Lio/ktor/client/webrtc/WebRTC$SessionDescription;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	protected final fun setNegotiationNeededCallback (Lkotlin/jvm/functions/Function0;)V
+	public abstract fun setRemoteDescription (Lio/ktor/client/webrtc/WebRTC$SessionDescription;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+

--- a/ktor-client/ktor-client-webrtc/build.gradle.kts
+++ b/ktor-client/ktor-client-webrtc/build.gradle.kts
@@ -8,6 +8,7 @@ import org.jetbrains.kotlin.gradle.ExperimentalWasmDsl
 description = "Ktor WebRTC client"
 
 plugins {
+    id("com.android.kotlin.multiplatform.library")
     id("kotlinx-serialization")
     id("ktorbuild.project.library")
 }
@@ -15,8 +16,17 @@ plugins {
 kotlin {
     jvmToolchain(17)
 
+    androidLibrary {
+        namespace = "io.ktor.client.webrtc"
+        compileSdk = 35
+        minSdk = 28
+    }
+
     sourceSets {
         commonMain.dependencies {
+            // using `atomicfu` as a library, but not a plugin
+            // because its plugin is not compatible with Android KMP plugin
+            implementation(libs.kotlinx.atomicfu)
             api(project(":ktor-io"))
             api(project(":ktor-utils"))
         }
@@ -30,6 +40,10 @@ kotlin {
             compilerOptions {
                 freeCompilerArgs.add("-Xwasm-attach-js-exception")
             }
+        }
+
+        androidMain.dependencies {
+            implementation(libs.stream.webrtc.android)
         }
     }
 }

--- a/ktor-client/ktor-client-webrtc/common/src/io/ktor/client/webrtc/WebRTCMedia.kt
+++ b/ktor-client/ktor-client-webrtc/common/src/io/ktor/client/webrtc/WebRTCMedia.kt
@@ -20,7 +20,7 @@ public object WebRTCMedia {
      * @property frameRate The frame rate of the video.
      * @property aspectRatio The aspect ratio of the video.
      * @property facingMode The camera-facing mode.
-     * @property resizeMode The resize mode for the video.
+     * @property resizeMode The resize mode for the video. Not supported for Android.
      *
      * @see <a href="https://developer.mozilla.org/en-US/docs/Web/API/MediaTrackConstraints">MDN MediaTrackConstraints</a>
      */
@@ -38,12 +38,12 @@ public object WebRTCMedia {
      *
      * @property volume The volume of the audio.
      * @property sampleRate The sample rate of the audio in Hz.
-     * @property sampleSize The sample size of the audio in bits.
+     * @property sampleSize The sample size of the audio in bits. Not supported for Android.
      * @property echoCancellation Whether echo cancellation is enabled.
      * @property autoGainControl Whether automatic gain control is enabled.
      * @property noiseSuppression Whether noise suppression is enabled.
-     * @property latency The latency of the audio in seconds.
-     * @property channelCount The number of audio channels.
+     * @property latency The latency of the audio in seconds. Not supported for Android.
+     * @property channelCount The number of audio channels. Not supported for Android.
      *
      * @see <a href="https://developer.mozilla.org/en-US/docs/Web/API/MediaTrackConstraints">MDN MediaTrackConstraints</a>
      */

--- a/ktor-client/ktor-client-webrtc/gradle.properties
+++ b/ktor-client/ktor-client-webrtc/gradle.properties
@@ -5,3 +5,4 @@ target.js.nodeJs=false
 target.wasmJs.nodeJs=false
 target.jvm=false
 target.posix=false
+target.android.unitTest=false

--- a/ktor-client/ktor-client-webrtc/src/androidMain/AndroidManifest.xml
+++ b/ktor-client/ktor-client-webrtc/src/androidMain/AndroidManifest.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright 2014-2025 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+  -->
+<!--
+  This file is located here because the Android KMP Gradle plugin does not support custom manifest location
+  -->
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <uses-permission android:name="android.permission.CAMERA" />
+    <uses-permission android:name="android.permission.RECORD_AUDIO" />
+    <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+
+    <uses-feature android:name="android.hardware.camera" />
+</manifest>

--- a/ktor-test-server/settings.gradle.kts
+++ b/ktor-test-server/settings.gradle.kts
@@ -5,6 +5,7 @@
 pluginManagement {
     // Add repositories required for build-settings-logic
     repositories {
+        google()
         gradlePluginPortal()
 
         // Should be in sync with ktorsettings.kotlin-user-project

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -8,6 +8,7 @@ enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")
 pluginManagement {
     // Add repositories required for build-settings-logic
     repositories {
+        google()
         gradlePluginPortal()
 
         // Should be in sync with ktorsettings.kotlin-user-project


### PR DESCRIPTION
**Subsystem**
Client

**Motivation**
[KTOR-7958](https://youtrack.jetbrains.com/issue/KTOR-7958) WebRTC Client.

**Solution**
The solution implements Android WebRTC Engine. It is based on [webrtc-android](https://github.com/GetStream/webrtc-android), which depends on Android API (like Camera, Audio), so Android Native target couldn't be used. Instead, the [Android-KMP plugin](https://developer.android.com/kotlin/multiplatform/plugin#features) was added and configured. The Android team recommends using this one instead of the [old Gradle plugin](https://developer.android.com/build/releases/gradle-plugin) for KMP projects. The Android JVM target is not added until the Android-KMP plugin is applied.

Tests are running on the device (Android emulator) because even if we mock all Android API, org.webrtc uses a native library which is only compiled for Android devices.

