### PR TITLE
KTOR-9012 Restore allowance of sibling staticResources

### DIFF
--- a/ktor-server/ktor-server-core/jvm/src/io/ktor/server/http/content/StaticContent.kt
+++ b/ktor-server/ktor-server-core/jvm/src/io/ktor/server/http/content/StaticContent.kt
@@ -692,12 +692,7 @@ private fun Route.staticContentRoute(
     remotePath: String,
     autoHead: Boolean,
     handler: suspend (ApplicationCall).() -> Unit
-) = createChild(object : RouteSelector() {
-    override suspend fun evaluate(context: RoutingResolveContext, segmentIndex: Int): RouteSelectorEvaluation =
-        RouteSelectorEvaluation.Success(quality = RouteSelectorEvaluation.qualityTailcard)
-
-    override fun toString() = "(staticContent)"
-}).apply {
+) = createChild(TailcardSelector).apply {
     route(remotePath) {
         route("{$pathParameterName...}") {
             get {
@@ -963,4 +958,10 @@ public interface FileSystemPaths {
      * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.server.http.content.FileSystemPaths.getPath)
      */
     public fun getPath(first: String, vararg more: String): Path
+}
+
+// Adds lower priority to the route so that it can be used as a fallback
+private object TailcardSelector : RouteSelector() {
+    override suspend fun evaluate(context: RoutingResolveContext, segmentIndex: Int): RouteSelectorEvaluation =
+        RouteSelectorEvaluation.Success(quality = RouteSelectorEvaluation.qualityTailcard)
 }

--- a/ktor-server/ktor-server-tests/jvm/test/io/ktor/server/plugins/StaticContentTest.kt
+++ b/ktor-server/ktor-server-tests/jvm/test/io/ktor/server/plugins/StaticContentTest.kt
@@ -1495,6 +1495,22 @@ class StaticContentTest {
         testCustomEtagAndLastModified("staticZip/nested/file-nested.txt", etag, date, "br")
     }
 
+    @Test
+    fun testSiblings() = testApplication {
+        routing {
+            staticResources("/remote", "public/nested")
+            staticResources("/remote", "public")
+        }
+
+        val responseFileNested = client.get("/remote/file-nested.txt")
+        assertEquals(HttpStatusCode.OK, responseFileNested.status)
+        assertEquals("file-nested.txt", responseFileNested.bodyAsText().trim())
+
+        val responseFile = client.get("/remote/file.txt")
+        assertEquals(HttpStatusCode.OK, responseFile.status)
+        assertEquals("file.txt", responseFile.bodyAsText().trim())
+    }
+
     private suspend fun ApplicationTestBuilder.testCustomEtagAndLastModified(
         url: String,
         expectedEtag: String,


### PR DESCRIPTION
**Subsystem**
Server, StaticContent

**Motivation**
[KTOR-9012](https://youtrack.jetbrains.com/issue/KTOR-9012) StaticContent doesn't allow siblings
Regression after [PR](https://github.com/ktorio/ktor/pull/4667)

**Solution**
Remove selector creation every time and use a shared one

