### PR TITLE
always complete or cancel responseReady in NettyApplicationResponse

### DIFF
--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyApplicationResponse.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyApplicationResponse.kt
@@ -55,7 +55,7 @@ public abstract class NettyApplicationResponse(
         val chunked = headers[HttpHeaders.TransferEncoding] == "chunked"
 
         if (!canRespond) {
-            cancelInChannelNotActive()
+            cancelIfChannelNotActive()
             return
         }
 
@@ -118,7 +118,7 @@ public abstract class NettyApplicationResponse(
 
     internal fun sendResponse(chunked: Boolean = true, content: ByteReadChannel) {
         if (!canRespond) {
-            cancelInChannelNotActive()
+            cancelIfChannelNotActive()
             return
         }
 
@@ -151,7 +151,7 @@ public abstract class NettyApplicationResponse(
         // while close only does flush() and doesn't terminate connection
     }
 
-    private fun cancelInChannelNotActive() {
+    private fun cancelIfChannelNotActive() {
         if (!context.channel().isActive) {
             cancel()
         }

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyApplicationResponse.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyApplicationResponse.kt
@@ -33,9 +33,6 @@ public abstract class NettyApplicationResponse(
 
     internal var responseChannel: ByteReadChannel = ByteReadChannel.Empty
 
-    private val canRespond: Boolean
-        get() = !responseMessageSent && context.channel().isActive
-
     override suspend fun respondOutgoingContent(content: OutgoingContent) {
         try {
             super.respondOutgoingContent(content)
@@ -54,7 +51,12 @@ public abstract class NettyApplicationResponse(
         // because it should've been set by commitHeaders earlier
         val chunked = headers[HttpHeaders.TransferEncoding] == "chunked"
 
-        if (!canRespond) return
+        if (responseMessageSent) return
+
+        if (!context.channel().isActive) {
+            cancel()
+            return
+        }
 
         val message = responseMessage(chunked, bytes)
         responseChannel = when (message) {
@@ -114,7 +116,12 @@ public abstract class NettyApplicationResponse(
     }
 
     internal fun sendResponse(chunked: Boolean = true, content: ByteReadChannel) {
-        if (!canRespond) return
+        if (responseMessageSent) return
+
+        if (!context.channel().isActive) {
+            cancel()
+            return
+        }
 
         responseChannel = content
         responseMessage = when {

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyApplicationResponse.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyApplicationResponse.kt
@@ -33,6 +33,9 @@ public abstract class NettyApplicationResponse(
 
     internal var responseChannel: ByteReadChannel = ByteReadChannel.Empty
 
+    private val canRespond: Boolean
+        get() = !responseMessageSent && context.channel().isActive
+
     override suspend fun respondOutgoingContent(content: OutgoingContent) {
         try {
             super.respondOutgoingContent(content)
@@ -51,10 +54,8 @@ public abstract class NettyApplicationResponse(
         // because it should've been set by commitHeaders earlier
         val chunked = headers[HttpHeaders.TransferEncoding] == "chunked"
 
-        if (responseMessageSent) return
-
-        if (!context.channel().isActive) {
-            cancel()
+        if (!canRespond) {
+            cancelInChannelNotActive()
             return
         }
 
@@ -116,10 +117,8 @@ public abstract class NettyApplicationResponse(
     }
 
     internal fun sendResponse(chunked: Boolean = true, content: ByteReadChannel) {
-        if (responseMessageSent) return
-
-        if (!context.channel().isActive) {
-            cancel()
+        if (!canRespond) {
+            cancelInChannelNotActive()
             return
         }
 
@@ -150,6 +149,12 @@ public abstract class NettyApplicationResponse(
         ensureResponseSent()
         // we don't need to suspendAwait() here as it handled in NettyApplicationCall
         // while close only does flush() and doesn't terminate connection
+    }
+
+    private fun cancelInChannelNotActive() {
+        if (!context.channel().isActive) {
+            cancel()
+        }
     }
 
     public fun cancel() {

--- a/ktor-server/ktor-server-netty/jvm/test/io/ktor/tests/server/netty/NettySpecificTest.kt
+++ b/ktor-server/ktor-server-netty/jvm/test/io/ktor/tests/server/netty/NettySpecificTest.kt
@@ -20,10 +20,12 @@ import io.ktor.server.response.*
 import io.ktor.server.routing.*
 import io.ktor.test.dispatcher.*
 import io.ktor.utils.io.*
+import io.netty.channel.Channel
 import kotlinx.coroutines.*
 import java.net.BindException
 import java.net.ServerSocket
 import java.util.concurrent.ExecutorService
+import java.util.concurrent.atomic.AtomicReference
 import kotlin.test.*
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
@@ -178,12 +180,14 @@ class NettySpecificTest {
         val shouldRespond = CompletableDeferred<Unit>()
         val callFinished = CompletableDeferred<Unit>()
         val appStarted = CompletableDeferred<Application>()
+        val channel : AtomicReference<Channel> = AtomicReference(null)
 
         val serverJob = launch(Dispatchers.IO) {
             val server = embeddedServer(Netty, port = 0) {
                 routing {
                     get("/test") {
                         handlerStarted.complete(Unit)
+                        channel.set((call.pipelineCall.engineCall as NettyApplicationCall).context.channel())
                         shouldRespond.await()
 
                         // responseReady is only completed once call.respond() runs;
@@ -221,7 +225,11 @@ class NettySpecificTest {
             }
 
             // Give Netty time to process the channel-inactive event
-            delay(300.milliseconds)
+            withTimeout(20.seconds) {
+                while (channel.get() == null || channel.get().isActive) {
+                    delay(10.milliseconds)
+                }
+            }
 
             // Now let the handler try to respond to the already-closed channel
             shouldRespond.complete(Unit)

--- a/ktor-server/ktor-server-netty/jvm/test/io/ktor/tests/server/netty/NettySpecificTest.kt
+++ b/ktor-server/ktor-server-netty/jvm/test/io/ktor/tests/server/netty/NettySpecificTest.kt
@@ -180,7 +180,7 @@ class NettySpecificTest {
         val shouldRespond = CompletableDeferred<Unit>()
         val callFinished = CompletableDeferred<Unit>()
         val appStarted = CompletableDeferred<Application>()
-        val channel : AtomicReference<Channel> = AtomicReference(null)
+        val channel: AtomicReference<Channel> = AtomicReference(null)
 
         val serverJob = launch(Dispatchers.IO) {
             val server = embeddedServer(Netty, port = 0) {

--- a/ktor-server/ktor-server-netty/jvm/test/io/ktor/tests/server/netty/NettySpecificTest.kt
+++ b/ktor-server/ktor-server-netty/jvm/test/io/ktor/tests/server/netty/NettySpecificTest.kt
@@ -228,7 +228,7 @@ class NettySpecificTest {
 
             // finishedEvent must be resolved (success or failure) — if responseReady is
             // never completed, this deferred hangs forever and the test times out
-            withTimeout(5.seconds) { callFinished.await() }
+            withTimeout(20.seconds) { callFinished.await() }
         } finally {
             serverJob.cancel()
         }

--- a/ktor-server/ktor-server-netty/jvm/test/io/ktor/tests/server/netty/NettySpecificTest.kt
+++ b/ktor-server/ktor-server-netty/jvm/test/io/ktor/tests/server/netty/NettySpecificTest.kt
@@ -25,6 +25,7 @@ import java.net.BindException
 import java.net.ServerSocket
 import java.util.concurrent.ExecutorService
 import kotlin.test.*
+import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 
 class NettySpecificTest {
@@ -166,6 +167,68 @@ class NettySpecificTest {
                 assertEquals(earlyHints, client.get("/info-channel-writer").status)
                 assertEquals(earlyHints, client.get("/info-read-channel").status)
             }
+        } finally {
+            serverJob.cancel()
+        }
+    }
+
+    @Test
+    fun `call finishes when channel becomes inactive before response is sent`() = runTestWithRealTime {
+        val handlerStarted = CompletableDeferred<Unit>()
+        val shouldRespond = CompletableDeferred<Unit>()
+        val callFinished = CompletableDeferred<Unit>()
+        val appStarted = CompletableDeferred<Application>()
+
+        val serverJob = launch(Dispatchers.IO) {
+            val server = embeddedServer(Netty, port = 0) {
+                routing {
+                    get("/test") {
+                        handlerStarted.complete(Unit)
+                        shouldRespond.await()
+
+                        // responseReady is only completed once call.respond() runs;
+                        // if it is never completed, finishedEvent is never set and
+                        // responseWriteJob.join() in call.finish() hangs forever.
+                        (call.pipelineCall.engineCall as NettyApplicationCall).finishedEvent.addListener {
+                            callFinished.complete(Unit)
+                        }
+
+                        call.respond(HttpStatusCode.OK, "Hello")
+                    }
+                }
+            }
+            server.monitor.subscribe(ApplicationStarted) { app ->
+                appStarted.complete(app)
+            }
+            server.start(wait = true)
+        }
+
+        try {
+            val serverApp = withTimeout(10.seconds) { appStarted.await() }
+            val connector = serverApp.engine.resolvedConnectors()[0]
+
+            SelectorManager().use { manager ->
+                val socket = aSocket(manager).tcp().connect(connector.host, connector.port)
+                val writeChannel = socket.openWriteChannel()
+                writeChannel.writeStringUtf8("GET /test HTTP/1.1\r\n")
+                writeChannel.writeStringUtf8("Host: ${connector.host}:${connector.port}\r\n")
+                writeChannel.writeStringUtf8("Connection: close\r\n\r\n")
+                writeChannel.flush()
+
+                // Wait until the handler is running, then close the connection
+                withTimeout(5.seconds) { handlerStarted.await() }
+                socket.close()
+            }
+
+            // Give Netty time to process the channel-inactive event
+            delay(300.milliseconds)
+
+            // Now let the handler try to respond to the already-closed channel
+            shouldRespond.complete(Unit)
+
+            // finishedEvent must be resolved (success or failure) — if responseReady is
+            // never completed, this deferred hangs forever and the test times out
+            withTimeout(5.seconds) { callFinished.await() }
         } finally {
             serverJob.cancel()
         }


### PR DESCRIPTION
**Subsystem**
ktor-server-netty

**Motivation**
We have observed hangs between ktor request finishing, and client getting the response, causing the client to time out. This problem started with ktor 3.4.0. 

This change introduced a possibility of not completing the promise when channel is inactive: https://github.com/ktorio/ktor/pull/5181.

I do not have clear evidence that this is the root cause, but I think the new behavior in this PR is an improvement. 

**Solution**
When channel is inactive, cancel the response instead of leaving the promise in a non-completed state.

