### PR TITLE
Update commons-beanutils to 1.11.0 - resolve CVE-2025-48734

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -14,15 +14,6 @@ plugins {
 logger.lifecycle("Build version: ${project.version}")
 logger.lifecycle("Kotlin version: ${libs.versions.kotlin.get()}")
 
-subprojects {
-
-    configurations.all {
-        resolutionStrategy {
-            force("commons-beanutils:commons-beanutils:1.11.0")
-        }
-    }
-}
-
 wirePackageJsonAggregationTasks()
 
 configureYarn()

--- a/ktor-server/ktor-server-plugins/ktor-server-velocity/build.gradle.kts
+++ b/ktor-server/ktor-server-plugins/ktor-server-velocity/build.gradle.kts
@@ -6,6 +6,12 @@ plugins {
     id("ktorbuild.project.server-plugin")
 }
 
+configurations.all {
+    resolutionStrategy {
+        force("commons-beanutils:commons-beanutils:1.11.0")
+    }
+}
+
 kotlin {
     sourceSets {
         jvmMain.dependencies {


### PR DESCRIPTION
**Subsystem**
Client/Server, related modules

**Motivation**
Address vulnerability CVE-2025-48734.

**Solution**
Force use of commons-beanutils:1.11.0 across subprojects

