### PR TITLE
KTOR-9340: Support ES2015 for testApplication

### DIFF
--- a/ktor-server/ktor-server-core/common/src/io/ktor/server/application/Application.kt
+++ b/ktor-server/ktor-server-core/common/src/io/ktor/server/application/Application.kt
@@ -35,7 +35,7 @@ public class ServerConfigBuilder(
      *
      * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.server.application.ServerConfigBuilder.watchPaths)
      */
-    public var watchPaths: List<String> = listOf(WORKING_DIRECTORY_PATH)
+    public var watchPaths: List<String> = defaultWatchPaths()
 
     /**
      * Application's root path (prefix, context path in servlet container).
@@ -80,6 +80,8 @@ public class ServerConfigBuilder(
     internal fun build(): ServerConfig =
         ServerConfig(environment, modules.toList(), watchPaths, rootPath, developmentMode, parentCoroutineContext)
 }
+
+internal expect fun defaultWatchPaths(): List<String>
 
 /**
  * Core configuration for a running server.

--- a/ktor-server/ktor-server-core/jvm/src/io/ktor/server/application/Application.jvm.kt
+++ b/ktor-server/ktor-server-core/jvm/src/io/ktor/server/application/Application.jvm.kt
@@ -1,0 +1,5 @@
+package io.ktor.server.application
+
+import io.ktor.server.engine.WORKING_DIRECTORY_PATH
+
+internal actual fun defaultWatchPaths(): List<String> = listOf(WORKING_DIRECTORY_PATH)

--- a/ktor-server/ktor-server-core/nonJvm/src/io/ktor/server/application/Application.nonJvm.kt
+++ b/ktor-server/ktor-server-core/nonJvm/src/io/ktor/server/application/Application.nonJvm.kt
@@ -1,0 +1,6 @@
+package io.ktor.server.application
+
+/**
+ * Hot reload is only supported on JVM
+ */
+internal actual fun defaultWatchPaths(): List<String> = emptyList()

--- a/ktor-server/ktor-server-test-host/build.gradle.kts
+++ b/ktor-server/ktor-server-test-host/build.gradle.kts
@@ -9,6 +9,12 @@ plugins {
 }
 
 kotlin {
+    js {
+        compilerOptions {
+            target = "es2015"
+        }
+    }
+
     sourceSets {
         commonMain.dependencies {
             api(projects.ktorClientCio)


### PR DESCRIPTION
**Subsystem**
Server, server-test-host

**Motivation**
KTOR-9340: Support ES2015 for testApplication

**Solution**
Make the failing `WORKING_DIRECTORY_PATH` overridable.

Open question: How do I test it? I tested it manually, but should I overwrite the js target of `server-test-host`? Or do you prefer an integration module for js tests, to also test https://youtrack.jetbrains.com/issue/KTOR-9341?

To manually test it, add this target setup in `ktor-server-test-host`:
```kotlin
js {
  compilerOptions {
    target = "es2015"
  }
}
```
