### PR TITLE
KTOR-8821 Fix auto-reload issue / exception on lambda

### DIFF
--- a/ktor-server/ktor-server-core/api/ktor-server-core.api
+++ b/ktor-server/ktor-server-core/api/ktor-server-core.api
@@ -1785,6 +1785,7 @@ public final class io/ktor/server/routing/RoutingPathSegmentKind : java/lang/Enu
 }
 
 public final class io/ktor/server/routing/RoutingPipelineCall : io/ktor/server/application/PipelineCall, kotlinx/coroutines/CoroutineScope {
+	public fun <init> (Lio/ktor/server/application/PipelineCall;Lio/ktor/server/routing/RoutingNode;Lio/ktor/server/request/ApplicationReceivePipeline;Lio/ktor/server/response/ApplicationSendPipeline;Lio/ktor/http/Parameters;)V
 	public fun <init> (Lio/ktor/server/application/PipelineCall;Lio/ktor/server/routing/RoutingNode;Lkotlin/coroutines/CoroutineContext;Lio/ktor/server/request/ApplicationReceivePipeline;Lio/ktor/server/response/ApplicationSendPipeline;Lio/ktor/http/Parameters;)V
 	public fun getApplication ()Lio/ktor/server/application/Application;
 	public fun getAttributes ()Lio/ktor/util/Attributes;

--- a/ktor-server/ktor-server-core/api/ktor-server-core.klib.api
+++ b/ktor-server/ktor-server-core/api/ktor-server-core.klib.api
@@ -1106,6 +1106,7 @@ final class io.ktor.server.routing/RoutingPathSegment { // io.ktor.server.routin
 }
 
 final class io.ktor.server.routing/RoutingPipelineCall : io.ktor.server.application/PipelineCall, kotlinx.coroutines/CoroutineScope { // io.ktor.server.routing/RoutingPipelineCall|null[0]
+    constructor <init>(io.ktor.server.application/PipelineCall, io.ktor.server.routing/RoutingNode, io.ktor.server.request/ApplicationReceivePipeline, io.ktor.server.response/ApplicationSendPipeline, io.ktor.http/Parameters) // io.ktor.server.routing/RoutingPipelineCall.<init>|<init>(io.ktor.server.application.PipelineCall;io.ktor.server.routing.RoutingNode;io.ktor.server.request.ApplicationReceivePipeline;io.ktor.server.response.ApplicationSendPipeline;io.ktor.http.Parameters){}[0]
     constructor <init>(io.ktor.server.application/PipelineCall, io.ktor.server.routing/RoutingNode, kotlin.coroutines/CoroutineContext, io.ktor.server.request/ApplicationReceivePipeline, io.ktor.server.response/ApplicationSendPipeline, io.ktor.http/Parameters) // io.ktor.server.routing/RoutingPipelineCall.<init>|<init>(io.ktor.server.application.PipelineCall;io.ktor.server.routing.RoutingNode;kotlin.coroutines.CoroutineContext;io.ktor.server.request.ApplicationReceivePipeline;io.ktor.server.response.ApplicationSendPipeline;io.ktor.http.Parameters){}[0]
 
     final val application // io.ktor.server.routing/RoutingPipelineCall.application|{}application[0]

--- a/ktor-server/ktor-server-core/common/src/io/ktor/server/routing/RoutingPipelineCall.kt
+++ b/ktor-server/ktor-server-core/common/src/io/ktor/server/routing/RoutingPipelineCall.kt
@@ -23,14 +23,29 @@ import kotlin.coroutines.*
 public class RoutingPipelineCall(
     public val engineCall: PipelineCall,
     public val route: RoutingNode,
-    override val coroutineContext: CoroutineContext,
     receivePipeline: ApplicationReceivePipeline,
     responsePipeline: ApplicationSendPipeline,
     public val pathParameters: Parameters
 ) : PipelineCall, CoroutineScope {
+    @Deprecated(level = DeprecationLevel.WARNING, message = "CoroutineContext is delegated to engineCall now.")
+    public constructor(
+        engineCall: PipelineCall,
+        route: RoutingNode,
+        coroutineContext: CoroutineContext,
+        receivePipeline: ApplicationReceivePipeline,
+        responsePipeline: ApplicationSendPipeline,
+        pathParameters: Parameters
+    ) : this(
+        engineCall,
+        route,
+        receivePipeline,
+        responsePipeline,
+        pathParameters
+    )
 
     override val application: Application get() = engineCall.application
     override val attributes: Attributes get() = engineCall.attributes
+    override val coroutineContext: CoroutineContext get() = engineCall.coroutineContext
 
     override val request: RoutingPipelineRequest =
         RoutingPipelineRequest(this, receivePipeline, engineCall.request)

--- a/ktor-server/ktor-server-core/common/src/io/ktor/server/routing/RoutingRoot.kt
+++ b/ktor-server/ktor-server-core/common/src/io/ktor/server/routing/RoutingRoot.kt
@@ -94,7 +94,6 @@ public class RoutingRoot(
         val routingApplicationCall = RoutingPipelineCall(
             context.call,
             route,
-            context.coroutineContext,
             receivePipeline,
             responsePipeline,
             parameters

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyApplicationEngine.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyApplicationEngine.kt
@@ -212,9 +212,9 @@ public class NettyApplicationEngine(
                 channel(getChannelClass().java)
             }
 
-            val userContext = applicationProvider().coroutineContext +
+            val userContext =
                 NettyApplicationCallHandler.CallHandlerCoroutineName +
-                DefaultUncaughtExceptionHandler(environment.log)
+                    DefaultUncaughtExceptionHandler(environment.log)
 
             childHandler(
                 NettyChannelInitializer(

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyChannelInitializer.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyChannelInitializer.kt
@@ -182,11 +182,12 @@ public class NettyChannelInitializer(
     private fun configurePipeline(pipeline: ChannelPipeline, protocol: String) {
         when (protocol) {
             ApplicationProtocolNames.HTTP_2 -> {
+                val application = applicationProvider()
                 val handler = NettyHttp2Handler(
                     enginePipeline,
-                    applicationProvider(),
+                    application,
                     callEventGroup,
-                    userContext,
+                    application.coroutineContext + userContext,
                     runningLimit
                 )
 

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http1/NettyHttp1Handler.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http1/NettyHttp1Handler.kt
@@ -139,13 +139,14 @@ internal class NettyHttp1Handler(
             else -> prepareRequestContentChannel(context, message)
         }
 
+        val application = applicationProvider()
         return NettyHttp1ApplicationCall(
-            applicationProvider(),
+            application,
             context,
             message,
             requestBodyChannel,
             engineContext,
-            userContext
+            application.coroutineContext + userContext
         )
     }
 

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http1/NettyHttp1Handler.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http1/NettyHttp1Handler.kt
@@ -47,7 +47,13 @@ internal class NettyHttp1Handler(
         context.channel().read()
         context.pipeline().apply {
             addLast(RequestBodyHandler(context))
-            addLast(callEventGroup, NettyApplicationCallHandler(userContext, enginePipeline))
+            addLast(
+                callEventGroup,
+                NettyApplicationCallHandler(
+                    applicationProvider().coroutineContext + userContext,
+                    enginePipeline
+                )
+            )
         }
         context.fireChannelActive()
     }


### PR DESCRIPTION
**Subsystem**
Server, Core

**Motivation**
[KTOR-8821](https://youtrack.jetbrains.com/issue/KTOR-8821) Autoreloading: it doesn't reload rebuilt classes since 3.2.0
[KTOR-8810](https://youtrack.jetbrains.com/issue/KTOR-8810) Autoreloading: JobCancellationException when app is reloaded in the debugger since 3.2.0

**Solution**
Fix 1: dynamic module wrapping for lambdas would cause errors on reloads
Fix 2: Netty was using the old application instance in the coroutine context, which caused auto-reloading to fail when debugging.

This also fixes the issue with the static resources.