### PR TITLE
KTOR-9629 Close RawSourceChannel when Job is canceled

### DIFF
--- a/ktor-io/common/src/io/ktor/utils/io/ByteChannelUtils.kt
+++ b/ktor-io/common/src/io/ktor/utils/io/ByteChannelUtils.kt
@@ -4,6 +4,7 @@
 
 package io.ktor.utils.io
 
+import kotlinx.coroutines.InternalCoroutinesApi
 import kotlinx.coroutines.Job
 
 /**
@@ -11,11 +12,10 @@ import kotlinx.coroutines.Job
  *
  * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.utils.io.attachJob)
  */
+@OptIn(InternalCoroutinesApi::class)
 public fun ByteChannel.attachJob(job: Job) {
-    job.invokeOnCompletion {
-        if (it != null) {
-            cancel(it)
-        }
+    job.invokeOnCompletion(onCancelling = true) {
+        if (it != null) cancel(it)
     }
 }
 

--- a/ktor-io/jvm/src/io/ktor/utils/io/jvm/javaio/Reading.kt
+++ b/ktor-io/jvm/src/io/ktor/utils/io/jvm/javaio/Reading.kt
@@ -9,13 +9,12 @@ import io.ktor.utils.io.CloseToken.Companion.wrapCause
 import io.ktor.utils.io.core.*
 import io.ktor.utils.io.pool.*
 import kotlinx.coroutines.*
+import kotlinx.coroutines.CancellationException
 import kotlinx.io.*
 import kotlinx.io.Buffer
-import kotlinx.io.EOFException
-import kotlinx.io.IOException
-import java.io.*
-import java.nio.*
-import kotlin.coroutines.*
+import java.io.InputStream
+import java.nio.ByteBuffer
+import kotlin.coroutines.CoroutineContext
 
 /**
  * Open a channel and launch a coroutine to copy bytes from the input stream to the channel.
@@ -46,7 +45,7 @@ public fun InputStream.toByteReadChannel(
 
 internal class RawSourceChannel(
     private val source: RawSource,
-    private val parent: CoroutineContext
+    parent: CoroutineContext
 ) : ByteReadChannel {
     private var closedToken: CloseToken? = null
     private val buffer = Buffer()
@@ -64,9 +63,16 @@ internal class RawSourceChannel(
     override val readBuffer: Source
         get() = buffer
 
+    init {
+        job.invokeOnCompletion { cause ->
+            if (cause != null) closeSource(cause.asCancellationException())
+        }
+    }
+
+    @OptIn(InternalAPI::class)
     override suspend fun awaitContent(min: Int): Boolean {
         if (closedToken != null) {
-            closedCause?.let { throw it }
+            rethrowCloseCauseIfNeeded()
             return buffer.remaining >= min
         }
 
@@ -75,15 +81,19 @@ internal class RawSourceChannel(
             while (buffer.remaining < min && result >= 0) {
                 result = try {
                     source.readAtMostTo(buffer, Long.MAX_VALUE)
-                } catch (cause: EOFException) {
+                } catch (_: EOFException) {
                     -1L
+                } catch (cause: IOException) {
+                    rethrowCloseCauseIfNeeded()
+                    throw cause
                 }
             }
 
             if (result == -1L) {
                 source.close()
                 job.complete()
-                closedToken = CloseToken(null)
+                rethrowCloseCauseIfNeeded()
+                closedToken = CLOSED
             }
         }
 
@@ -92,8 +102,17 @@ internal class RawSourceChannel(
 
     override fun cancel(cause: Throwable?) {
         if (closedToken != null) return
-        job.cancel(cause?.message ?: "Channel was cancelled", cause)
-        source.close()
-        closedToken = CloseToken(IOException(cause?.message ?: "Channel was cancelled", cause))
+        val cause = cause?.asCancellationException()
+        job.cancel(cause)
+        closeSource(cause)
     }
+
+    private fun closeSource(cause: CancellationException?) {
+        if (closedToken != null) return
+        closedToken = CloseToken(cause)
+        source.close()
+    }
+
+    private fun Throwable.asCancellationException(): CancellationException =
+        this as? CancellationException ?: CancellationException(message ?: "Channel was cancelled", this)
 }

--- a/ktor-io/jvm/src/io/ktor/utils/io/jvm/javaio/Reading.kt
+++ b/ktor-io/jvm/src/io/ktor/utils/io/jvm/javaio/Reading.kt
@@ -64,7 +64,8 @@ internal class RawSourceChannel(
         get() = buffer
 
     init {
-        job.invokeOnCompletion { cause ->
+        @OptIn(InternalCoroutinesApi::class)
+        job.invokeOnCompletion(onCancelling = true) { cause ->
             if (cause != null) closeSource(cause.asCancellationException())
         }
     }

--- a/ktor-io/jvm/test/io/ktor/utils/io/jvm/javaio/RawSourceChannelTest.kt
+++ b/ktor-io/jvm/test/io/ktor/utils/io/jvm/javaio/RawSourceChannelTest.kt
@@ -5,9 +5,12 @@
 package io.ktor.utils.io.jvm.javaio
 
 import io.ktor.utils.io.*
-import kotlinx.coroutines.test.*
-import kotlinx.io.*
-import kotlin.test.*
+import kotlinx.coroutines.test.runTest
+import kotlinx.io.IOException
+import kotlin.test.Test
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 
 class RawSourceChannelTest {
 
@@ -41,7 +44,7 @@ class RawSourceChannelTest {
     fun `awaitContent throws when channel is cancelled`() = runTest {
         val channel = ByteArray(0).inputStream().toByteReadChannel()
         channel.cancel(IOException("test cancellation"))
-        assertFailsWith<IOException> {
+        assertFailsWith<CancellationException> {
             channel.awaitContent(1)
         }
     }


### PR DESCRIPTION
**Subsystem**
ktor-io

**Motivation**
[KTOR-9629](https://youtrack.jetbrains.com/issue/KTOR-9629) RawSourceChannel: coroutine cancellation is not propagated to the RawSource

After merging https://github.com/ktorio/ktor/pull/5575, one engine is still flaky - Android ([test history](https://ktor.teamcity.com/test/-5690675197340020900?currentProjectId=Ktor_ProjectKtorCore), look at test runs with duration longer than 2s).

**Solution**
Android engine uses `InputStream.toByteReadChannel` and the resulting channel is not attached to any `Job`.
I've made it attached to the job `RawSourceChannel` creates, so if `parent: CoroutineContext` has `Job`, cancelling that job would cancel its children and trigger `closeSource`.