### PR TITLE
KTOR-9269 Fix incorrect dependency reference for OpenAPI routing

### DIFF
--- a/ktor-server/ktor-server-plugins/ktor-server-openapi/build.gradle.kts
+++ b/ktor-server/ktor-server-plugins/ktor-server-openapi/build.gradle.kts
@@ -13,7 +13,7 @@ kotlin {
     sourceSets {
         jvmMain.dependencies {
             implementation(projects.ktorServerHtmlBuilder)
-            implementation(projects.ktorServerRoutingOpenapi)
+            api(projects.ktorServerRoutingOpenapi)
 
             implementation(libs.kotlinx.serialization.core)
             implementation(libs.kotlinx.serialization.json)

--- a/ktor-server/ktor-server-plugins/ktor-server-swagger/build.gradle.kts
+++ b/ktor-server/ktor-server-plugins/ktor-server-swagger/build.gradle.kts
@@ -10,7 +10,7 @@ kotlin {
     sourceSets {
         jvmMain.dependencies {
             implementation(projects.ktorServerHtmlBuilder)
-            implementation(projects.ktorServerRoutingOpenapi)
+            api(projects.ktorServerRoutingOpenapi)
 
             implementation(libs.kotlinx.serialization.core)
             implementation(libs.kotlinx.serialization.json)


### PR DESCRIPTION
**Subsystem**
Server, OpenAPI, Swagger

**Motivation**
[KTOR-9269](https://youtrack.jetbrains.com/issue/KTOR-9269) Incorrect dependency declaration in swagger / openapi

**Solution**
Change `implementation` to `api`.

