### PR TITLE
Fix cache misses with content negotiation

### DIFF
--- a/ktor-client/ktor-client-core/build.gradle.kts
+++ b/ktor-client/ktor-client-core/build.gradle.kts
@@ -34,6 +34,7 @@ kotlin {
             implementation(projects.ktorTestDispatcher)
             implementation(projects.ktorClientMock)
             implementation(projects.ktorServerTestHost)
+            implementation(projects.ktorClientContentNegotiation)
         }
     }
 }

--- a/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/cache/HttpCache.kt
+++ b/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/cache/HttpCache.kt
@@ -393,8 +393,8 @@ internal fun mergedHeadersLookup(
         }
 
         else -> {
-            val value = content.headers.getAll(header) ?: allHeadersExtractor(header) ?: emptyList()
-            value.joinToString(";")
+            val value = content.headers.getAll(header) ?: allHeadersExtractor(header)
+            value.joinHeaderValues()
         }
     }
 }

--- a/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/cache/HttpCacheEntry.kt
+++ b/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/cache/HttpCacheEntry.kt
@@ -50,6 +50,9 @@ public class HttpCacheEntry internal constructor(
     }
 }
 
+// RFC 7230 §3.2.2: multiple values for the same header field are equivalent to a comma-separated list.
+internal fun List<String>?.joinHeaderValues(): String = this?.joinToString(",") ?: ""
+
 internal fun HttpResponse.varyKeys(): Map<String, String> {
     val validationKeys = vary() ?: return emptyMap()
 
@@ -57,7 +60,7 @@ internal fun HttpResponse.varyKeys(): Map<String, String> {
     val requestHeaders = call.request.headers
 
     for (key in validationKeys) {
-        result[key.lowercase()] = requestHeaders.getAll(key)?.joinToString(",") ?: ""
+        result[key.lowercase()] = requestHeaders.getAll(key).joinHeaderValues()
     }
 
     return result

--- a/ktor-client/ktor-client-core/common/test/HttpCacheTest.kt
+++ b/ktor-client/ktor-client-core/common/test/HttpCacheTest.kt
@@ -199,31 +199,27 @@ class HttpCacheTest {
     )
 
     /**
-     * Unit test: shows the separator mismatch between how varyKeys are stored and looked up.
+     * Regression test: varyKeys() and mergedHeadersLookup() must produce identical strings for
+     * the same multi-value header so that findResponse() can match cached entries.
      *
-     * HttpCacheEntry.varyKeys() stores multi-value headers joined with "," (comma):
-     *   result[key.lowercase()] = requestHeaders.getAll(key)?.joinToString(",") ?: ""
-     *
-     * mergedHeadersLookup() in HttpCache.kt joins them with ";" (semicolon):
-     *   value.joinToString(";")
-     *
-     * When ContentNegotiation appends a second Accept value, the stored "a,b" never equals
-     * the looked-up "a;b", so findResponse() always discards the cached entry.
+     * Before the fix, varyKeys() joined with "," while mergedHeadersLookup() joined with ";",
+     * so stored "a,b" never equalled looked-up "a;b" and every request was a cache miss.
+     * Both now delegate to joinHeaderValues() (RFC 7230 §3.2.2 comma separator).
      */
     @Test
-    fun varyKeysStoredWithCommaSeparatorButMergedHeadersLookupUsesSemicolon() {
+    fun varyKeysSeparatorMatchesMergedHeadersLookupSeparator() {
         val requestHeaders = Headers.build {
             append(HttpHeaders.Accept, "application/vnd.github+json") // set by caller
             append(HttpHeaders.Accept, "application/json")            // appended by ContentNegotiation
         }
 
-        // How HttpCacheEntry.varyKeys() stores the value:
-        val stored = requestHeaders.getAll(HttpHeaders.Accept)?.joinToString(",")
+        // How HttpCacheEntry.varyKeys() stores the value (joinHeaderValues → comma):
+        val stored = requestHeaders.getAll(HttpHeaders.Accept).joinHeaderValues()
         //  → "application/vnd.github+json,application/json"
 
-        // How mergedHeadersLookup() computes the lookup value:
-        val lookup = (requestHeaders.getAll(HttpHeaders.Accept) ?: emptyList()).joinToString(";")
-        //  → "application/vnd.github+json;application/json"
+        // How mergedHeadersLookup() now computes the lookup value (joinHeaderValues → comma):
+        val lookup = requestHeaders.getAll(HttpHeaders.Accept).joinHeaderValues()
+        //  → "application/vnd.github+json,application/json"
 
         assertEquals(stored, lookup)
     }
@@ -234,7 +230,7 @@ class HttpCacheTest {
      * mismatch in findResponse() causes it to always discard the cached entry.
      */
     @Test
-    fun freshCacheableEntryWithVaryAcceptIsNeverServedFromCacheWhenContentNegotiationIsInstalled() =
+    fun cacheHitOccursWithContentNegotiationAndVaryAccept() =
         runTest {
             var serverCallCount = 0
             val client = HttpClient(
@@ -255,7 +251,6 @@ class HttpCacheTest {
 
             // First response is cacheable (max-age=60) and the second request is identical.
             // Expected: second request served from cache → serverCallCount == 1.
-            // Actual:   varyKey filter fails due to "," vs ";" separator → serverCallCount == 2.
             assertEquals(1, serverCallCount)
             client.close()
         }

--- a/ktor-client/ktor-client-core/common/test/HttpCacheTest.kt
+++ b/ktor-client/ktor-client-core/common/test/HttpCacheTest.kt
@@ -2,17 +2,24 @@
  * Copyright 2014-2025 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
+import io.ktor.client.*
 import io.ktor.client.call.*
+import io.ktor.client.engine.mock.*
 import io.ktor.client.plugins.api.*
 import io.ktor.client.plugins.cache.*
+import io.ktor.client.plugins.contentnegotiation.*
 import io.ktor.client.request.*
 import io.ktor.client.statement.*
 import io.ktor.http.*
+import io.ktor.http.content.*
+import io.ktor.serialization.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
 import io.ktor.server.testing.*
 import io.ktor.util.*
+import io.ktor.util.reflect.*
 import io.ktor.utils.io.*
+import io.ktor.utils.io.charsets.*
 import kotlinx.coroutines.*
 import kotlinx.coroutines.test.TestResult
 import kotlinx.coroutines.test.runTest
@@ -161,6 +168,123 @@ class HttpCacheTest {
         assertEquals("after(before(Hello))", firstResponse)
         assertEquals(firstResponse, secondResponse)
     }
+
+    // A no-op converter whose only effect is to register application/json as an Accept type.
+    // ContentNegotiation unconditionally appends Accept for every registered codec via
+    // `request.accept(it.contentTypeToSend)`, which creates a second header value when the
+    // caller also sets Accept explicitly. This is sufficient to trigger the varyKey mismatch.
+    private val noOpJsonConverter = object : ContentConverter {
+        override suspend fun serialize(
+            contentType: ContentType,
+            charset: Charset,
+            typeInfo: TypeInfo,
+            value: Any?
+        ): OutgoingContent? = null
+
+        override suspend fun deserialize(
+            charset: Charset,
+            typeInfo: TypeInfo,
+            content: ByteReadChannel
+        ): Any? = null
+    }
+
+    private fun MockRequestHandleScope.cacheableJsonResponse() = respond(
+        content = """{"id":1}""",
+        headers = headersOf(
+            HttpHeaders.ContentType to listOf(ContentType.Application.Json.toString()),
+            HttpHeaders.CacheControl to listOf("max-age=60"),
+            HttpHeaders.Vary to listOf("Accept"),
+            HttpHeaders.ETag to listOf("\"abc123\""),
+        )
+    )
+
+    /**
+     * Unit test: shows the separator mismatch between how varyKeys are stored and looked up.
+     *
+     * HttpCacheEntry.varyKeys() stores multi-value headers joined with "," (comma):
+     *   result[key.lowercase()] = requestHeaders.getAll(key)?.joinToString(",") ?: ""
+     *
+     * mergedHeadersLookup() in HttpCache.kt joins them with ";" (semicolon):
+     *   value.joinToString(";")
+     *
+     * When ContentNegotiation appends a second Accept value, the stored "a,b" never equals
+     * the looked-up "a;b", so findResponse() always discards the cached entry.
+     */
+    @Test
+    fun varyKeysStoredWithCommaSeparatorButMergedHeadersLookupUsesSemicolon() {
+        val requestHeaders = Headers.build {
+            append(HttpHeaders.Accept, "application/vnd.github+json") // set by caller
+            append(HttpHeaders.Accept, "application/json")            // appended by ContentNegotiation
+        }
+
+        // How HttpCacheEntry.varyKeys() stores the value:
+        val stored = requestHeaders.getAll(HttpHeaders.Accept)?.joinToString(",")
+        //  → "application/vnd.github+json,application/json"
+
+        // How mergedHeadersLookup() computes the lookup value:
+        val lookup = (requestHeaders.getAll(HttpHeaders.Accept) ?: emptyList()).joinToString(";")
+        //  → "application/vnd.github+json;application/json"
+
+        assertEquals(stored, lookup)
+    }
+
+    /**
+     * Integration test: a fresh cacheable response (max-age=60, Vary: Accept) is never served
+     * from cache when ContentNegotiation is installed, because the comma/semicolon separator
+     * mismatch in findResponse() causes it to always discard the cached entry.
+     */
+    @Test
+    fun freshCacheableEntryWithVaryAcceptIsNeverServedFromCacheWhenContentNegotiationIsInstalled() =
+        runTest {
+            var serverCallCount = 0
+            val client = HttpClient(
+                MockEngine { _ ->
+                    serverCallCount++
+                    cacheableJsonResponse()
+                }
+            ) {
+                install(HttpCache)
+                install(ContentNegotiation) {
+                    register(ContentType.Application.Json, noOpJsonConverter)
+                }
+            }
+
+            val url = "https://example.com/api/resource"
+            client.get(url) { accept(ContentType.parse("application/vnd.github+json")) }
+            client.get(url) { accept(ContentType.parse("application/vnd.github+json")) }
+
+            // First response is cacheable (max-age=60) and the second request is identical.
+            // Expected: second request served from cache → serverCallCount == 1.
+            // Actual:   varyKey filter fails due to "," vs ";" separator → serverCallCount == 2.
+            assertEquals(1, serverCallCount)
+            client.close()
+        }
+
+    /**
+     * Counterpart: without ContentNegotiation each header has a single value, so the
+     * "," vs ";" mismatch doesn't matter and the cache hit works correctly.
+     */
+    @Test
+    fun freshCacheableEntryWithVaryAcceptIsServedFromCacheWhenContentNegotiationIsNotInstalled() =
+        runTest {
+            var serverCallCount = 0
+            val client = HttpClient(
+                MockEngine { _ ->
+                    serverCallCount++
+                    cacheableJsonResponse()
+                }
+            ) {
+                install(HttpCache)
+                // ContentNegotiation intentionally absent: one Accept value → separator irrelevant
+            }
+
+            val url = "https://example.com/api/resource"
+            client.get(url) { accept(ContentType.parse("application/vnd.github+json")) }
+            client.get(url) { accept(ContentType.parse("application/vnd.github+json")) }
+
+            assertEquals(1, serverCallCount)
+            client.close()
+        }
 
     private fun testApplication(block: suspend ApplicationTestBuilder.() -> Unit): TestResult {
         return if (!PlatformUtils.IS_BROWSER) {

--- a/ktor-client/ktor-client-core/common/test/HttpCacheTest.kt
+++ b/ktor-client/ktor-client-core/common/test/HttpCacheTest.kt
@@ -199,31 +199,27 @@ class HttpCacheTest {
     )
 
     /**
-     * Unit test: shows the separator mismatch between how varyKeys are stored and looked up.
+     * Regression test: varyKeys() and mergedHeadersLookup() must produce identical strings for
+     * the same multi-value header so that findResponse() can match cached entries.
      *
-     * HttpCacheEntry.varyKeys() stores multi-value headers joined with "," (comma):
-     *   result[key.lowercase()] = requestHeaders.getAll(key)?.joinToString(",") ?: ""
-     *
-     * mergedHeadersLookup() in HttpCache.kt joins them with ";" (semicolon):
-     *   value.joinToString(";")
-     *
-     * When ContentNegotiation appends a second Accept value, the stored "a,b" never equals
-     * the looked-up "a;b", so findResponse() always discards the cached entry.
+     * Before the fix, varyKeys() joined with "," while mergedHeadersLookup() joined with ";",
+     * so stored "a,b" never equalled looked-up "a;b" and every request was a cache miss.
+     * Both now delegate to joinHeaderValues() (RFC 7230 §3.2.2 comma separator).
      */
     @Test
-    fun varyKeysStoredWithCommaSeparatorButMergedHeadersLookupUsesSemicolon() {
+    fun varyKeysSeparatorMatchesMergedHeadersLookupSeparator() {
         val requestHeaders = Headers.build {
             append(HttpHeaders.Accept, "application/vnd.github+json") // set by caller
-            append(HttpHeaders.Accept, "application/json")            // appended by ContentNegotiation
+            append(HttpHeaders.Accept, "application/json") // appended by ContentNegotiation
         }
 
-        // How HttpCacheEntry.varyKeys() stores the value:
-        val stored = requestHeaders.getAll(HttpHeaders.Accept)?.joinToString(",")
+        // How HttpCacheEntry.varyKeys() stores the value (joinHeaderValues → comma):
+        val stored = requestHeaders.getAll(HttpHeaders.Accept).joinHeaderValues()
         //  → "application/vnd.github+json,application/json"
 
-        // How mergedHeadersLookup() computes the lookup value:
-        val lookup = (requestHeaders.getAll(HttpHeaders.Accept) ?: emptyList()).joinToString(";")
-        //  → "application/vnd.github+json;application/json"
+        // How mergedHeadersLookup() now computes the lookup value (joinHeaderValues → comma):
+        val lookup = requestHeaders.getAll(HttpHeaders.Accept).joinHeaderValues()
+        //  → "application/vnd.github+json,application/json"
 
         assertEquals(stored, lookup)
     }
@@ -234,7 +230,7 @@ class HttpCacheTest {
      * mismatch in findResponse() causes it to always discard the cached entry.
      */
     @Test
-    fun freshCacheableEntryWithVaryAcceptIsNeverServedFromCacheWhenContentNegotiationIsInstalled() =
+    fun cacheHitOccursWithContentNegotiationAndVaryAccept() =
         runTest {
             var serverCallCount = 0
             val client = HttpClient(
@@ -255,7 +251,6 @@ class HttpCacheTest {
 
             // First response is cacheable (max-age=60) and the second request is identical.
             // Expected: second request served from cache → serverCallCount == 1.
-            // Actual:   varyKey filter fails due to "," vs ";" separator → serverCallCount == 2.
             assertEquals(1, serverCallCount)
             client.close()
         }


### PR DESCRIPTION
**Subsystem**
Client, HttpCache

**Motivation**
When a `Vary` header contains multiple values, requests always generate cache-misses and  `If-None-Match` / `If-Modified-Since` are never sent


**Solution**
Centralize multi-values header serialization in one place to force the same serialization approach (i.e. use `,` instead of `;`) 



**Use Case**

When `HttpCache` and `ContentNegotiation` are both installed, responses with `Accept` in the `Vary` header (e.g. `Vary: Accept`) are **never served from cache** if the client specifies a specific Accept header.

e.g. to make requests to github, the client should use `Accept: application/vnd.github+json` but the ContentNegotiation plugin also unconditionally appends an `Accept` for every registered codec:

```kotlin
registrations.forEach { request.accept(it.contentTypeToSend) }
```

When the caller also sets `Accept` (e.g. `accept(ContentType.parse("application/vnd.github+json"))`), the request ends up with **two** `Accept` values. The stored varyKey and the lookup key then differ only in separator:

| | Value |
|---|---|
| **Stored** (`joinToString(",")`) | `"application/vnd.github+json,application/json"` |
| **Lookup** (`joinToString(";")`) | `"application/vnd.github+json;application/json"` |



## Ktor version

Reproduced on **3.5.0-dev** (main branch as of 2026-05-15) and **2.3.7**.

In 2.3.7: `varyKeys()` stored values using `Headers.get()` (first value only) while `mergedHeadersLookup` used `getAll().joinToString(";")`. An earlier fix changed `get()` to `getAll().joinToString(",")` but left the separator in `mergedHeadersLookup` as `";"`, so the mismatch persists.

## Platform / engine

JVM — the bug is in `ktor-client-core`, not engine-specific.

## Steps to reproduce

### Option A — Checkout the failing tests from this fork

```bash
git clone https://github.com/ktorio/ktor.git
cd ktor
# Check out the commit that adds the three failing tests:
git checkout 6b806fb2d

# Run only the relevant test class (uses MockEngine, no server needed):
./gradlew :ktor-client-core:jvmTest \
  --tests "HttpCacheTest.varyKeysStoredWithCommaSeparatorButMergedHeadersLookupUsesSemicolon" \
  --tests "HttpCacheTest.freshCacheableEntryWithVaryAcceptIsNeverServedFromCacheWhenContentNegotiationIsInstalled" \
  --tests "HttpCacheTest.freshCacheableEntryWithVaryAcceptIsServedFromCacheWhenContentNegotiationIsNotInstalled"
```

Expected: 2 tests fail (the unit test and the integration test), 1 passes (the counterpart without `ContentNegotiation`).



## Expected behaviour

The second GET should be served from in-memory cache (`max-age=60` has not expired). `serverCallCount == 1`.

## Actual behaviour

`serverCallCount == 2`. The cache entry is stored after the first request but **never matched** on subsequent requests.


