### PR TITLE
KTOR-8700 fix Websocket binary frames fin on wasm and js

### DIFF
--- a/ktor-client/ktor-client-core/js/src/io/ktor/client/plugins/websocket/JsWebSocketSession.kt
+++ b/ktor-client/ktor-client-core/js/src/io/ktor/client/plugins/websocket/JsWebSocketSession.kt
@@ -55,7 +55,7 @@ internal class JsWebSocketSession(
                 val event = it.unsafeCast<MessageEvent>()
 
                 val frame: Frame = when (val data = event.data) {
-                    is ArrayBuffer -> Frame.Binary(false, Int8Array(data).unsafeCast<ByteArray>())
+                    is ArrayBuffer -> Frame.Binary(true, Int8Array(data).unsafeCast<ByteArray>())
                     is String -> Frame.Text(data)
                     else -> {
                         val error = IllegalStateException("Unknown frame type: ${event.type}")

--- a/ktor-client/ktor-client-core/wasmJs/src/io/ktor/client/plugins/websocket/JsWebSocketSession.kt
+++ b/ktor-client/ktor-client-core/wasmJs/src/io/ktor/client/plugins/websocket/JsWebSocketSession.kt
@@ -73,7 +73,7 @@ internal class JsWebSocketSession(
             } else {
                 val dataAsBuffer = tryGetEventDataAsArrayBuffer(data)
                 if (dataAsBuffer != null) {
-                    Frame.Binary(false, Uint8Array(dataAsBuffer).asByteArray())
+                    Frame.Binary(true, Uint8Array(dataAsBuffer).asByteArray())
                 } else {
                     val error = IllegalStateException("Unknown frame type: ${event.type}")
                     _closeReason.completeExceptionally(error)


### PR DESCRIPTION
**Subsystem**
Client
**Motivation**
[KTOR-8700](https://youtrack.jetbrains.com/issue/KTOR-8700/Websocket-binary-frames-have-fin-always-set-to-false)

**Solution**
Described in KTOR-8700
