### PR TITLE
KTOR-9544 Apache: Attach response body channel to callContext

### DIFF
--- a/ktor-client/ktor-client-apache5/jvm/src/io/ktor/client/engine/apache5/ApacheResponseConsumer.kt
+++ b/ktor-client/ktor-client-apache5/jvm/src/io/ktor/client/engine/apache5/ApacheResponseConsumer.kt
@@ -83,11 +83,11 @@ internal class ApacheResponseConsumer(
     private val requestData: HttpRequestData
 ) : AsyncEntityConsumer<Unit>, CoroutineScope {
 
-    private val consumerJob = Job(parentContext[Job])
+    private val consumerJob = Job(parentContext.job)
     override val coroutineContext: CoroutineContext = parentContext + consumerJob
 
     private val channel = ByteChannel().also {
-        it.attachJob(consumerJob)
+        it.attachJob(parentContext.job)
     }
 
     @Volatile
@@ -101,7 +101,7 @@ internal class ApacheResponseConsumer(
     private val capacity = atomic(channel.availableForWrite)
 
     init {
-        coroutineContext[Job]?.invokeOnCompletion(onCancelling = true) { cause ->
+        parentContext.job.invokeOnCompletion(onCancelling = true) { cause ->
             if (cause != null) {
                 responseChannel.cancel(cause)
             }
@@ -140,9 +140,11 @@ internal class ApacheResponseConsumer(
     }
 
     override fun consume(src: ByteBuffer) {
-        if (channel.isClosedForWrite) {
-            channel.closedCause?.let { throw it }
-        }
+        // Silently discard when the channel is closed (e.g. caller scope was cancelled).
+        // Throwing here (even IOException per the interface contract) causes Apache to invoke its
+        // error-recovery path mid-body-stream, which either corrupts the connection pool state or
+        // triggers a retry on an already-shutdown scheduler (RejectedExecutionException).
+        if (channel.isClosedForWrite) return
         messagesQueue.trySend(src.copy())
     }
 

--- a/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/ContentTest.kt
+++ b/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/ContentTest.kt
@@ -393,9 +393,8 @@ class ContentTest : ClientLoader() {
         }
     }
 
-    // Flaky on Apache: KTOR-9544
     @Test
-    fun testBodyChannelCancelledWhenCallerScopeIsCancelled() = clientTests(except("Apache5")) {
+    fun testBodyChannelCancelledWhenCallerScopeIsCancelled() = clientTests {
         test { client ->
             val bodyDeferred = CompletableDeferred<ByteReadChannel>()
             coroutineScope {


### PR DESCRIPTION
**Subsystem**
ktor-client-apache5

**Motivation**
[KTOR-9544](https://youtrack.jetbrains.com/issue/KTOR-9544) Apache: body channel not cancelled when caller scope is cancelled

**Solution**
Attach the response body channel to `callContext`'s job directly (matching CIO/OkHttp/Apache pattern) so caller-scope cancellation propagates the exact cause to `closedCause`. Previously the channel was attached to an intermediate `consumerJob`, causing cause wrapping that made `closedCause` unreachable.

Also silently discard data in `consume()` when the channel is closed instead of throwing. Throwing (even `IOException` per the interface contract) triggers Apache's error-recovery path mid-body-stream, which either corrupts connection pool state or causes a `RejectedExecutionException` on an already-shutdown scheduler.
