### PR TITLE
KTOR-9360 Skip flaky testHead for CIO engine on JS/Node

### DIFF
--- a/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/HttpTimeoutTest.kt
+++ b/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/HttpTimeoutTest.kt
@@ -92,7 +92,7 @@ class HttpTimeoutTest : ClientLoader(timeout = 3.seconds) {
     }
 
     @Test
-    fun testHead() = clientTests {
+    fun testHead() = clientTests(except("web:CIO")) {
         config {
             install(HttpTimeout)
         }


### PR DESCRIPTION
## Summary
- Fixes [KTOR-9360](https://youtrack.jetbrains.com/issue/KTOR-9360)
- `HttpTimeoutTest.testHead` flakily fails on JS/Node with the CIO engine due to the 3-second test timeout being too tight for CIO's socket lifecycle
- Excluded `web:CIO` from `testHead()` using the established engine selection pattern already used in `ContentTest` and `ProxyTest`

Closes KTOR-9360

## Test plan
- Verified `testHead` still passes on JVM with all engines
- Full `ktor-client-tests:jvmTest` suite passes
- Formatting and linting pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)