### PR TITLE
Implement Jetty 12 upgrade API

### DIFF
--- a/ktor-server/ktor-server-jetty-jakarta/jvm/src/io/ktor/server/jetty/jakarta/internal/JettyUpgradeImpl.kt
+++ b/ktor-server/ktor-server-jetty-jakarta/jvm/src/io/ktor/server/jetty/jakarta/internal/JettyUpgradeImpl.kt
@@ -1,0 +1,41 @@
+package io.ktor.server.jetty.jakarta.internal
+
+import io.ktor.http.content.OutgoingContent
+import io.ktor.server.jetty.jakarta.JettyWebsocketConnection
+import io.ktor.server.jetty.jakarta.bufferPool
+import io.ktor.server.servlet.jakarta.ServletUpgrade
+import io.ktor.util.*
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import kotlinx.coroutines.CoroutineName
+import kotlinx.coroutines.withContext
+import org.eclipse.jetty.io.Connection
+import org.eclipse.jetty.server.HttpConnection
+import java.util.concurrent.Executor
+import kotlin.coroutines.CoroutineContext
+
+@InternalAPI
+public object JettyUpgradeImpl : ServletUpgrade {
+    private val sameThreadExecutor = Executor { it.run() }
+
+    override suspend fun performUpgrade(
+        upgrade: OutgoingContent.ProtocolUpgrade,
+        servletRequest: HttpServletRequest,
+        servletResponse: HttpServletResponse,
+        engineContext: CoroutineContext,
+        userContext: CoroutineContext
+    ) {
+        val connection = servletRequest.getAttribute(HttpConnection::class.qualifiedName) as Connection
+        val endPoint = connection.endPoint
+
+        withContext(engineContext + CoroutineName("jetty-upgrade")) {
+            val wsConnection = JettyWebsocketConnection(
+                endPoint,
+                bufferPool,
+                coroutineContext,
+                sameThreadExecutor
+            )
+            upgrade.upgradeAndAwait(wsConnection, userContext)
+        }
+    }
+}

--- a/ktor-server/ktor-server-jetty-jakarta/jvm/test/io/ktor/tests/server/jetty/jakarta/JettyAsyncServletContainerTest.kt
+++ b/ktor-server/ktor-server-jetty-jakarta/jvm/test/io/ktor/tests/server/jetty/jakarta/JettyAsyncServletContainerTest.kt
@@ -35,8 +35,9 @@ class JettyAsyncServletContainerHttpServerJvmTest :
     override fun testPipeliningWithFlushingHeaders() {
     }
 
-    @Ignore
+
     override fun testUpgrade() {
+        super.testUpgrade()
     }
 }
 

--- a/ktor-server/ktor-server-jetty-jakarta/jvm/test/io/ktor/tests/server/jetty/jakarta/JettyBlockingServletContainerTest.kt
+++ b/ktor-server/ktor-server-jetty-jakarta/jvm/test/io/ktor/tests/server/jetty/jakarta/JettyBlockingServletContainerTest.kt
@@ -28,8 +28,9 @@ class JettyBlockingServletContainerHttpServerJvmTest :
         Servlet(async = false)
     ) {
 
-    @Ignore
+
     override fun testUpgrade() {
+        super.testUpgrade()
     }
 
     @Ignore

--- a/ktor-server/ktor-server-jetty-jakarta/ktor-server-jetty-test-http2-jakarta/jvm/test/io/ktor/tests/server/jetty/http2/jakarta/JettyHttp2ServletAsyncTest.kt
+++ b/ktor-server/ktor-server-jetty-jakarta/ktor-server-jetty-test-http2-jakarta/jvm/test/io/ktor/tests/server/jetty/http2/jakarta/JettyHttp2ServletAsyncTest.kt
@@ -35,8 +35,9 @@ class JettyHttp2AsyncServletContainerHttpServerJvmTest :
     override fun testPipeliningWithFlushingHeaders() {
     }
 
-    @Ignore
+
     override fun testUpgrade() {
+        super.testUpgrade()
     }
 }
 

--- a/ktor-server/ktor-server-jetty-jakarta/ktor-server-jetty-test-http2-jakarta/jvm/test/io/ktor/tests/server/jetty/http2/jakarta/JettyHttp2ServletBlockingTest.kt
+++ b/ktor-server/ktor-server-jetty-jakarta/ktor-server-jetty-test-http2-jakarta/jvm/test/io/ktor/tests/server/jetty/http2/jakarta/JettyHttp2ServletBlockingTest.kt
@@ -28,8 +28,9 @@ class JettyHttp2BlockingServletContainerHttpServerJvmTest :
         Servlet(async = false)
     ) {
 
-    @Ignore
+
     override fun testUpgrade() {
+        super.testUpgrade()
     }
 
     @Ignore


### PR DESCRIPTION
## Summary
- implement Jetty 12 upgrade logic for servlet engine
- reenable upgrade tests for Jetty servlet containers

## Testing
- `./gradlew projects` *(fails: Could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_b_684296e94e1483259c1ec740e9b95ad3