### PR TITLE
KTOR-6837 Fix client URL handling for invalid DefaultRequest.host

### DIFF
--- a/ktor-client/ktor-client-cio/common/src/io/ktor/client/engine/cio/CIOEngine.kt
+++ b/ktor-client/ktor-client-cio/common/src/io/ktor/client/engine/cio/CIOEngine.kt
@@ -107,6 +107,8 @@ internal class CIOEngine(
     }
 
     private fun selectEndpoint(url: Url, proxy: ProxyConfig?, unixSocket: UnixSocketSettings?): Endpoint {
+        val url = url.rebuildIfNeeded()
+
         val host: String
         val port: Int
         val protocol: URLProtocol = url.protocol
@@ -138,5 +140,13 @@ internal class CIOEngine(
                 unixSocket,
             )
         }
+    }
+}
+
+internal fun Url.rebuildIfNeeded(): Url {
+    return if (host.contains('/') || host.contains("?") || host.contains("#")) {
+        Url(this.toString())
+    } else {
+        this
     }
 }

--- a/ktor-client/ktor-client-cio/common/src/io/ktor/client/engine/cio/utils.kt
+++ b/ktor-client/ktor-client-cio/common/src/io/ktor/client/engine/cio/utils.kt
@@ -41,7 +41,7 @@ internal suspend fun writeHeaders(
     val builder = RequestResponseBuilder()
 
     val method = request.method
-    val url = request.url
+    val url = request.url.rebuildIfNeeded()
     val headers = request.headers
     val body = request.body
 

--- a/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/DefaultRequest.kt
+++ b/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/DefaultRequest.kt
@@ -210,6 +210,13 @@ public class DefaultRequest private constructor(private val block: DefaultReques
         public var host: String
             get() = url.host
             set(value) {
+                if (value.contains("/") || value.contains("?") || value.contains("#")) {
+                    LOGGER.warn(
+                        "DefaultRequest.host was set to '$value', which is not a valid host. " +
+                            "Host must not contain scheme, path, query or fragment. " +
+                            "Use `url(...)` or `url{ ... }` instead."
+                    )
+                }
                 url.host = value
             }
 

--- a/ktor-client/ktor-client-darwin-legacy/darwin/src/io/ktor/client/engine/darwin/internal/legacy/DarwinLegacyUrlUtils.kt
+++ b/ktor-client/ktor-client-darwin-legacy/darwin/src/io/ktor/client/engine/darwin/internal/legacy/DarwinLegacyUrlUtils.kt
@@ -19,47 +19,49 @@ internal fun Url.toNSUrl(): NSURL {
         return NSURL(string = toString())
     }
 
-    val components = NSURLComponents()
+    with(Url(this.toString())) {
+        val components = NSURLComponents()
 
-    components.scheme = protocol.name
+        components.scheme = protocol.name
 
-    components.percentEncodedUser = when {
-        userEncoded -> encodedUser
-        else -> user?.sanitize(NSCharacterSet.URLUserAllowedCharacterSet)
-    }
-    components.percentEncodedPassword = when {
-        passwordEncoded -> encodedPassword
-        else -> password?.sanitize(NSCharacterSet.URLUserAllowedCharacterSet)
-    }
+        components.percentEncodedUser = when {
+            userEncoded -> encodedUser
+            else -> user?.sanitize(NSCharacterSet.URLUserAllowedCharacterSet)
+        }
+        components.percentEncodedPassword = when {
+            passwordEncoded -> encodedPassword
+            else -> password?.sanitize(NSCharacterSet.URLUserAllowedCharacterSet)
+        }
 
-    components.percentEncodedHost = when {
-        hostEncoded -> host
-        else -> host.sanitize(NSCharacterSet.URLHostAllowedCharacterSet)
-    }
-    if (port != DEFAULT_PORT && port != protocol.defaultPort) {
-        components.port = NSNumber(int = port)
-    }
+        components.percentEncodedHost = when {
+            hostEncoded -> host
+            else -> host.sanitize(NSCharacterSet.URLHostAllowedCharacterSet)
+        }
+        if (port != DEFAULT_PORT && port != protocol.defaultPort) {
+            components.port = NSNumber(int = port)
+        }
 
-    components.percentEncodedPath = when {
-        pathEncoded -> encodedPath
-        else -> rawSegments.joinToString("/").sanitize(NSCharacterSet.URLPathAllowedCharacterSet)
-    }
+        components.percentEncodedPath = when {
+            pathEncoded -> encodedPath
+            else -> rawSegments.joinToString("/").sanitize(NSCharacterSet.URLPathAllowedCharacterSet)
+        }
 
-    when {
-        encodedQuery.isEmpty() -> components.percentEncodedQuery = null
-        queryEncoded -> components.percentEncodedQuery = encodedQuery
-        else -> components.percentEncodedQueryItems = parameters.toMap()
-            .flatMap { (key, value) -> if (value.isEmpty()) listOf(key to null) else value.map { key to it } }
-            .map { NSURLQueryItem(it.first.encodeQueryKey(), it.second?.encodeQueryValue()) }
-    }
+        when {
+            encodedQuery.isEmpty() -> components.percentEncodedQuery = null
+            queryEncoded -> components.percentEncodedQuery = encodedQuery
+            else -> components.percentEncodedQueryItems = parameters.toMap()
+                .flatMap { (key, value) -> if (value.isEmpty()) listOf(key to null) else value.map { key to it } }
+                .map { NSURLQueryItem(it.first.encodeQueryKey(), it.second?.encodeQueryValue()) }
+        }
 
-    components.percentEncodedFragment = when {
-        encodedFragment.isEmpty() -> null
-        fragmentEncoded -> encodedFragment
-        else -> fragment.sanitize(NSCharacterSet.URLFragmentAllowedCharacterSet)
-    }
+        components.percentEncodedFragment = when {
+            encodedFragment.isEmpty() -> null
+            fragmentEncoded -> encodedFragment
+            else -> fragment.sanitize(NSCharacterSet.URLFragmentAllowedCharacterSet)
+        }
 
-    return components.URL ?: error("Invalid url: $this")
+        return components.URL ?: error("Invalid url: $this")
+    }
 }
 
 private fun String.sanitize(allowed: NSCharacterSet): String =

--- a/ktor-client/ktor-client-darwin/darwin/src/io/ktor/client/engine/darwin/internal/DarwinUrlUtils.kt
+++ b/ktor-client/ktor-client-darwin/darwin/src/io/ktor/client/engine/darwin/internal/DarwinUrlUtils.kt
@@ -19,47 +19,49 @@ internal fun Url.toNSUrl(): NSURL {
         return NSURL(string = toString())
     }
 
-    val components = NSURLComponents()
+    with(Url(this.toString())) {
+        val components = NSURLComponents()
 
-    components.scheme = protocol.name
+        components.scheme = protocol.name
 
-    components.percentEncodedUser = when {
-        userEncoded -> encodedUser
-        else -> user?.sanitize(NSCharacterSet.URLUserAllowedCharacterSet)
-    }
-    components.percentEncodedPassword = when {
-        passwordEncoded -> encodedPassword
-        else -> password?.sanitize(NSCharacterSet.URLUserAllowedCharacterSet)
-    }
+        components.percentEncodedUser = when {
+            userEncoded -> encodedUser
+            else -> user?.sanitize(NSCharacterSet.URLUserAllowedCharacterSet)
+        }
+        components.percentEncodedPassword = when {
+            passwordEncoded -> encodedPassword
+            else -> password?.sanitize(NSCharacterSet.URLUserAllowedCharacterSet)
+        }
 
-    components.percentEncodedHost = when {
-        hostEncoded -> host
-        else -> host.sanitize(NSCharacterSet.URLHostAllowedCharacterSet)
-    }
-    if (port != DEFAULT_PORT && port != protocol.defaultPort) {
-        components.port = NSNumber(int = port)
-    }
+        components.percentEncodedHost = when {
+            hostEncoded -> host
+            else -> host.sanitize(NSCharacterSet.URLHostAllowedCharacterSet)
+        }
+        if (port != DEFAULT_PORT && port != protocol.defaultPort) {
+            components.port = NSNumber(int = port)
+        }
 
-    components.percentEncodedPath = when {
-        pathEncoded -> encodedPath
-        else -> rawSegments.joinToString("/").sanitize(NSCharacterSet.URLPathAllowedCharacterSet)
-    }
+        components.percentEncodedPath = when {
+            pathEncoded -> encodedPath
+            else -> rawSegments.joinToString("/").sanitize(NSCharacterSet.URLPathAllowedCharacterSet)
+        }
 
-    when {
-        encodedQuery.isEmpty() -> components.percentEncodedQuery = null
-        queryEncoded -> components.percentEncodedQuery = encodedQuery
-        else -> components.percentEncodedQueryItems = parameters.toMap()
-            .flatMap { (key, value) -> if (value.isEmpty()) listOf(key to null) else value.map { key to it } }
-            .map { NSURLQueryItem(it.first.encodeQueryKey(), it.second?.encodeQueryValue()) }
-    }
+        when {
+            encodedQuery.isEmpty() -> components.percentEncodedQuery = null
+            queryEncoded -> components.percentEncodedQuery = encodedQuery
+            else -> components.percentEncodedQueryItems = parameters.toMap()
+                .flatMap { (key, value) -> if (value.isEmpty()) listOf(key to null) else value.map { key to it } }
+                .map { NSURLQueryItem(it.first.encodeQueryKey(), it.second?.encodeQueryValue()) }
+        }
 
-    components.percentEncodedFragment = when {
-        encodedFragment.isEmpty() -> null
-        fragmentEncoded -> encodedFragment
-        else -> fragment.sanitize(NSCharacterSet.URLFragmentAllowedCharacterSet)
-    }
+        components.percentEncodedFragment = when {
+            encodedFragment.isEmpty() -> null
+            fragmentEncoded -> encodedFragment
+            else -> fragment.sanitize(NSCharacterSet.URLFragmentAllowedCharacterSet)
+        }
 
-    return components.URL ?: error("Invalid url: $this")
+        return components.URL ?: error("Invalid url: $this")
+    }
 }
 
 private fun String.sanitize(allowed: NSCharacterSet): String =

--- a/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/ConnectionTest.kt
+++ b/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/ConnectionTest.kt
@@ -6,6 +6,7 @@ package io.ktor.client.tests
 
 import io.ktor.client.*
 import io.ktor.client.call.*
+import io.ktor.client.plugins.defaultRequest
 import io.ktor.client.request.*
 import io.ktor.client.statement.*
 import io.ktor.client.test.base.*
@@ -45,6 +46,21 @@ class ConnectionTest : ClientLoader() {
         test { client ->
             client.testCall()
             assertEquals(testContent, client.testCall().body())
+        }
+    }
+
+    @Test
+    fun testInvalidHostInDefaultRequest() = clientTests {
+        val testServer = TEST_SERVER.removePrefix("http://")
+        config {
+            defaultRequest {
+                host = "$testServer/content"
+            }
+        }
+        test { client ->
+            client.get("/hello").apply {
+                assertEquals("hello", bodyAsText())
+            }
         }
     }
 }


### PR DESCRIPTION
**Subsystem**
Client, DefaultRequest, CIO, Darwin

**Motivation**
[KTOR-6837](https://youtrack.jetbrains.com/issue/KTOR-6837) 

**Solution**
`DefaultRequest.host` allows setting non-host values, which can include path, query, or fragment (e.g., "httpbin.org/status"), and this produces an invalid URL where the host field contains path segments. Most engines recover by parsing the full URL string and sending a correct request, but CIO and Darwin use the host field directly and therefore fail.
Since this behaviour could be used, the solution is to add a warning now and throw an exception for an invalid host in DefaultRequest in 4.0.0. Also, normalize URLs in CIO and Darwin by reparsing from url.toString() only when the host is invalid, aligning their behavior with that of other client engines.

