### PR TITLE
#5461 Fix flaky HttpTimeoutTest failures on native platforms

### DIFF
--- a/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/HttpTimeoutTest.kt
+++ b/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/HttpTimeoutTest.kt
@@ -25,7 +25,7 @@ private const val TEST_URL = "$TEST_SERVER/timeout"
 private val ENGINES_WITHOUT_REQUEST_TIMEOUT = listOf("Android")
 private val ENGINES_WITHOUT_SOCKET_TIMEOUT = listOf("Java", "Curl", "Js")
 
-class HttpTimeoutTest : ClientLoader(timeout = 3.seconds) {
+class HttpTimeoutTest : ClientLoader(timeout = 30.seconds) {
     @Test
     fun testGet() = clientTests {
         config {
@@ -442,7 +442,7 @@ class HttpTimeoutTest : ClientLoader(timeout = 3.seconds) {
     }
 
     @Test
-    fun testSocketTimeoutRead() = clientTests(except(ENGINES_WITHOUT_SOCKET_TIMEOUT, "native:CIO")) {
+    fun testSocketTimeoutRead() = clientTests(except(ENGINES_WITHOUT_SOCKET_TIMEOUT, "native:CIO"), retries = 5) {
         config {
             install(HttpTimeout) { socketTimeoutMillis = 1000 }
         }
@@ -477,7 +477,8 @@ class HttpTimeoutTest : ClientLoader(timeout = 3.seconds) {
 
     @Test
     fun testSocketTimeoutWriteFailOnWrite() = clientTests(
-        except(ENGINES_WITHOUT_SOCKET_TIMEOUT, "Android", "native:CIO", "web:CIO", "WinHttp", "DarwinLegacy")
+        except(ENGINES_WITHOUT_SOCKET_TIMEOUT, "Android", "native:CIO", "web:CIO", "WinHttp", "DarwinLegacy"),
+        retries = 5,
     ) {
         config {
             install(HttpTimeout) { socketTimeoutMillis = 500 }


### PR DESCRIPTION
## Summary
- Fixes https://github.com/ktorio/ktor/issues/5461
- Increases `HttpTimeoutTest` class-level `runTest` timeout from 3s to 30s — the previous value was too aggressive for timeout tests on slow CI machines (these tests wait 500ms–1000ms for socket/request timeouts plus connection overhead)
- Adds `retries = 5` to `testSocketTimeoutWriteFailOnWrite` (flaky `UncompletedCoroutinesError` on Darwin due to async `NSURLSession` cleanup) and `testSocketTimeoutRead` (timeout imprecision on mingwX64)
- `testGetRequestTimeoutWithSeparateReceive` already had `retries = 5`; the increased class timeout resolves its flakiness on Curl/CIO mingwX64

Closes #5461

## Test plan
- All existing `HttpTimeoutTest` tests continue to pass on JVM
- The retry and timeout changes only affect flaky native platform runs (macOS X64 Darwin, mingwX64)
- CI should validate that the previously flaky tests now pass reliably

🤖 Generated with [Claude Code](https://claude.com/claude-code)