### PR TITLE
KTOR-9552 Improve deprecation notice for io.ktor.server.auth.Principal

### DIFF
--- a/ktor-server/ktor-server-plugins/ktor-server-auth/common/src/io/ktor/server/auth/AuthenticationInterceptors.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-auth/common/src/io/ktor/server/auth/AuthenticationInterceptors.kt
@@ -237,7 +237,7 @@ private fun AuthenticationConfig.findProvider(configurationName: String?): Authe
 /**
  *  A resolution strategy for nested authentication providers.
  *  [AuthenticationStrategy.Optional] - if the client provides no authentication,
- *  a call continues but with a null [Principal].
+ *  a call continues but with a null principal.
  *  [AuthenticationStrategy.FirstSuccessful] - client must provide authentication data for at least one provider
  *  registered for this route
  *  [AuthenticationStrategy.Required] - client must provide authentication data for all providers registered for
@@ -257,7 +257,7 @@ public enum class AuthenticationStrategy { Optional, FirstSuccessful, Required }
  *
  * @param configurations names of authentication providers defined in the [Authentication] plugin configuration.
  * @param optional when set, if the client provides no authentication,
- * a call continues but with a null [Principal].
+ * a call continues but with a null authenticated value.
  * @throws MissingApplicationPluginException if no [Authentication] plugin installed first.
  * @throws IllegalArgumentException if there are no registered providers referred by [configurations] names.
  */
@@ -284,7 +284,7 @@ public fun Route.authenticate(
  * @param configurations names of authentication providers defined in the [Authentication] plugin configuration.
  * @param strategy defines resolution strategy for nested authentication providers.
  *  [AuthenticationStrategy.Optional] - if the client provides no authentication,
- *  a call continues but with a null [Principal].
+ *  a call continues but with a null authenticated value.
  *  [AuthenticationStrategy.FirstSuccessful] - client must provide authentication data for at least one provider
  *  registered for this route
  *  [AuthenticationStrategy.Required] - client must provide authentication data for all providers registered for

--- a/ktor-server/ktor-server-plugins/ktor-server-auth/common/src/io/ktor/server/auth/Principal.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-auth/common/src/io/ktor/server/auth/Principal.kt
@@ -15,11 +15,13 @@ import kotlin.reflect.*
 public interface Credential
 
 /**
- * A marker interface indicating that a class represents an authenticated principal.
+ * A deprecated marker interface that is no longer required for authenticated principals.
+ *
+ * Remove this interface from principal classes, or use [Any] when a principal type is still needed.
  *
  * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.server.auth.Principal)
  */
-@Deprecated("This interface can be safely removed")
+@Deprecated("Principal is not required anymore. Remove this interface or replace it with Any.")
 public interface Principal
 
 internal class CombinedPrincipal {

--- a/ktor-server/ktor-server-plugins/ktor-server-auth/common/src/io/ktor/server/auth/SessionAuth.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-auth/common/src/io/ktor/server/auth/SessionAuth.kt
@@ -19,7 +19,8 @@ import kotlin.reflect.*
  *
  * @property type of session
  * @property challengeFunction to be used if there is no session
- * @property validator applied to an application all and session providing a [Principal]
+ * @property validator applied to an application call and session providing an authenticated principal or null
+ * if credentials are invalid
  */
 public class SessionAuthenticationProvider<T : Any> private constructor(
     config: Config<T>


### PR DESCRIPTION
**Subsystem**
Server

**Motivation**
[KTOR-9552](https://youtrack.jetbrains.com/issue/KTOR-9552) Deprecation notice for `io.ktor.server.auth.Principal` does not explain what to use instead

**Solution**
Ask the user to remove Principal or use any instead

