### PR TITLE
KTOR-8838 Fix exception handling in client cache

### DIFF
--- a/ktor-client/ktor-client-core/jvm/src/io/ktor/client/plugins/cache/storage/FileCacheStorage.kt
+++ b/ktor-client/ktor-client-core/jvm/src/io/ktor/client/plugins/cache/storage/FileCacheStorage.kt
@@ -160,9 +160,8 @@ private class FileCacheStorage(
                     channel.copyTo(output)
                 }
             }
-        } catch (cause: CancellationException) {
-            throw cause
         } catch (cause: Exception) {
+            if (cause is CancellationException) currentCoroutineContext().ensureActive()
             LOGGER.trace { "Exception during saving a cache to a file: ${cause.stackTraceToString()}" }
         } finally {
             channel.close()


### PR DESCRIPTION
**Subsystem**
Client, Cache

**Motivation**
[KTOR-8838](https://youtrack.jetbrains.com/issue/KTOR-8838) 

**Solution**
Wrap `coroutineScope` in try/catch, so exceptions thrown inside the launch also could be caught