### PR TITLE
Fix SSE (CIO) GET content length handling (KTOR-9588)

### DIFF
--- a/ktor-client/ktor-client-apache5/jvm/src/io/ktor/client/engine/apache5/ApacheRequestProducer.kt
+++ b/ktor-client/ktor-client-apache5/jvm/src/io/ktor/client/engine/apache5/ApacheRequestProducer.kt
@@ -42,7 +42,7 @@ internal fun ApacheRequestProducer(
     }
 
     val supportsRequestBody = requestData.method.supportsRequestBody
-    val hasContent = requestData.body !is OutgoingContent.NoContent
+    val hasContent = !requestData.body.isEmpty()
     val contentLength = length?.toLong() ?: -1
     val isChunked = contentLength == -1L && supportsRequestBody && hasContent
 

--- a/ktor-client/ktor-client-cio/common/src/io/ktor/client/engine/cio/utils.kt
+++ b/ktor-client/ktor-client-cio/common/src/io/ktor/client/engine/cio/utils.kt
@@ -45,10 +45,11 @@ internal suspend fun writeHeaders(
     val url = request.url.rebuildIfNeeded()
     val headers = request.headers
     val body = request.body
+    val contentBody = body.getUnwrapped()
 
-    val contentLength = headers[HttpHeaders.ContentLength] ?: body.contentLength?.toString()
+    val contentLength = headers[HttpHeaders.ContentLength] ?: contentBody.contentLength?.toString()
     val contentEncoding = headers[HttpHeaders.TransferEncoding]
-    val responseEncoding = body.headers[HttpHeaders.TransferEncoding]
+    val responseEncoding = contentBody.headers[HttpHeaders.TransferEncoding]
     val chunked = isChunked(contentLength, responseEncoding, contentEncoding)
     val expected = headers[HttpHeaders.Expect]
 
@@ -67,7 +68,7 @@ internal suspend fun writeHeaders(
             builder.headerLine(HttpHeaders.Host, host)
         }
 
-        val hasContent = body !is OutgoingContent.NoContent
+        val hasContent = contentBody !is OutgoingContent.NoContent
         if (contentLength != null) {
             if (method.supportsRequestBody || hasContent) {
                 builder.headerLine(HttpHeaders.ContentLength, contentLength)
@@ -80,7 +81,7 @@ internal suspend fun writeHeaders(
             builder.headerLine(key, value)
         }
 
-        if (chunked && contentEncoding == null && responseEncoding == null && body !is OutgoingContent.NoContent) {
+        if (chunked && contentEncoding == null && responseEncoding == null && hasContent) {
             builder.headerLine(HttpHeaders.TransferEncoding, "chunked")
         }
 

--- a/ktor-client/ktor-client-java/jvm/src/io/ktor/client/engine/java/JavaHttpRequest.kt
+++ b/ktor-client/ktor-client-java/jvm/src/io/ktor/client/engine/java/JavaHttpRequest.kt
@@ -50,10 +50,19 @@ internal fun HttpRequestData.convertToHttpRequest(callContext: CoroutineContext)
             }
         }
 
-        method(method.value, body.convertToHttpRequestBody(callContext))
+        if (method == HttpMethod.Get && body.getUnwrapped() is OutgoingContent.NoContent) {
+            GET()
+        } else {
+            method(method.value, body.convertToHttpRequestBody(callContext))
+        }
     }
 
     return builder.build()
+}
+
+private fun OutgoingContent.getUnwrapped(): OutgoingContent = when (this) {
+    is OutgoingContent.ContentWrapper -> delegate().getUnwrapped()
+    else -> this
 }
 
 @OptIn(DelicateCoroutinesApi::class)

--- a/ktor-client/ktor-client-java/jvm/src/io/ktor/client/engine/java/JavaHttpRequest.kt
+++ b/ktor-client/ktor-client-java/jvm/src/io/ktor/client/engine/java/JavaHttpRequest.kt
@@ -50,7 +50,11 @@ internal fun HttpRequestData.convertToHttpRequest(callContext: CoroutineContext)
             }
         }
 
-        method(method.value, body.convertToHttpRequestBody(callContext))
+        if (method == HttpMethod.Get && body.isEmpty()) {
+            GET()
+        } else {
+            method(method.value, body.convertToHttpRequestBody(callContext))
+        }
     }
 
     return builder.build()

--- a/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/plugins/ServerSentEventsTest.kt
+++ b/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/plugins/ServerSentEventsTest.kt
@@ -384,6 +384,19 @@ class ServerSentEventsTest : ClientLoader() {
     }
 
     @Test
+    fun testGetRequestWithoutBodyDoesNotSendContentLength() = clientTests(only("CIO", "Java")) {
+        config {
+            install(SSE)
+        }
+
+        test { client ->
+            client.sse("$TEST_SERVER/sse/headers") {
+                assertEquals("", incoming.single().data)
+            }
+        }
+    }
+
+    @Test
     fun testRequestBody() = clientTests {
         config {
             install(SSE)
@@ -400,6 +413,24 @@ class ServerSentEventsTest : ClientLoader() {
             }) {
                 assertEquals(contentType, call.request.contentType()?.withoutParameters())
                 assertEquals(body, incoming.single().data)
+            }
+        }
+    }
+
+    @Test
+    fun testPostRequestWithBodySendsContentLength() = clientTests(only("CIO", "Java")) {
+        config {
+            install(SSE)
+        }
+
+        val body = "hello"
+        test { client ->
+            client.sse({
+                method = HttpMethod.Post
+                url("$TEST_SERVER/sse/echo-headers")
+                setBody(body)
+            }) {
+                assertEquals(body.length.toString(), incoming.single().data)
             }
         }
     }

--- a/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/plugins/ServerSentEventsTest.kt
+++ b/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/plugins/ServerSentEventsTest.kt
@@ -403,6 +403,38 @@ class ServerSentEventsTest : ClientLoader() {
         }
     }
 
+    // Fails on Java before 19 because of https://bugs.openjdk.org/browse/JDK-8283544
+    @Test
+    fun testGetRequestWithoutBodyDoesNotSendContentLength() = clientTests(except("Java")) {
+        config {
+            install(SSE)
+        }
+
+        test { client ->
+            client.sse("$TEST_SERVER/sse/content-length") {
+                assertEquals("", incoming.single().data)
+            }
+        }
+    }
+
+    @Test
+    fun testPostRequestWithBodySendsContentLength() = clientTests {
+        config {
+            install(SSE)
+        }
+
+        val body = "hello"
+        test { client ->
+            client.sse({
+                method = HttpMethod.Post
+                url("$TEST_SERVER/sse/content-length")
+                setBody(body)
+            }) {
+                assertEquals(body.length.toString(), incoming.single().data)
+            }
+        }
+    }
+
     @Test
     fun testErrorForProtocolUpgradeRequestBody() = clientTests {
         config {

--- a/ktor-test-server/src/main/kotlin/test/server/tests/ServerSentEvents.kt
+++ b/ktor-test-server/src/main/kotlin/test/server/tests/ServerSentEvents.kt
@@ -73,10 +73,24 @@ internal fun Application.serverSentEvents() {
                     writeSseEvents(events)
                 }
             }
+            get("/headers") {
+                call.respondSseEvents(
+                    flow {
+                        emit(SseEvent(call.request.headers[HttpHeaders.ContentLength] ?: ""))
+                    }
+                )
+            }
             post("/echo") {
                 call.respondSseEvents(
                     flow {
                         emit(SseEvent(call.receiveText()))
+                    }
+                )
+            }
+            post("/echo-headers") {
+                call.respondSseEvents(
+                    flow {
+                        emit(SseEvent(call.request.headers[HttpHeaders.ContentLength] ?: ""))
                     }
                 )
             }

--- a/ktor-test-server/src/main/kotlin/test/server/tests/ServerSentEvents.kt
+++ b/ktor-test-server/src/main/kotlin/test/server/tests/ServerSentEvents.kt
@@ -14,6 +14,7 @@ import io.ktor.utils.io.*
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
 
 internal fun Application.serverSentEvents() {
@@ -71,6 +72,14 @@ internal fun Application.serverSentEvents() {
                 val contentType = ContentType.Text.EventStream.withCharset(Charsets.UTF_8)
                 call.respondBytesWriter(contentType = contentType) {
                     writeSseEvents(events)
+                }
+            }
+            route("/content-length") {
+                handle {
+                    val events = flowOf(
+                        SseEvent(call.request.headers[HttpHeaders.ContentLength].orEmpty())
+                    )
+                    call.respondSseEvents(events)
                 }
             }
             post("/echo") {


### PR DESCRIPTION
Subsystem
Client, ktor-client-cio, ktor-client-java, SSE

Motivation
Body-less SSE GET requests through CIO and Java could emit `Content-Length: 0` because the SSE content wrapper hid the original `OutgoingContent.NoContent` semantics. That makes Ktor send an explicit zero content length for a request that should be treated as body-less.

Solution
- Detect wrapped no-content bodies when preparing CIO and Java client requests.
- Omit `Content-Length` for body-less SSE GET requests while preserving SSE wrapper headers.
- Add regression coverage for CIO and Java engines and preserve content length behavior for SSE POST requests with a real body.

Verification
- Targeted SSE regression tests for CIO and Java.
- `./gradlew :ktor-client-cio:jvmTest`
- `./gradlew :ktor-client-java:jvmTest`
- `./gradlew :ktor-client-cio:formatKotlin :ktor-client-cio:lintKotlin`
- `./gradlew :ktor-client-java:formatKotlin :ktor-client-java:lintKotlin`

Notes
Full multiplatform assemble was not run locally because this environment lacks Xcode for Apple targets. No public/protected API changed, so ABI dumps were not updated.