### PR TITLE
Deprecate `DarwinLegacy` Engine

### DIFF
--- a/ktor-client/ktor-client-darwin-legacy/darwin/src/io/ktor/client/engine/darwin/DarwinLegacy.kt
+++ b/ktor-client/ktor-client-darwin-legacy/darwin/src/io/ktor/client/engine/darwin/DarwinLegacy.kt
@@ -18,13 +18,13 @@ private val initHook = DarwinLegacy
  *
  * To create the client with this engine, pass it to the `HttpClient` constructor:
  * ```kotlin
- * val client = HttpClient(Darwin)
+ * val client = HttpClient(DarwinLegacy)
  * ```
- * To configure the engine, pass settings exposed by [DarwinClientEngineConfig] to the `engine` method:
+ * To configure the engine, pass settings exposed by [DarwinLegacyClientEngineConfig] to the `engine` method:
  * ```kotlin
- * val client = HttpClient(Darwin) {
+ * val client = HttpClient(DarwinLegacy) {
  *     engine {
- *         // this: DarwinClientEngineConfig
+ *         // this: DarwinLegacyClientEngineConfig
  *     }
  * }
  * ```
@@ -34,6 +34,15 @@ private val initHook = DarwinLegacy
  * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.client.engine.darwin.DarwinLegacy)
  */
 @OptIn(InternalAPI::class)
+@Deprecated(
+    message = "DarwinLegacy engine is deprecated. Consider using Darwin engine instead.",
+    replaceWith = ReplaceWith(
+        "Darwin",
+        "io.ktor.client.engine.darwin.Darwin"
+    ),
+    level = DeprecationLevel.WARNING
+)
+@Suppress("Deprecation")
 public data object DarwinLegacy : HttpClientEngineFactory<DarwinLegacyClientEngineConfig> {
     init {
         engines.append(this)

--- a/ktor-client/ktor-client-darwin-legacy/darwin/src/io/ktor/client/engine/darwin/DarwinLegacyClientEngine.kt
+++ b/ktor-client/ktor-client-darwin-legacy/darwin/src/io/ktor/client/engine/darwin/DarwinLegacyClientEngine.kt
@@ -14,6 +14,7 @@ import platform.Foundation.NSOperationQueue
 
 @OptIn(InternalAPI::class)
 internal class DarwinLegacyClientEngine(
+    @Suppress("DEPRECATION")
     override val config: DarwinLegacyClientEngineConfig
 ) : HttpClientEngineBase("ktor-darwin-legacy") {
 

--- a/ktor-client/ktor-client-darwin-legacy/darwin/src/io/ktor/client/engine/darwin/DarwinLegacyClientEngineConfig.kt
+++ b/ktor-client/ktor-client-darwin-legacy/darwin/src/io/ktor/client/engine/darwin/DarwinLegacyClientEngineConfig.kt
@@ -26,6 +26,14 @@ public typealias ChallengeHandler = (
  *
  * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.client.engine.darwin.DarwinLegacyClientEngineConfig)
  */
+@Deprecated(
+    message = "DarwinLegacy engine is deprecated. Consider using DarwinClientEngineConfig instead.",
+    replaceWith = ReplaceWith(
+        "DarwinClientEngineConfig",
+        "io.ktor.client.engine.darwin.DarwinClientEngineConfig"
+    ),
+    level = DeprecationLevel.WARNING
+)
 public class DarwinLegacyClientEngineConfig : HttpClientEngineConfig() {
     /**
      * A request configuration.
@@ -73,6 +81,7 @@ public class DarwinLegacyClientEngineConfig : HttpClientEngineConfig() {
     /**
      * Specifies a session to use for making HTTP requests.
      */
+    @Suppress("DEPRECATION")
     internal var sessionAndDelegate: Pair<NSURLSession, KtorLegacyNSURLSessionDelegate>? = null
 
     /**
@@ -106,7 +115,7 @@ public class DarwinLegacyClientEngineConfig : HttpClientEngineConfig() {
     }
 
     /**
-     * Set a [session] to be used to make HTTP requests, [null] to create default session.
+     * Set a [session] to be used to make HTTP requests, null to create default session.
      * If the preconfigured session is set, [configureSession] block will be ignored.
      *
      * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.client.engine.darwin.DarwinLegacyClientEngineConfig.usePreconfiguredSession)
@@ -126,6 +135,7 @@ public class DarwinLegacyClientEngineConfig : HttpClientEngineConfig() {
      *
      * @see [KtorLegacyNSURLSessionDelegate] for details.
      */
+    @Suppress("DEPRECATION")
     public fun usePreconfiguredSession(session: NSURLSession, delegate: KtorLegacyNSURLSessionDelegate) {
         sessionAndDelegate = session to delegate
     }

--- a/ktor-client/ktor-client-darwin-legacy/darwin/src/io/ktor/client/engine/darwin/KtorLegacyNSURLSessionDelegate.kt
+++ b/ktor-client/ktor-client-darwin-legacy/darwin/src/io/ktor/client/engine/darwin/KtorLegacyNSURLSessionDelegate.kt
@@ -18,6 +18,7 @@ import kotlin.coroutines.*
  *
  * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.client.engine.darwin.KtorLegacyNSURLSessionDelegate)
  */
+@Suppress("DEPRECATION")
 @OptIn(UnsafeNumber::class)
 public fun KtorLegacyNSURLSessionDelegate(): KtorLegacyNSURLSessionDelegate {
     return KtorLegacyNSURLSessionDelegate(null)
@@ -28,7 +29,7 @@ public fun KtorLegacyNSURLSessionDelegate(): KtorLegacyNSURLSessionDelegate {
  * If users set custom session in [DarwinLegacyClientEngineConfig.sessionAndDelegate],
  * they need to register this delegate in their session.
  * This can be done by registering it directly,
- * extending their custom delegate from it
+ * extending their custom delegate from it,
  * or by calling required methods from their custom delegate.
  *
  * For HTTP requests to work property, it's important that users call these functions:
@@ -39,6 +40,14 @@ public fun KtorLegacyNSURLSessionDelegate(): KtorLegacyNSURLSessionDelegate {
  * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.client.engine.darwin.KtorLegacyNSURLSessionDelegate)
  */
 @OptIn(UnsafeNumber::class)
+@Deprecated(
+    message = "DarwinLegacy engine is deprecated. Consider using KtorNSURLSessionDelegate from Darwin engine instead.",
+    replaceWith = ReplaceWith(
+        "KtorNSURLSessionDelegate",
+        "io.ktor.client.engine.darwin.KtorNSURLSessionDelegate"
+    ),
+    level = DeprecationLevel.WARNING
+)
 public class KtorLegacyNSURLSessionDelegate(
     internal val challengeHandler: ChallengeHandler?
 ) : NSObject(), NSURLSessionDataDelegateProtocol {

--- a/ktor-client/ktor-client-darwin-legacy/darwin/src/io/ktor/client/engine/darwin/ProxySupportLegacyCommon.kt
+++ b/ktor-client/ktor-client-darwin-legacy/darwin/src/io/ktor/client/engine/darwin/ProxySupportLegacyCommon.kt
@@ -11,6 +11,7 @@ private const val HTTP_ENABLE_KEY = "HTTPEnable"
 private const val HTTP_PROXY_KEY = "HTTPProxy"
 private const val HTTP_PORT_KEY = "HTTPPort"
 
+@Suppress("DEPRECATION")
 internal fun NSURLSessionConfiguration.setupProxy(config: DarwinLegacyClientEngineConfig) {
     val proxy = config.proxy ?: return
     val url = proxy.url

--- a/ktor-client/ktor-client-darwin-legacy/darwin/src/io/ktor/client/engine/darwin/internal/legacy/DarwinLegacySession.kt
+++ b/ktor-client/ktor-client-darwin-legacy/darwin/src/io/ktor/client/engine/darwin/internal/legacy/DarwinLegacySession.kt
@@ -15,6 +15,7 @@ import platform.Foundation.*
 import kotlin.coroutines.*
 
 @OptIn(UnsafeNumber::class)
+@Suppress("DEPRECATION")
 internal class DarwinLegacySession(
     private val config: DarwinLegacyClientEngineConfig,
     private val requestQueue: NSOperationQueue?
@@ -55,6 +56,7 @@ internal class DarwinLegacySession(
 }
 
 @OptIn(UnsafeNumber::class)
+@Suppress("DEPRECATION")
 internal fun createSession(
     config: DarwinLegacyClientEngineConfig,
     requestQueue: NSOperationQueue?

--- a/ktor-client/ktor-client-darwin-legacy/darwin/test/DarwinLegacyEngineTest.kt
+++ b/ktor-client/ktor-client-darwin-legacy/darwin/test/DarwinLegacyEngineTest.kt
@@ -22,6 +22,7 @@ import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 import kotlin.time.Duration.Companion.seconds
 
+@Suppress("DEPRECATION")
 class DarwinLegacyEngineTest : ClientEngineTest<DarwinLegacyClientEngineConfig>(DarwinLegacy) {
 
     @Test


### PR DESCRIPTION
**Subsystem**
Client

**Motivation**
[KTOR-9014](https://youtrack.jetbrains.com/issue/KTOR-9014) Deprecate DarwinLegacy engine

**Solution**
Mark `DarwinLegacy` as deprecated with a warning error level.

