### PR TITLE
KTOR-9497 Preventing a fatal crash in DarwinSession on close

### DIFF
--- a/ktor-client/ktor-client-darwin/darwin/src/io/ktor/client/engine/darwin/internal/DarwinSession.kt
+++ b/ktor-client/ktor-client-darwin/darwin/src/io/ktor/client/engine/darwin/internal/DarwinSession.kt
@@ -9,10 +9,13 @@ import io.ktor.client.request.*
 import io.ktor.utils.io.*
 import io.ktor.utils.io.core.*
 import kotlinx.atomicfu.*
+import kotlinx.atomicfu.locks.SynchronizedObject
+import kotlinx.atomicfu.locks.synchronized
 import kotlinx.cinterop.*
 import kotlinx.coroutines.*
 import platform.Foundation.*
 import kotlin.coroutines.*
+import kotlin.coroutines.cancellation.CancellationException
 
 @OptIn(UnsafeNumber::class)
 internal class DarwinSession(
@@ -20,6 +23,7 @@ internal class DarwinSession(
     requestQueue: NSOperationQueue?
 ) : Closeable {
     private val closed = atomic(false)
+    private val closedLock = SynchronizedObject()
 
     private val sessionAndDelegate = config.sessionAndDelegate ?: createSession(config, requestQueue)
     private val session = sessionAndDelegate.first
@@ -30,11 +34,11 @@ internal class DarwinSession(
         val nativeRequest = request.toNSUrlRequest()
             .apply(config.requestConfig)
         val (task, response) = if (request.isUpgradeRequest()) {
-            val task = session.webSocketTaskWithRequest(nativeRequest)
+            val task = withSession { webSocketTaskWithRequest(nativeRequest) }
             val response = delegate.read(request, task, callContext)
             task to response
         } else {
-            val task = session.dataTaskWithRequest(nativeRequest)
+            val task = withSession { dataTaskWithRequest(nativeRequest) }
             val response = delegate.read(request, callContext, task)
             task to response
         }
@@ -55,9 +59,24 @@ internal class DarwinSession(
         }
     }
 
+    private inline fun <T> withSession(block: NSURLSession.() -> T): T {
+        cancelIfClosed()
+        return synchronized(closedLock) {
+            cancelIfClosed()
+            block(session)
+        }
+    }
+
     override fun close() {
-        if (!closed.compareAndSet(expect = false, update = true)) return
-        session.finishTasksAndInvalidate()
+        if (closed.value) return
+        synchronized(closedLock) {
+            if (!closed.compareAndSet(expect = false, update = true)) return
+            session.finishTasksAndInvalidate()
+        }
+    }
+
+    private fun cancelIfClosed() {
+        if (closed.value) throw CancellationException("Darwin session is closed")
     }
 }
 

--- a/ktor-client/ktor-client-darwin/darwin/src/io/ktor/client/engine/darwin/internal/DarwinSession.kt
+++ b/ktor-client/ktor-client-darwin/darwin/src/io/ktor/client/engine/darwin/internal/DarwinSession.kt
@@ -22,7 +22,7 @@ internal class DarwinSession(
     requestQueue: NSOperationQueue?
 ) : Closeable {
     private val closed = atomic(false)
-    private val closedLock = SynchronizedObject()
+    private val sessionLock = SynchronizedObject()
 
     private val sessionAndDelegate = config.sessionAndDelegate ?: createSession(config, requestQueue)
     private val session = sessionAndDelegate.first
@@ -60,7 +60,7 @@ internal class DarwinSession(
 
     private inline fun <T> withSession(block: NSURLSession.() -> T): T {
         cancelIfClosed()
-        return synchronized(closedLock) {
+        return synchronized(sessionLock) {
             cancelIfClosed()
             block(session)
         }
@@ -68,7 +68,7 @@ internal class DarwinSession(
 
     override fun close() {
         if (closed.value) return
-        synchronized(closedLock) {
+        synchronized(sessionLock) {
             if (!closed.compareAndSet(expect = false, update = true)) return
             session.finishTasksAndInvalidate()
         }

--- a/ktor-client/ktor-client-darwin/darwin/src/io/ktor/client/engine/darwin/internal/DarwinSession.kt
+++ b/ktor-client/ktor-client-darwin/darwin/src/io/ktor/client/engine/darwin/internal/DarwinSession.kt
@@ -15,7 +15,6 @@ import kotlinx.cinterop.*
 import kotlinx.coroutines.*
 import platform.Foundation.*
 import kotlin.coroutines.*
-import kotlin.coroutines.cancellation.CancellationException
 
 @OptIn(UnsafeNumber::class)
 internal class DarwinSession(
@@ -76,7 +75,7 @@ internal class DarwinSession(
     }
 
     private fun cancelIfClosed() {
-        if (closed.value) throw CancellationException("Darwin session is closed")
+        check(!closed.value) { "Darwin session is closed" }
     }
 }
 

--- a/ktor-client/ktor-client-darwin/darwin/test/DarwinEngineTest.kt
+++ b/ktor-client/ktor-client-darwin/darwin/test/DarwinEngineTest.kt
@@ -12,6 +12,7 @@ import io.ktor.client.request.*
 import io.ktor.client.statement.*
 import io.ktor.client.test.base.*
 import io.ktor.http.*
+import io.ktor.utils.io.*
 import io.ktor.websocket.*
 import kotlinx.cinterop.ExperimentalForeignApi
 import kotlinx.cinterop.UnsafeNumber
@@ -273,6 +274,49 @@ class DarwinEngineTest : ClientEngineTest<DarwinClientEngineConfig>(Darwin) {
 
         val thrownException = assertFails { client.get(TEST_SERVER_TLS) }
         assertSame(thrownException, challengeException, "Expected exception to be rethrown")
+    }
+
+    // Issue: KTOR-9497
+    @Test
+    fun testExecuteAfterSessionCloseThrowsCatchableException() = runBlocking {
+        val config = DarwinClientEngineConfig()
+        val session = DarwinSession(config, null)
+        session.close()
+
+        val request = HttpRequestBuilder().apply {
+            url(TEST_SERVER)
+        }.build()
+
+        // Executing on a closed session must throw a catchable Kotlin exception,
+        // not crash with SIGABRT from an NSException on the invalidated NSURLSession
+        assertFailsWith<IllegalStateException> {
+            session.execute(request, coroutineContext)
+        }
+        return@runBlocking
+    }
+
+    // Issue: KTOR-9497
+    @OptIn(InternalAPI::class)
+    @Test
+    fun testWebSocketExecuteAfterSessionCloseThrowsCatchableException() = runBlocking {
+        val config = DarwinClientEngineConfig()
+        val session = DarwinSession(config, null)
+        session.close()
+
+        // ClientUpgradeContent body is needed to trigger the webSocketTaskWithRequest branch
+        // in DarwinSession.execute(), since isUpgradeRequest() checks `body is ClientUpgradeContent`
+        val request = HttpRequestBuilder().apply {
+            url(TEST_WEBSOCKET_SERVER)
+            body = object : ClientUpgradeContent() {
+                override fun verify(headers: Headers) {}
+            }
+        }.build()
+
+        // WebSocket execute on a closed session must throw a catchable Kotlin exception,
+        // not crash with SIGABRT from an NSException on the invalidated NSURLSession
+        assertFailsWith<IllegalStateException> {
+            session.execute(request, coroutineContext)
+        }
     }
 
     private fun stringToNSUrlString(value: String): String {

--- a/ktor-client/ktor-client-darwin/darwin/test/DarwinEngineTest.kt
+++ b/ktor-client/ktor-client-darwin/darwin/test/DarwinEngineTest.kt
@@ -308,7 +308,7 @@ class DarwinEngineTest : ClientEngineTest<DarwinClientEngineConfig>(Darwin) {
         val request = HttpRequestBuilder().apply {
             url(TEST_WEBSOCKET_SERVER)
             body = object : ClientUpgradeContent() {
-                override fun verify(headers: Headers) {}
+                override fun verify(headers: Headers) = Unit
             }
         }.build()
 

--- a/ktor-client/ktor-client-darwin/darwin/test/DarwinEngineTest.kt
+++ b/ktor-client/ktor-client-darwin/darwin/test/DarwinEngineTest.kt
@@ -289,7 +289,7 @@ class DarwinEngineTest : ClientEngineTest<DarwinClientEngineConfig>(Darwin) {
 
         // Executing on a closed session must throw a catchable Kotlin exception,
         // not crash with SIGABRT from an NSException on the invalidated NSURLSession
-        assertFailsWith<IllegalStateException> {
+        assertFailsWith<CancellationException> {
             session.execute(request, coroutineContext)
         }
         return@runBlocking
@@ -314,7 +314,7 @@ class DarwinEngineTest : ClientEngineTest<DarwinClientEngineConfig>(Darwin) {
 
         // WebSocket execute on a closed session must throw a catchable Kotlin exception,
         // not crash with SIGABRT from an NSException on the invalidated NSURLSession
-        assertFailsWith<IllegalStateException> {
+        assertFailsWith<CancellationException> {
             session.execute(request, coroutineContext)
         }
         return@runBlocking

--- a/ktor-client/ktor-client-darwin/darwin/test/DarwinEngineTest.kt
+++ b/ktor-client/ktor-client-darwin/darwin/test/DarwinEngineTest.kt
@@ -317,6 +317,7 @@ class DarwinEngineTest : ClientEngineTest<DarwinClientEngineConfig>(Darwin) {
         assertFailsWith<IllegalStateException> {
             session.execute(request, coroutineContext)
         }
+        return@runBlocking
     }
 
     private fun stringToNSUrlString(value: String): String {

--- a/ktor-client/ktor-client-darwin/darwin/test/DarwinEngineTest.kt
+++ b/ktor-client/ktor-client-darwin/darwin/test/DarwinEngineTest.kt
@@ -289,7 +289,7 @@ class DarwinEngineTest : ClientEngineTest<DarwinClientEngineConfig>(Darwin) {
 
         // Executing on a closed session must throw a catchable Kotlin exception,
         // not crash with SIGABRT from an NSException on the invalidated NSURLSession
-        assertFailsWith<CancellationException> {
+        assertFailsWith<IllegalStateException> {
             session.execute(request, coroutineContext)
         }
         return@runBlocking
@@ -314,7 +314,7 @@ class DarwinEngineTest : ClientEngineTest<DarwinClientEngineConfig>(Darwin) {
 
         // WebSocket execute on a closed session must throw a catchable Kotlin exception,
         // not crash with SIGABRT from an NSException on the invalidated NSURLSession
-        assertFailsWith<CancellationException> {
+        assertFailsWith<IllegalStateException> {
             session.execute(request, coroutineContext)
         }
         return@runBlocking

--- a/ktor-client/ktor-client-darwin/darwin/test/DarwinEngineTest.kt
+++ b/ktor-client/ktor-client-darwin/darwin/test/DarwinEngineTest.kt
@@ -276,7 +276,6 @@ class DarwinEngineTest : ClientEngineTest<DarwinClientEngineConfig>(Darwin) {
         assertSame(thrownException, challengeException, "Expected exception to be rethrown")
     }
 
-    // Issue: KTOR-9497
     @Test
     fun testExecuteAfterSessionCloseThrowsCatchableException() = runBlocking {
         val config = DarwinClientEngineConfig()
@@ -295,7 +294,6 @@ class DarwinEngineTest : ClientEngineTest<DarwinClientEngineConfig>(Darwin) {
         return@runBlocking
     }
 
-    // Issue: KTOR-9497
     @OptIn(InternalAPI::class)
     @Test
     fun testWebSocketExecuteAfterSessionCloseThrowsCatchableException() = runBlocking {


### PR DESCRIPTION
**Subsystem**
Client, ktor-client-darwin

**Motivation**
`DarwinSession.execute()` doesn't check the `closed` flag before calling `NSURLSession.dataTaskWithRequest()` /`webSocketTaskWithRequest()`. When `close()` races with an in-flight `execute()`, the invalidated `NSURLSession` throws an Objective-C `NSException` — which Kotlin/Native cannot catch, resulting in an unconditional `SIGABRT` crash. See [KTOR-9497](https://youtrack.jetbrains.com/issue/KTOR-9497/).

**Solution**
Add reproducer tests for both HTTP and WebSocket code paths that call `DarwinSession.execute()` on an already-closed session, verifying the failure is a catchable Kotlin exception rather than a process crash.