### PR TITLE
KTOR-8770 Fix double shutdownGracePeriod on Netty

### DIFF
--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyApplicationEngine.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyApplicationEngine.kt
@@ -288,7 +288,6 @@ public class NettyApplicationEngine(
         try {
             val shutdownConnections =
                 connectionEventGroup.shutdownGracefully(gracePeriodMillis, timeoutMillis, TimeUnit.MILLISECONDS)
-            shutdownConnections.await()
 
             val shutdownWorkers =
                 workerEventGroup.shutdownGracefully(gracePeriodMillis, timeoutMillis, TimeUnit.MILLISECONDS)
@@ -300,6 +299,7 @@ public class NettyApplicationEngine(
                 shutdownWorkers.await()
                 shutdownCall.await()
             }
+            shutdownConnections.await()
         } finally {
             channelFutures.forEach { it.sync() }
         }


### PR DESCRIPTION
**Subsystem**
Server, Netty

**Motivation**
[KTOR-8770](https://youtrack.jetbrains.com/issue/KTOR-8770) Netty: EmbeddedServer.stop always blocks for twice of shutdownGracePeriod


