### PR TITLE
KTOR-8821 Undeprecate blocking overloads

### DIFF
--- a/ktor-server/ktor-server-core/common/src/io/ktor/server/engine/EmbeddedServer.kt
+++ b/ktor-server/ktor-server-core/common/src/io/ktor/server/engine/EmbeddedServer.kt
@@ -87,7 +87,6 @@ public interface ApplicationEngineFactory<
  * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.server.engine.embeddedServer)
  */
 @OptIn(DelicateCoroutinesApi::class)
-@Deprecated("Replaced with suspend function parameter", level = DeprecationLevel.HIDDEN)
 public fun <TEngine : ApplicationEngine, TConfiguration : ApplicationEngine.Configuration> embeddedServer(
     factory: ApplicationEngineFactory<TEngine, TConfiguration>,
     port: Int = 80,
@@ -118,7 +117,6 @@ public fun <TEngine : ApplicationEngine, TConfiguration : ApplicationEngine.Conf
  * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.server.engine.embeddedServer)
  */
 @Suppress("ktlint:standard:max-line-length")
-@Deprecated("Replaced with suspend function parameter", level = DeprecationLevel.HIDDEN)
 public fun <TEngine : ApplicationEngine, TConfiguration : ApplicationEngine.Configuration> CoroutineScope.embeddedServer(
     factory: ApplicationEngineFactory<TEngine, TConfiguration>,
     port: Int = 80,
@@ -177,7 +175,6 @@ public fun <TEngine : ApplicationEngine, TConfiguration : ApplicationEngine.Conf
  * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.server.engine.embeddedServer)
  */
 @Suppress("ktlint:standard:max-line-length")
-@Deprecated("Replaced with suspend function parameter", level = DeprecationLevel.HIDDEN)
 public fun <TEngine : ApplicationEngine, TConfiguration : ApplicationEngine.Configuration> CoroutineScope.embeddedServer(
     factory: ApplicationEngineFactory<TEngine, TConfiguration>,
     vararg connectors: EngineConnectorConfig = arrayOf(),
@@ -233,7 +230,6 @@ public fun <TEngine : ApplicationEngine, TConfiguration : ApplicationEngine.Conf
  *
  * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.server.engine.embeddedServer)
  */
-@Deprecated("Replaced with suspend function parameter", level = DeprecationLevel.HIDDEN)
 public fun <TEngine : ApplicationEngine, TConfiguration : ApplicationEngine.Configuration> embeddedServer(
     factory: ApplicationEngineFactory<TEngine, TConfiguration>,
     environment: ApplicationEnvironment = applicationEnvironment(),


### PR DESCRIPTION
**Subsystem**
Server, Core

**Motivation**
[KTOR-8821](https://youtrack.jetbrains.com/issue/KTOR-8821) Autoreloading: module function refs not working since 3.2.0

**Solution**
Now that Kotlin 2.2.0 has been out for a little while, we should be able to deprecate these overloads, which should allow blocking function calls to pass to the embedded server without wrapping, which should fix auto-reloading here...  I will test it out now.

