### PR TITLE
KTOR-9235: Ignore exceptions when parsing cookie expires date

### DIFF
--- a/ktor-http/common/src/io/ktor/http/Cookie.kt
+++ b/ktor-http/common/src/io/ktor/http/Cookie.kt
@@ -109,7 +109,7 @@ public fun parseServerSetCookieHeader(cookiesHeader: String): Cookie {
         value = decodeCookieValue(first.value, encoding),
         encoding = encoding,
         maxAge = loweredMap["max-age"]?.toIntClamping(),
-        expires = loweredMap["expires"]?.fromCookieToGmtDate(),
+        expires = runCatching { loweredMap["expires"]?.fromCookieToGmtDate() }.getOrNull(),
         domain = loweredMap["domain"],
         path = loweredMap["path"],
         secure = "secure" in loweredMap,


### PR DESCRIPTION
Some websites may set invalid expires date in cookies, which caused the parsing to throw an exception. We now ignore such exceptions and treat the expires date as null.

**Subsystem**
Client, ktor-http

**Motivation**
I'm developing an unofficial API library and cannot control the server's response format.

The server returns a Set-Cookie header with a date value that causes a parsing error in Ktor's HttpCookies plugin.

The error occurs when the plugin tries to parse the cookie's expiration date. The server returns "Wed" as part of the date string, which is not a valid format for String.fromHttpToGmtDate() parsing, resulting in an IllegalStateException.

**Solution**
Use runCatching to ignore the error  and return null instead.
