### PR TITLE
KTOR-646 Log client-disconnect IOException at TRACE in Netty HTTP/1 handler

### DIFF
--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http1/NettyHttp1Handler.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http1/NettyHttp1Handler.kt
@@ -104,7 +104,7 @@ internal class NettyHttp1Handler(
     override fun exceptionCaught(context: ChannelHandlerContext, cause: Throwable) {
         when (cause) {
             is IOException -> {
-                environment.log.debug("I/O operation failed", cause)
+                environment.log.trace("I/O operation failed", cause)
                 handlerJob.cancel()
                 context.close()
             }

--- a/ktor-server/ktor-server-netty/jvm/test/io/ktor/tests/server/netty/NettySpecificTest.kt
+++ b/ktor-server/ktor-server-netty/jvm/test/io/ktor/tests/server/netty/NettySpecificTest.kt
@@ -4,6 +4,10 @@
 
 package io.ktor.tests.server.netty
 
+import ch.qos.logback.classic.Level
+import ch.qos.logback.classic.Logger
+import ch.qos.logback.classic.spi.ILoggingEvent
+import ch.qos.logback.core.read.ListAppender
 import io.ktor.client.*
 import io.ktor.client.engine.cio.*
 import io.ktor.client.plugins.*
@@ -16,14 +20,20 @@ import io.ktor.server.application.*
 import io.ktor.server.application.hooks.*
 import io.ktor.server.engine.*
 import io.ktor.server.netty.*
+import io.ktor.server.netty.http1.NettyHttp1Handler
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
 import io.ktor.test.dispatcher.*
 import io.ktor.utils.io.*
+import io.mockk.mockk
+import io.netty.channel.embedded.EmbeddedChannel
 import kotlinx.coroutines.*
+import org.slf4j.LoggerFactory
+import java.io.IOException
 import java.net.BindException
 import java.net.ServerSocket
 import java.util.concurrent.ExecutorService
+import kotlin.coroutines.EmptyCoroutineContext
 import kotlin.test.*
 import kotlin.time.Duration.Companion.seconds
 
@@ -168,6 +178,53 @@ class NettySpecificTest {
             }
         } finally {
             serverJob.cancel()
+        }
+    }
+
+    @Test
+    fun `KTOR-646 client-disconnect IOException is logged at TRACE not DEBUG`() {
+        val logger = LoggerFactory.getLogger("io.ktor.tests.server.netty.KTOR-646") as Logger
+        val previousLevel = logger.level
+        val listAppender = ListAppender<ILoggingEvent>().apply { start() }
+        logger.level = Level.TRACE
+        logger.addAppender(listAppender)
+
+        val environment = applicationEnvironment { log = logger }
+        val handler = NettyHttp1Handler(
+            applicationProvider = { mockk(relaxed = true) },
+            enginePipeline = mockk(relaxed = true),
+            environment = environment,
+            engineContext = EmptyCoroutineContext,
+            userContext = EmptyCoroutineContext,
+            runningLimit = 32
+        )
+
+        // EmbeddedChannel without firing the full pipeline lifecycle: we only
+        // want to exercise exceptionCaught. Use a fresh channel and add only
+        // this handler so RequestBodyHandler isn't installed via channelActive.
+        val channel = EmbeddedChannel()
+        channel.pipeline().addLast(handler)
+        try {
+            channel.pipeline().fireExceptionCaught(IOException("Connection reset by peer"))
+
+            logger.detachAppender(listAppender)
+
+            val ioOpFailedEvents = listAppender.list.filter { it.formattedMessage == "I/O operation failed" }
+            assertEquals(
+                1,
+                ioOpFailedEvents.size,
+                "Expected one 'I/O operation failed' log entry for client-disconnect IOException, " +
+                    "got ${ioOpFailedEvents.size}"
+            )
+            assertEquals(
+                Level.TRACE,
+                ioOpFailedEvents.single().level,
+                "Client-disconnect IOException must be logged at TRACE to avoid noise in DEBUG logs"
+            )
+        } finally {
+            logger.detachAppender(listAppender)
+            logger.level = previousLevel
+            channel.finishAndReleaseAll()
         }
     }
 

--- a/ktor-server/ktor-server-netty/jvm/test/io/ktor/tests/server/netty/NettySpecificTest.kt
+++ b/ktor-server/ktor-server-netty/jvm/test/io/ktor/tests/server/netty/NettySpecificTest.kt
@@ -182,8 +182,8 @@ class NettySpecificTest {
     }
 
     @Test
-    fun `KTOR-646 client-disconnect IOException is logged at TRACE not DEBUG`() {
-        val logger = LoggerFactory.getLogger("io.ktor.tests.server.netty.KTOR-646") as Logger
+    fun `client disconnect is logged at trace level`() {
+        val logger = LoggerFactory.getLogger("io.ktor.tests.server.netty.ClientDisconnectLogging") as Logger
         val previousLevel = logger.level
         val listAppender = ListAppender<ILoggingEvent>().apply { start() }
         logger.level = Level.TRACE
@@ -206,8 +206,6 @@ class NettySpecificTest {
         channel.pipeline().addLast(handler)
         try {
             channel.pipeline().fireExceptionCaught(IOException("Connection reset by peer"))
-
-            logger.detachAppender(listAppender)
 
             val ioOpFailedEvents = listAppender.list.filter { it.formattedMessage == "I/O operation failed" }
             assertEquals(


### PR DESCRIPTION
**Subsystem**
Server, Netty

**Motivation**
[KTOR-646](https://youtrack.jetbrains.com/issue/KTOR-646) / #1030 — `NettyHttp1Handler.exceptionCaught` logs every `IOException` at DEBUG, so routine client disconnects ("Connection reset by peer") show up as noise in default DEBUG logs.

**Solution**
Lower the log level to TRACE. Information stays available for deep debugging without polluting DEBUG output.