### PR TITLE
KTOR-8364 Fix flaky Darwin engine test timeouts on macOS

### DIFF
--- a/ktor-client/ktor-client-darwin-legacy/darwin/test/DarwinLegacyEngineTest.kt
+++ b/ktor-client/ktor-client-darwin-legacy/darwin/test/DarwinLegacyEngineTest.kt
@@ -30,7 +30,7 @@ class DarwinLegacyEngineTest : ClientEngineTest<DarwinLegacyClientEngineConfig>(
         val client = HttpClient(DarwinLegacy)
 
         try {
-            withTimeout(1000) {
+            withTimeout(30.seconds) {
                 val response = client.get(TEST_SERVER)
                 assertEquals("Hello, world!", response.bodyAsText())
             }

--- a/ktor-client/ktor-client-darwin/darwin/test/DarwinEngineTest.kt
+++ b/ktor-client/ktor-client-darwin/darwin/test/DarwinEngineTest.kt
@@ -34,7 +34,7 @@ class DarwinEngineTest : ClientEngineTest<DarwinClientEngineConfig>(Darwin) {
         val client = HttpClient(Darwin)
 
         try {
-            withTimeout(1000) {
+            withTimeout(30.seconds) {
                 val response = client.get(TEST_SERVER)
                 assertEquals("Hello, world!", response.bodyAsText())
             }
@@ -48,7 +48,7 @@ class DarwinEngineTest : ClientEngineTest<DarwinClientEngineConfig>(Darwin) {
         val client = HttpClient(Darwin)
 
         try {
-            withTimeout(1000) {
+            withTimeout(30.seconds) {
                 val response = client.get(TEST_SERVER)
                 assertEquals("Hello, world!", response.bodyAsText())
             }
@@ -62,7 +62,7 @@ class DarwinEngineTest : ClientEngineTest<DarwinClientEngineConfig>(Darwin) {
         val client = HttpClient(Darwin)
 
         try {
-            withTimeout(1000) {
+            withTimeout(30.seconds) {
                 val response = client.get(TEST_SERVER)
                 assertEquals("Hello, world!", response.bodyAsText())
             }


### PR DESCRIPTION
[KTOR-8364](https://youtrack.jetbrains.com/issue/KTOR-8364) Fix flaky tests in DarwinEngineTest and DarwinLegacyEngineTest

## Summary
- Fixes https://github.com/ktorio/ktor/issues/5462
- The `withTimeout(1000)` (1 second) in `DarwinEngineTest` and `DarwinLegacyEngineTest` runBlocking tests was too tight for CI environments under load, causing intermittent `TimeoutCancellationException` failures on macOS Arm64
- Increased timeout to 30 seconds, which is generous enough for loaded CI while still catching actual hangs

Closes #5462

## Test plan
- All affected tests (`testRequestInRunBlockingDispatchersDefault`, `testRequestInRunBlockingDispatchersUnconfined`, `testRequestInRunBlockingDispatchersNone`, `testRequestInRunBlocking`) pass locally on macosArm64
- No public API changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)