### PR TITLE
CORS: Allow any header for the simmetry with anyHost

### DIFF
--- a/ktor-server/ktor-server-plugins/ktor-server-cors/common/src/io/ktor/server/plugins/cors/CORSConfig.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-cors/common/src/io/ktor/server/plugins/cors/CORSConfig.kt
@@ -258,6 +258,16 @@ public class CORSConfig {
     }
 
     /**
+     * Allows any header to be used for the actual [CORS] request.
+     *
+     * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.server.plugins.cors.CORSConfig.anyHeader)
+     */
+    public fun anyHeader() {
+        allowNonSimpleContentTypes = true
+        headers.add("*")
+    }
+
+    /**
      * Allows using headers prefixed with [headerPrefix] for the actual [CORS] request.
      *
      * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.server.plugins.cors.CORSConfig.allowHeadersPrefixed)


### PR DESCRIPTION
**Subsystem**
Server: CORS

**Motivation**
There is a function to allow any host (anyHost). Since 2016 it is allowed to pass '*' to headers as well: https://github.com/whatwg/fetch/issues/251. I expect to have anyHeader.

**Solution**
Added the function.
