### PR TITLE
CVE-2025-5115: Update jetty to 9.4.58.v20250814

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -19,7 +19,7 @@ ktor = "3.2.0-eap-1336"
 netty = "4.2.2.Final"
 netty-tcnative = "2.0.72.Final"
 
-jetty = "9.4.57.v20241219"
+jetty = "9.4.58.v20250814"
 jetty-jakarta = "11.0.25"
 jetty-alpn-api = "1.1.3.v20160715"
 jetty-alpn-openjdk8 = "9.4.57.v20241219"


### PR DESCRIPTION
**Subsystem**
Server

**Motivation**
To address vulnerability [CVE-2025-5115](https://www.cve.org/CVERecord?id=CVE-2025-5115).

**Solution**
Update jetty with [latest release](https://github.com/jetty/jetty.project/releases/tag/jetty-9.4.58.v20250814)

