### PR TITLE
KTOR-8717 Migrate to KGP ABI dumps

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,7 +31,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - Run relevant tests with `./gradlew jvmTest` to verify functionality
 - Run `./gradlew lintKotlin` and fix all linting issues before giving control back to the user
 - Use `./gradlew formatKotlin` to automatically fix formatting issues
-- Run `./gradlew apiDump` after making API changes to update API signature files
+- Run `./gradlew updateLegacyAbi` after making ABI changes to update ABI signature files
 - CRITICAL: Never return control to the user without ensuring code compiles, tests pass, and ALL linting issues are fixed
 - Start with JVM-only implementation and tests unless the user specifically requests otherwise
 - Focus on core functionality first before expanding to other platforms (JS, Native)
@@ -43,10 +43,9 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - Error handling follows Kotlin conventions with specific Ktor exceptions
 
 ## API Compatibility
-- Binary compatibility is enforced using the binary-compatibility-validator plugin
+- Binary compatibility is enforced using Kotlin Gradle Plugin ABI validation
 - All public API changes must be tracked in the `/api/` directories
-- Run `./gradlew apiDump` to update all API signature files after making API changes
-- Module-specific API dumps: `./gradlew :module-name:apiDump`
-- Platform-specific dumps: `./gradlew jvmApiDump` or `./gradlew klibApiDump`
+- Validate ABI: `./gradlew checkLegacyAbi`
+- Update ABI dumps: `./gradlew updateLegacyAbi` (module-specific: `./gradlew :module-name:updateLegacyAbi`)
 - API changes must be intentional and well-documented
 - Breaking changes are only allowed in major version releases

--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -10,7 +10,6 @@ dependencies {
     implementation(libs.kotlin.gradlePlugin)
     implementation(libs.kotlin.serialization)
     implementation(libs.kotlinx.atomicfu.gradlePlugin)
-    implementation(libs.kotlinx.binaryCompatibilityValidator)
     implementation(libs.dokka.gradlePlugin)
     implementation(libs.develocity)
     implementation(libs.gradleDoctor)

--- a/build-logic/src/main/kotlin/ktorbuild.compatibility.gradle.kts
+++ b/build-logic/src/main/kotlin/ktorbuild.compatibility.gradle.kts
@@ -1,14 +1,26 @@
 /*
  * Copyright 2014-2025 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
+@file:OptIn(ExperimentalAbiValidation::class)
 
-plugins {
-    id("binary-compatibility-validator")
+import ktorbuild.internal.abiValidation
+import org.jetbrains.kotlin.gradle.dsl.abi.*
+import org.jetbrains.kotlin.gradle.dsl.kotlinExtension
+
+kotlinExtension.abiValidation {
+    enabled = true
 }
 
-apiValidation {
-    @OptIn(kotlinx.validation.ExperimentalBCVApi::class)
-    klib {
-        enabled = true
+// Make it possible to run the ABI check task using the old name to simplify migration on CI.
+// TODO 21.08.25: Remove in a week or so, when all branches will be updated to the latest main
+tasks.register("apiCheck") {
+    dependsOn(tasks.named("checkLegacyAbi"))
+}
+
+// The property 'enabled' is not a part of the AbiValidationVariantSpec, so we need this bridge-method to unify enabling
+private val AbiValidationVariantSpec.enabled: Property<Boolean>
+    get() = when (this) {
+        is AbiValidationMultiplatformExtension -> this.enabled
+        is AbiValidationExtension -> this.enabled
+        else -> error("Unexpected type: ${this::class.qualifiedName}")
     }
-}

--- a/build-logic/src/main/kotlin/ktorbuild/internal/Accessors.kt
+++ b/build-logic/src/main/kotlin/ktorbuild/internal/Accessors.kt
@@ -9,6 +9,8 @@ import org.gradle.api.Project
 import org.gradle.api.plugins.JavaPluginExtension
 import org.gradle.kotlin.dsl.getByType
 import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
+import org.jetbrains.kotlin.gradle.dsl.KotlinProjectExtension
+import org.jetbrains.kotlin.gradle.dsl.abi.AbiValidationVariantSpec
 
 /*
  * Gradle doesn't generate accessors for plugins defined in this module,
@@ -21,3 +23,6 @@ internal val Project.java: JavaPluginExtension get() = extensions.getByType()
 
 internal fun Project.kotlin(configure: KotlinMultiplatformExtension.() -> Unit) =
     extensions.configure("kotlin", configure)
+
+internal fun KotlinProjectExtension.abiValidation(configure: AbiValidationVariantSpec.() -> Unit) =
+    extensions.configure("abiValidation", configure)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,7 +7,6 @@ kotlinx-io = "0.8.0"
 coroutines = "1.10.2"
 atomicfu = "0.29.0"
 serialization = "1.9.0"
-binaryCompatibilityValidator = "0.18.0"
 dokka = "2.0.0"
 kover = "0.9.1"
 kotlinter = "5.1.1"
@@ -131,8 +130,6 @@ kotlinx-io-core = { module = "org.jetbrains.kotlinx:kotlinx-io-core", version.re
 
 kotlinx-browser = { module = "org.jetbrains.kotlinx:kotlinx-browser", version.ref = "kotlinx-browser" }
 
-kotlinx-binaryCompatibilityValidator = { module = "org.jetbrains.kotlinx:binary-compatibility-validator", version.ref = "binaryCompatibilityValidator" }
-
 dokka-gradlePlugin = { module = "org.jetbrains.dokka:dokka-gradle-plugin", version.ref = "dokka" }
 dokka-plugin-versioning = { module = "org.jetbrains.dokka:versioning-plugin", version.ref = "dokka" }
 
@@ -239,7 +236,6 @@ mavenPublishing = { module = "com.vanniktech:gradle-maven-publish-plugin", versi
 
 [plugins]
 
-binaryCompatibilityValidator = { id = "org.jetbrains.kotlinx.binary-compatibility-validator", version.ref = "binaryCompatibilityValidator" }
 kover = { id = "org.jetbrains.kotlinx.kover", version.ref = "kover" }
 
 doctor = { id = "com.osacky.doctor", version.ref = "gradleDoctor" }


### PR DESCRIPTION
**Subsystem**
Infrastructure

**Motivation**
[KTOR-8717](https://youtrack.jetbrains.com/issue/KTOR-8717) Migrate ABI validation from BCV to KGP

**Solution**
Remove the BCV plugin and configure ABI validation in KGP instead.

