### PR TITLE
KTOR-8559 Thymeleaf: Allow null values in template model

### DIFF
--- a/ktor-server/ktor-server-plugins/ktor-server-thymeleaf/jvm/src/io/ktor/server/thymeleaf/RespondTemplate.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-thymeleaf/jvm/src/io/ktor/server/thymeleaf/RespondTemplate.kt
@@ -16,7 +16,7 @@ import java.util.*
  */
 public suspend fun ApplicationCall.respondTemplate(
     template: String,
-    model: Map<String, Any> = emptyMap(),
+    model: Map<String, Any?> = emptyMap(),
     etag: String? = null,
     contentType: ContentType = ContentType.Text.Html.withCharset(Charsets.UTF_8),
     locale: Locale = Locale.getDefault(),

--- a/ktor-server/ktor-server-plugins/ktor-server-thymeleaf/jvm/src/io/ktor/server/thymeleaf/Thymeleaf.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-thymeleaf/jvm/src/io/ktor/server/thymeleaf/Thymeleaf.kt
@@ -9,8 +9,8 @@ import io.ktor.http.content.*
 import io.ktor.server.application.*
 import io.ktor.server.application.hooks.*
 import io.ktor.utils.io.*
-import org.thymeleaf.*
-import org.thymeleaf.context.*
+import org.thymeleaf.TemplateEngine
+import org.thymeleaf.context.Context
 import java.util.*
 
 /**
@@ -28,7 +28,7 @@ import java.util.*
  */
 public class ThymeleafContent(
     public val template: String,
-    public val model: Map<String, Any>,
+    public val model: Map<String, Any?>,
     public val etag: String? = null,
     public val contentType: ContentType = ContentType.Text.Html.withCharset(Charsets.UTF_8),
     public val locale: Locale = Locale.getDefault(),

--- a/ktor-server/ktor-server-plugins/ktor-server-thymeleaf/jvm/src/io/ktor/server/thymeleaf/Thymeleaf.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-thymeleaf/jvm/src/io/ktor/server/thymeleaf/Thymeleaf.kt
@@ -9,8 +9,8 @@ import io.ktor.http.content.*
 import io.ktor.server.application.*
 import io.ktor.server.application.hooks.*
 import io.ktor.utils.io.*
-import org.thymeleaf.TemplateEngine
-import org.thymeleaf.context.Context
+import org.thymeleaf.*
+import org.thymeleaf.context.*
 import java.util.*
 
 /**

--- a/ktor-server/ktor-server-plugins/ktor-server-thymeleaf/jvm/test/io/ktor/server/thymeleaf/ThymeleafTest.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-thymeleaf/jvm/test/io/ktor/server/thymeleaf/ThymeleafTest.kt
@@ -270,6 +270,30 @@ class ThymeleafTest {
         assertEquals("<div><p>Hello, first fragment</p></div>", response.bodyAsText())
     }
 
+    @Test
+    fun testNullValueInModel() = testApplication {
+        application {
+            setUpThymeleafStringTemplate()
+            install(ConditionalHeaders)
+
+            routing {
+                val model = mapOf("id" to 1, "title" to null)
+
+                get("/") {
+                    call.respondTemplate(STRING_TEMPLATE, model)
+                }
+            }
+        }
+
+        val response = client.get("/")
+        assertEquals(ContentType.Text.Html.withCharset(Charsets.UTF_8), response.contentType())
+
+        val content = response.bodyAsText().lines()
+        assertEquals(2, content.size)
+        assertEquals("<p>Hello, 1</p>", content[0])
+        assertEquals("<h1></h1>", content[1])
+    }
+
     private fun Application.setUpThymeleafStringTemplate() {
         install(Thymeleaf) {
             setTemplateResolver(StringTemplateResolver())


### PR DESCRIPTION
**Subsystem**
Server `Thymeleaf` plugin.

**Motivation**
https://youtrack.jetbrains.com/issue/KTOR-8559

Allows `null`/nullable values to be passed to the model used for thymeleaf.

imo this is a bugfix as it does not involve any breaking api changes & is just matching features with what thymeleaf already supports (ie. if you do an unchecked cast to `Map<String, Any>` and pass a null value, everything will work just fine), however the issue in youtrack was marked as "Feature" rather than "Bug", so I named my branch following that.

**Solution**
`Any` -> `Any?`

