### PR TITLE
KTOR-9536 Ignore test failure to unblock other merges

### DIFF
--- a/ktor-server/ktor-server-netty/jvm/test/io/ktor/tests/server/netty/NettySpecificTest.kt
+++ b/ktor-server/ktor-server-netty/jvm/test/io/ktor/tests/server/netty/NettySpecificTest.kt
@@ -174,6 +174,7 @@ class NettySpecificTest {
         }
     }
 
+    @Ignore // KTOR-9536
     @Test
     fun `call finishes when channel becomes inactive before response is sent`() = runTestWithRealTime {
         val handlerStarted = CompletableDeferred<Unit>()


### PR DESCRIPTION
**Subsystem**
Server, Netty (Testing)

**Motivation**
[KTOR-9536](https://youtrack.jetbrains.com/issue/KTOR-9536) Netty inactive channel test failure

**Solution**
Disable this test for now since it is failing everywhere on TC.  Seems to be introduced with the 3.4.3 merge.

