### PR TITLE
WebRTC Client: retain iOS delegate to keep messages flowing

### DIFF
--- a/ktor-client/ktor-client-webrtc/ios/src/io/ktor/client/webrtc/DataChannel.kt
+++ b/ktor-client/ktor-client-webrtc/ios/src/io/ktor/client/webrtc/DataChannel.kt
@@ -25,6 +25,11 @@ public class IosWebRtcDataChannel(
     receiveOptions: DataChannelReceiveOptions
 ) : WebRtcDataChannel(receiveOptions) {
 
+    // Apple's `RTCDataChannel.delegate` is `weak` — keep a strong reference on the
+    // Kotlin side so the anonymous delegate object stays alive for the connection's lifetime.
+    @Suppress("unused")
+    private lateinit var retainedDelegate: NSObject
+
     override val id: Int?
         get() = nativeChannel.channelId.let { if (it < 0) null else it }
 
@@ -88,7 +93,8 @@ public class IosWebRtcDataChannel(
     }
 
     internal fun setupEvents(eventsEmitter: WebRtcConnectionEventsEmitter) {
-        nativeChannel.setDelegate(object : RTCDataChannelDelegateProtocol, NSObject() {
+        check(!::retainedDelegate.isInitialized) { "setupEvents() must be called at most once per channel." }
+        val delegate = object : RTCDataChannelDelegateProtocol, NSObject() {
             override fun dataChannel(dataChannel: RTCDataChannel, didChangeBufferedAmount: ULong) =
                 runInConnectionScope {
                     // guard against duplicate events
@@ -123,7 +129,9 @@ public class IosWebRtcDataChannel(
             ) = runInConnectionScope {
                 emitMessage(didReceiveMessageWithBuffer.toKtor())
             }
-        })
+        }
+        retainedDelegate = delegate
+        nativeChannel.setDelegate(delegate)
     }
 }
 

--- a/ktor-client/ktor-client-webrtc/ios/src/io/ktor/client/webrtc/DataChannel.kt
+++ b/ktor-client/ktor-client-webrtc/ios/src/io/ktor/client/webrtc/DataChannel.kt
@@ -27,8 +27,7 @@ public class IosWebRtcDataChannel(
 
     // Apple's `RTCDataChannel.delegate` is `weak` — keep a strong reference on the
     // Kotlin side so the anonymous delegate object stays alive for the connection's lifetime.
-    @Suppress("unused")
-    private lateinit var retainedDelegate: NSObject
+    private var retainedDelegate: NSObject? = null
 
     override val id: Int?
         get() = nativeChannel.channelId.let { if (it < 0) null else it }
@@ -93,7 +92,7 @@ public class IosWebRtcDataChannel(
     }
 
     internal fun setupEvents(eventsEmitter: WebRtcConnectionEventsEmitter) {
-        check(!::retainedDelegate.isInitialized) { "setupEvents() must be called at most once per channel." }
+        check(retainedDelegate == null) { "setupEvents() must be called at most once per channel." }
         val delegate = object : RTCDataChannelDelegateProtocol, NSObject() {
             override fun dataChannel(dataChannel: RTCDataChannel, didChangeBufferedAmount: ULong) =
                 runInConnectionScope {

--- a/ktor-client/ktor-client-webrtc/ios/src/io/ktor/client/webrtc/PeerConnection.kt
+++ b/ktor-client/ktor-client-webrtc/ios/src/io/ktor/client/webrtc/PeerConnection.kt
@@ -33,8 +33,7 @@ public class IosWebRtcConnection(
 
     // Apple's `RTCPeerConnection.delegate` is `weak` — keep a strong reference on the
     // Kotlin side so the anonymous delegate object stays alive for the connection's lifetime.
-    @Suppress("unused")
-    private val retainedDelegate: NSObject
+    private var retainedDelegate: NSObject? = null
 
     init {
         val delegate = createDelegate()
@@ -243,6 +242,7 @@ public class IosWebRtcConnection(
     override fun close() {
         super.close()
         peerConnection.close()
+        retainedDelegate = null
     }
 }
 

--- a/ktor-client/ktor-client-webrtc/ios/src/io/ktor/client/webrtc/PeerConnection.kt
+++ b/ktor-client/ktor-client-webrtc/ios/src/io/ktor/client/webrtc/PeerConnection.kt
@@ -31,8 +31,15 @@ public class IosWebRtcConnection(
 ) : WebRtcPeerConnection(coroutineContext, config) {
     internal val peerConnection: RTCPeerConnection
 
+    // Apple's `RTCPeerConnection.delegate` is `weak` — keep a strong reference on the
+    // Kotlin side so the anonymous delegate object stays alive for the connection's lifetime.
+    @Suppress("unused")
+    private val retainedDelegate: NSObject
+
     init {
-        peerConnection = createConnection(createDelegate()) ?: error("Failed to create peer connection.")
+        val delegate = createDelegate()
+        retainedDelegate = delegate
+        peerConnection = createConnection(delegate) ?: error("Failed to create peer connection.")
     }
 
     override suspend fun getStatistics(): List<WebRtc.Stats> = suspendCancellableCoroutine { cont ->

--- a/ktor-client/ktor-client-webrtc/ios/test/io/ktor/client/webrtc/IosDelegateRetentionTest.kt
+++ b/ktor-client/ktor-client-webrtc/ios/test/io/ktor/client/webrtc/IosDelegateRetentionTest.kt
@@ -20,6 +20,7 @@ import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.seconds
 
 /**
  * Regression tests for the iOS delegate-retention bug.
@@ -79,7 +80,7 @@ class IosDelegateRetentionTest {
                 connect(pc1, pc2, jobs)
 
                 // Wait for pc2 to receive the remote channel.
-                val remote = withTimeout(5000) {
+                val remote = withTimeout(5.seconds) {
                     val event = pc2DataChannels.receive()
                     assertTrue(event is DataChannelEvent.Open, "Expected Open, got $event")
                     event.channel
@@ -95,12 +96,12 @@ class IosDelegateRetentionTest {
 
                 val pc1ToPc2 = "hello after GC"
                 local.send(pc1ToPc2)
-                val receivedAtPc2 = withTimeout(5000) { remote.receiveText() }
+                val receivedAtPc2 = withTimeout(5.seconds) { remote.receiveText() }
                 assertEquals(pc1ToPc2, receivedAtPc2)
 
                 val pc2ToPc1 = "reply after GC"
                 remote.send(pc2ToPc1)
-                val receivedAtPc1 = withTimeout(5000) { local.receiveText() }
+                val receivedAtPc1 = withTimeout(5.seconds) { local.receiveText() }
                 assertEquals(pc2ToPc1, receivedAtPc1)
 
                 // Second round: GC between every message to make sure delivery stays
@@ -108,7 +109,7 @@ class IosDelegateRetentionTest {
                 repeat(8) { i ->
                     forceGc(rounds = 2)
                     local.send("msg-$i")
-                    val got = withTimeout(5000) { remote.receiveText() }
+                    val got = withTimeout(5.seconds) { remote.receiveText() }
                     assertEquals("msg-$i", got)
                 }
             }
@@ -134,13 +135,13 @@ class IosDelegateRetentionTest {
                 connect(pc1, pc2, jobs)
 
                 // Drain pc2's channels flow so the connection settles into CONNECTED.
-                withTimeout(5000) { pc2DataChannels.receive() }
+                withTimeout(5.seconds) { pc2DataChannels.receive() }
 
                 // We must observe CONNECTED on pc1; that only arrives if the PC delegate
                 // is still alive to fire `didChangeConnectionState`. `state` is a
                 // StateFlow whose current value is replayed to new collectors, so
                 // `first { }` will see CONNECTED even if it was reached earlier.
-                withTimeout(5000) {
+                withTimeout(5.seconds) {
                     pc1.state.first { it == WebRtc.ConnectionState.CONNECTED }
                 }
             }

--- a/ktor-client/ktor-client-webrtc/ios/test/io/ktor/client/webrtc/IosDelegateRetentionTest.kt
+++ b/ktor-client/ktor-client-webrtc/ios/test/io/ktor/client/webrtc/IosDelegateRetentionTest.kt
@@ -1,0 +1,149 @@
+/*
+ * Copyright 2014-2026 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.client.webrtc
+
+import io.ktor.client.webrtc.utils.collectToChannel
+import io.ktor.client.webrtc.utils.connect
+import io.ktor.client.webrtc.utils.createTestWebRtcClient
+import io.ktor.client.webrtc.utils.runTestWithPermissions
+import io.ktor.utils.io.ExperimentalKtorApi
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.TestResult
+import kotlinx.coroutines.withTimeout
+import kotlin.experimental.ExperimentalNativeApi
+import kotlin.native.runtime.GC
+import kotlin.native.runtime.NativeRuntimeApi
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Regression tests for the iOS delegate-retention bug.
+ *
+ * Apple's `RTCDataChannel.delegate` and `RTCPeerConnection.delegate` are both
+ * declared `@property(nonatomic, weak)`. Earlier versions of this library passed
+ * an anonymous `NSObject` to those setters without keeping a Kotlin-side strong
+ * reference, so once Kotlin/Native's ARC observed no remaining references the
+ * delegate was deallocated and the framework's weak pointer was nilled out —
+ * silently halting message delivery and lifecycle callbacks on the channel.
+ *
+ * These tests force GC after the channel is established and verify that
+ * subsequent traffic continues to flow. They will fail (timeout on `receive()`)
+ * against any build of `ktor-client-webrtc` that doesn't hold a strong reference
+ * to the iOS delegate.
+ */
+@OptIn(ExperimentalKtorApi::class, ExperimentalNativeApi::class, NativeRuntimeApi::class)
+class IosDelegateRetentionTest {
+
+    private lateinit var client: WebRtcClient
+
+    @BeforeTest
+    fun setup() {
+        client = createTestWebRtcClient()
+    }
+
+    @AfterTest
+    fun cleanup() {
+        client.close()
+    }
+
+    /**
+     * Aggressively reclaims unreferenced Kotlin/Native objects so a delegate the
+     * library forgot to retain has every opportunity to be freed before we send.
+     * The 1 MiB allocation per round goes out of scope before the next iteration's
+     * `GC.collect()`, creating real allocation churn to exercise the collector.
+     */
+    private fun forceGc(rounds: Int = 5) {
+        repeat(rounds) {
+            @Suppress("UNUSED_VARIABLE")
+            val ballast = ByteArray(1 shl 20) // 1 MiB
+            GC.collect()
+        }
+    }
+
+    @Test
+    fun dataChannelDelegateSurvivesGcAfterSetup(): TestResult = runTestWithPermissions(
+        audio = false,
+        video = false,
+        realTime = true,
+    ) { jobs ->
+        client.createPeerConnection().use { pc1 ->
+            client.createPeerConnection().use { pc2 ->
+                val pc2DataChannels = pc2.dataChannelEvents.collectToChannel(this, jobs)
+
+                val local = pc1.createDataChannel("delegate-retention-local")
+                connect(pc1, pc2, jobs)
+
+                // Wait for pc2 to receive the remote channel.
+                val remote = withTimeout(5000) {
+                    val event = pc2DataChannels.receive()
+                    assertTrue(event is DataChannelEvent.Open, "Expected Open, got $event")
+                    event.channel
+                }
+                assertEquals(WebRtc.DataChannel.State.OPEN, local.state)
+                assertEquals(WebRtc.DataChannel.State.OPEN, remote.state)
+
+                // The bug-reproducing step: nothing in user code is holding the delegates
+                // alive — collect now and verify the channel still works in BOTH directions.
+                // (Local-channel delegate fires on pc1's send-side `bufferedAmount` etc.;
+                // remote-channel delegate fires on pc2's `didReceiveMessage`.)
+                forceGc()
+
+                val pc1ToPc2 = "hello after GC"
+                local.send(pc1ToPc2)
+                val receivedAtPc2 = withTimeout(5000) { remote.receiveText() }
+                assertEquals(pc1ToPc2, receivedAtPc2)
+
+                val pc2ToPc1 = "reply after GC"
+                remote.send(pc2ToPc1)
+                val receivedAtPc1 = withTimeout(5000) { local.receiveText() }
+                assertEquals(pc2ToPc1, receivedAtPc1)
+
+                // Second round: GC between every message to make sure delivery stays
+                // healthy across repeated reclamation cycles, not just one.
+                repeat(8) { i ->
+                    forceGc(rounds = 2)
+                    local.send("msg-$i")
+                    val got = withTimeout(5000) { remote.receiveText() }
+                    assertEquals("msg-$i", got)
+                }
+            }
+        }
+    }
+
+    @Test
+    fun peerConnectionDelegateSurvivesGcAfterSetup(): TestResult = runTestWithPermissions(
+        audio = false,
+        video = false,
+        realTime = true,
+    ) { jobs ->
+        client.createPeerConnection().use { pc1 ->
+            client.createPeerConnection().use { pc2 ->
+                val pc2DataChannels = pc2.dataChannelEvents.collectToChannel(this, jobs)
+
+                pc1.createDataChannel("pc-delegate-test")
+
+                // GC before negotiation so any unretained PC delegate gets reclaimed
+                // before the state-transition callbacks would have fired.
+                forceGc()
+
+                connect(pc1, pc2, jobs)
+
+                // Drain pc2's channels flow so the connection settles into CONNECTED.
+                withTimeout(5000) { pc2DataChannels.receive() }
+
+                // We must observe CONNECTED on pc1; that only arrives if the PC delegate
+                // is still alive to fire `didChangeConnectionState`. `state` is a
+                // StateFlow whose current value is replayed to new collectors, so
+                // `first { }` will see CONNECTED even if it was reached earlier.
+                withTimeout(5000) {
+                    pc1.state.first { it == WebRtc.ConnectionState.CONNECTED }
+                }
+            }
+        }
+    }
+}

--- a/ktor-client/ktor-client-webrtc/ios/test/io/ktor/client/webrtc/IosDelegateRetentionTest.kt
+++ b/ktor-client/ktor-client-webrtc/ios/test/io/ktor/client/webrtc/IosDelegateRetentionTest.kt
@@ -66,7 +66,7 @@ class IosDelegateRetentionTest {
     }
 
     @Test
-    fun dataChannelDelegateSurvivesGcAfterSetup(): TestResult = runTestWithPermissions(
+    fun `data channel delegate survives GC after setup`(): TestResult = runTestWithPermissions(
         audio = false,
         video = false,
         realTime = true,
@@ -116,7 +116,7 @@ class IosDelegateRetentionTest {
     }
 
     @Test
-    fun peerConnectionDelegateSurvivesGcAfterSetup(): TestResult = runTestWithPermissions(
+    fun `peer connection delegate survives GC after setup`(): TestResult = runTestWithPermissions(
         audio = false,
         video = false,
         realTime = true,


### PR DESCRIPTION
**Subsystem**
ktor-client-webrtc (iOS specific)

**Motivation**
We're converting the Music Assistant mobile app over to ktor's webrtc library. As soon as we had a 'large' WebRTC message (we pass album art over the WebRTC data channel, as a for-instance) the RTCDataChannel.delegate and RTCPeerConnection.delegate would get reclaimed and callbacks / messages would silently stop flowing. This is because iOS's `RTCDataChannel.delegate` and `RTCPeerConnection.delegate` are declared `@property(nonatomic, weak)`. The iOS implementation passed an anonymous `NSObject` to those setters without keeping a Kotlin-side strong reference.

**Solution**
Store the delegate in a private property on the wrapper class so it lives as long as the wrapper does. `IosWebRtcConnection` uses a `val` since the delegate is created in `init`; `IosWebRtcDataChannel` uses a `lateinit var` because `setupEvents()` is called after construction, with a `check` to enforce the single-assignment invariant.

Also, we added `IosDelegateRetentionTest` which forces `GC.collect()` after the channel is established and verifies both directions of traffic, plus that the peer connection still reaches CONNECTED.