### PR TITLE
KTOR-9373 Make ConcurrentMap iteration safe on Native

### DIFF
--- a/ktor-client/ktor-client-cio/common/test/CIOEngineTest.kt
+++ b/ktor-client/ktor-client-cio/common/test/CIOEngineTest.kt
@@ -172,6 +172,26 @@ class CIOEngineTest : ClientEngineTest<CIOEngineConfig>(CIO) {
     }
 
     @Test
+    fun `KTOR-9373 close engine with active endpoints does not throw ConcurrentModificationException`() = testClient {
+        test { client ->
+            // Make requests to multiple distinct endpoints to populate the endpoints map
+            val jobs = (1..5).map { i ->
+                client.async {
+                    runCatching {
+                        client.get("$TEST_SERVER/content/hello?i=$i")
+                    }
+                }
+            }
+            jobs.forEach { it.await() }
+
+            // Closing the client triggers CIOEngine.close(), which:
+            // 1. Calls super.close() - cancels child coroutines (including Endpoint timeout coroutines)
+            // 2. Iterates endpoints.forEach - but onDone callbacks from cancelled coroutines may
+            //    concurrently remove entries from the map, causing ConcurrentModificationException on Native
+        }
+    }
+
+    @Test
     fun testErrorMessageWhenServerDontRespondWithUpgrade() = testClient {
         config {
             install(WebSockets)

--- a/ktor-client/ktor-client-cio/common/test/CIOEngineTest.kt
+++ b/ktor-client/ktor-client-cio/common/test/CIOEngineTest.kt
@@ -172,9 +172,8 @@ class CIOEngineTest : ClientEngineTest<CIOEngineConfig>(CIO) {
     }
 
     @Test
-    fun `KTOR-9373 close engine with active endpoints does not throw ConcurrentModificationException`() = testClient {
+    fun `close engine with active endpoints does not throw ConcurrentModificationException`() = testClient {
         test { client ->
-            // Make requests to multiple distinct endpoints to populate the endpoints map
             val jobs = (1..5).map { i ->
                 client.async {
                     runCatching {
@@ -183,11 +182,6 @@ class CIOEngineTest : ClientEngineTest<CIOEngineConfig>(CIO) {
                 }
             }
             jobs.forEach { it.await() }
-
-            // Closing the client triggers CIOEngine.close(), which:
-            // 1. Calls super.close() - cancels child coroutines (including Endpoint timeout coroutines)
-            // 2. Iterates endpoints.forEach - but onDone callbacks from cancelled coroutines may
-            //    concurrently remove entries from the map, causing ConcurrentModificationException on Native
         }
     }
 

--- a/ktor-utils/posix/src/io/ktor/util/collections/ConcurrentMapNative.kt
+++ b/ktor-utils/posix/src/io/ktor/util/collections/ConcurrentMapNative.kt
@@ -32,7 +32,7 @@ public actual class ConcurrentMap<Key, Value> public actual constructor(
     }
 
     actual override val size: Int
-        get() = delegate.size
+        get() = synchronized(lock) { delegate.size }
 
     actual override fun containsKey(key: Key): Boolean = synchronized(lock) { delegate.containsKey(key) }
 
@@ -40,16 +40,16 @@ public actual class ConcurrentMap<Key, Value> public actual constructor(
 
     actual override fun get(key: Key): Value? = synchronized(lock) { delegate[key] }
 
-    actual override fun isEmpty(): Boolean = delegate.isEmpty()
+    actual override fun isEmpty(): Boolean = synchronized(lock) { delegate.isEmpty() }
 
     actual override val entries: MutableSet<MutableMap.MutableEntry<Key, Value>>
-        get() = synchronized(lock) { delegate.entries }
+        get() = synchronized(lock) { LinkedHashSet(delegate.entries) }
 
     actual override val keys: MutableSet<Key>
-        get() = synchronized(lock) { delegate.keys }
+        get() = synchronized(lock) { LinkedHashSet(delegate.keys) }
 
     actual override val values: MutableCollection<Value>
-        get() = synchronized(lock) { delegate.values }
+        get() = synchronized(lock) { ArrayList(delegate.values) }
 
     actual override fun clear() {
         synchronized(lock) {

--- a/ktor-utils/posix/src/io/ktor/util/collections/ConcurrentMapNative.kt
+++ b/ktor-utils/posix/src/io/ktor/util/collections/ConcurrentMapNative.kt
@@ -43,7 +43,7 @@ public actual class ConcurrentMap<Key, Value> public actual constructor(
     actual override fun isEmpty(): Boolean = synchronized(lock) { delegate.isEmpty() }
 
     actual override val entries: MutableSet<MutableMap.MutableEntry<Key, Value>>
-        get() = synchronized(lock) { LinkedHashSet(delegate.entries) }
+        get() = synchronized(lock) { LinkedHashMap(delegate).entries }
 
     actual override val keys: MutableSet<Key>
         get() = synchronized(lock) { LinkedHashSet(delegate.keys) }


### PR DESCRIPTION
## Summary
- Fixes [KTOR-9373](https://youtrack.jetbrains.com/issue/KTOR-9373)
- On Native, `ConcurrentMap.entries`/`keys`/`values` returned live views of the underlying `LinkedHashMap` — the lock was only held during property access, not during iteration. Concurrent modification (e.g. `remove` from another thread) during iteration caused `ConcurrentModificationException`.
- Fix: return snapshot copies from `entries`/`keys`/`values`, matching JVM `ConcurrentHashMap`'s weakly-consistent iteration semantics. Also synchronize `size` and `isEmpty()` which were reading without the lock.

## Test plan
- Added test that exercises `CIOEngine.close()` with active endpoints (the original crash site)
- All existing tests in `ktor-utils` and `ktor-client-cio` continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)