### PR TITLE
KTOR-470 Sessions. Add sendOnlyIfModified option to skip unchanged session resend

### DIFF
--- a/ktor-server/ktor-server-plugins/ktor-server-sessions/api/ktor-server-sessions.api
+++ b/ktor-server/ktor-server-plugins/ktor-server-sessions/api/ktor-server-sessions.api
@@ -128,13 +128,13 @@ public final class io/ktor/server/sessions/SessionNotYetConfiguredException : ja
 }
 
 public final class io/ktor/server/sessions/SessionProvider {
-	public fun <init> (Ljava/lang/String;Lkotlin/reflect/KClass;Lio/ktor/server/sessions/SessionTransport;Lio/ktor/server/sessions/SessionTracker;)V
+	public fun <init> (Ljava/lang/String;Lkotlin/reflect/KClass;Lio/ktor/server/sessions/SessionTransport;Lio/ktor/server/sessions/SessionTracker;Z)V
+	public synthetic fun <init> (Ljava/lang/String;Lkotlin/reflect/KClass;Lio/ktor/server/sessions/SessionTransport;Lio/ktor/server/sessions/SessionTracker;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getName ()Ljava/lang/String;
 	public final fun getSendOnlyIfModified ()Z
 	public final fun getTracker ()Lio/ktor/server/sessions/SessionTracker;
 	public final fun getTransport ()Lio/ktor/server/sessions/SessionTransport;
 	public final fun getType ()Lkotlin/reflect/KClass;
-	public final fun setSendOnlyIfModified (Z)V
 	public fun toString ()Ljava/lang/String;
 }
 

--- a/ktor-server/ktor-server-plugins/ktor-server-sessions/api/ktor-server-sessions.api
+++ b/ktor-server/ktor-server-plugins/ktor-server-sessions/api/ktor-server-sessions.api
@@ -44,10 +44,12 @@ public final class io/ktor/server/sessions/CookieIdSessionBuilder : io/ktor/serv
 public class io/ktor/server/sessions/CookieSessionBuilder {
 	public fun <init> (Lkotlin/reflect/KClass;Lkotlin/reflect/KType;)V
 	public final fun getCookie ()Lio/ktor/server/sessions/CookieConfiguration;
+	public final fun getSendOnlyIfModified ()Z
 	public final fun getSerializer ()Lio/ktor/server/sessions/SessionSerializer;
 	public final fun getTransformers ()Ljava/util/List;
 	public final fun getType ()Lkotlin/reflect/KClass;
 	public final fun getTypeInfo ()Lkotlin/reflect/KType;
+	public final fun setSendOnlyIfModified (Z)V
 	public final fun setSerializer (Lio/ktor/server/sessions/SessionSerializer;)V
 	public final fun transform (Lio/ktor/server/sessions/SessionTransportTransformer;)V
 }
@@ -81,10 +83,12 @@ public final class io/ktor/server/sessions/HeaderIdSessionBuilder : io/ktor/serv
 
 public class io/ktor/server/sessions/HeaderSessionBuilder {
 	public fun <init> (Lkotlin/reflect/KClass;Lkotlin/reflect/KType;)V
+	public final fun getSendOnlyIfModified ()Z
 	public final fun getSerializer ()Lio/ktor/server/sessions/SessionSerializer;
 	public final fun getTransformers ()Ljava/util/List;
 	public final fun getType ()Lkotlin/reflect/KClass;
 	public final fun getTypeInfo ()Lkotlin/reflect/KType;
+	public final fun setSendOnlyIfModified (Z)V
 	public final fun setSerializer (Lio/ktor/server/sessions/SessionSerializer;)V
 	public final fun transform (Lio/ktor/server/sessions/SessionTransportTransformer;)V
 }
@@ -126,9 +130,11 @@ public final class io/ktor/server/sessions/SessionNotYetConfiguredException : ja
 public final class io/ktor/server/sessions/SessionProvider {
 	public fun <init> (Ljava/lang/String;Lkotlin/reflect/KClass;Lio/ktor/server/sessions/SessionTransport;Lio/ktor/server/sessions/SessionTracker;)V
 	public final fun getName ()Ljava/lang/String;
+	public final fun getSendOnlyIfModified ()Z
 	public final fun getTracker ()Lio/ktor/server/sessions/SessionTracker;
 	public final fun getTransport ()Lio/ktor/server/sessions/SessionTransport;
 	public final fun getType ()Lkotlin/reflect/KClass;
+	public final fun setSendOnlyIfModified (Z)V
 	public fun toString ()Ljava/lang/String;
 }
 

--- a/ktor-server/ktor-server-plugins/ktor-server-sessions/api/ktor-server-sessions.klib.api
+++ b/ktor-server/ktor-server-plugins/ktor-server-sessions/api/ktor-server-sessions.klib.api
@@ -87,6 +87,10 @@ final class <#A: kotlin/Any> io.ktor.server.sessions/SessionProvider { // io.kto
     final val type // io.ktor.server.sessions/SessionProvider.type|{}type[0]
         final fun <get-type>(): kotlin.reflect/KClass<#A> // io.ktor.server.sessions/SessionProvider.type.<get-type>|<get-type>(){}[0]
 
+    final var sendOnlyIfModified // io.ktor.server.sessions/SessionProvider.sendOnlyIfModified|{}sendOnlyIfModified[0]
+        final fun <get-sendOnlyIfModified>(): kotlin/Boolean // io.ktor.server.sessions/SessionProvider.sendOnlyIfModified.<get-sendOnlyIfModified>|<get-sendOnlyIfModified>(){}[0]
+        final fun <set-sendOnlyIfModified>(kotlin/Boolean) // io.ktor.server.sessions/SessionProvider.sendOnlyIfModified.<set-sendOnlyIfModified>|<set-sendOnlyIfModified>(kotlin.Boolean){}[0]
+
     final fun toString(): kotlin/String // io.ktor.server.sessions/SessionProvider.toString|toString(){}[0]
 }
 
@@ -231,6 +235,9 @@ open class <#A: kotlin/Any> io.ktor.server.sessions/CookieSessionBuilder { // io
     final val typeInfo // io.ktor.server.sessions/CookieSessionBuilder.typeInfo|{}typeInfo[0]
         final fun <get-typeInfo>(): kotlin.reflect/KType // io.ktor.server.sessions/CookieSessionBuilder.typeInfo.<get-typeInfo>|<get-typeInfo>(){}[0]
 
+    final var sendOnlyIfModified // io.ktor.server.sessions/CookieSessionBuilder.sendOnlyIfModified|{}sendOnlyIfModified[0]
+        final fun <get-sendOnlyIfModified>(): kotlin/Boolean // io.ktor.server.sessions/CookieSessionBuilder.sendOnlyIfModified.<get-sendOnlyIfModified>|<get-sendOnlyIfModified>(){}[0]
+        final fun <set-sendOnlyIfModified>(kotlin/Boolean) // io.ktor.server.sessions/CookieSessionBuilder.sendOnlyIfModified.<set-sendOnlyIfModified>|<set-sendOnlyIfModified>(kotlin.Boolean){}[0]
     final var serializer // io.ktor.server.sessions/CookieSessionBuilder.serializer|{}serializer[0]
         final fun <get-serializer>(): io.ktor.server.sessions/SessionSerializer<#A> // io.ktor.server.sessions/CookieSessionBuilder.serializer.<get-serializer>|<get-serializer>(){}[0]
         final fun <set-serializer>(io.ktor.server.sessions/SessionSerializer<#A>) // io.ktor.server.sessions/CookieSessionBuilder.serializer.<set-serializer>|<set-serializer>(io.ktor.server.sessions.SessionSerializer<1:0>){}[0]
@@ -248,6 +255,9 @@ open class <#A: kotlin/Any> io.ktor.server.sessions/HeaderSessionBuilder { // io
     final val typeInfo // io.ktor.server.sessions/HeaderSessionBuilder.typeInfo|{}typeInfo[0]
         final fun <get-typeInfo>(): kotlin.reflect/KType // io.ktor.server.sessions/HeaderSessionBuilder.typeInfo.<get-typeInfo>|<get-typeInfo>(){}[0]
 
+    final var sendOnlyIfModified // io.ktor.server.sessions/HeaderSessionBuilder.sendOnlyIfModified|{}sendOnlyIfModified[0]
+        final fun <get-sendOnlyIfModified>(): kotlin/Boolean // io.ktor.server.sessions/HeaderSessionBuilder.sendOnlyIfModified.<get-sendOnlyIfModified>|<get-sendOnlyIfModified>(){}[0]
+        final fun <set-sendOnlyIfModified>(kotlin/Boolean) // io.ktor.server.sessions/HeaderSessionBuilder.sendOnlyIfModified.<set-sendOnlyIfModified>|<set-sendOnlyIfModified>(kotlin.Boolean){}[0]
     final var serializer // io.ktor.server.sessions/HeaderSessionBuilder.serializer|{}serializer[0]
         final fun <get-serializer>(): io.ktor.server.sessions/SessionSerializer<#A> // io.ktor.server.sessions/HeaderSessionBuilder.serializer.<get-serializer>|<get-serializer>(){}[0]
         final fun <set-serializer>(io.ktor.server.sessions/SessionSerializer<#A>) // io.ktor.server.sessions/HeaderSessionBuilder.serializer.<set-serializer>|<set-serializer>(io.ktor.server.sessions.SessionSerializer<1:0>){}[0]

--- a/ktor-server/ktor-server-plugins/ktor-server-sessions/api/ktor-server-sessions.klib.api
+++ b/ktor-server/ktor-server-plugins/ktor-server-sessions/api/ktor-server-sessions.klib.api
@@ -76,20 +76,18 @@ final class <#A: kotlin/Any> io.ktor.server.sessions/HeaderIdSessionBuilder : io
 }
 
 final class <#A: kotlin/Any> io.ktor.server.sessions/SessionProvider { // io.ktor.server.sessions/SessionProvider|null[0]
-    constructor <init>(kotlin/String, kotlin.reflect/KClass<#A>, io.ktor.server.sessions/SessionTransport, io.ktor.server.sessions/SessionTracker<#A>) // io.ktor.server.sessions/SessionProvider.<init>|<init>(kotlin.String;kotlin.reflect.KClass<1:0>;io.ktor.server.sessions.SessionTransport;io.ktor.server.sessions.SessionTracker<1:0>){}[0]
+    constructor <init>(kotlin/String, kotlin.reflect/KClass<#A>, io.ktor.server.sessions/SessionTransport, io.ktor.server.sessions/SessionTracker<#A>, kotlin/Boolean = ...) // io.ktor.server.sessions/SessionProvider.<init>|<init>(kotlin.String;kotlin.reflect.KClass<1:0>;io.ktor.server.sessions.SessionTransport;io.ktor.server.sessions.SessionTracker<1:0>;kotlin.Boolean){}[0]
 
     final val name // io.ktor.server.sessions/SessionProvider.name|{}name[0]
         final fun <get-name>(): kotlin/String // io.ktor.server.sessions/SessionProvider.name.<get-name>|<get-name>(){}[0]
+    final val sendOnlyIfModified // io.ktor.server.sessions/SessionProvider.sendOnlyIfModified|{}sendOnlyIfModified[0]
+        final fun <get-sendOnlyIfModified>(): kotlin/Boolean // io.ktor.server.sessions/SessionProvider.sendOnlyIfModified.<get-sendOnlyIfModified>|<get-sendOnlyIfModified>(){}[0]
     final val tracker // io.ktor.server.sessions/SessionProvider.tracker|{}tracker[0]
         final fun <get-tracker>(): io.ktor.server.sessions/SessionTracker<#A> // io.ktor.server.sessions/SessionProvider.tracker.<get-tracker>|<get-tracker>(){}[0]
     final val transport // io.ktor.server.sessions/SessionProvider.transport|{}transport[0]
         final fun <get-transport>(): io.ktor.server.sessions/SessionTransport // io.ktor.server.sessions/SessionProvider.transport.<get-transport>|<get-transport>(){}[0]
     final val type // io.ktor.server.sessions/SessionProvider.type|{}type[0]
         final fun <get-type>(): kotlin.reflect/KClass<#A> // io.ktor.server.sessions/SessionProvider.type.<get-type>|<get-type>(){}[0]
-
-    final var sendOnlyIfModified // io.ktor.server.sessions/SessionProvider.sendOnlyIfModified|{}sendOnlyIfModified[0]
-        final fun <get-sendOnlyIfModified>(): kotlin/Boolean // io.ktor.server.sessions/SessionProvider.sendOnlyIfModified.<get-sendOnlyIfModified>|<get-sendOnlyIfModified>(){}[0]
-        final fun <set-sendOnlyIfModified>(kotlin/Boolean) // io.ktor.server.sessions/SessionProvider.sendOnlyIfModified.<set-sendOnlyIfModified>|<set-sendOnlyIfModified>(kotlin.Boolean){}[0]
 
     final fun toString(): kotlin/String // io.ktor.server.sessions/SessionProvider.toString|toString(){}[0]
 }

--- a/ktor-server/ktor-server-plugins/ktor-server-sessions/common/src/io/ktor/server/sessions/SessionData.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-sessions/common/src/io/ktor/server/sessions/SessionData.kt
@@ -261,6 +261,9 @@ internal suspend fun <S : Any> SessionProviderData<S>.sendSessionData(call: Appl
     val newValue = newValue
     when {
         newValue != null -> {
+            if (provider.sendOnlyIfModified && incoming && newValue == oldValue) {
+                return
+            }
             val wrapped = provider.tracker.store(call, newValue)
             provider.transport.send(call, wrapped)
         }

--- a/ktor-server/ktor-server-plugins/ktor-server-sessions/common/src/io/ktor/server/sessions/SessionData.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-sessions/common/src/io/ktor/server/sessions/SessionData.kt
@@ -261,7 +261,7 @@ internal suspend fun <S : Any> SessionProviderData<S>.sendSessionData(call: Appl
     val newValue = newValue
     when {
         newValue != null -> {
-            if (provider.sendOnlyIfModified && incoming && newValue == oldValue) {
+            if (provider.sendOnlyIfModified && incoming && newValue !== oldValue && newValue == oldValue) {
                 return
             }
             val wrapped = provider.tracker.store(call, newValue)

--- a/ktor-server/ktor-server-plugins/ktor-server-sessions/common/src/io/ktor/server/sessions/SessionProvider.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-sessions/common/src/io/ktor/server/sessions/SessionProvider.kt
@@ -15,7 +15,7 @@ import kotlin.reflect.*
  * @param transport specifies the [SessionTransport] for this provider
  * @param tracker specifies the [SessionTracker] for this provider
  * @param sendOnlyIfModified when set to `true`, session data is not re-sent if unchanged from the incoming value.
- * This avoids unnecessary `Set-Cookie` headers but prevents cookie expiration refresh.
+ * This avoids unnecessary session response headers. For cookie sessions, this also prevents cookie expiration refresh.
  * Session classes should properly implement `equals()` for this to work correctly.
  * Default: `false`.
  * @property name session name
@@ -29,6 +29,7 @@ public class SessionProvider<S : Any>(
     public val sendOnlyIfModified: Boolean = false
 ) {
     override fun toString(): String {
-        return "SessionProvider(name = $name, type = $type, transport = $transport, tracker = $tracker)"
+        return "SessionProvider(name = $name, type = $type, transport = $transport, tracker = $tracker, " +
+            "sendOnlyIfModified = $sendOnlyIfModified)"
     }
 }

--- a/ktor-server/ktor-server-plugins/ktor-server-sessions/common/src/io/ktor/server/sessions/SessionProvider.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-sessions/common/src/io/ktor/server/sessions/SessionProvider.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2014-2026 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package io.ktor.server.sessions
@@ -14,6 +14,10 @@ import kotlin.reflect.*
  *
  * @param transport specifies the [SessionTransport] for this provider
  * @param tracker specifies the [SessionTracker] for this provider
+ * @param sendOnlyIfModified when set to `true`, session data is not re-sent if unchanged from the incoming value.
+ * This avoids unnecessary `Set-Cookie` headers but prevents cookie expiration refresh.
+ * Session classes should properly implement `equals()` for this to work correctly.
+ * Default: `false`.
  * @property name session name
  * @property type session instance type
  */
@@ -21,18 +25,9 @@ public class SessionProvider<S : Any>(
     public val name: String,
     public val type: KClass<S>,
     public val transport: SessionTransport,
-    public val tracker: SessionTracker<S>
+    public val tracker: SessionTracker<S>,
+    public val sendOnlyIfModified: Boolean = false
 ) {
-    /**
-     * When set to `true`, session data is not re-sent if unchanged from the incoming value.
-     * This avoids unnecessary `Set-Cookie` headers but prevents cookie expiration refresh.
-     * Session classes should properly implement `equals()` for this to work correctly.
-     * Default: `false`.
-     *
-     * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.server.sessions.SessionProvider.sendOnlyIfModified)
-     */
-    public var sendOnlyIfModified: Boolean = false
-
     override fun toString(): String {
         return "SessionProvider(name = $name, type = $type, transport = $transport, tracker = $tracker)"
     }

--- a/ktor-server/ktor-server-plugins/ktor-server-sessions/common/src/io/ktor/server/sessions/SessionProvider.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-sessions/common/src/io/ktor/server/sessions/SessionProvider.kt
@@ -23,6 +23,16 @@ public class SessionProvider<S : Any>(
     public val transport: SessionTransport,
     public val tracker: SessionTracker<S>
 ) {
+    /**
+     * When set to `true`, session data is not re-sent if unchanged from the incoming value.
+     * This avoids unnecessary `Set-Cookie` headers but prevents cookie expiration refresh.
+     * Session classes should properly implement `equals()` for this to work correctly.
+     * Default: `false`.
+     *
+     * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.server.sessions.SessionProvider.sendOnlyIfModified)
+     */
+    public var sendOnlyIfModified: Boolean = false
+
     override fun toString(): String {
         return "SessionProvider(name = $name, type = $type, transport = $transport, tracker = $tracker)"
     }

--- a/ktor-server/ktor-server-plugins/ktor-server-sessions/common/src/io/ktor/server/sessions/SessionsBuilder.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-sessions/common/src/io/ktor/server/sessions/SessionsBuilder.kt
@@ -43,8 +43,7 @@ internal fun <S : Any> SessionsConfig.cookie(
 ) {
     val transport = SessionTransportCookie(name, builder.cookie, builder.transformers)
     val tracker = SessionTrackerById(sessionType, builder.serializer, storage, builder::provideSessionId)
-    val provider = SessionProvider(name, sessionType, transport, tracker)
-    provider.sendOnlyIfModified = builder.sendOnlyIfModified
+    val provider = SessionProvider(name, sessionType, transport, tracker, builder.sendOnlyIfModified)
     register(provider)
 }
 
@@ -162,8 +161,7 @@ internal fun <S : Any> SessionsConfig.header(
 
         else -> SessionTrackerByValue(sessionType, builder.serializer)
     }
-    val provider = SessionProvider(name, sessionType, transport, tracker)
-    provider.sendOnlyIfModified = builder.sendOnlyIfModified
+    val provider = SessionProvider(name, sessionType, transport, tracker, builder.sendOnlyIfModified)
     register(provider)
 }
 
@@ -253,8 +251,7 @@ internal fun <S : Any> SessionsConfig.cookie(
 ) {
     val transport = SessionTransportCookie(name, builder.cookie, builder.transformers)
     val tracker = SessionTrackerByValue(sessionType, builder.serializer)
-    val provider = SessionProvider(name, sessionType, transport, tracker)
-    provider.sendOnlyIfModified = builder.sendOnlyIfModified
+    val provider = SessionProvider(name, sessionType, transport, tracker, builder.sendOnlyIfModified)
     register(provider)
 }
 

--- a/ktor-server/ktor-server-plugins/ktor-server-sessions/common/src/io/ktor/server/sessions/SessionsBuilder.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-sessions/common/src/io/ktor/server/sessions/SessionsBuilder.kt
@@ -44,6 +44,7 @@ internal fun <S : Any> SessionsConfig.cookie(
     val transport = SessionTransportCookie(name, builder.cookie, builder.transformers)
     val tracker = SessionTrackerById(sessionType, builder.serializer, storage, builder::provideSessionId)
     val provider = SessionProvider(name, sessionType, transport, tracker)
+    provider.sendOnlyIfModified = builder.sendOnlyIfModified
     register(provider)
 }
 
@@ -162,6 +163,7 @@ internal fun <S : Any> SessionsConfig.header(
         else -> SessionTrackerByValue(sessionType, builder.serializer)
     }
     val provider = SessionProvider(name, sessionType, transport, tracker)
+    provider.sendOnlyIfModified = builder.sendOnlyIfModified
     register(provider)
 }
 
@@ -252,6 +254,7 @@ internal fun <S : Any> SessionsConfig.cookie(
     val transport = SessionTransportCookie(name, builder.cookie, builder.transformers)
     val tracker = SessionTrackerByValue(sessionType, builder.serializer)
     val provider = SessionProvider(name, sessionType, transport, tracker)
+    provider.sendOnlyIfModified = builder.sendOnlyIfModified
     register(provider)
 }
 
@@ -416,6 +419,16 @@ internal constructor(
     }
 
     /**
+     * When set to `true`, session data is not re-sent if unchanged from the incoming value.
+     * This avoids unnecessary `Set-Cookie` headers but prevents cookie expiration refresh.
+     * Session classes should properly implement `equals()` for this to work correctly.
+     * Default: `false`.
+     *
+     * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.server.sessions.CookieSessionBuilder.sendOnlyIfModified)
+     */
+    public var sendOnlyIfModified: Boolean = false
+
+    /**
      * Gets a configuration used to specify additional cookie attributes for [Sessions].
      *
      * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.server.sessions.CookieSessionBuilder.cookie)
@@ -442,6 +455,16 @@ internal constructor(
      * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.server.sessions.HeaderSessionBuilder.serializer)
      */
     public var serializer: SessionSerializer<S> = defaultSessionSerializer(typeInfo)
+
+    /**
+     * When set to `true`, session data is not re-sent if unchanged from the incoming value.
+     * This avoids unnecessary session headers but prevents session expiration refresh.
+     * Session classes should properly implement `equals()` for this to work correctly.
+     * Default: `false`.
+     *
+     * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.server.sessions.HeaderSessionBuilder.sendOnlyIfModified)
+     */
+    public var sendOnlyIfModified: Boolean = false
 
     private val _transformers = mutableListOf<SessionTransportTransformer>()
 

--- a/ktor-server/ktor-server-tests/common/test/io/ktor/tests/server/sessions/SessionTest.kt
+++ b/ktor-server/ktor-server-tests/common/test/io/ktor/tests/server/sessions/SessionTest.kt
@@ -953,6 +953,45 @@ class SessionTest {
         }
     }
 
+    @Test
+    fun `sendOnlyIfModified detects in-place mutation of same instance`() = testApplication {
+        install(Sessions) {
+            cookie<MutableSession>(cookieName) {
+                sendOnlyIfModified = true
+            }
+        }
+
+        routing {
+            get("/set") {
+                call.sessions.set(MutableSession(mutableListOf("a")))
+                call.respondText("ok")
+            }
+            get("/mutate") {
+                val session = call.sessions.get<MutableSession>()!!
+                session.items.add("b")
+                call.sessions.set(session)
+                call.respondText("ok")
+            }
+        }
+
+        // First request: create session
+        val sessionParam = client.get("/set").let { response ->
+            val sessionCookie = response.cookies[cookieName]
+            assertNotNull(sessionCookie, "New session must send Set-Cookie")
+            sessionCookie.value
+        }
+
+        // Second request: mutate in-place and re-set the same instance → must send Set-Cookie
+        client.get("/mutate") {
+            header(HttpHeaders.Cookie, "$cookieName=${sessionParam.encodeURLParameter()}")
+        }.let { response ->
+            assertNotNull(
+                response.cookies[cookieName],
+                "In-place mutated session must send Set-Cookie"
+            )
+        }
+    }
+
     private suspend fun HttpClient.getWithCookie(url: String, cookie: String): HttpResponse =
         get(url) { header(HttpHeaders.Cookie, "$cookieName=$cookie") }
 
@@ -1100,6 +1139,9 @@ data class TestUserSession(val userId: String, val cart: List<String>)
 
 @Serializable
 data class TestUserSessionB(val userId: String, val cart: List<String>)
+
+@Serializable
+data class MutableSession(val items: MutableList<String>)
 
 // Custom serializer should work without kotlinx-serialization
 data class TestUserSessionCustom(val userId: String, val cart: List<String>) {

--- a/ktor-server/ktor-server-tests/common/test/io/ktor/tests/server/sessions/SessionTest.kt
+++ b/ktor-server/ktor-server-tests/common/test/io/ktor/tests/server/sessions/SessionTest.kt
@@ -786,6 +786,173 @@ class SessionTest {
         }
     }
 
+    @Test
+    fun `sendOnlyIfModified cookie session does not resend unchanged value`() = testApplication {
+        install(Sessions) {
+            cookie<TestUserSession>(cookieName) {
+                sendOnlyIfModified = true
+            }
+        }
+
+        routing {
+            get("/set") {
+                call.sessions.set(TestUserSession("id1", listOf("a")))
+                call.respondText("ok")
+            }
+            get("/same") {
+                call.sessions.set(TestUserSession("id1", listOf("a")))
+                call.respondText("ok")
+            }
+            get("/different") {
+                call.sessions.set(TestUserSession("id2", listOf("b")))
+                call.respondText("ok")
+            }
+        }
+
+        // First request: new session → must send Set-Cookie
+        val sessionParam = client.get("/set").let { response ->
+            val sessionCookie = response.cookies[cookieName]
+            assertNotNull(sessionCookie, "New session must send Set-Cookie")
+            sessionCookie.value
+        }
+
+        // Second request: same value → must NOT send Set-Cookie
+        client.get("/same") {
+            header(HttpHeaders.Cookie, "$cookieName=${sessionParam.encodeURLParameter()}")
+        }.let { response ->
+            assertNull(response.cookies[cookieName], "Unchanged session must not resend Set-Cookie")
+        }
+
+        // Third request: different value → must send Set-Cookie
+        client.get("/different") {
+            header(HttpHeaders.Cookie, "$cookieName=${sessionParam.encodeURLParameter()}")
+        }.let { response ->
+            assertNotNull(response.cookies[cookieName], "Changed session must send Set-Cookie")
+        }
+    }
+
+    @Test
+    fun `sendOnlyIfModified default false still resends unchanged session`() = testApplication {
+        install(Sessions) {
+            cookie<TestUserSession>(cookieName)
+        }
+
+        routing {
+            get("/set") {
+                call.sessions.set(TestUserSession("id1", listOf("a")))
+                call.respondText("ok")
+            }
+            get("/same") {
+                call.sessions.set(TestUserSession("id1", listOf("a")))
+                call.respondText("ok")
+            }
+        }
+
+        val sessionParam = client.get("/set").let { response ->
+            val sessionCookie = response.cookies[cookieName]
+            assertNotNull(sessionCookie)
+            sessionCookie.value
+        }
+
+        // Default behavior: resend even if unchanged
+        client.get("/same") {
+            header(HttpHeaders.Cookie, "$cookieName=${sessionParam.encodeURLParameter()}")
+        }.let { response ->
+            assertNotNull(response.cookies[cookieName], "Default must resend Set-Cookie even if unchanged")
+        }
+    }
+
+    @Test
+    fun `sendOnlyIfModified with server storage does not rewrite unchanged session`() = testApplication {
+        val storage = SessionStorageMemory()
+        install(Sessions) {
+            cookie<TestUserSession>(cookieName, storage) {
+                sendOnlyIfModified = true
+            }
+        }
+
+        routing {
+            get("/set") {
+                call.sessions.set(TestUserSession("id1", listOf("a")))
+                call.respondText("ok")
+            }
+            get("/same") {
+                call.sessions.set(TestUserSession("id1", listOf("a")))
+                call.respondText("ok")
+            }
+            get("/different") {
+                call.sessions.set(TestUserSession("id2", listOf("b")))
+                call.respondText("ok")
+            }
+        }
+
+        val sessionId = client.get("/set").let { response ->
+            val sessionCookie = response.cookies[cookieName]
+            assertNotNull(sessionCookie, "New session must send Set-Cookie")
+            sessionCookie.value
+        }
+
+        // Same value → no Set-Cookie
+        client.get("/same") {
+            header(HttpHeaders.Cookie, "$cookieName=$sessionId")
+        }.let { response ->
+            assertNull(response.cookies[cookieName], "Unchanged session must not resend Set-Cookie")
+        }
+
+        // Different value → Set-Cookie
+        client.get("/different") {
+            header(HttpHeaders.Cookie, "$cookieName=$sessionId")
+        }.let { response ->
+            assertNotNull(response.cookies[cookieName], "Changed session must send Set-Cookie")
+        }
+    }
+
+    @Test
+    fun `sendOnlyIfModified header session does not resend unchanged value`() = testApplication {
+        val headerName = "X-Session"
+        install(Sessions) {
+            header<TestUserSession>(headerName) {
+                sendOnlyIfModified = true
+            }
+        }
+
+        routing {
+            get("/set") {
+                call.sessions.set(TestUserSession("id1", listOf("a")))
+                call.respondText("ok")
+            }
+            get("/same") {
+                call.sessions.set(TestUserSession("id1", listOf("a")))
+                call.respondText("ok")
+            }
+            get("/different") {
+                call.sessions.set(TestUserSession("id2", listOf("b")))
+                call.respondText("ok")
+            }
+        }
+
+        // First request: new session → must send header
+        val sessionValue = client.get("/set").let { response ->
+            val header = response.headers[headerName]
+            assertNotNull(header, "New session must send header")
+            header
+        }
+
+        // Same value → no header
+        client.get("/same") {
+            header(headerName, sessionValue)
+        }.let { response ->
+            assertNull(response.headers[headerName], "Unchanged session must not resend header")
+        }
+
+        // Different value → header sent
+        client.get("/different") {
+            header(headerName, sessionValue)
+        }.let { response ->
+            assertNotNull(response.headers[headerName], "Changed session must send header")
+        }
+    }
+
     private suspend fun HttpClient.getWithCookie(url: String, cookie: String): HttpResponse =
         get(url) { header(HttpHeaders.Cookie, "$cookieName=$cookie") }
 


### PR DESCRIPTION
**Subsystem**
Server Sessions

**Motivation**
https://youtrack.jetbrains.com/issue/KTOR-470

Sessions plugin resends `Set-Cookie` on every response even when session data hasn't changed. This wastes bandwidth and prevents caching proxies (e.g. Cloudflare) from caching static assets that share the same response.

**Solution**
Add an opt-in `sendOnlyIfModified` property to `CookieSessionBuilder` and `HeaderSessionBuilder`. When enabled, the plugin compares `newValue` to `oldValue` using structural equality (`equals()`) and skips `Set-Cookie` / header resend if unchanged.

Default is `false` — existing behavior (always resend for cookie expiration refresh) is preserved.

```kotlin
install(Sessions) {
    cookie<MySession>("SESSION") {
        sendOnlyIfModified = true
    }
}
```

Session classes should implement `equals()` (e.g. `data class`) for correct comparison.