### PR TITLE
KTOR-9290 Jetty Jakarta idleTimeout does not cancel the request's job

### DIFF
--- a/ktor-server/ktor-server-jetty-jakarta/jvm/src/io/ktor/server/jetty/jakarta/JettyKtorHandler.kt
+++ b/ktor-server/ktor-server-jetty-jakarta/jvm/src/io/ktor/server/jetty/jakarta/JettyKtorHandler.kt
@@ -16,6 +16,7 @@ import org.eclipse.jetty.server.Request
 import org.eclipse.jetty.server.Response
 import org.eclipse.jetty.util.Callback
 import java.util.concurrent.*
+import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicLong
 import kotlin.coroutines.CoroutineContext
 
@@ -68,6 +69,13 @@ internal class JettyKtorHandler(
         try {
             val application = applicationProvider()
 
+            val callbackCompleted = AtomicBoolean(false)
+            fun completeCallback(action: () -> Unit) {
+                if (callbackCompleted.compareAndSet(false, true)) {
+                    action()
+                }
+            }
+
             val job = application.launch(handlerContext) {
                 val call = JettyApplicationCall(
                     application,
@@ -81,20 +89,20 @@ internal class JettyKtorHandler(
 
                 try {
                     pipeline.execute(call)
-                    callback.succeeded()
+                    completeCallback { callback.succeeded() }
                 } catch (cancelled: kotlinx.coroutines.CancellationException) {
-                    tryWriteError(response, request, callback, cancelled)
+                    completeCallback { tryWriteError(response, request, callback, cancelled) }
                 } catch (channelFailed: ChannelIOException) {
-                    callback.failed(channelFailed)
+                    completeCallback { callback.failed(channelFailed) }
                 } catch (error: Throwable) {
                     logError(call, error)
-                    tryWriteError(response, request, callback, error)
+                    completeCallback { tryWriteError(response, request, callback, error) }
                 }
             }
 
             request.addIdleTimeoutListener { timeoutException ->
                 job.cancel(CancellationException("Jetty idle timeout expired", timeoutException))
-                tryWriteError(response, request, callback, timeoutException)
+                completeCallback { tryWriteError(response, request, callback, timeoutException) }
                 // Returning true indicates that the idle timeout should be handled by the container as a fatal failure.
                 true
             }

--- a/ktor-server/ktor-server-jetty-jakarta/jvm/src/io/ktor/server/jetty/jakarta/JettyKtorHandler.kt
+++ b/ktor-server/ktor-server-jetty-jakarta/jvm/src/io/ktor/server/jetty/jakarta/JettyKtorHandler.kt
@@ -83,19 +83,7 @@ internal class JettyKtorHandler(
                     pipeline.execute(call)
                     callback.succeeded()
                 } catch (cancelled: kotlinx.coroutines.CancellationException) {
-                    if (response.isCommitted || runCatching {
-                            Response.writeError(
-                                request,
-                                response,
-                                callback,
-                                HttpStatus.GONE_410,
-                                cancelled.message,
-                                cancelled
-                            )
-                        }.isFailure
-                    ) {
-                        callback.failed(cancelled)
-                    }
+                    tryWriteError(response, request, callback, cancelled)
                 } catch (channelFailed: ChannelIOException) {
                     callback.failed(channelFailed)
                 } catch (error: Throwable) {

--- a/ktor-server/ktor-server-jetty-jakarta/jvm/test/io/ktor/tests/server/jetty/jakarta/JettyIdleTimeoutTest.kt
+++ b/ktor-server/ktor-server-jetty-jakarta/jvm/test/io/ktor/tests/server/jetty/jakarta/JettyIdleTimeoutTest.kt
@@ -37,7 +37,7 @@ class JettyIdleTimeoutTest : EngineTestBase<JettyApplicationEngine, JettyApplica
     }
 
     /**
-     * For this test we want to test how an unhanded CancellationException is handled,
+     * For this test we want to test how an unhandled CancellationException is handled,
      * so we override afterTest to avoid the test framework interpreting it as a failed test condition.
      */
     override fun afterTest() {


### PR DESCRIPTION
**Subsystem**
Jetty Jakarta Ktor Server

**Motivation**
https://youtrack.jetbrains.com/issue/KTOR-9290/Jetty-Jakarta-idleTimeout-does-not-cancel-the-requests-job

When Jetty's idle timeout expires during request processing, the timeout is effectively ignored if the server-side coroutine is performing slow work. Clients would still receive the intended status code beyond the idle timeout time.

The current tests are focussed on clients being slow to read and write.

The fix adds an idle timeout listener to the Jetty request that cancels the handler's coroutine job when the timeout fires therefore making it effective on server resources.