### PR TITLE
KTOR-9344 Disable switching to engine dispatcher by default

### DIFF
--- a/ktor-client/ktor-client-core/api/ktor-client-core.api
+++ b/ktor-client/ktor-client-core/api/ktor-client-core.api
@@ -1552,6 +1552,10 @@ public final class io/ktor/client/statement/DefaultHttpResponse : io/ktor/client
 	public fun getVersion ()Lio/ktor/http/HttpProtocolVersion;
 }
 
+public final class io/ktor/client/statement/DispatcherSwitching_jvmKt {
+	public static final fun getUseEngineDispatcher ()Z
+}
+
 public final class io/ktor/client/statement/HttpReceivePipeline : io/ktor/util/pipeline/Pipeline {
 	public static final field Phases Lio/ktor/client/statement/HttpReceivePipeline$Phases;
 	public fun <init> ()V

--- a/ktor-client/ktor-client-core/api/ktor-client-core.klib.api
+++ b/ktor-client/ktor-client-core/api/ktor-client-core.klib.api
@@ -1453,6 +1453,8 @@ final val io.ktor.client.statement/content // io.ktor.client.statement/content|@
     final fun (io.ktor.client.statement/HttpResponse).<get-content>(): io.ktor.utils.io/ByteReadChannel // io.ktor.client.statement/content.<get-content>|<get-content>@io.ktor.client.statement.HttpResponse(){}[0]
 final val io.ktor.client.statement/request // io.ktor.client.statement/request|@io.ktor.client.statement.HttpResponse{}request[0]
     final fun (io.ktor.client.statement/HttpResponse).<get-request>(): io.ktor.client.request/HttpRequest // io.ktor.client.statement/request.<get-request>|<get-request>@io.ktor.client.statement.HttpResponse(){}[0]
+final val io.ktor.client.statement/useEngineDispatcher // io.ktor.client.statement/useEngineDispatcher|{}useEngineDispatcher[0]
+    final fun <get-useEngineDispatcher>(): kotlin/Boolean // io.ktor.client.statement/useEngineDispatcher.<get-useEngineDispatcher>|<get-useEngineDispatcher>(){}[0]
 final val io.ktor.client.utils/HttpRequestCreated // io.ktor.client.utils/HttpRequestCreated|{}HttpRequestCreated[0]
     final fun <get-HttpRequestCreated>(): io.ktor.events/EventDefinition<io.ktor.client.request/HttpRequestBuilder> // io.ktor.client.utils/HttpRequestCreated.<get-HttpRequestCreated>|<get-HttpRequestCreated>(){}[0]
 final val io.ktor.client.utils/HttpRequestIsReadyForSending // io.ktor.client.utils/HttpRequestIsReadyForSending|{}HttpRequestIsReadyForSending[0]

--- a/ktor-client/ktor-client-core/common/src/io/ktor/client/statement/DispatcherSwitching.kt
+++ b/ktor-client/ktor-client-core/common/src/io/ktor/client/statement/DispatcherSwitching.kt
@@ -1,0 +1,12 @@
+/*
+ * Copyright 2014-2026 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.client.statement
+
+/**
+ * Controls whether HttpStatement.execute and body blocks are executed on the engine's dispatcher by default.
+ * Can be overridden via system property `io.ktor.client.statement.useEngineDispatcher` on JVM.
+ */
+@PublishedApi
+internal expect val useEngineDispatcher: Boolean

--- a/ktor-client/ktor-client-core/common/src/io/ktor/client/statement/HttpStatement.kt
+++ b/ktor-client/ktor-client-core/common/src/io/ktor/client/statement/HttpStatement.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2014-2026 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package io.ktor.client.statement
@@ -47,8 +47,16 @@ public class HttpStatement(
      * The response object should not be accessed outside of [block] as it will be canceled upon
      * block completion.
      *
-     * The [block] is executed on the engine's dispatcher, making it safe to perform IO operations
-     * such as reading the response content and writing it into a file.
+     * ## Dispatcher Behavior
+     * On non-JVM platforms (Web, Native), the [block] is executed on the engine's dispatcher,
+     * making it safe to perform IO operations such as reading the response content and writing it into a file.
+     *
+     * On JVM, the [block] runs on the caller's dispatcher by default for backward compatibility.
+     * To enable engine dispatcher switching on JVM, set the system property:
+     * `-Dio.ktor.client.statement.useEngineDispatcher=true`
+     *
+     * **Note:** Starting from Ktor 4.0, dispatcher switching will be enabled by default on all platforms.
+     * It is recommended to opt-in early to ensure compatibility with the upcoming release.
      *
      * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.client.statement.HttpStatement.execute)
      *
@@ -59,7 +67,11 @@ public class HttpStatement(
         val response = fetchStreamingResponse()
 
         try {
-            return withContext(response.coroutineContext[ContinuationInterceptor]!!) {
+            return if (useEngineDispatcher) {
+                withContext(response.coroutineContext[ContinuationInterceptor]!!) {
+                    block(response)
+                }
+            } else {
                 block(response)
             }
         } finally {
@@ -114,8 +126,16 @@ public class HttpStatement(
      * Once [block] completes, the resources associated with the response are automatically cleaned up, freeing
      * any network or memory resources held by the response.
      *
-     * The [block] is executed on the engine's dispatcher, making it safe to perform IO operations
-     * such as writing to a file.
+     * ## Dispatcher Behavior
+     * On non-JVM platforms (Web, Native), the [block] is executed on the engine's dispatcher,
+     * making it safe to perform IO operations such as writing to a file.
+     *
+     * On JVM, the [block] runs on the caller's dispatcher by default for backward compatibility.
+     * To enable engine dispatcher switching on JVM, set the system property:
+     * `-Dio.ktor.client.statement.useEngineDispatcher=true`
+     *
+     * **Note:** Starting from Ktor 4.0, dispatcher switching will be enabled by default on all platforms.
+     * It is recommended to opt-in early to ensure compatibility with the upcoming release.
      *
      * ## Usage Example
      * ```
@@ -140,7 +160,12 @@ public class HttpStatement(
     ): R = unwrapRequestTimeoutException {
         val response: HttpResponse = fetchStreamingResponse()
         try {
-            return withContext(response.coroutineContext[ContinuationInterceptor]!!) {
+            return if (useEngineDispatcher) {
+                withContext(response.coroutineContext[ContinuationInterceptor]!!) {
+                    val result = response.body<T>()
+                    block(result)
+                }
+            } else {
                 val result = response.body<T>()
                 block(result)
             }

--- a/ktor-client/ktor-client-core/jvm/src/io/ktor/client/statement/DispatcherSwitching.jvm.kt
+++ b/ktor-client/ktor-client-core/jvm/src/io/ktor/client/statement/DispatcherSwitching.jvm.kt
@@ -1,0 +1,10 @@
+/*
+ * Copyright 2014-2026 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.client.statement
+
+private const val USE_ENGINE_DISPATCHER_KEY: String = "io.ktor.client.statement.useEngineDispatcher"
+
+@PublishedApi
+internal actual val useEngineDispatcher: Boolean = System.getProperty(USE_ENGINE_DISPATCHER_KEY, "false").toBoolean()

--- a/ktor-client/ktor-client-core/nonJvm/src/io/ktor/client/statement/DispatcherSwitching.nonJvm.kt
+++ b/ktor-client/ktor-client-core/nonJvm/src/io/ktor/client/statement/DispatcherSwitching.nonJvm.kt
@@ -1,0 +1,8 @@
+/*
+ * Copyright 2014-2026 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.client.statement
+
+@PublishedApi
+internal actual val useEngineDispatcher: Boolean = true

--- a/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/DispatcherTest.kt
+++ b/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/DispatcherTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2014-2026 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package io.ktor.client.tests
@@ -43,7 +43,7 @@ class DispatcherTest : ClientLoader() {
     }
 
     @Test
-    fun `test HttpStatement_execute uses the engine dispatcher`() = clientTests {
+    fun `test HttpStatement_execute uses the engine dispatcher on non-JVM platforms`() = clientTests(except("jvm:*")) {
         test { client ->
             client.prepareGet("$TEST_SERVER/").execute {
                 val currentDispatcher = currentCoroutineContext()[ContinuationInterceptor]
@@ -53,11 +53,39 @@ class DispatcherTest : ClientLoader() {
     }
 
     @Test
-    fun `test HttpStatement_body uses the engine dispatcher`() = clientTests {
+    fun `test HttpStatement_body uses the engine dispatcher on non-JVM platforms`() = clientTests(except("jvm:*")) {
         test { client ->
             client.prepareGet("$TEST_SERVER/").body { _: String ->
                 val currentDispatcher = currentCoroutineContext()[ContinuationInterceptor]
                 assertEquals(client.engine.dispatcher, currentDispatcher)
+            }
+        }
+    }
+
+    @Test
+    fun `test HttpStatement_execute stays on caller dispatcher on JVM by default`() = clientTests(only("jvm:*")) {
+        val testDispatcher = Dispatchers.Default.limitedParallelism(1)
+
+        test { client ->
+            kotlinx.coroutines.withContext(testDispatcher) {
+                client.prepareGet("$TEST_SERVER/").execute {
+                    val currentDispatcher = currentCoroutineContext()[ContinuationInterceptor]
+                    assertEquals(testDispatcher, currentDispatcher)
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `test HttpStatement_body stays on caller dispatcher on JVM by default`() = clientTests(only("jvm:*")) {
+        val testDispatcher = Dispatchers.Default.limitedParallelism(1)
+
+        test { client ->
+            kotlinx.coroutines.withContext(testDispatcher) {
+                client.prepareGet("$TEST_SERVER/").body { _: String ->
+                    val currentDispatcher = currentCoroutineContext()[ContinuationInterceptor]
+                    assertEquals(testDispatcher, currentDispatcher)
+                }
             }
         }
     }


### PR DESCRIPTION
**Subsystem**
Client Core

**Motivation**
[KTOR-9344](https://youtrack.jetbrains.com/issue/KTOR-9344) Flow invariant error happens after update to Ktor 3.4.0

**Solution**
Disable dispatcher switching by default on JVM, introduce a system property `io.ktor.client.statement.useEngineDispatcher` to make it possible to enable it.