### PR TITLE
Fix JSON schema inference tests

### DIFF
--- a/ktor-shared/ktor-openapi-schema/ktor-openapi-schema-reflect/jvm/test-resources/schema/Address.yaml
+++ b/ktor-shared/ktor-openapi-schema/ktor-openapi-schema-reflect/jvm/test-resources/schema/Address.yaml
@@ -1,5 +1,5 @@
 type: object
-title: io.ktor.openapi.Address
+title: io.ktor.openapi.reflect.Address
 required:
   - houseNumber
   - street
@@ -18,7 +18,7 @@ properties:
     type: string
   municipality:
     type: object
-    title: io.ktor.openapi.Municipality
+    title: io.ktor.openapi.reflect.Municipality
     required:
       - city
       - country
@@ -30,7 +30,7 @@ properties:
         nullable: true
       country:
         type: object
-        title: io.ktor.openapi.Country
+        title: io.ktor.openapi.reflect.Country
         required:
           - name
           - code

--- a/ktor-shared/ktor-openapi-schema/ktor-openapi-schema-reflect/jvm/test-resources/schema/AnnotatedUser.yaml
+++ b/ktor-shared/ktor-openapi-schema/ktor-openapi-schema-reflect/jvm/test-resources/schema/AnnotatedUser.yaml
@@ -1,5 +1,5 @@
 type: object
-title: io.ktor.openapi.AnnotatedUser
+title: io.ktor.openapi.reflect.AnnotatedUser
 required:
   - id
   - username

--- a/ktor-shared/ktor-openapi-schema/ktor-openapi-schema-reflect/jvm/test-resources/schema/ContainerTestData.yaml
+++ b/ktor-shared/ktor-openapi-schema/ktor-openapi-schema-reflect/jvm/test-resources/schema/ContainerTestData.yaml
@@ -1,5 +1,5 @@
 type: object
-title: io.ktor.openapi.ContainerTestData
+title: io.ktor.openapi.reflect.ContainerTestData
 required:
   - tags
   - metadata

--- a/ktor-shared/ktor-openapi-schema/ktor-openapi-schema-reflect/jvm/test-resources/schema/LogicalOperatorsData.yaml
+++ b/ktor-shared/ktor-openapi-schema/ktor-openapi-schema-reflect/jvm/test-resources/schema/LogicalOperatorsData.yaml
@@ -1,15 +1,15 @@
 type: object
-title: io.ktor.openapi.LogicalOperatorsData
+title: io.ktor.openapi.reflect.LogicalOperatorsData
 required:
   - location
   - nonColorValue
 properties:
   location:
     type: object
-    title: io.ktor.openapi.Location
+    title: io.ktor.openapi.reflect.Location
     oneOf:
       - type: object
-        title: io.ktor.openapi.Address
+        title: io.ktor.openapi.reflect.Address
         required:
           - houseNumber
           - street
@@ -28,7 +28,7 @@ properties:
             type: string
           municipality:
             type: object
-            title: io.ktor.openapi.Municipality
+            title: io.ktor.openapi.reflect.Municipality
             required:
               - city
               - country
@@ -40,7 +40,7 @@ properties:
                 nullable: true
               country:
                 type: object
-                title: io.ktor.openapi.Country
+                title: io.ktor.openapi.reflect.Country
                 required:
                   - name
                   - code
@@ -54,7 +54,7 @@ properties:
           postalCode:
             type: string
       - type: object
-        title: io.ktor.openapi.Country
+        title: io.ktor.openapi.reflect.Country
         required:
           - name
           - code
@@ -68,9 +68,9 @@ properties:
     discriminator:
       propertyName: type
       mapping:
-        io.ktor.openapi.Address: "#/components/schemas/Address"
-        io.ktor.openapi.Country: "#/components/schemas/Country"
-        io.ktor.openapi.Municipality: "#/components/schemas/Municipality"
+        io.ktor.openapi.reflect.Address: "#/components/schemas/Address"
+        io.ktor.openapi.reflect.Country: "#/components/schemas/Country"
+        io.ktor.openapi.reflect.Municipality: "#/components/schemas/Municipality"
   nonColorValue:
     type: string
     not:

--- a/ktor-shared/ktor-openapi-schema/ktor-openapi-schema-reflect/jvm/test-resources/schema/Shape.yaml
+++ b/ktor-shared/ktor-openapi-schema/ktor-openapi-schema-reflect/jvm/test-resources/schema/Shape.yaml
@@ -1,7 +1,7 @@
 type: object
-title: io.ktor.openapi.Shape
+title: io.ktor.openapi.reflect.Shape
 discriminator:
   propertyName: type
   mapping:
-    io.ktor.openapi.Shape.Circle: "#/components/schemas/Circle"
-    io.ktor.openapi.Shape.Rectangle: "#/components/schemas/Rectangle"
+    io.ktor.openapi.reflect.Shape.Circle: "#/components/schemas/Circle"
+    io.ktor.openapi.reflect.Shape.Rectangle: "#/components/schemas/Rectangle"


### PR DESCRIPTION
Looks like I broke these tests after renaming the package for the module.  They must have passed from cached resources from the previous run.

