### PR TITLE
Fix auto-reload leaving server stopped after failed reload

### DIFF
--- a/ktor-server/ktor-server-core/jvm/src/io/ktor/server/engine/EmbeddedServerJvm.kt
+++ b/ktor-server/ktor-server-core/jvm/src/io/ktor/server/engine/EmbeddedServerJvm.kt
@@ -91,16 +91,16 @@ actual constructor(
     }
 
     /**
-     * Reload application: destroy it first and then create again
+     * Reload application: build a new instance first, then dispose of the previous one.
+     *
+     * If the new application cannot be created (for example, because the user code throws during
+     * module loading), the previous instance is preserved and the failure is rethrown.
      *
      * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.server.engine.EmbeddedServer.reload)
      */
     public fun reload() {
         applicationInstanceLock.write {
-            destroyApplication()
-            val (application, classLoader) = createApplication()
-            applicationInstance = application
-            applicationClassLoader = classLoader
+            reloadApplication()
         }
     }
 
@@ -116,13 +116,60 @@ actual constructor(
         }
 
         applicationInstanceLock.write {
-            destroyApplication()
-            val (application, classLoader) = createApplication()
-            applicationInstance = application
-            applicationClassLoader = classLoader
+            try {
+                reloadApplication()
+            } catch (cause: Throwable) {
+                environment.log.error(
+                    "Auto-reload failed; continuing to serve the previously loaded application.",
+                    cause,
+                )
+            }
         }
 
         return@read applicationInstance ?: error("EmbeddedServer was stopped")
+    }
+
+    /**
+     * Build a new application and swap it in, disposing of the previous one only on success.
+     *
+     * On failure the previous application, its class loader, and the registered watch keys
+     * are left intact so the server keeps serving requests against the last known-good code.
+     *
+     * Must be called while holding the write lock on [applicationInstanceLock].
+     */
+    private fun reloadApplication() {
+        val previousApplication = applicationInstance
+        val previousClassLoader = applicationClassLoader
+        val previousWatchKeys = packageWatchKeys
+
+        val (newApplication, newClassLoader) = try {
+            createApplication()
+        } catch (cause: Throwable) {
+            // createClassLoader -> watchUrls() may have already replaced packageWatchKeys before
+            // instantiateAndConfigureApplication() failed. Cancel those freshly-registered keys
+            // (they belong to a class loader we are discarding) and restore the previous ones.
+            if (packageWatchKeys !== previousWatchKeys) {
+                packageWatchKeys.forEach { it.cancel() }
+                packageWatchKeys = previousWatchKeys
+            }
+            throw cause
+        }
+
+        if (previousApplication != null) {
+            safeRaiseEvent(ApplicationStopping, previousApplication)
+            try {
+                destroyBlocking(previousApplication, previousClassLoader)
+            } catch (e: Throwable) {
+                environment.log.error("Failed to destroy previous application instance.", e)
+            }
+            safeRaiseEvent(ApplicationStopped, previousApplication)
+        }
+        if (packageWatchKeys !== previousWatchKeys) {
+            previousWatchKeys.forEach { it.cancel() }
+        }
+
+        applicationInstance = newApplication
+        applicationClassLoader = newClassLoader
     }
 
     private fun getFileChanges(): List<WatchEvent<*>>? {

--- a/ktor-server/ktor-server-core/jvm/test/io/ktor/tests/hosts/EmbeddedServerReloadingTests.kt
+++ b/ktor-server/ktor-server-core/jvm/test/io/ktor/tests/hosts/EmbeddedServerReloadingTests.kt
@@ -605,6 +605,35 @@ class EmbeddedServerReloadingTests {
     }
 
     @Test
+    fun `reload preserves previous application when module fails to load`() {
+        var moduleCallCount = 0
+        val props = serverConfig {
+            developmentMode = false
+            module {
+                val callIndex = moduleCallCount++
+                if (callIndex == 0) {
+                    attributes.put(TestKey, "first-load")
+                } else {
+                    error("Simulated reload failure on call #$callIndex")
+                }
+            }
+        }
+        val server = EmbeddedServer(props, DummyEngineFactory)
+
+        server.start()
+        val initialApp = server.application
+        assertEquals("first-load", initialApp.attributes[TestKey])
+
+        assertFailsWith<IllegalStateException> { server.reload() }
+        assertEquals(2, moduleCallCount)
+
+        val appAfterFailedReload = server.application
+        assertEquals("first-load", appAfterFailedReload.attributes[TestKey])
+
+        server.stop()
+    }
+
+    @Test
     fun `application is available before environment start`() {
         val env = dummyEnv()
         val props = serverConfig(env)


### PR DESCRIPTION
**Subsystem**
Server core, auto-reload

**Motivation**
Fixes #4717. When auto-reload fires while a Gradle compile is still in progress, `createApplication()` may throw — leaving `applicationInstance` as `null`, so every subsequent request fails with `EmbeddedServer was stopped` until the JVM is restarted.

**Solution**
- Switch reload to a create-then-swap pattern in a new private `reloadApplication()` helper: create the new application first, dispose the previous one only on success, restore the previous watch keys on failure.
- `reload()` rethrows so explicit callers still see the error; the auto-reload path in `currentApplication()` catches and logs, keeping the previously loaded application alive.