### PR TITLE
KTOR-9353: Override toString for TailcardSelector and LocalPortRouteSelector

### DIFF
--- a/ktor-server/ktor-server-core/common/src/io/ktor/server/routing/LocalPortRoutingBuilder.kt
+++ b/ktor-server/ktor-server-core/common/src/io/ktor/server/routing/LocalPortRoutingBuilder.kt
@@ -49,6 +49,8 @@ public data class LocalPortRouteSelector(val port: Int) : RouteSelector() {
             RouteSelectorEvaluation.Failed
         }
 
+    override fun toString(): String = "(port:$port)"
+
     public companion object {
         /**
          * A parameter name for [ApplicationCall.parameters] for a request host.

--- a/ktor-server/ktor-server-core/jvm/src/io/ktor/server/http/content/StaticContent.kt
+++ b/ktor-server/ktor-server-core/jvm/src/io/ktor/server/http/content/StaticContent.kt
@@ -964,4 +964,6 @@ public interface FileSystemPaths {
 private object TailcardSelector : RouteSelector() {
     override suspend fun evaluate(context: RoutingResolveContext, segmentIndex: Int): RouteSelectorEvaluation =
         RouteSelectorEvaluation.Success(quality = RouteSelectorEvaluation.qualityTailcard)
+
+    override fun toString(): String = "(static-content)"
 }

--- a/ktor-server/ktor-server-tests/common/test/io/ktor/tests/server/routing/RoutingTracingTest.kt
+++ b/ktor-server/ktor-server-tests/common/test/io/ktor/tests/server/routing/RoutingTracingTest.kt
@@ -280,25 +280,25 @@ class RoutingTracingTest {
 
         assertEquals(
             $$"""
-    Trace for [route, port]
-    /, segment:0 -> SUCCESS @ /
-      /bar, segment:0 -> FAILURE "Selector didn't match" @ /bar
-      /baz, segment:0 -> FAILURE "Selector didn't match" @ /baz
-      /{param}, segment:1 -> SUCCESS; Parameters [param=[route]] @ /{param}
-        /{param} [(method:GET)], segment:1 -> FAILURE "Not all segments matched" @ /{param} [(method:GET)]
-        /{param}/x, segment:1 -> FAILURE "Selector didn't match" @ /{param}/x
-      /*, segment:1 -> SUCCESS @ /*
-        /*/extra, segment:1 -> FAILURE "Selector didn't match" @ /*/extra
-      / [(header:a = x)], segment:0 -> FAILURE "Selector didn't match" @ / [(header:a = x)]
-      / [(header:b = x)], segment:0 -> FAILURE "Selector didn't match" @ / [(header:b = x)]
-      /route, segment:1 -> SUCCESS @ /route
-        /route [LocalPortRouteSelector(port=80)], segment:1 -> SUCCESS; Parameters [$LocalPort=[80]] @ /route [LocalPortRouteSelector(port=80)]
-          /route/port [LocalPortRouteSelector(port=80)], segment:2 -> SUCCESS @ /route/port [LocalPortRouteSelector(port=80)]
-            /route/port [LocalPortRouteSelector(port=80), (method:GET)], segment:2 -> SUCCESS @ /route/port [LocalPortRouteSelector(port=80), (method:GET)]
-    Matched routes:
-      "" -> "route" -> "LocalPortRouteSelector(port=80)" -> "port" -> "(method:GET)"
-    Routing resolve result:
-      SUCCESS; Parameters [$LocalPort=[80]] @ /route/port [LocalPortRouteSelector(port=80), (method:GET)]
+            Trace for [route, port]
+            /, segment:0 -> SUCCESS @ /
+              /bar, segment:0 -> FAILURE "Selector didn't match" @ /bar
+              /baz, segment:0 -> FAILURE "Selector didn't match" @ /baz
+              /{param}, segment:1 -> SUCCESS; Parameters [param=[route]] @ /{param}
+                /{param} [(method:GET)], segment:1 -> FAILURE "Not all segments matched" @ /{param} [(method:GET)]
+                /{param}/x, segment:1 -> FAILURE "Selector didn't match" @ /{param}/x
+              /*, segment:1 -> SUCCESS @ /*
+                /*/extra, segment:1 -> FAILURE "Selector didn't match" @ /*/extra
+              / [(header:a = x)], segment:0 -> FAILURE "Selector didn't match" @ / [(header:a = x)]
+              / [(header:b = x)], segment:0 -> FAILURE "Selector didn't match" @ / [(header:b = x)]
+              /route, segment:1 -> SUCCESS @ /route
+                /route [(port:80)], segment:1 -> SUCCESS; Parameters [$LocalPort=[80]] @ /route [(port:80)]
+                  /route/port [(port:80)], segment:2 -> SUCCESS @ /route/port [(port:80)]
+                    /route/port [(port:80), (method:GET)], segment:2 -> SUCCESS @ /route/port [(port:80), (method:GET)]
+            Matched routes:
+              "" -> "route" -> "(port:80)" -> "port" -> "(method:GET)"
+            Routing resolve result:
+              SUCCESS; Parameters [$LocalPort=[80]] @ /route/port [(port:80), (method:GET)]
             """.trimIndent(),
             trace()
         )

--- a/ktor-server/ktor-server-tests/jvm/test/io/ktor/tests/server/routing/RoutingTracingJvmTest.kt
+++ b/ktor-server/ktor-server-tests/jvm/test/io/ktor/tests/server/routing/RoutingTracingJvmTest.kt
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2014-2026 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.tests.server.routing
+
+import io.ktor.client.request.*
+import io.ktor.http.*
+import io.ktor.server.http.content.*
+import io.ktor.server.routing.*
+import io.ktor.server.testing.*
+import java.io.File
+import kotlin.test.*
+
+class RoutingTracingJvmTest {
+
+    private val basedir = listOf(File("jvm/test"), File("ktor-server/ktor-server-tests/jvm/test"))
+        .map { it.resolve("io/ktor/server") }
+        .first(File::exists)
+
+    @Test
+    fun testStaticFilesRouteTracing() = testApplication {
+        var trace: RoutingResolveTrace? = null
+        application {
+            routing {
+                trace { trace = it }
+                staticFiles("/static", basedir)
+            }
+        }
+
+        assertEquals(HttpStatusCode.OK, client.get("/static/plugins/StaticContentTest.kt").status)
+
+        assertEquals(
+            """
+            Trace for [static, plugins, StaticContentTest.kt]
+            /, segment:0 -> SUCCESS @ /
+              / [(static-content)], segment:0 -> SUCCESS @ / [(static-content)]
+                /static [(static-content)], segment:1 -> SUCCESS @ /static [(static-content)]
+                  /static/{...} [(static-content)], segment:3 -> SUCCESS; Parameters [static-content-path-parameter=[plugins, StaticContentTest.kt]] @ /static/{...} [(static-content)]
+                    /static/{...} [(static-content), (method:GET)], segment:3 -> SUCCESS @ /static/{...} [(static-content), (method:GET)]
+            Matched routes:
+              "" -> "(static-content)" -> "static" -> "{...}" -> "(method:GET)"
+            Routing resolve result:
+              SUCCESS; Parameters [static-content-path-parameter=[plugins, StaticContentTest.kt]] @ /static/{...} [(static-content), (method:GET)]
+            """.trimIndent(),
+            trace!!.buildText()
+        )
+    }
+}


### PR DESCRIPTION
**Subsystem**
ktor-server-core

**Motivation**
[KTOR-9353](https://youtrack.jetbrains.com/issue/KTOR-9353) Routing: TailcardSelector missing toString(), which clutters the logs

**Solution**
Override `toString()` for selectors where it wasn't specified.
