### PR TITLE
KTOR-9431 Fix context leak in SFG

### DIFF
--- a/ktor-utils/common/src/io/ktor/util/pipeline/SuspendFunctionGun.kt
+++ b/ktor-utils/common/src/io/ktor/util/pipeline/SuspendFunctionGun.kt
@@ -5,8 +5,14 @@
 package io.ktor.util.pipeline
 
 import io.ktor.util.*
-import kotlin.coroutines.*
-import kotlin.coroutines.intrinsics.*
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlin.coroutines.Continuation
+import kotlin.coroutines.ContinuationInterceptor
+import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.intrinsics.COROUTINE_SUSPENDED
+import kotlin.coroutines.intrinsics.intercepted
+import kotlin.coroutines.intrinsics.suspendCoroutineUninterceptedOrReturn
+import kotlin.coroutines.resumeWithException
 
 internal class SuspendFunctionGun<TSubject : Any, TContext : Any>(
     initial: TSubject,
@@ -32,7 +38,7 @@ internal class SuspendFunctionGun<TSubject : Any, TContext : Any>(
                 return null
             }
             // this is only invoked by debug agent during job state probes
-            // lastPeekedIndex is non-volatile intentionally
+            // currentIndex is non-volatile intentionally
             // and the list of continuations is not synchronized too
             // so this is not guaranteed to work properly (may produce incorrect trace),
             // but the only we care is to not crash here
@@ -84,7 +90,7 @@ internal class SuspendFunctionGun<TSubject : Any, TContext : Any>(
     override suspend fun proceed(): TSubject = suspendCoroutineUninterceptedOrReturn { continuation ->
         if (index == blocks.size) return@suspendCoroutineUninterceptedOrReturn subject
 
-        addContinuation(continuation.intercepted())
+        addContinuation(continuation)
 
         if (loop(true)) {
             discardLastRootContinuation()
@@ -142,11 +148,19 @@ internal class SuspendFunctionGun<TSubject : Any, TContext : Any>(
         val next = suspensions[lastSuspensionIndex]!!
         suspensions[lastSuspensionIndex--] = null
 
+        // Dispatch only when the continuation's dispatcher requires it.
+        // When already on the correct thread, resume unintercepted to avoid a second updateThreadContext call —
+        // the incoming dispatch already applied the context.
+        val toResume = when (val interceptor = next.context[ContinuationInterceptor]) {
+            is CoroutineDispatcher -> if (interceptor.isDispatchNeeded(next.context)) next.intercepted() else next
+            else -> next.intercepted()
+        }
+
         if (!result.isFailure) {
-            next.resumeWith(result)
+            toResume.resumeWith(result)
         } else {
             val exception = recoverStackTraceBridge(result.exceptionOrNull()!!, next)
-            next.resumeWithException(exception)
+            toResume.resumeWithException(exception)
         }
     }
 

--- a/ktor-utils/common/src/io/ktor/util/pipeline/SuspendFunctionGun.kt
+++ b/ktor-utils/common/src/io/ktor/util/pipeline/SuspendFunctionGun.kt
@@ -14,10 +14,40 @@ import kotlin.coroutines.intrinsics.intercepted
 import kotlin.coroutines.intrinsics.suspendCoroutineUninterceptedOrReturn
 import kotlin.coroutines.resumeWithException
 
+/**
+ * Executes pipeline [interceptors] with minimal overhead on the hot path.
+ *
+ * Instead of resuming each interceptor through a separate continuation step, it continues directly
+ * to the next one until one suspends and stores only the state needed to resume later.
+ * This reduces allocations and avoids unnecessary rescheduling through the dispatcher.
+ *
+ * ## Implementation Notes
+ *
+ * ### Shared continuation
+ *
+ * All interceptors are started with the same [continuation] instance, so they all complete back
+ * into the same pipeline driver and the whole pipeline can be advanced as one state machine.
+ *
+ * ### Saved caller continuations
+ *
+ * When [proceed] invokes the next interceptor, it saves the caller continuation in [suspensions].
+ * When downstream work completes, [resumeRootWith] pops and resumes the top saved continuation, so
+ * each [proceed] returns to its caller after later interceptors finish.
+ *
+ * ### Current coroutine context
+ *
+ * The shared [continuation] resolves [Continuation.context] from the top saved continuation, so
+ * each interceptor sees the coroutine context of the caller that last invoked [proceed].
+ *
+ * ### Conditional redispatch
+ *
+ * [resumeRootWith] resumes saved continuations directly when execution is already in the right
+ * thread, and otherwise resumes them through the intercepted continuation.
+ */
 internal class SuspendFunctionGun<TSubject : Any, TContext : Any>(
     initial: TSubject,
     context: TContext,
-    private val blocks: List<PipelineInterceptor<TSubject, TContext>>
+    private val interceptors: List<PipelineInterceptor<TSubject, TContext>>
 ) : PipelineContext<TSubject, TContext>(context) {
 
     override val coroutineContext: CoroutineContext get() = continuation.context
@@ -55,44 +85,39 @@ internal class SuspendFunctionGun<TSubject : Any, TContext : Any>(
 
         override val context: CoroutineContext
             get() {
-                val continuation = suspensions[lastSuspensionIndex]
-                if (continuation !== this && continuation != null) return continuation.context
-
-                var index = lastSuspensionIndex - 1
-                while (index >= 0) {
-                    val cont = suspensions[index--]
+                for (index in lastSuspensionIndex downTo 0) {
+                    val cont = suspensions[index]
                     if (cont !== this && cont != null) return cont.context
                 }
-
                 error("Not started")
             }
 
         override fun resumeWith(result: Result<Unit>) {
-            if (result.isFailure) {
-                resumeRootWith(Result.failure(result.exceptionOrNull()!!))
+            result.onFailure { exception ->
+                resumeRootWith(Result.failure(exception))
                 return
             }
 
-            loop(false)
+            loop(direct = false)
         }
     }
 
     override var subject: TSubject = initial
 
-    private val suspensions: Array<Continuation<TSubject>?> = arrayOfNulls(blocks.size)
+    private val suspensions: Array<Continuation<TSubject>?> = arrayOfNulls(interceptors.size)
     private var lastSuspensionIndex: Int = -1
     private var index = 0
 
     override fun finish() {
-        index = blocks.size
+        index = interceptors.size
     }
 
     override suspend fun proceed(): TSubject = suspendCoroutineUninterceptedOrReturn { continuation ->
-        if (index == blocks.size) return@suspendCoroutineUninterceptedOrReturn subject
+        if (index == interceptors.size) return@suspendCoroutineUninterceptedOrReturn subject
 
         addContinuation(continuation)
 
-        if (loop(true)) {
+        if (loop(direct = true)) {
             discardLastRootContinuation()
             return@suspendCoroutineUninterceptedOrReturn subject
         }
@@ -107,21 +132,27 @@ internal class SuspendFunctionGun<TSubject : Any, TContext : Any>(
 
     override suspend fun execute(initial: TSubject): TSubject {
         index = 0
-        if (index == blocks.size) return initial
+        if (index == interceptors.size) return initial
         subject = initial
 
-        if (lastSuspensionIndex >= 0) throw IllegalStateException("Already started")
-
+        check(lastSuspensionIndex < 0) { "Already started" }
         return proceed()
     }
 
     /**
-     * @return `true` if it is possible to return result immediately
+     * Runs the remaining [interceptors] until one suspends or the pipeline completes.
+     * Returns `true` when the caller can return [subject] immediately, without going through
+     * [resumeRootWith].
+     *
+     * [direct] is used when [loop] is entered from [proceed], while execution is still moving
+     * forward through [interceptors] and completion can be returned directly to the current caller.
+     * When [loop] is entered later from the shared [continuation], completion must be delivered
+     * through [resumeRootWith] instead.
      */
     private fun loop(direct: Boolean): Boolean {
         do {
             val currentIndex = index // it is important to read index every time
-            if (currentIndex == blocks.size) {
+            if (currentIndex == interceptors.size) {
                 if (!direct) {
                     resumeRootWith(Result.success(subject))
                     return false
@@ -131,7 +162,7 @@ internal class SuspendFunctionGun<TSubject : Any, TContext : Any>(
             }
 
             index = currentIndex + 1 // it is important to increase it before function invocation
-            val next = blocks[currentIndex]
+            val next = interceptors[currentIndex]
 
             try {
                 val result = pipelineStartCoroutineUninterceptedOrReturn(next, this, subject, continuation)
@@ -144,7 +175,7 @@ internal class SuspendFunctionGun<TSubject : Any, TContext : Any>(
     }
 
     private fun resumeRootWith(result: Result<TSubject>) {
-        if (lastSuspensionIndex < 0) error("No more continuations to resume")
+        check(lastSuspensionIndex >= 0) { "No more continuations to resume" }
         val next = suspensions[lastSuspensionIndex]!!
         suspensions[lastSuspensionIndex--] = null
 
@@ -156,16 +187,17 @@ internal class SuspendFunctionGun<TSubject : Any, TContext : Any>(
             else -> next.intercepted()
         }
 
-        if (!result.isFailure) {
-            toResume.resumeWith(result)
-        } else {
-            val exception = recoverStackTraceBridge(result.exceptionOrNull()!!, next)
-            toResume.resumeWithException(exception)
+        when (val exception = result.exceptionOrNull()) {
+            null -> toResume.resumeWith(result)
+            else -> {
+                val recoveredException = recoverStackTraceBridge(exception, next)
+                toResume.resumeWithException(recoveredException)
+            }
         }
     }
 
     private fun discardLastRootContinuation() {
-        if (lastSuspensionIndex < 0) throw IllegalStateException("No more continuations to resume")
+        check(lastSuspensionIndex >= 0) { "No more continuations to resume" }
         suspensions[lastSuspensionIndex--] = null
     }
 

--- a/ktor-utils/jvm/test/io/ktor/util/PipelineContractsJvmTest.kt
+++ b/ktor-utils/jvm/test/io/ktor/util/PipelineContractsJvmTest.kt
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2014-2026 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.util
+
+import io.ktor.util.pipeline.*
+import kotlinx.coroutines.*
+import java.util.concurrent.LinkedBlockingQueue
+import kotlin.coroutines.Continuation
+import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.intrinsics.COROUTINE_SUSPENDED
+import kotlin.coroutines.intrinsics.suspendCoroutineUninterceptedOrReturn
+import kotlin.coroutines.startCoroutine
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertSame
+
+class PipelineContractsJvmTest {
+
+    // Regression test for KTOR-9431.
+    @Test
+    fun `thread context is not leaked into outer interceptor after proceed`() {
+        val threadLocal = ThreadLocal<String?>()
+        val phase = PipelinePhase("test")
+        val dispatcher = ExternalEventLoopDispatcher()
+
+        dispatcher.runEventLoop {
+            val pipeline = Pipeline<Unit, Unit>(phase)
+            var capturedValue: String? = null
+
+            pipeline.intercept(phase) {
+                proceed()
+                capturedValue = threadLocal.get()
+            }
+
+            pipeline.intercept(phase) {
+                withContext(threadLocal.asContextElement("set")) {
+                    proceed()
+                }
+            }
+
+            pipeline.intercept(phase) {
+                yield()
+            }
+
+            pipeline.execute(Unit, Unit)
+
+            assertNull(threadLocal.get(), "SFG leaked thread local after pipeline")
+            assertNull(capturedValue, "SFG leaked thread local into outer interceptor after proceed")
+        }
+    }
+
+    // Regression test for KTOR-2644.
+    @Test
+    fun `thread context is set inside withContext after cross-thread resume`() {
+        val threadLocal = ThreadLocal<String?>()
+        val phase = PipelinePhase("test")
+        val dispatcher = ExternalEventLoopDispatcher()
+
+        dispatcher.runEventLoop {
+            val loopThread = Thread.currentThread()
+            var resumedThread: Thread? = null
+
+            val pipeline = Pipeline<Unit, Unit>(phase)
+            var capturedValue: String? = null
+
+            pipeline.intercept(phase) {
+                withContext(threadLocal.asContextElement("set")) {
+                    proceed()
+                    capturedValue = threadLocal.get()
+                    resumedThread = Thread.currentThread()
+                }
+            }
+
+            pipeline.intercept(phase) {
+                yieldToAnotherThread()
+            }
+
+            pipeline.execute(Unit, Unit)
+
+            assertNull(threadLocal.get(), "SFG leaked thread local after pipeline")
+            assertEquals("set", capturedValue, "Thread local not set inside withContext after cross-thread resume")
+            assertSame(loopThread, resumedThread, "proceed() returned on wrong thread after cross-thread suspension")
+        }
+    }
+}
+
+// Suspends the coroutine unintercepted and resumes it from a raw background thread.
+// This ensures SFG.continuation.resumeWith is called from a non-dispatcher thread,
+// triggering the isDispatchNeeded=true branch in resumeRootWith.
+private suspend fun yieldToAnotherThread(): Unit = suspendCoroutineUninterceptedOrReturn { cont ->
+    Thread { cont.resumeWith(Result.success(Unit)) }.start()
+    COROUTINE_SUSPENDED
+}
+
+// Mimics a Netty/Vert.x event loop: isDispatchNeeded=false on the loop thread, but NOT a
+// kotlinx.coroutines EventLoopImplBase, so executeUnconfined runs continuations inline.
+private class ExternalEventLoopDispatcher : CoroutineDispatcher() {
+    private val onLoopThread = ThreadLocal.withInitial { false }
+    private val queue = LinkedBlockingQueue<Runnable>()
+
+    override fun isDispatchNeeded(context: CoroutineContext): Boolean = !onLoopThread.get()
+
+    override fun dispatch(context: CoroutineContext, block: Runnable) {
+        queue.put(block)
+    }
+
+    fun runEventLoop(block: suspend () -> Unit) {
+        onLoopThread.set(true)
+        var failure: Throwable? = null
+        val done = Runnable {}
+        try {
+            block.startCoroutine(
+                Continuation(this) { result ->
+                    failure = result.exceptionOrNull()
+                    queue.put(done)
+                }
+            )
+            while (true) {
+                val task = queue.take()
+                if (task === done) break
+                task.run()
+            }
+            failure?.let { throw it }
+        } finally {
+            onLoopThread.set(false)
+        }
+    }
+}


### PR DESCRIPTION
**Subsystem**
`ktor-utils`

**Motivation**
[KTOR-9431](https://youtrack.jetbrains.com/issue/KTOR-9431) SuspendFunctionGun: OTel context leaks across requests

**Investigation**

Unconditional wrapping continuations into `DispatchedContinuation` in SFG leads to violation of the `ThreadContextElement` contract. `ThreadContextElement` requires `updateThreadContext`/`restoreThreadContext` pairs to be called exactly once per dispatch step. But currently, it's possible to get into the state when `updateThreadContext` was called twice in a row.

Here is the problematic scenario:
```kotlin
val threadLocal = ThreadLocal<String?>()
val phase = PipelinePhase("test")
val pipeline = Pipeline<Unit, Unit>(phase)

// I1 - outer interceptor. Verifies that ThreadContextElement is not leaked
pipeline.intercept(phase) {
    proceed()
    assertNull(threadLocal.get(), "Leaked!")
}
// I2 - middle interceptor. Adds the ThreadContextElement
pipeline.intercept(phase) {
    withContext(threadLocal.asContextElement("set")) {
        proceed()
    }
}
// I3 - inner interceptor. Suspends execution
pipeline.intercept(phase) {
    yield() // suspends
}

pipeline.execute(Unit, Unit)
```

When `execute` is called, all three interceptors are called in `loop(direct = true)`: `I1` -> `I2` -> `I3`.
And `I3` suspends execution. So the coroutine is added to the dispatcher's queue, preserving the current coroutine context (`TL == "set"`).

When the dispatcher takes the task, it calls `DispatchedTask.run()` which wraps execution in `withContinuationContext`. This function is responsible for calling `updateThreadContext` before execution and `restoreThreadContext` after it.
**Here the first `updateThreadContext` call happens (`update1`).**

When `I3` completes, `I3.resumeWith()` called and this leads to `loop(direct = false)`. We take the saved before continuation (which is wrapped with `DispatchedContinuation`) and call `resumeWith` on it.
`DispatchedContinuation` also calls `withContinuationContext` under the hood, so **here we get the second `updateThreadContext` call (`update2`).**

It's important that to hit this code path, two conditions should be met:
1. `CoroutineDispatcher.isDispatchNeeded` returns `false` (so we should be on the same thread)
2. The dispatcher is NOT a `kotlinx.coroutines.EventLoopImplBase` — for `EventLoopImplBase` dispatchers (e.g. `runBlocking`'s `BlockingEventLoop`), `executeUnconfined` routes through the event loop's own queue rather than running inline, so the nested `withContinuationContext` never fires

With these conditions met, we fall into the inline path in `executeUnconfined`:
```kotlin
withContinuationContext(context, TL("set")) {
    continuation.resumeWith(result)
}
```
At this point `updateThreadContext` is called twice in a row.

### Simplified traces before and after the fix
```
BEFORE — store DispatchedContinuation                   AFTER — store raw continuations

DispatchedTask.run()                                    DispatchedTask.run()
└─ withContinuationContext                              └─ withContinuationContext
      update1: save1=null, TL="set"                           update1: save1=null, TL="set"
   I3.resumeWith() — completes                             I3.resumeWith() — completes
   resumeRootWith() → DispatchedContinuation(I2)           resumeRootWith() → I2 (raw)
   └─ executeUnconfined                                    I2.resumeWith() — direct, no wrapping
      └─ withContinuationContext        ← nested!             I2 resumes inside withContext
            update2: save2="set"  ← BUG                       UndispatchedCoroutine.restore: TL=null
         I2 resumes inside withContext                        resumeRootWith() → I1 (raw)
         UndispatchedCoroutine.restore: TL=null               I1.resumeWith() — direct, no wrapping
         resumeRootWith() → DispatchedContinuation(I1)           threadLocal.get() == null ✓
             → QUEUED (unconfined loop active)          └─ restore1: TL=null ✓
         [I2 returns]
      └─ restore2: TL="set"   ← LEAK
      drain queue: I1.resumeWith()
          threadLocal.get() == "set"  ← OBSERVED
└─ restore1: TL=null  (too late)
```

`save2="set"` is wrong because `update1` already set TL before `update2` ran.
`restore2` then reinstates `"set"` *after* `UndispatchedCoroutine` correctly cleared it,
and *before* `I1` reads the value — because `I1` was queued to the unconfined loop and runs
only after `restore2` fires.


**Solution**

Store raw continuations. `resumeRootWith` calls `raw.resumeWith()` directly when
`isDispatchNeeded=false` — no `DispatchedContinuation` wrapper, no `executeUnconfined`, no nested
`withContinuationContext`. One `update`/`restore` pair brackets the entire dispatch step.

> [!NOTE]
> The fix itself is in the first commit. The second one is just cleaning up the implementation a bit, plus KDocs to simplify learning what SFG does.
