### PR TITLE
#5033 Fix scoped Sessions plugin not sending Set-Cookie without call.respond()

### DIFF
--- a/ktor-server/ktor-server-core/common/src/io/ktor/server/routing/RoutingRoot.kt
+++ b/ktor-server/ktor-server-core/common/src/io/ktor/server/routing/RoutingRoot.kt
@@ -105,6 +105,9 @@ public class RoutingRoot(
         application.monitor.raise(RoutingCallStarted, routingCall)
         try {
             routingCallPipeline.execute(routingApplicationCall)
+            if (!routingApplicationCall.isHandled && routingApplicationCall.response.status() != null) {
+                routingApplicationCall.respond(routingApplicationCall.response.status()!!)
+            }
         } catch (cause: Throwable) {
             routingCall.attributes.put(routingCallKey, routingCall)
             throw cause

--- a/ktor-server/ktor-server-core/common/src/io/ktor/server/routing/RoutingRoot.kt
+++ b/ktor-server/ktor-server-core/common/src/io/ktor/server/routing/RoutingRoot.kt
@@ -105,8 +105,10 @@ public class RoutingRoot(
         application.monitor.raise(RoutingCallStarted, routingCall)
         try {
             routingCallPipeline.execute(routingApplicationCall)
-            if (!routingApplicationCall.isHandled && routingApplicationCall.response.status() != null) {
-                routingApplicationCall.respond(routingApplicationCall.response.status()!!)
+            if (!routingApplicationCall.isHandled) {
+                routingApplicationCall.response.status()?.let { status ->
+                    routingApplicationCall.respond(status)
+                }
             }
         } catch (cause: Throwable) {
             routingCall.attributes.put(routingCallKey, routingCall)

--- a/ktor-server/ktor-server-tests/common/test/io/ktor/tests/server/sessions/SessionTest.kt
+++ b/ktor-server/ktor-server-tests/common/test/io/ktor/tests/server/sessions/SessionTest.kt
@@ -742,6 +742,28 @@ class SessionTest {
             assertEquals(TestUserSessionCustom.serialize(expected), bodyAsText())
         }
     }
+
+    @Test
+    fun `scoped session sends Set-Cookie header without explicit respond`() = testApplication {
+        routing {
+            route("/scoped") {
+                install(Sessions) {
+                    cookie<TestUserSession>(cookieName)
+                }
+                get("/set") {
+                    call.sessions.set(TestUserSession("id1", emptyList()))
+                    call.response.status(HttpStatusCode.OK)
+                }
+            }
+        }
+        client.get("/scoped/set").apply {
+            assertEquals(HttpStatusCode.OK, status)
+            assertNotNull(
+                cookies[cookieName],
+                "Session cookie should be set even without call.respond()"
+            )
+        }
+    }
 }
 
 @Serializable


### PR DESCRIPTION
**Subsystem**
Server, ktor-server-core (routing)

**Motivation**
Fixes #5033. Scoped `Sessions` plugin doesn't send `Set-Cookie` when handler sets status without `call.respond()`.

**Solution**
Call `respond()` through `RoutingPipelineCall` when handler set status but didn't respond, so scoped sendPipeline interceptors fire.