### PR TITLE
KTOR-9597 Fix sealed subtype schema name collisions in OpenAPI

### DIFF
--- a/ktor-server/ktor-server-plugins/ktor-server-routing-openapi/common/src/io/ktor/server/routing/openapi/OpenApiRoutes.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-routing-openapi/common/src/io/ktor/server/routing/openapi/OpenApiRoutes.kt
@@ -77,6 +77,9 @@ private fun JsonSchemaDiscriminator.rewriteSchemaComponentReferences(
     schemaComponentNameMapping: Map<String, String>
 ): JsonSchemaDiscriminator {
     val updatedMapping = mapping?.mapValues { (_, refValue) ->
+        if (!refValue.startsWith("#/components/schemas/")) {
+            return@mapValues refValue
+        }
         val refSchemaName = refValue.removePrefix("#/components/schemas/")
         "#/components/schemas/${schemaComponentNameMapping[refSchemaName] ?: refSchemaName}"
     }

--- a/ktor-server/ktor-server-plugins/ktor-server-routing-openapi/common/src/io/ktor/server/routing/openapi/OpenApiRoutes.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-routing-openapi/common/src/io/ktor/server/routing/openapi/OpenApiRoutes.kt
@@ -21,7 +21,7 @@ public fun Sequence<Route>.mapToPathItemsAndSchema(): Pair<Map<String, PathItem>
     // unqualifiedTitle -> original qualified title, for conflict detection without relying on stored schema title
     val qualifiedNameMap = mutableMapOf<String, String>()
     // original qualified title -> component name, for rewriting discriminator $ref values after collection
-    val nameMapping = mutableMapOf<String, String>()
+    val schemaComponentNameMapping = mutableMapOf<String, String>()
     val jsonSchema = mutableMapOf<String, JsonSchema>()
     val pathItems = mapToPathItems(
         PopulateMediaTypeDefaults + CollectSchemaReferences { schema ->
@@ -37,24 +37,68 @@ public fun Sequence<Route>.mapToPathItemsAndSchema(): Pair<Map<String, PathItem>
                 jsonSchema[unqualifiedTitle] = schema.copy(title = unqualifiedTitle)
                 unqualifiedTitle
             }
-            nameMapping[title] = componentName
+            schemaComponentNameMapping[title] = componentName
             componentName
         }
     )
-    // Rewrite discriminator mapping $ref values to use the simplified component names
     for ((key, schema) in jsonSchema.toMap()) {
-        val discriminator = schema.discriminator ?: continue
-        val mapping = discriminator.mapping ?: continue
-        val updatedMapping = mapping.mapValues { (_, refValue) ->
-            val refSchemaName = refValue.removePrefix("#/components/schemas/")
-            "#/components/schemas/${nameMapping[refSchemaName] ?: refSchemaName}"
-        }
-        if (updatedMapping != mapping) {
-            jsonSchema[key] = schema.copy(discriminator = discriminator.copy(mapping = updatedMapping))
-        }
+        jsonSchema[key] = schema.rewriteSchemaComponentReferences(schemaComponentNameMapping)
     }
     return pathItems to jsonSchema
 }
+
+private fun JsonSchema.rewriteSchemaComponentReferences(schemaComponentNameMapping: Map<String, String>): JsonSchema =
+    copy(
+        allOf = allOf?.map { it.rewriteSchemaComponentReferences(schemaComponentNameMapping) },
+        oneOf = oneOf?.map { it.rewriteSchemaComponentReferences(schemaComponentNameMapping) },
+        not = not?.rewriteSchemaComponentReferences(schemaComponentNameMapping),
+        anyOf = anyOf?.map { it.rewriteSchemaComponentReferences(schemaComponentNameMapping) },
+        properties = properties?.mapValues { (_, schema) ->
+            schema.rewriteSchemaComponentReferences(schemaComponentNameMapping)
+        },
+        additionalProperties = additionalProperties?.rewriteSchemaComponentReferences(schemaComponentNameMapping),
+        discriminator = discriminator?.rewriteSchemaComponentReferences(schemaComponentNameMapping),
+        items = items?.rewriteSchemaComponentReferences(schemaComponentNameMapping),
+        prefixItems = prefixItems?.map { it.rewriteSchemaComponentReferences(schemaComponentNameMapping) },
+    )
+
+private fun AdditionalProperties.rewriteSchemaComponentReferences(
+    schemaComponentNameMapping: Map<String, String>
+): AdditionalProperties =
+    when (this) {
+        is AdditionalProperties.Allowed -> this
+
+        is AdditionalProperties.PSchema -> AdditionalProperties.PSchema(
+            value.rewriteSchemaComponentReferences(schemaComponentNameMapping)
+        )
+    }
+
+private fun JsonSchemaDiscriminator.rewriteSchemaComponentReferences(
+    schemaComponentNameMapping: Map<String, String>
+): JsonSchemaDiscriminator {
+    val updatedMapping = mapping?.mapValues { (_, refValue) ->
+        val refSchemaName = refValue.removePrefix("#/components/schemas/")
+        "#/components/schemas/${schemaComponentNameMapping[refSchemaName] ?: refSchemaName}"
+    }
+    return if (updatedMapping == mapping) this else copy(mapping = updatedMapping)
+}
+
+private fun ReferenceOr<JsonSchema>.rewriteSchemaComponentReferences(
+    schemaComponentNameMapping: Map<String, String>
+): ReferenceOr<JsonSchema> =
+    when (this) {
+        is ReferenceOr.Reference -> {
+            val refSchemaName = ref.removePrefix("#/components/schemas/")
+            val mappedName = schemaComponentNameMapping[refSchemaName] ?: refSchemaName
+            if (mappedName == refSchemaName) {
+                this
+            } else {
+                ReferenceOr.Reference("#/components/schemas/$mappedName", isDynamic)
+            }
+        }
+
+        is ReferenceOr.Value -> value(value.rewriteSchemaComponentReferences(schemaComponentNameMapping))
+    }
 
 /**
  * Converts the sequence of [Route]s to a map of [String] to [PathItem]s.

--- a/ktor-server/ktor-server-plugins/ktor-server-routing-openapi/jvm/test/io/ktor/server/routing/openapi/DescribeRouteTest.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-routing-openapi/jvm/test/io/ktor/server/routing/openapi/DescribeRouteTest.kt
@@ -958,6 +958,49 @@ class DescribeRouteTest {
         )
     }
 
+    @Test
+    fun `discriminator mappings keep external refs during component rewrite`() = testApplication {
+        install(ContentNegotiation) {
+            json(jsonFormat)
+        }
+        @OptIn(ExperimentalKtorApi::class)
+        routing {
+            get("/routes") {
+                call.respond(
+                    OpenApiDoc(info = OpenApiInfo("Test API", "1.0.0")) +
+                        call.application.routingRoot.descendants()
+                )
+            }.hide()
+
+            get("/external-mapping") {
+                call.respondText("ok")
+            }.describe {
+                responses {
+                    HttpStatusCode.OK {
+                        schema = JsonSchema(
+                            title = "ExternalDiscriminator",
+                            discriminator = JsonSchemaDiscriminator(
+                                propertyName = "kind",
+                                mapping = mapOf("external" to "https://example.com/schemas/shared_case")
+                            )
+                        )
+                    }
+                }
+            }
+        }
+
+        val routesResponse = client.get("/routes")
+        val responseText = routesResponse.bodyAsText()
+        val openApiSpec = jsonFormat.decodeFromString<OpenApiDoc>(responseText)
+        val schemas = openApiSpec.components?.schemas ?: fail("Schema components should be defined")
+
+        val schema = schemas["ExternalDiscriminator"] ?: fail("ExternalDiscriminator schema should be present")
+        assertEquals(
+            "https://example.com/schemas/shared_case",
+            schema.discriminator?.mapping?.get("external"),
+        )
+    }
+
     private inline fun <reified T : Any> componentName(): String =
         T::class.qualifiedName ?: fail("Missing qualified name")
 

--- a/ktor-server/ktor-server-plugins/ktor-server-routing-openapi/jvm/test/io/ktor/server/routing/openapi/DescribeRouteTest.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-routing-openapi/jvm/test/io/ktor/server/routing/openapi/DescribeRouteTest.kt
@@ -23,10 +23,13 @@ import io.ktor.server.routing.*
 import io.ktor.server.testing.*
 import io.ktor.utils.io.ExperimentalKtorApi
 import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.builtins.serializer
 import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonClassDiscriminator
+import kotlin.reflect.typeOf
 import kotlin.test.*
 
 class DescribeRouteTest {
@@ -638,6 +641,326 @@ class DescribeRouteTest {
         assertFalse("hidden" in responseText)
     }
 
+    @Test
+    fun `same serial name across sealed hierarchies keeps distinct component schemas`() = testApplication {
+        val firstSchema = KotlinxJsonSchemaInference.jsonSchema<FirstResponse>()
+        val secondSchema = KotlinxJsonSchemaInference.jsonSchema<SecondResponse>()
+        assertEquals(
+            listOf(componentName<FirstResponse.SharedCase>()),
+            firstSchema.oneOf?.mapNotNull { it.valueOrNull()?.title },
+        )
+        assertEquals(
+            listOf(componentName<SecondResponse.SharedCase>()),
+            secondSchema.oneOf?.mapNotNull { it.valueOrNull()?.title },
+        )
+
+        install(ContentNegotiation) {
+            json(jsonFormat)
+        }
+        @OptIn(ExperimentalKtorApi::class)
+        routing {
+            get("/routes") {
+                call.respond(
+                    OpenApiDoc(info = OpenApiInfo("Test API", "1.0.0")) +
+                        call.application.routingRoot.descendants()
+                )
+            }.hide()
+
+            get("/first") {
+                call.respondText("ok")
+            }.describe {
+                responses {
+                    HttpStatusCode.OK {
+                        schema = jsonSchema<FirstResponse>()
+                    }
+                }
+            }
+
+            get("/second") {
+                call.respondText("ok")
+            }.describe {
+                responses {
+                    HttpStatusCode.OK {
+                        schema = jsonSchema<SecondResponse>()
+                    }
+                }
+            }
+        }
+
+        val routesResponse = client.get("/routes")
+        val responseText = routesResponse.bodyAsText()
+        val openApiSpec = jsonFormat.decodeFromString<OpenApiDoc>(responseText)
+        val schemas = openApiSpec.components?.schemas
+        assertNotNull(schemas, "Schema components should be defined")
+
+        assertFalse("shared_case" in schemas, "SerialName should not be used as a component key: ${schemas.keys}")
+
+        val sharedCaseSchemas = schemas.filterKeys { it == "SharedCase" || it.endsWith(".SharedCase") }
+        assertEquals(2, sharedCaseSchemas.size, "Expected two distinct SharedCase schemas, but found: ${schemas.keys}")
+        assertTrue(
+            sharedCaseSchemas.values.any { "value" in (it.properties ?: emptyMap()) },
+            "Expected one SharedCase schema with property 'value', but found: $sharedCaseSchemas"
+        )
+        assertTrue(
+            sharedCaseSchemas.values.any { "count" in (it.properties ?: emptyMap()) },
+            "Expected one SharedCase schema with property 'count', but found: $sharedCaseSchemas"
+        )
+    }
+
+    @Test
+    fun `same serial name across nested sealed hierarchies keeps distinct component schemas`() = testApplication {
+        val nestedSchema = KotlinxJsonSchemaInference.jsonSchema<NestedResponses>()
+        val nestedProperties = nestedSchema.properties ?: fail("NestedResponses should expose properties")
+        assertEquals(
+            componentName<FirstResponse>(),
+            nestedProperties["first"]?.valueOrNull()?.title
+                ?: (nestedProperties["first"] as? ReferenceOr.Reference)?.ref?.substringAfterLast('/'),
+        )
+        assertEquals(
+            componentName<SecondResponse>(),
+            nestedProperties["second"]?.valueOrNull()?.title
+                ?: (nestedProperties["second"] as? ReferenceOr.Reference)?.ref?.substringAfterLast('/'),
+        )
+
+        install(ContentNegotiation) {
+            json(jsonFormat)
+        }
+        @OptIn(ExperimentalKtorApi::class)
+        routing {
+            get("/routes") {
+                call.respond(
+                    OpenApiDoc(info = OpenApiInfo("Test API", "1.0.0")) +
+                        call.application.routingRoot.descendants()
+                )
+            }.hide()
+
+            get("/nested") {
+                call.respondText("ok")
+            }.describe {
+                responses {
+                    HttpStatusCode.OK {
+                        schema = jsonSchema<NestedResponses>()
+                    }
+                }
+            }
+        }
+
+        val routesResponse = client.get("/routes")
+        val responseText = routesResponse.bodyAsText()
+        val openApiSpec = jsonFormat.decodeFromString<OpenApiDoc>(responseText)
+        val schemas = openApiSpec.components?.schemas
+        assertNotNull(schemas, "Schema components should be defined")
+
+        assertFalse("shared_case" in schemas, "SerialName should not be used as a component key: ${schemas.keys}")
+
+        val nestedComponent = schemas["NestedResponses"] ?: fail("NestedResponses schema should be present")
+        val properties = nestedComponent.properties ?: fail("NestedResponses schema should have properties")
+        assertEquals(
+            "#/components/schemas/FirstResponse",
+            (properties["first"] as? ReferenceOr.Reference)?.ref,
+        )
+        assertEquals(
+            "#/components/schemas/SecondResponse",
+            (properties["second"] as? ReferenceOr.Reference)?.ref,
+        )
+
+        val firstRootSchema = schemas["FirstResponse"] ?: fail("FirstResponse schema should be present")
+        val secondRootSchema = schemas["SecondResponse"] ?: fail("SecondResponse schema should be present")
+        assertNotNull(firstRootSchema.oneOf, "FirstResponse should remain polymorphic")
+        assertNotNull(secondRootSchema.oneOf, "SecondResponse should remain polymorphic")
+
+        val sharedCaseSchemas = schemas.filterKeys { it == "SharedCase" || it.endsWith(".SharedCase") }
+        assertEquals(2, sharedCaseSchemas.size, "Expected two distinct SharedCase schemas, but found: ${schemas.keys}")
+        assertTrue(
+            sharedCaseSchemas.values.any { "value" in (it.properties ?: emptyMap()) },
+            "Expected one SharedCase schema with property 'value', but found: $sharedCaseSchemas"
+        )
+        assertTrue(
+            sharedCaseSchemas.values.any { "count" in (it.properties ?: emptyMap()) },
+            "Expected one SharedCase schema with property 'count', but found: $sharedCaseSchemas"
+        )
+    }
+
+    @Test
+    fun `nullable sealed schema generation keeps distinct subtype component names`() {
+        val nullableSchema = KotlinxJsonSchemaInference.buildSchema(typeOf<FirstResponse?>())
+        assertEquals(
+            listOf(componentName<FirstResponse.SharedCase>()),
+            nullableSchema.oneOf?.mapNotNull { it.valueOrNull()?.title },
+        )
+    }
+
+    @Test
+    fun `nullable sealed root preserves nested sealed subtype naming`() {
+        val nullableSchema = KotlinxJsonSchemaInference.buildSchema(typeOf<NullableNestedRoot?>())
+        val subtypeSchemas = nullableSchema.oneOf?.mapNotNull { it.valueOrNull() } ?: fail("Expected sealed subtypes")
+
+        val firstNestedSchema = subtypeSchemas
+            .firstOrNull { it.title == componentName<NullableNestedRoot.First>() }
+            ?.properties?.get("nested")?.valueOrNull()
+            ?: fail("Expected nested schema for first subtype")
+        val secondNestedSchema = subtypeSchemas
+            .firstOrNull { it.title == componentName<NullableNestedRoot.Second>() }
+            ?.properties?.get("nested")?.valueOrNull()
+            ?: fail("Expected nested schema for second subtype")
+
+        assertEquals(
+            listOf(componentName<FirstNested.SharedCase>()),
+            firstNestedSchema.oneOf?.mapNotNull { it.valueOrNull()?.title },
+            "Unexpected nested schema for first subtype: $firstNestedSchema",
+        )
+        assertEquals(
+            listOf(componentName<SecondNested.SharedCase>()),
+            secondNestedSchema.oneOf?.mapNotNull { it.valueOrNull()?.title },
+            "Unexpected nested schema for second subtype: $secondNestedSchema",
+        )
+    }
+
+    @Test
+    fun `recursive sealed subtype references renamed component`() {
+        val schema = KotlinxJsonSchemaInference.jsonSchema<RecursiveResponse>()
+        val recursiveSubtype = schema.oneOf?.singleOrNull()?.valueOrNull() ?: fail("Expected recursive subtype")
+        val nextSchema =
+            recursiveSubtype.properties?.get("next")?.valueOrNull() ?: fail("Expected nullable next schema")
+        assertEquals(
+            "#/components/schemas/${componentName<RecursiveResponse.Node>()}",
+            (nextSchema.oneOf?.firstOrNull() as? ReferenceOr.Reference)?.ref,
+            "Unexpected recursive subtype schema: $recursiveSubtype",
+        )
+    }
+
+    @Test
+    fun `recursive sealed subtype references shortened component in final openapi`() = testApplication {
+        install(ContentNegotiation) {
+            json(jsonFormat)
+        }
+        @OptIn(ExperimentalKtorApi::class)
+        routing {
+            get("/routes") {
+                call.respond(
+                    OpenApiDoc(info = OpenApiInfo("Test API", "1.0.0")) +
+                        call.application.routingRoot.descendants()
+                )
+            }.hide()
+
+            get("/recursive") {
+                call.respondText("ok")
+            }.describe {
+                responses {
+                    HttpStatusCode.OK {
+                        schema = jsonSchema<RecursiveResponse>()
+                    }
+                }
+            }
+        }
+
+        val routesResponse = client.get("/routes")
+        val responseText = routesResponse.bodyAsText()
+        val openApiSpec = jsonFormat.decodeFromString<OpenApiDoc>(responseText)
+        val schemas = openApiSpec.components?.schemas ?: fail("Schema components should be defined")
+
+        val nodeSchema = schemas["Node"] ?: fail("Node schema should be present: ${schemas.keys}")
+        val nextSchema = nodeSchema.properties?.get("next")?.valueOrNull() ?: fail("Expected nullable next schema")
+        assertEquals(
+            "#/components/schemas/Node",
+            (nextSchema.oneOf?.firstOrNull() as? ReferenceOr.Reference)?.ref,
+            "Unexpected recursive subtype schema in final OpenAPI: $nodeSchema",
+        )
+    }
+
+    @Test
+    fun `recursive sealed subtype in list references shortened component in final openapi`() = testApplication {
+        install(ContentNegotiation) {
+            json(jsonFormat)
+        }
+        @OptIn(ExperimentalKtorApi::class)
+        routing {
+            get("/routes") {
+                call.respond(
+                    OpenApiDoc(info = OpenApiInfo("Test API", "1.0.0")) +
+                        call.application.routingRoot.descendants()
+                )
+            }.hide()
+
+            get("/recursive-list") {
+                call.respondText("ok")
+            }.describe {
+                responses {
+                    HttpStatusCode.OK {
+                        schema = jsonSchema<RecursiveListResponse>()
+                    }
+                }
+            }
+        }
+
+        val routesResponse = client.get("/routes")
+        val responseText = routesResponse.bodyAsText()
+        val openApiSpec = jsonFormat.decodeFromString<OpenApiDoc>(responseText)
+        val schemas = openApiSpec.components?.schemas ?: fail("Schema components should be defined")
+
+        val nodeSchema = schemas["Node"] ?: fail("Node schema should be present: ${schemas.keys}")
+        val childrenSchema = nodeSchema.properties?.get("children")?.valueOrNull() ?: fail("Expected children schema")
+        assertEquals(
+            "#/components/schemas/Node",
+            (childrenSchema.items as? ReferenceOr.Reference)?.ref,
+            "Unexpected recursive list subtype schema in final OpenAPI: $nodeSchema",
+        )
+    }
+
+    @Test
+    fun `annotation item refs keep distinct sealed subtype component names`() = testApplication {
+        install(ContentNegotiation) {
+            json(jsonFormat)
+        }
+        @OptIn(ExperimentalKtorApi::class)
+        routing {
+            get("/routes") {
+                call.respond(
+                    OpenApiDoc(info = OpenApiInfo("Test API", "1.0.0")) +
+                        call.application.routingRoot.descendants()
+                )
+            }.hide()
+
+            get("/annotated-lists") {
+                call.respondText("ok")
+            }.describe {
+                responses {
+                    HttpStatusCode.OK {
+                        schema = jsonSchema<AnnotatedSharedCaseLists>()
+                    }
+                }
+            }
+        }
+
+        val routesResponse = client.get("/routes")
+        val responseText = routesResponse.bodyAsText()
+        val openApiSpec = jsonFormat.decodeFromString<OpenApiDoc>(responseText)
+        val schemas = openApiSpec.components?.schemas ?: fail("Schema components should be defined")
+
+        val annotatedSchema =
+            schemas["AnnotatedSharedCaseLists"] ?: fail("AnnotatedSharedCaseLists schema should be present")
+        val properties = annotatedSchema.properties ?: fail("AnnotatedSharedCaseLists should have properties")
+        val firstSchema = properties["first"]?.valueOrNull() ?: fail("Expected first schema")
+        val secondSchema = properties["second"]?.valueOrNull() ?: fail("Expected second schema")
+        val firstRef = (firstSchema.items as? ReferenceOr.Reference)?.ref ?: fail("Expected first items ref")
+        val secondRef = (secondSchema.items as? ReferenceOr.Reference)?.ref ?: fail("Expected second items ref")
+        assertNotEquals(firstRef, secondRef, "Annotated item refs should point to distinct components")
+
+        val sharedCaseSchemas = schemas.filterKeys { it == "SharedCase" || it.endsWith(".SharedCase") }
+        assertEquals(2, sharedCaseSchemas.size, "Expected two distinct SharedCase schemas, but found: ${schemas.keys}")
+        assertTrue(
+            sharedCaseSchemas.values.any { "value" in (it.properties ?: emptyMap()) },
+            "Expected one SharedCase schema with property 'value', but found: $sharedCaseSchemas",
+        )
+        assertTrue(
+            sharedCaseSchemas.values.any { "count" in (it.properties ?: emptyMap()) },
+            "Expected one SharedCase schema with property 'count', but found: $sharedCaseSchemas",
+        )
+    }
+
+    private inline fun <reified T : Any> componentName(): String =
+        T::class.qualifiedName ?: fail("Missing qualified name")
+
     private fun TestApplicationBuilder.openApiTestRoutes(authProvider: String) {
         routing {
             authenticate(authProvider) {
@@ -677,3 +1000,84 @@ sealed interface Message {
         override val timestamp: Long
     ) : Message
 }
+
+@OptIn(ExperimentalSerializationApi::class)
+@JsonClassDiscriminator("status")
+@Serializable
+sealed interface FirstResponse {
+    @Serializable
+    @SerialName("shared_case")
+    data class SharedCase(val value: String) : FirstResponse
+}
+
+@OptIn(ExperimentalSerializationApi::class)
+@JsonClassDiscriminator("status")
+@Serializable
+sealed interface SecondResponse {
+    @Serializable
+    @SerialName("shared_case")
+    data class SharedCase(val count: Int) : SecondResponse
+}
+
+@Serializable
+data class NestedResponses(
+    val first: FirstResponse,
+    val second: SecondResponse,
+)
+
+@OptIn(ExperimentalSerializationApi::class)
+@JsonClassDiscriminator("status")
+@Serializable
+sealed interface NullableNestedRoot {
+    @Serializable
+    @SerialName("first")
+    data class First(val nested: FirstNested) : NullableNestedRoot
+
+    @Serializable
+    @SerialName("second")
+    data class Second(val nested: SecondNested) : NullableNestedRoot
+}
+
+@OptIn(ExperimentalSerializationApi::class)
+@JsonClassDiscriminator("kind")
+@Serializable
+sealed interface FirstNested {
+    @Serializable
+    @SerialName("shared_case")
+    data class SharedCase(val value: String) : FirstNested
+}
+
+@OptIn(ExperimentalSerializationApi::class)
+@JsonClassDiscriminator("kind")
+@Serializable
+sealed interface SecondNested {
+    @Serializable
+    @SerialName("shared_case")
+    data class SharedCase(val count: Int) : SecondNested
+}
+
+@OptIn(ExperimentalSerializationApi::class)
+@JsonClassDiscriminator("status")
+@Serializable
+sealed interface RecursiveResponse {
+    @Serializable
+    @SerialName("node")
+    data class Node(val next: Node?) : RecursiveResponse
+}
+
+@OptIn(ExperimentalSerializationApi::class)
+@JsonClassDiscriminator("status")
+@Serializable
+sealed interface RecursiveListResponse {
+    @Serializable
+    @SerialName("node")
+    data class Node(val children: List<Node>) : RecursiveListResponse
+}
+
+@Serializable
+data class AnnotatedSharedCaseLists(
+    @JsonSchema.ItemsRef(FirstNested.SharedCase::class)
+    val first: List<String>,
+    @JsonSchema.ItemsRef(SecondNested.SharedCase::class)
+    val second: List<String>,
+)

--- a/ktor-shared/ktor-openapi-schema/common/src/io/ktor/openapi/JsonSchemaInference.kt
+++ b/ktor-shared/ktor-openapi-schema/common/src/io/ktor/openapi/JsonSchemaInference.kt
@@ -83,11 +83,13 @@ public class KotlinxSerializerJsonSchemaInference(
 
     override fun buildSchema(type: KType): JsonSchema {
         includeKType(type)
+        val serializer = module.serializer(type)
         return buildSchemaFromDescriptor(
-            module.serializer(type).descriptor,
+            serializer.descriptor,
             // parameterized types cannot be referenced from their serial name
             includeTitle = type.arguments.isEmpty(),
-            visiting = mutableSetOf()
+            visiting = mutableSetOf(),
+            serializer = serializer,
         )
     }
 
@@ -110,13 +112,21 @@ public class KotlinxSerializerJsonSchemaInference(
         includeTitle: Boolean = !descriptor.isParameterized(),
         includeAnnotations: List<Annotation> = emptyList(),
         visiting: MutableSet<String>,
+        serializer: KSerializer<*>? = null,
+        titleOverride: String? = null,
+        visitingNameOverride: String? = null,
     ): JsonSchema {
         val reflectJsonSchema: KClass<*>.() -> ReferenceOr<JsonSchema> = {
+            val serializer = module.serializer(this, emptyList(), false)
+            val componentName = subclassComponentName(serializer)
             Value(
                 buildSchemaFromDescriptor(
-                    descriptor = module.serializer(this, emptyList(), false).descriptor,
+                    descriptor = serializer.descriptor,
                     includeTitle = includeTitle,
                     visiting = visiting,
+                    serializer = serializer,
+                    titleOverride = componentName,
+                    visitingNameOverride = componentName,
                 )
             )
         }
@@ -129,12 +139,16 @@ public class KotlinxSerializerJsonSchemaInference(
                 descriptor = descriptor.getElementDescriptor(0),
                 includeAnnotations = includeAnnotations,
                 visiting = visiting,
+                serializer = nestedSerializerAt(serializer, 0),
+                titleOverride = titleOverride,
+                visitingNameOverride = visitingNameOverride,
             )
         }
 
         return when (descriptor.kind) {
             StructureKind.CLASS, StructureKind.OBJECT -> {
-                visiting += descriptor.nonNullSerialName
+                val visitingName = visitingNameOverride ?: descriptor.nonNullSerialName
+                visiting += visitingName
 
                 val properties = mutableMapOf<String, ReferenceOr<JsonSchema>>()
                 val required = mutableListOf<String>()
@@ -142,7 +156,13 @@ public class KotlinxSerializerJsonSchemaInference(
                 for (i in 0 until descriptor.elementsCount) {
                     val name = descriptor.getElementName(i)
                     val elementDescriptor = descriptor.getElementDescriptor(i)
-                    val elementName = elementDescriptor.nonNullSerialName
+                    val childSerializer = nestedSerializerAt(serializer, i)
+                    val elementReferenceName = referenceNameForChild(
+                        parentDescriptor = descriptor,
+                        childDescriptor = elementDescriptor,
+                        parentReferenceName = visitingName,
+                        childSerializer = childSerializer,
+                    )
                     val annotations = descriptor.getElementAnnotations(i)
                     if (annotations.any { it is Ignore }) continue
 
@@ -152,18 +172,19 @@ public class KotlinxSerializerJsonSchemaInference(
 
                     properties[name] = buildSchemaOrReference(
                         elementDescriptor,
-                        elementName,
+                        elementReferenceName,
                         visiting,
                         descriptor.getElementAnnotations(i),
+                        serializer = childSerializer,
                     )
                 }
-                visiting -= descriptor.nonNullSerialName
+                visiting -= visitingName
 
                 jsonSchemaFromAnnotations(
                     annotations = annotations,
                     reflectSchema = reflectJsonSchema,
                     type = JsonType.OBJECT,
-                    title = descriptor.nonNullSerialName.takeIf { includeTitle },
+                    title = titleOverride ?: descriptor.nonNullSerialName.takeIf { includeTitle },
                     properties = properties,
                     required = required.takeIf { it.isNotEmpty() },
                 ).wrapIfNullable(isNullable)
@@ -173,18 +194,41 @@ public class KotlinxSerializerJsonSchemaInference(
                 if (descriptor.elementsCount == 2) {
                     val discriminatorProperty = descriptor.getElementName(0)
                     val sealedElementsDescriptor = descriptor.getElementDescriptor(1)
+                    val sealedSubclassComponentNames = sealedSubclassComponentNameMapping(serializer)
                     val sealedElementsSchema = (0..<sealedElementsDescriptor.elementsCount)
                         .map { i ->
+                            val subclassDescriptor = sealedElementsDescriptor.getElementDescriptor(i)
+                            val serialName = sealedElementsDescriptor.getElementName(i)
+                            val subclassSerializer = nestedSerializerAt(serializer, i)
+                            val componentName =
+                                subclassComponentName(subclassSerializer)
+                                    ?: sealedSubclassComponentNames[serialName]
+                                    ?: fallbackSealedSubclassComponentName(
+                                        descriptor = descriptor,
+                                        subclassDescriptor = subclassDescriptor,
+                                        serialName = serialName,
+                                    )
                             buildSchemaOrReference(
-                                descriptor = sealedElementsDescriptor.getElementDescriptor(i),
-                                title = sealedElementsDescriptor.getElementName(i),
+                                descriptor = subclassDescriptor,
+                                referenceName = componentName,
                                 visiting = visiting,
                                 annotations = sealedElementsDescriptor.getElementAnnotations(i),
+                                serializer = subclassSerializer,
+                                schemaTitleOverride = componentName,
                             )
                         }
                     val discriminatorMapping = (0..<sealedElementsDescriptor.elementsCount)
-                        .map(sealedElementsDescriptor::getElementName)
-                        .associateWith { fqName -> ReferenceOr.schema(fqName).ref }
+                        .associate { i ->
+                            val serialName = sealedElementsDescriptor.getElementName(i)
+                            val componentName = subclassComponentName(nestedSerializerAt(serializer, i))
+                                ?: sealedSubclassComponentNames[serialName]
+                                ?: fallbackSealedSubclassComponentName(
+                                    descriptor = descriptor,
+                                    subclassDescriptor = sealedElementsDescriptor.getElementDescriptor(i),
+                                    serialName = serialName,
+                                )
+                            serialName to ReferenceOr.schema(componentName).ref
+                        }
 
                     jsonSchemaFromAnnotations(
                         annotations = annotations,
@@ -206,11 +250,16 @@ public class KotlinxSerializerJsonSchemaInference(
 
             StructureKind.LIST -> {
                 val itemDescriptor = descriptor.getElementDescriptor(0)
-                val itemName = itemDescriptor.nonNullSerialName
                 val itemSchema = buildSchemaOrReference(
                     descriptor = itemDescriptor,
-                    title = itemName,
+                    referenceName = referenceNameForChild(
+                        parentDescriptor = descriptor,
+                        childDescriptor = itemDescriptor,
+                        parentReferenceName = visitingNameOverride ?: descriptor.nonNullSerialName,
+                        childSerializer = nestedSerializerAt(serializer, 0),
+                    ),
                     visiting = visiting,
+                    serializer = nestedSerializerAt(serializer, 0),
                 )
                 jsonSchemaFromAnnotations(
                     annotations = annotations,
@@ -226,8 +275,14 @@ public class KotlinxSerializerJsonSchemaInference(
                     PSchema(
                         buildSchemaOrReference(
                             descriptor = valueDescriptor,
-                            title = valueDescriptor.nonNullSerialName,
+                            referenceName = referenceNameForChild(
+                                parentDescriptor = descriptor,
+                                childDescriptor = valueDescriptor,
+                                parentReferenceName = visitingNameOverride ?: descriptor.nonNullSerialName,
+                                childSerializer = nestedSerializerAt(serializer, 1),
+                            ),
                             visiting = visiting,
+                            serializer = nestedSerializerAt(serializer, 1),
                         )
                     )
                 } else {
@@ -299,12 +354,14 @@ public class KotlinxSerializerJsonSchemaInference(
     @OptIn(InternalAPI::class)
     private fun buildSchemaOrReference(
         descriptor: SerialDescriptor,
-        title: String,
+        referenceName: String,
         visiting: MutableSet<String>,
         annotations: List<Annotation> = emptyList(),
+        serializer: KSerializer<*>? = null,
+        schemaTitleOverride: String? = null,
     ): ReferenceOr<JsonSchema> =
-        if (!descriptor.isContainerType() && !visiting.add(title)) {
-            ReferenceOr.schema(title)
+        if (!descriptor.isContainerType() && !visiting.add(referenceName)) {
+            ReferenceOr.schema(referenceName)
                 .wrapIfNullable(descriptor.isNullable)
         } else {
             try {
@@ -313,15 +370,50 @@ public class KotlinxSerializerJsonSchemaInference(
                         descriptor = descriptor,
                         includeAnnotations = annotations,
                         visiting = visiting,
+                        serializer = serializer,
+                        titleOverride = schemaTitleOverride,
+                        visitingNameOverride = referenceName,
                     )
                 )
             } finally {
-                visiting.remove(title)
+                visiting.remove(referenceName)
             }
         }
 
     private fun SerialDescriptor.isContainerType() =
         kind == StructureKind.LIST || kind == StructureKind.MAP
+
+    private fun recursiveReferenceName(
+        parentDescriptor: SerialDescriptor,
+        childDescriptor: SerialDescriptor,
+        parentReferenceName: String,
+    ): String? = parentReferenceName.takeIf { parentDescriptor.nonNullSerialName == childDescriptor.nonNullSerialName }
+
+    private fun referenceNameForChild(
+        parentDescriptor: SerialDescriptor,
+        childDescriptor: SerialDescriptor,
+        parentReferenceName: String,
+        childSerializer: KSerializer<*>? = null,
+    ): String = subclassComponentName(childSerializer)
+        ?: recursiveReferenceName(
+            parentDescriptor = parentDescriptor,
+            childDescriptor = childDescriptor,
+            parentReferenceName = parentReferenceName,
+        )
+        ?: childDescriptor.nonNullSerialName
+
+    private fun fallbackSealedSubclassComponentName(
+        descriptor: SerialDescriptor,
+        subclassDescriptor: SerialDescriptor,
+        serialName: String,
+    ): String {
+        val subclassName = subclassDescriptor.nonNullSerialName
+        return if (subclassName == serialName) {
+            "${descriptor.nonNullSerialName}.$serialName"
+        } else {
+            subclassName
+        }
+    }
 }
 
 /**
@@ -499,6 +591,9 @@ public fun jsonSchemaFromAnnotations(
 }
 
 internal expect fun typeName(mapping: Discriminator.Mapping): String?
+internal expect fun sealedSubclassComponentNameMapping(serializer: KSerializer<*>?): Map<String, String>
+internal expect fun nestedSerializerAt(serializer: KSerializer<*>?, index: Int): KSerializer<*>?
+internal expect fun subclassComponentName(serializer: KSerializer<*>?): String?
 
 private inline fun <reified T : Annotation> List<Annotation>.firstInstanceOf(): T? =
     filterIsInstance<T>().firstOrNull()

--- a/ktor-shared/ktor-openapi-schema/jvm/src/io/ktor/openapi/JsonSchemaInference.jvm.kt
+++ b/ktor-shared/ktor-openapi-schema/jvm/src/io/ktor/openapi/JsonSchemaInference.jvm.kt
@@ -4,5 +4,140 @@
 
 package io.ktor.openapi
 
+import kotlinx.serialization.InternalSerializationApi
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.descriptors.StructureKind
+import kotlinx.serialization.internal.GeneratedSerializer
+
 internal actual fun typeName(mapping: JsonSchema.Discriminator.Mapping): String? =
     mapping.ref.qualifiedName ?: mapping.ref.simpleName
+
+internal actual fun sealedSubclassComponentNameMapping(serializer: KSerializer<*>?): Map<String, String> {
+    val sealedSerializer = serializer?.unwrapNullableSerializer() ?: return emptyMap()
+    return sealedSubclassEntries(sealedSerializer)
+        .mapNotNull { (subclass, subclassSerializer) ->
+            val componentName = subclass.qualifiedName ?: subclass.simpleName ?: return@mapNotNull null
+            subclassSerializer.descriptor.serialName to componentName
+        }
+        .toMap()
+}
+
+@OptIn(InternalSerializationApi::class)
+internal actual fun nestedSerializerAt(serializer: KSerializer<*>?, index: Int): KSerializer<*>? {
+    if (serializer == null) return null
+
+    if (serializer.descriptor.isNullable) {
+        val nestedSerializer = serializer.findFieldValue<KSerializer<*>>("serializer") ?: return null
+        return nestedSerializerAt(nestedSerializer, index)
+    }
+
+    sealedSubclassEntries(serializer).getOrNull(index)?.second?.let { return it }
+
+    if (serializer is GeneratedSerializer<*>) {
+        return serializer.childSerializers().getOrNull(index)
+    }
+
+    val fieldNames = when {
+        serializer.descriptor.kind == StructureKind.LIST -> listOf(
+            "elementSerializer"
+        )
+
+        serializer.descriptor.kind == StructureKind.MAP && index == 0 ->
+            listOf("keySerializer")
+
+        serializer.descriptor.kind == StructureKind.MAP && index == 1 ->
+            listOf("valueSerializer")
+
+        else -> emptyList()
+    }
+
+    return fieldNames.firstNotNullOfOrNull { fieldName ->
+        serializer.findFieldValue<KSerializer<*>>(fieldName)
+    }
+}
+
+internal actual fun subclassComponentName(serializer: KSerializer<*>?): String? {
+    if (serializer == null) return null
+
+    serializer.javaClass.enclosingClass?.name?.let { return it.replace('$', '.') }
+
+    val serializerClassName = serializer.javaClass.name
+    if (serializerClassName.endsWith($$"$$serializer")) {
+        return serializerClassName.removeSuffix($$"$$serializer").replace('$', '.')
+    }
+
+    return null
+}
+
+private fun KSerializer<*>.unwrapNullableSerializer(): KSerializer<*>? =
+    if (descriptor.isNullable) findFieldValue("serializer") else this
+
+private fun sealedSubclassEntries(serializer: KSerializer<*>): List<Pair<kotlin.reflect.KClass<*>, KSerializer<*>>> {
+    @Suppress("UNCHECKED_CAST")
+    val classToSerializer = when {
+        serializer.javaClass.methods.any { it.name == $$"getClass2Serializer$kotlinx_serialization_core" } -> {
+            val method = serializer.javaClass.methods
+                .first { it.name == $$"getClass2Serializer$kotlinx_serialization_core" }
+            method.invoke(serializer) as? Map<*, *>
+        }
+
+        else -> serializer.findFieldValue("class2Serializer")
+    }
+
+    classToSerializer?.mapNotNull { (subclass, subclassSerializer) ->
+        val kClass = subclass.toKClassOrNull() ?: return@mapNotNull null
+        val serializerValue = subclassSerializer as? KSerializer<*> ?: return@mapNotNull null
+        kClass to serializerValue
+    }?.let { return it }
+
+    val subclasses = sealedSubclassKClasses(serializer) ?: return emptyList()
+    val subclassSerializers = sealedSubclassSerializers(serializer) ?: return emptyList()
+    return subclasses.zip(subclassSerializers)
+}
+
+private fun sealedSubclassKClasses(serializer: KSerializer<*>): List<kotlin.reflect.KClass<*>>? {
+    val subclassesArray = serializer.findFieldValue<Array<*>>("subclasses")
+    if (subclassesArray != null) {
+        return subclassesArray.mapNotNull { it.toKClassOrNull() }
+    }
+
+    val subclassesList = serializer.findFieldValue<List<*>>("subclasses")
+    if (subclassesList != null) {
+        return subclassesList.mapNotNull { it.toKClassOrNull() }
+    }
+
+    return null
+}
+
+private fun sealedSubclassSerializers(serializer: KSerializer<*>): List<KSerializer<*>>? {
+    val serializersArray = serializer.findFieldValue<Array<*>>("subclassSerializers")
+    if (serializersArray != null) {
+        return serializersArray.filterIsInstance<KSerializer<*>>()
+    }
+
+    val serializersList = serializer.findFieldValue<List<*>>("subclassSerializers")
+    if (serializersList != null) {
+        return serializersList.filterIsInstance<KSerializer<*>>()
+    }
+
+    return null
+}
+
+private fun <T> Any.findFieldValue(name: String): T? {
+    var current: Class<*>? = javaClass
+    while (current != null) {
+        current.declaredFields.firstOrNull { it.name == name }?.let { field ->
+            field.isAccessible = true
+            @Suppress("UNCHECKED_CAST")
+            return field.get(this) as? T
+        }
+        current = current.superclass
+    }
+    return null
+}
+
+private fun Any?.toKClassOrNull(): kotlin.reflect.KClass<*>? = when (this) {
+    is kotlin.reflect.KClass<*> -> this
+    is Class<*> -> kotlin
+    else -> null
+}

--- a/ktor-shared/ktor-openapi-schema/nonJvm/src/io/ktor/openapi/JsonSchemaInference.nonJvm.kt
+++ b/ktor-shared/ktor-openapi-schema/nonJvm/src/io/ktor/openapi/JsonSchemaInference.nonJvm.kt
@@ -4,5 +4,18 @@
 
 package io.ktor.openapi
 
+import kotlinx.serialization.InternalSerializationApi
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.internal.GeneratedSerializer
+
 internal actual fun typeName(mapping: JsonSchema.Discriminator.Mapping): String? =
     mapping.ref.simpleName
+
+internal actual fun sealedSubclassComponentNameMapping(serializer: KSerializer<*>?): Map<String, String> =
+    emptyMap()
+
+@OptIn(InternalSerializationApi::class)
+internal actual fun nestedSerializerAt(serializer: KSerializer<*>?, index: Int): KSerializer<*>? =
+    (serializer as? GeneratedSerializer<*>)?.childSerializers()?.getOrNull(index)
+
+internal actual fun subclassComponentName(serializer: KSerializer<*>?): String? = null

--- a/ktor-shared/ktor-openapi-schema/nonJvm/src/io/ktor/openapi/JsonSchemaInference.nonJvm.kt
+++ b/ktor-shared/ktor-openapi-schema/nonJvm/src/io/ktor/openapi/JsonSchemaInference.nonJvm.kt
@@ -4,18 +4,74 @@
 
 package io.ktor.openapi
 
+import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.InternalSerializationApi
 import kotlinx.serialization.KSerializer
+import kotlinx.serialization.descriptors.PolymorphicKind
 import kotlinx.serialization.internal.GeneratedSerializer
 
 internal actual fun typeName(mapping: JsonSchema.Discriminator.Mapping): String? =
     mapping.ref.simpleName
 
-internal actual fun sealedSubclassComponentNameMapping(serializer: KSerializer<*>?): Map<String, String> =
-    emptyMap()
+@OptIn(ExperimentalSerializationApi::class)
+internal actual fun sealedSubclassComponentNameMapping(serializer: KSerializer<*>?): Map<String, String> {
+    val sealedSerializer = serializer?.unwrapNullableSerializer() ?: return emptyMap()
+    if (sealedSerializer.descriptor.kind != PolymorphicKind.SEALED || sealedSerializer.descriptor.elementsCount != 2) {
+        return emptyMap()
+    }
+
+    val sealedElementsDescriptor = sealedSerializer.descriptor.getElementDescriptor(1)
+    return (0..<sealedElementsDescriptor.elementsCount).associate { index ->
+        val serialName = sealedElementsDescriptor.getElementName(index)
+        val subclassDescriptor = sealedElementsDescriptor.getElementDescriptor(index)
+        val componentName = subclassComponentName(nestedSerializerAt(sealedSerializer, index))
+            ?: fallbackSealedSubclassComponentName(
+                descriptorSerialName = sealedSerializer.descriptor.serialName,
+                subclassSerialName = subclassDescriptor.serialName,
+                serialName = serialName,
+            )
+        serialName to componentName
+    }
+}
 
 @OptIn(InternalSerializationApi::class)
 internal actual fun nestedSerializerAt(serializer: KSerializer<*>?, index: Int): KSerializer<*>? =
-    (serializer as? GeneratedSerializer<*>)?.childSerializers()?.getOrNull(index)
+    (serializer?.unwrapNullableSerializer() as? GeneratedSerializer<*>)?.childSerializers()?.getOrNull(index)
 
-internal actual fun subclassComponentName(serializer: KSerializer<*>?): String? = null
+internal actual fun subclassComponentName(serializer: KSerializer<*>?): String? =
+    serializer
+        ?.unwrapNullableSerializer()
+        ?.let(::serializerComponentName)
+
+private fun KSerializer<*>.unwrapNullableSerializer(): KSerializer<*> = nestedSerializerAtNullable(this) ?: this
+
+@OptIn(InternalSerializationApi::class)
+private fun nestedSerializerAtNullable(serializer: KSerializer<*>): KSerializer<*>? =
+    (serializer as? GeneratedSerializer<*>)?.takeIf {
+        serializer.descriptor.isNullable
+    }?.childSerializers()?.firstOrNull()
+
+private fun serializerComponentName(serializer: KSerializer<*>): String? {
+    val renderedClassName = serializer::class.toString()
+        .substringAfter("class ", missingDelimiterValue = serializer::class.toString())
+        .substringAfter("interface ", missingDelimiterValue = serializer::class.toString())
+    return renderedClassName.toComponentName()
+        ?: serializer::class.simpleName?.toComponentName()
+}
+
+private fun String.toComponentName(): String? =
+    takeIf { it.endsWith("\$\$serializer") }
+        ?.removeSuffix("\$\$serializer")
+        ?.replace('$', '.')
+        ?.takeIf { it.isNotBlank() }
+
+private fun fallbackSealedSubclassComponentName(
+    descriptorSerialName: String,
+    subclassSerialName: String,
+    serialName: String,
+): String =
+    if (subclassSerialName.trimEnd('?') == serialName) {
+        "${descriptorSerialName.trimEnd('?')}.$serialName"
+    } else {
+        subclassSerialName.trimEnd('?')
+    }


### PR DESCRIPTION
**Subsystem**
Server, `ktor-openapi-schema`, `ktor-server-routing-openapi`

**Motivation**
This PR fixes [KTOR-9597](https://youtrack.jetbrains.com/issue/KTOR-9597).

When generating OpenAPI for sealed hierarchies with `kotlinx.serialization`, Ktor used `@SerialName` of sealed subtypes as the schema component name.

That caused two issues:

1. Different sealed hierarchies could collide in `components.schemas` when they reused the same `@SerialName`.
2. Recursive sealed subtypes could end up with broken `$ref` values in the final OpenAPI output, because schema inference used qualified names internally while `routing-openapi` later shortened component names without rewriting general schema references.

This is important because `@SerialName` controls the serialized wire format / discriminator value and should not also define OpenAPI component identity.

For example:

```kotlin
@OptIn(ExperimentalSerializationApi::class)
@JsonClassDiscriminator("status")
@Serializable
sealed interface FirstResponse {
    @Serializable
    @SerialName("shared_case")
    data class SharedCase(val value: String) : FirstResponse
}

@OptIn(ExperimentalSerializationApi::class)
@JsonClassDiscriminator("status")
@Serializable
sealed interface SecondResponse {
    @Serializable
    @SerialName("shared_case")
    data class SharedCase(val count: Int) : SecondResponse
}
```

Before this change, both subtypes tried to use the same component name:

```yaml
components:
  schemas:
    shared_case:
      ...
```

That made the generated OpenAPI unstable or invalid depending on how the schemas were collected.

Another problematic case is a recursive sealed subtype:

```kotlin
@OptIn(ExperimentalSerializationApi::class)
@JsonClassDiscriminator("status")
@Serializable
sealed interface RecursiveResponse {
    @Serializable
    @SerialName("node")
    data class Node(val next: Node?) : RecursiveResponse
}
```

Before this change, the final OpenAPI could contain a self-reference like this:

```yaml
components:
  schemas:
    Node:
      properties:
        next:
          oneOf:
            - $ref: "#/components/schemas/io.ktor.server.routing.openapi.RecursiveResponse.Node"
            - type: "null"
```

but only expose this component key:

```yaml
components:
  schemas:
    Node:
      ...
```

So the published `$ref` pointed to a component that did not exist.

**Solution**
This PR separates sealed subtype wire names from OpenAPI component names.

The new behavior is:

- discriminator mapping keys still use `@SerialName`
- sealed subtype schema component names use stable type-based names during schema inference
- when `routing-openapi` shortens collected component names for the final document, it now rewrites all schema component `$ref` values, not only discriminator mappings

This preserves the serialized API shape while avoiding schema name collisions and dangling references.

Example 1: same `@SerialName` reused across sealed hierarchies

```kotlin
@OptIn(ExperimentalSerializationApi::class)
@JsonClassDiscriminator("status")
@Serializable
sealed interface FirstResponse {
    @Serializable
    @SerialName("shared_case")
    data class SharedCase(val value: String) : FirstResponse
}

@OptIn(ExperimentalSerializationApi::class)
@JsonClassDiscriminator("status")
@Serializable
sealed interface SecondResponse {
    @Serializable
    @SerialName("shared_case")
    data class SharedCase(val count: Int) : SecondResponse
}
```

Before:

```yaml
components:
  schemas:
    shared_case:
      ...
```

After schema inference:

```yaml
oneOf:
  - title: io.ktor.server.routing.openapi.FirstResponse.SharedCase
discriminator:
  mapping:
    shared_case: "#/components/schemas/io.ktor.server.routing.openapi.FirstResponse.SharedCase"
```

and:

```yaml
oneOf:
  - title: io.ktor.server.routing.openapi.SecondResponse.SharedCase
discriminator:
  mapping:
    shared_case: "#/components/schemas/io.ktor.server.routing.openapi.SecondResponse.SharedCase"
```

After final OpenAPI normalization:

```yaml
components:
  schemas:
    FirstResponse:
      oneOf:
        - $ref: "#/components/schemas/FirstResponse.SharedCase"
      discriminator:
        propertyName: status
        mapping:
          shared_case: "#/components/schemas/FirstResponse.SharedCase"

    SecondResponse:
      oneOf:
        - $ref: "#/components/schemas/SecondResponse.SharedCase"
      discriminator:
        propertyName: status
        mapping:
          shared_case: "#/components/schemas/SecondResponse.SharedCase"

    FirstResponse.SharedCase:
      type: object
      required: [value]
      properties:
        value:
          type: string

    SecondResponse.SharedCase:
      type: object
      required: [count]
      properties:
        count:
          type: integer
```

Example 2: nested sealed hierarchies

```kotlin
@Serializable
data class NestedResponses(
    val first: FirstResponse,
    val second: SecondResponse,
)
```

Before, the nested properties could still collapse to the same `shared_case` component.

After:

```yaml
components:
  schemas:
    NestedResponses:
      type: object
      properties:
        first:
          $ref: "#/components/schemas/FirstResponse"
        second:
          $ref: "#/components/schemas/SecondResponse"
```

and the underlying subtype schemas remain distinct.

Example 3: nullable sealed root with nested sealed properties

```kotlin
@OptIn(ExperimentalSerializationApi::class)
@JsonClassDiscriminator("status")
@Serializable
sealed interface NullableNestedRoot {
    @Serializable
    @SerialName("first")
    data class First(val nested: FirstNested) : NullableNestedRoot

    @Serializable
    @SerialName("second")
    data class Second(val nested: SecondNested) : NullableNestedRoot
}

@OptIn(ExperimentalSerializationApi::class)
@JsonClassDiscriminator("kind")
@Serializable
sealed interface FirstNested {
    @Serializable
    @SerialName("shared_case")
    data class SharedCase(val value: String) : FirstNested
}

@OptIn(ExperimentalSerializationApi::class)
@JsonClassDiscriminator("kind")
@Serializable
sealed interface SecondNested {
    @Serializable
    @SerialName("shared_case")
    data class SharedCase(val count: Int) : SecondNested
}
```

Before, nested sealed schemas under nullable roots could still fall back to names like:

```yaml
title: io.ktor.server.routing.openapi.FirstNested.shared_case
```

After:

```yaml
title: io.ktor.server.routing.openapi.FirstNested.SharedCase
```

and similarly for `SecondNested.SharedCase`.

Example 4: recursive sealed subtype

```kotlin
@OptIn(ExperimentalSerializationApi::class)
@JsonClassDiscriminator("status")
@Serializable
sealed interface RecursiveResponse {
    @Serializable
    @SerialName("node")
    data class Node(val next: Node?) : RecursiveResponse
}
```

Before final OpenAPI output:

```yaml
components:
  schemas:
    Node:
      properties:
        next:
          oneOf:
            - $ref: "#/components/schemas/io.ktor.server.routing.openapi.RecursiveResponse.Node"
            - type: "null"
```

After final OpenAPI output:

```yaml
components:
  schemas:
    Node:
      properties:
        next:
          oneOf:
            - $ref: "#/components/schemas/Node"
            - type: "null"
```

So the published reference now points to the actual exported component.

This PR also adds regression coverage for:

- same `@SerialName` reused across sealed hierarchies
- nested sealed hierarchies
- nullable sealed roots and nested sealed properties
- recursive sealed subtypes
- final OpenAPI `$ref` rewriting after component name shortening

