### PR TITLE
KTOR-9546 Fix streaming responses cancellation

### DIFF
--- a/ktor-client/ktor-client-apache5/jvm/src/io/ktor/client/engine/apache5/ApacheResponseConsumer.kt
+++ b/ktor-client/ktor-client-apache5/jvm/src/io/ktor/client/engine/apache5/ApacheResponseConsumer.kt
@@ -77,17 +77,16 @@ internal class BasicResponseConsumer(private val dataConsumer: ApacheResponseCon
     }
 }
 
-@OptIn(InternalCoroutinesApi::class)
 internal class ApacheResponseConsumer(
     parentContext: CoroutineContext,
     private val requestData: HttpRequestData
 ) : AsyncEntityConsumer<Unit>, CoroutineScope {
 
-    private val consumerJob = Job(parentContext[Job])
+    private val consumerJob = Job(parentContext.job)
     override val coroutineContext: CoroutineContext = parentContext + consumerJob
 
-    private val channel = ByteChannel().also {
-        it.attachJob(consumerJob)
+    private val channel = ByteChannel().apply {
+        attachJob(consumerJob)
     }
 
     @Volatile
@@ -101,12 +100,6 @@ internal class ApacheResponseConsumer(
     private val capacity = atomic(channel.availableForWrite)
 
     init {
-        coroutineContext[Job]?.invokeOnCompletion(onCancelling = true) { cause ->
-            if (cause != null) {
-                responseChannel.cancel(cause)
-            }
-        }
-
         launch(CoroutineName("apache-response-consumer")) {
             for (message in messagesQueue) {
                 when (message) {
@@ -140,9 +133,11 @@ internal class ApacheResponseConsumer(
     }
 
     override fun consume(src: ByteBuffer) {
-        if (channel.isClosedForWrite) {
-            channel.closedCause?.let { throw it }
-        }
+        // Silently discard when the channel is closed (e.g. caller scope was cancelled).
+        // Throwing here (even IOException per the interface contract) causes Apache to invoke its
+        // error-recovery path mid-body-stream, which either corrupts the connection pool state or
+        // triggers a retry on an already-shutdown scheduler (RejectedExecutionException).
+        if (channel.isClosedForWrite) return
         messagesQueue.trySend(src.copy())
     }
 

--- a/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/DefaultTransform.kt
+++ b/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/DefaultTransform.kt
@@ -5,7 +5,7 @@
 package io.ktor.client.plugins
 
 import io.ktor.client.*
-import io.ktor.client.call.checkContentLength
+import io.ktor.client.call.*
 import io.ktor.client.request.*
 import io.ktor.client.statement.*
 import io.ktor.http.*
@@ -14,9 +14,11 @@ import io.ktor.http.content.*
 import io.ktor.util.logging.*
 import io.ktor.utils.io.*
 import io.ktor.utils.io.core.*
-import kotlinx.coroutines.*
 import kotlinx.coroutines.CancellationException
-import kotlinx.io.*
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.job
+import kotlinx.io.Source
 
 private val LOGGER = KtorSimpleLogger("io.ktor.client.plugins.defaultTransformers")
 
@@ -96,10 +98,11 @@ public fun HttpClient.defaultTransformers() {
                 // the response job could be already completed, so the job holder
                 // could be canceled immediately, but it doesn't matter
                 // since the copying job is running under the client job
-                val responseJobHolder = Job(response.coroutineContext[Job])
+                val responseJobHolder = Job(response.coroutineContext.job)
                 val channel: ByteReadChannel = writer(this@defaultTransformers.coroutineContext) {
                     try {
                         body.copyTo(channel, limit = Long.MAX_VALUE)
+                        body.rethrowCloseCauseIfNeeded()
                     } catch (cause: CancellationException) {
                         response.cancel(cause)
                         throw cause
@@ -111,6 +114,7 @@ public fun HttpClient.defaultTransformers() {
                     writerJob.invokeOnCompletion {
                         responseJobHolder.complete()
                     }
+                    body.attachWriterJob(writerJob)
                 }.channel
 
                 proceedWith(HttpResponseContainer(info, channel))

--- a/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/ContentTest.kt
+++ b/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/ContentTest.kt
@@ -342,10 +342,9 @@ class ContentTest : ClientLoader() {
     }
 
     @Test
-    @Ignore
-    fun testDownloadStreamChannelWithCancel() = clientTests {
+    fun testDownloadStreamChannelWithCancel() = clientTests(timeout = 1.seconds) {
         test { client ->
-            val content = client.get("$TEST_SERVER/content/stream").body<ByteReadChannel>()
+            val content = client.prepareGet("$TEST_SERVER/content/stream?delay=5000").body<ByteReadChannel>()
             content.cancel()
         }
     }
@@ -393,9 +392,8 @@ class ContentTest : ClientLoader() {
         }
     }
 
-    // Flaky on Apache: KTOR-9544
     @Test
-    fun testBodyChannelCancelledWhenCallerScopeIsCancelled() = clientTests(except("Apache5")) {
+    fun testBodyChannelCancelledWhenCallerScopeIsCancelled() = clientTests {
         test { client ->
             val bodyDeferred = CompletableDeferred<ByteReadChannel>()
             coroutineScope {

--- a/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/ExceptionsTest.kt
+++ b/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/ExceptionsTest.kt
@@ -15,10 +15,11 @@ import io.ktor.http.*
 import io.ktor.test.dispatcher.*
 import io.ktor.util.*
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Job
+import kotlinx.coroutines.job
 import kotlinx.coroutines.launch
 import kotlin.reflect.KClass
 import kotlin.test.*
+import kotlin.time.Duration.Companion.seconds
 
 class ExceptionsTest : ClientLoader() {
 
@@ -132,24 +133,23 @@ class ExceptionsTest : ClientLoader() {
     }
 
     @Test
-    fun testErrorOnResponseCoroutine() = clientTests(except("Curl", "CIO", "Darwin", "DarwinLegacy")) {
+    fun testErrorOnResponseCoroutine() = clientTests(except("Curl", "Darwin", "DarwinLegacy"), timeout = 2.seconds) {
         test { client ->
             val requestBuilder = HttpRequestBuilder()
             requestBuilder.url.takeFrom("$TEST_SERVER/download/infinite")
 
             assertFailsWith<IllegalStateException> {
                 client.prepareGet(requestBuilder).execute { response ->
-                    try {
+                    runCatching {
                         CoroutineScope(response.coroutineContext).launch {
                             throw IllegalStateException("failed on receive")
                         }.join()
-                    } catch (cause: Exception) {
                     }
                     response.body<String>()
                 }
             }
 
-            assertTrue(requestBuilder.executionContext[Job]!!.isActive)
+            assertTrue(requestBuilder.executionContext.job.isActive)
         }
     }
 }

--- a/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/HttpTimeoutTest.kt
+++ b/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/HttpTimeoutTest.kt
@@ -81,13 +81,12 @@ class HttpTimeoutTest : ClientLoader(timeout = 30.seconds) {
                 parameter("delay", 60000)
             }
 
-            val exception = assertFails {
+            assertFailsWith<TimeoutCancellationException> {
                 withTimeout(500.milliseconds) {
                     client.request(requestBuilder).body<String>()
                 }
             }
 
-            assertTrue { exception is TimeoutCancellationException }
             assertTrue { requestBuilder.executionContext.getActiveChildren().none() }
         }
     }
@@ -120,24 +119,24 @@ class HttpTimeoutTest : ClientLoader(timeout = 30.seconds) {
     }
 
     @Test
-    fun testGetWithCancellation() = clientTests(except(ENGINES_WITHOUT_REQUEST_TIMEOUT), retries = 3) {
+    fun testGetWithCancellation() = clientTests(except(ENGINES_WITHOUT_REQUEST_TIMEOUT)) {
         config {
             install(HttpTimeout) {
                 requestTimeoutMillis = 1000
             }
+        }
 
-            test { client ->
-                val requestBuilder = HttpRequestBuilder().apply {
-                    method = HttpMethod.Get
-                    url("$TEST_URL/with-stream")
-                    parameter("delay", 2000)
-                }
+        test { client ->
+            val requestBuilder = request {
+                method = HttpMethod.Get
+                url("$TEST_URL/with-stream")
+                parameter("delay", 2000)
+            }
 
-                client.prepareRequest(requestBuilder).body<ByteReadChannel>().cancel()
+            client.prepareRequest(requestBuilder).body<ByteReadChannel>().cancel()
 
-                waitForCondition("all children to be cancelled") {
-                    requestBuilder.executionContext.getActiveChildren().none()
-                }
+            waitForCondition("all children to be cancelled", timeout = 500.milliseconds) {
+                requestBuilder.executionContext.getActiveChildren().none()
             }
         }
     }

--- a/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/utils/WaitUtils.kt
+++ b/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/utils/WaitUtils.kt
@@ -8,12 +8,11 @@ import kotlinx.coroutines.delay
 import kotlin.test.assertTrue
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
-import kotlin.time.Duration.Companion.seconds
 import kotlin.time.TimeSource
 
 suspend fun waitForCondition(
     description: String,
-    timeout: Duration = 10.seconds,
+    timeout: Duration,
     delay: Duration = (timeout / 10).coerceAtMost(100.milliseconds),
     condition: () -> Boolean,
 ) {

--- a/ktor-io/api/ktor-io.api
+++ b/ktor-io/api/ktor-io.api
@@ -37,6 +37,7 @@ public final class io/ktor/utils/io/ByteChannelCtorKt {
 public final class io/ktor/utils/io/ByteChannelUtilsKt {
 	public static final fun attachJob (Lio/ktor/utils/io/ByteChannel;Lio/ktor/utils/io/ChannelJob;)V
 	public static final fun attachJob (Lio/ktor/utils/io/ByteChannel;Lkotlinx/coroutines/Job;)V
+	public static final fun attachWriterJob (Lio/ktor/utils/io/ByteReadChannel;Lio/ktor/utils/io/WriterJob;)V
 }
 
 public abstract interface class io/ktor/utils/io/ByteReadChannel {

--- a/ktor-io/api/ktor-io.klib.api
+++ b/ktor-io/api/ktor-io.klib.api
@@ -412,6 +412,7 @@ final fun (io.ktor.utils.io/ByteChannel).io.ktor.utils.io/attachJob(io.ktor.util
 final fun (io.ktor.utils.io/ByteChannel).io.ktor.utils.io/attachJob(kotlinx.coroutines/Job) // io.ktor.utils.io/attachJob|attachJob@io.ktor.utils.io.ByteChannel(kotlinx.coroutines.Job){}[0]
 final fun (io.ktor.utils.io/ByteChannel).io.ktor.utils.io/cancel() // io.ktor.utils.io/cancel|cancel@io.ktor.utils.io.ByteChannel(){}[0]
 final fun (io.ktor.utils.io/ByteChannel).io.ktor.utils.io/rethrowCloseCauseIfNeeded() // io.ktor.utils.io/rethrowCloseCauseIfNeeded|rethrowCloseCauseIfNeeded@io.ktor.utils.io.ByteChannel(){}[0]
+final fun (io.ktor.utils.io/ByteReadChannel).io.ktor.utils.io/attachWriterJob(io.ktor.utils.io/WriterJob) // io.ktor.utils.io/attachWriterJob|attachWriterJob@io.ktor.utils.io.ByteReadChannel(io.ktor.utils.io.WriterJob){}[0]
 final fun (io.ktor.utils.io/ByteReadChannel).io.ktor.utils.io/cancel() // io.ktor.utils.io/cancel|cancel@io.ktor.utils.io.ByteReadChannel(){}[0]
 final fun (io.ktor.utils.io/ByteReadChannel).io.ktor.utils.io/counted(): io.ktor.utils.io/CountedByteReadChannel // io.ktor.utils.io/counted|counted@io.ktor.utils.io.ByteReadChannel(){}[0]
 final fun (io.ktor.utils.io/ByteReadChannel).io.ktor.utils.io/readAvailable(kotlin/Int, kotlin/Function1<kotlinx.io/Buffer, kotlin/Int>): kotlin/Int // io.ktor.utils.io/readAvailable|readAvailable@io.ktor.utils.io.ByteReadChannel(kotlin.Int;kotlin.Function1<kotlinx.io.Buffer,kotlin.Int>){}[0]

--- a/ktor-io/common/src/io/ktor/utils/io/ByteChannel.kt
+++ b/ktor-io/common/src/io/ktor/utils/io/ByteChannel.kt
@@ -7,6 +7,7 @@ package io.ktor.utils.io
 import io.ktor.utils.io.locks.*
 import kotlinx.atomicfu.AtomicRef
 import kotlinx.atomicfu.atomic
+import kotlinx.coroutines.DisposableHandle
 import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.io.Buffer
 import kotlinx.io.Sink
@@ -38,6 +39,7 @@ public class ByteChannel(public override val autoFlush: Boolean = false) : ByteR
     private val _readBuffer = Buffer()
     private val _writeBuffer = Buffer()
     private val _closedCause = atomic<CloseToken?>(null)
+    private val closeHandler = atomic<((Throwable?) -> Unit)?>(null)
 
     @InternalAPI
     override val readBuffer: Source
@@ -143,6 +145,24 @@ public class ByteChannel(public override val autoFlush: Boolean = false) : ByteR
         closeSlot(wrappedCause)
     }
 
+    internal fun invokeOnClose(handler: (cause: Throwable?) -> Unit): DisposableHandle {
+        val existingCause = _closedCause.value
+        if (existingCause != null) {
+            handler(existingCause.wrapCause())
+            return DisposableHandle {}
+        }
+        if (!closeHandler.compareAndSet(null, handler)) {
+            error("Only one invokeOnClose handler is supported per channel")
+        }
+        // Guard against race: channel closed between the check above and the CAS
+        val cause = _closedCause.value
+        if (cause != null && closeHandler.compareAndSet(handler, null)) {
+            handler(cause.wrapCause())
+            return DisposableHandle {}
+        }
+        return DisposableHandle { closeHandler.compareAndSet(handler, null) }
+    }
+
     override fun toString(): String = "ByteChannel[${hashCode()}]"
 
     private suspend inline fun <reified TaskType : Slot.Task> sleepWhile(
@@ -175,6 +195,7 @@ public class ByteChannel(public override val autoFlush: Boolean = false) : ByteR
         val closeContinuation = if (cause != null) Slot.Closed(cause) else Slot.CLOSED
         val continuation = suspensionSlot.getAndSet(closeContinuation)
         if (continuation is Slot.Task) continuation.resume(cause)
+        closeHandler.getAndSet(null)?.invoke(cause)
     }
 
     private inline fun <reified TaskType : Slot.Task> trySuspend(

--- a/ktor-io/common/src/io/ktor/utils/io/ByteChannelUtils.kt
+++ b/ktor-io/common/src/io/ktor/utils/io/ByteChannelUtils.kt
@@ -4,7 +4,7 @@
 
 package io.ktor.utils.io
 
-import kotlinx.coroutines.*
+import kotlinx.coroutines.Job
 
 /**
  * Ensures that when the given job is canceled, the ByteChannel is canceled with the same exception.
@@ -26,4 +26,14 @@ public fun ByteChannel.attachJob(job: Job) {
  */
 public fun ByteChannel.attachJob(job: ChannelJob) {
     attachJob(job.job)
+}
+
+/**
+ * Ensures that when the [WriterJob]'s output channel is canceled, this [ByteReadChannel] is also canceled.
+ */
+@InternalAPI
+public fun ByteReadChannel.attachWriterJob(writerJob: WriterJob) {
+    (writerJob.channel as? ByteChannel)?.invokeOnClose { cause ->
+        if (cause != null) cancel(cause)
+    }
 }


### PR DESCRIPTION
**Subsystem**
`ktor-io`, `ktor-client-core`, `ktor-client-apache5`

**Motivation**
[KTOR-9546](https://youtrack.jetbrains.com/issue/KTOR-9546) HttpClient: cancelling ByteReadChannel body does not propagate to engine
[KTOR-9544](https://youtrack.jetbrains.com/issue/KTOR-9544) Apache: body channel not cancelled when caller scope is cancelled

**Solution**
When a caller cancels a streaming `ByteReadChannel` response body, the cancellation did not propagate back to the engine's active network transfer. The root cause was in `DefaultTransform`: the `ByteReadChannel` case wraps the engine body in a `writer { body.copyTo(channel) }` coroutine and returns its output channel to the caller. Cancelling the returned channel had no effect on body, so `copyTo` stayed blocked in `awaitContent()` — leaving
`responseJobHolder` alive.

Two fixes applied in `DefaultTransform`:

1. `body.attachWriterJob(writerJob)` — when the caller cancels the returned channel, `body` (the engine channel) is cancelled immediately, unblocking
`copyTo`'s `awaitContent()`.
2. `body.rethrowCloseCauseIfNeeded()` after `copyTo` returns — handles the race where `copyTo` exits its while loop normally via `!isClosedForRead` (rather than throwing), meaning the catch block never fires and the cancellation cause would otherwise be silently dropped.

New `ByteReadChannel.attachWriterJob` API introduced to support this — wires cancel propagation from a writer's output channel back to a source ByteReadChannel

Also fixed:
- `testBodyChannelCancelledWhenCallerScopeIsCancelled` is now enabled for Apache5 (as KTOR-9544 also fixed with this fix)
- `testDownloadStreamChannelWithCancel` is un-ignored and given a proper assertion
- `testGetWithCancellation` tightened to catch the regression: checks cleanup within 500ms instead of relying on the 10s default
- `testErrorOnResponseCoroutine` re-enabled for CIO

