### PR TITLE
Server Core. Fix docs for default value of formFieldLimit

### DIFF
--- a/ktor-server/ktor-server-core/common/src/io/ktor/server/request/ApplicationReceiveFunctions.kt
+++ b/ktor-server/ktor-server-core/common/src/io/ktor/server/request/ApplicationReceiveFunctions.kt
@@ -199,7 +199,8 @@ public suspend inline fun ApplicationCall.receiveChannel(): ByteReadChannel = re
  * Represents the limit for form field size in bytes for an [ApplicationCall].
  * This limit determines the maximum size allowed for form field data in a request.
  *
- * The default value is 65536 bytes (64 KB).
+ * The default value is 50 MiB.
+ * On JVM, default value can be set using the system property `io.ktor.server.request.formFieldLimit`.
  *
  * To get the value of the formFieldLimit, use the getter:
  * ```


### PR DESCRIPTION
**Subsystem**
Server Core KDocs

**Motivation**
[KTOR-9412](https://youtrack.jetbrains.com/issue/KTOR-9412) KDoc for `formFieldLimit` documents incorrect default value (64 KB instead of 50 MiB)

