### PR TITLE
KTOR-8565 Fix for merged config properties

### DIFF
--- a/ktor-server/ktor-server-config-yaml/jvmAndPosix/test/YamlConfigTest.kt
+++ b/ktor-server/ktor-server-config-yaml/jvmAndPosix/test/YamlConfigTest.kt
@@ -338,7 +338,15 @@ class YamlConfigTest {
 
         val expectedSecurity = SecurityConfig("SHA-256", "SALT&PEPPA", listOf(SecurityUser("test", "asd")))
         val expectedDeployment = DeploymentConfig("localhost", 8080)
-        val expectedDatabase = DatabaseConfig("org.postgresql.Driver", "jdbc:postgresql://localhost:5432/ktor", "ktor", "ktor", "public", 2)
+        val expectedDatabase =
+            DatabaseConfig(
+                "org.postgresql.Driver",
+                "jdbc:postgresql://localhost:5432/ktor",
+                "ktor",
+                "ktor",
+                "public",
+                2
+            )
 
         assertEquals(
             expectedSecurity,

--- a/ktor-server/ktor-server-core/common/src/io/ktor/server/config/MapConfigDecoder.kt
+++ b/ktor-server/ktor-server-core/common/src/io/ktor/server/config/MapConfigDecoder.kt
@@ -142,7 +142,7 @@ private fun Map<String, String>.listSize(path: String): Int =
 
 internal fun Map<String, String>.containsPrefix(prefix: String): Boolean =
     prefix.isEmpty() ||
-    containsKey(prefix) ||
+        containsKey(prefix) ||
         containsKey("$prefix.size") ||
         keys.any {
             it.startsWith(prefix) &&

--- a/ktor-server/ktor-server-core/common/src/io/ktor/server/config/MergedApplicationConfig.kt
+++ b/ktor-server/ktor-server-core/common/src/io/ktor/server/config/MergedApplicationConfig.kt
@@ -4,6 +4,7 @@
 
 package io.ktor.server.config
 
+import io.ktor.server.config.ApplicationConfigValue.Type.*
 import io.ktor.server.config.MapApplicationConfig.Companion.flatten
 
 /**
@@ -30,9 +31,12 @@ public fun List<ApplicationConfig>.merge(): ApplicationConfig {
  *
  * @see [withFallback]
  */
-public fun ApplicationConfig.mergeWith(other: ApplicationConfig): ApplicationConfig {
-    return MergedApplicationConfig(other, this)
-}
+public fun ApplicationConfig.mergeWith(other: ApplicationConfig): ApplicationConfig =
+    when {
+        keys().isEmpty() -> other
+        other.keys().isEmpty() -> this
+        else -> MergedApplicationConfig(other, this)
+    }
 
 /**
  * Merge configuration combining all their keys.
@@ -105,12 +109,14 @@ internal class MergedApplicationConfig(
     private fun merge(
         first: ApplicationConfigValue?,
         second: ApplicationConfigValue?,
-    ): ApplicationConfigValue? = when {
-        first == null -> second
-        second == null -> first
-        first.type != ApplicationConfigValue.Type.OBJECT ||
-            second.type != ApplicationConfigValue.Type.OBJECT -> first
-        else -> mergeMapConfigValues(first, second)
+    ): ApplicationConfigValue? {
+        val value = when {
+            first == null -> second
+            second == null -> first
+            first.type != OBJECT || second.type != OBJECT -> first
+            else -> mergeMapConfigValues(first, second)
+        }
+        return value
     }
 
     /**


### PR DESCRIPTION
**Subsystem**
Server, Config

**Motivation**
[KTOR-8565](https://youtrack.jetbrains.com/issue/KTOR-8565) Incorrect loading of ApplicationConfig

**Solution**
There was a missing clause that caused the merged property to be interpreted wrong when merging a second time, so merging more than once would cause this problem.

