### PR TITLE
KTOR-9507: Update Netty and Jackson

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -36,9 +36,9 @@ okio = "3.16.4"
 json-simple = "1.1.1"
 gson = "2.13.2"
 
-jackson = "2.20.1"
-jackson3 = "3.0.3"
-jackson-annotations = "2.20"
+jackson = "2.21.0"
+jackson3 = "3.1.0"
+jackson-annotations = "2.21"
 
 junit = "5.14.2"
 slf4j = "2.0.17"
@@ -54,7 +54,7 @@ typesafe = "1.4.5"
 # Wait until https://github.com/mockk/mockk/issues/1433 is resolved.
 mockk = "1.14.7"
 
-java-jwt = "4.5.0"
+java-jwt = "4.5.1"
 
 jwks-rsa = "0.23.0"
 mustache = "0.9.14"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,8 +14,8 @@ kover = "0.9.4"
 kotlinter = "5.2.0"
 kotlinx-browser = "0.5.0"
 
-netty = "4.2.9.Final"
-netty-tcnative = "2.0.74.Final"
+netty = "4.2.12.Final"
+netty-tcnative = "2.0.76.Final"
 
 jetty = "9.4.58.v20250814"
 jetty-jakarta = "12.0.29"


### PR DESCRIPTION
**Subsystem**
Server, Shared

**Motivation**
[KTOR-9507](https://youtrack.jetbrains.com/issue/KTOR-9507) Vulnerable versions of Netty and Jackson in 3.4.2

**Solution**
Update to non-vulnerable versions: 
- [GHSA-72hv-8253-57qq](https://github.com/advisories/GHSA-72hv-8253-57qq) fixed in Jackson 2.21 and 3.1
- [CVE-2026-33871](https://github.com/advisories/GHSA-w9fj-cfpg-grvv) fixed in Netty 4.2.11.Final

