### PR TITLE
KTOR-9567 Flaky UnixSockets on Windows: WSAEOPNOTSUPP from bind()

### DIFF
--- a/ktor-network/posix/src/io/ktor/network/sockets/ConnectUtilsNative.kt
+++ b/ktor-network/posix/src/io/ktor/network/sockets/ConnectUtilsNative.kt
@@ -7,9 +7,10 @@ package io.ktor.network.sockets
 import io.ktor.network.selector.*
 import io.ktor.network.util.*
 import io.ktor.utils.io.errors.*
-import kotlinx.cinterop.*
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.convert
 import kotlinx.io.IOException
-import platform.posix.*
+import platform.posix.SOCK_STREAM
 
 private const val DEFAULT_BACKLOG_SIZE = 50
 
@@ -28,7 +29,7 @@ internal actual suspend fun tcpConnect(
 
             val socket = buildOrCloseSocket(descriptor) {
                 assignOptions(descriptor, socketOptions)
-                nonBlocking(descriptor)
+                nonBlocking(descriptor).check()
 
                 TCPSocketNative(
                     selector,
@@ -64,7 +65,7 @@ internal actual suspend fun tcpBind(
 
     buildOrCloseSocket(descriptor) {
         assignOptions(descriptor, socketOptions)
-        nonBlocking(descriptor)
+        nonBlocking(descriptor).check()
 
         address.nativeAddress { pointer, size ->
             ktor_bind(descriptor, pointer, size).check()

--- a/ktor-network/windows/interop/afunix.def
+++ b/ktor-network/windows/interop/afunix.def
@@ -16,3 +16,8 @@ struct sockaddr_un {
   char sun_path[UNIX_PATH_MAX];
 } SOCKADDR_UN, *PSOCKADDR_UN;
 #endif
+
+// K/N interop interprets 'const char*' as a String, but we should be able to pass any pointer here
+static int ktor_setsockopt_raw(SOCKET s, int level, int optname, const void* optval, int optlen) {
+    return setsockopt(s, level, optname, (const char*)optval, optlen);
+}

--- a/ktor-network/windows/src/io/ktor/network/util/SocketUtilsWindows.kt
+++ b/ktor-network/windows/src/io/ktor/network/util/SocketUtilsWindows.kt
@@ -27,7 +27,6 @@ import platform.posix.ioctlsocket
 import platform.posix.listen
 import platform.posix.recv
 import platform.posix.recvfrom
-import platform.posix.setsockopt
 import platform.posix.shutdown
 import platform.posix.socket
 import platform.windows.*
@@ -248,11 +247,11 @@ internal actual fun ktor_setsockopt(
     __optval: CPointer<*>?,
     __optlen: UInt
 ): Int {
-    return setsockopt(
+    return ktor_setsockopt_raw(
         __fd.convert(),
         __level,
         __optname,
-        __optval?.reinterpret<ByteVar>()?.toKString(),
+        __optval,
         __optlen.convert()
     )
 }


### PR DESCRIPTION
**Subsystem**
ktor-network

**Motivation**
[KTOR-9567](https://youtrack.jetbrains.com/issue/KTOR-9567) Flaky UnixSockets on Windows: WSAEOPNOTSUPP from bind()

**Solution**

The root cause is unclear. However, two bugs were found in the Windows socket setup path in `tcpBind`, either or both of which may cause the intermittent failure:

**1. `nonBlocking()` return value silently discarded**

In `ConnectUtilsNative.kt`, both `tcpConnect` and `tcpBind` call `nonBlocking(descriptor)` without checking the return value:
```kotlin
nonBlocking(descriptor)  // return value ignored
```
If `ioctlsocket(FIONBIO)` fails and leaves the socket in a bad state, `bind()` subsequently returns `WSAEOPNOTSUPP`. The error was invisible because no `.check()` was present.

**2. `ktor_setsockopt` passes wrong bytes on Windows**

`SocketUtilsWindows.kt` had a broken `optval` conversion:
```kotlin
__optval?.reinterpret<ByteVar>()?.toKString()  // wrong
```
The K/N Windows binding for `setsockopt` annotates `optval` as `@CCall.CString String?`, meaning K/N applies UTF-8 encoding before passing the pointer. For an `IntVar` with value `1` (bytes `01 00 00 00`), `toKString()` reads until the null byte and produces a 1-character string. K/N passes a 2-byte buffer (`01 00`) while `optlen` is 4 — a 2-byte buffer overread, causing undefined behavior. The extra bytes read come from adjacent stack memory. This would explain the non-deterministic failure rate.

Applied fixes for both, and will monitor this test behavior after the fixes. 
