### PR TITLE
Update Jetty Jakarta to 12.0.35

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -18,7 +18,7 @@ netty = "4.2.12.Final"
 netty-tcnative = "2.0.76.Final"
 
 jetty = "9.4.58.v20250814"
-jetty-jakarta = "12.0.29"
+jetty-jakarta = "12.0.35"
 jetty-alpn-api = "1.1.3.v20160715"
 jetty-alpn-openjdk8 = "9.4.58.v20250814"
 


### PR DESCRIPTION
**Subsystem**

ktor-server-jetty-jakarta, ktor-client-jetty-jakarta, ktor-server-servlet-jakarta

**Motivation**

There are several vulnerabilities in Jetty 12.0.29, which have been fixed in the latest 12.0.x version.

1. [CVE-2026-1605](https://www.cve.org/CVERecord?id=CVE-2026-1605) - Score 7.5
2. [CVE-2026-2332](https://www.cve.org/CVERecord?id=CVE-2026-2332) - Score 7.4
3. [CVE-2025-11143](https://www.cve.org/CVERecord?id=CVE-2025-11143) - Score 3.7

**Solution**

Update Jetty to 12.0.35