### PR TITLE
[KTOR-8627] Reorder SSE fields for streaming deserialization

### DIFF
--- a/ktor-server/ktor-server-plugins/ktor-server-sse/common/test/io/ktor/server/sse/ServerSentEventsTest.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-sse/common/test/io/ktor/server/sse/ServerSentEventsTest.kt
@@ -38,8 +38,8 @@ class ServerSentEventsTest {
 
         val client = createSseClient()
         val expected = """
-            data: world
             event: send
+            data: world
             id: 100
             retry: 1000
             : comment

--- a/ktor-shared/ktor-sse/common/src/io/ktor/sse/ServerSentEvent.kt
+++ b/ktor-shared/ktor-sse/common/src/io/ktor/sse/ServerSentEvent.kt
@@ -80,7 +80,8 @@ public data class TypedServerSentEvent<T>(
 }
 
 /**
- * Serialize event to string representation according to the [spec](https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events/Using_server-sent_events#event_stream_format)
+ * Serialize [event](https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events/Using_server-sent_events#event_stream_format)
+ * to a string representation
  */
 private fun eventToString(data: String?, event: String?, id: String?, retry: Long?, comments: String?): String {
     return buildString {

--- a/ktor-shared/ktor-sse/common/src/io/ktor/sse/ServerSentEvent.kt
+++ b/ktor-shared/ktor-sse/common/src/io/ktor/sse/ServerSentEvent.kt
@@ -79,10 +79,13 @@ public data class TypedServerSentEvent<T>(
         eventToString(data?.let { serializer(it) }, event, id, retry, comments)
 }
 
+/**
+ * Serialize event to string representation according to the [spec](https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events/Using_server-sent_events#event_stream_format)
+ */
 private fun eventToString(data: String?, event: String?, id: String?, retry: Long?, comments: String?): String {
     return buildString {
-        appendField("data", data)
         appendField("event", event)
+        appendField("data", data)
         appendField("id", id)
         appendField("retry", retry)
         appendField("", comments)


### PR DESCRIPTION
Ticket: [KTOR-8627](https://youtrack.jetbrains.com/issue/KTOR-8627) Change the order of SSE field serialization: put `event` before `data`

**Subsystem**
SSE: ktor-shared/ktor-sse

**Motivation**

Currently, the `data` field comes before the `event` field in the SSE payload. If the streaming parser used the `event` field as a discriminator to determine the deserializer, it must buffer the `data`. Moving `event` before `data` would allow streaming SSE parsers to avoid buffering SSE's `data` field and choosing the right deserializer before reading the data field. In the [reference](https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events/Using_server-sent_events#event_stream_format) `event` field also comes before the `data`.

**Solution**

Change the order of field serialization to put `event` before `data`. This allows using `event` as a discriminator for streaming parsers.


