### PR TITLE
KTOR-9348 Make deprecated Base64 decoders accept optional padding (#5336)

### DIFF
--- a/ktor-utils/common/src/io/ktor/util/Base64.kt
+++ b/ktor-utils/common/src/io/ktor/util/Base64.kt
@@ -58,7 +58,7 @@ public fun Source.encodeBase64(): String = Base64.encode(readByteArray())
 public fun String.decodeBase64String(): String = decodeBase64Bytes().decodeToString()
 
 /**
- * Decode [String] from base64 format
+ * Decode [String] from base64 format with optional padding
  *
  * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.util.decodeBase64Bytes)
  */
@@ -68,10 +68,11 @@ public fun String.decodeBase64String(): String = decodeBase64Bytes().decodeToStr
     replaceWith = ReplaceWith("Base64.decode(this)", "kotlin.io.encoding.Base64")
 )
 public fun String.decodeBase64Bytes(): ByteArray =
-    runCatching { Base64.decode(this) }.getOrElse { Base64.UrlSafe.decode(this) }
+    runCatching { Base64.withPadding(Base64.PaddingOption.PRESENT_OPTIONAL).decode(this) }
+        .getOrElse { Base64.UrlSafe.withPadding(Base64.PaddingOption.PRESENT_OPTIONAL).decode(this) }
 
 /**
- * Decode [ByteReadPacket] from base64 format
+ * Decode [ByteReadPacket] from base64 format with optional padding
  *
  * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.util.decodeBase64Bytes)
  */
@@ -82,6 +83,7 @@ public fun String.decodeBase64Bytes(): ByteArray =
 )
 public fun Source.decodeBase64Bytes(): Input = buildPacket {
     val raw = readByteArray()
-    val decoded = runCatching { Base64.decode(raw) }.getOrElse { Base64.UrlSafe.decode(raw) }
+    val decoded = runCatching { Base64.withPadding(Base64.PaddingOption.PRESENT_OPTIONAL).decode(raw) }
+        .getOrElse { Base64.UrlSafe.withPadding(Base64.PaddingOption.PRESENT_OPTIONAL).decode(raw) }
     writeFully(decoded)
 }

--- a/ktor-utils/common/test/io/ktor/util/Base64Test.kt
+++ b/ktor-utils/common/test/io/ktor/util/Base64Test.kt
@@ -37,7 +37,7 @@ class Base64Test {
     }
 
     @Test
-    fun paddingTest() {
+    fun encodeDecodeWithPaddingTest() {
         val cases = mapOf(
             "This" to "VGhpcw==",
             "Thi" to "VGhp",
@@ -48,6 +48,21 @@ class Base64Test {
 
         cases.forEach { (text, encodedText) ->
             assertEquals(encodedText, text.encodeBase64())
+            assertEquals(text, encodedText.decodeBase64String())
+        }
+    }
+
+    @Test
+    fun decodeWithoutPaddingTest() {
+        val cases = mapOf(
+            "This" to "VGhpcw",
+            "Thi" to "VGhp",
+            "Th" to "VGg",
+            "T" to "VA",
+            "" to ""
+        )
+
+        cases.forEach { (text, encodedText) ->
             assertEquals(text, encodedText.decodeBase64String())
         }
     }


### PR DESCRIPTION
**Subsystem**
ktor-utils

**Motivation**
`decodeBase64String` / `decodeBase64Bytes` in `ktor-utils` became too strict after migrating to stdlib Base64 decoders and no longer accept unpadded Base64 / Base64URL inputs.

This broke existing integrations that parse JWT segments, since JWT header, payload, and signature are commonly Base64URL encoded without padding.

Fixes: #5336

**Solution**
Restore backward-compatible behavior in the deprecated helpers by decoding with optional padding for both standard and URL-safe variants:

```kotlin
Base64.withPadding(Base64.PaddingOption.PRESENT_OPTIONAL)
Base64.UrlSafe.withPadding(Base64.PaddingOption.PRESENT_OPTIONAL)
```
Apply this in both:

```kotlin
String.decodeBase64Bytes()
Source.decodeBase64Bytes()
```

