### PR TITLE
KTOR-8674 Fix ShutdownUrl plugin

### DIFF
--- a/ktor-server/ktor-server-core/api/ktor-server-core.api
+++ b/ktor-server/ktor-server-core/api/ktor-server-core.api
@@ -751,8 +751,10 @@ public final class io/ktor/server/engine/ShutDownUrl$Companion {
 
 public final class io/ktor/server/engine/ShutDownUrl$Config {
 	public fun <init> ()V
+	public final fun getExit ()Lkotlin/jvm/functions/Function1;
 	public final fun getExitCodeSupplier ()Lkotlin/jvm/functions/Function1;
 	public final fun getShutDownUrl ()Ljava/lang/String;
+	public final fun setExit (Lkotlin/jvm/functions/Function1;)V
 	public final fun setExitCodeSupplier (Lkotlin/jvm/functions/Function1;)V
 	public final fun setShutDownUrl (Ljava/lang/String;)V
 }

--- a/ktor-server/ktor-server-core/api/ktor-server-core.api
+++ b/ktor-server/ktor-server-core/api/ktor-server-core.api
@@ -737,8 +737,10 @@ public abstract interface class io/ktor/server/engine/EngineSSLConnectorConfig :
 
 public final class io/ktor/server/engine/ShutDownUrl {
 	public static final field Companion Lio/ktor/server/engine/ShutDownUrl$Companion;
-	public fun <init> (Ljava/lang/String;Lkotlin/jvm/functions/Function1;)V
+	public fun <init> (Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)V
+	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun doShutdown (Lio/ktor/server/application/ApplicationCall;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getExit ()Lkotlin/jvm/functions/Function1;
 	public final fun getExitCode ()Lkotlin/jvm/functions/Function1;
 	public final fun getUrl ()Ljava/lang/String;
 }

--- a/ktor-server/ktor-server-core/jvm/src/io/ktor/server/engine/ShutDownUrl.kt
+++ b/ktor-server/ktor-server-core/jvm/src/io/ktor/server/engine/ShutDownUrl.kt
@@ -24,8 +24,13 @@ import kotlin.system.*
  *
  * @property url to handle
  * @property exitCode is a function to compute a process exit code
+ * @property exit the function for exiting the process; defaults to the system function [exitProcess]
  */
-public class ShutDownUrl(public val url: String, public val exitCode: ApplicationCall.() -> Int) {
+public class ShutDownUrl(
+    public val url: String,
+    public val exitCode: ApplicationCall.() -> Int,
+    public val exit: (Int) -> Unit = ::exitProcess
+) {
     /**
      * Shuts down an application using the specified [call].
      *
@@ -33,19 +38,27 @@ public class ShutDownUrl(public val url: String, public val exitCode: Applicatio
      */
     @OptIn(InternalAPI::class)
     public suspend fun doShutdown(call: ApplicationCall) {
-        call.application.log.warn("Shutdown URL was called: server is going down")
         val application = call.application
+        val log = application.log
         val environment = application.environment
-        val exitCode = exitCode(call)
+        log.warn("Shutdown URL was called: server is going down")
 
         val latch = CompletableDeferred<Nothing>()
-        call.application.launch {
-            latch.join()
 
-            application.monitor.raise(ApplicationStopPreparing, environment)
-            application.disposeAndJoin()
+        // Launch in an independent scope,
+        // so it may outlive the application for process shutdown
+        CoroutineScope(Dispatchers.Default).launch {
+            try {
+                latch.join()
 
-            exitProcess(exitCode)
+                application.monitor.raise(ApplicationStopPreparing, environment)
+                application.disposeAndJoin()
+
+                exit(this@ShutDownUrl.exitCode(call))
+            } catch (e: Exception) {
+                log.error("Exception occurred during shutdown!", e)
+                exit(1)
+            }
         }
 
         try {
@@ -98,6 +111,11 @@ public class ShutDownUrl(public val url: String, public val exitCode: Applicatio
          * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.server.engine.ShutDownUrl.Config.exitCodeSupplier)
          */
         public var exitCodeSupplier: ApplicationCall.() -> Int = { 0 }
+
+        /**
+         * Internal config item for testing shutdown.
+         */
+        internal var exit: (Int) -> Unit = ::exitProcess
     }
 
     public companion object {
@@ -109,7 +127,11 @@ public class ShutDownUrl(public val url: String, public val exitCode: Applicatio
          */
         public val ApplicationCallPlugin: BaseApplicationPlugin<Application, Config, PluginInstance> =
             createApplicationPlugin("shutdown.url", ::Config) {
-                val plugin = ShutDownUrl(pluginConfig.shutDownUrl, pluginConfig.exitCodeSupplier)
+                val plugin = ShutDownUrl(
+                    pluginConfig.shutDownUrl,
+                    pluginConfig.exitCodeSupplier,
+                    pluginConfig.exit
+                )
 
                 onCall { call ->
                     if (call.request.uri == plugin.url) {

--- a/ktor-server/ktor-server-core/jvm/src/io/ktor/server/engine/ShutDownUrl.kt
+++ b/ktor-server/ktor-server-core/jvm/src/io/ktor/server/engine/ShutDownUrl.kt
@@ -115,7 +115,7 @@ public class ShutDownUrl(
         /**
          * Internal config item for testing shutdown.
          */
-        internal var exit: (Int) -> Unit = ::exitProcess
+        public var exit: (Int) -> Unit = ::exitProcess
     }
 
     public companion object {

--- a/ktor-server/ktor-server-core/jvm/test/io/ktor/server/engine/ShutDownUrlTest.kt
+++ b/ktor-server/ktor-server-core/jvm/test/io/ktor/server/engine/ShutDownUrlTest.kt
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2014-2025 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.server.engine
+
+import io.ktor.client.request.*
+import io.ktor.client.statement.*
+import io.ktor.http.*
+import io.ktor.server.response.*
+import io.ktor.server.routing.*
+import io.ktor.server.testing.*
+import kotlinx.coroutines.*
+import kotlin.test.*
+
+class ShutDownUrlTest {
+
+    @Test
+    fun testShutdownUrlRespondsWithGone() = testApplication {
+        var exitCode = CompletableDeferred<Int>()
+
+        install(ShutDownUrl.ApplicationCallPlugin) {
+            shutDownUrl = "/shutdown"
+            exitCodeSupplier = { 42 }
+            exit = exitCode::complete
+        }
+
+        routing {
+            get("/normal") {
+                call.respondText("Normal response")
+            }
+        }
+
+        client.get("/normal").let { response ->
+            assertEquals(HttpStatusCode.OK, response.status)
+            assertEquals("Normal response", response.bodyAsText())
+        }
+
+        assertEquals(HttpStatusCode.Gone, client.get("/shutdown").status)
+        assertEquals(42, exitCode.await())
+    }
+
+    @Test
+    fun testShutdownUnderLoad() = testApplication {
+        val completedRequests = mutableListOf<Boolean>()
+        val deferred = CompletableDeferred<Unit>()
+
+        install(ShutDownUrl.ApplicationCallPlugin) {
+            shutDownUrl = "/shutdown"
+            exitCodeSupplier = { 42 }
+            exit = {
+                deferred.complete(Unit)
+            }
+        }
+
+        routing {
+            // Simulate a slow endpoint
+            get("/slow") {
+                delay(1000)
+                completedRequests.add(true)
+                call.respondText("Slow response")
+            }
+        }
+
+        // Start multiple slow requests in parallel
+        val slowJobs = List(5) {
+            application.launch {
+                try {
+                    client.get("/slow")
+                } catch (e: Exception) {
+                    // Request may be canceled during shutdown
+                }
+            }
+        }
+
+        assertEquals(HttpStatusCode.Gone, client.get("/shutdown").status)
+
+        withTimeout(5000) {
+            deferred.await()
+        }
+
+        assertFalse(slowJobs.any { it.isActive }, "Expected jobs to be canceled")
+    }
+
+    @Test
+    fun testExceptionHandlingDuringShutdown() = testApplication {
+        val exitCode = CompletableDeferred<Int>()
+
+        install(ShutDownUrl.ApplicationCallPlugin) {
+            shutDownUrl = "/shutdown"
+            exitCodeSupplier = {
+                throw IllegalStateException("Something went wrong")
+            }
+            exit = exitCode::complete
+        }
+
+        // Call the shutdown endpoint
+        assertEquals(HttpStatusCode.Gone, client.get("/shutdown").status)
+
+        // Verify exit was called with error code 1 due to exception
+        assertEquals(1, exitCode.await())
+    }
+}


### PR DESCRIPTION
**Subsystem**
Server, ShutdownUrl

**Motivation**
[KTOR-8674](https://youtrack.jetbrains.com/issue/KTOR-8674) ShutDownUrl: The server cannot shut down since 3.2.0

**Solution**
The improvements for structured concurrency introduced in 3.2 a deadlock in this plugin due to the shutdown coroutine being launched on the application's context and waiting for the context to join.

