### PR TITLE
KTOR-9554  Add `dns` config to OkHttp engine

### DIFF
--- a/ktor-client/ktor-client-okhttp/api/ktor-client-okhttp.api
+++ b/ktor-client/ktor-client-okhttp/api/ktor-client-okhttp.api
@@ -12,10 +12,12 @@ public final class io/ktor/client/engine/okhttp/OkHttpConfig : io/ktor/client/en
 	public final fun addNetworkInterceptor (Lokhttp3/Interceptor;)V
 	public final fun config (Lkotlin/jvm/functions/Function1;)V
 	public final fun getClientCacheSize ()I
+	public final fun getDns ()Lokhttp3/Dns;
 	public final fun getDuplexStreamingEnabled ()Z
 	public final fun getPreconfigured ()Lokhttp3/OkHttpClient;
 	public final fun getWebSocketFactory ()Lokhttp3/WebSocket$Factory;
 	public final fun setClientCacheSize (I)V
+	public final fun setDns (Lokhttp3/Dns;)V
 	public final fun setDuplexStreamingEnabled (Z)V
 	public final fun setPreconfigured (Lokhttp3/OkHttpClient;)V
 	public final fun setWebSocketFactory (Lokhttp3/WebSocket$Factory;)V

--- a/ktor-client/ktor-client-okhttp/jvm/src/io/ktor/client/engine/okhttp/OkHttpConfig.kt
+++ b/ktor-client/ktor-client-okhttp/jvm/src/io/ktor/client/engine/okhttp/OkHttpConfig.kt
@@ -56,6 +56,24 @@ public class OkHttpConfig : HttpClientEngineConfig() {
     public var duplexStreamingEnabled: Boolean = false
 
     /**
+     * Specifies the [Dns] resolver used by the [OkHttpClient] to look up IP addresses for hostnames.
+     * When `null`, OkHttp's default [Dns.SYSTEM] resolver is used.
+     *
+     * Set this to inject a custom resolver, for example to enable DNS-over-HTTPS or
+     * to override host resolution in tests:
+     * ```kotlin
+     * install(OkHttp) {
+     *     engine {
+     *         dns = Dns { hostname -> listOf(InetAddress.getByName("127.0.0.1")) }
+     *     }
+     * }
+     * ```
+     *
+     * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.client.engine.okhttp.OkHttpConfig.dns)
+     */
+    public var dns: Dns? = null
+
+    /**
      * Configures [OkHttpClient] using [OkHttpClient.Builder].
      *
      * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.client.engine.okhttp.OkHttpConfig.config)

--- a/ktor-client/ktor-client-okhttp/jvm/src/io/ktor/client/engine/okhttp/OkHttpEngine.kt
+++ b/ktor-client/ktor-client-okhttp/jvm/src/io/ktor/client/engine/okhttp/OkHttpEngine.kt
@@ -152,6 +152,7 @@ public class OkHttpEngine(override val config: OkHttpConfig) : HttpClientEngineB
         }
         builder.apply(config.config)
         config.proxy?.let { builder.proxy(it) }
+        config.dns?.let { builder.dns(it) }
         timeoutExtension?.let {
             builder.setupTimeoutAttributes(it)
         }

--- a/ktor-client/ktor-client-okhttp/jvm/test/io/ktor/client/engine/okhttp/OkHttpEngineTest.kt
+++ b/ktor-client/ktor-client-okhttp/jvm/test/io/ktor/client/engine/okhttp/OkHttpEngineTest.kt
@@ -5,7 +5,9 @@
 package io.ktor.client.engine.okhttp
 
 import okhttp3.Dispatcher
+import okhttp3.Dns
 import okhttp3.OkHttpClient
+import java.net.InetAddress
 import kotlin.test.Test
 import kotlin.test.assertSame
 
@@ -25,5 +27,37 @@ class OkHttpEngineTest {
         val client = clientCache[null] as OkHttpClient
 
         assertSame(dispatcher, client.dispatcher)
+    }
+
+    @Test
+    fun `dns config is applied to OkHttpClient`() {
+        val customDns = Dns { _ -> listOf(InetAddress.getByName("127.0.0.1")) }
+
+        val engine = OkHttpEngine(OkHttpConfig().apply { dns = customDns })
+        try {
+            val cacheField = engine.javaClass.getDeclaredField("clientCache").apply { isAccessible = true }
+            val clientCache = cacheField.get(engine) as Map<*, *>
+
+            val client = clientCache[null] as OkHttpClient
+
+            assertSame(customDns, client.dns)
+        } finally {
+            engine.close()
+        }
+    }
+
+    @Test
+    fun `default dns is preserved when dns config is not set`() {
+        val engine = OkHttpEngine(OkHttpConfig())
+        try {
+            val cacheField = engine.javaClass.getDeclaredField("clientCache").apply { isAccessible = true }
+            val clientCache = cacheField.get(engine) as Map<*, *>
+
+            val client = clientCache[null] as OkHttpClient
+
+            assertSame(Dns.SYSTEM, client.dns)
+        } finally {
+            engine.close()
+        }
     }
 }


### PR DESCRIPTION
**Subsystem**
Client / OkHttp engine

**Motivation**
[KTOR-462](https://youtrack.jetbrains.com/issue/KTOR-462) / #1678 / #1924

OkHttp exposes a `Dns` interface but `OkHttpConfig` does not surface it as a first-class option. Users currently have to drop down to `engine { config { dns(...) } }` to inject a custom resolver (DNS-over-HTTPS, host overrides for tests, etc.).

**Solution**
Add `OkHttpConfig.dns: Dns?` and apply it in `OkHttpEngine.createOkHttpClient` right after `proxy`, mirroring the existing pattern. Defaults to `null` → `Dns.SYSTEM` is used as before.

```kotlin
HttpClient(OkHttp) {
    engine {
        dns = Dns { hostname -> listOf(InetAddress.getByName("127.0.0.1")) }
    }
}
```

Scoped to the OkHttp engine; the broader unified resolver abstraction (KTOR-462) is out of scope here. The same per-engine pattern can follow for Apache5 in a separate PR.