### PR TITLE
KTOR-8199 Decode URL-encoded path before matching watch patterns

### DIFF
--- a/ktor-server/ktor-server-core/jvm/src/io/ktor/server/engine/EmbeddedServerJvm.kt
+++ b/ktor-server/ktor-server-core/jvm/src/io/ktor/server/engine/EmbeddedServerJvm.kt
@@ -492,7 +492,8 @@ actual constructor(
 }
 
 internal fun checkUrlMatches(url: URL, pattern: String): Boolean {
-    val urlPath = url.path?.replace(File.separatorChar, '/') ?: return false
+    val rawPath = url.path ?: return false
+    val urlPath = URLDecoder.decode(rawPath, "utf-8").replace(File.separatorChar, '/')
     val normalizedPattern = pattern.replace(File.separatorChar, '/')
     return urlPath.contains(normalizedPattern, ignoreCase = true)
 }

--- a/ktor-server/ktor-server-core/jvm/test/io/ktor/server/engine/EmbeddedServerTest.kt
+++ b/ktor-server/ktor-server-core/jvm/test/io/ktor/server/engine/EmbeddedServerTest.kt
@@ -54,4 +54,12 @@ class EmbeddedServerTest {
 
         assertTrue(checkUrlMatches(url, pattern))
     }
+
+    @Test
+    fun `checkUrlMatches matches when URL path contains URL-encoded spaces`() {
+        val url = URI.create("file:///some/my%20project/build/classes/").toURL()
+        val pattern = "/some/my project/build"
+
+        assertTrue(checkUrlMatches(url, pattern))
+    }
 }


### PR DESCRIPTION
**Subsystem**
Server, Auto-reload

**Motivation**
[KTOR-8199](https://youtrack.jetbrains.com/issue/KTOR-8199) Autoreloading: default watch patterns don't match anything when project path contains spaces

The default watch pattern is `WORKING_DIRECTORY_PATH = SystemFileSystem.resolve(Path(".")).toString()`, which preserves literal characters from the filesystem path (e.g. a space when the project lives under `/Users/me/my project/...`). The classpath URLs passed to `checkUrlMatches` expose their path in URL-encoded form (`/Users/me/my%20project/build/...`), so the substring match always fails and the engine logs:

```
No ktor.deployment.watch patterns match classpath entries, automatic reload is not active
```

The same file already URL-decodes the path inside `watchUrls()` (`URLDecoder.decode(path, "utf-8")`), so the encoded-vs-decoded mismatch was inconsistent within the same module.

**Solution**
Decode `url.path` before normalizing separators and matching against the pattern, mirroring the existing `watchUrls()` call site. The fix generalizes to any URL-encoded segment, not just spaces.