### PR TITLE
KTOR-9617 Fix OutputStreamContent and WriterContent exhausting Dispatchers.IO

### DIFF
--- a/ktor-http/jvm/src/io/ktor/http/content/BlockingBridge.kt
+++ b/ktor-http/jvm/src/io/ktor/http/content/BlockingBridge.kt
@@ -13,6 +13,22 @@ import kotlinx.coroutines.withContext
 import java.io.OutputStream
 import java.io.Writer
 
+private const val BLOCKING_BRIDGE_PARALLELISM_PROPERTY_NAME = "io.ktor.blocking.bridge.parallelism"
+
+/**
+ * Dispatcher used by Ktor blocking bridges.
+ *
+ * Blocking bridges expose synchronous APIs over suspending Ktor I/O primitives. Their operations may block
+ * waiting for backpressure or suspending I/O completion. This dispatcher gives such bridges a dedicated parallelism
+ * budget so they don't exhaust shared [Dispatchers.IO] capacity used by user code and other Ktor internals.
+ *
+ * The parallelism can be configured with [BLOCKING_BRIDGE_PARALLELISM_PROPERTY_NAME].
+ */
+private val BlockingBridgeDispatcher = Dispatchers.IO.limitedParallelism(
+    parallelism = System.getProperty(BLOCKING_BRIDGE_PARALLELISM_PROPERTY_NAME)?.toIntOrNull() ?: 64,
+    name = "ktor-blocking-bridge",
+)
+
 /**
  * Executes [block] with this channel represented as a blocking [OutputStream].
  *
@@ -23,7 +39,7 @@ import java.io.Writer
  * The stream passed to [block] is owned by this function and must not be used after [block] returns.
  */
 internal suspend inline fun ByteWriteChannel.withBlockingOutputStream(
-    dispatcher: CoroutineDispatcher = Dispatchers.IO,
+    dispatcher: CoroutineDispatcher = BlockingBridgeDispatcher,
     crossinline block: suspend (OutputStream) -> Unit,
 ) {
     withContext(dispatcher) {
@@ -43,7 +59,7 @@ internal suspend inline fun ByteWriteChannel.withBlockingOutputStream(
  */
 internal suspend inline fun ByteWriteChannel.withBlockingWriter(
     charset: Charset,
-    dispatcher: CoroutineDispatcher = Dispatchers.IO,
+    dispatcher: CoroutineDispatcher = BlockingBridgeDispatcher,
     crossinline block: suspend (Writer) -> Unit,
 ) {
     withContext(dispatcher) {

--- a/ktor-http/jvm/src/io/ktor/http/content/BlockingBridge.kt
+++ b/ktor-http/jvm/src/io/ktor/http/content/BlockingBridge.kt
@@ -4,18 +4,61 @@
 
 package io.ktor.http.content
 
+import io.ktor.utils.io.*
+import io.ktor.utils.io.charsets.*
+import io.ktor.utils.io.jvm.javaio.*
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import java.io.OutputStream
+import java.io.Writer
 
 /**
- * Redispatches [block] onto [Dispatchers.IO] for blocking I/O.
+ * Executes [block] with this channel represented as a blocking [OutputStream].
  *
- * This is used by non-blocking engines (CIO, Netty) where the calling thread is an event-loop
- * thread that must not block. Servlet-based engines bypass this entirely via
- * [OutputStreamContent.writeTo] with a native [java.io.OutputStream].
+ * Blocking operations are dispatched to [dispatcher] so they don't block event loop threads. This function doesn't
+ * close the channel after [block] finishes: the caller that owns the [ByteWriteChannel] lifecycle is responsible for
+ * closing it from a suspending context.
+ *
+ * The stream passed to [block] is owned by this function and must not be used after [block] returns.
  */
-internal suspend fun withBlocking(block: suspend () -> Unit) {
-    withContext(Dispatchers.IO) {
-        block()
+internal suspend inline fun ByteWriteChannel.withBlockingOutputStream(
+    dispatcher: CoroutineDispatcher = Dispatchers.IO,
+    crossinline block: suspend (OutputStream) -> Unit,
+) {
+    withContext(dispatcher) {
+        val outputStream = toOutputStream()
+        block(outputStream)
     }
+}
+
+/**
+ * Executes [block] with this channel represented as a blocking [Writer] using [charset].
+ *
+ * Blocking operations are dispatched to [dispatcher] so they don't block event loop threads. The [Writer] is closed
+ * inside [dispatcher] to finalize encoder state, but the underlying stream close is suppressed: the caller that owns
+ * the [ByteWriteChannel] lifecycle is responsible for closing the channel from a suspending context.
+ *
+ * The writer passed to [block] is owned by this function and must not be used after [block] returns.
+ */
+internal suspend inline fun ByteWriteChannel.withBlockingWriter(
+    charset: Charset,
+    dispatcher: CoroutineDispatcher = Dispatchers.IO,
+    crossinline block: suspend (Writer) -> Unit,
+) {
+    withContext(dispatcher) {
+        val writer = toOutputStream().nonClosing().writer(charset)
+        writer.use { block(it) }
+    }
+}
+
+private fun OutputStream.nonClosing(): OutputStream = NonClosingOutputStream(this)
+
+/** A wrapper preventing calling `runBlocking { flushAndClose() }` which could lead to a deadlock. */
+private class NonClosingOutputStream(private val delegate: OutputStream) : OutputStream() {
+    override fun write(b: Int) = delegate.write(b)
+    override fun write(b: ByteArray) = delegate.write(b)
+    override fun write(b: ByteArray, off: Int, len: Int) = delegate.write(b, off, len)
+    override fun flush() = delegate.flush()
+    override fun close() = Unit
 }

--- a/ktor-http/jvm/src/io/ktor/http/content/OutputStreamContent.kt
+++ b/ktor-http/jvm/src/io/ktor/http/content/OutputStreamContent.kt
@@ -7,7 +7,7 @@ package io.ktor.http.content
 import io.ktor.http.*
 import io.ktor.utils.io.*
 import io.ktor.utils.io.jvm.javaio.*
-import java.io.*
+import java.io.OutputStream
 
 /**
  * [OutgoingContent] to respond with [OutputStream].
@@ -23,13 +23,7 @@ public class OutputStreamContent(
 ) : OutgoingContent.WriteChannelContent() {
 
     override suspend fun writeTo(channel: ByteWriteChannel) {
-        withBlocking {
-            // use block should be inside because closing OutputStream is blocking as well
-            // and should not be invoked in a epoll/kqueue/reactor thread
-            channel.toOutputStream().use { stream ->
-                stream.body()
-            }
-        }
+        channel.withBlockingOutputStream(block = body)
     }
 
     /**

--- a/ktor-http/jvm/src/io/ktor/http/content/WriterContent.kt
+++ b/ktor-http/jvm/src/io/ktor/http/content/WriterContent.kt
@@ -5,9 +5,8 @@
 package io.ktor.http.content
 
 import io.ktor.http.*
-import io.ktor.util.cio.*
 import io.ktor.utils.io.*
-import java.io.*
+import java.io.Writer
 
 /**
  * Represents a content that is produced by [body] function
@@ -23,10 +22,6 @@ public class WriterContent(
 
     override suspend fun writeTo(channel: ByteWriteChannel) {
         val charset = contentType.charset() ?: Charsets.UTF_8
-        withBlocking {
-            channel.writer(charset).use {
-                it.body()
-            }
-        }
+        channel.withBlockingWriter(charset, block = body)
     }
 }

--- a/ktor-http/jvm/test/io/ktor/tests/http/content/BlockingBridgeTest.kt
+++ b/ktor-http/jvm/test/io/ktor/tests/http/content/BlockingBridgeTest.kt
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2014-2026 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.tests.http.content
+
+import io.ktor.http.content.*
+import io.ktor.util.cio.*
+import io.ktor.utils.io.*
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineName
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.debug.junit5.CoroutinesTimeout
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+
+@CoroutinesTimeout(testTimeoutMs = 5_000)
+class BlockingBridgeTest {
+
+    // Limit parallelism to 1 thread to make it easier to exhaust the dispatcher
+    private val singleThreadDispatcher = Dispatchers.IO.limitedParallelism(1, "test-io-dispatcher")
+
+    @OptIn(InternalAPI::class)
+    @Test
+    fun `withBlockingOutputStream in combination with reader should not exhaust dispatcher`() = runTest {
+        val readerStarted = CompletableDeferred<Unit>()
+
+        val channel = reader(singleThreadDispatcher + CoroutineName("reader")) {
+            readerStarted.complete(Unit)
+            val buffer = ByteArray(1)
+            while (channel.readAvailable(buffer) != -1) {
+                // consume until close
+            }
+        }.channel
+
+        readerStarted.await()
+        launch(singleThreadDispatcher + CoroutineName("writer")) {
+            channel.use {
+                // Direct usage of channel.toOutputStream().use { ... } would exhaust the dispatcher
+                withBlockingOutputStream(singleThreadDispatcher) { stream ->
+                    stream.write(42)
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `withBlockingWriter in combination with reader should not exhaust dispatcher`() = runTest {
+        val readerStarted = CompletableDeferred<Unit>()
+
+        val channel = reader(singleThreadDispatcher + CoroutineName("reader")) {
+            readerStarted.complete(Unit)
+            val buffer = ByteArray(64)
+            while (channel.readAvailable(buffer) != -1) {
+                // consume until close
+            }
+        }.channel
+
+        readerStarted.await()
+        launch(singleThreadDispatcher + CoroutineName("writer")) {
+            channel.use {
+                // Direct usage of channel.writer().use { ... } would exhaust the dispatcher
+                withBlockingWriter(Charsets.UTF_8, singleThreadDispatcher) { writer ->
+                    writer.write("Hello")
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
**Subsystem**
IO

**Motivation**
[KTOR-9617](https://youtrack.jetbrains.com/issue/KTOR-9617) OutputStreamContent and WriterContent can exhaust Dispatchers.IO
[KTOR-9626](https://youtrack.jetbrains.com/issue/KTOR-9626) Do not use blocking bridges on Dispatchers.IO (partially fixed)

**Solution**
Do not close the channel inside the `runBlocking`. Similarly to how it's done for other `OutgoingContent.WriteChannelContent` implementations the channel closing is handled in `BaseApplicationResponse.respondWriteChannelContent`.
