### PR TITLE
KTOR-9327 Curl: Support WebSockets maxFrameSize option

### DIFF
--- a/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/websocket/WebSockets.kt
+++ b/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/websocket/WebSockets.kt
@@ -16,7 +16,6 @@ import io.ktor.util.*
 import io.ktor.util.logging.*
 import io.ktor.utils.io.*
 import io.ktor.websocket.*
-import io.ktor.websocket.WebSocketChannelsConfig
 
 private val REQUEST_EXTENSIONS_KEY = AttributeKey<List<WebSocketExtension<*>>>("Websocket extensions")
 
@@ -64,8 +63,8 @@ public class WebSockets internal constructor(
      *
      * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.client.plugins.websocket.WebSockets.WebSockets)
      *
-     * @property pingIntervalMillis - interval between [FrameType.PING] messages.
-     * @property maxFrameSize - max size of a single websocket frame.
+     * @param pingIntervalMillis - interval between [FrameType.PING] messages.
+     * @param maxFrameSize - max size of a single websocket frame.
      */
     public constructor(
         pingIntervalMillis: Long = PINGER_DISABLED,

--- a/ktor-client/ktor-client-curl/desktop/src/io/ktor/client/engine/curl/internal/CurlMultiApiHandler.kt
+++ b/ktor-client/ktor-client-curl/desktop/src/io/ktor/client/engine/curl/internal/CurlMultiApiHandler.kt
@@ -61,7 +61,8 @@ internal class CurlMultiApiHandler : Closeable {
             val wsConfig = request.attributes[WEBSOCKETS_KEY]
             CurlWebSocketResponseBody(
                 easyHandle,
-                wsConfig.channelsConfig.incoming
+                wsConfig.channelsConfig.incoming,
+                wsConfig.maxFrameSize,
             )
         } else {
             CurlHttpResponseBody(request.executionContext) {

--- a/ktor-client/ktor-client-curl/desktop/src/io/ktor/client/engine/curl/internal/CurlWebSocketResponseBody.kt
+++ b/ktor-client/ktor-client-curl/desktop/src/io/ktor/client/engine/curl/internal/CurlWebSocketResponseBody.kt
@@ -19,7 +19,8 @@ import platform.posix.size_t
 @OptIn(InternalAPI::class, ExperimentalForeignApi::class)
 internal class CurlWebSocketResponseBody(
     internal val easyHandle: EasyHandle,
-    incomingFramesConfig: ChannelConfig
+    incomingFramesConfig: ChannelConfig,
+    var maxFrameSize: Long,
 ) : CurlResponseBodyData {
 
     private val closed = atomic(false)
@@ -32,6 +33,11 @@ internal class CurlWebSocketResponseBody(
 
     val incoming: ReceiveChannel<Frame>
         get() = _incoming
+
+    /**
+     * Exception that occurred during frame processing, to be propagated when closing the channel.
+     */
+    private var pendingException: Throwable? = null
 
     /**
      * Buffer for collecting WebSocket frame data that libcurl splits across multiple write callbacks
@@ -69,6 +75,13 @@ internal class CurlWebSocketResponseBody(
         val offset = meta.offset
         val bytesLeft = meta.bytesleft
 
+        val totalFrameSize = offset + chunk.size + bytesLeft
+        if (totalFrameSize > maxFrameSize) {
+            frameDataBuffer = null
+            pendingException = FrameTooBigException(totalFrameSize)
+            return false
+        }
+
         // Fast path: complete frame in a single chunk
         if (offset == 0L && bytesLeft == 0L) {
             return handleIncomingFrame(dataFrame(chunk, flags))
@@ -99,7 +112,8 @@ internal class CurlWebSocketResponseBody(
     override fun close(cause: Throwable?) {
         if (!closed.compareAndSet(expect = false, update = true)) return
         frameDataBuffer = null
-        _incoming.close()
+        val actualCause = pendingException ?: cause
+        _incoming.close(actualCause)
     }
 }
 

--- a/ktor-client/ktor-client-curl/desktop/src/io/ktor/client/engine/curl/internal/CurlWebSocketSession.kt
+++ b/ktor-client/ktor-client-curl/desktop/src/io/ktor/client/engine/curl/internal/CurlWebSocketSession.kt
@@ -37,8 +37,10 @@ internal class CurlWebSocketSession(
         set(_) {}
 
     override var maxFrameSize: Long
-        get() = Long.MAX_VALUE
-        set(_) {}
+        get() = websocket.maxFrameSize
+        set(value) {
+            websocket.maxFrameSize = value
+        }
 
     override val incoming: ReceiveChannel<Frame>
         get() = websocket.incoming

--- a/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/WebSocketTest.kt
+++ b/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/WebSocketTest.kt
@@ -26,10 +26,10 @@ import kotlin.test.*
 import kotlin.time.Duration.Companion.seconds
 
 internal val ENGINES_WITHOUT_WS = listOf("Android", "Apache", "Apache5", "DarwinLegacy")
-internal val ENGINES_NOT_SUPPORTING_MAX_FRAME_SIZE = listOf("OkHttp", "Js", "Java", "Curl", "WinHttp")
+internal val ENGINES_NOT_SUPPORTING_MAX_FRAME_SIZE = listOf("OkHttp", "Js", "Java", "WinHttp")
 
 // TODO: KTOR-9328 Options `maxFrameSize` and `masking` are silently ignored on some engines
-internal val ENGINES_NOT_SUPPORTING_MAX_FRAME_SIZE_SILENTLY = listOf("Java", "Curl", "WinHttp")
+internal val ENGINES_NOT_SUPPORTING_MAX_FRAME_SIZE_SILENTLY = listOf("Java", "WinHttp")
 
 private const val TEST_SIZE: Int = 100
 


### PR DESCRIPTION
**Subsystem**
Client Curl

**Motivation**
[KTOR-9327](https://youtrack.jetbrains.com/issue/KTOR-9327) Curl: Support WebSockets maxFrameSize option

**Solution**
- Throw an exception if `totalFrameSize` exceeds the specified limit.
- Remove Curl from the list of engines not supporting `maxFrameSize`
