### PR TITLE
Direct renovate to the appropriate branches

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,7 +6,7 @@
     ":label(dependencies)",
     "schedule:automergeNonOfficeHours"
   ],
-  "baseBranchPatterns": ["main","release/*"],
+  "baseBranchPatterns": ["main","/^release\\/.*/"],
   "rebaseWhen": "conflicted",
   "packageRules": [
     {
@@ -67,14 +67,14 @@
       "enabled": false
     },
     {
-      "description": "Patch updates go to release branch",
+      "description": "Don't create PRs to main branch for patch updates",
       "matchUpdateTypes": ["patch"],
-      "matchBaseBranches": ["release/*"],
-      "automerge": true
+      "matchBaseBranches": ["main"],
+      "enabled": false
     },
     {
-      "description": "Minor updates go to main branch",
-      "matchUpdateTypes": ["minor"],
+      "description": "Minor/major updates go to main branch",
+      "matchUpdateTypes": ["minor", "major"],
       "matchBaseBranches": ["main"],
       "automerge": true
     },
@@ -91,7 +91,7 @@
         "org.jmailen.gradle:kotlinter-gradle",
         "org.junit.jupiter:junit-jupiter"
       ],
-      "matchBaseBranches": ["release/*"],
+      "matchBaseBranches": ["/^release\\/.*/"],
       "automerge": true
     }
   ]

--- a/renovate.json
+++ b/renovate.json
@@ -6,6 +6,7 @@
     ":label(dependencies)",
     "schedule:automergeNonOfficeHours"
   ],
+  "baseBranchPatterns": ["main","release/*"],
   "rebaseWhen": "conflicted",
   "packageRules": [
     {
@@ -66,11 +67,15 @@
       "enabled": false
     },
     {
-      "description": "Automerge non-major releases",
-      "matchUpdateTypes": [
-        "patch",
-        "minor"
-      ],
+      "description": "Patch updates go to release branch",
+      "matchUpdateTypes": ["patch"],
+      "matchBaseBranches": ["release/*"],
+      "automerge": true
+    },
+    {
+      "description": "Minor updates go to main branch",
+      "matchUpdateTypes": ["minor"],
+      "matchBaseBranches": ["main"],
       "automerge": true
     },
     {
@@ -86,6 +91,7 @@
         "org.jmailen.gradle:kotlinter-gradle",
         "org.junit.jupiter:junit-jupiter"
       ],
+      "matchBaseBranches": ["release/*"],
       "automerge": true
     }
   ]

--- a/renovate.json
+++ b/renovate.json
@@ -67,16 +67,16 @@
       "enabled": false
     },
     {
-      "description": "Don't create PRs to main branch for patch updates",
+      "description": "Ignore patch updates for main branch",
       "matchUpdateTypes": ["patch"],
       "matchBaseBranches": ["main"],
       "enabled": false
     },
     {
-      "description": "Minor/major updates go to main branch",
+      "description": "Ignore major/minor for release branches",
       "matchUpdateTypes": ["minor", "major"],
-      "matchBaseBranches": ["main"],
-      "automerge": true
+      "matchBaseBranches": ["release/*"],
+      "enabled": false
     },
     {
       "description": "Automerge test and infrastructure dependencies",


### PR DESCRIPTION
This should map patches to release and others to main.
