### PR TITLE
Fix default methods filtering in CORS plugin (#5103)

### DIFF
--- a/ktor-server/ktor-server-plugins/ktor-server-cors/common/src/io/ktor/server/plugins/cors/CORS.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-cors/common/src/io/ktor/server/plugins/cors/CORS.kt
@@ -54,10 +54,7 @@ internal fun PluginBuilder<CORSConfig>.buildPlugin() {
     val allowNonSimpleContentTypes: Boolean = pluginConfig.allowNonSimpleContentTypes
     val headersList = pluginConfig.headers.filterNot { it in CORSConfig.CorsSimpleRequestHeaders }
         .let { if (allowNonSimpleContentTypes) it + HttpHeaders.ContentType else it }
-    val methodsListHeaderValue = methods.filterNot { it in CORSConfig.CorsDefaultMethods }
-        .map { it.value }
-        .sorted()
-        .joinToString(", ")
+    val methodsListHeaderValue = methods.map { it.value }.sorted().joinToString(", ")
     val maxAgeHeaderValue = pluginConfig.maxAgeInSeconds.let { if (it > 0) it.toString() else null }
     val exposedHeaders = when {
         pluginConfig.exposedHeaders.isNotEmpty() -> pluginConfig.exposedHeaders.sorted().joinToString(", ")

--- a/ktor-server/ktor-server-tests/common/test/io/ktor/tests/server/plugins/CORSTest.kt
+++ b/ktor-server/ktor-server-tests/common/test/io/ktor/tests/server/plugins/CORSTest.kt
@@ -1592,4 +1592,33 @@ class CORSTest {
             assertEquals(response.status, HttpStatusCode.Forbidden)
         }
     }
+
+    @Test
+    fun testDefaultMethodsIncludedInAllowMethodsHeader() = testApplication {
+        install(CORS) {
+            allowMethod(HttpMethod.Post)
+            anyHost()
+        }
+
+        routing {
+            post("/") {
+                call.respond("OK")
+            }
+        }
+
+        val response = client.options("/") {
+            header(HttpHeaders.Origin, "https://example.com")
+            header(HttpHeaders.AccessControlRequestMethod, "POST")
+        }
+
+        assertEquals(HttpStatusCode.OK, response.status)
+        val allowMethodsHeader = response.headers[HttpHeaders.AccessControlAllowMethods]
+
+        assertNotNull(allowMethodsHeader, "Access-Control-Allow-Methods header should not be null")
+        assertTrue(
+            allowMethodsHeader.contains("POST"),
+            "Expected Access-Control-Allow-Methods to include POST, but got: $allowMethodsHeader"
+        )
+    }
+
 }

--- a/ktor-server/ktor-server-tests/common/test/io/ktor/tests/server/plugins/CORSTest.kt
+++ b/ktor-server/ktor-server-tests/common/test/io/ktor/tests/server/plugins/CORSTest.kt
@@ -1620,5 +1620,4 @@ class CORSTest {
             "Expected Access-Control-Allow-Methods to include POST, but got: $allowMethodsHeader"
         )
     }
-
 }

--- a/ktor-server/ktor-server-tests/common/test/io/ktor/tests/server/plugins/CORSTest.kt
+++ b/ktor-server/ktor-server-tests/common/test/io/ktor/tests/server/plugins/CORSTest.kt
@@ -1615,9 +1615,6 @@ class CORSTest {
         val allowMethodsHeader = response.headers[HttpHeaders.AccessControlAllowMethods]
 
         assertNotNull(allowMethodsHeader, "Access-Control-Allow-Methods header should not be null")
-        assertTrue(
-            allowMethodsHeader.contains("POST"),
-            "Expected Access-Control-Allow-Methods to include POST, but got: $allowMethodsHeader"
-        )
+        assertEquals("GET, HEAD, POST", allowMethodsHeader)
     }
 }


### PR DESCRIPTION
Fixes #5103

This PR ensures that default HTTP methods (`GET`, `POST`, `HEAD`) are included explicitly in the `Access-Control-Allow-Methods` header instead of being filtered out. Modern browsers strictly require these methods to be present in the preflight (OPTIONS) response header when custom configurations (like non-simple Content-Types) trigger a preflight validation.

Changes :
- Removed `.filterNot { it in CORSConfig.CorsDefaultMethods }` from `methodsListHeaderValue` computation.
- Added a dedicated unit test `testDefaultMethodsIncludedInAllowMethodsHeader` to verify the fix.