### PR TITLE
KTOR-9203 Add non-blocking release function for multi-part content

### DIFF
--- a/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/MultiPartFormDataTest.kt
+++ b/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/MultiPartFormDataTest.kt
@@ -85,7 +85,7 @@ class MultiPartFormDataTest : ClientLoader() {
                     }
                     else -> fail("Unexpected part type: ${part::class.simpleName}")
                 }
-                part.dispose()
+                part.release()
             }
 
             assertTrue(textFound, "Text part not found")

--- a/ktor-http/api/ktor-http.api
+++ b/ktor-http/api/ktor-http.api
@@ -1518,32 +1518,37 @@ public final class io/ktor/http/content/OutputStreamContent : io/ktor/http/conte
 }
 
 public abstract class io/ktor/http/content/PartData {
-	public synthetic fun <init> (Lkotlin/jvm/functions/Function0;Lio/ktor/http/Headers;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Lkotlin/jvm/functions/Function0;Lio/ktor/http/Headers;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getContentDisposition ()Lio/ktor/http/ContentDisposition;
 	public final fun getContentType ()Lio/ktor/http/ContentType;
 	public final fun getDispose ()Lkotlin/jvm/functions/Function0;
 	public final fun getHeaders ()Lio/ktor/http/Headers;
 	public final fun getName ()Ljava/lang/String;
+	public final fun getRelease ()Lkotlin/jvm/functions/Function1;
 }
 
 public final class io/ktor/http/content/PartData$BinaryChannelItem : io/ktor/http/content/PartData {
-	public fun <init> (Lkotlin/jvm/functions/Function0;Lio/ktor/http/Headers;)V
+	public fun <init> (Lkotlin/jvm/functions/Function0;Lio/ktor/http/Headers;Lkotlin/jvm/functions/Function1;)V
+	public synthetic fun <init> (Lkotlin/jvm/functions/Function0;Lio/ktor/http/Headers;Lkotlin/jvm/functions/Function1;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getProvider ()Lkotlin/jvm/functions/Function0;
 }
 
 public final class io/ktor/http/content/PartData$BinaryItem : io/ktor/http/content/PartData {
-	public fun <init> (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;Lio/ktor/http/Headers;)V
+	public fun <init> (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;Lio/ktor/http/Headers;Lkotlin/jvm/functions/Function1;)V
+	public synthetic fun <init> (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;Lio/ktor/http/Headers;Lkotlin/jvm/functions/Function1;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getProvider ()Lkotlin/jvm/functions/Function0;
 }
 
 public final class io/ktor/http/content/PartData$FileItem : io/ktor/http/content/PartData {
-	public fun <init> (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;Lio/ktor/http/Headers;)V
+	public fun <init> (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;Lio/ktor/http/Headers;Lkotlin/jvm/functions/Function1;)V
+	public synthetic fun <init> (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;Lio/ktor/http/Headers;Lkotlin/jvm/functions/Function1;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getOriginalFileName ()Ljava/lang/String;
 	public final fun getProvider ()Lkotlin/jvm/functions/Function0;
 }
 
 public final class io/ktor/http/content/PartData$FormItem : io/ktor/http/content/PartData {
-	public fun <init> (Ljava/lang/String;Lkotlin/jvm/functions/Function0;Lio/ktor/http/Headers;)V
+	public fun <init> (Ljava/lang/String;Lkotlin/jvm/functions/Function0;Lio/ktor/http/Headers;Lkotlin/jvm/functions/Function1;)V
+	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/functions/Function0;Lio/ktor/http/Headers;Lkotlin/jvm/functions/Function1;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getValue ()Ljava/lang/String;
 }
 

--- a/ktor-http/api/ktor-http.api
+++ b/ktor-http/api/ktor-http.api
@@ -1528,18 +1528,19 @@ public abstract class io/ktor/http/content/PartData {
 }
 
 public final class io/ktor/http/content/PartData$BinaryChannelItem : io/ktor/http/content/PartData {
-	public fun <init> (Lkotlin/jvm/functions/Function0;Lio/ktor/http/Headers;Lkotlin/jvm/functions/Function1;)V
-	public synthetic fun <init> (Lkotlin/jvm/functions/Function0;Lio/ktor/http/Headers;Lkotlin/jvm/functions/Function1;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lkotlin/jvm/functions/Function0;Lio/ktor/http/Headers;)V
 	public final fun getProvider ()Lkotlin/jvm/functions/Function0;
 }
 
 public final class io/ktor/http/content/PartData$BinaryItem : io/ktor/http/content/PartData {
+	public synthetic fun <init> (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;Lio/ktor/http/Headers;)V
 	public fun <init> (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;Lio/ktor/http/Headers;Lkotlin/jvm/functions/Function1;)V
 	public synthetic fun <init> (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;Lio/ktor/http/Headers;Lkotlin/jvm/functions/Function1;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getProvider ()Lkotlin/jvm/functions/Function0;
 }
 
 public final class io/ktor/http/content/PartData$FileItem : io/ktor/http/content/PartData {
+	public synthetic fun <init> (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;Lio/ktor/http/Headers;)V
 	public fun <init> (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;Lio/ktor/http/Headers;Lkotlin/jvm/functions/Function1;)V
 	public synthetic fun <init> (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;Lio/ktor/http/Headers;Lkotlin/jvm/functions/Function1;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getOriginalFileName ()Ljava/lang/String;
@@ -1547,6 +1548,7 @@ public final class io/ktor/http/content/PartData$FileItem : io/ktor/http/content
 }
 
 public final class io/ktor/http/content/PartData$FormItem : io/ktor/http/content/PartData {
+	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/functions/Function0;Lio/ktor/http/Headers;)V
 	public fun <init> (Ljava/lang/String;Lkotlin/jvm/functions/Function0;Lio/ktor/http/Headers;Lkotlin/jvm/functions/Function1;)V
 	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/functions/Function0;Lio/ktor/http/Headers;Lkotlin/jvm/functions/Function1;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getValue ()Ljava/lang/String;

--- a/ktor-http/api/ktor-http.klib.api
+++ b/ktor-http/api/ktor-http.klib.api
@@ -1414,23 +1414,25 @@ sealed class io.ktor.http.content/PartData { // io.ktor.http.content/PartData|nu
         final fun <get-headers>(): io.ktor.http/Headers // io.ktor.http.content/PartData.headers.<get-headers>|<get-headers>(){}[0]
     final val name // io.ktor.http.content/PartData.name|{}name[0]
         final fun <get-name>(): kotlin/String? // io.ktor.http.content/PartData.name.<get-name>|<get-name>(){}[0]
+    final val release // io.ktor.http.content/PartData.release|{}release[0]
+        final fun <get-release>(): kotlin.coroutines/SuspendFunction0<kotlin/Unit> // io.ktor.http.content/PartData.release.<get-release>|<get-release>(){}[0]
 
     final class BinaryChannelItem : io.ktor.http.content/PartData { // io.ktor.http.content/PartData.BinaryChannelItem|null[0]
-        constructor <init>(kotlin/Function0<io.ktor.utils.io/ByteReadChannel>, io.ktor.http/Headers) // io.ktor.http.content/PartData.BinaryChannelItem.<init>|<init>(kotlin.Function0<io.ktor.utils.io.ByteReadChannel>;io.ktor.http.Headers){}[0]
+        constructor <init>(kotlin/Function0<io.ktor.utils.io/ByteReadChannel>, io.ktor.http/Headers, kotlin.coroutines/SuspendFunction0<kotlin/Unit> = ...) // io.ktor.http.content/PartData.BinaryChannelItem.<init>|<init>(kotlin.Function0<io.ktor.utils.io.ByteReadChannel>;io.ktor.http.Headers;kotlin.coroutines.SuspendFunction0<kotlin.Unit>){}[0]
 
         final val provider // io.ktor.http.content/PartData.BinaryChannelItem.provider|{}provider[0]
             final fun <get-provider>(): kotlin/Function0<io.ktor.utils.io/ByteReadChannel> // io.ktor.http.content/PartData.BinaryChannelItem.provider.<get-provider>|<get-provider>(){}[0]
     }
 
     final class BinaryItem : io.ktor.http.content/PartData { // io.ktor.http.content/PartData.BinaryItem|null[0]
-        constructor <init>(kotlin/Function0<kotlinx.io/Source>, kotlin/Function0<kotlin/Unit>, io.ktor.http/Headers) // io.ktor.http.content/PartData.BinaryItem.<init>|<init>(kotlin.Function0<kotlinx.io.Source>;kotlin.Function0<kotlin.Unit>;io.ktor.http.Headers){}[0]
+        constructor <init>(kotlin/Function0<kotlinx.io/Source>, kotlin/Function0<kotlin/Unit>, io.ktor.http/Headers, kotlin.coroutines/SuspendFunction0<kotlin/Unit> = ...) // io.ktor.http.content/PartData.BinaryItem.<init>|<init>(kotlin.Function0<kotlinx.io.Source>;kotlin.Function0<kotlin.Unit>;io.ktor.http.Headers;kotlin.coroutines.SuspendFunction0<kotlin.Unit>){}[0]
 
         final val provider // io.ktor.http.content/PartData.BinaryItem.provider|{}provider[0]
             final fun <get-provider>(): kotlin/Function0<kotlinx.io/Source> // io.ktor.http.content/PartData.BinaryItem.provider.<get-provider>|<get-provider>(){}[0]
     }
 
     final class FileItem : io.ktor.http.content/PartData { // io.ktor.http.content/PartData.FileItem|null[0]
-        constructor <init>(kotlin/Function0<io.ktor.utils.io/ByteReadChannel>, kotlin/Function0<kotlin/Unit>, io.ktor.http/Headers) // io.ktor.http.content/PartData.FileItem.<init>|<init>(kotlin.Function0<io.ktor.utils.io.ByteReadChannel>;kotlin.Function0<kotlin.Unit>;io.ktor.http.Headers){}[0]
+        constructor <init>(kotlin/Function0<io.ktor.utils.io/ByteReadChannel>, kotlin/Function0<kotlin/Unit>, io.ktor.http/Headers, kotlin.coroutines/SuspendFunction0<kotlin/Unit> = ...) // io.ktor.http.content/PartData.FileItem.<init>|<init>(kotlin.Function0<io.ktor.utils.io.ByteReadChannel>;kotlin.Function0<kotlin.Unit>;io.ktor.http.Headers;kotlin.coroutines.SuspendFunction0<kotlin.Unit>){}[0]
 
         final val originalFileName // io.ktor.http.content/PartData.FileItem.originalFileName|{}originalFileName[0]
             final fun <get-originalFileName>(): kotlin/String? // io.ktor.http.content/PartData.FileItem.originalFileName.<get-originalFileName>|<get-originalFileName>(){}[0]
@@ -1439,7 +1441,7 @@ sealed class io.ktor.http.content/PartData { // io.ktor.http.content/PartData|nu
     }
 
     final class FormItem : io.ktor.http.content/PartData { // io.ktor.http.content/PartData.FormItem|null[0]
-        constructor <init>(kotlin/String, kotlin/Function0<kotlin/Unit>, io.ktor.http/Headers) // io.ktor.http.content/PartData.FormItem.<init>|<init>(kotlin.String;kotlin.Function0<kotlin.Unit>;io.ktor.http.Headers){}[0]
+        constructor <init>(kotlin/String, kotlin/Function0<kotlin/Unit>, io.ktor.http/Headers, kotlin.coroutines/SuspendFunction0<kotlin/Unit> = ...) // io.ktor.http.content/PartData.FormItem.<init>|<init>(kotlin.String;kotlin.Function0<kotlin.Unit>;io.ktor.http.Headers;kotlin.coroutines.SuspendFunction0<kotlin.Unit>){}[0]
 
         final val value // io.ktor.http.content/PartData.FormItem.value|{}value[0]
             final fun <get-value>(): kotlin/String // io.ktor.http.content/PartData.FormItem.value.<get-value>|<get-value>(){}[0]

--- a/ktor-http/api/ktor-http.klib.api
+++ b/ktor-http/api/ktor-http.klib.api
@@ -1418,13 +1418,14 @@ sealed class io.ktor.http.content/PartData { // io.ktor.http.content/PartData|nu
         final fun <get-release>(): kotlin.coroutines/SuspendFunction0<kotlin/Unit> // io.ktor.http.content/PartData.release.<get-release>|<get-release>(){}[0]
 
     final class BinaryChannelItem : io.ktor.http.content/PartData { // io.ktor.http.content/PartData.BinaryChannelItem|null[0]
-        constructor <init>(kotlin/Function0<io.ktor.utils.io/ByteReadChannel>, io.ktor.http/Headers, kotlin.coroutines/SuspendFunction0<kotlin/Unit> = ...) // io.ktor.http.content/PartData.BinaryChannelItem.<init>|<init>(kotlin.Function0<io.ktor.utils.io.ByteReadChannel>;io.ktor.http.Headers;kotlin.coroutines.SuspendFunction0<kotlin.Unit>){}[0]
+        constructor <init>(kotlin/Function0<io.ktor.utils.io/ByteReadChannel>, io.ktor.http/Headers) // io.ktor.http.content/PartData.BinaryChannelItem.<init>|<init>(kotlin.Function0<io.ktor.utils.io.ByteReadChannel>;io.ktor.http.Headers){}[0]
 
         final val provider // io.ktor.http.content/PartData.BinaryChannelItem.provider|{}provider[0]
             final fun <get-provider>(): kotlin/Function0<io.ktor.utils.io/ByteReadChannel> // io.ktor.http.content/PartData.BinaryChannelItem.provider.<get-provider>|<get-provider>(){}[0]
     }
 
     final class BinaryItem : io.ktor.http.content/PartData { // io.ktor.http.content/PartData.BinaryItem|null[0]
+        constructor <init>(kotlin/Function0<kotlinx.io/Source>, kotlin/Function0<kotlin/Unit>, io.ktor.http/Headers) // io.ktor.http.content/PartData.BinaryItem.<init>|<init>(kotlin.Function0<kotlinx.io.Source>;kotlin.Function0<kotlin.Unit>;io.ktor.http.Headers){}[0]
         constructor <init>(kotlin/Function0<kotlinx.io/Source>, kotlin/Function0<kotlin/Unit>, io.ktor.http/Headers, kotlin.coroutines/SuspendFunction0<kotlin/Unit> = ...) // io.ktor.http.content/PartData.BinaryItem.<init>|<init>(kotlin.Function0<kotlinx.io.Source>;kotlin.Function0<kotlin.Unit>;io.ktor.http.Headers;kotlin.coroutines.SuspendFunction0<kotlin.Unit>){}[0]
 
         final val provider // io.ktor.http.content/PartData.BinaryItem.provider|{}provider[0]
@@ -1432,6 +1433,7 @@ sealed class io.ktor.http.content/PartData { // io.ktor.http.content/PartData|nu
     }
 
     final class FileItem : io.ktor.http.content/PartData { // io.ktor.http.content/PartData.FileItem|null[0]
+        constructor <init>(kotlin/Function0<io.ktor.utils.io/ByteReadChannel>, kotlin/Function0<kotlin/Unit>, io.ktor.http/Headers) // io.ktor.http.content/PartData.FileItem.<init>|<init>(kotlin.Function0<io.ktor.utils.io.ByteReadChannel>;kotlin.Function0<kotlin.Unit>;io.ktor.http.Headers){}[0]
         constructor <init>(kotlin/Function0<io.ktor.utils.io/ByteReadChannel>, kotlin/Function0<kotlin/Unit>, io.ktor.http/Headers, kotlin.coroutines/SuspendFunction0<kotlin/Unit> = ...) // io.ktor.http.content/PartData.FileItem.<init>|<init>(kotlin.Function0<io.ktor.utils.io.ByteReadChannel>;kotlin.Function0<kotlin.Unit>;io.ktor.http.Headers;kotlin.coroutines.SuspendFunction0<kotlin.Unit>){}[0]
 
         final val originalFileName // io.ktor.http.content/PartData.FileItem.originalFileName|{}originalFileName[0]
@@ -1441,6 +1443,7 @@ sealed class io.ktor.http.content/PartData { // io.ktor.http.content/PartData|nu
     }
 
     final class FormItem : io.ktor.http.content/PartData { // io.ktor.http.content/PartData.FormItem|null[0]
+        constructor <init>(kotlin/String, kotlin/Function0<kotlin/Unit>, io.ktor.http/Headers) // io.ktor.http.content/PartData.FormItem.<init>|<init>(kotlin.String;kotlin.Function0<kotlin.Unit>;io.ktor.http.Headers){}[0]
         constructor <init>(kotlin/String, kotlin/Function0<kotlin/Unit>, io.ktor.http/Headers, kotlin.coroutines/SuspendFunction0<kotlin/Unit> = ...) // io.ktor.http.content/PartData.FormItem.<init>|<init>(kotlin.String;kotlin.Function0<kotlin.Unit>;io.ktor.http.Headers;kotlin.coroutines.SuspendFunction0<kotlin.Unit>){}[0]
 
         final val value // io.ktor.http.content/PartData.FormItem.value|{}value[0]

--- a/ktor-http/common/src/io/ktor/http/content/Multipart.kt
+++ b/ktor-http/common/src/io/ktor/http/content/Multipart.kt
@@ -6,6 +6,8 @@ package io.ktor.http.content
 
 import io.ktor.http.*
 import io.ktor.http.content.PartData.*
+import io.ktor.http.content.PartData.BinaryItem
+import io.ktor.http.content.PartData.FileItem
 import io.ktor.utils.io.*
 import io.ktor.utils.io.core.*
 import kotlinx.coroutines.flow.*
@@ -36,8 +38,14 @@ public sealed class PartData(
         dispose: () -> Unit,
         partHeaders: Headers,
         release: suspend () -> Unit = {},
-    ) :
-        PartData(dispose, partHeaders, release)
+    ) : PartData(dispose, partHeaders, release) {
+        @Deprecated("Binary compatability", level = DeprecationLevel.HIDDEN)
+        public constructor(
+            value: String,
+            dispose: () -> Unit,
+            partHeaders: Headers
+        ) : this(value, dispose, partHeaders, {})
+    }
 
     /**
      * Represents a file item.
@@ -53,6 +61,13 @@ public sealed class PartData(
         partHeaders: Headers,
         release: suspend () -> Unit = {},
     ) : PartData(dispose, partHeaders, release) {
+        @Deprecated("Binary compatability", level = DeprecationLevel.HIDDEN)
+        public constructor(
+            provider: () -> ByteReadChannel,
+            dispose: () -> Unit,
+            partHeaders: Headers
+        ) : this(provider, dispose, partHeaders, {})
+
         /**
          * Original file name if present
          *
@@ -74,7 +89,14 @@ public sealed class PartData(
         dispose: () -> Unit,
         partHeaders: Headers,
         release: suspend () -> Unit = {},
-    ) : PartData(dispose, partHeaders, release)
+    ) : PartData(dispose, partHeaders, release) {
+        @Deprecated("Binary compatability", level = DeprecationLevel.HIDDEN)
+        public constructor(
+            provider: () -> Input,
+            dispose: () -> Unit,
+            partHeaders: Headers
+        ) : this(provider, dispose, partHeaders, {})
+    }
 
     /**
      * Represents a binary part with a provider that supplies [ByteReadChannel].
@@ -86,8 +108,7 @@ public sealed class PartData(
     public class BinaryChannelItem(
         public val provider: () -> ByteReadChannel,
         partHeaders: Headers,
-        release: suspend () -> Unit = {},
-    ) : PartData({}, partHeaders, release)
+    ) : PartData({}, partHeaders, {})
 
     /**
      * Parsed `Content-Disposition` header or `null` if missing.

--- a/ktor-http/common/src/io/ktor/http/content/Multipart.kt
+++ b/ktor-http/common/src/io/ktor/http/content/Multipart.kt
@@ -17,8 +17,9 @@ import kotlinx.coroutines.flow.*
  *
  * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.http.content.PartData)
  *
- * @property dispose to be invoked when this part is no longer needed
+ * @property dispose former blocking call to close the part; use release instead
  * @property headers of this part, could be inaccurate on some engines
+ * @property release to be invoked when this part is no longer needed
  */
 public sealed class PartData(
     @Deprecated("Use release instead", level = DeprecationLevel.WARNING)
@@ -39,7 +40,7 @@ public sealed class PartData(
         partHeaders: Headers,
         release: suspend () -> Unit = {},
     ) : PartData(dispose, partHeaders, release) {
-        @Deprecated("Binary compatability", level = DeprecationLevel.HIDDEN)
+        @Deprecated("Binary compatibility", level = DeprecationLevel.HIDDEN)
         public constructor(
             value: String,
             dispose: () -> Unit,

--- a/ktor-http/ktor-http-cio/api/ktor-http-cio.api
+++ b/ktor-http/ktor-http-cio/api/ktor-http-cio.api
@@ -88,12 +88,14 @@ public final class io/ktor/http/cio/HttpParserKt {
 
 public abstract class io/ktor/http/cio/MultipartEvent {
 	public abstract fun release ()V
+	public abstract fun releaseSuspend (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public final class io/ktor/http/cio/MultipartEvent$Epilogue : io/ktor/http/cio/MultipartEvent {
 	public fun <init> (Lkotlinx/io/Source;)V
 	public final fun getBody ()Lkotlinx/io/Source;
 	public fun release ()V
+	public fun releaseSuspend (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public final class io/ktor/http/cio/MultipartEvent$MultipartPart : io/ktor/http/cio/MultipartEvent {
@@ -101,12 +103,14 @@ public final class io/ktor/http/cio/MultipartEvent$MultipartPart : io/ktor/http/
 	public final fun getBody ()Lio/ktor/utils/io/ByteReadChannel;
 	public final fun getHeaders ()Lkotlinx/coroutines/Deferred;
 	public fun release ()V
+	public fun releaseSuspend (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public final class io/ktor/http/cio/MultipartEvent$Preamble : io/ktor/http/cio/MultipartEvent {
 	public fun <init> (Lkotlinx/io/Source;)V
 	public final fun getBody ()Lkotlinx/io/Source;
 	public fun release ()V
+	public fun releaseSuspend (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public final class io/ktor/http/cio/MultipartKt {

--- a/ktor-http/ktor-http-cio/api/ktor-http-cio.klib.api
+++ b/ktor-http/ktor-http-cio/api/ktor-http-cio.klib.api
@@ -136,6 +136,7 @@ final class io.ktor.http.cio/Response : io.ktor.http.cio/HttpMessage { // io.kto
 
 sealed class io.ktor.http.cio/MultipartEvent { // io.ktor.http.cio/MultipartEvent|null[0]
     abstract fun release() // io.ktor.http.cio/MultipartEvent.release|release(){}[0]
+    abstract suspend fun releaseSuspend() // io.ktor.http.cio/MultipartEvent.releaseSuspend|releaseSuspend(){}[0]
 
     final class Epilogue : io.ktor.http.cio/MultipartEvent { // io.ktor.http.cio/MultipartEvent.Epilogue|null[0]
         constructor <init>(kotlinx.io/Source) // io.ktor.http.cio/MultipartEvent.Epilogue.<init>|<init>(kotlinx.io.Source){}[0]
@@ -144,6 +145,7 @@ sealed class io.ktor.http.cio/MultipartEvent { // io.ktor.http.cio/MultipartEven
             final fun <get-body>(): kotlinx.io/Source // io.ktor.http.cio/MultipartEvent.Epilogue.body.<get-body>|<get-body>(){}[0]
 
         final fun release() // io.ktor.http.cio/MultipartEvent.Epilogue.release|release(){}[0]
+        final suspend fun releaseSuspend() // io.ktor.http.cio/MultipartEvent.Epilogue.releaseSuspend|releaseSuspend(){}[0]
     }
 
     final class MultipartPart : io.ktor.http.cio/MultipartEvent { // io.ktor.http.cio/MultipartEvent.MultipartPart|null[0]
@@ -155,6 +157,7 @@ sealed class io.ktor.http.cio/MultipartEvent { // io.ktor.http.cio/MultipartEven
             final fun <get-headers>(): kotlinx.coroutines/Deferred<io.ktor.http.cio/HttpHeadersMap> // io.ktor.http.cio/MultipartEvent.MultipartPart.headers.<get-headers>|<get-headers>(){}[0]
 
         final fun release() // io.ktor.http.cio/MultipartEvent.MultipartPart.release|release(){}[0]
+        final suspend fun releaseSuspend() // io.ktor.http.cio/MultipartEvent.MultipartPart.releaseSuspend|releaseSuspend(){}[0]
     }
 
     final class Preamble : io.ktor.http.cio/MultipartEvent { // io.ktor.http.cio/MultipartEvent.Preamble|null[0]
@@ -164,6 +167,7 @@ sealed class io.ktor.http.cio/MultipartEvent { // io.ktor.http.cio/MultipartEven
             final fun <get-body>(): kotlinx.io/Source // io.ktor.http.cio/MultipartEvent.Preamble.body.<get-body>|<get-body>(){}[0]
 
         final fun release() // io.ktor.http.cio/MultipartEvent.Preamble.release|release(){}[0]
+        final suspend fun releaseSuspend() // io.ktor.http.cio/MultipartEvent.Preamble.releaseSuspend|releaseSuspend(){}[0]
     }
 }
 

--- a/ktor-http/ktor-http-cio/common/src/io/ktor/http/cio/CIOMultipartDataBase.kt
+++ b/ktor-http/ktor-http-cio/common/src/io/ktor/http/cio/CIOMultipartDataBase.kt
@@ -32,7 +32,7 @@ public class CIOMultipartDataBase(
         parseMultipart(channel, contentType, contentLength, formFieldLimit)
 
     override suspend fun readPart(): PartData? {
-        previousPart?.dispose?.invoke()
+        previousPart?.release()
 
         while (true) {
             val event = events.tryReceive().getOrNull() ?: break

--- a/ktor-http/ktor-http-cio/common/src/io/ktor/http/cio/CIOMultipartDataBase.kt
+++ b/ktor-http/ktor-http-cio/common/src/io/ktor/http/cio/CIOMultipartDataBase.kt
@@ -61,12 +61,12 @@ public class CIOMultipartDataBase(
             when (event) {
                 is MultipartEvent.MultipartPart -> partToData(event)
                 else -> {
-                    event.release()
+                    event.releaseSuspend()
                     null
                 }
             }
         } catch (cause: Throwable) {
-            event.release()
+            event.releaseSuspend()
             throw cause
         }
     }
@@ -81,14 +81,15 @@ public class CIOMultipartDataBase(
         if (filename == null) {
             val packet = body.readRemaining()
             packet.use {
-                return PartData.FormItem(it.readText(), { part.release() }, CIOHeaders(headers))
+                return PartData.FormItem(it.readText(), part::release, CIOHeaders(headers), part::releaseSuspend)
             }
         }
 
         return PartData.FileItem(
             { part.body },
-            { part.release() },
-            CIOHeaders(headers)
+            part::release,
+            CIOHeaders(headers),
+            part::releaseSuspend
         )
     }
 }

--- a/ktor-http/ktor-http-cio/common/src/io/ktor/http/cio/CIOMultipartDataBase.kt
+++ b/ktor-http/ktor-http-cio/common/src/io/ktor/http/cio/CIOMultipartDataBase.kt
@@ -72,24 +72,33 @@ public class CIOMultipartDataBase(
     }
 
     private suspend fun partToData(part: MultipartEvent.MultipartPart): PartData {
-        val headers = part.headers.await()
+        val rawHeaders = part.headers.await()
+        // Snapshot headers into a non-pooled instance so that PartData remains
+        // valid after MultipartPart.releaseSuspend() recycles the pooled HttpHeadersMap.
+        val partHeaders = rawHeaders.snapshot()
 
-        val contentDisposition = headers["Content-Disposition"]?.let { ContentDisposition.parse(it.toString()) }
+        val contentDisposition = partHeaders[HttpHeaders.ContentDisposition]?.let { ContentDisposition.parse(it) }
         val filename = contentDisposition?.parameter("filename")
 
         val body = part.body
         if (filename == null) {
             val packet = body.readRemaining()
             packet.use {
-                return PartData.FormItem(it.readText(), part::release, CIOHeaders(headers), part::releaseSuspend)
+                return PartData.FormItem(it.readText(), part::release, partHeaders, part::releaseSuspend)
             }
         }
 
         return PartData.FileItem(
             { part.body },
             part::release,
-            CIOHeaders(headers),
+            partHeaders,
             part::releaseSuspend
         )
+    }
+
+    private fun HttpHeadersMap.snapshot(): Headers = Headers.build {
+        for (offset in offsets()) {
+            append(nameAtOffset(offset).toString(), valueAtOffset(offset).toString())
+        }
     }
 }

--- a/ktor-http/ktor-http-cio/common/src/io/ktor/http/cio/Multipart.kt
+++ b/ktor-http/ktor-http-cio/common/src/io/ktor/http/cio/Multipart.kt
@@ -75,6 +75,7 @@ public sealed class MultipartEvent {
         public val headers: Deferred<HttpHeadersMap>,
         public val body: ByteReadChannel
     ) : MultipartEvent() {
+        @Deprecated("Use releaseSuspend instead", level = DeprecationLevel.WARNING)
         @OptIn(ExperimentalCoroutinesApi::class)
         override fun release() {
             headers.invokeOnCompletion { t ->
@@ -86,8 +87,11 @@ public sealed class MultipartEvent {
             body.discardBlocking()
         }
         override suspend fun releaseSuspend() {
-            headers.await().release()
-            body.discard()
+            try {
+                headers.await().release()
+            } finally {
+                body.discard()
+            }
         }
     }
 

--- a/ktor-http/ktor-http-cio/common/src/io/ktor/http/cio/Multipart.kt
+++ b/ktor-http/ktor-http-cio/common/src/io/ktor/http/cio/Multipart.kt
@@ -79,7 +79,7 @@ public sealed class MultipartEvent {
         @OptIn(ExperimentalCoroutinesApi::class)
         override fun release() {
             headers.invokeOnCompletion { t ->
-                if (t != null) {
+                if (t == null) {
                     headers.getCompleted().release()
                 }
             }

--- a/ktor-server/ktor-server-core/common/src/io/ktor/server/engine/DefaultTransform.kt
+++ b/ktor-server/ktor-server-core/common/src/io/ktor/server/engine/DefaultTransform.kt
@@ -61,7 +61,7 @@ public fun ApplicationReceivePipeline.installDefaultTransformations() {
                                     }
                                 }
 
-                                part.dispose()
+                                part.release()
                             }
                         }
                     }

--- a/ktor-server/ktor-server-plugins/ktor-server-content-negotiation/jvm/test/ContentNegotiationJvmTest.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-content-negotiation/jvm/test/ContentNegotiationJvmTest.kt
@@ -148,7 +148,7 @@ internal fun buildMultipart(
 
         append("--$boundary--\r\n")
     } finally {
-        parts.forEach { it.dispose() }
+        parts.forEach { it.release() }
     }
 }.channel
 

--- a/ktor-server/ktor-server-tests/common/test/io/ktor/tests/server/http/TestEngineMultipartTest.kt
+++ b/ktor-server/ktor-server-tests/common/test/io/ktor/tests/server/http/TestEngineMultipartTest.kt
@@ -68,7 +68,7 @@ class TestEngineMultipartTest {
             assertEquals("file.bin", file.originalFileName)
             assertEquals(bytes.toHexString(), file.provider().readRemaining().readByteArray().toHexString())
 
-            file.dispose()
+            file.release()
         }) {
             header(HttpHeaders.ContentType, contentType.toString())
             val partHeaders = headersOf(
@@ -133,7 +133,7 @@ class TestEngineMultipartTest {
                                 part.provider().readByteArray()
                             }
                         }
-                        part.dispose()
+                        part.release()
                     }
                     call.respondText("OK")
                 }
@@ -212,7 +212,7 @@ class TestEngineMultipartTest {
         assertEquals(filename, file.originalFileName)
         extraFileAssertions(file)
 
-        file.dispose()
+        file.release()
     }, setup = {
         header(HttpHeaders.ContentType, contentType.toString())
         setBody(
@@ -278,7 +278,7 @@ internal fun buildMultipart(
 
                 append("--$boundary--\r\n")
             } finally {
-                parts.forEach { it.dispose() }
+                parts.forEach { it.release() }
             }
         }.channel
 

--- a/ktor-server/ktor-server-tests/jvm/test/io/ktor/server/http/MultipartServerTest.kt
+++ b/ktor-server/ktor-server-tests/jvm/test/io/ktor/server/http/MultipartServerTest.kt
@@ -46,7 +46,7 @@ class MultipartServerTest {
                             }
                         }
                     } finally {
-                        it.dispose()
+                        it.release()
                     }
                 }
                 call.respond(HttpStatusCode.OK)


### PR DESCRIPTION
**Subsystem**
Server, Core

**Motivation**
[KTOR-9203](https://youtrack.jetbrains.com/issue/KTOR-9203) CIOMultipartDataBase: Call thread is blocked when releasing file parts since 3.2.0

**Solution**
Added function for releasing multi-part contents with suspend instead of blocking.

