### PR TITLE
Drop `@JsExport` and make `initHook` private on JS

### DIFF
--- a/ktor-client/ktor-client-cio/api/ktor-client-cio.klib.api
+++ b/ktor-client/ktor-client-cio/api/ktor-client-cio.klib.api
@@ -62,7 +62,3 @@ final object io.ktor.client.engine.cio/CIO : io.ktor.client.engine/HttpClientEng
 }
 
 final fun (io.ktor.client.engine.cio/CIOEngineConfig).io.ktor.client.engine.cio/endpoint(kotlin/Function1<io.ktor.client.engine.cio/EndpointConfig, kotlin/Unit>): io.ktor.client.engine.cio/EndpointConfig // io.ktor.client.engine.cio/endpoint|endpoint@io.ktor.client.engine.cio.CIOEngineConfig(kotlin.Function1<io.ktor.client.engine.cio.EndpointConfig,kotlin.Unit>){}[0]
-
-// Targets: [js]
-final val io.ktor.client.engine.cio/initHook // io.ktor.client.engine.cio/initHook|{}initHook[0]
-    final fun <get-initHook>(): dynamic // io.ktor.client.engine.cio/initHook.<get-initHook>|<get-initHook>(){}[0]

--- a/ktor-client/ktor-client-cio/js/src/io/ktor/client/engine/cio/Loader.js.kt
+++ b/ktor-client/ktor-client-cio/js/src/io/ktor/client/engine/cio/Loader.js.kt
@@ -9,10 +9,8 @@ import io.ktor.util.*
 import io.ktor.utils.io.*
 
 @Suppress("DEPRECATION")
-@OptIn(ExperimentalStdlibApi::class, ExperimentalJsExport::class, InternalAPI::class)
-@Deprecated("", level = DeprecationLevel.HIDDEN)
-@JsExport
+@OptIn(ExperimentalStdlibApi::class, InternalAPI::class)
 @EagerInitialization
-public val initHook: dynamic = run {
+private val initHook: Unit = run {
     if (PlatformUtils.IS_NODE) engines.append(CIO)
 }

--- a/ktor-client/ktor-client-core/api/ktor-client-core.klib.api
+++ b/ktor-client/ktor-client-core/api/ktor-client-core.klib.api
@@ -2373,10 +2373,6 @@ abstract interface io.ktor.client.fetch/Uint8ArrayConstructor { // io.ktor.clien
 }
 
 // Targets: [js]
-final val io.ktor.client.engine.js/initHook // io.ktor.client.engine.js/initHook|{}initHook[0]
-    final fun <get-initHook>(): dynamic // io.ktor.client.engine.js/initHook.<get-initHook>|<get-initHook>(){}[0]
-
-// Targets: [js]
 final inline fun (io.ktor.client.fetch/Uint8Array).io.ktor.client.fetch/get(kotlin/Number): kotlin/Number? // io.ktor.client.fetch/get|get@io.ktor.client.fetch.Uint8Array(kotlin.Number){}[0]
 
 // Targets: [js]

--- a/ktor-client/ktor-client-core/js/src/io/ktor/client/engine/js/Js.kt
+++ b/ktor-client/ktor-client-core/js/src/io/ktor/client/engine/js/Js.kt
@@ -69,8 +69,6 @@ public actual open class JsClientEngineConfig : HttpClientEngineConfig() {
 }
 
 @Suppress("DEPRECATION")
-@OptIn(ExperimentalStdlibApi::class, ExperimentalJsExport::class, InternalAPI::class)
-@Deprecated("", level = DeprecationLevel.HIDDEN)
-@JsExport
+@OptIn(ExperimentalStdlibApi::class, InternalAPI::class)
 @EagerInitialization
-public val initHook: dynamic = engines.append(Js)
+private val initHook: Unit = engines.append(Js)


### PR DESCRIPTION
Related to [KT-51626](https://youtrack.jetbrains.com/issue/KT-51626) Kotlin/JS: EagerInitialization annotation has no effect on unused properties

Looks like it's not needed anymore (based on [thread](https://kotlinlang.slack.com/archives/C0A974TJ9/p1777994511720679))