### PR TITLE
Darwin Client. Use correct pins for certificate pinning

### DIFF
--- a/ktor-client/ktor-client-darwin/darwin/src/io/ktor/client/engine/darwin/certificates/CertificatePinner.kt
+++ b/ktor-client/ktor-client-darwin/darwin/src/io/ktor/client/engine/darwin/certificates/CertificatePinner.kt
@@ -173,8 +173,8 @@ public data class CertificatePinner(
             throw TlsPeerUnverifiedException("Unknown certificates")
         }
 
-        if (!hasOnePinnedCertificate(certificates)) {
-            val message = buildErrorMessage(certificates, hostname)
+        if (!hasOnePinnedCertificate(certificates, matchingPins)) {
+            val message = buildErrorMessage(certificates, hostname, matchingPins)
             throw TlsPeerUnverifiedException(message)
         }
         return true
@@ -185,14 +185,15 @@ public data class CertificatePinner(
      */
     @OptIn(ExperimentalForeignApi::class)
     private fun hasOnePinnedCertificate(
-        certificates: List<SecCertificateRef>
+        certificates: List<SecCertificateRef>,
+        pins: Collection<PinnedCertificate>
     ): Boolean = certificates.any { certificate ->
         val publicKey = certificate.getPublicKeyBytes() ?: return@any false
         // Lazily compute the hashes for each public key.
         var sha1: String? = null
         var sha256: String? = null
 
-        pinnedCertificates.any { pin ->
+        pins.any { pin ->
             when (pin.hashAlgorithm) {
                 CertificatesInfo.HASH_ALGORITHM_SHA_256 -> {
                     if (sha256 == null) {
@@ -221,7 +222,8 @@ public data class CertificatePinner(
     @OptIn(ExperimentalForeignApi::class)
     private fun buildErrorMessage(
         certificates: List<SecCertificateRef>,
-        hostname: String
+        hostname: String,
+        matchingPins: Collection<PinnedCertificate>
     ): String = buildString {
         append("Certificate pinning failure!")
         append("\n  Peer certificate chain:")
@@ -237,7 +239,7 @@ public data class CertificatePinner(
         append("\n  Pinned certificates for ")
         append(hostname)
         append(":")
-        for (pin in pinnedCertificates) {
+        for (pin in matchingPins) {
             append("\n    ")
             append(pin)
         }


### PR DESCRIPTION
**Subsystem**
Darwin Client

**Motivation**
See https://github.com/ktorio/ktor/issues/5309
YouTrack issue: [KTOR-9393](https://youtrack.jetbrains.com/issue/KTOR-9393) Certificate pinning matches against all pins instead of hostname-scoped pins

**Solution**
The solution is already described in the issue



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes – Version 3.4.1

* **New Features**
  * Added configurable dispatcher switching behavior for HTTP requests (enabled on non-JVM platforms, configurable on JVM via system property).
  * Enhanced JWT authentication with automatic EC key algorithm detection.

* **Bug Fixes**
  * Improved resource cleanup in native HTTP engines.
  * Enhanced error handling for socket timeout scenarios.

* **Tests**
  * Added dispatcher behavior validation tests across platforms.
  * Added JWT authentication tests for elliptic curve keys.
  * Added routing trace output validation tests.

* **Chores**
  * Applied security-focused dependency constraints.
  * Updated routing trace display format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->