### PR TITLE
fix: ensure awaitContent returns false when closed and buffer is empty

### DIFF
--- a/ktor-io/jvm/src/io/ktor/utils/io/jvm/javaio/Reading.kt
+++ b/ktor-io/jvm/src/io/ktor/utils/io/jvm/javaio/Reading.kt
@@ -64,9 +64,9 @@ internal class RawSourceChannel(
         get() = buffer
 
     override suspend fun awaitContent(min: Int): Boolean {
-        if (closedToken != null) return true
+        if (closedToken != null) return buffer.size >= min
 
-        withContext(coroutineContext) {
+        return  withContext(coroutineContext) {
             var result = 0L
             while (buffer.remaining < min && result >= 0) {
                 result = try {
@@ -81,9 +81,8 @@ internal class RawSourceChannel(
                 job.complete()
                 closedToken = CloseToken(null)
             }
+            buffer.size >= min
         }
-
-        return buffer.remaining >= min
     }
 
     override fun cancel(cause: Throwable?) {


### PR DESCRIPTION
The `awaitContent` function in `RawSourceChannel` incorrectly returned `true` immediately if the channel was closed, regardless of whether the buffer actually contained the minimum requested bytes.

This behavior led to:
- Callers being misled into thinking data was available.
- Subsequent read attempts hitting unexpected EOFs.

Changes:
- Removed the immediate `return true` when `closedToken` is non-null.
- Updated logic to check `buffer.size >= min` even after closure.
- Refactored closing logic into a helper to ensure consistency.

Resolves migration issue identified in PR #4940.

**Subsystem**
Client/Server, related modules

**Motivation**
Describe what problem this PR solves and why it is important. Refer to a bug/ticket #.

**Solution**
Describe your solution.

