### PR TITLE
KTOR-9086 Default content types for OpenAPI spec

### DIFF
--- a/ktor-server/ktor-server-core/api/ktor-server-core.api
+++ b/ktor-server/ktor-server-core/api/ktor-server-core.api
@@ -818,6 +818,10 @@ public final class io/ktor/server/http/content/CompressedFileType : java/lang/En
 	public static fun values ()[Lio/ktor/server/http/content/CompressedFileType;
 }
 
+public final class io/ktor/server/http/content/DefaultContentTypesKt {
+	public static final fun getDefaultContentTypesAttribute ()Lio/ktor/util/AttributeKey;
+}
+
 public final class io/ktor/server/http/content/DefaultTransformKt {
 	public static final fun transformDefaultContent (Lio/ktor/server/application/ApplicationCall;Ljava/lang/Object;)Lio/ktor/http/content/OutgoingContent;
 }

--- a/ktor-server/ktor-server-core/api/ktor-server-core.klib.api
+++ b/ktor-server/ktor-server-core/api/ktor-server-core.klib.api
@@ -1709,6 +1709,8 @@ final val io.ktor.server.application/startupTimeout // io.ktor.server.applicatio
     final fun (io.ktor.server.application/ApplicationEnvironment).<get-startupTimeout>(): kotlin.time/Duration // io.ktor.server.application/startupTimeout.<get-startupTimeout>|<get-startupTimeout>@io.ktor.server.application.ApplicationEnvironment(){}[0]
 final val io.ktor.server.config/configLoaders // io.ktor.server.config/configLoaders|{}configLoaders[0]
     final fun <get-configLoaders>(): kotlin.collections/List<io.ktor.server.config/ConfigLoader> // io.ktor.server.config/configLoaders.<get-configLoaders>|<get-configLoaders>(){}[0]
+final val io.ktor.server.http.content/DefaultContentTypesAttribute // io.ktor.server.http.content/DefaultContentTypesAttribute|{}DefaultContentTypesAttribute[0]
+    final fun <get-DefaultContentTypesAttribute>(): io.ktor.util/AttributeKey<kotlin.collections/List<io.ktor.http/ContentType>> // io.ktor.server.http.content/DefaultContentTypesAttribute.<get-DefaultContentTypesAttribute>|<get-DefaultContentTypesAttribute>(){}[0]
 final val io.ktor.server.http.content/SuppressionAttribute // io.ktor.server.http.content/SuppressionAttribute|{}SuppressionAttribute[0]
     final fun <get-SuppressionAttribute>(): io.ktor.util/AttributeKey<kotlin/Boolean> // io.ktor.server.http.content/SuppressionAttribute.<get-SuppressionAttribute>|<get-SuppressionAttribute>(){}[0]
 final val io.ktor.server.http.content/isCompressionSuppressed // io.ktor.server.http.content/isCompressionSuppressed|@io.ktor.server.application.ApplicationCall{}isCompressionSuppressed[0]

--- a/ktor-server/ktor-server-core/common/src/io/ktor/server/http/content/DefaultContentTypes.kt
+++ b/ktor-server/ktor-server-core/common/src/io/ktor/server/http/content/DefaultContentTypes.kt
@@ -1,0 +1,14 @@
+/*
+ * Copyright 2014-2025 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.server.http.content
+
+import io.ktor.http.ContentType
+import io.ktor.util.AttributeKey
+
+/**
+ * Used for inferring what the server might expect when serializing responses or parsing requests.
+ */
+public val DefaultContentTypesAttribute: AttributeKey<List<ContentType>> =
+    AttributeKey<List<ContentType>>("DefaultContentTypes")

--- a/ktor-server/ktor-server-plugins/ktor-server-content-negotiation/common/src/io/ktor/server/plugins/contentnegotiation/ContentNegotiation.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-content-negotiation/common/src/io/ktor/server/plugins/contentnegotiation/ContentNegotiation.kt
@@ -61,6 +61,9 @@ public val ContentNegotiation: RouteScopedPlugin<ContentNegotiationConfig> = cre
 ) {
     convertRequestBody()
     convertResponseBody()
+
+    // register default content types for application metadata, used in OpenAPI
+    application.attributes[DefaultContentTypesAttribute] = pluginConfig.registrations.map { it.contentType }.distinct()
 }
 
 /**

--- a/ktor-server/ktor-server-plugins/ktor-server-routing-annotate/api/ktor-server-routing-annotate.api
+++ b/ktor-server/ktor-server-plugins/ktor-server-routing-annotate/api/ktor-server-routing-annotate.api
@@ -23,5 +23,6 @@ public final class io/ktor/annotate/RouteAnnotationApiKt {
 	public static synthetic fun findPathItems$default (Lio/ktor/server/routing/RoutingNode;Lio/ktor/annotate/OperationMapping;ILjava/lang/Object;)Ljava/util/Map;
 	public static final fun generateOpenApiSpec (Lio/ktor/openapi/OpenApiInfo;Lio/ktor/server/routing/RoutingNode;)Lio/ktor/openapi/OpenApiSpecification;
 	public static final fun getEndpointAnnotationAttributeKey ()Lio/ktor/util/AttributeKey;
+	public static final fun getJsonSchemaAttributeKey ()Lio/ktor/util/AttributeKey;
 }
 

--- a/ktor-server/ktor-server-plugins/ktor-server-routing-annotate/api/ktor-server-routing-annotate.klib.api
+++ b/ktor-server/ktor-server-plugins/ktor-server-routing-annotate/api/ktor-server-routing-annotate.klib.api
@@ -19,6 +19,8 @@ final class io.ktor.annotate/CollectSchemaReferences : io.ktor.annotate/Operatio
 
 final val io.ktor.annotate/EndpointAnnotationAttributeKey // io.ktor.annotate/EndpointAnnotationAttributeKey|{}EndpointAnnotationAttributeKey[0]
     final fun <get-EndpointAnnotationAttributeKey>(): io.ktor.util/AttributeKey<kotlin.collections/List<kotlin/Function1<io.ktor.openapi/Operation.Builder, kotlin/Unit>>> // io.ktor.annotate/EndpointAnnotationAttributeKey.<get-EndpointAnnotationAttributeKey>|<get-EndpointAnnotationAttributeKey>(){}[0]
+final val io.ktor.annotate/JsonSchemaAttributeKey // io.ktor.annotate/JsonSchemaAttributeKey|{}JsonSchemaAttributeKey[0]
+    final fun <get-JsonSchemaAttributeKey>(): io.ktor.util/AttributeKey<io.ktor.openapi/JsonSchemaInference> // io.ktor.annotate/JsonSchemaAttributeKey.<get-JsonSchemaAttributeKey>|<get-JsonSchemaAttributeKey>(){}[0]
 final val io.ktor.annotate/PopulateMediaTypeDefaults // io.ktor.annotate/PopulateMediaTypeDefaults|{}PopulateMediaTypeDefaults[0]
     final fun <get-PopulateMediaTypeDefaults>(): io.ktor.annotate/OperationMapping // io.ktor.annotate/PopulateMediaTypeDefaults.<get-PopulateMediaTypeDefaults>|<get-PopulateMediaTypeDefaults>(){}[0]
 

--- a/ktor-server/ktor-server-plugins/ktor-server-routing-annotate/common/src/io/ktor/annotate/OperationMapping.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-routing-annotate/common/src/io/ktor/annotate/OperationMapping.kt
@@ -41,7 +41,6 @@ internal class JoinedOperationMapping(private val operations: List<OperationMapp
  * - Response headers: if both `schema` and `content` are missing, set `content` to `text/plain`.
  */
 public val PopulateMediaTypeDefaults: OperationMapping = OperationMapping { operation ->
-    // Fast path: detect whether any defaults are needed
     val hasMissingParamMediaInfo = operation.parameters.orEmpty()
         .filterIsInstance<ReferenceOr.Value<Parameter>>()
         .any { paramRef ->

--- a/ktor-server/ktor-server-plugins/ktor-server-routing-annotate/common/test/io/ktor/annotate/RouteAnnotationApiTest.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-routing-annotate/common/test/io/ktor/annotate/RouteAnnotationApiTest.kt
@@ -146,7 +146,7 @@ class RouteAnnotationApiTest {
                 responses {
                     HttpStatusCode.OK {
                         description = "A list of messages"
-                        jsonSchema = jsonSchema<List<Message>>()
+                        schema = jsonSchema<List<Message>>()
                         extension("x-sample-message", testMessage)
                     }
                     HttpStatusCode.BadRequest {
@@ -240,7 +240,7 @@ class RouteAnnotationApiTest {
                     responses {
                         HttpStatusCode.OK {
                             description = "A list of messages"
-                            jsonSchema = jsonSchema<List<Message>>()
+                            schema = jsonSchema<List<Message>>()
                             extension("x-bonus", "child")
                         }
                     }

--- a/ktor-shared/ktor-openapi-schema/api/ktor-openapi-schema.api
+++ b/ktor-shared/ktor-openapi-schema/api/ktor-openapi-schema.api
@@ -627,7 +627,8 @@ public abstract interface class io/ktor/openapi/JsonSchemaInference {
 }
 
 public final class io/ktor/openapi/JsonSchemaInferenceKt {
-	public static final fun buildJsonSchema (Lkotlinx/serialization/descriptors/SerialDescriptor;)Lio/ktor/openapi/JsonSchema;
+	public static final fun buildJsonSchema (Lkotlinx/serialization/descriptors/SerialDescriptor;Z)Lio/ktor/openapi/JsonSchema;
+	public static synthetic fun buildJsonSchema$default (Lkotlinx/serialization/descriptors/SerialDescriptor;ZILjava/lang/Object;)Lio/ktor/openapi/JsonSchema;
 	public static final fun getKotlinxJsonSchemaInference ()Lio/ktor/openapi/JsonSchemaInference;
 }
 
@@ -937,7 +938,7 @@ public final synthetic class io/ktor/openapi/Operation$$serializer : kotlinx/ser
 }
 
 public final class io/ktor/openapi/Operation$Builder : io/ktor/openapi/JsonSchemaInference {
-	public fun <init> (Lio/ktor/openapi/JsonSchemaInference;)V
+	public fun <init> (Lio/ktor/openapi/JsonSchemaInference;Ljava/util/List;)V
 	public fun buildSchema (Lkotlin/reflect/KType;)Lio/ktor/openapi/JsonSchema;
 	public final fun callback-Fy7AELE (Ljava/lang/String;Ljava/util/Map;)V
 	public final fun getCallbacks ()Ljava/util/Map;
@@ -969,8 +970,8 @@ public final class io/ktor/openapi/Operation$Builder : io/ktor/openapi/JsonSchem
 }
 
 public final class io/ktor/openapi/Operation$Companion {
-	public final fun build (Lio/ktor/openapi/JsonSchemaInference;Lkotlin/jvm/functions/Function1;)Lio/ktor/openapi/Operation;
-	public static synthetic fun build$default (Lio/ktor/openapi/Operation$Companion;Lio/ktor/openapi/JsonSchemaInference;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lio/ktor/openapi/Operation;
+	public final fun build (Lio/ktor/openapi/JsonSchemaInference;Ljava/util/List;Lkotlin/jvm/functions/Function1;)Lio/ktor/openapi/Operation;
+	public static synthetic fun build$default (Lio/ktor/openapi/Operation$Companion;Lio/ktor/openapi/JsonSchemaInference;Ljava/util/List;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lio/ktor/openapi/Operation;
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
@@ -1025,8 +1026,9 @@ public final synthetic class io/ktor/openapi/Parameter$$serializer : kotlinx/ser
 }
 
 public final class io/ktor/openapi/Parameter$Builder : io/ktor/openapi/JsonSchemaInference {
-	public fun <init> (Lio/ktor/openapi/JsonSchemaInference;)V
+	public fun <init> (Lio/ktor/openapi/JsonSchemaInference;Ljava/util/List;)V
 	public fun buildSchema (Lkotlin/reflect/KType;)Lio/ktor/openapi/JsonSchema;
+	public final fun content (Lkotlin/jvm/functions/Function1;)V
 	public final fun example (Ljava/lang/String;Lio/ktor/openapi/ExampleObject;)V
 	public final fun getAllowEmptyValue ()Ljava/lang/Boolean;
 	public final fun getAllowReserved ()Ljava/lang/Boolean;
@@ -1101,7 +1103,7 @@ public final synthetic class io/ktor/openapi/Parameters$$serializer : kotlinx/se
 }
 
 public final class io/ktor/openapi/Parameters$Builder {
-	public fun <init> (Lio/ktor/openapi/JsonSchemaInference;)V
+	public fun <init> (Lio/ktor/openapi/JsonSchemaInference;Ljava/util/List;)V
 	public final fun cookie (Ljava/lang/String;Lkotlin/jvm/functions/Function1;)V
 	public static synthetic fun cookie$default (Lio/ktor/openapi/Parameters$Builder;Ljava/lang/String;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
 	public final fun getParameters ()Ljava/util/List;
@@ -1260,19 +1262,19 @@ public final synthetic class io/ktor/openapi/RequestBody$$serializer : kotlinx/s
 }
 
 public final class io/ktor/openapi/RequestBody$Builder : io/ktor/openapi/JsonSchemaInference {
-	public fun <init> (Lio/ktor/openapi/JsonSchemaInference;)V
+	public fun <init> (Lio/ktor/openapi/JsonSchemaInference;Ljava/util/List;)V
 	public fun buildSchema (Lkotlin/reflect/KType;)Lio/ktor/openapi/JsonSchema;
+	public final fun content (Lkotlin/jvm/functions/Function1;)V
 	public final fun getContent ()Ljava/util/Map;
 	public final fun getDescription ()Ljava/lang/String;
 	public final fun getExtensions ()Ljava/util/Map;
-	public final fun getJsonSchema ()Lio/ktor/openapi/JsonSchema;
 	public final fun getRequired ()Z
+	public final fun getSchema ()Lio/ktor/openapi/JsonSchema;
 	public final fun invoke (Lio/ktor/http/ContentType;Lkotlin/jvm/functions/Function1;)V
 	public static synthetic fun invoke$default (Lio/ktor/openapi/RequestBody$Builder;Lio/ktor/http/ContentType;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
 	public final fun setDescription (Ljava/lang/String;)V
-	public final fun setJsonSchema (Lio/ktor/openapi/JsonSchema;)V
 	public final fun setRequired (Z)V
-	public final fun xml (Lio/ktor/openapi/JsonSchema;)V
+	public final fun setSchema (Lio/ktor/openapi/JsonSchema;)V
 }
 
 public final class io/ktor/openapi/RequestBody$Companion {
@@ -1312,20 +1314,21 @@ public final synthetic class io/ktor/openapi/Response$$serializer : kotlinx/seri
 }
 
 public final class io/ktor/openapi/Response$Builder : io/ktor/openapi/JsonSchemaInference {
-	public fun <init> (Lio/ktor/openapi/JsonSchemaInference;)V
+	public fun <init> (Lio/ktor/openapi/JsonSchemaInference;Ljava/util/List;)V
 	public fun buildSchema (Lkotlin/reflect/KType;)Lio/ktor/openapi/JsonSchema;
+	public final fun content (Lkotlin/jvm/functions/Function1;)V
 	public final fun getContent ()Ljava/util/Map;
 	public final fun getDescription ()Ljava/lang/String;
 	public final fun getExtensions ()Ljava/util/Map;
 	public final fun getHeaders ()Ljava/util/Map;
-	public final fun getJsonSchema ()Lio/ktor/openapi/JsonSchema;
 	public final fun getLinks ()Ljava/util/Map;
+	public final fun getSchema ()Lio/ktor/openapi/JsonSchema;
 	public final fun headers (Lkotlin/jvm/functions/Function1;)V
 	public final fun invoke (Lio/ktor/http/ContentType;Lkotlin/jvm/functions/Function1;)V
 	public static synthetic fun invoke$default (Lio/ktor/openapi/Response$Builder;Lio/ktor/http/ContentType;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
 	public final fun link (Ljava/lang/String;Lkotlin/jvm/functions/Function1;)V
 	public final fun setDescription (Ljava/lang/String;)V
-	public final fun setJsonSchema (Lio/ktor/openapi/JsonSchema;)V
+	public final fun setSchema (Lio/ktor/openapi/JsonSchema;)V
 }
 
 public final class io/ktor/openapi/Response$Companion {
@@ -1362,7 +1365,7 @@ public final synthetic class io/ktor/openapi/Responses$$serializer : kotlinx/ser
 }
 
 public final class io/ktor/openapi/Responses$Builder {
-	public fun <init> (Lio/ktor/openapi/JsonSchemaInference;)V
+	public fun <init> (Lio/ktor/openapi/JsonSchemaInference;Ljava/util/List;)V
 	public final fun default (Lkotlin/jvm/functions/Function1;)V
 	public final fun getDefault ()Lio/ktor/openapi/Response$Builder;
 	public final fun getExtensions ()Ljava/util/Map;

--- a/ktor-shared/ktor-openapi-schema/api/ktor-openapi-schema.klib.api
+++ b/ktor-shared/ktor-openapi-schema/api/ktor-openapi-schema.klib.api
@@ -1054,7 +1054,7 @@ final class io.ktor.openapi/Operation : io.ktor.openapi/Extensible { // io.ktor.
     final fun toString(): kotlin/String // io.ktor.openapi/Operation.toString|toString(){}[0]
 
     final class Builder : io.ktor.openapi/JsonSchemaInference { // io.ktor.openapi/Operation.Builder|null[0]
-        constructor <init>(io.ktor.openapi/JsonSchemaInference) // io.ktor.openapi/Operation.Builder.<init>|<init>(io.ktor.openapi.JsonSchemaInference){}[0]
+        constructor <init>(io.ktor.openapi/JsonSchemaInference, kotlin.collections/List<io.ktor.http/ContentType>) // io.ktor.openapi/Operation.Builder.<init>|<init>(io.ktor.openapi.JsonSchemaInference;kotlin.collections.List<io.ktor.http.ContentType>){}[0]
 
         final val callbacks // io.ktor.openapi/Operation.Builder.callbacks|{}callbacks[0]
             final fun <get-callbacks>(): kotlin.collections/Map<kotlin/String, io.ktor.openapi/ReferenceOr<io.ktor.openapi/Callback>> // io.ktor.openapi/Operation.Builder.callbacks.<get-callbacks>|<get-callbacks>(){}[0]
@@ -1114,7 +1114,7 @@ final class io.ktor.openapi/Operation : io.ktor.openapi/Extensible { // io.ktor.
     final object Companion { // io.ktor.openapi/Operation.Companion|null[0]
         final val $childSerializers // io.ktor.openapi/Operation.Companion.$childSerializers|{}$childSerializers[0]
 
-        final fun build(io.ktor.openapi/JsonSchemaInference = ..., kotlin/Function1<io.ktor.openapi/Operation.Builder, kotlin/Unit>): io.ktor.openapi/Operation // io.ktor.openapi/Operation.Companion.build|build(io.ktor.openapi.JsonSchemaInference;kotlin.Function1<io.ktor.openapi.Operation.Builder,kotlin.Unit>){}[0]
+        final fun build(io.ktor.openapi/JsonSchemaInference = ..., kotlin.collections/List<io.ktor.http/ContentType> = ..., kotlin/Function1<io.ktor.openapi/Operation.Builder, kotlin/Unit>): io.ktor.openapi/Operation // io.ktor.openapi/Operation.Companion.build|build(io.ktor.openapi.JsonSchemaInference;kotlin.collections.List<io.ktor.http.ContentType>;kotlin.Function1<io.ktor.openapi.Operation.Builder,kotlin.Unit>){}[0]
         final fun serializer(): kotlinx.serialization/KSerializer<io.ktor.openapi/Operation> // io.ktor.openapi/Operation.Companion.serializer|serializer(){}[0]
     }
 }
@@ -1171,7 +1171,7 @@ final class io.ktor.openapi/Parameter : io.ktor.openapi/Extensible { // io.ktor.
     final fun toString(): kotlin/String // io.ktor.openapi/Parameter.toString|toString(){}[0]
 
     final class Builder : io.ktor.openapi/JsonSchemaInference { // io.ktor.openapi/Parameter.Builder|null[0]
-        constructor <init>(io.ktor.openapi/JsonSchemaInference) // io.ktor.openapi/Parameter.Builder.<init>|<init>(io.ktor.openapi.JsonSchemaInference){}[0]
+        constructor <init>(io.ktor.openapi/JsonSchemaInference, kotlin.collections/List<io.ktor.http/ContentType>) // io.ktor.openapi/Parameter.Builder.<init>|<init>(io.ktor.openapi.JsonSchemaInference;kotlin.collections.List<io.ktor.http.ContentType>){}[0]
 
         final val content // io.ktor.openapi/Parameter.Builder.content|{}content[0]
             final fun <get-content>(): kotlin.collections/Map<io.ktor.http/ContentType, io.ktor.openapi/MediaType> // io.ktor.openapi/Parameter.Builder.content.<get-content>|<get-content>(){}[0]
@@ -1217,6 +1217,7 @@ final class io.ktor.openapi/Parameter : io.ktor.openapi/Extensible { // io.ktor.
 
         final fun (io.ktor.http/ContentType).invoke(kotlin/Function1<io.ktor.openapi/MediaType.Builder, kotlin/Unit> = ...) // io.ktor.openapi/Parameter.Builder.invoke|invoke@io.ktor.http.ContentType(kotlin.Function1<io.ktor.openapi.MediaType.Builder,kotlin.Unit>){}[0]
         final fun buildSchema(kotlin.reflect/KType): io.ktor.openapi/JsonSchema // io.ktor.openapi/Parameter.Builder.buildSchema|buildSchema(kotlin.reflect.KType){}[0]
+        final fun content(kotlin/Function1<io.ktor.openapi/MediaType.Builder, kotlin/Unit>) // io.ktor.openapi/Parameter.Builder.content|content(kotlin.Function1<io.ktor.openapi.MediaType.Builder,kotlin.Unit>){}[0]
         final fun example(kotlin/String, io.ktor.openapi/ExampleObject) // io.ktor.openapi/Parameter.Builder.example|example(kotlin.String;io.ktor.openapi.ExampleObject){}[0]
         final inline fun <#A2: reified kotlin/Any> extension(kotlin/String, #A2) // io.ktor.openapi/Parameter.Builder.extension|extension(kotlin.String;0:0){0§<kotlin.Any>}[0]
     }
@@ -1250,7 +1251,7 @@ final class io.ktor.openapi/Parameters { // io.ktor.openapi/Parameters|null[0]
     final fun toString(): kotlin/String // io.ktor.openapi/Parameters.toString|toString(){}[0]
 
     final class Builder { // io.ktor.openapi/Parameters.Builder|null[0]
-        constructor <init>(io.ktor.openapi/JsonSchemaInference) // io.ktor.openapi/Parameters.Builder.<init>|<init>(io.ktor.openapi.JsonSchemaInference){}[0]
+        constructor <init>(io.ktor.openapi/JsonSchemaInference, kotlin.collections/List<io.ktor.http/ContentType>) // io.ktor.openapi/Parameters.Builder.<init>|<init>(io.ktor.openapi.JsonSchemaInference;kotlin.collections.List<io.ktor.http.ContentType>){}[0]
 
         final val parameters // io.ktor.openapi/Parameters.Builder.parameters|{}parameters[0]
             final fun <get-parameters>(): kotlin.collections/List<io.ktor.openapi/Parameter> // io.ktor.openapi/Parameters.Builder.parameters.<get-parameters>|<get-parameters>(){}[0]
@@ -1364,7 +1365,7 @@ final class io.ktor.openapi/RequestBody : io.ktor.openapi/Extensible { // io.kto
     final fun toString(): kotlin/String // io.ktor.openapi/RequestBody.toString|toString(){}[0]
 
     final class Builder : io.ktor.openapi/JsonSchemaInference { // io.ktor.openapi/RequestBody.Builder|null[0]
-        constructor <init>(io.ktor.openapi/JsonSchemaInference) // io.ktor.openapi/RequestBody.Builder.<init>|<init>(io.ktor.openapi.JsonSchemaInference){}[0]
+        constructor <init>(io.ktor.openapi/JsonSchemaInference, kotlin.collections/List<io.ktor.http/ContentType>) // io.ktor.openapi/RequestBody.Builder.<init>|<init>(io.ktor.openapi.JsonSchemaInference;kotlin.collections.List<io.ktor.http.ContentType>){}[0]
 
         final val content // io.ktor.openapi/RequestBody.Builder.content|{}content[0]
             final fun <get-content>(): kotlin.collections/Map<io.ktor.http/ContentType, io.ktor.openapi/MediaType> // io.ktor.openapi/RequestBody.Builder.content.<get-content>|<get-content>(){}[0]
@@ -1374,16 +1375,16 @@ final class io.ktor.openapi/RequestBody : io.ktor.openapi/Extensible { // io.kto
         final var description // io.ktor.openapi/RequestBody.Builder.description|{}description[0]
             final fun <get-description>(): kotlin/String? // io.ktor.openapi/RequestBody.Builder.description.<get-description>|<get-description>(){}[0]
             final fun <set-description>(kotlin/String?) // io.ktor.openapi/RequestBody.Builder.description.<set-description>|<set-description>(kotlin.String?){}[0]
-        final var jsonSchema // io.ktor.openapi/RequestBody.Builder.jsonSchema|{}jsonSchema[0]
-            final fun <get-jsonSchema>(): io.ktor.openapi/JsonSchema? // io.ktor.openapi/RequestBody.Builder.jsonSchema.<get-jsonSchema>|<get-jsonSchema>(){}[0]
-            final fun <set-jsonSchema>(io.ktor.openapi/JsonSchema?) // io.ktor.openapi/RequestBody.Builder.jsonSchema.<set-jsonSchema>|<set-jsonSchema>(io.ktor.openapi.JsonSchema?){}[0]
         final var required // io.ktor.openapi/RequestBody.Builder.required|{}required[0]
             final fun <get-required>(): kotlin/Boolean // io.ktor.openapi/RequestBody.Builder.required.<get-required>|<get-required>(){}[0]
             final fun <set-required>(kotlin/Boolean) // io.ktor.openapi/RequestBody.Builder.required.<set-required>|<set-required>(kotlin.Boolean){}[0]
+        final var schema // io.ktor.openapi/RequestBody.Builder.schema|{}schema[0]
+            final fun <get-schema>(): io.ktor.openapi/JsonSchema? // io.ktor.openapi/RequestBody.Builder.schema.<get-schema>|<get-schema>(){}[0]
+            final fun <set-schema>(io.ktor.openapi/JsonSchema?) // io.ktor.openapi/RequestBody.Builder.schema.<set-schema>|<set-schema>(io.ktor.openapi.JsonSchema?){}[0]
 
         final fun (io.ktor.http/ContentType).invoke(kotlin/Function1<io.ktor.openapi/MediaType.Builder, kotlin/Unit> = ...) // io.ktor.openapi/RequestBody.Builder.invoke|invoke@io.ktor.http.ContentType(kotlin.Function1<io.ktor.openapi.MediaType.Builder,kotlin.Unit>){}[0]
         final fun buildSchema(kotlin.reflect/KType): io.ktor.openapi/JsonSchema // io.ktor.openapi/RequestBody.Builder.buildSchema|buildSchema(kotlin.reflect.KType){}[0]
-        final fun xml(io.ktor.openapi/JsonSchema) // io.ktor.openapi/RequestBody.Builder.xml|xml(io.ktor.openapi.JsonSchema){}[0]
+        final fun content(kotlin/Function1<io.ktor.openapi/MediaType.Builder, kotlin/Unit>) // io.ktor.openapi/RequestBody.Builder.content|content(kotlin.Function1<io.ktor.openapi.MediaType.Builder,kotlin.Unit>){}[0]
         final inline fun <#A2: reified kotlin/Any> extension(kotlin/String, #A2) // io.ktor.openapi/RequestBody.Builder.extension|extension(kotlin.String;0:0){0§<kotlin.Any>}[0]
     }
 
@@ -1428,7 +1429,7 @@ final class io.ktor.openapi/Response : io.ktor.openapi/Extensible { // io.ktor.o
     final fun toString(): kotlin/String // io.ktor.openapi/Response.toString|toString(){}[0]
 
     final class Builder : io.ktor.openapi/JsonSchemaInference { // io.ktor.openapi/Response.Builder|null[0]
-        constructor <init>(io.ktor.openapi/JsonSchemaInference) // io.ktor.openapi/Response.Builder.<init>|<init>(io.ktor.openapi.JsonSchemaInference){}[0]
+        constructor <init>(io.ktor.openapi/JsonSchemaInference, kotlin.collections/List<io.ktor.http/ContentType>) // io.ktor.openapi/Response.Builder.<init>|<init>(io.ktor.openapi.JsonSchemaInference;kotlin.collections.List<io.ktor.http.ContentType>){}[0]
 
         final val content // io.ktor.openapi/Response.Builder.content|{}content[0]
             final fun <get-content>(): kotlin.collections/Map<io.ktor.http/ContentType, io.ktor.openapi/MediaType> // io.ktor.openapi/Response.Builder.content.<get-content>|<get-content>(){}[0]
@@ -1442,12 +1443,13 @@ final class io.ktor.openapi/Response : io.ktor.openapi/Extensible { // io.ktor.o
         final var description // io.ktor.openapi/Response.Builder.description|{}description[0]
             final fun <get-description>(): kotlin/String // io.ktor.openapi/Response.Builder.description.<get-description>|<get-description>(){}[0]
             final fun <set-description>(kotlin/String) // io.ktor.openapi/Response.Builder.description.<set-description>|<set-description>(kotlin.String){}[0]
-        final var jsonSchema // io.ktor.openapi/Response.Builder.jsonSchema|{}jsonSchema[0]
-            final fun <get-jsonSchema>(): io.ktor.openapi/JsonSchema? // io.ktor.openapi/Response.Builder.jsonSchema.<get-jsonSchema>|<get-jsonSchema>(){}[0]
-            final fun <set-jsonSchema>(io.ktor.openapi/JsonSchema?) // io.ktor.openapi/Response.Builder.jsonSchema.<set-jsonSchema>|<set-jsonSchema>(io.ktor.openapi.JsonSchema?){}[0]
+        final var schema // io.ktor.openapi/Response.Builder.schema|{}schema[0]
+            final fun <get-schema>(): io.ktor.openapi/JsonSchema? // io.ktor.openapi/Response.Builder.schema.<get-schema>|<get-schema>(){}[0]
+            final fun <set-schema>(io.ktor.openapi/JsonSchema?) // io.ktor.openapi/Response.Builder.schema.<set-schema>|<set-schema>(io.ktor.openapi.JsonSchema?){}[0]
 
         final fun (io.ktor.http/ContentType).invoke(kotlin/Function1<io.ktor.openapi/MediaType.Builder, kotlin/Unit> = ...) // io.ktor.openapi/Response.Builder.invoke|invoke@io.ktor.http.ContentType(kotlin.Function1<io.ktor.openapi.MediaType.Builder,kotlin.Unit>){}[0]
         final fun buildSchema(kotlin.reflect/KType): io.ktor.openapi/JsonSchema // io.ktor.openapi/Response.Builder.buildSchema|buildSchema(kotlin.reflect.KType){}[0]
+        final fun content(kotlin/Function1<io.ktor.openapi/MediaType.Builder, kotlin/Unit>) // io.ktor.openapi/Response.Builder.content|content(kotlin.Function1<io.ktor.openapi.MediaType.Builder,kotlin.Unit>){}[0]
         final fun headers(kotlin/Function1<io.ktor.openapi/Headers.Builder, kotlin/Unit>) // io.ktor.openapi/Response.Builder.headers|headers(kotlin.Function1<io.ktor.openapi.Headers.Builder,kotlin.Unit>){}[0]
         final fun link(kotlin/String, kotlin/Function1<io.ktor.openapi/Link.Builder, kotlin/Unit>) // io.ktor.openapi/Response.Builder.link|link(kotlin.String;kotlin.Function1<io.ktor.openapi.Link.Builder,kotlin.Unit>){}[0]
         final inline fun <#A2: reified kotlin/Any> extension(kotlin/String, #A2) // io.ktor.openapi/Response.Builder.extension|extension(kotlin.String;0:0){0§<kotlin.Any>}[0]
@@ -1488,7 +1490,7 @@ final class io.ktor.openapi/Responses : io.ktor.openapi/Extensible { // io.ktor.
     final fun toString(): kotlin/String // io.ktor.openapi/Responses.toString|toString(){}[0]
 
     final class Builder { // io.ktor.openapi/Responses.Builder|null[0]
-        constructor <init>(io.ktor.openapi/JsonSchemaInference) // io.ktor.openapi/Responses.Builder.<init>|<init>(io.ktor.openapi.JsonSchemaInference){}[0]
+        constructor <init>(io.ktor.openapi/JsonSchemaInference, kotlin.collections/List<io.ktor.http/ContentType>) // io.ktor.openapi/Responses.Builder.<init>|<init>(io.ktor.openapi.JsonSchemaInference;kotlin.collections.List<io.ktor.http.ContentType>){}[0]
 
         final val extensions // io.ktor.openapi/Responses.Builder.extensions|{}extensions[0]
             final fun <get-extensions>(): kotlin.collections/Map<kotlin/String, io.ktor.openapi/GenericElement> // io.ktor.openapi/Responses.Builder.extensions.<get-extensions>|<get-extensions>(){}[0]
@@ -1770,7 +1772,7 @@ final object io.ktor.openapi/JsonElementSerialAdapter : io.ktor.openapi/GenericE
 final val io.ktor.openapi/KotlinxJsonSchemaInference // io.ktor.openapi/KotlinxJsonSchemaInference|{}KotlinxJsonSchemaInference[0]
     final fun <get-KotlinxJsonSchemaInference>(): io.ktor.openapi/JsonSchemaInference // io.ktor.openapi/KotlinxJsonSchemaInference.<get-KotlinxJsonSchemaInference>|<get-KotlinxJsonSchemaInference>(){}[0]
 
-final fun (kotlinx.serialization.descriptors/SerialDescriptor).io.ktor.openapi/buildJsonSchema(): io.ktor.openapi/JsonSchema // io.ktor.openapi/buildJsonSchema|buildJsonSchema@kotlinx.serialization.descriptors.SerialDescriptor(){}[0]
+final fun (kotlinx.serialization.descriptors/SerialDescriptor).io.ktor.openapi/buildJsonSchema(kotlin/Boolean = ...): io.ktor.openapi/JsonSchema // io.ktor.openapi/buildJsonSchema|buildJsonSchema@kotlinx.serialization.descriptors.SerialDescriptor(kotlin.Boolean){}[0]
 final fun io.ktor.openapi/GenericElement(kotlin.collections/Collection<kotlin/Pair<kotlin/String, io.ktor.openapi/GenericElement>>): io.ktor.openapi/GenericElement // io.ktor.openapi/GenericElement|GenericElement(kotlin.collections.Collection<kotlin.Pair<kotlin.String,io.ktor.openapi.GenericElement>>){}[0]
 final inline fun <#A: reified kotlin/Any> (io.ktor.openapi/JsonSchemaInference).io.ktor.openapi/jsonSchema(): io.ktor.openapi/JsonSchema // io.ktor.openapi/jsonSchema|jsonSchema@io.ktor.openapi.JsonSchemaInference(){0§<kotlin.Any>}[0]
 final inline fun <#A: reified kotlin/Any> io.ktor.openapi/GenericElement(#A): io.ktor.openapi/GenericElement // io.ktor.openapi/GenericElement|GenericElement(0:0){0§<kotlin.Any>}[0]

--- a/ktor-shared/ktor-openapi-schema/common/test/io/ktor/openapi/OperationSerializationTests.kt
+++ b/ktor-shared/ktor-openapi-schema/common/test/io/ktor/openapi/OperationSerializationTests.kt
@@ -52,7 +52,7 @@ class OperationSerializationTests {
             requestBody {
                 description = "Article to create"
                 required = true
-                jsonSchema = jsonSchema<Article>()
+                schema = jsonSchema<Article>()
             }
         }
 
@@ -124,13 +124,13 @@ class OperationSerializationTests {
             requestBody {
                 description = "Article data"
                 required = true
-                jsonSchema = jsonSchema<Article>()
+                schema = jsonSchema<Article>()
             }
 
             responses {
                 HttpStatusCode.Created {
                     description = "Article created successfully"
-                    jsonSchema = jsonSchema<Article>()
+                    schema = jsonSchema<Article>()
                     headers {
                         header("Location") {
                             description = "Location of the created resource"
@@ -213,7 +213,7 @@ class OperationSerializationTests {
             requestBody {
                 description = "Article data"
                 required = true
-                jsonSchema = jsonSchema<Article>()
+                schema = jsonSchema<Article>()
                 extension("x-validation-schema", "article-v1")
                 extension("x-max-size-bytes", 1048576) // 1MB
             }


### PR DESCRIPTION
**Subsystem**
Server, OpenAPI

**Motivation**
[KTOR-9086](https://youtrack.jetbrains.com/issue/KTOR-9086) Read OpenAPI default content type information from ContentNegotiation plugin

**Solution**
Introduced an attribute to define the default content types that will be used for cases where it is unspecified, like `call.respond(T)`.  This is assigned upon installing `ContentNegotiation` and read later when generating the OpenAPI specification.

