### PR TITLE
KTOR-8975 BodyProgress: Keep the response body replayable

### DIFF
--- a/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/BodyProgress.kt
+++ b/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/BodyProgress.kt
@@ -70,8 +70,7 @@ internal object AfterRenderHook : ClientHook<suspend (HttpRequestBuilder, Outgoi
 
 @OptIn(InternalAPI::class)
 internal fun HttpResponse.withObservableDownload(listener: ProgressListener): HttpResponse {
-    val observableByteChannel = rawContent.observable(coroutineContext, contentLength(), listener)
-    return call.replaceResponse { observableByteChannel }.response
+    return call.replaceResponse { rawContent.observable(coroutineContext, contentLength(), listener) }.response
 }
 
 /**


### PR DESCRIPTION
**Subsystem**
Client, BodyProgress plugin

**Motivation**
[KTOR-8975](https://youtrack.jetbrains.com/issue/KTOR-8975) Response body channel is canceled while the body is being saved when having HttpRequestRetry and onDownload

**Solution**
Fixed `withObservableDownload` to create a fresh observable channel on each `rawContent` access instead of reusing a single instance. Previously, when `HttpRequestRetry` cancelled the channel during validation (see `throwOnInvalidResponseBody`), it became unavailable for subsequent reads by `SaveBody`, causing `ClosedByteChannelException`. The fix passes a lambda to `replaceResponse` that creates a new channel on each access, making cancellation safe.
