### PR TITLE
KTOR-6963 Fix for Darwin engine ws frame limit

### DIFF
--- a/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/websocket/WebSockets.kt
+++ b/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/websocket/WebSockets.kt
@@ -19,6 +19,9 @@ import io.ktor.websocket.*
 
 private val REQUEST_EXTENSIONS_KEY = AttributeKey<List<WebSocketExtension<*>>>("Websocket extensions")
 
+@InternalAPI
+public val WEBSOCKETS_KEY: AttributeKey<WebSockets> = AttributeKey<WebSockets>("Websocket plugin config")
+
 internal val LOGGER = KtorSimpleLogger("io.ktor.client.plugins.websocket.WebSockets")
 
 /**
@@ -184,6 +187,7 @@ public class WebSockets internal constructor(
                 if (extensionsSupported) {
                     plugin.installExtensions(context)
                 }
+                context.attributes[WEBSOCKETS_KEY] = plugin
 
                 proceedWith(WebSocketContent())
             }

--- a/ktor-client/ktor-client-darwin/darwin/src/io/ktor/client/engine/darwin/internal/DarwinSession.kt
+++ b/ktor-client/ktor-client-darwin/darwin/src/io/ktor/client/engine/darwin/internal/DarwinSession.kt
@@ -5,6 +5,7 @@
 package io.ktor.client.engine.darwin.internal
 
 import io.ktor.client.engine.darwin.*
+import io.ktor.client.plugins.websocket.WEBSOCKETS_KEY
 import io.ktor.client.request.*
 import io.ktor.utils.io.*
 import io.ktor.utils.io.core.*
@@ -32,6 +33,9 @@ internal class DarwinSession(
         val (task, response) = if (request.isUpgradeRequest()) {
             val task = session.webSocketTaskWithRequest(nativeRequest)
             val response = delegate.read(task, callContext)
+            val maxFrameSize = request.attributes[WEBSOCKETS_KEY].maxFrameSize
+            task.setMaximumMessageSize(maxFrameSize / 10)
+
             task to response
         } else {
             val task = session.dataTaskWithRequest(nativeRequest)

--- a/ktor-client/ktor-client-darwin/darwin/test/DarwinEngineTest.kt
+++ b/ktor-client/ktor-client-darwin/darwin/test/DarwinEngineTest.kt
@@ -260,6 +260,29 @@ class DarwinEngineTest : ClientEngineTest<DarwinClientEngineConfig>(Darwin) {
         }
     }
 
+    @Test
+    fun testWebSocketMaxFrameSize() = testClient {
+        config {
+            install(WebSockets) {
+                maxFrameSize = 100
+            }
+        }
+
+        val shortMessage = "abc".repeat(5)
+        val longMessage = "def".repeat(500)
+        test { client ->
+            assertFailsWith<DarwinHttpRequestException> {
+                client.webSocket("$TEST_WEBSOCKET_SERVER/websockets/echo") {
+                    send(shortMessage)
+                    assertEquals(shortMessage, (incoming.receive() as Frame.Text).readText())
+                    send(longMessage)
+                    val frame = incoming.receive() as Frame.Text
+                    assertEquals(longMessage, frame.readText())
+                }
+            }
+        }
+    }
+
     @OptIn(UnsafeNumber::class)
     @Test
     fun testRethrowExceptionThrownDuringCustomChallenge() = runBlocking {


### PR DESCRIPTION
**Subsystem**
Client, iOS, Websockets

**Motivation**
[KTOR-6963](https://youtrack.jetbrains.com/issue/KTOR-6963) Darwin: The `maxFrameSize` option has no effect

**Solution**
We were assuming that we could set `maxFrameSize` on the session after the upgrade, but for Darwin, the property needs to be assigned _before_ `NSURLSessionWebSocketTask.resume()` is called.  So to provide access to the config value, I included the plugin details as an attribute for WS requests.
