### PR TITLE
KTOR-8687 Fix missing `\r\n` in CIO Expect-Continue response

### DIFF
--- a/ktor-server/ktor-server-cio/common/src/io/ktor/server/cio/CIOApplicationEngine.kt
+++ b/ktor-server/ktor-server-cio/common/src/io/ktor/server/cio/CIOApplicationEngine.kt
@@ -120,6 +120,7 @@ public class CIOApplicationEngine(
                     handleRequest(request)
                 }
             }
+
             else -> {
                 val settings = HttpServerSettings(
                     host = connectorSpec.host,
@@ -136,7 +137,7 @@ public class CIOApplicationEngine(
     }
 
     private fun addHandlerForExpectedHeader(output: ByteWriteChannel, call: CIOApplicationCall) {
-        val continueResponse = "HTTP/1.1 100 Continue\r\n"
+        val continueResponse = "HTTP/1.1 100 Continue$CRLF$CRLF"
         val expectHeaderValue = "100-continue"
 
         val expectedHeaderPhase = PipelinePhase("ExpectedHeaderPhase")
@@ -249,3 +250,5 @@ public class CIOApplicationEngine(
         }
     }
 }
+
+private const val CRLF = "\r\n"

--- a/ktor-server/ktor-server-cio/common/test/io/ktor/tests/server/cio/CIOEngineTest.kt
+++ b/ktor-server/ktor-server-cio/common/test/io/ktor/tests/server/cio/CIOEngineTest.kt
@@ -92,6 +92,7 @@ class CIOHttpServerTest : HttpServerCommonTestSuite<CIOApplicationEngine, CIOApp
             writePostHeaders(writeChannel, body.length)
             val continueResponse = readChannel.readUTF8Line()
             assertEquals("HTTP/1.1 100 Continue", continueResponse)
+            assertTrue { readChannel.readUTF8Line()?.isEmpty() ?: false }
 
             writePostBody(writeChannel, body)
             val response = readAvailable(readChannel)


### PR DESCRIPTION
**Subsystem**
Server, CIO

**Motivation**
[KTOR-8687](https://youtrack.jetbrains.com/issue/KTOR-8687)

