### PR TITLE
Fix HttpTimeout not respecting test dispatchers in runTest

### DIFF
--- a/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/HttpTimeout.kt
+++ b/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/HttpTimeout.kt
@@ -149,6 +149,7 @@ public val HttpTimeout: ClientPlugin<HttpTimeoutConfig> = createClientPlugin(
             socketTimeoutMillis != null
 
     on(Send) { request ->
+        val callerContext = currentCoroutineContext()
         val supportsRequestTimeout = request.supportsRequestTimeout
         var configuration = request.getCapabilityOrNull(HttpTimeoutCapability)
         if (configuration == null && hasNotNullTimeouts(supportsRequestTimeout)) {
@@ -162,7 +163,7 @@ public val HttpTimeout: ClientPlugin<HttpTimeoutConfig> = createClientPlugin(
 
             if (supportsRequestTimeout) {
                 this.requestTimeoutMillis = this.requestTimeoutMillis ?: requestTimeoutMillis
-                applyRequestTimeout(request, this.requestTimeoutMillis)
+                CoroutineScope(callerContext).applyRequestTimeout(request, this.requestTimeoutMillis)
             }
         }
         proceed(request)

--- a/ktor-client/ktor-client-core/common/test/HttpTimeoutVirtualTimeTest.kt
+++ b/ktor-client/ktor-client-core/common/test/HttpTimeoutVirtualTimeTest.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2014-2025 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+import io.ktor.client.*
+import io.ktor.client.engine.mock.*
+import io.ktor.client.plugins.*
+import io.ktor.client.request.*
+import kotlinx.coroutines.awaitCancellation
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertFailsWith
+import kotlin.time.Duration.Companion.seconds
+
+class HttpTimeoutVirtualTimeTest {
+
+    @Test
+    fun testRequestTimeoutRespectsVirtualTimeInRunTest() = runTest(timeout = 5.seconds) {
+        val client = HttpClient(MockEngine) {
+            engine {
+                addHandler {
+                    awaitCancellation()
+                }
+            }
+            install(HttpTimeout) {
+                requestTimeoutMillis = 60_000
+            }
+        }
+
+        assertFailsWith<HttpRequestTimeoutException> {
+            client.get("http://localhost/test")
+        }
+
+        client.close()
+    }
+}

--- a/ktor-client/ktor-client-core/common/test/HttpTimeoutVirtualTimeTest.kt
+++ b/ktor-client/ktor-client-core/common/test/HttpTimeoutVirtualTimeTest.kt
@@ -15,7 +15,7 @@ import kotlin.time.Duration.Companion.seconds
 class HttpTimeoutVirtualTimeTest {
 
     @Test
-    fun testRequestTimeoutRespectsVirtualTimeInRunTest() = runTest(timeout = 5.seconds) {
+    fun `request timeout respects virtual time in runTest`() = runTest(timeout = 5.seconds) {
         val client = HttpClient(MockEngine) {
             engine {
                 addHandler {
@@ -27,10 +27,12 @@ class HttpTimeoutVirtualTimeTest {
             }
         }
 
-        assertFailsWith<HttpRequestTimeoutException> {
-            client.get("http://localhost/test")
+        try {
+            assertFailsWith<HttpRequestTimeoutException> {
+                client.get("http://localhost/test")
+            }
+        } finally {
+            client.close()
         }
-
-        client.close()
     }
 }


### PR DESCRIPTION
**Subsystem**
Client

**Motivation**
https://github.com/ktorio/ktor/issues/4720

**Solution**
Capture the caller's coroutine context before launching the timeout and use it when creating the `CoroutineScope` for `applyRequestTimeout`, so that test dispatchers (virtual time) are respected.