### PR TITLE
KTOR-9591 Fix @JsonClassDiscriminator being ignored for sealed types in OpenAPI schema

### DIFF
--- a/ktor-shared/ktor-openapi-schema/common/src/io/ktor/openapi/JsonSchemaInference.kt
+++ b/ktor-shared/ktor-openapi-schema/common/src/io/ktor/openapi/JsonSchemaInference.kt
@@ -11,6 +11,7 @@ import io.ktor.utils.io.*
 import kotlinx.serialization.*
 import kotlinx.serialization.descriptors.*
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonClassDiscriminator
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.modules.EmptySerializersModule
 import kotlinx.serialization.modules.SerializersModule
@@ -169,7 +170,10 @@ public class KotlinxSerializerJsonSchemaInference(
 
             PolymorphicKind.SEALED -> {
                 if (descriptor.elementsCount == 2) {
-                    val discriminatorProperty = descriptor.getElementName(0)
+                    val discriminatorProperty = descriptor.annotations
+                        .filterIsInstance<JsonClassDiscriminator>()
+                        .firstOrNull()?.discriminator
+                        ?: descriptor.getElementName(0)
                     val sealedElementsDescriptor = descriptor.getElementDescriptor(1)
                     val sealedElementsSchema = (0..<sealedElementsDescriptor.elementsCount)
                         .map { i ->

--- a/ktor-shared/ktor-openapi-schema/ktor-openapi-schema-reflect/api/ktor-openapi-schema-reflect.api
+++ b/ktor-shared/ktor-openapi-schema/ktor-openapi-schema-reflect/api/ktor-openapi-schema-reflect.api
@@ -11,6 +11,7 @@ public final class io/ktor/openapi/reflect/ReflectionJsonSchemaInference$Compani
 }
 
 public abstract interface class io/ktor/openapi/reflect/SchemaReflectionAdapter {
+	public fun getDiscriminatorProperty (Lkotlin/reflect/KClass;)Ljava/lang/String;
 	public fun getName (Lkotlin/reflect/KProperty1;)Ljava/lang/String;
 	public fun getName (Lkotlin/reflect/KType;)Ljava/lang/String;
 	public fun getProperties (Lkotlin/reflect/KClass;)Ljava/util/Collection;
@@ -19,6 +20,7 @@ public abstract interface class io/ktor/openapi/reflect/SchemaReflectionAdapter 
 }
 
 public final class io/ktor/openapi/reflect/SchemaReflectionAdapter$DefaultImpls {
+	public static fun getDiscriminatorProperty (Lio/ktor/openapi/reflect/SchemaReflectionAdapter;Lkotlin/reflect/KClass;)Ljava/lang/String;
 	public static fun getName (Lio/ktor/openapi/reflect/SchemaReflectionAdapter;Lkotlin/reflect/KProperty1;)Ljava/lang/String;
 	public static fun getName (Lio/ktor/openapi/reflect/SchemaReflectionAdapter;Lkotlin/reflect/KType;)Ljava/lang/String;
 	public static fun getProperties (Lio/ktor/openapi/reflect/SchemaReflectionAdapter;Lkotlin/reflect/KClass;)Ljava/util/Collection;

--- a/ktor-shared/ktor-openapi-schema/ktor-openapi-schema-reflect/build.gradle.kts
+++ b/ktor-shared/ktor-openapi-schema/ktor-openapi-schema-reflect/build.gradle.kts
@@ -20,6 +20,7 @@ kotlin {
         }
         jvmTest.dependencies {
             implementation(libs.kaml.serialization)
+            implementation(libs.kotlinx.serialization.json)
         }
     }
 }

--- a/ktor-shared/ktor-openapi-schema/ktor-openapi-schema-reflect/jvm/src/io/ktor/openapi/reflect/JsonSchemaInference.jvm.kt
+++ b/ktor-shared/ktor-openapi-schema/ktor-openapi-schema-reflect/jvm/src/io/ktor/openapi/reflect/JsonSchemaInference.jvm.kt
@@ -83,6 +83,17 @@ public interface SchemaReflectionAdapter {
      */
     public fun isNullable(type: KType): Boolean =
         type.isMarkedNullable
+
+    /**
+     * Returns the discriminator property name for the given sealed [kClass].
+     * By default, returns `"type"`.
+     *
+     * Override this to support serialization-framework-specific discriminator annotations,
+     * for example `@JsonClassDiscriminator` from kotlinx.serialization.
+     *
+     * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.openapi.reflect.SchemaReflectionAdapter.getDiscriminatorProperty)
+     */
+    public fun getDiscriminatorProperty(kClass: KClass<*>): String = "type"
 }
 
 /**
@@ -222,13 +233,14 @@ public class ReflectionJsonSchemaInference(
                         subclass.qualifiedName!! to "#/components/schemas/${subclass.qualifiedName}"
                     }
 
+                val discriminatorProperty = adapter.getDiscriminatorProperty(kClass)
                 return jsonSchemaFromAnnotations(
                     title = typeName,
                     annotations = includeAnnotations + kClass.annotations,
                     reflectSchema = ::schemaRefForClass,
                     type = JsonType.OBJECT.wrapIfNullable(nullable),
                     oneOf = sealedSubclassSchema,
-                    discriminator = JsonSchemaDiscriminator("type", discriminatorMapping),
+                    discriminator = JsonSchemaDiscriminator(discriminatorProperty, discriminatorMapping),
                 )
             }
 

--- a/ktor-shared/ktor-openapi-schema/ktor-openapi-schema-reflect/jvm/test-resources/schema/KindShape.kotlinx.yaml
+++ b/ktor-shared/ktor-openapi-schema/ktor-openapi-schema-reflect/jvm/test-resources/schema/KindShape.kotlinx.yaml
@@ -1,0 +1,25 @@
+type: object
+title: io.ktor.openapi.reflect.KindShape
+oneOf:
+  - type: object
+    title: circle
+    required:
+      - radius
+    properties:
+      radius:
+        type: number
+  - type: object
+    title: rectangle
+    required:
+      - width
+      - height
+    properties:
+      width:
+        type: number
+      height:
+        type: number
+discriminator:
+  propertyName: kind
+  mapping:
+    circle: "#/components/schemas/circle"
+    rectangle: "#/components/schemas/rectangle"

--- a/ktor-shared/ktor-openapi-schema/ktor-openapi-schema-reflect/jvm/test-resources/schema/KindShape.yaml
+++ b/ktor-shared/ktor-openapi-schema/ktor-openapi-schema-reflect/jvm/test-resources/schema/KindShape.yaml
@@ -1,0 +1,25 @@
+type: object
+title: io.ktor.openapi.reflect.KindShape
+oneOf:
+  - type: object
+    title: io.ktor.openapi.reflect.KindShape.Circle
+    required:
+      - radius
+    properties:
+      radius:
+        type: number
+  - type: object
+    title: io.ktor.openapi.reflect.KindShape.Rectangle
+    required:
+      - width
+      - height
+    properties:
+      width:
+        type: number
+      height:
+        type: number
+discriminator:
+  propertyName: kind
+  mapping:
+    io.ktor.openapi.reflect.KindShape.Circle: "#/components/schemas/io.ktor.openapi.reflect.KindShape.Circle"
+    io.ktor.openapi.reflect.KindShape.Rectangle: "#/components/schemas/io.ktor.openapi.reflect.KindShape.Rectangle"

--- a/ktor-shared/ktor-openapi-schema/ktor-openapi-schema-reflect/jvm/test/io/ktor/openapi/reflect/AbstractSchemaInferenceTest.kt
+++ b/ktor-shared/ktor-openapi-schema/ktor-openapi-schema-reflect/jvm/test/io/ktor/openapi/reflect/AbstractSchemaInferenceTest.kt
@@ -9,8 +9,11 @@ import com.charleskorn.kaml.Yaml
 import com.charleskorn.kaml.YamlConfiguration
 import io.ktor.openapi.*
 import io.ktor.openapi.JsonSchema.*
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.JsonClassDiscriminator
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
@@ -44,6 +47,10 @@ abstract class AbstractSchemaInferenceTest(
     @Test
     fun `sealed type inference`() =
         assertSchemaMatches<Shape>()
+
+    @Test
+    fun `custom discriminator annotation with serial names`() =
+        assertSchemaMatches<KindShape>()
 
     @Test
     fun `advanced container annotations`() =
@@ -392,3 +399,17 @@ data class Page<out E>(
     val items: List<E>,
     val total: Int,
 )
+
+@OptIn(ExperimentalSerializationApi::class)
+@JsonClassDiscriminator("kind")
+@Serializable
+sealed interface KindShape {
+    @Serializable
+    @SerialName("circle")
+    data class Circle(val radius: Double) : KindShape
+
+    @Serializable
+    @SerialName("rectangle")
+    data class Rectangle(val width: Double, val height: Double) : KindShape
+}
+

--- a/ktor-shared/ktor-openapi-schema/ktor-openapi-schema-reflect/jvm/test/io/ktor/openapi/reflect/AbstractSchemaInferenceTest.kt
+++ b/ktor-shared/ktor-openapi-schema/ktor-openapi-schema-reflect/jvm/test/io/ktor/openapi/reflect/AbstractSchemaInferenceTest.kt
@@ -412,4 +412,3 @@ sealed interface KindShape {
     @SerialName("rectangle")
     data class Rectangle(val width: Double, val height: Double) : KindShape
 }
-

--- a/ktor-shared/ktor-openapi-schema/ktor-openapi-schema-reflect/jvm/test/io/ktor/openapi/reflect/ReflectionJsonSchemaInferenceTest.kt
+++ b/ktor-shared/ktor-openapi-schema/ktor-openapi-schema-reflect/jvm/test/io/ktor/openapi/reflect/ReflectionJsonSchemaInferenceTest.kt
@@ -4,6 +4,9 @@
 
 package io.ktor.openapi.reflect
 
+import io.ktor.openapi.*
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.json.JsonClassDiscriminator
 import kotlin.reflect.KClass
 import kotlin.reflect.KProperty1
 import kotlin.reflect.full.memberProperties
@@ -19,6 +22,11 @@ class ReflectionJsonSchemaInferenceTest : AbstractSchemaInferenceTest(
             val props = kClass.memberProperties.associateBy { it.name }
             return constructorParams.mapNotNull { props[it] }
         }
+
+        @OptIn(ExperimentalSerializationApi::class)
+        override fun getDiscriminatorProperty(kClass: KClass<*>): String =
+            kClass.annotations.filterIsInstance<JsonClassDiscriminator>().firstOrNull()?.discriminator
+                ?: super.getDiscriminatorProperty(kClass)
     }),
     "reflect"
 )


### PR DESCRIPTION
**Subsystem**
Server, `ktor-openapi-schema`, `ktor-openapi-schema-reflect`

**Motivation**
When generating OpenAPI schemas for sealed types, the `@JsonClassDiscriminator` annotation was ignored and the discriminator property name was always hardcoded to `"type"`. This caused a mismatch between the generated schema and the actual JSON produced by kotlinx.serialization.

Fixes [KTOR-9591](https://youtrack.jetbrains.com/issue/KTOR-9591)

**Solution**
- `KotlinxSerializerJsonSchemaInference`: reads `@JsonClassDiscriminator` from the sealed descriptor's annotations and uses its value as the discriminator property name, falling back to the default (`"type"`) if the annotation is absent.
- `ReflectionJsonSchemaInference`: added `getDiscriminatorProperty(kClass: KClass<*>): String` to `SchemaReflectionAdapter` (default returns `"type"`). Since this implementation is designed for non-kotlinx scenarios (Jackson, Gson, etc.), annotation handling is intentionally left to the caller via the adapter rather than baked in.