### PR TITLE
Fix DI async flaky test

### DIFF
--- a/ktor-server/ktor-server-plugins/ktor-server-di/common/test/io/ktor/server/plugins/di/DependencyInjectionTest.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-di/common/test/io/ktor/server/plugins/di/DependencyInjectionTest.kt
@@ -310,7 +310,7 @@ class DependencyInjectionTest {
     fun `async support`() = testApplication(Dispatchers.Unconfined) {
         val greeter = GreetingServiceImpl()
         val bank = BankServiceImpl()
-        val resolutionChannel = Channel<String>(3)
+        val resolutionChannel = Channel<String>(Channel.UNLIMITED)
 
         application {
             dependencies {


### PR DESCRIPTION
Because `dependency.resolve()` is called within the endpoint handlers, it's possible that the instantiation is invoked twice for the greeting service because there's no internal mutex for instantiation.