### PR TITLE
CVE-2025-55163: Update netty to `4.2.4.Final`

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -15,7 +15,7 @@ kotlinx-browser = "0.3"
 # Used for test server in buildSrc
 ktor = "3.2.0-eap-1336"
 
-netty = "4.2.2.Final"
+netty = "4.2.4.Final"
 netty-tcnative = "2.0.72.Final"
 
 jetty = "9.4.57.v20241219"


### PR DESCRIPTION
**Subsystem**
Server.

**Motivation**
To address vulnerability [CVE-2025-55163](https://www.cve.org/CVERecord?id=CVE-2025-55163).

**Solution**
Perform Netty version update as suggested.

