### PR TITLE
Fix flaky tests

### DIFF
--- a/ktor-client/ktor-client-curl/desktop/src/io/ktor/client/engine/curl/CurlClientEngine.kt
+++ b/ktor-client/ktor-client-curl/desktop/src/io/ktor/client/engine/curl/CurlClientEngine.kt
@@ -48,7 +48,7 @@ internal class CurlClientEngine(
 
             val status = HttpStatusCode.fromValue(status)
 
-            val responseBody: Any = if (data.isUpgradeRequest()) {
+            val responseBody: Any = if (data.isUpgradeRequest() && status == HttpStatusCode.SwitchingProtocols) {
                 val wsConfig = data.attributes[WEBSOCKETS_KEY]
                 val websocket = responseBody as CurlWebSocketResponseBody
                 CurlWebSocketSession(
@@ -57,6 +57,11 @@ internal class CurlClientEngine(
                     wsConfig.channelsConfig.outgoing,
                     curlProcessor,
                 )
+            } else if (data.isUpgradeRequest()) {
+                // Server rejected the upgrade (e.g., 401 Unauthorized). The easy handle is already
+                // cleaned up by this point — don't create a WebSocket session or cancelWebSocket
+                // would enqueue a stale handle that may be reallocated for the retry request.
+                ByteReadChannel.Empty
             } else {
                 val httpResponse = responseBody as CurlHttpResponseBody
                 data.attributes.getOrNull(ResponseAdapterAttributeKey)

--- a/ktor-client/ktor-client-curl/desktop/src/io/ktor/client/engine/curl/CurlProcessor.kt
+++ b/ktor-client/ktor-client-curl/desktop/src/io/ktor/client/engine/curl/CurlProcessor.kt
@@ -62,8 +62,8 @@ internal class CurlProcessor(coroutineContext: CoroutineContext) {
      * is removed from the multi handle, preventing stale handles from blocking
      * the event loop.
      */
-    fun cancelWebSocket(easyHandle: EasyHandle) {
-        val sent = taskQueue.trySend(CancelWebSocket(easyHandle))
+    fun cancelWebSocket(websocket: CurlWebSocketResponseBody) {
+        val sent = taskQueue.trySend(CancelWebSocket(websocket))
         if (sent.isSuccess) {
             curlApi!!.wakeup()
         }
@@ -94,7 +94,7 @@ internal class CurlProcessor(coroutineContext: CoroutineContext) {
                 is SendWebSocketFrame ->
                     api.sendWebSocketFrame(task.websocket, task.flags, task.data, task.completionHandler)
                 is CancelWebSocket ->
-                    api.cancelRequest(task.easyHandle, CancellationException("WebSocket session closed"))
+                    api.cancelWebSocket(task.websocket, CancellationException("WebSocket session closed"))
             }
         }
     }
@@ -149,8 +149,7 @@ private sealed interface CurlTask {
         val completionHandler: CompletableJob,
     ) : CurlTask
 
-    @OptIn(ExperimentalForeignApi::class)
     class CancelWebSocket(
-        val easyHandle: EasyHandle,
+        val websocket: CurlWebSocketResponseBody,
     ) : CurlTask
 }

--- a/ktor-client/ktor-client-curl/desktop/src/io/ktor/client/engine/curl/internal/CurlMultiApiHandler.kt
+++ b/ktor-client/ktor-client-curl/desktop/src/io/ktor/client/engine/curl/internal/CurlMultiApiHandler.kt
@@ -42,7 +42,7 @@ internal class CurlMultiApiHandler : Closeable {
     private val easyHandlesToUnpause = mutableListOf<EasyHandle>()
 
     override fun close() {
-        if (activeHandles.isNotEmpty()) handleCompleted()
+        if (activeHandles.isNotEmpty() || cancelledHandles.isNotEmpty()) handleCompleted()
         for ((handle, holder) in activeHandles) {
             cleanupEasyHandle(handle)
             holder.dispose()
@@ -134,11 +134,20 @@ internal class CurlMultiApiHandler : Closeable {
         cancelledHandles += Pair(easyHandle, cause)
     }
 
+    fun cancelWebSocket(websocket: CurlWebSocketResponseBody, cause: Throwable) {
+        val easyHandle = websocket.easyHandle
+        val handler = activeHandles[easyHandle] ?: return
+        if (handler.responseWrapper.get() !== websocket) return
+        activeHandles.remove(easyHandle)
+        processCancelledEasyHandle(easyHandle, cause)
+        handler.responseCompletable.completeExceptionally(cause)
+        handler.dispose()
+    }
+
     fun perform(transfersRunning: IntVarOf<Int>) {
         if (activeHandles.isEmpty()) return
 
-        // Process cancelled handles before performing to remove stale handles
-        // (e.g., closed WebSocket sessions) and prevent them from blocking curl_multi_poll.
+        // Process cancelled handles before performing to prevent them from blocking curl_multi_poll.
         if (cancelledHandles.isNotEmpty()) {
             handleCompleted()
         }

--- a/ktor-client/ktor-client-curl/desktop/src/io/ktor/client/engine/curl/internal/CurlWebSocketSession.kt
+++ b/ktor-client/ktor-client-curl/desktop/src/io/ktor/client/engine/curl/internal/CurlWebSocketSession.kt
@@ -104,6 +104,6 @@ internal class CurlWebSocketSession(
 
         websocket.close(cause)
         _outgoing.cancel()
-        curlProcessor.cancelWebSocket(websocket.easyHandle)
+        curlProcessor.cancelWebSocket(websocket)
     }
 }

--- a/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/HttpTimeoutTest.kt
+++ b/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/HttpTimeoutTest.kt
@@ -17,6 +17,7 @@ import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.withTimeout
 import kotlinx.io.IOException
 import kotlin.test.*
+import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 
 private const val TEST_URL = "$TEST_SERVER/timeout"
@@ -81,7 +82,7 @@ class HttpTimeoutTest : ClientLoader(timeout = 30.seconds) {
             }
 
             val exception = assertFails {
-                withTimeout(500) {
+                withTimeout(500.milliseconds) {
                     client.request(requestBuilder).body<String>()
                 }
             }
@@ -258,12 +259,10 @@ class HttpTimeoutTest : ClientLoader(timeout = 30.seconds) {
         }
 
         test { client ->
-            val response = client.prepareGet("$TEST_URL/with-stream") {
-                parameter("delay", 10000)
-                timeout { requestTimeoutMillis = 1000 }
-            }.body<ByteReadChannel>()
-            assertFailsWith<CancellationException> {
-                response.readLine()
+            assertFailsWith<HttpRequestTimeoutException> {
+                client.get("$TEST_URL/with-stream?delay=10000") {
+                    timeout { requestTimeoutMillis = 1000 }
+                }.bodyAsText()
             }
             val result = client.get("$TEST_URL/with-delay?delay=1") {
                 timeout { requestTimeoutMillis = 1000 }

--- a/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/WebSocketTest.kt
+++ b/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/WebSocketTest.kt
@@ -395,7 +395,7 @@ class WebSocketTest : ClientLoader(except(ENGINES_WITHOUT_WS)) {
     }
 
     @Test
-    fun testAuthenticationWithValidRefreshToken() = clientTests(except("Js", "WinHttp"), retries = 5) {
+    fun testAuthenticationWithValidRefreshToken() = clientTests(except("Js", "WinHttp")) {
         config {
             install(WebSockets)
 
@@ -417,7 +417,7 @@ class WebSocketTest : ClientLoader(except(ENGINES_WITHOUT_WS)) {
     }
 
     @Test
-    fun testAuthenticationWithValidInitialToken() = clientTests(except("Js", "Darwin"), retries = 5) {
+    fun testAuthenticationWithValidInitialToken() = clientTests(except("Js", "Darwin")) {
         config {
             install(WebSockets)
 
@@ -438,7 +438,7 @@ class WebSocketTest : ClientLoader(except(ENGINES_WITHOUT_WS)) {
     }
 
     @Test
-    fun testAuthenticationWithInvalidToken() = clientTests(except("Js", "WinHttp"), retries = 5) {
+    fun testAuthenticationWithInvalidToken() = clientTests(except("Js", "WinHttp")) {
         config {
             install(WebSockets)
 

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyApplicationResponse.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyApplicationResponse.kt
@@ -160,7 +160,7 @@ public abstract class NettyApplicationResponse(
     public fun cancel() {
         if (!responseMessageSent) {
             responseChannel = ByteReadChannel.Empty
-            responseReady.setFailure(CancellationException("Response was cancelled"))
+            responseReady.tryFailure(CancellationException("Response was cancelled"))
             responseMessageSent = true
         }
     }

--- a/ktor-server/ktor-server-netty/jvm/test/io/ktor/tests/server/netty/NettySpecificTest.kt
+++ b/ktor-server/ktor-server-netty/jvm/test/io/ktor/tests/server/netty/NettySpecificTest.kt
@@ -174,7 +174,6 @@ class NettySpecificTest {
         }
     }
 
-    @Ignore // KTOR-9536
     @Test
     fun `call finishes when channel becomes inactive before response is sent`() = runTestWithRealTime {
         val handlerStarted = CompletableDeferred<Unit>()

--- a/ktor-server/ktor-server-plugins/ktor-server-di/common/test/io/ktor/server/plugins/di/DependencyInjectionTest.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-di/common/test/io/ktor/server/plugins/di/DependencyInjectionTest.kt
@@ -4,34 +4,26 @@
 
 package io.ktor.server.plugins.di
 
-import io.ktor.client.request.get
-import io.ktor.client.statement.HttpResponse
-import io.ktor.client.statement.bodyAsText
+import io.ktor.client.request.*
+import io.ktor.client.statement.*
 import io.ktor.server.application.*
-import io.ktor.server.response.respondText
+import io.ktor.server.response.*
 import io.ktor.server.routing.*
 import io.ktor.server.testing.*
-import io.ktor.test.dispatcher.runTestWithRealTime
-import io.ktor.util.logging.Logger
-import io.ktor.util.reflect.TypeInfo
+import io.ktor.test.dispatcher.*
+import io.ktor.util.logging.*
+import io.ktor.util.reflect.*
 import io.ktor.utils.io.CancellationException
-import kotlinx.coroutines.CompletableDeferred
-import kotlinx.coroutines.Deferred
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.awaitCancellation
-import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.*
 import kotlinx.coroutines.channels.Channel
-import kotlinx.coroutines.coroutineScope
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.consumeAsFlow
 import kotlinx.coroutines.flow.toList
-import kotlinx.coroutines.joinAll
-import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.TestResult
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.Serializable
 import kotlin.reflect.KClass
 import kotlin.test.*
+import kotlin.time.Duration.Companion.milliseconds
 
 internal const val HELLO = "Hello, world!"
 internal const val HELLO_CUSTOMER = "Hello, customer!"
@@ -311,20 +303,22 @@ class DependencyInjectionTest {
     fun `async support`() = testApplication(Dispatchers.Unconfined) {
         val greeter = GreetingServiceImpl()
         val bank = BankServiceImpl()
+        val bankResolved = Job()
         val resolutionChannel = Channel<String>(Channel.UNLIMITED)
 
         application {
             dependencies {
                 provide<GreetingService> {
-                    delay(100)
+                    bankResolved.join()
                     greeter.also {
                         resolutionChannel.trySend("greeting").getOrThrow()
                     }
                 }
                 provide<BankService> {
-                    delay(50)
+                    delay(50.milliseconds)
                     bank.also {
                         resolutionChannel.trySend("bank").getOrThrow()
+                        bankResolved.complete()
                     }
                 }
                 provide<BankTeller> {
@@ -374,11 +368,11 @@ class DependencyInjectionTest {
         val bank = BankServiceImpl()
 
         val fetchGreetingService: suspend () -> GreetingService = {
-            delay(100)
+            delay(100.milliseconds)
             greeter
         }
         val fetchBankService: suspend () -> BankService = {
-            delay(50)
+            delay(50.milliseconds)
             bank
         }
 
@@ -433,7 +427,7 @@ class DependencyInjectionTest {
                     routing {
                         get("/hello") {
                             call.launch {
-                                delay(50)
+                                delay(50.milliseconds)
                                 registryDeferred.complete(dependencies)
                             }
                             val service: GreetingService = dependencies.resolve()

--- a/ktor-server/ktor-server-plugins/ktor-server-rate-limit/common/test/io/ktor/server/plugins/ratelimit/RateLimitTest.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-rate-limit/common/test/io/ktor/server/plugins/ratelimit/RateLimitTest.kt
@@ -39,14 +39,10 @@ class RateLimitTest {
         }
 
         repeat(10) {
-            client.get("/").let {
-                assertEquals(HttpStatusCode.OK, it.status)
-            }
+            client.get("/").assertOk()
         }
 
-        client.get("/").let {
-            assertEquals(HttpStatusCode.TooManyRequests, it.status)
-        }
+        client.get("/").assertTooManyRequests()
     }
 
     @Test
@@ -61,14 +57,10 @@ class RateLimitTest {
         }
 
         repeat(10) {
-            client.get("/").let {
-                assertEquals(HttpStatusCode.OK, it.status)
-            }
+            client.get("/").assertOk()
         }
 
-        client.get("/").let {
-            assertEquals(HttpStatusCode.TooManyRequests, it.status)
-        }
+        client.get("/").assertTooManyRequests()
     }
 
     @Test
@@ -103,31 +95,19 @@ class RateLimitTest {
         }
 
         repeat(10) {
-            client.get("/a").let {
-                assertEquals(HttpStatusCode.OK, it.status)
-            }
+            client.get("/a").assertOk()
         }
-        client.get("/a").let {
-            assertEquals(HttpStatusCode.TooManyRequests, it.status)
-        }
+        client.get("/a").assertTooManyRequests()
 
         repeat(5) {
-            client.get("/b").let {
-                assertEquals(HttpStatusCode.OK, it.status)
-            }
+            client.get("/b").assertOk()
         }
-        client.get("/b").let {
-            assertEquals(HttpStatusCode.TooManyRequests, it.status)
-        }
+        client.get("/b").assertTooManyRequests()
 
         repeat(3) {
-            client.get("/c").let {
-                assertEquals(HttpStatusCode.OK, it.status)
-            }
+            client.get("/c").assertOk()
         }
-        client.get("/c").let {
-            assertEquals(HttpStatusCode.TooManyRequests, it.status)
-        }
+        client.get("/c").assertTooManyRequests()
     }
 
     @Test
@@ -155,26 +135,16 @@ class RateLimitTest {
         }
 
         repeat(6) {
-            client.get("/default").let {
-                assertEquals(HttpStatusCode.OK, it.status)
-            }
+            client.get("/default").assertOk()
         }
-        client.get("/default").let {
-            assertEquals(HttpStatusCode.TooManyRequests, it.status)
-        }
-        client.get("/custom").let {
-            assertEquals(HttpStatusCode.TooManyRequests, it.status)
-        }
+        client.get("/default").assertTooManyRequests()
+        client.get("/custom").assertTooManyRequests()
 
         time += 7000
         repeat(5) {
-            client.get("/custom").let {
-                assertEquals(HttpStatusCode.OK, it.status)
-            }
+            client.get("/custom").assertOk()
         }
-        client.get("/custom").let {
-            assertEquals(HttpStatusCode.TooManyRequests, it.status)
-        }
+        client.get("/custom").assertTooManyRequests()
     }
 
     @Test
@@ -199,23 +169,15 @@ class RateLimitTest {
         }
 
         repeat(5) {
-            client.get("/a").let {
-                assertEquals(HttpStatusCode.OK, it.status)
-            }
+            client.get("/a").assertOk()
         }
-        client.get("/a").let {
-            assertEquals(HttpStatusCode.TooManyRequests, it.status)
-        }
+        client.get("/a").assertTooManyRequests()
 
         time += 7000
         repeat(4) {
-            client.get("/a").let {
-                assertEquals(HttpStatusCode.OK, it.status)
-            }
+            client.get("/a").assertOk()
         }
-        client.get("/a").let {
-            assertEquals(HttpStatusCode.TooManyRequests, it.status)
-        }
+        client.get("/a").assertTooManyRequests()
     }
 
     @Test
@@ -237,23 +199,15 @@ class RateLimitTest {
         }
 
         repeat(10) {
-            client.get("/a").let {
-                assertEquals(HttpStatusCode.OK, it.status)
-            }
+            client.get("/a").assertOk()
         }
-        client.get("/a").let {
-            assertEquals(HttpStatusCode.TooManyRequests, it.status)
-        }
+        client.get("/a").assertTooManyRequests()
 
         time += 5000
         repeat(10) {
-            client.get("/a").let {
-                assertEquals(HttpStatusCode.OK, it.status)
-            }
+            client.get("/a").assertOk()
         }
-        client.get("/a").let {
-            assertEquals(HttpStatusCode.TooManyRequests, it.status)
-        }
+        client.get("/a").assertTooManyRequests()
     }
 
     @Test
@@ -273,24 +227,16 @@ class RateLimitTest {
         }
 
         repeat(10) {
-            client.get("/").let {
-                assertEquals(HttpStatusCode.OK, it.status)
-            }
+            client.get("/").assertOk()
         }
-        client.get("/").let {
-            assertEquals(HttpStatusCode.TooManyRequests, it.status)
-        }
+        client.get("/").assertTooManyRequests()
 
         time += 5.seconds.inWholeMilliseconds
 
         repeat(10) {
-            client.get("/").let {
-                assertEquals(HttpStatusCode.OK, it.status)
-            }
+            client.get("/").assertOk()
         }
-        client.get("/").let {
-            assertEquals(HttpStatusCode.TooManyRequests, it.status)
-        }
+        client.get("/").assertTooManyRequests()
     }
 
     @Test
@@ -336,16 +282,10 @@ class RateLimitTest {
         }
 
         repeat(2) {
-            client.get("/?price=4").let {
-                assertEquals(HttpStatusCode.OK, it.status)
-            }
+            client.get("/?price=4").assertOk()
         }
-        client.get("/?price=3").let {
-            assertEquals(HttpStatusCode.TooManyRequests, it.status)
-        }
-        client.get("/?price=2").let {
-            assertEquals(HttpStatusCode.OK, it.status)
-        }
+        client.get("/?price=3").assertTooManyRequests()
+        client.get("/?price=2").assertOk()
     }
 
     @Test
@@ -365,21 +305,13 @@ class RateLimitTest {
         }
 
         repeat(10) {
-            client.get("/?key=1").let {
-                assertEquals(HttpStatusCode.OK, it.status)
-            }
+            client.get("/?key=1").assertOk()
         }
         repeat(10) {
-            client.get("/?key=2").let {
-                assertEquals(HttpStatusCode.OK, it.status)
-            }
+            client.get("/?key=2").assertOk()
         }
-        client.get("/?key=1").let {
-            assertEquals(HttpStatusCode.TooManyRequests, it.status)
-        }
-        client.get("/?key=2").let {
-            assertEquals(HttpStatusCode.TooManyRequests, it.status)
-        }
+        client.get("/?key=1").assertTooManyRequests()
+        client.get("/?key=2").assertTooManyRequests()
     }
 
     @Test
@@ -401,21 +333,13 @@ class RateLimitTest {
         }
 
         repeat(10) {
-            client.get("/?key=key1").let {
-                assertEquals(HttpStatusCode.OK, it.status)
-            }
+            client.get("/?key=key1").assertOk()
         }
         repeat(5) {
-            client.get("/?key=key2").let {
-                assertEquals(HttpStatusCode.OK, it.status)
-            }
+            client.get("/?key=key2").assertOk()
         }
-        client.get("/?key=key1").let {
-            assertEquals(HttpStatusCode.TooManyRequests, it.status)
-        }
-        client.get("/?key=key2").let {
-            assertEquals(HttpStatusCode.TooManyRequests, it.status)
-        }
+        client.get("/?key=key1").assertTooManyRequests()
+        client.get("/?key=key2").assertTooManyRequests()
     }
 
     @Test
@@ -443,21 +367,13 @@ class RateLimitTest {
         }
 
         repeat(5) {
-            client.get("/a").let {
-                assertEquals(HttpStatusCode.OK, it.status)
-            }
+            client.get("/a").assertOk()
         }
         repeat(5) {
-            client.get("/b").let {
-                assertEquals(HttpStatusCode.OK, it.status)
-            }
+            client.get("/b").assertOk()
         }
-        client.get("/a").let {
-            assertEquals(HttpStatusCode.TooManyRequests, it.status)
-        }
-        client.get("/b").let {
-            assertEquals(HttpStatusCode.TooManyRequests, it.status)
-        }
+        client.get("/a").assertTooManyRequests()
+        client.get("/b").assertTooManyRequests()
     }
 
     @Test
@@ -691,21 +607,13 @@ class RateLimitTest {
             }
         }
 
-        client.get("/").let {
-            assertEquals(HttpStatusCode.OK, it.status)
-        }
+        client.get("/").assertOk()
         time += 60
-        client.get("/").let {
-            assertEquals(HttpStatusCode.OK, it.status)
-        }
+        client.get("/").assertOk()
         time += 60
-        client.get("/").let {
-            assertEquals(HttpStatusCode.OK, it.status)
-        }
+        client.get("/").assertOk()
         time += 60
-        client.get("/").let {
-            assertEquals(HttpStatusCode.TooManyRequests, it.status)
-        }
+        client.get("/").assertTooManyRequests()
         assertEquals(1, rateLimitersRegistry.size)
         rateLimitersRegistry[rateLimitersRegistry.keys.first()] = RateLimiter.default(
             limit = 3,
@@ -718,9 +626,7 @@ class RateLimitTest {
         assertEquals(1, rateLimitersRegistry.size)
         assertEquals(1, createCount)
 
-        client.get("/").let {
-            assertEquals(HttpStatusCode.OK, it.status)
-        }
+        client.get("/").assertOk()
         assertEquals(1, rateLimitersRegistry.size)
         assertEquals(1, createCount)
     }
@@ -825,3 +731,7 @@ class RateLimitTest {
         }
     }
 }
+
+private fun HttpResponse.assertOk(): HttpResponse = assertStatus(HttpStatusCode.OK)
+private fun HttpResponse.assertTooManyRequests(): HttpResponse = assertStatus(HttpStatusCode.TooManyRequests)
+private fun HttpResponse.assertStatus(expected: HttpStatusCode): HttpResponse = apply { assertEquals(expected, status) }

--- a/ktor-server/ktor-server-plugins/ktor-server-rate-limit/common/test/io/ktor/server/plugins/ratelimit/RateLimitTest.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-rate-limit/common/test/io/ktor/server/plugins/ratelimit/RateLimitTest.kt
@@ -544,7 +544,7 @@ class RateLimitTest {
             register {
                 rateLimiter { _, _ ->
                     createCount++
-                    RateLimiter.default(limit = 3, refillPeriod = 2.seconds)
+                    RateLimiter.default(limit = 3, refillPeriod = 500.milliseconds)
                 }
             }
         }
@@ -556,29 +556,15 @@ class RateLimitTest {
             }
         }
 
-        client.get("/").let {
-            assertEquals(HttpStatusCode.OK, it.status)
+        repeat(3) {
+            client.get("/").assertOk()
         }
-        delay(500)
-        client.get("/").let {
-            assertEquals(HttpStatusCode.OK, it.status)
-        }
-        delay(500)
-        client.get("/").let {
-            assertEquals(HttpStatusCode.OK, it.status)
-        }
-        delay(500)
-        client.get("/").let {
-            assertEquals(HttpStatusCode.TooManyRequests, it.status)
-        }
+        client.get("/").assertTooManyRequests()
 
-        assertEquals(1, createCount)
-        delay(600)
+        delay(1.seconds)
         assertEquals(1, createCount)
 
-        client.get("/").let {
-            assertEquals(HttpStatusCode.OK, it.status)
-        }
+        client.get("/").assertOk()
         assertEquals(2, createCount)
     }
 
@@ -622,7 +608,7 @@ class RateLimitTest {
 
         assertEquals(1, createCount)
         assertEquals(1, rateLimitersRegistry.size)
-        delay(550)
+        delay(550.milliseconds)
         assertEquals(1, rateLimitersRegistry.size)
         assertEquals(1, createCount)
 

--- a/ktor-shared/ktor-test-base/common/test/io/ktor/test/RunTestWithDataTest.kt
+++ b/ktor-shared/ktor-test-base/common/test/io/ktor/test/RunTestWithDataTest.kt
@@ -13,8 +13,8 @@ import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 
-// We can't make this value too small as tests become flaky
-private val singleTestDuration = 100.milliseconds
+// We can't make this value too small as tests become flaky on slow CI (especially Windows)
+private val singleTestDuration = 200.milliseconds
 
 class RunTestWithDataTest {
 
@@ -160,7 +160,7 @@ class RunTestWithDataTest {
                     listOf(
                         "Test 1: attempt 0 failed: First attempt failed",
                         "Test 1: attempt 1 succeeded",
-                        "Test 2: attempt 0 failed: After waiting for 100ms, the test body did not run to completion",
+                        "Test 2: attempt 0 failed: After waiting for 200ms, the test body did not run to completion",
                         "Test 2: attempt 1 succeeded",
                         "Test 3: attempt 0 succeeded",
                     ),


### PR DESCRIPTION
**Subsystem**
Test Infrastructure

**Motivation**
Make tests a bit more stable

**Solution**
- `HttpTimeoutTest.testGetAfterTimeout`: Remove streaming and expect `HttpRequestTimeoutException` instead of `CancellationException`. We have separate tests for streaming get and for this test it is not what we're testing.
- `RateLimitTest.testRemovesUnusedRateLimitersOnRefill`: Remove intermittent delays causing status `OK` instead of `TooManyRequests`
- `RunTestWithDataTest`: Increase test duration to give a twice larger window to cover OS scheduling overhead.
- `WebSocketTest.testAuthenticationWithValidRefreshToken`: This one was legitimately failing on Curl because of [KTOR-9539](https://youtrack.jetbrains.com/issue/KTOR-9539)
- `NettySpecificTest`: Fix Netty call hang when channel becomes inactive before response is sent ([KTOR-9536](https://youtrack.jetbrains.com/issue/KTOR-9536)).
- `WebSocketTest.testHttpRequestAfterWebSocketClose`: Fix ABA pointer-reuse bug in Curl WebSocket cancellation ([KTOR-9540](https://youtrack.jetbrains.com/issue/KTOR-9540)).
- `DependencyInjectionTest.async support`: Replace timing-based delays with a `Job` barrier to make resolution order deterministic without relying on real-time scheduling.

_It's better to review commit-by-commit_