### PR TITLE
Do not generate dokka for snapshots and EAPs

### DIFF
--- a/build-logic/src/main/kotlin/ktorbuild.dokka.gradle.kts
+++ b/build-logic/src/main/kotlin/ktorbuild.dokka.gradle.kts
@@ -28,6 +28,11 @@ dokka {
 }
 
 tasks.withType<DokkaGeneratePublicationTask>().configureEach {
+    // Generate Dokka only for stable releases 'X.Y.Z' to save time when building snapshots, EAPs, etc.
+    // Comment these lines if you want to test Dokka generation locally
+    val projectVersion = project.version.toString()
+    onlyIf { isStableVersion(projectVersion) }
+
     // Reduce memory consumption on CI
     if (ktorBuild.isCI.get()) {
         withLimitedParallelism("dokka", maxParallelTasks = 2)

--- a/build-logic/src/main/kotlin/ktorbuild/internal/Version.kt
+++ b/build-logic/src/main/kotlin/ktorbuild/internal/Version.kt
@@ -24,3 +24,8 @@ internal fun Project.resolveVersion(): String {
         else -> projectVersion
     }
 }
+
+private val stableVersionRegex = Regex("""^\d+\.\d+\.\d+$""")
+
+/** Checks whether the given [version] stable or not. */
+internal fun isStableVersion(version: String) = version matches stableVersionRegex


### PR DESCRIPTION
**Motivation**
Save some time when publishing snapshots and EAPs.

**Solution**
Enable dokka generation only if the version is stable (matches the regex `\d+\.\d+\.\d+`).
