### PR TITLE
KTOR-8602 Fix handling of optional module parameters

### DIFF
--- a/ktor-server/ktor-server-core/jvm/src/io/ktor/server/engine/internal/CallableUtils.kt
+++ b/ktor-server/ktor-server-core/jvm/src/io/ktor/server/engine/internal/CallableUtils.kt
@@ -33,9 +33,9 @@ internal suspend fun executeModuleFunction(
         ?: throw ReloadingException("Module function cannot be found for the fully qualified name '$fqName'")
 
     val staticFunctions = clazz.methods
-        .filter { it.name == functionName && Modifier.isStatic(it.modifiers) }
+        .filter { Modifier.isStatic(it.modifiers) }
         .mapNotNull { it.kotlinFunction }
-        .filter { it.isApplicableFunction() }
+        .filter { it.name == functionName && it.isApplicableFunction() }
 
     staticFunctions.bestFunction()?.let { moduleFunction ->
         if (moduleFunction.parameters.none { it.kind == KParameter.Kind.INSTANCE }) {

--- a/ktor-server/ktor-server-core/jvm/test/io/ktor/tests/hosts/EmbeddedServerReloadingTests.kt
+++ b/ktor-server/ktor-server-core/jvm/test/io/ktor/tests/hosts/EmbeddedServerReloadingTests.kt
@@ -398,6 +398,7 @@ class EmbeddedServerReloadingTests {
                         "ktor.application.modules" to listOf(
                             Application::defaultArgBoolean.fqName,
                             Application::defaultArgContainingApplicationWord.fqName,
+                            Application::defaultArgInline.fqName,
                         )
                     )
                 )
@@ -415,6 +416,7 @@ class EmbeddedServerReloadingTests {
             setOf(
                 "defaultArgBoolean",
                 "defaultArgContainingApplicationWord",
+                "defaultArgInline",
             ),
             application.loadedModules,
         )
@@ -678,6 +680,13 @@ fun Application.defaultArgBoolean(testing: Boolean = false) {
 
 fun Application.defaultArgContainingApplicationWord(configure: Application.() -> Unit = {}) {
     addLoadedModule("defaultArgContainingApplicationWord")
+}
+
+@JvmInline
+value class InstanceId(val value: String)
+
+fun Application.defaultArgInline(id: InstanceId = InstanceId("default")) {
+    addLoadedModule("defaultArgInline")
 }
 
 @JvmOverloads


### PR DESCRIPTION
**Subsystem**
Server

**Motivation**
[KTOR-8602](https://youtrack.jetbrains.com/issue/KTOR-8602) Module parameter type Application.() -> kotlin.Unit is not supported in 3.2.0
[KTOR-8608](https://youtrack.jetbrains.com/issue/KTOR-8608) Ktor fails to boot with default jvminline argument

**Solution**
- Fix order of parameter checks. Move checks throwing an exception to the end.
- Check name of Kotlin function instead of Java function to handle mangled names properly

