### PR TITLE
Use cache redirector in build-settings-logic

### DIFF
--- a/build-settings-logic/settings.gradle.kts
+++ b/build-settings-logic/settings.gradle.kts
@@ -5,6 +5,11 @@
 pluginManagement {
     repositories {
         maven("https://cache-redirector.jetbrains.com/plugins.gradle.org/m2")
+        gradlePluginPortal()
+        
+        // Consistent with dependencyResolutionManagement
+        val kotlinRepoUrl = providers.gradleProperty("kotlin_repo_url").orNull
+        if (kotlinRepoUrl != null) maven(kotlinRepoUrl) { name = "KotlinDev" }
     }
 }
 

--- a/build-settings-logic/settings.gradle.kts
+++ b/build-settings-logic/settings.gradle.kts
@@ -2,6 +2,12 @@
  * Copyright 2014-2025 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
+pluginManagement {
+    repositories {
+        maven("https://cache-redirector.jetbrains.com/plugins.gradle.org/m2")
+    }
+}
+
 plugins {
     // Keep it in sync with libs.versions.toml
     id("com.gradle.develocity") version "4.3.2"


### PR DESCRIPTION
Adding more cache redirector to get around the 429's coming in from maven central.  Our builds were getting blocked when resolving the build-settings-config plugins 😒 