### PR TITLE
Improve zstd performance & fix KTOR-9487

### DIFF
--- a/ktor-shared/ktor-encoding-zstd/jvm/src/io/ktor/encoding/zstd/Zstd.jvm.kt
+++ b/ktor-shared/ktor-encoding-zstd/jvm/src/io/ktor/encoding/zstd/Zstd.jvm.kt
@@ -107,7 +107,7 @@ public class Zstd(private val compressionLevel: Int) : Encoder {
                 if (bytesRead <= 0) continue
                 inputBuf.flip()
 
-                ctx.compress(outputBuf, inputBuf).toLong()
+                ctx.compress(outputBuf, inputBuf)
                 outputBuf.flip()
                 destination.writeFully(outputBuf)
             }

--- a/ktor-shared/ktor-encoding-zstd/jvm/src/io/ktor/encoding/zstd/Zstd.jvm.kt
+++ b/ktor-shared/ktor-encoding-zstd/jvm/src/io/ktor/encoding/zstd/Zstd.jvm.kt
@@ -6,18 +6,14 @@ package io.ktor.encoding.zstd
 
 import com.github.luben.zstd.ZstdCompressCtx
 import com.github.luben.zstd.ZstdDecompressCtx
-import com.github.luben.zstd.ZstdException
 import io.ktor.util.*
 import io.ktor.util.cio.*
 import io.ktor.utils.io.*
 import io.ktor.utils.io.pool.*
 import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.GlobalScope
-import kotlinx.io.EOFException
-import kotlinx.io.IOException
 import java.nio.ByteBuffer
 import kotlin.coroutines.CoroutineContext
-import com.github.luben.zstd.Zstd as ZstdUtils
 
 /**
  * Implementation of [ContentEncoder] using zstd algorithm
@@ -44,13 +40,13 @@ public class Zstd(private val compressionLevel: Int) : Encoder {
     @OptIn(DelicateCoroutinesApi::class)
     override fun encode(source: ByteReadChannel, coroutineContext: CoroutineContext): ByteReadChannel =
         GlobalScope.writer(coroutineContext, autoFlush = true) {
-            source.encodeTo(channel, KtorDefaultPool, compressionLevel)
+            source.encodeTo(channel, KtorDefaultDirectPool, compressionLevel)
         }.channel
 
     @OptIn(DelicateCoroutinesApi::class)
     override fun encode(source: ByteWriteChannel, coroutineContext: CoroutineContext): ByteWriteChannel =
         GlobalScope.reader(coroutineContext, autoFlush = true) {
-            channel.encodeTo(source, KtorDefaultPool, compressionLevel)
+            channel.encodeTo(source, KtorDefaultDirectPool, compressionLevel)
         }.channel
 
     @OptIn(DelicateCoroutinesApi::class)
@@ -58,14 +54,15 @@ public class Zstd(private val compressionLevel: Int) : Encoder {
         source: ByteReadChannel,
         coroutineContext: CoroutineContext
     ): ByteReadChannel = GlobalScope.writer(coroutineContext) {
-        source.decodeTo(channel, KtorDefaultPool)
+        source.decodeTo(channel, KtorDefaultDirectPool)
     }.channel
 
     internal suspend fun ByteReadChannel.decodeTo(
         destination: ByteWriteChannel,
-        pool: ObjectPool<ByteBuffer> = KtorDefaultPool
+        pool: ObjectPool<ByteBuffer> = KtorDefaultDirectPool
     ) {
         val inputBuf = pool.borrow()
+        val outputBuf = pool.borrow()
         val ctx = ZstdDecompressCtx()
 
         try {
@@ -74,73 +71,23 @@ public class Zstd(private val compressionLevel: Int) : Encoder {
                 if (bytesRead <= 0) continue
 
                 inputBuf.flip()
+
                 while (inputBuf.hasRemaining()) {
-                    val srcOffset = inputBuf.arrayOffset() + inputBuf.position()
-                    val srcLength = inputBuf.remaining()
+                    outputBuf.clear()
+                    ctx.decompressDirectByteBufferStream(outputBuf, inputBuf)
 
-                    val frameCompressedSize = try {
-                        ZstdUtils.findFrameCompressedSize(inputBuf.array(), srcOffset, srcLength).toInt()
-                    } catch (_: ZstdException) {
-                        // an exception could be thrown if the rest of inputBuf does not contain a whole frame,
-                        // so we need to break to read the next chunk
-                        break
-                    }
-                    // inputBuf does not contain the whole frame - wait for more data
-                    if (frameCompressedSize > srcLength) break
-
-                    val frameContentSize = getFrameContentSize(
-                        inputBuf,
-                        srcOffset,
-                        frameCompressedSize
-                    )
-                    val outArray = ByteArray(frameContentSize)
-                    ctx.decompressByteArray(
-                        outArray,
-                        0,
-                        frameContentSize,
-                        inputBuf.array(),
-                        srcOffset,
-                        frameCompressedSize
-                    )
-                    destination.writeFully(outArray)
-                    inputBuf.position(inputBuf.position() + frameCompressedSize)
+                    outputBuf.flip()
+                    destination.writeFully(outputBuf)
                 }
 
                 inputBuf.compact()
-                if (!inputBuf.hasRemaining()) {
-                    throw IOException("Zstd frame exceeds buffer capacity of ${inputBuf.capacity()} bytes")
-                }
             }
             inputBuf.flip()
-            if (inputBuf.hasRemaining()) {
-                throw EOFException("Incomplete zstd frame at end of stream")
-            }
         } finally {
             ctx.close()
             pool.recycle(inputBuf)
+            pool.recycle(outputBuf)
         }
-    }
-
-    private fun getFrameContentSize(
-        inputBuf: ByteBuffer,
-        srcOffset: Int,
-        frameCompressedSize: Int
-    ): Int {
-        val frameContentSize = ZstdUtils.getFrameContentSize(
-            inputBuf.array(),
-            srcOffset,
-            frameCompressedSize
-        )
-        if (ZstdUtils.isError(frameContentSize)) {
-            throw IOException("Invalid zstd frame: ${ZstdUtils.getErrorName(frameContentSize)}")
-        }
-        if (frameContentSize == -1L) {
-            throw IOException("Content size is unknown")
-        }
-        if (frameContentSize > Int.MAX_VALUE) {
-            throw IOException("Zstd frame content size $frameContentSize exceeds Int.MAX_VALUE")
-        }
-        return frameContentSize.toInt()
     }
 
     private suspend fun ByteReadChannel.encodeTo(
@@ -155,25 +102,14 @@ public class Zstd(private val compressionLevel: Int) : Encoder {
         try {
             while (!isClosedForRead) {
                 inputBuf.clear()
+                outputBuf.clear()
                 val bytesRead = readAvailable(inputBuf)
                 if (bytesRead <= 0) continue
+                inputBuf.flip()
 
-                val maxCompressedSize = ZstdUtils.compressBound(bytesRead.toLong()).toInt()
-                val outArray = if (maxCompressedSize > outputBuf.capacity()) {
-                    ByteArray(maxCompressedSize)
-                } else {
-                    outputBuf.array()
-                }
-                val compressedSize = ctx.compressByteArray(
-                    outArray,
-                    0,
-                    outArray.size,
-                    inputBuf.array(),
-                    0,
-                    bytesRead
-                )
-
-                destination.writeFully(outArray, 0, compressedSize)
+                ctx.compress(outputBuf, inputBuf).toLong()
+                outputBuf.flip()
+                destination.writeFully(outputBuf)
             }
         } finally {
             ctx.close()

--- a/ktor-shared/ktor-encoding-zstd/jvm/src/io/ktor/encoding/zstd/Zstd.jvm.kt
+++ b/ktor-shared/ktor-encoding-zstd/jvm/src/io/ktor/encoding/zstd/Zstd.jvm.kt
@@ -92,7 +92,7 @@ public class Zstd(private val compressionLevel: Int) : Encoder {
 
     private suspend fun ByteReadChannel.encodeTo(
         destination: ByteWriteChannel,
-        pool: ObjectPool<ByteBuffer> = KtorDefaultPool,
+        pool: ObjectPool<ByteBuffer> = KtorDefaultDirectPool,
         compressionLevel: Int,
     ) {
         val inputBuf = pool.borrow()

--- a/ktor-shared/ktor-encoding-zstd/jvm/test/io/ktor/encoding/zstd/ZstdTest.kt
+++ b/ktor-shared/ktor-encoding-zstd/jvm/test/io/ktor/encoding/zstd/ZstdTest.kt
@@ -36,7 +36,9 @@ class ZstdTest {
         val encodedReadChannel = Zstd(DEFAULT_COMPRESSION_LEVEL).encode(ByteReadChannel(string.toByteArray()))
         val decodedReadChannel = ByteChannel()
         with(Zstd(DEFAULT_COMPRESSION_LEVEL)) {
-            encodedReadChannel.decodeTo(decodedReadChannel, ByteBufferPool(capacity = 10, bufferSize = 32))
+            // the absolute smallest possible zstd frame is 6 bytes,
+            // so use 5 bytes to be sure we're smaller than that
+            encodedReadChannel.decodeTo(decodedReadChannel, DirectByteBufferPool(capacity = 10, bufferSize = 5))
         }
         decodedReadChannel.close()
         val decodedString = decodedReadChannel.readRemaining().readText()

--- a/ktor-utils/api/ktor-utils.api
+++ b/ktor-utils/api/ktor-utils.api
@@ -498,6 +498,7 @@ public final class io/ktor/util/ThrowableKt {
 }
 
 public final class io/ktor/util/cio/ByteBufferPoolKt {
+	public static final fun getKtorDefaultDirectPool ()Lio/ktor/utils/io/pool/ObjectPool;
 	public static final fun getKtorDefaultPool ()Lio/ktor/utils/io/pool/ObjectPool;
 }
 

--- a/ktor-utils/jvm/src/io/ktor/util/cio/ByteBufferPool.kt
+++ b/ktor-utils/jvm/src/io/ktor/util/cio/ByteBufferPool.kt
@@ -16,3 +16,10 @@ internal const val DEFAULT_KTOR_POOL_SIZE = 2048
  * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.util.cio.KtorDefaultPool)
  */
 public val KtorDefaultPool: ObjectPool<ByteBuffer> = ByteBufferPool(DEFAULT_KTOR_POOL_SIZE, DEFAULT_BUFFER_SIZE)
+
+/**
+ * The default ktor direct byte buffer pool
+ *
+ * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.util.cio.KtorDefaultDirectPool)
+ */
+public val KtorDefaultDirectPool: ObjectPool<ByteBuffer> = DirectByteBufferPool(DEFAULT_KTOR_POOL_SIZE, DEFAULT_BUFFER_SIZE)

--- a/ktor-utils/jvm/src/io/ktor/util/cio/ByteBufferPool.kt
+++ b/ktor-utils/jvm/src/io/ktor/util/cio/ByteBufferPool.kt
@@ -5,7 +5,7 @@
 package io.ktor.util.cio
 
 import io.ktor.utils.io.pool.*
-import java.nio.*
+import java.nio.ByteBuffer
 
 internal const val DEFAULT_BUFFER_SIZE = 4098
 internal const val DEFAULT_KTOR_POOL_SIZE = 2048
@@ -22,4 +22,5 @@ public val KtorDefaultPool: ObjectPool<ByteBuffer> = ByteBufferPool(DEFAULT_KTOR
  *
  * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.util.cio.KtorDefaultDirectPool)
  */
-public val KtorDefaultDirectPool: ObjectPool<ByteBuffer> = DirectByteBufferPool(DEFAULT_KTOR_POOL_SIZE, DEFAULT_BUFFER_SIZE)
+public val KtorDefaultDirectPool: ObjectPool<ByteBuffer> =
+    DirectByteBufferPool(DEFAULT_KTOR_POOL_SIZE, DEFAULT_BUFFER_SIZE)


### PR DESCRIPTION
**Subsystem**
shared/ktor-encoding-zstd

**Motivation**
I didn't like the way it did things so I took a deeper look at it and cleaned it up.
in the process I also discovered [KTOR-9487](https://youtrack.jetbrains.com/issue/KTOR-9487).

**Solution**
This should improve zstd encoding & decoding performance because it avoids allocating byte arrays on the heap, instead relying on the byte buffers.

Also fixes [KTOR-9487](https://youtrack.jetbrains.com/issue/KTOR-9487) by just using the streaming api like it should have from the start.
I also fixed the test which wasn't actually correctly testing what it said it was testing.

I had to add a new byte buffer pool because the zstd encoder needs direct byte buffers.