### PR TITLE
KTOR-9559 Add `dnsResolver` config to Apache5 engine

### DIFF
--- a/ktor-client/ktor-client-apache5/api/ktor-client-apache5.api
+++ b/ktor-client/ktor-client-apache5/api/ktor-client-apache5.api
@@ -13,12 +13,14 @@ public final class io/ktor/client/engine/apache5/Apache5EngineConfig : io/ktor/c
 	public final fun customizeRequest (Lkotlin/jvm/functions/Function1;)V
 	public final fun getConnectTimeout ()J
 	public final fun getConnectionRequestTimeout ()J
+	public final fun getDnsResolver ()Lorg/apache/hc/client5/http/DnsResolver;
 	public final fun getFollowRedirects ()Z
 	public final fun getSocketTimeout ()I
 	public final fun getSslContext ()Ljavax/net/ssl/SSLContext;
 	public final fun getSslHostnameVerificationPolicy ()Lorg/apache/hc/client5/http/ssl/HostnameVerificationPolicy;
 	public final fun setConnectTimeout (J)V
 	public final fun setConnectionRequestTimeout (J)V
+	public final fun setDnsResolver (Lorg/apache/hc/client5/http/DnsResolver;)V
 	public final fun setFollowRedirects (Z)V
 	public final fun setSocketTimeout (I)V
 	public final fun setSslContext (Ljavax/net/ssl/SSLContext;)V

--- a/ktor-client/ktor-client-apache5/jvm/src/io/ktor/client/engine/apache5/Apache5Engine.kt
+++ b/ktor-client/ktor-client-apache5/jvm/src/io/ktor/client/engine/apache5/Apache5Engine.kt
@@ -101,6 +101,7 @@ internal class Apache5Engine(override val config: Apache5EngineConfig) : HttpCli
                                 .setSocketTimeout(socketTimeout)
                                 .build()
                         )
+                        .apply { config.dnsResolver?.let { setDnsResolver(it) } }
                         .apply(config.configureConnectionManager)
                         .build()
                 )

--- a/ktor-client/ktor-client-apache5/jvm/src/io/ktor/client/engine/apache5/Apache5EngineConfig.kt
+++ b/ktor-client/ktor-client-apache5/jvm/src/io/ktor/client/engine/apache5/Apache5EngineConfig.kt
@@ -5,6 +5,7 @@
 package io.ktor.client.engine.apache5
 
 import io.ktor.client.engine.*
+import org.apache.hc.client5.http.DnsResolver
 import org.apache.hc.client5.http.config.RequestConfig
 import org.apache.hc.client5.http.impl.async.HttpAsyncClientBuilder
 import org.apache.hc.client5.http.impl.nio.PoolingAsyncClientConnectionManagerBuilder
@@ -78,6 +79,24 @@ public class Apache5EngineConfig : HttpClientEngineConfig() {
      * @see HostnameVerificationPolicy
      */
     public var sslHostnameVerificationPolicy: HostnameVerificationPolicy = HostnameVerificationPolicy.BOTH
+
+    /**
+     * Specifies the [DnsResolver] used by the Apache5 connection manager to look up IP addresses for hostnames.
+     * When `null`, Apache HttpClient's default resolver is used.
+     *
+     * Set this to inject a custom resolver, for example to enable DNS-over-HTTPS or
+     * to override host resolution in tests:
+     * ```kotlin
+     * install(Apache5) {
+     *     engine {
+     *         dnsResolver = SystemDefaultDnsResolver.INSTANCE
+     *     }
+     * }
+     * ```
+     *
+     * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.client.engine.apache5.Apache5EngineConfig.dnsResolver)
+     */
+    public var dnsResolver: DnsResolver? = null
 
     internal var customRequest: (RequestConfig.Builder.() -> RequestConfig.Builder) = { this }
 

--- a/ktor-client/ktor-client-apache5/jvm/test/io/ktor/client/engine/apache5/Apache5EngineConfigTest.kt
+++ b/ktor-client/ktor-client-apache5/jvm/test/io/ktor/client/engine/apache5/Apache5EngineConfigTest.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2014-2026 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.client.engine.apache5
+
+import io.ktor.client.HttpClient
+import io.ktor.client.request.get
+import kotlinx.coroutines.runBlocking
+import org.apache.hc.client5.http.DnsResolver
+import java.net.InetAddress
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+class Apache5EngineConfigTest {
+
+    @Test
+    fun `dnsResolver config is invoked when set`() = runBlocking {
+        val callCount = AtomicInteger()
+        val resolver = object : DnsResolver {
+            override fun resolve(host: String): Array<InetAddress> {
+                callCount.incrementAndGet()
+                return arrayOf(InetAddress.getByName("127.0.0.1"))
+            }
+
+            override fun resolveCanonicalHostname(host: String): String = "127.0.0.1"
+        }
+
+        val client = HttpClient(Apache5) {
+            engine { dnsResolver = resolver }
+        }
+
+        try {
+            runCatching { client.get("http://example.invalid:1/") }
+        } finally {
+            client.close()
+        }
+
+        assertTrue(callCount.get() > 0, "Custom DnsResolver should have been invoked")
+    }
+}


### PR DESCRIPTION
**Subsystem**
Client / Apache5 engine

**Motivation**
[KTOR-9559](https://youtrack.jetbrains.com/issue/KTOR-9559) (umbrella: [KTOR-462](https://youtrack.jetbrains.com/issue/KTOR-462)) / #1678 / #1924

Apache HttpClient 5 has a `DnsResolver` interface but `Apache5EngineConfig` does not surface it as a first-class option. Users currently have to drop down to `engine { configureConnectionManager { setDnsResolver(...) } }` to inject a custom resolver.

**Solution**
Add `Apache5EngineConfig.dnsResolver: DnsResolver?` and apply it on the `PoolingAsyncClientConnectionManagerBuilder` before `configureConnectionManager`. Defaults to `null` → Apache's default resolver is used as before.

```kotlin
HttpClient(Apache5) {
    engine {
        dnsResolver = SystemDefaultDnsResolver.INSTANCE
    }
}
```

Follow-up to the OkHttp `dns` config PR (#5570); same per-engine pattern. The unified resolver abstraction (KTOR-462) remains out of scope.