### PR TITLE
Allow external test services during startup

### DIFF
--- a/ktor-server/ktor-server-test-host/common/src/io/ktor/server/testing/client/DelegatingTestClientEngine.kt
+++ b/ktor-server/ktor-server-test-host/common/src/io/ktor/server/testing/client/DelegatingTestClientEngine.kt
@@ -45,15 +45,17 @@ internal class DelegatingTestClientEngine(
 
     @InternalAPI
     override suspend fun execute(data: HttpRequestData): HttpResponseData {
+        val authority = data.url.protocolWithAuthority
+        val externalApplication = config.testApplicationProvder().externalApplications[authority]
+        if (externalApplication != null) {
+            externalApplication.start()
+            return externalEngines[authority]!!.execute(data)
+        }
+
         config.testApplicationProvder().start()
         val mainEngineHostWithPorts = mainEngineHostWithPortsDeferred.await()
-        val authority = data.url.protocolWithAuthority
         val hostWithPort = data.url.hostWithPort
         return when {
-            externalEngines.containsKey(authority) -> {
-                externalEngines[authority]!!.execute(data)
-            }
-
             hostWithPort in mainEngineHostWithPorts -> {
                 mainEngine.execute(data)
             }

--- a/ktor-server/ktor-server-test-host/common/test/TestApplicationTest.kt
+++ b/ktor-server/ktor-server-test-host/common/test/TestApplicationTest.kt
@@ -175,6 +175,33 @@ class TestApplicationTest {
     }
 
     @Test
+    fun testCanAccessExternalServicesWhileStartingApplication() = testApplication {
+        val startupClient = client
+        var externalValue = ""
+
+        externalServices {
+            hosts("https://test.com") {
+                routing {
+                    get {
+                        call.respond("TEST_VALUE")
+                    }
+                }
+            }
+        }
+        application {
+            externalValue = startupClient.get("https://test.com").bodyAsText()
+        }
+        routing {
+            get {
+                call.respond(externalValue)
+            }
+        }
+
+        val response = client.get("/")
+        assertEquals("TEST_VALUE", response.bodyAsText())
+    }
+
+    @Test
     fun testingSchema() = testApplication {
         routing {
             get("/echo") {


### PR DESCRIPTION
**Subsystem**
Server Auth

**Motivation**

Needed for testing [KTOR-5001](https://youtrack.jetbrains.com/issue/KTOR-5001) Add OpenID Connect (OIDC) support on client and server

**Solution**
This fixes `testApplication` so external services registered with `externalServices { ... }` are available while the tested application is starting.

Previously, calls made during startup could fail because the delegated test client engine was not yet wired to the external services routing. This PR makes the delegation available early enough and adds a regression test covering startup-time external service calls.


