### PR TITLE
KTOR-8443 Respect parameters in contentType and accept route selectors

### DIFF
--- a/ktor-server/ktor-server-core/common/src/io/ktor/server/routing/RouteSelector.kt
+++ b/ktor-server/ktor-server-core/common/src/io/ktor/server/routing/RouteSelector.kt
@@ -831,9 +831,9 @@ private fun ContentType.isCompatibleWith(other: ContentType): Boolean = when {
 
 private fun HeaderValue.toContentType(): ContentType {
     val contentType = ContentType.parse(value)
-    return if (params.isEmpty())
+    return if (params.isEmpty()) {
         contentType
-    else {
+    } else {
         ContentType(
             contentType.contentType,
             contentType.contentSubtype,

--- a/ktor-server/ktor-server-core/common/src/io/ktor/server/routing/RouteSelector.kt
+++ b/ktor-server/ktor-server-core/common/src/io/ktor/server/routing/RouteSelector.kt
@@ -708,7 +708,7 @@ internal data class ContentTypeHeaderRouteSelector(
         val parsedHeaders = parseAndSortContentTypeHeader(headers)
 
         val header = parsedHeaders.firstOrNull { header ->
-            contentTypes.any { it.isCompatibleWith(ContentType.parse(header.value)) }
+            contentTypes.any { header.toContentType().match(it) }
         } ?: return failedEvaluation
 
         return RouteSelectorEvaluation.Success(header.quality)
@@ -758,7 +758,7 @@ public data class HttpMultiAcceptRouteSelector(
             }
 
             val header = parsedHeaders.firstOrNull { header ->
-                contentTypes.any { it.isCompatibleWith(ContentType.parse(header.value)) }
+                contentTypes.any { it.isCompatibleWith(header.toContentType()) }
             }
             if (header != null) {
                 return RouteSelectorEvaluation.Success(header.quality)
@@ -828,3 +828,8 @@ private fun ContentType.isCompatibleWith(other: ContentType): Boolean = when {
     this.contentSubtype == "*" -> other.match(this)
     else -> this.match(other)
 }
+
+private fun HeaderValue.toContentType(): ContentType =
+    params.asSequence()
+        .filter { it.name != "q" }
+        .fold(ContentType.parse(value)) { acc, p -> acc.withParameter(p.name, p.value) }

--- a/ktor-server/ktor-server-core/common/src/io/ktor/server/routing/RouteSelector.kt
+++ b/ktor-server/ktor-server-core/common/src/io/ktor/server/routing/RouteSelector.kt
@@ -829,7 +829,15 @@ private fun ContentType.isCompatibleWith(other: ContentType): Boolean = when {
     else -> this.match(other)
 }
 
-private fun HeaderValue.toContentType(): ContentType =
-    params.asSequence()
-        .filter { it.name != "q" }
-        .fold(ContentType.parse(value)) { acc, p -> acc.withParameter(p.name, p.value) }
+private fun HeaderValue.toContentType(): ContentType {
+    val contentType = ContentType.parse(value)
+    return if (params.isEmpty())
+        contentType
+    else {
+        ContentType(
+            contentType.contentType,
+            contentType.contentSubtype,
+            params.filter { it.name != "q" }
+        )
+    }
+}

--- a/ktor-server/ktor-server-tests/common/test/io/ktor/tests/server/routing/RoutingProcessingTest.kt
+++ b/ktor-server/ktor-server-tests/common/test/io/ktor/tests/server/routing/RoutingProcessingTest.kt
@@ -644,6 +644,75 @@ class RoutingProcessingTest {
     }
 
     @Test
+    fun testContentTypeHeaderWithParameters() = testApplication {
+        val soapWithAction = ContentType.parse("application/soap+xml; action=foo")
+        routing {
+            route("/") {
+                contentType(soapWithAction) {
+                    handle {
+                        call.respond("matched")
+                    }
+                }
+                contentType(ContentType.Application.Any) {
+                    handle {
+                        call.respond("fallback")
+                    }
+                }
+            }
+        }
+
+        client.get("/") {
+            header(HttpHeaders.ContentType, "application/soap+xml; action=foo")
+        }.let {
+            assertEquals("matched", it.bodyAsText())
+        }
+
+        client.get("/") {
+            header(HttpHeaders.ContentType, "application/soap+xml; action=bar")
+        }.let {
+            assertEquals("fallback", it.bodyAsText())
+        }
+
+        client.get("/") {
+            header(HttpHeaders.ContentType, "application/soap+xml")
+        }.let {
+            assertEquals("fallback", it.bodyAsText())
+        }
+    }
+
+    @Test
+    fun testAcceptHeaderWithParameters() = testApplication {
+        val soapWithAction = ContentType.parse("application/soap+xml; action=foo")
+        routing {
+            route("/") {
+                accept(soapWithAction) {
+                    handle {
+                        call.respond("matched")
+                    }
+                }
+            }
+        }
+
+        client.get("/") {
+            header(HttpHeaders.Accept, "application/soap+xml; action=foo")
+        }.let {
+            assertEquals("matched", it.bodyAsText())
+        }
+
+        client.get("/") {
+            header(HttpHeaders.Accept, "application/soap+xml; action=bar")
+        }.let {
+            assertEquals(HttpStatusCode.NotAcceptable, it.status)
+        }
+
+        client.get("/") {
+            header(HttpHeaders.Accept, "application/soap+xml; action=foo; q=0.5")
+        }.let {
+            assertEquals("matched", it.bodyAsText())
+        }
+    }
+
+    @Test
     fun testTransparentSelectorWithHandler() = testApplication {
         routing {
             route("") {


### PR DESCRIPTION
**Subsystem**
ktor-server

**Motivation**
https://youtrack.jetbrains.com/issue/KTOR-8443

**Solution**
Preserve Content-Type parameters when matching `contentType` and `accept` route selectors.