### PR TITLE
KTOR-9329 Fix 'hx-on' attributes

### DIFF
--- a/ktor-shared/ktor-htmx/ktor-htmx-html/common/src/io/ktor/htmx/html/HxAttributes.kt
+++ b/ktor-shared/ktor-htmx/ktor-htmx-html/common/src/io/ktor/htmx/html/HxAttributes.kt
@@ -61,16 +61,16 @@ public class HxAttributes(override val map: DelegatingMap) : StringMapDelegate {
         get() = On(map)
 
     public fun on(event: String, script: String) {
-        map["hx-on:$event"] = script
+        map["hx-on::$event"] = script
     }
 
     @JvmInline
     public value class On(private val attributes: MutableMap<String, String>) {
         public operator fun set(event: String, script: String?) {
             if (script == null) {
-                attributes.remove("${HxAttributeKeys.On}:$event")
+                attributes.remove("${HxAttributeKeys.On}::$event")
             } else {
-                attributes["${HxAttributeKeys.On}:$event"] = script
+                attributes["${HxAttributeKeys.On}::$event"] = script
             }
         }
 

--- a/ktor-shared/ktor-htmx/ktor-htmx-html/common/test/io/ktor/htmx/html/HxAttributesTest.kt
+++ b/ktor-shared/ktor-htmx/ktor-htmx-html/common/test/io/ktor/htmx/html/HxAttributesTest.kt
@@ -27,15 +27,23 @@ class HxAttributesTest {
                             target = "#replaceMe"
                             swap = HxSwap.outerHtml
                             trigger = "click[console.log('Hello!')||true]"
+                            on("before-request", "alert('hey')")
                         }
                     }
                 }
             }
         }
+        val expectedAttributes = listOf(
+            "hx-get=\"/?page=1\"",
+            "hx-target=\"#replaceMe\"",
+            "hx-swap=\"outerHTML\"",
+            "hx-trigger=\"click[console.log('Hello!')||true]\"",
+            "hx-on::before-request=\"alert('hey')\""
+        ).joinToString(" ")
         assertEquals(
             """
             <html>
-              <body><button hx-get="/?page=1" hx-target="#replaceMe" hx-swap="outerHTML" hx-trigger="click[console.log('Hello!')||true]"></button></body>
+              <body><button $expectedAttributes></button></body>
             </html>
             """.trimIndent(),
             actual.trim()


### PR DESCRIPTION
**Subsystem**
Server, HTMX DSL

**Motivation**
[KTOR-9329](https://youtrack.jetbrains.com/issue/KTOR-9329) HTMX: "on" attributes extension not working

**Solution**
There's supposed to be 2 colons in these attributes but we had 1 ☹️ 

Reference: https://htmx.org/attributes/hx-on/