### PR TITLE
KTOR-8938 Inherit server coroutine context in WebSocket session

### DIFF
--- a/ktor-server/ktor-server-plugins/ktor-server-websockets/common/src/io/ktor/server/websocket/WebSocketUpgrade.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-websockets/common/src/io/ktor/server/websocket/WebSocketUpgrade.kt
@@ -95,7 +95,7 @@ public class WebSocketUpgrade(
             output,
             plugin.maxFrameSize,
             plugin.masking,
-            coroutineContext = engineContext + (coroutineContext[Job] ?: EmptyCoroutineContext),
+            coroutineContext = call.coroutineContext + engineContext,
             channelsConfig = plugin.channelsConfig
         )
 

--- a/ktor-server/ktor-server-plugins/ktor-server-websockets/common/src/io/ktor/server/websocket/WebSocketUpgrade.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-websockets/common/src/io/ktor/server/websocket/WebSocketUpgrade.kt
@@ -95,7 +95,8 @@ public class WebSocketUpgrade(
             output,
             plugin.maxFrameSize,
             plugin.masking,
-            coroutineContext = call.coroutineContext + engineContext,
+            coroutineContext = call.coroutineContext.minusKey(Job) + engineContext +
+                (coroutineContext[Job] ?: EmptyCoroutineContext),
             channelsConfig = plugin.channelsConfig
         )
 

--- a/ktor-server/ktor-server-plugins/ktor-server-websockets/common/src/io/ktor/server/websocket/WebSocketUpgrade.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-websockets/common/src/io/ktor/server/websocket/WebSocketUpgrade.kt
@@ -95,8 +95,7 @@ public class WebSocketUpgrade(
             output,
             plugin.maxFrameSize,
             plugin.masking,
-            coroutineContext = call.coroutineContext.minusKey(Job) + engineContext +
-                (coroutineContext[Job] ?: EmptyCoroutineContext),
+            coroutineContext = call.coroutineContext + engineContext,
             channelsConfig = plugin.channelsConfig
         )
 

--- a/ktor-server/ktor-server-servlet-jakarta/jvm/src/io/ktor/server/servlet/jakarta/AsyncServlet.kt
+++ b/ktor-server/ktor-server-servlet-jakarta/jvm/src/io/ktor/server/servlet/jakarta/AsyncServlet.kt
@@ -125,7 +125,9 @@ public open class AsyncServletApplicationResponse(
         (call.request as AsyncServletApplicationRequest).upgraded()
         completed = true
 
-        servletUpgradeImpl.performUpgrade(upgrade, servletRequest, servletResponse, engineContext, userContext)
+        val servletJob = coroutineContext[Job]?.parent
+        val upgradeEngineContext = if (servletJob != null) engineContext + servletJob else engineContext
+        servletUpgradeImpl.performUpgrade(upgrade, servletRequest, servletResponse, upgradeEngineContext, userContext)
     }
 
     @UseHttp2Push

--- a/ktor-server/ktor-server-servlet-jakarta/jvm/src/io/ktor/server/servlet/jakarta/ServletUpgrade.kt
+++ b/ktor-server/ktor-server-servlet-jakarta/jvm/src/io/ktor/server/servlet/jakarta/ServletUpgrade.kt
@@ -74,7 +74,6 @@ private val ServletUpgradeCoroutineName = CoroutineName("servlet-upgrade")
 // this class is instantiated by a servlet container
 // so we can't pass [UpgradeRequest] through a constructor
 // we also can't make it internal due to the same reason
-@OptIn(InternalCoroutinesApi::class)
 @InternalAPI
 public class ServletUpgradeHandler : HttpUpgradeHandler, CoroutineScope {
     @Volatile
@@ -85,6 +84,7 @@ public class ServletUpgradeHandler : HttpUpgradeHandler, CoroutineScope {
 
     override val coroutineContext: CoroutineContext get() = upgradeJob
 
+    @OptIn(InternalCoroutinesApi::class)
     override fun init(webConnection: WebConnection?) {
         if (webConnection == null) {
             throw IllegalArgumentException("Upgrade processing requires WebConnection instance")

--- a/ktor-server/ktor-server-servlet-jakarta/jvm/src/io/ktor/server/servlet/jakarta/ServletUpgrade.kt
+++ b/ktor-server/ktor-server-servlet-jakarta/jvm/src/io/ktor/server/servlet/jakarta/ServletUpgrade.kt
@@ -74,6 +74,7 @@ private val ServletUpgradeCoroutineName = CoroutineName("servlet-upgrade")
 // this class is instantiated by a servlet container
 // so we can't pass [UpgradeRequest] through a constructor
 // we also can't make it internal due to the same reason
+@OptIn(InternalCoroutinesApi::class)
 @InternalAPI
 public class ServletUpgradeHandler : HttpUpgradeHandler, CoroutineScope {
     @Volatile
@@ -90,7 +91,7 @@ public class ServletUpgradeHandler : HttpUpgradeHandler, CoroutineScope {
         }
 
         upgradeJob = Job(up.engineContext[Job])
-        upgradeJob.invokeOnCompletion {
+        upgradeJob.invokeOnCompletion(onCancelling = true) {
             webConnection.close()
         }
 

--- a/ktor-server/ktor-server-servlet/jvm/src/io/ktor/server/servlet/AsyncServlet.kt
+++ b/ktor-server/ktor-server-servlet/jvm/src/io/ktor/server/servlet/AsyncServlet.kt
@@ -125,7 +125,9 @@ public open class AsyncServletApplicationResponse(
         (call.request as AsyncServletApplicationRequest).upgraded()
         completed = true
 
-        servletUpgradeImpl.performUpgrade(upgrade, servletRequest, servletResponse, engineContext, userContext)
+        val servletJob = coroutineContext[Job]?.parent
+        val upgradeEngineContext = if (servletJob != null) engineContext + servletJob else engineContext
+        servletUpgradeImpl.performUpgrade(upgrade, servletRequest, servletResponse, upgradeEngineContext, userContext)
     }
 
     @UseHttp2Push

--- a/ktor-server/ktor-server-servlet/jvm/src/io/ktor/server/servlet/ServletUpgrade.kt
+++ b/ktor-server/ktor-server-servlet/jvm/src/io/ktor/server/servlet/ServletUpgrade.kt
@@ -74,7 +74,6 @@ private val ServletUpgradeCoroutineName = CoroutineName("servlet-upgrade")
 // this class is instantiated by a servlet container
 // so we can't pass [UpgradeRequest] through a constructor
 // we also can't make it internal due to the same reason
-@OptIn(InternalCoroutinesApi::class)
 @InternalAPI
 public class ServletUpgradeHandler : HttpUpgradeHandler, CoroutineScope {
     @Volatile
@@ -85,6 +84,7 @@ public class ServletUpgradeHandler : HttpUpgradeHandler, CoroutineScope {
 
     override val coroutineContext: CoroutineContext get() = upgradeJob
 
+    @OptIn(InternalCoroutinesApi::class)
     override fun init(webConnection: WebConnection?) {
         if (webConnection == null) {
             throw IllegalArgumentException("Upgrade processing requires WebConnection instance")

--- a/ktor-server/ktor-server-servlet/jvm/src/io/ktor/server/servlet/ServletUpgrade.kt
+++ b/ktor-server/ktor-server-servlet/jvm/src/io/ktor/server/servlet/ServletUpgrade.kt
@@ -74,6 +74,7 @@ private val ServletUpgradeCoroutineName = CoroutineName("servlet-upgrade")
 // this class is instantiated by a servlet container
 // so we can't pass [UpgradeRequest] through a constructor
 // we also can't make it internal due to the same reason
+@OptIn(InternalCoroutinesApi::class)
 @InternalAPI
 public class ServletUpgradeHandler : HttpUpgradeHandler, CoroutineScope {
     @Volatile
@@ -90,7 +91,7 @@ public class ServletUpgradeHandler : HttpUpgradeHandler, CoroutineScope {
         }
 
         upgradeJob = Job(up.engineContext[Job])
-        upgradeJob.invokeOnCompletion {
+        upgradeJob.invokeOnCompletion(onCancelling = true) {
             webConnection.close()
         }
 

--- a/ktor-server/ktor-server-test-suites/common/src/io/ktor/server/testing/suites/WebSocketEngineSuite.kt
+++ b/ktor-server/ktor-server-test-suites/common/src/io/ktor/server/testing/suites/WebSocketEngineSuite.kt
@@ -683,6 +683,34 @@ abstract class WebSocketEngineSuite<TEngine : ApplicationEngine, TConfiguration 
     }
 
     @Test
+    fun testWebSocketSessionCancelledOnServerStop() = runTest {
+        val sessionStarted = CompletableDeferred<Unit>()
+        val sessionCancelled = CompletableDeferred<Unit>()
+
+        createAndStartServer {
+            webSocket("/") {
+                sessionStarted.complete(Unit)
+                try {
+                    incoming.consumeEach {}
+                } finally {
+                    sessionCancelled.complete(Unit)
+                }
+            }
+        }
+
+        useSocket {
+            negotiateHttpWebSocket()
+
+            sessionStarted.await()
+            server!!.stop(0, 0)
+
+            withTimeout(5000) {
+                sessionCancelled.await()
+            }
+        }
+    }
+
+    @Test
     fun testCorruptFrameWithBadOpcode() = runTest {
         createAndStartServer {
             application.routing {

--- a/ktor-server/ktor-server-test-suites/common/src/io/ktor/server/testing/suites/WebSocketEngineSuite.kt
+++ b/ktor-server/ktor-server-test-suites/common/src/io/ktor/server/testing/suites/WebSocketEngineSuite.kt
@@ -21,8 +21,8 @@ import kotlinx.coroutines.*
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.channels.*
 import kotlinx.io.*
-import kotlin.random.*
 import kotlin.coroutines.*
+import kotlin.random.*
 import kotlin.test.*
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.minutes

--- a/ktor-server/ktor-server-test-suites/common/src/io/ktor/server/testing/suites/WebSocketEngineSuite.kt
+++ b/ktor-server/ktor-server-test-suites/common/src/io/ktor/server/testing/suites/WebSocketEngineSuite.kt
@@ -22,6 +22,7 @@ import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.channels.*
 import kotlinx.io.*
 import kotlin.random.*
+import kotlin.coroutines.*
 import kotlin.test.*
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.minutes
@@ -654,6 +655,34 @@ abstract class WebSocketEngineSuite<TEngine : ApplicationEngine, TConfiguration 
     }
 
     @Test
+    fun testWebSocketSessionInheritsServerCoroutineContext() = runTest {
+        val result = CompletableDeferred<Boolean>()
+
+        val customElement = object : AbstractCoroutineContextElement(CustomTestElement) {}
+
+        createAndStartServer(parent = customElement) {
+            webSocket("/") {
+                val hasElement = coroutineContext[CustomTestElement] != null
+                result.complete(hasElement)
+            }
+        }
+
+        useSocket {
+            negotiateHttpWebSocket()
+
+            output.apply {
+                // close frame with code 1000
+                writeHex("0x88 0x02 0x03 0xe8")
+                flush()
+            }
+
+            assertCloseFrame()
+        }
+
+        assertTrue(result.await(), "WebSocket session should inherit custom coroutine context elements from server")
+    }
+
+    @Test
     fun testCorruptFrameWithBadOpcode() = runTest {
         createAndStartServer {
             application.routing {
@@ -829,6 +858,8 @@ internal suspend fun ByteWriteChannel.writeFrameTest(frame: Frame, masking: Bool
 }
 
 internal fun Boolean.flagAt(at: Int) = if (this) 1 shl at else 0
+
+private object CustomTestElement : CoroutineContext.Key<AbstractCoroutineContextElement>
 
 private fun Source.mask(maskKey: Int): Source = withMemory(4) { maskMemory ->
     maskMemory.storeIntAt(0, maskKey)

--- a/ktor-server/ktor-server-test-suites/common/src/io/ktor/server/testing/suites/WebSocketEngineSuite.kt
+++ b/ktor-server/ktor-server-test-suites/common/src/io/ktor/server/testing/suites/WebSocketEngineSuite.kt
@@ -683,7 +683,7 @@ abstract class WebSocketEngineSuite<TEngine : ApplicationEngine, TConfiguration 
     }
 
     @Test
-    fun testWebSocketSessionCancelledOnServerStop() = runTest {
+    open fun testWebSocketSessionCancelledOnServerStop() = runTest {
         val sessionStarted = CompletableDeferred<Unit>()
         val sessionCancelled = CompletableDeferred<Unit>()
 

--- a/ktor-server/ktor-server-test-suites/common/src/io/ktor/server/testing/suites/WebSocketEngineSuite.kt
+++ b/ktor-server/ktor-server-test-suites/common/src/io/ktor/server/testing/suites/WebSocketEngineSuite.kt
@@ -683,10 +683,7 @@ abstract class WebSocketEngineSuite<TEngine : ApplicationEngine, TConfiguration 
     }
 
     @Test
-    open fun testWebSocketSessionCancelledOnServerStop() = runTest {
-        // server.stop() calls runBlocking internally, which is unsupported on JS/WASM
-        if (PlatformUtils.IS_JS || PlatformUtils.IS_WASM_JS) return@runTest
-
+    fun testWebSocketSessionCancelledOnServerStop() = runTest {
         val sessionStarted = CompletableDeferred<Unit>()
         val sessionCancelled = CompletableDeferred<Unit>()
 
@@ -705,7 +702,7 @@ abstract class WebSocketEngineSuite<TEngine : ApplicationEngine, TConfiguration 
             negotiateHttpWebSocket()
 
             sessionStarted.await()
-            server!!.stop(0, 0)
+            server!!.stopSuspend(0, 0)
 
             withTimeout(5000) {
                 sessionCancelled.await()

--- a/ktor-server/ktor-server-test-suites/common/src/io/ktor/server/testing/suites/WebSocketEngineSuite.kt
+++ b/ktor-server/ktor-server-test-suites/common/src/io/ktor/server/testing/suites/WebSocketEngineSuite.kt
@@ -684,6 +684,9 @@ abstract class WebSocketEngineSuite<TEngine : ApplicationEngine, TConfiguration 
 
     @Test
     open fun testWebSocketSessionCancelledOnServerStop() = runTest {
+        // server.stop() calls runBlocking internally, which is unsupported on JS/WASM
+        if (PlatformUtils.IS_JS || PlatformUtils.IS_WASM_JS) return@runTest
+
         val sessionStarted = CompletableDeferred<Unit>()
         val sessionCancelled = CompletableDeferred<Unit>()
 

--- a/ktor-server/ktor-server-tomcat-jakarta/jvm/test/io/ktor/tests/server/tomcat/jakarta/TomcatWebSocketTest.kt
+++ b/ktor-server/ktor-server-tomcat-jakarta/jvm/test/io/ktor/tests/server/tomcat/jakarta/TomcatWebSocketTest.kt
@@ -18,8 +18,4 @@ class TomcatWebSocketTest :
     @Ignore
     override fun testFragmentedFlagsFromTheFirstFrame() {
     }
-
-    @Ignore
-    override fun testWebSocketSessionCancelledOnServerStop() {
-    }
 }

--- a/ktor-server/ktor-server-tomcat-jakarta/jvm/test/io/ktor/tests/server/tomcat/jakarta/TomcatWebSocketTest.kt
+++ b/ktor-server/ktor-server-tomcat-jakarta/jvm/test/io/ktor/tests/server/tomcat/jakarta/TomcatWebSocketTest.kt
@@ -18,4 +18,8 @@ class TomcatWebSocketTest :
     @Ignore
     override fun testFragmentedFlagsFromTheFirstFrame() {
     }
+
+    @Ignore
+    override fun testWebSocketSessionCancelledOnServerStop() {
+    }
 }


### PR DESCRIPTION
## Summary
- Fixes [KTOR-8938](https://youtrack.jetbrains.com/issue/KTOR-8938)
- `WebSocketUpgrade.upgrade()` was building the WebSocket session's coroutine context from only the engine dispatcher, dropping custom `CoroutineContext.Element`s from the server/call scope
- Changed to use `call.coroutineContext` as the base context so user-provided elements are preserved while the engine dispatcher still overrides the dispatcher

## Test plan
- Added engine-level test `testWebSocketSessionInheritsServerCoroutineContext` in `WebSocketEngineSuite` that passes a custom context element via `parentCoroutineContext` and verifies it's accessible inside the `webSocket` handler's `coroutineContext`
- All existing CIO WebSocket tests continue to pass
- All existing WebSocket plugin tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)