### PR TITLE
KTOR-7067 Add list-returning variant of parseClientCookiesHeader

### DIFF
--- a/ktor-http/api/ktor-http.api
+++ b/ktor-http/api/ktor-http.api
@@ -355,6 +355,8 @@ public final class io/ktor/http/CookieEncoding : java/lang/Enum {
 public final class io/ktor/http/CookieKt {
 	public static final fun decodeCookieValue (Ljava/lang/String;Lio/ktor/http/CookieEncoding;)Ljava/lang/String;
 	public static final fun encodeCookieValue (Ljava/lang/String;Lio/ktor/http/CookieEncoding;)Ljava/lang/String;
+	public static final fun parseClientCookies (Ljava/lang/String;Z)Ljava/util/List;
+	public static synthetic fun parseClientCookies$default (Ljava/lang/String;ZILjava/lang/Object;)Ljava/util/List;
 	public static final fun parseClientCookiesHeader (Ljava/lang/String;Z)Ljava/util/Map;
 	public static synthetic fun parseClientCookiesHeader$default (Ljava/lang/String;ZILjava/lang/Object;)Ljava/util/Map;
 	public static final fun parseServerSetCookieHeader (Ljava/lang/String;)Lio/ktor/http/Cookie;

--- a/ktor-http/api/ktor-http.klib.api
+++ b/ktor-http/api/ktor-http.klib.api
@@ -1963,6 +1963,7 @@ final fun io.ktor.http/parametersOf(kotlin/String, kotlin.collections/List<kotli
 final fun io.ktor.http/parametersOf(kotlin/String, kotlin/String): io.ktor.http/Parameters // io.ktor.http/parametersOf|parametersOf(kotlin.String;kotlin.String){}[0]
 final fun io.ktor.http/parseAndSortContentTypeHeader(kotlin/String?): kotlin.collections/List<io.ktor.http/HeaderValue> // io.ktor.http/parseAndSortContentTypeHeader|parseAndSortContentTypeHeader(kotlin.String?){}[0]
 final fun io.ktor.http/parseAndSortHeader(kotlin/String?): kotlin.collections/List<io.ktor.http/HeaderValue> // io.ktor.http/parseAndSortHeader|parseAndSortHeader(kotlin.String?){}[0]
+final fun io.ktor.http/parseClientCookies(kotlin/String, kotlin/Boolean = ...): kotlin.collections/List<kotlin/Pair<kotlin/String, kotlin/String>> // io.ktor.http/parseClientCookies|parseClientCookies(kotlin.String;kotlin.Boolean){}[0]
 final fun io.ktor.http/parseClientCookiesHeader(kotlin/String, kotlin/Boolean = ...): kotlin.collections/Map<kotlin/String, kotlin/String> // io.ktor.http/parseClientCookiesHeader|parseClientCookiesHeader(kotlin.String;kotlin.Boolean){}[0]
 final fun io.ktor.http/parseHeaderValue(kotlin/String?): kotlin.collections/List<io.ktor.http/HeaderValue> // io.ktor.http/parseHeaderValue|parseHeaderValue(kotlin.String?){}[0]
 final fun io.ktor.http/parseHeaderValue(kotlin/String?, kotlin/Boolean): kotlin.collections/List<io.ktor.http/HeaderValue> // io.ktor.http/parseHeaderValue|parseHeaderValue(kotlin.String?;kotlin.Boolean){}[0]

--- a/ktor-http/common/src/io/ktor/http/Cookie.kt
+++ b/ktor-http/common/src/io/ktor/http/Cookie.kt
@@ -122,12 +122,7 @@ public fun parseServerSetCookieHeader(cookiesHeader: String): Cookie {
 
 private val clientCookieHeaderPattern = """(^|;)\s*([^;=\{\}\s]+)\s*(=\s*("[^"]*"|[^;]*))?""".toRegex()
 
-/**
- * Parse client's `Cookie` header value
- *
- * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.http.parseClientCookiesHeader)
- */
-public fun parseClientCookiesHeader(cookiesHeader: String, skipEscaped: Boolean = true): Map<String, String> =
+private fun clientCookies(cookiesHeader: String, skipEscaped: Boolean): Sequence<Pair<String, String>> =
     clientCookieHeaderPattern.findAll(cookiesHeader)
         .map { (it.groups[2]?.value ?: "") to (it.groups[4]?.value ?: "") }
         .filter { !skipEscaped || !it.first.startsWith("$") }
@@ -138,7 +133,29 @@ public fun parseClientCookiesHeader(cookiesHeader: String, skipEscaped: Boolean 
                 cookie
             }
         }
-        .toMap()
+
+/**
+ * Parse client's `Cookie` header value into a list of name/value pairs.
+ *
+ * Unlike [parseClientCookiesHeader], this variant preserves every cookie in the header,
+ * including multiple entries that share the same name (allowed by RFC 6265 section 5.4).
+ *
+ * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.http.parseClientCookies)
+ */
+public fun parseClientCookies(cookiesHeader: String, skipEscaped: Boolean = true): List<Pair<String, String>> =
+    clientCookies(cookiesHeader, skipEscaped).toList()
+
+/**
+ * Parse client's `Cookie` header value.
+ *
+ * Note that when the header contains multiple cookies with the same name, only the last
+ * value is retained. Use [parseClientCookies] to preserve all entries as required by
+ * RFC 6265 section 5.4.
+ *
+ * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.http.parseClientCookiesHeader)
+ */
+public fun parseClientCookiesHeader(cookiesHeader: String, skipEscaped: Boolean = true): Map<String, String> =
+    clientCookies(cookiesHeader, skipEscaped).toMap()
 
 /**
  * Format `Set-Cookie` header value

--- a/ktor-http/common/test/io/ktor/tests/http/ParseClientCookiesHeaderTest.kt
+++ b/ktor-http/common/test/io/ktor/tests/http/ParseClientCookiesHeaderTest.kt
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2014-2025 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.tests.http
+
+import io.ktor.http.parseClientCookies
+import io.ktor.http.parseClientCookiesHeader
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class ParseClientCookiesHeaderTest {
+
+    @Test
+    fun `single cookie is parsed into one entry`() {
+        assertEquals(listOf("name" to "value"), parseClientCookies("name=value"))
+        assertEquals(mapOf("name" to "value"), parseClientCookiesHeader("name=value"))
+    }
+
+    @Test
+    fun `multiple distinct cookies are preserved`() {
+        val header = "a=1; b=2; c=3"
+        assertEquals(
+            listOf("a" to "1", "b" to "2", "c" to "3"),
+            parseClientCookies(header)
+        )
+        assertEquals(mapOf("a" to "1", "b" to "2", "c" to "3"), parseClientCookiesHeader(header))
+    }
+
+    @Test
+    fun `duplicate names are all preserved by list variant`() {
+        assertEquals(
+            listOf("name" to "value1", "name" to "value2"),
+            parseClientCookies("name=value1; name=value2")
+        )
+    }
+
+    @Test
+    fun `duplicate names collapse to last value in map variant for backward compatibility`() {
+        assertEquals(mapOf("name" to "value2"), parseClientCookiesHeader("name=value1; name=value2"))
+    }
+
+    @Test
+    fun `quoted values are unwrapped`() {
+        assertEquals(
+            listOf("name" to "value with spaces"),
+            parseClientCookies("name=\"value with spaces\"")
+        )
+    }
+
+    @Test
+    fun `escaped keys are skipped by default`() {
+        val header = "name=value; \$x-enc=URI_ENCODING"
+        assertEquals(listOf("name" to "value"), parseClientCookies(header))
+    }
+
+    @Test
+    fun `escaped keys are preserved when skipEscaped is false`() {
+        val header = "name=value; \$x-enc=URI_ENCODING"
+        assertEquals(
+            listOf("name" to "value", "\$x-enc" to "URI_ENCODING"),
+            parseClientCookies(header, skipEscaped = false)
+        )
+    }
+
+    @Test
+    fun `empty header yields empty result`() {
+        assertEquals(emptyList(), parseClientCookies(""))
+        assertEquals(emptyMap(), parseClientCookiesHeader(""))
+    }
+
+    @Test
+    fun `ordering of duplicate cookies is preserved`() {
+        val header = "x=3; x=1; x=2"
+        assertEquals(
+            listOf("x" to "3", "x" to "1", "x" to "2"),
+            parseClientCookies(header)
+        )
+    }
+}


### PR DESCRIPTION
**Subsystem**
ktor-http

**Motivation**
[KTOR-7067](https://youtrack.jetbrains.com/issue/KTOR-7067)

`parseClientCookiesHeader` returns `Map<String, String>` and silently drops duplicate cookie names. [RFC 6265 §5.4](https://datatracker.ietf.org/doc/html/rfc6265#section-5.4) explicitly allows multiple cookies with the same name in a `Cookie` header.

**Solution**
Add `parseClientCookies(cookiesHeader, skipEscaped)` returning `List<Pair<String, String>>` that preserves all entries. `parseClientCookiesHeader` keeps its signature for backward compatibility; both delegate to a shared private sequence helper. Migrating `RequestCookies`/`HttpCookies` callers would change `call.request.cookies["name"]` semantics and is left for a follow-up.