### PR TITLE
KTOR-6651 JWT Auth: Potential DOS vulnerability because of blocking jwkProvider.get call

### DIFF
--- a/ktor-server/ktor-server-plugins/ktor-server-auth-jwt/api/ktor-server-auth-jwt.api
+++ b/ktor-server/ktor-server-plugins/ktor-server-auth-jwt/api/ktor-server-auth-jwt.api
@@ -22,7 +22,8 @@ public final class io/ktor/server/auth/jwt/JWTAuthenticationProvider$Config : io
 	public final fun verifier (Lcom/auth0/jwt/interfaces/JWTVerifier;)V
 	public final fun verifier (Ljava/lang/String;Ljava/lang/String;Lcom/auth0/jwt/algorithms/Algorithm;Lkotlin/jvm/functions/Function1;)V
 	public final fun verifier (Ljava/lang/String;Lkotlin/jvm/functions/Function1;)V
-	public final fun verifier (Lkotlin/jvm/functions/Function1;)V
+	public final synthetic fun verifier (Lkotlin/jvm/functions/Function1;)V
+	public final fun verifier (Lkotlin/jvm/functions/Function2;)V
 	public static synthetic fun verifier$default (Lio/ktor/server/auth/jwt/JWTAuthenticationProvider$Config;Lcom/auth0/jwk/JwkProvider;Ljava/lang/String;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
 	public static synthetic fun verifier$default (Lio/ktor/server/auth/jwt/JWTAuthenticationProvider$Config;Lcom/auth0/jwk/JwkProvider;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
 	public static synthetic fun verifier$default (Lio/ktor/server/auth/jwt/JWTAuthenticationProvider$Config;Ljava/lang/String;Ljava/lang/String;Lcom/auth0/jwt/algorithms/Algorithm;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V

--- a/ktor-server/ktor-server-plugins/ktor-server-auth-jwt/jvm/src/io/ktor/server/auth/jwt/JWTAuth.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-auth-jwt/jvm/src/io/ktor/server/auth/jwt/JWTAuth.kt
@@ -180,7 +180,7 @@ public class JWTAuthenticationProvider internal constructor(config: Config) : Au
     private val realm: String = config.realm
     private val schemes: JWTAuthSchemes = config.schemes
     private val authHeader: (ApplicationCall) -> HttpAuthHeader? = config.authHeader
-    private val verifier: ((HttpAuthHeader) -> JWTVerifier?) = config.verifier
+    private val verifier: suspend ((HttpAuthHeader) -> JWTVerifier?) = config.verifier
     private val authenticationFunction = config.authenticationFunction ?: throw IllegalArgumentException(
         "JWT auth validate function is not specified. Use jwt { validate { ... } } to fix."
     )
@@ -240,7 +240,7 @@ public class JWTAuthenticationProvider internal constructor(config: Config) : Au
         internal var authHeader: (ApplicationCall) -> HttpAuthHeader? =
             { call -> call.request.parseAuthorizationHeaderOrNull() }
 
-        internal var verifier: ((HttpAuthHeader) -> JWTVerifier?) = { null }
+        internal var verifier: suspend ((HttpAuthHeader) -> JWTVerifier?) = { null }
 
         internal var challenge: JWTAuthChallengeFunction = { scheme, realm ->
             call.respond(
@@ -297,7 +297,17 @@ public class JWTAuthenticationProvider internal constructor(config: Config) : Au
          *
          * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.server.auth.jwt.JWTAuthenticationProvider.Config.verifier)
          */
+        @Deprecated("Use suspend verifier instead", level = DeprecationLevel.HIDDEN)
         public fun verifier(verifier: (HttpAuthHeader) -> JWTVerifier?) {
+            this.verifier = { header -> verifier(header) }
+        }
+
+        /**
+         * Provides a [JWTVerifier] used to verify a token format and signature.
+         *
+         * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.server.auth.jwt.JWTAuthenticationProvider.Config.verifier)
+         */
+        public fun verifier(verifier: suspend (HttpAuthHeader) -> JWTVerifier?) {
             this.verifier = verifier
         }
 

--- a/ktor-server/ktor-server-plugins/ktor-server-auth-jwt/jvm/src/io/ktor/server/auth/jwt/JWTUtils.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-auth-jwt/jvm/src/io/ktor/server/auth/jwt/JWTUtils.kt
@@ -15,6 +15,7 @@ import io.ktor.http.auth.*
 import io.ktor.server.application.*
 import io.ktor.server.auth.*
 import io.ktor.server.request.*
+import kotlinx.coroutines.*
 import java.security.interfaces.*
 import java.util.*
 
@@ -54,7 +55,7 @@ internal fun AuthenticationContext.bearerChallenge(
     }
 }
 
-internal fun getVerifier(
+internal suspend fun getVerifier(
     jwkProvider: JwkProvider,
     issuer: String?,
     token: HttpAuthHeader,
@@ -63,7 +64,9 @@ internal fun getVerifier(
 ): JWTVerifier? {
     val jwk = token.getBlob(schemes)?.let { blob ->
         try {
-            jwkProvider.get(JWT.decode(blob).keyId)
+            withContext(Dispatchers.IO) {
+                jwkProvider.get(JWT.decode(blob).keyId)
+            }
         } catch (cause: JwkException) {
             JWTLogger.trace("Failed to get JWK", cause)
             null
@@ -86,7 +89,7 @@ internal fun getVerifier(
     }.apply(jwtConfigure).build()
 }
 
-internal fun getVerifier(
+internal suspend fun getVerifier(
     jwkProvider: JwkProvider,
     token: HttpAuthHeader,
     schemes: JWTAuthSchemes,


### PR DESCRIPTION
**Subsystem**
Server Auth JWT

**Motivation**
[KTOR-6651](https://youtrack.jetbrains.com/issue/KTOR-6651) JWT Auth: Potential DOS vulnerability because of blocking jwkProvider.get call

**Solution**
Run `jwkProvider.get` using `Dispatchers.IO`, which makes `getVerifier` suspend.
Suspend verifier could also be useful for some users.