### PR TITLE
KTOR-9561 Rethrow closedCause after copyTo

### DIFF
--- a/ktor-io/common/src/io/ktor/utils/io/ByteChannel.kt
+++ b/ktor-io/common/src/io/ktor/utils/io/ByteChannel.kt
@@ -96,9 +96,14 @@ public class ByteChannel(public override val autoFlush: Boolean = false) : ByteR
         sleepWhile(Slot::Read) {
             flushBufferSize + _readBuffer.size < min && _closedCause.value == null
         }
+        rethrowCloseCauseIfNeeded()
 
         if (_readBuffer.size < CHANNEL_MAX_SIZE) moveFlushToReadBuffer()
         return _readBuffer.size >= min
+    }
+
+    private fun rethrowCloseCauseIfNeeded() {
+        closedCause?.let { throw it }
     }
 
     @OptIn(InternalAPI::class)

--- a/ktor-io/common/src/io/ktor/utils/io/ByteChannel.kt
+++ b/ktor-io/common/src/io/ktor/utils/io/ByteChannel.kt
@@ -94,9 +94,14 @@ public class ByteChannel(public override val autoFlush: Boolean = false) : ByteR
         sleepWhile(Slot::Read) {
             flushBufferSize + _readBuffer.size < min && _closedCause.value == null
         }
+        rethrowCloseCauseIfNeeded()
 
         if (_readBuffer.size < CHANNEL_MAX_SIZE) moveFlushToReadBuffer()
         return _readBuffer.size >= min
+    }
+
+    private fun rethrowCloseCauseIfNeeded() {
+        closedCause?.let { throw it }
     }
 
     @OptIn(InternalAPI::class)

--- a/ktor-io/common/src/io/ktor/utils/io/ByteReadChannelOperations.kt
+++ b/ktor-io/common/src/io/ktor/utils/io/ByteReadChannelOperations.kt
@@ -162,6 +162,7 @@ public suspend fun ByteReadChannel.copyTo(channel: ByteWriteChannel): Long {
         channel.flush()
     }
 
+    rethrowCloseCauseIfNeeded()
     return result
 }
 
@@ -216,6 +217,7 @@ public suspend fun ByteReadChannel.copyTo(channel: ByteWriteChannel, limit: Long
         channel.flush()
     }
 
+    rethrowCloseCauseIfNeeded()
     return limit - remaining
 }
 

--- a/ktor-io/common/src/io/ktor/utils/io/ByteReadChannelOperations.kt
+++ b/ktor-io/common/src/io/ktor/utils/io/ByteReadChannelOperations.kt
@@ -162,7 +162,6 @@ public suspend fun ByteReadChannel.copyTo(channel: ByteWriteChannel): Long {
         channel.flush()
     }
 
-    rethrowCloseCauseIfNeeded()
     return result
 }
 
@@ -217,7 +216,6 @@ public suspend fun ByteReadChannel.copyTo(channel: ByteWriteChannel, limit: Long
         channel.flush()
     }
 
-    rethrowCloseCauseIfNeeded()
     return limit - remaining
 }
 

--- a/ktor-io/common/test/ByteReadChannelOperationsTest.kt
+++ b/ktor-io/common/test/ByteReadChannelOperationsTest.kt
@@ -8,6 +8,7 @@ import kotlinx.coroutines.CoroutineName
 import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.yield
 import kotlinx.io.IOException
 import kotlinx.io.InternalIoApi
 import kotlinx.io.bytestring.ByteString
@@ -116,12 +117,13 @@ class ByteReadChannelOperationsTest {
     }
 
     @Test
-    fun `copyTo propagates closedCause from cancelled source`() = runTest {
+    fun `copyTo propagates closedCause cancelled mid-await`() = runTest {
         val src = ByteChannel()
         val dst = ByteChannel()
-        src.writeFully(byteArrayOf(1, 2, 3))
-        src.flush()
-        src.cancel(IOException("source cancelled"))
+        launch {
+            yield()
+            src.cancel(IOException("source cancelled"))
+        }
         assertFailsWith<IOException> {
             src.copyTo(dst)
         }
@@ -129,12 +131,13 @@ class ByteReadChannelOperationsTest {
     }
 
     @Test
-    fun `copyTo with limit propagates closedCause from cancelled source`() = runTest {
+    fun `copyTo with limit propagates closedCause cancelled mid-await`() = runTest {
         val src = ByteChannel()
         val dst = ByteChannel()
-        src.writeFully(byteArrayOf(1, 2, 3))
-        src.flush()
-        src.cancel(IOException("source cancelled"))
+        launch {
+            yield()
+            src.cancel(IOException("source cancelled"))
+        }
         assertFailsWith<IOException> {
             src.copyTo(dst, limit = 1024L)
         }
@@ -149,6 +152,19 @@ class ByteReadChannelOperationsTest {
         src.flushAndClose()
         val copied = src.copyTo(dst)
         assertEquals(3, copied)
+    }
+
+    @Test
+    fun `awaitContent rethrows closedCause after suspension`() = runTest {
+        val channel = ByteChannel()
+        launch {
+            yield()
+            channel.cancel(IOException("cancelled mid-await"))
+        }
+        assertFailsWith<IOException> {
+            channel.awaitContent()
+        }
+        assertTrue(channel.isClosedForRead)
     }
 
     @Test

--- a/ktor-io/common/test/ByteReadChannelOperationsTest.kt
+++ b/ktor-io/common/test/ByteReadChannelOperationsTest.kt
@@ -116,6 +116,42 @@ class ByteReadChannelOperationsTest {
     }
 
     @Test
+    fun `copyTo propagates closedCause from cancelled source`() = runTest {
+        val src = ByteChannel()
+        val dst = ByteChannel()
+        src.writeFully(byteArrayOf(1, 2, 3))
+        src.flush()
+        src.cancel(IOException("source cancelled"))
+        assertFailsWith<IOException> {
+            src.copyTo(dst)
+        }
+        assertTrue(src.isClosedForRead)
+    }
+
+    @Test
+    fun `copyTo with limit propagates closedCause from cancelled source`() = runTest {
+        val src = ByteChannel()
+        val dst = ByteChannel()
+        src.writeFully(byteArrayOf(1, 2, 3))
+        src.flush()
+        src.cancel(IOException("source cancelled"))
+        assertFailsWith<IOException> {
+            src.copyTo(dst, limit = 1024L)
+        }
+        assertTrue(src.isClosedForRead)
+    }
+
+    @Test
+    fun `copyTo does not throw on normal close`() = runTest {
+        val src = ByteChannel()
+        val dst = ByteChannel()
+        src.writeFully(byteArrayOf(1, 2, 3))
+        src.flushAndClose()
+        val copied = src.copyTo(dst)
+        assertEquals(3, copied)
+    }
+
+    @Test
     fun readFully() = runTest {
         val expected = ByteArray(10) { it.toByte() }
         val actual = ByteArray(10)

--- a/ktor-io/common/test/ByteReadChannelOperationsTest.kt
+++ b/ktor-io/common/test/ByteReadChannelOperationsTest.kt
@@ -8,6 +8,7 @@ import io.ktor.utils.io.core.*
 import kotlinx.coroutines.CoroutineName
 import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.yield
 import kotlinx.io.IOException
 import kotlinx.io.InternalIoApi
 import kotlinx.io.bytestring.ByteString
@@ -116,12 +117,13 @@ class ByteReadChannelOperationsTest {
     }
 
     @Test
-    fun `copyTo propagates closedCause from cancelled source`() = runTest {
+    fun `copyTo propagates closedCause cancelled mid-await`() = runTest {
         val src = ByteChannel()
         val dst = ByteChannel()
-        src.writeFully(byteArrayOf(1, 2, 3))
-        src.flush()
-        src.cancel(IOException("source cancelled"))
+        launch {
+            yield()
+            src.cancel(IOException("source cancelled"))
+        }
         assertFailsWith<IOException> {
             src.copyTo(dst)
         }
@@ -129,12 +131,13 @@ class ByteReadChannelOperationsTest {
     }
 
     @Test
-    fun `copyTo with limit propagates closedCause from cancelled source`() = runTest {
+    fun `copyTo with limit propagates closedCause cancelled mid-await`() = runTest {
         val src = ByteChannel()
         val dst = ByteChannel()
-        src.writeFully(byteArrayOf(1, 2, 3))
-        src.flush()
-        src.cancel(IOException("source cancelled"))
+        launch {
+            yield()
+            src.cancel(IOException("source cancelled"))
+        }
         assertFailsWith<IOException> {
             src.copyTo(dst, limit = 1024L)
         }
@@ -149,6 +152,19 @@ class ByteReadChannelOperationsTest {
         src.flushAndClose()
         val copied = src.copyTo(dst)
         assertEquals(3, copied)
+    }
+
+    @Test
+    fun `awaitContent rethrows closedCause after suspension`() = runTest {
+        val channel = ByteChannel()
+        launch {
+            yield()
+            channel.cancel(IOException("cancelled mid-await"))
+        }
+        assertFailsWith<IOException> {
+            channel.awaitContent()
+        }
+        assertTrue(channel.isClosedForRead)
     }
 
     @Test


### PR DESCRIPTION
**Subsystem**
ktor-io

**Motivation**
[KTOR-9561](https://youtrack.jetbrains.com/issue/KTOR-9561) ByteReadChannel.copyTo does not propagate source closedCause on normal exit

**Solution**
Call `rethrowCloseCauseIfNeeded()` in both `copyTo` overloads, matching `readTo`/`readRemaining`.