### PR TITLE
KTOR-9273 Fix children of hidden routes appearing

### DIFF
--- a/ktor-server/ktor-server-plugins/ktor-server-openapi/jvm/test/io/ktor/server/plugins/openapi/OpenAPITest.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-openapi/jvm/test/io/ktor/server/plugins/openapi/OpenAPITest.kt
@@ -20,6 +20,7 @@ import io.ktor.utils.io.ExperimentalKtorApi
 import kotlin.test.Test
 import kotlin.test.assertContains
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 
 class OpenAPITest {
 
@@ -99,6 +100,7 @@ class OpenAPITest {
             assertEquals(HttpStatusCode.OK, response.status)
             val responseText = response.bodyAsText()
             assertContains(responseText, "Books API from routes")
+            assertFalse("/routes/docs" in responseText)
             for (description in descriptions) {
                 assertContains(responseText, description, message = "Response should contain '$description'")
             }

--- a/ktor-server/ktor-server-plugins/ktor-server-routing-openapi/common/src/io/ktor/server/routing/openapi/OpenApiRoutes.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-routing-openapi/common/src/io/ktor/server/routing/openapi/OpenApiRoutes.kt
@@ -45,9 +45,13 @@ public fun Sequence<Route>.mapToPathItemsAndSchema(): Pair<Map<String, PathItem>
 public fun Sequence<Route>.mapToPathItems(
     onOperation: OperationMapping = PopulateMediaTypeDefaults
 ): Map<String, PathItem> {
-    return mapNotNull {
-        if (it.attributes.contains(OperationHiddenAttributeKey)) return@mapNotNull null
-        it.asPathItem(onOperation)
+    return mapNotNull { node ->
+        val isHidden = node.lineage()
+            .any { OperationHiddenAttributeKey in it.attributes }
+        if (isHidden) {
+            return@mapNotNull null
+        }
+        node.asPathItem(onOperation)
     }.fold(mutableMapOf()) { map, (route, pathItem) ->
         map.also {
             if (route in map) {


### PR DESCRIPTION
**Subsystem**
Server, OpenAPI

**Motivation**
[KTOR-9273](https://youtrack.jetbrains.com/issue/KTOR-9273) OpenAPI static content path appears in resulting model

**Solution**
Check ancestors of nodes for the "hide" attribute when filtering them in the model.

