### PR TITLE
KTOR-9589 Fix duplicate PROPERTY_SETTER target in InternalAPI annotation

### DIFF
--- a/ktor-io/common/src/io/ktor/utils/io/Annotations.kt
+++ b/ktor-io/common/src/io/ktor/utils/io/Annotations.kt
@@ -22,7 +22,6 @@ package io.ktor.utils.io
     AnnotationTarget.PROPERTY,
     AnnotationTarget.FIELD,
     AnnotationTarget.CONSTRUCTOR,
-    AnnotationTarget.PROPERTY_SETTER,
     AnnotationTarget.PROPERTY_SETTER
 )
 @Retention(AnnotationRetention.BINARY)

--- a/ktor-io/common/src/io/ktor/utils/io/Annotations.kt
+++ b/ktor-io/common/src/io/ktor/utils/io/Annotations.kt
@@ -22,6 +22,7 @@ package io.ktor.utils.io
     AnnotationTarget.PROPERTY,
     AnnotationTarget.FIELD,
     AnnotationTarget.CONSTRUCTOR,
+    AnnotationTarget.PROPERTY_GETTER,
     AnnotationTarget.PROPERTY_SETTER
 )
 @Retention(AnnotationRetention.BINARY)


### PR DESCRIPTION
**Subsystem**
ktor-io

**Motivation**
Fixes a duplication in the `@InternalAPI` annotation where `AnnotationTarget.PROPERTY_SETTER` was listed twice in the `@Target` declaration, making one of the entries redundant. Refers to `KTOR-9589` (https://youtrack.jetbrains.com/issue/KTOR-9589).

**Solution**
Removed the duplicate AnnotationTarget.PROPERTY_SETTER entry from the `@Target` declaration of `@InternalAPI` in Annotations.kt.

