### PR TITLE
KTOR-9615 Apache5: Close the underlying request on job cancel

### DIFF
--- a/ktor-client/ktor-client-apache5/jvm/src/io/ktor/client/engine/apache5/ApacheHttpRequest.kt
+++ b/ktor-client/ktor-client-apache5/jvm/src/io/ktor/client/engine/apache5/ApacheHttpRequest.kt
@@ -9,14 +9,16 @@ import io.ktor.client.request.*
 import io.ktor.http.*
 import io.ktor.util.date.*
 import io.ktor.utils.io.*
-import kotlinx.coroutines.*
-import org.apache.hc.client5.http.*
-import org.apache.hc.client5.http.impl.async.*
-import org.apache.hc.core5.concurrent.*
-import org.apache.hc.core5.http.message.*
-import org.apache.hc.core5.http.nio.*
-import java.net.*
-import kotlin.coroutines.*
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.cancel
+import org.apache.hc.client5.http.ConnectTimeoutException
+import org.apache.hc.client5.http.impl.async.CloseableHttpAsyncClient
+import org.apache.hc.core5.concurrent.FutureCallback
+import org.apache.hc.core5.http.message.StatusLine
+import org.apache.hc.core5.http.nio.AsyncRequestProducer
+import java.net.ConnectException
+import java.net.SocketTimeoutException
+import kotlin.coroutines.CoroutineContext
 
 @OptIn(InternalAPI::class)
 internal suspend fun CloseableHttpAsyncClient.sendRequest(
@@ -36,6 +38,8 @@ internal suspend fun CloseableHttpAsyncClient.sendRequest(
     }
 
     val future = execute(request, responseConsumer, callback)!!
+    bodyConsumer.attachFuture(future)
+
     try {
         val rawResponse = responseConsumer.responseDeferred.await()
 
@@ -66,9 +70,9 @@ internal suspend fun CloseableHttpAsyncClient.sendRequest(
     }
 }
 
-internal fun mapCause(exception: Exception, requestData: HttpRequestData): Exception = when {
-    exception is ConnectTimeoutException -> ConnectTimeoutException(requestData, exception)
-    exception is ConnectException && exception.isTimeoutException() -> ConnectTimeoutException(requestData, exception)
-    exception is SocketTimeoutException -> SocketTimeoutException(requestData, exception)
+internal fun mapCause(exception: Exception, requestData: HttpRequestData): Exception = when (exception) {
+    is ConnectTimeoutException -> ConnectTimeoutException(requestData, exception)
+    is ConnectException if exception.isTimeoutException() -> ConnectTimeoutException(requestData, exception)
+    is SocketTimeoutException -> SocketTimeoutException(requestData, exception)
     else -> exception
 }

--- a/ktor-client/ktor-client-apache5/jvm/src/io/ktor/client/engine/apache5/ApacheResponseConsumer.kt
+++ b/ktor-client/ktor-client-apache5/jvm/src/io/ktor/client/engine/apache5/ApacheResponseConsumer.kt
@@ -9,6 +9,7 @@ import io.ktor.util.*
 import io.ktor.utils.io.*
 import kotlinx.atomicfu.atomic
 import kotlinx.coroutines.*
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.channels.Channel.Factory.UNLIMITED
 import org.apache.hc.core5.concurrent.CallbackContribution
@@ -21,6 +22,7 @@ import org.apache.hc.core5.http.nio.AsyncResponseConsumer
 import org.apache.hc.core5.http.nio.CapacityChannel
 import org.apache.hc.core5.http.protocol.HttpContext
 import java.nio.ByteBuffer
+import java.util.concurrent.Future
 import kotlin.coroutines.CoroutineContext
 
 private object CloseChannel
@@ -81,6 +83,9 @@ internal class ApacheResponseConsumer(
     parentContext: CoroutineContext,
     private val requestData: HttpRequestData
 ) : AsyncEntityConsumer<Unit>, CoroutineScope {
+
+    private val closed = atomic(false)
+    private val cancellationCause = atomic<Throwable?>(null)
 
     private val consumerJob = Job(parentContext.job)
     override val coroutineContext: CoroutineContext = parentContext + consumerJob
@@ -150,17 +155,42 @@ internal class ApacheResponseConsumer(
     }
 
     override fun failed(cause: Exception) {
+        if (!closed.compareAndSet(expect = false, update = true)) return
+        if (completeCallbackFromCancellationCause()) return
+
         val mappedCause = mapCause(cause, requestData)
         consumerJob.completeExceptionally(mappedCause)
-        responseChannel.cancel(mappedCause)
         streamResultCallback.getAndSet(null)?.failed(cause)
     }
 
     internal fun close() {
+        if (!closed.compareAndSet(expect = false, update = true)) return
+        if (completeCallbackFromCancellationCause()) return
+
         channel.close()
         consumerJob.complete()
         streamResultCallback.getAndSet(null)?.completed(Unit)
     }
 
+    private fun completeCallbackFromCancellationCause(): Boolean {
+        val completionCause = cancellationCause.getAndSet(null) ?: return false
+        if (completionCause is CancellationException) {
+            streamResultCallback.getAndSet(null)?.cancelled()
+        } else {
+            streamResultCallback.getAndSet(null)?.failed(
+                completionCause as? Exception ?: CancellationException("Response consumer failed", completionCause)
+            )
+        }
+        return true
+    }
+
     override fun getContent() = Unit
+
+    @OptIn(InternalCoroutinesApi::class)
+    fun attachFuture(future: Future<Unit>) {
+        consumerJob.invokeOnCompletion(onCancelling = true) { cause ->
+            // Calling `future.cancel()` triggers `failed` path with `InterruptedIOException`
+            if (cause != null && cancellationCause.compareAndSet(null, cause)) future.cancel(true)
+        }
+    }
 }

--- a/ktor-client/ktor-client-apache5/jvm/test/io/ktor/client/engine/apache5/Apache5HttpClientTest.kt
+++ b/ktor-client/ktor-client-apache5/jvm/test/io/ktor/client/engine/apache5/Apache5HttpClientTest.kt
@@ -9,22 +9,22 @@ import io.ktor.client.plugins.*
 import io.ktor.client.request.*
 import io.ktor.client.statement.*
 import io.ktor.client.tests.*
-import io.ktor.network.sockets.*
 import io.ktor.util.*
 import io.ktor.utils.io.*
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runTest
 import org.apache.hc.client5.http.config.ConnectionConfig
 import org.apache.hc.core5.util.Timeout
-import org.junit.jupiter.api.Assertions.assertTrue
+import java.net.SocketTimeoutException
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertIs
 
 class Apache5HttpClientTest : HttpClientTest(Apache5) {
 
     @Test
     @OptIn(InternalAPI::class)
-    fun testSocketTimeoutWithCustomConnectionManager() = runBlocking {
+    fun testSocketTimeoutWithCustomConnectionManager() = runTest {
         val client = HttpClient(Apache5) {
             engine {
                 configureConnectionManager {
@@ -45,14 +45,13 @@ class Apache5HttpClientTest : HttpClientTest(Apache5) {
                 }
             }
         }.apply {
-            assertTrue(rootCause is SocketTimeoutException)
+            assertIs<SocketTimeoutException>(rootCause)
         }
-        Unit
     }
 
     @Test
     @OptIn(InternalAPI::class)
-    fun testCustomTimeoutOverridesHttpTimeout() = runBlocking {
+    fun testCustomTimeoutOverridesHttpTimeout() = runTest {
         val client = HttpClient(Apache5) {
             engine {
                 configureConnectionManager {

--- a/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/plugins/ServerSentEventsTest.kt
+++ b/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/plugins/ServerSentEventsTest.kt
@@ -31,7 +31,6 @@ import kotlinx.serialization.json.Json
 import kotlinx.serialization.serializer
 import kotlin.coroutines.CoroutineContext
 import kotlin.coroutines.resume
-import kotlin.coroutines.suspendCoroutine
 import kotlin.test.*
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
@@ -200,7 +199,7 @@ class ServerSentEventsTest : ClientLoader() {
         test { client ->
             coroutineScope {
                 val job: Job
-                suspendCoroutine { cont ->
+                suspendCancellableCoroutine { cont ->
                     job = launch {
                         client.serverSentEvents("$TEST_SERVER/sse/hello") {
                             cont.resume(Unit)
@@ -1007,7 +1006,7 @@ class ServerSentEventsTest : ClientLoader() {
     }
 
     @Test
-    fun testCancellingUnderlyingConnection() = clientTests(except("WinHttp")) {
+    fun testCancellingUnderlyingConnection() = clientTests(except("WinHttp"), timeout = 5.seconds) {
         config {
             install(SSE)
         }
@@ -1018,12 +1017,10 @@ class ServerSentEventsTest : ClientLoader() {
                 assertEquals("ok", it.data)
                 sseSession.cancel()
             }
-            withTimeout(5000) {
-                while (true) {
-                    val count = client.get("$TEST_SERVER/sse/active-sessions-count").bodyAsText().toInt()
-                    if (count == 0) break
-                    delay(100)
-                }
+            while (true) {
+                val count = client.get("$TEST_SERVER/sse/active-sessions-count").bodyAsText().toInt()
+                if (count == 0) break
+                delay(100.milliseconds)
             }
         }
     }


### PR DESCRIPTION
**Subsystem**
`ktor-client-apache5`

**Motivation**
[KTOR-9615](https://youtrack.jetbrains.com/issue/KTOR-9615) Apache5: The underlying request is not aborted when coroutine Job is cancelled

**Solution**
Cancel the request `Future` when coroutine job is cancelled.

The result can be observed [here](https://ktor.teamcity.com/test/1628683479014970233?currentProjectId=Ktor_ProjectKtorCore). Previously this test succeeded only after retry.
