### PR TITLE
Server bearer auth. Set principal with provider name

### DIFF
--- a/ktor-server/ktor-server-plugins/ktor-server-auth/common/src/io/ktor/server/auth/BearerAuth.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-auth/common/src/io/ktor/server/auth/BearerAuth.kt
@@ -45,7 +45,7 @@ public class BearerAuthenticationProvider internal constructor(config: Config) :
                 return
             }
 
-        context.principal(principal)
+        context.principal(name, principal)
     }
 
     /**

--- a/ktor-server/ktor-server-plugins/ktor-server-auth/common/test/io/ktor/tests/auth/BearerAuthTest.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-auth/common/test/io/ktor/tests/auth/BearerAuthTest.kt
@@ -156,6 +156,32 @@ class BearerAuthTest {
         assertEquals("", response.bodyAsText())
     }
 
+    @Test
+    fun `principal is retrievable by provider name`() = testApplication {
+        val providerName = "my-bearer"
+        install(Authentication) {
+            bearer(providerName) {
+                authenticate { UserIdPrincipal("admin") }
+            }
+        }
+
+        routing {
+            authenticate(providerName) {
+                get("/") {
+                    val principal = call.principal<UserIdPrincipal>(providerName)
+                    call.respondText(principal?.name ?: "missing")
+                }
+            }
+        }
+
+        val response = client.get("/") {
+            withToken("any-token")
+        }
+
+        assertEquals(HttpStatusCode.OK, response.status)
+        assertEquals("admin", response.bodyAsText())
+    }
+
     private fun HttpRequestBuilder.withToken(token: String) {
         header(HttpHeaders.Authorization, "${AuthScheme.Bearer} $token")
     }


### PR DESCRIPTION
**Subsystem**
Server auth

**Motivation**
All other providers set the principal specifying the provider name
Found this during new typesafe DSL testing