### PR TITLE
KTOR-9386 Show actual Unix socket path in startup log

### DIFF
--- a/ktor-server/ktor-server-cio/api/ktor-server-cio.api
+++ b/ktor-server/ktor-server-cio/api/ktor-server-cio.api
@@ -57,6 +57,7 @@ public final class io/ktor/server/cio/HttpServerSettings {
 
 public final class io/ktor/server/cio/UnixSocketConnectorBuilder : io/ktor/server/engine/EngineConnectorBuilder, io/ktor/server/cio/UnixSocketConnectorConfig {
 	public fun <init> ()V
+	public fun getAddressDescription ()Ljava/lang/String;
 	public fun getSocketPath ()Ljava/lang/String;
 	public fun setSocketPath (Ljava/lang/String;)V
 	public fun toString ()Ljava/lang/String;
@@ -64,6 +65,10 @@ public final class io/ktor/server/cio/UnixSocketConnectorBuilder : io/ktor/serve
 
 public abstract interface class io/ktor/server/cio/UnixSocketConnectorConfig : io/ktor/server/engine/EngineConnectorConfig {
 	public abstract fun getSocketPath ()Ljava/lang/String;
+}
+
+public final class io/ktor/server/cio/UnixSocketConnectorConfig$DefaultImpls {
+	public static fun getAddressDescription (Lio/ktor/server/cio/UnixSocketConnectorConfig;)Ljava/lang/String;
 }
 
 public final class io/ktor/server/cio/UnixSocketConnectorConfigKt {

--- a/ktor-server/ktor-server-cio/api/ktor-server-cio.klib.api
+++ b/ktor-server/ktor-server-cio/api/ktor-server-cio.klib.api
@@ -100,6 +100,9 @@ final class io.ktor.server.cio/HttpServerSettings { // io.ktor.server.cio/HttpSe
 final class io.ktor.server.cio/UnixSocketConnectorBuilder : io.ktor.server.cio/UnixSocketConnectorConfig, io.ktor.server.engine/EngineConnectorBuilder { // io.ktor.server.cio/UnixSocketConnectorBuilder|null[0]
     constructor <init>() // io.ktor.server.cio/UnixSocketConnectorBuilder.<init>|<init>(){}[0]
 
+    final val addressDescription // io.ktor.server.cio/UnixSocketConnectorBuilder.addressDescription|{}addressDescription[0]
+        final fun <get-addressDescription>(): kotlin/String // io.ktor.server.cio/UnixSocketConnectorBuilder.addressDescription.<get-addressDescription>|<get-addressDescription>(){}[0]
+
     final var socketPath // io.ktor.server.cio/UnixSocketConnectorBuilder.socketPath|{}socketPath[0]
         final fun <get-socketPath>(): kotlin/String // io.ktor.server.cio/UnixSocketConnectorBuilder.socketPath.<get-socketPath>|<get-socketPath>(){}[0]
         final fun <set-socketPath>(kotlin/String) // io.ktor.server.cio/UnixSocketConnectorBuilder.socketPath.<set-socketPath>|<set-socketPath>(kotlin.String){}[0]

--- a/ktor-server/ktor-server-cio/common/src/io/ktor/server/cio/UnixSocketConnectorConfig.kt
+++ b/ktor-server/ktor-server-cio/common/src/io/ktor/server/cio/UnixSocketConnectorConfig.kt
@@ -33,6 +33,8 @@ public class UnixSocketConnectorBuilder : EngineConnectorBuilder(ConnectorType.U
      */
     override var socketPath: String = "/tmp/ktor.sock"
 
+    override val addressDescription: String get() = "unix://$socketPath"
+
     override fun toString(): String = "${type.name} $socketPath"
 }
 

--- a/ktor-server/ktor-server-cio/jvm/test/io/ktor/tests/server/cio/UnixSocketConnectorDescribeTest.kt
+++ b/ktor-server/ktor-server-cio/jvm/test/io/ktor/tests/server/cio/UnixSocketConnectorDescribeTest.kt
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2014-2026 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.tests.server.cio
+
+import io.ktor.server.cio.*
+import io.ktor.server.engine.*
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class UnixSocketConnectorDescribeTest {
+
+    @Test
+    fun `unix socket connector exposes socket path as address description`() {
+        val connector = UnixSocketConnectorBuilder().apply {
+            socketPath = "/tmp/test.sock"
+        }
+        assertEquals("unix:///tmp/test.sock", connector.addressDescription)
+    }
+
+    @Test
+    fun `http connector keeps default null address description`() {
+        val connector = EngineConnectorBuilder(ConnectorType.HTTP).apply {
+            host = "127.0.0.1"
+            port = 8080
+        }
+        assertNull(connector.addressDescription)
+    }
+}

--- a/ktor-server/ktor-server-core/api/ktor-server-core.api
+++ b/ktor-server/ktor-server-core/api/ktor-server-core.api
@@ -666,6 +666,7 @@ public class io/ktor/server/engine/EngineConnectorBuilder : io/ktor/server/engin
 	public fun <init> ()V
 	public fun <init> (Lio/ktor/server/engine/ConnectorType;)V
 	public synthetic fun <init> (Lio/ktor/server/engine/ConnectorType;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun getAddressDescription ()Ljava/lang/String;
 	public fun getHost ()Ljava/lang/String;
 	public fun getPort ()I
 	public fun getType ()Lio/ktor/server/engine/ConnectorType;
@@ -675,9 +676,14 @@ public class io/ktor/server/engine/EngineConnectorBuilder : io/ktor/server/engin
 }
 
 public abstract interface class io/ktor/server/engine/EngineConnectorConfig {
+	public fun getAddressDescription ()Ljava/lang/String;
 	public abstract fun getHost ()Ljava/lang/String;
 	public abstract fun getPort ()I
 	public abstract fun getType ()Lio/ktor/server/engine/ConnectorType;
+}
+
+public final class io/ktor/server/engine/EngineConnectorConfig$DefaultImpls {
+	public static fun getAddressDescription (Lio/ktor/server/engine/EngineConnectorConfig;)Ljava/lang/String;
 }
 
 public final class io/ktor/server/engine/EngineConnectorConfigJvmKt {
@@ -741,6 +747,10 @@ public abstract interface class io/ktor/server/engine/EngineSSLConnectorConfig :
 	public abstract fun getPrivateKeyPassword ()Lkotlin/jvm/functions/Function0;
 	public abstract fun getTrustStore ()Ljava/security/KeyStore;
 	public abstract fun getTrustStorePath ()Ljava/io/File;
+}
+
+public final class io/ktor/server/engine/EngineSSLConnectorConfig$DefaultImpls {
+	public static fun getAddressDescription (Lio/ktor/server/engine/EngineSSLConnectorConfig;)Ljava/lang/String;
 }
 
 public final class io/ktor/server/engine/ShutDownUrl {

--- a/ktor-server/ktor-server-core/api/ktor-server-core.klib.api
+++ b/ktor-server/ktor-server-core/api/ktor-server-core.klib.api
@@ -178,6 +178,8 @@ abstract interface io.ktor.server.engine/EngineConnectorConfig { // io.ktor.serv
         abstract fun <get-port>(): kotlin/Int // io.ktor.server.engine/EngineConnectorConfig.port.<get-port>|<get-port>(){}[0]
     abstract val type // io.ktor.server.engine/EngineConnectorConfig.type|{}type[0]
         abstract fun <get-type>(): io.ktor.server.engine/ConnectorType // io.ktor.server.engine/EngineConnectorConfig.type.<get-type>|<get-type>(){}[0]
+    open val addressDescription // io.ktor.server.engine/EngineConnectorConfig.addressDescription|{}addressDescription[0]
+        open fun <get-addressDescription>(): kotlin/String? // io.ktor.server.engine/EngineConnectorConfig.addressDescription.<get-addressDescription>|<get-addressDescription>(){}[0]
 }
 
 abstract interface io.ktor.server.logging/MDCProvider { // io.ktor.server.logging/MDCProvider|null[0]

--- a/ktor-server/ktor-server-core/common/src/io/ktor/server/engine/EngineConnectorConfig.kt
+++ b/ktor-server/ktor-server-core/common/src/io/ktor/server/engine/EngineConnectorConfig.kt
@@ -64,6 +64,17 @@ public interface EngineConnectorConfig {
      * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.server.engine.EngineConnectorConfig.port)
      */
     public val port: Int
+
+    /**
+     * Optional human-readable address shown in startup logs.
+     *
+     * Defaults to `null`, in which case the connector is logged as `type://host:port`.
+     * Engines that bind to addresses not expressible as `host:port` (e.g. Unix domain sockets)
+     * should override this to display the actual location.
+     *
+     * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.server.engine.EngineConnectorConfig.addressDescription)
+     */
+    public val addressDescription: String? get() = null
 }
 
 /**

--- a/ktor-server/ktor-server-core/jvm/src/io/ktor/server/engine/EmbeddedServerJvm.kt
+++ b/ktor-server/ktor-server-core/jvm/src/io/ktor/server/engine/EmbeddedServerJvm.kt
@@ -381,10 +381,9 @@ actual constructor(
 
         CoroutineScope(application.coroutineContext).launch {
             engine.resolvedConnectors().forEach {
-                val host = escapeHostname(it.host)
-                environment.log.info(
-                    "Responding at ${it.type.name.lowercase()}://$host:${it.port}"
-                )
+                val address = it.addressDescription
+                    ?: "${it.type.name.lowercase()}://${escapeHostname(it.host)}:${it.port}"
+                environment.log.info("Responding at $address")
             }
         }
 

--- a/ktor-server/ktor-server-core/posix/src/io/ktor/server/engine/EmbeddedServerNix.kt
+++ b/ktor-server/ktor-server-core/posix/src/io/ktor/server/engine/EmbeddedServerNix.kt
@@ -65,10 +65,9 @@ actual constructor(
 
         CoroutineScope(application.coroutineContext).launch {
             engine.resolvedConnectors().forEach {
-                val host = escapeHostname(it.host)
-                environment.log.info(
-                    "Responding at ${it.type.name.lowercase()}://$host:${it.port}"
-                )
+                val address = it.addressDescription
+                    ?: "${it.type.name.lowercase()}://${escapeHostname(it.host)}:${it.port}"
+                environment.log.info("Responding at $address")
             }
         }
 

--- a/ktor-server/ktor-server-core/web/src/io/ktor/server/engine/EmbeddedServer.web.kt
+++ b/ktor-server/ktor-server-core/web/src/io/ktor/server/engine/EmbeddedServer.web.kt
@@ -63,10 +63,9 @@ actual constructor(
 
         CoroutineScope(application.coroutineContext).launch {
             engine.resolvedConnectors().forEach {
-                val host = escapeHostname(it.host)
-                environment.log.info(
-                    "Responding at ${it.type.name.lowercase()}://$host:${it.port}"
-                )
+                val address = it.addressDescription
+                    ?: "${it.type.name.lowercase()}://${escapeHostname(it.host)}:${it.port}"
+                environment.log.info("Responding at $address")
             }
         }
     }


### PR DESCRIPTION
**Subsystem**
ktor-server-core, ktor-server-cio

**Motivation**
[KTOR-9386](https://youtrack.jetbrains.com/issue/KTOR-9386) Misleading log output for Unix Domain Socket servers: "Responding at unix://0.0.0.0:80"

**Solution**
Add optional `EngineConnectorConfig.addressDescription` (default `null`). `UnixSocketConnectorBuilder` overrides it to `unix://$socketPath`; `EmbeddedServer` uses it when non-null.