### PR TITLE
Fix breaking change in `AuthenticationProvider.Config`

### DIFF
--- a/ktor-server/ktor-server-plugins/ktor-server-auth/api/ktor-server-auth.api
+++ b/ktor-server/ktor-server-plugins/ktor-server-auth/api/ktor-server-auth.api
@@ -108,6 +108,7 @@ public abstract class io/ktor/server/auth/AuthenticationProvider {
 
 public class io/ktor/server/auth/AuthenticationProvider$Config {
 	protected fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getDescription ()Ljava/lang/String;
 	public final fun getName ()Ljava/lang/String;
 	public final fun skipWhen (Lkotlin/jvm/functions/Function1;)V

--- a/ktor-server/ktor-server-plugins/ktor-server-auth/api/ktor-server-auth.klib.api
+++ b/ktor-server/ktor-server-plugins/ktor-server-auth/api/ktor-server-auth.klib.api
@@ -46,7 +46,7 @@ abstract class io.ktor.server.auth/AuthenticationProvider { // io.ktor.server.au
     abstract suspend fun onAuthenticate(io.ktor.server.auth/AuthenticationContext) // io.ktor.server.auth/AuthenticationProvider.onAuthenticate|onAuthenticate(io.ktor.server.auth.AuthenticationContext){}[0]
 
     open class Config { // io.ktor.server.auth/AuthenticationProvider.Config|null[0]
-        constructor <init>(kotlin/String?, kotlin/String?) // io.ktor.server.auth/AuthenticationProvider.Config.<init>|<init>(kotlin.String?;kotlin.String?){}[0]
+        constructor <init>(kotlin/String?, kotlin/String? = ...) // io.ktor.server.auth/AuthenticationProvider.Config.<init>|<init>(kotlin.String?;kotlin.String?){}[0]
 
         final val description // io.ktor.server.auth/AuthenticationProvider.Config.description|{}description[0]
             final fun <get-description>(): kotlin/String? // io.ktor.server.auth/AuthenticationProvider.Config.description.<get-description>|<get-description>(){}[0]

--- a/ktor-server/ktor-server-plugins/ktor-server-auth/common/src/io/ktor/server/auth/AuthenticationProvider.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-auth/common/src/io/ktor/server/auth/AuthenticationProvider.kt
@@ -68,7 +68,7 @@ public abstract class AuthenticationProvider(config: Config) {
      */
     public open class Config protected constructor(
         public val name: String?,
-        public val description: String?
+        public val description: String? = null
     ) {
 
         /**


### PR DESCRIPTION
**Subsystem**
Server Auth

**Motivation**
I introduced breaking changes in [KTOR-9085](https://youtrack.jetbrains.com/issue/KTOR-9085)

The following code compiles with 3.3.3 but throws an error with 3.4.0-SNAPSHOT:
```kotlin
class Config : AuthenticationProvider.Config("myname") {
    
}
```

**Solution**
Add a default value for the description field.
I checked all other occurrences of `description`; it's required only in internal constructors. 

