### PR TITLE
KTOR-7760 Clean up resources when bind fails with non-BindException

### DIFF
--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyApplicationEngine.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyApplicationEngine.kt
@@ -24,7 +24,6 @@ import io.netty.handler.codec.http.HttpObjectDecoder
 import io.netty.handler.codec.http.HttpServerCodec
 import kotlinx.coroutines.CompletableJob
 import kotlinx.coroutines.asCoroutineDispatcher
-import java.net.BindException
 import java.util.concurrent.TimeUnit
 import kotlin.reflect.KClass
 import kotlin.system.measureTimeMillis
@@ -257,11 +256,8 @@ public class NettyApplicationEngine(
             val connectors = channels!!.zip(configuration.connectors)
                 .map { it.second.withPort(it.first.localAddress().port) }
             resolvedConnectorsDeferred.complete(connectors)
-        } catch (cause: BindException) {
-            terminate()
-            throw cause
         } catch (cause: Throwable) {
-            stop(0, 0)
+            terminate()
             throw cause
         }
 

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyApplicationEngine.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyApplicationEngine.kt
@@ -260,6 +260,9 @@ public class NettyApplicationEngine(
         } catch (cause: BindException) {
             terminate()
             throw cause
+        } catch (cause: Throwable) {
+            stop(0, 0)
+            throw cause
         }
 
         monitor.raiseCatching(ServerReady, environment, environment.log)

--- a/ktor-server/ktor-server-netty/jvm/test/io/ktor/tests/server/netty/NettySpecificTest.kt
+++ b/ktor-server/ktor-server-netty/jvm/test/io/ktor/tests/server/netty/NettySpecificTest.kt
@@ -66,6 +66,20 @@ class NettySpecificTest {
     }
 
     @Test
+    fun `start cleans up resources on non-BindException failure`() {
+        val server = embeddedServer(Netty, port = 70000) {}
+
+        assertFailsWith<IllegalArgumentException> {
+            server.start(wait = false)
+        }
+
+        assertTrue(
+            server.engine.bootstraps.all { (it.config().group() as ExecutorService).isTerminated },
+            "event loop groups must be terminated when bind fails with a non-BindException"
+        )
+    }
+
+    @Test
     fun testStartMultipleConnectorsOnUsedPort() = runTestWithRealTime {
         val socket = ServerSocket(0)
         val port = socket.localPort


### PR DESCRIPTION
**Subsystem**
Server, Netty

**Motivation**
[KTOR-7760](https://youtrack.jetbrains.com/issue/KTOR-7760) Server finishes working without an exception when no privileges to open the port

`NettyApplicationEngine.start()` only catches `BindException`. Other bind failures (`SocketException` from Linux NIO, `Errors.NativeIoException` from epoll, `IllegalArgumentException` for invalid ports) propagate uncaught while the already-initialized Netty event loop groups stay alive on non-daemon threads, so the process hangs or appears to exit silently instead of surfacing the error.

**Solution**
Add a `catch (Throwable)` branch that calls `stop(0, 0)` before rethrowing, mirroring the existing `BindException` cleanup path. New test (`start cleans up resources on non-BindException failure`) triggers an out-of-range port to assert the event loop groups are terminated after a non-`BindException` failure.