### PR TITLE
KTOR-2162 Ktor Server Jetty Jakarta enable thread pool expansion

### DIFF
--- a/ktor-server/ktor-server-jetty-jakarta/jvm/test/io/ktor/tests/server/jetty/jakarta/JettyHandlingCapacityTest.kt
+++ b/ktor-server/ktor-server-jetty-jakarta/jvm/test/io/ktor/tests/server/jetty/jakarta/JettyHandlingCapacityTest.kt
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2014-2024 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.tests.server.jetty.jakarta
+
+import io.ktor.server.jetty.jakarta.*
+import io.ktor.server.response.*
+import io.ktor.server.routing.*
+import io.ktor.server.test.base.*
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.joinAll
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runInterruptible
+import java.util.concurrent.*
+import kotlin.test.*
+
+class JettyHandlingCapacityTest : EngineTestBase<JettyApplicationEngine, JettyApplicationEngineBase.Configuration>(
+    Jetty
+) {
+    init {
+        enableSsl = false
+    }
+
+    private val corePoolSize = 2
+    private val concurrentRequests = 10
+
+    override fun configure(configuration: JettyApplicationEngineBase.Configuration) {
+        configuration.callGroupSize = corePoolSize
+    }
+
+    /**
+     * Verifies that the thread pool expands beyond the configured callGroupSize when handlers block,
+     * handling these requests immediately.
+     */
+    @Test
+    fun testBlockingHandlersPoolExpansion() = runTest {
+        val handlerEnteredLatch = CountDownLatch(concurrentRequests)
+        val blockHandlerLatch = CountDownLatch(1)
+        val handlingThreads = ConcurrentHashMap.newKeySet<String>()
+
+        createAndStartServer {
+            get("/blocking") {
+                handlingThreads.add(Thread.currentThread().name)
+                handlerEnteredLatch.countDown()
+                blockHandlerLatch.await()
+                call.respondText("OK")
+            }
+        }
+
+        val clientJobs = List(concurrentRequests) {
+            launch {
+                withUrl("/blocking") { }
+            }
+        }
+
+        // If the pool does not expand beyond callGroupSize, this will timeout
+        // because only callGroupSize requests can be handled concurrently
+        val allEntered = runInterruptible(Dispatchers.IO) { handlerEnteredLatch.await(5, TimeUnit.SECONDS) }
+
+        blockHandlerLatch.countDown()
+        clientJobs.joinAll()
+
+        assertTrue(
+            allEntered,
+            "Not all $concurrentRequests requests entered handler concurrently - pool did not expand"
+        )
+        assertTrue(
+            handlingThreads.size > corePoolSize,
+            "Expected pool expansion beyond $corePoolSize core threads, but only ${handlingThreads.size} unique threads handled requests"
+        )
+        assertTrue(
+            handlingThreads.all { it.startsWith("ktor-jetty-") },
+            "Expected all handling threads to be from JettyKtorHandler pool, but got: $handlingThreads"
+        )
+    }
+}


### PR DESCRIPTION
**Subsystem**
Server, Jetty + Jetty Jakarta

**Motivation**

https://youtrack.jetbrains.com/issue/KTOR-2162

Describe what problem this PR solves and why it is important. Refer to a bug/ticket #.

**Solution**
Fix `ThreadPoolExecutor` in `JettyKtorHandler` to actually utilize the configured maxPoolSize (8x burst capacity) by replacing the unbounded `LinkedBlockingQueue` with `SynchronousQueue`, which has no capacity and forces thread creation up to `maxPoolSize` before blocking.

This is the same pattern used by `Executors.newCachedThreadPool()`.

**Impact**
Backpressure behavior: When the pool reaches `callGroupSize * 8` threads and all are busy, the calling Jetty worker thread blocks. However, Jetty's own `QueuedThreadPool` provides natural request buffering upstream. Clients only experience connection-level backpressure after both pools are saturated.

This does change the client experience under overload:
* Current (unbounded queue): Connections accepted indefinitely, requests queue in memory, potential OOM, eventual response timeouts.
* After fix: Connections accepted up to Jetty's buffer capacity, then new connections wait/timeout at TCP level, fail-fast(er) behavior.

Edit: The `QueuedThreadPool` implemented in Ktor is currently done with an unbounded queue as well, so the behaviour will be unchanged for clients.

Benefit for user code: If application handlers inadvertently perform blocking operations (common, in my opinion), the pool now grows to absorb the load (up to 8x) rather than serializing all requests through `callGroupSize` threads while the unbounded queue grows silently.

I would like to explore being able to monitor this threadpool closer in the future, but for now - concurrent ktor handler threads can be a proxy. Also if Jetty threads become more reliably consumed these will be easier to monitor.