### PR TITLE
Add GraphQL plugin for Ktor server

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -75,6 +75,8 @@ xmlutil = "0.91.3"
 yamlkt = "0.13.0"
 kaml = "0.79.0"
 
+graphql-java = "25.0"
+
 swagger-codegen = "3.0.75"
 swagger-codegen-generators = "1.0.59"
 swagger-parser = "2.1.37"
@@ -228,6 +230,8 @@ jakarta-servlet = { module = "jakarta.servlet:jakarta.servlet-api", version.ref 
 xmlutil-serialization = { module = "io.github.pdvrieze.xmlutil:serialization", version.ref = "xmlutil" }
 yamlkt-serialization = { module = "net.mamoe.yamlkt:yamlkt", version.ref = "yamlkt" }
 kaml-serialization = { module = "com.charleskorn.kaml:kaml", version.ref = "kaml" }
+
+graphql-java = { module = "com.graphql-java:graphql-java", version.ref = "graphql-java" }
 
 swagger-codegen = { module = "io.swagger.codegen.v3:swagger-codegen", version.ref = "swagger-codegen" }
 swagger-codegen-generators = { module = "io.swagger.codegen.v3:swagger-codegen-generators", version.ref = "swagger-codegen-generators" }

--- a/ktor-server/ktor-server-plugins/ktor-server-graphql/README.md
+++ b/ktor-server/ktor-server-plugins/ktor-server-graphql/README.md
@@ -1,0 +1,201 @@
+# ktor-server-graphql
+
+A Ktor server plugin that provides a GraphQL endpoint powered by [graphql-java](https://github.com/graphql-java/graphql-java).
+
+## Features
+
+- **SDL-first schema definition** with runtime wiring via the graphql-java DSL
+- **Pre-built schema support** for programmatic schema construction
+- **Async execution** using Kotlin coroutines
+- **Per-request context** injection from the `ApplicationCall`
+- **Custom engine configuration** for instrumentation, execution strategies, etc.
+- **GraphiQL IDE** - optional built-in interactive query editor
+- **Self-contained JSON handling** - no ContentNegotiation plugin required
+
+## Installation
+
+Add the dependency to your project:
+
+```kotlin
+dependencies {
+    implementation("io.ktor:ktor-server-graphql:$ktor_version")
+}
+```
+
+## Quick Start
+
+```kotlin
+fun Application.module() {
+    routing {
+        graphQL {
+            schema("""
+                type Query {
+                    hello: String
+                    greet(name: String!): String
+                }
+            """) {
+                type("Query") {
+                    it.dataFetcher("hello") { "Hello, World!" }
+                        .dataFetcher("greet") { env ->
+                            "Hello, ${env.getArgument<String>("name")}!"
+                        }
+                }
+            }
+        }
+    }
+}
+```
+
+Send a query:
+
+```bash
+curl -X POST http://localhost:8080/graphql \
+  -H "Content-Type: application/json" \
+  -d '{"query": "{ hello }"}'
+```
+
+Response:
+
+```json
+{
+  "data": {
+    "hello": "Hello, World!"
+  }
+}
+```
+
+## Configuration
+
+### Schema Definition (SDL)
+
+Define your schema using the GraphQL Schema Definition Language and bind data fetchers:
+
+```kotlin
+graphQL {
+    schema("""
+        type Query {
+            users: [User]
+            user(id: ID!): User
+        }
+
+        type User {
+            id: ID!
+            name: String!
+            email: String
+        }
+    """) {
+        type("Query") {
+            it.dataFetcher("users") { userService.findAll() }
+                .dataFetcher("user") { env ->
+                    userService.findById(env.getArgument("id"))
+                }
+        }
+    }
+}
+```
+
+### Pre-built Schema
+
+Pass a pre-built `GraphQLSchema` instance:
+
+```kotlin
+graphQL {
+    schema(myPrebuiltSchema)
+}
+```
+
+Or use a factory function:
+
+```kotlin
+graphQL {
+    schema {
+        SchemaGenerator().makeExecutableSchema(typeRegistry, runtimeWiring)
+    }
+}
+```
+
+### Custom Endpoint Path
+
+```kotlin
+graphQL {
+    endpoint = "api/graphql"  // default: "graphql"
+    // ...
+}
+```
+
+### GraphiQL IDE
+
+Enable the interactive GraphiQL IDE:
+
+```kotlin
+graphQL {
+    graphiql = true                      // default: false
+    graphiqlEndpoint = "playground"      // default: "graphiql"
+    // ...
+}
+```
+
+Then open `http://localhost:8080/graphiql` (or your custom endpoint) in a browser.
+
+### Per-Request Context
+
+Inject values from the `ApplicationCall` into the GraphQL context, making them available to data fetchers:
+
+```kotlin
+graphQL {
+    context { call ->
+        mapOf(
+            "userId" to call.principal<UserPrincipal>()?.id,
+            "locale" to call.request.headers["Accept-Language"]
+        )
+    }
+    schema(/* ... */) {
+        type("Query") {
+            it.dataFetcher("profile") { env ->
+                val userId = env.graphQlContext.get<String>("userId")
+                userService.findById(userId)
+            }
+        }
+    }
+}
+```
+
+### Custom GraphQL Engine
+
+Customize the `graphql-java` engine for instrumentation, execution strategies, or other advanced settings:
+
+```kotlin
+graphQL {
+    engine { schema ->
+        GraphQL.newGraphQL(schema)
+            .instrumentation(myInstrumentation)
+            .defaultDataFetcherExceptionHandler(myHandler)
+            .build()
+    }
+    // ...
+}
+```
+
+## GraphQL Request Format
+
+The plugin accepts POST requests with a JSON body following the [GraphQL over HTTP specification](https://graphql.github.io/graphql-over-http/):
+
+```json
+{
+  "query": "query GetUser($id: ID!) { user(id: $id) { name email } }",
+  "operationName": "GetUser",
+  "variables": { "id": "123" },
+  "extensions": {}
+}
+```
+
+| Field           | Type                | Required | Description                          |
+|-----------------|---------------------|----------|--------------------------------------|
+| `query`         | `String`            | Yes      | The GraphQL query/mutation string    |
+| `operationName` | `String`            | No       | Operation name for multi-op queries  |
+| `variables`     | `Map<String, Any?>` | No       | Variable values                      |
+| `extensions`    | `Map<String, Any?>` | No       | Protocol extensions                  |
+
+## Requirements
+
+- JDK 11 or higher (required by graphql-java)

--- a/ktor-server/ktor-server-plugins/ktor-server-graphql/api/ktor-server-graphql.api
+++ b/ktor-server/ktor-server-plugins/ktor-server-graphql/api/ktor-server-graphql.api
@@ -1,0 +1,150 @@
+public final class io/ktor/server/plugins/graphql/GraphQLConfig {
+ public fun <init> ()V
+ public final fun context (Lkotlin/jvm/functions/Function2;)V
+ public final fun engine (Lkotlin/jvm/functions/Function1;)V
+ public final fun getEndpoint ()Ljava/lang/String;
+ public final fun getGraphiql ()Z
+ public final fun getGraphiqlEndpoint ()Ljava/lang/String;
+ public final fun schema (Lgraphql/schema/GraphQLSchema;)V
+ public final fun schema (Ljava/lang/String;Lkotlin/jvm/functions/Function1;)V
+ public final fun schema (Lkotlin/jvm/functions/Function0;)V
+ public static synthetic fun schema$default (Lio/ktor/server/plugins/graphql/GraphQLConfig;Ljava/lang/String;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+ public final fun setEndpoint (Ljava/lang/String;)V
+ public final fun setGraphiql (Z)V
+ public final fun setGraphiqlEndpoint (Ljava/lang/String;)V
+}
+
+public final class io/ktor/server/plugins/graphql/GraphQLError {
+ public static final field Companion Lio/ktor/server/plugins/graphql/GraphQLError$Companion;
+ public fun <init> (Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/Map;)V
+ public synthetic fun <init> (Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+ public final fun component1 ()Ljava/lang/String;
+ public final fun component2 ()Ljava/util/List;
+ public final fun component3 ()Ljava/util/List;
+ public final fun component4 ()Ljava/util/Map;
+ public final fun copy (Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/Map;)Lio/ktor/server/plugins/graphql/GraphQLError;
+ public static synthetic fun copy$default (Lio/ktor/server/plugins/graphql/GraphQLError;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/Map;ILjava/lang/Object;)Lio/ktor/server/plugins/graphql/GraphQLError;
+ public fun equals (Ljava/lang/Object;)Z
+ public final fun getExtensions ()Ljava/util/Map;
+ public final fun getLocations ()Ljava/util/List;
+ public final fun getMessage ()Ljava/lang/String;
+ public final fun getPath ()Ljava/util/List;
+ public fun hashCode ()I
+ public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/ktor/server/plugins/graphql/GraphQLError$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+ public static final field INSTANCE Lio/ktor/server/plugins/graphql/GraphQLError$$serializer;
+ public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+ public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/ktor/server/plugins/graphql/GraphQLError;
+ public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+ public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+ public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/ktor/server/plugins/graphql/GraphQLError;)V
+ public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+ public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/ktor/server/plugins/graphql/GraphQLError$Companion {
+ public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/ktor/server/plugins/graphql/GraphQLKt {
+ public static final fun graphQL (Lio/ktor/server/routing/Route;Lkotlin/jvm/functions/Function1;)Lio/ktor/server/routing/Route;
+}
+
+public final class io/ktor/server/plugins/graphql/GraphQLRequest {
+ public static final field Companion Lio/ktor/server/plugins/graphql/GraphQLRequest$Companion;
+ public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/util/Map;)V
+ public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+ public final fun component1 ()Ljava/lang/String;
+ public final fun component2 ()Ljava/lang/String;
+ public final fun component3 ()Ljava/util/Map;
+ public final fun component4 ()Ljava/util/Map;
+ public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/util/Map;)Lio/ktor/server/plugins/graphql/GraphQLRequest;
+ public static synthetic fun copy$default (Lio/ktor/server/plugins/graphql/GraphQLRequest;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/util/Map;ILjava/lang/Object;)Lio/ktor/server/plugins/graphql/GraphQLRequest;
+ public fun equals (Ljava/lang/Object;)Z
+ public final fun getExtensions ()Ljava/util/Map;
+ public final fun getOperationName ()Ljava/lang/String;
+ public final fun getQuery ()Ljava/lang/String;
+ public final fun getVariables ()Ljava/util/Map;
+ public fun hashCode ()I
+ public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/ktor/server/plugins/graphql/GraphQLRequest$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+ public static final field INSTANCE Lio/ktor/server/plugins/graphql/GraphQLRequest$$serializer;
+ public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+ public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/ktor/server/plugins/graphql/GraphQLRequest;
+ public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+ public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+ public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/ktor/server/plugins/graphql/GraphQLRequest;)V
+ public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+ public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/ktor/server/plugins/graphql/GraphQLRequest$Companion {
+ public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/ktor/server/plugins/graphql/GraphQLResponse {
+ public static final field Companion Lio/ktor/server/plugins/graphql/GraphQLResponse$Companion;
+ public fun <init> ()V
+ public fun <init> (Lkotlinx/serialization/json/JsonElement;Ljava/util/List;Ljava/util/Map;)V
+ public synthetic fun <init> (Lkotlinx/serialization/json/JsonElement;Ljava/util/List;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+ public final fun component1 ()Lkotlinx/serialization/json/JsonElement;
+ public final fun component2 ()Ljava/util/List;
+ public final fun component3 ()Ljava/util/Map;
+ public final fun copy (Lkotlinx/serialization/json/JsonElement;Ljava/util/List;Ljava/util/Map;)Lio/ktor/server/plugins/graphql/GraphQLResponse;
+ public static synthetic fun copy$default (Lio/ktor/server/plugins/graphql/GraphQLResponse;Lkotlinx/serialization/json/JsonElement;Ljava/util/List;Ljava/util/Map;ILjava/lang/Object;)Lio/ktor/server/plugins/graphql/GraphQLResponse;
+ public fun equals (Ljava/lang/Object;)Z
+ public final fun getData ()Lkotlinx/serialization/json/JsonElement;
+ public final fun getErrors ()Ljava/util/List;
+ public final fun getExtensions ()Ljava/util/Map;
+ public fun hashCode ()I
+ public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/ktor/server/plugins/graphql/GraphQLResponse$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+ public static final field INSTANCE Lio/ktor/server/plugins/graphql/GraphQLResponse$$serializer;
+ public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+ public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/ktor/server/plugins/graphql/GraphQLResponse;
+ public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+ public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+ public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/ktor/server/plugins/graphql/GraphQLResponse;)V
+ public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+ public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/ktor/server/plugins/graphql/GraphQLResponse$Companion {
+ public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/ktor/server/plugins/graphql/GraphQLSourceLocation {
+ public static final field Companion Lio/ktor/server/plugins/graphql/GraphQLSourceLocation$Companion;
+ public fun <init> (II)V
+ public final fun component1 ()I
+ public final fun component2 ()I
+ public final fun copy (II)Lio/ktor/server/plugins/graphql/GraphQLSourceLocation;
+ public static synthetic fun copy$default (Lio/ktor/server/plugins/graphql/GraphQLSourceLocation;IIILjava/lang/Object;)Lio/ktor/server/plugins/graphql/GraphQLSourceLocation;
+ public fun equals (Ljava/lang/Object;)Z
+ public final fun getColumn ()I
+ public final fun getLine ()I
+ public fun hashCode ()I
+ public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/ktor/server/plugins/graphql/GraphQLSourceLocation$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+ public static final field INSTANCE Lio/ktor/server/plugins/graphql/GraphQLSourceLocation$$serializer;
+ public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+ public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/ktor/server/plugins/graphql/GraphQLSourceLocation;
+ public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+ public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+ public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/ktor/server/plugins/graphql/GraphQLSourceLocation;)V
+ public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+ public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/ktor/server/plugins/graphql/GraphQLSourceLocation$Companion {
+ public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+

--- a/ktor-server/ktor-server-plugins/ktor-server-graphql/build.gradle.kts
+++ b/ktor-server/ktor-server-plugins/ktor-server-graphql/build.gradle.kts
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2014-2025 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+description = "Ktor server GraphQL plugin"
+
+plugins {
+    id("ktorbuild.project.server-plugin")
+    id("kotlinx-serialization")
+}
+
+kotlin {
+    jvmToolchain(11)
+
+    sourceSets {
+        jvmMain.dependencies {
+            api(libs.graphql.java)
+            implementation(libs.kotlinx.serialization.json)
+        }
+    }
+}

--- a/ktor-server/ktor-server-plugins/ktor-server-graphql/jvm/src/io/ktor/server/plugins/graphql/GraphQL.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-graphql/jvm/src/io/ktor/server/plugins/graphql/GraphQL.kt
@@ -1,0 +1,201 @@
+/*
+ * Copyright 2014-2025 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.server.plugins.graphql
+
+import graphql.*
+import graphql.GraphQL
+import io.ktor.http.*
+import io.ktor.server.application.*
+import io.ktor.server.request.*
+import io.ktor.server.response.*
+import io.ktor.server.routing.*
+import io.ktor.util.logging.*
+import kotlinx.coroutines.future.await
+import kotlinx.serialization.*
+import kotlinx.serialization.json.*
+
+private val LOGGER = KtorSimpleLogger("io.ktor.server.plugins.graphql")
+
+/**
+ * Installs a GraphQL endpoint under the specified route.
+ *
+ * This sets up a POST endpoint for executing GraphQL queries and mutations,
+ * and optionally a GET endpoint serving the GraphiQL interactive IDE.
+ *
+ * Example:
+ * ```kotlin
+ * routing {
+ *     graphQL {
+ *         schema("""
+ *             type Query {
+ *                 hello: String
+ *             }
+ *         """) {
+ *             type("Query") {
+ *                 dataFetcher("hello") { "Hello, World!" }
+ *             }
+ *         }
+ *     }
+ * }
+ * ```
+ *
+ * @param block A configuration block for [GraphQLConfig].
+ * @return The created [Route].
+ */
+public fun Route.graphQL(block: GraphQLConfig.() -> Unit): Route {
+    val config = GraphQLConfig().apply(block)
+
+    val schemaFactory = requireNotNull(config.schemaFactory) {
+        "GraphQL schema must be configured. Use schema(sdl) { ... } or schema(graphQLSchema) in the graphQL block."
+    }
+
+    val schema = schemaFactory()
+    val graphql = config.graphQLFactory?.invoke(schema)
+        ?: GraphQL.newGraphQL(schema).build()
+
+    val contextFactory = config.contextFactory
+
+    val json = Json { ignoreUnknownKeys = true }
+
+    val route = route(config.endpoint) {
+        post {
+            val body = call.receiveText()
+            val request = json.decodeFromString<GraphQLRequest>(body)
+            val response = executeGraphQL(graphql, request, call, contextFactory)
+            val responseJson = json.encodeToString(response)
+            call.respondText(responseJson, ContentType.Application.Json)
+        }
+    }
+
+    if (config.graphiql) {
+        route(config.graphiqlEndpoint) {
+            get {
+                val graphqlPath = call.request.path().removeSuffix(config.graphiqlEndpoint) + config.endpoint
+                call.respondText(buildGraphiQLPage(graphqlPath), ContentType.Text.Html)
+            }
+        }
+    }
+
+    return route
+}
+
+internal suspend fun executeGraphQL(
+    graphql: GraphQL,
+    request: GraphQLRequest,
+    call: ApplicationCall,
+    contextFactory: (suspend (ApplicationCall) -> Map<Any, Any>)?,
+): GraphQLResponse {
+    val inputBuilder = ExecutionInput.newExecutionInput()
+        .query(request.query)
+
+    request.operationName?.let { inputBuilder.operationName(it) }
+    request.variables?.let { inputBuilder.variables(jsonElementMapToJavaMap(it)) }
+
+    if (contextFactory != null) {
+        val contextValues = contextFactory(call)
+        inputBuilder.graphQLContext(contextValues)
+    }
+
+    val executionResult = try {
+        graphql.executeAsync(inputBuilder.build()).await()
+    } catch (
+        @Suppress("TooGenericExceptionCaught")
+        e: Exception
+    ) {
+        LOGGER.error("GraphQL execution failed", e)
+        return GraphQLResponse(
+            errors = listOf(
+                GraphQLError(message = e.message ?: "Internal server error")
+            )
+        )
+    }
+
+    return executionResult.toGraphQLResponse()
+}
+
+internal fun ExecutionResult.toGraphQLResponse(): GraphQLResponse {
+    val jsonData = getData<Any?>()?.let { javaValueToJsonElement(it) }
+    val jsonErrors = errors?.takeIf { it.isNotEmpty() }?.map { error ->
+        GraphQLError(
+            message = error.message,
+            locations = error.locations?.map { loc ->
+                GraphQLSourceLocation(line = loc.line, column = loc.column)
+            },
+            path = error.path?.map { segment ->
+                when (segment) {
+                    is Int -> JsonPrimitive(segment)
+                    is Number -> JsonPrimitive(segment.toInt())
+                    else -> JsonPrimitive(segment.toString())
+                }
+            },
+            extensions = error.extensions?.let { javaMapToJsonElementMap(it) },
+        )
+    }
+    val jsonExtensions = extensions?.takeIf { it.isNotEmpty() }?.let { javaMapToJsonElementMap(it) }
+
+    return GraphQLResponse(
+        data = jsonData,
+        errors = jsonErrors,
+        extensions = jsonExtensions,
+    )
+}
+
+@Suppress("UNCHECKED_CAST")
+internal fun javaValueToJsonElement(value: Any?): JsonElement = when (value) {
+    null -> JsonNull
+    is Boolean -> JsonPrimitive(value)
+    is Number -> JsonPrimitive(value)
+    is String -> JsonPrimitive(value)
+    is Map<*, *> -> JsonObject(
+        (value as Map<String, Any?>).mapValues { (_, v) -> javaValueToJsonElement(v) }
+    )
+    is List<*> -> JsonArray(value.map { javaValueToJsonElement(it) })
+    else -> JsonPrimitive(value.toString())
+}
+
+@Suppress("UNCHECKED_CAST")
+internal fun javaMapToJsonElementMap(map: Map<*, *>): Map<String, JsonElement> =
+    (map as Map<String, Any?>).mapValues { (_, v) -> javaValueToJsonElement(v) }
+
+internal fun jsonElementToJavaValue(element: JsonElement): Any? = when (element) {
+    is JsonNull -> null
+    is JsonPrimitive -> when {
+        element.isString -> element.content
+        element.content.equals("true", ignoreCase = true) -> true
+        element.content.equals("false", ignoreCase = true) -> false
+        element.content.contains('.') -> element.content.toDoubleOrNull() ?: element.content
+        else -> element.content.toLongOrNull() ?: element.content
+    }
+    is JsonObject -> element.mapValues { (_, v) -> jsonElementToJavaValue(v) }
+    is JsonArray -> element.map { jsonElementToJavaValue(it) }
+}
+
+internal fun jsonElementMapToJavaMap(map: Map<String, JsonElement>): Map<String, Any?> =
+    map.mapValues { (_, v) -> jsonElementToJavaValue(v) }
+
+internal fun buildGraphiQLPage(graphqlEndpoint: String): String = """
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>GraphiQL</title>
+    <link rel="stylesheet" href="https://unpkg.com/graphiql/graphiql.min.css" />
+</head>
+<body style="margin: 0;">
+    <div id="graphiql" style="height: 100vh;"></div>
+    <script crossorigin src="https://unpkg.com/react/umd/react.production.min.js"></script>
+    <script crossorigin src="https://unpkg.com/react-dom/umd/react-dom.production.min.js"></script>
+    <script crossorigin src="https://unpkg.com/graphiql/graphiql.min.js"></script>
+    <script>
+        const fetcher = GraphiQL.createFetcher({ url: '$graphqlEndpoint' });
+        ReactDOM.render(
+            React.createElement(GraphiQL, { fetcher: fetcher }),
+            document.getElementById('graphiql'),
+        );
+    </script>
+</body>
+</html>
+""".trimIndent()

--- a/ktor-server/ktor-server-plugins/ktor-server-graphql/jvm/src/io/ktor/server/plugins/graphql/GraphQL.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-graphql/jvm/src/io/ktor/server/plugins/graphql/GraphQL.kt
@@ -113,13 +113,13 @@ internal suspend fun executeGraphQL(
     val executionResult = try {
         graphql.executeAsync(inputBuilder.build()).await()
     } catch (
-        @Suppress("TooGenericExceptionCaught")
+        `@Suppress`("TooGenericExceptionCaught")
         e: Exception
     ) {
         LOGGER.error("GraphQL execution failed", e)
         return GraphQLResponse(
             errors = listOf(
-                GraphQLError(message = e.message ?: "Internal server error")
+                GraphQLError(message = "Internal server error")
             )
         )
     }

--- a/ktor-server/ktor-server-plugins/ktor-server-graphql/jvm/src/io/ktor/server/plugins/graphql/GraphQL.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-graphql/jvm/src/io/ktor/server/plugins/graphql/GraphQL.kt
@@ -177,8 +177,7 @@ internal fun jsonElementToJavaValue(element: JsonElement): Any? = when (element)
         element.isString -> element.content
         element.content.equals("true", ignoreCase = true) -> true
         element.content.equals("false", ignoreCase = true) -> false
-        element.content.contains('.') -> element.content.toDoubleOrNull() ?: element.content
-        else -> element.content.toLongOrNull() ?: element.content
+        else -> element.content.toLongOrNull() ?: element.content.toDoubleOrNull() ?: element.content
     }
     is JsonObject -> element.mapValues { (_, v) -> jsonElementToJavaValue(v) }
     is JsonArray -> element.map { jsonElementToJavaValue(it) }

--- a/ktor-server/ktor-server-plugins/ktor-server-graphql/jvm/src/io/ktor/server/plugins/graphql/GraphQL.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-graphql/jvm/src/io/ktor/server/plugins/graphql/GraphQL.kt
@@ -187,7 +187,9 @@ internal fun jsonElementToJavaValue(element: JsonElement): Any? = when (element)
 internal fun jsonElementMapToJavaMap(map: Map<String, JsonElement>): Map<String, Any?> =
     map.mapValues { (_, v) -> jsonElementToJavaValue(v) }
 
-internal fun buildGraphiQLPage(graphqlEndpoint: String): String = """
+internal fun buildGraphiQLPage(graphqlEndpoint: String): String {
+    val encodedEndpoint = Json.encodeToString(graphqlEndpoint)
+    return """
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -202,7 +204,7 @@ internal fun buildGraphiQLPage(graphqlEndpoint: String): String = """
     <script crossorigin src="https://unpkg.com/react-dom/umd/react-dom.production.min.js"></script>
     <script crossorigin src="https://unpkg.com/graphiql/graphiql.min.js"></script>
     <script>
-        const fetcher = GraphiQL.createFetcher({ url: '$graphqlEndpoint' });
+        const fetcher = GraphiQL.createFetcher({ url: '$encodedEndpoint' });
         ReactDOM.render(
             React.createElement(GraphiQL, { fetcher: fetcher }),
             document.getElementById('graphiql'),
@@ -211,3 +213,4 @@ internal fun buildGraphiQLPage(graphqlEndpoint: String): String = """
 </body>
 </html>
 """.trimIndent()
+}

--- a/ktor-server/ktor-server-plugins/ktor-server-graphql/jvm/src/io/ktor/server/plugins/graphql/GraphQL.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-graphql/jvm/src/io/ktor/server/plugins/graphql/GraphQL.kt
@@ -61,11 +61,23 @@ public fun Route.graphQL(block: GraphQLConfig.() -> Unit): Route {
 
     val route = route(config.endpoint) {
         post {
-            val body = call.receiveText()
-            val request = json.decodeFromString<GraphQLRequest>(body)
+            val request = try {
+                json.decodeFromString<GraphQLRequest>(call.receiveText())
+            } catch (cause: SerializationException) {
+                val errorResponse = GraphQLResponse(
+                    errors = listOf(GraphQLError(message = "Invalid GraphQL request body"))
+                )
+                call.respondText(
+                    text = json.encodeToString(errorResponse),
+                    contentType = ContentType.Application.Json,
+                    status = HttpStatusCode.BadRequest,
+                )
+                return@post
+            }
             val response = executeGraphQL(graphql, request, call, contextFactory)
             val responseJson = json.encodeToString(response)
             call.respondText(responseJson, ContentType.Application.Json)
+        }
         }
     }
 

--- a/ktor-server/ktor-server-plugins/ktor-server-graphql/jvm/src/io/ktor/server/plugins/graphql/GraphQLConfig.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-graphql/jvm/src/io/ktor/server/plugins/graphql/GraphQLConfig.kt
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2014-2025 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.server.plugins.graphql
+
+import graphql.*
+import graphql.schema.*
+import graphql.schema.idl.*
+import io.ktor.server.application.*
+import io.ktor.utils.io.*
+
+/**
+ * Configuration for the [GraphQL] plugin.
+ *
+ * Provides a DSL to configure the GraphQL schema, execution strategy,
+ * instrumentation, and optional GraphiQL IDE endpoint.
+ */
+@KtorDsl
+public class GraphQLConfig {
+
+    /**
+     * The path at which the GraphQL endpoint will be mounted.
+     * Defaults to `"graphql"`.
+     */
+    public var endpoint: String = "graphql"
+
+    /**
+     * Whether to enable the GraphiQL interactive IDE.
+     * When enabled, a GET request to [graphiqlEndpoint] will serve the GraphiQL HTML page.
+     * Defaults to `false`.
+     */
+    public var graphiql: Boolean = false
+
+    /**
+     * The path at which the GraphiQL IDE will be served.
+     * Only used when [graphiql] is `true`.
+     * Defaults to `"graphiql"`.
+     */
+    public var graphiqlEndpoint: String = "graphiql"
+
+    internal var schemaFactory: (() -> GraphQLSchema)? = null
+    internal var graphQLFactory: ((GraphQLSchema) -> GraphQL)? = null
+    internal var contextFactory: (suspend (ApplicationCall) -> Map<Any, Any>)? = null
+
+    /**
+     * Configures the GraphQL schema using the SDL (Schema Definition Language) and runtime wiring.
+     *
+     * @param sdl The GraphQL schema definition in SDL format.
+     * @param block A configuration block for the [RuntimeWiring.Builder] to bind data fetchers and type resolvers.
+     */
+    public fun schema(sdl: String, block: RuntimeWiring.Builder.() -> Unit = {}) {
+        schemaFactory = {
+            val typeRegistry = SchemaParser().parse(sdl)
+            val runtimeWiring = RuntimeWiring.newRuntimeWiring().apply(block).build()
+            SchemaGenerator().makeExecutableSchema(typeRegistry, runtimeWiring)
+        }
+    }
+
+    /**
+     * Configures the GraphQL schema using a pre-built [GraphQLSchema] instance.
+     *
+     * @param schema The pre-built schema.
+     */
+    public fun schema(schema: GraphQLSchema) {
+        schemaFactory = { schema }
+    }
+
+    /**
+     * Configures the GraphQL schema using a factory function.
+     *
+     * @param factory A function that produces a [GraphQLSchema].
+     */
+    public fun schema(factory: () -> GraphQLSchema) {
+        schemaFactory = factory
+    }
+
+    /**
+     * Customizes the [GraphQL] execution engine built from the configured schema.
+     *
+     * Use this to add instrumentation, custom execution strategies, or other
+     * advanced [GraphQL.Builder] settings.
+     *
+     * @param block A configuration block that receives the schema and returns a configured [GraphQL] instance.
+     */
+    public fun engine(block: (GraphQLSchema) -> GraphQL) {
+        graphQLFactory = block
+    }
+
+    /**
+     * Provides a custom context factory that produces per-request context values.
+     *
+     * The returned map is made available to data fetchers via
+     * `DataFetchingEnvironment.graphQlContext`.
+     *
+     * @param factory A suspending function that creates a context map from the [ApplicationCall].
+     */
+    public fun context(factory: suspend (ApplicationCall) -> Map<Any, Any>) {
+        contextFactory = factory
+    }
+}

--- a/ktor-server/ktor-server-plugins/ktor-server-graphql/jvm/src/io/ktor/server/plugins/graphql/GraphQLRequest.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-graphql/jvm/src/io/ktor/server/plugins/graphql/GraphQLRequest.kt
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2014-2025 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.server.plugins.graphql
+
+import kotlinx.serialization.*
+import kotlinx.serialization.json.*
+
+/**
+ * Represents a GraphQL request received from a client.
+ *
+ * @property query The GraphQL query string.
+ * @property operationName An optional name of the operation to execute when the query contains multiple operations.
+ * @property variables An optional map of variable values to substitute into the query.
+ * @property extensions An optional map of extension values for protocol extensions.
+ */
+@Serializable
+public data class GraphQLRequest(
+    val query: String,
+    val operationName: String? = null,
+    val variables: Map<String, JsonElement>? = null,
+    val extensions: Map<String, JsonElement>? = null,
+)
+
+/**
+ * Represents a GraphQL response returned to the client.
+ *
+ * Follows the [GraphQL over HTTP specification](https://graphql.github.io/graphql-over-http/).
+ *
+ * @property data The result of the executed operation. May be `null` if errors occurred before execution.
+ * @property errors A list of errors that occurred during request processing, if any.
+ * @property extensions An optional map of extension values for protocol extensions.
+ */
+@Serializable
+public data class GraphQLResponse(
+    val data: JsonElement? = null,
+    val errors: List<GraphQLError>? = null,
+    val extensions: Map<String, JsonElement>? = null,
+)
+
+/**
+ * Represents a single error in a GraphQL response.
+ *
+ * @property message A description of the error.
+ * @property locations The locations in the GraphQL document where the error occurred, if applicable.
+ * @property path The path of the response field that experienced the error, if applicable.
+ * @property extensions Additional error information for protocol extensions.
+ */
+@Serializable
+public data class GraphQLError(
+    val message: String,
+    val locations: List<GraphQLSourceLocation>? = null,
+    val path: List<JsonElement>? = null,
+    val extensions: Map<String, JsonElement>? = null,
+)
+
+/**
+ * Represents a location in a GraphQL document.
+ *
+ * @property line The line number (1-indexed) where the error occurred.
+ * @property column The column number (1-indexed) where the error occurred.
+ */
+@Serializable
+public data class GraphQLSourceLocation(
+    val line: Int,
+    val column: Int,
+)

--- a/ktor-server/ktor-server-plugins/ktor-server-graphql/jvm/test/io/ktor/tests/plugins/graphql/GraphQLTest.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-graphql/jvm/test/io/ktor/tests/plugins/graphql/GraphQLTest.kt
@@ -1,0 +1,259 @@
+/*
+ * Copyright 2014-2025 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.tests.plugins.graphql
+
+import io.ktor.client.request.*
+import io.ktor.client.statement.*
+import io.ktor.http.*
+import io.ktor.server.plugins.graphql.*
+import io.ktor.server.routing.*
+import io.ktor.server.testing.*
+import kotlinx.serialization.json.*
+import kotlin.test.*
+
+class GraphQLTest {
+
+    private val testSchema = """
+        type Query {
+            hello: String
+            greet(name: String!): String
+            sum(a: Int!, b: Int!): Int
+        }
+
+        type Mutation {
+            setMessage(text: String!): String
+        }
+    """.trimIndent()
+
+    @Test
+    fun `simple query returns expected data`() = testApplication {
+        configureServer()
+
+        val response = client.post("/graphql") {
+            contentType(ContentType.Application.Json)
+            setBody("""{"query": "{ hello }"}""")
+        }
+
+        assertEquals(HttpStatusCode.OK, response.status)
+        val body = Json.decodeFromString<GraphQLResponse>(response.bodyAsText())
+        assertEquals(JsonPrimitive("Hello, World!"), body.data?.jsonObject?.get("hello"))
+        assertNull(body.errors)
+    }
+
+    @Test
+    fun `query with variables resolves correctly`() = testApplication {
+        configureServer()
+
+        val response = client.post("/graphql") {
+            contentType(ContentType.Application.Json)
+            setBody(
+                """
+                {
+                    "query": "query Greet(${'$'}name: String!) { greet(name: ${'$'}name) }",
+                    "variables": { "name": "Ktor" }
+                }
+                """.trimIndent()
+            )
+        }
+
+        assertEquals(HttpStatusCode.OK, response.status)
+        val body = Json.decodeFromString<GraphQLResponse>(response.bodyAsText())
+        assertEquals(JsonPrimitive("Hello, Ktor!"), body.data?.jsonObject?.get("greet"))
+    }
+
+    @Test
+    fun `query with operation name selects correct operation`() = testApplication {
+        configureServer()
+
+        val response = client.post("/graphql") {
+            contentType(ContentType.Application.Json)
+            setBody(
+                """
+                {
+                    "query": "query Hello { hello } query Sum { sum(a: 2, b: 3) }",
+                    "operationName": "Sum"
+                }
+                """.trimIndent()
+            )
+        }
+
+        assertEquals(HttpStatusCode.OK, response.status)
+        val body = Json.decodeFromString<GraphQLResponse>(response.bodyAsText())
+        assertEquals(JsonPrimitive(5), body.data?.jsonObject?.get("sum"))
+    }
+
+    @Test
+    fun `mutation executes successfully`() = testApplication {
+        configureServer()
+
+        val response = client.post("/graphql") {
+            contentType(ContentType.Application.Json)
+            setBody(
+                """
+                {
+                    "query": "mutation { setMessage(text: \"updated\") }"
+                }
+                """.trimIndent()
+            )
+        }
+
+        assertEquals(HttpStatusCode.OK, response.status)
+        val body = Json.decodeFromString<GraphQLResponse>(response.bodyAsText())
+        assertEquals(JsonPrimitive("updated"), body.data?.jsonObject?.get("setMessage"))
+    }
+
+    @Test
+    fun `invalid query returns errors`() = testApplication {
+        configureServer()
+
+        val response = client.post("/graphql") {
+            contentType(ContentType.Application.Json)
+            setBody("""{"query": "{ nonExistentField }"}""")
+        }
+
+        assertEquals(HttpStatusCode.OK, response.status)
+        val body = Json.decodeFromString<GraphQLResponse>(response.bodyAsText())
+        assertNotNull(body.errors)
+        assertTrue(body.errors.isNotEmpty())
+    }
+
+    @Test
+    fun `syntax error in query returns errors`() = testApplication {
+        configureServer()
+
+        val response = client.post("/graphql") {
+            contentType(ContentType.Application.Json)
+            setBody("""{"query": "{ hello"}""")
+        }
+
+        assertEquals(HttpStatusCode.OK, response.status)
+        val body = Json.decodeFromString<GraphQLResponse>(response.bodyAsText())
+        assertNotNull(body.errors)
+        assertTrue(body.errors.isNotEmpty())
+    }
+
+    @Test
+    fun `custom endpoint path is respected`() = testApplication {
+        routing {
+            graphQL {
+                endpoint = "api/graphql"
+                schema(testSchema) {
+                    type("Query") {
+                        it.dataFetcher("hello") { "Hello!" }
+                            .dataFetcher("greet") { env -> "Hello, ${env.getArgument<String>("name")}!" }
+                            .dataFetcher("sum") { env ->
+                                env.getArgument<Int>("a")!! + env.getArgument<Int>("b")!!
+                            }
+                    }
+                    type("Mutation") {
+                        it.dataFetcher("setMessage") { env -> env.getArgument<String>("text") }
+                    }
+                }
+            }
+        }
+
+        val response = client.post("/api/graphql") {
+            contentType(ContentType.Application.Json)
+            setBody("""{"query": "{ hello }"}""")
+        }
+
+        assertEquals(HttpStatusCode.OK, response.status)
+        val body = Json.decodeFromString<GraphQLResponse>(response.bodyAsText())
+        assertEquals(JsonPrimitive("Hello!"), body.data?.jsonObject?.get("hello"))
+    }
+
+    @Test
+    fun `graphiql endpoint serves HTML when enabled`() = testApplication {
+        routing {
+            graphQL {
+                graphiql = true
+                schema(testSchema) {
+                    type("Query") {
+                        it.dataFetcher("hello") { "Hello!" }
+                            .dataFetcher("greet") { env -> "Hello, ${env.getArgument<String>("name")}!" }
+                            .dataFetcher("sum") { env ->
+                                env.getArgument<Int>("a")!! + env.getArgument<Int>("b")!!
+                            }
+                    }
+                    type("Mutation") {
+                        it.dataFetcher("setMessage") { env -> env.getArgument<String>("text") }
+                    }
+                }
+            }
+        }
+
+        val response = client.get("/graphiql")
+
+        assertEquals(HttpStatusCode.OK, response.status)
+        val body = response.bodyAsText()
+        assertTrue(body.contains("GraphiQL"))
+        assertTrue(body.contains("graphiql.min.js"))
+    }
+
+    @Test
+    fun `pre-built schema is accepted`() = testApplication {
+        routing {
+            val prebuiltSchema = graphql.schema.idl.SchemaGenerator().makeExecutableSchema(
+                graphql.schema.idl.SchemaParser().parse("type Query { ping: String }"),
+                graphql.schema.idl.RuntimeWiring.newRuntimeWiring()
+                    .type("Query") { it.dataFetcher("ping") { "pong" } }
+                    .build()
+            )
+
+            graphQL {
+                schema(prebuiltSchema)
+            }
+        }
+
+        val response = client.post("/graphql") {
+            contentType(ContentType.Application.Json)
+            setBody("""{"query": "{ ping }"}""")
+        }
+
+        assertEquals(HttpStatusCode.OK, response.status)
+        val body = Json.decodeFromString<GraphQLResponse>(response.bodyAsText())
+        assertEquals(JsonPrimitive("pong"), body.data?.jsonObject?.get("ping"))
+    }
+
+    @Test
+    fun `integer arguments are correctly coerced`() = testApplication {
+        configureServer()
+
+        val response = client.post("/graphql") {
+            contentType(ContentType.Application.Json)
+            setBody(
+                """
+                {
+                    "query": "query Add(${'$'}a: Int!, ${'$'}b: Int!) { sum(a: ${'$'}a, b: ${'$'}b) }",
+                    "variables": { "a": 10, "b": 20 }
+                }
+                """.trimIndent()
+            )
+        }
+
+        assertEquals(HttpStatusCode.OK, response.status)
+        val body = Json.decodeFromString<GraphQLResponse>(response.bodyAsText())
+        assertEquals(JsonPrimitive(30), body.data?.jsonObject?.get("sum"))
+    }
+
+    private fun ApplicationTestBuilder.configureServer() {
+        routing {
+            graphQL {
+                schema(testSchema) {
+                    type("Query") {
+                        it.dataFetcher("hello") { "Hello, World!" }
+                            .dataFetcher("greet") { env -> "Hello, ${env.getArgument<String>("name")}!" }
+                            .dataFetcher("sum") { env ->
+                                env.getArgument<Int>("a")!! + env.getArgument<Int>("b")!!
+                            }
+                    }
+                    type("Mutation") {
+                        it.dataFetcher("setMessage") { env -> env.getArgument<String>("text") }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/ktor-server/ktor-server-plugins/ktor-server-graphql/jvm/test/io/ktor/tests/plugins/graphql/JsonConversionTest.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-graphql/jvm/test/io/ktor/tests/plugins/graphql/JsonConversionTest.kt
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2014-2025 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.tests.plugins.graphql
+
+import io.ktor.server.plugins.graphql.*
+import kotlinx.serialization.json.*
+import kotlin.test.*
+
+class JsonConversionTest {
+
+    @Test
+    fun `javaValueToJsonElement converts null`() {
+        assertEquals(JsonNull, javaValueToJsonElement(null))
+    }
+
+    @Test
+    fun `javaValueToJsonElement converts string`() {
+        assertEquals(JsonPrimitive("hello"), javaValueToJsonElement("hello"))
+    }
+
+    @Test
+    fun `javaValueToJsonElement converts boolean`() {
+        assertEquals(JsonPrimitive(true), javaValueToJsonElement(true))
+        assertEquals(JsonPrimitive(false), javaValueToJsonElement(false))
+    }
+
+    @Test
+    fun `javaValueToJsonElement converts integers`() {
+        assertEquals(JsonPrimitive(42), javaValueToJsonElement(42))
+    }
+
+    @Test
+    fun `javaValueToJsonElement converts doubles`() {
+        assertEquals(JsonPrimitive(3.14), javaValueToJsonElement(3.14))
+    }
+
+    @Test
+    fun `javaValueToJsonElement converts nested maps`() {
+        val input = mapOf("key" to "value", "nested" to mapOf("inner" to 1))
+        val expected = JsonObject(
+            mapOf(
+                "key" to JsonPrimitive("value"),
+                "nested" to JsonObject(mapOf("inner" to JsonPrimitive(1)))
+            )
+        )
+        assertEquals(expected, javaValueToJsonElement(input))
+    }
+
+    @Test
+    fun `javaValueToJsonElement converts lists`() {
+        val input = listOf(1, "two", null)
+        val expected = JsonArray(listOf(JsonPrimitive(1), JsonPrimitive("two"), JsonNull))
+        assertEquals(expected, javaValueToJsonElement(input))
+    }
+
+    @Test
+    fun `jsonElementToJavaValue converts string`() {
+        assertEquals("hello", jsonElementToJavaValue(JsonPrimitive("hello")))
+    }
+
+    @Test
+    fun `jsonElementToJavaValue converts boolean`() {
+        assertEquals(true, jsonElementToJavaValue(JsonPrimitive(true)))
+        assertEquals(false, jsonElementToJavaValue(JsonPrimitive(false)))
+    }
+
+    @Test
+    fun `jsonElementToJavaValue converts integer`() {
+        assertEquals(42L, jsonElementToJavaValue(JsonPrimitive(42)))
+    }
+
+    @Test
+    fun `jsonElementToJavaValue converts double`() {
+        assertEquals(3.14, jsonElementToJavaValue(JsonPrimitive(3.14)))
+    }
+
+    @Test
+    fun `jsonElementToJavaValue converts null`() {
+        assertNull(jsonElementToJavaValue(JsonNull))
+    }
+
+    @Test
+    fun `jsonElementToJavaValue converts objects`() {
+        val input = JsonObject(mapOf("key" to JsonPrimitive("value")))
+        val result = jsonElementToJavaValue(input) as Map<*, *>
+        assertEquals("value", result["key"])
+    }
+
+    @Test
+    fun `jsonElementToJavaValue converts arrays`() {
+        val input = JsonArray(listOf(JsonPrimitive(1), JsonPrimitive(2)))
+        val result = jsonElementToJavaValue(input) as List<*>
+        assertEquals(listOf(1L, 2L), result)
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -81,6 +81,7 @@ projects {
             +"ktor-server-double-receive"
             +"ktor-server-forwarded-header"
             +"ktor-server-freemarker"
+            +"ktor-server-graphql"
             +"ktor-server-hsts"
             +"ktor-server-html-builder"
             +"ktor-server-htmx"


### PR DESCRIPTION
Description: Add GraphQL Server Plugin

## Summary

Add a new `ktor-server-graphql` module that provides first-class GraphQL support for Ktor server applications. The plugin is powered by [graphql-java](https://github.com/graphql-java/graphql-java) v25.0 and exposes a `Route.graphQL { }` extension for mounting GraphQL endpoints.

- Introduces `ktor-server-graphql` module with SDL-first schema definition, pre-built schema support, async execution via coroutines, per-request context injection, and an optional GraphiQL IDE endpoint
- Handles JSON serialization internally (no ContentNegotiation dependency required) following the [GraphQL over HTTP specification](https://graphql.github.io/graphql-over-http/)
- Includes comprehensive tests covering queries, mutations, variables, operation names, error handling, custom endpoints, GraphiQL, and pre-built schemas

## Changes

### New Module: `ktor-server-graphql`

**Location:** `ktor-server/ktor-server-plugins/ktor-server-graphql/`

**Files:**

| File | Description |
|------|-------------|
| `build.gradle.kts` | Module build configuration with `graphql-java` dependency |
| `jvm/src/.../GraphQL.kt` | Route extension, execution engine, JSON conversion utilities, GraphiQL page |
| `jvm/src/.../GraphQLConfig.kt` | `@KtorDsl`-annotated configuration class |
| `jvm/src/.../GraphQLRequest.kt` | `@Serializable` request/response data classes |
| `jvm/test/.../GraphQLTest.kt` | Integration tests (10 test cases) |
| `jvm/test/.../JsonConversionTest.kt` | Unit tests for JSON/Java value conversion (12 test cases) |
| `api/ktor-server-graphql.api` | ABI dump |
| `README.md` | Module documentation with usage examples |

### Modified Files

| File | Change |
|------|--------|
| `settings.gradle.kts` | Register `ktor-server-graphql` in the plugins block |
| `gradle/libs.versions.toml` | Add `graphql-java = "25.0"` version and library entry |

## Public API

```kotlin
// Route extension - primary entry point
fun Route.graphQL(block: GraphQLConfig.() -> Unit): Route

// Configuration DSL
@KtorDsl
class GraphQLConfig {
    var endpoint: String        // default: "graphql"
    var graphiql: Boolean       // default: false
    var graphiqlEndpoint: String // default: "graphiql"

    fun schema(sdl: String, block: RuntimeWiring.Builder.() -> Unit = {})
    fun schema(schema: GraphQLSchema)
    fun schema(factory: () -> GraphQLSchema)
    fun engine(block: (GraphQLSchema) -> GraphQL)
    fun context(factory: suspend (ApplicationCall) -> Map<Any, Any>)
}

// Request/Response models
@Serializable data class GraphQLRequest(...)
@Serializable data class GraphQLResponse(...)
@Serializable data class GraphQLError(...)
@Serializable data class GraphQLSourceLocation(...)
```

## Usage Example

```kotlin
fun Application.module() {
    routing {
        graphQL {
            graphiql = true
            schema("""
                type Query {
                    hello: String
                }
            """) {
                type("Query") {
                    it.dataFetcher("hello") { "Hello, World!" }
                }
            }
        }
    }
}
```

