### PR TITLE
KTOR-9079 Remove JUnit from transitive dependencies of ktor-server-test-host

### DIFF
--- a/ktor-server/ktor-server-test-host/build.gradle.kts
+++ b/ktor-server/ktor-server-test-host/build.gradle.kts
@@ -2,7 +2,7 @@
  * Copyright 2014-2025 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
-description = ""
+description = "Test utilities for testing Ktor server applications without starting a real server"
 
 plugins {
     id("ktorbuild.project.library")
@@ -25,17 +25,16 @@ kotlin {
             api(projects.ktorServerCallLogging)
 
             // Not ideal, but prevents an additional artifact, and this is usually just included for testing,
-            // so shouldn"t increase the size of the final artifact.
+            // so shouldn't increase the size of the final artifact.
             api(projects.ktorServerWebsockets)
 
-            api(libs.kotlin.test)
-            api(libs.junit)
             implementation(libs.kotlinx.coroutines.debug)
         }
 
         jvmTest.dependencies {
             api(projects.ktorServerConfigYaml)
             api(libs.kotlin.test)
+            api(libs.junit)
         }
     }
 }


### PR DESCRIPTION
**Subsystem**
Server

**Motivation**
[KTOR-9079](https://youtrack.jetbrains.com/issue/KTOR-9079) The ktor-server-test-host module, having `junit-jupiter` runtime dependency, causes conflicts

**Solution**
JUnit shouldn't be transitively exposed as users might use any other test framework

