### PR TITLE
Fix KTOR-8232 StatusPages: OutgoingContent headers aren't available in the status handlers

### DIFF
--- a/ktor-server/ktor-server-plugins/ktor-server-status-pages/build.gradle.kts
+++ b/ktor-server/ktor-server-plugins/ktor-server-status-pages/build.gradle.kts
@@ -12,6 +12,7 @@ kotlin {
     sourceSets {
         commonTest.dependencies {
             implementation(projects.ktorServerCallId)
+            implementation(projects.ktorServerAuth)
         }
     }
 }

--- a/ktor-server/ktor-server-plugins/ktor-server-status-pages/common/src/io/ktor/server/plugins/statuspages/StatusPages.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-status-pages/common/src/io/ktor/server/plugins/statuspages/StatusPages.kt
@@ -68,6 +68,12 @@ public val StatusPages: ApplicationPlugin<StatusPagesConfig> = createApplication
             return@on
         }
 
+        content.headers.entries().forEach { (key, values) ->
+            values.forEach { value ->
+                call.response.headers.append(key, value)
+            }
+        }
+
         call.attributes.put(statusPageMarker, Unit)
         try {
             LOGGER.trace("Executing $handler for status code $status for call: ${call.request.uri}")


### PR DESCRIPTION
**Subsystem**
Server, StatusPages plugin

**Motivation**
[KTOR-8232](https://youtrack.jetbrains.com/issue/KTOR-8232) 

**Solution**
Append OutgoingContent headers in the `ResponseBodyReadyForSend` hook 

