### PR TITLE
Remove `String.encodeBase64` from the codebase.

### DIFF
--- a/ktor-client/ktor-client-core/common/src/io/ktor/client/request/utils.kt
+++ b/ktor-client/ktor-client-core/common/src/io/ktor/client/request/utils.kt
@@ -5,8 +5,8 @@
 package io.ktor.client.request
 
 import io.ktor.http.*
-import io.ktor.util.*
 import io.ktor.util.date.*
+import kotlin.io.encoding.Base64
 
 /**
  * Gets the associated URL's host.
@@ -98,7 +98,7 @@ public fun HttpMessageBuilder.accept(contentType: ContentType): Unit =
  * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.client.request.basicAuth)
  */
 public fun HttpMessageBuilder.basicAuth(username: String, password: String): Unit =
-    header(HttpHeaders.Authorization, "Basic ${"$username:$password".encodeBase64()}")
+    header(HttpHeaders.Authorization, "Basic ${Base64.encode("$username:$password".encodeToByteArray())}")
 
 /**
  * Appends the [HttpHeaders.Authorization] to Bearer Authorization with the provided [token].

--- a/ktor-client/ktor-client-plugins/ktor-client-auth/common/src/io/ktor/client/plugins/auth/providers/BasicAuthProvider.kt
+++ b/ktor-client/ktor-client-plugins/ktor-client-auth/common/src/io/ktor/client/plugins/auth/providers/BasicAuthProvider.kt
@@ -9,10 +9,10 @@ import io.ktor.client.request.*
 import io.ktor.client.statement.*
 import io.ktor.http.*
 import io.ktor.http.auth.*
-import io.ktor.util.*
 import io.ktor.utils.io.*
 import io.ktor.utils.io.charsets.*
 import io.ktor.utils.io.core.*
+import kotlin.io.encoding.Base64
 
 /**
  * Installs the client's [BasicAuthProvider].
@@ -208,7 +208,7 @@ public class BasicAuthProvider(
 
 internal fun constructBasicAuthValue(credentials: BasicAuthCredentials): String {
     val authString = "${credentials.username}:${credentials.password}"
-    val authBuf = authString.toByteArray(Charsets.UTF_8).encodeBase64()
+    val authBuf = Base64.encode(authString.toByteArray(Charsets.UTF_8))
 
     return "Basic $authBuf"
 }

--- a/ktor-client/ktor-client-tests/common/src/io/ktor/client/tests/utils/Generators.kt
+++ b/ktor-client/ktor-client-tests/common/src/io/ktor/client/tests/utils/Generators.kt
@@ -14,7 +14,9 @@ import kotlin.io.encoding.Base64
 
 fun makeArray(size: Int): ByteArray = ByteArray(size) { it.toByte() }
 
-fun makeString(size: Int): String = Base64.encode(CharArray(size) { it.toChar() }.concatToString().encodeToByteArray()).take(size)
+fun makeString(size: Int): String = Base64.encode(
+    CharArray(size) { it.toChar() }.concatToString().encodeToByteArray()
+).take(size)
 
 suspend fun List<PartData>.makeString(): String = buildString {
     val list = this@makeString

--- a/ktor-client/ktor-client-tests/common/src/io/ktor/client/tests/utils/Generators.kt
+++ b/ktor-client/ktor-client-tests/common/src/io/ktor/client/tests/utils/Generators.kt
@@ -6,15 +6,15 @@ package io.ktor.client.tests.utils
 
 import io.ktor.http.*
 import io.ktor.http.content.*
-import io.ktor.util.*
 import io.ktor.utils.io.*
 import io.ktor.utils.io.charsets.*
 import io.ktor.utils.io.core.*
 import kotlinx.io.readByteArray
+import kotlin.io.encoding.Base64
 
 fun makeArray(size: Int): ByteArray = ByteArray(size) { it.toByte() }
 
-fun makeString(size: Int): String = CharArray(size) { it.toChar() }.concatToString().encodeBase64().take(size)
+fun makeString(size: Int): String = Base64.encode(CharArray(size) { it.toChar() }.concatToString().encodeToByteArray()).take(size)
 
 suspend fun List<PartData>.makeString(): String = buildString {
     val list = this@makeString

--- a/ktor-http/common/src/io/ktor/http/Cookie.kt
+++ b/ktor-http/common/src/io/ktor/http/Cookie.kt
@@ -236,7 +236,9 @@ public fun encodeCookieValue(value: String, encoding: CookieEncoding): String = 
 
         else -> value
     }
+
     CookieEncoding.BASE64_ENCODING -> Base64.encode(value.encodeToByteArray())
+
     CookieEncoding.URI_ENCODING -> value.encodeURLParameter(spaceToPlus = true)
 }
 

--- a/ktor-http/common/src/io/ktor/http/Cookie.kt
+++ b/ktor-http/common/src/io/ktor/http/Cookie.kt
@@ -236,9 +236,7 @@ public fun encodeCookieValue(value: String, encoding: CookieEncoding): String = 
 
         else -> value
     }
-
-    CookieEncoding.BASE64_ENCODING -> value.encodeBase64()
-
+    CookieEncoding.BASE64_ENCODING -> Base64.encode(value.encodeToByteArray())
     CookieEncoding.URI_ENCODING -> value.encodeURLParameter(spaceToPlus = true)
 }
 

--- a/ktor-http/common/src/io/ktor/http/websocket/Utils.kt
+++ b/ktor-http/common/src/io/ktor/http/websocket/Utils.kt
@@ -7,6 +7,7 @@ package io.ktor.http.websocket
 import io.ktor.util.*
 import io.ktor.utils.io.charsets.*
 import io.ktor.utils.io.core.*
+import kotlin.io.encoding.Base64
 
 private const val WEBSOCKET_SERVER_ACCEPT_TAIL = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11"
 
@@ -16,4 +17,4 @@ private const val WEBSOCKET_SERVER_ACCEPT_TAIL = "258EAFA5-E914-47DA-95CA-C5AB0D
  * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.http.websocket.websocketServerAccept)
  */
 public fun websocketServerAccept(nonce: String): String =
-    sha1("${nonce.trim()}$WEBSOCKET_SERVER_ACCEPT_TAIL".toByteArray(Charsets.ISO_8859_1)).encodeBase64()
+    Base64.encode(sha1("${nonce.trim()}$WEBSOCKET_SERVER_ACCEPT_TAIL".toByteArray(Charsets.ISO_8859_1)))

--- a/ktor-server/ktor-server-plugins/ktor-server-auth/common/src/io/ktor/server/auth/OAuth2.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-auth/common/src/io/ktor/server/auth/OAuth2.kt
@@ -15,14 +15,12 @@ import io.ktor.server.request.*
 import io.ktor.server.response.*
 import io.ktor.util.*
 import io.ktor.util.internal.*
-import io.ktor.util.logging.*
 import io.ktor.utils.io.charsets.*
 import io.ktor.utils.io.core.*
 import kotlinx.coroutines.*
 import kotlinx.io.*
 import kotlinx.serialization.json.*
-
-private val Logger: Logger = KtorSimpleLogger("io.ktor.auth.oauth")
+import kotlin.io.encoding.Base64
 
 internal suspend fun ApplicationCall.oauth2HandleCallback(): OAuthCallback? {
     val params = when (request.contentType()) {
@@ -192,7 +190,7 @@ private suspend fun oauth2RequestAccessToken(
                 HttpHeaders.Authorization,
                 HttpAuthHeader.Single(
                     AuthScheme.Basic,
-                    "$clientId:$clientSecret".toByteArray(Charsets.ISO_8859_1).encodeBase64()
+                    Base64.encode("$clientId:$clientSecret".toByteArray(Charsets.ISO_8859_1))
                 ).render()
             )
         }

--- a/ktor-server/ktor-server-plugins/ktor-server-auth/common/test/io/ktor/tests/auth/BasicAuthTest.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-auth/common/test/io/ktor/tests/auth/BasicAuthTest.kt
@@ -14,9 +14,9 @@ import io.ktor.server.plugins.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
 import io.ktor.server.testing.*
-import io.ktor.util.*
 import io.ktor.utils.io.charsets.*
 import io.ktor.utils.io.core.*
+import kotlin.io.encoding.Base64
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotEquals
@@ -226,7 +226,7 @@ class BasicAuthTest {
         charset: Charset = Charsets.ISO_8859_1
     ): HttpResponse = client.get(url) {
         val up = "$user:$pass"
-        val encoded = up.toByteArray(charset).encodeBase64()
+        val encoded = Base64.encode(up.toByteArray(charset))
         header(HttpHeaders.Authorization, "Basic $encoded")
     }
 

--- a/ktor-server/ktor-server-plugins/ktor-server-auth/common/test/io/ktor/tests/auth/CryptoTest.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-auth/common/test/io/ktor/tests/auth/CryptoTest.kt
@@ -13,7 +13,7 @@ import kotlin.test.*
 class CryptoTest {
     @Test
     fun testBase64() {
-        assertEquals("AAAA", ByteArray(3).encodeBase64())
+        assertEquals("AAAA", Base64.encode(ByteArray(3)))
         assertEquals(ByteArray(3), Base64.decode("AAAA"))
     }
 

--- a/ktor-server/ktor-server-plugins/ktor-server-auth/common/test/io/ktor/tests/auth/OAuth2Test.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-auth/common/test/io/ktor/tests/auth/OAuth2Test.kt
@@ -30,6 +30,7 @@ import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
+import kotlin.io.encoding.Base64
 import kotlin.test.*
 
 class OAuth2Test {
@@ -893,7 +894,7 @@ class OAuth2Test {
 private suspend fun ApplicationTestBuilder.handleRequestWithBasic(url: String, user: String, pass: String) =
     client.get(url) {
         val up = "$user:$pass"
-        val encoded = up.toByteArray(Charsets.ISO_8859_1).encodeBase64()
+        val encoded = Base64.encode(up.toByteArray(Charsets.ISO_8859_1))
         header(HttpHeaders.Authorization, "Basic $encoded")
     }
 

--- a/ktor-utils/common/test/io/ktor/util/Base64Test.kt
+++ b/ktor-utils/common/test/io/ktor/util/Base64Test.kt
@@ -6,6 +6,7 @@ package io.ktor.util
 
 import kotlin.test.*
 
+@Suppress("DEPRECATION")
 class Base64Test {
 
     @Test
@@ -26,13 +27,13 @@ class Base64Test {
             "MuIElmIHlvdSBhcmUgbm90IHN1cmUgaG93IHRvIHNvbHZlIGEgS29hbiwgb3IgeW91J3JlIGxvb2tpbmcgZm9yIG" +
             "EgbW9yZSBlbGVnYW50IHNvbHV0aW9uLCBjaGVjayBvdXQgS290bGluIGlkaW9tcy4="
 
-        assertEquals(encodedText, text.encodeBase64())
+        assertEquals(encodedText, text.encodeToByteArray().encodeBase64())
         assertEquals(text, encodedText.decodeBase64String())
     }
 
     @Test
     fun encodeEmptyTest() {
-        assertEquals("", "".encodeBase64())
+        assertEquals("", "".encodeToByteArray().encodeBase64())
         assertEquals("", "".decodeBase64String())
     }
 
@@ -47,7 +48,7 @@ class Base64Test {
         )
 
         cases.forEach { (text, encodedText) ->
-            assertEquals(encodedText, text.encodeBase64())
+            assertEquals(encodedText, text.encodeToByteArray().encodeBase64())
             assertEquals(text, encodedText.decodeBase64String())
         }
     }


### PR DESCRIPTION
**Subsystem**
Shared

**Motivation**
There are some usages of the deprecated `String.encodeBase64` method that lead to warnings during tests and create noise.