### PR TITLE
Remove obsolete withWasm override from tracked hierarchy

### DIFF
--- a/build-logic/src/main/kotlin/ktorbuild/internal/TrackedKotlinHierarchy.kt
+++ b/build-logic/src/main/kotlin/ktorbuild/internal/TrackedKotlinHierarchy.kt
@@ -116,8 +116,6 @@ private class KotlinHierarchyTrackerImpl(
     override fun withJs() = addTarget("js")
     override fun withJvm() = addTarget("jvm")
 
-    @Deprecated("Renamed to 'withWasmJs'", replaceWith = ReplaceWith("withWasmJs()"))
-    override fun withWasm() = withWasmJs()
     override fun withWasmJs() = addTarget("wasmJs")
     override fun withWasmWasi() = addTarget("wasmWasi")
     override fun withAndroidTarget() = addTarget("android")


### PR DESCRIPTION
`withWasm()` was removed from the Kotlin hierarchy builder API, and this deprecated override now breaks build-logic compilation with `NOTHING_TO_OVERRIDE`. Remove the obsolete compatibility method. 

KT-85509


