### PR TITLE
Rename Jackson.streamRequestBody

### DIFF
--- a/ktor-shared/ktor-serialization/ktor-serialization-jackson/api/ktor-serialization-jackson.api
+++ b/ktor-shared/ktor-serialization/ktor-serialization-jackson/api/ktor-serialization-jackson.api
@@ -2,12 +2,16 @@ public final class io/ktor/serialization/jackson/JacksonConverter : io/ktor/seri
 	public fun <init> ()V
 	public fun <init> (Lcom/fasterxml/jackson/databind/ObjectMapper;Z)V
 	public synthetic fun <init> (Lcom/fasterxml/jackson/databind/ObjectMapper;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lcom/fasterxml/jackson/databind/ObjectMapper;ZLkotlin/Unit;)V
+	public synthetic fun <init> (Lcom/fasterxml/jackson/databind/ObjectMapper;ZLkotlin/Unit;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun deserialize (Ljava/nio/charset/Charset;Lio/ktor/util/reflect/TypeInfo;Lio/ktor/utils/io/ByteReadChannel;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun serialize (Lio/ktor/http/ContentType;Ljava/nio/charset/Charset;Lio/ktor/util/reflect/TypeInfo;Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public final class io/ktor/serialization/jackson/JacksonConverterKt {
+	public static final fun jackson (Lio/ktor/serialization/Configuration;Lio/ktor/http/ContentType;ZLkotlin/Unit;Lkotlin/jvm/functions/Function1;)V
 	public static final fun jackson (Lio/ktor/serialization/Configuration;Lio/ktor/http/ContentType;ZLkotlin/jvm/functions/Function1;)V
+	public static synthetic fun jackson$default (Lio/ktor/serialization/Configuration;Lio/ktor/http/ContentType;ZLkotlin/Unit;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
 	public static synthetic fun jackson$default (Lio/ktor/serialization/Configuration;Lio/ktor/http/ContentType;ZLkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
 }
 

--- a/ktor-shared/ktor-serialization/ktor-serialization-jackson/jvm/src/JacksonConverter.kt
+++ b/ktor-shared/ktor-serialization/ktor-serialization-jackson/jvm/src/JacksonConverter.kt
@@ -27,12 +27,12 @@ import kotlin.text.*
  * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.serialization.jackson.JacksonConverter)
  *
  * @param objectMapper a configured instance of [ObjectMapper]
- * @param streamRequestBody if set to true, will stream request body, without keeping it whole in memory.
+ * @param streamBody if set to true, will stream request/response body, without keeping it whole in memory.
  * This will set `Transfer-Encoding: chunked` header.
  */
 public class JacksonConverter(
     private val objectMapper: ObjectMapper = jacksonObjectMapper(),
-    private val streamRequestBody: Boolean = true
+    private val streamBody: Boolean = true,
 ) : ContentConverter {
 
     override suspend fun serialize(
@@ -41,7 +41,7 @@ public class JacksonConverter(
         typeInfo: TypeInfo,
         value: Any?
     ): OutgoingContent {
-        if (!streamRequestBody && typeInfo.type != Flow::class) {
+        if (!streamBody && typeInfo.type != Flow::class) {
             return TextContent(
                 objectMapper.writeValueAsString(value),
                 contentType.withCharsetIfNeeded(charset)
@@ -153,14 +153,14 @@ public class JacksonConverter(
  *
  * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.serialization.jackson.jackson)
  *
- * @param contentType the content type to send with request
- * @param streamRequestBody if set to true, will stream request body, without keeping it whole in memory.
+ * @param contentType the content type to send with a request
+ * @param streamBody if set to true, will stream request/response body, without keeping it whole in memory.
  * This will set `Transfer-Encoding: chunked` header.
  * @param block a configuration block for [ObjectMapper]
  */
 public fun Configuration.jackson(
     contentType: ContentType = ContentType.Application.Json,
-    streamRequestBody: Boolean = true,
+    streamBody: Boolean = true,
     block: ObjectMapper.() -> Unit = {}
 ) {
     val mapper = ObjectMapper()
@@ -174,6 +174,6 @@ public fun Configuration.jackson(
     }
     mapper.apply(block)
     mapper.registerKotlinModule()
-    val converter = JacksonConverter(mapper, streamRequestBody)
+    val converter = JacksonConverter(mapper, streamBody)
     register(contentType, converter)
 }

--- a/ktor-shared/ktor-serialization/ktor-serialization-jackson/jvm/src/JacksonConverter.kt
+++ b/ktor-shared/ktor-serialization/ktor-serialization-jackson/jvm/src/JacksonConverter.kt
@@ -35,6 +35,17 @@ public class JacksonConverter(
     private val streamBody: Boolean = true,
 ) : ContentConverter {
 
+    @Deprecated(
+        "Use constructor(objectMapper, streamBody) instead",
+        replaceWith = ReplaceWith("JacksonConverter(objectMapper, streamBody = streamRequestBody)"),
+        level = DeprecationLevel.WARNING
+    )
+    public constructor(
+        objectMapper: ObjectMapper = jacksonObjectMapper(),
+        streamRequestBody: Boolean = true,
+        dummy: Unit = Unit
+    ) : this(objectMapper, streamBody = streamRequestBody)
+
     override suspend fun serialize(
         contentType: ContentType,
         charset: Charset,
@@ -177,3 +188,29 @@ public fun Configuration.jackson(
     val converter = JacksonConverter(mapper, streamBody)
     register(contentType, converter)
 }
+
+/**
+ * Registers the `application/json` content type to the [ContentNegotiation] plugin using Jackson.
+ *
+ * You can learn more from the corresponding [client](https://ktor.io/docs/client-serialization.html#-3bcvpz_158) and [server](https://ktor.io/docs/server-serialization.html#-230zkf_175) documentation.
+ *
+ *
+ * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.serialization.jackson.jackson)
+ *
+ * @param contentType the content type to send with a request
+ * @param streamRequestBody if set to true, will stream request body, without keeping it whole in memory.
+ * This will set `Transfer-Encoding: chunked` header.
+ * @param block a configuration block for [ObjectMapper]
+ */
+@Deprecated(
+    "Use jackson(contentType, streamBody, block) instead",
+    replaceWith = ReplaceWith("jackson(contentType, streamBody = streamRequestBody, block)"),
+    level = DeprecationLevel.WARNING
+)
+public fun Configuration.jackson(
+    contentType: ContentType = ContentType.Application.Json,
+    streamRequestBody: Boolean = true,
+    @Suppress("UNUSED_PARAMETER")
+    dummy: Unit = Unit,
+    block: ObjectMapper.() -> Unit = {}
+): Unit = jackson(contentType, streamRequestBody, block)

--- a/ktor-shared/ktor-serialization/ktor-serialization-jackson/jvm/test/ClientJacksonTest.kt
+++ b/ktor-shared/ktor-serialization/ktor-serialization-jackson/jvm/test/ClientJacksonTest.kt
@@ -111,7 +111,7 @@ class ClientJacksonTest : AbstractClientContentNegotiationTest() {
     fun testNotChunkedEncodingIfSet() = testWithEngine(CIO) {
         config {
             install(ContentNegotiation) {
-                jackson(streamRequestBody = false)
+                jackson(streamBody = false)
             }
         }
 

--- a/ktor-shared/ktor-serialization/ktor-serialization-jackson3/api/ktor-serialization-jackson3.api
+++ b/ktor-shared/ktor-serialization/ktor-serialization-jackson3/api/ktor-serialization-jackson3.api
@@ -2,12 +2,16 @@ public final class io/ktor/serialization/jackson3/JacksonConverter : io/ktor/ser
 	public fun <init> ()V
 	public fun <init> (Ltools/jackson/databind/ObjectMapper;Z)V
 	public synthetic fun <init> (Ltools/jackson/databind/ObjectMapper;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ltools/jackson/databind/ObjectMapper;ZLkotlin/Unit;)V
+	public synthetic fun <init> (Ltools/jackson/databind/ObjectMapper;ZLkotlin/Unit;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun deserialize (Ljava/nio/charset/Charset;Lio/ktor/util/reflect/TypeInfo;Lio/ktor/utils/io/ByteReadChannel;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun serialize (Lio/ktor/http/ContentType;Ljava/nio/charset/Charset;Lio/ktor/util/reflect/TypeInfo;Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public final class io/ktor/serialization/jackson3/JacksonConverterKt {
+	public static final fun jackson (Lio/ktor/serialization/Configuration;Lio/ktor/http/ContentType;ZLkotlin/Unit;Lkotlin/jvm/functions/Function1;)V
 	public static final fun jackson (Lio/ktor/serialization/Configuration;Lio/ktor/http/ContentType;ZLkotlin/jvm/functions/Function1;)V
+	public static synthetic fun jackson$default (Lio/ktor/serialization/Configuration;Lio/ktor/http/ContentType;ZLkotlin/Unit;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
 	public static synthetic fun jackson$default (Lio/ktor/serialization/Configuration;Lio/ktor/http/ContentType;ZLkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
 }
 

--- a/ktor-shared/ktor-serialization/ktor-serialization-jackson3/jvm/src/JacksonConverter.kt
+++ b/ktor-shared/ktor-serialization/ktor-serialization-jackson3/jvm/src/JacksonConverter.kt
@@ -34,8 +34,19 @@ import kotlin.text.*
  */
 public class JacksonConverter(
     private val objectMapper: ObjectMapper = jacksonObjectMapper(),
-    private val streamBody: Boolean = true
+    private val streamBody: Boolean = true,
 ) : ContentConverter {
+
+    @Deprecated(
+        "Use constructor(objectMapper, streamBody) instead",
+        replaceWith = ReplaceWith("JacksonConverter(objectMapper, streamBody = streamRequestBody)"),
+        level = DeprecationLevel.WARNING
+    )
+    public constructor(
+        objectMapper: ObjectMapper = jacksonObjectMapper(),
+        streamRequestBody: Boolean = true,
+        dummy: Unit = Unit
+    ) : this(objectMapper, streamBody = streamRequestBody)
 
     override suspend fun serialize(
         contentType: ContentType,
@@ -173,3 +184,29 @@ public fun Configuration.jackson(
     val converter = JacksonConverter(mapper, streamBody)
     register(contentType, converter)
 }
+
+/**
+ * Registers the `application/json` content type to the [ContentNegotiation] plugin using Jackson.
+ *
+ * You can learn more from the corresponding [client](https://ktor.io/docs/client-serialization.html#-3bcvpz_158) and [server](https://ktor.io/docs/server-serialization.html#-230zkf_175) documentation.
+ *
+ *
+ * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.serialization.jackson3.jackson)
+ *
+ * @param contentType the content type to send with a request
+ * @param streamRequestBody if set to true, will stream request body, without keeping it whole in memory.
+ * This will set `Transfer-Encoding: chunked` header.
+ * @param block a configuration block for [JsonMapper.Builder]
+ */
+@Deprecated(
+    "Use jackson(contentType, streamBody, block) instead",
+    replaceWith = ReplaceWith("jackson(contentType, streamBody = streamRequestBody, block)"),
+    level = DeprecationLevel.WARNING
+)
+public fun Configuration.jackson(
+    contentType: ContentType = ContentType.Application.Json,
+    streamRequestBody: Boolean = true,
+    @Suppress("UNUSED_PARAMETER")
+    dummy: Unit = Unit,
+    block: JsonMapper.Builder.() -> Unit = {}
+): Unit = jackson(contentType, streamRequestBody, block)

--- a/ktor-shared/ktor-serialization/ktor-serialization-jackson3/jvm/src/JacksonConverter.kt
+++ b/ktor-shared/ktor-serialization/ktor-serialization-jackson3/jvm/src/JacksonConverter.kt
@@ -29,12 +29,12 @@ import kotlin.text.*
  * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.serialization.jackson3.JacksonConverter)
  *
  * @param objectMapper a configured instance of [ObjectMapper]
- * @param streamRequestBody if set to true, will stream request body, without keeping it whole in memory.
+ * @param streamBody if set to true, will stream request/response body, without keeping it whole in memory.
  * This will set `Transfer-Encoding: chunked` header.
  */
 public class JacksonConverter(
     private val objectMapper: ObjectMapper = jacksonObjectMapper(),
-    private val streamRequestBody: Boolean = true
+    private val streamBody: Boolean = true
 ) : ContentConverter {
 
     override suspend fun serialize(
@@ -43,7 +43,7 @@ public class JacksonConverter(
         typeInfo: TypeInfo,
         value: Any?
     ): OutgoingContent {
-        if (!streamRequestBody && typeInfo.type != Flow::class) {
+        if (!streamBody && typeInfo.type != Flow::class) {
             return TextContent(
                 objectMapper.writeValueAsString(value),
                 contentType.withCharsetIfNeeded(charset)
@@ -148,14 +148,14 @@ public class JacksonConverter(
  *
  * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.serialization.jackson3.jackson)
  *
- * @param contentType the content type to send with request
- * @param streamRequestBody if set to true, will stream request body, without keeping it whole in memory.
+ * @param contentType the content type to send with a request
+ * @param streamBody if set to true, will stream request/response body, without keeping it whole in memory.
  * This will set `Transfer-Encoding: chunked` header.
  * @param block a configuration block for [JsonMapper.Builder]
  */
 public fun Configuration.jackson(
     contentType: ContentType = ContentType.Application.Json,
-    streamRequestBody: Boolean = true,
+    streamBody: Boolean = true,
     block: JsonMapper.Builder.() -> Unit = {}
 ) {
     val builder = JsonMapper.builder()
@@ -170,6 +170,6 @@ public fun Configuration.jackson(
     builder.apply(block)
     val mapper = builder.build()
 
-    val converter = JacksonConverter(mapper, streamRequestBody)
+    val converter = JacksonConverter(mapper, streamBody)
     register(contentType, converter)
 }

--- a/ktor-shared/ktor-serialization/ktor-serialization-jackson3/jvm/test/ClientJacksonTest.kt
+++ b/ktor-shared/ktor-serialization/ktor-serialization-jackson3/jvm/test/ClientJacksonTest.kt
@@ -114,7 +114,7 @@ class ClientJacksonTest : AbstractClientContentNegotiationTest() {
     fun testNotChunkedEncodingIfSet() = testWithEngine(CIO) {
         config {
             install(ContentNegotiation) {
-                jackson(streamRequestBody = false)
+                jackson(streamBody = false)
             }
         }
 


### PR DESCRIPTION
**Subsystem**
Shared

**Motivation**
[KTOR-9503](https://youtrack.jetbrains.com/issue/KTOR-9503) The JacksonConverter.streamRequestBody property name is confusing

**Solution**
Rename `streamRequestBody` -> `streamBody`