### PR TITLE
Deprecate `Apache`(4) Client Engine.

### DIFF
--- a/ktor-client/ktor-client-apache/jvm/src/io/ktor/client/engine/apache/Apache.kt
+++ b/ktor-client/ktor-client-apache/jvm/src/io/ktor/client/engine/apache/Apache.kt
@@ -27,6 +27,14 @@ import io.ktor.client.engine.*
  *
  * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.client.engine.apache.Apache)
  */
+@Deprecated(
+    message = "Apache engine is deprecated. Consider using Apache5 engine instead.",
+    replaceWith = ReplaceWith(
+        "Apache5",
+        "io.ktor.client.engine.apache5.Apache5"
+    ),
+    level = DeprecationLevel.WARNING
+)
 public data object Apache : HttpClientEngineFactory<ApacheEngineConfig> {
     override fun create(block: ApacheEngineConfig.() -> Unit): HttpClientEngine {
         val config = ApacheEngineConfig().apply(block)
@@ -34,6 +42,10 @@ public data object Apache : HttpClientEngineFactory<ApacheEngineConfig> {
     }
 }
 
+@Deprecated(
+    message = "Apache engine is deprecated. Consider using Apache5 engine instead.",
+    level = DeprecationLevel.WARNING
+)
 public class ApacheEngineContainer : HttpClientEngineContainer {
     override val factory: HttpClientEngineFactory<*> = Apache
 

--- a/ktor-client/ktor-client-apache/jvm/src/io/ktor/client/engine/apache/ApacheEngineConfig.kt
+++ b/ktor-client/ktor-client-apache/jvm/src/io/ktor/client/engine/apache/ApacheEngineConfig.kt
@@ -14,6 +14,14 @@ import javax.net.ssl.SSLContext
  *
  * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.client.engine.apache.ApacheEngineConfig)
  */
+@Deprecated(
+    message = "Apache engine is deprecated. Consider using Apache5EngineConfig instead.",
+    replaceWith = ReplaceWith(
+        "Apache5EngineConfig",
+        "io.ktor.client.engine.apache5.Apache5EngineConfig"
+    ),
+    level = DeprecationLevel.WARNING
+)
 public class ApacheEngineConfig : HttpClientEngineConfig() {
     /**
      * Specifies whether to follow redirects automatically.

--- a/ktor-client/ktor-client-apache5/jvm/src/io/ktor/client/engine/apache5/Apache5.kt
+++ b/ktor-client/ktor-client-apache5/jvm/src/io/ktor/client/engine/apache5/Apache5.kt
@@ -12,13 +12,13 @@ import io.ktor.client.engine.*
  *
  * To create the client with this engine, pass it to the `HttpClient` constructor:
  * ```kotlin
- * val client = HttpClient(Apache)
+ * val client = HttpClient(Apache5)
  * ```
- * To configure the engine, pass settings exposed by [ApacheEngineConfig] to the `engine` method:
+ * To configure the engine, pass settings exposed by [Apache5EngineConfig] to the `engine` method:
  * ```kotlin
- * val client = HttpClient(Apache) {
+ * val client = HttpClient(Apache5) {
  *     engine {
- *         // this: ApacheEngineConfig
+ *         // this: Apache5EngineConfig
  *     }
  * }
  * ```

--- a/ktor-client/ktor-client-core/common/src/io/ktor/client/HttpClient.kt
+++ b/ktor-client/ktor-client-core/common/src/io/ktor/client/HttpClient.kt
@@ -321,10 +321,10 @@ import kotlin.coroutines.CoroutineContext
  *
  * Example with manual engine specification:
  * ```
- * val client = HttpClient(Apache) // Explicitly uses Apache engine, bypassing service loader
+ * val client = HttpClient(Apache5) // Explicitly uses Apache5 engine, bypassing service loader
  * ```
  *
- * By directly setting the engine (e.g., `Apache`, `OkHttp`), you can optimize startup performance
+ * By directly setting the engine (e.g., `Apache5`, `OkHttp`), you can optimize startup performance
  * by preventing the default service loader mechanism.
  *
  * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.client.HttpClient)
@@ -633,10 +633,10 @@ public expect fun HttpClient(
  *
  * Example with manual engine specification:
  * ```
- * val client = HttpClient(Apache) // Explicitly uses Apache engine, bypassing service loader
+ * val client = HttpClient(Apache5) // Explicitly uses Apache5 engine, bypassing service loader
  * ```
  *
- * By directly setting the engine (e.g., `Apache`, `OkHttp`), you can optimize startup performance
+ * By directly setting the engine (e.g., `Apache5`, `OkHttp`), you can optimize startup performance
  * by preventing the default service loader mechanism.
  *
  * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.client.HttpClient)
@@ -958,10 +958,10 @@ public fun <T : HttpClientEngineConfig> HttpClient(
  *
  * Example with manual engine specification:
  * ```
- * val client = HttpClient(Apache) // Explicitly uses Apache engine, bypassing service loader
+ * val client = HttpClient(Apache5) // Explicitly uses Apache5 engine, bypassing service loader
  * ```
  *
- * By directly setting the engine (e.g., `Apache`, `OkHttp`), you can optimize startup performance
+ * By directly setting the engine (e.g., `Apache5`, `OkHttp`), you can optimize startup performance
  * by preventing the default service loader mechanism.
  *
  * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.client.HttpClient)
@@ -1271,10 +1271,10 @@ public fun HttpClient(
  *
  * Example with manual engine specification:
  * ```
- * val client = HttpClient(Apache) // Explicitly uses Apache engine, bypassing service loader
+ * val client = HttpClient(Apache5) // Explicitly uses Apache5 engine, bypassing service loader
  * ```
  *
- * By directly setting the engine (e.g., `Apache`, `OkHttp`), you can optimize startup performance
+ * By directly setting the engine (e.g., `Apache5`, `OkHttp`), you can optimize startup performance
  * by preventing the default service loader mechanism.
  *
  * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.client.HttpClient)

--- a/ktor-client/ktor-client-tests/build.gradle.kts
+++ b/ktor-client/ktor-client-tests/build.gradle.kts
@@ -42,7 +42,6 @@ kotlin {
         }
 
         jvmTest.dependencies {
-            api(projects.ktorClientApache)
             api(projects.ktorClientApache5)
             runtimeOnly(projects.ktorClientAndroid)
             runtimeOnly(projects.ktorClientOkhttp)

--- a/ktor-client/ktor-client-tests/jvm/test/io/ktor/client/tests/ExceptionsJvmTest.kt
+++ b/ktor-client/ktor-client-tests/jvm/test/io/ktor/client/tests/ExceptionsJvmTest.kt
@@ -5,7 +5,7 @@
 package io.ktor.client.tests
 
 import io.ktor.client.*
-import io.ktor.client.engine.apache.*
+import io.ktor.client.engine.apache5.Apache5
 import io.ktor.client.request.*
 import io.ktor.client.test.base.*
 import kotlinx.coroutines.DelicateCoroutinesApi
@@ -22,7 +22,7 @@ class ExceptionsJvmTest {
 
     @Test
     fun testConnectionCloseException(): Unit = runBlocking {
-        val client = HttpClient(Apache)
+        val client = HttpClient(Apache5)
 
         client.use {
             assertFailsWith<IOException> {
@@ -57,7 +57,7 @@ class ExceptionsJvmTest {
             server.close()
         }
 
-        HttpClient(Apache).use { client ->
+        HttpClient(Apache5).use { client ->
             repeat(100) {
                 assertFailsWith<IOException> {
                     client.get("http://127.0.0.1:$port")

--- a/ktor-server/ktor-server-test-base/build.gradle.kts
+++ b/ktor-server/ktor-server-test-base/build.gradle.kts
@@ -19,7 +19,6 @@ kotlin {
             api(projects.ktorNetworkTls)
 
             api(projects.ktorClientApache5)
-            api(projects.ktorClientApache)
             api(projects.ktorNetworkTlsCertificates)
             api(projects.ktorServerCallLogging)
 


### PR DESCRIPTION
**Subsystem**
Client

**Motivation**
[KTOR-6766](https://youtrack.jetbrains.com/issue/KTOR-6766) Deprecate Apache 4 engine

**Solution**
Mark `Apache` Engine and its config as deprecated with level `Warning`.
Update the docs and tests to use Apache5.
