### PR TITLE
KTOR-9190 Fix "Unresolved classifier: platform/posix/pthread_mutex_t"

### DIFF
--- a/build-logic/src/main/kotlin/ktorbuild.kmp.gradle.kts
+++ b/build-logic/src/main/kotlin/ktorbuild.kmp.gradle.kts
@@ -73,6 +73,12 @@ if (targets.hasNative) {
     // A workaround for KT-77609
     tasks.matching { it::class.simpleName?.startsWith("CInteropCommonizerTask") == true }
         .configureEach { withLimitedParallelism("native-tools", maxParallelTasks = 3) }
+
+    // A workaround for KT-83710
+    tasks.named { it == "commonizeNativeDistribution" }
+        .configureEach { dependsOn("downloadKotlinNativeDistribution") }
+    tasks.named { it == "downloadKotlinNativeDistribution" }
+        .configureEach { outputs.upToDateWhen { false } }
 }
 
 if (ktorBuild.isCI.get()) configureTestTasksOnCi()


### PR DESCRIPTION
**Subsystem**
Infrastructure, Native

**Motivation**
[KTOR-9190](https://youtrack.jetbrains.com/issue/KTOR-9190) "Unresolved classifier: platform/posix/pthread_mutex_t" when executing :ktor-io:commonizeCInterop on latest main branch

**Solution**
Apply a workaround for [KT-83710](https://youtrack.jetbrains.com/issue/KT-83710/commonizeNativeDistribution-doesnt-depend-on-downloadKotlinNativeDistribution-causing-build-failures-due-to-race-condition)
