### PR TITLE
KTOR-9549: add @JsName to avoid toRaw collision with Vue in Vite bundles

### DIFF
--- a/ktor-client/ktor-client-core/js/src/io/ktor/client/utils/JsUtils.js.kt
+++ b/ktor-client/ktor-client-core/js/src/io/ktor/client/utils/JsUtils.js.kt
@@ -20,6 +20,8 @@ import org.w3c.fetch.MANUAL
 import org.w3c.fetch.RequestRedirect
 import kotlin.coroutines.CoroutineContext
 
+// Prefixed to avoid a name collision with Vue's `toRaw` export when bundled by Vite (KTOR-9549).
+@JsName("ktor_toRaw")
 @OptIn(InternalAPI::class)
 internal suspend fun HttpRequestData.toRaw(
     clientConfig: HttpClientConfig<*>,


### PR DESCRIPTION
**Subsystem**
Client JS

**Motivation**
[KTOR-9549](https://youtrack.jetbrains.com/issue/KTOR-9549) Kotlin/JS: ktor-ktor-client-core.mjs is incompatible with Vite: toRaw naming conflict and yield* failure in SSR module runner

**Solution**
Rename the problematic function in JS code

