### PR TITLE
Fix data race on shared BadRequestPacket Source in CIO server

### DIFF
--- a/ktor-server/ktor-server-cio/common/src/io/ktor/server/cio/backend/ServerPipeline.kt
+++ b/ktor-server/ktor-server-cio/common/src/io/ktor/server/cio/backend/ServerPipeline.kt
@@ -16,6 +16,7 @@ import kotlinx.coroutines.*
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.channels.ReceiveChannel
+import kotlinx.io.Buffer
 import kotlinx.io.IOException
 import kotlinx.io.InternalIoApi
 import kotlinx.io.Source
@@ -194,10 +195,9 @@ public fun CoroutineScope.startServerConnectionPipeline(
     }
 }
 
-@OptIn(InternalIoApi::class)
 private fun String?.toBadRequestPacket(): Source {
     if (this == null) {
-        return BadRequestPacket.buffer.copy()
+        return buildBadRequestPacket()
     }
     val bytes = encodeToByteArray()
     return RequestResponseBuilder().apply {
@@ -245,11 +245,14 @@ private val BadRequestPacketCommon = RequestResponseBuilder().apply {
     headerLine("Content-Type", "text/plain; charset=utf-8")
 }.build().buffer.readByteArray()
 
-private val BadRequestPacket = RequestResponseBuilder().apply {
+@OptIn(InternalIoApi::class)
+private val BadRequestPacketBytes: ByteArray = RequestResponseBuilder().apply {
     responseLine("HTTP/1.0", HttpStatusCode.BadRequest.value, "Bad Request")
     headerLine("Connection", "close")
     emptyLine()
-}.build()
+}.build().buffer.readByteArray()
+
+internal fun buildBadRequestPacket(): Source = Buffer().apply { write(BadRequestPacketBytes) }
 
 internal fun isLastHttpRequest(version: HttpProtocolVersion, connectionOptions: ConnectionOptions?): Boolean {
     return when {

--- a/ktor-server/ktor-server-cio/jvm/test/io/ktor/tests/server/cio/BadRequestPacketSourceTest.kt
+++ b/ktor-server/ktor-server-cio/jvm/test/io/ktor/tests/server/cio/BadRequestPacketSourceTest.kt
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2014-2025 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.tests.server.cio
+
+import io.ktor.server.cio.backend.buildBadRequestPacket
+import kotlinx.io.Buffer
+import kotlinx.io.Segment
+import java.lang.reflect.Field
+import java.util.Collections
+import java.util.IdentityHashMap
+import java.util.concurrent.CyclicBarrier
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import kotlin.test.Test
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.fail
+
+class BadRequestPacketSourceTest {
+
+    @Test
+    fun `concurrent calls return independent buffers with no shared segment metadata`() {
+        val threads = 16
+        val iterations = 10_000
+        val executor = Executors.newFixedThreadPool(threads)
+        try {
+            for (iteration in 0 until iterations) {
+                val barrier = CyclicBarrier(threads)
+                val futures = (0 until threads).map {
+                    executor.submit<Buffer> {
+                        barrier.await()
+                        buildBadRequestPacket() as Buffer
+                    }
+                }
+                val results = futures.map { it.get(30, TimeUnit.SECONDS) }
+
+                val seenHeads = Collections.newSetFromMap(IdentityHashMap<Any, Boolean>())
+                results.forEachIndexed { idx, buf ->
+                    val head = SegmentReflection.headOf(buf)
+                    assertNotNull(head, "iteration $iteration source[$idx] missing head segment")
+                    assertNull(
+                        SegmentReflection.copyTrackerOf(head),
+                        "iteration $iteration source[$idx]: expected fresh segment but copyTracker " +
+                            "is non-null. Indicates segments are being shared across calls — regression " +
+                            "of the BadRequestPacket buffer.copy() data race.",
+                    )
+                    seenHeads.add(head)
+                }
+
+                if (seenHeads.size != threads) {
+                    fail(
+                        "iteration $iteration: expected $threads distinct head segments across " +
+                            "concurrent buildBadRequestPacket() calls, got ${seenHeads.size}. " +
+                            "Calls are sharing underlying buffers.",
+                    )
+                }
+            }
+        } finally {
+            executor.shutdown()
+            executor.awaitTermination(10, TimeUnit.SECONDS)
+        }
+    }
+}
+
+private object SegmentReflection {
+    private val headField: Field =
+        Buffer::class.java.getDeclaredField("head").apply { isAccessible = true }
+    private val copyTrackerField: Field =
+        Segment::class.java.getDeclaredField("copyTracker").apply { isAccessible = true }
+
+    fun headOf(buffer: Buffer): Segment? = headField.get(buffer) as Segment?
+    fun copyTrackerOf(segment: Segment): Any? = copyTrackerField.get(segment)
+}


### PR DESCRIPTION
## Summary

`ServerPipeline` defined a file-private `BadRequestPacket: Source` built once and shared across all CIO server connections. The null-message branch of `String?.toBadRequestPacket()` called `BadRequestPacket.buffer.copy()` from per-connection coroutines concurrently. `Buffer.copy()` walks the segment chain calling `Segment.sharedCopy()`, which performs an unsynchronized check-then-set of `Segment.copyTracker` — a non-`@Volatile` field whose contract ([`kotlinx-io Segment.kt:108-110`](https://github.com/Kotlin/kotlinx-io/blob/master/core/common/src/Segment.kt#L108-L110)) explicitly forbids concurrent segment mutation.

Replace the shared `Source` with a cached `ByteArray` (mirroring `BadRequestPacketCommon` directly above) plus a per-call `buildBadRequestPacket()` factory that returns a fresh `Buffer`. `toBadRequestPacket()` now calls the factory; no `Source` is shared between coroutines.

- Production fix: ~7 lines in `ServerPipeline.kt`.
- Regression test: `BadRequestPacketSourceTest` races 16 threads × 10,000 iterations on the factory and asserts via reflection that each returned `Buffer` has its own fresh, non-shared segment. Fails on unfixed code (segments share a `copyTracker` after `Buffer.copy()`); passes on the fix.

## Test plan

- [x] `./gradlew :ktor-server-cio:assemble`
- [x] `./gradlew :ktor-server-cio:jvmTest` (incl. new `BadRequestPacketSourceTest`)
- [x] `./gradlew :ktor-server-cio:formatKotlin :ktor-server-cio:lintKotlin`
- [x] `./gradlew :ktor-server-cio:checkKotlinAbi` (no public ABI change; `buildBadRequestPacket` is `internal` for testability)
- [ ] CI to verify other targets (Native/JS unaffected — change is JVM-test-only on the test side; production change is in `common/`)

## Notes

- `internal fun buildBadRequestPacket()` exists primarily to give the regression test a stable handle on the production factory. Could be folded back into `toBadRequestPacket()`'s null branch if preferred — open to feedback.
- No public API surface changed.
- YouTrack issue still to be filed; happy to link `KTOR-NNNNN` once it's up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)