### PR TITLE
Fix awaitContent returning true for closed empty channel

### DIFF
--- a/ktor-io/jvm/src/io/ktor/utils/io/jvm/javaio/Reading.kt
+++ b/ktor-io/jvm/src/io/ktor/utils/io/jvm/javaio/Reading.kt
@@ -64,7 +64,10 @@ internal class RawSourceChannel(
         get() = buffer
 
     override suspend fun awaitContent(min: Int): Boolean {
-        if (closedToken != null) return true
+        if (closedToken != null) {
+            closedCause?.let { throw it }
+            return buffer.remaining >= min
+        }
 
         withContext(coroutineContext) {
             var result = 0L

--- a/ktor-io/jvm/test/io/ktor/utils/io/jvm/javaio/RawSourceChannelTest.kt
+++ b/ktor-io/jvm/test/io/ktor/utils/io/jvm/javaio/RawSourceChannelTest.kt
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2014-2025 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.utils.io.jvm.javaio
+
+import io.ktor.utils.io.*
+import kotlinx.coroutines.test.*
+import kotlinx.io.*
+import kotlin.test.*
+
+class RawSourceChannelTest {
+
+    @Test
+    fun `awaitContent returns false when channel is closed with empty buffer`() = runTest {
+        val channel = ByteArray(0).inputStream().toByteReadChannel()
+
+        // First call closes the channel internally (EOF)
+        val firstResult = channel.awaitContent(1)
+        assertFalse(firstResult, "awaitContent should return false on EOF")
+
+        // Second call hits the closedToken != null path
+        val secondResult = channel.awaitContent(1)
+        assertFalse(secondResult, "awaitContent should return false when channel is already closed with empty buffer")
+    }
+
+    @Test
+    fun `awaitContent returns true when channel is closed with data in buffer`() = runTest {
+        val channel = ByteArray(10) { it.toByte() }.inputStream().toByteReadChannel()
+
+        // Request more than available to trigger EOF and close the channel
+        val firstResult = channel.awaitContent(20)
+        assertFalse(firstResult, "awaitContent should return false when not enough data")
+
+        // Channel is now closed, but 10 bytes remain in the buffer
+        val secondResult = channel.awaitContent(1)
+        assertTrue(secondResult, "awaitContent should return true when closed channel still has data in buffer")
+    }
+
+    @Test
+    fun `awaitContent throws when channel is cancelled`() = runTest {
+        val channel = ByteArray(0).inputStream().toByteReadChannel()
+        channel.cancel(IOException("test cancellation"))
+        assertFailsWith<IOException> {
+            channel.awaitContent(1)
+        }
+    }
+}


### PR DESCRIPTION
**Subsystem**
ktor-io

**Motivation**
Fixes #4941. `RawSourceChannel.awaitContent()` returned `true` when closed with empty buffer.