### PR TITLE
Add reproduction for 3.4.3 Netty request handler executing on worker group

### DIFF
--- a/ktor-server/ktor-server-netty/jvm/test/io/ktor/tests/server/netty/NettySpecificTest.kt
+++ b/ktor-server/ktor-server-netty/jvm/test/io/ktor/tests/server/netty/NettySpecificTest.kt
@@ -21,6 +21,7 @@ import io.ktor.server.routing.*
 import io.ktor.test.dispatcher.*
 import io.ktor.utils.io.*
 import io.netty.channel.Channel
+import io.netty.channel.EventLoopGroup
 import kotlinx.coroutines.*
 import java.net.BindException
 import java.net.ServerSocket
@@ -296,6 +297,50 @@ class NettySpecificTest {
             }
         } finally {
             serverJob.cancel()
+        }
+    }
+
+    @Test
+    fun `request handler runs on call event group`() = runTestWithRealTime {
+        val handlerThread = AtomicReference<Thread>()
+
+        val server = embeddedServer(
+            factory = Netty,
+            rootConfig = serverConfig {
+                module {
+                    routing {
+                        get("/") {
+                            handlerThread.set(Thread.currentThread())
+                            call.respondText("ok")
+                        }
+                    }
+                }
+            },
+            configure = {
+                connector { port = 0 }
+                // This issue is not relevant if call and worker groups are shared
+                shareWorkGroup = false
+            }
+        )
+        server.startSuspend(wait = false)
+
+        try {
+            val connector = server.engine.resolvedConnectors().first()
+            HttpClient(CIO).use { it.get("http://${connector.host}:${connector.port}/") }
+
+            // Ugly, but we'd like to access the call event group somehow
+            val callEventGroup = NettyApplicationEngine::class.java
+                .getDeclaredMethod("getCallEventGroup")
+                .apply { isAccessible = true }
+                .invoke(server.engine) as EventLoopGroup
+
+            val thread = handlerThread.get()
+            assertTrue(
+                callEventGroup.any { it.inEventLoop(thread) },
+                "Handler ran on '${thread.name}', not on any call event group thread"
+            )
+        } finally {
+            server.stopSuspend(0L, 0L)
         }
     }
 }


### PR DESCRIPTION
**Subsystem**
Server

**Motivation**
3.4.3 introduced a bug where request handlers execute on the worker group instead of the call group when using Netty.

I've created an issue here: [KTOR-9542](https://youtrack.jetbrains.com/issue/KTOR-9542/Netty-server-runs-requests-on-worker-group-after-3.4.3)

I'd guess that [KTOR-9531](https://youtrack.jetbrains.com/issue/KTOR-9531/Netty-server-intermittently-drops-requests-after-upgrading-to-3.4.3) is at least somewhat related.

Appears to have been introduced in https://github.com/ktorio/ktor/pull/5421

**Solution**
This PR isn't intended to be merged, only to demonstrate the issue.

