### PR TITLE
KTOR-8622 ForwardedHeaders: Parse parameters case insensitively

### DIFF
--- a/ktor-server/ktor-server-plugins/ktor-server-forwarded-header/common/src/io/ktor/server/plugins/forwardedheaders/ForwardedHeaders.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-forwarded-header/common/src/io/ktor/server/plugins/forwardedheaders/ForwardedHeaders.kt
@@ -178,7 +178,7 @@ public val ForwardedHeaders: ApplicationPlugin<ForwardedHeadersConfig> = createA
     ::ForwardedHeadersConfig
 ) {
     fun parseForwardedValue(value: HeaderValue): ForwardedHeaderValue {
-        val map = value.params.associateByTo(HashMap(), { it.name }, { it.value })
+        val map = value.params.associateByTo(HashMap(), { it.name.lowercase() }, { it.value })
 
         return ForwardedHeaderValue(
             map.remove("host"),


### PR DESCRIPTION
**Subsystem**
Server `ForwardedHeaders` plugin

**Motivation**
https://youtrack.jetbrains.com/issue/KTOR-8622

Ensures compliance with [RFC 7239](https://datatracker.ietf.org/doc/html/rfc7239):
> The first element in this list holds information added by the first proxy that implements and uses this header field, and each subsequent element holds information added by each subsequent proxy.  Because this header field is optional, any proxy in the chain may choose not to update this header field.  Each field-value is a semicolon-separated list; this sublist consists of parameter-identifier pairs. Parameter-identifier pairs are grouped together by an equals sign. Each parameter MUST NOT occur more than once per field-value.  **The parameter names are case-insensitive.**

emphasis my own.

**Solution**
just `.lowercase()` the parameter names before they're added to the map.
