### PR TITLE
HTTP/3 for Netty engine

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -136,6 +136,7 @@ dokka-plugin-versioning = { module = "org.jetbrains.dokka:versioning-plugin", ve
 
 netty-handler = { module = "io.netty:netty-handler", version.ref = "netty" }
 netty-codec-http2 = { module = "io.netty:netty-codec-http2", version.ref = "netty" }
+netty-codec-http3 = { module = "io.netty:netty-codec-http3", version.ref = "netty" }
 netty-transport-native-kqueue = { module = "io.netty:netty-transport-native-kqueue", version.ref = "netty" }
 netty-transport-native-epoll = { module = "io.netty:netty-transport-native-epoll", version.ref = "netty" }
 netty-tcnative = { module = "io.netty:netty-tcnative", version.ref = "netty-tcnative" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -149,6 +149,7 @@ dokka-plugin-versioning = { module = "org.jetbrains.dokka:versioning-plugin", ve
 netty-handler = { module = "io.netty:netty-handler", version.ref = "netty" }
 netty-codec = { module = "io.netty:netty-codec", version.ref = "netty" }
 netty-codec-http2 = { module = "io.netty:netty-codec-http2", version.ref = "netty" }
+netty-codec-http3 = { module = "io.netty:netty-codec-http3", version.ref = "netty" }
 netty-transport-native-kqueue = { module = "io.netty:netty-transport-native-kqueue", version.ref = "netty" }
 netty-transport-native-epoll = { module = "io.netty:netty-transport-native-epoll", version.ref = "netty" }
 netty-tcnative = { module = "io.netty:netty-tcnative", version.ref = "netty-tcnative" }

--- a/ktor-server/ktor-server-netty/api/ktor-server-netty.api
+++ b/ktor-server/ktor-server-netty/api/ktor-server-netty.api
@@ -83,6 +83,7 @@ public final class io/ktor/server/netty/NettyApplicationEngine$Configuration : i
 	public fun <init> ()V
 	public final fun getChannelPipelineConfig ()Lkotlin/jvm/functions/Function1;
 	public final fun getConfigureBootstrap ()Lkotlin/jvm/functions/Function1;
+	public final fun getConfigureQuicServerCodec ()Lkotlin/jvm/functions/Function1;
 	public final fun getEnableH2c ()Z
 	public final fun getEnableHttp2 ()Z
 	public final fun getEnableHttp3 ()Z
@@ -90,6 +91,11 @@ public final class io/ktor/server/netty/NettyApplicationEngine$Configuration : i
 	public final fun getMaxChunkSize ()I
 	public final fun getMaxHeaderSize ()I
 	public final fun getMaxInitialLineLength ()I
+	public final fun getQuicInitialMaxData ()J
+	public final fun getQuicInitialMaxStreamDataBidirectionalLocal ()J
+	public final fun getQuicInitialMaxStreamDataBidirectionalRemote ()J
+	public final fun getQuicInitialMaxStreamsBidirectional ()J
+	public final fun getQuicMaxIdleTimeoutMillis ()J
 	public final fun getQuicTokenHandler ()Lio/netty/handler/codec/quic/QuicTokenHandler;
 	public final fun getRequestReadTimeoutSeconds ()I
 	public final fun getResponseWriteTimeoutSeconds ()I
@@ -98,6 +104,7 @@ public final class io/ktor/server/netty/NettyApplicationEngine$Configuration : i
 	public final fun getTcpKeepAlive ()Z
 	public final fun setChannelPipelineConfig (Lkotlin/jvm/functions/Function1;)V
 	public final fun setConfigureBootstrap (Lkotlin/jvm/functions/Function1;)V
+	public final fun setConfigureQuicServerCodec (Lkotlin/jvm/functions/Function1;)V
 	public final fun setEnableH2c (Z)V
 	public final fun setEnableHttp2 (Z)V
 	public final fun setEnableHttp3 (Z)V
@@ -105,6 +112,11 @@ public final class io/ktor/server/netty/NettyApplicationEngine$Configuration : i
 	public final fun setMaxChunkSize (I)V
 	public final fun setMaxHeaderSize (I)V
 	public final fun setMaxInitialLineLength (I)V
+	public final fun setQuicInitialMaxData (J)V
+	public final fun setQuicInitialMaxStreamDataBidirectionalLocal (J)V
+	public final fun setQuicInitialMaxStreamDataBidirectionalRemote (J)V
+	public final fun setQuicInitialMaxStreamsBidirectional (J)V
+	public final fun setQuicMaxIdleTimeoutMillis (J)V
 	public final fun setQuicTokenHandler (Lio/netty/handler/codec/quic/QuicTokenHandler;)V
 	public final fun setRequestReadTimeoutSeconds (I)V
 	public final fun setResponseWriteTimeoutSeconds (I)V

--- a/ktor-server/ktor-server-netty/api/ktor-server-netty.api
+++ b/ktor-server/ktor-server-netty/api/ktor-server-netty.api
@@ -90,6 +90,7 @@ public final class io/ktor/server/netty/NettyApplicationEngine$Configuration : i
 	public final fun getMaxChunkSize ()I
 	public final fun getMaxHeaderSize ()I
 	public final fun getMaxInitialLineLength ()I
+	public final fun getQuicTokenHandler ()Lio/netty/handler/codec/quic/QuicTokenHandler;
 	public final fun getRequestReadTimeoutSeconds ()I
 	public final fun getResponseWriteTimeoutSeconds ()I
 	public final fun getRunningLimit ()I
@@ -104,6 +105,7 @@ public final class io/ktor/server/netty/NettyApplicationEngine$Configuration : i
 	public final fun setMaxChunkSize (I)V
 	public final fun setMaxHeaderSize (I)V
 	public final fun setMaxInitialLineLength (I)V
+	public final fun setQuicTokenHandler (Lio/netty/handler/codec/quic/QuicTokenHandler;)V
 	public final fun setRequestReadTimeoutSeconds (I)V
 	public final fun setResponseWriteTimeoutSeconds (I)V
 	public final fun setRunningLimit (I)V

--- a/ktor-server/ktor-server-netty/api/ktor-server-netty.api
+++ b/ktor-server/ktor-server-netty/api/ktor-server-netty.api
@@ -85,6 +85,7 @@ public final class io/ktor/server/netty/NettyApplicationEngine$Configuration : i
 	public final fun getConfigureBootstrap ()Lkotlin/jvm/functions/Function1;
 	public final fun getEnableH2c ()Z
 	public final fun getEnableHttp2 ()Z
+	public final fun getEnableHttp3 ()Z
 	public final fun getHttpServerCodec ()Lkotlin/jvm/functions/Function0;
 	public final fun getMaxChunkSize ()I
 	public final fun getMaxHeaderSize ()I
@@ -98,6 +99,7 @@ public final class io/ktor/server/netty/NettyApplicationEngine$Configuration : i
 	public final fun setConfigureBootstrap (Lkotlin/jvm/functions/Function1;)V
 	public final fun setEnableH2c (Z)V
 	public final fun setEnableHttp2 (Z)V
+	public final fun setEnableHttp3 (Z)V
 	public final fun setHttpServerCodec (Lkotlin/jvm/functions/Function0;)V
 	public final fun setMaxChunkSize (I)V
 	public final fun setMaxHeaderSize (I)V

--- a/ktor-server/ktor-server-netty/api/ktor-server-netty.api
+++ b/ktor-server/ktor-server-netty/api/ktor-server-netty.api
@@ -81,22 +81,16 @@ public final class io/ktor/server/netty/NettyApplicationEngine : io/ktor/server/
 
 public final class io/ktor/server/netty/NettyApplicationEngine$Configuration : io/ktor/server/engine/BaseApplicationEngine$Configuration {
 	public fun <init> ()V
+	public final fun enableHttp3 (Lkotlin/jvm/functions/Function1;)V
+	public static synthetic fun enableHttp3$default (Lio/ktor/server/netty/NettyApplicationEngine$Configuration;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
 	public final fun getChannelPipelineConfig ()Lkotlin/jvm/functions/Function1;
 	public final fun getConfigureBootstrap ()Lkotlin/jvm/functions/Function1;
-	public final fun getConfigureQuicServerCodec ()Lkotlin/jvm/functions/Function1;
 	public final fun getEnableH2c ()Z
 	public final fun getEnableHttp2 ()Z
-	public final fun getEnableHttp3 ()Z
 	public final fun getHttpServerCodec ()Lkotlin/jvm/functions/Function0;
 	public final fun getMaxChunkSize ()I
 	public final fun getMaxHeaderSize ()I
 	public final fun getMaxInitialLineLength ()I
-	public final fun getQuicInitialMaxData ()J
-	public final fun getQuicInitialMaxStreamDataBidirectionalLocal ()J
-	public final fun getQuicInitialMaxStreamDataBidirectionalRemote ()J
-	public final fun getQuicInitialMaxStreamsBidirectional ()J
-	public final fun getQuicMaxIdleTimeoutMillis ()J
-	public final fun getQuicTokenHandler ()Lio/netty/handler/codec/quic/QuicTokenHandler;
 	public final fun getRequestReadTimeoutSeconds ()I
 	public final fun getResponseWriteTimeoutSeconds ()I
 	public final fun getRunningLimit ()I
@@ -104,20 +98,12 @@ public final class io/ktor/server/netty/NettyApplicationEngine$Configuration : i
 	public final fun getTcpKeepAlive ()Z
 	public final fun setChannelPipelineConfig (Lkotlin/jvm/functions/Function1;)V
 	public final fun setConfigureBootstrap (Lkotlin/jvm/functions/Function1;)V
-	public final fun setConfigureQuicServerCodec (Lkotlin/jvm/functions/Function1;)V
 	public final fun setEnableH2c (Z)V
 	public final fun setEnableHttp2 (Z)V
-	public final fun setEnableHttp3 (Z)V
 	public final fun setHttpServerCodec (Lkotlin/jvm/functions/Function0;)V
 	public final fun setMaxChunkSize (I)V
 	public final fun setMaxHeaderSize (I)V
 	public final fun setMaxInitialLineLength (I)V
-	public final fun setQuicInitialMaxData (J)V
-	public final fun setQuicInitialMaxStreamDataBidirectionalLocal (J)V
-	public final fun setQuicInitialMaxStreamDataBidirectionalRemote (J)V
-	public final fun setQuicInitialMaxStreamsBidirectional (J)V
-	public final fun setQuicMaxIdleTimeoutMillis (J)V
-	public final fun setQuicTokenHandler (Lio/netty/handler/codec/quic/QuicTokenHandler;)V
 	public final fun setRequestReadTimeoutSeconds (I)V
 	public final fun setResponseWriteTimeoutSeconds (I)V
 	public final fun setRunningLimit (I)V
@@ -186,5 +172,23 @@ public final class io/ktor/server/netty/NettyChannelInitializer$Companion {
 
 public final class io/ktor/server/netty/cio/NettyResponsePipelineException : java/lang/Exception {
 	public fun <init> (Ljava/lang/String;)V
+}
+
+public final class io/ktor/server/netty/http3/NettyHttp3Configuration {
+	public fun <init> ()V
+	public final fun getConfigureQuicServerCodec ()Lkotlin/jvm/functions/Function1;
+	public final fun getQuicInitialMaxData ()J
+	public final fun getQuicInitialMaxStreamDataBidirectionalLocal ()J
+	public final fun getQuicInitialMaxStreamDataBidirectionalRemote ()J
+	public final fun getQuicInitialMaxStreamsBidirectional ()J
+	public final fun getQuicMaxIdleTimeoutMillis-UwyO8pc ()J
+	public final fun getQuicTokenHandler ()Lio/netty/handler/codec/quic/QuicTokenHandler;
+	public final fun setConfigureQuicServerCodec (Lkotlin/jvm/functions/Function1;)V
+	public final fun setQuicInitialMaxData (J)V
+	public final fun setQuicInitialMaxStreamDataBidirectionalLocal (J)V
+	public final fun setQuicInitialMaxStreamDataBidirectionalRemote (J)V
+	public final fun setQuicInitialMaxStreamsBidirectional (J)V
+	public final fun setQuicMaxIdleTimeoutMillis-LRDsOJo (J)V
+	public final fun setQuicTokenHandler (Lio/netty/handler/codec/quic/QuicTokenHandler;)V
 }
 

--- a/ktor-server/ktor-server-netty/api/ktor-server-netty.api
+++ b/ktor-server/ktor-server-netty/api/ktor-server-netty.api
@@ -181,14 +181,14 @@ public final class io/ktor/server/netty/http3/NettyHttp3Configuration {
 	public final fun getQuicInitialMaxStreamDataBidirectionalLocal ()J
 	public final fun getQuicInitialMaxStreamDataBidirectionalRemote ()J
 	public final fun getQuicInitialMaxStreamsBidirectional ()J
-	public final fun getQuicMaxIdleTimeoutMillis-UwyO8pc ()J
+	public final fun getQuicMaxIdleTimeout-UwyO8pc ()J
 	public final fun getQuicTokenHandler ()Lio/netty/handler/codec/quic/QuicTokenHandler;
 	public final fun setConfigureQuicServerCodec (Lkotlin/jvm/functions/Function1;)V
 	public final fun setQuicInitialMaxData (J)V
 	public final fun setQuicInitialMaxStreamDataBidirectionalLocal (J)V
 	public final fun setQuicInitialMaxStreamDataBidirectionalRemote (J)V
 	public final fun setQuicInitialMaxStreamsBidirectional (J)V
-	public final fun setQuicMaxIdleTimeoutMillis-LRDsOJo (J)V
+	public final fun setQuicMaxIdleTimeout-LRDsOJo (J)V
 	public final fun setQuicTokenHandler (Lio/netty/handler/codec/quic/QuicTokenHandler;)V
 }
 

--- a/ktor-server/ktor-server-netty/build.gradle.kts
+++ b/ktor-server/ktor-server-netty/build.gradle.kts
@@ -29,6 +29,7 @@ kotlin {
             api(projects.ktorServerCore)
 
             api(libs.netty.codec.http2)
+            api(libs.netty.codec.http3)
             api(libs.jetty.alpn.api)
 
             api(libs.netty.transport.native.kqueue)

--- a/ktor-server/ktor-server-netty/build.gradle.kts
+++ b/ktor-server/ktor-server-netty/build.gradle.kts
@@ -30,6 +30,7 @@ kotlin {
 
             api(libs.netty.codec)
             api(libs.netty.codec.http2)
+            api(libs.netty.codec.http3)
             api(libs.jetty.alpn.api)
 
             api(libs.netty.transport.native.kqueue)

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyApplicationEngine.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyApplicationEngine.kt
@@ -30,6 +30,7 @@ import io.netty.handler.codec.http.HttpObjectDecoder
 import io.netty.handler.codec.http.HttpServerCodec
 import io.netty.handler.codec.quic.QuicSslContext
 import io.netty.handler.codec.quic.QuicSslContextBuilder
+import io.netty.handler.codec.quic.QuicTokenHandler
 import kotlinx.coroutines.CompletableJob
 import kotlinx.coroutines.asCoroutineDispatcher
 import java.net.BindException
@@ -164,6 +165,19 @@ public class NettyApplicationEngine(
         public var enableHttp3: Boolean = false
 
         /**
+         * The [QuicTokenHandler] used to generate and validate QUIC retry tokens
+         * when HTTP/3 is enabled. By default, a secure HMAC-SHA256-based handler
+         * is used that cryptographically signs tokens with a randomly generated key
+         * and rejects forged or expired tokens.
+         *
+         * Callers may replace this with a custom [QuicTokenHandler] implementation
+         * to use a different signing strategy or integrate with external token services.
+         *
+         * Only takes effect when [enableHttp3] is `true`.
+         */
+        public var quicTokenHandler: QuicTokenHandler = HmacQuicTokenHandler()
+
+        /**
          * Default function to configure Netty's
          */
         private fun defaultHttpServerCodec() = HttpServerCodec(
@@ -293,7 +307,8 @@ public class NettyApplicationEngine(
                     callEventGroup,
                     userContext,
                     configuration.runningLimit,
-                    quicSslContext
+                    quicSslContext,
+                    configuration.quicTokenHandler
                 )
             )
         }

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyApplicationEngine.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyApplicationEngine.kt
@@ -236,6 +236,9 @@ public class NettyApplicationEngine(
     }
     private val http3Bootstraps: List<Bootstrap> by lazy {
         if (!configuration.enableHttp3) return@lazy emptyList()
+        require(configuration.connectors.any { it is EngineSSLConnectorConfig }) {
+            "Netty HTTP/3 requires at least one SSL connector. Add an SSL connector or disable enableHttp3."
+        }
         configuration.connectors
             .filterIsInstance<EngineSSLConnectorConfig>()
             .map { createHttp3Bootstrap(it) }

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyApplicationEngine.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyApplicationEngine.kt
@@ -28,6 +28,7 @@ import io.netty.channel.socket.nio.NioDatagramChannel
 import io.netty.channel.socket.nio.NioServerSocketChannel
 import io.netty.handler.codec.http.HttpObjectDecoder
 import io.netty.handler.codec.http.HttpServerCodec
+import io.netty.handler.codec.quic.QuicServerCodecBuilder
 import io.netty.handler.codec.quic.QuicSslContext
 import io.netty.handler.codec.quic.QuicSslContextBuilder
 import io.netty.handler.codec.quic.QuicTokenHandler
@@ -178,6 +179,56 @@ public class NettyApplicationEngine(
         public var quicTokenHandler: QuicTokenHandler = HmacQuicTokenHandler()
 
         /**
+         * Maximum idle timeout for QUIC connections in milliseconds.
+         * If no data is exchanged within this period, the connection is closed.
+         *
+         * Only takes effect when [enableHttp3] is `true`.
+         */
+        public var quicMaxIdleTimeoutMillis: Long = 30_000
+
+        /**
+         * The initial value for the maximum amount of data that can be sent
+         * on the entire QUIC connection, in bytes.
+         *
+         * Only takes effect when [enableHttp3] is `true`.
+         */
+        public var quicInitialMaxData: Long = 10_000_000
+
+        /**
+         * The initial flow-control limit for locally-initiated bidirectional
+         * QUIC streams, in bytes.
+         *
+         * Only takes effect when [enableHttp3] is `true`.
+         */
+        public var quicInitialMaxStreamDataBidirectionalLocal: Long = 1_000_000
+
+        /**
+         * The initial flow-control limit for remotely-initiated bidirectional
+         * QUIC streams, in bytes.
+         *
+         * Only takes effect when [enableHttp3] is `true`.
+         */
+        public var quicInitialMaxStreamDataBidirectionalRemote: Long = 1_000_000
+
+        /**
+         * The initial maximum number of bidirectional streams that the remote
+         * peer is allowed to open.
+         *
+         * Only takes effect when [enableHttp3] is `true`.
+         */
+        public var quicInitialMaxStreamsBidirectional: Long = 100
+
+        /**
+         * User-provided function to configure the QUIC server codec builder
+         * used when HTTP/3 is enabled. This lambda is invoked on the
+         * [QuicServerCodecBuilder] after all default settings have been applied,
+         * allowing callers to override or add any QUIC transport parameters.
+         *
+         * Only takes effect when [enableHttp3] is `true`.
+         */
+        public var configureQuicServerCodec: QuicServerCodecBuilder.() -> Unit = {}
+
+        /**
          * Default function to configure Netty's
          */
         private fun defaultHttpServerCodec() = HttpServerCodec(
@@ -311,7 +362,13 @@ public class NettyApplicationEngine(
                     userContext,
                     configuration.runningLimit,
                     quicSslContext,
-                    configuration.quicTokenHandler
+                    configuration.quicTokenHandler,
+                    configuration.quicMaxIdleTimeoutMillis,
+                    configuration.quicInitialMaxData,
+                    configuration.quicInitialMaxStreamDataBidirectionalLocal,
+                    configuration.quicInitialMaxStreamDataBidirectionalRemote,
+                    configuration.quicInitialMaxStreamsBidirectional,
+                    configuration.configureQuicServerCodec
                 )
             )
         }

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyApplicationEngine.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyApplicationEngine.kt
@@ -403,6 +403,9 @@ public class NettyApplicationEngine(
         } catch (cause: BindException) {
             terminate()
             throw cause
+        } catch (cause: Throwable) {
+            stop(0, 0)
+            throw cause
         }
 
         monitor.raiseCatching(ServerReady, environment, environment.log)

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyApplicationEngine.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyApplicationEngine.kt
@@ -7,24 +7,34 @@ package io.ktor.server.netty
 import io.ktor.events.*
 import io.ktor.server.application.*
 import io.ktor.server.engine.*
+import io.ktor.server.netty.http3.*
 import io.ktor.util.network.*
 import io.ktor.util.pipeline.*
+import io.netty.bootstrap.Bootstrap
 import io.netty.bootstrap.ServerBootstrap
 import io.netty.channel.Channel
 import io.netty.channel.ChannelOption
 import io.netty.channel.ChannelPipeline
 import io.netty.channel.EventLoopGroup
 import io.netty.channel.epoll.Epoll
+import io.netty.channel.epoll.EpollDatagramChannel
 import io.netty.channel.epoll.EpollServerSocketChannel
 import io.netty.channel.kqueue.KQueue
+import io.netty.channel.kqueue.KQueueDatagramChannel
 import io.netty.channel.kqueue.KQueueServerSocketChannel
+import io.netty.channel.socket.DatagramChannel
 import io.netty.channel.socket.ServerSocketChannel
+import io.netty.channel.socket.nio.NioDatagramChannel
 import io.netty.channel.socket.nio.NioServerSocketChannel
 import io.netty.handler.codec.http.HttpObjectDecoder
 import io.netty.handler.codec.http.HttpServerCodec
+import io.netty.handler.codec.quic.QuicSslContext
+import io.netty.handler.codec.quic.QuicSslContextBuilder
 import kotlinx.coroutines.CompletableJob
 import kotlinx.coroutines.asCoroutineDispatcher
 import java.net.BindException
+import java.security.PrivateKey
+import java.security.cert.X509Certificate
 import java.util.concurrent.TimeUnit
 import kotlin.reflect.KClass
 import kotlin.system.measureTimeMillis
@@ -147,6 +157,13 @@ public class NettyApplicationEngine(
         public var channelPipelineConfig: ChannelPipeline.() -> Unit = {}
 
         /**
+         * If set to `true`, enables HTTP/3 protocol (over QUIC/UDP) for Netty engine.
+         * Requires an SSL connector to be configured (HTTP/3 always uses TLS).
+         * The HTTP/3 endpoint will listen on the same port as the SSL connector but over UDP.
+         */
+        public var enableHttp3: Boolean = false
+
+        /**
          * Default function to configure Netty's
          */
         private fun defaultHttpServerCodec() = HttpServerCodec(
@@ -199,8 +216,15 @@ public class NettyApplicationEngine(
     private var cancellationJob: CompletableJob? = null
 
     private var channels: List<Channel>? = null
+    private var http3Channels: List<Channel>? = null
     internal val bootstraps: List<ServerBootstrap> by lazy {
         configuration.connectors.map(::createBootstrap)
+    }
+    private val http3Bootstraps: List<Bootstrap> by lazy {
+        if (!configuration.enableHttp3) return@lazy emptyList()
+        configuration.connectors
+            .filterIsInstance<EngineSSLConnectorConfig>()
+            .map { createHttp3Bootstrap(it) }
     }
 
     private fun createBootstrap(connector: EngineConnectorConfig): ServerBootstrap {
@@ -242,6 +266,39 @@ public class NettyApplicationEngine(
         }
     }
 
+    @Suppress("UNCHECKED_CAST")
+    private fun createHttp3Bootstrap(connector: EngineSSLConnectorConfig): Bootstrap {
+        val chain = connector.keyStore.getCertificateChain(connector.keyAlias).toList() as List<X509Certificate>
+        val certs = chain.toTypedArray()
+        val password = connector.privateKeyPassword()
+        val pk = connector.keyStore.getKey(connector.keyAlias, password) as PrivateKey
+        password.fill('\u0000')
+
+        val quicSslContext: QuicSslContext = QuicSslContextBuilder.forServer(pk, null, *certs)
+            .applicationProtocols(*io.netty.handler.codec.http3.Http3.supportedApplicationProtocols())
+            .build()
+
+        val userContext =
+            NettyApplicationCallHandler.CallHandlerCoroutineName +
+                NettyDispatcher +
+                DefaultUncaughtExceptionHandler(environment.log)
+
+        return Bootstrap().apply {
+            group(workerEventGroup)
+            channel(getDatagramChannelClass().java)
+            handler(
+                NettyHttp3ChannelInitializer(
+                    applicationProvider,
+                    pipeline,
+                    callEventGroup,
+                    userContext,
+                    configuration.runningLimit,
+                    quicSslContext
+                )
+            )
+        }
+    }
+
     init {
         pipeline.insertPhaseAfter(EnginePipeline.Call, AFTER_CALL_PHASE)
         pipeline.intercept(AFTER_CALL_PHASE) {
@@ -254,8 +311,19 @@ public class NettyApplicationEngine(
             channels = bootstraps.zip(configuration.connectors)
                 .map { it.first.bind(it.second.host, it.second.port) }
                 .map { it.sync().channel() }
+
             val connectors = channels!!.zip(configuration.connectors)
                 .map { it.second.withPort(it.first.localAddress().port) }
+
+            // Bind HTTP/3 (QUIC/UDP) on the same resolved port as the TCP SSL connector.
+            // TCP and UDP can share the same port number since they are different protocols.
+            val resolvedSslConnectors = channels!!.zip(configuration.connectors)
+                .filter { it.second is EngineSSLConnectorConfig }
+                .map { it.second.host to (it.first.localAddress() as java.net.InetSocketAddress).port }
+            http3Channels = http3Bootstraps.zip(resolvedSslConnectors)
+                .map { (bootstrap, hostPort) -> bootstrap.bind(hostPort.first, hostPort.second) }
+                .map { it.sync().channel() }
+
             resolvedConnectorsDeferred.complete(connectors)
         } catch (cause: BindException) {
             terminate()
@@ -271,7 +339,8 @@ public class NettyApplicationEngine(
         )
 
         if (wait) {
-            channels?.map { it.closeFuture() }?.forEach { it.sync() }
+            val allChannels = (channels.orEmpty() + http3Channels.orEmpty())
+            allChannels.map { it.closeFuture() }.forEach { it.sync() }
             stop(configuration.shutdownGracePeriod, configuration.shutdownTimeout)
         }
         return this
@@ -297,7 +366,8 @@ public class NettyApplicationEngine(
         monitor.raise(ApplicationStopPreparing, environment)
 
         val channelsCloseTime = measureTimeMillis {
-            val channelFutures = channels?.mapNotNull { if (it.isOpen) it.close() else null }.orEmpty()
+            val allChannels = (channels.orEmpty() + http3Channels.orEmpty())
+            val channelFutures = allChannels.mapNotNull { if (it.isOpen) it.close() else null }
             channelFutures.forEach { future ->
                 withStopException { future.sync() }
             }
@@ -341,4 +411,10 @@ internal fun getChannelClass(): KClass<out ServerSocketChannel> = when {
     KQueue.isAvailable() -> KQueueServerSocketChannel::class
     Epoll.isAvailable() -> EpollServerSocketChannel::class
     else -> NioServerSocketChannel::class
+}
+
+internal fun getDatagramChannelClass(): KClass<out DatagramChannel> = when {
+    KQueue.isAvailable() -> KQueueDatagramChannel::class
+    Epoll.isAvailable() -> EpollDatagramChannel::class
+    else -> NioDatagramChannel::class
 }

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyApplicationEngine.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyApplicationEngine.kt
@@ -403,6 +403,9 @@ public class NettyApplicationEngine(
         } catch (cause: Throwable) {
             terminate()
             throw cause
+        } catch (cause: Throwable) {
+            stop(0, 0)
+            throw cause
         }
 
         monitor.raiseCatching(ServerReady, environment, environment.log)

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyApplicationEngine.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyApplicationEngine.kt
@@ -10,6 +10,7 @@ import io.ktor.server.engine.*
 import io.ktor.server.netty.http3.*
 import io.ktor.util.network.*
 import io.ktor.util.pipeline.*
+import io.ktor.utils.io.ExperimentalKtorApi
 import io.netty.bootstrap.Bootstrap
 import io.netty.bootstrap.ServerBootstrap
 import io.netty.channel.Channel
@@ -28,10 +29,8 @@ import io.netty.channel.socket.nio.NioDatagramChannel
 import io.netty.channel.socket.nio.NioServerSocketChannel
 import io.netty.handler.codec.http.HttpObjectDecoder
 import io.netty.handler.codec.http.HttpServerCodec
-import io.netty.handler.codec.quic.QuicServerCodecBuilder
 import io.netty.handler.codec.quic.QuicSslContext
 import io.netty.handler.codec.quic.QuicSslContextBuilder
-import io.netty.handler.codec.quic.QuicTokenHandler
 import kotlinx.coroutines.CompletableJob
 import kotlinx.coroutines.asCoroutineDispatcher
 import java.net.BindException
@@ -159,74 +158,29 @@ public class NettyApplicationEngine(
         public var channelPipelineConfig: ChannelPipeline.() -> Unit = {}
 
         /**
-         * If set to `true`, enables HTTP/3 protocol (over QUIC/UDP) for Netty engine.
+         * Holds the HTTP/3 configuration when HTTP/3 is enabled, or `null` when disabled.
+         *
+         * Configured via [enableHttp3].
+         */
+        internal var http3Configuration: NettyHttp3Configuration? = null
+            private set
+
+        /**
+         * Enables the HTTP/3 protocol (over QUIC/UDP) for the Netty engine.
+         *
          * Requires an SSL connector to be configured (HTTP/3 always uses TLS).
          * The HTTP/3 endpoint will listen on the same port as the SSL connector but over UDP.
-         */
-        public var enableHttp3: Boolean = false
-
-        /**
-         * The [QuicTokenHandler] used to generate and validate QUIC retry tokens
-         * when HTTP/3 is enabled. By default, a secure HMAC-SHA256-based handler
-         * is used that cryptographically signs tokens with a randomly generated key
-         * and rejects forged or expired tokens.
          *
-         * Callers may replace this with a custom [QuicTokenHandler] implementation
-         * to use a different signing strategy or integrate with external token services.
+         * QUIC- and HTTP/3-specific options can be customized through the [configure] lambda,
+         * which receives a [NettyHttp3Configuration] as its receiver. These options apply only
+         * to the HTTP/3 transport and have no effect on HTTP/1.1 or HTTP/2.
          *
-         * Only takes effect when [enableHttp3] is `true`.
+         * Calling this function multiple times replaces the previous configuration.
          */
-        public var quicTokenHandler: QuicTokenHandler = HmacQuicTokenHandler()
-
-        /**
-         * Maximum idle timeout for QUIC connections in milliseconds.
-         * If no data is exchanged within this period, the connection is closed.
-         *
-         * Only takes effect when [enableHttp3] is `true`.
-         */
-        public var quicMaxIdleTimeoutMillis: Long = 30_000
-
-        /**
-         * The initial value for the maximum amount of data that can be sent
-         * on the entire QUIC connection, in bytes.
-         *
-         * Only takes effect when [enableHttp3] is `true`.
-         */
-        public var quicInitialMaxData: Long = 10_000_000
-
-        /**
-         * The initial flow-control limit for locally-initiated bidirectional
-         * QUIC streams, in bytes.
-         *
-         * Only takes effect when [enableHttp3] is `true`.
-         */
-        public var quicInitialMaxStreamDataBidirectionalLocal: Long = 1_000_000
-
-        /**
-         * The initial flow-control limit for remotely-initiated bidirectional
-         * QUIC streams, in bytes.
-         *
-         * Only takes effect when [enableHttp3] is `true`.
-         */
-        public var quicInitialMaxStreamDataBidirectionalRemote: Long = 1_000_000
-
-        /**
-         * The initial maximum number of bidirectional streams that the remote
-         * peer is allowed to open.
-         *
-         * Only takes effect when [enableHttp3] is `true`.
-         */
-        public var quicInitialMaxStreamsBidirectional: Long = 100
-
-        /**
-         * User-provided function to configure the QUIC server codec builder
-         * used when HTTP/3 is enabled. This lambda is invoked on the
-         * [QuicServerCodecBuilder] after all default settings have been applied,
-         * allowing callers to override or add any QUIC transport parameters.
-         *
-         * Only takes effect when [enableHttp3] is `true`.
-         */
-        public var configureQuicServerCodec: QuicServerCodecBuilder.() -> Unit = {}
+        @ExperimentalKtorApi
+        public fun enableHttp3(configure: NettyHttp3Configuration.() -> Unit = {}) {
+            http3Configuration = NettyHttp3Configuration().apply(configure)
+        }
 
         /**
          * Default function to configure Netty's
@@ -286,13 +240,13 @@ public class NettyApplicationEngine(
         configuration.connectors.map(::createBootstrap)
     }
     private val http3Bootstraps: List<Bootstrap> by lazy {
-        if (!configuration.enableHttp3) return@lazy emptyList()
+        val http3Configuration = configuration.http3Configuration ?: return@lazy emptyList()
         require(configuration.connectors.any { it is EngineSSLConnectorConfig }) {
             "Netty HTTP/3 requires at least one SSL connector. Add an SSL connector or disable enableHttp3."
         }
         configuration.connectors
             .filterIsInstance<EngineSSLConnectorConfig>()
-            .map { createHttp3Bootstrap(it) }
+            .map { createHttp3Bootstrap(it, http3Configuration) }
     }
 
     private fun createBootstrap(connector: EngineConnectorConfig): ServerBootstrap {
@@ -335,7 +289,10 @@ public class NettyApplicationEngine(
     }
 
     @Suppress("UNCHECKED_CAST")
-    private fun createHttp3Bootstrap(connector: EngineSSLConnectorConfig): Bootstrap {
+    private fun createHttp3Bootstrap(
+        connector: EngineSSLConnectorConfig,
+        http3Configuration: NettyHttp3Configuration
+    ): Bootstrap {
         val chain = connector.keyStore.getCertificateChain(connector.keyAlias).toList() as List<X509Certificate>
         val certs = chain.toTypedArray()
         val password = connector.privateKeyPassword()
@@ -358,17 +315,10 @@ public class NettyApplicationEngine(
                 NettyHttp3ChannelInitializer(
                     applicationProvider,
                     pipeline,
-                    callEventGroup,
                     userContext,
                     configuration.runningLimit,
                     quicSslContext,
-                    configuration.quicTokenHandler,
-                    configuration.quicMaxIdleTimeoutMillis,
-                    configuration.quicInitialMaxData,
-                    configuration.quicInitialMaxStreamDataBidirectionalLocal,
-                    configuration.quicInitialMaxStreamDataBidirectionalRemote,
-                    configuration.quicInitialMaxStreamsBidirectional,
-                    configuration.configureQuicServerCodec
+                    http3Configuration
                 )
             )
         }

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyApplicationEngine.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyApplicationEngine.kt
@@ -7,23 +7,34 @@ package io.ktor.server.netty
 import io.ktor.events.*
 import io.ktor.server.application.*
 import io.ktor.server.engine.*
+import io.ktor.server.netty.http3.*
 import io.ktor.util.network.*
 import io.ktor.util.pipeline.*
+import io.netty.bootstrap.Bootstrap
 import io.netty.bootstrap.ServerBootstrap
 import io.netty.channel.Channel
 import io.netty.channel.ChannelOption
 import io.netty.channel.ChannelPipeline
 import io.netty.channel.EventLoopGroup
 import io.netty.channel.epoll.Epoll
+import io.netty.channel.epoll.EpollDatagramChannel
 import io.netty.channel.epoll.EpollServerSocketChannel
 import io.netty.channel.kqueue.KQueue
+import io.netty.channel.kqueue.KQueueDatagramChannel
 import io.netty.channel.kqueue.KQueueServerSocketChannel
+import io.netty.channel.socket.DatagramChannel
 import io.netty.channel.socket.ServerSocketChannel
+import io.netty.channel.socket.nio.NioDatagramChannel
 import io.netty.channel.socket.nio.NioServerSocketChannel
 import io.netty.handler.codec.http.HttpObjectDecoder
 import io.netty.handler.codec.http.HttpServerCodec
+import io.netty.handler.codec.quic.QuicSslContext
+import io.netty.handler.codec.quic.QuicSslContextBuilder
 import kotlinx.coroutines.CompletableJob
 import kotlinx.coroutines.asCoroutineDispatcher
+import java.net.BindException
+import java.security.PrivateKey
+import java.security.cert.X509Certificate
 import java.util.concurrent.TimeUnit
 import kotlin.reflect.KClass
 import kotlin.system.measureTimeMillis
@@ -146,6 +157,13 @@ public class NettyApplicationEngine(
         public var channelPipelineConfig: ChannelPipeline.() -> Unit = {}
 
         /**
+         * If set to `true`, enables HTTP/3 protocol (over QUIC/UDP) for Netty engine.
+         * Requires an SSL connector to be configured (HTTP/3 always uses TLS).
+         * The HTTP/3 endpoint will listen on the same port as the SSL connector but over UDP.
+         */
+        public var enableHttp3: Boolean = false
+
+        /**
          * Default function to configure Netty's
          */
         private fun defaultHttpServerCodec() = HttpServerCodec(
@@ -198,8 +216,15 @@ public class NettyApplicationEngine(
     private var cancellationJob: CompletableJob? = null
 
     private var channels: List<Channel>? = null
+    private var http3Channels: List<Channel>? = null
     internal val bootstraps: List<ServerBootstrap> by lazy {
         configuration.connectors.map(::createBootstrap)
+    }
+    private val http3Bootstraps: List<Bootstrap> by lazy {
+        if (!configuration.enableHttp3) return@lazy emptyList()
+        configuration.connectors
+            .filterIsInstance<EngineSSLConnectorConfig>()
+            .map { createHttp3Bootstrap(it) }
     }
 
     private fun createBootstrap(connector: EngineConnectorConfig): ServerBootstrap {
@@ -241,6 +266,39 @@ public class NettyApplicationEngine(
         }
     }
 
+    @Suppress("UNCHECKED_CAST")
+    private fun createHttp3Bootstrap(connector: EngineSSLConnectorConfig): Bootstrap {
+        val chain = connector.keyStore.getCertificateChain(connector.keyAlias).toList() as List<X509Certificate>
+        val certs = chain.toTypedArray()
+        val password = connector.privateKeyPassword()
+        val pk = connector.keyStore.getKey(connector.keyAlias, password) as PrivateKey
+        password.fill('\u0000')
+
+        val quicSslContext: QuicSslContext = QuicSslContextBuilder.forServer(pk, null, *certs)
+            .applicationProtocols(*io.netty.handler.codec.http3.Http3.supportedApplicationProtocols())
+            .build()
+
+        val userContext =
+            NettyApplicationCallHandler.CallHandlerCoroutineName +
+                NettyDispatcher +
+                DefaultUncaughtExceptionHandler(environment.log)
+
+        return Bootstrap().apply {
+            group(workerEventGroup)
+            channel(getDatagramChannelClass().java)
+            handler(
+                NettyHttp3ChannelInitializer(
+                    applicationProvider,
+                    pipeline,
+                    callEventGroup,
+                    userContext,
+                    configuration.runningLimit,
+                    quicSslContext
+                )
+            )
+        }
+    }
+
     init {
         pipeline.insertPhaseAfter(EnginePipeline.Call, AFTER_CALL_PHASE)
         pipeline.intercept(AFTER_CALL_PHASE) {
@@ -253,8 +311,19 @@ public class NettyApplicationEngine(
             channels = bootstraps.zip(configuration.connectors)
                 .map { it.first.bind(it.second.host, it.second.port) }
                 .map { it.sync().channel() }
+
             val connectors = channels!!.zip(configuration.connectors)
                 .map { it.second.withPort(it.first.localAddress().port) }
+
+            // Bind HTTP/3 (QUIC/UDP) on the same resolved port as the TCP SSL connector.
+            // TCP and UDP can share the same port number since they are different protocols.
+            val resolvedSslConnectors = channels!!.zip(configuration.connectors)
+                .filter { it.second is EngineSSLConnectorConfig }
+                .map { it.second.host to (it.first.localAddress() as java.net.InetSocketAddress).port }
+            http3Channels = http3Bootstraps.zip(resolvedSslConnectors)
+                .map { (bootstrap, hostPort) -> bootstrap.bind(hostPort.first, hostPort.second) }
+                .map { it.sync().channel() }
+
             resolvedConnectorsDeferred.complete(connectors)
         } catch (cause: Throwable) {
             terminate()
@@ -270,7 +339,8 @@ public class NettyApplicationEngine(
         )
 
         if (wait) {
-            channels?.map { it.closeFuture() }?.forEach { it.sync() }
+            val allChannels = (channels.orEmpty() + http3Channels.orEmpty())
+            allChannels.map { it.closeFuture() }.forEach { it.sync() }
             stop(configuration.shutdownGracePeriod, configuration.shutdownTimeout)
         }
         return this
@@ -296,7 +366,8 @@ public class NettyApplicationEngine(
         monitor.raise(ApplicationStopPreparing, environment)
 
         val channelsCloseTime = measureTimeMillis {
-            val channelFutures = channels?.mapNotNull { if (it.isOpen) it.close() else null }.orEmpty()
+            val allChannels = (channels.orEmpty() + http3Channels.orEmpty())
+            val channelFutures = allChannels.mapNotNull { if (it.isOpen) it.close() else null }
             channelFutures.forEach { future ->
                 withStopException { future.sync() }
             }
@@ -340,4 +411,10 @@ internal fun getChannelClass(): KClass<out ServerSocketChannel> = when {
     KQueue.isAvailable() -> KQueueServerSocketChannel::class
     Epoll.isAvailable() -> EpollServerSocketChannel::class
     else -> NioServerSocketChannel::class
+}
+
+internal fun getDatagramChannelClass(): KClass<out DatagramChannel> = when {
+    KQueue.isAvailable() -> KQueueDatagramChannel::class
+    Epoll.isAvailable() -> EpollDatagramChannel::class
+    else -> NioDatagramChannel::class
 }

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/cio/NettyHttpResponsePipeline.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/cio/NettyHttpResponsePipeline.kt
@@ -11,6 +11,7 @@ import io.ktor.utils.io.*
 import io.netty.channel.*
 import io.netty.handler.codec.http.*
 import io.netty.handler.codec.http2.*
+import io.netty.handler.codec.http3.*
 import kotlinx.atomicfu.*
 import kotlinx.coroutines.*
 import java.io.*
@@ -184,6 +185,7 @@ internal class NettyHttpResponsePipeline(
         val contentType = when (responseMessage) {
             is HttpResponse -> responseMessage.headers().get(HttpHeaders.ContentType)
             is Http2HeadersFrame -> responseMessage.headers().get("content-type")?.toString()
+            is Http3HeadersFrame -> responseMessage.headers().get("content-type")?.toString()
             else -> null
         }
         if (contentType?.contains("text/event-stream", ignoreCase = true) == true) {
@@ -208,6 +210,9 @@ internal class NettyHttpResponsePipeline(
             responseChannel === ByteReadChannel.Empty -> 0
             responseMessage is HttpResponse -> responseMessage.headers().getInt("Content-Length", -1)
             responseMessage is Http2HeadersFrame -> responseMessage.headers().getInt("content-length", -1)
+            responseMessage is Http3HeadersFrame -> {
+                responseMessage.headers().get("content-length")?.toString()?.toIntOrNull() ?: -1
+            }
             else -> -1
         }
 

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/cio/NettyHttpResponsePipeline.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/cio/NettyHttpResponsePipeline.kt
@@ -210,9 +210,7 @@ internal class NettyHttpResponsePipeline(
             responseChannel === ByteReadChannel.Empty -> 0
             responseMessage is HttpResponse -> responseMessage.headers().getInt("Content-Length", -1)
             responseMessage is Http2HeadersFrame -> responseMessage.headers().getInt("content-length", -1)
-            responseMessage is Http3HeadersFrame -> {
-                responseMessage.headers().get("content-length")?.toString()?.toIntOrNull() ?: -1
-            }
+            responseMessage is Http3HeadersFrame -> responseMessage.headers().getInt("content-length", -1)
             else -> -1
         }
 

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/cio/NettyHttpResponsePipeline.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/cio/NettyHttpResponsePipeline.kt
@@ -205,9 +205,7 @@ internal class NettyHttpResponsePipeline(
             responseChannel === ByteReadChannel.Empty -> 0
             responseMessage is HttpResponse -> responseMessage.headers().getInt("Content-Length", -1)
             responseMessage is Http2HeadersFrame -> responseMessage.headers().getInt("content-length", -1)
-            responseMessage is Http3HeadersFrame -> {
-                responseMessage.headers().get("content-length")?.toString()?.toIntOrNull() ?: -1
-            }
+            responseMessage is Http3HeadersFrame -> responseMessage.headers().getInt("content-length", -1)
             else -> -1
         }
 

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/cio/NettyHttpResponsePipeline.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/cio/NettyHttpResponsePipeline.kt
@@ -14,6 +14,7 @@ import io.netty.channel.ChannelPromise
 import io.netty.handler.codec.http.FullHttpResponse
 import io.netty.handler.codec.http.HttpResponse
 import io.netty.handler.codec.http2.Http2HeadersFrame
+import io.netty.handler.codec.http3.Http3HeadersFrame
 import kotlinx.atomicfu.AtomicBoolean
 import kotlinx.atomicfu.atomic
 import kotlinx.coroutines.CoroutineScope
@@ -204,6 +205,9 @@ internal class NettyHttpResponsePipeline(
             responseChannel === ByteReadChannel.Empty -> 0
             responseMessage is HttpResponse -> responseMessage.headers().getInt("Content-Length", -1)
             responseMessage is Http2HeadersFrame -> responseMessage.headers().getInt("content-length", -1)
+            responseMessage is Http3HeadersFrame -> {
+                responseMessage.headers().get("content-length")?.toString()?.toIntOrNull() ?: -1
+            }
             else -> -1
         }
 

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http/HttpMultiplexedConnectionPoint.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http/HttpMultiplexedConnectionPoint.kt
@@ -39,15 +39,14 @@ internal class HttpMultiplexedConnectionPoint(
         level = DeprecationLevel.ERROR
     )
     override val host: String
-        get() = pseudoAuthority?.toString()?.substringBefore(":") ?: "localhost"
+        get() = pseudoAuthority?.toString()?.let { parseAuthorityHost(it) } ?: "localhost"
 
     @Deprecated(
         "Use localPort or serverPort instead",
         level = DeprecationLevel.ERROR
     )
     override val port: Int
-        get() = pseudoAuthority?.toString()
-            ?.substringAfter(":", "")?.takeIf { it.isNotEmpty() }?.toInt()
+        get() = pseudoAuthority?.toString()?.let { parseAuthorityPort(it) }
             ?: localNetworkAddress?.port
             ?: 80
 
@@ -56,7 +55,7 @@ internal class HttpMultiplexedConnectionPoint(
     override val serverHost: String
         get() = pseudoAuthority
             ?.toString()
-            ?.substringBefore(":")
+            ?.let { parseAuthorityHost(it) }
             ?: localHost
     override val localAddress: String
         get() = localNetworkAddress?.hostString ?: "localhost"
@@ -68,7 +67,7 @@ internal class HttpMultiplexedConnectionPoint(
     override val serverPort: Int
         get() = pseudoAuthority
             ?.toString()
-            ?.substringAfter(":", defaultPort.toString())?.toInt()
+            ?.let { parseAuthorityPort(it) }
             ?: localPort
 
     override val remoteHost: String
@@ -79,6 +78,27 @@ internal class HttpMultiplexedConnectionPoint(
         get() = remoteNetworkAddress?.port ?: 0
     override val remoteAddress: String
         get() = remoteNetworkAddress?.hostString ?: "unknown"
+
+    private fun parseAuthorityHost(authority: String): String {
+        if (authority.startsWith("[")) {
+            val closingBracket = authority.indexOf(']')
+            if (closingBracket != -1) return authority.substring(0, closingBracket + 1)
+        }
+        val lastColon = authority.lastIndexOf(':')
+        return if (lastColon > 0) authority.substring(0, lastColon) else authority
+    }
+
+    private fun parseAuthorityPort(authority: String): Int? {
+        if (authority.startsWith("[")) {
+            val afterBracket = authority.substringAfter("]:", "")
+            return afterBracket.takeIf { it.isNotEmpty() }?.toIntOrNull()
+        }
+        val lastColon = authority.lastIndexOf(':')
+        if (lastColon > 0) {
+            return authority.substring(lastColon + 1).toIntOrNull()
+        }
+        return null
+    }
 
     override fun toString(): String =
         "HttpMultiplexedConnectionPoint(uri=$uri, method=$method, version=$version, localAddress=$localAddress, " +

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http/HttpMultiplexedConnectionPoint.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http/HttpMultiplexedConnectionPoint.kt
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2014-2025 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.server.netty.http
+
+import io.ktor.http.*
+import java.net.*
+
+/**
+ * A shared [RequestConnectionPoint] implementation for multiplexed HTTP protocols (HTTP/2 and HTTP/3).
+ *
+ * Both HTTP/2 and HTTP/3 use pseudo-headers (`:method`, `:scheme`, `:authority`, `:path`) for request metadata.
+ * This class abstracts over those pseudo-headers so the same connection point logic
+ * can be reused regardless of the specific protocol version.
+ */
+internal class HttpMultiplexedConnectionPoint(
+    private val pseudoMethod: CharSequence?,
+    private val pseudoScheme: CharSequence?,
+    private val pseudoAuthority: CharSequence?,
+    private val pseudoPath: CharSequence?,
+    private val localNetworkAddress: InetSocketAddress?,
+    private val remoteNetworkAddress: InetSocketAddress?,
+    private val httpVersion: String,
+) : RequestConnectionPoint {
+    override val method: HttpMethod = pseudoMethod?.let { HttpMethod.parse(it.toString()) } ?: HttpMethod.Get
+
+    override val scheme: String
+        get() = pseudoScheme?.toString() ?: "http"
+
+    override val version: String
+        get() = httpVersion
+
+    override val uri: String
+        get() = pseudoPath?.toString() ?: "/"
+
+    @Deprecated(
+        "Use localHost or serverHost instead",
+        level = DeprecationLevel.ERROR
+    )
+    override val host: String
+        get() = pseudoAuthority?.toString()?.substringBefore(":") ?: "localhost"
+
+    @Deprecated(
+        "Use localPort or serverPort instead",
+        level = DeprecationLevel.ERROR
+    )
+    override val port: Int
+        get() = pseudoAuthority?.toString()
+            ?.substringAfter(":", "")?.takeIf { it.isNotEmpty() }?.toInt()
+            ?: localNetworkAddress?.port
+            ?: 80
+
+    override val localHost: String
+        get() = localNetworkAddress?.let { it.hostName ?: it.hostString } ?: "localhost"
+    override val serverHost: String
+        get() = pseudoAuthority
+            ?.toString()
+            ?.substringBefore(":")
+            ?: localHost
+    override val localAddress: String
+        get() = localNetworkAddress?.hostString ?: "localhost"
+
+    private val defaultPort
+        get() = URLProtocol.createOrDefault(scheme).defaultPort
+    override val localPort: Int
+        get() = localNetworkAddress?.port ?: defaultPort
+    override val serverPort: Int
+        get() = pseudoAuthority
+            ?.toString()
+            ?.substringAfter(":", defaultPort.toString())?.toInt()
+            ?: localPort
+
+    override val remoteHost: String
+        get() = remoteNetworkAddress
+            ?.let { it.hostName ?: it.address.hostAddress }
+            ?: "unknown"
+    override val remotePort: Int
+        get() = remoteNetworkAddress?.port ?: 0
+    override val remoteAddress: String
+        get() = remoteNetworkAddress?.hostString ?: "unknown"
+
+    override fun toString(): String =
+        "HttpMultiplexedConnectionPoint(uri=$uri, method=$method, version=$version, localAddress=$localAddress, " +
+            "localPort=$localPort, remoteAddress=$remoteAddress, remotePort=$remotePort)"
+}

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http/HttpMultiplexedResponseHeaders.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http/HttpMultiplexedResponseHeaders.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2014-2026 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.server.netty.http
+
+import io.ktor.server.response.*
+import io.ktor.util.*
+import io.netty.handler.codec.*
+
+/**
+ * Shared [ResponseHeaders] implementation for multiplexed HTTP protocols (HTTP/2 and HTTP/3).
+ *
+ * Both HTTP/2 and HTTP/3 use `DefaultHeaders<CharSequence, CharSequence, T>` for response headers.
+ * This class abstracts over those headers so the same response header logic
+ * can be reused regardless of the specific protocol version.
+ */
+internal class HttpMultiplexedResponseHeaders(
+    private val underlying: Headers<CharSequence, CharSequence, *>
+) : ResponseHeaders() {
+    override fun engineAppendHeader(name: String, value: String) {
+        underlying.add(name.toLowerCasePreservingASCIIRules(), value)
+    }
+
+    override fun get(name: String): String? = if (name.startsWith(':')) null else underlying[name]?.toString()
+
+    override fun getEngineHeaderNames(): List<String> = underlying.names()
+        .filter { !it.startsWith(':') }.map { it.toString() }
+
+    override fun getEngineHeaderValues(name: String): List<String> =
+        if (name.startsWith(':')) emptyList() else underlying.getAll(name).map { it.toString() }
+}

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http/NettyByteBufWriter.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http/NettyByteBufWriter.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2014-2026 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.server.netty.http
+
+import io.ktor.utils.io.*
+import io.netty.buffer.*
+
+/**
+ * Transfers all readable bytes from a [ByteBuf] into a [ByteWriteChannel],
+ * then flushes the channel. This is shared logic used by both HTTP/2 and HTTP/3
+ * frame adapters when converting protocol-specific data frames into a byte channel.
+ */
+internal suspend fun transferByteBuf(content: ByteBuf, bc: ByteWriteChannel) {
+    while (content.readableBytes() > 0) {
+        bc.write { bb ->
+            val size = content.readableBytes()
+            if (bb.remaining() > size) {
+                val l = bb.limit()
+                bb.limit(bb.position() + size)
+                content.readBytes(bb)
+                bb.limit(l)
+            } else {
+                content.readBytes(bb)
+            }
+        }
+    }
+    bc.flush()
+}

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http2/Http2LocalConnectionPoint.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http2/Http2LocalConnectionPoint.kt
@@ -1,76 +1,24 @@
 /*
-* Copyright 2014-2021 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+* Copyright 2014-2025 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
 */
 
 package io.ktor.server.netty.http2
 
 import io.ktor.http.*
+import io.ktor.server.netty.http.*
 import io.netty.handler.codec.http2.*
 import java.net.*
 
 internal class Http2LocalConnectionPoint(
-    private val nettyHeaders: Http2Headers,
-    private val localNetworkAddress: InetSocketAddress?,
-    private val remoteNetworkAddress: InetSocketAddress?,
-) : RequestConnectionPoint {
-    override val method: HttpMethod = nettyHeaders.method()?.let { HttpMethod.parse(it.toString()) } ?: HttpMethod.Get
-
-    override val scheme: String
-        get() = nettyHeaders.scheme()?.toString() ?: "http"
-
-    override val version: String
-        get() = "HTTP/2"
-
-    override val uri: String
-        get() = nettyHeaders.path()?.toString() ?: "/"
-
-    @Deprecated(
-        "Use localHost or serverHost instead",
-        level = DeprecationLevel.ERROR
-    )
-    override val host: String
-        get() = nettyHeaders.authority()?.toString()?.substringBefore(":") ?: "localhost"
-
-    @Deprecated(
-        "Use localPort or serverPort instead",
-        level = DeprecationLevel.ERROR
-    )
-    override val port: Int
-        get() = nettyHeaders.authority()?.toString()
-            ?.substringAfter(":", "")?.takeIf { it.isNotEmpty() }?.toInt()
-            ?: localNetworkAddress?.port
-            ?: 80
-
-    override val localHost: String
-        get() = localNetworkAddress?.let { it.hostName ?: it.hostString } ?: "localhost"
-    override val serverHost: String
-        get() = nettyHeaders.authority()
-            ?.toString()
-            ?.substringBefore(":")
-            ?: localHost
-    override val localAddress: String
-        get() = localNetworkAddress?.hostString ?: "localhost"
-
-    private val defaultPort
-        get() = URLProtocol.createOrDefault(scheme).defaultPort
-    override val localPort: Int
-        get() = localNetworkAddress?.port ?: defaultPort
-    override val serverPort: Int
-        get() = nettyHeaders.authority()
-            ?.toString()
-            ?.substringAfter(":", defaultPort.toString())?.toInt()
-            ?: localPort
-
-    override val remoteHost: String
-        get() = remoteNetworkAddress
-            ?.let { it.hostName ?: it.address.hostAddress }
-            ?: "unknown"
-    override val remotePort: Int
-        get() = remoteNetworkAddress?.port ?: 0
-    override val remoteAddress: String
-        get() = remoteNetworkAddress?.hostString ?: "unknown"
-
-    override fun toString(): String =
-        "Http2LocalConnectionPoint(uri=$uri, method=$method, version=$version, localAddress=$localAddress, " +
-            "localPort=$localPort, remoteAddress=$remoteAddress, remotePort=$remotePort)"
-}
+    nettyHeaders: Http2Headers,
+    localNetworkAddress: InetSocketAddress?,
+    remoteNetworkAddress: InetSocketAddress?,
+) : RequestConnectionPoint by HttpMultiplexedConnectionPoint(
+    pseudoMethod = nettyHeaders.method(),
+    pseudoScheme = nettyHeaders.scheme(),
+    pseudoAuthority = nettyHeaders.authority(),
+    pseudoPath = nettyHeaders.path(),
+    localNetworkAddress = localNetworkAddress,
+    remoteNetworkAddress = remoteNetworkAddress,
+    httpVersion = "HTTP/2",
+)

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http2/HttpFrameAdapter.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http2/HttpFrameAdapter.kt
@@ -16,8 +16,11 @@ internal suspend fun ReceiveChannel<Http2DataFrame>.http2frameLoop(bc: ByteWrite
             val message = receive()
             val content = message.content() ?: Unpooled.EMPTY_BUFFER
 
-            transferByteBuf(content, bc)
-            content.release()
+            try {
+                transferByteBuf(content, bc)
+            } finally {
+                content.release()
+            }
 
             if (message.isEndStream) {
                 break

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http2/HttpFrameAdapter.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http2/HttpFrameAdapter.kt
@@ -14,19 +14,18 @@ internal suspend fun ReceiveChannel<Http2DataFrame>.http2frameLoop(bc: ByteWrite
     try {
         while (true) {
             val message = receive()
-            val content = message.content() ?: Unpooled.EMPTY_BUFFER
-
             try {
+                val content = message.content() ?: Unpooled.EMPTY_BUFFER
                 transferByteBuf(content, bc)
             } finally {
-                content.release()
+                message.release()
             }
 
             if (message.isEndStream) {
                 break
             }
         }
-    } catch (closed: ClosedReceiveChannelException) {
+    } catch (expected: ClosedReceiveChannelException) {
     } catch (t: Throwable) {
         bc.close(t)
     } finally {

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http2/NettyHttp2ApplicationRequest.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http2/NettyHttp2ApplicationRequest.kt
@@ -45,7 +45,7 @@ internal class NettyHttp2ApplicationRequest(
     }
 
     @OptIn(ObsoleteCoroutinesApi::class)
-    val contentActor = actor<Http2DataFrame>(
+    val contentActor = actor(
         Dispatchers.Unconfined,
         kotlinx.coroutines.channels.Channel.UNLIMITED
     ) {

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http3/HmacQuicTokenHandler.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http3/HmacQuicTokenHandler.kt
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2014-2026 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.server.netty.http3
+
+import io.netty.buffer.*
+import io.netty.handler.codec.quic.*
+import java.net.*
+import java.security.*
+import javax.crypto.*
+
+/**
+ * Maximum age of a valid token in milliseconds (default: 60 seconds).
+ */
+private const val TOKEN_LIFETIME_MS = 60_000L
+
+/**
+ * Length of the HMAC-SHA256 output in bytes.
+ */
+private const val HMAC_LENGTH = 32
+
+/**
+ * Length of the timestamp in bytes (Long = 8 bytes).
+ */
+private const val TIMESTAMP_LENGTH = 8
+
+/**
+ * A secure [QuicTokenHandler] that generates and validates QUIC retry tokens
+ * using HMAC-SHA256. Tokens bind the client's address and port to a timestamp
+ * and are cryptographically signed to prevent forgery. Expired tokens are
+ * rejected to mitigate replay attacks.
+ *
+ * Token format:
+ * ```
+ * [timestamp (8 bytes)] [HMAC-SHA256 (32 bytes)] [dcid (variable)]
+ * ```
+ *
+ * The HMAC is computed over:
+ * ```
+ * [timestamp (8 bytes)] [address bytes] [port (4 bytes)] [dcid bytes]
+ * ```
+ *
+ * The destination connection id is appended after the HMAC so that the QUIC
+ * implementation can extract it at the offset returned by [validateToken].
+ *
+ * @param key the secret key used for HMAC signing and validation.
+ *   If not provided, a random 256-bit key is generated.
+ * @param tokenLifetimeMillis maximum age of a valid token in milliseconds.
+ */
+internal class HmacQuicTokenHandler(
+    key: SecretKey = generateDefaultKey(),
+    private val tokenLifetimeMillis: Long = TOKEN_LIFETIME_MS,
+) : QuicTokenHandler {
+
+    private val secretKey: SecretKey = key
+
+    override fun writeToken(out: ByteBuf, dcid: ByteBuf, address: InetSocketAddress): Boolean {
+        val timestamp = System.currentTimeMillis()
+
+        val dcidBytes = ByteArray(dcid.readableBytes())
+        dcid.getBytes(dcid.readerIndex(), dcidBytes)
+
+        val mac = computeHmac(timestamp, address, dcidBytes)
+
+        out.writeLong(timestamp)
+        out.writeBytes(mac)
+        out.writeBytes(dcid, dcid.readerIndex(), dcid.readableBytes())
+        return true
+    }
+
+    override fun validateToken(token: ByteBuf, address: InetSocketAddress): Int {
+        val readable = token.readableBytes()
+        val headerLength = TIMESTAMP_LENGTH + HMAC_LENGTH
+        if (readable < headerLength) return -1
+
+        val timestamp = token.getLong(token.readerIndex())
+
+        val now = System.currentTimeMillis()
+        if (now - timestamp > tokenLifetimeMillis || timestamp > now) return -1
+
+        val receivedMac = ByteArray(HMAC_LENGTH)
+        token.getBytes(token.readerIndex() + TIMESTAMP_LENGTH, receivedMac)
+
+        val dcidLength = readable - headerLength
+        val dcidBytes = ByteArray(dcidLength)
+        token.getBytes(token.readerIndex() + headerLength, dcidBytes)
+
+        val expectedMac = computeHmac(timestamp, address, dcidBytes)
+
+        if (!MessageDigest.isEqual(receivedMac, expectedMac)) return -1
+
+        return headerLength
+    }
+
+    override fun maxTokenLength(): Int = TIMESTAMP_LENGTH + HMAC_LENGTH + Quic.MAX_CONN_ID_LEN
+
+    private fun computeHmac(timestamp: Long, address: InetSocketAddress, dcidBytes: ByteArray): ByteArray {
+        val mac = Mac.getInstance("HmacSHA256")
+        mac.init(secretKey)
+
+        val timestampBytes = ByteArray(TIMESTAMP_LENGTH)
+        for (i in 0 until TIMESTAMP_LENGTH) {
+            timestampBytes[i] = (timestamp shr (56 - i * 8) and 0xFF).toByte()
+        }
+        mac.update(timestampBytes)
+        mac.update(address.address.address)
+
+        val portBytes = ByteArray(4)
+        val port = address.port
+        portBytes[0] = (port shr 24 and 0xFF).toByte()
+        portBytes[1] = (port shr 16 and 0xFF).toByte()
+        portBytes[2] = (port shr 8 and 0xFF).toByte()
+        portBytes[3] = (port and 0xFF).toByte()
+        mac.update(portBytes)
+
+        mac.update(dcidBytes)
+
+        return mac.doFinal()
+    }
+
+    internal companion object {
+        internal fun generateDefaultKey(): SecretKey {
+            val keyGen = KeyGenerator.getInstance("HmacSHA256")
+            keyGen.init(256, SecureRandom())
+            return keyGen.generateKey()
+        }
+    }
+}

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http3/HmacQuicTokenHandler.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http3/HmacQuicTokenHandler.kt
@@ -111,7 +111,6 @@ internal class HmacQuicTokenHandler(
         mac.init(secretKey)
 
         KtorDefaultPool.useInstance { timestampBuffer ->
-            timestampBuffer.clear()
             timestampBuffer.limit(TIMESTAMP_LENGTH)
             timestampBuffer.putLong(0, timestamp)
             timestampBuffer.position(0)

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http3/HmacQuicTokenHandler.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http3/HmacQuicTokenHandler.kt
@@ -90,6 +90,7 @@ internal class HmacQuicTokenHandler(
         token.getBytes(token.readerIndex() + TIMESTAMP_LENGTH, receivedMac)
 
         val dcidLength = readable - headerLength
+        if (dcidLength !in 0..Quic.MAX_CONN_ID_LEN) return -1
 
         val expectedMac = KtorDefaultPool.useInstance { dcidBuffer ->
             dcidBuffer.clear()

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http3/HmacQuicTokenHandler.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http3/HmacQuicTokenHandler.kt
@@ -4,9 +4,12 @@
 
 package io.ktor.server.netty.http3
 
+import io.ktor.util.cio.*
+import io.ktor.utils.io.pool.useInstance
 import io.netty.buffer.*
 import io.netty.handler.codec.quic.*
 import java.net.*
+import java.nio.*
 import java.security.*
 import javax.crypto.*
 
@@ -44,28 +47,32 @@ private const val TIMESTAMP_LENGTH = 8
  * The destination connection id is appended after the HMAC so that the QUIC
  * implementation can extract it at the offset returned by [validateToken].
  *
- * @param key the secret key used for HMAC signing and validation.
+ * @param keyGen the secret key used for HMAC signing and validation.
  *   If not provided, a random 256-bit key is generated.
  * @param tokenLifetimeMillis maximum age of a valid token in milliseconds.
  */
 internal class HmacQuicTokenHandler(
-    key: SecretKey = generateDefaultKey(),
+    keyGen: () -> SecretKey = ::generateDefaultKey,
     private val tokenLifetimeMillis: Long = TOKEN_LIFETIME_MS,
 ) : QuicTokenHandler {
 
-    private val secretKey: SecretKey = key
+    private val secretKey: SecretKey by lazy(keyGen)
 
     override fun writeToken(out: ByteBuf, dcid: ByteBuf, address: InetSocketAddress): Boolean {
         val timestamp = System.currentTimeMillis()
 
-        val dcidBytes = ByteArray(dcid.readableBytes())
-        dcid.getBytes(dcid.readerIndex(), dcidBytes)
+        KtorDefaultPool.useInstance { dcidBuffer ->
+            dcidBuffer.clear()
+            dcidBuffer.limit(dcid.readableBytes())
+            dcid.getBytes(dcid.readerIndex(), dcidBuffer.array(), 0, dcid.readableBytes())
 
-        val mac = computeHmac(timestamp, address, dcidBytes)
+            val mac = computeHmac(timestamp, address, dcidBuffer)
 
-        out.writeLong(timestamp)
-        out.writeBytes(mac)
-        out.writeBytes(dcid, dcid.readerIndex(), dcid.readableBytes())
+            out.writeLong(timestamp)
+            out.writeBytes(mac)
+            out.writeBytes(dcid, dcid.readerIndex(), dcid.readableBytes())
+        }
+
         return true
     }
 
@@ -83,10 +90,13 @@ internal class HmacQuicTokenHandler(
         token.getBytes(token.readerIndex() + TIMESTAMP_LENGTH, receivedMac)
 
         val dcidLength = readable - headerLength
-        val dcidBytes = ByteArray(dcidLength)
-        token.getBytes(token.readerIndex() + headerLength, dcidBytes)
 
-        val expectedMac = computeHmac(timestamp, address, dcidBytes)
+        val expectedMac = KtorDefaultPool.useInstance { dcidBuffer ->
+            dcidBuffer.clear()
+            dcidBuffer.limit(dcidLength)
+            token.getBytes(token.readerIndex() + headerLength, dcidBuffer.array(), 0, dcidLength)
+            computeHmac(timestamp, address, dcidBuffer)
+        }
 
         if (!MessageDigest.isEqual(receivedMac, expectedMac)) return -1
 
@@ -95,28 +105,38 @@ internal class HmacQuicTokenHandler(
 
     override fun maxTokenLength(): Int = TIMESTAMP_LENGTH + HMAC_LENGTH + Quic.MAX_CONN_ID_LEN
 
-    private fun computeHmac(timestamp: Long, address: InetSocketAddress, dcidBytes: ByteArray): ByteArray {
+    private fun computeHmac(timestamp: Long, address: InetSocketAddress, dcidBytes: ByteBuffer): ByteArray {
         val mac = Mac.getInstance("HmacSHA256")
         mac.init(secretKey)
 
-        val timestampBytes = ByteArray(TIMESTAMP_LENGTH)
-        for (i in 0 until TIMESTAMP_LENGTH) {
-            timestampBytes[i] = (timestamp shr (56 - i * 8) and 0xFF).toByte()
+        KtorDefaultPool.useInstance { timestampBuffer ->
+            timestampBuffer.clear()
+            timestampBuffer.limit(TIMESTAMP_LENGTH)
+            timestampBuffer.putLong(0, timestamp)
+            timestampBuffer.position(0)
+            timestampBuffer.limit(TIMESTAMP_LENGTH)
+
+            mac.update(timestampBuffer)
+
+            KtorDefaultPool.useInstance { portBuffer ->
+                portBuffer.clear()
+                portBuffer.limit(4)
+
+                val port = address.port
+                portBuffer.put(0, (port shr 24 and 0xFF).toByte())
+                portBuffer.put(1, (port shr 16 and 0xFF).toByte())
+                portBuffer.put(2, (port shr 8 and 0xFF).toByte())
+                portBuffer.put(3, (port and 0xFF).toByte())
+                portBuffer.position(0)
+                portBuffer.limit(4)
+
+                mac.update(address.address.address)
+                mac.update(portBuffer)
+                mac.update(dcidBytes)
+
+                return mac.doFinal()
+            }
         }
-        mac.update(timestampBytes)
-        mac.update(address.address.address)
-
-        val portBytes = ByteArray(4)
-        val port = address.port
-        portBytes[0] = (port shr 24 and 0xFF).toByte()
-        portBytes[1] = (port shr 16 and 0xFF).toByte()
-        portBytes[2] = (port shr 8 and 0xFF).toByte()
-        portBytes[3] = (port and 0xFF).toByte()
-        mac.update(portBytes)
-
-        mac.update(dcidBytes)
-
-        return mac.doFinal()
     }
 
     internal companion object {

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http3/HmacQuicTokenHandler.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http3/HmacQuicTokenHandler.kt
@@ -5,13 +5,17 @@
 package io.ktor.server.netty.http3
 
 import io.ktor.util.cio.*
-import io.ktor.utils.io.pool.useInstance
-import io.netty.buffer.*
-import io.netty.handler.codec.quic.*
-import java.net.*
-import java.nio.*
-import java.security.*
-import javax.crypto.*
+import io.ktor.utils.io.pool.*
+import io.netty.buffer.ByteBuf
+import io.netty.handler.codec.quic.Quic
+import io.netty.handler.codec.quic.QuicTokenHandler
+import java.net.InetSocketAddress
+import java.nio.ByteBuffer
+import java.security.MessageDigest
+import java.security.SecureRandom
+import javax.crypto.KeyGenerator
+import javax.crypto.Mac
+import javax.crypto.SecretKey
 
 /**
  * Maximum age of a valid token in milliseconds (default: 60 seconds).
@@ -47,7 +51,7 @@ private const val TIMESTAMP_LENGTH = 8
  * The destination connection id is appended after the HMAC so that the QUIC
  * implementation can extract it at the offset returned by [validateToken].
  *
- * @param keyGen the secret key used for HMAC signing and validation.
+ * @param keyGen a function for providing the secret key used in HMAC signing and validation.
  *   If not provided, a random 256-bit key is generated.
  * @param tokenLifetimeMillis maximum age of a valid token in milliseconds.
  */

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http3/Http3FrameAdapter.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http3/Http3FrameAdapter.kt
@@ -16,8 +16,11 @@ internal suspend fun ReceiveChannel<Http3DataFrame>.http3frameLoop(bc: ByteWrite
             val message = receive()
             val content = message.content() ?: Unpooled.EMPTY_BUFFER
 
-            transferByteBuf(content, bc)
-            content.release()
+            try {
+                transferByteBuf(content, bc)
+            } finally {
+                content.release()
+            }
         }
     } catch (closed: ClosedReceiveChannelException) {
     } catch (t: Throwable) {

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http3/Http3FrameAdapter.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http3/Http3FrameAdapter.kt
@@ -1,16 +1,16 @@
 /*
-* Copyright 2014-2025 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
-*/
+ * Copyright 2014-2025 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
 
-package io.ktor.server.netty.http2
+package io.ktor.server.netty.http3
 
 import io.ktor.server.netty.http.*
 import io.ktor.utils.io.*
 import io.netty.buffer.*
-import io.netty.handler.codec.http2.*
+import io.netty.handler.codec.http3.*
 import kotlinx.coroutines.channels.*
 
-internal suspend fun ReceiveChannel<Http2DataFrame>.http2frameLoop(bc: ByteWriteChannel) {
+internal suspend fun ReceiveChannel<Http3DataFrame>.http3frameLoop(bc: ByteWriteChannel) {
     try {
         while (true) {
             val message = receive()
@@ -18,10 +18,6 @@ internal suspend fun ReceiveChannel<Http2DataFrame>.http2frameLoop(bc: ByteWrite
 
             transferByteBuf(content, bc)
             content.release()
-
-            if (message.isEndStream) {
-                break
-            }
         }
     } catch (closed: ClosedReceiveChannelException) {
     } catch (t: Throwable) {

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http3/Http3FrameAdapter.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http3/Http3FrameAdapter.kt
@@ -14,15 +14,14 @@ internal suspend fun ReceiveChannel<Http3DataFrame>.http3frameLoop(bc: ByteWrite
     try {
         while (true) {
             val message = receive()
-            val content = message.content() ?: Unpooled.EMPTY_BUFFER
-
             try {
+                val content = message.content() ?: Unpooled.EMPTY_BUFFER
                 transferByteBuf(content, bc)
             } finally {
-                content.release()
+                message.release()
             }
         }
-    } catch (closed: ClosedReceiveChannelException) {
+    } catch (expected: ClosedReceiveChannelException) {
     } catch (t: Throwable) {
         bc.close(t)
     } finally {

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http3/NettyHttp3ApplicationCall.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http3/NettyHttp3ApplicationCall.kt
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2014-2026 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.server.netty.http3
+
+import io.ktor.server.application.*
+import io.ktor.server.netty.*
+import io.netty.buffer.*
+import io.netty.channel.*
+import io.netty.handler.codec.http3.*
+import kotlin.coroutines.*
+
+internal class NettyHttp3ApplicationCall(
+    application: Application,
+    context: ChannelHandlerContext,
+    val headers: Http3Headers,
+    engineContext: CoroutineContext,
+    userContext: CoroutineContext
+) : NettyApplicationCall(application, context, headers) {
+
+    override val coroutineContext: CoroutineContext = userContext
+
+    override val request = NettyHttp3ApplicationRequest(this, engineContext, context, headers)
+    override val response = NettyHttp3ApplicationResponse(this, context, engineContext, userContext)
+
+    init {
+        putResponseAttribute()
+    }
+
+    override fun prepareMessage(buf: ByteBuf, isLastContent: Boolean): Any {
+        if (isByteBufferContent) {
+            return super.prepareMessage(buf, isLastContent)
+        }
+        return DefaultHttp3DataFrame(buf)
+    }
+
+    override fun prepareEndOfStreamMessage(lastTransformed: Boolean): Any? {
+        if (isByteBufferContent) {
+            return super.prepareEndOfStreamMessage(lastTransformed)
+        }
+        // HTTP/3 signals end of stream by closing the QUIC stream, not via a frame flag
+        return null
+    }
+
+    override fun upgrade(dst: ChannelHandlerContext) {
+        if (isByteBufferContent) {
+            return super.upgrade(dst)
+        }
+        throw IllegalStateException("HTTP/3 doesn't support upgrade")
+    }
+
+    override fun isContextCloseRequired(): Boolean = true
+}

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http3/NettyHttp3ApplicationRequest.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http3/NettyHttp3ApplicationRequest.kt
@@ -17,6 +17,23 @@ import kotlinx.coroutines.channels.*
 import java.net.*
 import kotlin.coroutines.*
 
+/**
+ * Completes the trailer headers deferred with the given [Http3Headers], closing the content actor
+ * to signal that no more data frames are expected after trailers.
+ */
+internal fun NettyHttp3ApplicationRequest.receiveTrailers(trailerHeaders: Http3Headers) {
+    val headers = Headers.build {
+        trailerHeaders.forEach { (name, value) ->
+            val nameStr = name.toString()
+            if (nameStr.isNotEmpty() && nameStr[0] != ':') {
+                append(nameStr, value.toString())
+            }
+        }
+    }
+    requestTrailers.complete(headers)
+    contentActor.close()
+}
+
 internal class NettyHttp3ApplicationRequest(
     call: PipelineCall,
     coroutineContext: CoroutineContext,
@@ -64,4 +81,6 @@ internal class NettyHttp3ApplicationRequest(
     )
 
     override val cookies: RequestCookies = NettyApplicationRequestCookies(this)
+
+    internal val requestTrailers: CompletableDeferred<Headers> = CompletableDeferred()
 }

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http3/NettyHttp3ApplicationRequest.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http3/NettyHttp3ApplicationRequest.kt
@@ -63,7 +63,7 @@ internal class NettyHttp3ApplicationRequest(
     }
 
     @OptIn(ObsoleteCoroutinesApi::class)
-    val contentActor = actor<Http3DataFrame>(
+    val contentActor = actor(
         Dispatchers.Unconfined,
         kotlinx.coroutines.channels.Channel.UNLIMITED
     ) {

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http3/NettyHttp3ApplicationRequest.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http3/NettyHttp3ApplicationRequest.kt
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2014-2026 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.server.netty.http3
+
+import io.ktor.http.*
+import io.ktor.server.application.*
+import io.ktor.server.netty.*
+import io.ktor.server.netty.http.*
+import io.ktor.server.request.*
+import io.ktor.utils.io.*
+import io.netty.channel.*
+import io.netty.handler.codec.http3.*
+import kotlinx.coroutines.*
+import kotlinx.coroutines.channels.*
+import java.net.*
+import kotlin.coroutines.*
+
+internal class NettyHttp3ApplicationRequest(
+    call: PipelineCall,
+    coroutineContext: CoroutineContext,
+    context: ChannelHandlerContext,
+    val nettyHeaders: Http3Headers,
+    val contentByteChannel: ByteChannel = ByteChannel()
+) : NettyApplicationRequest(
+    call,
+    coroutineContext,
+    context,
+    contentByteChannel,
+    nettyHeaders.path()?.toString() ?: "/",
+    keepAlive = false
+) {
+
+    override val engineHeaders: Headers by lazy {
+        Headers.build {
+            nettyHeaders.forEach { (name, value) ->
+                if (name.isNotEmpty() && name[0] != ':') {
+                    append(
+                        name.toString(),
+                        value.toString()
+                    )
+                }
+            }
+        }
+    }
+
+    @OptIn(ObsoleteCoroutinesApi::class)
+    val contentActor = actor<Http3DataFrame>(
+        Dispatchers.Unconfined,
+        kotlinx.coroutines.channels.Channel.UNLIMITED
+    ) {
+        http3frameLoop(contentByteChannel)
+    }
+
+    override val local = HttpMultiplexedConnectionPoint(
+        pseudoMethod = nettyHeaders.method(),
+        pseudoScheme = nettyHeaders.scheme(),
+        pseudoAuthority = nettyHeaders.authority(),
+        pseudoPath = nettyHeaders.path(),
+        localNetworkAddress = context.channel().localAddress() as? InetSocketAddress,
+        remoteNetworkAddress = context.channel().remoteAddress() as? InetSocketAddress,
+        httpVersion = "HTTP/3",
+    )
+
+    override val cookies: RequestCookies = NettyApplicationRequestCookies(this)
+}

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http3/NettyHttp3ApplicationResponse.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http3/NettyHttp3ApplicationResponse.kt
@@ -1,8 +1,8 @@
 /*
-* Copyright 2014-2025 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
-*/
+ * Copyright 2014-2026 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
 
-package io.ktor.server.netty.http2
+package io.ktor.server.netty.http3
 
 import io.ktor.http.*
 import io.ktor.http.content.*
@@ -10,22 +10,21 @@ import io.ktor.server.netty.*
 import io.ktor.server.netty.http.*
 import io.ktor.server.response.*
 import io.netty.channel.*
-import io.netty.handler.codec.http2.*
+import io.netty.handler.codec.http3.*
 import kotlin.coroutines.*
 
-internal class NettyHttp2ApplicationResponse(
+internal class NettyHttp3ApplicationResponse(
     call: NettyApplicationCall,
-    val handler: NettyHttp2Handler,
     context: ChannelHandlerContext,
     engineContext: CoroutineContext,
     userContext: CoroutineContext
 ) : NettyApplicationResponse(call, context, engineContext, userContext) {
 
-    private val responseHeaders = DefaultHttp2Headers().apply {
+    private val responseHeaders = DefaultHttp3Headers().apply {
         status(HttpStatusCode.OK.value.toString())
     }
 
-    private val responseTrailers = DefaultHttp2Headers()
+    private val responseTrailers = DefaultHttp3Headers()
 
     override fun setStatus(statusCode: HttpStatusCode) {
         responseHeaders.status(statusCode.value.toString())
@@ -36,21 +35,19 @@ internal class NettyHttp2ApplicationResponse(
     }
 
     override fun responseMessage(chunked: Boolean, last: Boolean): Any {
-        // transfer encoding should never be set for HTTP/2,
+        // transfer encoding should never be set for HTTP/3,
         // so we simply remove header
-        // it should be a lower case
         responseHeaders.remove("transfer-encoding")
-        return DefaultHttp2HeadersFrame(responseHeaders, last)
+        return DefaultHttp3HeadersFrame(responseHeaders)
     }
 
     override fun prepareTrailerMessage(): Any? {
-        return if (responseTrailers.isEmpty) null else DefaultHttp2HeadersFrame(responseTrailers, true)
+        return if (responseTrailers.isEmpty) null else DefaultHttp3HeadersFrame(responseTrailers)
     }
 
     override suspend fun respondOutgoingContent(content: OutgoingContent) {
         super.respondOutgoingContent(content)
 
-        // write all trailers
         content.trailers()?.let { it ->
             it.forEach { name, values ->
                 for (value in values) {
@@ -61,7 +58,7 @@ internal class NettyHttp2ApplicationResponse(
     }
 
     override suspend fun respondUpgrade(upgrade: OutgoingContent.ProtocolUpgrade) {
-        throw UnsupportedOperationException("HTTP/2 doesn't support upgrade")
+        throw UnsupportedOperationException("HTTP/3 doesn't support upgrade")
     }
 
     override val headers: ResponseHeaders = HttpMultiplexedResponseHeaders(responseHeaders)
@@ -70,8 +67,6 @@ internal class NettyHttp2ApplicationResponse(
 
     @UseHttp2Push
     override fun push(builder: ResponsePushBuilder) {
-        context.executor().execute {
-            handler.startHttp2PushPromise(this@NettyHttp2ApplicationResponse.context, builder)
-        }
+        // HTTP/3 push is not yet supported
     }
 }

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http3/NettyHttp3ChannelInitializer.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http3/NettyHttp3ChannelInitializer.kt
@@ -23,7 +23,8 @@ internal class NettyHttp3ChannelInitializer(
     private val callEventGroup: EventExecutorGroup,
     private val userContext: CoroutineContext,
     private val runningLimit: Int,
-    private val quicSslContext: QuicSslContext
+    private val quicSslContext: QuicSslContext,
+    private val quicTokenHandler: QuicTokenHandler
 ) : ChannelInitializer<DatagramChannel>() {
 
     override fun initChannel(ch: DatagramChannel) {
@@ -39,7 +40,7 @@ internal class NettyHttp3ChannelInitializer(
 
         val quicServerCodec = Http3.newQuicServerCodecBuilder()
             .sslContext(quicSslContext)
-            .tokenHandler(InsecureQuicTokenHandler.INSTANCE)
+            .tokenHandler(quicTokenHandler)
             .maxIdleTimeout(30_000, java.util.concurrent.TimeUnit.MILLISECONDS)
             .initialMaxData(10_000_000)
             .initialMaxStreamDataBidirectionalLocal(1_000_000)

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http3/NettyHttp3ChannelInitializer.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http3/NettyHttp3ChannelInitializer.kt
@@ -11,6 +11,7 @@ import io.netty.channel.socket.*
 import io.netty.handler.codec.http3.*
 import io.netty.handler.codec.quic.*
 import io.netty.util.concurrent.*
+import java.util.concurrent.TimeUnit
 import kotlin.coroutines.*
 
 /**
@@ -24,7 +25,13 @@ internal class NettyHttp3ChannelInitializer(
     private val userContext: CoroutineContext,
     private val runningLimit: Int,
     private val quicSslContext: QuicSslContext,
-    private val quicTokenHandler: QuicTokenHandler
+    private val quicTokenHandler: QuicTokenHandler,
+    private val quicMaxIdleTimeoutMillis: Long,
+    private val quicInitialMaxData: Long,
+    private val quicInitialMaxStreamDataBidirectionalLocal: Long,
+    private val quicInitialMaxStreamDataBidirectionalRemote: Long,
+    private val quicInitialMaxStreamsBidirectional: Long,
+    private val configureQuicServerCodec: QuicServerCodecBuilder.() -> Unit
 ) : ChannelInitializer<DatagramChannel>() {
 
     override fun initChannel(ch: DatagramChannel) {
@@ -41,11 +48,12 @@ internal class NettyHttp3ChannelInitializer(
         val quicServerCodec = Http3.newQuicServerCodecBuilder()
             .sslContext(quicSslContext)
             .tokenHandler(quicTokenHandler)
-            .maxIdleTimeout(30_000, java.util.concurrent.TimeUnit.MILLISECONDS)
-            .initialMaxData(10_000_000)
-            .initialMaxStreamDataBidirectionalLocal(1_000_000)
-            .initialMaxStreamDataBidirectionalRemote(1_000_000)
-            .initialMaxStreamsBidirectional(100)
+            .maxIdleTimeout(quicMaxIdleTimeoutMillis, TimeUnit.MILLISECONDS)
+            .initialMaxData(quicInitialMaxData)
+            .initialMaxStreamDataBidirectionalLocal(quicInitialMaxStreamDataBidirectionalLocal)
+            .initialMaxStreamDataBidirectionalRemote(quicInitialMaxStreamDataBidirectionalRemote)
+            .initialMaxStreamsBidirectional(quicInitialMaxStreamsBidirectional)
+            .apply(configureQuicServerCodec)
             .handler(Http3ServerConnectionHandler(streamInitializer))
             .build()
 

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http3/NettyHttp3ChannelInitializer.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http3/NettyHttp3ChannelInitializer.kt
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2014-2026 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.server.netty.http3
+
+import io.ktor.server.application.*
+import io.ktor.server.engine.*
+import io.netty.channel.*
+import io.netty.channel.socket.*
+import io.netty.handler.codec.http3.*
+import io.netty.handler.codec.quic.*
+import io.netty.util.concurrent.*
+import kotlin.coroutines.*
+
+/**
+ * A [ChannelInitializer] for QUIC/HTTP3 that configures the [DatagramChannel] pipeline
+ * with the QUIC server codec and HTTP/3 connection handler.
+ */
+internal class NettyHttp3ChannelInitializer(
+    private val applicationProvider: () -> Application,
+    private val enginePipeline: EnginePipeline,
+    private val callEventGroup: EventExecutorGroup,
+    private val userContext: CoroutineContext,
+    private val runningLimit: Int,
+    private val quicSslContext: QuicSslContext
+) : ChannelInitializer<DatagramChannel>() {
+
+    override fun initChannel(ch: DatagramChannel) {
+        val application = applicationProvider()
+
+        val streamInitializer = NettyHttp3RequestStreamInitializer(
+            enginePipeline,
+            application,
+            callEventGroup,
+            userContext,
+            runningLimit
+        )
+
+        val quicServerCodec = Http3.newQuicServerCodecBuilder()
+            .sslContext(quicSslContext)
+            .tokenHandler(InsecureQuicTokenHandler.INSTANCE)
+            .maxIdleTimeout(30_000, java.util.concurrent.TimeUnit.MILLISECONDS)
+            .initialMaxData(10_000_000)
+            .initialMaxStreamDataBidirectionalLocal(1_000_000)
+            .initialMaxStreamDataBidirectionalRemote(1_000_000)
+            .initialMaxStreamsBidirectional(100)
+            .handler(Http3ServerConnectionHandler(streamInitializer))
+            .build()
+
+        ch.pipeline().addLast(quicServerCodec)
+    }
+}

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http3/NettyHttp3ChannelInitializer.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http3/NettyHttp3ChannelInitializer.kt
@@ -6,13 +6,13 @@ package io.ktor.server.netty.http3
 
 import io.ktor.server.application.*
 import io.ktor.server.engine.*
-import io.netty.channel.*
-import io.netty.channel.socket.*
-import io.netty.handler.codec.http3.*
-import io.netty.handler.codec.quic.*
-import io.netty.util.concurrent.*
+import io.netty.channel.ChannelInitializer
+import io.netty.channel.socket.DatagramChannel
+import io.netty.handler.codec.http3.Http3
+import io.netty.handler.codec.http3.Http3ServerConnectionHandler
+import io.netty.handler.codec.quic.QuicSslContext
 import java.util.concurrent.TimeUnit
-import kotlin.coroutines.*
+import kotlin.coroutines.CoroutineContext
 
 /**
  * A [ChannelInitializer] for QUIC/HTTP3 that configures the [DatagramChannel] pipeline
@@ -21,17 +21,10 @@ import kotlin.coroutines.*
 internal class NettyHttp3ChannelInitializer(
     private val applicationProvider: () -> Application,
     private val enginePipeline: EnginePipeline,
-    private val callEventGroup: EventExecutorGroup,
     private val userContext: CoroutineContext,
     private val runningLimit: Int,
     private val quicSslContext: QuicSslContext,
-    private val quicTokenHandler: QuicTokenHandler,
-    private val quicMaxIdleTimeoutMillis: Long,
-    private val quicInitialMaxData: Long,
-    private val quicInitialMaxStreamDataBidirectionalLocal: Long,
-    private val quicInitialMaxStreamDataBidirectionalRemote: Long,
-    private val quicInitialMaxStreamsBidirectional: Long,
-    private val configureQuicServerCodec: QuicServerCodecBuilder.() -> Unit
+    private val http3Configuration: NettyHttp3Configuration
 ) : ChannelInitializer<DatagramChannel>() {
 
     override fun initChannel(ch: DatagramChannel) {
@@ -40,20 +33,19 @@ internal class NettyHttp3ChannelInitializer(
         val streamInitializer = NettyHttp3RequestStreamInitializer(
             enginePipeline,
             application,
-            callEventGroup,
             userContext,
             runningLimit
         )
 
         val quicServerCodec = Http3.newQuicServerCodecBuilder()
             .sslContext(quicSslContext)
-            .tokenHandler(quicTokenHandler)
-            .maxIdleTimeout(quicMaxIdleTimeoutMillis, TimeUnit.MILLISECONDS)
-            .initialMaxData(quicInitialMaxData)
-            .initialMaxStreamDataBidirectionalLocal(quicInitialMaxStreamDataBidirectionalLocal)
-            .initialMaxStreamDataBidirectionalRemote(quicInitialMaxStreamDataBidirectionalRemote)
-            .initialMaxStreamsBidirectional(quicInitialMaxStreamsBidirectional)
-            .apply(configureQuicServerCodec)
+            .tokenHandler(http3Configuration.quicTokenHandler)
+            .maxIdleTimeout(http3Configuration.quicMaxIdleTimeoutMillis.inWholeMilliseconds, TimeUnit.MILLISECONDS)
+            .initialMaxData(http3Configuration.quicInitialMaxData)
+            .initialMaxStreamDataBidirectionalLocal(http3Configuration.quicInitialMaxStreamDataBidirectionalLocal)
+            .initialMaxStreamDataBidirectionalRemote(http3Configuration.quicInitialMaxStreamDataBidirectionalRemote)
+            .initialMaxStreamsBidirectional(http3Configuration.quicInitialMaxStreamsBidirectional)
+            .apply(http3Configuration.configureQuicServerCodec)
             .handler(Http3ServerConnectionHandler(streamInitializer))
             .build()
 

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http3/NettyHttp3ChannelInitializer.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http3/NettyHttp3ChannelInitializer.kt
@@ -40,7 +40,7 @@ internal class NettyHttp3ChannelInitializer(
         val quicServerCodec = Http3.newQuicServerCodecBuilder()
             .sslContext(quicSslContext)
             .tokenHandler(http3Configuration.quicTokenHandler)
-            .maxIdleTimeout(http3Configuration.quicMaxIdleTimeoutMillis.inWholeMilliseconds, TimeUnit.MILLISECONDS)
+            .maxIdleTimeout(http3Configuration.quicMaxIdleTimeout.inWholeMilliseconds, TimeUnit.MILLISECONDS)
             .initialMaxData(http3Configuration.quicInitialMaxData)
             .initialMaxStreamDataBidirectionalLocal(http3Configuration.quicInitialMaxStreamDataBidirectionalLocal)
             .initialMaxStreamDataBidirectionalRemote(http3Configuration.quicInitialMaxStreamDataBidirectionalRemote)

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http3/NettyHttp3Configuration.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http3/NettyHttp3Configuration.kt
@@ -35,32 +35,72 @@ public class NettyHttp3Configuration {
     /**
      * Maximum idle timeout for QUIC connections.
      * If no data is exchanged within this period, the connection is closed.
+     *
+     * Must be strictly positive.
      */
-    public var quicMaxIdleTimeoutMillis: Duration = 30.seconds
+    public var quicMaxIdleTimeout: Duration = 30.seconds
+        set(value) {
+            require(value > Duration.ZERO) {
+                "quicMaxIdleTimeout must be > 0, but was $value"
+            }
+            field = value
+        }
 
     /**
      * The initial value for the maximum amount of data that can be sent
      * on the entire QUIC connection, in bytes.
+     *
+     * Must be strictly positive.
      */
     public var quicInitialMaxData: Long = 10_000_000
+        set(value) {
+            require(value > 0) {
+                "quicInitialMaxData must be > 0, but was $value"
+            }
+            field = value
+        }
 
     /**
      * The initial flow-control limit for locally-initiated bidirectional
      * QUIC streams, in bytes.
+     *
+     * Must be strictly positive.
      */
     public var quicInitialMaxStreamDataBidirectionalLocal: Long = 1_000_000
+        set(value) {
+            require(value > 0) {
+                "quicInitialMaxStreamDataBidirectionalLocal must be > 0, but was $value"
+            }
+            field = value
+        }
 
     /**
      * The initial flow-control limit for remotely-initiated bidirectional
      * QUIC streams, in bytes.
+     *
+     * Must be strictly positive.
      */
     public var quicInitialMaxStreamDataBidirectionalRemote: Long = 1_000_000
+        set(value) {
+            require(value > 0) {
+                "quicInitialMaxStreamDataBidirectionalRemote must be > 0, but was $value"
+            }
+            field = value
+        }
 
     /**
      * The initial maximum number of bidirectional streams that the remote
      * peer is allowed to open.
+     *
+     * Must be strictly positive.
      */
     public var quicInitialMaxStreamsBidirectional: Long = 100
+        set(value) {
+            require(value > 0) {
+                "quicInitialMaxStreamsBidirectional must be > 0, but was $value"
+            }
+            field = value
+        }
 
     /**
      * User-provided function to configure the QUIC server codec builder.

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http3/NettyHttp3Configuration.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http3/NettyHttp3Configuration.kt
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2014-2026 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.server.netty.http3
+
+import io.ktor.utils.io.*
+import io.netty.handler.codec.quic.QuicServerCodecBuilder
+import io.netty.handler.codec.quic.QuicTokenHandler
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Configuration for the HTTP/3 (QUIC) transport in the Netty engine.
+ *
+ * Options defined here apply only to the HTTP/3 endpoint. They have no effect
+ * on HTTP/1.1 or HTTP/2 connectors.
+ *
+ * An instance of this class is provided to the lambda passed to
+ * [io.ktor.server.netty.NettyApplicationEngine.Configuration.enableHttp3].
+ */
+@KtorDsl
+public class NettyHttp3Configuration {
+
+    /**
+     * The [QuicTokenHandler] used to generate and validate QUIC retry tokens.
+     * By default, a secure HMAC-SHA256-based handler is used that cryptographically
+     * signs tokens with a randomly generated key and rejects forged or expired tokens.
+     *
+     * Callers may replace this with a custom [QuicTokenHandler] implementation
+     * to use a different signing strategy or integrate with external token services.
+     */
+    public var quicTokenHandler: QuicTokenHandler = HmacQuicTokenHandler()
+
+    /**
+     * Maximum idle timeout for QUIC connections.
+     * If no data is exchanged within this period, the connection is closed.
+     */
+    public var quicMaxIdleTimeoutMillis: Duration = 30.seconds
+
+    /**
+     * The initial value for the maximum amount of data that can be sent
+     * on the entire QUIC connection, in bytes.
+     */
+    public var quicInitialMaxData: Long = 10_000_000
+
+    /**
+     * The initial flow-control limit for locally-initiated bidirectional
+     * QUIC streams, in bytes.
+     */
+    public var quicInitialMaxStreamDataBidirectionalLocal: Long = 1_000_000
+
+    /**
+     * The initial flow-control limit for remotely-initiated bidirectional
+     * QUIC streams, in bytes.
+     */
+    public var quicInitialMaxStreamDataBidirectionalRemote: Long = 1_000_000
+
+    /**
+     * The initial maximum number of bidirectional streams that the remote
+     * peer is allowed to open.
+     */
+    public var quicInitialMaxStreamsBidirectional: Long = 100
+
+    /**
+     * User-provided function to configure the QUIC server codec builder.
+     * This lambda is invoked on the [QuicServerCodecBuilder] after all default
+     * settings have been applied, allowing callers to override or add any
+     * QUIC transport parameters.
+     */
+    public var configureQuicServerCodec: QuicServerCodecBuilder.() -> Unit = {}
+}

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http3/NettyHttp3Handler.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http3/NettyHttp3Handler.kt
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2014-2026 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.server.netty.http3
+
+import io.ktor.server.application.*
+import io.ktor.server.engine.*
+import io.ktor.server.netty.*
+import io.ktor.server.netty.cio.*
+import io.netty.channel.*
+import io.netty.handler.codec.http3.*
+import io.netty.util.*
+import io.netty.util.concurrent.*
+import kotlinx.coroutines.*
+import kotlin.coroutines.*
+
+internal class NettyHttp3Handler(
+    private val enginePipeline: EnginePipeline,
+    private val application: Application,
+    private val callEventGroup: EventExecutorGroup,
+    private val userCoroutineContext: CoroutineContext,
+    runningLimit: Int
+) : Http3RequestStreamInboundHandler(), CoroutineScope {
+    private val handlerJob = SupervisorJob(userCoroutineContext[Job])
+
+    private val state = NettyHttpHandlerState(runningLimit)
+    private lateinit var responseWriter: NettyHttpResponsePipeline
+
+    override val coroutineContext: CoroutineContext
+        get() = handlerJob
+
+    override fun channelActive(context: ChannelHandlerContext) {
+        responseWriter = NettyHttpResponsePipeline(
+            context,
+            state,
+            coroutineContext
+        )
+
+        context.pipeline()?.apply {
+            addLast(callEventGroup, NettyApplicationCallHandler(userCoroutineContext, enginePipeline))
+        }
+        context.fireChannelActive()
+    }
+
+    override fun channelRead(context: ChannelHandlerContext, frame: Http3HeadersFrame) {
+        state.isChannelReadCompleted.compareAndSet(expect = true, update = false)
+        state.activeRequests.incrementAndGet()
+        startHttp3(context, frame.headers())
+    }
+
+    override fun channelRead(context: ChannelHandlerContext, frame: Http3DataFrame) {
+        context.applicationCall?.request?.apply {
+            contentActor.trySend(frame).isSuccess
+        } ?: frame.release()
+    }
+
+    override fun channelInputClosed(context: ChannelHandlerContext) {
+        context.applicationCall?.request?.apply {
+            contentActor.close()
+            state.isCurrentRequestFullyRead.compareAndSet(expect = false, update = true)
+        }
+    }
+
+    override fun channelReadComplete(context: ChannelHandlerContext) {
+        state.isChannelReadCompleted.compareAndSet(expect = false, update = true)
+        responseWriter.flushIfNeeded()
+        context.fireChannelReadComplete()
+    }
+
+    @Suppress("OVERRIDE_DEPRECATION")
+    override fun exceptionCaught(ctx: ChannelHandlerContext, cause: Throwable) {
+        application.log.error("HTTP/3 stream exception", cause)
+        ctx.close()
+    }
+
+    private fun startHttp3(context: ChannelHandlerContext, headers: Http3Headers) {
+        val call = NettyHttp3ApplicationCall(
+            application,
+            context,
+            headers,
+            handlerJob + Dispatchers.Unconfined,
+            userCoroutineContext
+        )
+        context.applicationCall = call
+
+        context.fireChannelRead(call)
+        responseWriter.processResponse(call)
+    }
+
+    companion object {
+        private val ApplicationCallKey = AttributeKey.valueOf<NettyHttp3ApplicationCall>("ktor.Http3ApplicationCall")
+
+        private var ChannelHandlerContext.applicationCall: NettyHttp3ApplicationCall?
+            get() = channel().attr(ApplicationCallKey).get()
+            set(newValue) {
+                channel().attr(ApplicationCallKey).set(newValue)
+            }
+    }
+}

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http3/NettyHttp3Handler.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http3/NettyHttp3Handler.kt
@@ -45,13 +45,21 @@ internal class NettyHttp3Handler(
 
     override fun channelRead(context: ChannelHandlerContext, frame: Http3HeadersFrame) {
         state.isChannelReadCompleted.compareAndSet(expect = true, update = false)
-        state.activeRequests.incrementAndGet()
-        startHttp3(context, frame.headers())
+
+        val existingCall = context.applicationCall
+        if (existingCall == null) {
+            state.activeRequests.incrementAndGet()
+            startHttp3(context, frame.headers())
+        } else {
+            existingCall.request.receiveTrailers(frame.headers())
+        }
     }
 
     override fun channelRead(context: ChannelHandlerContext, frame: Http3DataFrame) {
-        context.applicationCall?.request?.apply {
-            contentActor.trySend(frame).isSuccess
+        context.applicationCall?.request?.let { request ->
+            if (!request.contentActor.trySend(frame).isSuccess) {
+                frame.release()
+            }
         } ?: frame.release()
     }
 

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http3/NettyHttp3Handler.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http3/NettyHttp3Handler.kt
@@ -56,11 +56,10 @@ internal class NettyHttp3Handler(
     }
 
     override fun channelRead(context: ChannelHandlerContext, frame: Http3DataFrame) {
-        context.applicationCall?.request?.let { request ->
-            if (!request.contentActor.trySend(frame).isSuccess) {
-                frame.release()
-            }
-        } ?: frame.release()
+        val request = context.applicationCall?.request
+        if (request == null || !request.contentActor.trySend(frame).isSuccess) {
+            frame.release()
+        }
     }
 
     override fun channelInputClosed(context: ChannelHandlerContext) {

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http3/NettyHttp3Handler.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http3/NettyHttp3Handler.kt
@@ -69,6 +69,11 @@ internal class NettyHttp3Handler(
         }
     }
 
+    override fun channelInactive(context: ChannelHandlerContext) {
+        handlerJob.cancel()
+        context.fireChannelInactive()
+    }
+
     override fun channelReadComplete(context: ChannelHandlerContext) {
         state.isChannelReadCompleted.compareAndSet(expect = false, update = true)
         responseWriter.flushIfNeeded()

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http3/NettyHttp3Handler.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http3/NettyHttp3Handler.kt
@@ -7,18 +7,21 @@ package io.ktor.server.netty.http3
 import io.ktor.server.application.*
 import io.ktor.server.engine.*
 import io.ktor.server.netty.*
+import io.ktor.server.netty.NettyApplicationCallHandler.CallHandlerCoroutineName
 import io.ktor.server.netty.cio.*
-import io.netty.channel.*
-import io.netty.handler.codec.http3.*
-import io.netty.util.*
-import io.netty.util.concurrent.*
+import io.ktor.util.pipeline.*
+import io.netty.channel.ChannelHandlerContext
+import io.netty.handler.codec.http3.Http3DataFrame
+import io.netty.handler.codec.http3.Http3Headers
+import io.netty.handler.codec.http3.Http3HeadersFrame
+import io.netty.handler.codec.http3.Http3RequestStreamInboundHandler
+import io.netty.util.AttributeKey
 import kotlinx.coroutines.*
-import kotlin.coroutines.*
+import kotlin.coroutines.CoroutineContext
 
 internal class NettyHttp3Handler(
     private val enginePipeline: EnginePipeline,
     private val application: Application,
-    private val callEventGroup: EventExecutorGroup,
     private val userCoroutineContext: CoroutineContext,
     runningLimit: Int
 ) : Http3RequestStreamInboundHandler(), CoroutineScope {
@@ -37,9 +40,6 @@ internal class NettyHttp3Handler(
             coroutineContext
         )
 
-        context.pipeline()?.apply {
-            addLast(callEventGroup, NettyApplicationCallHandler(userCoroutineContext, enginePipeline))
-        }
         context.fireChannelActive()
     }
 
@@ -75,24 +75,39 @@ internal class NettyHttp3Handler(
         context.fireChannelReadComplete()
     }
 
-    @Suppress("OVERRIDE_DEPRECATION")
+    @Suppress("OverridingDeprecatedMember")
     override fun exceptionCaught(ctx: ChannelHandlerContext, cause: Throwable) {
         application.log.error("HTTP/3 stream exception", cause)
         ctx.close()
     }
 
     private fun startHttp3(context: ChannelHandlerContext, headers: Http3Headers) {
+        val callJob = Job(parent = userCoroutineContext[Job])
+        val callContext =
+            userCoroutineContext + NettyDispatcher.CurrentContext(context) + callJob + CallHandlerCoroutineName
         val call = NettyHttp3ApplicationCall(
             application,
             context,
             headers,
             handlerJob + Dispatchers.Unconfined,
-            userCoroutineContext
+            callContext
         )
         context.applicationCall = call
 
-        context.fireChannelRead(call)
         responseWriter.processResponse(call)
+
+        context.executor().execute {
+            val callScope = CoroutineScope(context = callContext)
+            callScope.launch(start = CoroutineStart.UNDISPATCHED) {
+                try {
+                    enginePipeline.execute(call)
+                } catch (error: Throwable) {
+                    handleFailure(call, error)
+                } finally {
+                    callJob.complete()
+                }
+            }
+        }
     }
 
     companion object {

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http3/NettyHttp3RequestStreamInitializer.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http3/NettyHttp3RequestStreamInitializer.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2014-2026 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.server.netty.http3
+
+import io.ktor.server.application.*
+import io.ktor.server.engine.*
+import io.netty.channel.*
+import io.netty.handler.codec.quic.*
+import io.netty.util.concurrent.*
+import kotlin.coroutines.*
+
+/**
+ * Initializer for HTTP/3 request streams. Creates a new [NettyHttp3Handler] for each
+ * incoming QUIC stream, since HTTP/3 request stream handlers are not sharable.
+ *
+ * This extends [ChannelInitializer] rather than [io.netty.handler.codec.http3.Http3RequestStreamInitializer]
+ * because [io.netty.handler.codec.http3.Http3ServerConnectionHandler] already sets up the HTTP/3 codec
+ * pipeline in its [io.netty.handler.codec.http3.Http3ServerConnectionHandler.initBidirectionalStream] method.
+ * Using [io.netty.handler.codec.http3.Http3RequestStreamInitializer] would result in duplicate codec handlers.
+ */
+internal class NettyHttp3RequestStreamInitializer(
+    private val enginePipeline: EnginePipeline,
+    private val application: Application,
+    private val callEventGroup: EventExecutorGroup,
+    private val userCoroutineContext: CoroutineContext,
+    private val runningLimit: Int
+) : ChannelInitializer<QuicStreamChannel>() {
+
+    override fun initChannel(ch: QuicStreamChannel) {
+        ch.pipeline().addLast(
+            NettyHttp3Handler(
+                enginePipeline,
+                application,
+                callEventGroup,
+                userCoroutineContext,
+                runningLimit
+            )
+        )
+    }
+}

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http3/NettyHttp3RequestStreamInitializer.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http3/NettyHttp3RequestStreamInitializer.kt
@@ -6,10 +6,9 @@ package io.ktor.server.netty.http3
 
 import io.ktor.server.application.*
 import io.ktor.server.engine.*
-import io.netty.channel.*
-import io.netty.handler.codec.quic.*
-import io.netty.util.concurrent.*
-import kotlin.coroutines.*
+import io.netty.channel.ChannelInitializer
+import io.netty.handler.codec.quic.QuicStreamChannel
+import kotlin.coroutines.CoroutineContext
 
 /**
  * Initializer for HTTP/3 request streams. Creates a new [NettyHttp3Handler] for each
@@ -23,7 +22,6 @@ import kotlin.coroutines.*
 internal class NettyHttp3RequestStreamInitializer(
     private val enginePipeline: EnginePipeline,
     private val application: Application,
-    private val callEventGroup: EventExecutorGroup,
     private val userCoroutineContext: CoroutineContext,
     private val runningLimit: Int
 ) : ChannelInitializer<QuicStreamChannel>() {
@@ -33,7 +31,6 @@ internal class NettyHttp3RequestStreamInitializer(
             NettyHttp3Handler(
                 enginePipeline,
                 application,
-                callEventGroup,
                 userCoroutineContext,
                 runningLimit
             )

--- a/ktor-server/ktor-server-netty/jvm/test/io/ktor/tests/server/netty/HmacQuicTokenHandlerTest.kt
+++ b/ktor-server/ktor-server-netty/jvm/test/io/ktor/tests/server/netty/HmacQuicTokenHandlerTest.kt
@@ -1,0 +1,197 @@
+/*
+ * Copyright 2014-2026 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.tests.server.netty
+
+import io.ktor.server.netty.http3.*
+import io.netty.buffer.*
+import java.net.*
+import kotlin.test.*
+
+class HmacQuicTokenHandlerTest {
+
+    private val handler = HmacQuicTokenHandler()
+
+    @Test
+    fun `writeToken produces token with expected structure`() {
+        val out = Unpooled.buffer()
+        val dcid = Unpooled.wrappedBuffer(ByteArray(8) { it.toByte() })
+        val address = InetSocketAddress(InetAddress.getByName("127.0.0.1"), 12345)
+
+        val result = handler.writeToken(out, dcid, address)
+
+        assertTrue(result, "writeToken should return true")
+        // 8 bytes timestamp + 32 bytes HMAC + 8 bytes dcid
+        assertEquals(48, out.readableBytes())
+
+        out.release()
+        dcid.release()
+    }
+
+    @Test
+    fun `valid token is accepted and returns correct dcid offset`() {
+        val out = Unpooled.buffer()
+        val dcidBytes = ByteArray(8) { it.toByte() }
+        val dcid = Unpooled.wrappedBuffer(dcidBytes)
+        val address = InetSocketAddress(InetAddress.getByName("127.0.0.1"), 12345)
+
+        handler.writeToken(out, dcid, address)
+
+        val offset = handler.validateToken(out, address)
+        // offset should point to where dcid starts (after timestamp + HMAC)
+        assertEquals(40, offset)
+
+        // Verify dcid bytes are accessible at the returned offset
+        val extractedDcid = ByteArray(out.readableBytes() - offset)
+        out.getBytes(out.readerIndex() + offset, extractedDcid)
+        assertContentEquals(dcidBytes, extractedDcid)
+
+        out.release()
+        dcid.release()
+    }
+
+    @Test
+    fun `token from different address is rejected`() {
+        val out = Unpooled.buffer()
+        val dcid = Unpooled.wrappedBuffer(ByteArray(8) { it.toByte() })
+        val originalAddress = InetSocketAddress(InetAddress.getByName("127.0.0.1"), 12345)
+        val differentAddress = InetSocketAddress(InetAddress.getByName("192.168.1.1"), 12345)
+
+        handler.writeToken(out, dcid, originalAddress)
+
+        val offset = handler.validateToken(out, differentAddress)
+        assertEquals(-1, offset, "Token from different address should be rejected")
+
+        out.release()
+        dcid.release()
+    }
+
+    @Test
+    fun `token from different port is rejected`() {
+        val out = Unpooled.buffer()
+        val dcid = Unpooled.wrappedBuffer(ByteArray(8) { it.toByte() })
+        val originalAddress = InetSocketAddress(InetAddress.getByName("127.0.0.1"), 12345)
+        val differentPort = InetSocketAddress(InetAddress.getByName("127.0.0.1"), 54321)
+
+        handler.writeToken(out, dcid, originalAddress)
+
+        val offset = handler.validateToken(out, differentPort)
+        assertEquals(-1, offset, "Token from different port should be rejected")
+
+        out.release()
+        dcid.release()
+    }
+
+    @Test
+    fun `expired token is rejected`() {
+        val shortLivedHandler = HmacQuicTokenHandler(
+            key = HmacQuicTokenHandler.generateDefaultKey(),
+            tokenLifetimeMillis = 1
+        )
+
+        val out = Unpooled.buffer()
+        val dcid = Unpooled.wrappedBuffer(ByteArray(8) { it.toByte() })
+        val address = InetSocketAddress(InetAddress.getByName("127.0.0.1"), 12345)
+
+        shortLivedHandler.writeToken(out, dcid, address)
+
+        Thread.sleep(10)
+
+        val offset = shortLivedHandler.validateToken(out, address)
+        assertEquals(-1, offset, "Expired token should be rejected")
+
+        out.release()
+        dcid.release()
+    }
+
+    @Test
+    fun `forged token is rejected`() {
+        val out = Unpooled.buffer()
+        val dcid = Unpooled.wrappedBuffer(ByteArray(8) { it.toByte() })
+        val address = InetSocketAddress(InetAddress.getByName("127.0.0.1"), 12345)
+
+        handler.writeToken(out, dcid, address)
+
+        // Corrupt one byte of the HMAC (after the 8-byte timestamp)
+        val hmacStart = out.readerIndex() + 8
+        val original = out.getByte(hmacStart)
+        out.setByte(hmacStart, (original.toInt() xor 0xFF).toByte().toInt())
+
+        val offset = handler.validateToken(out, address)
+        assertEquals(-1, offset, "Forged token should be rejected")
+
+        out.release()
+        dcid.release()
+    }
+
+    @Test
+    fun `truncated token is rejected`() {
+        val token = Unpooled.wrappedBuffer(ByteArray(5))
+        val address = InetSocketAddress(InetAddress.getByName("127.0.0.1"), 12345)
+
+        val offset = handler.validateToken(token, address)
+        assertEquals(-1, offset, "Truncated token should be rejected")
+
+        token.release()
+    }
+
+    @Test
+    fun `token with different key is rejected`() {
+        val handler1 = HmacQuicTokenHandler()
+        val handler2 = HmacQuicTokenHandler()
+
+        val out = Unpooled.buffer()
+        val dcid = Unpooled.wrappedBuffer(ByteArray(8) { it.toByte() })
+        val address = InetSocketAddress(InetAddress.getByName("127.0.0.1"), 12345)
+
+        handler1.writeToken(out, dcid, address)
+
+        val offset = handler2.validateToken(out, address)
+        assertEquals(-1, offset, "Token signed with different key should be rejected")
+
+        out.release()
+        dcid.release()
+    }
+
+    @Test
+    fun `maxTokenLength accounts for max connection id`() {
+        // 8 bytes timestamp + 32 bytes HMAC + MAX_CONN_ID_LEN
+        assertTrue(handler.maxTokenLength() >= 40)
+    }
+
+    @Test
+    fun `valid token with IPv6 address`() {
+        val out = Unpooled.buffer()
+        val dcid = Unpooled.wrappedBuffer(ByteArray(8) { it.toByte() })
+        val address = InetSocketAddress(InetAddress.getByName("::1"), 12345)
+
+        handler.writeToken(out, dcid, address)
+
+        val offset = handler.validateToken(out, address)
+        assertTrue(offset >= 0, "Valid IPv6 token should be accepted")
+
+        out.release()
+        dcid.release()
+    }
+
+    @Test
+    fun `tampered dcid in token is rejected`() {
+        val out = Unpooled.buffer()
+        val dcid = Unpooled.wrappedBuffer(ByteArray(8) { it.toByte() })
+        val address = InetSocketAddress(InetAddress.getByName("127.0.0.1"), 12345)
+
+        handler.writeToken(out, dcid, address)
+
+        // Corrupt a byte in the dcid portion (after timestamp + HMAC)
+        val dcidStart = out.readerIndex() + 40
+        val original = out.getByte(dcidStart)
+        out.setByte(dcidStart, (original.toInt() xor 0xFF).toByte().toInt())
+
+        val offset = handler.validateToken(out, address)
+        assertEquals(-1, offset, "Token with tampered dcid should be rejected")
+
+        out.release()
+        dcid.release()
+    }
+}

--- a/ktor-server/ktor-server-netty/jvm/test/io/ktor/tests/server/netty/HmacQuicTokenHandlerTest.kt
+++ b/ktor-server/ktor-server-netty/jvm/test/io/ktor/tests/server/netty/HmacQuicTokenHandlerTest.kt
@@ -86,7 +86,7 @@ class HmacQuicTokenHandlerTest {
     @Test
     fun `expired token is rejected`() {
         val shortLivedHandler = HmacQuicTokenHandler(
-            key = HmacQuicTokenHandler.generateDefaultKey(),
+            keyGen = HmacQuicTokenHandler::generateDefaultKey,
             tokenLifetimeMillis = 1
         )
 

--- a/ktor-server/ktor-server-netty/jvm/test/io/ktor/tests/server/netty/NettyEngineTest.kt
+++ b/ktor-server/ktor-server-netty/jvm/test/io/ktor/tests/server/netty/NettyEngineTest.kt
@@ -13,6 +13,7 @@ import io.ktor.network.selector.*
 import io.ktor.network.sockets.*
 import io.ktor.server.application.*
 import io.ktor.server.netty.*
+import io.ktor.server.request.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
 import io.ktor.server.test.base.*
@@ -20,13 +21,22 @@ import io.ktor.server.testing.suites.*
 import io.ktor.server.websocket.*
 import io.ktor.utils.io.*
 import io.ktor.websocket.*
+import io.netty.bootstrap.Bootstrap
 import io.netty.buffer.ByteBuf
 import io.netty.buffer.Unpooled
+import io.netty.channel.*
+import io.netty.channel.nio.NioEventLoopGroup
+import io.netty.channel.socket.nio.NioDatagramChannel
 import io.netty.handler.codec.http.HttpResponseStatus
 import io.netty.handler.codec.http2.*
 import io.netty.handler.codec.http2.Http2CodecUtil.readUnsignedInt
+import io.netty.handler.codec.http3.*
+import io.netty.handler.codec.quic.*
 import kotlinx.coroutines.*
 import kotlinx.coroutines.flow.consumeAsFlow
+import java.net.InetSocketAddress
+import java.util.concurrent.LinkedBlockingQueue
+import java.util.concurrent.TimeUnit
 import kotlin.test.Ignore
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -560,6 +570,247 @@ class NettyH2cFlushTest :
         val streamId: Int,
         val payload: ByteArray,
     )
+}
+
+class NettyHttp3Test :
+    EngineTestBase<NettyApplicationEngine, NettyApplicationEngine.Configuration>(Netty) {
+
+    init {
+        enableSsl = true
+    }
+
+    override fun configure(configuration: NettyApplicationEngine.Configuration) {
+        configuration.enableHttp3 = true
+    }
+
+    @Test
+    fun `test HTTP3 simple GET request`() = runTest {
+        createAndStartServer {
+            application.routing {
+                get("/") {
+                    call.respondText("Hello, HTTP/3!")
+                }
+            }
+        }
+
+        withHttp3Client { quicChannel ->
+            val response = sendHttp3Request(quicChannel, "GET", "/")
+            assertEquals("200", response.status)
+            assertEquals("Hello, HTTP/3!", response.body)
+        }
+    }
+
+    @Test
+    fun `test HTTP3 request with query parameters`() = runTest {
+        createAndStartServer {
+            application.routing {
+                get("/greet") {
+                    val name = call.request.queryParameters["name"] ?: "World"
+                    call.respondText("Hello, $name!")
+                }
+            }
+        }
+
+        withHttp3Client { quicChannel ->
+            val response = sendHttp3Request(quicChannel, "GET", "/greet?name=Ktor")
+            assertEquals("200", response.status)
+            assertEquals("Hello, Ktor!", response.body)
+        }
+    }
+
+    @Test
+    fun `test HTTP3 POST request with body`() = runTest {
+        createAndStartServer {
+            application.routing {
+                post("/echo") {
+                    val text = call.receiveText()
+                    call.respondText(text)
+                }
+            }
+        }
+
+        withHttp3Client { quicChannel ->
+            val body = "Hello from HTTP/3 client"
+            val response = sendHttp3Request(quicChannel, "POST", "/echo", body)
+            assertEquals("200", response.status)
+            assertEquals(body, response.body)
+        }
+    }
+
+    @Test
+    fun `test HTTP3 response headers`() = runTest {
+        createAndStartServer {
+            application.routing {
+                get("/headers") {
+                    call.response.headers.append("X-Custom-Header", "custom-value")
+                    call.respondText("ok")
+                }
+            }
+        }
+
+        withHttp3Client { quicChannel ->
+            val response = sendHttp3Request(quicChannel, "GET", "/headers")
+            assertEquals("200", response.status)
+            assertEquals("custom-value", response.headers["x-custom-header"])
+            assertEquals("ok", response.body)
+        }
+    }
+
+    @Test
+    fun `test HTTP3 404 response`() = runTest {
+        createAndStartServer {
+            application.routing {
+                get("/exists") {
+                    call.respondText("found")
+                }
+            }
+        }
+
+        withHttp3Client { quicChannel ->
+            val response = sendHttp3Request(quicChannel, "GET", "/not-found")
+            assertEquals("404", response.status)
+        }
+    }
+
+    @Test
+    fun `test HTTP3 multiple sequential requests on same connection`() = runTest {
+        createAndStartServer {
+            application.routing {
+                get("/count/{n}") {
+                    val n = call.parameters["n"]
+                    call.respondText("Request $n")
+                }
+            }
+        }
+
+        withHttp3Client { quicChannel ->
+            for (i in 1..3) {
+                val response = sendHttp3Request(quicChannel, "GET", "/count/$i")
+                assertEquals("200", response.status)
+                assertEquals("Request $i", response.body)
+            }
+        }
+    }
+
+    private data class Http3Response(
+        val status: String,
+        val headers: Map<String, String>,
+        val body: String
+    )
+
+    private class Http3ResponseHandler : ChannelInboundHandlerAdapter() {
+        val responseQueue = LinkedBlockingQueue<Http3Response>()
+        private var status: String = ""
+        private var headers: MutableMap<String, String> = mutableMapOf()
+        private val bodyParts = mutableListOf<ByteArray>()
+
+        override fun channelRead(ctx: ChannelHandlerContext, msg: Any) {
+            when (msg) {
+                is Http3HeadersFrame -> {
+                    val h = msg.headers()
+                    status = h.status()?.toString() ?: ""
+                    h.forEach { (name, value) ->
+                        val nameStr = name.toString()
+                        if (!nameStr.startsWith(":")) {
+                            headers[nameStr] = value.toString()
+                        }
+                    }
+                }
+
+                is Http3DataFrame -> {
+                    val content = msg.content()
+                    val bytes = ByteArray(content.readableBytes())
+                    content.readBytes(bytes)
+                    bodyParts.add(bytes)
+                    msg.release()
+                }
+
+                else -> {
+                    super.channelRead(ctx, msg)
+                }
+            }
+        }
+
+        override fun channelInactive(ctx: ChannelHandlerContext) {
+            val body = bodyParts.joinToString("") { String(it, Charsets.UTF_8) }
+            responseQueue.offer(Http3Response(status, headers, body))
+            status = ""
+            headers = mutableMapOf()
+            bodyParts.clear()
+            super.channelInactive(ctx)
+        }
+    }
+
+    private suspend fun withHttp3Client(block: suspend (QuicChannel) -> Unit) {
+        val group = NioEventLoopGroup(1)
+        try {
+            val quicSslContext = QuicSslContextBuilder.forClient()
+                .trustManager(io.netty.handler.ssl.util.InsecureTrustManagerFactory.INSTANCE)
+                .applicationProtocols(*Http3.supportedApplicationProtocols())
+                .build()
+
+            val quicClientCodec = Http3.newQuicClientCodecBuilder()
+                .sslContext(quicSslContext)
+                .maxIdleTimeout(30_000, TimeUnit.MILLISECONDS)
+                .initialMaxData(10_000_000)
+                .initialMaxStreamDataBidirectionalLocal(1_000_000)
+                .initialMaxStreamDataBidirectionalRemote(1_000_000)
+                .initialMaxStreamsBidirectional(100)
+                .build()
+
+            val udpChannel = Bootstrap()
+                .group(group)
+                .channel(NioDatagramChannel::class.java)
+                .handler(quicClientCodec)
+                .bind(0)
+                .sync()
+                .channel()
+
+            val quicChannel = QuicChannel.newBootstrap(udpChannel)
+                .handler(Http3ClientConnectionHandler())
+                .remoteAddress(InetSocketAddress("127.0.0.1", sslPort))
+                .connect()
+                .get()
+
+            try {
+                block(quicChannel)
+            } finally {
+                quicChannel.close().sync()
+                udpChannel.close().sync()
+            }
+        } finally {
+            group.shutdownGracefully().sync()
+        }
+    }
+
+    private fun sendHttp3Request(
+        quicChannel: QuicChannel,
+        method: String,
+        path: String,
+        body: String? = null
+    ): Http3Response {
+        val responseHandler = Http3ResponseHandler()
+
+        val stream = Http3.newRequestStream(quicChannel, responseHandler).sync().getNow()
+
+        val headers = DefaultHttp3Headers().apply {
+            method(method)
+            path(path)
+            scheme("https")
+            authority("localhost:$sslPort")
+        }
+        stream.writeAndFlush(DefaultHttp3HeadersFrame(headers)).sync()
+
+        if (body != null) {
+            val buf = Unpooled.copiedBuffer(body, Charsets.UTF_8)
+            stream.writeAndFlush(DefaultHttp3DataFrame(buf)).sync()
+        }
+
+        stream.shutdownOutput().sync()
+
+        return responseHandler.responseQueue.poll(10, TimeUnit.SECONDS)
+            ?: error("Timed out waiting for HTTP/3 response")
+    }
 }
 
 class NettyHttpRequestLifecycleTest :

--- a/ktor-server/ktor-server-netty/jvm/test/io/ktor/tests/server/netty/NettyEngineTest.kt
+++ b/ktor-server/ktor-server-netty/jvm/test/io/ktor/tests/server/netty/NettyEngineTest.kt
@@ -692,6 +692,48 @@ class NettyHttp3Test :
         }
     }
 
+    @Test
+    fun `test HTTP3 POST request with trailers does not break stream`() = runTest {
+        createAndStartServer {
+            application.routing {
+                post("/echo-with-trailers") {
+                    val text = call.receiveText()
+                    call.respondText(text)
+                }
+            }
+        }
+
+        withHttp3Client { quicChannel ->
+            val responseHandler = Http3ResponseHandler()
+            val stream = Http3.newRequestStream(quicChannel, responseHandler).sync().getNow()
+
+            val headers = DefaultHttp3Headers().apply {
+                method("POST")
+                path("/echo-with-trailers")
+                scheme("https")
+                authority("localhost:$sslPort")
+            }
+            stream.writeAndFlush(DefaultHttp3HeadersFrame(headers)).sync()
+
+            val body = "Hello with trailers"
+            val buf = Unpooled.copiedBuffer(body, Charsets.UTF_8)
+            stream.writeAndFlush(DefaultHttp3DataFrame(buf)).sync()
+
+            // Send trailing HEADERS frame (trailers)
+            val trailers = DefaultHttp3Headers().apply {
+                add("x-checksum", "abc123")
+            }
+            stream.writeAndFlush(DefaultHttp3HeadersFrame(trailers)).sync()
+
+            stream.shutdownOutput().sync()
+
+            val response = responseHandler.responseQueue.poll(10, TimeUnit.SECONDS)
+                ?: error("Timed out waiting for HTTP/3 response")
+            assertEquals("200", response.status)
+            assertEquals(body, response.body)
+        }
+    }
+
     private data class Http3Response(
         val status: String,
         val headers: Map<String, String>,

--- a/ktor-server/ktor-server-netty/jvm/test/io/ktor/tests/server/netty/NettyEngineTest.kt
+++ b/ktor-server/ktor-server-netty/jvm/test/io/ktor/tests/server/netty/NettyEngineTest.kt
@@ -579,12 +579,13 @@ class NettyHttp3Test :
         enableSsl = true
     }
 
+    @OptIn(ExperimentalKtorApi::class)
     override fun configure(configuration: NettyApplicationEngine.Configuration) {
-        configuration.enableHttp3 = true
+        configuration.enableHttp3()
     }
 
     @Test
-    fun `test HTTP3 simple GET request`() = runTest {
+    fun `simple GET request`() = runTest {
         createAndStartServer {
             application.routing {
                 get("/") {
@@ -601,7 +602,7 @@ class NettyHttp3Test :
     }
 
     @Test
-    fun `test HTTP3 request with query parameters`() = runTest {
+    fun `request with query parameters`() = runTest {
         createAndStartServer {
             application.routing {
                 get("/greet") {
@@ -619,7 +620,7 @@ class NettyHttp3Test :
     }
 
     @Test
-    fun `test HTTP3 POST request with body`() = runTest {
+    fun `POST request with body`() = runTest {
         createAndStartServer {
             application.routing {
                 post("/echo") {
@@ -638,7 +639,7 @@ class NettyHttp3Test :
     }
 
     @Test
-    fun `test HTTP3 response headers`() = runTest {
+    fun `response headers`() = runTest {
         createAndStartServer {
             application.routing {
                 get("/headers") {
@@ -657,7 +658,7 @@ class NettyHttp3Test :
     }
 
     @Test
-    fun `test HTTP3 404 response`() = runTest {
+    fun `404 response`() = runTest {
         createAndStartServer {
             application.routing {
                 get("/exists") {
@@ -673,7 +674,7 @@ class NettyHttp3Test :
     }
 
     @Test
-    fun `test HTTP3 multiple sequential requests on same connection`() = runTest {
+    fun `multiple sequential requests on same connection`() = runTest {
         createAndStartServer {
             application.routing {
                 get("/count/{n}") {
@@ -693,7 +694,7 @@ class NettyHttp3Test :
     }
 
     @Test
-    fun `test HTTP3 POST request with trailers does not break stream`() = runTest {
+    fun `POST request with trailers does not break stream`() = runTest {
         createAndStartServer {
             application.routing {
                 post("/echo-with-trailers") {

--- a/ktor-server/ktor-server-netty/jvm/test/io/ktor/tests/server/netty/NettyHttp3ApplicationResponseTest.kt
+++ b/ktor-server/ktor-server-netty/jvm/test/io/ktor/tests/server/netty/NettyHttp3ApplicationResponseTest.kt
@@ -1,19 +1,19 @@
 /*
- * Copyright 2014-2025 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2014-2026 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package io.ktor.tests.server.netty
 
 import io.ktor.http.*
 import io.ktor.server.netty.http.*
-import io.netty.handler.codec.http2.*
+import io.netty.handler.codec.http3.*
 import kotlin.test.*
 
-class NettyHttp2ApplicationResponseTest {
+class NettyHttp3ApplicationResponseTest {
 
     @Test
-    fun testAllHeadersSkipPseudoHeaders() {
-        val nettyHeaders = DefaultHttp2Headers()
+    fun `test all headers skip pseudo headers`() {
+        val nettyHeaders = DefaultHttp3Headers()
         val headers = HttpMultiplexedResponseHeaders(nettyHeaders)
         nettyHeaders.status("200")
         headers.append(HttpHeaders.ContentType, "text/plain")
@@ -21,8 +21,8 @@ class NettyHttp2ApplicationResponseTest {
     }
 
     @Test
-    fun testGetHeaderSkipPseudoHeaders() {
-        val nettyHeaders = DefaultHttp2Headers()
+    fun `test get header skip pseudo headers`() {
+        val nettyHeaders = DefaultHttp3Headers()
         val headers = HttpMultiplexedResponseHeaders(nettyHeaders)
         nettyHeaders.status("200")
         headers.append(HttpHeaders.ContentType, "text/plain")
@@ -31,8 +31,8 @@ class NettyHttp2ApplicationResponseTest {
     }
 
     @Test
-    fun testGetHeaderValuesSkipPseudoHeaders() {
-        val nettyHeaders = DefaultHttp2Headers()
+    fun `test get header values skip pseudo headers`() {
+        val nettyHeaders = DefaultHttp3Headers()
         val headers = HttpMultiplexedResponseHeaders(nettyHeaders)
         nettyHeaders.status("200")
         headers.append(HttpHeaders.ContentType, "text/plain")
@@ -41,8 +41,8 @@ class NettyHttp2ApplicationResponseTest {
     }
 
     @Test
-    fun testAppendThrowsOnPseudoHeaders() {
-        val nettyHeaders = DefaultHttp2Headers()
+    fun `test append throws on pseudo headers`() {
+        val nettyHeaders = DefaultHttp3Headers()
         val headers = HttpMultiplexedResponseHeaders(nettyHeaders)
         headers.append(HttpHeaders.ContentType, "text/plain")
         assertFailsWith<IllegalHeaderNameException> { headers.append(":status", "200") }

--- a/ktor-server/ktor-server-netty/jvm/test/io/ktor/tests/server/netty/NettyHttp3LocalConnectionPointTest.kt
+++ b/ktor-server/ktor-server-netty/jvm/test/io/ktor/tests/server/netty/NettyHttp3LocalConnectionPointTest.kt
@@ -164,6 +164,61 @@ class NettyHttp3LocalConnectionPointTest {
         assertEquals(234, point.serverPort)
     }
 
+    @Test
+    fun `test host from IPv6 authority with port`() {
+        val point = point {
+            authority("[::1]:8443")
+        }
+
+        assertEquals("[::1]", point.host)
+        assertEquals(8443, point.port)
+    }
+
+    @Test
+    fun `test host from IPv6 authority without port`() {
+        val point = point {
+            authority("[::1]")
+        }
+
+        assertEquals("[::1]", point.host)
+        assertEquals(80, point.port)
+    }
+
+    @Test
+    fun `test server host and port from IPv6 authority`() {
+        val point = point(
+            remoteAddress = InetSocketAddress("remote", 123),
+            localAddress = InetSocketAddress("local", 234),
+        ) {
+            authority("[::1]:8443")
+        }
+        assertEquals("[::1]", point.serverHost)
+        assertEquals(8443, point.serverPort)
+    }
+
+    @Test
+    fun `test server host and port from IPv6 authority without port`() {
+        val point = point(
+            remoteAddress = InetSocketAddress("remote", 123),
+            localAddress = InetSocketAddress("local", 234),
+        ) {
+            scheme("https")
+            authority("[::1]")
+        }
+        assertEquals("[::1]", point.serverHost)
+        assertEquals(234, point.serverPort)
+    }
+
+    @Test
+    fun `test host from full IPv6 authority with port`() {
+        val point = point {
+            authority("[2001:db8::1]:9090")
+        }
+
+        assertEquals("[2001:db8::1]", point.host)
+        assertEquals(9090, point.port)
+    }
+
     private fun point(
         localAddress: InetSocketAddress? = null,
         remoteAddress: InetSocketAddress? = null,

--- a/ktor-server/ktor-server-netty/jvm/test/io/ktor/tests/server/netty/NettyHttp3LocalConnectionPointTest.kt
+++ b/ktor-server/ktor-server-netty/jvm/test/io/ktor/tests/server/netty/NettyHttp3LocalConnectionPointTest.kt
@@ -1,0 +1,183 @@
+/*
+ * Copyright 2014-2026 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.tests.server.netty
+
+import io.ktor.http.*
+import io.ktor.server.netty.http.*
+import io.netty.handler.codec.http3.*
+import java.net.*
+import kotlin.test.*
+
+@Suppress("DEPRECATION_ERROR")
+class NettyHttp3LocalConnectionPointTest {
+    @Test
+    fun `test method`() {
+        val point = point {
+            method("PUT")
+        }
+
+        assertEquals(HttpMethod.Put, point.method)
+    }
+
+    @Test
+    fun `test version is HTTP 3`() {
+        val point = point {
+            method("PUT")
+        }
+
+        assertEquals("HTTP/3", point.version)
+    }
+
+    @Test
+    fun `test scheme`() {
+        val point = point {
+            scheme("https")
+        }
+
+        assertEquals("https", point.scheme)
+    }
+
+    @Test
+    fun `test scheme missing defaults to http`() {
+        val point = point {
+        }
+
+        assertEquals("http", point.scheme)
+    }
+
+    @Test
+    fun `test port from authority`() {
+        val point = point {
+            authority("host:443")
+        }
+
+        assertEquals(443, point.port)
+    }
+
+    @Test
+    fun `test port unspecified defaults to 80`() {
+        val point = point {
+            authority("host")
+        }
+
+        assertEquals(80, point.port)
+    }
+
+    @Test
+    fun `test host from authority`() {
+        val point = point {
+            authority("host1")
+        }
+
+        assertEquals("host1", point.host)
+    }
+
+    @Test
+    fun `test host with port from authority`() {
+        val point = point {
+            authority("host1:80")
+        }
+
+        assertEquals("host1", point.host)
+    }
+
+    @Test
+    fun `test host missing defaults to localhost`() {
+        val point = point {
+        }
+
+        assertEquals("localhost", point.host)
+    }
+
+    @Test
+    fun `test uri from path`() {
+        val point = point {
+            path("/path/to/resource")
+        }
+
+        assertEquals("/path/to/resource", point.uri)
+    }
+
+    @Test
+    fun `test uri missing defaults to root`() {
+        val point = point {
+        }
+
+        assertEquals("/", point.uri)
+    }
+
+    @Test
+    fun `test remote address`() {
+        val address = InetSocketAddress.createUnresolved("some-host", 8554)
+        val point = point(remoteAddress = address) {
+        }
+
+        assertEquals("some-host", point.remoteHost)
+        assertTrue(address.isUnresolved)
+    }
+
+    @Test
+    fun `test remote address resolved`() {
+        val address = InetSocketAddress(
+            Inet4Address.getByAddress("z", byteArrayOf(192.toByte(), 168.toByte(), 1, 1)),
+            7777
+        )
+        val point = point(remoteAddress = address) {
+        }
+
+        assertEquals("z", point.remoteHost)
+    }
+
+    @Test
+    fun `test local host and port`() {
+        val point = point(
+            remoteAddress = InetSocketAddress("remote", 123),
+            localAddress = InetSocketAddress("local", 234),
+        ) {
+            authority("host1:80")
+        }
+        assertEquals("local", point.localHost)
+        assertEquals(234, point.localPort)
+    }
+
+    @Test
+    fun `test server host and port`() {
+        val point = point(
+            remoteAddress = InetSocketAddress("remote", 123),
+            localAddress = InetSocketAddress("local", 234),
+        ) {
+            authority("host1:81")
+        }
+        assertEquals("host1", point.serverHost)
+        assertEquals(81, point.serverPort)
+    }
+
+    @Test
+    fun `test server host and port no header`() {
+        val point = point(
+            remoteAddress = InetSocketAddress("remote", 123),
+            localAddress = InetSocketAddress("local", 234),
+        ) {}
+        assertEquals("local", point.serverHost)
+        assertEquals(234, point.serverPort)
+    }
+
+    private fun point(
+        localAddress: InetSocketAddress? = null,
+        remoteAddress: InetSocketAddress? = null,
+        block: DefaultHttp3Headers.() -> Unit
+    ): HttpMultiplexedConnectionPoint {
+        val headers = DefaultHttp3Headers().apply(block)
+        return HttpMultiplexedConnectionPoint(
+            pseudoMethod = headers.method(),
+            pseudoScheme = headers.scheme(),
+            pseudoAuthority = headers.authority(),
+            pseudoPath = headers.path(),
+            localNetworkAddress = localAddress,
+            remoteNetworkAddress = remoteAddress,
+            httpVersion = "HTTP/3",
+        )
+    }
+}


### PR DESCRIPTION
**Subsystem**
Server, Netty

**Motivation**
[KTOR-9498](https://youtrack.jetbrains.com/issue/KTOR-9498) Support HTTP/3 for Netty

**Solution**
Introduced HTTP/3 codec with relevant configurations.  It started out as an exploratory session to see how different it would be to the HTTP/2 implementation, then it seemed to be pretty doable.

