### PR TITLE
KTOR-9157 Introduce signal for SIGINT on js and wasm, and SIGTERM on Native.

### DIFF
--- a/ktor-server/ktor-server-core/posix/src/io/ktor/server/engine/ShutdownHookNative.kt
+++ b/ktor-server/ktor-server-core/posix/src/io/ktor/server/engine/ShutdownHookNative.kt
@@ -21,7 +21,12 @@ private val shutdownHook: AtomicReference<() -> Unit> = AtomicReference {}
  */
 @OptIn(ExperimentalForeignApi::class)
 internal actual fun EmbeddedServer<*, *>.platformAddShutdownHook(stop: () -> Unit) {
-    shutdownHook.value = stop
+    val shouldStop = AtomicReference(true)
+    shutdownHook.value = {
+        if (shouldStop.compareAndSet(true, false)) {
+            stop()
+        }
+    }
 
     signal(
         SIGINT,

--- a/ktor-server/ktor-server-core/web/src/io/ktor/server/engine/ShutdownHook.web.kt
+++ b/ktor-server/ktor-server-core/web/src/io/ktor/server/engine/ShutdownHook.web.kt
@@ -22,8 +22,15 @@ internal actual fun EmbeddedServer<*, *>.platformAddShutdownHook(stop: () -> Uni
 }
 
 private fun addProcessShutdownHook(block: () -> Unit) {
-    processOn("SIGTERM", block)
-    processOn("SIGINT", block)
+    var called = false
+    val guardedBlock = {
+        if (!called) {
+            called = true
+            block()
+        }
+    }
+    processOn("SIGTERM", guardedBlock)
+    processOn("SIGINT", guardedBlock)
 }
 
 private fun processOn(signal: String, block: () -> Unit) {


### PR DESCRIPTION
**Subsystem**
Server Core module

**Motivation**
[KTOR-9157](https://youtrack.jetbrains.com/projects/KTOR/issues/KTOR-9157) Support SIGINT on web and SIGTERM on Native
JS was only registered to gracefully shut down on SIGTERM, and Native was only registered to gracefully shutdown on SIGINT.
While JVM gracefully shut down on both SIGTERM, and SIGINT.

**Solution**

This PR registers both SIGTERM, and SIGINT for JS/WASM and Native in order to align behavior among platforms.
Depending on the environment used SIGTERM or SIGINT will be used. I.e. K8s uses SIGTERM, while CTRL+C in terminal results in SIGINT.

