### PR TITLE
KTOR-9396: Fix Java HTTP client not sending Content-Length header for GET requests with no body

### DIFF
--- a/ktor-client/ktor-client-java/jvm/src/io/ktor/client/engine/java/JavaHttpRequest.kt
+++ b/ktor-client/ktor-client-java/jvm/src/io/ktor/client/engine/java/JavaHttpRequest.kt
@@ -51,7 +51,9 @@ internal fun HttpRequestData.convertToHttpRequest(callContext: CoroutineContext)
             }
         }
 
-        method(method.value, body.convertToHttpRequestBody(callContext))
+        if (method.supportsRequestBody || body !is OutgoingContent.NoContent) {
+            method(method.value, body.convertToHttpRequestBody(callContext))
+        }
     }
 
     return builder.build()

--- a/ktor-client/ktor-client-java/jvm/src/io/ktor/client/engine/java/JavaHttpRequest.kt
+++ b/ktor-client/ktor-client-java/jvm/src/io/ktor/client/engine/java/JavaHttpRequest.kt
@@ -51,7 +51,9 @@ internal fun HttpRequestData.convertToHttpRequest(callContext: CoroutineContext)
             }
         }
 
-        if (method.supportsRequestBody || body !is OutgoingContent.NoContent) {
+        if (method == HttpMethod.Get && body is OutgoingContent.NoContent) {
+            // Leave builder as default GET to avoid Content-Length: 0 (JDK bug)
+        } else {
             method(method.value, body.convertToHttpRequestBody(callContext))
         }
     }

--- a/ktor-client/ktor-client-java/jvm/test/io/ktor/client/engine/java/RequestTests.kt
+++ b/ktor-client/ktor-client-java/jvm/test/io/ktor/client/engine/java/RequestTests.kt
@@ -119,7 +119,7 @@ class RequestTests : TestWithKtor() {
     }
 
     @Test
-    fun testGetRequestDoesNotSendContentLengthHeader() {
+    fun `get request does not send Content-Length header`() {
         val response = HttpClient(Java).use { client ->
             runBlocking {
                 client.get("$testUrl/headers").body<String>()

--- a/ktor-client/ktor-client-java/jvm/test/io/ktor/client/engine/java/RequestTests.kt
+++ b/ktor-client/ktor-client-java/jvm/test/io/ktor/client/engine/java/RequestTests.kt
@@ -24,7 +24,6 @@ import kotlinx.coroutines.runBlocking
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
-import kotlin.test.assertFalse
 
 class RequestTests : TestWithKtor() {
 
@@ -53,10 +52,13 @@ class RequestTests : TestWithKtor() {
                 )
             }
 
-            get("/headers") {
-                val headers = call.request.headers.entries()
-                    .joinToString("\n") { (key, values) -> "$key: ${values.joinToString(", ")}" }
-                call.respondText(headers)
+            route("/headers") {
+                handle {
+                    val contentLength = call.request.header(HttpHeaders.ContentLength)
+                    call.response.header("X-Request-Method", call.request.httpMethod.value)
+                    call.response.header("X-Request-Content-Length", contentLength ?: "absent")
+                    call.respondText("OK")
+                }
             }
         }
     }
@@ -119,16 +121,29 @@ class RequestTests : TestWithKtor() {
     }
 
     @Test
-    fun `get request does not send Content-Length header`() {
+    fun `GET request does not send Content-Length header`() {
         val response = HttpClient(Java).use { client ->
             runBlocking {
-                client.get("$testUrl/headers").body<String>()
+                client.get("$testUrl/headers")
             }
         }
 
-        assertFalse(
-            response.contains("Content-Length: 0", ignoreCase = true),
-            "GET request should not contain Content-Length: 0 header. Received headers:\n$response"
+        assertEquals("GET", response.headers["X-Request-Method"])
+        assertEquals(
+            "absent",
+            response.headers["X-Request-Content-Length"],
+            "GET request should not send Content-Length header"
         )
+    }
+
+    @Test
+    fun `OPTIONS request uses correct HTTP method`() {
+        val response = HttpClient(Java).use { client ->
+            runBlocking {
+                client.options("$testUrl/headers")
+            }
+        }
+
+        assertEquals("OPTIONS", response.headers["X-Request-Method"])
     }
 }

--- a/ktor-client/ktor-client-java/jvm/test/io/ktor/client/engine/java/RequestTests.kt
+++ b/ktor-client/ktor-client-java/jvm/test/io/ktor/client/engine/java/RequestTests.kt
@@ -24,6 +24,7 @@ import kotlinx.coroutines.runBlocking
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
 
 class RequestTests : TestWithKtor() {
 
@@ -50,6 +51,12 @@ class RequestTests : TestWithKtor() {
                         }
                     }
                 )
+            }
+
+            get("/headers") {
+                val headers = call.request.headers.entries()
+                    .joinToString("\n") { (key, values) -> "$key: ${values.joinToString(", ")}" }
+                call.respondText(headers)
             }
         }
     }
@@ -109,5 +116,19 @@ class RequestTests : TestWithKtor() {
         }
 
         assertEquals(payload, response)
+    }
+
+    @Test
+    fun testGetRequestDoesNotSendContentLengthHeader() {
+        val response = HttpClient(Java).use { client ->
+            runBlocking {
+                client.get("$testUrl/headers").body<String>()
+            }
+        }
+
+        assertFalse(
+            response.contains("Content-Length: 0", ignoreCase = true),
+            "GET request should not contain Content-Length: 0 header. Received headers:\n$response"
+        )
     }
 }


### PR DESCRIPTION
**Subsystem**
Client (Java Http)

**Motivation**
[KTOR-9396](https://youtrack.jetbrains.com/issue/KTOR-9396) The Java HTTP Client adds the "Content-Length: 0" header to GET requests with no body

**Solution**
Skip adding body content for HTTP methods not in supportsRequestBody (GET, OPTIONS, HEAD) that have no content.

Adds a test, and the youtrack ticket has an example server that I've used to test against. 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * GET requests with no body no longer include a "Content-Length: 0" header, improving HTTP compliance.
  * Method selection logic adjusted to avoid sending unnecessary Content-Length for requests without a body.

* **Tests**
  * Added a test verifying GET requests do not send a Content-Length header.
  * Added a test confirming non-GET methods (e.g., OPTIONS) use the correct HTTP method.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->