### PR TITLE
Improve crypto performance

### DIFF
--- a/ktor-client/ktor-client-core/jvm/src/io/ktor/client/plugins/cache/storage/FileCacheStorage.kt
+++ b/ktor-client/ktor-client-core/jvm/src/io/ktor/client/plugins/cache/storage/FileCacheStorage.kt
@@ -113,7 +113,9 @@ private class FileCacheStorage(
         deleteCache(urlHex)
     }
 
-    private fun key(url: Url) = hex(MessageDigest.getInstance("SHA-256").digest(url.toString().encodeToByteArray()))
+    private fun key(url: Url): String {
+        return MessageDigest.getInstance("SHA-256").digest(url.toString().encodeToByteArray()).toHexString()
+    }
 
     private suspend fun readCache(urlHex: String): Set<CachedResponseData> {
         val mutex = mutexes.computeIfAbsent(urlHex) { Mutex() }

--- a/ktor-client/ktor-client-plugins/ktor-client-auth/common/src/io/ktor/client/plugins/auth/providers/DigestAuthProvider.kt
+++ b/ktor-client/ktor-client-plugins/ktor-client-auth/common/src/io/ktor/client/plugins/auth/providers/DigestAuthProvider.kt
@@ -174,8 +174,8 @@ public class DigestAuthProvider(
         val credentials = tokenHolder.loadToken() ?: return
         val credential = makeDigest("${credentials.username}:$realm:${credentials.password}")
 
-        val start = hex(credential)
-        val end = hex(makeDigest("$methodName:${url.fullPath}"))
+        val start = credential.toHexString()
+        val end = makeDigest("$methodName:${url.fullPath}").toHexString()
         val tokenSequence = if (actualQop == null) {
             listOf(start, nonce, end)
         } else {
@@ -192,7 +192,7 @@ public class DigestAuthProvider(
                 this["username"] = credentials.username.quote()
                 this["nonce"] = nonce.quote()
                 this["cnonce"] = clientNonce.quote()
-                this["response"] = hex(token).quote()
+                this["response"] = token.toHexString().quote()
                 this["uri"] = url.fullPath.quote()
                 actualQop?.let { this["qop"] = it }
                 this["nc"] = nonceCount

--- a/ktor-client/ktor-client-plugins/ktor-client-auth/common/src/io/ktor/client/plugins/auth/providers/DigestAuthProvider.kt
+++ b/ktor-client/ktor-client-plugins/ktor-client-auth/common/src/io/ktor/client/plugins/auth/providers/DigestAuthProvider.kt
@@ -119,7 +119,7 @@ public class DigestAuthProvider(
 
     private val qop = atomic<String?>(null)
     private val opaque = atomic<String?>(null)
-    private val clientNonce = generateNonce()
+    private val clientNonce = generateNonceBlocking()
 
     private val requestCounter = atomic(0)
 

--- a/ktor-http/common/src/io/ktor/http/auth/HttpAuthHeader.kt
+++ b/ktor-http/common/src/io/ktor/http/auth/HttpAuthHeader.kt
@@ -421,7 +421,7 @@ public sealed class HttpAuthHeader(public val authScheme: String) {
          */
         public fun digestAuthChallenge(
             realm: String,
-            nonce: String = generateNonce(),
+            nonce: String = generateNonceBlocking(),
             domain: List<String> = emptyList(),
             opaque: String? = null,
             stale: Boolean? = null,
@@ -460,7 +460,7 @@ public sealed class HttpAuthHeader(public val authScheme: String) {
         @Deprecated("Maintained for binary compatibility", level = DeprecationLevel.WARNING)
         public fun digestAuthChallenge(
             realm: String,
-            nonce: String = generateNonce(),
+            nonce: String = generateNonceBlocking(),
             domain: List<String> = emptyList(),
             opaque: String? = null,
             stale: Boolean? = null,

--- a/ktor-server/ktor-server-plugins/ktor-server-auth/common/test/io/ktor/tests/auth/CryptoTest.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-auth/common/test/io/ktor/tests/auth/CryptoTest.kt
@@ -18,6 +18,7 @@ class CryptoTest {
     }
 
     @Test
+    @Suppress("DEPRECATION")
     fun testHex() {
         assertEquals("00af", hex(byteArrayOf(0, 0xaf.toByte())))
         assertEquals(byteArrayOf(0, 0xaf.toByte()), hex("00af"))

--- a/ktor-server/ktor-server-plugins/ktor-server-auth/jvm/src/io/ktor/server/auth/DigestCredential.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-auth/jvm/src/io/ktor/server/auth/DigestCredential.kt
@@ -294,10 +294,10 @@ internal fun DigestCredential.verifyWithHA1(
     ha1: ByteArray,
     entityBodyHash: ByteArray? = null
 ): Boolean {
-    val ha1Hex = hex(bytes = ha1)
+    val ha1Hex = ha1.toHexString()
     val validDigest = computeDigestResponse(method, ha1Hex, entityBodyHash)
     val incoming: ByteArray = try {
-        hex(response)
+        response.hexToByteArray()
     } catch (_: NumberFormatException) {
         return false
     }
@@ -322,7 +322,7 @@ public fun DigestCredential.expectedDigest(
     userNameRealmPasswordDigest: ByteArray,
     entityBodyHash: ByteArray? = null
 ): ByteArray {
-    val ha1Hex = hex(bytes = computeHA1(userNameRealmPasswordDigest))
+    val ha1Hex = computeHA1(userNameRealmPasswordDigest).toHexString()
     return computeDigestResponse(method, ha1Hex, entityBodyHash)
 }
 
@@ -339,10 +339,10 @@ private fun DigestCredential.computeDigestResponse(
     // For qop=auth-int: H(A2) = H(method:uri:H(entity-body))
     val methodValue = method.value.toUpperCasePreservingASCIIRules()
     val a2 = when (qop) {
-        DigestQop.AUTH_INT.value -> "$methodValue:$digestUri:${hex(entityBodyHash!!)}"
+        DigestQop.AUTH_INT.value -> "$methodValue:$digestUri:${entityBodyHash!!.toHexString()}"
         else -> "$methodValue:$digestUri"
     }
-    val ha2 = hex(digest(a2))
+    val ha2 = digest(a2).toHexString()
 
     // Final response calculation per RFC 7616 Section 3.4.1
     // Without qop: response = H(H(A1):nonce:H(A2))
@@ -368,7 +368,7 @@ internal fun DigestCredential.computeHA1(userNameRealmPasswordDigest: ByteArray)
     if (!digestAlgorithm.isSession || cnonce == null) {
         return userNameRealmPasswordDigest
     }
-    val baseHa1 = hex(bytes = userNameRealmPasswordDigest)
+    val baseHa1 = userNameRealmPasswordDigest.toHexString()
     return digest("$baseHa1:$nonce:$cnonce")
 }
 
@@ -398,15 +398,15 @@ internal fun DigestCredential.buildAuthenticationInfoHeader(
     // If the qop value is "auth" or is unspecified, then A2 is: A2 = ":" request-uri
     // If the qop value is "auth-int", then A2 is: A2 = ":" request-uri ":" H(entity-body)
     val a2 = when (qop) {
-        DigestQop.AUTH_INT.value -> ":$digestUri:${hex(bytes = responseBodyHash!!)}"
+        DigestQop.AUTH_INT.value -> ":$digestUri:${responseBodyHash!!.toHexString()}"
         else -> ":$digestUri"
     }
-    val ha2 = hex(digest(a2))
-    val ha1Hex = hex(ha1)
+    val ha2 = digest(a2).toHexString()
+    val ha1Hex = ha1.toHexString()
 
     // Calculate rspauth with qop (always present when this function is called)
     val rspAuthInput = "$ha1Hex:$nonce:${nonceCount!!}:${cnonce!!}:$qop:$ha2"
-    val rspAuth = hex(digest(rspAuthInput))
+    val rspAuth = digest(rspAuthInput).toHexString()
 
     return buildString {
         append("rspauth=\"$rspAuth\"")

--- a/ktor-server/ktor-server-plugins/ktor-server-auth/jvm/src/io/ktor/server/auth/OAuth1a.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-auth/jvm/src/io/ktor/server/auth/OAuth1a.kt
@@ -35,7 +35,7 @@ internal suspend fun simpleOAuth1aStep1(
     client: HttpClient,
     settings: OAuthServerSettings.OAuth1aServerSettings,
     callbackUrl: String,
-    nonce: String = generateNonce(),
+    nonce: String? = null,
     extraParameters: List<Pair<String, String>> = emptyList()
 ): OAuthCallback.TokenPair = simpleOAuth1aStep1(
     client,
@@ -43,7 +43,7 @@ internal suspend fun simpleOAuth1aStep1(
     settings.requestTokenUrl,
     callbackUrl,
     settings.consumerKey,
-    nonce,
+    nonce ?: generateNonceSuspend(),
     extraParameters
 )
 
@@ -53,13 +53,13 @@ private suspend fun simpleOAuth1aStep1(
     baseUrl: String,
     callback: String,
     consumerKey: String,
-    nonce: String = generateNonce(),
+    nonce: String? = null,
     extraParameters: List<Pair<String, String>> = emptyList()
 ): OAuthCallback.TokenPair {
     val authHeader = createObtainRequestTokenHeaderInternal(
         callback = callback,
         consumerKey = consumerKey,
-        nonce = nonce
+        nonce = nonce ?: generateNonceSuspend()
     ).signInternal(HttpMethod.Post, baseUrl, secretKey, extraParameters)
 
     val url = baseUrl.appendUrlParameters(extraParameters.formUrlEncode())
@@ -107,7 +107,7 @@ internal suspend fun requestOAuth1aAccessToken(
     client: HttpClient,
     settings: OAuthServerSettings.OAuth1aServerSettings,
     callbackResponse: OAuthCallback.TokenPair,
-    nonce: String = generateNonce(),
+    nonce: String? = null,
     extraParameters: Map<String, String> = emptyMap()
 ): OAuthAccessTokenResponse.OAuth1a = requestOAuth1aAccessToken(
     client,
@@ -116,7 +116,7 @@ internal suspend fun requestOAuth1aAccessToken(
     settings.consumerKey,
     token = callbackResponse.token,
     verifier = callbackResponse.tokenSecret,
-    nonce = nonce,
+    nonce = nonce ?: generateNonceSuspend(),
     extraParameters = extraParameters,
     accessTokenInterceptor = settings.accessTokenInterceptor
 )
@@ -128,12 +128,12 @@ private suspend fun requestOAuth1aAccessToken(
     consumerKey: String,
     token: String,
     verifier: String,
-    nonce: String = generateNonce(),
+    nonce: String? = null,
     extraParameters: Map<String, String> = emptyMap(),
     accessTokenInterceptor: (HttpRequestBuilder.() -> Unit)?
 ): OAuthAccessTokenResponse.OAuth1a {
     val params = listOf(HttpAuthHeader.Parameters.OAuthVerifier to verifier) + extraParameters.toList()
-    val authHeader = createUpgradeRequestTokenHeaderInternal(consumerKey, token, nonce)
+    val authHeader = createUpgradeRequestTokenHeaderInternal(consumerKey, token, nonce ?: generateNonceSuspend())
         .signInternal(HttpMethod.Post, baseUrl, secretKey, params)
 
     // some of really existing OAuth servers don't support other accept header values so keep it

--- a/ktor-server/ktor-server-plugins/ktor-server-auth/jvm/test/io/ktor/tests/auth/DigestApacheClientIntegrationTest.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-auth/jvm/test/io/ktor/tests/auth/DigestApacheClientIntegrationTest.kt
@@ -479,7 +479,7 @@ class DigestApacheClientIntegrationTest {
      */
     private fun computeUserHash(username: String, realm: String, algorithm: DigestAlgorithm): String {
         val digester = algorithm.toDigester()
-        return hex(digester.digest("$username:$realm".toByteArray(Charsets.UTF_8)))
+        return digester.digest("$username:$realm".toByteArray(Charsets.UTF_8)).toHexString()
     }
 
     companion object {

--- a/ktor-server/ktor-server-plugins/ktor-server-auth/jvm/test/io/ktor/tests/auth/DigestRFC7616Test.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-auth/jvm/test/io/ktor/tests/auth/DigestRFC7616Test.kt
@@ -11,7 +11,6 @@ import io.ktor.server.auth.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
 import io.ktor.server.testing.*
-import io.ktor.util.*
 import io.ktor.utils.io.charsets.Charset
 import java.security.MessageDigest
 import kotlin.test.*
@@ -40,7 +39,7 @@ class DigestRFC7616Test {
     private fun computeUserHash(username: String, realm: String, algorithm: DigestAlgorithm): String {
         val digester = algorithm.toDigester()
         digester.update("$username:$realm".toByteArray(Charsets.UTF_8))
-        return hex(digester.digest())
+        return digester.digest().toHexString()
     }
 
     private fun createCredential(
@@ -128,26 +127,29 @@ class DigestRFC7616Test {
 
         // Test SHA-256 HA1
         val ha1Sha256 = digest(DigestAlgorithm.SHA_256, "$userName:$realm:$password")
-        assertEquals("4e4b0731c5b9505beb5a6778cae26063644cebafe6969275be09e7bca2b4da6e", hex(ha1Sha256))
+        assertEquals("4e4b0731c5b9505beb5a6778cae26063644cebafe6969275be09e7bca2b4da6e", ha1Sha256.toHexString())
 
         // Test SHA-256 response
         val credentialSha256 = createCredential(realm, userName, "/dir/index.html", nonce, "SHA-256", cnonce)
         assertEquals(
             "1065210cae09a9f712a625aae28b6119cbb2bb852820f94706624b43328c7b0d",
-            hex(credentialSha256.expectedDigest(HttpMethod.Get, ha1Sha256))
+            credentialSha256.expectedDigest(HttpMethod.Get, ha1Sha256).toHexString()
         )
 
         // Test SHA-512-256 produces the correct length
         val ha1Sha512 = digest(DigestAlgorithm.SHA_512_256, "$userName:$realm:$password")
         val credentialSha512 = createCredential(realm, userName, "/dir/index.html", nonce, "SHA-512-256", cnonce)
-        assertEquals(64, hex(credentialSha512.expectedDigest(HttpMethod.Get, ha1Sha512)).length)
+        assertEquals(64, credentialSha512.expectedDigest(HttpMethod.Get, ha1Sha512).toHexString().length)
 
         // Test MD5 legacy compatibility (RFC 2617)
         val realmMd5 = "testrealm@host.com"
         val passwordMd5 = "Circle Of Life"
         val ha1Md5 = digest(DigestAlgorithm.MD5, "$userName:$realmMd5:$passwordMd5", Charsets.ISO_8859_1)
         val credentialMd5 = createCredential(realmMd5, userName, "/dir/index.html", nonce, "MD5", cnonce)
-        assertEquals("6629fae49393a05397450978507c4ef1", hex(credentialMd5.expectedDigest(HttpMethod.Get, ha1Md5)))
+        assertEquals(
+            "6629fae49393a05397450978507c4ef1",
+            credentialMd5.expectedDigest(HttpMethod.Get, ha1Md5).toHexString()
+        )
     }
 
     @Test
@@ -160,14 +162,17 @@ class DigestRFC7616Test {
 
         // Test SHA-256-sess
         val baseHa1Sha256 = digest(DigestAlgorithm.SHA_256, "$userName:$realm:$password")
-        val sessionHa1Sha256 = digest(DigestAlgorithm.SHA_256, "${hex(baseHa1Sha256)}:$nonce:$cnonce")
+        val sessionHa1Sha256 = digest(DigestAlgorithm.SHA_256, "${baseHa1Sha256.toHexString()}:$nonce:$cnonce")
         val credentialSha256Sess = createCredential(realm, userName, "/", nonce, "SHA-256-sess", cnonce)
         val ha2Sha256 = digest(DigestAlgorithm.SHA_256, "GET:/")
         val expectedSha256 = digest(
             DigestAlgorithm.SHA_256,
-            "${hex(sessionHa1Sha256)}:$nonce:00000001:$cnonce:auth:${hex(ha2Sha256)}"
+            "${sessionHa1Sha256.toHexString()}:$nonce:00000001:$cnonce:auth:${ha2Sha256.toHexString()}"
         )
-        assertEquals(hex(expectedSha256), hex(credentialSha256Sess.expectedDigest(HttpMethod.Get, baseHa1Sha256)))
+        assertEquals(
+            expectedSha256.toHexString(),
+            credentialSha256Sess.expectedDigest(HttpMethod.Get, baseHa1Sha256).toHexString()
+        )
 
         // Test MD5-sess
         val realmMd5 = "testrealm@host.com"
@@ -175,15 +180,22 @@ class DigestRFC7616Test {
         val nonceMd5 = "dcd98b7102dd2f0e8b11d0f600bfb0c093"
         val cnonceMd5 = "0a4f113b"
         val baseHa1Md5 = digest(DigestAlgorithm.MD5, "$userName:$realmMd5:$passwordMd5", Charsets.ISO_8859_1)
-        val sessionHa1Md5 = digest(DigestAlgorithm.MD5, "${hex(baseHa1Md5)}:$nonceMd5:$cnonceMd5", Charsets.ISO_8859_1)
+        val sessionHa1Md5 = digest(
+            DigestAlgorithm.MD5,
+            "${baseHa1Md5.toHexString()}:$nonceMd5:$cnonceMd5",
+            Charsets.ISO_8859_1
+        )
         val credentialMd5Sess = createCredential(realmMd5, userName, "/dir/index.html", nonceMd5, "MD5-sess", cnonceMd5)
         val ha2Md5 = digest(DigestAlgorithm.MD5, "GET:/dir/index.html", Charsets.ISO_8859_1)
         val expectedMd5 = digest(
             DigestAlgorithm.MD5,
-            "${hex(sessionHa1Md5)}:$nonceMd5:00000001:$cnonceMd5:auth:${hex(ha2Md5)}",
+            "${sessionHa1Md5.toHexString()}:$nonceMd5:00000001:$cnonceMd5:auth:${ha2Md5.toHexString()}",
             Charsets.ISO_8859_1
         )
-        assertEquals(hex(expectedMd5), hex(credentialMd5Sess.expectedDigest(HttpMethod.Get, baseHa1Md5)))
+        assertEquals(
+            expectedMd5.toHexString(),
+            credentialMd5Sess.expectedDigest(HttpMethod.Get, baseHa1Md5).toHexString()
+        )
     }
 
     @Test
@@ -194,18 +206,21 @@ class DigestRFC7616Test {
 
         val ha1 = digest(algorithm, "user:$realm:pass")
         val entityBodyHash = algorithm.toDigester().apply { update(entityBody.toByteArray()) }.digest()
-        val ha2 = digest(algorithm, "POST:/api/data:${hex(entityBodyHash)}")
-        val expectedResponse = digest(algorithm, "${hex(ha1)}:abc123:00000001:xyz789:auth-int:${hex(ha2)}")
+        val ha2 = digest(algorithm, "POST:/api/data:${entityBodyHash.toHexString()}")
+        val expectedResponse = digest(
+            algorithm,
+            "${ha1.toHexString()}:abc123:00000001:xyz789:auth-int:${ha2.toHexString()}"
+        )
 
         val credential = DigestCredential(
             realm = realm, userName = "user", digestUri = "/api/data", nonce = "abc123",
             opaque = null, nonceCount = "00000001", digestAlgorithm = DigestAlgorithm.SHA_256,
-            response = hex(expectedResponse), cnonce = "xyz789", qop = "auth-int"
+            response = expectedResponse.toHexString(), cnonce = "xyz789", qop = "auth-int"
         )
 
         assertEquals(
             credential.response,
-            hex(credential.expectedDigest(HttpMethod.Post, ha1, entityBodyHash))
+            credential.expectedDigest(HttpMethod.Post, ha1, entityBodyHash).toHexString()
         )
     }
 
@@ -228,7 +243,7 @@ class DigestRFC7616Test {
         val algorithm = DigestAlgorithm.SHA_256
 
         val userhash = computeUserHash(username, realm, algorithm)
-        val expected = hex(digest(algorithm, "$username:$realm"))
+        val expected = digest(algorithm, "$username:$realm").toHexString()
 
         assertEquals(expected, userhash)
         assertEquals(64, userhash.length)
@@ -252,7 +267,7 @@ class DigestRFC7616Test {
         val userhash = computeUserHash("Mufasa", realm, DigestAlgorithm.SHA_256)
         val ha1 = computeHA1("Mufasa", realm, "CircleOfLife", DigestAlgorithm.SHA_256)
         val credential = createCredential(realm, userhash, "/", nonce, "SHA-256", cnonce, userHash = true)
-        val response = hex(credential.expectedDigest(HttpMethod.Get, ha1))
+        val response = credential.expectedDigest(HttpMethod.Get, ha1).toHexString()
 
         // Test successful userhash authentication
         val authResponse = client.get("/") {
@@ -351,7 +366,7 @@ class DigestRFC7616Test {
         val nc = "00000001"
         val ha1 = computeHA1("user", "test", "pass", DigestAlgorithm.MD5)
         val credential = createCredential("test", "user", "/", nonce, "MD5", cnonce)
-        val response = hex(credential.expectedDigest(HttpMethod.Get, ha1))
+        val response = credential.expectedDigest(HttpMethod.Get, ha1).toHexString()
 
         val authResponse = client.get("/") {
             header(HttpHeaders.Authorization, buildAuthHeader("user", "test", nonce, "/", response, "MD5", nc, cnonce))
@@ -366,9 +381,13 @@ class DigestRFC7616Test {
         assertTrue(authInfo.contains("cnonce=\"$cnonce\""))
 
         // Verify rspauth value
-        val ha2ForRspauth = hex(digest(DigestAlgorithm.MD5, ":/", Charsets.ISO_8859_1))
+        val ha2ForRspauth = digest(DigestAlgorithm.MD5, ":/", Charsets.ISO_8859_1).toHexString()
         val expectedRspauth =
-            hex(digest(DigestAlgorithm.MD5, "${hex(ha1)}:$nonce:$nc:$cnonce:auth:$ha2ForRspauth", Charsets.ISO_8859_1))
+            digest(
+                DigestAlgorithm.MD5,
+                "${ha1.toHexString()}:$nonce:$nc:$cnonce:auth:$ha2ForRspauth",
+                Charsets.ISO_8859_1
+            ).toHexString()
         assertTrue(authInfo.contains("rspauth=\"$expectedRspauth\""))
     }
 
@@ -387,9 +406,9 @@ class DigestRFC7616Test {
             update(data.toByteArray(Charsets.ISO_8859_1))
         }.digest()
 
-        val sessionHa1 = md5("${hex(baseHa1)}:$nonce:$cnonce")
+        val sessionHa1 = md5("${baseHa1.toHexString()}:$nonce:$cnonce")
         val ha2 = md5("GET:/")
-        val response = hex(md5("${hex(sessionHa1)}:$nonce:$nc:$cnonce:auth:${hex(ha2)}"))
+        val response = md5("${sessionHa1.toHexString()}:$nonce:$nc:$cnonce:auth:${ha2.toHexString()}").toHexString()
 
         val authResponse = client.get("/") {
             header(
@@ -402,7 +421,8 @@ class DigestRFC7616Test {
         val authInfo = authResponse.headers["Authentication-Info"]!!
         assertTrue(authInfo.contains("rspauth="))
 
-        val expectedRspauth = hex(md5("${hex(sessionHa1)}:$nonce:$nc:$cnonce:auth:${hex(md5(":/"))}"))
+        val expectedRspauth =
+            md5("${sessionHa1.toHexString()}:$nonce:$nc:$cnonce:auth:${md5(":/").toHexString()}").toHexString()
         assertTrue(authInfo.contains("rspauth=\"$expectedRspauth\""))
     }
 
@@ -465,7 +485,7 @@ class DigestRFC7616Test {
         // Session: returns H(baseDigest:nonce:cnonce)
         val credentialSess = createCredential("realm", "user", "/", "nonce", "MD5-sess", "cnonce")
         val digester = MessageDigest.getInstance("MD5")
-        digester.update("${hex(baseDigest)}:nonce:cnonce".toByteArray(Charsets.ISO_8859_1))
+        digester.update("${baseDigest.toHexString()}:nonce:cnonce".toByteArray(Charsets.ISO_8859_1))
         assertContentEquals(digester.digest(), credentialSess.computeHA1(baseDigest))
     }
 
@@ -481,9 +501,9 @@ class DigestRFC7616Test {
         assertTrue(authInfo.contains("cnonce=\"cnonce\""))
         assertTrue(authInfo.contains("nextnonce=\"nextnonce\""))
 
-        val ha2 = hex(digest(DigestAlgorithm.MD5, ":/path", Charsets.ISO_8859_1))
-        val rspauthInput = "${hex(ha1)}:nonce:00000001:cnonce:auth:$ha2"
-        val expectedRspauth = hex(digest(DigestAlgorithm.MD5, rspauthInput, Charsets.ISO_8859_1))
+        val ha2 = digest(DigestAlgorithm.MD5, ":/path", Charsets.ISO_8859_1).toHexString()
+        val rspauthInput = "${ha1.toHexString()}:nonce:00000001:cnonce:auth:$ha2"
+        val expectedRspauth = digest(DigestAlgorithm.MD5, rspauthInput, Charsets.ISO_8859_1).toHexString()
         assertTrue(authInfo.contains("rspauth=\"$expectedRspauth\""))
     }
 

--- a/ktor-server/ktor-server-plugins/ktor-server-auth/jvm/test/io/ktor/tests/auth/DigestTest.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-auth/jvm/test/io/ktor/tests/auth/DigestTest.kt
@@ -127,7 +127,7 @@ class DigestTest {
 
         assertEquals(
             digest.response,
-            hex(digest.expectedDigest(HttpMethod.Get, digester, digest(digester, userNameRealmPassword)))
+            digest.expectedDigest(HttpMethod.Get, digester, digest(digester, userNameRealmPassword)).toHexString()
         )
         assertTrue(digest.verifier(HttpMethod.Get, digester) { user, realm -> digest(digester, "$user:$realm:$p") })
     }
@@ -377,7 +377,7 @@ class DigestTest {
             client.request("/") {
                 header(
                     HttpHeaders.Authorization,
-                    authHeader.withReplacedParameter("response", hex(expectedDigest)).render()
+                    authHeader.withReplacedParameter("response", expectedDigest.toHexString()).render()
                 )
             }.let { response ->
                 assertEquals(HttpStatusCode.OK, response.status)
@@ -386,7 +386,7 @@ class DigestTest {
             client.request("/") {
                 header(
                     HttpHeaders.Authorization,
-                    authHeader.withReplacedParameter("response", hex(expectedDigest)).withReplacedParameter(
+                    authHeader.withReplacedParameter("response", expectedDigest.toHexString()).withReplacedParameter(
                         "nonce",
                         flipLastHexDigit(nonce)
                     ).render()

--- a/ktor-server/ktor-server-plugins/ktor-server-partial-content/common/src/io/ktor/server/plugins/partialcontent/PartialContentUtils.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-partial-content/common/src/io/ktor/server/plugins/partialcontent/PartialContentUtils.kt
@@ -11,7 +11,6 @@ import io.ktor.server.http.content.*
 import io.ktor.server.plugins.conditionalheaders.*
 import io.ktor.server.request.*
 import io.ktor.server.response.*
-import io.ktor.util.*
 import io.ktor.util.date.*
 import kotlin.coroutines.*
 import kotlin.random.*
@@ -116,7 +115,7 @@ internal suspend fun BodyTransformedHook.Context.processMultiRange(
     ranges: List<LongRange>,
     length: Long
 ) {
-    val boundary = "ktor-boundary-" + hex(Random.nextBytes(16))
+    val boundary = "ktor-boundary-" + Random.nextBytes(16).toHexString()
 
     call.suppressCompression() // multirange with compression is not supported yet (KTOR-5794)
 

--- a/ktor-server/ktor-server-plugins/ktor-server-sessions/common/src/io/ktor/server/sessions/SessionIdProvider.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-sessions/common/src/io/ktor/server/sessions/SessionIdProvider.kt
@@ -11,4 +11,4 @@ import io.ktor.util.*
  *
  * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.server.sessions.generateSessionId)
  */
-public fun generateSessionId(): String = generateNonce() + generateNonce()
+public fun generateSessionId(): String = generateNonceBlocking(64)

--- a/ktor-server/ktor-server-plugins/ktor-server-sessions/jvm/src/io/ktor/server/sessions/SessionTransportTransformerEncrypt.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-sessions/jvm/src/io/ktor/server/sessions/SessionTransportTransformerEncrypt.kt
@@ -4,7 +4,6 @@
 
 package io.ktor.server.sessions
 
-import io.ktor.util.*
 import org.slf4j.*
 import java.security.*
 import javax.crypto.*
@@ -81,16 +80,16 @@ public class SessionTransportTransformerEncrypt(
         try {
             val encryptedAndMac = transportValue.substringAfterLast('/', "")
             val macHex = encryptedAndMac.substringAfterLast(':', "")
-            val encrypted = hex(encryptedAndMac.substringBeforeLast(':'))
-            val macCheck = hex(mac(encrypted)) == macHex
+            val encrypted = encryptedAndMac.substringBeforeLast(':').hexToByteArray()
+            val macCheck = mac(encrypted).toHexString() == macHex
             if (!macCheck && !backwardCompatibleRead) {
                 return null
             }
 
-            val iv = hex(transportValue.substringBeforeLast('/'))
+            val iv = transportValue.substringBeforeLast('/').hexToByteArray()
             val decrypted = decrypt(iv, encrypted)
 
-            if (!macCheck && hex(mac(decrypted)) != macHex) {
+            if (!macCheck && mac(decrypted).toHexString() != macHex) {
                 return null
             }
 
@@ -110,7 +109,7 @@ public class SessionTransportTransformerEncrypt(
         val decrypted = transportValue.toByteArray(charset)
         val encrypted = encrypt(iv, decrypted)
         val mac = mac(encrypted)
-        return "${hex(iv)}/${hex(encrypted)}:${hex(mac)}"
+        return "${iv.toHexString()}/${encrypted.toHexString()}:${mac.toHexString()}"
     }
 
     private fun encrypt(initVector: ByteArray, decrypted: ByteArray): ByteArray {

--- a/ktor-server/ktor-server-plugins/ktor-server-sessions/jvm/src/io/ktor/server/sessions/SessionTransportTransformerMessageAuthentication.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-sessions/jvm/src/io/ktor/server/sessions/SessionTransportTransformerMessageAuthentication.kt
@@ -4,7 +4,6 @@
 
 package io.ktor.server.sessions
 
-import io.ktor.util.*
 import java.security.*
 import javax.crypto.*
 import javax.crypto.spec.*
@@ -46,6 +45,6 @@ public class SessionTransportTransformerMessageAuthentication(
         val mac = Mac.getInstance(algorithm)
         mac.init(keySpec)
 
-        return hex(mac.doFinal(value.toByteArray()))
+        return mac.doFinal(value.toByteArray()).toHexString()
     }
 }

--- a/ktor-server/ktor-server-plugins/ktor-server-websockets/jvm/test/io/ktor/tests/websocket/WebSocketTest.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-websockets/jvm/test/io/ktor/tests/websocket/WebSocketTest.kt
@@ -13,7 +13,6 @@ import io.ktor.server.routing.*
 import io.ktor.server.testing.*
 import io.ktor.server.websocket.*
 import io.ktor.server.websocket.WebSockets
-import io.ktor.util.*
 import io.ktor.util.reflect.*
 import io.ktor.utils.io.charsets.*
 import io.ktor.utils.io.core.*
@@ -191,7 +190,7 @@ class WebSocketTest {
 
         client.webSocket("/receiveSize") {
             send("+".repeat(0xcdef))
-            assertEquals("0000cdef", hex(incoming.receive().readBytes()))
+            assertEquals("0000cdef", incoming.receive().readBytes().toHexString())
         }
     }
 

--- a/ktor-server/ktor-server-test-suites/common/src/io/ktor/server/testing/suites/WebSocketEngineSuite.kt
+++ b/ktor-server/ktor-server-test-suites/common/src/io/ktor/server/testing/suites/WebSocketEngineSuite.kt
@@ -12,7 +12,6 @@ import io.ktor.server.engine.*
 import io.ktor.server.routing.*
 import io.ktor.server.test.base.*
 import io.ktor.server.websocket.*
-import io.ktor.util.*
 import io.ktor.utils.io.*
 import io.ktor.utils.io.charsets.*
 import io.ktor.utils.io.core.*
@@ -721,14 +720,14 @@ abstract class WebSocketEngineSuite<TEngine : ApplicationEngine, TConfiguration 
                     break@loop
                 }
 
-                else -> fail("Unexpected frame $frame: \n${hex(frame.data)}")
+                else -> fail("Unexpected frame $frame: \n${frame.data.toHexString()}")
             }
         }
     }
 
     private suspend fun ByteWriteChannel.writeHex(hex: String) = writeFully(fromHexDump(hex))
 
-    private fun fromHexDump(hex: String) = hex(hex.replace("0x", "").replace("\\s+".toRegex(), ""))
+    private fun fromHexDump(hex: String) = hex.replace("0x", "").replace("\\s+".toRegex(), "").hexToByteArray()
 
     //
     private suspend fun ByteReadChannel.parseStatus(): HttpStatusCode {

--- a/ktor-server/ktor-server-tests/common/test/io/ktor/tests/server/http/TestEngineMultipartTest.kt
+++ b/ktor-server/ktor-server-tests/common/test/io/ktor/tests/server/http/TestEngineMultipartTest.kt
@@ -39,8 +39,8 @@ class TestEngineMultipartTest {
             provider = { ByteReadChannel(bytes) },
             extraFileAssertions = { file ->
                 assertEquals(
-                    hex(bytes),
-                    hex(file.provider().readRemaining().readByteArray())
+                    bytes.toHexString(),
+                    file.provider().readRemaining().readByteArray().toHexString()
                 )
             }
         )
@@ -66,7 +66,7 @@ class TestEngineMultipartTest {
 
             assertEquals("fileField", file.name)
             assertEquals("file.bin", file.originalFileName)
-            assertEquals(hex(bytes), hex(file.provider().readRemaining().readByteArray()))
+            assertEquals(bytes.toHexString(), file.provider().readRemaining().readByteArray().toHexString())
 
             file.dispose()
         }) {

--- a/ktor-server/ktor-server-tests/jvm/test/io/ktor/server/sessions/SessionTestJvm.kt
+++ b/ktor-server/ktor-server-tests/jvm/test/io/ktor/server/sessions/SessionTestJvm.kt
@@ -20,7 +20,7 @@ class SessionTestJvm {
 
     @Test
     fun testSessionByValueMac() = testApplication {
-        val key = "03515606058610610561058".hexToByteArray()
+        val key = "003515606058610610561058".hexToByteArray()
 
         install(Sessions) {
             cookie<TestUserSession>(cookieName) {

--- a/ktor-server/ktor-server-tests/jvm/test/io/ktor/server/sessions/SessionTestJvm.kt
+++ b/ktor-server/ktor-server-tests/jvm/test/io/ktor/server/sessions/SessionTestJvm.kt
@@ -11,7 +11,6 @@ import io.ktor.server.response.*
 import io.ktor.server.routing.*
 import io.ktor.server.testing.*
 import io.ktor.tests.server.sessions.*
-import io.ktor.util.*
 import kotlin.random.*
 import kotlin.test.*
 
@@ -21,7 +20,7 @@ class SessionTestJvm {
 
     @Test
     fun testSessionByValueMac() = testApplication {
-        val key = hex("03515606058610610561058")
+        val key = "03515606058610610561058".hexToByteArray()
 
         install(Sessions) {
             cookie<TestUserSession>(cookieName) {
@@ -34,9 +33,9 @@ class SessionTestJvm {
 
     @Test
     fun testSessionEncrypted() = testApplication {
-        val encryptKey = hex("00112233445566778899aabbccddeeff")
-        val signKey = hex("02030405060708090a0b0c")
-        val forcedIvForTesting = hex("00112233445566778899aabbccddeeff")
+        val encryptKey = "00112233445566778899aabbccddeeff".hexToByteArray()
+        val signKey = "02030405060708090a0b0c".hexToByteArray()
+        val forcedIvForTesting = "00112233445566778899aabbccddeeff".hexToByteArray()
 
         install(Sessions) {
             cookie<TestUserSession>(cookieName) {
@@ -81,9 +80,9 @@ class SessionTestJvm {
 
     @Test
     fun testSessionEncryptedBackwardCompatible() = testApplication {
-        val encryptKey = hex("00112233445566778899aabbccddeeff")
-        val signKey = hex("02030405060708090a0b0c")
-        val forcedIvForTesting = hex("00112233445566778899aabbccddeeff")
+        val encryptKey = "00112233445566778899aabbccddeeff".hexToByteArray()
+        val signKey = "02030405060708090a0b0c".hexToByteArray()
+        val forcedIvForTesting = "00112233445566778899aabbccddeeff".hexToByteArray()
 
         install(Sessions) {
             cookie<TestUserSession>(cookieName) {
@@ -135,9 +134,9 @@ class SessionTestJvm {
 
     @Test
     fun testSessionEncryptedNotBackwardCompatible() = testApplication {
-        val encryptKey = hex("00112233445566778899aabbccddeeff")
-        val signKey = hex("02030405060708090a0b0c")
-        val forcedIvForTesting = hex("00112233445566778899aabbccddeeff")
+        val encryptKey = "00112233445566778899aabbccddeeff".hexToByteArray()
+        val signKey = "02030405060708090a0b0c".hexToByteArray()
+        val forcedIvForTesting = "00112233445566778899aabbccddeeff".hexToByteArray()
 
         install(Sessions) {
             cookie<TestUserSession>(cookieName) {

--- a/ktor-shared/ktor-websockets/common/src/io/ktor/websocket/PingPong.kt
+++ b/ktor-shared/ktor-websockets/common/src/io/ktor/websocket/PingPong.kt
@@ -4,7 +4,6 @@
 
 package io.ktor.websocket
 
-import io.ktor.util.*
 import io.ktor.util.date.*
 import io.ktor.utils.io.ClosedByteChannelException
 import io.ktor.utils.io.charsets.*
@@ -70,7 +69,7 @@ internal fun CoroutineScope.pinger(
                 }
 
                 random.nextBytes(pingIdBytes)
-                val pingMessage = "[ping ${hex(pingIdBytes)} ping]"
+                val pingMessage = "[ping ${pingIdBytes.toHexString()} ping]"
 
                 val rc = withTimeoutOrNull(timeoutMillis) {
                     LOGGER.trace("WebSocket Pinger: sending ping frame")

--- a/ktor-shared/ktor-websockets/jvm/test/ParserTest.kt
+++ b/ktor-shared/ktor-websockets/jvm/test/ParserTest.kt
@@ -107,5 +107,5 @@ class ParserTest {
     }
 
     private fun String.trimHex() = replace("\\s+".toRegex(), "").replace("0x", "")
-    private fun bufferOf(hex: String) = ByteBuffer.wrap(hex(hex.trimHex()))
+    private fun bufferOf(hex: String) = ByteBuffer.wrap(hex.trimHex().hexToByteArray())
 }

--- a/ktor-utils/api/ktor-utils.api
+++ b/ktor-utils/api/ktor-utils.api
@@ -151,6 +151,10 @@ public final class io/ktor/util/CryptoKt {
 	public static synthetic fun build$default (Lio/ktor/util/Digest;Ljava/lang/String;Ljava/nio/charset/Charset;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public static final fun generateNonce ()Ljava/lang/String;
 	public static final fun generateNonce (I)[B
+	public static final fun generateNonceBlocking (I)Ljava/lang/String;
+	public static synthetic fun generateNonceBlocking$default (IILjava/lang/Object;)Ljava/lang/String;
+	public static final fun generateNonceSuspend (ILkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun generateNonceSuspend$default (ILkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public static final fun getDigestFunction (Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Lkotlin/jvm/functions/Function1;
 	public static final fun hex (Ljava/lang/String;)[B
 	public static final fun hex ([B)Ljava/lang/String;

--- a/ktor-utils/api/ktor-utils.klib.api
+++ b/ktor-utils/api/ktor-utils.klib.api
@@ -1000,6 +1000,7 @@ final fun io.ktor.util/Digest(kotlin/String): io.ktor.util/Digest // io.ktor.uti
 final fun io.ktor.util/SilentSupervisor(kotlinx.coroutines/Job? = ...): kotlin.coroutines/CoroutineContext // io.ktor.util/SilentSupervisor|SilentSupervisor(kotlinx.coroutines.Job?){}[0]
 final fun io.ktor.util/generateNonce(): kotlin/String // io.ktor.util/generateNonce|generateNonce(){}[0]
 final fun io.ktor.util/generateNonce(kotlin/Int): kotlin/ByteArray // io.ktor.util/generateNonce|generateNonce(kotlin.Int){}[0]
+final fun io.ktor.util/generateNonceBlocking(kotlin/Int = ...): kotlin/String // io.ktor.util/generateNonceBlocking|generateNonceBlocking(kotlin.Int){}[0]
 final fun io.ktor.util/hex(kotlin/ByteArray): kotlin/String // io.ktor.util/hex|hex(kotlin.ByteArray){}[0]
 final fun io.ktor.util/hex(kotlin/String): kotlin/ByteArray // io.ktor.util/hex|hex(kotlin.String){}[0]
 final fun io.ktor.util/sha1(kotlin/ByteArray): kotlin/ByteArray // io.ktor.util/sha1|sha1(kotlin.ByteArray){}[0]
@@ -1022,6 +1023,7 @@ final suspend fun (io.ktor.utils.io/ByteReadChannel).io.ktor.util.cio/toByteArra
 final suspend fun <#A: kotlin.coroutines/CoroutineContext.Element> io.ktor.util.debug/useContextElementInDebugMode(kotlin.coroutines/CoroutineContext.Key<#A>, kotlin/Function1<#A, kotlin/Unit>) // io.ktor.util.debug/useContextElementInDebugMode|useContextElementInDebugMode(kotlin.coroutines.CoroutineContext.Key<0:0>;kotlin.Function1<0:0,kotlin.Unit>){0§<kotlin.coroutines.CoroutineContext.Element>}[0]
 final suspend fun <#A: kotlin/Any?> io.ktor.util.debug/addToContextInDebugMode(kotlin/String, kotlin.coroutines/SuspendFunction0<#A>): #A // io.ktor.util.debug/addToContextInDebugMode|addToContextInDebugMode(kotlin.String;kotlin.coroutines.SuspendFunction0<0:0>){0§<kotlin.Any?>}[0]
 final suspend fun <#A: kotlin/Any?> io.ktor.util.debug/initContextInDebugMode(kotlin.coroutines/SuspendFunction0<#A>): #A // io.ktor.util.debug/initContextInDebugMode|initContextInDebugMode(kotlin.coroutines.SuspendFunction0<0:0>){0§<kotlin.Any?>}[0]
+final suspend fun io.ktor.util/generateNonceSuspend(kotlin/Int = ...): kotlin/String // io.ktor.util/generateNonceSuspend|generateNonceSuspend(kotlin.Int){}[0]
 final suspend inline fun <#A: kotlin/Any> (io.ktor.util.pipeline/Pipeline<kotlin/Unit, #A>).io.ktor.util.pipeline/execute(#A) // io.ktor.util.pipeline/execute|execute@io.ktor.util.pipeline.Pipeline<kotlin.Unit,0:0>(0:0){0§<kotlin.Any>}[0]
 
 // Targets: [native]

--- a/ktor-utils/common/src/io/ktor/util/Crypto.kt
+++ b/ktor-utils/common/src/io/ktor/util/Crypto.kt
@@ -19,6 +19,10 @@ private val digits = "0123456789abcdef".toCharArray()
  *
  * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.util.hex)
  */
+@Deprecated(
+    "prefer kotlin.text.toHexString",
+    replaceWith = ReplaceWith("bytes.toHexString()", imports = ["kotlin.text.toHexString"]),
+)
 public fun hex(bytes: ByteArray): String {
     val result = CharArray(bytes.size * 2)
     var resultIndex = 0
@@ -38,6 +42,10 @@ public fun hex(bytes: ByteArray): String {
  *
  * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.util.hex)
  */
+@Deprecated(
+    "prefer kotlin.text.hexToByteArray",
+    replaceWith = ReplaceWith("s.hexToByteArray()", imports = ["kotlin.text.hexToByteArray"]),
+)
 public fun hex(s: String): ByteArray {
     val result = ByteArray(s.length / 2)
     for (idx in result.indices) {

--- a/ktor-utils/common/src/io/ktor/util/Crypto.kt
+++ b/ktor-utils/common/src/io/ktor/util/Crypto.kt
@@ -14,8 +14,6 @@ import kotlinx.io.*
 
 private val digits = "0123456789abcdef".toCharArray()
 
-internal const val NONCE_SIZE_IN_BYTES = 16
-
 /**
  * Encode [bytes] as a HEX string with no spaces, newlines and `0x` prefixes.
  *
@@ -53,20 +51,42 @@ public fun hex(s: String): ByteArray {
 }
 
 /**
- * Generates a nonce string. Could block if the system's entropy source is empty
+ * Generates a nonce string 32 characters long. Could block if the system's entropy source is empty
  *
  * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.util.generateNonce)
  */
-public expect fun generateNonce(): String
+@Deprecated(
+    "Use generateNonceBlocking in blocking contexts and generateNonceSuspend in non-blocking contexts",
+    replaceWith = ReplaceWith("generateNonceBlocking()")
+)
+public fun generateNonce(): String = generateNonceBlocking(32)
+
+/**
+ * Generates a nonce string [length] characters long. Could suspend if the system's entropy source is empty.
+ *
+ * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.util.generateNonce)
+ */
+public expect suspend fun generateNonceSuspend(length: Int = 32): String
+
+/**
+ * Generates a nonce string [length] characters long. Could block if the system's entropy source is empty.
+ *
+ * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.util.generateNonce)
+ */
+public expect fun generateNonceBlocking(length: Int = 32): String
 
 /**
  * Generates a nonce bytes of [size]. Could block if the system's entropy source is empty
  *
  * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.util.generateNonce)
  */
+@Deprecated(
+    "Use generateNonceBlocking in blocking contexts and generateNonceSuspend in non-blocking contexts",
+    replaceWith = ReplaceWith("generateNonceBlocking(size).toByteArray()", "io.ktor.utils.io.core.toByteArray")
+)
 public fun generateNonce(size: Int): ByteArray = buildPacket {
     while (this.size < size) {
-        writeText(generateNonce())
+        writeText(generateNonceBlocking())
     }
 }.readByteArray(size)
 

--- a/ktor-utils/common/src/io/ktor/util/Crypto.kt
+++ b/ktor-utils/common/src/io/ktor/util/Crypto.kt
@@ -14,6 +14,10 @@ import kotlinx.io.*
 
 private val digits = "0123456789abcdef".toCharArray()
 
+internal const val NONCE_SIZE_IN_BYTES = 16
+
+internal const val NONCE_SIZE_IN_CHARS = NONCE_SIZE_IN_BYTES * 2
+
 /**
  * Encode [bytes] as a HEX string with no spaces, newlines and `0x` prefixes.
  *
@@ -67,21 +71,21 @@ public fun hex(s: String): ByteArray {
     "Use generateNonceBlocking in blocking contexts and generateNonceSuspend in non-blocking contexts",
     replaceWith = ReplaceWith("generateNonceBlocking()")
 )
-public fun generateNonce(): String = generateNonceBlocking(32)
+public fun generateNonce(): String = generateNonceBlocking(NONCE_SIZE_IN_CHARS)
 
 /**
  * Generates a nonce string [length] characters long. Could suspend if the system's entropy source is empty.
  *
  * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.util.generateNonce)
  */
-public expect suspend fun generateNonceSuspend(length: Int = 32): String
+public expect suspend fun generateNonceSuspend(length: Int = NONCE_SIZE_IN_CHARS): String
 
 /**
  * Generates a nonce string [length] characters long. Could block if the system's entropy source is empty.
  *
  * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.util.generateNonce)
  */
-public expect fun generateNonceBlocking(length: Int = 32): String
+public expect fun generateNonceBlocking(length: Int = NONCE_SIZE_IN_CHARS): String
 
 /**
  * Generates a nonce bytes of [size]. Could block if the system's entropy source is empty

--- a/ktor-utils/common/src/io/ktor/util/NonceManager.kt
+++ b/ktor-utils/common/src/io/ktor/util/NonceManager.kt
@@ -41,7 +41,7 @@ public interface NonceManager {
  */
 public object GenerateOnlyNonceManager : NonceManager {
     override suspend fun newNonce(): String {
-        return generateNonce()
+        return generateNonceSuspend()
     }
 
     override suspend fun verifyNonce(nonce: String): Boolean {

--- a/ktor-utils/common/test/io/ktor/util/HashFunctionTest.kt
+++ b/ktor-utils/common/test/io/ktor/util/HashFunctionTest.kt
@@ -8,6 +8,7 @@ import kotlin.test.*
 
 class HashFunctionTest {
     @Test
+    @Suppress("DEPRECATION")
     fun sha1() {
         assertEquals(
             "a9993e364706816aba3e25717850c26c9cd0d89d",

--- a/ktor-utils/common/test/io/ktor/util/HashFunctionTest.kt
+++ b/ktor-utils/common/test/io/ktor/util/HashFunctionTest.kt
@@ -12,7 +12,7 @@ class HashFunctionTest {
     fun sha1() {
         assertEquals(
             "a9993e364706816aba3e25717850c26c9cd0d89d",
-            hex(Sha1().digest("abc".encodeToByteArray()))
+            Sha1().digest("abc".encodeToByteArray()).toHexString()
         )
     }
 

--- a/ktor-utils/common/test/io/ktor/util/NonceTest.kt
+++ b/ktor-utils/common/test/io/ktor/util/NonceTest.kt
@@ -10,8 +10,8 @@ class NonceTest {
 
     @Test
     fun testGenerateNonce() {
-        val nonce1 = generateNonce()
-        val nonce2 = generateNonce()
+        val nonce1 = generateNonceBlocking()
+        val nonce2 = generateNonceBlocking()
         assertNotEquals(nonce1, nonce2)
     }
 }

--- a/ktor-utils/jvm/src/io/ktor/util/CryptoJvm.kt
+++ b/ktor-utils/jvm/src/io/ktor/util/CryptoJvm.kt
@@ -71,7 +71,11 @@ public actual suspend fun generateNonceSuspend(length: Int): String {
         return nonce.substring(0, length)
     }
 
-    return generateNonceLoop(nonce, length)
+    return if (length <= NONCE_SIZE_IN_CHARS) {
+        seedChannel.receive().substring(0, length)
+    } else {
+        generateNonceLong(nonce, length)
+    }
 }
 
 /**
@@ -88,10 +92,16 @@ public actual fun generateNonceBlocking(length: Int): String {
 
     ensureNonceGeneratorRunning()
 
-    return runBlocking { generateNonceLoop(nonce, length) }
+    return runBlocking {
+        if (length <= NONCE_SIZE_IN_CHARS) {
+            seedChannel.receive().substring(0, length)
+        } else {
+            generateNonceLong(nonce, length)
+        }
+    }
 }
 
-private suspend fun generateNonceLoop(initial: String?, length: Int) = buildString(length) {
+private suspend fun generateNonceLong(initial: CharSequence?, length: Int) = buildString(length) {
     if (initial != null) {
         append(initial)
     }

--- a/ktor-utils/jvm/src/io/ktor/util/CryptoJvm.kt
+++ b/ktor-utils/jvm/src/io/ktor/util/CryptoJvm.kt
@@ -64,14 +64,26 @@ private value class DigestImpl(val delegate: MessageDigest) : Digest {
  */
 public actual fun generateNonce(): String {
     val nonce = seedChannel.tryReceive().getOrNull()
-    if (nonce != null) return nonce
 
-    return generateNonceBlocking()
+    if (nonce != null && nonce.length >= 32) {
+        return nonce.substring(0, 32)
+    }
+
+    return generateNonceBlocking(nonce, 32)
 }
 
-private fun generateNonceBlocking(): String {
+private fun generateNonceBlocking(initial: String?, length: Int): String {
     ensureNonceGeneratorRunning()
     return runBlocking {
-        seedChannel.receive()
+        buildString(length) {
+            if (initial != null) {
+                append(initial)
+            }
+
+            while (length > this.length) {
+                val toAppend = seedChannel.receive()
+                append(toAppend, 0, (length - this.length).coerceAtMost(toAppend.length))
+            }
+        }.substring(0, length)
     }
 }

--- a/ktor-utils/jvm/src/io/ktor/util/CryptoJvm.kt
+++ b/ktor-utils/jvm/src/io/ktor/util/CryptoJvm.kt
@@ -65,14 +65,14 @@ private value class DigestImpl(val delegate: MessageDigest) : Digest {
 public actual suspend fun generateNonceSuspend(length: Int): String {
     ensureNonceGeneratorRunning()
 
-    val nonce = seedChannel.receive()
+    val nonce = nonceChannel.receive()
 
     if (nonce.length >= length) {
         return nonce.substring(0, length)
     }
 
     return if (length <= NONCE_SIZE_IN_CHARS) {
-        seedChannel.receive().substring(0, length)
+        nonceChannel.receive().substring(0, length)
     } else {
         generateNonceLong(nonce, length)
     }
@@ -84,7 +84,7 @@ public actual suspend fun generateNonceSuspend(length: Int): String {
  * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.util.generateNonceBlocking)
  */
 public actual fun generateNonceBlocking(length: Int): String {
-    val nonce = seedChannel.tryReceive().getOrNull()
+    val nonce = nonceChannel.tryReceive().getOrNull()
 
     if (nonce != null && nonce.length >= length) {
         return nonce.substring(0, length)
@@ -94,7 +94,7 @@ public actual fun generateNonceBlocking(length: Int): String {
 
     return runBlocking {
         if (length <= NONCE_SIZE_IN_CHARS) {
-            seedChannel.receive().substring(0, length)
+            nonceChannel.receive().substring(0, length)
         } else {
             generateNonceLong(nonce, length)
         }
@@ -107,7 +107,7 @@ private suspend fun generateNonceLong(initial: CharSequence?, length: Int) = bui
     }
 
     while (length > this.length) {
-        val toAppend = seedChannel.receive()
+        val toAppend = nonceChannel.receive()
         append(toAppend, 0, (length - this.length).coerceAtMost(toAppend.length))
     }
 }.substring(0, length)

--- a/ktor-utils/jvm/src/io/ktor/util/CryptoJvm.kt
+++ b/ktor-utils/jvm/src/io/ktor/util/CryptoJvm.kt
@@ -58,32 +58,46 @@ private value class DigestImpl(val delegate: MessageDigest) : Digest {
 }
 
 /**
- * Generates a nonce string 16 characters long. Could block if the system's entropy source is empty
+ * Generates a nonce string [length] characters long. Could block if the system's entropy source is empty.
  *
- * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.util.generateNonce)
+ * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.util.generateNonceSuspend)
  */
-public actual fun generateNonce(): String {
+public actual suspend fun generateNonceSuspend(length: Int): String {
+    ensureNonceGeneratorRunning()
+
+    val nonce = seedChannel.receive()
+
+    if (nonce.length >= length) {
+        return nonce.substring(0, length)
+    }
+
+    return generateNonceLoop(nonce, length)
+}
+
+/**
+ * Generates a nonce string [length] characters long. Could block if the system's entropy source is empty.
+ *
+ * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.util.generateNonceBlocking)
+ */
+public actual fun generateNonceBlocking(length: Int): String {
     val nonce = seedChannel.tryReceive().getOrNull()
 
-    if (nonce != null && nonce.length >= 32) {
-        return nonce.substring(0, 32)
+    if (nonce != null && nonce.length >= length) {
+        return nonce.substring(0, length)
     }
 
-    return generateNonceBlocking(nonce, 32)
-}
-
-private fun generateNonceBlocking(initial: String?, length: Int): String {
     ensureNonceGeneratorRunning()
-    return runBlocking {
-        buildString(length) {
-            if (initial != null) {
-                append(initial)
-            }
 
-            while (length > this.length) {
-                val toAppend = seedChannel.receive()
-                append(toAppend, 0, (length - this.length).coerceAtMost(toAppend.length))
-            }
-        }.substring(0, length)
-    }
+    return runBlocking { generateNonceLoop(nonce, length) }
 }
+
+private suspend fun generateNonceLoop(initial: String?, length: Int) = buildString(length) {
+    if (initial != null) {
+        append(initial)
+    }
+
+    while (length > this.length) {
+        val toAppend = seedChannel.receive()
+        append(toAppend, 0, (length - this.length).coerceAtMost(toAppend.length))
+    }
+}.substring(0, length)

--- a/ktor-utils/jvm/src/io/ktor/util/Nonce.kt
+++ b/ktor-utils/jvm/src/io/ktor/util/Nonce.kt
@@ -161,7 +161,9 @@ private fun getSystemPropertyInt(key: String, default: Int): Int {
         try {
             return property.toInt()
         } catch (_: NumberFormatException) {
-            logger.warn("Invalid integer '$property' for property $SYSTEM_PROPERTY_PREFIX.$key, falling back to default")
+            logger.warn(
+                "Invalid integer '$property' for property $SYSTEM_PROPERTY_PREFIX.$key, falling back to default"
+            )
         }
     }
     return default

--- a/ktor-utils/jvm/src/io/ktor/util/Nonce.kt
+++ b/ktor-utils/jvm/src/io/ktor/util/Nonce.kt
@@ -8,6 +8,7 @@ import kotlinx.coroutines.*
 import kotlinx.coroutines.channels.*
 import org.slf4j.*
 import java.security.*
+import kotlin.random.asKotlinRandom
 
 private const val SHA1PRNG = "SHA1PRNG"
 
@@ -23,20 +24,32 @@ private const val SECURE_NONCE_COUNT = 8
 
 private const val INSECURE_NONCE_COUNT_FACTOR = 4
 
+private const val NONCE_SIZE_IN_BYTES = 16
+
+private const val RANDOM_BYTES_CHUNK_SIZE = 16
+
 internal val seedChannel: Channel<String> = Channel(1024)
 
 private val NonceGeneratorCoroutineName = CoroutineName("nonce-generator")
 
 @OptIn(DelicateCoroutinesApi::class)
+@Suppress("CoroutineContextWithJob")
 private val nonceGeneratorJob = GlobalScope.launch(
     context = Dispatchers.Default + NonCancellable + NonceGeneratorCoroutineName,
     start = CoroutineStart.LAZY
 ) {
     val seedChannel = seedChannel
     var lastReseed = 0L
-    val previousRoundNonceList = ArrayList<String>()
+    // empty strings are fine, because generateNonce cares about the string length
+    val randomNonces =
+        Array(
+            SECURE_NONCE_COUNT * NONCE_SIZE_IN_BYTES * INSECURE_NONCE_COUNT_FACTOR * 2 / RANDOM_BYTES_CHUNK_SIZE * 2
+        ) {
+            ""
+        }
     val secureInstance = lookupSecureRandom()
     val weakRandom = SecureRandom.getInstance(SHA1PRNG)
+    val weakKotlinRandom = weakRandom.asKotlinRandom() // we need a kotlin random for kotlin.collections.shuffle
 
     val secureBytes = ByteArray(SECURE_NONCE_COUNT * NONCE_SIZE_IN_BYTES)
     val weakBytes = ByteArray(secureBytes.size * INSECURE_NONCE_COUNT_FACTOR)
@@ -67,19 +80,29 @@ private val nonceGeneratorJob = GlobalScope.launch(
                 weakRandom.setSeed(secureBytes)
             }
 
-            // concat entries with entries from the previous round
-            // and shuffle with weak random (reseeded)
-            val randomNonceList = (hex(weakBytes).chunked(16) + previousRoundNonceList).shuffled(weakRandom)
+            /*
+            concat entries with entries from the previous round
 
-            // send first part to the channel
-            for (index in 0 until randomNonceList.size / 2) {
-                seedChannel.send(randomNonceList[index])
+            realistically, hex.length here could be a constant as it *should* always be the same length
+            but it's just easier to use hex.length
+
+            we're only setting the first 1/2 elements in randomNonces not the full array,
+            the remaining elements are preserved from the last iteration
+
+            we overwrite the first half of the elements,
+            as those are the ones that were previously sent to the channel
+             */
+            val hex = weakBytes.toHexString()
+            for (index in 0..<hex.length / RANDOM_BYTES_CHUNK_SIZE) {
+                val offset = index * RANDOM_BYTES_CHUNK_SIZE
+                randomNonces[index] = hex.substring(offset, offset + RANDOM_BYTES_CHUNK_SIZE)
             }
+            // and shuffle with weak random (reseeded)
+            randomNonces.shuffle(weakKotlinRandom) // shuffle array in-place to avoid extra allocations
 
-            // stash the second part for the next round
-            previousRoundNonceList.clear()
-            for (index in randomNonceList.size / 2 until randomNonceList.size) {
-                previousRoundNonceList.add(randomNonceList[index])
+            // send first half to the channel
+            for (index in 0 until randomNonces.size / 2) {
+                seedChannel.send(randomNonces[index])
             }
         }
     } catch (t: Throwable) {
@@ -102,9 +125,21 @@ private fun lookupSecureRandom(): SecureRandom {
         getInstanceOrNull(name)?.let { return it }
     }
 
-    LoggerFactory.getLogger("io.ktor.util.random")
-        .warn("None of the ${SECURE_RANDOM_PROVIDERS.joinToString(separator = ", ")} found, fallback to default")
+    val logger = LoggerFactory.getLogger("io.ktor.util.random")
 
+    logger.warn("None of the ${SECURE_RANDOM_PROVIDERS.joinToString()} found, falling back to the JDK strong default")
+
+    // try JVM-determined strong instances
+    // on OpenJDK, this is set to Windows-PRNG:SunMSCAPI and DRBG:SUN on Windows and NativePRNGBlocking:SUN and DRBG:SUN otherwise.
+    try {
+        return SecureRandom.getInstanceStrong()
+    } catch (_: NoSuchAlgorithmException) {
+        // ignored
+    }
+
+    logger.warn("None of the JDK determined strong SecureRandom providers were available, falling back to the default")
+
+    // fallback (*should* never be null)
     return getInstanceOrNull() ?: error("No SecureRandom implementation found")
 }
 
@@ -114,6 +149,6 @@ private fun getInstanceOrNull(name: String? = null) = try {
     } else {
         SecureRandom()
     }
-} catch (notFound: NoSuchAlgorithmException) {
+} catch (_: NoSuchAlgorithmException) {
     null
 }

--- a/ktor-utils/jvm/src/io/ktor/util/Nonce.kt
+++ b/ktor-utils/jvm/src/io/ktor/util/Nonce.kt
@@ -8,7 +8,9 @@ import kotlinx.coroutines.*
 import kotlinx.coroutines.channels.*
 import org.slf4j.*
 import java.security.*
-import kotlin.random.asKotlinRandom
+import kotlin.random.*
+
+private val logger = LoggerFactory.getLogger("io.ktor.util.random")
 
 private const val SHA1PRNG = "SHA1PRNG"
 
@@ -18,15 +20,19 @@ private val SECURE_RANDOM_PROVIDERS: List<String> = listOf(
     "DRBG"
 )
 
-private const val SECURE_RESEED_PERIOD = 30_000
+private const val SYSTEM_PROPERTY_PREFIX = "io.ktor.random.secure"
 
-private const val SECURE_NONCE_COUNT = 8
+// Note: these defaults are just random guesses, and were not chosen through any benchmarks.
 
-private const val SECURE_RESEED_BYTES = 128
+private val SECURE_RESEED_PERIOD = getSystemPropertyInt("reseed-period", 30_000)
 
-private const val INSECURE_NONCE_COUNT_FACTOR = 4
+private val SECURE_NONCE_COUNT = getSystemPropertyInt("nonce.buffer-size", 32)
 
-internal val nonceChannel: Channel<String> = Channel(1024)
+private val SECURE_RESEED_BYTES = getSystemPropertyInt("reseed-bytes", 256)
+
+private val INSECURE_NONCE_COUNT_FACTOR = getSystemPropertyInt("insecure-factor", 4)
+
+internal val nonceChannel: Channel<String> = Channel(getSystemPropertyInt("nonce.channel-size", 128))
 
 private val NonceGeneratorCoroutineName = CoroutineName("nonce-generator")
 
@@ -115,15 +121,13 @@ internal fun ensureNonceGeneratorRunning() {
 }
 
 private fun lookupSecureRandom(): SecureRandom {
-    System.getProperty("io.ktor.random.secure.random.provider")?.let { name ->
+    System.getProperty("$SYSTEM_PROPERTY_PREFIX.random.provider")?.let { name ->
         getInstanceOrNull(name)?.let { return it }
     }
 
     for (name in SECURE_RANDOM_PROVIDERS) {
         getInstanceOrNull(name)?.let { return it }
     }
-
-    val logger = LoggerFactory.getLogger("io.ktor.util.random")
 
     logger.warn("None of the ${SECURE_RANDOM_PROVIDERS.joinToString()} found, falling back to the JDK strong default")
 
@@ -149,4 +153,16 @@ private fun getInstanceOrNull(name: String? = null) = try {
     }
 } catch (_: NoSuchAlgorithmException) {
     null
+}
+
+private fun getSystemPropertyInt(key: String, default: Int): Int {
+    val property = System.getProperty("$SYSTEM_PROPERTY_PREFIX.$key", null)
+    if (property != null) {
+        try {
+            return property.toInt()
+        } catch (_: NumberFormatException) {
+            logger.warn("Invalid integer '$property' for property $SYSTEM_PROPERTY_PREFIX.$key, falling back to default")
+        }
+    }
+    return default
 }

--- a/ktor-utils/jvm/src/io/ktor/util/Nonce.kt
+++ b/ktor-utils/jvm/src/io/ktor/util/Nonce.kt
@@ -26,7 +26,7 @@ private const val SYSTEM_PROPERTY_PREFIX = "io.ktor.random.secure"
 
 private val SECURE_RESEED_PERIOD = getSystemPropertyInt("reseed-period", 30_000)
 
-private val SECURE_NONCE_COUNT = getSystemPropertyInt("nonce.buffer-size", 32)
+private val SECURE_NONCE_COUNT = getSystemPropertyInt("nonce.buffer-size", 64)
 
 private val SECURE_RESEED_BYTES = getSystemPropertyInt("reseed-bytes", 256)
 
@@ -52,8 +52,8 @@ private val nonceGeneratorJob = GlobalScope.launch(
     val weakRandom = SecureRandom.getInstance(SHA1PRNG)
     val weakKotlinRandom = weakRandom.asKotlinRandom() // we need a kotlin random for kotlin.collections.shuffle
 
-    val secureBytes = ByteArray(SECURE_NONCE_COUNT * NONCE_SIZE_IN_BYTES)
-    val weakBytes = ByteArray(secureBytes.size * INSECURE_NONCE_COUNT_FACTOR)
+    val secureBytes = ByteArray(SECURE_NONCE_COUNT * NONCE_SIZE_IN_BYTES / INSECURE_NONCE_COUNT_FACTOR)
+    val weakBytes = ByteArray(SECURE_NONCE_COUNT * NONCE_SIZE_IN_BYTES)
 
     weakRandom.setSeed(strongRandom.generateSeed(SECURE_RESEED_BYTES))
 

--- a/ktor-utils/jvm/src/io/ktor/util/Nonce.kt
+++ b/ktor-utils/jvm/src/io/ktor/util/Nonce.kt
@@ -24,10 +24,6 @@ private const val SECURE_NONCE_COUNT = 8
 
 private const val INSECURE_NONCE_COUNT_FACTOR = 4
 
-private const val NONCE_SIZE_IN_BYTES = 16
-
-private const val RANDOM_BYTES_CHUNK_SIZE = 16
-
 internal val seedChannel: Channel<String> = Channel(1024)
 
 private val NonceGeneratorCoroutineName = CoroutineName("nonce-generator")
@@ -40,13 +36,11 @@ private val nonceGeneratorJob = GlobalScope.launch(
 ) {
     val seedChannel = seedChannel
     var lastReseed = 0L
-    // empty strings are fine, because generateNonce cares about the string length
-    val randomNonces =
-        Array(
-            SECURE_NONCE_COUNT * NONCE_SIZE_IN_BYTES * INSECURE_NONCE_COUNT_FACTOR * 2 / RANDOM_BYTES_CHUNK_SIZE * 2
-        ) {
-            ""
-        }
+    // empty strings are fine, because we only send non-empty strings
+    val randomNonces: Array<String> = Array(
+        SECURE_NONCE_COUNT * NONCE_SIZE_IN_BYTES * INSECURE_NONCE_COUNT_FACTOR * 2 / NONCE_SIZE_IN_CHARS * 2
+    ) { "" }
+
     val secureInstance = lookupSecureRandom()
     val weakRandom = SecureRandom.getInstance(SHA1PRNG)
     val weakKotlinRandom = weakRandom.asKotlinRandom() // we need a kotlin random for kotlin.collections.shuffle
@@ -93,16 +87,19 @@ private val nonceGeneratorJob = GlobalScope.launch(
             as those are the ones that were previously sent to the channel
              */
             val hex = weakBytes.toHexString()
-            for (index in 0..<hex.length / RANDOM_BYTES_CHUNK_SIZE) {
-                val offset = index * RANDOM_BYTES_CHUNK_SIZE
-                randomNonces[index] = hex.substring(offset, offset + RANDOM_BYTES_CHUNK_SIZE)
+            for (index in 0..<hex.length / NONCE_SIZE_IN_CHARS) {
+                val offset = index * NONCE_SIZE_IN_CHARS
+                randomNonces[index] = hex.substring(offset, offset + NONCE_SIZE_IN_CHARS)
             }
             // and shuffle with weak random (reseeded)
             randomNonces.shuffle(weakKotlinRandom) // shuffle array in-place to avoid extra allocations
 
             // send first half to the channel
             for (index in 0 until randomNonces.size / 2) {
-                seedChannel.send(randomNonces[index])
+                val nonce = randomNonces[index]
+                if (nonce.isNotEmpty()) {
+                    seedChannel.send(randomNonces[index])
+                }
             }
         }
     } catch (t: Throwable) {

--- a/ktor-utils/jvm/src/io/ktor/util/Nonce.kt
+++ b/ktor-utils/jvm/src/io/ktor/util/Nonce.kt
@@ -22,9 +22,11 @@ private const val SECURE_RESEED_PERIOD = 30_000
 
 private const val SECURE_NONCE_COUNT = 8
 
+private const val SECURE_RESEED_BYTES = 128
+
 private const val INSECURE_NONCE_COUNT_FACTOR = 4
 
-internal val seedChannel: Channel<String> = Channel(1024)
+internal val nonceChannel: Channel<String> = Channel(1024)
 
 private val NonceGeneratorCoroutineName = CoroutineName("nonce-generator")
 
@@ -34,26 +36,25 @@ private val nonceGeneratorJob = GlobalScope.launch(
     context = Dispatchers.Default + NonCancellable + NonceGeneratorCoroutineName,
     start = CoroutineStart.LAZY
 ) {
-    val seedChannel = seedChannel
+    val nonceChannel = nonceChannel
     var lastReseed = 0L
     // empty strings are fine, because we only send non-empty strings
-    val randomNonces: Array<String> = Array(
-        SECURE_NONCE_COUNT * NONCE_SIZE_IN_BYTES * INSECURE_NONCE_COUNT_FACTOR * 2 / NONCE_SIZE_IN_CHARS * 2
-    ) { "" }
+    val randomNonces = arrayOfNulls<String>(SECURE_NONCE_COUNT * 2)
 
-    val secureInstance = lookupSecureRandom()
+    val strongRandom = lookupSecureRandom()
+    // note that technically the SHA1PRNG is not in the jvm spec, so this will fail on JVMs without the SHA1PRNG.
     val weakRandom = SecureRandom.getInstance(SHA1PRNG)
     val weakKotlinRandom = weakRandom.asKotlinRandom() // we need a kotlin random for kotlin.collections.shuffle
 
     val secureBytes = ByteArray(SECURE_NONCE_COUNT * NONCE_SIZE_IN_BYTES)
     val weakBytes = ByteArray(secureBytes.size * INSECURE_NONCE_COUNT_FACTOR)
 
-    weakRandom.setSeed(secureInstance.generateSeed(secureBytes.size))
+    weakRandom.setSeed(strongRandom.generateSeed(SECURE_RESEED_BYTES))
 
     try {
         while (true) {
             // fill both
-            secureInstance.nextBytes(secureBytes)
+            strongRandom.nextBytes(secureBytes)
             weakRandom.nextBytes(weakBytes)
 
             // mix secure and weak
@@ -68,7 +69,7 @@ private val nonceGeneratorJob = GlobalScope.launch(
 
             if (currentTime - lastReseed > SECURE_RESEED_PERIOD) {
                 weakRandom.setSeed(lastReseed - currentTime)
-                weakRandom.setSeed(secureInstance.generateSeed(secureBytes.size))
+                weakRandom.setSeed(strongRandom.generateSeed(SECURE_RESEED_BYTES))
                 lastReseed = currentTime
             } else {
                 weakRandom.setSeed(secureBytes)
@@ -96,16 +97,16 @@ private val nonceGeneratorJob = GlobalScope.launch(
 
             // send first half to the channel
             for (index in 0 until randomNonces.size / 2) {
-                val nonce = randomNonces[index]
+                val nonce = randomNonces[index] ?: continue
                 if (nonce.isNotEmpty()) {
-                    seedChannel.send(randomNonces[index])
+                    nonceChannel.send(nonce)
                 }
             }
         }
     } catch (t: Throwable) {
-        seedChannel.close(t)
+        nonceChannel.close(t)
     } finally {
-        seedChannel.close()
+        nonceChannel.close()
     }
 }
 

--- a/ktor-utils/jvm/src/io/ktor/util/StatelessHmacNonceManager.kt
+++ b/ktor-utils/jvm/src/io/ktor/util/StatelessHmacNonceManager.kt
@@ -23,7 +23,7 @@ public class StatelessHmacNonceManager(
     public val keySpec: SecretKeySpec,
     public val algorithm: String = "HmacSHA256",
     public val timeoutMillis: Long = 60000,
-    public val nonceGenerator: () -> String = { generateNonce() }
+    public val nonceGenerator: () -> String = { generateNonceBlocking() }
 ) : NonceManager {
     /**
      * Helper constructor that makes a secret key from [key] ByteArray
@@ -34,7 +34,7 @@ public class StatelessHmacNonceManager(
         key: ByteArray,
         algorithm: String = "HmacSHA256",
         timeoutMillis: Long = 60000,
-        nonceGenerator: () -> String = { generateNonce() }
+        nonceGenerator: () -> String = { generateNonceBlocking() }
     ) : this(
         SecretKeySpec(
             key,

--- a/ktor-utils/jvm/src/io/ktor/util/StatelessHmacNonceManager.kt
+++ b/ktor-utils/jvm/src/io/ktor/util/StatelessHmacNonceManager.kt
@@ -57,12 +57,10 @@ public class StatelessHmacNonceManager(
         val random = nonceGenerator()
         val time = System.nanoTime().toString(16).padStart(16, '0')
 
-        val mac = hex(
-            Mac.getInstance(algorithm).apply {
-                init(keySpec)
-                update("$random:$time".toByteArray(Charsets.ISO_8859_1))
-            }.doFinal()
-        )
+        val mac = Mac.getInstance(algorithm).apply {
+            init(keySpec)
+            update("$random:$time".toByteArray(Charsets.ISO_8859_1))
+        }.doFinal().toHexString()
 
         return "$random+$time+$mac"
     }
@@ -79,12 +77,10 @@ public class StatelessHmacNonceManager(
         val nanoTime = time.toLong(16)
         if (nanoTime + TimeUnit.MILLISECONDS.toNanos(timeoutMillis) < System.nanoTime()) return false
 
-        val computedMac = hex(
-            Mac.getInstance(algorithm).apply {
-                init(keySpec)
-                update("$random:$time".toByteArray(Charsets.ISO_8859_1))
-            }.doFinal()
-        )
+        val computedMac = Mac.getInstance(algorithm).apply {
+            init(keySpec)
+            update("$random:$time".toByteArray(Charsets.ISO_8859_1))
+        }.doFinal().toHexString()
 
         var validCount = 0
         for (i in 0 until minOf(computedMac.length, mac.length)) {

--- a/ktor-utils/jvm/test/io/ktor/tests/utils/HexFunctionsTest.kt
+++ b/ktor-utils/jvm/test/io/ktor/tests/utils/HexFunctionsTest.kt
@@ -7,6 +7,7 @@ package io.ktor.tests.utils
 import io.ktor.util.*
 import kotlin.test.*
 
+@Suppress("DEPRECATION")
 class HexFunctionsTest {
     @Test
     fun testEmpty() {

--- a/ktor-utils/jvm/test/io/ktor/tests/utils/NonceSmokeTest.kt
+++ b/ktor-utils/jvm/test/io/ktor/tests/utils/NonceSmokeTest.kt
@@ -13,7 +13,7 @@ class NonceSmokeTest {
         val nonceSet = HashSet<String>(4096)
 
         repeat(4096) {
-            nonceSet.add(generateNonce())
+            nonceSet.add(generateNonceBlocking())
         }
 
         assertTrue { nonceSet.size == 4096 }

--- a/ktor-utils/posix/src/io/ktor/util/CryptoNative.kt
+++ b/ktor-utils/posix/src/io/ktor/util/CryptoNative.kt
@@ -5,14 +5,22 @@
 package io.ktor.util
 
 /**
- * Generates a nonce string 32 characters long. Could block if the system's entropy source is empty
+ * Generates a nonce string [length] characters long. Could suspend if the system's entropy source is empty.
  *
- * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.util.generateNonce)
+ * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.util.generateNonceSuspend)
  */
-public actual fun generateNonce(): String {
-    val bytes = ByteArray(16)
+public actual suspend fun generateNonceSuspend(length: Int): String = generateNonceBlocking(length)
+
+/**
+ * Generates a nonce string [length] characters long. Could block if the system's entropy source is empty.
+ *
+ * [Report a
+ * problem](https://ktor.io/feedback/?fqname=io.ktor.util.generateNonceBlocking)
+ */
+public actual fun generateNonceBlocking(length: Int): String {
+    val bytes = ByteArray(length / 2 + 1)
     secureRandom(bytes)
-    return hex(bytes)
+    return bytes.toHexString().substring(0, length)
 }
 
 internal expect fun secureRandom(bytes: ByteArray)

--- a/ktor-utils/web/src/io/ktor/util/Crypto.web.kt
+++ b/ktor-utils/web/src/io/ktor/util/Crypto.web.kt
@@ -11,12 +11,19 @@ import kotlin.js.*
 /**
  * Generates a nonce string.
  *
- * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.util.generateNonce)
+ * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.util.generateNonceSuspend)
  */
-public actual fun generateNonce(): String {
-    val buffer = ByteArray(NONCE_SIZE_IN_BYTES).toJsArray()
+public actual suspend fun generateNonceSuspend(length: Int): String = generateNonceBlocking(length)
+
+/**
+ * Generates a nonce string.
+ *
+ * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.util.generateNonceBlocking)
+ */
+public actual fun generateNonceBlocking(length: Int): String {
+    val buffer = ByteArray(length / 2 + 1).toJsArray()
     _crypto.getRandomValues(buffer)
-    return hex(buffer.toByteArray())
+    return buffer.toByteArray().toHexString().substring(0, length)
 }
 
 /**

--- a/ktor-utils/web/test/io.ktor.util/CryptoTest.kt
+++ b/ktor-utils/web/test/io.ktor.util/CryptoTest.kt
@@ -18,6 +18,6 @@ class CryptoTest {
         checkMsCrypto()
         defineCrypto()
         deleteCrypto()
-        assertEquals(32, generateNonce().length)
+        assertEquals(32, generateNonceBlocking().length)
     }
 }


### PR DESCRIPTION
**Subsystem**
ktor-utils

**Motivation**
`generateNonce()` (on the JVM platform) was using an array list and did a bunch of unnecessary allocations and that annoyed me.

Fixes [KTOR-9488](https://youtrack.jetbrains.com/issue/KTOR-9488)

**Solution**
I rewrote `generateNonce()` in such a way that doesn't use a list to decrease the number of allocations. also it doesn't do unnecessary things like clearing it or creating a copy of it just to shuffle the elements.

I've also done two other changes:
- deprecate `generateNonce()` in favour of `generateNonceSuspend()` (if I could I'd name this `generateNonce()`) and `generateNonceBlocking()`
- mark the `hex()` functions as deprecated. the kotlin stdlib now has functions for converting to/from hex, and those will be much more performance because they don't create a bunch of unnecessary strings.

both of those changes were done in separate commits so that I can drop them if needed.