### PR TITLE
Apache 5 Client. Don't ignore resultCallback

### DIFF
--- a/ktor-client/ktor-client-apache5/build.gradle.kts
+++ b/ktor-client/ktor-client-apache5/build.gradle.kts
@@ -17,6 +17,7 @@ kotlin {
         }
         jvmTest.dependencies {
             implementation(projects.ktorClientTests)
+            implementation(libs.kotlinx.coroutines.test)
         }
     }
 }

--- a/ktor-client/ktor-client-apache5/jvm/src/io/ktor/client/engine/apache5/ApacheResponseConsumer.kt
+++ b/ktor-client/ktor-client-apache5/jvm/src/io/ktor/client/engine/apache5/ApacheResponseConsumer.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2014-2026 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package io.ktor.client.engine.apache5
@@ -93,6 +93,9 @@ internal class ApacheResponseConsumer(
     @Volatile
     private var capacityChannel: CapacityChannel? = null
 
+    @Volatile
+    private var streamResultCallback: FutureCallback<Unit>? = null
+
     private val messagesQueue = Channel<Any>(capacity = UNLIMITED)
 
     internal val responseChannel: ByteReadChannel = channel
@@ -105,7 +108,7 @@ internal class ApacheResponseConsumer(
             }
         }
 
-        launch(coroutineContext) {
+        launch {
             for (message in messagesQueue) {
                 when (message) {
                     is CloseChannel -> close()
@@ -114,13 +117,13 @@ internal class ApacheResponseConsumer(
                         val written = message.remaining()
                         channel.writeFully(message)
                         channel.flush()
-                        when (capacityChannel) {
+                        when (val channel = capacityChannel) {
                             null -> capacity.addAndGet(written)
-                            else -> capacityChannel!!.update(written)
+                            else -> channel.update(written)
                         }
                     }
 
-                    else -> throw IllegalStateException("Unknown message $message")
+                    else -> error("Unknown message $message")
                 }
             }
         }
@@ -148,17 +151,21 @@ internal class ApacheResponseConsumer(
         messagesQueue.trySend(CloseChannel)
     }
 
-    override fun streamStart(entityDetails: EntityDetails, resultCallback: FutureCallback<Unit>) {}
+    override fun streamStart(entityDetails: EntityDetails, resultCallback: FutureCallback<Unit>) {
+        streamResultCallback = resultCallback
+    }
 
     override fun failed(cause: Exception) {
         val mappedCause = mapCause(cause, requestData)
         consumerJob.completeExceptionally(mappedCause)
         responseChannel.cancel(mappedCause)
+        streamResultCallback?.failed(cause)
     }
 
     internal fun close() {
         channel.close()
         consumerJob.complete()
+        streamResultCallback?.completed(Unit)
     }
 
     override fun getContent() = Unit

--- a/ktor-client/ktor-client-apache5/jvm/src/io/ktor/client/engine/apache5/ApacheResponseConsumer.kt
+++ b/ktor-client/ktor-client-apache5/jvm/src/io/ktor/client/engine/apache5/ApacheResponseConsumer.kt
@@ -108,7 +108,7 @@ internal class ApacheResponseConsumer(
             }
         }
 
-        launch {
+        launch(CoroutineName("apache-response-consumer")) {
             for (message in messagesQueue) {
                 when (message) {
                     is CloseChannel -> close()

--- a/ktor-client/ktor-client-apache5/jvm/src/io/ktor/client/engine/apache5/ApacheResponseConsumer.kt
+++ b/ktor-client/ktor-client-apache5/jvm/src/io/ktor/client/engine/apache5/ApacheResponseConsumer.kt
@@ -93,8 +93,7 @@ internal class ApacheResponseConsumer(
     @Volatile
     private var capacityChannel: CapacityChannel? = null
 
-    @Volatile
-    private var streamResultCallback: FutureCallback<Unit>? = null
+    private val streamResultCallback = atomic<FutureCallback<Unit>?>(null)
 
     private val messagesQueue = Channel<Any>(capacity = UNLIMITED)
 
@@ -152,20 +151,20 @@ internal class ApacheResponseConsumer(
     }
 
     override fun streamStart(entityDetails: EntityDetails, resultCallback: FutureCallback<Unit>) {
-        streamResultCallback = resultCallback
+        streamResultCallback.value = resultCallback
     }
 
     override fun failed(cause: Exception) {
         val mappedCause = mapCause(cause, requestData)
         consumerJob.completeExceptionally(mappedCause)
         responseChannel.cancel(mappedCause)
-        streamResultCallback?.failed(cause)
+        streamResultCallback.getAndSet(null)?.failed(cause)
     }
 
     internal fun close() {
         channel.close()
         consumerJob.complete()
-        streamResultCallback?.completed(Unit)
+        streamResultCallback.getAndSet(null)?.completed(Unit)
     }
 
     override fun getContent() = Unit

--- a/ktor-client/ktor-client-apache5/jvm/test/io/ktor/client/engine/apache5/ApacheResponseConsumerTest.kt
+++ b/ktor-client/ktor-client-apache5/jvm/test/io/ktor/client/engine/apache5/ApacheResponseConsumerTest.kt
@@ -10,6 +10,7 @@ import io.ktor.http.content.*
 import io.ktor.util.*
 import io.ktor.utils.io.*
 import kotlinx.coroutines.*
+import kotlinx.coroutines.test.*
 import org.apache.hc.core5.concurrent.FutureCallback
 import org.apache.hc.core5.http.ContentType
 import org.apache.hc.core5.http.impl.BasicEntityDetails
@@ -20,13 +21,14 @@ import java.util.concurrent.atomic.AtomicInteger
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
-import kotlin.test.assertTrue
 import kotlin.time.Duration.Companion.seconds
 
 class ApacheResponseConsumerTest {
 
     @Test
-    fun `FutureCallback completed is called when response with body is fully consumed`() = runBlocking {
+    fun `FutureCallback completed is called when response with body is fully consumed`() = runTest(
+        timeout = 10.seconds
+    ) {
         val callbackResult = CompletableDeferred<Unit>()
         val callback = trackingCallback(onCompleted = { callbackResult.complete(Unit) })
 
@@ -44,12 +46,11 @@ class ApacheResponseConsumerTest {
         responseConsumer.consume(ByteBuffer.wrap("hello".toByteArray()))
         responseConsumer.streamEnd(null)
 
-        withTimeout(5.seconds) { callbackResult.await() }
-        assertTrue(callbackResult.isCompleted)
+        callbackResult.await()
     }
 
     @Test
-    fun `FutureCallback completed is called for response without body`() = runBlocking {
+    fun `FutureCallback completed is called for response without body`() = runTest(timeout = 10.seconds) {
         val callbackResult = CompletableDeferred<Unit>()
         val callback = trackingCallback(onCompleted = { callbackResult.complete(Unit) })
 
@@ -59,12 +60,11 @@ class ApacheResponseConsumerTest {
 
         responseConsumer.consumeResponse(BasicHttpResponse(204), null, null, callback)
 
-        withTimeout(5.seconds) { callbackResult.await() }
-        assertTrue(callbackResult.isCompleted)
+        callbackResult.await()
     }
 
     @Test
-    fun `FutureCallback failed is called on error`() = runBlocking {
+    fun `FutureCallback failed is called on error`() = runTest(timeout = 10.seconds) {
         val failureException = CompletableDeferred<Exception>()
         val callback = trackingCallback(onFailed = { failureException.complete(it) })
 
@@ -82,13 +82,13 @@ class ApacheResponseConsumerTest {
         val cause = IOException("connection reset")
         responseConsumer.failed(cause)
 
-        val received = withTimeout(5.seconds) { failureException.await() }
+        val received = failureException.await()
         assertNotNull(received)
         assertEquals("connection reset", received.message)
     }
 
     @Test
-    fun `FutureCallback is called at most once when both streamEnd and failed fire`() = runBlocking {
+    fun `FutureCallback is called at most once when both streamEnd and failed fire`() = runTest(timeout = 10.seconds) {
         val terminalCallCount = AtomicInteger(0)
         val firstTerminal = CompletableDeferred<Unit>()
         val callback = object : FutureCallback<Unit> {
@@ -102,10 +102,11 @@ class ApacheResponseConsumerTest {
                 firstTerminal.complete(Unit)
             }
 
-            override fun cancelled() {}
+            override fun cancelled() = Unit
         }
 
-        val consumerContext = Dispatchers.Default + Job()
+        val parentJob = Job()
+        val consumerContext = Dispatchers.Default + parentJob
         val bodyConsumer = ApacheResponseConsumer(consumerContext, requestData)
         val responseConsumer = BasicResponseConsumer(bodyConsumer)
 
@@ -116,12 +117,13 @@ class ApacheResponseConsumerTest {
             callback,
         )
 
-        responseConsumer.consume(ByteBuffer.wrap("hello".toByteArray()))
-        responseConsumer.streamEnd(null) // will eventually call close() → completed()
-        responseConsumer.failed(IOException("network error")) // may also call failed()
+        responseConsumer.streamEnd(null) // enqueues CloseChannel → close() runs asynchronously
+        responseConsumer.failed(IOException("network error")) // may also invoke the callback
 
-        withTimeout(5.seconds) { firstTerminal.await() }
-        delay(100) // give a chance for a second invocation to sneak in
+        // Close the queue so the message-queue coroutine finishes after processing CloseChannel,
+        // then join consumerJob (child of parentJob) which waits for all its children too.
+        responseConsumer.releaseResources()
+        parentJob.children.forEach { it.join() }
 
         assertEquals(1, terminalCallCount.get(), "FutureCallback must be invoked exactly once")
     }
@@ -132,7 +134,7 @@ class ApacheResponseConsumerTest {
     ) = object : FutureCallback<Unit> {
         override fun completed(result: Unit) = onCompleted()
         override fun failed(ex: Exception) = onFailed(ex)
-        override fun cancelled() {}
+        override fun cancelled() = Unit
     }
 
     @OptIn(InternalAPI::class)

--- a/ktor-client/ktor-client-apache5/jvm/test/io/ktor/client/engine/apache5/ApacheResponseConsumerTest.kt
+++ b/ktor-client/ktor-client-apache5/jvm/test/io/ktor/client/engine/apache5/ApacheResponseConsumerTest.kt
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2014-2026 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.client.engine.apache5
+
+import io.ktor.client.request.*
+import io.ktor.http.*
+import io.ktor.http.content.*
+import io.ktor.util.*
+import io.ktor.utils.io.*
+import kotlinx.coroutines.*
+import org.apache.hc.core5.concurrent.FutureCallback
+import org.apache.hc.core5.http.ContentType
+import org.apache.hc.core5.http.impl.BasicEntityDetails
+import org.apache.hc.core5.http.message.BasicHttpResponse
+import java.io.IOException
+import java.nio.ByteBuffer
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.seconds
+
+class ApacheResponseConsumerTest {
+
+    @Test
+    fun `FutureCallback completed is called when response with body is fully consumed`() = runBlocking {
+        val callbackResult = CompletableDeferred<Unit>()
+        val callback = trackingCallback(onCompleted = { callbackResult.complete(Unit) })
+
+        val consumerContext = Dispatchers.Default + Job()
+        val bodyConsumer = ApacheResponseConsumer(consumerContext, requestData)
+        val responseConsumer = BasicResponseConsumer(bodyConsumer)
+
+        responseConsumer.consumeResponse(
+            BasicHttpResponse(200),
+            BasicEntityDetails(5, ContentType.TEXT_PLAIN),
+            null,
+            callback,
+        )
+
+        responseConsumer.consume(ByteBuffer.wrap("hello".toByteArray()))
+        responseConsumer.streamEnd(null)
+
+        withTimeout(5.seconds) { callbackResult.await() }
+        assertTrue(callbackResult.isCompleted)
+    }
+
+    @Test
+    fun `FutureCallback completed is called for response without body`() = runBlocking {
+        val callbackResult = CompletableDeferred<Unit>()
+        val callback = trackingCallback(onCompleted = { callbackResult.complete(Unit) })
+
+        val consumerContext = Dispatchers.Default + Job()
+        val bodyConsumer = ApacheResponseConsumer(consumerContext, requestData)
+        val responseConsumer = BasicResponseConsumer(bodyConsumer)
+
+        responseConsumer.consumeResponse(BasicHttpResponse(204), null, null, callback)
+
+        withTimeout(5.seconds) { callbackResult.await() }
+        assertTrue(callbackResult.isCompleted)
+    }
+
+    @Test
+    fun `FutureCallback failed is called on error`() = runBlocking {
+        val failureException = CompletableDeferred<Exception>()
+        val callback = trackingCallback(onFailed = { failureException.complete(it) })
+
+        val consumerContext = Dispatchers.Default + Job()
+        val bodyConsumer = ApacheResponseConsumer(consumerContext, requestData)
+        val responseConsumer = BasicResponseConsumer(bodyConsumer)
+
+        responseConsumer.consumeResponse(
+            BasicHttpResponse(200),
+            BasicEntityDetails(5, ContentType.TEXT_PLAIN),
+            null,
+            callback,
+        )
+
+        val cause = IOException("connection reset")
+        responseConsumer.failed(cause)
+
+        val received = withTimeout(5.seconds) { failureException.await() }
+        assertNotNull(received)
+        assertEquals("connection reset", received.message)
+    }
+
+    private fun trackingCallback(
+        onCompleted: () -> Unit = {},
+        onFailed: (Exception) -> Unit = {},
+    ) = object : FutureCallback<Unit> {
+        override fun completed(result: Unit) = onCompleted()
+        override fun failed(ex: Exception) = onFailed(ex)
+        override fun cancelled() {}
+    }
+
+    @OptIn(InternalAPI::class)
+    private val requestData = HttpRequestData(
+        Url("http://localhost"),
+        HttpMethod.Get,
+        Headers.Empty,
+        TextContent("", io.ktor.http.ContentType.Text.Any),
+        Job(),
+        Attributes(),
+    )
+}

--- a/ktor-client/ktor-client-apache5/jvm/test/io/ktor/client/engine/apache5/ApacheResponseConsumerTest.kt
+++ b/ktor-client/ktor-client-apache5/jvm/test/io/ktor/client/engine/apache5/ApacheResponseConsumerTest.kt
@@ -16,6 +16,7 @@ import org.apache.hc.core5.http.impl.BasicEntityDetails
 import org.apache.hc.core5.http.message.BasicHttpResponse
 import java.io.IOException
 import java.nio.ByteBuffer
+import java.util.concurrent.atomic.AtomicInteger
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
@@ -84,6 +85,45 @@ class ApacheResponseConsumerTest {
         val received = withTimeout(5.seconds) { failureException.await() }
         assertNotNull(received)
         assertEquals("connection reset", received.message)
+    }
+
+    @Test
+    fun `FutureCallback is called at most once when both streamEnd and failed fire`() = runBlocking {
+        val terminalCallCount = AtomicInteger(0)
+        val firstTerminal = CompletableDeferred<Unit>()
+        val callback = object : FutureCallback<Unit> {
+            override fun completed(result: Unit) {
+                terminalCallCount.incrementAndGet()
+                firstTerminal.complete(Unit)
+            }
+
+            override fun failed(ex: Exception) {
+                terminalCallCount.incrementAndGet()
+                firstTerminal.complete(Unit)
+            }
+
+            override fun cancelled() {}
+        }
+
+        val consumerContext = Dispatchers.Default + Job()
+        val bodyConsumer = ApacheResponseConsumer(consumerContext, requestData)
+        val responseConsumer = BasicResponseConsumer(bodyConsumer)
+
+        responseConsumer.consumeResponse(
+            BasicHttpResponse(200),
+            BasicEntityDetails(5, ContentType.TEXT_PLAIN),
+            null,
+            callback,
+        )
+
+        responseConsumer.consume(ByteBuffer.wrap("hello".toByteArray()))
+        responseConsumer.streamEnd(null) // will eventually call close() → completed()
+        responseConsumer.failed(IOException("network error")) // may also call failed()
+
+        withTimeout(5.seconds) { firstTerminal.await() }
+        delay(100) // give a chance for a second invocation to sneak in
+
+        assertEquals(1, terminalCallCount.get(), "FutureCallback must be invoked exactly once")
     }
 
     private fun trackingCallback(


### PR DESCRIPTION
**Subsystem**
Apache5 Client

**Motivation**
[KTOR-9485](https://youtrack.jetbrains.com/issue/KTOR-9485) Apache5: FutureCallback never called, breaking Java agent instrumentation

**Solution**
- Store `streamResultCallback`
- Unit-test it

