### PR TITLE
KTOR-8771 Use `shutdownTimeout` instead of `shutdownGracePeriod`

### DIFF
--- a/ktor-server/ktor-server-core/common/src/io/ktor/server/engine/EmbeddedServer.kt
+++ b/ktor-server/ktor-server-core/common/src/io/ktor/server/engine/EmbeddedServer.kt
@@ -46,12 +46,12 @@ public expect class EmbeddedServer<TEngine : ApplicationEngine, TConfiguration :
 
     public fun stop(
         gracePeriodMillis: Long = engineConfig.shutdownGracePeriod,
-        timeoutMillis: Long = engineConfig.shutdownGracePeriod
+        timeoutMillis: Long = engineConfig.shutdownTimeout
     )
 
     public suspend fun stopSuspend(
         gracePeriodMillis: Long = engineConfig.shutdownGracePeriod,
-        timeoutMillis: Long = engineConfig.shutdownGracePeriod
+        timeoutMillis: Long = engineConfig.shutdownTimeout
     )
 }
 


### PR DESCRIPTION
**Subsystem**
Server

**Motivation**
[KTOR-8771](https://youtrack.jetbrains.com/issue/KTOR-8771) shutdownGracePeriod is used instead of shutdownTimeout in EmbeddedServer.stop()


