### PR TITLE
KTOR-9399 Disable auto-reload when classloader is not a URLClassLoader

### DIFF
--- a/ktor-server/ktor-server-core/jvm/src/io/ktor/server/engine/ClassLoaders.kt
+++ b/ktor-server/ktor-server-core/jvm/src/io/ktor/server/engine/ClassLoaders.kt
@@ -7,6 +7,20 @@ package io.ktor.server.engine
 import java.lang.reflect.*
 import java.net.*
 
+/**
+ * Returns `true` if this classloader is compatible with Ktor's auto-reload mechanism.
+ *
+ * Auto-reload uses [OverridingClassLoader], which extends [URLClassLoader] and therefore requires
+ * a standard URL-based classpath. Non-standard classloaders — such as Spring Boot's
+ * `LaunchedClassLoader` or Amper's fat-JAR launcher — use custom URL schemes (e.g. `jar:nested:/`)
+ * that [URLClassLoader] cannot handle, leading to duplicate class identities and [LinkageError].
+ *
+ * JDK's built-in `AppClassLoader` is not a [URLClassLoader] since JDK 11 but is still compatible.
+ */
+internal fun ClassLoader.supportsAutoReload(): Boolean =
+    this is URLClassLoader ||
+        javaClass.name == "jdk.internal.loader.ClassLoaders\$AppClassLoader"
+
 internal fun ClassLoader.allURLs(): Set<URL> {
     val parentUrls = parent?.allURLs() ?: emptySet()
     if (this is URLClassLoader) {

--- a/ktor-server/ktor-server-core/jvm/src/io/ktor/server/engine/EmbeddedServerJvm.kt
+++ b/ktor-server/ktor-server-core/jvm/src/io/ktor/server/engine/EmbeddedServerJvm.kt
@@ -185,6 +185,15 @@ actual constructor(
             return baseClassLoader
         }
 
+        if (!baseClassLoader.supportsAutoReload()) {
+            environment.log.warn(
+                "Auto-reload is disabled: application is loaded by ${baseClassLoader.javaClass.name}, " +
+                    "which is not a standard URLClassLoader. This typically happens when running inside " +
+                    "a fat-JAR (e.g. Spring Boot Launcher, Amper). Set ktor.development=false to suppress this warning."
+            )
+            return baseClassLoader
+        }
+
         val allUrls = baseClassLoader.allURLs()
         val jre = File(System.getProperty("java.home")).parent
         val debugUrls = allUrls.map { it.file }

--- a/ktor-server/ktor-server-core/jvm/test/io/ktor/tests/hosts/EmbeddedServerReloadingTests.kt
+++ b/ktor-server/ktor-server-core/jvm/test/io/ktor/tests/hosts/EmbeddedServerReloadingTests.kt
@@ -567,6 +567,44 @@ class EmbeddedServerReloadingTests {
     }
 
     @Test
+    fun `auto-reload is disabled when classloader is not a URLClassLoader`() {
+        // Simulate a fat-JAR launcher classloader (e.g. Spring Boot LaunchedClassLoader),
+        // which is NOT a URLClassLoader. Using OverridingClassLoader in this case causes
+        // LinkageError / ClassCastException because it can't handle the custom URL scheme.
+        val realLoader = Thread.currentThread().contextClassLoader
+        val fatJarSimulator = object : ClassLoader(realLoader) {
+            override fun toString() = "FatJarSimulatorClassLoader"
+        }
+
+        var capturedClassLoader: ClassLoader? = null
+        val environment = applicationEnvironment {
+            classLoader = fatJarSimulator
+            config = HoconApplicationConfig(
+                ConfigFactory.parseMap(mapOf("ktor.deployment.watch" to listOf("ktor-server-core")))
+            )
+        }
+        val props = serverConfig(environment) {
+            developmentMode = true
+            module { capturedClassLoader = Thread.currentThread().contextClassLoader }
+        }
+        val server = EmbeddedServer(props, DummyEngineFactory)
+
+        server.start()
+        assertNotNull(server.application)
+
+        // When the base classloader is not a URLClassLoader, auto-reload must be disabled:
+        // the module must run under the original base classloader, not under OverridingClassLoader.
+        assertSame(
+            fatJarSimulator,
+            capturedClassLoader,
+            "Expected the original classloader. " +
+                "Auto-reload should be disabled for non-URLClassLoader environments (fat-JARs)."
+        )
+
+        server.stop()
+    }
+
+    @Test
     fun `application is available before environment start`() {
         val env = dummyEnv()
         val props = serverConfig(env)


### PR DESCRIPTION
**Subsystem**
Server

**Motivation**
[KTOR-9399](https://youtrack.jetbrains.com/issue/KTOR-9399) LinkageError when running Ktor app with development mode inside Spring Boot / Amper fat-JAR

**Solution**
Skip auto-reloading for non-standard class loaders.

