### PR TITLE
Fix SustainabilityTestSuite.testBigFile performance

### DIFF
--- a/ktor-server/ktor-server-test-suites/jvm/src/io/ktor/server/testing/suites/SustainabilityTestSuite.kt
+++ b/ktor-server/ktor-server-test-suites/jvm/src/io/ktor/server/testing/suites/SustainabilityTestSuite.kt
@@ -34,16 +34,11 @@ import org.slf4j.event.Level
 import org.slf4j.helpers.AbstractLogger
 import java.io.File
 import java.io.IOException
-import java.io.InputStream
 import java.net.HttpURLConnection
 import java.net.Proxy
 import java.net.URL
 import java.util.*
-import java.util.concurrent.CopyOnWriteArrayList
-import java.util.concurrent.CountDownLatch
-import java.util.concurrent.Executors
-import java.util.concurrent.LinkedBlockingQueue
-import java.util.concurrent.TimeUnit
+import java.util.concurrent.*
 import java.util.concurrent.atomic.AtomicInteger
 import kotlin.test.*
 import kotlin.time.Duration.Companion.minutes
@@ -384,7 +379,7 @@ abstract class SustainabilityTestSuite<TEngine : ApplicationEngine, TConfigurati
 
     @OptIn(InternalAPI::class)
     @Test
-    fun testBigFile() = runTest(timeout = 3.minutes) {
+    fun testBigFile() = runTest(timeout = 1.minutes) {
         val file = File("build/large-file.dat")
         val rnd = Random()
 
@@ -408,7 +403,7 @@ abstract class SustainabilityTestSuite<TEngine : ApplicationEngine, TConfigurati
         }
 
         withUrl("/file") {
-            val (actualChecksum, actualCount) = body<InputStream>().crcWithSize()
+            val (actualChecksum, actualCount) = rawContent.crcWithSize()
             assertEquals(fileCount, actualCount, "Response size differs from file")
             assertEquals(fileChecksum, actualChecksum, "Response checksum differs from file")
         }
@@ -797,7 +792,7 @@ abstract class SustainabilityTestSuite<TEngine : ApplicationEngine, TConfigurati
         withUrl("/blocking/large") {
             assertEquals(HttpStatusCode.OK, status)
             assertEquals(ContentType.Text.Plain, contentType()?.withoutParameters())
-            val result = rawContent.toInputStream().crcWithSize()
+            val result = rawContent.crcWithSize()
             assertEquals(10000 * 13L, result.second)
         }
     }

--- a/ktor-server/ktor-server-test-suites/jvm/src/io/ktor/server/testing/suites/Utils.kt
+++ b/ktor-server/ktor-server-test-suites/jvm/src/io/ktor/server/testing/suites/Utils.kt
@@ -4,10 +4,15 @@
 
 package io.ktor.server.testing.suites
 
-import java.io.*
+import io.ktor.utils.io.*
+import java.io.BufferedReader
+import java.io.File
+import java.io.InputStream
 import java.util.*
-import java.util.zip.*
-import kotlin.test.*
+import java.util.zip.CRC32
+import kotlin.test.assertNotEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
 
 internal suspend fun assertFailsSuspend(block: suspend () -> Unit): Throwable {
     var exception: Throwable? = null
@@ -21,19 +26,22 @@ internal suspend fun assertFailsSuspend(block: suspend () -> Unit): Throwable {
     return exception
 }
 
-internal fun InputStream.crcWithSize(): Pair<Long, Long> {
+internal fun InputStream.crcWithSize(): Pair<Long, Long> = crcWithSize { read(it) }
+internal suspend fun ByteReadChannel.crcWithSize(): Pair<Long, Long> = crcWithSize { readAvailable(it) }
+
+private inline fun crcWithSize(readBytes: (ByteArray) -> Int): Pair<Long, Long> {
     val checksum = CRC32()
-    val bytes = ByteArray(8192)
+    val bytes = ByteArray(64 * 1024)
     var count = 0L
 
-    do {
-        val rc = read(bytes)
-        if (rc == -1) {
-            break
-        }
+    while (true) {
+        val rc = readBytes(bytes)
+        if (rc == -1) break
+        if (rc == 0) continue
+
         count += rc
         checksum.update(bytes, 0, rc)
-    } while (true)
+    }
 
     return checksum.value to count
 }


### PR DESCRIPTION
**Subsystem**
Tests

**Motivation**
Sometimes this test takes 2+ minutes on CI because of using blocking bridge, which can exhaust IO dispatcher.

**Solution**
Drop `toInputStream` and use `ReadByteChannel` directly.

