### PR TITLE
KTOR-6610: feat: add debug log of ConfigLoader when server starts

### DIFF
--- a/ktor-server/ktor-server-core/common/src/io/ktor/server/config/ConfigLoaders.kt
+++ b/ktor-server/ktor-server-core/common/src/io/ktor/server/config/ConfigLoaders.kt
@@ -4,7 +4,11 @@
 
 package io.ktor.server.config
 
+import io.ktor.util.logging.*
+
 internal expect val CONFIG_PATH: List<String>
+
+private val logger = KtorSimpleLogger("io.ktor.server.config.ConfigLoader")
 
 /**
  * Loads an application configuration.
@@ -51,23 +55,36 @@ public interface ConfigLoader {
          */
         public fun load(path: String? = null): ApplicationConfig {
             if (path == null) {
+                logger.debug("Loading default configuration")
                 val default = loadDefault()
                 if (default != null) return default
             }
 
             for (loader in configLoaders) {
+                logger.debug("Trying ConfigLoader: ${loader::class.simpleName}")
                 val config = loader.load(path)
-                if (config != null) return config
+                if (config != null) {
+                    logger.debug("Configuration loaded successfully using ${loader::class.simpleName} from path: $path")
+                    return config
+                }
             }
 
+            logger.debug("No configuration found, using empty MapApplicationConfig")
             return MapApplicationConfig()
         }
 
         private fun loadDefault(): ApplicationConfig? {
             for (defaultPath in CONFIG_PATH) {
+                logger.debug("Trying default config path: $defaultPath")
                 for (loader in configLoaders) {
+                    logger.debug("Trying ConfigLoader: ${loader::class.simpleName} for path: $defaultPath")
                     val config = loader.load(defaultPath)
-                    if (config != null) return config
+                    if (config != null) {
+                        logger.debug(
+                            "Default configuration loaded using ${loader::class.simpleName} from path: $defaultPath"
+                        )
+                        return config
+                    }
                 }
             }
 


### PR DESCRIPTION
**Subsystem**
`ktor-server-core` (`io.ktor.server.config`)

**Motivation**
This PR fixes [KTOR-6610](https://youtrack.jetbrains.com/issue/KTOR-6610/Log-which-ConfigLoader-has-been-used-for-loading-the-server-configuration). Related to [KTOR-8992](https://youtrack.jetbrains.com/issue/KTOR-8992/HoconConfigLoader-is-not-loaded-when-ktor-server-config-yaml-on-the-classpath), too.
Adding debug log when server starts will reveal which configuration file is used.
If configuration is inappropriate, it gives following error as is.
```
Exception in thread "main" java.lang.IllegalArgumentException: Neither port nor sslPort specified. Use command line options -port/-sslPort or configure connectors in application.conf
        at io.ktor.server.engine.CommandLineKt.CommandLineConfig(CommandLine.kt:74)
        at io.ktor.server.netty.EngineMain.createServer(EngineMain.kt:39)
        at io.ktor.server.netty.EngineMain.main(EngineMain.kt:24)
```

However, adding debug log, the output is like: 

```
2025-10-22 17:15:38.848 [main] DEBUG io.ktor.server.config.ConfigLoader - Trying ConfigLoader: YamlConfigLoader
2025-10-22 17:15:38.858 [main] DEBUG io.ktor.server.config.ConfigLoader - No configuration found, using empty MapApplicationConfig
Exception in thread "main" java.lang.IllegalArgumentException: Neither port nor sslPort specified. Use command line options -port/-sslPort or configure connectors in application.conf
        at io.ktor.server.engine.CommandLineKt.CommandLineConfig(CommandLine.kt:74)
        at io.ktor.server.netty.EngineMain.createServer(EngineMain.kt:39)
        at io.ktor.server.netty.EngineMain.main(EngineMain.kt:24)
```

Thus we can realize the ConfigLoader is not HoconConfigLoader, but YamlConfigLoader because we include `ktor-server-config-yaml` on the classpath.


**Solution**
Using KtorSimpleLogger and add debug log to ConfigLoader companion object.
I referred https://github.com/ktorio/ktor/blob/main/ktor-server/ktor-server-core/jvm/src/io/ktor/server/http/content/ETagProvider.kt as code style.

### output example

**Hocon**

```
2025-10-22 17:27:12.861 [main] DEBUG io.ktor.server.config.ConfigLoader - Trying ConfigLoader: HoconConfigLoader
2025-10-22 17:27:12.896 [main] DEBUG io.ktor.server.config.ConfigLoader - Configuration loaded successfully using HoconConfigLoader from path: application_custom.conf
```

**Yaml**

```
2025-10-22 15:59:50.016 [main] DEBUG io.ktor.server.config.ConfigLoader - Trying ConfigLoader: YamlConfigLoader
2025-10-22 15:59:50.058 [main] DEBUG io.ktor.server.config.ConfigLoader - Configuration loaded successfully using YamlConfigLoader from path: application_custom.yaml
```

**No configuration**

```
2025-10-22 17:15:38.848 [main] DEBUG io.ktor.server.config.ConfigLoader - Trying ConfigLoader: YamlConfigLoader
2025-10-22 17:15:38.858 [main] DEBUG io.ktor.server.config.ConfigLoader - No configuration found, using empty MapApplicationConfig
```
