### PR TITLE
KTOR-8901 Remove @KtorDsl from functions

### DIFF
--- a/ktor-client/ktor-client-core/common/src/io/ktor/client/HttpClient.kt
+++ b/ktor-client/ktor-client-core/common/src/io/ktor/client/HttpClient.kt
@@ -329,7 +329,6 @@ import kotlin.coroutines.CoroutineContext
  *
  * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.client.HttpClient)
  */
-@KtorDsl
 public expect fun HttpClient(
     block: HttpClientConfig<*>.() -> Unit = {}
 ): HttpClient
@@ -642,7 +641,6 @@ public expect fun HttpClient(
  *
  * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.client.HttpClient)
  */
-@KtorDsl
 public fun <T : HttpClientEngineConfig> HttpClient(
     engineFactory: HttpClientEngineFactory<T>,
     block: HttpClientConfig<T>.() -> Unit = {}
@@ -968,7 +966,6 @@ public fun <T : HttpClientEngineConfig> HttpClient(
  *
  * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.client.HttpClient)
  */
-@KtorDsl
 public fun HttpClient(
     engine: HttpClientEngine,
     block: HttpClientConfig<*>.() -> Unit

--- a/ktor-client/ktor-client-core/jsAndWasmShared/src/io/ktor/client/HttpClientJs.kt
+++ b/ktor-client/ktor-client-core/jsAndWasmShared/src/io/ktor/client/HttpClientJs.kt
@@ -16,7 +16,6 @@ import io.ktor.utils.io.*
  *
  * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.client.HttpClient)
  */
-@KtorDsl
 public actual fun HttpClient(
     block: HttpClientConfig<*>.() -> Unit
 ): HttpClient = HttpClient(FACTORY, block)

--- a/ktor-client/ktor-client-core/jvm/src/io/ktor/client/HttpClientJvm.kt
+++ b/ktor-client/ktor-client-core/jvm/src/io/ktor/client/HttpClientJvm.kt
@@ -20,7 +20,6 @@ import java.util.*
  *
  * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.client.HttpClient)
  */
-@KtorDsl
 public actual fun HttpClient(
     block: HttpClientConfig<*>.() -> Unit
 ): HttpClient = HttpClient(FACTORY, block)

--- a/ktor-client/ktor-client-core/posix/src/io/ktor/client/HttpClient.kt
+++ b/ktor-client/ktor-client-core/posix/src/io/ktor/client/HttpClient.kt
@@ -15,7 +15,6 @@ import io.ktor.utils.io.*
  *
  * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.client.HttpClient)
  */
-@KtorDsl
 public actual fun HttpClient(
     block: HttpClientConfig<*>.() -> Unit
 ): HttpClient = HttpClient(FACTORY, block)

--- a/ktor-client/ktor-client-plugins/ktor-client-auth/common/src/io/ktor/client/plugins/auth/providers/BasicAuthProvider.kt
+++ b/ktor-client/ktor-client-plugins/ktor-client-auth/common/src/io/ktor/client/plugins/auth/providers/BasicAuthProvider.kt
@@ -19,7 +19,6 @@ import io.ktor.utils.io.core.*
  *
  * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.client.plugins.auth.providers.basic)
  */
-@KtorDsl
 public fun AuthConfig.basic(block: BasicAuthConfig.() -> Unit) {
     with(BasicAuthConfig().apply(block)) {
         this@basic.providers.add(BasicAuthProvider(credentials, realm, _sendWithoutRequest))

--- a/ktor-client/ktor-client-webrtc/common/src/io/ktor/client/webrtc/WebRtcClient.kt
+++ b/ktor-client/ktor-client-webrtc/common/src/io/ktor/client/webrtc/WebRtcClient.kt
@@ -45,7 +45,6 @@ public fun interface WebRtcClientEngineFactory<out T : WebRtcConfig> {
  * ```
  * @param block configuration block for the client
  */
-@KtorDsl
 @ExperimentalKtorApi
 public fun <T : WebRtcConfig> WebRtcClient(
     factory: WebRtcClientEngineFactory<T>,

--- a/ktor-io/common/src/io/ktor/utils/io/Annotations.kt
+++ b/ktor-io/common/src/io/ktor/utils/io/Annotations.kt
@@ -108,5 +108,6 @@ public annotation class PublicAPICandidate(val version: String)
  * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.utils.io.KtorDsl)
  */
 @DslMarker
+// TODO KTOR-8901: Remove AnnotationTarget.FUNCTION
 @Target(AnnotationTarget.CLASS, AnnotationTarget.TYPEALIAS, AnnotationTarget.TYPE, AnnotationTarget.FUNCTION)
 public annotation class KtorDsl

--- a/ktor-server/ktor-server-core/common/src/io/ktor/server/application/Application.kt
+++ b/ktor-server/ktor-server-core/common/src/io/ktor/server/application/Application.kt
@@ -21,6 +21,9 @@ import kotlin.coroutines.EmptyCoroutineContext
  *
  * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.server.application.ServerConfigBuilder)
  */
+@Suppress("ktlint:standard:no-consecutive-comments")
+// TODO KTOR-8809: Uncomment the annotation
+// @KtorDsl
 public class ServerConfigBuilder(
     public val environment: ApplicationEnvironment
 ) {

--- a/ktor-server/ktor-server-core/common/src/io/ktor/server/engine/ApplicationEngine.kt
+++ b/ktor-server/ktor-server-core/common/src/io/ktor/server/engine/ApplicationEngine.kt
@@ -6,7 +6,8 @@ package io.ktor.server.engine
 
 import io.ktor.server.application.*
 import io.ktor.server.engine.internal.*
-import kotlinx.coroutines.*
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 
 /**
  * An engine which runs an application.
@@ -20,7 +21,9 @@ public interface ApplicationEngine {
      *
      * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.server.engine.ApplicationEngine.Configuration)
      */
-    @Suppress("MemberVisibilityCanBePrivate")
+    @Suppress("MemberVisibilityCanBePrivate", "ktlint:standard:no-consecutive-comments")
+    // TODO KTOR-8809: Uncomment the annotation
+    // @KtorDsl
     public open class Configuration {
         /**
          * Returns the current parallelism level (e.g. the number of available processors).

--- a/ktor-server/ktor-server-core/common/src/io/ktor/server/routing/RegexRouting.kt
+++ b/ktor-server/ktor-server-core/common/src/io/ktor/server/routing/RegexRouting.kt
@@ -8,8 +8,7 @@ import io.ktor.http.*
 import io.ktor.server.application.*
 import io.ktor.server.request.*
 import io.ktor.util.*
-import io.ktor.utils.io.*
-import kotlin.jvm.*
+import kotlin.jvm.JvmName
 
 /**
  * Builds a route to match the specified regex [path].
@@ -27,7 +26,6 @@ import kotlin.jvm.*
  *
  * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.server.routing.route)
  */
-@KtorDsl
 public fun Route.route(path: Regex, build: Route.() -> Unit): Route =
     createRouteFromRegexPath(path).apply(build)
 
@@ -47,7 +45,6 @@ public fun Route.route(path: Regex, build: Route.() -> Unit): Route =
  *
  * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.server.routing.route)
  */
-@KtorDsl
 public fun Route.route(path: Regex, method: HttpMethod, build: Route.() -> Unit): Route {
     val selector = HttpMethodRouteSelector(method)
     return createRouteFromRegexPath(path).createChild(selector).apply(build)
@@ -67,7 +64,6 @@ public fun Route.route(path: Regex, method: HttpMethod, build: Route.() -> Unit)
  *
  * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.server.routing.get)
  */
-@KtorDsl
 public fun Route.get(path: Regex, body: RoutingHandler): Route {
     return route(path, HttpMethod.Get) { handle(body) }
 }
@@ -86,7 +82,6 @@ public fun Route.get(path: Regex, body: RoutingHandler): Route {
  *
  * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.server.routing.post)
  */
-@KtorDsl
 public fun Route.post(path: Regex, body: RoutingHandler): Route {
     return route(path, HttpMethod.Post) { handle(body) }
 }
@@ -105,7 +100,6 @@ public fun Route.post(path: Regex, body: RoutingHandler): Route {
  *
  * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.server.routing.post)
  */
-@KtorDsl
 @JvmName("postTypedPath")
 public inline fun <reified R : Any> Route.post(
     path: Regex,
@@ -128,7 +122,6 @@ public inline fun <reified R : Any> Route.post(
  *
  * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.server.routing.head)
  */
-@KtorDsl
 public fun Route.head(path: Regex, body: RoutingHandler): Route {
     return route(path, HttpMethod.Head) { handle(body) }
 }
@@ -147,7 +140,6 @@ public fun Route.head(path: Regex, body: RoutingHandler): Route {
  *
  * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.server.routing.put)
  */
-@KtorDsl
 public fun Route.put(path: Regex, body: RoutingHandler): Route {
     return route(path, HttpMethod.Put) { handle(body) }
 }
@@ -166,7 +158,6 @@ public fun Route.put(path: Regex, body: RoutingHandler): Route {
  *
  * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.server.routing.put)
  */
-@KtorDsl
 @JvmName("putTypedPath")
 public inline fun <reified R : Any> Route.put(
     path: Regex,
@@ -189,7 +180,6 @@ public inline fun <reified R : Any> Route.put(
  *
  * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.server.routing.patch)
  */
-@KtorDsl
 public fun Route.patch(path: Regex, body: RoutingHandler): Route {
     return route(path, HttpMethod.Patch) { handle(body) }
 }
@@ -208,7 +198,6 @@ public fun Route.patch(path: Regex, body: RoutingHandler): Route {
  *
  * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.server.routing.patch)
  */
-@KtorDsl
 @JvmName("patchTypedPath")
 public inline fun <reified R : Any> Route.patch(
     path: Regex,
@@ -231,7 +220,6 @@ public inline fun <reified R : Any> Route.patch(
  *
  * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.server.routing.delete)
  */
-@KtorDsl
 public fun Route.delete(path: Regex, body: RoutingHandler): Route {
     return route(path, HttpMethod.Delete) { handle(body) }
 }
@@ -250,7 +238,6 @@ public fun Route.delete(path: Regex, body: RoutingHandler): Route {
  *
  * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.server.routing.options)
  */
-@KtorDsl
 public fun Route.options(path: Regex, body: RoutingHandler): Route {
     return route(path, HttpMethod.Options) { handle(body) }
 }

--- a/ktor-server/ktor-server-core/common/src/io/ktor/server/routing/RoutingBuilder.kt
+++ b/ktor-server/ktor-server-core/common/src/io/ktor/server/routing/RoutingBuilder.kt
@@ -9,8 +9,7 @@ package io.ktor.server.routing
 import io.ktor.http.*
 import io.ktor.server.application.*
 import io.ktor.server.request.*
-import io.ktor.utils.io.*
-import kotlin.jvm.*
+import kotlin.jvm.JvmName
 
 /**
  * Builds a route to match the specified [path].
@@ -19,7 +18,6 @@ import kotlin.jvm.*
  *
  * @see [Application.routing]
  */
-@KtorDsl
 public fun Route.route(path: String, build: Route.() -> Unit): Route =
     createRouteFromPath(path).apply(build)
 
@@ -30,7 +28,6 @@ public fun Route.route(path: String, build: Route.() -> Unit): Route =
  *
  * @see [Application.routing]
  */
-@KtorDsl
 public fun Route.route(path: String, method: HttpMethod, build: Route.() -> Unit): Route {
     val selector = HttpMethodRouteSelector(method)
     return createRouteFromPath(path).createChild(selector).apply(build)
@@ -43,7 +40,6 @@ public fun Route.route(path: String, method: HttpMethod, build: Route.() -> Unit
  *
  * @see [Application.routing]
  */
-@KtorDsl
 public fun Route.method(method: HttpMethod, body: Route.() -> Unit): Route {
     val selector = HttpMethodRouteSelector(method)
     return createChild(selector).apply(body)
@@ -56,7 +52,6 @@ public fun Route.method(method: HttpMethod, body: Route.() -> Unit): Route {
  *
  * @see [Application.routing]
  */
-@KtorDsl
 public fun Route.param(name: String, value: String, build: Route.() -> Unit): Route {
     val selector = ConstantParameterRouteSelector(name, value)
     return createChild(selector).apply(build)
@@ -69,7 +64,6 @@ public fun Route.param(name: String, value: String, build: Route.() -> Unit): Ro
  *
  * @see [Application.routing]
  */
-@KtorDsl
 public fun Route.param(name: String, build: Route.() -> Unit): Route {
     val selector = ParameterRouteSelector(name)
     return createChild(selector).apply(build)
@@ -82,7 +76,6 @@ public fun Route.param(name: String, build: Route.() -> Unit): Route {
  *
  * @see [Application.routing]
  */
-@KtorDsl
 public fun Route.optionalParam(name: String, build: Route.() -> Unit): Route {
     val selector = OptionalParameterRouteSelector(name)
     return createChild(selector).apply(build)
@@ -95,7 +88,6 @@ public fun Route.optionalParam(name: String, build: Route.() -> Unit): Route {
  *
  * @see [Application.routing]
  */
-@KtorDsl
 public fun Route.header(name: String, value: String, build: Route.() -> Unit): Route {
     val selector = HttpHeaderRouteSelector(name, value)
     return createChild(selector).apply(build)
@@ -108,7 +100,6 @@ public fun Route.header(name: String, value: String, build: Route.() -> Unit): R
  *
  * @see [Application.routing]
  */
-@KtorDsl
 public fun Route.accept(vararg contentTypes: ContentType, build: Route.() -> Unit): Route {
     val selector = HttpMultiAcceptRouteSelector(listOf(*contentTypes))
     return createChild(selector).apply(build)
@@ -121,7 +112,6 @@ public fun Route.accept(vararg contentTypes: ContentType, build: Route.() -> Uni
  *
  * @see [Application.routing]
  */
-@KtorDsl
 public fun Route.contentType(contentType: ContentType, build: Route.() -> Unit): Route {
     val selector = ContentTypeHeaderRouteSelector(contentType)
     return createChild(selector).apply(build)
@@ -134,7 +124,6 @@ public fun Route.contentType(contentType: ContentType, build: Route.() -> Unit):
  *
  * @see [Application.routing]
  */
-@KtorDsl
 public fun Route.get(path: String, body: RoutingHandler): Route {
     return route(path, HttpMethod.Get) { handle(body) }
 }
@@ -146,7 +135,6 @@ public fun Route.get(path: String, body: RoutingHandler): Route {
  *
  * @see [Application.routing]
  */
-@KtorDsl
 public fun Route.get(body: RoutingHandler): Route {
     return method(HttpMethod.Get) { handle(body) }
 }
@@ -158,7 +146,6 @@ public fun Route.get(body: RoutingHandler): Route {
  *
  * @see [Application.routing]
  */
-@KtorDsl
 public fun Route.post(path: String, body: RoutingHandler): Route {
     return route(path, HttpMethod.Post) { handle(body) }
 }
@@ -170,7 +157,6 @@ public fun Route.post(path: String, body: RoutingHandler): Route {
  *
  * @see [Application.routing]
  */
-@KtorDsl
 @JvmName("postTyped")
 public inline fun <reified R : Any> Route.post(
     crossinline body: suspend RoutingContext.(R) -> Unit
@@ -185,7 +171,6 @@ public inline fun <reified R : Any> Route.post(
  *
  * @see [Application.routing]
  */
-@KtorDsl
 @JvmName("postTypedPath")
 public inline fun <reified R : Any> Route.post(
     path: String,
@@ -201,7 +186,6 @@ public inline fun <reified R : Any> Route.post(
  *
  * @see [Application.routing]
  */
-@KtorDsl
 public fun Route.post(body: RoutingHandler): Route {
     return method(HttpMethod.Post) { handle(body) }
 }
@@ -213,7 +197,6 @@ public fun Route.post(body: RoutingHandler): Route {
  *
  * @see [Application.routing]
  */
-@KtorDsl
 public fun Route.head(path: String, body: RoutingHandler): Route {
     return route(path, HttpMethod.Head) { handle(body) }
 }
@@ -225,7 +208,6 @@ public fun Route.head(path: String, body: RoutingHandler): Route {
  *
  * @see [Application.routing]
  */
-@KtorDsl
 public fun Route.head(body: RoutingHandler): Route {
     return method(HttpMethod.Head) { handle(body) }
 }
@@ -237,7 +219,6 @@ public fun Route.head(body: RoutingHandler): Route {
  *
  * @see [Application.routing]
  */
-@KtorDsl
 public fun Route.put(path: String, body: RoutingHandler): Route {
     return route(path, HttpMethod.Put) { handle(body) }
 }
@@ -249,7 +230,6 @@ public fun Route.put(path: String, body: RoutingHandler): Route {
  *
  * @see [Application.routing]
  */
-@KtorDsl
 public fun Route.put(body: RoutingHandler): Route {
     return method(HttpMethod.Put) { handle(body) }
 }
@@ -261,7 +241,6 @@ public fun Route.put(body: RoutingHandler): Route {
  *
  * @see [Application.routing]
  */
-@KtorDsl
 @JvmName("putTyped")
 public inline fun <reified R : Any> Route.put(
     crossinline body: suspend RoutingContext.(R) -> Unit
@@ -276,7 +255,6 @@ public inline fun <reified R : Any> Route.put(
  *
  * @see [Application.routing]
  */
-@KtorDsl
 @JvmName("putTypedPath")
 public inline fun <reified R : Any> Route.put(
     path: String,
@@ -292,7 +270,6 @@ public inline fun <reified R : Any> Route.put(
  *
  * @see [Application.routing]
  */
-@KtorDsl
 public fun Route.patch(path: String, body: RoutingHandler): Route {
     return route(path, HttpMethod.Patch) { handle(body) }
 }
@@ -304,7 +281,6 @@ public fun Route.patch(path: String, body: RoutingHandler): Route {
  *
  * @see [Application.routing]
  */
-@KtorDsl
 public fun Route.patch(body: RoutingHandler): Route {
     return method(HttpMethod.Patch) { handle(body) }
 }
@@ -316,7 +292,6 @@ public fun Route.patch(body: RoutingHandler): Route {
  *
  * @see [Application.routing]
  */
-@KtorDsl
 @JvmName("patchTyped")
 public inline fun <reified R : Any> Route.patch(
     crossinline body: suspend RoutingContext.(R) -> Unit
@@ -331,7 +306,6 @@ public inline fun <reified R : Any> Route.patch(
  *
  * @see [Application.routing]
  */
-@KtorDsl
 @JvmName("patchTypedPath")
 public inline fun <reified R : Any> Route.patch(
     path: String,
@@ -347,7 +321,6 @@ public inline fun <reified R : Any> Route.patch(
  *
  * @see [Application.routing]
  */
-@KtorDsl
 public fun Route.delete(path: String, body: RoutingHandler): Route {
     return route(path, HttpMethod.Delete) { handle(body) }
 }
@@ -359,7 +332,6 @@ public fun Route.delete(path: String, body: RoutingHandler): Route {
  *
  * @see [Application.routing]
  */
-@KtorDsl
 public fun Route.delete(body: RoutingHandler): Route {
     return method(HttpMethod.Delete) { handle(body) }
 }
@@ -371,7 +343,6 @@ public fun Route.delete(body: RoutingHandler): Route {
  *
  * @see [Application.routing]
  */
-@KtorDsl
 public fun Route.options(path: String, body: RoutingHandler): Route {
     return route(path, HttpMethod.Options) { handle(body) }
 }
@@ -383,7 +354,6 @@ public fun Route.options(path: String, body: RoutingHandler): Route {
  *
  * @see [Application.routing]
  */
-@KtorDsl
 public fun Route.options(body: RoutingHandler): Route {
     return method(HttpMethod.Options) { handle(body) }
 }

--- a/ktor-server/ktor-server-core/common/src/io/ktor/server/routing/RoutingNode.kt
+++ b/ktor-server/ktor-server-core/common/src/io/ktor/server/routing/RoutingNode.kt
@@ -254,6 +254,9 @@ public class RoutingCall internal constructor(
  *
  * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.server.routing.RoutingContext)
  */
+@Suppress("ktlint:standard:no-consecutive-comments")
+// TODO KTOR-8809: Uncomment the annotation
+// @KtorDsl
 public class RoutingContext(
     public val call: RoutingCall
 )
@@ -270,6 +273,9 @@ public typealias RoutingHandler = suspend RoutingContext.() -> Unit
  *
  * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.server.routing.Route)
  */
+@Suppress("ktlint:standard:no-consecutive-comments")
+// TODO KTOR-8809: Uncomment the annotation
+// @KtorDsl
 public interface Route {
     public val environment: ApplicationEnvironment
     public val attributes: Attributes

--- a/ktor-server/ktor-server-core/common/src/io/ktor/server/routing/RoutingRoot.kt
+++ b/ktor-server/ktor-server-core/common/src/io/ktor/server/routing/RoutingRoot.kt
@@ -178,7 +178,6 @@ public val Route.application: Application
  *
  * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.server.routing.routing)
  */
-@KtorDsl
 public fun Application.routing(configuration: Routing.() -> Unit): RoutingRoot =
     pluginOrNull(RoutingRoot)?.apply(configuration) ?: install(RoutingRoot, configuration)
 

--- a/ktor-server/ktor-server-plugins/ktor-server-di/common/src/io/ktor/server/plugins/di/DependencyProviderLambdaOverloads.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-di/common/src/io/ktor/server/plugins/di/DependencyProviderLambdaOverloads.kt
@@ -6,8 +6,6 @@
 
 package io.ktor.server.plugins.di
 
-import io.ktor.utils.io.*
-
 /**
  * Registers a dependency provider that takes no parameters and returns a value of type [E].
  *
@@ -17,7 +15,7 @@ import io.ktor.utils.io.*
  * @param function A function that creates and returns an instance of [E]
  * @return A [DependencyRegistry.KeyContext] for further configuration of the dependency
  */
-@KtorDsl public inline fun <reified E> DependencyRegistry.provide(
+public inline fun <reified E> DependencyRegistry.provide(
     crossinline function: suspend () -> E
 ): DependencyRegistry.KeyContext<E> = provide {
     function()
@@ -33,7 +31,7 @@ import io.ktor.utils.io.*
  * @param function A function that takes one parameter of type [I1] and returns an instance of [E]
  * @return A [DependencyRegistry.KeyContext] for further configuration of the dependency
  */
-@KtorDsl public inline fun <reified E, reified I1> DependencyRegistry.provide(
+public inline fun <reified E, reified I1> DependencyRegistry.provide(
     crossinline function: suspend (I1) -> E
 ): DependencyRegistry.KeyContext<E> = provide { function(resolve()) }
 
@@ -48,7 +46,7 @@ import io.ktor.utils.io.*
  * @param function A function that takes two parameters and returns an instance of [E]
  * @return A [DependencyRegistry.KeyContext] for further configuration of the dependency
  */
-@KtorDsl public inline fun <reified E, reified I1, reified I2> DependencyRegistry.provide(
+public inline fun <reified E, reified I1, reified I2> DependencyRegistry.provide(
     crossinline function: suspend (I1, I2) -> E
 ): DependencyRegistry.KeyContext<E> = provide { function(resolve(), resolve()) }
 
@@ -64,7 +62,7 @@ import io.ktor.utils.io.*
  * @param function A function that takes three parameters and returns an instance of [E]
  * @return A [DependencyRegistry.KeyContext] for further configuration of the dependency
  */
-@KtorDsl public inline fun <reified E, reified I1, reified I2, reified I3> DependencyRegistry.provide(
+public inline fun <reified E, reified I1, reified I2, reified I3> DependencyRegistry.provide(
     crossinline function: suspend (I1, I2, I3) -> E
 ): DependencyRegistry.KeyContext<E> = provide { function(resolve(), resolve(), resolve()) }
 
@@ -81,7 +79,7 @@ import io.ktor.utils.io.*
  * @param function A function that takes four parameters and returns an instance of [E]
  * @return A [DependencyRegistry.KeyContext] for further configuration of the dependency
  */
-@KtorDsl public inline fun <reified E, reified I1, reified I2, reified I3, reified I4> DependencyRegistry.provide(
+public inline fun <reified E, reified I1, reified I2, reified I3, reified I4> DependencyRegistry.provide(
     crossinline function: suspend (I1, I2, I3, I4) -> E
 ): DependencyRegistry.KeyContext<E> = provide { function(resolve(), resolve(), resolve(), resolve()) }
 
@@ -99,7 +97,7 @@ import io.ktor.utils.io.*
  * @param function A function that takes five parameters and returns an instance of [E]
  * @return A [DependencyRegistry.KeyContext] for further configuration of the dependency
  */
-@KtorDsl public inline fun <reified E, reified I1, reified I2, reified I3, reified I4, reified I5> DependencyRegistry.provide(
+public inline fun <reified E, reified I1, reified I2, reified I3, reified I4, reified I5> DependencyRegistry.provide(
     crossinline function: suspend (I1, I2, I3, I4, I5) -> E
 ): DependencyRegistry.KeyContext<E> = provide { function(resolve(), resolve(), resolve(), resolve(), resolve()) }
 
@@ -118,7 +116,7 @@ import io.ktor.utils.io.*
  * @param function A function that takes six parameters and returns an instance of [E]
  * @return A [DependencyRegistry.KeyContext] for further configuration of the dependency
  */
-@KtorDsl public inline fun <reified E, reified I1, reified I2, reified I3, reified I4, reified I5, reified I6> DependencyRegistry.provide(
+public inline fun <reified E, reified I1, reified I2, reified I3, reified I4, reified I5, reified I6> DependencyRegistry.provide(
     crossinline function: suspend (I1, I2, I3, I4, I5, I6) -> E
 ): DependencyRegistry.KeyContext<E> = provide {
     function(resolve(), resolve(), resolve(), resolve(), resolve(), resolve())

--- a/ktor-server/ktor-server-plugins/ktor-server-di/common/src/io/ktor/server/plugins/di/DependencyRegistry.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-di/common/src/io/ktor/server/plugins/di/DependencyRegistry.kt
@@ -174,7 +174,6 @@ public class DependencyRegistry(
  *
  * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.server.plugins.di.dependencies)
  */
-@KtorDsl
 public fun <T> Application.dependencies(action: DependencyRegistry.() -> T): T =
     dependencies.action()
 

--- a/ktor-server/ktor-server-plugins/ktor-server-htmx/common/src/io/ktor/server/htmx/HxRouting.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-htmx/common/src/io/ktor/server/htmx/HxRouting.kt
@@ -23,11 +23,7 @@ public val Route.hx: HxRoute get() = HxRoute.wrap(this)
  * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.server.htmx.hx)
  */
 @ExperimentalKtorApi
-public fun Route.hx(configuration: HxRoute.() -> Unit): Route = with(HxRoute.wrap(this)) {
-    header(HxRequestHeaders.Request, "true") {
-        configuration()
-    }
-}
+public fun Route.hx(configuration: HxRoute.() -> Unit): Route = hx.apply(configuration)
 
 /**
  * Provides custom routes based on common HTMX headers.

--- a/ktor-server/ktor-server-test-host/common/src/io/ktor/server/testing/TestApplication.kt
+++ b/ktor-server/ktor-server-test-host/common/src/io/ktor/server/testing/TestApplication.kt
@@ -55,7 +55,6 @@ public interface ClientProvider {
      *
      * @see [testApplication]
      */
-    @KtorDsl
     public fun createClient(block: HttpClientConfig<out HttpClientEngineConfig>.() -> Unit): HttpClient
 }
 
@@ -133,7 +132,6 @@ public class TestApplication internal constructor(
  *
  * @see [testApplication]
  */
-@KtorDsl
 public fun TestApplication(
     block: TestApplicationBuilder.() -> Unit
 ): TestApplication {
@@ -160,7 +158,6 @@ public class ExternalServicesBuilder internal constructor(private val testApplic
      *
      * @see [testApplication]
      */
-    @KtorDsl
     public fun hosts(vararg hosts: String, block: Application.() -> Unit) {
         check(hosts.isNotEmpty()) { "hosts can not be empty" }
 
@@ -226,7 +223,6 @@ public open class TestApplicationBuilder {
      *
      * @see [testApplication]
      */
-    @KtorDsl
     public fun externalServices(block: ExternalServicesBuilder.() -> Unit) {
         checkNotBuilt()
         externalServices.block()
@@ -239,7 +235,6 @@ public open class TestApplicationBuilder {
      *
      * @see [testApplication]
      */
-    @KtorDsl
     public fun engine(block: TestApplicationEngine.Configuration.() -> Unit) {
         checkNotBuilt()
         val oldBuilder = engineConfig
@@ -256,7 +251,6 @@ public open class TestApplicationBuilder {
      *
      * @see [testApplication]
      */
-    @KtorDsl
     public fun serverConfig(block: ServerConfigBuilder.() -> Unit) {
         checkNotBuilt()
         val oldBuilder = applicationProperties
@@ -273,7 +267,6 @@ public open class TestApplicationBuilder {
      *
      * @see [testApplication]
      */
-    @KtorDsl
     public fun environment(block: ApplicationEnvironmentBuilder.() -> Unit) {
         checkNotBuilt()
         val oldBuilder = environmentBuilder
@@ -303,7 +296,6 @@ public open class TestApplicationBuilder {
      *
      * @see [testApplication]
      */
-    @KtorDsl
     public fun application(block: suspend Application.() -> Unit) {
         checkNotBuilt()
         applicationModules.add(block)
@@ -314,11 +306,11 @@ public open class TestApplicationBuilder {
      *
      * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.server.testing.TestApplicationBuilder.install)
      */
-    @Suppress("UNCHECKED_CAST")
-    @KtorDsl
+    @Suppress("UNCHECKED_CAST", "ktlint:standard:no-consecutive-comments", "ktlint:standard:value-parameter-comment")
+    // TODO KTOR-8809: Uncomment the KtorDsl annotation
     public fun <P : Pipeline<*, PipelineCall>, B : Any, F : Any> install(
         plugin: Plugin<P, B, F>,
-        configure: B.() -> Unit = {}
+        configure: /* @KtorDsl */ B.() -> Unit = {}
     ) {
         checkNotBuilt()
         applicationModules.add { install(plugin as Plugin<ApplicationCallPipeline, B, F>, configure) }
@@ -329,7 +321,6 @@ public open class TestApplicationBuilder {
      *
      * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.server.testing.TestApplicationBuilder.routing)
      */
-    @KtorDsl
     public fun routing(configuration: Route.() -> Unit) {
         checkNotBuilt()
         applicationModules.add { routing(configuration) }
@@ -346,10 +337,11 @@ public open class TestApplicationBuilder {
      *
      * @param configPaths Optional paths to configuration files.
      */
-    @KtorDsl
+    @Suppress("ktlint:standard:no-consecutive-comments", "ktlint:standard:value-parameter-comment")
+    // TODO KTOR-8809: Uncomment the KtorDsl annotation
     public fun configure(
         vararg configPaths: String,
-        overrides: (MutableMap<String, String>.() -> Unit)? = null
+        overrides: /* @KtorDsl */ (MutableMap<String, String>.() -> Unit)? = null
     ) {
         checkNotBuilt()
         environment {
@@ -424,7 +416,6 @@ public class ApplicationTestBuilder : TestApplicationBuilder(), ClientProvider {
         testApplication.start()
     }
 
-    @KtorDsl
     override fun createClient(
         block: HttpClientConfig<out HttpClientEngineConfig>.() -> Unit
     ): HttpClient = HttpClient(DelegatingTestClientEngine) {
@@ -470,7 +461,6 @@ public class ApplicationTestBuilder : TestApplicationBuilder(), ClientProvider {
  *
  * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.server.testing.testApplication)
  */
-@KtorDsl
 public fun testApplication(block: suspend ApplicationTestBuilder.() -> Unit): TestResult {
     return testApplication(EmptyCoroutineContext, block)
 }
@@ -509,7 +499,6 @@ public fun testApplication(block: suspend ApplicationTestBuilder.() -> Unit): Te
  *
  * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.server.testing.testApplication)
  */
-@KtorDsl
 public fun testApplication(
     parentCoroutineContext: CoroutineContext = EmptyCoroutineContext,
     block: suspend ApplicationTestBuilder.() -> Unit
@@ -519,7 +508,6 @@ public fun testApplication(
 
 // allows running multiple servers during one test
 // not really needed outside ktor probably
-@KtorDsl
 public suspend fun runTestApplication(
     parentCoroutineContext: CoroutineContext = EmptyCoroutineContext,
     block: suspend ApplicationTestBuilder.() -> Unit


### PR DESCRIPTION
**Subsystem**
Core

**Motivation**
[KTOR-8901](https://youtrack.jetbrains.com/issue/KTOR-8901) Remove `AnnotationTarget.FUNCTION` from `@KtorDsl`

**Solution**
This PR removes wrongly used `@KtorDsl` annotation to make it possible to remove the annotation target `FUNCTION` in the future.