### PR TITLE
KTOR-9187 Darwin Client. Close session once engine is closed

### DIFF
--- a/ktor-client/ktor-client-darwin-legacy/darwin/src/io/ktor/client/engine/darwin/DarwinLegacyClientEngine.kt
+++ b/ktor-client/ktor-client-darwin-legacy/darwin/src/io/ktor/client/engine/darwin/DarwinLegacyClientEngine.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2014-2026 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package io.ktor.client.engine.darwin
@@ -30,5 +30,10 @@ internal class DarwinLegacyClientEngine(
     override suspend fun execute(data: HttpRequestData): HttpResponseData {
         val callContext = callContext()
         return session.execute(data, callContext)
+    }
+
+    override fun close() {
+        super.close()
+        session.close()
     }
 }

--- a/ktor-client/ktor-client-darwin-legacy/darwin/src/io/ktor/client/engine/darwin/internal/legacy/DarwinLegacySession.kt
+++ b/ktor-client/ktor-client-darwin-legacy/darwin/src/io/ktor/client/engine/darwin/internal/legacy/DarwinLegacySession.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2023 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2014-2026 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package io.ktor.client.engine.darwin.internal.legacy
@@ -18,7 +18,7 @@ import kotlin.coroutines.*
 @Suppress("DEPRECATION")
 internal class DarwinLegacySession(
     private val config: DarwinLegacyClientEngineConfig,
-    private val requestQueue: NSOperationQueue?
+    requestQueue: NSOperationQueue?
 ) : Closeable {
     private val closed = atomic(false)
 
@@ -50,7 +50,7 @@ internal class DarwinLegacySession(
     }
 
     override fun close() {
-        if (!closed.compareAndSet(false, true)) return
+        if (!closed.compareAndSet(expect = false, update = true)) return
         session.finishTasksAndInvalidate()
     }
 }

--- a/ktor-client/ktor-client-darwin/darwin/src/io/ktor/client/engine/darwin/DarwinClientEngine.kt
+++ b/ktor-client/ktor-client-darwin/darwin/src/io/ktor/client/engine/darwin/DarwinClientEngine.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2014-2026 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package io.ktor.client.engine.darwin
@@ -28,5 +28,10 @@ internal class DarwinClientEngine(override val config: DarwinClientEngineConfig)
     override suspend fun execute(data: HttpRequestData): HttpResponseData {
         val callContext = callContext()
         return session.execute(data, callContext)
+    }
+
+    override fun close() {
+        super.close()
+        session.close()
     }
 }

--- a/ktor-client/ktor-client-darwin/darwin/src/io/ktor/client/engine/darwin/internal/DarwinSession.kt
+++ b/ktor-client/ktor-client-darwin/darwin/src/io/ktor/client/engine/darwin/internal/DarwinSession.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2024 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2014-2026 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package io.ktor.client.engine.darwin.internal
@@ -56,7 +56,7 @@ internal class DarwinSession(
     }
 
     override fun close() {
-        if (!closed.compareAndSet(false, true)) return
+        if (!closed.compareAndSet(expect = false, update = true)) return
         session.finishTasksAndInvalidate()
     }
 }


### PR DESCRIPTION
**Subsystem**
Darwin Client

**Motivation**
[KTOR-9187](https://youtrack.jetbrains.com/issue/KTOR-9187) Darwin: reference captured in `handleChallenge` is never deinitialized, leading to a memory leak

**Solution**
- call `DarwinSession.close` which was implemented, but not used

