### PR TITLE
KTOR-9355 Deprecate HttpHeaders.AcceptCharset

### DIFF
--- a/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/HttpPlainText.kt
+++ b/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/HttpPlainText.kt
@@ -125,6 +125,7 @@ public val HttpPlainText: ClientPlugin<HttpPlainTextConfig> =
             return body.readText(charset = actualCharset)
         }
 
+        @Suppress("DEPRECATION")
         fun HttpRequestBuilder.addAcceptCharsetHeader(value: String?) {
             if (value == null || headers[HttpHeaders.AcceptCharset] != null) return
             LOGGER.trace("Adding Accept-Charset=$value to $url")

--- a/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/CharsetTest.kt
+++ b/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/CharsetTest.kt
@@ -19,6 +19,7 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
 
+@Suppress("DEPRECATION")
 class CharsetTest {
 
     @Test

--- a/ktor-http/common/src/io/ktor/http/HttpHeaders.kt
+++ b/ktor-http/common/src/io/ktor/http/HttpHeaders.kt
@@ -1,8 +1,10 @@
 /*
-* Copyright 2014-2021 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
-*/
+ * Copyright 2014-2026 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
 
 package io.ktor.http
+
+import io.ktor.http.HttpHeaders.UnsafeHeadersList
 
 @Suppress(
     "unused",
@@ -15,6 +17,11 @@ public object HttpHeaders {
     // The list is taken from https://www.iana.org/assignments/message-headers/message-headers.xml#perm-headers
 
     public const val Accept: String = "Accept"
+
+    @Deprecated(
+        "The Accept-Charset request header has been deprecated in RFC 9110. " +
+            "UTF-8 should be used by default in modern applications."
+    )
     public const val AcceptCharset: String = "Accept-Charset"
     public const val AcceptEncoding: String = "Accept-Encoding"
     public const val AcceptLanguage: String = "Accept-Language"
@@ -184,6 +191,7 @@ public object HttpHeaders {
     @Deprecated("Use Accept constant instead.", ReplaceWith("Accept"), DeprecationLevel.ERROR)
     public fun getAccept(): String = Accept
 
+    @Suppress("DEPRECATION")
     @Deprecated("Use AcceptCharset constant instead.", ReplaceWith("AcceptCharset"), DeprecationLevel.ERROR)
     public fun getAcceptCharset(): String = AcceptCharset
 

--- a/ktor-server/ktor-server-core/common/src/io/ktor/server/request/ApplicationRequestProperties.kt
+++ b/ktor-server/ktor-server-core/common/src/io/ktor/server/request/ApplicationRequestProperties.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2024 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2014-2026 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
 @file:Suppress("unused")
@@ -125,6 +125,7 @@ public fun ApplicationRequest.acceptLanguageItems(): List<HeaderValue> =
  *
  * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.server.request.acceptCharset)
  */
+@Suppress("DEPRECATION")
 public fun ApplicationRequest.acceptCharset(): String? = header(HttpHeaders.AcceptCharset)
 
 /**
@@ -132,6 +133,7 @@ public fun ApplicationRequest.acceptCharset(): String? = header(HttpHeaders.Acce
  *
  * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.server.request.acceptCharsetItems)
  */
+@Suppress("DEPRECATION")
 public fun ApplicationRequest.acceptCharsetItems(): List<HeaderValue> =
     parseAndSortHeader(header(HttpHeaders.AcceptCharset))
 

--- a/ktor-server/ktor-server-plugins/ktor-server-content-negotiation/common/test/ContentNegotiationTest.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-content-negotiation/common/test/ContentNegotiationTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2023 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2014-2026 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package io.ktor.server.plugins.contentnegotiation
@@ -245,6 +245,7 @@ class ContentNegotiationTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun testCustom() = testApplication {
         install(ContentNegotiation) {

--- a/ktor-shared/ktor-serialization/common/src/ContentConverter.kt
+++ b/ktor-shared/ktor-serialization/common/src/ContentConverter.kt
@@ -1,18 +1,17 @@
 /*
- * Copyright 2014-2021 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2014-2026 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package io.ktor.serialization
 
 import io.ktor.http.*
 import io.ktor.http.content.*
-import io.ktor.util.*
-import io.ktor.util.pipeline.*
 import io.ktor.util.reflect.*
 import io.ktor.utils.io.*
 import io.ktor.utils.io.charsets.*
-import io.ktor.utils.io.core.*
-import kotlinx.coroutines.flow.*
+import kotlinx.coroutines.flow.asFlow
+import kotlinx.coroutines.flow.firstOrNull
+import kotlinx.coroutines.flow.map
 
 /**
  * A custom content converter that could be registered in [ContentNegotiation] plugin for any particular content type
@@ -74,6 +73,7 @@ public fun Headers.suitableCharset(defaultCharset: Charset = Charsets.UTF_8): Ch
  * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.serialization.suitableCharsetOrNull)
  */
 public fun Headers.suitableCharsetOrNull(defaultCharset: Charset = Charsets.UTF_8): Charset? {
+    @Suppress("DEPRECATION")
     for ((charset, _) in parseAndSortHeader(get(HttpHeaders.AcceptCharset))) {
         when {
             charset == "*" -> return defaultCharset

--- a/ktor-shared/ktor-serialization/ktor-serialization-jackson/jvm/test/ServerJacksonTest.kt
+++ b/ktor-shared/ktor-serialization/ktor-serialization-jackson/jvm/test/ServerJacksonTest.kt
@@ -1,9 +1,10 @@
 /*
- * Copyright 2014-2024 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2014-2026 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
-import com.fasterxml.jackson.databind.*
-import com.fasterxml.jackson.dataformat.smile.*
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.SerializationFeature
+import com.fasterxml.jackson.dataformat.smile.SmileFactory
 import com.fasterxml.jackson.module.kotlin.*
 import io.ktor.client.request.*
 import io.ktor.client.statement.*
@@ -15,9 +16,11 @@ import io.ktor.server.request.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
 import io.ktor.server.testing.*
-import kotlinx.coroutines.flow.*
-import java.nio.charset.*
-import kotlin.test.*
+import kotlinx.coroutines.flow.flowOf
+import java.nio.charset.Charset
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
 
 class ServerJacksonTest : AbstractServerSerializationTest() {
     private val objectMapper = jacksonObjectMapper()
@@ -60,6 +63,7 @@ class ServerJacksonTest : AbstractServerSerializationTest() {
 
         client.get("/") {
             header(HttpHeaders.Accept, "application/json")
+            @Suppress("DEPRECATION")
             header(HttpHeaders.AcceptCharset, "UTF-16")
         }.let { response ->
             assertEquals(HttpStatusCode.OK, response.status)

--- a/ktor-shared/ktor-serialization/ktor-serialization-jackson3/jvm/test/ServerJacksonTest.kt
+++ b/ktor-shared/ktor-serialization/ktor-serialization-jackson3/jvm/test/ServerJacksonTest.kt
@@ -6,21 +6,22 @@ import io.ktor.client.request.*
 import io.ktor.client.statement.*
 import io.ktor.http.*
 import io.ktor.serialization.jackson3.*
-import io.ktor.serialization.jackson3.JacksonConverter
 import io.ktor.serialization.test.*
 import io.ktor.server.plugins.contentnegotiation.*
 import io.ktor.server.request.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
 import io.ktor.server.testing.*
-import kotlinx.coroutines.flow.*
-import tools.jackson.databind.*
-import tools.jackson.dataformat.smile.*
+import kotlinx.coroutines.flow.flowOf
+import tools.jackson.databind.ObjectMapper
+import tools.jackson.databind.SerializationFeature
+import tools.jackson.dataformat.smile.SmileFactory
+import tools.jackson.dataformat.smile.SmileMapper
 import tools.jackson.module.kotlin.*
-import tools.jackson.module.kotlin.jacksonObjectMapper
-import tools.jackson.module.kotlin.jacksonTypeRef
-import java.nio.charset.*
-import kotlin.test.*
+import java.nio.charset.Charset
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
 
 class ServerJacksonTest : AbstractServerSerializationTest() {
     private val objectMapper = jacksonObjectMapper()
@@ -63,6 +64,7 @@ class ServerJacksonTest : AbstractServerSerializationTest() {
 
         client.get("/") {
             header(HttpHeaders.Accept, "application/json")
+            @Suppress("DEPRECATION")
             header(HttpHeaders.AcceptCharset, "UTF-16")
         }.let { response ->
             assertEquals(HttpStatusCode.OK, response.status)

--- a/ktor-shared/ktor-serialization/ktor-serialization-tests/jvm/src/AbstractServerSerializationTest.kt
+++ b/ktor-shared/ktor-serialization/ktor-serialization-tests/jvm/src/AbstractServerSerializationTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2024 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2014-2026 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package io.ktor.serialization.test
@@ -12,10 +12,12 @@ import io.ktor.server.request.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
 import io.ktor.server.testing.*
-import kotlinx.coroutines.flow.*
-import kotlinx.serialization.*
-import java.nio.charset.*
-import kotlin.test.*
+import kotlinx.coroutines.flow.asFlow
+import kotlinx.serialization.Serializable
+import java.nio.charset.Charset
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
 
 public abstract class AbstractServerSerializationTest {
     private val uc = "\u0422"
@@ -114,6 +116,7 @@ public abstract class AbstractServerSerializationTest {
     @Test
     public fun testListAcceptUtf16(): Unit = withTestSerializingApplication {
         client.get("/list") {
+            @Suppress("DEPRECATION")
             header(HttpHeaders.AcceptCharset, "UTF-16")
         }.let { response -> verifyListResponse(response, Charsets.UTF_16) }
     }
@@ -129,6 +132,7 @@ public abstract class AbstractServerSerializationTest {
     @Test
     public open fun testFlowAcceptUtf16(): Unit = withTestSerializingApplication {
         client.get("/flow") {
+            @Suppress("DEPRECATION")
             header(HttpHeaders.AcceptCharset, "UTF-16")
         }.let { response -> verifyListResponse(response, Charsets.UTF_16) }
     }


### PR DESCRIPTION
**Subsystem**
`ktor-http`

**Motivation**
[KTOR-9355](https://youtrack.jetbrains.com/issue/KTOR-9355) Deprecate HttpHeaders.AcceptCharset

