### PR TITLE
KTOR-8883 Support nested jars in static resources

### DIFF
--- a/ktor-server/ktor-server-core/jvm/src/io/ktor/server/http/content/StaticContentResolution.kt
+++ b/ktor-server/ktor-server-core/jvm/src/io/ktor/server/http/content/StaticContentResolution.kt
@@ -119,7 +119,7 @@ public fun resourceClasspathResource(
  * Examples:
  * - `jar:file:/dist/app.jar!/static/index.html`              → returns `/dist/app.jar`
  * - `jar:file:/dist/app.jar!`                                → returns `/dist/app.jar`
- * - `jar:file:/outer.jar!/lib/dep.jar!/x.css`                → throws IllegalArgumentException (nested)
+ * - `jar:file:/outer.jar!/lib/dep.jar!/x.css`                → returns `null` (nested local container)
  * - `jar:nested:/path/to/app.jar/!BOOT-INF/classes/!/static` → returns `null` (non-local container)
  */
 internal fun findContainingJarFile(url: String): File? {
@@ -131,8 +131,9 @@ internal fun findContainingJarFile(url: String): File? {
     }
     val nextJarSeparator = url.indexOf("!", startIndex = jarPathSeparator + 1)
     if (nextJarSeparator != -1) {
-        // KTOR-8883 Support nested jars in static resources
-        throw IllegalArgumentException("Only local jars are supported (jar:file:)")
+        // java.util.jar.JarFile only supports single-level archives, so let the caller
+        // fall back to URIFileContent (relies on a registered URL handler, e.g. Spring Boot 2.x).
+        return null
     }
 
     return File(url.substring(JAR_PREFIX.length, jarPathSeparator).decodeURLPart())

--- a/ktor-server/ktor-server-core/jvm/test/io/ktor/tests/http/FindContainingJarFileTest.kt
+++ b/ktor-server/ktor-server-core/jvm/test/io/ktor/tests/http/FindContainingJarFileTest.kt
@@ -7,7 +7,6 @@ package io.ktor.tests.http
 import io.ktor.server.http.content.*
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertFailsWith
 import kotlin.test.assertNull
 
 class FindContainingJarFileTest {
@@ -32,8 +31,7 @@ class FindContainingJarFileTest {
     @Test
     fun testNestedAndNonLocalJars() {
         assertNull(findContainingJarFile("jar:nested:/pathto/app.jar/!BOOT-INF/classes/!/static"))
-        assertFailsWith<IllegalArgumentException> {
-            findContainingJarFile("jar:file:/pathto/app.jar/!BOOT-INF/classes/!/static")
-        }
+        assertNull(findContainingJarFile("jar:file:/pathto/app.jar!/BOOT-INF/classes/!/static"))
+        assertNull(findContainingJarFile("jar:file:/outer.jar!/lib/dep.jar!/x.css"))
     }
 }

--- a/ktor-server/ktor-server-core/jvm/test/io/ktor/tests/http/content/StaticContentResolutionTest.kt
+++ b/ktor-server/ktor-server-core/jvm/test/io/ktor/tests/http/content/StaticContentResolutionTest.kt
@@ -7,6 +7,7 @@ package io.ktor.tests.http.content
 import io.ktor.client.request.*
 import io.ktor.client.statement.*
 import io.ktor.http.*
+import io.ktor.http.content.*
 import io.ktor.server.http.content.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
@@ -19,6 +20,7 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
+import kotlin.test.assertTrue
 
 class StaticContentResolutionTest {
 
@@ -46,6 +48,20 @@ class StaticContentResolutionTest {
             val data = String(runBlocking { readFrom().toByteArray() })
             assertEquals("test\n", data)
         }
+    }
+
+    @OptIn(InternalAPI::class)
+    @Test
+    fun testResourceClasspathResourceFallsBackToURIFileContentForNestedJar() {
+        val nestedJarUrl = URL("jar:file:/outer.jar!/lib/dep.jar!/static/index.html")
+        val content = resourceClasspathResource(nestedJarUrl, "static/index.html") {
+            ContentType.Text.Html
+        }
+
+        assertNotNull(content)
+        assertTrue(content is URIFileContent)
+        assertEquals(nestedJarUrl.toURI(), content.uri)
+        assertEquals(ContentType.Text.Html, content.contentType)
     }
 
     @Test

--- a/ktor-server/ktor-server-core/jvm/test/io/ktor/tests/http/content/StaticContentResolutionTest.kt
+++ b/ktor-server/ktor-server-core/jvm/test/io/ktor/tests/http/content/StaticContentResolutionTest.kt
@@ -52,7 +52,7 @@ class StaticContentResolutionTest {
 
     @OptIn(InternalAPI::class)
     @Test
-    fun testResourceClasspathResourceFallsBackToURIFileContentForNestedJar() {
+    fun `resourceClasspathResource falls back to URIFileContent for nested jar URL`() {
         val nestedJarUrl = URL("jar:file:/outer.jar!/lib/dep.jar!/static/index.html")
         val content = resourceClasspathResource(nestedJarUrl, "static/index.html") {
             ContentType.Text.Html


### PR DESCRIPTION
**Subsystem**
Server, Static Content

**Motivation**
[KTOR-8883](https://youtrack.jetbrains.com/issue/KTOR-8883) Support nested jars in static resources

**Solution**
Follow-up to [#5086](https://github.com/ktorio/ktor/pull/5086). `findContainingJarFile` now returns `null` for nested `jar:file:` URLs (Spring Boot 2.x bootJar, WAR/EAR) so `resourceClasspathResource` falls back to `URIFileContent` instead of throwing. `java.util.jar.JarFile` cannot open nested archives; environments with a registered URL handler can still stream the entry.