### PR TITLE
Fix grammatical errors in KDoc comments

### DIFF
--- a/ktor-client/ktor-client-plugins/ktor-client-tracing/ktor-client-tracing-stetho/android/src/io/ktor/client/features/tracing/StethoTracer.kt
+++ b/ktor-client/ktor-client-plugins/ktor-client-tracing/ktor-client-tracing-stetho/android/src/io/ktor/client/features/tracing/StethoTracer.kt
@@ -14,7 +14,7 @@ import io.ktor.utils.io.*
 import io.ktor.utils.io.jvm.javaio.*
 
 /**
- * Shortcut that allows to easily wrap engine factory into Stetho tracer.
+ * Shortcut that allows easily wrapping an engine factory into a Stetho tracer.
  *
  * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.client.plugin.tracing.Stetho)
  */

--- a/ktor-client/ktor-client-winhttp/windows/src/io/ktor/client/engine/winhttp/WinHttpClientEngineConfig.kt
+++ b/ktor-client/ktor-client-winhttp/windows/src/io/ktor/client/engine/winhttp/WinHttpClientEngineConfig.kt
@@ -18,8 +18,8 @@ public class WinHttpClientEngineConfig : HttpClientEngineConfig() {
     public var protocolVersion: HttpProtocolVersion = HttpProtocolVersion.HTTP_2_0
 
     /**
-     * A value that allows to set required security protocol versions.
-     * By default will be used system setting.
+     * A value that allows setting the required security protocol versions.
+     * By default, the system setting will be used.
      *
      * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.client.engine.winhttp.WinHttpClientEngineConfig.securityProtocols)
      */

--- a/ktor-server/ktor-server-core/common/src/io/ktor/server/util/Parameters.kt
+++ b/ktor-server/ktor-server-core/common/src/io/ktor/server/util/Parameters.kt
@@ -11,7 +11,7 @@ import io.ktor.util.reflect.*
 import kotlin.reflect.*
 
 /**
- * Operator function that allows to delegate variables by call parameters.
+ * Operator function that allows delegating variables to call parameters.
  * It does conversion to type [R] using [DefaultConversionService]
  *
  * Example


### PR DESCRIPTION

**Repo:** ktorio/ktor (⭐ 12000)
**Type:** docs
**Files changed:** 3
**Lines:** +4/-4

## What
Fixes three "allows to <verb>" grammatical errors in public KDoc comments across `StethoTracer.kt`, `WinHttpClientEngineConfig.kt`, and `Parameters.kt`. Also rewords the awkward "By default will be used system setting" sentence in `WinHttpClientEngineConfig.kt` for clarity.

## Why
The pattern `allows to <bare-verb>` is ungrammatical English (correct forms are `allows <noun> to <verb>` or `allows <gerund>`). These KDocs are surfaced in Ktor's public API documentation and on dokka pages, so the wording is reader-facing. The change improves doc quality without touching any code or behavior.

## Testing
Pure comment-only change; no functional impact. Verified `git diff` only modifies comment lines inside `/** ... */` blocks. No build run (out of budget; would require `./gradlew assemble` with JDK 21 and ~12 GB RAM).

## Risk
Low — KDoc text only, no code, types, or signatures changed.
