### PR TITLE
KTOR-9513 Honour the max argument for decode

### DIFF
--- a/ktor-io/common/test/CharsetDecoderTest.kt
+++ b/ktor-io/common/test/CharsetDecoderTest.kt
@@ -74,4 +74,14 @@ class CharsetDecoderTest {
             // Expected on native platforms
         }
     }
+
+    @Test
+    fun `decoding valid UTF-8 with max limit should stop at max`() {
+        val data = "Hello, world!".toByteArray()
+        val source = buildPacket { writeFully(data) }
+
+        val result = Charsets.UTF_8.newDecoder().decode(source, 5)
+
+        assertEquals("Hello", result)
+    }
 }

--- a/ktor-io/darwin/src/CharsetDarwin.kt
+++ b/ktor-io/darwin/src/CharsetDarwin.kt
@@ -66,12 +66,8 @@ internal actual fun CharsetEncoder.encodeImpl(input: CharSequence, fromIndex: In
 @Suppress("CAST_NEVER_SUCCEEDS")
 @OptIn(UnsafeNumber::class, BetaInteropApi::class)
 public actual fun CharsetDecoder.decode(input: Source, dst: Appendable, max: Int): Int {
-    if (max != Int.MAX_VALUE) {
-        throw IOException("Max argument is deprecated")
-    }
-
     val charset = _charset as? CharsetDarwin ?: error("Charset $this is not supported by darwin.")
-    val source: ByteArray = input.readByteArray()
+    val source: ByteArray = input.readByteArray(max)
 
     val data = source.toNSData()
     val content = NSString.create(data, charset.encoding) as? String

--- a/ktor-io/jvm/src/io/ktor/utils/io/charsets/CharsetJVM.kt
+++ b/ktor-io/jvm/src/io/ktor/utils/io/charsets/CharsetJVM.kt
@@ -80,11 +80,11 @@ public actual val CharsetDecoder.charset: Charset get() = charset()!!
 
 public actual fun CharsetDecoder.decode(input: Source, dst: Appendable, max: Int): Int {
     if (charset == Charsets.UTF_8) {
-        return input.readString().also { dst.append(it) }.length
+        return input.readString(max.toLong()).also { dst.append(it) }.length
     }
 
     val result = input.remaining
-    dst.append(input.readByteString().decodeToString(charset))
+    dst.append(input.readByteString(max).decodeToString(charset))
     return result.toInt()
 }
 


### PR DESCRIPTION
**Subsystem**
Server, Core

**Motivation**
[KTOR-9513](https://youtrack.jetbrains.com/issue/KTOR-9513) CharsetDecoder.decode() ignores the max argument on JVM

**Solution**
Just passed the max into the kotlinx-io reads.  I don't know why we weren't processing it.

