### PR TITLE
Add ByteArray constructor to InetSocketAddress

### DIFF
--- a/ktor-network/api/ktor-network.api
+++ b/ktor-network/api/ktor-network.api
@@ -192,6 +192,7 @@ public final class io/ktor/network/sockets/DatagramWriteChannel$DefaultImpls {
 
 public final class io/ktor/network/sockets/InetSocketAddress : io/ktor/network/sockets/SocketAddress {
 	public fun <init> (Ljava/lang/String;I)V
+	public fun <init> ([BI)V
 	public final fun component1 ()Ljava/lang/String;
 	public final fun component2 ()I
 	public final fun copy (Ljava/lang/String;I)Lio/ktor/network/sockets/InetSocketAddress;

--- a/ktor-network/api/ktor-network.klib.api
+++ b/ktor-network/api/ktor-network.klib.api
@@ -123,6 +123,7 @@ final class io.ktor.network.sockets/Datagram { // io.ktor.network.sockets/Datagr
 }
 
 final class io.ktor.network.sockets/InetSocketAddress : io.ktor.network.sockets/SocketAddress { // io.ktor.network.sockets/InetSocketAddress|null[0]
+    constructor <init>(kotlin/ByteArray, kotlin/Int) // io.ktor.network.sockets/InetSocketAddress.<init>|<init>(kotlin.ByteArray;kotlin.Int){}[0]
     constructor <init>(kotlin/String, kotlin/Int) // io.ktor.network.sockets/InetSocketAddress.<init>|<init>(kotlin.String;kotlin.Int){}[0]
 
     final val hostname // io.ktor.network.sockets/InetSocketAddress.hostname|{}hostname[0]

--- a/ktor-network/common/src/io/ktor/network/sockets/SocketAddress.kt
+++ b/ktor-network/common/src/io/ktor/network/sockets/SocketAddress.kt
@@ -36,6 +36,16 @@ public expect class InetSocketAddress(
     hostname: String,
     port: Int
 ) : SocketAddress {
+
+    /**
+     * Creates an [InetSocketAddress] from raw IP address bytes and a port number.
+     *
+     * @param address the raw IP address bytes in network byte order: 4 bytes for IPv4 or 16 bytes for IPv6.
+     * @param port the port number.
+     * @throws IllegalArgumentException if [address] is neither 4 nor 16 bytes long.
+     */
+    public constructor(address: ByteArray, port: Int)
+
     /**
      * The hostname of the socket address.
      *

--- a/ktor-network/common/test/io/ktor/network/sockets/tests/InetSocketAddressTest.kt
+++ b/ktor-network/common/test/io/ktor/network/sockets/tests/InetSocketAddressTest.kt
@@ -6,9 +6,7 @@ package io.ktor.network.sockets.tests
 
 import io.ktor.network.sockets.*
 import io.ktor.util.*
-import kotlin.test.BeforeTest
-import kotlin.test.Test
-import kotlin.test.assertContentEquals
+import kotlin.test.*
 
 class InetSocketAddressTest {
 
@@ -31,6 +29,37 @@ class InetSocketAddressTest {
             val address = InetSocketAddress(hostname, 8080)
             val resolved = address.resolveAddress()
             assertContentEquals(expectedBytes, resolved, "Unexpected bytes for the address '$hostname'")
+        }
+    }
+
+    @Test
+    fun `construct from IPv4 byte array`() {
+        // Address resolving is not supported on JS and WASM platforms
+        if (PlatformUtils.IS_JS || PlatformUtils.IS_WASM_JS) return
+
+        val bytes = byteArrayOf(127, 0, 0, 1)
+        val address = InetSocketAddress(bytes, 8080)
+
+        assertEquals(8080, address.port)
+        assertContentEquals(bytes, address.resolveAddress())
+    }
+
+    @Test
+    fun `construct from IPv6 byte array`() {
+        // Address resolving is not supported on JS and WASM platforms
+        if (PlatformUtils.IS_JS || PlatformUtils.IS_WASM_JS) return
+
+        val bytes = byteArrayOf(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1)
+        val address = InetSocketAddress(bytes, 8080)
+
+        assertEquals(8080, address.port)
+        assertContentEquals(bytes, address.resolveAddress())
+    }
+
+    @Test
+    fun `construct from invalid byte array length throws exception`() {
+        assertFailsWith<IllegalArgumentException> {
+            InetSocketAddress(byteArrayOf(1, 2, 3), 8080)
         }
     }
 }

--- a/ktor-network/jvm/src/io/ktor/network/sockets/SocketAddressJvm.kt
+++ b/ktor-network/jvm/src/io/ktor/network/sockets/SocketAddressJvm.kt
@@ -24,6 +24,19 @@ public actual class InetSocketAddress internal constructor(
     public actual constructor(hostname: String, port: Int) :
         this(java.net.InetSocketAddress(hostname, port))
 
+    public actual constructor(address: ByteArray, port: Int) : this(
+        java.net.InetSocketAddress(
+            java.net.InetAddress.getByAddress(
+                address.also {
+                    require(it.size == 4 || it.size == 16) {
+                        "Invalid IP address byte array length: ${it.size}. Expected 4 (IPv4) or 16 (IPv6)."
+                    }
+                }
+            ),
+            port
+        )
+    )
+
     public actual operator fun component1(): String = hostname
 
     public actual operator fun component2(): Int = port

--- a/ktor-network/nonJvm/src/io/ktor/network/sockets/SocketAddress.nonJvm.kt
+++ b/ktor-network/nonJvm/src/io/ktor/network/sockets/SocketAddress.nonJvm.kt
@@ -10,6 +10,9 @@ public actual class InetSocketAddress actual constructor(
     public actual val hostname: String,
     public actual val port: Int
 ) : SocketAddress() {
+
+    public actual constructor(address: ByteArray, port: Int) : this(address.toIpString(), port)
+
     public actual fun resolveAddress(): ByteArray? {
         return platformResolveAddress()
     }
@@ -108,3 +111,16 @@ public actual class UnixSocketAddress actual constructor(
 internal expect fun isUnixSocketSupported(): Boolean
 
 internal expect fun InetSocketAddress.platformResolveAddress(): ByteArray?
+
+internal fun ByteArray.toIpString(): String {
+    require(size == 4 || size == 16) {
+        "Invalid IP address byte array length: $size. Expected 4 (IPv4) or 16 (IPv6)."
+    }
+    return when (size) {
+        4 -> joinToString(".") { it.toUByte().toString() }
+        else -> (0 until 8).joinToString(":") { i ->
+            val value = ((this[i * 2].toInt() and 0xFF) shl 8) or (this[i * 2 + 1].toInt() and 0xFF)
+            value.toString(16).padStart(4, '0')
+        }
+    }
+}


### PR DESCRIPTION
**Subsystem**
Network

**Motivation**
Fixes #4978. When callers already have raw IP bytes (e.g. from a parsed packet), there is no way to construct an `InetSocketAddress` without first converting to a string.

**Solution**
Add a secondary constructor `InetSocketAddress(address: ByteArray, port: Int)` that accepts 4-byte (IPv4) or 16-byte (IPv6) arrays in network byte order. Invalid lengths throw `IllegalArgumentException`.