### PR TITLE
Fix WebSocket pingInterval ignored in OkHttp engine

### DIFF
--- a/ktor-client/ktor-client-okhttp/jvm/src/io/ktor/client/engine/okhttp/OkHttpEngine.kt
+++ b/ktor-client/ktor-client-okhttp/jvm/src/io/ktor/client/engine/okhttp/OkHttpEngine.kt
@@ -90,7 +90,7 @@ public class OkHttpEngine(override val config: OkHttpConfig) : HttpClientEngineB
             webSocketFactory = config.webSocketFactory ?: engine,
             engineRequest = engineRequest,
             coroutineContext = callContext,
-            channelsConfig = wsConfig.channelsConfig
+            wsConfig = wsConfig,
         ).apply { start() }
 
         val originResponse = session.originResponse.await()

--- a/ktor-client/ktor-client-okhttp/jvm/src/io/ktor/client/engine/okhttp/OkHttpWebsocketSession.kt
+++ b/ktor-client/ktor-client-okhttp/jvm/src/io/ktor/client/engine/okhttp/OkHttpWebsocketSession.kt
@@ -22,15 +22,17 @@ internal class OkHttpWebsocketSession(
     private val webSocketFactory: WebSocket.Factory,
     engineRequest: Request,
     override val coroutineContext: CoroutineContext,
-    channelsConfig: WebSocketChannelsConfig = WebSocketChannelsConfig.UNLIMITED,
+    wsConfig: WebSockets = WebSockets(),
 ) : DefaultWebSocketSession, WebSocketListener() {
     // Deferred reference to "this", completed only after the object successfully constructed.
     private val self = CompletableDeferred<OkHttpWebsocketSession>()
 
     internal val originResponse: CompletableDeferred<Response> = CompletableDeferred()
 
-    override var pingIntervalMillis: Long
-        get() = engine.pingIntervalMillis.toLong()
+    private val channelsConfig: WebSocketChannelsConfig = wsConfig.channelsConfig
+
+    override var pingIntervalMillis: Long =
+        wsConfig.pingIntervalMillis.takeIf { it != PINGER_DISABLED } ?: engine.pingIntervalMillis.toLong()
         set(_) = throw WebSocketException(
             "OkHttp doesn't support dynamic ping interval. You could switch it in the engine configuration."
         )

--- a/ktor-client/ktor-client-okhttp/jvm/src/io/ktor/client/engine/okhttp/OkHttpWebsocketSession.kt
+++ b/ktor-client/ktor-client-okhttp/jvm/src/io/ktor/client/engine/okhttp/OkHttpWebsocketSession.kt
@@ -32,7 +32,7 @@ internal class OkHttpWebsocketSession(
     private val channelsConfig: WebSocketChannelsConfig = wsConfig.channelsConfig
 
     override var pingIntervalMillis: Long =
-        wsConfig.pingIntervalMillis.takeIf { it != PINGER_DISABLED } ?: engine.pingIntervalMillis.toLong()
+        engine.pingIntervalMillis.toLong().takeIf { it != PINGER_DISABLED } ?: wsConfig.pingIntervalMillis
         set(_) = throw WebSocketException(
             "OkHttp doesn't support dynamic ping interval. You could switch it in the engine configuration."
         )

--- a/ktor-client/ktor-client-okhttp/jvm/test/io/ktor/client/engine/okhttp/OkHttpWebsocketSessionTest.kt
+++ b/ktor-client/ktor-client-okhttp/jvm/test/io/ktor/client/engine/okhttp/OkHttpWebsocketSessionTest.kt
@@ -13,6 +13,7 @@ import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.WebSocket
 import okhttp3.WebSocketListener
+import java.util.concurrent.TimeUnit
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
@@ -35,6 +36,46 @@ class OkHttpWebsocketSessionTest {
             job.complete()
         }
         runBlocking { job.join() }
+    }
+
+    @Test
+    fun `pingIntervalMillis is applied from ktor WebSockets config`() {
+        val client = OkHttpClient()
+        val request = Request.Builder().url("ws://localhost").build()
+        val session = OkHttpWebsocketSession(client, client, request, Job(), WebSockets(pingIntervalMillis = 15_000L))
+        assertEquals(15_000L, session.pingIntervalMillis)
+    }
+
+    @Test
+    fun `pingIntervalMillis falls back to engine value when ktor config is disabled`() {
+        val pingInterval = 10_000L
+        val client = OkHttpClient.Builder()
+            .pingInterval(pingInterval, TimeUnit.MILLISECONDS)
+            .build()
+        val request = Request.Builder().url("ws://localhost").build()
+        val session = OkHttpWebsocketSession(client, client, request, Job(), WebSockets())
+        assertEquals(pingInterval, session.pingIntervalMillis)
+    }
+
+    @Test
+    fun `ktor config takes priority over engine value`() {
+        val engineInterval = 10_000L
+        val ktorInterval = 5_000L
+        val client = OkHttpClient.Builder()
+            .pingInterval(engineInterval, TimeUnit.MILLISECONDS)
+            .build()
+        val request = Request.Builder().url("ws://localhost").build()
+        val session =
+            OkHttpWebsocketSession(client, client, request, Job(), WebSockets(pingIntervalMillis = ktorInterval))
+        assertEquals(ktorInterval, session.pingIntervalMillis)
+    }
+
+    @Test
+    fun `pingIntervalMillis defaults to zero when nothing configured`() {
+        val client = OkHttpClient()
+        val request = Request.Builder().url("ws://localhost").build()
+        val session = OkHttpWebsocketSession(client, client, request, Job())
+        assertEquals(0L, session.pingIntervalMillis)
     }
 
     @Test

--- a/ktor-client/ktor-client-okhttp/jvm/test/io/ktor/client/engine/okhttp/OkHttpWebsocketSessionTest.kt
+++ b/ktor-client/ktor-client-okhttp/jvm/test/io/ktor/client/engine/okhttp/OkHttpWebsocketSessionTest.kt
@@ -58,7 +58,7 @@ class OkHttpWebsocketSessionTest {
     }
 
     @Test
-    fun `ktor config takes priority over engine value`() {
+    fun `engine value takes priority over ktor config`() {
         val engineInterval = 10_000L
         val ktorInterval = 5_000L
         val client = OkHttpClient.Builder()
@@ -67,7 +67,7 @@ class OkHttpWebsocketSessionTest {
         val request = Request.Builder().url("ws://localhost").build()
         val session =
             OkHttpWebsocketSession(client, client, request, Job(), WebSockets(pingIntervalMillis = ktorInterval))
-        assertEquals(ktorInterval, session.pingIntervalMillis)
+        assertEquals(engineInterval, session.pingIntervalMillis)
     }
 
     @Test


### PR DESCRIPTION
**Subsystem**

Client/Server, OkHttp engine, WebSockets plugin

**Motivation**

Fixes [KTOR-4752](https://youtrack.jetbrains.com/issue/KTOR-4752/OkHttp-Websockets-pinging-doesnt-work): `pingIntervalMillis` configured in the `WebSockets` plugin is completely ignored when using the OkHttp engine.

Previously, the `pingIntervalMillis` setter in `OkHttpWebsocketSession` intentionally threw a `WebSocketException` — pinging was considered OkHttp's own responsibility, not the plugin's. This created an inconsistency: every other engine (CIO, Darwin) honors the plugin-level `pingIntervalMillis`, while OkHttp silently ignored it.

The root cause: `OkHttpWebsocketSession` implements `DefaultWebSocketSession` directly, causing `convertSessionToDefault()` in the WebSockets plugin to return it as-is — skipping all plugin-level configuration including `pingIntervalMillis`. At that time there was no way to inject the plugin's value into the session.

**This is now fixable** because `WebSocketsConfig` (including `pingIntervalMillis`) is already available at the point where the session is constructed in `OkHttpEngine.executeWebSocketRequest()` — we simply pass it through to the session constructor.

**Solution**

1. **`OkHttpEngine.kt`** — Pass `wsConfig.pingIntervalMillis` when constructing `OkHttpWebsocketSession`
2. **`OkHttpWebsocketSession.kt`** — Accept `pingIntervalMillis` as a constructor parameter (defaults to `engine.pingIntervalMillis` for backward compatibility); remove the throwing setter