### PR TITLE
KTOR-9361 Fix JsWebSocketSession._closeReason completed twice

### DIFF
--- a/ktor-client/ktor-client-core/js/src/io/ktor/client/engine/js/JsClientEngine.kt
+++ b/ktor-client/ktor-client-core/js/src/io/ktor/client/engine/js/JsClientEngine.kt
@@ -132,7 +132,10 @@ internal class JsClientEngine(
 private suspend fun WebSocket.awaitConnection(): WebSocket = suspendCancellableCoroutine { continuation ->
     if (continuation.isCancelled) return@suspendCancellableCoroutine
 
-    val eventListener = { event: Event ->
+    lateinit var eventListener: (Event) -> Unit
+    eventListener = { event: Event ->
+        removeEventListener("open", callback = eventListener)
+        removeEventListener("error", callback = eventListener)
         when (event.type) {
             "open" -> continuation.resume(this)
             "error" -> {

--- a/ktor-client/ktor-client-core/js/src/io/ktor/client/plugins/websocket/JsWebSocketSession.kt
+++ b/ktor-client/ktor-client-core/js/src/io/ktor/client/plugins/websocket/JsWebSocketSession.kt
@@ -8,10 +8,17 @@ import io.ktor.utils.io.*
 import io.ktor.utils.io.core.*
 import io.ktor.websocket.*
 import kotlinx.coroutines.*
-import kotlinx.coroutines.channels.*
-import org.khronos.webgl.*
-import org.w3c.dom.*
-import kotlin.coroutines.*
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.channels.ReceiveChannel
+import kotlinx.coroutines.channels.SendChannel
+import kotlinx.coroutines.channels.consumeEach
+import org.khronos.webgl.ArrayBuffer
+import org.khronos.webgl.Int8Array
+import org.w3c.dom.ARRAYBUFFER
+import org.w3c.dom.BinaryType
+import org.w3c.dom.MessageEvent
+import org.w3c.dom.WebSocket
+import kotlin.coroutines.CoroutineContext
 
 @OptIn(InternalAPI::class)
 @Suppress("CAST_NEVER_SUCCEEDS")

--- a/ktor-client/ktor-client-core/wasmJs/src/io/ktor/client/engine/js/WasmJsClientEngine.kt
+++ b/ktor-client/ktor-client-core/wasmJs/src/io/ktor/client/engine/js/WasmJsClientEngine.kt
@@ -141,8 +141,11 @@ internal class JsClientEngine(
 private suspend fun WebSocket.awaitConnection(): WebSocket = suspendCancellableCoroutine { continuation ->
     if (continuation.isCancelled) return@suspendCancellableCoroutine
 
-    val eventListener = { it: JsAny ->
+    lateinit var eventListener: (JsAny) -> Unit
+    eventListener = { it: JsAny ->
         val event: Event = it.unsafeCast()
+        removeEventListener("open", callback = eventListener)
+        removeEventListener("error", callback = eventListener)
         when (event.type) {
             "open" -> continuation.resume(this)
             "error" -> {

--- a/ktor-client/ktor-client-core/wasmJs/src/io/ktor/client/plugins/websocket/JsWebSocketSession.kt
+++ b/ktor-client/ktor-client-core/wasmJs/src/io/ktor/client/plugins/websocket/JsWebSocketSession.kt
@@ -9,10 +9,14 @@ import io.ktor.utils.io.*
 import io.ktor.utils.io.core.*
 import io.ktor.websocket.*
 import kotlinx.coroutines.*
-import kotlinx.coroutines.channels.*
-import org.khronos.webgl.*
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.channels.ReceiveChannel
+import kotlinx.coroutines.channels.SendChannel
+import kotlinx.coroutines.channels.consumeEach
+import org.khronos.webgl.ArrayBuffer
+import org.khronos.webgl.Uint8Array
 import org.w3c.dom.*
-import kotlin.coroutines.*
+import kotlin.coroutines.CoroutineContext
 
 @Suppress("UNUSED_PARAMETER")
 private fun tryGetEventDataAsString(data: JsAny): String? =


### PR DESCRIPTION
**Subsystem**
Client Js

**Motivation**
[KTOR-9361](https://youtrack.jetbrains.com/issue/KTOR-9361) WebSockets: `JsWebSocketSession._closeReason` is completed twice

**Solution**

In `awaitConnection()`, the combined open/error event listener was never removed after the open event fired. When an error occurred on an established connection, the stale listener tried to resume the already- completed continuation, logging "Already resumed, but proposed with update". Fixed by using `lateinit var` so the listener can remove itself on first fire.