### PR TITLE
KTOR-8635 Use kotlin.time.Clock instead of kotlinx.datetime.Clock

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,6 @@
 
 kotlin = "2.1.21"
 kotlinx-html = "0.12.0"
-kotlinx-datetime = "0.6.2"
 kotlinx-io = "0.7.0"
 coroutines = "1.10.2"
 atomicfu = "0.27.0"
@@ -124,8 +123,6 @@ kotlinx-serialization-cbor = { module = "org.jetbrains.kotlinx:kotlinx-serializa
 kotlinx-serialization-protobuf = { module = "org.jetbrains.kotlinx:kotlinx-serialization-protobuf", version.ref = "serialization" }
 
 kotlinx-html = { module = "org.jetbrains.kotlinx:kotlinx-html", version.ref = "kotlinx-html" }
-
-kotlinx-datetime = { module = "org.jetbrains.kotlinx:kotlinx-datetime", version.ref = "kotlinx-datetime" }
 
 kotlinx-io-core = { module = "org.jetbrains.kotlinx:kotlinx-io-core", version.ref = "kotlinx-io" }
 

--- a/kotlin-js-store/yarn.lock
+++ b/kotlin-js-store/yarn.lock
@@ -66,11 +66,6 @@
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
 
-"@js-joda/core@3.2.0":
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/@js-joda/core/-/core-3.2.0.tgz#3e61e21b7b2b8a6be746df1335cf91d70db2a273"
-  integrity sha512-PMqgJ0sw5B7FKb2d5bWYIoxjri+QlW/Pys7+Rw82jSH0QN3rB05jZ/VrrsUdh1w4+i2kw9JOejXGq/KhDOX7Kg==
-
 "@puppeteer/browsers@1.8.0":
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/@puppeteer/browsers/-/browsers-1.8.0.tgz#fb6ee61de15e7f0e67737aea9f9bab1512dbd7d8"

--- a/ktor-server/ktor-server-plugins/ktor-server-default-headers/build.gradle.kts
+++ b/ktor-server/ktor-server-plugins/ktor-server-default-headers/build.gradle.kts
@@ -2,6 +2,7 @@
  * Copyright 2014-2025 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
+import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
 import java.time.Year
 
 description = ""
@@ -11,10 +12,10 @@ plugins {
 }
 
 kotlin {
-    sourceSets {
-        commonMain.dependencies {
-            api(libs.kotlinx.datetime)
-        }
+    compilerOptions {
+        // For now set API version 2.1 only for this module
+        // TODO KTOR-8637: Update API level for the whole project
+        apiVersion = KotlinVersion.KOTLIN_2_1
     }
 }
 

--- a/ktor-server/ktor-server-plugins/ktor-server-default-headers/common/src/io/ktor/server/plugins/defaultheaders/DefaultHeaders.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-default-headers/common/src/io/ktor/server/plugins/defaultheaders/DefaultHeaders.kt
@@ -6,11 +6,11 @@ package io.ktor.server.plugins.defaultheaders
 
 import io.ktor.http.*
 import io.ktor.server.application.*
-import io.ktor.server.plugins.defaultheaders.DefaultHeadersConfig.*
 import io.ktor.server.response.*
 import io.ktor.util.date.*
 import io.ktor.utils.io.*
 import kotlinx.atomicfu.atomic
+import kotlin.time.ExperimentalTime
 
 /**
  * A configuration for the [DefaultHeaders] plugin.
@@ -37,7 +37,8 @@ public class DefaultHeadersConfig {
      *
      * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.server.plugins.defaultheaders.DefaultHeadersConfig.clock)
      */
-    public var clock: Clock = Clock { kotlinx.datetime.Clock.System.now().toEpochMilliseconds() }
+    @OptIn(ExperimentalTime::class)
+    public var clock: Clock = Clock { kotlin.time.Clock.System.now().toEpochMilliseconds() }
 
     /**
      * Utility interface for obtaining timestamp.


### PR DESCRIPTION
**Subsystem**
Server, ktor-server-default-headers

**Motivation**
[KTOR-8635](https://youtrack.jetbrains.com/issue/KTOR-8635/Replace-kotlinx.datetime-APIs-with-kotlin.time) Replace kotlinx.datetime APIs with kotlin.time

**Solution**
Bump API version for the `ktor-server-default-headers` module and drop usage of the kotlinx-datetime.

Fixes #4969