### PR TITLE
KTOR-8523 Fix for empty part parse exception

### DIFF
--- a/ktor-http/ktor-http-cio/common/src/io/ktor/http/cio/Multipart.kt
+++ b/ktor-http/ktor-http-cio/common/src/io/ktor/http/cio/Multipart.kt
@@ -109,7 +109,6 @@ private suspend fun parsePreambleImpl(
  */
 private suspend fun parsePartHeadersImpl(input: ByteReadChannel): HttpHeadersMap {
     val builder = CharArrayBuilder()
-
     try {
         return parseHeaders(input, builder)
             ?: throw EOFException("Failed to parse multipart headers: unexpected end of stream")
@@ -214,6 +213,11 @@ private fun CoroutineScope.parseMultipart(
 
     while (!countedInput.isClosedForRead && !countedInput.skipIfFound(PrefixString)) {
         countedInput.skipIfFound(CrLf)
+
+        // empty contents, no headers
+        if (countedInput.skipIfFound(firstBoundary)) {
+            continue
+        }
 
         val body = ByteChannel()
         val headers = CompletableDeferred<HttpHeadersMap>()


### PR DESCRIPTION
**Subsystem**
Server, Core

**Motivation**
[KTOR-8523](https://youtrack.jetbrains.com/issue/KTOR-8523) Intermittent "ParserException: No colon in HTTP header" when parsing multipart request

**Solution**
It's technically valid to have empty multipart segments, but our parser dies when it sees the boundary instead of headers.  The fix is to check the input for the boundary before parsing headers.

