### PR TITLE
KTOR-9195 Add option for filtering body with custom logic

### DIFF
--- a/ktor-client/ktor-client-plugins/ktor-client-logging/api/ktor-client-logging.api
+++ b/ktor-client/ktor-client-plugins/ktor-client-logging/api/ktor-client-logging.api
@@ -1,5 +1,61 @@
+public abstract interface class io/ktor/client/plugins/logging/BodyFilterResult {
+	public fun getByteSize ()Ljava/lang/Long;
+}
+
+public final class io/ktor/client/plugins/logging/BodyFilterResult$BufferContent : io/ktor/client/plugins/logging/BodyFilterResult$Content {
+	public fun <init> (Lkotlinx/io/Buffer;Ljava/nio/charset/Charset;J)V
+	public synthetic fun <init> (Lkotlinx/io/Buffer;Ljava/nio/charset/Charset;JILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun getByteSize ()Ljava/lang/Long;
+	public fun read ()Ljava/lang/String;
+}
+
+public abstract interface class io/ktor/client/plugins/logging/BodyFilterResult$Content : io/ktor/client/plugins/logging/BodyFilterResult {
+	public abstract fun read ()Ljava/lang/String;
+}
+
+public final class io/ktor/client/plugins/logging/BodyFilterResult$Content$DefaultImpls {
+	public static fun getByteSize (Lio/ktor/client/plugins/logging/BodyFilterResult$Content;)Ljava/lang/Long;
+}
+
+public final class io/ktor/client/plugins/logging/BodyFilterResult$DefaultImpls {
+	public static fun getByteSize (Lio/ktor/client/plugins/logging/BodyFilterResult;)Ljava/lang/Long;
+}
+
+public final class io/ktor/client/plugins/logging/BodyFilterResult$Empty : io/ktor/client/plugins/logging/BodyFilterResult {
+	public static final field INSTANCE Lio/ktor/client/plugins/logging/BodyFilterResult$Empty;
+	public fun getByteSize ()Ljava/lang/Long;
+}
+
+public final class io/ktor/client/plugins/logging/BodyFilterResult$Skip : io/ktor/client/plugins/logging/BodyFilterResult {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;Ljava/lang/Long;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/Long;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun getByteSize ()Ljava/lang/Long;
+	public final fun getReason ()Ljava/lang/String;
+}
+
+public abstract interface class io/ktor/client/plugins/logging/CommonLogBodyFilter : io/ktor/client/plugins/logging/LogBodyFilter {
+	public abstract fun filterAll (Ljava/lang/Long;Lio/ktor/http/ContentType;Lio/ktor/http/Headers;Lio/ktor/utils/io/ByteReadChannel;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun filterRequest (Lio/ktor/http/Url;Ljava/lang/Long;Lio/ktor/http/ContentType;Lio/ktor/http/Headers;Lio/ktor/utils/io/ByteReadChannel;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun filterResponse (Lio/ktor/http/Url;Ljava/lang/Long;Lio/ktor/http/ContentType;Lio/ktor/http/Headers;Lio/ktor/utils/io/ByteReadChannel;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class io/ktor/client/plugins/logging/CommonLogBodyFilter$DefaultImpls {
+	public static fun filterRequest (Lio/ktor/client/plugins/logging/CommonLogBodyFilter;Lio/ktor/http/Url;Ljava/lang/Long;Lio/ktor/http/ContentType;Lio/ktor/http/Headers;Lio/ktor/utils/io/ByteReadChannel;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun filterResponse (Lio/ktor/client/plugins/logging/CommonLogBodyFilter;Lio/ktor/http/Url;Ljava/lang/Long;Lio/ktor/http/ContentType;Lio/ktor/http/Headers;Lio/ktor/utils/io/ByteReadChannel;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
 public final class io/ktor/client/plugins/logging/KtorMDCContext_jvmKt {
 	public static final fun MDCContext ()Lkotlin/coroutines/CoroutineContext$Element;
+}
+
+public abstract interface class io/ktor/client/plugins/logging/LogBodyFilter {
+	public abstract fun filterRequest (Lio/ktor/http/Url;Ljava/lang/Long;Lio/ktor/http/ContentType;Lio/ktor/http/Headers;Lio/ktor/utils/io/ByteReadChannel;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun filterResponse (Lio/ktor/http/Url;Ljava/lang/Long;Lio/ktor/http/ContentType;Lio/ktor/http/Headers;Lio/ktor/utils/io/ByteReadChannel;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class io/ktor/client/plugins/logging/LogBodyFilterKt {
+	public static final fun getBinaryLogBodyFilter ()Lio/ktor/client/plugins/logging/LogBodyFilter;
 }
 
 public final class io/ktor/client/plugins/logging/LogLevel : java/lang/Enum {
@@ -37,11 +93,13 @@ public final class io/ktor/client/plugins/logging/LoggerKt {
 public final class io/ktor/client/plugins/logging/LoggingConfig {
 	public fun <init> ()V
 	public final fun filter (Lkotlin/jvm/functions/Function1;)V
+	public final fun getBodyFilter ()Lio/ktor/client/plugins/logging/LogBodyFilter;
 	public final fun getFormat ()Lio/ktor/client/plugins/logging/LoggingFormat;
 	public final fun getLevel ()Lio/ktor/client/plugins/logging/LogLevel;
 	public final fun getLogger ()Lio/ktor/client/plugins/logging/Logger;
 	public final fun sanitizeHeader (Ljava/lang/String;Lkotlin/jvm/functions/Function1;)V
 	public static synthetic fun sanitizeHeader$default (Lio/ktor/client/plugins/logging/LoggingConfig;Ljava/lang/String;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+	public final fun setBodyFilter (Lio/ktor/client/plugins/logging/LogBodyFilter;)V
 	public final fun setFormat (Lio/ktor/client/plugins/logging/LoggingFormat;)V
 	public final fun setLevel (Lio/ktor/client/plugins/logging/LogLevel;)V
 	public final fun setLogger (Lio/ktor/client/plugins/logging/Logger;)V

--- a/ktor-client/ktor-client-plugins/ktor-client-logging/api/ktor-client-logging.klib.api
+++ b/ktor-client/ktor-client-plugins/ktor-client-logging/api/ktor-client-logging.klib.api
@@ -37,15 +37,58 @@ final enum class io.ktor.client.plugins.logging/LoggingFormat : kotlin/Enum<io.k
     final fun values(): kotlin/Array<io.ktor.client.plugins.logging/LoggingFormat> // io.ktor.client.plugins.logging/LoggingFormat.values|values#static(){}[0]
 }
 
+abstract fun interface io.ktor.client.plugins.logging/CommonLogBodyFilter : io.ktor.client.plugins.logging/LogBodyFilter { // io.ktor.client.plugins.logging/CommonLogBodyFilter|null[0]
+    abstract suspend fun filterAll(kotlin/Long?, io.ktor.http/ContentType?, io.ktor.http/Headers, io.ktor.utils.io/ByteReadChannel): io.ktor.client.plugins.logging/BodyFilterResult // io.ktor.client.plugins.logging/CommonLogBodyFilter.filterAll|filterAll(kotlin.Long?;io.ktor.http.ContentType?;io.ktor.http.Headers;io.ktor.utils.io.ByteReadChannel){}[0]
+    open suspend fun filterRequest(io.ktor.http/Url, kotlin/Long?, io.ktor.http/ContentType?, io.ktor.http/Headers, io.ktor.utils.io/ByteReadChannel): io.ktor.client.plugins.logging/BodyFilterResult // io.ktor.client.plugins.logging/CommonLogBodyFilter.filterRequest|filterRequest(io.ktor.http.Url;kotlin.Long?;io.ktor.http.ContentType?;io.ktor.http.Headers;io.ktor.utils.io.ByteReadChannel){}[0]
+    open suspend fun filterResponse(io.ktor.http/Url, kotlin/Long?, io.ktor.http/ContentType?, io.ktor.http/Headers, io.ktor.utils.io/ByteReadChannel): io.ktor.client.plugins.logging/BodyFilterResult // io.ktor.client.plugins.logging/CommonLogBodyFilter.filterResponse|filterResponse(io.ktor.http.Url;kotlin.Long?;io.ktor.http.ContentType?;io.ktor.http.Headers;io.ktor.utils.io.ByteReadChannel){}[0]
+}
+
+abstract interface io.ktor.client.plugins.logging/LogBodyFilter { // io.ktor.client.plugins.logging/LogBodyFilter|null[0]
+    abstract suspend fun filterRequest(io.ktor.http/Url, kotlin/Long?, io.ktor.http/ContentType?, io.ktor.http/Headers, io.ktor.utils.io/ByteReadChannel): io.ktor.client.plugins.logging/BodyFilterResult // io.ktor.client.plugins.logging/LogBodyFilter.filterRequest|filterRequest(io.ktor.http.Url;kotlin.Long?;io.ktor.http.ContentType?;io.ktor.http.Headers;io.ktor.utils.io.ByteReadChannel){}[0]
+    abstract suspend fun filterResponse(io.ktor.http/Url, kotlin/Long?, io.ktor.http/ContentType?, io.ktor.http/Headers, io.ktor.utils.io/ByteReadChannel): io.ktor.client.plugins.logging/BodyFilterResult // io.ktor.client.plugins.logging/LogBodyFilter.filterResponse|filterResponse(io.ktor.http.Url;kotlin.Long?;io.ktor.http.ContentType?;io.ktor.http.Headers;io.ktor.utils.io.ByteReadChannel){}[0]
+}
+
 abstract interface io.ktor.client.plugins.logging/Logger { // io.ktor.client.plugins.logging/Logger|null[0]
     abstract fun log(kotlin/String) // io.ktor.client.plugins.logging/Logger.log|log(kotlin.String){}[0]
 
     final object Companion // io.ktor.client.plugins.logging/Logger.Companion|null[0]
 }
 
+sealed interface io.ktor.client.plugins.logging/BodyFilterResult { // io.ktor.client.plugins.logging/BodyFilterResult|null[0]
+    open val byteSize // io.ktor.client.plugins.logging/BodyFilterResult.byteSize|{}byteSize[0]
+        open fun <get-byteSize>(): kotlin/Long? // io.ktor.client.plugins.logging/BodyFilterResult.byteSize.<get-byteSize>|<get-byteSize>(){}[0]
+
+    abstract interface Content : io.ktor.client.plugins.logging/BodyFilterResult { // io.ktor.client.plugins.logging/BodyFilterResult.Content|null[0]
+        abstract fun read(): kotlin/String // io.ktor.client.plugins.logging/BodyFilterResult.Content.read|read(){}[0]
+    }
+
+    final class BufferContent : io.ktor.client.plugins.logging/BodyFilterResult.Content { // io.ktor.client.plugins.logging/BodyFilterResult.BufferContent|null[0]
+        constructor <init>(kotlinx.io/Buffer, io.ktor.utils.io.charsets/Charset, kotlin/Long = ...) // io.ktor.client.plugins.logging/BodyFilterResult.BufferContent.<init>|<init>(kotlinx.io.Buffer;io.ktor.utils.io.charsets.Charset;kotlin.Long){}[0]
+
+        final val byteSize // io.ktor.client.plugins.logging/BodyFilterResult.BufferContent.byteSize|{}byteSize[0]
+            final fun <get-byteSize>(): kotlin/Long // io.ktor.client.plugins.logging/BodyFilterResult.BufferContent.byteSize.<get-byteSize>|<get-byteSize>(){}[0]
+
+        final fun read(): kotlin/String // io.ktor.client.plugins.logging/BodyFilterResult.BufferContent.read|read(){}[0]
+    }
+
+    final class Skip : io.ktor.client.plugins.logging/BodyFilterResult { // io.ktor.client.plugins.logging/BodyFilterResult.Skip|null[0]
+        constructor <init>(kotlin/String? = ..., kotlin/Long? = ...) // io.ktor.client.plugins.logging/BodyFilterResult.Skip.<init>|<init>(kotlin.String?;kotlin.Long?){}[0]
+
+        final val byteSize // io.ktor.client.plugins.logging/BodyFilterResult.Skip.byteSize|{}byteSize[0]
+            final fun <get-byteSize>(): kotlin/Long? // io.ktor.client.plugins.logging/BodyFilterResult.Skip.byteSize.<get-byteSize>|<get-byteSize>(){}[0]
+        final val reason // io.ktor.client.plugins.logging/BodyFilterResult.Skip.reason|{}reason[0]
+            final fun <get-reason>(): kotlin/String? // io.ktor.client.plugins.logging/BodyFilterResult.Skip.reason.<get-reason>|<get-reason>(){}[0]
+    }
+
+    final object Empty : io.ktor.client.plugins.logging/BodyFilterResult // io.ktor.client.plugins.logging/BodyFilterResult.Empty|null[0]
+}
+
 final class io.ktor.client.plugins.logging/LoggingConfig { // io.ktor.client.plugins.logging/LoggingConfig|null[0]
     constructor <init>() // io.ktor.client.plugins.logging/LoggingConfig.<init>|<init>(){}[0]
 
+    final var bodyFilter // io.ktor.client.plugins.logging/LoggingConfig.bodyFilter|{}bodyFilter[0]
+        final fun <get-bodyFilter>(): io.ktor.client.plugins.logging/LogBodyFilter // io.ktor.client.plugins.logging/LoggingConfig.bodyFilter.<get-bodyFilter>|<get-bodyFilter>(){}[0]
+        final fun <set-bodyFilter>(io.ktor.client.plugins.logging/LogBodyFilter) // io.ktor.client.plugins.logging/LoggingConfig.bodyFilter.<set-bodyFilter>|<set-bodyFilter>(io.ktor.client.plugins.logging.LogBodyFilter){}[0]
     final var format // io.ktor.client.plugins.logging/LoggingConfig.format|{}format[0]
         final fun <get-format>(): io.ktor.client.plugins.logging/LoggingFormat // io.ktor.client.plugins.logging/LoggingConfig.format.<get-format>|<get-format>(){}[0]
         final fun <set-format>(io.ktor.client.plugins.logging/LoggingFormat) // io.ktor.client.plugins.logging/LoggingConfig.format.<set-format>|<set-format>(io.ktor.client.plugins.logging.LoggingFormat){}[0]
@@ -60,6 +103,8 @@ final class io.ktor.client.plugins.logging/LoggingConfig { // io.ktor.client.plu
     final fun sanitizeHeader(kotlin/String = ..., kotlin/Function1<kotlin/String, kotlin/Boolean>) // io.ktor.client.plugins.logging/LoggingConfig.sanitizeHeader|sanitizeHeader(kotlin.String;kotlin.Function1<kotlin.String,kotlin.Boolean>){}[0]
 }
 
+final val io.ktor.client.plugins.logging/BinaryLogBodyFilter // io.ktor.client.plugins.logging/BinaryLogBodyFilter|{}BinaryLogBodyFilter[0]
+    final fun <get-BinaryLogBodyFilter>(): io.ktor.client.plugins.logging/LogBodyFilter // io.ktor.client.plugins.logging/BinaryLogBodyFilter.<get-BinaryLogBodyFilter>|<get-BinaryLogBodyFilter>(){}[0]
 final val io.ktor.client.plugins.logging/DEFAULT // io.ktor.client.plugins.logging/DEFAULT|@io.ktor.client.plugins.logging.Logger.Companion{}DEFAULT[0]
     final fun (io.ktor.client.plugins.logging/Logger.Companion).<get-DEFAULT>(): io.ktor.client.plugins.logging/Logger // io.ktor.client.plugins.logging/DEFAULT.<get-DEFAULT>|<get-DEFAULT>@io.ktor.client.plugins.logging.Logger.Companion(){}[0]
 final val io.ktor.client.plugins.logging/EMPTY // io.ktor.client.plugins.logging/EMPTY|@io.ktor.client.plugins.logging.Logger.Companion{}EMPTY[0]

--- a/ktor-client/ktor-client-plugins/ktor-client-logging/build.gradle.kts
+++ b/ktor-client/ktor-client-plugins/ktor-client-logging/build.gradle.kts
@@ -15,6 +15,7 @@ kotlin {
         commonTest.dependencies {
             api(projects.ktorClientMock)
             api(projects.ktorClientContentNegotiation)
+            implementation(projects.ktorServerTestHost)
         }
         jvmTest.dependencies {
             api(projects.ktorSerializationJackson)

--- a/ktor-client/ktor-client-plugins/ktor-client-logging/common/src/io/ktor/client/plugins/logging/LogBodyFilter.kt
+++ b/ktor-client/ktor-client-plugins/ktor-client-logging/common/src/io/ktor/client/plugins/logging/LogBodyFilter.kt
@@ -1,0 +1,221 @@
+/*
+ * Copyright 2014-2026 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.client.plugins.logging
+
+import io.ktor.http.*
+import io.ktor.utils.io.*
+import io.ktor.utils.io.charsets.*
+import io.ktor.utils.io.core.*
+import kotlinx.io.Buffer
+
+/**
+ * Decides to include the body of a response in the logs (if body logging is enabled).
+ *
+ * The result can be a subset of the complete response, or some alternative format.
+ */
+public interface LogBodyFilter {
+    /**
+     * Applies a filtering operation on the request body based on the specified parameters.
+     * Determines how the request body should be included in the logs.
+     *
+     * @param url The URL of the request.
+     * @param contentLength The length of the request content, or null if unknown.
+     * @param contentType The content type of the request, or null if unspecified.
+     * @param headers The headers of the request.
+     * @param body The channel containing the request body data.
+     * @return The result of applying the body filter, which may include a subset or an alternative representation of the body.
+     */
+    public suspend fun filterRequest(
+        url: Url,
+        contentLength: Long?,
+        contentType: ContentType?,
+        headers: Headers,
+        body: ByteReadChannel,
+    ): BodyFilterResult
+
+    /**
+     * Applies a filtering operation on the response body based on the specified parameters.
+     * Determines how the response body should be included in the logs.
+     *
+     * @param url The URL of the request.
+     * @param contentLength The length of the response content, or null if unknown.
+     * @param contentType The content type of the response, or null if unspecified.
+     * @param headers The headers of the response.
+     * @param body The channel containing the response body data.
+     * @return The result of applying the body filter, which may include a subset or an alternative representation of the body.
+     */
+    public suspend fun filterResponse(
+        url: Url,
+        contentLength: Long?,
+        contentType: ContentType?,
+        headers: Headers,
+        body: ByteReadChannel,
+    ): BodyFilterResult
+}
+
+/**
+ * Convenience interface for two-way filtering using a common method.
+ */
+public fun interface CommonLogBodyFilter : LogBodyFilter {
+    override suspend fun filterRequest(
+        url: Url,
+        contentLength: Long?,
+        contentType: ContentType?,
+        headers: Headers,
+        body: ByteReadChannel
+    ): BodyFilterResult = filterAll(contentLength, contentType, headers, body)
+
+    override suspend fun filterResponse(
+        url: Url,
+        contentLength: Long?,
+        contentType: ContentType?,
+        headers: Headers,
+        body: ByteReadChannel
+    ): BodyFilterResult = filterAll(contentLength, contentType, headers, body)
+
+    /**
+     * Filters the body content using the provided parameters during both request and response processing.
+     *
+     * @param contentLength The length of the content, or null if the length is unknown.
+     * @param contentType The type of the content, or null if the type is not specified.
+     * @param headers The headers associated with the content.
+     * @param body The channel for reading the body content.
+     * @return A [BodyFilterResult] containing the result of the filtering operation.
+     */
+    public suspend fun filterAll(
+        contentLength: Long?,
+        contentType: ContentType?,
+        headers: Headers,
+        body: ByteReadChannel
+    ): BodyFilterResult
+}
+
+/**
+ * A [LogBodyFilter] that filters out binary content.
+ */
+public val BinaryLogBodyFilter: LogBodyFilter = object : CommonLogBodyFilter {
+    override suspend fun filterAll(
+        contentLength: Long?,
+        contentType: ContentType?,
+        headers: Headers,
+        body: ByteReadChannel
+    ): BodyFilterResult {
+        if (headers.contains(HttpHeaders.ContentEncoding)) {
+            return BodyFilterResult.Skip("encoded", contentLength)
+        }
+
+        if (contentType != null && contentType.isTextType()) {
+            return BodyFilterResult.BufferContent(
+                body.readBuffer(),
+                contentType.charset() ?: Charsets.UTF_8
+            )
+        }
+
+        val charset = if (contentType != null) {
+            contentType.charset() ?: Charsets.UTF_8
+        } else {
+            Charsets.UTF_8
+        }
+
+        var isBinary = false
+        val firstChunk = ByteArray(1024)
+        val firstReadSize = body.readAvailable(firstChunk)
+
+        if (firstReadSize < 1) {
+            return BodyFilterResult.Empty
+        }
+
+        val buffer = Buffer().apply { writeFully(firstChunk, 0, firstReadSize) }
+
+        val firstChunkText = try {
+            charset.newDecoder().decode(buffer)
+        } catch (_: MalformedInputException) {
+            isBinary = true
+            ""
+        }
+
+        if (!isBinary) {
+            var lastCharIndex = -1
+            for (ch in firstChunkText) {
+                lastCharIndex += 1
+            }
+
+            for ((i, ch) in firstChunkText.withIndex()) {
+                if (ch == '\ufffd' && i != lastCharIndex) {
+                    isBinary = true
+                    break
+                }
+            }
+        }
+
+        return if (isBinary) {
+            BodyFilterResult.Skip("binary", contentLength)
+        } else {
+            BodyFilterResult.BufferContent(
+                Buffer().apply {
+                    writeFully(firstChunk, 0, firstReadSize)
+                    transferFrom(body.readBuffer())
+                },
+                contentType?.charset() ?: Charsets.UTF_8
+            )
+        }
+    }
+}
+
+/**
+ * Represents the result of a body filtering process, which can determine the state of the body after processing.
+ */
+public sealed interface BodyFilterResult {
+    public val byteSize: Long? get() = null
+
+    /**
+     * Represents an empty body.
+     */
+    public object Empty : BodyFilterResult
+
+    /**
+     * Represents a body filtering result that skips processing for a specific reason.
+     *
+     * This result indicates that the body should not be processed further.
+     * A reason for skipping can be optionally provided as well as the size of the body in bytes.
+     *
+     * @property reason An optional explanation for why the body processing was skipped.
+     * @property byteSize The size of the body in bytes, or null if unknown.
+     */
+    public class Skip(
+        public val reason: String? = null,
+        override val byteSize: Long? = null,
+    ) : BodyFilterResult
+
+    /**
+     * Represents a body filtering result that contains readable content.
+     *
+     * This interface defines the functionality to access the content of a body after filtering.
+     * Implementations should specify how the content is stored and provide the ability to read it as a string.
+     */
+    public interface Content : BodyFilterResult {
+        public fun read(): String
+    }
+
+    /**
+     * Implements the [BodyFilterResult.Content] interface, representing a filtering result
+     * that contains readable content from a buffer.
+     *
+     * This class provides functionality to decode the content of a given [buffer] into a string
+     * using the specified [charset]. It also includes the size of the buffer as its byte size.
+     *
+     * @property buffer The [Buffer] containing the content to be read.
+     * @property charset The [Charset] used for decoding the buffer content into a string.
+     * @property byteSize The size of the buffer in bytes.
+     */
+    public class BufferContent(
+        private val buffer: Buffer,
+        private val charset: Charset,
+        override val byteSize: Long = buffer.size,
+    ) : Content {
+        override fun read(): String =
+            buffer.readText(charset)
+    }
+}

--- a/ktor-client/ktor-client-plugins/ktor-client-logging/common/src/io/ktor/client/plugins/logging/Logging.kt
+++ b/ktor-client/ktor-client-plugins/ktor-client-logging/common/src/io/ktor/client/plugins/logging/Logging.kt
@@ -19,9 +19,7 @@ import io.ktor.util.*
 import io.ktor.util.pipeline.*
 import io.ktor.utils.io.*
 import io.ktor.utils.io.charsets.*
-import io.ktor.utils.io.core.*
 import kotlinx.coroutines.*
-import kotlinx.io.Buffer
 
 private val ClientCallLogger = AttributeKey<HttpClientCallLogger>("CallLogger")
 private val DisableLogging = AttributeKey<Unit>("DisableLogging")
@@ -76,6 +74,20 @@ public class LoggingConfig {
     public var level: LogLevel = LogLevel.HEADERS
 
     /**
+     * Configures the filter applied to the response body when logging.
+     *
+     * The `bodyFilter` property specifies the logic used to selectively log, modify,
+     * or exclude the body of HTTP responses. It uses a [LogBodyFilter] implementation
+     * to determine how the response body is included in the logs. By default, the filter
+     * is set to [BinaryLogBodyFilter].
+     *
+     * The associated filter can be customized to handle specific logging requirements
+     * such as hiding sensitive data, truncating long responses, or modifying the
+     * format of the logged body content.
+     */
+    public var bodyFilter: LogBodyFilter = BinaryLogBodyFilter
+
+    /**
      * Allows you to filter log messages for calls matching a [predicate].
      *
      * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.client.plugins.logging.LoggingConfig.filter)
@@ -112,6 +124,7 @@ public val Logging: ClientPlugin<LoggingConfig> = createClientPlugin("Logging", 
     val filters: List<(HttpRequestBuilder) -> Boolean> = pluginConfig.filters
     val sanitizedHeaders: List<SanitizedHeader> = pluginConfig.sanitizedHeaders
     val okHttpFormat = pluginConfig.format == LoggingFormat.OkHttp
+    val bodyFilter: LogBodyFilter = pluginConfig.bodyFilter
 
     fun shouldBeLogged(request: HttpRequestBuilder): Boolean = filters.isEmpty() || filters.any { it(request) }
 
@@ -120,77 +133,8 @@ public val Logging: ClientPlugin<LoggingConfig> = createClientPlugin("Logging", 
     fun isHeaders(): Boolean = level == LogLevel.HEADERS
     fun isBody(): Boolean = level == LogLevel.BODY || level == LogLevel.ALL
 
-    /**
-     * Detects if the body is a binary data
-     * @return
-     * Boolean: true if the body is a binary data.
-     * Long?: body size if calculated.
-     * ByteReadChannel: body channel with the original data.
-     */
-    suspend fun detectIfBinary(
-        body: ByteReadChannel,
-        contentLength: Long?,
-        contentType: ContentType?,
-        headers: Headers
-    ): Triple<Boolean, Long?, ByteReadChannel> {
-        if (headers.contains(HttpHeaders.ContentEncoding)) {
-            return Triple(true, contentLength, body)
-        }
-
-        if (contentType != null && contentType.isTextType()) {
-            return Triple(false, contentLength, body)
-        }
-
-        val charset = if (contentType != null) {
-            contentType.charset() ?: Charsets.UTF_8
-        } else {
-            Charsets.UTF_8
-        }
-
-        var isBinary = false
-        val firstChunk = ByteArray(1024)
-        val firstReadSize = body.readAvailable(firstChunk)
-
-        if (firstReadSize < 1) {
-            return Triple(false, 0L, body)
-        }
-
-        val buffer = Buffer().apply { writeFully(firstChunk, 0, firstReadSize) }
-
-        val firstChunkText = try {
-            charset.newDecoder().decode(buffer)
-        } catch (_: MalformedInputException) {
-            isBinary = true
-            ""
-        }
-
-        if (!isBinary) {
-            var lastCharIndex = -1
-            for (ch in firstChunkText) {
-                lastCharIndex += 1
-            }
-
-            for ((i, ch) in firstChunkText.withIndex()) {
-                if (ch == '\ufffd' && i != lastCharIndex) {
-                    isBinary = true
-                    break
-                }
-            }
-        }
-
-        if (!isBinary) {
-            val channel = client.writer {
-                channel.writeFully(firstChunk, 0, firstReadSize)
-                body.copyTo(channel)
-            }.channel
-
-            return Triple(isBinary, null, channel)
-        }
-
-        return Triple(isBinary, contentLength, body)
-    }
-
     suspend fun logRequestBody(
+        url: Url,
         content: OutgoingContent,
         contentLength: Long?,
         headers: Headers,
@@ -198,35 +142,42 @@ public val Logging: ClientPlugin<LoggingConfig> = createClientPlugin("Logging", 
         logLines: MutableList<String>,
         body: ByteReadChannel
     ) {
-        val (isBinary, size, newBody) = detectIfBinary(body, contentLength, content.contentType, headers)
-
-        if (!isBinary) {
-            val contentType = content.contentType
-            val charset = if (contentType != null) {
-                contentType.charset() ?: Charsets.UTF_8
-            } else {
-                Charsets.UTF_8
+        val filteredBody = bodyFilter.filterRequest(
+            url,
+            contentLength,
+            content.contentType,
+            headers,
+            body,
+        )
+        when (filteredBody) {
+            is BodyFilterResult.Empty -> {
+                logLines.add("--> END ${method.value} (0-byte body)")
             }
 
-            val buffer = newBody.readBuffer()
-            var byteSize = buffer.size
-            logLines.add(buffer.readText(charset = charset))
-            logLines.add("--> END ${method.value} (${size ?: byteSize}-byte body)")
-        } else {
-            var type = "binary"
-            if (headers.contains(HttpHeaders.ContentEncoding)) {
-                type = "encoded"
+            is BodyFilterResult.Skip -> {
+                logLines.add(
+                    buildString {
+                        append("--> END ${method.value} (")
+                        filteredBody.reason?.let {
+                            append("$it ")
+                        }
+                        filteredBody.byteSize?.let {
+                            append("$it-byte ")
+                        }
+                        append("body omitted)")
+                    }
+                )
             }
 
-            if (size != null) {
-                logLines.add("--> END ${method.value} ($type $size-byte body omitted)")
-            } else {
-                logLines.add("--> END ${method.value} ($type body omitted)")
+            is BodyFilterResult.Content -> {
+                logLines.add(filteredBody.read())
+                logLines.add("--> END ${method.value} (${filteredBody.byteSize}-byte body)")
             }
         }
     }
 
     suspend fun logOutgoingContent(
+        url: Url,
         content: OutgoingContent,
         method: HttpMethod,
         headers: Headers,
@@ -235,7 +186,7 @@ public val Logging: ClientPlugin<LoggingConfig> = createClientPlugin("Logging", 
     ): OutgoingContent? {
         return when (content) {
             is io.ktor.client.content.ObservableContent -> {
-                logOutgoingContent(content.delegate, method, headers, logLines, process)
+                logOutgoingContent(url, content.delegate, method, headers, logLines, process)
             }
 
             is MultiPartFormDataContent -> {
@@ -267,12 +218,12 @@ public val Logging: ClientPlugin<LoggingConfig> = createClientPlugin("Logging", 
             }
             is OutgoingContent.ByteArrayContent -> {
                 val bytes = content.bytes()
-                logRequestBody(content, bytes.size.toLong(), headers, method, logLines, ByteReadChannel(bytes))
+                logRequestBody(url, content, bytes.size.toLong(), headers, method, logLines, ByteReadChannel(bytes))
                 null
             }
 
             is OutgoingContent.ContentWrapper -> {
-                logOutgoingContent(content.delegate(), method, headers, logLines, process)
+                logOutgoingContent(url, content.delegate(), method, headers, logLines, process)
             }
 
             is OutgoingContent.NoContent -> {
@@ -287,7 +238,7 @@ public val Logging: ClientPlugin<LoggingConfig> = createClientPlugin("Logging", 
 
             is OutgoingContent.ReadChannelContent -> {
                 val (origChannel, newChannel) = content.readFrom().split(client)
-                logRequestBody(content, content.contentLength, headers, method, logLines, newChannel)
+                logRequestBody(url, content, content.contentLength, headers, method, logLines, newChannel)
                 LoggedContent(content, origChannel)
             }
 
@@ -300,7 +251,7 @@ public val Logging: ClientPlugin<LoggingConfig> = createClientPlugin("Logging", 
                 }
 
                 val (origChannel, newChannel) = channel.split(client)
-                logRequestBody(content, content.contentLength, headers, method, logLines, newChannel)
+                logRequestBody(url, content, content.contentLength, headers, method, logLines, newChannel)
                 LoggedContent(content, origChannel)
             }
         }
@@ -373,11 +324,11 @@ public val Logging: ClientPlugin<LoggingConfig> = createClientPlugin("Logging", 
         }
 
         val newContent = if (request.headers[HttpHeaders.ContentEncoding] == "gzip") {
-            logOutgoingContent(body, request.method, headers, logLines) { channel ->
+            logOutgoingContent(request.url.build(), body, request.method, headers, logLines) { channel ->
                 GZipEncoder.decode(channel)
             }
         } else {
-            logOutgoingContent(body, request.method, headers, logLines)
+            logOutgoingContent(request.url.build(), body, request.method, headers, logLines)
         }
 
         return newContent
@@ -386,40 +337,40 @@ public val Logging: ClientPlugin<LoggingConfig> = createClientPlugin("Logging", 
     suspend fun logResponseBody(response: HttpResponse, body: ByteReadChannel, logLines: MutableList<String>) {
         logLines.add("")
 
-        val (isBinary, size, newBody) = detectIfBinary(
-            body,
+        val filteredBody = bodyFilter.filterResponse(
+            response.call.request.url,
             response.contentLength(),
             response.contentType(),
-            response.headers
+            response.headers,
+            body,
         )
         val duration = response.responseTime.timestamp - response.requestTime.timestamp
 
-        if (size == 0L) {
-            logLines.add("<-- END HTTP (${duration}ms, $size-byte body)")
-            return
-        }
-
-        if (!isBinary) {
-            val contentType = response.contentType()
-            val charset = if (contentType != null) {
-                contentType.charset() ?: Charsets.UTF_8
-            } else {
-                Charsets.UTF_8
-            }
-            val buffer = newBody.readBuffer()
-            var byteSize = buffer.size
-            logLines.add(buffer.readText(charset = charset))
-            logLines.add("<-- END HTTP (${duration}ms, ${size ?: byteSize}-byte body)")
-        } else {
-            var type = "binary"
-            if (response.headers.contains(HttpHeaders.ContentEncoding)) {
-                type = "encoded"
+        when (filteredBody) {
+            is BodyFilterResult.Empty -> {
+                logLines.add("<-- END HTTP (${duration}ms, 0-byte body)")
             }
 
-            if (size != null) {
-                logLines.add("<-- END HTTP (${duration}ms, $type $size-byte body omitted)")
-            } else {
-                logLines.add("<-- END HTTP (${duration}ms, $type body omitted)")
+            is BodyFilterResult.Skip -> {
+                logLines.add(
+                    buildString {
+                        append("<-- END HTTP (")
+                        append(duration)
+                        append("ms, ")
+                        filteredBody.reason?.let {
+                            append("$it ")
+                        }
+                        filteredBody.byteSize?.let {
+                            append("$it-byte ")
+                        }
+                        append("body omitted)")
+                    }
+                )
+            }
+
+            is BodyFilterResult.Content -> {
+                logLines.add(filteredBody.read())
+                logLines.add("<-- END HTTP (${duration}ms, ${filteredBody.byteSize}-byte body)")
             }
         }
     }

--- a/ktor-client/ktor-client-plugins/ktor-client-logging/jvm/test/io/ktor/client/plugins/logging/LogBodyFilterTest.kt
+++ b/ktor-client/ktor-client-plugins/ktor-client-logging/jvm/test/io/ktor/client/plugins/logging/LogBodyFilterTest.kt
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2014-2026 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.client.plugins.logging
+
+import io.ktor.client.request.*
+import io.ktor.client.statement.*
+import io.ktor.http.*
+import io.ktor.server.response.*
+import io.ktor.server.routing.*
+import io.ktor.server.testing.*
+import io.ktor.utils.io.charsets.*
+import kotlinx.io.Buffer
+import kotlinx.io.writeString
+import kotlin.test.*
+
+class LogBodyFilterTest {
+
+    @Test
+    fun testCustomBodyFilterResults() = testApplication {
+        val logs = mutableListOf<String>()
+        val testLogger = object : Logger {
+            override fun log(message: String) {
+                logs.add(message)
+            }
+        }
+
+        application {
+            routing {
+                get("/{type}") {
+                    val type = call.parameters["type"]
+                    call.respondText(
+                        "original content",
+                        ContentType.parse("application/$type")
+                    )
+                }
+            }
+        }
+
+        val testClient = createClient {
+            install(Logging) {
+                logger = testLogger
+                level = LogLevel.ALL
+                format = LoggingFormat.OkHttp
+                bodyFilter = CommonLogBodyFilter { _, contentType, _, _ ->
+                    when (contentType?.contentSubtype) {
+                        "empty" -> BodyFilterResult.Empty
+                        "skipped" -> BodyFilterResult.Skip("custom reason", 123L)
+                        "buffered" -> {
+                            val buffer = Buffer().also { it.writeString("filtered content") }
+                            BodyFilterResult.BufferContent(buffer, Charsets.UTF_8)
+                        }
+                        else -> BodyFilterResult.Skip("unsupported")
+                    }
+                }
+            }
+        }
+
+        // empty responses
+        testClient.get("/empty").bodyAsText()
+        assertTrue(logs.any { it.contains("0-byte body") }, "Should log empty body")
+
+        // skipped responses
+        logs.clear()
+        testClient.get("/skipped").bodyAsText()
+        assertTrue(logs.any { it.contains("custom reason 123-byte body omitted") }, "Should log skipped with reason")
+
+        // logged content
+        logs.clear()
+        testClient.get("/buffered").bodyAsText()
+        assertTrue(logs.any { it.contains("filtered content") }, "Should log filtered content")
+        assertTrue(logs.none { it.contains("original content") }, "Should not log the original content")
+    }
+}

--- a/ktor-client/ktor-client-plugins/ktor-client-logging/jvm/test/io/ktor/client/plugins/logging/OkHttpFormatTest.kt
+++ b/ktor-client/ktor-client-plugins/ktor-client-logging/jvm/test/io/ktor/client/plugins/logging/OkHttpFormatTest.kt
@@ -53,7 +53,11 @@ class OkHttpFormatTest {
 
         fun assertLogEqual(msg: String): LogRecorder {
             assertTrue(message = "No more logs to check") { currentLine < loggedLines.size }
-            assertEquals(msg, loggedLines[currentLine])
+            assertEquals(
+                msg,
+                loggedLines[currentLine],
+                "Expected size ${msg.length}; actual size: ${loggedLines[currentLine].length}"
+            )
             currentLine++
             return this
         }


### PR DESCRIPTION
**Subsystem**
Client, Logging

**Motivation**
[KTOR-9195](https://youtrack.jetbrains.com/issue/KTOR-9195) Client logging plugin improvements

Request from AI platform team for better control over how request/response bodies are logged in the client.

**Solution**
I introduced an override for the default request body logic which currently just avoids logging when binary data is encountered.

Note, this ignores multi-part bodies atm because it requires different processing.

