### PR TITLE
CORS Plugin: Access-Control-Allow-Methods header does not include default methods (GET, POST, HEAD)

### DIFF
--- a/ktor-server/ktor-server-plugins/ktor-server-cors/common/src/io/ktor/server/plugins/cors/CORS.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-cors/common/src/io/ktor/server/plugins/cors/CORS.kt
@@ -54,7 +54,7 @@ internal fun PluginBuilder<CORSConfig>.buildPlugin() {
     val allowNonSimpleContentTypes: Boolean = pluginConfig.allowNonSimpleContentTypes
     val headersList = pluginConfig.headers.filterNot { it in CORSConfig.CorsSimpleRequestHeaders }
         .let { if (allowNonSimpleContentTypes) it + HttpHeaders.ContentType else it }
-    val methodsListHeaderValue = methods.filterNot { it in CORSConfig.CorsDefaultMethods }
+    val methodsListHeaderValue = methods.distinct()
         .map { it.value }
         .sorted()
         .joinToString(", ")

--- a/ktor-server/ktor-server-tests/common/test/io/ktor/tests/server/plugins/CORSTest.kt
+++ b/ktor-server/ktor-server-tests/common/test/io/ktor/tests/server/plugins/CORSTest.kt
@@ -1592,4 +1592,33 @@ class CORSTest {
             assertEquals(response.status, HttpStatusCode.Forbidden)
         }
     }
+
+    @Test
+    fun testPreflightIncludesDefaultMethods() = testApplication {
+        install(CORS) {
+            anyHost()
+            allowMethod(HttpMethod.Put)
+        }
+
+        routing {
+            get("/") { call.respond("OK") }
+            post("/") { call.respond("OK") }
+            put("/") { call.respond("OK") }
+        }
+
+        val response = client.options("/") {
+            header(HttpHeaders.Origin, "http://my-host")
+            header(HttpHeaders.AccessControlRequestMethod, "PUT")
+        }
+
+        assertEquals(HttpStatusCode.OK, response.status)
+        val allowMethods = response.headers[HttpHeaders.AccessControlAllowMethods]?.split(", ")?.toSet()
+        assertNotNull(allowMethods)
+
+        assertTrue(HttpMethod.Get.value in allowMethods!!)
+        assertTrue(HttpMethod.Post.value in allowMethods)
+        assertTrue(HttpMethod.Head.value in allowMethods)
+        assertTrue(HttpMethod.Put.value in allowMethods)
+    }
+
 }


### PR DESCRIPTION
Fixes #5103

Problem
In Ktor 3.3.0, the CORS plugin does not correctly include the default HTTP methods (GET, POST, HEAD) in the Access-Control-Allow-Methods response header.

Current implementation in CORSConfig builds the header value like this:

`val methodsListHeaderValue = methods.filterNot { it in CorsDefaultMethods }
    .map { it.value }
    .sorted()
    .joinToString(", ")
`

Since CorsDefaultMethods = { GET, POST, HEAD }, these methods are filtered out and not included in the final header.
This results in browsers seeing an incomplete Access-Control-Allow-Methods (often only OPTIONS), which breaks CORS preflight validation.

Solution
Replaced filtering logic with a distinct collection:

`val methodsListHeaderValue = methods.distinct()
    .map { it.value }
    .sorted()
    .joinToString(", ")
`
This ensures that the default methods (GET, POST, HEAD) are included along with any additional configured methods.

Tests
Added a new test testPreflightIncludesDefaultMethods to verify that:

GET, POST, and HEAD are always present in Access-Control-Allow-Methods

Custom allowed methods (e.g., PUT) are also included

Before the fix, this test fails. After the fix, it passes ✅

Environment

Ktor version: 3.3.0

Module: ktor-server-cors

JVM: 17

OS: Ubuntu 22.04 / Windows 11