### PR TITLE
KTOR-9590 Improved JSON schema inference context

### DIFF
--- a/ktor-server/ktor-server-core/common/src/io/ktor/server/application/ApplicationPlugin.kt
+++ b/ktor-server/ktor-server-core/common/src/io/ktor/server/application/ApplicationPlugin.kt
@@ -173,6 +173,14 @@ private fun <B : Any, F : Any> RoutingNode.installIntoRoute(
         copyChildrenRecursively(child)
     }
 
+    // Transfer attributes from the exposed route
+    fakePipeline.attributes.allKeys
+        .filter { it != pluginRegistryKey }
+        .forEach { key ->
+            @Suppress("UNCHECKED_CAST")
+            attributes.put(key as AttributeKey<Any>, fakePipeline.attributes[key])
+        }
+
     mergePhases(fakePipeline)
     receivePipeline.mergePhases(fakePipeline.receivePipeline)
     sendPipeline.mergePhases(fakePipeline.sendPipeline)

--- a/ktor-server/ktor-server-plugins/ktor-server-content-negotiation/build.gradle.kts
+++ b/ktor-server/ktor-server-plugins/ktor-server-content-negotiation/build.gradle.kts
@@ -10,6 +10,9 @@ plugins {
 
 kotlin {
     sourceSets {
+        commonMain.dependencies {
+            implementation(projects.ktorServerRoutingOpenapi)
+        }
         commonTest.dependencies {
             implementation(projects.ktorServerDoubleReceive)
         }

--- a/ktor-server/ktor-server-plugins/ktor-server-content-negotiation/common/src/io/ktor/server/plugins/contentnegotiation/ContentNegotiation.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-content-negotiation/common/src/io/ktor/server/plugins/contentnegotiation/ContentNegotiation.kt
@@ -6,12 +6,14 @@ package io.ktor.server.plugins.contentnegotiation
 
 import io.ktor.http.*
 import io.ktor.http.content.*
+import io.ktor.openapi.JsonSchemaInference
 import io.ktor.serialization.*
 import io.ktor.server.application.*
 import io.ktor.server.http.content.*
 import io.ktor.server.plugins.*
 import io.ktor.server.request.*
 import io.ktor.server.response.*
+import io.ktor.server.routing.openapi.JsonSchemaAttributeKey
 import io.ktor.util.*
 import io.ktor.util.logging.*
 import io.ktor.utils.io.*
@@ -64,6 +66,13 @@ public val ContentNegotiation: RouteScopedPlugin<ContentNegotiationConfig> = cre
 
     // register default content types for application metadata, used in OpenAPI
     application.attributes[DefaultContentTypesAttribute] = pluginConfig.registrations.map { it.contentType }.distinct()
+
+    // content converters can optionally implement JsonSchemaInference
+    // so that the models supplied to `describe {}` will be aligned
+    pluginConfig.registrations.firstNotNullOfOrNull { it.converter as? JsonSchemaInference }?.let { schemaInference ->
+        val attributes = route?.attributes ?: application.attributes
+        attributes.put(JsonSchemaAttributeKey, schemaInference)
+    }
 }
 
 /**

--- a/ktor-server/ktor-server-plugins/ktor-server-openapi/build.gradle.kts
+++ b/ktor-server/ktor-server-plugins/ktor-server-openapi/build.gradle.kts
@@ -4,6 +4,7 @@
 
 plugins {
     id("ktorbuild.project.server-plugin")
+    id("kotlinx-serialization")
 }
 
 kotlin {
@@ -23,6 +24,7 @@ kotlin {
         }
         jvmTest.dependencies {
             implementation(projects.ktorServerContentNegotiation)
+            implementation(projects.ktorClientContentNegotiation)
             implementation(projects.ktorSerializationKotlinxJson)
             implementation(projects.ktorOpenapiSchemaReflect)
         }

--- a/ktor-server/ktor-server-plugins/ktor-server-openapi/jvm/test/io/ktor/server/plugins/openapi/OpenAPITest.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-openapi/jvm/test/io/ktor/server/plugins/openapi/OpenAPITest.kt
@@ -4,6 +4,7 @@
 
 package io.ktor.server.plugins.openapi
 
+import io.ktor.client.call.body
 import io.ktor.client.request.*
 import io.ktor.client.statement.*
 import io.ktor.http.*
@@ -13,20 +14,38 @@ import io.ktor.serialization.kotlinx.json.*
 import io.ktor.server.plugins.contentnegotiation.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
-import io.ktor.server.routing.openapi.OpenApiDocSource
-import io.ktor.server.routing.openapi.describe
+import io.ktor.server.routing.openapi.*
 import io.ktor.server.testing.*
 import io.ktor.utils.io.ExperimentalKtorApi
+import kotlinx.serialization.Contextual
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.descriptors.buildClassSerialDescriptor
+import kotlinx.serialization.descriptors.element
+import kotlinx.serialization.encoding.*
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.modules.SerializersModule
+import kotlinx.serialization.modules.serializersModuleOf
+import java.time.ZoneId
+import java.time.ZonedDateTime
 import kotlin.test.Test
 import kotlin.test.assertContains
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertNotEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
 
 class OpenAPITest {
 
     private val sampleBook = Book(
         "The Hitchhiker's Guide to the Galaxy",
         "Douglas Adams"
+    )
+    private val sampleAuthor = Author(
+        "Douglas Adams",
+        ZonedDateTime.parse("1974-04-25T00:00:00Z")
     )
     private val descriptions = listOf(
         "List all books",
@@ -106,9 +125,216 @@ class OpenAPITest {
             }
         }
     }
+
+    @OptIn(ExperimentalKtorApi::class)
+    @Test
+    fun `uses custom serializers module`() = testApplication {
+        val externalModule = serializersModuleOf(ZonedDateTime::class, ZonedDateTimeAsStringSerializer)
+        val internalModule = serializersModuleOf(ZonedDateTime::class, ZonedDateTimeAsStructSerializer)
+
+        // The schema inference call is the same for each endpoint,
+        // but implemented differently from the serializers module.
+        fun Route.authorsEndpoint(module: SerializersModule) = route("/authors") {
+            install(ContentNegotiation) {
+                json(Json { serializersModule = module })
+            }
+            get {
+                call.respond(listOf(sampleAuthor))
+            }.describe {
+                responses {
+                    HttpStatusCode.OK {
+                        description = "List of authors"
+                        schema = jsonSchema<List<Author>>()
+                    }
+                }
+            }
+            get("/{id}") {
+                call.respond(sampleAuthor)
+            }.describe {
+                responses {
+                    HttpStatusCode.OK {
+                        description = "Author by id"
+                        schema = jsonSchema<Author>()
+                    }
+                }
+            }
+            post {
+                call.respond(HttpStatusCode.Created)
+            }
+            put("/{id}") {
+                call.respond(HttpStatusCode.NoContent)
+            }
+        }
+
+        routing {
+            route("/api") {
+                route("/internal") {
+                    authorsEndpoint(internalModule)
+                }
+                route("/external") {
+                    authorsEndpoint(externalModule)
+                }
+            }
+
+            route("/routes") {
+                install(ContentNegotiation) {
+                    json()
+                }
+                get {
+                    call.respond(
+                        OpenApiDoc(info = OpenApiInfo("Internal API", "1.0.0")) +
+                            call.application.routingRoot.descendants()
+                    )
+                }.hide()
+            }
+        }
+
+        val httpClient = client.config {
+            install(io.ktor.client.plugins.contentnegotiation.ContentNegotiation) {
+                json()
+            }
+        }
+
+        val openApiDoc = httpClient.get("/routes").let { response ->
+            assertEquals(HttpStatusCode.OK, response.status)
+            response.body<OpenApiDoc>()
+        }
+
+        val internalSchema = openApiDoc.authorDateOfBirthSchema("/api/internal/authors/{id}")
+        val externalSchema = openApiDoc.authorDateOfBirthSchema("/api/external/authors/{id}")
+
+        // The internal API documents ZonedDateTime as a structured object with year/month/etc.
+        assertEquals(JsonType.OBJECT, internalSchema.type)
+        val properties = assertNotNull(internalSchema.properties)
+        assertTrue("year" in properties, "Expected 'year' property in $properties")
+        assertTrue("month" in properties, "Expected 'month' property in $properties")
+        assertTrue("zoneId" in properties, "Expected 'zoneId' property in $properties")
+
+        // The external API documents ZonedDateTime as a single ISO string.
+        assertEquals(JsonType.STRING, externalSchema.type)
+
+        // The two routes must produce distinct schemas for the same Kotlin type.
+        assertNotEquals(internalSchema, externalSchema)
+    }
+
+    /**
+     * Returns the first descendant route whose full path matches [path]. Used to scope OpenAPI
+     * document generation to a subtree of the routing graph.
+     */
+    private fun Route.findRoute(path: String): Route =
+        assertNotNull(
+            descendants().firstOrNull { (it as? RoutingNode)?.path() == path },
+            "Could not find route $path"
+        )
+
+    /**
+     * Resolves the schema for the `dateOfBirth` property of the `Author` returned by the
+     * `GET <path>` operation, dereferencing component references as needed.
+     */
+    private fun OpenApiDoc.authorDateOfBirthSchema(path: String): JsonSchema {
+        val pathItem = assertNotNull(paths[path]?.valueOrNull(), "Missing path $path")
+        val operation = assertNotNull(pathItem.get, "Missing GET on $path")
+        val response = assertNotNull(operation.responses?.responses?.get(HttpStatusCode.OK.value)?.valueOrNull())
+        val mediaType = assertNotNull(response.content?.get(ContentType.Application.Json))
+        val authorSchema = assertNotNull(mediaType.schema?.dereference(this))
+        val dateOfBirth = assertNotNull(authorSchema.properties?.get("dateOfBirth"))
+        return assertNotNull(dateOfBirth.dereference(this))
+    }
+
+    private fun ReferenceOr<JsonSchema>.dereference(doc: OpenApiDoc): JsonSchema? = when (this) {
+        is ReferenceOr.Value -> value
+
+        is ReferenceOr.Reference -> {
+            val name = ref.removePrefix("#/components/schemas/")
+            doc.components?.schemas?.get(name)
+        }
+    }
 }
 
 data class Book(
     val title: String,
     val author: String
 )
+
+@Serializable
+data class Author(
+    val name: String,
+    val dateOfBirth: @Contextual ZonedDateTime,
+)
+
+/**
+ * Serializes a [ZonedDateTime] as a single ISO-8601 string, like the kotlinx-datetime defaults.
+ * This is the representation typically expected by external (third-party) clients.
+ */
+private object ZonedDateTimeAsStringSerializer : KSerializer<ZonedDateTime> {
+    override val descriptor: SerialDescriptor =
+        kotlinx.serialization.descriptors.PrimitiveSerialDescriptor(
+            "java.time.ZonedDateTime",
+            kotlinx.serialization.descriptors.PrimitiveKind.STRING,
+        )
+
+    override fun serialize(encoder: Encoder, value: ZonedDateTime) {
+        encoder.encodeString(value.toString())
+    }
+
+    override fun deserialize(decoder: Decoder): ZonedDateTime =
+        ZonedDateTime.parse(decoder.decodeString())
+}
+
+/**
+ * Serializes a [ZonedDateTime] as a structured object with year/month/day/hour/minute/second/nano/zoneId fields.
+ * This is convenient for internal callers that prefer to avoid date-time parsing.
+ */
+private object ZonedDateTimeAsStructSerializer : KSerializer<ZonedDateTime> {
+    override val descriptor: SerialDescriptor =
+        buildClassSerialDescriptor("java.time.ZonedDateTime") {
+            element<Int>("year")
+            element<Int>("month")
+            element<Int>("day")
+            element<Int>("hour")
+            element<Int>("minute")
+            element<Int>("second")
+            element<Int>("nano")
+            element<String>("zoneId")
+        }
+
+    override fun serialize(encoder: Encoder, value: ZonedDateTime) {
+        encoder.encodeStructure(descriptor) {
+            encodeIntElement(descriptor, 0, value.year)
+            encodeIntElement(descriptor, 1, value.monthValue)
+            encodeIntElement(descriptor, 2, value.dayOfMonth)
+            encodeIntElement(descriptor, 3, value.hour)
+            encodeIntElement(descriptor, 4, value.minute)
+            encodeIntElement(descriptor, 5, value.second)
+            encodeIntElement(descriptor, 6, value.nano)
+            encodeStringElement(descriptor, 7, value.zone.id)
+        }
+    }
+
+    override fun deserialize(decoder: Decoder): ZonedDateTime =
+        decoder.decodeStructure(descriptor) {
+            var year = 0
+            var month = 1
+            var day = 1
+            var hour = 0
+            var minute = 0
+            var second = 0
+            var nano = 0
+            var zoneId = "UTC"
+            while (true) {
+                when (val index = decodeElementIndex(descriptor)) {
+                    0 -> year = decodeIntElement(descriptor, 0)
+                    1 -> month = decodeIntElement(descriptor, 1)
+                    2 -> day = decodeIntElement(descriptor, 2)
+                    3 -> hour = decodeIntElement(descriptor, 3)
+                    4 -> minute = decodeIntElement(descriptor, 4)
+                    5 -> second = decodeIntElement(descriptor, 5)
+                    6 -> nano = decodeIntElement(descriptor, 6)
+                    7 -> zoneId = decodeStringElement(descriptor, 7)
+                    kotlinx.serialization.encoding.CompositeDecoder.DECODE_DONE -> break
+                    else -> error("Unexpected index: $index")
+                }
+            }
+            ZonedDateTime.of(year, month, day, hour, minute, second, nano, ZoneId.of(zoneId))
+        }
+}

--- a/ktor-server/ktor-server-plugins/ktor-server-routing-openapi/common/src/io/ktor/server/routing/openapi/DescribeRoute.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-routing-openapi/common/src/io/ktor/server/routing/openapi/DescribeRoute.kt
@@ -7,6 +7,7 @@
 package io.ktor.server.routing.openapi
 
 import io.ktor.openapi.*
+import io.ktor.server.application.*
 import io.ktor.server.routing.*
 import io.ktor.util.*
 import io.ktor.utils.io.*
@@ -28,7 +29,13 @@ public val OperationHiddenAttributeKey: AttributeKey<Unit> =
     AttributeKey("OperationHidden")
 
 /**
- * Attribute key for [io.ktor.server.application.Application] JSON schema inference override.
+ * Attribute key for the JSON schema inference override.
+ *
+ * The value may be set either on [io.ktor.server.application.Application.attributes] to provide
+ * an application-wide default, or on any [Route]'s attributes to override the inference for a
+ * subtree of routes. When resolving the inference for a given route, the nearest ancestor that
+ * carries the attribute wins, falling back to the application-wide value and finally to
+ * [KotlinxSerializerJsonSchemaInference.Default].
  *
  * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.server.routing.openapi.JsonSchemaAttributeKey)
  */

--- a/ktor-server/ktor-server-plugins/ktor-server-routing-openapi/common/src/io/ktor/server/routing/openapi/OpenApiRoutes.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-routing-openapi/common/src/io/ktor/server/routing/openapi/OpenApiRoutes.kt
@@ -23,6 +23,20 @@ public fun Sequence<Route>.mapToPathItemsAndSchema(): Pair<Map<String, PathItem>
     // original qualified title -> component name, for rewriting discriminator $ref values after collection
     val schemaComponentNameMapping = mutableMapOf<String, String>()
     val jsonSchema = mutableMapOf<String, JsonSchema>()
+
+    // Allocates a unique component name when distinct schemas share the same title (for example,
+    // when the same Kotlin type is documented under multiple routes with different schema inferences).
+    fun uniqueName(preferred: String, candidate: JsonSchema): String {
+        val existing = jsonSchema[preferred]
+        if (existing == null || existing == candidate.copy(title = preferred)) return preferred
+        var counter = 2
+        while (true) {
+            val name = "$preferred$counter"
+            val existingAlt = jsonSchema[name]
+            if (existingAlt == null || existingAlt == candidate.copy(title = name)) return name
+            counter++
+        }
+    }
     val pathItems = mapToPathItems(
         PopulateMediaTypeDefaults + CollectSchemaReferences { schema ->
             val title = schema.title ?: return@CollectSchemaReferences null
@@ -30,13 +44,12 @@ public fun Sequence<Route>.mapToPathItemsAndSchema(): Pair<Map<String, PathItem>
             val existingQualifiedTitle = qualifiedNameMap[unqualifiedTitle] ?: title
             // if the shortened title is already in use by a different type, use the full title instead
             val componentName = if (existingQualifiedTitle != title) {
-                jsonSchema[title] = schema.copy(title = title)
-                title
+                uniqueName(title, schema)
             } else {
                 qualifiedNameMap[unqualifiedTitle] = title
-                jsonSchema[unqualifiedTitle] = schema.copy(title = unqualifiedTitle)
-                unqualifiedTitle
+                uniqueName(unqualifiedTitle, schema)
             }
+            jsonSchema[componentName] = schema.copy(title = componentName)
             schemaComponentNameMapping[title] = componentName
             componentName
         }
@@ -149,13 +162,15 @@ private fun Route.method(): HttpMethod? =
         ?.method
 
 private fun Route.operation(): Operation? {
-    val schemaInference = application.attributes.getOrNull(JsonSchemaAttributeKey)
+    val lineageFromRoot = lineage().toList().asReversed()
+    val schemaInference = lineageFromRoot.firstNotNullOfOrNull { it.attributes.getOrNull(JsonSchemaAttributeKey) }
+        ?: application.attributes.getOrNull(JsonSchemaAttributeKey)
         ?: KotlinxSerializerJsonSchemaInference.Default
     val defaultContentTypes = application.attributes.getOrNull(DefaultContentTypesAttribute)
         ?: listOf(ContentType.Application.Json)
 
     // Merge operations from top to bottom, selectors to describe calls
-    return lineage().toList().asReversed().fold(null) { acc: Operation?, node: Route ->
+    return lineageFromRoot.fold(null) { acc: Operation?, node: Route ->
         val current = mergeNullable(
             node.operationFromSelector(),
             node.operationFromDescribeCalls(schemaInference, defaultContentTypes),

--- a/ktor-shared/ktor-openapi-schema/common/src/io/ktor/openapi/JsonSchemaInference.kt
+++ b/ktor-shared/ktor-openapi-schema/common/src/io/ktor/openapi/JsonSchemaInference.kt
@@ -18,8 +18,6 @@ import kotlinx.serialization.modules.SerializersModule
 import kotlin.reflect.KClass
 import kotlin.reflect.KType
 import kotlin.reflect.typeOf
-import kotlin.time.ExperimentalTime
-import kotlin.uuid.ExperimentalUuidApi
 
 /**
  * Context interface for creating schema from type metadata.
@@ -42,7 +40,6 @@ public fun interface JsonSchemaInference {
  */
 public val KotlinxJsonSchemaInference: JsonSchemaInference get() = KotlinxSerializerJsonSchemaInference.Default
 
-@OptIn(ExperimentalUuidApi::class, ExperimentalTime::class)
 public val KotlinxSerializerDefaultFormats: (SerialDescriptor) -> String? = { type ->
     when (type.nonNullSerialName) {
         "kotlin.uuid.Uuid" -> "uuid"
@@ -346,9 +343,29 @@ public class KotlinxSerializerJsonSchemaInference(
                 )
             }
 
-            PolymorphicKind.OPEN,
             SerialKind.CONTEXTUAL -> {
-                // For contextual serializers, we need to get the actual serializer from the context
+                // For contextual serializers, resolve the actual serializer from the module
+                // (if registered) and recurse into its descriptor so the schema reflects the
+                // concrete representation chosen by the caller.
+                val contextualDescriptor = descriptor.capturedKClass
+                    ?.let { kClass -> module.getContextual(kClass)?.descriptor }
+                if (contextualDescriptor != null) {
+                    buildSchemaFromDescriptor(
+                        descriptor = contextualDescriptor,
+                        includeTitle = includeTitle,
+                        includeAnnotations = includeAnnotations,
+                        visiting = visiting,
+                    ).wrapIfNullable(isNullable)
+                } else {
+                    jsonSchemaFromAnnotations(
+                        annotations = annotations,
+                        reflectSchema = reflectJsonSchema,
+                        type = JsonType.OBJECT.wrapIfNullable(isNullable),
+                    )
+                }
+            }
+
+            PolymorphicKind.OPEN -> {
                 jsonSchemaFromAnnotations(
                     annotations = annotations,
                     reflectSchema = reflectJsonSchema,

--- a/ktor-shared/ktor-serialization/ktor-serialization-kotlinx/api/ktor-serialization-kotlinx.api
+++ b/ktor-shared/ktor-serialization/ktor-serialization-kotlinx/api/ktor-serialization-kotlinx.api
@@ -1,5 +1,6 @@
-public final class io/ktor/serialization/kotlinx/KotlinxSerializationConverter : io/ktor/serialization/ContentConverter {
+public final class io/ktor/serialization/kotlinx/KotlinxSerializationConverter : io/ktor/openapi/JsonSchemaInference, io/ktor/serialization/ContentConverter {
 	public fun <init> (Lkotlinx/serialization/SerialFormat;)V
+	public fun buildSchema (Lkotlin/reflect/KType;)Lio/ktor/openapi/JsonSchema;
 	public fun deserialize (Ljava/nio/charset/Charset;Lio/ktor/util/reflect/TypeInfo;Lio/ktor/utils/io/ByteReadChannel;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun serialize (Lio/ktor/http/ContentType;Ljava/nio/charset/Charset;Lio/ktor/util/reflect/TypeInfo;Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }

--- a/ktor-shared/ktor-serialization/ktor-serialization-kotlinx/api/ktor-serialization-kotlinx.klib.api
+++ b/ktor-shared/ktor-serialization/ktor-serialization-kotlinx/api/ktor-serialization-kotlinx.klib.api
@@ -16,9 +16,10 @@ abstract interface io.ktor.serialization.kotlinx/KotlinxSerializationExtensionPr
     abstract fun extension(kotlinx.serialization/SerialFormat): io.ktor.serialization.kotlinx/KotlinxSerializationExtension? // io.ktor.serialization.kotlinx/KotlinxSerializationExtensionProvider.extension|extension(kotlinx.serialization.SerialFormat){}[0]
 }
 
-final class io.ktor.serialization.kotlinx/KotlinxSerializationConverter : io.ktor.serialization/ContentConverter { // io.ktor.serialization.kotlinx/KotlinxSerializationConverter|null[0]
+final class io.ktor.serialization.kotlinx/KotlinxSerializationConverter : io.ktor.openapi/JsonSchemaInference, io.ktor.serialization/ContentConverter { // io.ktor.serialization.kotlinx/KotlinxSerializationConverter|null[0]
     constructor <init>(kotlinx.serialization/SerialFormat) // io.ktor.serialization.kotlinx/KotlinxSerializationConverter.<init>|<init>(kotlinx.serialization.SerialFormat){}[0]
 
+    final fun buildSchema(kotlin.reflect/KType): io.ktor.openapi/JsonSchema // io.ktor.serialization.kotlinx/KotlinxSerializationConverter.buildSchema|buildSchema(kotlin.reflect.KType){}[0]
     final suspend fun deserialize(io.ktor.utils.io.charsets/Charset, io.ktor.util.reflect/TypeInfo, io.ktor.utils.io/ByteReadChannel): kotlin/Any? // io.ktor.serialization.kotlinx/KotlinxSerializationConverter.deserialize|deserialize(io.ktor.utils.io.charsets.Charset;io.ktor.util.reflect.TypeInfo;io.ktor.utils.io.ByteReadChannel){}[0]
     final suspend fun serialize(io.ktor.http/ContentType, io.ktor.utils.io.charsets/Charset, io.ktor.util.reflect/TypeInfo, kotlin/Any?): io.ktor.http.content/OutgoingContent // io.ktor.serialization.kotlinx/KotlinxSerializationConverter.serialize|serialize(io.ktor.http.ContentType;io.ktor.utils.io.charsets.Charset;io.ktor.util.reflect.TypeInfo;kotlin.Any?){}[0]
 }

--- a/ktor-shared/ktor-serialization/ktor-serialization-kotlinx/build.gradle.kts
+++ b/ktor-shared/ktor-serialization/ktor-serialization-kotlinx/build.gradle.kts
@@ -14,6 +14,7 @@ kotlin {
         commonMain.dependencies {
             api(projects.ktorSerialization)
             api(libs.kotlinx.serialization.core)
+            api(projects.ktorOpenapiSchema)
         }
         commonTest.dependencies {
             implementation(projects.ktorSerializationKotlinxJson)

--- a/ktor-shared/ktor-serialization/ktor-serialization-kotlinx/common/src/io/ktor/serialization/kotlinx/KotlinxSerializationConverter.kt
+++ b/ktor-shared/ktor-serialization/ktor-serialization-kotlinx/common/src/io/ktor/serialization/kotlinx/KotlinxSerializationConverter.kt
@@ -6,6 +6,7 @@ package io.ktor.serialization.kotlinx
 
 import io.ktor.http.*
 import io.ktor.http.content.*
+import io.ktor.openapi.*
 import io.ktor.serialization.*
 import io.ktor.util.reflect.*
 import io.ktor.utils.io.*
@@ -14,6 +15,8 @@ import io.ktor.utils.io.core.*
 import kotlinx.coroutines.flow.*
 import kotlinx.io.*
 import kotlinx.serialization.*
+import kotlin.jvm.*
+import kotlin.reflect.KType
 
 /**
  * Creates a converter serializing with the specified string [format]
@@ -23,15 +26,24 @@ import kotlinx.serialization.*
 @OptIn(ExperimentalSerializationApi::class, InternalSerializationApi::class)
 public class KotlinxSerializationConverter(
     private val format: SerialFormat,
-) : ContentConverter {
+) : ContentConverter, JsonSchemaInference {
 
     private val extensions: List<KotlinxSerializationExtension> = extensions(format)
+
+    /**
+     * JSON schema inference that respects the [SerializersModule] of the wrapped [format],
+     * so contextual serializers registered by the caller are reflected in the generated schema.
+     */
+    private val schemaInference: JsonSchemaInference =
+        KotlinxSerializerJsonSchemaInference(format.serializersModule)
 
     init {
         require(format is BinaryFormat || format is StringFormat) {
             "Only binary and string formats are supported, $format is not supported."
         }
     }
+
+    override fun buildSchema(type: KType): JsonSchema = schemaInference.buildSchema(type)
 
     @OptIn(InternalAPI::class)
     override suspend fun serialize(


### PR DESCRIPTION
**Subsystem**
Server, OpenAPI, Schema inference

**Motivation**
[KTOR-9590](https://youtrack.jetbrains.com/issue/KTOR-9590) OpenAPI Contextual JSON schema inference support

**Solution**
Previously, we'd only infer the default content type from the content negotiation plugin.  Now, we'll register the schema inference automatically from the serializers module.  Also, since this is a route-scoped plugin, we now use route attributes for assigning the inference method.

Note, I haven't done the same for the other JSON libraries.  This would be a useful feature in the future, though we don't have the relevant adapters atm.