### PR TITLE
KTOR-9097: feat!(ktor-client-java): Use HTTP/2 by default

### DIFF
--- a/ktor-client/ktor-client-java/jvm/src/io/ktor/client/engine/java/JavaHttpConfig.kt
+++ b/ktor-client/ktor-client-java/jvm/src/io/ktor/client/engine/java/JavaHttpConfig.kt
@@ -15,11 +15,11 @@ import java.net.http.*
 public class JavaHttpConfig : HttpClientEngineConfig() {
 
     /**
-     * An HTTP version to use.
+     * An HTTP version to use. The default is [HttpClient.Version.HTTP_2].
      *
      * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.client.engine.java.JavaHttpConfig.protocolVersion)
      */
-    public var protocolVersion: HttpClient.Version = HttpClient.Version.HTTP_1_1
+    public var protocolVersion: HttpClient.Version = HttpClient.Version.HTTP_2
 
     internal var config: HttpClient.Builder.() -> Unit = {
         followRedirects(HttpClient.Redirect.NEVER)


### PR DESCRIPTION
**Subsystem**
Client, ktor-client-java

**Motivation**
https://youtrack.jetbrains.com/issue/KTOR-9097/Java-Use-HTTP-2-by-default
> Java HttpClient uses HTTP/2 by default with fallback to HTTP/1.1
Ktor [changes the default protocol version to HTTP/1.1](https://github.com/ktorio/ktor/blob/3.3.2/ktor-client/ktor-client-java/jvm/src/io/ktor/client/engine/java/JavaHttpConfig.kt#L22)

https://docs.oracle.com/en/java/javase/21/docs/api/java.net.http/java/net/http/HttpClient.html
> The default settings include: the "GET" request method, a preference of [HTTP/2](https://docs.oracle.com/en/java/javase/21/docs/api/java.net.http/java/net/http/HttpClient.Version.html#HTTP_2), a redirection policy of [NEVER](https://docs.oracle.com/en/java/javase/21/docs/api/java.net.http/java/net/http/HttpClient.Redirect.html#NEVER), the [default proxy selector](https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/net/ProxySelector.html#getDefault()), and the [default SSL context](https://docs.oracle.com/en/java/javase/21/docs/api/java.base/javax/net/ssl/SSLContext.html#getDefault()).

**Solution**
Use `HttpClient.Version.HTTP_2` https://docs.oracle.com/en/java/javase/21/docs/api/java.net.http/java/net/http/HttpClient.Version.html#HTTP_2

