### PR TITLE
Zibet27/ktor client webrtc fix close

### DIFF
--- a/ktor-client/ktor-client-webrtc/android/src/io/ktor/client/webrtc/DataChannel.kt
+++ b/ktor-client/ktor-client-webrtc/android/src/io/ktor/client/webrtc/DataChannel.kt
@@ -129,6 +129,5 @@ public class AndroidWebRtcDataChannel(
  * Returns implementation of the data channel that is used under the hood. Use it with caution.
  */
 public fun WebRtcDataChannel.getNative(): DataChannel {
-    val channel = (this as? AndroidWebRtcDataChannel) ?: error("Wrong data channel implementation.")
-    return channel.nativeChannel
+    return (this as AndroidWebRtcDataChannel).nativeChannel
 }

--- a/ktor-client/ktor-client-webrtc/android/src/io/ktor/client/webrtc/PeerConnection.kt
+++ b/ktor-client/ktor-client-webrtc/android/src/io/ktor/client/webrtc/PeerConnection.kt
@@ -190,14 +190,14 @@ public class AndroidWebRtcPeerConnection(
     }
 
     override suspend fun addTrack(track: WebRtcMedia.Track): WebRtc.RtpSender {
-        val mediaTrack = track as? AndroidMediaTrack ?: error("Track should extend AndroidMediaTrack.")
+        val mediaTrack = track as AndroidMediaTrack
         val newSender = AndroidRtpSender(peerConnection.addTrack(mediaTrack.nativeTrack))
         rtpSenders.add(newSender)
         return newSender
     }
 
     override suspend fun removeTrack(track: WebRtcMedia.Track) {
-        val mediaTrack = track as? AndroidMediaTrack ?: error("Track should extend AndroidMediaTrack.")
+        val mediaTrack = track as AndroidMediaTrack
         val sender = rtpSenders.firstOrNull { it.track?.id == mediaTrack.id }
             ?: error("Track is not found.")
         if (!peerConnection.removeTrack(sender.nativeSender)) {
@@ -206,7 +206,7 @@ public class AndroidWebRtcPeerConnection(
     }
 
     override suspend fun removeTrack(sender: WebRtc.RtpSender) {
-        val rtpSender = sender as? AndroidRtpSender ?: error("Sender should extend AndroidRtpSender.")
+        val rtpSender = sender as AndroidRtpSender
         if (!peerConnection.removeTrack(rtpSender.nativeSender)) {
             error("Failed to remove track.")
         }

--- a/ktor-client/ktor-client-webrtc/android/src/io/ktor/client/webrtc/PeerConnection.kt
+++ b/ktor-client/ktor-client-webrtc/android/src/io/ktor/client/webrtc/PeerConnection.kt
@@ -7,12 +7,12 @@ package io.ktor.client.webrtc
 import io.ktor.client.webrtc.media.*
 import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.suspendCancellableCoroutine
 import org.webrtc.*
 import org.webrtc.PeerConnection.Observer
 import kotlin.coroutines.CoroutineContext
 import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
-import kotlin.coroutines.suspendCoroutine
 
 public class AndroidWebRtcPeerConnection(
     coroutineContext: CoroutineContext,
@@ -23,9 +23,10 @@ public class AndroidWebRtcPeerConnection(
     // remember RTP senders because method PeerConnection.getSenders() disposes all returned senders
     private val rtpSenders = arrayListOf<AndroidRtpSender>()
 
-    override suspend fun getStatistics(): List<WebRtc.Stats> = suspendCoroutine { cont ->
+    override suspend fun getStatistics(): List<WebRtc.Stats> = suspendCancellableCoroutine { cont ->
         if (this::peerConnection.isInitialized.not()) {
             cont.resume(emptyList())
+            return@suspendCancellableCoroutine
         }
         peerConnection.getStats { cont.resume(it.toKtor()) }
     }
@@ -120,14 +121,14 @@ public class AndroidWebRtcPeerConnection(
         get() = peerConnection.remoteDescription?.toKtor()
 
     override suspend fun createOffer(): WebRtc.SessionDescription {
-        val offer = suspendCoroutine { cont ->
+        val offer = suspendCancellableCoroutine { cont ->
             peerConnection.createOffer(cont.resumeAfterSdpCreate(), offerConstraints())
         }
         return offer.toKtor()
     }
 
     override suspend fun createAnswer(): WebRtc.SessionDescription {
-        val answer = suspendCoroutine { cont ->
+        val answer = suspendCancellableCoroutine { cont ->
             peerConnection.createAnswer(cont.resumeAfterSdpCreate(), offerConstraints())
         }
         return answer.toKtor()
@@ -160,13 +161,13 @@ public class AndroidWebRtcPeerConnection(
     }
 
     override suspend fun setLocalDescription(description: WebRtc.SessionDescription) {
-        suspendCoroutine { cont ->
+        suspendCancellableCoroutine { cont ->
             peerConnection.setLocalDescription(cont.resumeAfterSdpSet(), description.toNative())
         }
     }
 
     override suspend fun setRemoteDescription(description: WebRtc.SessionDescription) {
-        suspendCoroutine { cont ->
+        suspendCancellableCoroutine { cont ->
             peerConnection.setRemoteDescription(cont.resumeAfterSdpSet(), description.toNative())
         }
     }
@@ -177,7 +178,7 @@ public class AndroidWebRtcPeerConnection(
             candidate.sdpMLineIndex,
             candidate.candidate,
         )
-        suspendCoroutine { cont ->
+        suspendCancellableCoroutine { cont ->
             peerConnection.addIceCandidate(
                 iceCandidate,
                 object : AddIceObserver {
@@ -216,6 +217,7 @@ public class AndroidWebRtcPeerConnection(
     }
 
     override fun close() {
+        super.close()
         peerConnection.close()
     }
 }

--- a/ktor-client/ktor-client-webrtc/android/src/io/ktor/client/webrtc/Senders.kt
+++ b/ktor-client/ktor-client-webrtc/android/src/io/ktor/client/webrtc/Senders.kt
@@ -23,7 +23,7 @@ public class AndroidRtpSender(internal val nativeSender: RtpSender) : WebRtc.Rtp
             }
             return
         }
-        val track = withTrack as? AndroidMediaTrack ?: error("Track should extend AndroidMediaTrack.")
+        val track = withTrack as AndroidMediaTrack
         if (!nativeSender.setTrack(track.nativeTrack, false)) {
             error("Failed to replace track.")
         }
@@ -34,8 +34,7 @@ public class AndroidRtpSender(internal val nativeSender: RtpSender) : WebRtc.Rtp
     }
 
     override suspend fun setParameters(parameters: WebRtc.RtpParameters) {
-        val parameters = parameters as? AndroidRtpParameters ?: error("Parameters should extend AndroidRtpParameters.")
-        nativeSender.parameters = parameters.nativeRtpParameters
+        nativeSender.parameters = (parameters as AndroidRtpParameters).nativeRtpParameters
     }
 }
 
@@ -74,22 +73,19 @@ public class AndroidRtpParameters(internal val nativeRtpParameters: RtpParameter
  * Returns implementation of the rtp sender that is used under the hood. Use it with caution.
  */
 public fun WebRtc.RtpSender.getNative(): RtpSender {
-    val sender = this as? AndroidRtpSender ?: error("Wrong Rtp sender implementation.")
-    return sender.nativeSender
+    return (this as AndroidRtpSender).nativeSender
 }
 
 /**
  * Returns implementation of the dtmf sender that is used under the hood. Use it with caution.
  */
 public fun WebRtc.DtmfSender.getNative(): DtmfSender {
-    val sender = this as? AndroidDtmfSender ?: error("Wrong Dtmf sender implementation.")
-    return sender.nativeSender
+    return (this as AndroidDtmfSender).nativeSender
 }
 
 /**
  * Returns implementation of the rtp parameters that is used under the hood. Use it with caution.
  */
 public fun WebRtc.RtpParameters.getNative(): RtpParameters {
-    val parameters = this as? AndroidRtpParameters ?: error("Wrong parameters implementation.")
-    return parameters.nativeRtpParameters
+    return (this as AndroidRtpParameters).nativeRtpParameters
 }

--- a/ktor-client/ktor-client-webrtc/android/src/io/ktor/client/webrtc/media/MediaTrack.kt
+++ b/ktor-client/ktor-client-webrtc/android/src/io/ktor/client/webrtc/media/MediaTrack.kt
@@ -58,14 +58,12 @@ public class AndroidVideoTrack(nativeTrack: MediaStreamTrack, onDispose: (() -> 
  * Returns implementation of the native video stream track used under the hood. Use it with caution.
  */
 public fun WebRtcMedia.VideoTrack.getNative(): VideoTrack {
-    val track = this as? AndroidMediaTrack ?: error("Wrong track implementation.")
-    return track.nativeTrack as VideoTrack
+    return (this as AndroidMediaTrack).nativeTrack as VideoTrack
 }
 
 /**
  * Returns implementation of the native audio stream track used under the hood. Use it with caution.
  */
 public fun WebRtcMedia.AudioTrack.getNative(): AudioTrack {
-    val track = this as? AndroidMediaTrack ?: error("Wrong track implementation.")
-    return track.nativeTrack as AudioTrack
+    return (this as AndroidMediaTrack).nativeTrack as AudioTrack
 }

--- a/ktor-client/ktor-client-webrtc/common/src/io/ktor/client/webrtc/WebRtcPeerConnection.kt
+++ b/ktor-client/ktor-client-webrtc/common/src/io/ktor/client/webrtc/WebRtcPeerConnection.kt
@@ -9,6 +9,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlin.coroutines.CoroutineContext
 
@@ -34,7 +35,7 @@ public abstract class WebRtcPeerConnection private constructor(
         val refreshRate = config.statsRefreshRate
         if (refreshRate != null) {
             coroutineScope.launch {
-                while (true) {
+                while (isActive) {
                     delay(duration = refreshRate)
                     events.emitStats(stats = getStatistics())
                 }

--- a/ktor-client/ktor-client-webrtc/common/test/io/ktor/client/webrtc/WebRtcEngineTest.kt
+++ b/ktor-client/ktor-client-webrtc/common/test/io/ktor/client/webrtc/WebRtcEngineTest.kt
@@ -6,7 +6,7 @@ package io.ktor.client.webrtc
 
 import io.ktor.client.webrtc.utils.*
 import io.ktor.test.dispatcher.*
-import io.ktor.utils.io.ExperimentalKtorApi
+import io.ktor.utils.io.*
 import kotlinx.atomicfu.atomic
 import kotlinx.coroutines.*
 import kotlinx.coroutines.channels.Channel
@@ -200,6 +200,7 @@ class WebRtcEngineTest {
             peerConnection.addTrack(audioTrack)
 
             val stats = peerConnection.stats.collectToChannel(this, jobs)
+            assertNull(stats.tryReceive().getOrNull())
 
             withTimeout(5000) {
                 val firstStats = stats.receive()
@@ -213,6 +214,63 @@ class WebRtcEngineTest {
                 val mediaSource = realStats.first { it.type == "media-source" }
                 assertEquals("audio", mediaSource.props["kind"])
             }
+        }
+    }
+
+    private fun Channel<*>.assertOnlyOneReceived() {
+        assertNotNull(tryReceive().getOrNull())
+        assertNull(tryReceive().getOrNull())
+    }
+
+    @Test
+    fun testClientClose() = runTestWithRealTime {
+        val delay = 10
+        val connection1 = client.createPeerConnection {
+            statsRefreshRate = delay.milliseconds
+            exceptionHandler = CoroutineExceptionHandler { _, e -> throw e }
+        }
+        val jobs = mutableListOf<Job>()
+        try {
+            val stats1 = connection1.stats.collectToChannel(scope = this, jobs)
+            delay(duration = (delay * 1.5).milliseconds)
+            stats1.assertOnlyOneReceived()
+            client.close()
+
+            delay(duration = (delay * 5).milliseconds)
+            // ensure no more elements are emitted after close
+            assertNull(stats1.tryReceive().getOrNull())
+        } finally {
+            jobs.forEach { it.cancel() }
+        }
+    }
+
+    @Test
+    fun testConnectionClose() = runTestWithRealTime {
+        val delay = 10
+        val config = WebRtcConnectionConfig().apply {
+            statsRefreshRate = delay.milliseconds
+            exceptionHandler = CoroutineExceptionHandler { _, e -> throw e }
+        }
+        val connection1 = client.createPeerConnection(config)
+        val connection2 = client.createPeerConnection(config)
+        val jobs = mutableListOf<Job>()
+        try {
+            val stats1 = connection1.stats.collectToChannel(scope = this, jobs)
+            val stats2 = connection2.stats.collectToChannel(scope = this, jobs)
+            delay(duration = (delay * 1.5).milliseconds)
+
+            stats1.assertOnlyOneReceived()
+            stats2.assertOnlyOneReceived()
+
+            connection1.close()
+
+            delay(duration = (delay * 5).milliseconds)
+            // ensure no more elements are emitted after close
+            assertNull(stats1.tryReceive().getOrNull())
+            // connection2 should still receive stats
+            withTimeout(1000) { stats2.receive() }
+        } finally {
+            jobs.forEach { it.cancel() }
         }
     }
 

--- a/ktor-client/ktor-client-webrtc/ios/src/io/ktor/client/webrtc/PeerConnection.kt
+++ b/ktor-client/ktor-client-webrtc/ios/src/io/ktor/client/webrtc/PeerConnection.kt
@@ -252,6 +252,7 @@ public class IosWebRtcConnection(
     }
 
     override fun close() {
+        super.close()
         peerConnection.close()
     }
 }

--- a/ktor-client/ktor-client-webrtc/jsAndWasmShared/src/io/ktor/client/webrtc/Browser.kt
+++ b/ktor-client/ktor-client-webrtc/jsAndWasmShared/src/io/ktor/client/webrtc/Browser.kt
@@ -216,7 +216,7 @@ internal fun WebRtcDataChannelOptions.toJs(): RTCDataChannelInit = unsafeJso {
 internal fun RTCStatsReport.toKtor(): List<WebRtc.Stats> {
     val statsList = mutableListOf<WebRtc.Stats>()
     forEach { value, _ ->
-        val rtcStats = (value as? RTCStats) ?: return@forEach
+        val rtcStats = value as RTCStats
         statsList.add(rtcStats.toKtor())
     }
     return statsList

--- a/ktor-client/ktor-client-webrtc/jsAndWasmShared/src/io/ktor/client/webrtc/DataChannel.kt
+++ b/ktor-client/ktor-client-webrtc/jsAndWasmShared/src/io/ktor/client/webrtc/DataChannel.kt
@@ -114,6 +114,5 @@ public class JsWebRtcDataChannel(
  * Returns implementation of the data channel that is used under the hood. Use it with caution.
  */
 public fun WebRtcDataChannel.getNative(): RTCDataChannel {
-    val channel = (this as? JsWebRtcDataChannel) ?: error("Wrong data channel implementation.")
-    return channel.channel
+    return (this as JsWebRtcDataChannel).channel
 }

--- a/ktor-client/ktor-client-webrtc/jsAndWasmShared/src/io/ktor/client/webrtc/MediaDevices.kt
+++ b/ktor-client/ktor-client-webrtc/jsAndWasmShared/src/io/ktor/client/webrtc/MediaDevices.kt
@@ -95,6 +95,5 @@ public class JsVideoTrack(nativeTrack: MediaStreamTrack) :
  * Returns implementation of the native media stream track used under the hood. Use it with caution.
  */
 public fun WebRtcMedia.Track.getNative(): MediaStreamTrack {
-    val track = this as? JsMediaTrack ?: error("Wrong track implementation.")
-    return track.nativeTrack
+    return (this as JsMediaTrack).nativeTrack
 }

--- a/ktor-client/ktor-client-webrtc/jsAndWasmShared/src/io/ktor/client/webrtc/PeerConnection.kt
+++ b/ktor-client/ktor-client-webrtc/jsAndWasmShared/src/io/ktor/client/webrtc/PeerConnection.kt
@@ -130,6 +130,7 @@ public class JsWebRtcPeerConnection(
     }
 
     override fun close() {
+        super.close()
         connection.close()
     }
 }

--- a/ktor-client/ktor-client-webrtc/jsAndWasmShared/src/io/ktor/client/webrtc/PeerConnection.kt
+++ b/ktor-client/ktor-client-webrtc/jsAndWasmShared/src/io/ktor/client/webrtc/PeerConnection.kt
@@ -139,6 +139,5 @@ public class JsWebRtcPeerConnection(
  * Returns implementation of the peer connection that is used under the hood. Use it with caution.
  */
 public fun WebRtcPeerConnection.getNative(): RTCPeerConnection {
-    val connection = this as? JsWebRtcPeerConnection ?: error("Wrong peer connection implementation.")
-    return connection.connection
+    return (this as JsWebRtcPeerConnection).connection
 }

--- a/ktor-client/ktor-client-webrtc/jsAndWasmShared/src/io/ktor/client/webrtc/Rtp.kt
+++ b/ktor-client/ktor-client-webrtc/jsAndWasmShared/src/io/ktor/client/webrtc/Rtp.kt
@@ -28,8 +28,7 @@ public class JsRtpSender(internal val nativeSender: RTCRtpSender) : WebRtc.RtpSe
             nativeSender.replaceTrack(null)
             return
         }
-        val track = withTrack as? JsMediaTrack ?: error("Track should extend JsMediaTrack.")
-        nativeSender.replaceTrack(track.nativeTrack)
+        nativeSender.replaceTrack((withTrack as JsMediaTrack).nativeTrack)
     }
 
     override suspend fun getParameters(): WebRtc.RtpParameters {
@@ -37,7 +36,7 @@ public class JsRtpSender(internal val nativeSender: RTCRtpSender) : WebRtc.RtpSe
     }
 
     override suspend fun setParameters(parameters: WebRtc.RtpParameters) {
-        val params = parameters as? JsRtpParameters ?: error("Parameters should extend JsRtpParameters.")
+        val params = parameters as JsRtpParameters
         nativeSender.setParameters(params.nativeRtpParameters)
     }
 }
@@ -82,22 +81,19 @@ public class JsRtpParameters(internal val nativeRtpParameters: RTCRtpSendParamet
  * Returns implementation of the rtp sender that is used under the hood. Use it with caution.
  */
 public fun WebRtc.RtpSender.getNative(): RTCRtpSender {
-    val sender = this as? JsRtpSender ?: error("Wrong sender implementation.")
-    return sender.nativeSender
+    return (this as JsRtpSender).nativeSender
 }
 
 /**
  * Returns implementation of the dtmf sender that is used under the hood. Use it with caution.
  */
 public fun WebRtc.DtmfSender.getNative(): RTCDTMFSender {
-    val sender = this as? JsDtmfSender ?: error("Wrong sender implementation.")
-    return sender.nativeSender
+    return (this as JsDtmfSender).nativeSender
 }
 
 /**
  * Returns implementation of the rtp parameters that is used under the hood. Use it with caution.
  */
 public fun WebRtc.RtpParameters.getNative(): RTCRtpSendParameters {
-    val parameters = this as? JsRtpParameters ?: error("Wrong parameters implementation.")
-    return parameters.nativeRtpParameters
+    return (this as JsRtpParameters).nativeRtpParameters
 }


### PR DESCRIPTION
**Subsystem**
WebRTC Client

**Motivation**
All peer connection implementations didn't close the inner coroutine context on close.

**Solution**
- Call `super.close()` in classes that extend `WebRtcPeerConnection`
- update `suspendCoroutine` -> `suspendCancellableCoroutine`
- extra: remove redundant `as? T ?: error(...)` in the some code parts

