### PR TITLE
security: force commons-lang3:3.20.0 to resolve security vulnerabilities

### DIFF
--- a/ktor-server/ktor-server-plugins/ktor-server-auth-ldap/build.gradle.kts
+++ b/ktor-server/ktor-server-plugins/ktor-server-auth-ldap/build.gradle.kts
@@ -6,6 +6,12 @@ plugins {
     id("ktorbuild.project.server-plugin")
 }
 
+configurations.all {
+    resolutionStrategy {
+        force("org.apache.commons:commons-lang3:3.20.0")
+    }
+}
+
 kotlin {
     sourceSets {
         jvmMain.dependencies {

--- a/ktor-server/ktor-server-plugins/ktor-server-velocity/build.gradle.kts
+++ b/ktor-server/ktor-server-plugins/ktor-server-velocity/build.gradle.kts
@@ -6,6 +6,12 @@ plugins {
     id("ktorbuild.project.server-plugin")
 }
 
+configurations.all {
+    resolutionStrategy {
+        force("org.apache.commons:commons-lang3:3.20.0")
+    }
+}
+
 kotlin {
     sourceSets {
         jvmMain.dependencies {


### PR DESCRIPTION
**Subsystem**
Server plugins (ktor-server-auth-ldap, ktor-server-velocity)

**Motivation**
Addressing CVE: https://github.com/advisories/GHSA-j288-q9x7-2f5v

**Solution**
Forcing version 3.20.0 for affected modules ensures all transitive dependencies use
the most recent patched version.
