### PR TITLE
KTOR-9423 CannotTransformContentToTypeException leaks internal class

### DIFF
--- a/ktor-server/ktor-server-core/common/src/io/ktor/server/engine/BaseApplicationEngine.kt
+++ b/ktor-server/ktor-server-core/common/src/io/ktor/server/engine/BaseApplicationEngine.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2014-2026 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package io.ktor.server.engine
@@ -9,7 +9,6 @@ import io.ktor.http.*
 import io.ktor.http.content.*
 import io.ktor.server.application.*
 import io.ktor.server.http.content.*
-import io.ktor.server.plugins.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
 import io.ktor.util.date.*
@@ -113,18 +112,6 @@ private fun Application.installDefaultInterceptors() {
 }
 
 private fun Application.installDefaultTransformationChecker() {
-    // Respond with "415 Unsupported Media Type" if content cannot be transformed on receive
-    intercept(ApplicationCallPipeline.Plugins) {
-        try {
-            proceed()
-        } catch (e: CannotTransformContentToTypeException) {
-            when (val message = e.message) {
-                null -> call.respond(HttpStatusCode.UnsupportedMediaType)
-                else -> call.respond(HttpStatusCode.UnsupportedMediaType, message)
-            }
-        }
-    }
-
     val checkBodyPhase = PipelinePhase("BodyTransformationCheckPostRender")
     sendPipeline.insertPhaseAfter(ApplicationSendPipeline.Render, checkBodyPhase)
     sendPipeline.intercept(checkBodyPhase) { subject ->

--- a/ktor-server/ktor-server-core/common/src/io/ktor/server/engine/DefaultEnginePipeline.kt
+++ b/ktor-server/ktor-server-core/common/src/io/ktor/server/engine/DefaultEnginePipeline.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2014-2026 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package io.ktor.server.engine
@@ -91,7 +91,8 @@ public suspend fun logError(call: ApplicationCall, error: Throwable) {
 public fun defaultExceptionStatusCode(cause: Throwable): HttpStatusCode? = when (cause) {
     is BadRequestException -> HttpStatusCode.BadRequest
     is NotFoundException -> HttpStatusCode.NotFound
-    is UnsupportedMediaTypeException -> HttpStatusCode.UnsupportedMediaType
+    is UnsupportedMediaTypeException,
+    is CannotTransformContentToTypeException -> HttpStatusCode.UnsupportedMediaType
     is PayloadTooLargeException -> HttpStatusCode.PayloadTooLarge
     is TimeoutException, is TimeoutCancellationException -> HttpStatusCode.GatewayTimeout
     else -> null
@@ -126,7 +127,8 @@ private fun ApplicationEnvironment.logFailure(call: ApplicationCall, cause: Thro
             is BadRequestException,
             is NotFoundException,
             is PayloadTooLargeException,
-            is UnsupportedMediaTypeException -> log.debug(infoString, cause)
+            is UnsupportedMediaTypeException,
+            is CannotTransformContentToTypeException -> log.debug(infoString, cause)
 
             else -> log.error("$status: $logString", cause)
         }

--- a/ktor-server/ktor-server-plugins/ktor-server-status-pages/common/test/io/ktor/server/plugins/statuspages/StatusPagesTest.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-status-pages/common/test/io/ktor/server/plugins/statuspages/StatusPagesTest.kt
@@ -22,6 +22,7 @@ import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.async
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
+import kotlin.reflect.typeOf
 import kotlin.test.*
 
 class StatusPagesTest {
@@ -622,6 +623,28 @@ class StatusPagesTest {
             assertEquals("hello world", bodyAsText())
             assertEquals("Custom-Value-Content", headers["Custom-Header-Content"])
             assertEquals("Custom-Value-Response", headers["Custom-Header-Response"])
+        }
+    }
+
+    @Test
+    fun testCannotTransformContentToTypeException() = testApplication {
+        application {
+            install(StatusPages) {
+                exception<CannotTransformContentToTypeException> { call, _ ->
+                    call.respondText("Custom Unsupported Media Type", status = HttpStatusCode.UnsupportedMediaType)
+                }
+            }
+
+            routing {
+                post("/") {
+                    throw CannotTransformContentToTypeException(typeOf<String>())
+                }
+            }
+        }
+
+        client.post("/").let { response ->
+            assertEquals(HttpStatusCode.UnsupportedMediaType, response.status)
+            assertEquals("Custom Unsupported Media Type", response.bodyAsText())
         }
     }
 }


### PR DESCRIPTION
**Subsystem**
Server

**Motivation**
[KTOR-9423](https://youtrack.jetbrains.com/issue/KTOR-9423) CannotTransformContentToTypeException leaks internal class names in the response body

**Solution**
- Move `CannotTransformContentToTypeException` catching, allowing `StatusPages` to process it
- Don't send the error message in prod mode

