### PR TITLE
KTOR-9337 Add dedicated Netty TLS+HTTP/2 server for client tests

### DIFF
--- a/ktor-client/ktor-client-tests/common/src/io/ktor/client/tests/Http2Test.kt
+++ b/ktor-client/ktor-client-tests/common/src/io/ktor/client/tests/Http2Test.kt
@@ -19,7 +19,7 @@ abstract class Http2Test<T : HttpClientEngineConfig>(
     private val useH2c: Boolean = true,
 ) : ClientEngineTest<T>(factory) {
 
-    private val testHost = if (useH2c) "http://localhost:8084" else "https://localhost:8089"
+    private val testHost = if (useH2c) "http://localhost:8084" else "https://localhost:8085"
 
     protected open fun T.enableHttp2() {}
 

--- a/ktor-test-server/src/main/kotlin/test/server/TestServer.kt
+++ b/ktor-test-server/src/main/kotlin/test/server/TestServer.kt
@@ -23,6 +23,7 @@ private const val DEFAULT_TLS_PORT: Int = 8089
 private const val HTTP_PROXY_PORT: Int = 8082
 private const val SOCKS_PROXY_PORT: Int = 8083
 private const val HTTP2_SERVER_PORT: Int = 8084
+private const val HTTP2_TLS_SERVER_PORT: Int = 8085
 
 internal fun startServer(): Closeable {
     val scope = CloseableGroup()
@@ -39,6 +40,7 @@ internal fun startServer(): Closeable {
 
         scope.use(embeddedServer(CIO, DEFAULT_PORT, module = Application::tests))
         scope.use(setupHttp2Server(HTTP2_SERVER_PORT, module = Application::tests))
+        scope.use(setupHttp2TlsServer(HTTP2_TLS_SERVER_PORT, module = Application::tests))
         scope.use(setupTLSServer(DEFAULT_TLS_PORT, module = Application::tlsTests))
 
         Thread.sleep(1000)
@@ -87,3 +89,27 @@ private fun setupHttp2Server(
     },
     module = module,
 )
+
+private fun setupHttp2TlsServer(
+    @Suppress("SameParameterValue") port: Int,
+    module: suspend Application.() -> Unit,
+): EmbeddedServer<*, *> {
+    val file = File.createTempFile("server", "certificate")
+    val testKeyStore = generateCertificate(file)
+    return embeddedServer(
+        factory = Netty,
+        configure = {
+            sslConnector(
+                keyStore = testKeyStore,
+                keyAlias = "mykey",
+                keyStorePassword = { "changeit".toCharArray() },
+                privateKeyPassword = { "changeit".toCharArray() }
+            ) {
+                this.port = port
+                this.keyStorePath = file
+            }
+            enableHttp2 = true
+        },
+        module = module,
+    )
+}


### PR DESCRIPTION
## Summary
- Fixes [KTOR-9337](https://youtrack.jetbrains.com/issue/KTOR-9337)
- The `CurlHttp2Test` (and any `Http2Test` with `useH2c=false`) was connecting to the Jetty TLS server on port 8089, which was not specifically designed for HTTP/2 testing — it gets HTTP/2 implicitly from Jetty's `initializeServer`, not from explicit test infrastructure configuration
- Added a dedicated **Netty TLS+HTTP/2 server** on port 8085 with explicit ALPN configuration (`enableHttp2 = true` + `sslConnector`), and pointed `Http2Test` to use it for TLS-based HTTP/2 tests
- The existing Jetty TLS server on port 8089 remains unchanged for other TLS tests

KTOR-9337

## Test plan
- All JVM HTTP/2 tests pass (Java, Apache5, OkHttp, Jetty engines)
- The Curl test now connects to a server with reliable HTTP/2 over TLS via Netty's ALPN implementation
- No public API changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)