### PR TITLE
Add clear API to HttpCache for clearing all cached data

### DIFF
--- a/ktor-client/ktor-client-core/api/ktor-client-core.api
+++ b/ktor-client/ktor-client-core/api/ktor-client-core.api
@@ -633,6 +633,7 @@ public final class io/ktor/client/plugins/api/TransformResponseBodyContext {
 public final class io/ktor/client/plugins/cache/HttpCache {
 	public static final field Companion Lio/ktor/client/plugins/cache/HttpCache$Companion;
 	public synthetic fun <init> (Lio/ktor/client/plugins/cache/storage/HttpCacheStorage;Lio/ktor/client/plugins/cache/storage/HttpCacheStorage;Lio/ktor/client/plugins/cache/storage/CacheStorage;Lio/ktor/client/plugins/cache/storage/CacheStorage;ZZLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun clearAllCaches (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public final class io/ktor/client/plugins/cache/HttpCache$Companion : io/ktor/client/plugins/HttpClientPlugin {
@@ -671,6 +672,7 @@ public final class io/ktor/client/plugins/cache/InvalidCacheStateException : jav
 
 public abstract interface class io/ktor/client/plugins/cache/storage/CacheStorage {
 	public static final field Companion Lio/ktor/client/plugins/cache/storage/CacheStorage$Companion;
+	public fun clear (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun find (Lio/ktor/http/Url;Ljava/util/Map;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun findAll (Lio/ktor/http/Url;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun remove (Lio/ktor/http/Url;Ljava/util/Map;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -681,6 +683,10 @@ public abstract interface class io/ktor/client/plugins/cache/storage/CacheStorag
 public final class io/ktor/client/plugins/cache/storage/CacheStorage$Companion {
 	public final fun getDisabled ()Lio/ktor/client/plugins/cache/storage/CacheStorage;
 	public final fun getUnlimited ()Lkotlin/jvm/functions/Function0;
+}
+
+public final class io/ktor/client/plugins/cache/storage/CacheStorage$DefaultImpls {
+	public static fun clear (Lio/ktor/client/plugins/cache/storage/CacheStorage;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public final class io/ktor/client/plugins/cache/storage/CachedResponseData {

--- a/ktor-client/ktor-client-core/api/ktor-client-core.klib.api
+++ b/ktor-client/ktor-client-core/api/ktor-client-core.klib.api
@@ -65,6 +65,7 @@ abstract interface io.ktor.client.plugins.cache.storage/CacheStorage { // io.kto
     abstract suspend fun remove(io.ktor.http/Url, kotlin.collections/Map<kotlin/String, kotlin/String>) // io.ktor.client.plugins.cache.storage/CacheStorage.remove|remove(io.ktor.http.Url;kotlin.collections.Map<kotlin.String,kotlin.String>){}[0]
     abstract suspend fun removeAll(io.ktor.http/Url) // io.ktor.client.plugins.cache.storage/CacheStorage.removeAll|removeAll(io.ktor.http.Url){}[0]
     abstract suspend fun store(io.ktor.http/Url, io.ktor.client.plugins.cache.storage/CachedResponseData) // io.ktor.client.plugins.cache.storage/CacheStorage.store|store(io.ktor.http.Url;io.ktor.client.plugins.cache.storage.CachedResponseData){}[0]
+    open suspend fun clear() // io.ktor.client.plugins.cache.storage/CacheStorage.clear|clear(){}[0]
 
     final object Companion { // io.ktor.client.plugins.cache.storage/CacheStorage.Companion|null[0]
         final val Disabled // io.ktor.client.plugins.cache.storage/CacheStorage.Companion.Disabled|{}Disabled[0]
@@ -409,6 +410,8 @@ final class io.ktor.client.plugins.cache.storage/CachedResponseData { // io.ktor
 }
 
 final class io.ktor.client.plugins.cache/HttpCache { // io.ktor.client.plugins.cache/HttpCache|null[0]
+    final suspend fun clearAllCaches() // io.ktor.client.plugins.cache/HttpCache.clearAllCaches|clearAllCaches(){}[0]
+
     final class Config { // io.ktor.client.plugins.cache/HttpCache.Config|null[0]
         constructor <init>() // io.ktor.client.plugins.cache/HttpCache.Config.<init>|<init>(){}[0]
 

--- a/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/cache/HttpCache.kt
+++ b/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/cache/HttpCache.kt
@@ -140,10 +140,16 @@ public class HttpCache private constructor(
 
     /**
      * Removes all entries from both public and private cache storages.
+     *
+     * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.client.plugins.cache.HttpCache.clearAllCaches)
      */
     public suspend fun clearAllCaches() {
-        publicStorageNew.clear()
+        check(!useOldStorage) {
+            "clearAllCaches() is not supported with deprecated HttpCacheStorage. " +
+                "Please migrate to the new CacheStorage API."
+        }
         privateStorageNew.clear()
+        publicStorageNew.clear()
     }
 
     public companion object : HttpClientPlugin<Config, HttpCache> {

--- a/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/cache/HttpCache.kt
+++ b/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/cache/HttpCache.kt
@@ -138,6 +138,14 @@ public class HttpCache private constructor(
         }
     }
 
+    /**
+     * Removes all entries from both public and private cache storages.
+     */
+    public suspend fun clearAllCaches() {
+        publicStorageNew.clear()
+        privateStorageNew.clear()
+    }
+
     public companion object : HttpClientPlugin<Config, HttpCache> {
         override val key: AttributeKey<HttpCache> = AttributeKey("HttpCache")
 

--- a/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/cache/HttpCache.kt
+++ b/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/cache/HttpCache.kt
@@ -21,6 +21,7 @@ import io.ktor.util.date.*
 import io.ktor.util.logging.*
 import io.ktor.util.pipeline.*
 import io.ktor.utils.io.*
+import kotlinx.coroutines.CancellationException
 import kotlin.coroutines.CoroutineContext
 
 internal object CacheControl {
@@ -141,6 +142,9 @@ public class HttpCache private constructor(
     /**
      * Removes all entries from both public and private cache storages.
      *
+     * Both storages are always attempted: a failure clearing one does not skip the other.
+     * If both fail, the first failure is thrown with the second attached as a suppressed cause.
+     *
      * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.client.plugins.cache.HttpCache.clearAllCaches)
      */
     public suspend fun clearAllCaches() {
@@ -148,8 +152,22 @@ public class HttpCache private constructor(
             "clearAllCaches() is not supported with deprecated HttpCacheStorage. " +
                 "Please migrate to the new CacheStorage API."
         }
-        privateStorageNew.clear()
-        publicStorageNew.clear()
+        var firstError: Throwable? = null
+        try {
+            privateStorageNew.clear()
+        } catch (cause: CancellationException) {
+            throw cause
+        } catch (cause: Throwable) {
+            firstError = cause
+        }
+        try {
+            publicStorageNew.clear()
+        } catch (cause: CancellationException) {
+            throw cause
+        } catch (cause: Throwable) {
+            if (firstError == null) firstError = cause else firstError.addSuppressed(cause)
+        }
+        firstError?.let { throw it }
     }
 
     public companion object : HttpClientPlugin<Config, HttpCache> {

--- a/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/cache/storage/HttpCacheStorage.kt
+++ b/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/cache/storage/HttpCacheStorage.kt
@@ -113,6 +113,11 @@ public interface CacheStorage {
      */
     public suspend fun removeAll(url: Url)
 
+    /**
+     * Removes all entries from this cache storage.
+     */
+    public suspend fun clear() {}
+
     public companion object {
         /**
          * Default unlimited cache storage.

--- a/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/cache/storage/HttpCacheStorage.kt
+++ b/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/cache/storage/HttpCacheStorage.kt
@@ -115,6 +115,8 @@ public interface CacheStorage {
 
     /**
      * Removes all entries from this cache storage.
+     *
+     * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.client.plugins.cache.storage.CacheStorage.clear)
      */
     public suspend fun clear() {}
 

--- a/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/cache/storage/UnlimitedCacheStorage.kt
+++ b/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/cache/storage/UnlimitedCacheStorage.kt
@@ -60,4 +60,8 @@ internal class UnlimitedStorage : CacheStorage {
     override suspend fun removeAll(url: Url) {
         store.remove(url)
     }
+
+    override suspend fun clear() {
+        store.clear()
+    }
 }

--- a/ktor-client/ktor-client-core/jvm/src/io/ktor/client/plugins/cache/storage/FileCacheStorage.kt
+++ b/ktor-client/ktor-client-core/jvm/src/io/ktor/client/plugins/cache/storage/FileCacheStorage.kt
@@ -92,6 +92,9 @@ private class FileCacheStorage(
     private val mutexes = ConcurrentMap<String, Mutex>()
     private val semaphore = Semaphore(MAX_PERMITS)
 
+    // Serializes concurrent clear() calls so they cannot deadlock by splitting the semaphore permits.
+    private val clearMutex = Mutex()
+
     init {
         directory.mkdirs()
     }
@@ -137,21 +140,23 @@ private class FileCacheStorage(
     }
 
     override suspend fun clear(): Unit = withContext(dispatcher) {
-        var acquired = 0
-        try {
-            repeat(MAX_PERMITS) {
-                semaphore.acquire()
-                acquired++
-            }
-            val files = directory.listFiles() ?: return@withContext
-            for (file in files) {
-                if (!file.delete()) {
-                    LOGGER.trace { "Failed to delete cache file: ${file.name}" }
+        clearMutex.withLock {
+            var acquired = 0
+            try {
+                repeat(MAX_PERMITS) {
+                    semaphore.acquire()
+                    acquired++
                 }
+                val files = directory.listFiles() ?: return@withLock
+                for (file in files) {
+                    if (!file.delete()) {
+                        LOGGER.trace { "Failed to delete cache file: ${file.name}" }
+                    }
+                }
+                mutexes.clear()
+            } finally {
+                repeat(acquired) { semaphore.release() }
             }
-            mutexes.clear()
-        } finally {
-            repeat(acquired) { semaphore.release() }
         }
     }
 

--- a/ktor-client/ktor-client-core/jvm/src/io/ktor/client/plugins/cache/storage/FileCacheStorage.kt
+++ b/ktor-client/ktor-client-core/jvm/src/io/ktor/client/plugins/cache/storage/FileCacheStorage.kt
@@ -15,7 +15,9 @@ import io.ktor.utils.io.CancellationException
 import io.ktor.utils.io.jvm.javaio.*
 import kotlinx.coroutines.*
 import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.Semaphore
 import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.sync.withPermit
 import java.io.File
 import java.security.MessageDigest
 
@@ -38,40 +40,41 @@ internal class CachingCacheStorage(
 ) : CacheStorage {
 
     private val store = ConcurrentMap<Url, Set<CachedResponseData>>()
+    private val mutex = Mutex()
 
-    override suspend fun store(url: Url, data: CachedResponseData) {
+    override suspend fun store(url: Url, data: CachedResponseData): Unit = mutex.withLock {
         delegate.store(url, data)
         store[url] = delegate.findAll(url)
     }
 
-    override suspend fun find(url: Url, varyKeys: Map<String, String>): CachedResponseData? {
+    override suspend fun find(url: Url, varyKeys: Map<String, String>): CachedResponseData? = mutex.withLock {
         if (!store.containsKey(url)) {
             store[url] = delegate.findAll(url)
         }
         val data = store.getValue(url)
-        return data.find {
+        data.find {
             varyKeys.all { (key, value) -> it.varyKeys[key] == value }
         }
     }
 
-    override suspend fun findAll(url: Url): Set<CachedResponseData> {
+    override suspend fun findAll(url: Url): Set<CachedResponseData> = mutex.withLock {
         if (!store.containsKey(url)) {
             store[url] = delegate.findAll(url)
         }
-        return store.getValue(url)
+        store.getValue(url)
     }
 
-    override suspend fun remove(url: Url, varyKeys: Map<String, String>) {
+    override suspend fun remove(url: Url, varyKeys: Map<String, String>): Unit = mutex.withLock {
         delegate.remove(url, varyKeys)
         store[url] = delegate.findAll(url)
     }
 
-    override suspend fun removeAll(url: Url) {
+    override suspend fun removeAll(url: Url): Unit = mutex.withLock {
         delegate.removeAll(url)
         store.remove(url)
     }
 
-    override suspend fun clear() {
+    override suspend fun clear(): Unit = mutex.withLock {
         delegate.clear()
         store.clear()
     }
@@ -82,52 +85,74 @@ private class FileCacheStorage(
     private val dispatcher: CoroutineDispatcher = Dispatchers.IO
 ) : CacheStorage {
 
+    private companion object {
+        private const val MAX_PERMITS = 1000
+    }
+
     private val mutexes = ConcurrentMap<String, Mutex>()
+    private val semaphore = Semaphore(MAX_PERMITS)
 
     init {
         directory.mkdirs()
     }
 
     override suspend fun store(url: Url, data: CachedResponseData): Unit = withContext(dispatcher) {
-        val urlHex = key(url)
-        updateCache(urlHex) { caches ->
-            caches.filterNot { it.varyKeys == data.varyKeys } + data
+        semaphore.withPermit {
+            val urlHex = key(url)
+            updateCache(urlHex) { caches ->
+                caches.filterNot { it.varyKeys == data.varyKeys } + data
+            }
         }
     }
 
     override suspend fun findAll(url: Url): Set<CachedResponseData> = withContext(dispatcher) {
-        readCache(key(url)).toSet()
+        semaphore.withPermit {
+            readCache(key(url)).toSet()
+        }
     }
 
     override suspend fun find(url: Url, varyKeys: Map<String, String>): CachedResponseData? = withContext(dispatcher) {
-        val data = readCache(key(url))
-        data.find {
-            varyKeys.all { (key, value) -> it.varyKeys[key] == value }
+        semaphore.withPermit {
+            val data = readCache(key(url))
+            data.find {
+                varyKeys.all { (key, value) -> it.varyKeys[key] == value }
+            }
         }
     }
 
     override suspend fun remove(url: Url, varyKeys: Map<String, String>) = withContext(dispatcher) {
-        val urlHex = key(url)
-        updateCache(urlHex) { caches ->
-            caches.filterNot { it.varyKeys == varyKeys }
+        semaphore.withPermit {
+            val urlHex = key(url)
+            updateCache(urlHex) { caches ->
+                caches.filterNot { it.varyKeys == varyKeys }
+            }
         }
     }
 
     override suspend fun removeAll(url: Url) = withContext(dispatcher) {
-        val urlHex = key(url)
-        deleteCache(urlHex)
+        semaphore.withPermit {
+            val urlHex = key(url)
+            deleteCache(urlHex)
+        }
     }
 
     override suspend fun clear(): Unit = withContext(dispatcher) {
-        val files = directory.listFiles() ?: return@withContext
-        for (file in files) {
-            try {
-                file.delete()
-            } catch (cause: Exception) {
-                LOGGER.trace { "Exception during cache deletion in a file: ${cause.stackTraceToString()}" }
+        var acquired = 0
+        try {
+            repeat(MAX_PERMITS) {
+                semaphore.acquire()
+                acquired++
             }
+            val files = directory.listFiles() ?: return@withContext
+            for (file in files) {
+                if (!file.delete()) {
+                    LOGGER.trace { "Failed to delete cache file: ${file.name}" }
+                }
+            }
+            mutexes.clear()
+        } finally {
+            repeat(acquired) { semaphore.release() }
         }
-        mutexes.clear()
     }
 
     private fun key(url: Url) = hex(MessageDigest.getInstance("SHA-256").digest(url.toString().encodeToByteArray()))

--- a/ktor-client/ktor-client-core/jvm/src/io/ktor/client/plugins/cache/storage/FileCacheStorage.kt
+++ b/ktor-client/ktor-client-core/jvm/src/io/ktor/client/plugins/cache/storage/FileCacheStorage.kt
@@ -70,6 +70,11 @@ internal class CachingCacheStorage(
         delegate.removeAll(url)
         store.remove(url)
     }
+
+    override suspend fun clear() {
+        delegate.clear()
+        store.clear()
+    }
 }
 
 private class FileCacheStorage(
@@ -111,6 +116,18 @@ private class FileCacheStorage(
     override suspend fun removeAll(url: Url) = withContext(dispatcher) {
         val urlHex = key(url)
         deleteCache(urlHex)
+    }
+
+    override suspend fun clear(): Unit = withContext(dispatcher) {
+        val files = directory.listFiles() ?: return@withContext
+        for (file in files) {
+            try {
+                file.delete()
+            } catch (cause: Exception) {
+                LOGGER.trace { "Exception during cache deletion in a file: ${cause.stackTraceToString()}" }
+            }
+        }
+        mutexes.clear()
     }
 
     private fun key(url: Url) = hex(MessageDigest.getInstance("SHA-256").digest(url.toString().encodeToByteArray()))

--- a/ktor-client/ktor-client-core/jvm/src/io/ktor/client/plugins/cache/storage/FileCacheStorage.kt
+++ b/ktor-client/ktor-client-core/jvm/src/io/ktor/client/plugins/cache/storage/FileCacheStorage.kt
@@ -13,11 +13,11 @@ import io.ktor.util.logging.*
 import io.ktor.utils.io.*
 import io.ktor.utils.io.CancellationException
 import io.ktor.utils.io.jvm.javaio.*
+import kotlinx.atomicfu.atomic
 import kotlinx.coroutines.*
+import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.sync.Mutex
-import kotlinx.coroutines.sync.Semaphore
 import kotlinx.coroutines.sync.withLock
-import kotlinx.coroutines.sync.withPermit
 import java.io.File
 import java.security.MessageDigest
 
@@ -85,22 +85,20 @@ private class FileCacheStorage(
     private val dispatcher: CoroutineDispatcher = Dispatchers.IO
 ) : CacheStorage {
 
-    private companion object {
-        private const val MAX_PERMITS = 1000
-    }
-
     private val mutexes = ConcurrentMap<String, Mutex>()
-    private val semaphore = Semaphore(MAX_PERMITS)
 
-    // Serializes concurrent clear() calls so they cannot deadlock by splitting the semaphore permits.
-    private val clearMutex = Mutex()
+    // Read/write coordination: clear() holds accessGate for its full duration, so new readers
+    // cannot enter while files are being deleted, and waits for in-flight readers to drain.
+    private val accessGate = Mutex()
+    private val activeReaders = atomic(0)
+    private val readersDrained = Channel<Unit>(Channel.CONFLATED)
 
     init {
         directory.mkdirs()
     }
 
     override suspend fun store(url: Url, data: CachedResponseData): Unit = withContext(dispatcher) {
-        semaphore.withPermit {
+        withReadAccess {
             val urlHex = key(url)
             updateCache(urlHex) { caches ->
                 caches.filterNot { it.varyKeys == data.varyKeys } + data
@@ -109,13 +107,13 @@ private class FileCacheStorage(
     }
 
     override suspend fun findAll(url: Url): Set<CachedResponseData> = withContext(dispatcher) {
-        semaphore.withPermit {
+        withReadAccess {
             readCache(key(url)).toSet()
         }
     }
 
     override suspend fun find(url: Url, varyKeys: Map<String, String>): CachedResponseData? = withContext(dispatcher) {
-        semaphore.withPermit {
+        withReadAccess {
             val data = readCache(key(url))
             data.find {
                 varyKeys.all { (key, value) -> it.varyKeys[key] == value }
@@ -124,7 +122,7 @@ private class FileCacheStorage(
     }
 
     override suspend fun remove(url: Url, varyKeys: Map<String, String>) = withContext(dispatcher) {
-        semaphore.withPermit {
+        withReadAccess {
             val urlHex = key(url)
             updateCache(urlHex) { caches ->
                 caches.filterNot { it.varyKeys == varyKeys }
@@ -133,29 +131,34 @@ private class FileCacheStorage(
     }
 
     override suspend fun removeAll(url: Url) = withContext(dispatcher) {
-        semaphore.withPermit {
+        withReadAccess {
             val urlHex = key(url)
             deleteCache(urlHex)
         }
     }
 
     override suspend fun clear(): Unit = withContext(dispatcher) {
-        clearMutex.withLock {
-            var acquired = 0
-            try {
-                repeat(MAX_PERMITS) {
-                    semaphore.acquire()
-                    acquired++
+        accessGate.withLock {
+            while (activeReaders.value > 0) {
+                readersDrained.receive()
+            }
+            val files = directory.listFiles() ?: return@withLock
+            for (file in files) {
+                if (!file.delete()) {
+                    LOGGER.trace { "Failed to delete cache file: ${file.name}" }
                 }
-                val files = directory.listFiles() ?: return@withLock
-                for (file in files) {
-                    if (!file.delete()) {
-                        LOGGER.trace { "Failed to delete cache file: ${file.name}" }
-                    }
-                }
-                mutexes.clear()
-            } finally {
-                repeat(acquired) { semaphore.release() }
+            }
+            mutexes.clear()
+        }
+    }
+
+    private suspend inline fun <T> withReadAccess(block: () -> T): T {
+        accessGate.withLock { activeReaders.incrementAndGet() }
+        try {
+            return block()
+        } finally {
+            if (activeReaders.decrementAndGet() == 0) {
+                readersDrained.trySend(Unit)
             }
         }
     }

--- a/ktor-client/ktor-client-core/jvm/test/CachingCacheStorageTest.kt
+++ b/ktor-client/ktor-client-core/jvm/test/CachingCacheStorageTest.kt
@@ -101,7 +101,7 @@ class CachingCacheStorageTest {
     }
 
     @Test
-    fun testClearRemovesBothDelegateAndInMemoryCache(): Unit = runBlocking {
+    fun `clear removes both delegate and in-memory cache`(): Unit = runBlocking {
         val delegate = InMemoryCacheStorage()
         val storage = CachingCacheStorage(delegate)
 

--- a/ktor-client/ktor-client-core/jvm/test/CachingCacheStorageTest.kt
+++ b/ktor-client/ktor-client-core/jvm/test/CachingCacheStorageTest.kt
@@ -100,6 +100,25 @@ class CachingCacheStorageTest {
         assertEquals(1, delegate.removeAllCalledCount)
     }
 
+    @Test
+    fun testClearRemovesBothDelegateAndInMemoryCache(): Unit = runBlocking {
+        val delegate = InMemoryCacheStorage()
+        val storage = CachingCacheStorage(delegate)
+
+        storage.store(Url("http://example.com"), data())
+        storage.store(Url("http://example.com"), data(mapOf("key" to "value")))
+        storage.store(Url("http://other.com"), data())
+
+        assertEquals(2, storage.findAll(Url("http://example.com")).size)
+        assertEquals(1, storage.findAll(Url("http://other.com")).size)
+
+        storage.clear()
+
+        assertEquals(0, storage.findAll(Url("http://example.com")).size)
+        assertEquals(0, storage.findAll(Url("http://other.com")).size)
+        assertEquals(1, delegate.clearCalledCount)
+    }
+
     private fun data(varyKeys: Map<String, String> = emptyMap()) = CachedResponseData(
         Url("http://example.com"),
         HttpStatusCode.OK,
@@ -120,6 +139,7 @@ private class InMemoryCacheStorage : CacheStorage {
     var findAllCalledCount = 0
     var removeCalledCount = 0
     var removeAllCalledCount = 0
+    var clearCalledCount = 0
 
     override suspend fun store(url: Url, data: CachedResponseData) {
         val cache = store.computeIfAbsent(url) { mutableSetOf() }
@@ -150,5 +170,10 @@ private class InMemoryCacheStorage : CacheStorage {
     override suspend fun removeAll(url: Url) {
         removeAllCalledCount++
         store.remove(url)
+    }
+
+    override suspend fun clear() {
+        clearCalledCount++
+        store.clear()
     }
 }

--- a/ktor-client/ktor-client-core/jvm/test/FileStorageTest.kt
+++ b/ktor-client/ktor-client-core/jvm/test/FileStorageTest.kt
@@ -81,6 +81,22 @@ class FileStorageTest {
         assertEquals(0, storage.findAll(Url("http://example.com")).size)
     }
 
+    @Test
+    fun testClear() = runTest {
+        val storage = FileStorage(tempDirectory)
+        storage.store(Url("http://example.com"), data())
+        storage.store(Url("http://example.com"), data(mapOf("key" to "value")))
+        storage.store(Url("http://other.com"), data())
+
+        assertEquals(2, storage.findAll(Url("http://example.com")).size)
+        assertEquals(1, storage.findAll(Url("http://other.com")).size)
+
+        storage.clear()
+
+        assertEquals(0, storage.findAll(Url("http://example.com")).size)
+        assertEquals(0, storage.findAll(Url("http://other.com")).size)
+    }
+
     private fun data(varyKeys: Map<String, String> = emptyMap()) = CachedResponseData(
         Url("http://example.com"),
         HttpStatusCode.OK,

--- a/ktor-client/ktor-client-core/jvm/test/FileStorageTest.kt
+++ b/ktor-client/ktor-client-core/jvm/test/FileStorageTest.kt
@@ -82,7 +82,7 @@ class FileStorageTest {
     }
 
     @Test
-    fun testClear() = runTest {
+    fun `clear removes entries for all cached URLs`() = runTest {
         val storage = FileStorage(tempDirectory)
         storage.store(Url("http://example.com"), data())
         storage.store(Url("http://example.com"), data(mapOf("key" to "value")))


### PR DESCRIPTION
**Subsystem**
Client, HttpCache

**Motivation**
Fixes #4719. There is no way to clear the HttpCache, including the in-memory layer in `CachingCacheStorage`. Deleting cache files manually still leaves stale in-memory entries.

**Solution**
Add `suspend fun clear()` to `CacheStorage` (default no-op) with overrides in `UnlimitedStorage`, `CachingCacheStorage`, and `FileCacheStorage`. Expose `HttpCache.clearAllCaches()` so callers can do `client.plugin(HttpCache).clearAllCaches()`.