### PR TITLE
KTOR-9483 Curl: Implement response body backpressure

### DIFF
--- a/ktor-client/ktor-client-curl/desktop/interop/libcurl.def
+++ b/ktor-client/ktor-client-curl/desktop/interop/libcurl.def
@@ -1,4 +1,4 @@
-# curl version = 8.10.1
+# curl version = 8.18.0
 package = libcurl
 headers = curl/curl.h
 headerFilter = curl/*

--- a/ktor-client/ktor-client-curl/desktop/src/io/ktor/client/engine/curl/CurlProcessor.kt
+++ b/ktor-client/ktor-client-curl/desktop/src/io/ktor/client/engine/curl/CurlProcessor.kt
@@ -38,7 +38,7 @@ internal class CurlProcessor(coroutineContext: CoroutineContext) {
         }
 
         runEventLoop().invokeOnCompletion { cause ->
-            cause?.let { curlScope.cancel(cause = CancellationException(cause)) }
+            cause?.let { curlScope.cancel(cause = cause as? CancellationException ?: CancellationException(cause)) }
         }
     }
 

--- a/ktor-client/ktor-client-curl/desktop/src/io/ktor/client/engine/curl/internal/CurlHttpResponseBody.kt
+++ b/ktor-client/ktor-client-curl/desktop/src/io/ktor/client/engine/curl/internal/CurlHttpResponseBody.kt
@@ -7,67 +7,71 @@ package io.ktor.client.engine.curl.internal
 import io.ktor.client.engine.curl.internal.Libcurl.WRITEFUNC_ERROR
 import io.ktor.client.engine.curl.internal.Libcurl.WRITEFUNC_PAUSE
 import io.ktor.utils.io.*
-import kotlinx.atomicfu.atomic
+import io.ktor.utils.io.core.*
 import kotlinx.cinterop.ByteVar
 import kotlinx.cinterop.CPointer
 import kotlinx.cinterop.ExperimentalForeignApi
 import kotlinx.cinterop.convert
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.runBlocking
 import platform.posix.size_t
+import kotlin.concurrent.Volatile
+import kotlin.coroutines.CoroutineContext
 
 internal class CurlHttpResponseBody(
-    private val callContext: Job,
-    private val onUnpause: () -> Unit
-) : CurlResponseBodyData {
-    private val bytesWritten = atomic(0)
+    callContext: Job,
+    private val onUnpause: () -> Unit,
+) : CurlResponseBodyData, CoroutineScope {
 
-    val bodyChannel = ByteChannel(true).apply {
-        attachJob(callContext)
+    private val job = Job(callContext)
+    override val coroutineContext: CoroutineContext = job
+
+    val bodyChannel = ByteChannel().apply {
+        attachJob(job)
     }
 
-    @OptIn(ExperimentalForeignApi::class)
+    @Volatile
+    private var paused = false
+
+    @OptIn(ExperimentalForeignApi::class, InternalAPI::class)
     override fun onBodyChunkReceived(buffer: CPointer<ByteVar>, size: size_t, count: size_t): size_t {
         if (bodyChannel.isClosedForWrite) {
             return if (bodyChannel.closedCause != null) WRITEFUNC_ERROR else 0.convert()
         }
+        if (paused) return WRITEFUNC_PAUSE
 
-        val chunkSize = (size * count).toInt()
-
-        // TODO: delete `runBlocking` with fix of https://youtrack.jetbrains.com/issue/KTOR-6030/Migrate-to-new-kotlinx.io-library
-        val written = try {
-            runBlocking {
-                bodyChannel.writeFully(buffer, 0, chunkSize)
-            }
-            chunkSize
+        val chunkSize = (size * count).toLong()
+        return try {
+            bodyChannel.writeBuffer.writeFully(buffer, 0L, chunkSize)
+            bodyChannel.flushWriteBuffer()
+            if (!bodyChannel.hasFreeSpace) pauseUntilFreeSpaceAvailable()
+            chunkSize.convert()
         } catch (_: Throwable) {
-            return WRITEFUNC_ERROR
+            WRITEFUNC_ERROR
         }
-        if (written > 0) {
-            bytesWritten.addAndGet(written)
-        }
-        if (bytesWritten.value == chunkSize) {
-            bytesWritten.value = 0
-            return chunkSize.convert()
-        }
+    }
 
-        CoroutineScope(callContext).launch {
+    private fun pauseUntilFreeSpaceAvailable() {
+        paused = true
+        launch {
             try {
                 bodyChannel.awaitFreeSpace()
+            } catch (cause: CancellationException) {
+                throw cause
             } catch (_: Throwable) {
                 // no op, error will be handled on next write on cURL thread
             } finally {
+                paused = false
                 onUnpause()
             }
         }
-
-        return WRITEFUNC_PAUSE
     }
 
     override fun close(cause: Throwable?) {
         if (bodyChannel.isClosedForWrite) return
         bodyChannel.close(cause)
+        cancel(cause as? CancellationException ?: CancellationException(cause))
     }
 }

--- a/ktor-client/ktor-client-curl/desktop/src/io/ktor/client/engine/curl/internal/CurlMultiApiHandler.kt
+++ b/ktor-client/ktor-client-curl/desktop/src/io/ktor/client/engine/curl/internal/CurlMultiApiHandler.kt
@@ -154,7 +154,7 @@ internal class CurlMultiApiHandler : Closeable {
         synchronized(easyHandlesToUnpauseLock) {
             var handle = easyHandlesToUnpause.removeFirstOrNull()
             while (handle != null) {
-                curl_easy_pause(handle, CURLPAUSE_CONT)
+                if (handle in activeHandles) curl_easy_pause(handle, CURLPAUSE_CONT)
                 handle = easyHandlesToUnpause.removeFirstOrNull()
             }
         }

--- a/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/DownloadTest.kt
+++ b/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/DownloadTest.kt
@@ -7,8 +7,12 @@ package io.ktor.client.tests
 import io.ktor.client.call.*
 import io.ktor.client.request.*
 import io.ktor.client.test.base.*
+import io.ktor.utils.io.*
+import kotlinx.coroutines.delay
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
 
 class DownloadTest : ClientLoader() {
     @Test
@@ -20,6 +24,24 @@ class DownloadTest : ClientLoader() {
             }.body<String>()
 
             assertEquals(text, response)
+        }
+    }
+
+    @Test
+    fun testDownloadWithSlowConsumer() = clientTests(timeout = 10.seconds) {
+        test { client ->
+            val size = 4 * 1024 * 1024
+            client.prepareGet("$TEST_SERVER/download?size=$size").body<ByteReadChannel, Unit> { channel ->
+                var received = 0
+                val buffer = ByteArray(8 * 1024)
+                while (true) {
+                    val readBytes = channel.readAvailable(buffer)
+                    if (readBytes == -1) break
+                    received += readBytes
+                    delay(1.milliseconds)
+                }
+                assertEquals(size, received)
+            }
         }
     }
 

--- a/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/ExceptionsTest.kt
+++ b/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/ExceptionsTest.kt
@@ -133,7 +133,7 @@ class ExceptionsTest : ClientLoader() {
     }
 
     @Test
-    fun testErrorOnResponseCoroutine() = clientTests(except("Curl", "Darwin", "DarwinLegacy"), timeout = 2.seconds) {
+    fun testErrorOnResponseCoroutine() = clientTests(except("Darwin", "DarwinLegacy"), timeout = 2.seconds) {
         test { client ->
             val requestBuilder = HttpRequestBuilder()
             requestBuilder.url.takeFrom("$TEST_SERVER/download/infinite")

--- a/ktor-io/api/ktor-io.api
+++ b/ktor-io/api/ktor-io.api
@@ -19,6 +19,7 @@ public final class io/ktor/utils/io/ByteChannel : io/ktor/utils/io/BufferedByteW
 	public fun flushWriteBuffer ()V
 	public fun getAutoFlush ()Z
 	public fun getClosedCause ()Ljava/lang/Throwable;
+	public final fun getHasFreeSpace ()Z
 	public fun getReadBuffer ()Lkotlinx/io/Source;
 	public fun getWriteBuffer ()Lkotlinx/io/Sink;
 	public fun isClosedForRead ()Z

--- a/ktor-io/api/ktor-io.klib.api
+++ b/ktor-io/api/ktor-io.klib.api
@@ -217,6 +217,8 @@ final class io.ktor.utils.io/ByteChannel : io.ktor.utils.io/BufferedByteWriteCha
         final fun <get-autoFlush>(): kotlin/Boolean // io.ktor.utils.io/ByteChannel.autoFlush.<get-autoFlush>|<get-autoFlush>(){}[0]
     final val closedCause // io.ktor.utils.io/ByteChannel.closedCause|{}closedCause[0]
         final fun <get-closedCause>(): kotlin/Throwable? // io.ktor.utils.io/ByteChannel.closedCause.<get-closedCause>|<get-closedCause>(){}[0]
+    final val hasFreeSpace // io.ktor.utils.io/ByteChannel.hasFreeSpace|{}hasFreeSpace[0]
+        final fun <get-hasFreeSpace>(): kotlin/Boolean // io.ktor.utils.io/ByteChannel.hasFreeSpace.<get-hasFreeSpace>|<get-hasFreeSpace>(){}[0]
     final val isClosedForRead // io.ktor.utils.io/ByteChannel.isClosedForRead|{}isClosedForRead[0]
         final fun <get-isClosedForRead>(): kotlin/Boolean // io.ktor.utils.io/ByteChannel.isClosedForRead.<get-isClosedForRead>|<get-isClosedForRead>(){}[0]
     final val isClosedForWrite // io.ktor.utils.io/ByteChannel.isClosedForWrite|{}isClosedForWrite[0]

--- a/ktor-io/common/src/io/ktor/utils/io/ByteChannel.kt
+++ b/ktor-io/common/src/io/ktor/utils/io/ByteChannel.kt
@@ -32,6 +32,22 @@ public class ByteChannel(public override val autoFlush: Boolean = false) : ByteR
     @Volatile
     private var flushBufferSize = 0
 
+    /**
+     * Indicates whether there is free space available in the channel for additional write operations.
+     *
+     * This property checks if the current size of the flush buffer is less than the predefined maximum channel size.
+     * If true, it means there is space available for more data to be written to the channel without requiring
+     * an immediate flush.
+     *
+     * Note: This is an internal API and subject to change or removal without notice. If you need to use this property,
+     * please share your use case with us at [KTOR-9579](https://youtrack.jetbrains.com/issue/KTOR-9579).
+     *
+     * @return `true` if there is free space in the flush buffer; `false` otherwise.
+     */
+    @InternalAPI
+    public val hasFreeSpace: Boolean
+        get() = flushBufferSize < CHANNEL_MAX_SIZE
+
     @OptIn(InternalAPI::class)
     private val flushBufferMutex = SynchronizedObject()
 
@@ -98,10 +114,10 @@ public class ByteChannel(public override val autoFlush: Boolean = false) : ByteR
         rethrowCloseCauseIfNeeded()
 
         flushWriteBuffer()
-        if (flushBufferSize < CHANNEL_MAX_SIZE) return
+        if (hasFreeSpace) return
 
         sleepWhile(Slot::Write) {
-            flushBufferSize >= CHANNEL_MAX_SIZE && _closedCause.value == null
+            !hasFreeSpace && _closedCause.value == null
         }
     }
 


### PR DESCRIPTION
**Subsystem**
ktor-client-curl

**Motivation**
[KTOR-9483](https://youtrack.jetbrains.com/issue/KTOR-9483) Curl: backpressure implementation is never used
[KTOR-9527](https://youtrack.jetbrains.com/issue/KTOR-9527) Curl: Freeze when receiving large responses

**Solution**
Replace `runBlocking` with non-blocking writes via `writeBuffer`/`flushWriteBuffer`. When the channel's flush buffer reaches `CHANNEL_MAX_SIZE`, return `WRITEFUNC_PAUSE` to pause the specific easy handle. A background coroutine then calls `flush()`, suspending until the consumer drains the buffer, after  which `curl_easy_pause(CURLPAUSE_CONT)` resumes the transfer.

Also adds `ByteChannel.flushNeeded` (`@InternalAPI`) and a slow-consumer download test.