### PR TITLE
KTOR-8870 Don't close unopened file in readChannel

### DIFF
--- a/ktor-utils/jvm/src/io/ktor/util/cio/FileChannels.kt
+++ b/ktor-utils/jvm/src/io/ktor/util/cio/FileChannels.kt
@@ -26,7 +26,7 @@ public fun File.readChannel(
     coroutineContext: CoroutineContext = Dispatchers.IO
 ): ByteReadChannel {
     val fileLength = length()
-    val randomAccessFile by lazy { RandomAccessFile(this@readChannel, "r") }
+    val randomAccessFile = lazy { RandomAccessFile(this@readChannel, "r") }
     val writer = CoroutineScope(coroutineContext).writer(
         CoroutineName("file-reader") + coroutineContext,
         autoFlush = false
@@ -37,14 +37,19 @@ public fun File.readChannel(
         }
 
         @Suppress("BlockingMethodInNonBlockingContext")
-        randomAccessFile.use { file ->
+        randomAccessFile.value.use { file ->
             val fileChannel: FileChannel = file.channel
             fileChannel.writeToScope(this, start, endInclusive)
         }
     }
 
     writer.invokeOnCompletion {
-        randomAccessFile.close()
+        if (randomAccessFile.isInitialized()) {
+            // The writer block already closes the file via `use { ... }` on the happy path.
+            // Swallow errors here so an unopened or already-closed file doesn't surface as
+            // an uncaught CompletionHandlerException on a worker thread.
+            runCatching { randomAccessFile.value.close() }
+        }
     }
 
     return writer.channel

--- a/ktor-utils/jvm/test/io/ktor/tests/utils/FileChannelTest.kt
+++ b/ktor-utils/jvm/test/io/ktor/tests/utils/FileChannelTest.kt
@@ -129,4 +129,25 @@ class FileChannelTest {
         assertEquals(5, file.length())
         assertEquals("Hello", file.readText())
     }
+
+    @Test
+    fun `readChannel on nonexistent file does not leak exception from completion handler`() = runBlocking {
+        val nonexistent = File(sandbox, "definitely-does-not-exist-${System.nanoTime()}")
+        assertFalse(nonexistent.exists())
+
+        val caught = mutableListOf<Throwable>()
+        val handler = CoroutineExceptionHandler { _, t -> caught.add(t) }
+
+        val channel = nonexistent.readChannel(coroutineContext = Dispatchers.IO + handler)
+        runCatching { channel.discard() }
+
+        delay(200)
+
+        assertTrue(
+            caught.isEmpty(),
+            "completion handler leaked: ${caught.map {
+                "${it.javaClass.simpleName}(cause=${it.cause?.javaClass?.simpleName})"
+            }}"
+        )
+    }
 }


### PR DESCRIPTION
**Subsystem**
ktor-utils

**Motivation**
[KTOR-8870](https://youtrack.jetbrains.com/issue/KTOR-8870)

When `File.readChannel` is called for a nonexistent file, the writer fails before evaluating the lazy `RandomAccessFile`. `invokeOnCompletion` is then the first to touch it, re-throwing `FileNotFoundException` and surfacing as an uncaught `CompletionHandlerException` on a worker thread.

**Solution**
Hold the lazy directly, close only when `isInitialized()`, and swallow close errors with `runCatching`. Adds a regression test that asserts no exception leaks via `CoroutineExceptionHandler`.