### PR TITLE
KTOR-8151 Allow opting out of MeterFilter registration in MicrometerMetrics

### DIFF
--- a/ktor-server/ktor-server-plugins/ktor-server-metrics-micrometer/api/ktor-server-metrics-micrometer.api
+++ b/ktor-server/ktor-server-plugins/ktor-server-metrics-micrometer/api/ktor-server-metrics-micrometer.api
@@ -5,11 +5,13 @@ public final class io/ktor/server/metrics/micrometer/MicrometerMetricsConfig {
 	public final fun getDistributionStatisticConfig ()Lio/micrometer/core/instrument/distribution/DistributionStatisticConfig;
 	public final fun getMeterBinders ()Ljava/util/List;
 	public final fun getMetricName ()Ljava/lang/String;
+	public final fun getRegisterDistributionStatisticConfig ()Z
 	public final fun getRegistry ()Lio/micrometer/core/instrument/MeterRegistry;
 	public final fun setDistinctNotRegisteredRoutes (Z)V
 	public final fun setDistributionStatisticConfig (Lio/micrometer/core/instrument/distribution/DistributionStatisticConfig;)V
 	public final fun setMeterBinders (Ljava/util/List;)V
 	public final fun setMetricName (Ljava/lang/String;)V
+	public final fun setRegisterDistributionStatisticConfig (Z)V
 	public final fun setRegistry (Lio/micrometer/core/instrument/MeterRegistry;)V
 	public final fun timers (Lkotlin/jvm/functions/Function3;)V
 	public final fun transformRoute (Lkotlin/jvm/functions/Function1;)V

--- a/ktor-server/ktor-server-plugins/ktor-server-metrics-micrometer/jvm/src/io/ktor/server/metrics/micrometer/MicrometerMetrics.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-metrics-micrometer/jvm/src/io/ktor/server/metrics/micrometer/MicrometerMetrics.kt
@@ -127,6 +127,21 @@ public class MicrometerMetricsConfig {
     public var distributionStatisticConfig: DistributionStatisticConfig =
         DistributionStatisticConfig.Builder().percentiles(0.5, 0.9, 0.95, 0.99).build()
 
+    /**
+     * Controls whether the plugin registers a [MeterFilter] that applies [distributionStatisticConfig]
+     * to its request timers.
+     *
+     * Set to `false` if you register meters with [registry] before installing this plugin: Micrometer
+     * emits a warning when a [MeterFilter] is configured after a [Meter] has already been registered.
+     * When disabled, configure distribution statistics on the [registry] yourself before installing
+     * the plugin, otherwise [distributionStatisticConfig] has no effect.
+     *
+     * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.server.metrics.micrometer.MicrometerMetricsConfig.registerDistributionStatisticConfig)
+     *
+     * @see [MicrometerMetrics]
+     */
+    public var registerDistributionStatisticConfig: Boolean = true
+
     internal var timerBuilder: Timer.Builder.(ApplicationCall, Throwable?) -> Unit = { _, _ -> }
     internal val filters = mutableListOf<(ApplicationCall) -> Boolean>()
 
@@ -210,10 +225,12 @@ public val MicrometerMetrics: ApplicationPlugin<MicrometerMetricsConfig> =
         val registry = pluginConfig.registry
         val filters = pluginConfig.filters
 
-        registry.config().meterFilter(object : MeterFilter {
-            override fun configure(id: Meter.Id, config: DistributionStatisticConfig): DistributionStatisticConfig =
-                if (id.name == metricName) pluginConfig.distributionStatisticConfig.merge(config) else config
-        })
+        if (pluginConfig.registerDistributionStatisticConfig) {
+            registry.config().meterFilter(object : MeterFilter {
+                override fun configure(id: Meter.Id, config: DistributionStatisticConfig): DistributionStatisticConfig =
+                    if (id.name == metricName) pluginConfig.distributionStatisticConfig.merge(config) else config
+            })
+        }
 
         val active = registry.gauge(activeRequestsGaugeName, AtomicInteger(0))
         val measureKey = AttributeKey<CallMeasure>("micrometerMetrics")

--- a/ktor-server/ktor-server-plugins/ktor-server-metrics-micrometer/jvm/test/io/ktor/server/metrics/micrometer/MicrometerMetricsTests.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-metrics-micrometer/jvm/test/io/ktor/server/metrics/micrometer/MicrometerMetricsTests.kt
@@ -228,6 +228,33 @@ class MicrometerMetricsTests {
     }
 
     @Test
+    fun `default percentiles are not applied when registerDistributionStatisticConfig is false`() = testApplication {
+        val testRegistry = SimpleMeterRegistry()
+
+        install(MicrometerMetrics) {
+            registry = testRegistry
+            registerDistributionStatisticConfig = false
+        }
+
+        routing {
+            get("/uri") {
+                call.respond("hello")
+            }
+        }
+
+        client.request("/uri")
+
+        val timers = testRegistry.find(requestTimeTimerName).timers()
+        assertEquals(1, timers.size)
+        val percentileValues = timers.first().takeSnapshot().percentileValues()
+        assertEquals(
+            0,
+            percentileValues.size,
+            "no percentiles should be configured by the plugin, but were: ${percentileValues.toList()}"
+        )
+    }
+
+    @Test
     fun `no handler results in status 404 and no exception by default`() = testApplication {
         val testRegistry = SimpleMeterRegistry()
 


### PR DESCRIPTION
**Subsystem**
Server, ktor-server-metrics-micrometer

**Motivation**
[KTOR-8151](https://youtrack.jetbrains.com/issue/KTOR-8151) The plugin always registers a `MeterFilter`, triggering a Micrometer warning when meters already exist on the registry before installation.

**Solution**
Add `registerDistributionStatisticConfig: Boolean` (default `true`) to `MicrometerMetricsConfig`. Setting it to `false` skips the `MeterFilter` registration. Mirrors `DropwizardMetricsConfig.registerJvmMetricSets`.