### PR TITLE
KTOR-8606 Fix "Flow invariant is violated" in 3.2.0

### DIFF
--- a/ktor-server/ktor-server-core/jvm/src/io/ktor/server/application/ApplicationEnvironment.kt
+++ b/ktor-server/ktor-server-core/jvm/src/io/ktor/server/application/ApplicationEnvironment.kt
@@ -7,7 +7,9 @@ package io.ktor.server.application
 import io.ktor.events.*
 import io.ktor.server.config.*
 import io.ktor.util.logging.*
-import kotlin.coroutines.*
+import kotlin.coroutines.Continuation
+import kotlin.coroutines.ContinuationInterceptor
+import kotlin.coroutines.CoroutineContext
 
 /**
  * Represents an environment in which [Application] runs
@@ -65,8 +67,7 @@ internal actual class ApplicationRootConfigBridge actual constructor(
 }
 
 private object ClassLoaderAwareContinuationInterceptor : ContinuationInterceptor {
-    override val key: CoroutineContext.Key<*> =
-        object : CoroutineContext.Key<ClassLoaderAwareContinuationInterceptor> {}
+    override val key: CoroutineContext.Key<*> = ContinuationInterceptor.Key
 
     override fun <T> interceptContinuation(continuation: Continuation<T>): Continuation<T> {
         val classLoader = Thread.currentThread().contextClassLoader


### PR DESCRIPTION
**Subsystem**
Client

**Motivation**
[KTOR-8606](https://youtrack.jetbrains.com/issue/KTOR-8606) Regression in 3.2.0: Flow invariant is violated

**Solution**
`ClassLoaderAwareContinuationInterceptor` exposes `CoroutineContext.Key<ClassLoaderAwareContinuationInterceptor>` (a key for a specific type as well as the general one), but registers itself as a `ContinuationInterceptor`.
Changed the key to `ContinuationInterceptor.Key`.