### PR TITLE
KTOR-8947 Fix http/2 header name check with content-encoding

### DIFF
--- a/ktor-http/common/src/io/ktor/http/HttpHeaders.kt
+++ b/ktor-http/common/src/io/ktor/http/HttpHeaders.kt
@@ -160,7 +160,7 @@ public object HttpHeaders {
             if (ch <= ' ' || isDelimiter(ch)) {
                 // HTTP/2 pseudo header can start with `:`
                 val isPseudoHeader = index == 0 && ch == ':'
-                if(!isPseudoHeader) {
+                if (!isPseudoHeader) {
                     throw IllegalHeaderNameException(name, index)
                 }
             }


### PR DESCRIPTION
**Subsystem**
Client

**Motivation**
HTTP/2 header name can contain `:` symbol, but now it throws an error.

**Solution**
Just check that the unpermitted char is not a first colon in the key

link to the issue https://youtrack.jetbrains.com/issue/KTOR-9077/Content-Encoding-HTTP-2-pseudo-header-throws-an-error
