### PR TITLE
KTOR-9039 Make jsonIo content replayable

### DIFF
--- a/ktor-shared/ktor-serialization/ktor-serialization-kotlinx/ktor-serialization-kotlinx-json/common/src/io/ktor/serialization/kotlinx/json/ExperimentalJsonConverter.kt
+++ b/ktor-shared/ktor-serialization/ktor-serialization-kotlinx/ktor-serialization-kotlinx-json/common/src/io/ktor/serialization/kotlinx/json/ExperimentalJsonConverter.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2024 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2014-2026 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package io.ktor.serialization.kotlinx.json
@@ -13,9 +13,13 @@ import io.ktor.utils.io.*
 import io.ktor.utils.io.charsets.*
 import io.ktor.utils.io.core.*
 import kotlinx.io.Buffer
-import kotlinx.serialization.*
-import kotlinx.serialization.json.*
-import kotlinx.serialization.json.io.*
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.InternalSerializationApi
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.io.decodeFromSource
+import kotlinx.serialization.json.io.encodeToSink
 
 @OptIn(ExperimentalSerializationApi::class, InternalSerializationApi::class, InternalAPI::class)
 public class ExperimentalJsonConverter(private val format: Json) : ContentConverter {
@@ -29,7 +33,7 @@ public class ExperimentalJsonConverter(private val format: Json) : ContentConver
     ): OutgoingContent {
         val serializer = try {
             format.serializersModule.serializerForTypeInfo(typeInfo)
-        } catch (cause: SerializationException) {
+        } catch (_: SerializationException) {
             guessSerializer(value, format.serializersModule)
         }
         val buffer = Buffer().also {
@@ -40,8 +44,11 @@ public class ExperimentalJsonConverter(private val format: Json) : ContentConver
             )
         }
         return ChannelWriterContent(
-            { writeBuffer.transferFrom(buffer) },
-            contentType,
+            body = {
+                // copy buffer for replayability using copy-on-write segment sharing
+                writeBuffer.transferFrom(buffer.copy())
+            },
+            contentType = contentType,
             contentLength = buffer.remaining
         )
     }

--- a/ktor-shared/ktor-serialization/ktor-serialization-kotlinx/ktor-serialization-kotlinx-json/common/test/JsonSerializationTest.kt
+++ b/ktor-shared/ktor-serialization/ktor-serialization-kotlinx/ktor-serialization-kotlinx-json/common/test/JsonSerializationTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2024 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2014-2026 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package io.ktor.serialization.kotlinx.test.json
@@ -10,12 +10,12 @@ import io.ktor.serialization.*
 import io.ktor.serialization.kotlinx.*
 import io.ktor.serialization.kotlinx.json.*
 import io.ktor.serialization.kotlinx.test.*
-import io.ktor.test.dispatcher.*
 import io.ktor.util.*
 import io.ktor.util.reflect.*
 import io.ktor.utils.io.*
 import io.ktor.utils.io.charsets.*
 import io.ktor.utils.io.core.*
+import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.*
 import kotlinx.serialization.descriptors.*
 import kotlinx.serialization.encoding.*
@@ -33,7 +33,7 @@ class JsonSerializationTest : AbstractSerializationTest<Json>() {
     }
 
     @Test
-    fun testJsonElements() = testSuspend {
+    fun testJsonElements() = runTest {
         val testSerializer = KotlinxSerializationConverter(defaultSerializationFormat)
         testSerializer.testSerialize(
             buildJsonObject {
@@ -67,7 +67,7 @@ class JsonSerializationTest : AbstractSerializationTest<Json>() {
     }
 
     @Test
-    fun testContextual() = testSuspend {
+    fun testContextual() = runTest {
         val serializer = KotlinxSerializationConverter(
             Json {
                 prettyPrint = true
@@ -111,7 +111,7 @@ class JsonSerializationTest : AbstractSerializationTest<Json>() {
     }
 
     @Test
-    fun testExtraFields() = testSuspend {
+    fun testExtraFields() = runTest {
         val testSerializer = KotlinxSerializationConverter(defaultSerializationFormat)
         val dogExtraFieldJson = """{"age": 8,"name":"Auri","color":"Black"}"""
         assertFailsWith<JsonConvertException> {
@@ -124,7 +124,7 @@ class JsonSerializationTest : AbstractSerializationTest<Json>() {
     }
 
     @Test
-    fun testList() = testSuspend {
+    fun testList() = runTest {
         val testSerializer = KotlinxSerializationConverter(defaultSerializationFormat)
         val dogListJson = """[{"age": 8,"name":"Auri"}]"""
         assertEquals(
@@ -138,7 +138,7 @@ class JsonSerializationTest : AbstractSerializationTest<Json>() {
     }
 
     @Test
-    fun testListsWithExperimentApi() = testSuspend {
+    fun testListsWithExperimentApi() = runTest {
         val testSerializer = ExperimentalJsonConverter(defaultSerializationFormat)
         val expected = listOf(DogDTO(8, "Auri"))
         val serialized = testSerializer.serialize(
@@ -159,8 +159,31 @@ class JsonSerializationTest : AbstractSerializationTest<Json>() {
     }
 
     @Test
-    fun testSequence() = testSuspend {
-        if (!PlatformUtils.IS_JVM) return@testSuspend
+    fun testContentIsReplayable() = runTest {
+        val testSerializer = ExperimentalJsonConverter(defaultSerializationFormat)
+        val expected = DogDTO(8, "Auri")
+        val content = testSerializer.serialize(
+            ContentType.Application.Json,
+            Charsets.UTF_8,
+            typeInfo<DogDTO>(),
+            expected
+        )
+
+        // Verify content can be written multiple times (replayable)
+        // This is important for auth retry scenarios where the request body needs to be resent
+        val firstWrite = content.toByteArray().decodeToString()
+        val secondWrite = content.toByteArray().decodeToString()
+        val thirdWrite = content.toByteArray().decodeToString()
+
+        val expectedJson = """{"age":8,"name":"Auri"}"""
+        assertEquals(expectedJson, firstWrite)
+        assertEquals(expectedJson, secondWrite)
+        assertEquals(expectedJson, thirdWrite)
+    }
+
+    @Test
+    fun testSequence() = runTest {
+        if (!PlatformUtils.IS_JVM) return@runTest
 
         val testSerializer = KotlinxSerializationConverter(defaultSerializationFormat)
         val dogListJson = """[{"age":8,"name":"Auri"}]"""
@@ -205,7 +228,7 @@ class EitherSerializer<L, R>(
 
         return try {
             Either.Right(decoder.json.decodeFromJsonElement(rightSerializer, element))
-        } catch (throwable: Throwable) {
+        } catch (_: Throwable) {
             Either.Left(decoder.json.decodeFromJsonElement(leftSerializer, element))
         }
     }


### PR DESCRIPTION
**Subsystem**
Shared

**Motivation**
[KTOR-9039](https://youtrack.jetbrains.com/issue/KTOR-9039) Bearer Auth: Request body transformed with jsonIO isn't sent over again after refreshToken request

**Solution**
- use copy-on-write segment sharing in jsonIo

