### PR TITLE
KTOR-8898: add netty config load: enableHttp2 and enableH2c

### DIFF
--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/EngineMain.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/EngineMain.kt
@@ -70,5 +70,11 @@ public object EngineMain {
         deploymentConfig.propertyOrNull("maxChunkSize")?.getString()?.toInt()?.let {
             maxChunkSize = it
         }
+        deploymentConfig.propertyOrNull("enableHttp2")?.getString()?.toBoolean()?.let {
+            enableHttp2 = it
+        }
+        deploymentConfig.propertyOrNull("enableH2c")?.getString()?.toBoolean()?.let {
+            enableH2c = it
+        }
     }
 }


### PR DESCRIPTION
**Subsystem**
Server, Netty Engine

**Motivation**
Not all netty config are loaded with `loadConfiguration` method.

**Solution**
Add a new config fields.

