### PR TITLE
Netty request handling fixes

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,7 +14,7 @@ kover = "0.9.4"
 kotlinter = "5.2.0"
 kotlinx-browser = "0.5.0"
 
-netty = "4.2.12.Final"
+netty = "4.2.13.Final"
 netty-tcnative = "2.0.76.Final"
 
 jetty = "9.4.58.v20250814"
@@ -135,6 +135,7 @@ dokka-gradlePlugin = { module = "org.jetbrains.dokka:dokka-gradle-plugin", versi
 dokka-plugin-versioning = { module = "org.jetbrains.dokka:versioning-plugin", version.ref = "dokka" }
 
 netty-handler = { module = "io.netty:netty-handler", version.ref = "netty" }
+netty-codec = { module = "io.netty:netty-codec", version.ref = "netty" }
 netty-codec-http2 = { module = "io.netty:netty-codec-http2", version.ref = "netty" }
 netty-transport-native-kqueue = { module = "io.netty:netty-transport-native-kqueue", version.ref = "netty" }
 netty-transport-native-epoll = { module = "io.netty:netty-transport-native-epoll", version.ref = "netty" }

--- a/ktor-server/ktor-server-netty/build.gradle.kts
+++ b/ktor-server/ktor-server-netty/build.gradle.kts
@@ -28,6 +28,7 @@ kotlin {
         jvmMain.dependencies {
             api(projects.ktorServerCore)
 
+            api(libs.netty.codec)
             api(libs.netty.codec.http2)
             api(libs.jetty.alpn.api)
 

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/CIO.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/CIO.kt
@@ -78,12 +78,11 @@ public suspend fun <T> Future<T>.suspendAwait(exception: (Throwable, Continuatio
  */
 internal object NettyDispatcher : CoroutineDispatcher() {
     override fun isDispatchNeeded(context: CoroutineContext): Boolean {
-        return !context[CurrentContextKey]!!.context.executor().inEventLoop()
+        return !context[CurrentContextKey]!!.executor.inEventLoop()
     }
 
     override fun dispatch(context: CoroutineContext, block: Runnable) {
-        val nettyContext = context[CurrentContextKey]!!.context
-        val executor = nettyContext.executor()
+        val executor = context[CurrentContextKey]!!.executor
         if (executor.isShuttingDown) {
             Dispatchers.IO.dispatch(context, block)
         } else {
@@ -95,7 +94,16 @@ internal object NettyDispatcher : CoroutineDispatcher() {
         }
     }
 
-    class CurrentContext(val context: ChannelHandlerContext) : AbstractCoroutineContextElement(CurrentContextKey)
+    /**
+     * Carries the Netty channel context for the current call along with the executor that should be used
+     * to dispatch coroutine continuations. When [executor] is not provided, the channel's own
+     * event-loop executor is used (which runs I/O work).
+     */
+    class CurrentContext(
+        val context: ChannelHandlerContext,
+        val executor: EventExecutor = context.executor()
+    ) : AbstractCoroutineContextElement(CurrentContextKey)
+
     object CurrentContextKey : CoroutineContext.Key<CurrentContext>
 }
 

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyChannelInitializer.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyChannelInitializer.kt
@@ -185,6 +185,7 @@ public class NettyChannelInitializer(
                 val handler = NettyHttp2Handler(
                     enginePipeline,
                     application,
+                    callEventGroup,
                     application.coroutineContext + userContext,
                     runningLimit
                 )
@@ -200,6 +201,7 @@ public class NettyChannelInitializer(
                 val handler = NettyHttp2Handler(
                     enginePipeline,
                     applicationProvider(),
+                    callEventGroup,
                     userContext,
                     runningLimit
                 )
@@ -229,6 +231,7 @@ public class NettyChannelInitializer(
                             applicationProvider,
                             enginePipeline,
                             environment,
+                            callEventGroup,
                             engineContext,
                             userContext,
                             runningLimit
@@ -262,6 +265,7 @@ public class NettyChannelInitializer(
                     applicationProvider,
                     enginePipeline,
                     environment,
+                    callEventGroup,
                     engineContext,
                     userContext,
                     runningLimit

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyChannelInitializer.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyChannelInitializer.kt
@@ -191,6 +191,10 @@ public class NettyChannelInitializer(
                 )
 
                 pipeline.addLast(Http2MultiplexCodecBuilder.forServer(handler).build())
+                // Swallow connection-level Http2Frame messages (e.g. SETTINGS, PING, GOAWAY) that the
+                // Http2MultiplexCodec forwards down the parent pipeline. Without this, those frames
+                // would reach Netty's tail handler and trigger "Discarded inbound message" warnings.
+                pipeline.addLast(NettyHttp2ConnectionSink)
                 pipeline.channel().closeFuture().addListener {
                     handler.cancel()
                 }
@@ -221,6 +225,12 @@ public class NettyChannelInitializer(
                 )
 
                 pipeline.addLast("cleartextUpgradeHandler", cleartextHttp2ServerUpgradeHandler)
+                // Swallow connection-level Http2Frame messages (e.g. SETTINGS, PING, GOAWAY) once the
+                // connection has been upgraded to HTTP/2 and the multiplex codec is forwarding them down
+                // the parent pipeline. Without this, those frames would reach Netty's tail handler and
+                // trigger "Discarded inbound message" warnings. For requests that remain HTTP/1.1, this
+                // sink is a no-op.
+                pipeline.addLast(NettyHttp2ConnectionSink)
 
                 pipeline.addLast(object : SimpleChannelInboundHandler<HttpMessage>() {
                     @Throws(Exception::class)

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/PinnedCallExecutor.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/PinnedCallExecutor.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2014-2026 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.server.netty
+
+import io.netty.channel.ChannelHandlerContext
+import io.netty.util.AttributeKey
+import io.netty.util.concurrent.EventExecutor
+import io.netty.util.concurrent.EventExecutorGroup
+
+private val PinnedCallExecutorKey: AttributeKey<EventExecutor> =
+    AttributeKey.valueOf("ktor.netty.pinnedCallExecutor")
+
+/**
+ * Returns the [EventExecutor] from [callEventGroup] pinned to the given Netty channel.
+ *
+ * The executor is selected once per channel and cached as a channel attribute, so all calls on a given
+ * connection (HTTP/1) or stream (HTTP/2) are dispatched onto a single thread for the lifetime of the
+ * channel. This preserves thread affinity across coroutine suspensions, allowing user code to observe
+ * the same thread before and after `withContext` / other suspension points.
+ */
+internal fun pinnedCallExecutor(
+    context: ChannelHandlerContext,
+    callEventGroup: EventExecutorGroup
+): EventExecutor {
+    val attr = context.channel().attr(PinnedCallExecutorKey)
+    val existing = attr.get()
+    if (existing != null) return existing
+    val picked = callEventGroup.next()
+    return if (attr.compareAndSet(null, picked)) picked else attr.get()
+}

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http1/NettyHttp1Handler.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http1/NettyHttp1Handler.kt
@@ -43,7 +43,19 @@ internal class NettyHttp1Handler(
 
     private val activeCalls = ConcurrentLinkedQueue<NettyHttp1ApplicationCall>()
 
+    private var activated = false
+
     override fun channelActive(context: ChannelHandlerContext) {
+        // channelActive may be fired more than once on this handler (for example, when the pipeline is
+        // reconfigured during an HTTP/2 cleartext upgrade or via an explicit fireChannelActive call
+        // after adding the handler). Guard against re-adding the body handler and the tail sink, which
+        // must be present exactly once per pipeline.
+        if (activated) {
+            context.fireChannelActive()
+            return
+        }
+        activated = true
+
         responseWriter = NettyHttpResponsePipeline(
             context = context,
             httpHandlerState = state,

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http1/NettyHttp1Handler.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http1/NettyHttp1Handler.kt
@@ -12,10 +12,14 @@ import io.ktor.server.netty.NettyApplicationCallHandler.CallHandlerCoroutineName
 import io.ktor.server.netty.cio.*
 import io.ktor.util.pipeline.*
 import io.ktor.utils.io.*
+import io.netty.channel.ChannelHandler
 import io.netty.channel.ChannelHandlerContext
 import io.netty.channel.ChannelInboundHandlerAdapter
 import io.netty.handler.codec.http.*
 import io.netty.handler.timeout.ReadTimeoutException
+import io.netty.util.AttributeKey
+import io.netty.util.concurrent.EventExecutor
+import io.netty.util.concurrent.EventExecutorGroup
 import kotlinx.coroutines.*
 import java.io.IOException
 import java.util.concurrent.ConcurrentLinkedQueue
@@ -26,6 +30,7 @@ internal class NettyHttp1Handler(
     private val applicationProvider: () -> Application,
     private val enginePipeline: EnginePipeline,
     private val environment: ApplicationEnvironment,
+    private val callEventGroup: EventExecutorGroup,
     private val engineContext: CoroutineContext,
     private val userContext: CoroutineContext,
     private val runningLimit: Int
@@ -51,6 +56,12 @@ internal class NettyHttp1Handler(
         context.channel().read()
         context.pipeline().apply {
             addLast(RequestBodyHandler(context))
+            // Append a tail sink that consumes NettyHttp1ApplicationCall messages forwarded by this handler
+            // via fireChannelRead(call). This prevents Netty's tail handler from logging
+            // "Discarded inbound message" warnings for calls that pass through any user-added
+            // channelPipelineConfig handlers. The call lifecycle is driven by handleRequest, so the sink
+            // only needs to drop the call without further action.
+            addLast(NettyHttp1ApplicationCallSink)
         }
         context.fireChannelActive()
     }
@@ -137,7 +148,11 @@ internal class NettyHttp1Handler(
         val userAppContext = applicationProvider().coroutineContext + userContext
         val callJob = Job(parent = userAppContext[Job])
 
-        val callContext = userAppContext + NettyDispatcher.CurrentContext(context) + callJob + CallHandlerCoroutineName
+        val callExecutor = pinnedCallExecutor(context)
+        val callContext = userAppContext +
+            NettyDispatcher.CurrentContext(context, callExecutor) +
+            callJob +
+            CallHandlerCoroutineName
         val call = prepareCallFromRequest(context, message, callContext = callContext)
         activeCalls.add(call)
 
@@ -147,11 +162,13 @@ internal class NettyHttp1Handler(
         // Reserve response slot synchronously on the I/O thread for proper ordering
         responseWriter.processResponse(call)
 
-        // Defer coroutine start to the next event loop tick so that channelReadComplete() fires first
+        // Defer coroutine start to the next event loop tick so that channelReadComplete() fires first.
         // This allows the response pipeline to detect that the request body is still being received and flush headers
         // early instead of buffering them, which is required when the client waits for response headers
-        // before sending the request body
-        context.executor().execute {
+        // before sending the request body.
+        // Dispatching to the call event group also ensures user handler code does not run on the I/O worker
+        // event loop.
+        callExecutor.execute {
             val callScope = CoroutineScope(context = callContext)
             callScope.launch(start = CoroutineStart.UNDISPATCHED) {
                 try {
@@ -221,5 +238,39 @@ internal class NettyHttp1Handler(
         } else {
             state.skippedRead.value = true
         }
+    }
+
+    /**
+     * Returns the [EventExecutor] from [callEventGroup] pinned to the given channel.
+     * The executor is selected once per channel and stored as a channel attribute, ensuring that all calls on a
+     * given connection are dispatched onto a single thread for the lifetime of the connection. This preserves
+     * thread affinity across coroutine suspensions.
+     */
+    private fun pinnedCallExecutor(context: ChannelHandlerContext): EventExecutor {
+        val attr = context.channel().attr(PinnedCallExecutorKey)
+        val existing = attr.get()
+        if (existing != null) return existing
+        val picked = callEventGroup.next()
+        return if (attr.compareAndSet(null, picked)) picked else attr.get()
+    }
+
+    companion object {
+        private val PinnedCallExecutorKey: AttributeKey<EventExecutor> =
+            AttributeKey.valueOf("ktor.netty.pinnedCallExecutor")
+    }
+}
+
+/**
+ * A no-op tail handler that swallows [NettyHttp1ApplicationCall] messages forwarded by
+ * [NettyHttp1Handler.handleRequest] via [ChannelHandlerContext.fireChannelRead]. Its sole purpose is to
+ * prevent Netty's default tail handler from logging a "Discarded inbound message ... at the tail of the
+ * pipeline" warning. Non-call messages are propagated unchanged so they can reach Netty's tail and be
+ * released/handled normally.
+ */
+@ChannelHandler.Sharable
+internal object NettyHttp1ApplicationCallSink : ChannelInboundHandlerAdapter() {
+    override fun channelRead(ctx: ChannelHandlerContext, msg: Any) {
+        if (msg is NettyHttp1ApplicationCall) return
+        ctx.fireChannelRead(msg)
     }
 }

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http1/NettyHttp1Handler.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http1/NettyHttp1Handler.kt
@@ -17,8 +17,6 @@ import io.netty.channel.ChannelHandlerContext
 import io.netty.channel.ChannelInboundHandlerAdapter
 import io.netty.handler.codec.http.*
 import io.netty.handler.timeout.ReadTimeoutException
-import io.netty.util.AttributeKey
-import io.netty.util.concurrent.EventExecutor
 import io.netty.util.concurrent.EventExecutorGroup
 import kotlinx.coroutines.*
 import java.io.IOException
@@ -148,7 +146,7 @@ internal class NettyHttp1Handler(
         val userAppContext = applicationProvider().coroutineContext + userContext
         val callJob = Job(parent = userAppContext[Job])
 
-        val callExecutor = pinnedCallExecutor(context)
+        val callExecutor = pinnedCallExecutor(context, callEventGroup)
         val callContext = userAppContext +
             NettyDispatcher.CurrentContext(context, callExecutor) +
             callJob +
@@ -238,25 +236,6 @@ internal class NettyHttp1Handler(
         } else {
             state.skippedRead.value = true
         }
-    }
-
-    /**
-     * Returns the [EventExecutor] from [callEventGroup] pinned to the given channel.
-     * The executor is selected once per channel and stored as a channel attribute, ensuring that all calls on a
-     * given connection are dispatched onto a single thread for the lifetime of the connection. This preserves
-     * thread affinity across coroutine suspensions.
-     */
-    private fun pinnedCallExecutor(context: ChannelHandlerContext): EventExecutor {
-        val attr = context.channel().attr(PinnedCallExecutorKey)
-        val existing = attr.get()
-        if (existing != null) return existing
-        val picked = callEventGroup.next()
-        return if (attr.compareAndSet(null, picked)) picked else attr.get()
-    }
-
-    companion object {
-        private val PinnedCallExecutorKey: AttributeKey<EventExecutor> =
-            AttributeKey.valueOf("ktor.netty.pinnedCallExecutor")
     }
 }
 

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http2/NettyHttp2Handler.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http2/NettyHttp2Handler.kt
@@ -80,7 +80,9 @@ internal class NettyHttp2Handler(
         // "Discarded inbound message" warnings for calls that pass through any user-added
         // channelPipelineConfig handlers. The call lifecycle is driven by startHttp2, so the sink
         // only needs to drop the call without further action.
-        context.pipeline().addLast(NettyHttp2ApplicationCallSink)
+        if (context.pipeline().get(NettyHttp2ApplicationCallSink::class.java) == null) {
+            context.pipeline().addLast(NettyHttp2ApplicationCallSink)
+        }
         context.fireChannelActive()
     }
 

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http2/NettyHttp2Handler.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http2/NettyHttp2Handler.kt
@@ -19,7 +19,6 @@ import io.netty.channel.ChannelHandlerContext
 import io.netty.channel.ChannelInboundHandlerAdapter
 import io.netty.handler.codec.http2.*
 import io.netty.util.AttributeKey
-import io.netty.util.concurrent.EventExecutor
 import io.netty.util.concurrent.EventExecutorGroup
 import kotlinx.coroutines.*
 import java.lang.reflect.Field
@@ -104,7 +103,7 @@ internal class NettyHttp2Handler(
 
     private fun startHttp2(context: ChannelHandlerContext, headers: Http2Headers) {
         val callJob = Job(parent = userCoroutineContext[Job])
-        val callExecutor = pinnedCallExecutor(context)
+        val callExecutor = pinnedCallExecutor(context, callEventGroup)
         val callContext = userCoroutineContext +
             NettyDispatcher.CurrentContext(context, callExecutor) +
             callJob +
@@ -126,7 +125,7 @@ internal class NettyHttp2Handler(
         // deliver subsequent Http2DataFrame messages. Without this, the coroutine runs on the event loop,
         // blocking data frame delivery and causing EOFException.
         // Dispatching to the call event group also ensures user handler code does not run on the I/O worker
-        // event loop, matching the behavior prior to KTOR-9343.
+        // event loop.
         callExecutor.execute {
             val callScope = CoroutineScope(context = callContext)
             callScope.launch(start = CoroutineStart.UNDISPATCHED) {
@@ -253,25 +252,8 @@ internal class NettyHttp2Handler(
         handlerJob.cancel()
     }
 
-    /**
-     * Returns the [EventExecutor] from [callEventGroup] pinned to the given channel.
-     * The executor is selected once per channel and stored as a channel attribute, ensuring that all calls on a
-     * given stream are dispatched onto a single thread for the lifetime of the stream. This preserves
-     * thread affinity across coroutine suspensions, matching the behavior prior to KTOR-9343.
-     */
-    private fun pinnedCallExecutor(context: ChannelHandlerContext): EventExecutor {
-        val attr = context.channel().attr(PinnedCallExecutorKey)
-        val existing = attr.get()
-        if (existing != null) return existing
-        val picked = callEventGroup.next()
-        return if (attr.compareAndSet(null, picked)) picked else attr.get()
-    }
-
     companion object {
         private val ApplicationCallKey = AttributeKey.valueOf<NettyHttp2ApplicationCall>("ktor.ApplicationCall")
-
-        private val PinnedCallExecutorKey: AttributeKey<EventExecutor> =
-            AttributeKey.valueOf("ktor.netty.pinnedCallExecutor.http2")
 
         private var ChannelHandlerContext.applicationCall: NettyHttp2ApplicationCall?
             get() = channel().attr(ApplicationCallKey).get()

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http2/NettyHttp2Handler.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http2/NettyHttp2Handler.kt
@@ -19,6 +19,7 @@ import io.netty.channel.ChannelHandlerContext
 import io.netty.channel.ChannelInboundHandlerAdapter
 import io.netty.handler.codec.http2.*
 import io.netty.util.AttributeKey
+import io.netty.util.ReferenceCountUtil
 import io.netty.util.concurrent.EventExecutorGroup
 import kotlinx.coroutines.*
 import java.lang.reflect.Field
@@ -74,6 +75,12 @@ internal class NettyHttp2Handler(
             coroutineContext = handlerJob
         )
 
+        // Append a tail sink that consumes NettyHttp2ApplicationCall messages forwarded by this handler
+        // via fireChannelRead(call). This prevents Netty's tail handler from logging
+        // "Discarded inbound message" warnings for calls that pass through any user-added
+        // channelPipelineConfig handlers. The call lifecycle is driven by startHttp2, so the sink
+        // only needs to drop the call without further action.
+        context.pipeline().addLast(NettyHttp2ApplicationCallSink)
         context.fireChannelActive()
     }
 
@@ -117,6 +124,9 @@ internal class NettyHttp2Handler(
             coroutineContext = callContext
         )
         context.applicationCall = call
+
+        // Fire channel read for custom handlers added to the pipeline
+        context.fireChannelRead(call)
 
         // Reserve response slot synchronously on the I/O thread for proper ordering
         responseWriter.processResponse(call)
@@ -260,5 +270,40 @@ internal class NettyHttp2Handler(
             set(newValue) {
                 channel().attr(ApplicationCallKey).set(newValue)
             }
+    }
+}
+
+/**
+ * A no-op tail handler that swallows [NettyHttp2ApplicationCall] messages forwarded by
+ * [NettyHttp2Handler.startHttp2] via [ChannelHandlerContext.fireChannelRead]. Its sole purpose is to
+ * prevent Netty's default tail handler from logging a "Discarded inbound message ... at the tail of the
+ * pipeline" warning. Non-call messages are propagated unchanged so they can reach Netty's tail and be
+ * released/handled normally.
+ */
+@ChannelHandler.Sharable
+internal object NettyHttp2ApplicationCallSink : ChannelInboundHandlerAdapter() {
+    override fun channelRead(ctx: ChannelHandlerContext, msg: Any) {
+        if (msg is NettyHttp2ApplicationCall) return
+        ctx.fireChannelRead(msg)
+    }
+}
+
+/**
+ * A no-op tail handler installed on the HTTP/2 *connection* (parent) pipeline that swallows
+ * connection-level [Http2Frame] messages (e.g. SETTINGS, PING, GOAWAY) which Netty's
+ * [Http2MultiplexCodec] forwards down the parent pipeline after handling them.
+ *
+ * Without this sink, those frames reach Netty's default tail handler and trigger
+ * "Discarded inbound message ... at the tail of the pipeline" warnings. Non-frame messages are
+ * propagated unchanged so they can reach Netty's tail and be released/handled normally.
+ */
+@ChannelHandler.Sharable
+internal object NettyHttp2ConnectionSink : ChannelInboundHandlerAdapter() {
+    override fun channelRead(ctx: ChannelHandlerContext, msg: Any) {
+        if (msg is Http2Frame) {
+            ReferenceCountUtil.release(msg)
+            return
+        }
+        ctx.fireChannelRead(msg)
     }
 }

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http2/NettyHttp2Handler.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http2/NettyHttp2Handler.kt
@@ -19,6 +19,8 @@ import io.netty.channel.ChannelHandlerContext
 import io.netty.channel.ChannelInboundHandlerAdapter
 import io.netty.handler.codec.http2.*
 import io.netty.util.AttributeKey
+import io.netty.util.concurrent.EventExecutor
+import io.netty.util.concurrent.EventExecutorGroup
 import kotlinx.coroutines.*
 import java.lang.reflect.Field
 import java.nio.channels.ClosedChannelException
@@ -28,6 +30,7 @@ import kotlin.coroutines.CoroutineContext
 internal class NettyHttp2Handler(
     private val enginePipeline: EnginePipeline,
     private val application: Application,
+    private val callEventGroup: EventExecutorGroup,
     private val userCoroutineContext: CoroutineContext,
     runningLimit: Int
 ) : ChannelInboundHandlerAdapter() {
@@ -101,8 +104,11 @@ internal class NettyHttp2Handler(
 
     private fun startHttp2(context: ChannelHandlerContext, headers: Http2Headers) {
         val callJob = Job(parent = userCoroutineContext[Job])
-        val callContext =
-            userCoroutineContext + NettyDispatcher.CurrentContext(context) + callJob + CallHandlerCoroutineName
+        val callExecutor = pinnedCallExecutor(context)
+        val callContext = userCoroutineContext +
+            NettyDispatcher.CurrentContext(context, callExecutor) +
+            callJob +
+            CallHandlerCoroutineName
         val call = NettyHttp2ApplicationCall(
             application = application,
             context = context,
@@ -116,10 +122,12 @@ internal class NettyHttp2Handler(
         // Reserve response slot synchronously on the I/O thread for proper ordering
         responseWriter.processResponse(call)
 
-        // Defer coroutine start to the next event loop tick via context.executor().execute so that
-        // channelRead returns and Netty can deliver subsequent Http2DataFrame messages.
-        // Without this, the coroutine runs on the event loop, blocking data frame delivery and causing EOFException.
-        context.executor().execute {
+        // Defer coroutine start to the next event loop tick so that channelRead returns and Netty can
+        // deliver subsequent Http2DataFrame messages. Without this, the coroutine runs on the event loop,
+        // blocking data frame delivery and causing EOFException.
+        // Dispatching to the call event group also ensures user handler code does not run on the I/O worker
+        // event loop, matching the behavior prior to KTOR-9343.
+        callExecutor.execute {
             val callScope = CoroutineScope(context = callContext)
             callScope.launch(start = CoroutineStart.UNDISPATCHED) {
                 try {
@@ -245,8 +253,25 @@ internal class NettyHttp2Handler(
         handlerJob.cancel()
     }
 
+    /**
+     * Returns the [EventExecutor] from [callEventGroup] pinned to the given channel.
+     * The executor is selected once per channel and stored as a channel attribute, ensuring that all calls on a
+     * given stream are dispatched onto a single thread for the lifetime of the stream. This preserves
+     * thread affinity across coroutine suspensions, matching the behavior prior to KTOR-9343.
+     */
+    private fun pinnedCallExecutor(context: ChannelHandlerContext): EventExecutor {
+        val attr = context.channel().attr(PinnedCallExecutorKey)
+        val existing = attr.get()
+        if (existing != null) return existing
+        val picked = callEventGroup.next()
+        return if (attr.compareAndSet(null, picked)) picked else attr.get()
+    }
+
     companion object {
         private val ApplicationCallKey = AttributeKey.valueOf<NettyHttp2ApplicationCall>("ktor.ApplicationCall")
+
+        private val PinnedCallExecutorKey: AttributeKey<EventExecutor> =
+            AttributeKey.valueOf("ktor.netty.pinnedCallExecutor.http2")
 
         private var ChannelHandlerContext.applicationCall: NettyHttp2ApplicationCall?
             get() = channel().attr(ApplicationCallKey).get()

--- a/ktor-server/ktor-server-netty/jvm/test/io/ktor/tests/server/netty/NettyCustomChannelPipelineConfigurationTest.kt
+++ b/ktor-server/ktor-server-netty/jvm/test/io/ktor/tests/server/netty/NettyCustomChannelPipelineConfigurationTest.kt
@@ -7,17 +7,23 @@ package io.ktor.tests.server.netty
 import io.ktor.http.*
 import io.ktor.server.engine.*
 import io.ktor.server.netty.*
+import io.ktor.server.netty.http1.NettyHttp1ApplicationCall
 import io.ktor.server.response.*
 import io.ktor.server.test.base.*
 import io.netty.channel.*
+import kotlin.concurrent.atomics.AtomicReference
+import kotlin.concurrent.atomics.ExperimentalAtomicApi
 import kotlin.test.*
 
 abstract class NettyCustomChannelTest<TEngine : ApplicationEngine, TConfiguration : ApplicationEngine.Configuration>(
     hostFactory: ApplicationEngineFactory<TEngine, TConfiguration>
 ) : EngineTestBase<TEngine, TConfiguration>(hostFactory) {
 
+    @OptIn(ExperimentalAtomicApi::class)
+    val pipelineHandlerNames = AtomicReference<List<String>>(emptyList())
     var counter = 0
 
+    @OptIn(ExperimentalAtomicApi::class)
     @Test
     fun testCustomChannelHandlerInvoked() = runTest {
         createAndStartServer {
@@ -29,6 +35,10 @@ abstract class NettyCustomChannelTest<TEngine : ApplicationEngine, TConfiguratio
         withUrl("/") {
             assertEquals(HttpStatusCode.OK.value, status.value)
             assertNotEquals(0, counter)
+            val uniqueNames = mutableSetOf<String>()
+            if (pipelineHandlerNames.load().any { !uniqueNames.add(it) }) {
+                fail("Pipeline handlers are not unique")
+            }
         }
     }
 }
@@ -36,6 +46,7 @@ abstract class NettyCustomChannelTest<TEngine : ApplicationEngine, TConfiguratio
 class NettyCustomChannelPipelineConfigurationTest :
     NettyCustomChannelTest<NettyApplicationEngine, NettyApplicationEngine.Configuration>(Netty) {
 
+    @OptIn(ExperimentalAtomicApi::class)
     override fun configure(configuration: NettyApplicationEngine.Configuration) {
         configuration.shareWorkGroup = true
         configuration.channelPipelineConfig = {
@@ -44,6 +55,9 @@ class NettyCustomChannelPipelineConfigurationTest :
                 object : ChannelInboundHandlerAdapter() {
                     override fun channelRead(ctx: ChannelHandlerContext, msg: Any) {
                         counter = counter.plus(1)
+                        if (msg is NettyHttp1ApplicationCall) {
+                            pipelineHandlerNames.store(ctx.pipeline().names().map { it.substringBefore('#') })
+                        }
                         super.channelRead(ctx, msg)
                     }
                 }

--- a/ktor-server/ktor-server-netty/jvm/test/io/ktor/tests/server/netty/NettySpecificTest.kt
+++ b/ktor-server/ktor-server-netty/jvm/test/io/ktor/tests/server/netty/NettySpecificTest.kt
@@ -12,7 +12,7 @@ import io.ktor.client.*
 import io.ktor.client.engine.cio.*
 import io.ktor.client.plugins.*
 import io.ktor.client.request.*
-import io.ktor.client.statement.*
+import io.ktor.client.statement.bodyAsText
 import io.ktor.http.*
 import io.ktor.http.content.*
 import io.ktor.network.selector.*
@@ -22,7 +22,7 @@ import io.ktor.server.application.hooks.*
 import io.ktor.server.engine.*
 import io.ktor.server.netty.*
 import io.ktor.server.netty.http1.*
-import io.ktor.server.request.*
+import io.ktor.server.request.receive
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
 import io.ktor.test.dispatcher.*
@@ -39,10 +39,12 @@ import java.io.IOException
 import java.net.BindException
 import java.net.ServerSocket
 import java.util.concurrent.ExecutorService
-import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicReference
 import kotlin.coroutines.EmptyCoroutineContext
-import kotlin.test.*
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 
@@ -403,6 +405,55 @@ class NettySpecificTest {
             )
         } finally {
             server.stopSuspend()
+        }
+    }
+
+    @Test
+    fun `pipeline should not discard inbound messages`() = runTestWithRealTime {
+        // Netty logs "Discarded inbound message ... at the tail of the pipeline" at DEBUG level,
+        // so we need to capture DEBUG events from this logger to detect the issue (KTOR-9531).
+        val pipelineLogger = LoggerFactory.getLogger("io.netty.channel.DefaultChannelPipeline") as Logger
+        val previousLevel = pipelineLogger.level
+        val logEvents = ListAppender<ILoggingEvent>().apply {
+            context = pipelineLogger.loggerContext
+            start()
+        }
+        pipelineLogger.level = Level.DEBUG
+        pipelineLogger.addAppender(logEvents)
+
+        val server = embeddedServer(Netty, 0) {
+            routing {
+                post("/send") {
+                    call.respondText(call.receive())
+                }
+            }
+        }
+        server.startSuspend()
+        try {
+            val connector = server.engine.resolvedConnectors().first()
+            val sendUrl = "http://${connector.host}:${connector.port}/send"
+            val client = HttpClient(CIO)
+
+            repeat(5) { i ->
+                client.post(sendUrl) {
+                    contentType(ContentType.Application.Json)
+                    setBody("{\"foo\":\"bar-$i\"}")
+                }.bodyAsText()
+            }
+            val discarded = logEvents.list.filter {
+                it.message.orEmpty().contains("Discarded inbound message")
+            }
+
+            assertTrue(
+                discarded.isEmpty(),
+                "Netty pipeline discarded ${discarded.size} inbound messages." +
+                    "First message: ${discarded.firstOrNull()?.formattedMessage}"
+            )
+        } finally {
+            server.stopSuspend(0L, 0L)
+            pipelineLogger.detachAppender(logEvents)
+            logEvents.stop()
+            pipelineLogger.level = previousLevel
         }
     }
 }

--- a/ktor-server/ktor-server-netty/jvm/test/io/ktor/tests/server/netty/NettySpecificTest.kt
+++ b/ktor-server/ktor-server-netty/jvm/test/io/ktor/tests/server/netty/NettySpecificTest.kt
@@ -12,6 +12,7 @@ import io.ktor.client.*
 import io.ktor.client.engine.cio.*
 import io.ktor.client.plugins.*
 import io.ktor.client.request.*
+import io.ktor.client.statement.*
 import io.ktor.http.*
 import io.ktor.http.content.*
 import io.ktor.network.selector.*
@@ -21,19 +22,24 @@ import io.ktor.server.application.hooks.*
 import io.ktor.server.engine.*
 import io.ktor.server.netty.*
 import io.ktor.server.netty.http1.*
+import io.ktor.server.request.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
 import io.ktor.test.dispatcher.*
 import io.ktor.utils.io.*
 import io.mockk.mockk
 import io.netty.channel.Channel
+import io.netty.channel.EventLoopGroup
 import io.netty.channel.embedded.EmbeddedChannel
+import io.netty.channel.nio.NioEventLoopGroup
 import kotlinx.coroutines.*
+import org.junit.jupiter.api.Test
 import org.slf4j.LoggerFactory
 import java.io.IOException
 import java.net.BindException
 import java.net.ServerSocket
 import java.util.concurrent.ExecutorService
+import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicReference
 import kotlin.coroutines.EmptyCoroutineContext
 import kotlin.test.*
@@ -261,10 +267,12 @@ class NettySpecificTest {
         logger.addAppender(listAppender)
 
         val environment = applicationEnvironment { log = logger }
+        val callEventGroup = NioEventLoopGroup(1)
         val handler = NettyHttp1Handler(
             applicationProvider = { mockk(relaxed = true) },
             enginePipeline = mockk(relaxed = true),
             environment = environment,
+            callEventGroup = callEventGroup,
             engineContext = EmptyCoroutineContext,
             userContext = EmptyCoroutineContext,
             runningLimit = 32
@@ -294,6 +302,7 @@ class NettySpecificTest {
             logger.detachAppender(listAppender)
             logger.level = previousLevel
             channel.finishAndReleaseAll()
+            callEventGroup.shutdownGracefully()
         }
     }
 
@@ -333,7 +342,7 @@ class NettySpecificTest {
                     writeChannel.writeStringUtf8("Connection: close\r\n\r\n")
                     writeChannel.flush()
 
-                    withTimeout(5000) {
+                    withTimeout(5000.milliseconds) {
                         readChannel.awaitContent()
 
                         val responseLines = mutableListOf<String>()
@@ -350,6 +359,50 @@ class NettySpecificTest {
             }
         } finally {
             serverJob.cancel()
+        }
+    }
+
+    @Test
+    fun `request handler runs on call event group`() = runTestWithRealTime {
+        val handlerThread = AtomicReference<Thread>()
+
+        val server = embeddedServer(
+            factory = Netty,
+            rootConfig = serverConfig {
+                module {
+                    routing {
+                        get("/") {
+                            handlerThread.set(Thread.currentThread())
+                            call.respondText("ok")
+                        }
+                    }
+                }
+            },
+            configure = {
+                connector { port = 0 }
+                // This issue is not relevant if call and worker groups are shared
+                shareWorkGroup = false
+            }
+        )
+        server.startSuspend(wait = false)
+
+        try {
+            val connector = server.engine.resolvedConnectors().first()
+            HttpClient(CIO).use { it.get("http://${connector.host}:${connector.port}/") }
+
+            // Ugly, but we'd like to access the call event group somehow
+            val callEventGroup = NettyApplicationEngine::class.java
+                .getDeclaredMethod("getCallEventGroup")
+                .apply { isAccessible = true }
+                .invoke(server.engine) as EventLoopGroup
+
+            val thread = handlerThread.get()
+            assertTrue(
+                callEventGroup.any { it.inEventLoop(thread) },
+                "Handler ran on '${thread.name}', not on any call event group thread"
+            )
+        } finally {
+            server.stopSuspend()
         }
     }
 }

--- a/ktor-server/ktor-server-netty/jvm/test/io/ktor/tests/server/netty/NettySpecificTest.kt
+++ b/ktor-server/ktor-server-netty/jvm/test/io/ktor/tests/server/netty/NettySpecificTest.kt
@@ -409,9 +409,7 @@ class NettySpecificTest {
     }
 
     @Test
-    fun `pipeline should not discard inbound messages`() = runTestWithRealTime {
-        // Netty logs "Discarded inbound message ... at the tail of the pipeline" at DEBUG level,
-        // so we need to capture DEBUG events from this logger to detect the issue (KTOR-9531).
+    fun `no messages are discarded from the netty pipeline`() = runTestWithRealTime {
         val pipelineLogger = LoggerFactory.getLogger("io.netty.channel.DefaultChannelPipeline") as Logger
         val previousLevel = pipelineLogger.level
         val logEvents = ListAppender<ILoggingEvent>().apply {

--- a/ktor-server/ktor-server-netty/jvm/test/io/ktor/tests/server/netty/NettySpecificTest.kt
+++ b/ktor-server/ktor-server-netty/jvm/test/io/ktor/tests/server/netty/NettySpecificTest.kt
@@ -409,7 +409,62 @@ class NettySpecificTest {
     }
 
     @Test
-    fun `no messages are discarded from the netty pipeline`() = runTestWithRealTime {
+    fun `no messages are discarded from the netty pipeline for HTTP1`() = noDiscardedMessagesTest(enableH2c = false) {
+        val connector = engine.resolvedConnectors().first()
+        val sendUrl = "http://${connector.host}:${connector.port}/send"
+        HttpClient(CIO).use { client ->
+            repeat(5) { i ->
+                client.post(sendUrl) {
+                    contentType(ContentType.Application.Json)
+                    setBody("{\"foo\":\"bar-$i\"}")
+                }.bodyAsText()
+            }
+        }
+    }
+
+    @Test
+    fun `no messages are discarded from the netty pipeline for HTTP2`() = noDiscardedMessagesTest(enableH2c = true) {
+        val connector = engine.resolvedConnectors().first()
+        SelectorManager().use { selector ->
+            aSocket(selector).tcp().connect(connector.host, connector.port).use { socket ->
+                val writer = socket.openWriteChannel()
+                val reader = socket.openReadChannel()
+
+                // HTTP/2 prior-knowledge: send connection preface and an initial SETTINGS
+                writer.writeStringUtf8("PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n")
+                writer.writeFully(http2SettingsFrameBytes(ack = false))
+                writer.flush()
+
+                // Drain initial server frames (SETTINGS and SETTINGS-ACK)
+                readHttp2FrameRaw(reader)
+                readHttp2FrameRaw(reader)
+                writer.writeFully(http2SettingsFrameBytes(ack = true))
+                writer.flush()
+
+                repeat(5) { i ->
+                    val streamId = 1 + i * 2
+                    writer.writeFully(http2GetHeadersFrameBytes(streamId, "/ping"))
+                    writer.flush()
+
+                    // Read response frames until END_STREAM on this stream
+                    var endStream = false
+                    while (!endStream) {
+                        val frame = readHttp2FrameRaw(reader)
+                        if (frame.streamId == streamId &&
+                            (frame.flags.toInt() and 0x1) != 0
+                        ) {
+                            endStream = true
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private fun noDiscardedMessagesTest(
+        enableH2c: Boolean,
+        block: suspend EmbeddedServer<NettyApplicationEngine, NettyApplicationEngine.Configuration>.() -> Unit,
+    ) = runTestWithRealTime {
         val pipelineLogger = LoggerFactory.getLogger("io.netty.channel.DefaultChannelPipeline") as Logger
         val previousLevel = pipelineLogger.level
         val logEvents = ListAppender<ILoggingEvent>().apply {
@@ -419,25 +474,29 @@ class NettySpecificTest {
         pipelineLogger.level = Level.DEBUG
         pipelineLogger.addAppender(logEvents)
 
-        val server = embeddedServer(Netty, 0) {
-            routing {
-                post("/send") {
-                    call.respondText(call.receive())
+        val server = embeddedServer(
+            factory = Netty,
+            rootConfig = serverConfig {
+                module {
+                    routing {
+                        post("/send") {
+                            call.respondText(call.receive())
+                        }
+                        get("/ping") {
+                            call.respondText("pong")
+                        }
+                    }
                 }
+            },
+            configure = {
+                connector { port = 0 }
+                this.enableH2c = enableH2c
             }
-        }
+        )
         server.startSuspend()
         try {
-            val connector = server.engine.resolvedConnectors().first()
-            val sendUrl = "http://${connector.host}:${connector.port}/send"
-            val client = HttpClient(CIO)
+            server.block()
 
-            repeat(5) { i ->
-                client.post(sendUrl) {
-                    contentType(ContentType.Application.Json)
-                    setBody("{\"foo\":\"bar-$i\"}")
-                }.bodyAsText()
-            }
             val discarded = logEvents.list.filter {
                 it.message.orEmpty().contains("Discarded inbound message")
             }
@@ -453,5 +512,61 @@ class NettySpecificTest {
             logEvents.stop()
             pipelineLogger.level = previousLevel
         }
+    }
+
+    private class Http2RawFrame(
+        val frameType: Byte,
+        val flags: Byte,
+        val streamId: Int,
+        val payload: ByteArray,
+    )
+
+    private suspend fun readHttp2FrameRaw(channel: ByteReadChannel): Http2RawFrame {
+        val header = channel.readByteArray(9)
+        val payloadLength = ((header[0].toInt() and 0xFF) shl 16) or
+            ((header[1].toInt() and 0xFF) shl 8) or
+            (header[2].toInt() and 0xFF)
+        val frameType = header[3]
+        val flags = header[4]
+        val streamId = ((header[5].toInt() and 0x7F) shl 24) or
+            ((header[6].toInt() and 0xFF) shl 16) or
+            ((header[7].toInt() and 0xFF) shl 8) or
+            (header[8].toInt() and 0xFF)
+        val payload = channel.readByteArray(payloadLength)
+        return Http2RawFrame(frameType, flags, streamId, payload)
+    }
+
+    private fun http2SettingsFrameBytes(ack: Boolean): ByteArray =
+        buildHttp2Frame(type = 0x4, flags = if (ack) 0x1 else 0x0, streamId = 0, payload = ByteArray(0))
+
+    private fun http2GetHeadersFrameBytes(streamId: Int, path: String): ByteArray {
+        // Encode HEADERS payload using Netty's HPACK encoder via DefaultHttp2HeadersEncoder
+        val headers = io.netty.handler.codec.http2.DefaultHttp2Headers().also {
+            it.method("GET")
+            it.path(path)
+            it.scheme("http")
+        }
+        val encoded = io.netty.buffer.Unpooled.buffer()
+        io.netty.handler.codec.http2.DefaultHttp2HeadersEncoder().encodeHeaders(streamId, headers, encoded)
+        val payload = ByteArray(encoded.readableBytes())
+        encoded.readBytes(payload)
+        // END_HEADERS (0x4) | END_STREAM (0x1)
+        return buildHttp2Frame(type = 0x1, flags = 0x5, streamId = streamId, payload = payload)
+    }
+
+    private fun buildHttp2Frame(type: Int, flags: Int, streamId: Int, payload: ByteArray): ByteArray {
+        val length = payload.size
+        val buf = ByteArray(9 + length)
+        buf[0] = ((length shr 16) and 0xFF).toByte()
+        buf[1] = ((length shr 8) and 0xFF).toByte()
+        buf[2] = (length and 0xFF).toByte()
+        buf[3] = (type and 0xFF).toByte()
+        buf[4] = (flags and 0xFF).toByte()
+        buf[5] = ((streamId shr 24) and 0x7F).toByte()
+        buf[6] = ((streamId shr 16) and 0xFF).toByte()
+        buf[7] = ((streamId shr 8) and 0xFF).toByte()
+        buf[8] = (streamId and 0xFF).toByte()
+        payload.copyInto(buf, destinationOffset = 9)
+        return buf
     }
 }


### PR DESCRIPTION
**Subsystem**
Server, Netty

**Motivation**
- [KTOR-9531](https://youtrack.jetbrains.com/issue/KTOR-9531) Netty server intermittently drops requests after upgrading to 3.4.3
- [KTOR-9542](https://youtrack.jetbrains.com/issue/KTOR-9542) Netty: The request handler runs on worker event loop instead of call event loop since 3.4.3
- Another issue with updating from Netty 4.2.9.Final to 4.2.12.Final in Ktor 3.4.3: because of some classpath conflict issues, some libraries would encounter runtime problems with Netty actually failing to respond when `netty-codec` was imported from 4.1.*. This was wrongfully attributed to KTOR-9531 above.

**Solution**
- Worker loop fix: handlers now take a `callEventGroup` and pin one `EventExecutor` per channel via an `AttributeKey`, dispatch the deferred coroutine start onto it. `NettyDispatcher.CurrentContext` carries that pinned executor so suspensions stay on the call-event-group thread.
- Discarded event fix: added a `@Sharable` `NettyHttp1ApplicationCallSink` appended in `channelActive` after `RequestBodyHandler` and after user `channelPipelineConfig` handlers, swallowing `NettyHttp1ApplicationCall` messages so they don't reach Netty's tail.
- Classpath shenanigans fix: added `netty-codec` as a dependency to avoid clashing with older versions imported from `netty-grpc` and the like