### PR TITLE
KTOR-8820 Performance regression when using ContentEncoding and HttpRequestRetry since 3.2.0

### DIFF
--- a/ktor-client/ktor-client-cio/common/src/io/ktor/client/engine/cio/Endpoint.kt
+++ b/ktor-client/ktor-client-cio/common/src/io/ktor/client/engine/cio/Endpoint.kt
@@ -40,7 +40,7 @@ internal class Endpoint(
     private val deliveryPoint: Channel<RequestTask> = Channel()
     private val maxEndpointIdleTime: Long = 2 * config.endpoint.connectTimeout
 
-    private val timeout = launch(coroutineContext + CoroutineName("Endpoint timeout($host:$port)")) {
+    private val timeout = launch(coroutineContext + CoroutineName("cio-endpoint-timeout")) {
         try {
             while (true) {
                 val remaining = (lastActivity.value + maxEndpointIdleTime) - getTimeMillis()
@@ -317,7 +317,7 @@ internal class Endpoint(
 private fun setupTimeout(callContext: CoroutineContext, request: HttpRequestData, timeout: Long) {
     if (timeout == HttpTimeoutConfig.INFINITE_TIMEOUT_MS || timeout == 0L) return
 
-    val timeoutJob = GlobalScope.launch {
+    val timeoutJob = GlobalScope.launch(CoroutineName("cio-request-timeout")) {
         delay(timeout)
         callContext.job.cancel("Request is timed out", HttpRequestTimeoutException(request))
     }

--- a/ktor-client/ktor-client-core/common/src/io/ktor/client/call/SavedCall.kt
+++ b/ktor-client/ktor-client-core/common/src/io/ktor/client/call/SavedCall.kt
@@ -33,6 +33,8 @@ import kotlin.coroutines.CoroutineContext
  */
 @OptIn(InternalAPI::class)
 public suspend fun HttpClientCall.save(): HttpClientCall {
+    if (this is SavedHttpCall) return this
+
     val responseBody = response.rawContent.readRemaining().readByteArray()
     return SavedHttpCall(client, request, response, responseBody)
 }
@@ -49,13 +51,6 @@ internal class SavedHttpCall(
         this.response = SavedHttpResponse(this, responseBody, response)
 
         checkContentLength(response.contentLength(), responseBody.size.toLong(), request.method)
-    }
-
-    /**
-     * Returns a channel with [responseBody] data.
-     */
-    override suspend fun getResponseContent(): ByteReadChannel {
-        return ByteReadChannel(responseBody)
     }
 
     override val allowDoubleReceive: Boolean = true

--- a/ktor-client/ktor-client-core/common/src/io/ktor/client/engine/Utils.kt
+++ b/ktor-client/ktor-client-core/common/src/io/ktor/client/engine/Utils.kt
@@ -9,8 +9,11 @@ import io.ktor.http.*
 import io.ktor.http.content.*
 import io.ktor.util.*
 import io.ktor.utils.io.*
-import kotlinx.coroutines.*
-import kotlin.coroutines.*
+import kotlinx.coroutines.InternalCoroutinesApi
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.currentCoroutineContext
+import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.coroutineContext
 
 /**
  * Default user agent to use in a Ktor client.
@@ -98,7 +101,7 @@ internal class KtorCallContextElement(val callContext: CoroutineContext) : Corou
  */
 @OptIn(InternalCoroutinesApi::class)
 internal suspend inline fun attachToUserJob(callJob: Job) {
-    val userJob = coroutineContext[Job] ?: return
+    val userJob = currentCoroutineContext()[Job] ?: return
 
     val cleanupHandler = userJob.invokeOnCompletion(onCancelling = true) { cause ->
         cause ?: return@invokeOnCompletion

--- a/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/HttpRequestRetryTest.kt
+++ b/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/HttpRequestRetryTest.kt
@@ -4,15 +4,20 @@
 
 package io.ktor.client.tests
 
-import io.ktor.client.call.body
+import io.ktor.client.call.*
 import io.ktor.client.engine.mock.*
 import io.ktor.client.plugins.*
+import io.ktor.client.plugins.compression.*
 import io.ktor.client.request.*
 import io.ktor.client.test.base.*
 import io.ktor.http.*
+import io.ktor.util.*
+import io.ktor.utils.io.*
 import kotlinx.coroutines.*
+import kotlinx.coroutines.CancellationException
 import kotlinx.io.IOException
 import kotlin.test.*
+import kotlin.time.Duration.Companion.seconds
 
 class HttpRequestRetryTest {
 
@@ -480,6 +485,35 @@ class HttpRequestRetryTest {
             } catch (cause: Throwable) {
                 fail("No exception should be thrown", cause)
             }
+        }
+    }
+
+    // KTOR-8820
+    @Test
+    fun testRetryWithLargeEncodedBody() = testWithEngine(MockEngine, timeout = 1.seconds) {
+        config {
+            engine {
+                addHandler {
+                    // Compressed body size should be larger than DEFAULT_BUFFER_SIZE to reproduce the bug
+                    val bytes = ByteArray(2 * 1024 * 1024) { it.toByte() }
+                    respond(
+                        GZipEncoder.encode(ByteReadChannel(bytes)),
+                        headers = headersOf(HttpHeaders.ContentEncoding, "gzip"),
+                    )
+                }
+            }
+
+            install(HttpRequestRetry) {
+                noRetry()
+            }
+            install(ContentEncoding) {
+                gzip()
+            }
+        }
+
+        test { client ->
+            val response = client.get { }
+            assertEquals(HttpStatusCode.OK, response.status)
         }
     }
 }


### PR DESCRIPTION
**Subsystem**
Server

**Motivation**
[KTOR-8820](https://youtrack.jetbrains.com/issue/KTOR-8820) Performance regression when using ContentEncoding and HttpRequestRetry since 3.2.0

The bug was caused by a combination of `ContentEncoding`, `HttpRequestRetry` and `SaveBody` plugins.

1. `SaveBody`: creates a new channel on each `HttpResponse.rawContent` call
2. `ContentEnconding`: starts a coroutine for each created channel, and this coroutine exists until the entire body has been read
3. `HttpRequestRetry`: calls `rawContent` and then reads only one byte, leaving the channel not closed

As a result, the coroutine started by the `ContentEncoding` plugin hangs until the request fails by timeout (the default timeout is 15 seconds).

**Solution**

Added cancellation of the `rawContent` channel in the `HttpRetryRequest` plugin.
Also found that we were calling `rawContent` in `HttpResponse.cleanup` even for saved responses. Fixed this too