### PR TITLE
Fix Netty server becoming unavailable when cancelCallOnClose cancels a request

### DIFF
--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyApplicationCallHandler.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyApplicationCallHandler.kt
@@ -50,9 +50,10 @@ internal class NettyApplicationCallHandler(
 
     private fun handleRequest(context: ChannelHandlerContext, call: PipelineCall) {
         val callContext = CallHandlerCoroutineName + NettyDispatcher.CurrentContext(context)
+        val callJob = call.coroutineContext[Job]
 
         currentCall = call
-        currentJob = launch(callContext, start = CoroutineStart.UNDISPATCHED) {
+        currentJob = launch(callContext + (callJob ?: EmptyCoroutineContext), start = CoroutineStart.UNDISPATCHED) {
             when {
                 call is NettyHttp1ApplicationCall && !call.request.isValid() -> {
                     respondError400BadRequest(call)
@@ -65,6 +66,9 @@ internal class NettyApplicationCallHandler(
                         handleFailure(call, error)
                     }
             }
+        }
+        if (callJob is CompletableJob) {
+            currentJob!!.invokeOnCompletion { callJob.complete() }
         }
     }
 

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyApplicationCallHandler.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyApplicationCallHandler.kt
@@ -67,8 +67,8 @@ internal class NettyApplicationCallHandler(
                     }
             }
         }
-        if (callJob is CompletableJob) {
-            currentJob!!.invokeOnCompletion { callJob.complete() }
+        (callJob as? CompletableJob)?.let { job ->
+            currentJob!!.invokeOnCompletion { job.complete() }
         }
     }
 

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http1/NettyHttp1ApplicationCall.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http1/NettyHttp1ApplicationCall.kt
@@ -22,7 +22,7 @@ internal class NettyHttp1ApplicationCall(
     userContext: CoroutineContext,
 ) : NettyApplicationCall(application, context, httpRequest), CoroutineScope {
 
-    override val coroutineContext: CoroutineContext = userContext
+    override val coroutineContext: CoroutineContext = userContext + Job(userContext[Job])
 
     override val request = NettyHttp1ApplicationRequest(
         this,

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http2/NettyHttp2ApplicationCall.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http2/NettyHttp2ApplicationCall.kt
@@ -9,6 +9,7 @@ import io.ktor.server.netty.*
 import io.netty.buffer.*
 import io.netty.channel.*
 import io.netty.handler.codec.http2.*
+import kotlinx.coroutines.*
 import kotlin.coroutines.*
 
 internal class NettyHttp2ApplicationCall(
@@ -20,7 +21,7 @@ internal class NettyHttp2ApplicationCall(
     userContext: CoroutineContext
 ) : NettyApplicationCall(application, context, headers) {
 
-    override val coroutineContext: CoroutineContext = userContext
+    override val coroutineContext: CoroutineContext = userContext + Job(userContext[Job])
 
     override val request = NettyHttp2ApplicationRequest(this, engineContext, context, headers)
     override val response = NettyHttp2ApplicationResponse(this, handler, context, engineContext, userContext)

--- a/ktor-server/ktor-server-test-suites/jvm/src/io/ktor/server/testing/suites/HttpRequestLifecycleTest.kt
+++ b/ktor-server/ktor-server-test-suites/jvm/src/io/ktor/server/testing/suites/HttpRequestLifecycleTest.kt
@@ -126,7 +126,7 @@ abstract class HttpRequestLifecycleTest<TEngine : ApplicationEngine, TConfigurat
     @Test
     fun testServerAvailableAfterClientDisconnection() = runTest {
         val requestStarted = Channel<Unit>(Channel.UNLIMITED)
-        val requestCancelled = CompletableDeferred<Unit>()
+        val requestCancelled = Channel<Unit>(Channel.UNLIMITED)
 
         createAndStartServer {
             install(plugin = HttpRequestLifecycle) {
@@ -140,7 +140,7 @@ abstract class HttpRequestLifecycleTest<TEngine : ApplicationEngine, TConfigurat
                         delay(200.milliseconds)
                     }
                 } catch (_: CancellationException) {
-                    requestCancelled.complete(Unit)
+                    requestCancelled.send(Unit)
                 }
             }
             get("/health") {
@@ -148,28 +148,64 @@ abstract class HttpRequestLifecycleTest<TEngine : ApplicationEngine, TConfigurat
             }
         }
 
-        // Step 1: Make a request and disconnect the client to trigger cancellation
+        // HTTP/1 plain text
         client = createApacheClient()
         client.use {
             val requestJob = launch {
                 runCatching { withHttp1("http://127.0.0.1:$port/slow", port, {}, {}) }
             }
-            withTimeout(10.seconds) {
-                requestStarted.receive()
-            }
+            withTimeout(10.seconds) { requestStarted.receive() }
             requestJob.cancel()
         }
+        withTimeout(10.seconds) { requestCancelled.receive() }
 
-        withTimeout(10.seconds) {
-            requestCancelled.await()
-        }
-
-        // Step 2: Verify the server still accepts new requests
         client = createApacheClient()
         client.use {
             withHttp1("http://127.0.0.1:$port/health", port, {}) {
                 assertEquals(HttpStatusCode.OK, status)
                 assertEquals("OK", bodyAsText())
+            }
+        }
+
+        if (enableSsl) {
+            // HTTP/1 over SSL
+            client = createApacheClient()
+            client.use {
+                val requestJob = launch {
+                    runCatching { withHttp1("https://127.0.0.1:$sslPort/slow", sslPort, {}, {}) }
+                }
+                withTimeout(10.seconds) { requestStarted.receive() }
+                requestJob.cancel()
+            }
+            withTimeout(10.seconds) { requestCancelled.receive() }
+
+            client = createApacheClient()
+            client.use {
+                withHttp1("https://127.0.0.1:$sslPort/health", sslPort, {}) {
+                    assertEquals(HttpStatusCode.OK, status)
+                    assertEquals("OK", bodyAsText())
+                }
+            }
+        }
+
+        if (enableSsl && enableHttp2) {
+            // HTTP/2 over SSL
+            client = createApacheClient()
+            client.use {
+                val requestJob = launch {
+                    runCatching { withHttp2("https://127.0.0.1:$sslPort/slow", sslPort, {}, {}) }
+                }
+                withTimeout(10.seconds) { requestStarted.receive() }
+                requestJob.cancel()
+            }
+            withTimeout(10.seconds) { requestCancelled.receive() }
+
+            client = createApacheClient()
+            client.use {
+                withHttp2("https://127.0.0.1:$sslPort/health", sslPort, {}) {
+                    assertEquals(HttpStatusCode.OK, status)
+                    assertEquals("OK", bodyAsText())
+                }
             }
         }
     }

--- a/ktor-server/ktor-server-test-suites/jvm/src/io/ktor/server/testing/suites/HttpRequestLifecycleTest.kt
+++ b/ktor-server/ktor-server-test-suites/jvm/src/io/ktor/server/testing/suites/HttpRequestLifecycleTest.kt
@@ -124,6 +124,57 @@ abstract class HttpRequestLifecycleTest<TEngine : ApplicationEngine, TConfigurat
     }
 
     @Test
+    fun testServerAvailableAfterClientDisconnection() = runTest {
+        val requestStarted = Channel<Unit>(Channel.UNLIMITED)
+        val requestCancelled = CompletableDeferred<Unit>()
+
+        createAndStartServer {
+            install(plugin = HttpRequestLifecycle) {
+                cancelCallOnClose = true
+            }
+            get("/slow") {
+                requestStarted.send(Unit)
+                try {
+                    repeat(100) {
+                        call.coroutineContext.ensureActive()
+                        delay(200.milliseconds)
+                    }
+                } catch (_: CancellationException) {
+                    requestCancelled.complete(Unit)
+                }
+            }
+            get("/health") {
+                call.respondText("OK")
+            }
+        }
+
+        // Step 1: Make a request and disconnect the client to trigger cancellation
+        client = createApacheClient()
+        client.use {
+            val requestJob = launch {
+                runCatching { withHttp1("http://127.0.0.1:$port/slow", port, {}, {}) }
+            }
+            withTimeout(10.seconds) {
+                requestStarted.receive()
+            }
+            requestJob.cancel()
+        }
+
+        withTimeout(10.seconds) {
+            requestCancelled.await()
+        }
+
+        // Step 2: Verify the server still accepts new requests
+        client = createApacheClient()
+        client.use {
+            withHttp1("http://127.0.0.1:$port/health", port, {}) {
+                assertEquals(HttpStatusCode.OK, status)
+                assertEquals("OK", bodyAsText())
+            }
+        }
+    }
+
+    @Test
     fun testHttpRequestLifecycleWithStream() = runTest {
         val requestCompleted = CompletableDeferred<Unit>()
 


### PR DESCRIPTION
**Subsystem**
Server, ktor-server-netty

**Motivation**
Fixes #5516. `HttpRequestLifecycle { cancelCallOnClose = true }` with Netty calls `call.coroutineContext.cancel()` on client disconnect. The call's `coroutineContext` directly contained the application-level `SupervisorJob`, so cancelling it killed the entire server.

**Solution**
Add a per-call `Job` to `NettyHttp1ApplicationCall` and `NettyHttp2ApplicationCall` so that cancellation is scoped to the individual request. Wire the request-handling coroutine as a child of the per-call Job for proper structural cancellation and cleanup.