### PR TITLE
KTOR-8924 Curl: Client sends both Transfer-Encoding and Content-Length headers

### DIFF
--- a/ktor-client/ktor-client-curl/desktop/src/io/ktor/client/engine/curl/internal/CurlMultiApiHandler.kt
+++ b/ktor-client/ktor-client-curl/desktop/src/io/ktor/client/engine/curl/internal/CurlMultiApiHandler.kt
@@ -155,15 +155,24 @@ internal class CurlMultiApiHandler : Closeable {
         easyHandle.apply {
             when (method) {
                 "GET" -> option(CURLOPT_HTTPGET, 1L)
-                "PUT" -> option(CURLOPT_PUT, 1L)
+
+                "PUT" -> {
+                    option(CURLOPT_PUT, 1L)
+                    option(CURLOPT_INFILESIZE_LARGE, size)
+                }
+
                 "POST" -> {
                     option(CURLOPT_POST, 1L)
-                    option(CURLOPT_POSTFIELDSIZE, size)
+                    option(CURLOPT_POSTFIELDSIZE_LARGE, size)
                 }
 
                 "HEAD" -> option(CURLOPT_NOBODY, 1L)
+
                 else -> {
-                    if (size > 0) option(CURLOPT_POST, 1L)
+                    if (size > 0) {
+                        option(CURLOPT_POST, 1L)
+                        option(CURLOPT_POSTFIELDSIZE_LARGE, size)
+                    }
                     option(CURLOPT_CUSTOMREQUEST, method)
                 }
             }
@@ -182,7 +191,6 @@ internal class CurlMultiApiHandler : Closeable {
         easyHandle.apply {
             option(CURLOPT_READDATA, requestPointer)
             option(CURLOPT_READFUNCTION, staticCFunction(::onBodyChunkRequested))
-            option(CURLOPT_INFILESIZE_LARGE, request.contentLength)
         }
         return requestPointer
     }

--- a/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/HttpMethodTest.kt
+++ b/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/HttpMethodTest.kt
@@ -4,9 +4,9 @@
 
 package io.ktor.client.tests
 
-import io.ktor.client.*
 import io.ktor.client.request.*
 import io.ktor.client.test.base.*
+import io.ktor.client.tests.utils.*
 import io.ktor.http.*
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -24,17 +24,3 @@ class HttpMethodTest : ClientLoader() {
         }
     }
 }
-
-private val allMethods = HttpMethod.DefaultMethods + HttpMethod.Trace
-
-private fun HttpClient.supportedMethods(): List<HttpMethod> = when (engineName) {
-    // PATCH is not supported by HttpURLConnection
-    // https://bugs.openjdk.org/browse/JDK-7016595
-    "AndroidClientEngine" -> allMethods - HttpMethod.Patch
-    // Js engine throws: TypeError: 'TRACE' HTTP method is unsupported.
-    "JsClientEngine" -> allMethods - HttpMethod.Trace
-    else -> allMethods
-}
-
-private val HttpClient.engineName get() = engine::class.simpleName
-private val HttpMethod.Companion.Trace get() = HttpMethod("TRACE")

--- a/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/utils/HttpClient.kt
+++ b/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/utils/HttpClient.kt
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2014-2025 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.client.tests.utils
+
+import io.ktor.client.*
+import io.ktor.http.*
+
+internal val HttpClient.engineName get() = engine::class.simpleName?.removeSuffix("ClientEngine")
+
+private val allMethods = HttpMethod.DefaultMethods + HttpMethod.Trace
+
+internal fun HttpClient.supportedMethods(): List<HttpMethod> = when (engineName) {
+    // PATCH is not supported by HttpURLConnection
+    // https://bugs.openjdk.org/browse/JDK-7016595
+    "Android" -> allMethods - HttpMethod.Patch
+    // Js engine throws: TypeError: 'TRACE' HTTP method is unsupported.
+    "Js" -> allMethods - HttpMethod.Trace
+    else -> allMethods
+}
+
+private val HttpMethod.Companion.Trace get() = HttpMethod("TRACE")

--- a/ktor-test-server/src/main/kotlin/test/server/tests/Echo.kt
+++ b/ktor-test-server/src/main/kotlin/test/server/tests/Echo.kt
@@ -20,6 +20,15 @@ internal fun Application.echoTest() {
                     call.response.status(HttpStatusCode.OK)
                 }
             }
+
+            route("/headers") {
+                handle {
+                    val headers = call.request.headers.entries().joinToString("\n") { (name, value) ->
+                        "${name.lowercase()}: $value"
+                    }
+                    call.respondText(headers)
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
**Subsystem**
ktor-client-curl

**Motivation**
[KTOR-8924](https://youtrack.jetbrains.com/issue/KTOR-8924) Curl: Client sends both Transfer-Encoding and Content-Length headers for DELETE requests with body

**Solution**
`CURLOPT_INFILESIZE_LARGE` that we used to set Content-Length for all requests is effective only for PUT requests. For POST-like requests (PATCH, DELETE) `CURLOPT_POSTFIELDSIZE_LARGE` should be used

