### PR TITLE
KTOR-9183 Forward original CancellationException in attachToUserJob

### DIFF
--- a/ktor-client/ktor-client-core/common/src/io/ktor/client/engine/Utils.kt
+++ b/ktor-client/ktor-client-core/common/src/io/ktor/client/engine/Utils.kt
@@ -9,6 +9,7 @@ import io.ktor.http.*
 import io.ktor.http.content.*
 import io.ktor.util.*
 import io.ktor.utils.io.*
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.InternalCoroutinesApi
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.currentCoroutineContext
@@ -105,8 +106,7 @@ internal suspend inline fun attachToUserJob(callJob: Job) {
 
     val cleanupHandler = userJob.invokeOnCompletion(onCancelling = true) { cause ->
         cause ?: return@invokeOnCompletion
-        val cancellation = cause as? kotlinx.coroutines.CancellationException
-            ?: kotlinx.coroutines.CancellationException(cause.message)
+        val cancellation = cause as? CancellationException ?: CancellationException(cause.message)
         callJob.cancel(cancellation)
     }
 

--- a/ktor-client/ktor-client-core/common/src/io/ktor/client/engine/Utils.kt
+++ b/ktor-client/ktor-client-core/common/src/io/ktor/client/engine/Utils.kt
@@ -105,7 +105,9 @@ internal suspend inline fun attachToUserJob(callJob: Job) {
 
     val cleanupHandler = userJob.invokeOnCompletion(onCancelling = true) { cause ->
         cause ?: return@invokeOnCompletion
-        callJob.cancel(kotlinx.coroutines.CancellationException(cause.message))
+        val cancellation = cause as? kotlinx.coroutines.CancellationException
+            ?: kotlinx.coroutines.CancellationException(cause.message)
+        callJob.cancel(cancellation)
     }
 
     callJob.invokeOnCompletion {

--- a/ktor-client/ktor-client-core/jvm/test/AttachToUserJobTest.kt
+++ b/ktor-client/ktor-client-core/jvm/test/AttachToUserJobTest.kt
@@ -4,32 +4,25 @@
 
 package io.ktor.client.engine
 
-import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.awaitCancellation
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeout
+import org.junit.jupiter.api.assertThrows
 import kotlin.test.Test
-import kotlin.test.assertTrue
 
-class AttachToUserJobTimeoutTest {
+class AttachToUserJobTest {
 
     @Test
     fun `attachToUserJob preserves TimeoutCancellationException subtype`(): Unit = runBlocking {
         val callJob = Job()
-        val callJobCause = CompletableDeferred<Throwable?>()
-        callJob.invokeOnCompletion { callJobCause.complete(it) }
 
-        try {
+        assertThrows<TimeoutCancellationException> {
             withTimeout(50) {
                 attachToUserJob(callJob)
                 awaitCancellation()
             }
-        } catch (_: TimeoutCancellationException) {
         }
-
-        val cause = callJobCause.await()
-        assertTrue(cause is TimeoutCancellationException, "Expected TimeoutCancellationException, was $cause")
     }
 }

--- a/ktor-client/ktor-client-core/jvm/test/AttachToUserJobTimeoutTest.kt
+++ b/ktor-client/ktor-client-core/jvm/test/AttachToUserJobTimeoutTest.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2014-2025 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.client.engine
+
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.TimeoutCancellationException
+import kotlinx.coroutines.awaitCancellation
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+class AttachToUserJobTimeoutTest {
+
+    @Test
+    fun `attachToUserJob preserves TimeoutCancellationException subtype`(): Unit = runBlocking {
+        val callJob = Job()
+        val callJobCause = CompletableDeferred<Throwable?>()
+        callJob.invokeOnCompletion { callJobCause.complete(it) }
+
+        try {
+            withTimeout(50) {
+                attachToUserJob(callJob)
+                awaitCancellation()
+            }
+        } catch (_: TimeoutCancellationException) {
+        }
+
+        val cause = callJobCause.await()
+        assertTrue(cause is TimeoutCancellationException, "Expected TimeoutCancellationException, was $cause")
+    }
+}


### PR DESCRIPTION
**Subsystem**
Client / Core

**Motivation**
[KTOR-9183](https://youtrack.jetbrains.com/issue/KTOR-9183) — `attachToUserJob`'s cleanup handler substitutes a generic `CancellationException` for the user job's cause, dropping `TimeoutCancellationException`. As a result `withTimeout` / `withTimeoutOrNull` wrapping a client call no longer recognises its own timeout.

**Solution**
Forward the original `CancellationException` (including subtypes) when the cause already is one; wrap into `CancellationException(message)` only for non-cancellation throwables.