### PR TITLE
KTOR-6300 Native: Use IO dispatcher and allow dispatcher overriding

### DIFF
--- a/ktor-client/ktor-client-curl/desktop/src/io/ktor/client/engine/curl/CurlClientEngine.kt
+++ b/ktor-client/ktor-client-curl/desktop/src/io/ktor/client/engine/curl/CurlClientEngine.kt
@@ -10,17 +10,15 @@ import io.ktor.client.plugins.*
 import io.ktor.client.plugins.sse.*
 import io.ktor.client.plugins.websocket.*
 import io.ktor.client.request.*
-import io.ktor.client.utils.dropCompressionHeaders
+import io.ktor.client.utils.*
 import io.ktor.http.*
 import io.ktor.http.cio.*
 import io.ktor.util.date.*
 import io.ktor.utils.io.*
-import kotlinx.coroutines.*
 
 internal class CurlClientEngine(
     override val config: CurlClientEngineConfig
 ) : HttpClientEngineBase("ktor-curl") {
-    override val dispatcher = Dispatchers.Unconfined
 
     override val supportedCapabilities = setOf(HttpTimeoutCapability, WebSocketCapability, SSECapability)
 

--- a/ktor-client/ktor-client-darwin-legacy/darwin/src/io/ktor/client/engine/darwin/DarwinLegacyClientEngine.kt
+++ b/ktor-client/ktor-client-darwin-legacy/darwin/src/io/ktor/client/engine/darwin/DarwinLegacyClientEngine.kt
@@ -10,8 +10,7 @@ import io.ktor.client.plugins.*
 import io.ktor.client.plugins.sse.*
 import io.ktor.client.request.*
 import io.ktor.utils.io.*
-import kotlinx.coroutines.*
-import platform.Foundation.*
+import platform.Foundation.NSOperationQueue
 
 @OptIn(InternalAPI::class)
 internal class DarwinLegacyClientEngine(
@@ -22,8 +21,6 @@ internal class DarwinLegacyClientEngine(
         NSOperationQueue.mainQueue -> NSOperationQueue()
         else -> queue
     }
-
-    override val dispatcher = Dispatchers.Unconfined
 
     override val supportedCapabilities = setOf(HttpTimeoutCapability, SSECapability)
 

--- a/ktor-client/ktor-client-darwin/darwin/src/io/ktor/client/engine/darwin/DarwinClientEngine.kt
+++ b/ktor-client/ktor-client-darwin/darwin/src/io/ktor/client/engine/darwin/DarwinClientEngine.kt
@@ -11,8 +11,7 @@ import io.ktor.client.plugins.sse.*
 import io.ktor.client.plugins.websocket.*
 import io.ktor.client.request.*
 import io.ktor.utils.io.*
-import kotlinx.coroutines.*
-import platform.Foundation.*
+import platform.Foundation.NSOperationQueue
 
 @OptIn(InternalAPI::class)
 internal class DarwinClientEngine(override val config: DarwinClientEngineConfig) : HttpClientEngineBase("ktor-darwin") {
@@ -21,8 +20,6 @@ internal class DarwinClientEngine(override val config: DarwinClientEngineConfig)
         NSOperationQueue.mainQueue -> NSOperationQueue()
         else -> queue
     }
-
-    override val dispatcher = Dispatchers.Unconfined
 
     override val supportedCapabilities = setOf(HttpTimeoutCapability, WebSocketCapability, SSECapability)
 

--- a/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/DispatcherTest.kt
+++ b/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/DispatcherTest.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2014-2025 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.client.tests
+
+import io.ktor.client.test.base.*
+import kotlinx.coroutines.Dispatchers
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class DispatcherTest : ClientLoader() {
+
+    @Test
+    fun `test the default dispatcher is IO - except web`() = clientTests(except("web:*")) {
+        test { client ->
+            assertEquals("Dispatchers.IO", client.engine.dispatcher.toString())
+        }
+    }
+
+    @Test
+    fun `test the default dispatcher is used on web`() = clientTests(only("web:*")) {
+        test { client ->
+            assertEquals(Dispatchers.Default, client.engine.dispatcher)
+        }
+    }
+
+    @Test
+    fun `test the dispatcher can be configured`() = clientTests {
+        val customDispatcher = Dispatchers.Default.limitedParallelism(1)
+        config {
+            engine {
+                dispatcher = customDispatcher
+            }
+        }
+
+        test { client ->
+            assertEquals(customDispatcher, client.engine.dispatcher)
+        }
+    }
+}

--- a/ktor-client/ktor-client-winhttp/windows/src/io/ktor/client/engine/winhttp/WinHttpClientEngine.kt
+++ b/ktor-client/ktor-client-winhttp/windows/src/io/ktor/client/engine/winhttp/WinHttpClientEngine.kt
@@ -12,14 +12,11 @@ import io.ktor.client.plugins.websocket.*
 import io.ktor.client.request.*
 import io.ktor.util.date.*
 import io.ktor.utils.io.*
-import kotlinx.coroutines.*
-import kotlin.coroutines.*
+import kotlinx.coroutines.job
 
 internal class WinHttpClientEngine(
     override val config: WinHttpClientEngineConfig
 ) : HttpClientEngineBase("ktor-winhttp") {
-
-    override val dispatcher: CoroutineDispatcher = Dispatchers.Unconfined
 
     override val supportedCapabilities = setOf(HttpTimeoutCapability, WebSocketCapability, SSECapability)
 


### PR DESCRIPTION
**Subsystem**
Native clients: `ktor-client-darwin`, `ktor-client-winhttp`, `ktor-client-curl`

**Motivation**
[KTOR-6300](https://youtrack.jetbrains.com/issue/KTOR-6300) Native engines should use Dispatchers.IO not Dispatchers.Unconfined

**Solution**
Remove the hardcoded dispatcher and add a test that the default dispatcher is correct.
