### PR TITLE
KTOR-7631 Fix SerializationException when ContentNegotiation installed before SSE

### DIFF
--- a/ktor-client/ktor-client-plugins/ktor-client-content-negotiation/common/src/io/ktor/client/plugins/contentnegotiation/ContentNegotiation.kt
+++ b/ktor-client/ktor-client-plugins/ktor-client-content-negotiation/common/src/io/ktor/client/plugins/contentnegotiation/ContentNegotiation.kt
@@ -5,6 +5,7 @@
 package io.ktor.client.plugins.contentnegotiation
 
 import io.ktor.client.plugins.api.*
+import io.ktor.client.plugins.sse.*
 import io.ktor.client.request.*
 import io.ktor.client.statement.*
 import io.ktor.client.utils.*
@@ -25,7 +26,9 @@ internal val DefaultCommonIgnoredTypes: Set<KClass<*>> = setOf(
     String::class,
     HttpStatusCode::class,
     ByteReadChannel::class,
-    OutgoingContent::class
+    OutgoingContent::class,
+    ClientSSESession::class,
+    ClientSSESessionWithDeserialization::class,
 )
 
 internal expect val DefaultIgnoredTypes: Set<KClass<*>>

--- a/ktor-test-server/src/main/kotlin/test/server/tests/ServerSentEvents.kt
+++ b/ktor-test-server/src/main/kotlin/test/server/tests/ServerSentEvents.kt
@@ -174,6 +174,10 @@ internal fun Application.serverSentEvents() {
             get("/error") {
                 call.respond(HttpStatusCode.InternalServerError, "Server error")
             }
+            get("/bad-response-json") {
+                call.response.header(HttpHeaders.ContentType, ContentType.Application.Json.toString())
+                call.respond(HttpStatusCode.BadRequest, "{ 'error': 'Bad request' }")
+            }
         }
     }
 }


### PR DESCRIPTION
**Subsystem**
Client, ContentNegotiation, SSE

**Motivation**
[KTOR-7631](https://youtrack.jetbrains.com/issue/KTOR-7631)

**Solution**
Skip `ContentNegotiation` plugin for SSE sessions

