### PR TITLE
KTOR-9425 Use cipher block size for session IV

### DIFF
--- a/ktor-server/ktor-server-plugins/ktor-server-sessions/jvm/src/io/ktor/server/sessions/SessionTransportTransformerEncrypt.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-sessions/jvm/src/io/ktor/server/sessions/SessionTransportTransformerEncrypt.kt
@@ -58,7 +58,10 @@ public class SessionTransportTransformerEncrypt(
 
     // AES CBC IV length always equals the cipher block size (16 bytes for AES),
     // regardless of the key length. Using encryptionKeySize here used to break AES-256.
-    private val ivSize: Int = Cipher.getInstance("$encryptAlgorithm/CBC/PKCS5PADDING").blockSize
+    private val ivSize: Int = when (encryptionKeySpec.algorithm.uppercase()) {
+        "AES" -> 16
+        else -> Cipher.getInstance("$encryptAlgorithm/CBC/PKCS5PADDING").blockSize
+    }
 
     // Check that input keys are right
     init {

--- a/ktor-server/ktor-server-plugins/ktor-server-sessions/jvm/src/io/ktor/server/sessions/SessionTransportTransformerEncrypt.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-sessions/jvm/src/io/ktor/server/sessions/SessionTransportTransformerEncrypt.kt
@@ -56,9 +56,13 @@ public class SessionTransportTransformerEncrypt(
      */
     public val encryptionKeySize: Int get() = encryptionKeySpec.encoded.size
 
+    // AES CBC IV length always equals the cipher block size (16 bytes for AES),
+    // regardless of the key length. Using encryptionKeySize here used to break AES-256.
+    private val ivSize: Int = Cipher.getInstance("$encryptAlgorithm/CBC/PKCS5PADDING").blockSize
+
     // Check that input keys are right
     init {
-        encrypt(ivGenerator(encryptionKeySize), byteArrayOf())
+        encrypt(ivGenerator(ivSize), byteArrayOf())
         mac(byteArrayOf())
     }
 
@@ -105,7 +109,7 @@ public class SessionTransportTransformerEncrypt(
     }
 
     override fun transformWrite(transportValue: String): String {
-        val iv = ivGenerator(encryptionKeySize)
+        val iv = ivGenerator(ivSize)
         val decrypted = transportValue.toByteArray(charset)
         val encrypted = encrypt(iv, decrypted)
         val mac = mac(encrypted)

--- a/ktor-server/ktor-server-plugins/ktor-server-sessions/jvm/test/io/ktor/tests/sessions/SessionTransportTransformerEncryptTest.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-sessions/jvm/test/io/ktor/tests/sessions/SessionTransportTransformerEncryptTest.kt
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2014-2026 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.tests.sessions
+
+import io.ktor.server.sessions.*
+import kotlin.test.*
+
+class SessionTransportTransformerEncryptTest {
+
+    @Test
+    fun `accepts 32-byte AES-256 encryption key`() {
+        // AES-CBC requires a 16-byte IV regardless of key length. Constructing the transformer
+        // with a 32-byte key used to fail with InvalidAlgorithmParameterException because the
+        // IV was generated using the key size instead of the cipher block size.
+        SessionTransportTransformerEncrypt(ByteArray(32), ByteArray(32))
+    }
+
+    @Test
+    fun `transformWrite generates 16-byte IV for AES-256`() {
+        val transformer = SessionTransportTransformerEncrypt(ByteArray(32), ByteArray(32))
+        val encoded = transformer.transformWrite("hello")
+        val iv = encoded.substringBefore('/').hexToByteArray()
+        assertEquals(16, iv.size)
+    }
+
+    @Test
+    fun `round-trip preserves payload for AES-128, AES-192 and AES-256`() {
+        for (keyLength in intArrayOf(16, 24, 32)) {
+            val transformer = SessionTransportTransformerEncrypt(ByteArray(keyLength), ByteArray(32))
+            val original = "session-value-$keyLength"
+            val encoded = transformer.transformWrite(original)
+            val decoded = transformer.transformRead(encoded)
+            assertEquals(original, decoded, "round-trip failed for AES-${keyLength * 8}")
+        }
+    }
+}

--- a/ktor-server/ktor-server-plugins/ktor-server-sessions/jvm/test/io/ktor/tests/sessions/SessionTransportTransformerEncryptTest.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-sessions/jvm/test/io/ktor/tests/sessions/SessionTransportTransformerEncryptTest.kt
@@ -5,6 +5,7 @@
 package io.ktor.tests.sessions
 
 import io.ktor.server.sessions.*
+import javax.crypto.spec.SecretKeySpec
 import kotlin.test.*
 
 class SessionTransportTransformerEncryptTest {
@@ -34,5 +35,23 @@ class SessionTransportTransformerEncryptTest {
             val decoded = transformer.transformRead(encoded)
             assertEquals(original, decoded, "round-trip failed for AES-${keyLength * 8}")
         }
+    }
+
+    @Test
+    fun `uses cipher block size for non-AES algorithm (DESede)`() {
+        val encryptionKeySpec = SecretKeySpec(ByteArray(24), "DESede")
+        val signKeySpec = SecretKeySpec(ByteArray(32), "HmacSHA256")
+
+        val transformer = SessionTransportTransformerEncrypt(
+            encryptionKeySpec = encryptionKeySpec,
+            signKeySpec = signKeySpec,
+        )
+
+        val original = "non-aes-session-value"
+        val encoded = transformer.transformWrite(original)
+        val iv = encoded.substringBefore('/').hexToByteArray()
+
+        assertEquals(8, iv.size, "DESede should use an 8-byte IV matching its block size")
+        assertEquals(original, transformer.transformRead(encoded))
     }
 }


### PR DESCRIPTION
**Subsystem**
ktor-server-sessions

**Motivation**
[KTOR-9425](https://youtrack.jetbrains.com/issue/KTOR-9425) SessionTransportTransformerEncrypt init block uses wrong IV size for AES-256

**Solution**
Use cipher block size instead of `encryptionKeySize` for IV generation in `init` and `transformWrite`.