### PR TITLE
KTOR-7458 Add secureRequestCustomizer config to Jetty Jakarta engine

### DIFF
--- a/ktor-server/ktor-server-jetty-jakarta/api/ktor-server-jetty-jakarta.api
+++ b/ktor-server/ktor-server-jetty-jakarta/api/ktor-server-jetty-jakarta.api
@@ -60,9 +60,11 @@ public final class io/ktor/server/jetty/jakarta/JettyApplicationEngineBase$Confi
 	public final fun getConfigureServer ()Lkotlin/jvm/functions/Function1;
 	public final fun getHttpConfiguration ()Lkotlin/jvm/functions/Function1;
 	public final fun getIdleTimeout-UwyO8pc ()J
+	public final fun getSecureRequestCustomizer ()Lkotlin/jvm/functions/Function1;
 	public final fun setConfigureServer (Lkotlin/jvm/functions/Function1;)V
 	public final fun setHttpConfiguration (Lkotlin/jvm/functions/Function1;)V
 	public final fun setIdleTimeout-LRDsOJo (J)V
+	public final fun setSecureRequestCustomizer (Lkotlin/jvm/functions/Function1;)V
 }
 
 public final class io/ktor/server/jetty/jakarta/internal/JettyUpgradeImpl : io/ktor/server/servlet/jakarta/ServletUpgrade {

--- a/ktor-server/ktor-server-jetty-jakarta/jvm/src/io/ktor/server/jetty/jakarta/JettyApplicationEngineBase.kt
+++ b/ktor-server/ktor-server-jetty-jakarta/jvm/src/io/ktor/server/jetty/jakarta/JettyApplicationEngineBase.kt
@@ -9,6 +9,7 @@ import io.ktor.server.application.*
 import io.ktor.server.engine.*
 import kotlinx.coroutines.CompletableJob
 import org.eclipse.jetty.server.HttpConfiguration
+import org.eclipse.jetty.server.SecureRequestCustomizer
 import org.eclipse.jetty.server.Server
 import org.eclipse.jetty.server.ServerConnector
 import org.eclipse.jetty.util.thread.QueuedThreadPool
@@ -52,6 +53,15 @@ public open class JettyApplicationEngineBase(
          * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.server.jetty.jakarta.JettyApplicationEngineBase.Configuration.httpConfiguration)
          */
         public var httpConfiguration: HttpConfiguration.() -> Unit = {}
+
+        /**
+         * Property function that will be called during Jetty server initialization with the [SecureRequestCustomizer]
+         * instance that is added to HTTPS connectors as a receiver. Use it to adjust TLS-related request handling such
+         * as SNI host validation (`isSniHostCheck`, `isSniRequired`).
+         *
+         * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.server.jetty.jakarta.JettyApplicationEngineBase.Configuration.secureRequestCustomizer)
+         */
+        public var secureRequestCustomizer: SecureRequestCustomizer.() -> Unit = {}
 
         /**
          * The duration of time that a connection can be idle before the connector takes action to close the connection.

--- a/ktor-server/ktor-server-jetty-jakarta/jvm/src/io/ktor/server/jetty/jakarta/ServerInitializer.kt
+++ b/ktor-server/ktor-server-jetty-jakarta/jvm/src/io/ktor/server/jetty/jakarta/ServerInitializer.kt
@@ -22,7 +22,7 @@ internal fun Server.initializeServer(
             sendDateHeader = false
 
             if (ktorConnector.type == ConnectorType.HTTPS) {
-                addCustomizer(SecureRequestCustomizer())
+                addCustomizer(SecureRequestCustomizer().apply(configuration.secureRequestCustomizer))
             }
         }.apply(configuration.httpConfiguration)
 

--- a/ktor-server/ktor-server-jetty-jakarta/jvm/test/io/ktor/tests/server/jetty/jakarta/JettySecureRequestCustomizerTest.kt
+++ b/ktor-server/ktor-server-jetty-jakarta/jvm/test/io/ktor/tests/server/jetty/jakarta/JettySecureRequestCustomizerTest.kt
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2014-2026 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.tests.server.jetty.jakarta
+
+import io.ktor.network.tls.certificates.*
+import io.ktor.server.engine.*
+import io.ktor.server.jetty.jakarta.*
+import org.eclipse.jetty.server.*
+import java.io.*
+import kotlin.test.*
+
+class JettySecureRequestCustomizerTest {
+
+    @Test
+    fun `secureRequestCustomizer block is applied to HTTPS connectors`() {
+        val keyStorePassword = "changeit"
+        val keyAlias = "sampleAlias"
+        val keyStore = buildKeyStore {
+            certificate(keyAlias) {
+                password = keyStorePassword
+                domains = listOf("localhost")
+            }
+        }
+        val keyStoreFile = File.createTempFile("ktor-7458-keystore", ".jks").apply { deleteOnExit() }
+        keyStore.saveToFile(keyStoreFile, keyStorePassword)
+
+        var capturedCustomizer: SecureRequestCustomizer? = null
+        var invocations = 0
+
+        val server = embeddedServer(
+            Jetty,
+            configure = {
+                secureRequestCustomizer = {
+                    capturedCustomizer = this
+                    invocations++
+                    isSniHostCheck = false
+                    isSniRequired = true
+                }
+                sslConnector(
+                    keyStore = keyStore,
+                    keyAlias = keyAlias,
+                    keyStorePassword = { keyStorePassword.toCharArray() },
+                    privateKeyPassword = { keyStorePassword.toCharArray() },
+                ) {
+                    port = 0
+                    keyStorePath = keyStoreFile
+                }
+            },
+        ) {}
+        try {
+            server.start(wait = false)
+            val customizer = assertNotNull(capturedCustomizer, "secureRequestCustomizer block was not invoked")
+            assertEquals(
+                1,
+                invocations,
+                "secureRequestCustomizer block must be invoked exactly once per HTTPS connector"
+            )
+            assertFalse(customizer.isSniHostCheck, "isSniHostCheck override must be applied")
+            assertTrue(customizer.isSniRequired, "isSniRequired override must be applied")
+        } finally {
+            server.stop(50, 1000)
+        }
+    }
+
+    @Test
+    fun `secureRequestCustomizer block is not invoked when no HTTPS connector is configured`() {
+        var invoked = false
+
+        val server = embeddedServer(
+            Jetty,
+            configure = {
+                secureRequestCustomizer = { invoked = true }
+                connector { port = 0 }
+            },
+        ) {}
+        try {
+            server.start(wait = false)
+            assertFalse(invoked, "secureRequestCustomizer block must not be invoked for plain HTTP connectors")
+        } finally {
+            server.stop(50, 1000)
+        }
+    }
+}


### PR DESCRIPTION
**Subsystem**
Server, Jetty Jakarta

**Motivation**
[KTOR-7458](https://youtrack.jetbrains.com/issue/KTOR-7458) Jetty Jakarta: Provide an easy way to disable SNI hostname validation

`ktor-server-jetty-jakarta` installs `SecureRequestCustomizer` with default settings on each HTTPS connector, and there is no API to relax `isSniHostCheck` / `isSniRequired` short of replacing connector setup.

**Solution**
Add `secureRequestCustomizer: SecureRequestCustomizer.() -> Unit` on `JettyApplicationEngineBase.Configuration`, mirroring the existing `httpConfiguration` and `configureServer` hooks, and apply it to the customizer added during connector init.