### PR TITLE
KTOR-8364 Increase withTimeout in Darwin engine tests from 1s to 30s

### DIFF
--- a/ktor-client/ktor-client-darwin-legacy/darwin/test/DarwinLegacyEngineTest.kt
+++ b/ktor-client/ktor-client-darwin-legacy/darwin/test/DarwinLegacyEngineTest.kt
@@ -30,7 +30,7 @@ class DarwinLegacyEngineTest : ClientEngineTest<DarwinLegacyClientEngineConfig>(
         val client = HttpClient(DarwinLegacy)
 
         try {
-            withTimeout(1000) {
+            withTimeout(30.seconds) {
                 val response = client.get(TEST_SERVER)
                 assertEquals("Hello, world!", response.bodyAsText())
             }

--- a/ktor-client/ktor-client-darwin/darwin/test/DarwinEngineTest.kt
+++ b/ktor-client/ktor-client-darwin/darwin/test/DarwinEngineTest.kt
@@ -34,7 +34,7 @@ class DarwinEngineTest : ClientEngineTest<DarwinClientEngineConfig>(Darwin) {
         val client = HttpClient(Darwin)
 
         try {
-            withTimeout(1000) {
+            withTimeout(30.seconds) {
                 val response = client.get(TEST_SERVER)
                 assertEquals("Hello, world!", response.bodyAsText())
             }
@@ -48,7 +48,7 @@ class DarwinEngineTest : ClientEngineTest<DarwinClientEngineConfig>(Darwin) {
         val client = HttpClient(Darwin)
 
         try {
-            withTimeout(1000) {
+            withTimeout(30.seconds) {
                 val response = client.get(TEST_SERVER)
                 assertEquals("Hello, world!", response.bodyAsText())
             }
@@ -62,7 +62,7 @@ class DarwinEngineTest : ClientEngineTest<DarwinClientEngineConfig>(Darwin) {
         val client = HttpClient(Darwin)
 
         try {
-            withTimeout(1000) {
+            withTimeout(30.seconds) {
                 val response = client.get(TEST_SERVER)
                 assertEquals("Hello, world!", response.bodyAsText())
             }


### PR DESCRIPTION
**Subsystem**
Client

**Motivation**
Fixes #5475. Port of #5466 (`release/3.x`) to `main`.

`withTimeout(1000)` (1 second) in Darwin engine tests is too tight for CI under load, causing flaky `TimeoutCancellationException` on macOS Arm64.

**Solution**
Increase timeout to `30.seconds` in `DarwinEngineTest` (3 tests) and `DarwinLegacyEngineTest` (1 test).