### PR TITLE
KTOR-4237 Stop returning 403 from CORS plugin when checks fail

### DIFF
--- a/ktor-server/ktor-server-plugins/ktor-server-cors/common/src/io/ktor/server/plugins/cors/CORS.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-cors/common/src/io/ktor/server/plugins/cors/CORS.kt
@@ -117,7 +117,9 @@ internal fun PluginBuilder<CORSConfig>.buildPlugin() {
             OriginCheckResult.SkipCORS -> return@onCall
             OriginCheckResult.Failed -> {
                 LOGGER.trace { "${call.request.id()}: CORS check fails because Origin $origin does not match" }
-                call.respondCorsFailed()
+                if (call.request.httpMethod == HttpMethod.Options) {
+                    call.respond(HttpStatusCode.OK)
+                }
                 return@onCall
             }
         }
@@ -130,7 +132,9 @@ internal fun PluginBuilder<CORSConfig>.buildPlugin() {
                         "${call.request.id()}: CORS check fails because the requested content type $contentType " +
                             "is not in the list of the only allowed simple types ${CORSConfig.CorsSimpleContentTypes}"
                     }
-                    call.respondCorsFailed()
+                    if (call.request.httpMethod == HttpMethod.Options) {
+                        call.respond(HttpStatusCode.OK)
+                    }
                     return@onCall
                 }
             }
@@ -157,7 +161,6 @@ internal fun PluginBuilder<CORSConfig>.buildPlugin() {
                 "${call.request.id()}: CORS check fails because HTTP method ${call.request.httpMethod.value} " +
                     "is not allowed. Allowed methods: $methods"
             }
-            call.respondCorsFailed()
             return@onCall
         }
 
@@ -234,7 +237,7 @@ private suspend fun ApplicationCall.respondPreflight(
 
     if (!corsCheckRequestMethod(methods)) {
         LOGGER.trace { "${request.id()}: Preflight: Request method check fails" }
-        respond(HttpStatusCode.Forbidden)
+        respond(HttpStatusCode.OK)
         return
     }
 
@@ -250,7 +253,7 @@ private suspend fun ApplicationCall.respondPreflight(
         }
 
         LOGGER.trace { "${request.id()}: Preflight: Check on headers from Access-Control-Request-Headers fails" }
-        respond(HttpStatusCode.Forbidden)
+        respond(HttpStatusCode.OK)
         return
     }
 

--- a/ktor-server/ktor-server-plugins/ktor-server-cors/common/src/io/ktor/server/plugins/cors/CORSUtils.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-cors/common/src/io/ktor/server/plugins/cors/CORSUtils.kt
@@ -127,10 +127,6 @@ internal fun ApplicationCall.corsCheckRequestMethod(methods: Set<HttpMethod>): B
     return requestMethod != null && requestMethod in methods
 }
 
-internal suspend fun ApplicationCall.respondCorsFailed() {
-    respond(HttpStatusCode.Forbidden)
-}
-
 internal fun isValidOrigin(origin: String): Boolean {
     if (origin.isEmpty()) return false
     if (origin == "null") return true

--- a/ktor-server/ktor-server-tests/common/test/io/ktor/tests/server/plugins/CORSTest.kt
+++ b/ktor-server/ktor-server-tests/common/test/io/ktor/tests/server/plugins/CORSTest.kt
@@ -103,8 +103,9 @@ class CORSTest {
         client.get("/") {
             header(HttpHeaders.Origin, "http://other-host")
         }.let { call ->
-            assertEquals(HttpStatusCode.Forbidden, call.status)
-            assertEquals("", call.bodyAsText())
+            assertEquals(HttpStatusCode.OK, call.status)
+            assertNull(call.headers[HttpHeaders.AccessControlAllowOrigin])
+            assertEquals("OK", call.bodyAsText())
         }
     }
 
@@ -145,7 +146,9 @@ class CORSTest {
         client.get("/1") {
             header(HttpHeaders.Origin, "http://other-host")
         }.let { response ->
-            assertEquals(HttpStatusCode.Forbidden, response.status)
+            assertEquals(HttpStatusCode.OK, response.status)
+            assertNull(response.headers[HttpHeaders.AccessControlAllowOrigin])
+            assertEquals("OK", response.bodyAsText())
         }
 
         client.get("/2") {
@@ -189,8 +192,9 @@ class CORSTest {
         client.get("/") {
             header(HttpHeaders.Origin, "http://my-host:90")
         }.let { call ->
-            assertEquals(HttpStatusCode.Forbidden, call.status)
-            assertEquals("", call.bodyAsText())
+            assertEquals(HttpStatusCode.OK, call.status)
+            assertNull(call.headers[HttpHeaders.AccessControlAllowOrigin])
+            assertEquals("OK", call.bodyAsText())
         }
     }
 
@@ -281,8 +285,9 @@ class CORSTest {
         client.get("/") {
             header(HttpHeaders.Origin, "http://other-host")
         }.let { call ->
-            assertEquals(HttpStatusCode.Forbidden, call.status)
-            assertEquals("", call.bodyAsText())
+            assertEquals(HttpStatusCode.OK, call.status)
+            assertNull(call.headers[HttpHeaders.AccessControlAllowOrigin])
+            assertEquals("OK", call.bodyAsText())
         }
     }
 
@@ -317,8 +322,9 @@ class CORSTest {
         client.get("/") {
             header(HttpHeaders.Origin, "http://other.my-host")
         }.let { call ->
-            assertEquals(HttpStatusCode.Forbidden, call.status)
-            assertEquals("", call.bodyAsText())
+            assertEquals(HttpStatusCode.OK, call.status)
+            assertNull(call.headers[HttpHeaders.AccessControlAllowOrigin])
+            assertEquals("OK", call.bodyAsText())
         }
     }
 
@@ -445,7 +451,9 @@ class CORSTest {
         client.get("/") {
             header(HttpHeaders.Origin, "http://localhost:8080")
         }.let { call ->
-            assertEquals(HttpStatusCode.Forbidden, call.status)
+            assertEquals(HttpStatusCode.OK, call.status)
+            assertNull(call.headers[HttpHeaders.AccessControlAllowOrigin])
+            assertEquals("OK", call.bodyAsText())
         }
     }
 
@@ -464,13 +472,17 @@ class CORSTest {
         client.get("/") {
             header(HttpHeaders.Origin, "http://localhost")
         }.let { call ->
-            assertEquals(HttpStatusCode.Forbidden, call.status)
+            assertEquals(HttpStatusCode.OK, call.status)
+            assertNull(call.headers[HttpHeaders.AccessControlAllowOrigin])
+            assertEquals("OK", call.bodyAsText())
         }
 
         client.get("/") {
             header(HttpHeaders.Origin, "http://localhost:8080")
         }.let { call ->
-            assertEquals(HttpStatusCode.Forbidden, call.status)
+            assertEquals(HttpStatusCode.OK, call.status)
+            assertNull(call.headers[HttpHeaders.AccessControlAllowOrigin])
+            assertEquals("OK", call.bodyAsText())
         }
     }
 
@@ -512,7 +524,9 @@ class CORSTest {
             header(HttpHeaders.Origin, "http://my-host")
             header(HttpHeaders.ContentType, "application/json") // non-simple Content-Type value
         }.let { call ->
-            assertEquals(HttpStatusCode.Forbidden, call.status)
+            assertEquals(HttpStatusCode.OK, call.status)
+            assertNull(call.headers[HttpHeaders.AccessControlAllowOrigin])
+            assertEquals("OK", call.bodyAsText())
         }
 
         client.post("/") {
@@ -552,7 +566,8 @@ class CORSTest {
                 "${HttpHeaders.Accept},${HttpHeaders.ContentType}"
             )
         }.let { call ->
-            assertEquals(HttpStatusCode.Forbidden, call.status)
+            assertEquals(HttpStatusCode.OK, call.status)
+            assertNull(call.headers[HttpHeaders.AccessControlAllowOrigin])
         }
     }
 
@@ -582,7 +597,8 @@ class CORSTest {
             header(HttpHeaders.Origin, "http://my-host")
             header(HttpHeaders.AccessControlRequestMethod, "PUT")
         }.let { call ->
-            assertEquals(HttpStatusCode.Forbidden, call.status)
+            assertEquals(HttpStatusCode.OK, call.status)
+            assertNull(call.headers[HttpHeaders.AccessControlAllowOrigin])
         }
 
         // simple request header is always allowed
@@ -602,7 +618,8 @@ class CORSTest {
             header(HttpHeaders.AccessControlRequestMethod, "GET")
             header(HttpHeaders.AccessControlRequestHeaders, HttpHeaders.ContentType)
         }.let { call ->
-            assertEquals(HttpStatusCode.Forbidden, call.status)
+            assertEquals(HttpStatusCode.OK, call.status)
+            assertNull(call.headers[HttpHeaders.AccessControlAllowOrigin])
         }
 
         // custom header that is not allowed
@@ -611,7 +628,8 @@ class CORSTest {
             header(HttpHeaders.AccessControlRequestMethod, "GET")
             header(HttpHeaders.AccessControlRequestHeaders, HttpHeaders.ALPN)
         }.let { call ->
-            assertEquals(HttpStatusCode.Forbidden, call.status)
+            assertEquals(HttpStatusCode.OK, call.status)
+            assertNull(call.headers[HttpHeaders.AccessControlAllowOrigin])
         }
 
         // custom header that is allowed
@@ -654,7 +672,7 @@ class CORSTest {
             header(HttpHeaders.Origin, "http://my-host")
             header(HttpHeaders.AccessControlRequestMethod, "PUT")
         }.let { call ->
-            assertEquals(HttpStatusCode.Forbidden, call.status)
+            assertEquals(HttpStatusCode.OK, call.status)
             assertEquals(null, call.headers[HttpHeaders.AccessControlAllowOrigin])
         }
 
@@ -873,7 +891,8 @@ class CORSTest {
             header(HttpHeaders.AccessControlRequestMethod, "GET")
             header(HttpHeaders.AccessControlRequestHeaders, "x-header1")
         }.let { call ->
-            assertEquals(HttpStatusCode.Forbidden, call.status)
+            assertEquals(HttpStatusCode.OK, call.status)
+            assertNull(call.headers[HttpHeaders.AccessControlAllowOrigin])
         }
     }
 
@@ -971,13 +990,15 @@ class CORSTest {
         client.get("/") {
             header(HttpHeaders.Origin, "http://localhost:3000/")
         }.let {
-            assertEquals(HttpStatusCode.Forbidden, it.status)
+            assertEquals(HttpStatusCode.OK, it.status)
+            assertNull(it.headers[HttpHeaders.AccessControlAllowOrigin])
         }
 
         client.get("/") {
             header(HttpHeaders.Origin, "http://localhost:3000")
         }.let {
-            assertEquals(HttpStatusCode.Forbidden, it.status)
+            assertEquals(HttpStatusCode.OK, it.status)
+            assertNull(it.headers[HttpHeaders.AccessControlAllowOrigin])
         }
     }
 
@@ -1044,7 +1065,7 @@ class CORSTest {
             client.get { headers.append(HttpHeaders.Origin, "http://foo.bar.domain.com") }.status
         )
         assertEquals(
-            HttpStatusCode.Forbidden,
+            HttpStatusCode.OK,
             client.get { headers.append(HttpHeaders.Origin, "http://domain.net") }.status
         )
         assertEquals(
@@ -1056,11 +1077,11 @@ class CORSTest {
             client.get { headers.append(HttpHeaders.Origin, "https://www.domain.com") }.status
         )
         assertEquals(
-            HttpStatusCode.Forbidden,
+            HttpStatusCode.OK,
             client.get { headers.append(HttpHeaders.Origin, "https://domain.net") }.status
         )
         assertEquals(
-            HttpStatusCode.Forbidden,
+            HttpStatusCode.OK,
             client.get { headers.append(HttpHeaders.Origin, "sftp://domain.com") }.status
         )
     }
@@ -1098,7 +1119,7 @@ class CORSTest {
             }.status
         )
         assertEquals(
-            HttpStatusCode.Forbidden,
+            HttpStatusCode.OK,
             client.get {
                 headers.append(
                     HttpHeaders.Origin,
@@ -1204,15 +1225,17 @@ class CORSTest {
         client.get("/") {
             header(HttpHeaders.Origin, "https://forbidden-host")
         }.let { call ->
-            assertEquals(HttpStatusCode.Forbidden, call.status)
-            assertEquals("", call.bodyAsText())
+            assertEquals(HttpStatusCode.OK, call.status)
+            assertNull(call.headers[HttpHeaders.AccessControlAllowOrigin])
+            assertEquals("OK", call.bodyAsText())
         }
 
         client.get("/") {
             header(HttpHeaders.Origin, "http://allowed-host")
         }.let { call ->
-            assertEquals(HttpStatusCode.Forbidden, call.status)
-            assertEquals("", call.bodyAsText())
+            assertEquals(HttpStatusCode.OK, call.status)
+            assertNull(call.headers[HttpHeaders.AccessControlAllowOrigin])
+            assertEquals("OK", call.bodyAsText())
         }
     }
 
@@ -1253,8 +1276,9 @@ class CORSTest {
         client.get("/") {
             header(HttpHeaders.Origin, "https://host.net")
         }.let { call ->
-            assertEquals(HttpStatusCode.Forbidden, call.status)
-            assertEquals("", call.bodyAsText())
+            assertEquals(HttpStatusCode.OK, call.status)
+            assertNull(call.headers[HttpHeaders.AccessControlAllowOrigin])
+            assertEquals("OK", call.bodyAsText())
         }
     }
 
@@ -1342,7 +1366,8 @@ class CORSTest {
             header(HttpHeaders.Origin, "https://example.com")
             header(HttpHeaders.AccessControlRequestMethod, "GET")
         }.let { response ->
-            assertEquals(response.status, HttpStatusCode.Forbidden)
+            assertEquals(response.status, HttpStatusCode.OK)
+            assertNull(response.headers[HttpHeaders.AccessControlAllowOrigin])
         }
 
         client.options("/") {
@@ -1358,7 +1383,8 @@ class CORSTest {
             header(HttpHeaders.Origin, "https://another.com")
             header(HttpHeaders.AccessControlRequestMethod, "GET")
         }.let { response ->
-            assertEquals(response.status, HttpStatusCode.Forbidden)
+            assertEquals(response.status, HttpStatusCode.OK)
+            assertNull(response.headers[HttpHeaders.AccessControlAllowOrigin])
         }
     }
 
@@ -1510,7 +1536,8 @@ class CORSTest {
             header(HttpHeaders.Origin, "https://example.com")
             header(HttpHeaders.AccessControlRequestMethod, "PATCH")
         }.let { response ->
-            assertEquals(response.status, HttpStatusCode.Forbidden)
+            assertEquals(response.status, HttpStatusCode.OK)
+            assertNull(response.headers[HttpHeaders.AccessControlAllowOrigin])
         }
 
         client.options("/other") {
@@ -1526,7 +1553,8 @@ class CORSTest {
             header(HttpHeaders.Origin, "https://example.com")
             header(HttpHeaders.AccessControlRequestMethod, "PUT")
         }.let { response ->
-            assertEquals(response.status, HttpStatusCode.Forbidden)
+            assertEquals(response.status, HttpStatusCode.OK)
+            assertNull(response.headers[HttpHeaders.AccessControlAllowOrigin])
         }
     }
 
@@ -1589,7 +1617,8 @@ class CORSTest {
             header(HttpHeaders.Origin, "https://example.com")
             header(HttpHeaders.AccessControlRequestMethod, "GET")
         }.let { response ->
-            assertEquals(response.status, HttpStatusCode.Forbidden)
+            assertEquals(response.status, HttpStatusCode.OK)
+            assertNull(response.headers[HttpHeaders.AccessControlAllowOrigin])
         }
     }
 

--- a/ktor-server/ktor-server-tests/common/test/io/ktor/tests/server/plugins/CORSTest.kt
+++ b/ktor-server/ktor-server-tests/common/test/io/ktor/tests/server/plugins/CORSTest.kt
@@ -1592,4 +1592,91 @@ class CORSTest {
             assertEquals(response.status, HttpStatusCode.Forbidden)
         }
     }
+
+    @Test
+    fun `KTOR-4237 preflight with disallowed method should not respond with 403`() = testApplication {
+        install(CORS) {
+            anyHost()
+            allowMethod(HttpMethod.Delete)
+        }
+
+        routing {
+            get("/") {
+                call.respond("OK")
+            }
+        }
+
+        client.options("/") {
+            header(HttpHeaders.Origin, "http://my-host")
+            header(HttpHeaders.AccessControlRequestMethod, "PUT")
+        }.let { call ->
+            assertNotEquals(HttpStatusCode.Forbidden, call.status)
+            assertNull(call.headers[HttpHeaders.AccessControlAllowOrigin])
+        }
+    }
+
+    @Test
+    fun `KTOR-4237 preflight with disallowed headers should not respond with 403`() = testApplication {
+        install(CORS) {
+            anyHost()
+            allowHeader("X-Allowed")
+        }
+
+        routing {
+            get("/") {
+                call.respond("OK")
+            }
+        }
+
+        client.options("/") {
+            header(HttpHeaders.Origin, "http://my-host")
+            header(HttpHeaders.AccessControlRequestMethod, "GET")
+            header(HttpHeaders.AccessControlRequestHeaders, "X-Not-Allowed")
+        }.let { call ->
+            assertNotEquals(HttpStatusCode.Forbidden, call.status)
+            assertNull(call.headers[HttpHeaders.AccessControlAllowOrigin])
+        }
+    }
+
+    @Test
+    fun `KTOR-4237 actual request with disallowed origin should not respond with 403`() = testApplication {
+        install(CORS) {
+            allowHost("my-host")
+        }
+
+        routing {
+            get("/") {
+                call.respond("OK")
+            }
+        }
+
+        client.get("/") {
+            header(HttpHeaders.Origin, "http://other-host")
+        }.let { call ->
+            assertNotEquals(HttpStatusCode.Forbidden, call.status)
+            assertNull(call.headers[HttpHeaders.AccessControlAllowOrigin])
+            assertEquals("OK", call.bodyAsText())
+        }
+    }
+
+    @Test
+    fun `KTOR-4237 preflight with disallowed origin should not respond with 403`() = testApplication {
+        install(CORS) {
+            allowHost("my-host")
+        }
+
+        routing {
+            get("/") {
+                call.respond("OK")
+            }
+        }
+
+        client.options("/") {
+            header(HttpHeaders.Origin, "http://other-host")
+            header(HttpHeaders.AccessControlRequestMethod, "GET")
+        }.let { call ->
+            assertNotEquals(HttpStatusCode.Forbidden, call.status)
+            assertNull(call.headers[HttpHeaders.AccessControlAllowOrigin])
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- Fixes [KTOR-4237](https://youtrack.jetbrains.com/issue/KTOR-4237)
- The CORS specification does not define HTTP 403 as a valid response for failed CORS checks. Servers should simply omit CORS headers and let the browser enforce the policy. This PR removes all 403 responses from the CORS plugin:
  - Failed preflight (OPTIONS) requests now respond with 200 OK without CORS headers, so the browser blocks the subsequent actual request
  - Failed actual requests proceed to the route handler without CORS headers, so the browser blocks JavaScript access to the response
  - Removes the now-unused `respondCorsFailed()` utility function

KTOR-4237

## Test plan
- Added 4 new reproducer tests that validate the fix (committed separately as a failing test first)
- Updated all existing CORS tests to expect the new spec-compliant behavior
- All 60 CORS tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)