### PR TITLE
Hide CloseToken frames from stack traces

### DIFF
--- a/ktor-io/common/src/io/ktor/utils/io/ByteChannel.kt
+++ b/ktor-io/common/src/io/ktor/utils/io/ByteChannel.kt
@@ -4,6 +4,8 @@
 
 package io.ktor.utils.io
 
+import io.ktor.utils.io.CloseToken.Companion.throwOrNull
+import io.ktor.utils.io.CloseToken.Companion.wrapCause
 import io.ktor.utils.io.locks.*
 import kotlinx.atomicfu.AtomicRef
 import kotlinx.atomicfu.atomic

--- a/ktor-io/common/src/io/ktor/utils/io/CloseToken.kt
+++ b/ktor-io/common/src/io/ktor/utils/io/CloseToken.kt
@@ -13,15 +13,19 @@ internal val CLOSED = CloseToken(null)
 @OptIn(ExperimentalCoroutinesApi::class)
 internal class CloseToken(private val origin: Throwable?) {
 
-    fun wrapCause(wrap: (Throwable) -> Throwable = ::ClosedByteChannelException): Throwable? {
-        return when (origin) {
-            null -> null
-            is CopyableThrowable<*> -> origin.createCopy()
-            is CancellationException -> CancellationException(origin.message, origin)
-            else -> wrap(origin)
+    companion object {
+        inline fun CloseToken.wrapCause(
+            wrap: (Throwable) -> Throwable = ::ClosedByteChannelException
+        ): Throwable? {
+            return when (origin) {
+                null -> null
+                is CopyableThrowable<*> -> origin.createCopy()
+                is CancellationException -> CancellationException(origin.message, origin)
+                else -> wrap(origin)
+            }
         }
-    }
 
-    fun throwOrNull(wrap: (Throwable) -> Throwable): Unit? =
-        wrapCause(wrap)?.let { throw it }
+        inline fun CloseToken.throwOrNull(wrap: (Throwable) -> Throwable): Unit? =
+            wrapCause(wrap)?.let { throw it }
+    }
 }

--- a/ktor-io/common/src/io/ktor/utils/io/SinkByteWriteChannel.kt
+++ b/ktor-io/common/src/io/ktor/utils/io/SinkByteWriteChannel.kt
@@ -4,6 +4,7 @@
 
 package io.ktor.utils.io
 
+import io.ktor.utils.io.CloseToken.Companion.wrapCause
 import kotlinx.atomicfu.AtomicRef
 import kotlinx.atomicfu.atomic
 import kotlinx.io.IOException

--- a/ktor-io/common/src/io/ktor/utils/io/SourceByteReadChannel.kt
+++ b/ktor-io/common/src/io/ktor/utils/io/SourceByteReadChannel.kt
@@ -4,6 +4,7 @@
 
 package io.ktor.utils.io
 
+import io.ktor.utils.io.CloseToken.Companion.wrapCause
 import kotlinx.io.IOException
 import kotlinx.io.InternalIoApi
 import kotlinx.io.Source

--- a/ktor-io/jvm/src/io/ktor/utils/io/jvm/javaio/Reading.kt
+++ b/ktor-io/jvm/src/io/ktor/utils/io/jvm/javaio/Reading.kt
@@ -5,6 +5,7 @@
 package io.ktor.utils.io.jvm.javaio
 
 import io.ktor.utils.io.*
+import io.ktor.utils.io.CloseToken.Companion.wrapCause
 import io.ktor.utils.io.core.*
 import io.ktor.utils.io.pool.*
 import kotlinx.coroutines.*


### PR DESCRIPTION
**Subsystem**
ktor-io

**Motivation**
`wrapCause` and `throwOrNull` add some noise to stacktraces

**Solution**
Make them `inline`, so they don't add any trace frames.

Before:
```java
io.ktor.utils.io.ClosedByteChannelException: Socket timeout has expired [url=http://localhost:60230/sse/delay/2000, socket_timeout=1000] ms
	at io.ktor.utils.io.CloseToken$wrapCause$1.invoke(CloseToken.kt:17)
	at io.ktor.utils.io.CloseToken$wrapCause$1.invoke(CloseToken.kt:17)
	at io.ktor.utils.io.CloseToken.wrapCause(CloseToken.kt:23)
	at io.ktor.utils.io.CloseToken.wrapCause$default(CloseToken.kt:16)
	at io.ktor.utils.io.ByteChannel.cancel(ByteChannel.kt:145)
	at io.ktor.utils.io.ByteWriteChannelOperationsKt.close(ByteWriteChannelOperations.kt:130)
	at io.ktor.utils.io.ByteReadChannelOperationsKt.copyTo(ByteReadChannelOperations.kt:213)
	at io.ktor.utils.io.ByteReadChannelOperationsKt$copyTo$2.invokeSuspend(ByteReadChannelOperations.kt)
	at _COROUTINE._BOUNDARY._(CoroutineDebugging.kt:42)
	at io.ktor.utils.io.ByteChannel.awaitContent(ByteChannel.kt:307)
	at io.ktor.utils.io.ByteReadChannelOperationsKt.internalReadLineTo(ByteReadChannelOperations.kt:686)
	at io.ktor.utils.io.ByteReadChannelOperationsKt.readLineStrict(ByteReadChannelOperations.kt:638)
	at io.ktor.client.engine.apache5.Apache5HttpClientTest$testSocketTimeoutWithCustomConnectionManager$1$1$1.invokeSuspend(Apache5HttpClientTest.kt:44)
	at io.ktor.client.statement.HttpStatement.execute(HttpStatement.kt:77)
	at io.ktor.client.engine.apache5.Apache5HttpClientTest$testSocketTimeoutWithCustomConnectionManager$1.invokeSuspend(Apache5HttpClientTest.kt:41)
```

After:
```java
io.ktor.utils.io.ClosedByteChannelException: Socket timeout has expired [url=http://localhost:58759/sse/delay/2000, socket_timeout=1000] ms
	at io.ktor.utils.io.ByteChannel.cancel(ByteChannel.kt:446)
	at io.ktor.utils.io.ByteWriteChannelOperationsKt.close(ByteWriteChannelOperations.kt:130)
	at io.ktor.utils.io.ByteReadChannelOperationsKt.copyTo(ByteReadChannelOperations.kt:213)
	at io.ktor.utils.io.ByteReadChannelOperationsKt$copyTo$2.invokeSuspend(ByteReadChannelOperations.kt)
	at _COROUTINE._BOUNDARY._(CoroutineDebugging.kt:42)
	at io.ktor.utils.io.ByteChannel.awaitContent(ByteChannel.kt:307)
	at io.ktor.utils.io.ByteReadChannelOperationsKt.internalReadLineTo(ByteReadChannelOperations.kt:686)
	at io.ktor.utils.io.ByteReadChannelOperationsKt.readLineStrict(ByteReadChannelOperations.kt:638)
	at io.ktor.client.engine.apache5.Apache5HttpClientTest$testSocketTimeoutWithCustomConnectionManager$1$1$1.invokeSuspend(Apache5HttpClientTest.kt:44)
	at io.ktor.client.statement.HttpStatement.execute(HttpStatement.kt:77)
	at io.ktor.client.engine.apache5.Apache5HttpClientTest$testSocketTimeoutWithCustomConnectionManager$1.invokeSuspend(Apache5HttpClientTest.kt:41)
```