### PR TITLE
Fix ConcurrentMapNative snapshot views to avoid CME during iteration

### DIFF
--- a/ktor-utils/posix/src/io/ktor/util/collections/ConcurrentMapNative.kt
+++ b/ktor-utils/posix/src/io/ktor/util/collections/ConcurrentMapNative.kt
@@ -42,6 +42,9 @@ public actual class ConcurrentMap<Key, Value> public actual constructor(
 
     actual override fun isEmpty(): Boolean = delegate.isEmpty()
 
+    // Native returns detached snapshots instead of live views to avoid reintroducing
+    // ConcurrentModificationException when callers iterate outside the map lock.
+    // See https://github.com/ktorio/ktor/issues/5480.
     actual override val entries: MutableSet<MutableMap.MutableEntry<Key, Value>>
         get() = synchronized(lock) {
             LinkedHashSet(delegate.entries.map { DetachedMutableEntry(it.key, it.value) })

--- a/ktor-utils/posix/src/io/ktor/util/collections/ConcurrentMapNative.kt
+++ b/ktor-utils/posix/src/io/ktor/util/collections/ConcurrentMapNative.kt
@@ -43,13 +43,15 @@ public actual class ConcurrentMap<Key, Value> public actual constructor(
     actual override fun isEmpty(): Boolean = delegate.isEmpty()
 
     actual override val entries: MutableSet<MutableMap.MutableEntry<Key, Value>>
-        get() = synchronized(lock) { delegate.entries }
+        get() = synchronized(lock) {
+            LinkedHashSet(delegate.entries.map { DetachedMutableEntry(it.key, it.value) })
+        }
 
     actual override val keys: MutableSet<Key>
-        get() = synchronized(lock) { delegate.keys }
+        get() = synchronized(lock) { LinkedHashSet(delegate.keys) }
 
     actual override val values: MutableCollection<Value>
-        get() = synchronized(lock) { delegate.values }
+        get() = synchronized(lock) { ArrayList(delegate.values) }
 
     actual override fun clear() {
         synchronized(lock) {
@@ -81,4 +83,20 @@ public actual class ConcurrentMap<Key, Value> public actual constructor(
     }
 
     override fun toString(): String = "ConcurrentMapNative by $delegate"
+}
+
+private class DetachedMutableEntry<K, V>(
+    override val key: K,
+    value: V
+) : MutableMap.MutableEntry<K, V> {
+    private var currentValue: V = value
+
+    override val value: V
+        get() = currentValue
+
+    override fun setValue(newValue: V): V {
+        val oldValue = currentValue
+        currentValue = newValue
+        return oldValue
+    }
 }

--- a/ktor-utils/posix/src/io/ktor/util/collections/ConcurrentMapNative.kt
+++ b/ktor-utils/posix/src/io/ktor/util/collections/ConcurrentMapNative.kt
@@ -99,4 +99,11 @@ private class DetachedMutableEntry<K, V>(
         currentValue = newValue
         return oldValue
     }
+
+    override fun equals(other: Any?): Boolean {
+        if (other !is Map.Entry<*, *>) return false
+        return key == other.key && value == other.value
+    }
+
+    override fun hashCode(): Int = key.hashCode() xor value.hashCode()
 }

--- a/ktor-utils/posix/test/io/ktor/util/collections/ConcurrentMapNativeTest.kt
+++ b/ktor-utils/posix/test/io/ktor/util/collections/ConcurrentMapNativeTest.kt
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2014-2025 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.util.collections
+
+import kotlin.test.*
+
+class ConcurrentMapNativeTest {
+
+    @Test
+    fun `entries returns snapshot`() {
+        val map = ConcurrentMap<Int, String>(initialCapacity = 4)
+        map[1] = "one"
+        map[2] = "two"
+
+        val entries = map.entries
+        map.remove(1)
+        map[3] = "three"
+
+        assertEquals(listOf(1 to "one", 2 to "two"), entries.map { it.key to it.value }.sortedBy { it.first })
+    }
+
+    @Test
+    fun `keys returns snapshot`() {
+        val map = ConcurrentMap<Int, String>(initialCapacity = 4)
+        map[1] = "one"
+        map[2] = "two"
+
+        val keys = map.keys
+        map.remove(1)
+        map[3] = "three"
+
+        assertEquals(setOf(1, 2), keys.toSet())
+    }
+
+    @Test
+    fun `values returns snapshot`() {
+        val map = ConcurrentMap<Int, String>(initialCapacity = 4)
+        map[1] = "one"
+        map[2] = "two"
+
+        val values = map.values
+        map.remove(1)
+        map[3] = "three"
+
+        assertEquals(listOf("one", "two"), values.sorted())
+    }
+}

--- a/ktor-utils/posix/test/io/ktor/util/collections/ConcurrentMapNativeTest.kt
+++ b/ktor-utils/posix/test/io/ktor/util/collections/ConcurrentMapNativeTest.kt
@@ -46,4 +46,30 @@ class ConcurrentMapNativeTest {
 
         assertEquals(listOf("one", "two"), values.sorted())
     }
+
+    @Test
+    fun `entries snapshot supports value-based contains and remove`() {
+        val map = ConcurrentMap<Int, String>(initialCapacity = 4)
+        map[1] = "one"
+        map[2] = "two"
+
+        val entries = map.entries
+        assertTrue(entries.contains(TestMutableEntry(1, "one")))
+        assertTrue(entries.remove(TestMutableEntry(1, "one")))
+        assertFalse(entries.contains(TestMutableEntry(1, "one")))
+    }
+}
+
+private class TestMutableEntry<K, V>(
+    override val key: K,
+    override val value: V
+) : MutableMap.MutableEntry<K, V> {
+    override fun setValue(newValue: V): V = value
+
+    override fun equals(other: Any?): Boolean {
+        if (other !is Map.Entry<*, *>) return false
+        return key == other.key && value == other.value
+    }
+
+    override fun hashCode(): Int = key.hashCode() xor value.hashCode()
 }


### PR DESCRIPTION
## Summary
Fixes #5480 by returning detached snapshot collections from `ConcurrentMapNative` view properties.

- `entries` now returns a copied set of detached mutable entries
- `keys` now returns a copied set
- `values` now returns a copied list

This prevents iterating over map views from throwing `ConcurrentModificationException` when the backing map is mutated concurrently or during teardown flows.

## Tests
Added `ConcurrentMapNativeTest` under `ktor-utils/posix/test`:
- `entries returns snapshot`
- `keys returns snapshot`
- `values returns snapshot`

## Verification
- `./gradlew :ktor-utils:formatKotlin`
- `./gradlew :ktor-utils:lintKotlin`
- `./gradlew :ktor-utils:assemble`
- `./gradlew :ktor-utils:jvmTest :ktor-utils:macosArm64Test` (`macosArm64Test` is build-gated and skipped by task config)
- `./gradlew :ktor-utils:linkDebugTestMacosX64`
- `./ktor-utils/build/bin/macosX64/debugTest/test.kexe`
- `./ktor-utils/build/bin/macosX64/debugTest/test.kexe '--ktest_filter=io.ktor.util.collections.ConcurrentMapNativeTest.*'`
