### PR TITLE
Revert "Update eclipse-temurin Docker tag to v21.0.9_10-jdk-noble"

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -4,7 +4,7 @@
 # Enforce linux/amd64 platform because of two reasons:
 # 1. Chrome doesn't provide arm64 binaries for Linux (https://issues.chromium.org/issues/374811603)
 # 2. Kotlin/Native doesn't support linux/arm64 as a host platform (KT-36871)
-FROM --platform=linux/amd64 eclipse-temurin:21.0.9_10-jdk-noble AS dev
+FROM --platform=linux/amd64 eclipse-temurin:21.0.8_9-jdk-noble AS dev
 
 ARG USERNAME=developer
 ARG USER_UID=1001


### PR DESCRIPTION
Dependency update caused dev container build to fail.

