### PR TITLE
Tests. Downgrade  version.

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -51,7 +51,9 @@ micrometer = "1.15.5"
 jansi = "2.4.2"
 typesafe = "1.4.5"
 
-mockk = "1.14.6"
+# Version 1.14.6 is not compatible with Java 11.
+# Wait until https://github.com/mockk/mockk/issues/1433 is resolved.
+mockk = "1.14.5"
 
 java-jwt = "4.5.0"
 


### PR DESCRIPTION
**Subsystem**
JVM Tests

**Motivation**
JVM 8 and 11 tests are failing on the CI because of a new `mockk` version that is not compatible with Java 11, see this [issue](https://github.com/mockk/mockk/issues/1433).

**Solution**
Downgrade its version, for now.