### PR TITLE
KTOR-9411 Darwin: FrameTooBigException instead of generic exception

### DIFF
--- a/ktor-client/ktor-client-darwin/darwin/src/io/ktor/client/engine/darwin/internal/DarwinWebsocketSession.kt
+++ b/ktor-client/ktor-client-darwin/darwin/src/io/ktor/client/engine/darwin/internal/DarwinWebsocketSession.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2014-2026 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package io.ktor.client.engine.darwin.internal
@@ -8,13 +8,14 @@ import io.ktor.client.engine.darwin.*
 import io.ktor.client.request.*
 import io.ktor.http.*
 import io.ktor.util.date.*
-import io.ktor.utils.io.InternalAPI
+import io.ktor.utils.io.*
 import io.ktor.utils.io.core.*
 import io.ktor.websocket.*
 import kotlinx.cinterop.ExperimentalForeignApi
 import kotlinx.cinterop.UnsafeNumber
 import kotlinx.cinterop.convert
 import kotlinx.coroutines.*
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.channels.ReceiveChannel
 import kotlinx.coroutines.channels.SendChannel
@@ -22,6 +23,7 @@ import kotlinx.coroutines.channels.consumeEach
 import kotlinx.io.readByteArray
 import platform.Foundation.*
 import platform.darwin.NSInteger
+import platform.posix.EMSGSIZE
 import kotlin.coroutines.CoroutineContext
 import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
@@ -204,7 +206,7 @@ internal class DarwinWebsocketSession(
             return
         }
 
-        val exception = DarwinHttpRequestException(error)
+        val exception = convertWebsocketError(error)
         response.completeExceptionally(exception)
         socketJob.completeExceptionally(exception)
     }
@@ -239,7 +241,7 @@ private suspend fun NSURLSessionWebSocketTask.receiveMessage(): NSURLSessionWebS
                     return@receiveMessageWithCompletionHandler
                 }
 
-                it.resumeWithException(DarwinHttpRequestException(error))
+                it.resumeWithException(convertWebsocketError(error))
                 return@receiveMessageWithCompletionHandler
             }
             if (message == null) {
@@ -254,3 +256,12 @@ private suspend fun NSURLSessionWebSocketTask.receiveMessage(): NSURLSessionWebS
 @OptIn(UnsafeNumber::class)
 @Suppress("REDUNDANT_CALL_OF_CONVERSION_METHOD")
 internal fun NSURLSessionTask.getStatusCode() = (response() as NSHTTPURLResponse?)?.statusCode?.toInt()
+
+@OptIn(UnsafeNumber::class, ExperimentalForeignApi::class)
+private fun convertWebsocketError(error: NSError): Exception = when {
+    (error.domain == NSPOSIXErrorDomain || error.domain == "kNWErrorDomainPOSIX") &&
+        error.code.convert<Int>() == EMSGSIZE -> {
+        FrameTooBigException(frameSize = -1L, DarwinHttpRequestException(error))
+    }
+    else -> DarwinHttpRequestException(error)
+}

--- a/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/WebSocketTest.kt
+++ b/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/WebSocketTest.kt
@@ -547,9 +547,7 @@ class WebSocketTest : ClientLoader(except(ENGINES_WITHOUT_WS)) {
         val shortMessage = "abc"
         val longMessage = "def".repeat(500)
         test { client ->
-            // TODO: KTOR-9411 Darwin throws DarwinHttpRequestException instead of FrameTooBigException
-            // Replace Exception with FrameTooBigException after fix.
-            assertFailsWith<Exception> {
+            assertFailsWith<FrameTooBigException> {
                 client.webSocket("$TEST_WEBSOCKET_SERVER/websockets/echo") {
                     send(shortMessage)
                     assertEquals(shortMessage, (incoming.receive() as Frame.Text).readText())

--- a/ktor-shared/ktor-websockets/api/ktor-websockets.api
+++ b/ktor-shared/ktor-websockets/api/ktor-websockets.api
@@ -180,7 +180,9 @@ public final class io/ktor/websocket/FrameParser$State : java/lang/Enum {
 }
 
 public final class io/ktor/websocket/FrameTooBigException : java/lang/Exception, kotlinx/coroutines/CopyableThrowable {
-	public fun <init> (J)V
+	public synthetic fun <init> (J)V
+	public fun <init> (JLjava/lang/Throwable;)V
+	public synthetic fun <init> (JLjava/lang/Throwable;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun createCopy ()Lio/ktor/websocket/FrameTooBigException;
 	public synthetic fun createCopy ()Ljava/lang/Throwable;
 	public final fun getFrameSize ()J

--- a/ktor-shared/ktor-websockets/api/ktor-websockets.klib.api
+++ b/ktor-shared/ktor-websockets/api/ktor-websockets.klib.api
@@ -167,6 +167,7 @@ final class io.ktor.websocket/CloseReason { // io.ktor.websocket/CloseReason|nul
 
 final class io.ktor.websocket/FrameTooBigException : kotlin/Exception, kotlinx.coroutines/CopyableThrowable<io.ktor.websocket/FrameTooBigException> { // io.ktor.websocket/FrameTooBigException|null[0]
     constructor <init>(kotlin/Long) // io.ktor.websocket/FrameTooBigException.<init>|<init>(kotlin.Long){}[0]
+    constructor <init>(kotlin/Long, kotlin/Throwable? = ...) // io.ktor.websocket/FrameTooBigException.<init>|<init>(kotlin.Long;kotlin.Throwable?){}[0]
 
     final val frameSize // io.ktor.websocket/FrameTooBigException.frameSize|{}frameSize[0]
         final fun <get-frameSize>(): kotlin/Long // io.ktor.websocket/FrameTooBigException.frameSize.<get-frameSize>|<get-frameSize>(){}[0]

--- a/ktor-shared/ktor-websockets/common/src/io/ktor/websocket/FrameTooBigException.kt
+++ b/ktor-shared/ktor-websockets/common/src/io/ktor/websocket/FrameTooBigException.kt
@@ -1,11 +1,11 @@
 /*
- * Copyright 2014-2022 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2014-2026 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package io.ktor.websocket
 
-import io.ktor.util.internal.*
-import kotlinx.coroutines.*
+import kotlinx.coroutines.CopyableThrowable
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 
 /**
  * Raised when the frame is bigger than allowed in a current WebSocket session.
@@ -16,13 +16,18 @@ import kotlinx.coroutines.*
  */
 @OptIn(ExperimentalCoroutinesApi::class)
 public class FrameTooBigException(
-    public val frameSize: Long
-) : Exception(), CopyableThrowable<FrameTooBigException> {
+    public val frameSize: Long,
+    cause: Throwable? = null,
+) : Exception(cause), CopyableThrowable<FrameTooBigException> {
+
+    @Deprecated("Maintained for binary compatibility", level = DeprecationLevel.HIDDEN)
+    public constructor(frameSize: Long) : this(frameSize, cause = null)
 
     override val message: String
-        get() = "Frame is too big: $frameSize"
+        get() {
+            val sizeSuffix = if (frameSize >= 0) ": $frameSize" else ""
+            return "Frame is too big$sizeSuffix"
+        }
 
-    override fun createCopy(): FrameTooBigException = FrameTooBigException(frameSize).also {
-        it.initCauseBridge(this)
-    }
+    override fun createCopy(): FrameTooBigException = FrameTooBigException(frameSize, this)
 }


### PR DESCRIPTION
**Subsystem**
Client Darwin

**Motivation**
[KTOR-9411](https://youtrack.jetbrains.com/issue/KTOR-9411) Darwin throws DarwinHttpRequestException instead of FrameTooBigException

**Solution**
Add one more converter for NSError