### PR TITLE
Mark HttpMethod fields const

### DIFF
--- a/ktor-http/api/ktor-http.api
+++ b/ktor-http/api/ktor-http.api
@@ -634,6 +634,16 @@ public final class io/ktor/http/HttpMessagePropertiesKt {
 
 public final class io/ktor/http/HttpMethod {
 	public static final field Companion Lio/ktor/http/HttpMethod$Companion;
+	public static final field DefaultMethods Ljava/util/List;
+	public static final field Delete Lio/ktor/http/HttpMethod;
+	public static final field Get Lio/ktor/http/HttpMethod;
+	public static final field Head Lio/ktor/http/HttpMethod;
+	public static final field Options Lio/ktor/http/HttpMethod;
+	public static final field Patch Lio/ktor/http/HttpMethod;
+	public static final field Post Lio/ktor/http/HttpMethod;
+	public static final field Put Lio/ktor/http/HttpMethod;
+	public static final field Query Lio/ktor/http/HttpMethod;
+	public static final field Trace Lio/ktor/http/HttpMethod;
 	public fun <init> (Ljava/lang/String;)V
 	public final fun component1 ()Ljava/lang/String;
 	public final fun copy (Ljava/lang/String;)Lio/ktor/http/HttpMethod;
@@ -653,7 +663,6 @@ public final class io/ktor/http/HttpMethod$Companion {
 	public final fun getPatch ()Lio/ktor/http/HttpMethod;
 	public final fun getPost ()Lio/ktor/http/HttpMethod;
 	public final fun getPut ()Lio/ktor/http/HttpMethod;
-	public final fun getQuery ()Lio/ktor/http/HttpMethod;
 	public final fun getTrace ()Lio/ktor/http/HttpMethod;
 	public final fun parse (Ljava/lang/String;)Lio/ktor/http/HttpMethod;
 }

--- a/ktor-http/api/ktor-http.klib.api
+++ b/ktor-http/api/ktor-http.klib.api
@@ -784,6 +784,15 @@ final class io.ktor.http/HttpMethod { // io.ktor.http/HttpMethod|null[0]
         final val Trace // io.ktor.http/HttpMethod.Companion.Trace|{}Trace[0]
             final fun <get-Trace>(): io.ktor.http/HttpMethod // io.ktor.http/HttpMethod.Companion.Trace.<get-Trace>|<get-Trace>(){}[0]
 
+        final fun getDefaultMethods(): kotlin.collections/List<io.ktor.http/HttpMethod> // io.ktor.http/HttpMethod.Companion.getDefaultMethods|getDefaultMethods(){}[0]
+        final fun getDelete(): io.ktor.http/HttpMethod // io.ktor.http/HttpMethod.Companion.getDelete|getDelete(){}[0]
+        final fun getGet(): io.ktor.http/HttpMethod // io.ktor.http/HttpMethod.Companion.getGet|getGet(){}[0]
+        final fun getHead(): io.ktor.http/HttpMethod // io.ktor.http/HttpMethod.Companion.getHead|getHead(){}[0]
+        final fun getOptions(): io.ktor.http/HttpMethod // io.ktor.http/HttpMethod.Companion.getOptions|getOptions(){}[0]
+        final fun getPatch(): io.ktor.http/HttpMethod // io.ktor.http/HttpMethod.Companion.getPatch|getPatch(){}[0]
+        final fun getPost(): io.ktor.http/HttpMethod // io.ktor.http/HttpMethod.Companion.getPost|getPost(){}[0]
+        final fun getPut(): io.ktor.http/HttpMethod // io.ktor.http/HttpMethod.Companion.getPut|getPut(){}[0]
+        final fun getTrace(): io.ktor.http/HttpMethod // io.ktor.http/HttpMethod.Companion.getTrace|getTrace(){}[0]
         final fun parse(kotlin/String): io.ktor.http/HttpMethod // io.ktor.http/HttpMethod.Companion.parse|parse(kotlin.String){}[0]
     }
 }

--- a/ktor-http/common/src/io/ktor/http/HttpMethod.kt
+++ b/ktor-http/common/src/io/ktor/http/HttpMethod.kt
@@ -5,6 +5,7 @@
 package io.ktor.http
 
 import io.ktor.utils.io.*
+import kotlin.jvm.JvmField
 
 /**
  * Represents an HTTP method (verb)
@@ -16,18 +17,35 @@ import io.ktor.utils.io.*
 public data class HttpMethod(val value: String) {
     override fun toString(): String = value
 
+    // TODO: remove deprecated getters in the next major release.
     @Suppress("KDocMissingDocumentation")
     public companion object {
+        @JvmField
         public val Get: HttpMethod = HttpMethod("GET")
+
+        @JvmField
         public val Post: HttpMethod = HttpMethod("POST")
+
+        @JvmField
         public val Put: HttpMethod = HttpMethod("PUT")
 
         // https://tools.ietf.org/html/rfc5789
+        @JvmField
         public val Patch: HttpMethod = HttpMethod("PATCH")
+
+        @JvmField
         public val Delete: HttpMethod = HttpMethod("DELETE")
+
+        @JvmField
         public val Head: HttpMethod = HttpMethod("HEAD")
+
+        @JvmField
         public val Options: HttpMethod = HttpMethod("OPTIONS")
+
+        @JvmField
         public val Trace: HttpMethod = HttpMethod("TRACE")
+
+        @JvmField
         public val Query: HttpMethod = HttpMethod("QUERY")
 
         /**
@@ -55,7 +73,35 @@ public data class HttpMethod(val value: String) {
          *
          * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.http.HttpMethod.Companion.DefaultMethods)
          */
+        @JvmField
         public val DefaultMethods: List<HttpMethod> = listOf(Get, Post, Put, Patch, Delete, Head, Options)
+
+        @Deprecated("Use Get const instead", ReplaceWith("HttpMethod.Get"))
+        public fun getGet(): HttpMethod = Get
+
+        @Deprecated("Use Post const instead", ReplaceWith("HttpMethod.Post"))
+        public fun getPost(): HttpMethod = Post
+
+        @Deprecated("Use Put const instead", ReplaceWith("HttpMethod.Put"))
+        public fun getPut(): HttpMethod = Put
+
+        @Deprecated("Use Patch const instead", ReplaceWith("HttpMethod.Patch"))
+        public fun getPatch(): HttpMethod = Patch
+
+        @Deprecated("Use Delete const instead", ReplaceWith("HttpMethod.Delete"))
+        public fun getDelete(): HttpMethod = Delete
+
+        @Deprecated("Use Head const instead", ReplaceWith("HttpMethod.Head"))
+        public fun getHead(): HttpMethod = Head
+
+        @Deprecated("Use Options const instead", ReplaceWith("HttpMethod.Options"))
+        public fun getOptions(): HttpMethod = Options
+
+        @Deprecated("Use Trace const instead", ReplaceWith("HttpMethod.Trace"))
+        public fun getTrace(): HttpMethod = Trace
+
+        @Deprecated("Use DefaultMethods const instead", ReplaceWith("HttpMethod.DefaultMethods"))
+        public fun getDefaultMethods(): List<HttpMethod> = DefaultMethods
     }
 }
 


### PR DESCRIPTION
We don't have to deprecate `getQuery` as the newly added `Query` property has not been released yet.

