### PR TITLE
KTOR-6999 add zlib (RFC 1950) wrapping to deflate/inflate

### DIFF
--- a/ktor-server/ktor-server-tests/jvm/test/io/ktor/server/plugins/CompressionTest.kt
+++ b/ktor-server/ktor-server-tests/jvm/test/io/ktor/server/plugins/CompressionTest.kt
@@ -1141,7 +1141,7 @@ class CompressionTest {
 
     private suspend fun HttpResponse.readIdentity() = bodyAsChannel().toInputStream().reader().readText()
     private suspend fun HttpResponse.readDeflate() =
-        InflaterInputStream(bodyAsChannel().toInputStream(), Inflater(true)).reader().readText()
+        InflaterInputStream(bodyAsChannel().toInputStream()).reader().readText()
 
     private suspend fun HttpResponse.readGzip() = GZIPInputStream(bodyAsChannel().toInputStream()).reader().readText()
     private suspend fun HttpResponse.readZstd() = ZstdInputStream(bodyAsChannel().toInputStream()).reader().readText()

--- a/ktor-test-server/src/main/kotlin/test/server/tests/Encoding.kt
+++ b/ktor-test-server/src/main/kotlin/test/server/tests/Encoding.kt
@@ -12,17 +12,28 @@ import io.ktor.server.response.*
 import io.ktor.server.routing.*
 import io.ktor.util.*
 import io.ktor.utils.io.*
+import java.io.ByteArrayOutputStream
+import java.util.zip.DeflaterOutputStream
 import kotlinx.io.readByteArray
 
 internal fun Application.encodingTestServer() {
     routing {
         route("/compression") {
             route("/deflate") {
-                install(Compression) {
-                    deflate()
-                    minimumSize(0)
+                get {
+                    val content = "Compressed response!".toByteArray(Charsets.UTF_8)
+                    val baos = ByteArrayOutputStream()
+                    DeflaterOutputStream(baos).use { it.write(content) }
+                    val compressed = baos.toByteArray()
+                    call.respond(object : OutgoingContent.ReadChannelContent() {
+                        override val contentType = ContentType.Text.Plain.withCharset(Charsets.UTF_8)
+                        override val headers = Headers.build {
+                            append(HttpHeaders.ContentEncoding, "deflate")
+                            append(HttpHeaders.Vary, HttpHeaders.AcceptEncoding)
+                        }
+                        override fun readFrom() = ByteReadChannel(compressed)
+                    })
                 }
-                setCompressionEndpoints()
             }
             route("/gzip") {
                 install(Compression) {

--- a/ktor-test-server/src/main/kotlin/test/server/tests/Encoding.kt
+++ b/ktor-test-server/src/main/kotlin/test/server/tests/Encoding.kt
@@ -12,28 +12,17 @@ import io.ktor.server.response.*
 import io.ktor.server.routing.*
 import io.ktor.util.*
 import io.ktor.utils.io.*
-import java.io.ByteArrayOutputStream
-import java.util.zip.DeflaterOutputStream
 import kotlinx.io.readByteArray
 
 internal fun Application.encodingTestServer() {
     routing {
         route("/compression") {
             route("/deflate") {
-                get {
-                    val content = "Compressed response!".toByteArray(Charsets.UTF_8)
-                    val baos = ByteArrayOutputStream()
-                    DeflaterOutputStream(baos).use { it.write(content) }
-                    val compressed = baos.toByteArray()
-                    call.respond(object : OutgoingContent.ReadChannelContent() {
-                        override val contentType = ContentType.Text.Plain.withCharset(Charsets.UTF_8)
-                        override val headers = Headers.build {
-                            append(HttpHeaders.ContentEncoding, "deflate")
-                            append(HttpHeaders.Vary, HttpHeaders.AcceptEncoding)
-                        }
-                        override fun readFrom() = ByteReadChannel(compressed)
-                    })
+                install(Compression) {
+                    deflate()
+                    minimumSize(0)
                 }
+                setCompressionEndpoints()
             }
             route("/gzip") {
                 install(Compression) {

--- a/ktor-utils/jvm/src/io/ktor/util/Deflater.kt
+++ b/ktor-utils/jvm/src/io/ktor/util/Deflater.kt
@@ -68,7 +68,7 @@ private suspend fun ByteReadChannel.deflateTo(
     pool: ObjectPool<ByteBuffer> = KtorDefaultPool
 ) {
     val crc = CRC32()
-    val deflater = Deflater(Deflater.DEFAULT_COMPRESSION, true)
+    val deflater = Deflater(Deflater.DEFAULT_COMPRESSION, gzip)
     val input = pool.borrow()
     val compressed = pool.borrow()
 

--- a/ktor-utils/jvm/src/io/ktor/util/EncodersJvm.kt
+++ b/ktor-utils/jvm/src/io/ktor/util/EncodersJvm.kt
@@ -18,6 +18,7 @@ import java.util.zip.Inflater
 import kotlin.coroutines.CoroutineContext
 
 private const val GZIP_HEADER_SIZE: Int = 10
+private const val ZLIB_HEADER_SIZE: Int = 2
 
 // GZIP header flags bits
 private object GzipHeaderFlags {
@@ -83,7 +84,24 @@ private fun inflate(
     val readBuffer = KtorDefaultPool.borrow()
     val writeBuffer = KtorDefaultPool.borrow()
 
-    val inflater = Inflater(gzip)
+    val nowrap = if (gzip) {
+        // GZIP format does not have a zlib header, so we need to use nowrap mode
+        true
+    } else {
+        val header = source.peek(ZLIB_HEADER_SIZE)?.toByteArray()
+        if (header == null) {
+            // Unable to read zlib header, assume it's a raw deflate stream
+            true
+        } else {
+            // Check if the header is a valid zlib header
+            val cmf = header[0].toInt() and 0xFF
+            val flg = header[1].toInt() and 0xFF
+            val isZlibHeader = (cmf and 0x0F) == Deflater.DEFLATED && (cmf ushr 4) <= 7 && ((cmf shl 8) + flg) % 31 == 0
+            !isZlibHeader
+        }
+    }
+
+    val inflater = Inflater(nowrap)
     val checksum = CRC32()
 
     if (gzip) {

--- a/ktor-utils/jvm/src/io/ktor/util/EncodersJvm.kt
+++ b/ktor-utils/jvm/src/io/ktor/util/EncodersJvm.kt
@@ -83,7 +83,7 @@ private fun inflate(
     val readBuffer = KtorDefaultPool.borrow()
     val writeBuffer = KtorDefaultPool.borrow()
 
-    val inflater = Inflater(true)
+    val inflater = Inflater(gzip)
     val checksum = CRC32()
 
     if (gzip) {

--- a/ktor-utils/jvm/test/io/ktor/tests/utils/DeflateEncoderTest.kt
+++ b/ktor-utils/jvm/test/io/ktor/tests/utils/DeflateEncoderTest.kt
@@ -12,6 +12,7 @@ import java.io.ByteArrayOutputStream
 import java.util.zip.Deflater
 import java.util.zip.DeflaterOutputStream
 import java.util.zip.InflaterInputStream
+import kotlin.random.Random
 import kotlin.test.*
 
 class DeflateEncoderTest {
@@ -60,5 +61,31 @@ class DeflateEncoderTest {
         val decoded = Deflate.decode(encoded).readRemaining().readByteArray()
 
         assertContentEquals(original, decoded)
+    }
+
+    @Test
+    fun `decode correctly identifies format for 100000 random payloads`() = runBlocking {
+        val random = Random(seed = 42)
+        repeat(100_000) { iteration ->
+            val original = random.nextBytes(random.nextInt(1, 64))
+
+            val zlibCompressed = ByteArrayOutputStream().also { baos ->
+                DeflaterOutputStream(baos).use { it.write(original) }
+            }.toByteArray()
+            assertContentEquals(
+                original,
+                Deflate.decode(ByteReadChannel(zlibCompressed)).readRemaining().readByteArray(),
+                "zlib decode failed at iteration $iteration"
+            )
+
+            val rawCompressed = ByteArrayOutputStream().also { baos ->
+                DeflaterOutputStream(baos, Deflater(Deflater.DEFAULT_COMPRESSION, true)).use { it.write(original) }
+            }.toByteArray()
+            assertContentEquals(
+                original,
+                Deflate.decode(ByteReadChannel(rawCompressed)).readRemaining().readByteArray(),
+                "raw decode failed at iteration $iteration"
+            )
+        }
     }
 }

--- a/ktor-utils/jvm/test/io/ktor/tests/utils/DeflateEncoderTest.kt
+++ b/ktor-utils/jvm/test/io/ktor/tests/utils/DeflateEncoderTest.kt
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2014-2025 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.tests.utils
+
+import io.ktor.util.*
+import io.ktor.utils.io.*
+import kotlinx.coroutines.*
+import kotlinx.io.readByteArray
+import java.io.ByteArrayOutputStream
+import java.util.zip.Deflater
+import java.util.zip.DeflaterOutputStream
+import java.util.zip.InflaterInputStream
+import kotlin.test.*
+
+class DeflateEncoderTest {
+
+    @Test
+    fun `decode handles zlib-wrapped deflate`() = runBlocking {
+        val original = "Hello, zlib-wrapped deflate!".toByteArray(Charsets.UTF_8)
+        val compressed = ByteArrayOutputStream().also { baos ->
+            DeflaterOutputStream(baos).use { it.write(original) }
+        }.toByteArray()
+
+        val decoded = Deflate.decode(ByteReadChannel(compressed))
+            .readRemaining().readByteArray()
+
+        assertContentEquals(original, decoded)
+    }
+
+    @Test
+    fun `decode handles raw deflate`() = runBlocking {
+        val original = "Hello, raw deflate!".toByteArray(Charsets.UTF_8)
+        val compressed = ByteArrayOutputStream().also { baos ->
+            DeflaterOutputStream(baos, Deflater(Deflater.DEFAULT_COMPRESSION, true)).use { it.write(original) }
+        }.toByteArray()
+
+        val decoded = Deflate.decode(ByteReadChannel(compressed))
+            .readRemaining().readByteArray()
+
+        assertContentEquals(original, decoded)
+    }
+
+    @Test
+    fun `encode produces zlib-wrapped deflate`() = runBlocking {
+        val original = "Hello, encode deflate!".toByteArray(Charsets.UTF_8)
+        val encoded = Deflate.encode(ByteReadChannel(original))
+            .readRemaining().readByteArray()
+
+        val decoded = InflaterInputStream(encoded.inputStream()).readBytes()
+
+        assertContentEquals(original, decoded)
+    }
+
+    @Test
+    fun `encode and decode roundtrip`() = runBlocking {
+        val original = "Round-trip deflate test payload!".toByteArray(Charsets.UTF_8)
+        val encoded = Deflate.encode(ByteReadChannel(original))
+        val decoded = Deflate.decode(encoded).readRemaining().readByteArray()
+
+        assertContentEquals(original, decoded)
+    }
+}

--- a/ktor-utils/jvm/test/io/ktor/tests/utils/DeflateEncoderTest.kt
+++ b/ktor-utils/jvm/test/io/ktor/tests/utils/DeflateEncoderTest.kt
@@ -20,9 +20,7 @@ class DeflateEncoderTest {
     @Test
     fun `decode handles zlib-wrapped deflate`() = runBlocking {
         val original = "Hello, zlib-wrapped deflate!".toByteArray(Charsets.UTF_8)
-        val compressed = ByteArrayOutputStream().also { baos ->
-            DeflaterOutputStream(baos).use { it.write(original) }
-        }.toByteArray()
+        val compressed = deflateWithZibWrapping(original)
 
         val decoded = Deflate.decode(ByteReadChannel(compressed))
             .readRemaining().readByteArray()
@@ -33,9 +31,7 @@ class DeflateEncoderTest {
     @Test
     fun `decode handles raw deflate`() = runBlocking {
         val original = "Hello, raw deflate!".toByteArray(Charsets.UTF_8)
-        val compressed = ByteArrayOutputStream().also { baos ->
-            DeflaterOutputStream(baos, Deflater(Deflater.DEFAULT_COMPRESSION, true)).use { it.write(original) }
-        }.toByteArray()
+        val compressed = deflateRaw(original)
 
         val decoded = Deflate.decode(ByteReadChannel(compressed))
             .readRemaining().readByteArray()
@@ -69,18 +65,14 @@ class DeflateEncoderTest {
         repeat(10_000) { iteration ->
             val original = random.nextBytes(random.nextInt(0, 128))
 
-            val zlibCompressed = ByteArrayOutputStream().also { baos ->
-                DeflaterOutputStream(baos).use { it.write(original) }
-            }.toByteArray()
+            val zlibCompressed = deflateWithZibWrapping(original)
             assertContentEquals(
                 original,
                 Deflate.decode(ByteReadChannel(zlibCompressed)).readRemaining().readByteArray(),
                 "zlib decode failed at iteration $iteration"
             )
 
-            val rawCompressed = ByteArrayOutputStream().also { baos ->
-                DeflaterOutputStream(baos, Deflater(Deflater.DEFAULT_COMPRESSION, true)).use { it.write(original) }
-            }.toByteArray()
+            val rawCompressed = deflateRaw(original)
             assertContentEquals(
                 original,
                 Deflate.decode(ByteReadChannel(rawCompressed)).readRemaining().readByteArray(),
@@ -88,4 +80,12 @@ class DeflateEncoderTest {
             )
         }
     }
+
+    private fun deflateWithZibWrapping(data: ByteArray): ByteArray = ByteArrayOutputStream().also { baos ->
+        DeflaterOutputStream(baos).use { it.write(data) }
+    }.toByteArray()
+
+    private fun deflateRaw(data: ByteArray): ByteArray = ByteArrayOutputStream().also { baos ->
+        DeflaterOutputStream(baos, Deflater(Deflater.DEFAULT_COMPRESSION,true)).use { it.write(data) }
+    }.toByteArray()
 }

--- a/ktor-utils/jvm/test/io/ktor/tests/utils/DeflateEncoderTest.kt
+++ b/ktor-utils/jvm/test/io/ktor/tests/utils/DeflateEncoderTest.kt
@@ -66,8 +66,8 @@ class DeflateEncoderTest {
     @Test
     fun `decode correctly identifies format for 100000 random payloads`() = runBlocking {
         val random = Random(seed = 42)
-        repeat(100_000) { iteration ->
-            val original = random.nextBytes(random.nextInt(1, 64))
+        repeat(10_000) { iteration ->
+            val original = random.nextBytes(random.nextInt(0, 128))
 
             val zlibCompressed = ByteArrayOutputStream().also { baos ->
                 DeflaterOutputStream(baos).use { it.write(original) }

--- a/ktor-utils/jvm/test/io/ktor/tests/utils/DeflateEncoderTest.kt
+++ b/ktor-utils/jvm/test/io/ktor/tests/utils/DeflateEncoderTest.kt
@@ -60,7 +60,7 @@ class DeflateEncoderTest {
     }
 
     @Test
-    fun `decode correctly identifies format for 100000 random payloads`() = runBlocking {
+    fun `decode correctly identifies format for 10000 random payloads`() = runBlocking {
         val random = Random(seed = 42)
         repeat(10_000) { iteration ->
             val original = random.nextBytes(random.nextInt(0, 128))
@@ -86,6 +86,6 @@ class DeflateEncoderTest {
     }.toByteArray()
 
     private fun deflateRaw(data: ByteArray): ByteArray = ByteArrayOutputStream().also { baos ->
-        DeflaterOutputStream(baos, Deflater(Deflater.DEFAULT_COMPRESSION,true)).use { it.write(data) }
+        DeflaterOutputStream(baos, Deflater(Deflater.DEFAULT_COMPRESSION, true)).use { it.write(data) }
     }.toByteArray()
 }

--- a/ktor-utils/jvm/test/io/ktor/tests/utils/DeflateEncoderTest.kt
+++ b/ktor-utils/jvm/test/io/ktor/tests/utils/DeflateEncoderTest.kt
@@ -86,6 +86,8 @@ class DeflateEncoderTest {
     }.toByteArray()
 
     private fun deflateRaw(data: ByteArray): ByteArray = ByteArrayOutputStream().also { baos ->
-        DeflaterOutputStream(baos, Deflater(Deflater.DEFAULT_COMPRESSION, true)).use { it.write(data) }
+        val rawDeflater = Deflater(Deflater.DEFAULT_COMPRESSION, true)
+        DeflaterOutputStream(baos, rawDeflater).use { it.write(data) }
+        rawDeflater.end()
     }.toByteArray()
 }

--- a/ktor-utils/jvm/test/io/ktor/tests/utils/DeflateEncoderTest.kt
+++ b/ktor-utils/jvm/test/io/ktor/tests/utils/DeflateEncoderTest.kt
@@ -20,7 +20,7 @@ class DeflateEncoderTest {
     @Test
     fun `decode handles zlib-wrapped deflate`() = runBlocking {
         val original = "Hello, zlib-wrapped deflate!".toByteArray(Charsets.UTF_8)
-        val compressed = deflateWithZibWrapping(original)
+        val compressed = deflateWithZlibWrapping(original)
 
         val decoded = Deflate.decode(ByteReadChannel(compressed))
             .readRemaining().readByteArray()
@@ -65,7 +65,7 @@ class DeflateEncoderTest {
         repeat(10_000) { iteration ->
             val original = random.nextBytes(random.nextInt(0, 128))
 
-            val zlibCompressed = deflateWithZibWrapping(original)
+            val zlibCompressed = deflateWithZlibWrapping(original)
             assertContentEquals(
                 original,
                 Deflate.decode(ByteReadChannel(zlibCompressed)).readRemaining().readByteArray(),
@@ -81,7 +81,7 @@ class DeflateEncoderTest {
         }
     }
 
-    private fun deflateWithZibWrapping(data: ByteArray): ByteArray = ByteArrayOutputStream().also { baos ->
+    private fun deflateWithZlibWrapping(data: ByteArray): ByteArray = ByteArrayOutputStream().also { baos ->
         DeflaterOutputStream(baos).use { it.write(data) }
     }.toByteArray()
 


### PR DESCRIPTION
this is the standard for http, we should only skip zlib wrapping when we are adding gzip wrapping

Solves this issue https://youtrack.jetbrains.com/issue/KTOR-6999/Deflate-ContentEncoder-incorrectly-uses-raw-DEFLATE

**Subsystem**
ktor-client,ktor-server

**Motivation**
We wanted to start using the request compression in ktor, but our deflate tests failed because ktor lacks the standard wrapping.

From wikipedia: https://en.wikipedia.org/wiki/HTTP_compression

deflate – compression based on the [deflate](https://en.wikipedia.org/wiki/DEFLATE) algorithm (described in RFC [1951](https://www.rfc-editor.org/rfc/rfc1951)), a combination of the [LZ77](https://en.wikipedia.org/wiki/LZ77_and_LZ78#LZ77) algorithm and Huffman coding, wrapped inside the [zlib data format](https://en.wikipedia.org/wiki/Zlib#Data_format) (RFC [1950](https://www.rfc-editor.org/rfc/rfc1950));

**Solution**
Add zlib (RFC 1950) wrapping when not doing gzip.

I added wrapping detection in the decompression code, so we can allow both formats. This was necessary for client tests to work, as they run against an earlier version of the server.

