### PR TITLE
Remove outdated comment

### DIFF
--- a/ktor-server/ktor-server-test-host/common/src/io/ktor/server/testing/TestApplication.kt
+++ b/ktor-server/ktor-server-test-host/common/src/io/ktor/server/testing/TestApplication.kt
@@ -453,10 +453,6 @@ public class ApplicationTestBuilder : TestApplicationBuilder(), ClientProvider {
  *     assertEquals("Hello, world!", response.bodyAsText())
  * }
  * ```
- *
- * _Note: If you have the `application.conf` file in the `resources` folder,
- * [testApplication] loads all modules and properties specified in the configuration file automatically._
- *
  * You can learn more from [Testing](https://ktor.io/docs/testing.html).
  *
  * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.server.testing.testApplication)


### PR DESCRIPTION
testApplication block no longer automatic load `application.conf`, must be use `configure()`.

**Subsystem**
Server docs

**Motivation**
Not critical, but prevents users from writing incorrect code due to incorrect documentation.

**Solution**
Delete outdated comment.

