### PR TITLE
Gradle: Light sync mode

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,10 +37,6 @@ The project requires JDK 21.
 Make sure you have it installed before attempting to build the project.
 If you use IntelliJ IDEA, you should also select JDK 21 in **"Project Structure" > "Project" > "SDK"**
 
-Up to 12 GB of free RAM is required to build the project.
-This amount can be reduced by decreasing the `Xmx` value in `gradle.properties`.
-Read the comments in `gradle.properties` for more details.
-
 On macOS, install [Xcode and Xcode Command line tools](https://developer.apple.com/download/) to build Apple targets.
 Launch it and accept the license terms first.
 
@@ -115,9 +111,25 @@ includeBuild("/PATH/TO/KTOR")
 
 #### Importing into IntelliJ IDEA
 
-To import into IntelliJ IDEA, just open up the `Ktor` project folder. IntelliJ IDEA should automatically detect
-that it is a Gradle project and import it. It's important that you make sure that all building and test operations
-are delegated to Gradle under [Gradle Settings](https://www.jetbrains.com/help/idea/gradle-settings.html).
+Open the `Ktor` project folder — IntelliJ IDEA will detect it as a Gradle project and import it automatically.
+Make sure all building and test operations are delegated to Gradle under [Gradle Settings](https://www.jetbrains.com/help/idea/gradle-settings.html).
+
+##### IDE sync mode
+
+By default, IDE sync uses **light mode**, which excludes native targets to reduce memory consumption and sync time.
+This is sufficient for working on JVM or web targets.
+
+When working on native targets in the IDE, enable them via `ktorbuild.syncMode` in `~/.gradle/gradle.properties`:
+
+```properties
+# Include a specific native target alongside JVM/JS
+ktorbuild.syncMode=light+macosArm64
+
+# Include all targets (requires 10 GB of RAM for Gradle Daemon)
+ktorbuild.syncMode=full
+```
+
+See the **Performance** section in `gradle.properties` for all available options and tuning tips.
 
 #### Working with Rust-based Modules Locally
 

--- a/build-logic/src/main/kotlin/ktorbuild.optional.cocoapods.gradle.kts
+++ b/build-logic/src/main/kotlin/ktorbuild.optional.cocoapods.gradle.kts
@@ -9,27 +9,35 @@ import org.gradle.kotlin.dsl.support.serviceOf
 import org.jetbrains.kotlin.konan.target.HostManager
 import java.io.OutputStream
 
-pluginManager.withPlugin("org.jetbrains.kotlin.multiplatform") {
-    val cocoaPodsAvailable = localProperty(COCOAPODS_BIN_PROPERTY).map { true }
-        .orElse(providers.gradleProperty(COCOAPODS_BIN_PROPERTY).map { true })
-        .orElse(providers.of(CocoaPodsAvailableValueSource::class) {})
+plugins {
+    id("ktorbuild.base")
+}
 
-    if (!HostManager.hostIsMac || cocoaPodsAvailable.get()) {
-        apply(plugin = COCOAPODS_PLUGIN_ID)
-    } else @Suppress("UnstableApiUsage") {
-        // Disable Darwin targets if CocoaPods is not available
-        ktorBuild.targets["darwin"] = false
+// Darwin targets might be filtered out if Light Sync mode is active
+if (ktorBuild.targets.hasDarwin) {
+    pluginManager.withPlugin("org.jetbrains.kotlin.multiplatform") {
+        val cocoaPodsAvailable = localProperty(COCOAPODS_BIN_PROPERTY).map { true }
+            .orElse(providers.gradleProperty(COCOAPODS_BIN_PROPERTY).map { true })
+            .orElse(providers.of(CocoaPodsAvailableValueSource::class) {})
 
-        val problemReporter = project.serviceOf<Problems>().reporter
-        problemReporter.reportVisible(
-            KtorBuildProblems.missingCocoaPods,
-            details = "CocoaPods not found.",
-            contextualLabel = "Apple targets won't be added in the project.",
-        ) {
-            solution("Install CocoaPods")
-            solution("Ensure 'pod' command is available in PATH")
-            buildFileLocation()
-            documentedAt("https://github.com/ktorio/ktor/blob/main/CONTRIBUTING.md#building-the-project")
+        if (!HostManager.hostIsMac || cocoaPodsAvailable.get()) {
+            pluginManager.apply(COCOAPODS_PLUGIN_ID)
+        } else @Suppress("UnstableApiUsage") {
+            // Disable Darwin targets if CocoaPods is not available
+            val darwinTargets = KtorTargets.resolveTargets("darwin")
+            ktorBuild.targets.filterTargets { it !in darwinTargets }
+
+            val problemReporter = project.serviceOf<Problems>().reporter
+            problemReporter.reportVisible(
+                KtorBuildProblems.missingCocoaPods,
+                details = "CocoaPods not found.",
+                contextualLabel = "Apple targets won't be added in the project.",
+            ) {
+                solution("Install CocoaPods")
+                solution("Ensure 'pod' command is available in PATH")
+                buildFileLocation()
+                documentedAt("https://github.com/ktorio/ktor/blob/main/CONTRIBUTING.md#building-the-project")
+            }
         }
     }
 }

--- a/build-logic/src/main/kotlin/ktorbuild.publish.gradle.kts
+++ b/build-logic/src/main/kotlin/ktorbuild.publish.gradle.kts
@@ -6,6 +6,10 @@ import com.vanniktech.maven.publish.MavenPublishBaseExtension
 import ktorbuild.*
 import ktorbuild.internal.*
 import ktorbuild.internal.publish.*
+import org.gradle.api.Project
+import org.gradle.api.publish.maven.tasks.AbstractPublishToMaven
+import org.gradle.kotlin.dsl.*
+import org.gradle.plugins.signing.Sign
 
 plugins {
     id("com.vanniktech.maven.publish")
@@ -54,11 +58,14 @@ publishing {
 registerCommonPublishTask()
 
 plugins.withId("ktorbuild.kmp") {
-    tasks.withType<AbstractPublishToMaven>().configureEach {
-        val os = ktorBuild.os.get()
-        // Workaround for https://github.com/gradle/gradle/issues/22641
-        val predicate = provider { isAvailableForPublication(publication.name, os) }
-        onlyIf("Available for publication on $os") { predicate.get() }
+    // Don't allow cross-compilation on CI, but it is okay to use it locally
+    if (ktorBuild.isCI.get()) {
+        tasks.withType<AbstractPublishToMaven>().configureEach {
+            val os = ktorBuild.os.get()
+            // Workaround for https://github.com/gradle/gradle/issues/22641
+            val predicate = provider { isAvailableForPublication(publication.name, os) }
+            onlyIf("Available for publication on $os") { predicate.get() }
+        }
     }
 
     registerTargetsPublishTasks(ktorBuild.targets)

--- a/build-logic/src/main/kotlin/ktorbuild.root.gradle.kts
+++ b/build-logic/src/main/kotlin/ktorbuild.root.gradle.kts
@@ -2,14 +2,16 @@
  * Copyright 2014-2025 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
+import ktorbuild.*
 import ktorbuild.targets.*
-import ktorbuild.wirePackageJsonAggregationTasks
 
 plugins {
     id("ktorbuild.base")
     id("ktorbuild.doctor")
     id("ktorbuild.publish.verifier")
 }
+
+printSyncModeNotice()
 
 wirePackageJsonAggregationTasks()
 

--- a/build-logic/src/main/kotlin/ktorbuild.root.gradle.kts
+++ b/build-logic/src/main/kotlin/ktorbuild.root.gradle.kts
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2014-2025 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+import ktorbuild.targets.*
+import ktorbuild.wirePackageJsonAggregationTasks
+
+plugins {
+    id("ktorbuild.base")
+    id("ktorbuild.doctor")
+    id("ktorbuild.publish.verifier")
+}
+
+wirePackageJsonAggregationTasks()
+
+configureYarn()
+configureNodeJs()

--- a/build-logic/src/main/kotlin/ktorbuild/KtorSyncMode.kt
+++ b/build-logic/src/main/kotlin/ktorbuild/KtorSyncMode.kt
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2014-2026 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package ktorbuild
+
+import ktorbuild.internal.ktorBuild
+import ktorbuild.targets.KtorTargets
+import org.gradle.api.Project
+
+sealed class KtorSyncMode(internal val description: String) {
+    data object Full : KtorSyncMode("All targets")
+
+    /**
+     * The mode used to reduce memory consumption on IDE sync (see KTOR-8505).
+     * Allows specifying extra targets to include in the project model, e.g. `light+iosArm64`
+     */
+    data class Light(
+        val extraTargets: List<String> = emptyList(),
+    ) : KtorSyncMode("Native targets are excluded from the project model") {
+
+        override fun toString(): String =
+            if (extraTargets.isEmpty()) "Light" else "Light + $extraTargets"
+    }
+
+    internal companion object {
+        fun parse(value: String): KtorSyncMode {
+            val (modeName, extra) = value.split("+", limit = 2).let { it[0].lowercase() to it.getOrNull(1) }
+            return when (modeName) {
+                "full" -> Full
+                "light" -> {
+                    val extraTargets = extra.orEmpty()
+                        .split(",")
+                        .map(String::trim)
+                        .filter(String::isNotEmpty)
+                        .flatMap(KtorTargets::resolveTargets)
+                    val nativeTargets = KtorTargets.resolveTargets("posix")
+                    val unknownTargets = extraTargets.filterNot { it in nativeTargets }
+                    check(unknownTargets.isEmpty()) { "Unknown native targets: $unknownTargets" }
+                    Light(extraTargets)
+                }
+
+                else -> throw IllegalArgumentException(
+                    "Unknown sync mode: $value. Expected one of: full, light, light+<target>"
+                )
+            }
+        }
+    }
+}
+
+internal val KtorTargets.isLightSync: Boolean
+    get() = syncMode is KtorSyncMode.Light
+
+internal fun Project.printSyncModeNotice() {
+    val syncMode = ktorBuild.targets.syncMode ?: return
+    if (syncMode == KtorSyncMode.Full) return
+    logger.warn("w: Sync mode: $syncMode. ${syncMode.description}")
+}

--- a/build-logic/src/main/kotlin/ktorbuild/PackageJsonTask.kt
+++ b/build-logic/src/main/kotlin/ktorbuild/PackageJsonTask.kt
@@ -29,7 +29,7 @@ private fun Project.registerPackageJsonAggregationTask(target: String) {
  * This function should be called on the root project.
  * Issue: https://youtrack.jetbrains.com/issue/KT-55701
  */
-fun Project.wirePackageJsonAggregationTasks() {
+internal fun Project.wirePackageJsonAggregationTasks() {
     tasks.named { it == "kotlinPackageJsonUmbrella" }
         .configureEach { dependsOnPackageJsonAggregation("js") }
     tasks.named { it == "kotlinWasmPackageJsonUmbrella" }

--- a/build-logic/src/main/kotlin/ktorbuild/internal/gradle/NamedDomainObjectCollection.kt
+++ b/build-logic/src/main/kotlin/ktorbuild/internal/gradle/NamedDomainObjectCollection.kt
@@ -4,16 +4,19 @@
 
 package ktorbuild.internal.gradle
 
-import org.gradle.api.NamedDomainObjectCollection
-import org.gradle.api.NamedDomainObjectProvider
+import org.gradle.api.Task
+import org.gradle.api.tasks.TaskCollection
+import org.gradle.api.tasks.TaskProvider
 
-internal fun <T : Any> NamedDomainObjectCollection<T>.maybeNamed(name: String): NamedDomainObjectProvider<T>? {
+@Suppress("UNCHECKED_CAST")
+@JvmName("maybeNamedTyped")
+internal fun <T : Task> TaskCollection<Task>.maybeNamed(name: String): TaskProvider<T>? =
+    maybeNamed(name) as? TaskProvider<T>
+
+internal fun TaskCollection<Task>.maybeNamed(name: String): TaskProvider<Task>? {
     return if (name in names) named(name) else null
 }
 
-internal fun <T : Any> NamedDomainObjectCollection<T>.maybeNamed(name: String, configure: T.() -> Unit) {
+internal fun TaskCollection<Task>.maybeNamed(name: String, configure: Task.() -> Unit) {
     if (name in names) named(name).configure(configure)
 }
-
-@Suppress("EXTENSION_SHADOWED_BY_MEMBER")
-internal inline fun <reified T> NamedDomainObjectCollection<*>.findByName(name: String): T? = findByName(name) as? T

--- a/build-logic/src/main/kotlin/ktorbuild/targets/JsConfig.kt
+++ b/build-logic/src/main/kotlin/ktorbuild/targets/JsConfig.kt
@@ -105,8 +105,7 @@ internal fun Project.configureJsTestTasks(target: String) {
     tasks.maybeNamed("${target}BrowserTest") { onlyIf { false } }
 }
 
-fun Project.configureNodeJs() {
-    @Suppress("UnstableApiUsage")
+internal fun Project.configureNodeJs() {
     val nodeVersion = providers.fileContents(layout.settingsDirectory.file(".nvmrc"))
         .asText
         .map { it.trim() }
@@ -120,7 +119,7 @@ private fun BaseNodeJsEnvSpec.configure(nodeVersion: Provider<String>) {
     if (isKtorDevEnvironment) download = false
 }
 
-fun Project.configureYarn() {
+internal fun Project.configureYarn() {
     plugins.withType<YarnPlugin> { the<YarnRootEnvSpec>().configure() }
     plugins.withType<WasmYarnPlugin> { the<WasmYarnRootEnvSpec>().configure() }
 }

--- a/build-logic/src/main/kotlin/ktorbuild/targets/KtorTargets.kt
+++ b/build-logic/src/main/kotlin/ktorbuild/targets/KtorTargets.kt
@@ -7,12 +7,14 @@
 package ktorbuild.targets
 
 import com.android.build.api.dsl.KotlinMultiplatformAndroidLibraryTarget
+import ktorbuild.KtorSyncMode
 import ktorbuild.internal.KotlinHierarchyTracker
 import ktorbuild.internal.KtorBuildProblems
 import ktorbuild.internal.TrackedKotlinHierarchyTemplate
 import ktorbuild.internal.android
 import ktorbuild.internal.gradle.projectGradleProperties
 import ktorbuild.internal.gradle.projectTargetDirectories
+import ktorbuild.isLightSync
 import org.gradle.api.file.ProjectLayout
 import org.gradle.api.problems.ProblemReporter
 import org.gradle.api.problems.Problems
@@ -69,9 +71,26 @@ abstract class KtorTargets @Inject internal constructor(
     private val targetStates: MutableMap<String, Boolean> by lazy {
         loadDefaults(providers.projectGradleProperties(layout, "target.").get())
     }
-    private var targetStatesAccessed: Boolean = false
 
     private val targetDirectories: Provider<Set<String>> = providers.projectTargetDirectories(layout)
+
+    private val isIdeaSync: Provider<Boolean> =
+        providers.systemProperty("idea.sync.active")
+            .map(String::toBoolean)
+            .orElse(false)
+
+    private val syncModeProvider: Provider<KtorSyncMode> = isIdeaSync.flatMap { sync ->
+        if (sync) {
+            providers.gradleProperty("ktorbuild.syncMode")
+                .map(KtorSyncMode::parse)
+                .orElse(KtorSyncMode.Light())
+        } else {
+            null
+        }
+    }
+
+    val syncMode: KtorSyncMode?
+        get() = syncModeProvider.orNull
 
     val hasJvm: Boolean get() = isEnabled("jvm")
     val hasJs: Boolean get() = isEnabled("js")
@@ -85,6 +104,26 @@ abstract class KtorTargets @Inject internal constructor(
     val hasDarwin: Boolean get() = resolveTargets("darwin").any(::isEnabled)
     val hasAndroidNative: Boolean get() = resolveTargets("androidNative").any(::isEnabled)
 
+    private var filter: (String) -> Boolean = defaultFilter
+    private var filterFrozen: Boolean = false
+
+    init {
+        syncMode?.let(::applySyncMode)
+    }
+
+    private fun applySyncMode(syncMode: KtorSyncMode) {
+        if (syncMode !is KtorSyncMode.Light) return
+        val posixTargets = resolveTargets("posix")
+        filter = { it !in posixTargets || it in syncMode.extraTargets }
+
+    }
+
+    /** Applies a filter to the target list. The given [predicate] is combined with the existing filter. */
+    internal fun filterTargets(predicate: (String) -> Boolean) {
+        check(!filterFrozen) { "Can't change filter after targets have been finalized." }
+        filter = { filter(it) && predicate(it) }
+    }
+
     /**
      * Determines if the specified [target] is enabled.
      *
@@ -96,25 +135,16 @@ abstract class KtorTargets @Inject internal constructor(
      * For sub-targets (e.g., 'js.browser'), the state is inherited from the parent target
      * unless explicitly configured in `gradle.properties`.
      */
-    fun isEnabled(target: String): Boolean = targetStates.getOrPut(target) {
-        targetStatesAccessed = true
-
-        // Sub-targets inherit parent state
-        if (target.contains(".")) {
-            isEnabled(target.substringBefore("."))
-        } else {
-            hierarchyTracker.targetSourceSets.getValue(target).any { it in targetDirectories.get() }
+    fun isEnabled(target: String): Boolean {
+        val value = targetStates.getOrPut(target) {
+            // Sub-targets inherit parent state
+            if (target.contains(".")) {
+                isEnabled(target.substringBefore("."))
+            } else {
+                hierarchyTracker.targetSourceSets.getValue(target).any { it in targetDirectories.get() }
+            }
         }
-    }
-
-    /**
-     * Sets the state of the specified [target] to the given [value].
-     *
-     * This function takes effect only if used before first [isEnabled] call.
-     */
-    internal operator fun set(target: String, value: Boolean) {
-        check(!targetStatesAccessed) { "Can't change target state after it has been accessed." }
-        for (sourceSet in resolveTargets(target)) targetStates[sourceSet] = value
+        return if (value) filter(target) else false
     }
 
     private fun loadDefaults(rawDefaults: Map<String, String>): MutableMap<String, Boolean> {
@@ -126,7 +156,12 @@ abstract class KtorTargets @Inject internal constructor(
         return defaults
     }
 
+    internal fun finalize() {
+        filterFrozen = true
+    }
+
     companion object {
+        private val defaultFilter: (String) -> Boolean = { true }
         private val hierarchyTracker = KotlinHierarchyTracker()
 
         @OptIn(ExperimentalKotlinGradlePluginApi::class)
@@ -201,6 +236,9 @@ abstract class KtorTargets @Inject internal constructor(
 }
 
 internal fun KotlinMultiplatformExtension.addTargets(targets: KtorTargets, isCI: Boolean) {
+    targets.finalize()
+    if (targets.isLightSync) targets.ensureTargetsNotEmpty()
+
     if (targets.hasJvm) jvm()
     if (targets.hasAndroidJvm && project.hasAndroidPlugin()) {
         // device tests are not configured on the CI yet
@@ -240,11 +278,18 @@ internal fun KotlinMultiplatformExtension.addTargets(targets: KtorTargets, isCI:
     if (targets.isEnabled("mingwX64")) mingwX64()
     if (targets.isEnabled("watchosDeviceArm64")) watchosDeviceArm64()
 
-    freezeSourceSets()
+    freezeSourceSets(targets.isLightSync)
     flattenSourceSetsStructure()
 }
 
-private const val IGNORE_EXTRA_SOURCE_SETS_PROPERTY = "ktor.ignoreExtraSourceSets"
+/** Registers a JVM target to avoid the case when all targets in the module disabled. */
+context(kotlin: KotlinMultiplatformExtension)
+private fun KtorTargets.ensureTargetsNotEmpty() {
+    val hasNoTargets = KtorTargets.resolveTargets("common").none { isEnabled(it) }
+    if (hasNoTargets) kotlin.jvm()
+}
+
+private const val IGNORE_EXTRA_SOURCE_SETS_PROPERTY = "ktorbuild.ignoreExtraSourceSets"
 
 /**
  * Ensures that no additional source sets have been added after the initial automatic configuration phase.
@@ -252,9 +297,11 @@ private const val IGNORE_EXTRA_SOURCE_SETS_PROPERTY = "ktor.ignoreExtraSourceSet
  * By default, it throws an [IllegalStateException] if extra source sets are detected.
  * When [IGNORE_EXTRA_SOURCE_SETS_PROPERTY] property is set to `true`, extra source sets are ignored instead.
  */
-private fun KotlinMultiplatformExtension.freezeSourceSets() {
+private fun KotlinMultiplatformExtension.freezeSourceSets(isLightSync: Boolean) {
     val problemReporter = project.serviceOf<Problems>().reporter
-    val ignoreExtraSourceSets = project.providers.gradleProperty(IGNORE_EXTRA_SOURCE_SETS_PROPERTY).orNull.toBoolean()
+    val ignoreExtraSourceSets = project.providers.gradleProperty(IGNORE_EXTRA_SOURCE_SETS_PROPERTY)
+        .map(String::toBoolean)
+        .getOrElse(isLightSync)
     val extraSourceSets = mutableSetOf<KotlinSourceSet>()
 
     sourceSets.whenObjectAdded { extraSourceSets.add(this) }

--- a/build-logic/src/main/kotlin/ktorbuild/vcpkg/VcpkgTasks.kt
+++ b/build-logic/src/main/kotlin/ktorbuild/vcpkg/VcpkgTasks.kt
@@ -4,10 +4,10 @@
 
 package ktorbuild.vcpkg
 
+import ktorbuild.internal.gradle.maybeNamed
 import org.gradle.api.Project
 import org.gradle.api.tasks.Sync
 import org.gradle.api.tasks.TaskProvider
-import org.gradle.kotlin.dsl.named
 import org.gradle.kotlin.dsl.register
 import org.jetbrains.kotlin.gradle.targets.native.internal.KotlinNativeDownloadTask
 import org.jetbrains.kotlin.konan.target.KonanTarget
@@ -18,8 +18,11 @@ fun Project.registerVcpkgInstallTask(
     target: KonanTarget,
     configure: VcpkgInstall.() -> Unit = {}
 ): TaskProvider<VcpkgInstall> {
-    val downloadKotlinNative = tasks.named<KotlinNativeDownloadTask>("downloadKotlinNativeDistribution")
+    val downloadKotlinNative = tasks.maybeNamed<KotlinNativeDownloadTask>("downloadKotlinNativeDistribution")
     return tasks.register<VcpkgInstall>("${library}Install") {
+        onlyIf("Kotlin distribution should be available") { downloadKotlinNative != null }
+        if (downloadKotlinNative == null) return@register
+
         install(library, target)
         // Do not configure Toolchain on macOS as Konan uses native tools there
         if (!target.family.isAppleFamily) {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,18 +2,9 @@
  * Copyright 2014-2025 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
-import ktorbuild.targets.*
-import ktorbuild.wirePackageJsonAggregationTasks
-
 plugins {
-    id("ktorbuild.doctor")
-    id("ktorbuild.publish.verifier")
+    id("ktorbuild.root")
 }
 
 logger.lifecycle("Build version: ${project.version}")
 logger.lifecycle("Kotlin version: ${libs.versions.kotlin.get()}")
-
-wirePackageJsonAggregationTasks()
-
-configureYarn()
-configureNodeJs()

--- a/gradle.properties
+++ b/gradle.properties
@@ -12,29 +12,26 @@ group=io.ktor
 
 # JVM arguments used to run Gradle Daemon.
 # Notes:
-# * You can reduce '-Xmx' downto '6g' or even '4g', but this could lead to OOM on project sync in an IDE
-#   while it might be enough for other tasks.
-#   We use 10 GB by default as it is the minimum value giving us reliable IDE sync (see KTOR-8504)
-#   However, '-Xmx' can be reduced to '2g' if `ktorbuild.buildMode` is set to `light` (see below). If reducing
-#   '-Xmx' to such a small value, keep in mind that you should run module-scoped tasks not to get OOM.
-# * '-Dkotlin.daemon.jvm.option' is used for the Kotlin Daemon started by Gradle to compile buildSrc as it ignores
-#   the value from 'kotlin.daemon.jvmargs'
-# * We cannot specify default '-XX:MaxMetaspaceSize' value as it could lead to "OutOfMemory: Metaspace" problems
-#   on running BCV tasks. While it is okay to set this value on CI.
-#   See: https://github.com/Kotlin/binary-compatibility-validator/issues/282
+# * 'Xmx'
+#   Default: 6g — sufficient for most module-scoped builds and IDE sync.
+#   Increase to 10g when using `ktorbuild.syncMode=full` (KTOR-8504).
+#   Can be reduced to 2-4g, but limits you to module-scoped tasks to avoid OOM.
+# * '-Dkotlin.daemon.jvm.option'
+#   Used for the Kotlin Daemon started by Gradle to compile buildSrc as
+#   it ignores the value from 'kotlin.daemon.jvmargs'
+# * '-XX:MaxMetaspaceSize'
+#   Prevents Gradle Daemon from being killed due to unbounded usage of metaspace.
+#   See: https://github.com/gradle/gradle/issues/19750
+#   Use higher value if experiencing "OutOfMemory: Metaspace": 2g-4g
+#   The acceptible maximum depends on the number of Gradle workers that are run in parallel.
+#   The more workers used, the more metaspace memory is consumed.
 #
 # On CI it is recommended to add the following options:
 # * Reduce '-Xmx' as IDE sync is not needed on CI
-# * '-XX:MaxMetaspaceSize=1g'
-#   To prevent Gradle Daemon from being killed due to unbounded usage of metaspace.
-#   See: https://github.com/gradle/gradle/issues/19750
-#   Value '1g' should be enough if you aren't going to run BCV tasks, otherwise use higher value: 2g-4g
-#   The acceptible maximum depends on the number of Gradle workers that are run in parallel. The more workers,
-#   the more metaspace memory is consumed.
 # * '-Dkotlin.daemon.options=autoshutdownIdleSeconds=30'
 #   To save some memory, shutting down Kotlin Daemon used for buildSrc compilation after 30 seconds of idle.
 #   See: https://github.com/gradle/gradle/issues/29331
-org.gradle.jvmargs=-Xms2g -Xmx10g -XX:+HeapDumpOnOutOfMemoryError -XX:+UseParallelGC -Dfile.encoding=UTF-8 -Dkotlin.daemon.jvm.options="-Xmx512m,Xms256m,-XX:MaxMetaspaceSize=256m,XX:+HeapDumpOnOutOfMemoryError" -Dkotlin.daemon.options="autoshutdownIdleSeconds=1800"
+org.gradle.jvmargs=-Xms2g -Xmx6g -XX:MaxMetaspaceSize=1g -XX:+HeapDumpOnOutOfMemoryError -XX:+UseParallelGC -Dfile.encoding=UTF-8 -Dkotlin.daemon.jvm.options="-Xmx512m,Xms256m,-XX:MaxMetaspaceSize=256m,XX:+HeapDumpOnOutOfMemoryError" -Dkotlin.daemon.options="autoshutdownIdleSeconds=1800"
 kotlin.daemon.jvmargs=-Xms512m -Xmx2g -XX:MaxMetaspaceSize=256m -XX:+HeapDumpOnOutOfMemoryError
 kotlin.native.jvmargs=-Xms512m -Xmx2g -XX:MaxMetaspaceSize=256m -XX:+HeapDumpOnOutOfMemoryError
 kotlin.mpp.commonizerJvmArgs=-Xms512m -Xmx2g -XX:MaxMetaspaceSize=256m -XX:+HeapDumpOnOutOfMemoryError

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,7 +14,9 @@ group=io.ktor
 # Notes:
 # * You can reduce '-Xmx' downto '6g' or even '4g', but this could lead to OOM on project sync in an IDE
 #   while it might be enough for other tasks.
-#   We use 9 GB by default as it is the minimum value giving us reliable IDE sync (see KTOR-8504)
+#   We use 10 GB by default as it is the minimum value giving us reliable IDE sync (see KTOR-8504)
+#   However, '-Xmx' can be reduced to '2g' if `ktorbuild.buildMode` is set to `light` (see below). If reducing
+#   '-Xmx' to such a small value, keep in mind that you should run module-scoped tasks not to get OOM.
 # * '-Dkotlin.daemon.jvm.option' is used for the Kotlin Daemon started by Gradle to compile buildSrc as it ignores
 #   the value from 'kotlin.daemon.jvmargs'
 # * We cannot specify default '-XX:MaxMetaspaceSize' value as it could lead to "OutOfMemory: Metaspace" problems
@@ -87,10 +89,18 @@ android.useAndroidX=true
 # To enable `ktor-client-webrtc-rs` module set this to `true`
 ktorbuild.rustCompilation=false
 
+############ Local-only properties ############
 # NOTE: Add these properties to ~/.gradle/gradle.properties if you want to customize them.
+
 # Disable build scans publishing
 #ktor.develocity.skipBuildScans=true
 # A username to be shown in build scans. Set to '<default>' to show the real username.
 #ktor.develocity.username=<default>
 # A hostname to be shown in build scans
 #ktor.develocity.hostname=
+
+# IDE sync mode:
+# - light (default): Excludes native targets from the project model to reduce memory consumption during IDE sync.
+#   Use `light+<target>` to also include a specific native target, e.g. `light+macosArm64`.
+# - full: Includes all targets. Requires increasing 'Xmx' for Gradle Daemon.
+#ktorbuild.syncMode=light+macosArm64

--- a/teamcity.default.properties
+++ b/teamcity.default.properties
@@ -4,4 +4,4 @@
 
 # Should be in sync with org.gradle.jvmargs from gradle.properties
 # We have to duplicate system properties here because of TW-93433 "TeamCity ignores system properties specified in org.gradle.jvmargs"
-env.GRADLE_OPTS=-Xmx6g -Dkotlin.daemon.options="autoshutdownIdleSeconds=30" -Dkotlin.daemon.jvm.options="-Xmx512m,Xms256m,-XX:MaxMetaspaceSize=256m,XX:+HeapDumpOnOutOfMemoryError" -Dorg.gradle.internal.plugins.portal.url.override=https://cache-redirector.jetbrains.com/plugins.gradle.org/m2
+env.GRADLE_OPTS=-Dkotlin.daemon.options="autoshutdownIdleSeconds=30" -Dkotlin.daemon.jvm.options="-Xmx512m,Xms256m,-XX:MaxMetaspaceSize=256m,XX:+HeapDumpOnOutOfMemoryError" -Dorg.gradle.internal.plugins.portal.url.override=https://cache-redirector.jetbrains.com/plugins.gradle.org/m2


### PR DESCRIPTION
**Subsystem**
Infrastructure

**Motivation**
Make it easier for contributors to work on JVM/web-only tasks.

**Solution**
Light sync mode is enabled by default.
When working on native targets, it is possible to include specific targets or use full sync:
```properties
# Light mode with macosArm64 target included
ktorbuild.syncMode=light+macosArm64
# Full mode. Include all targets
ktorbuild.syncMode=full
```

In light mode native targets are ignored so import becomes significantly faster and consumes less memory.

**Hot sync benchmarks:**
<img width="506" height="170" alt="image" src="https://github.com/user-attachments/assets/edff695c-42f7-4403-a1a8-5cbb555721ce" />

_Better to review commit-by-commit_