### PR TITLE
Add http status code 428 Precondition Required

### DIFF
--- a/ktor-http/common/src/io/ktor/http/HttpStatusCode.kt
+++ b/ktor-http/common/src/io/ktor/http/HttpStatusCode.kt
@@ -92,6 +92,7 @@ public data class HttpStatusCode(val value: Int, val description: String) : Comp
         public val FailedDependency: HttpStatusCode = HttpStatusCode(424, "Failed Dependency")
         public val TooEarly: HttpStatusCode = HttpStatusCode(425, "Too Early")
         public val UpgradeRequired: HttpStatusCode = HttpStatusCode(426, "Upgrade Required")
+        public val PreconditionRequired: HttpStatusCode = HttpStatusCode(428, "Precondition Required")
         public val TooManyRequests: HttpStatusCode = HttpStatusCode(429, "Too Many Requests")
 
         public val RequestHeaderFieldTooLarge: HttpStatusCode =
@@ -163,6 +164,7 @@ internal fun allStatusCodes(): List<HttpStatusCode> = listOf(
     HttpStatusCode.Gone,
     HttpStatusCode.LengthRequired,
     HttpStatusCode.PreconditionFailed,
+    HttpStatusCode.PreconditionRequired,
     HttpStatusCode.PayloadTooLarge,
     HttpStatusCode.RequestURITooLong,
     HttpStatusCode.UnsupportedMediaType,

--- a/ktor-http/common/test/io/ktor/tests/http/HttpStatusCodeTest.kt
+++ b/ktor-http/common/test/io/ktor/tests/http/HttpStatusCodeTest.kt
@@ -10,7 +10,7 @@ import kotlin.test.*
 class HttpStatusCodeTest {
     @Test
     fun httpStatusCodeAll() {
-        assertEquals(53, HttpStatusCode.allStatusCodes.size)
+        assertEquals(54, HttpStatusCode.allStatusCodes.size)
     }
 
     @Test


### PR DESCRIPTION
**Subsystem**

`ktor-http`

**Motivation**

Within my organization we are communicating with a 3rd party using ktor http client. The 3rd party may return status code 428 Precondition Required, which appears to be missing from the status codes in `HttpStatusCode`.

**Solution**

Added status code 428 to `HttpStatusCode`.

