### PR TITLE
KTOR-9595 Fix ktor-network compatibility with jsBrowser and wasmJsBrowser

### DIFF
--- a/karma/chrome_bin.js
+++ b/karma/chrome_bin.js
@@ -14,27 +14,12 @@ config.set({
                 "--disable-web-security",
                 "--disable-setuid-sandbox",
                 "--use-mock-keychain",
+                "--password-store=basic",
                 "--enable-logging",
                 "--v=1",
                 "--use-fake-device-for-media-stream",
                 "--use-fake-ui-for-media-stream"
             ]
-        }
-    },
-    "client": {
-        captureConsole: true,
-        "mocha": {
-            // Disable timeout as we use individual timeouts for tests
-            timeout: 0
-        }
-    },
-    "webpack": {
-        // Workaround for Node.js built-in modules in browser tests.
-        // ktor-client-tests depends on ktor-network, which uses @JsModule("node:net") for Node.js socket support.
-        // Webpack cannot resolve the "node:" protocol in browser builds, so we stub it with an empty object.
-        // The Node.js socket code paths are not executed in browser tests anyway.
-        externals: {
-            'node:net': '{}'
         }
     }
 });

--- a/karma/config.js
+++ b/karma/config.js
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2014-2026 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+config.set({
+    client: {
+        captureConsole: true,
+        mocha: {
+            // Disable timeout as we use individual timeouts for tests
+            timeout: 0
+        }
+    },
+    webpack: {
+        // Workaround for Node.js built-in modules in browser tests.
+        // ktor-client-tests depends on ktor-network, which uses @JsModule("node:net") for Node.js socket support.
+        // Webpack cannot resolve the "node:" protocol in browser builds, so we stub it with an empty object.
+        // The Node.js socket code paths are not executed in browser tests anyway.
+        externals: {
+            'node:net': '{}'
+        }
+    }
+});

--- a/karma/config.js
+++ b/karma/config.js
@@ -9,14 +9,5 @@ config.set({
             // Disable timeout as we use individual timeouts for tests
             timeout: 0
         }
-    },
-    webpack: {
-        // Workaround for Node.js built-in modules in browser tests.
-        // ktor-client-tests depends on ktor-network, which uses @JsModule("node:net") for Node.js socket support.
-        // Webpack cannot resolve the "node:" protocol in browser builds, so we stub it with an empty object.
-        // The Node.js socket code paths are not executed in browser tests anyway.
-        externals: {
-            'node:net': '{}'
-        }
     }
 });

--- a/ktor-network/js/src/io/ktor/network/sockets/nodejs/node.net.js.kt
+++ b/ktor-network/js/src/io/ktor/network/sockets/nodejs/node.net.js.kt
@@ -5,8 +5,26 @@
 package io.ktor.network.sockets.nodejs
 
 import io.ktor.network.sockets.*
+import kotlinx.coroutines.await
 import org.khronos.webgl.ArrayBuffer
 import org.khronos.webgl.Int8Array
+import kotlin.js.Promise
+
+internal actual suspend fun loadNodeNet(): NodeNet = nodeNetPromise.await()
+    ?: throw UnsupportedOperationException("Module node:net is not available. Please verify that you are using Node.js")
+
+private val nodeNetPromise: Promise<NodeNet?> by lazy {
+    loadNodeModule(nodeNetModuleName())
+}
+
+// Keep the module name behind a function so browser bundlers don't resolve `node:net` statically.
+private fun nodeNetModuleName() = "node:net"
+
+@JsFun(
+    "moduleName => ((typeof process !== 'undefined') && process.release.name === 'node')" +
+        " ? import(moduleName) : Promise.resolve(null)"
+)
+private external fun loadNodeModule(moduleName: String): Promise<NodeNet?>
 
 internal actual fun TcpCreateConnectionOptions(
     block: TcpCreateConnectionOptions.() -> Unit

--- a/ktor-network/wasmJs/src/io/ktor/network/sockets/nodejs/node.net.wasmJs.kt
+++ b/ktor-network/wasmJs/src/io/ktor/network/sockets/nodejs/node.net.wasmJs.kt
@@ -10,6 +10,21 @@ import org.khronos.webgl.Uint8Array
 import org.khronos.webgl.get
 import org.khronos.webgl.set
 
+internal actual suspend fun loadNodeNet(): NodeNet = nodeNet
+
+private val nodeNet: NodeNet by lazy {
+    loadNodeNetModule()?.let { justCast<NodeNet>(it) }
+        ?: throw UnsupportedOperationException(
+            "Module node:net is not available. Please verify that you are using Node.js"
+        )
+}
+
+@JsFun(
+    "((module) => () => module)(((typeof process !== 'undefined') && process.release.name === 'node')" +
+        " ? await import(/* webpackIgnore: true */'node:net') : null)"
+)
+private external fun loadNodeNetModule(): JsAny?
+
 internal actual fun TcpCreateConnectionOptions(
     block: TcpCreateConnectionOptions.() -> Unit
 ): TcpCreateConnectionOptions = createObject(block)

--- a/ktor-network/web/src/io/ktor/network/sockets/SocketEngine.web.kt
+++ b/ktor-network/web/src/io/ktor/network/sockets/SocketEngine.web.kt
@@ -12,18 +12,24 @@ internal actual suspend fun tcpConnect(
     selector: SelectorManager,
     remoteAddress: SocketAddress,
     socketOptions: SocketOptions.TCPClientSocketOptions
-): Socket = suspendCancellableCoroutine { cont ->
-    val socket = nodeNet.createConnection(CreateConnectionOptions(remoteAddress, socketOptions))
-    SocketContext(socket, remoteAddress, null).initiate(cont)
+): Socket {
+    val nodeNet = loadNodeNet()
+    return suspendCancellableCoroutine { cont ->
+        val socket = nodeNet.createConnection(CreateConnectionOptions(remoteAddress, socketOptions))
+        SocketContext(socket, remoteAddress, null).initiate(cont)
+    }
 }
 
 internal actual suspend fun tcpBind(
     selector: SelectorManager,
     localAddress: SocketAddress?,
     socketOptions: SocketOptions.AcceptorOptions
-): ServerSocket = suspendCancellableCoroutine { cont ->
-    val server = nodeNet.createServer(CreateServerOptions {})
-    ServerSocketContext(server, localAddress, null).initiate(cont)
+): ServerSocket {
+    val nodeNet = loadNodeNet()
+    return suspendCancellableCoroutine { cont ->
+        val server = nodeNet.createServer(CreateServerOptions {})
+        ServerSocketContext(server, localAddress, null).initiate(cont)
+    }
 }
 
 internal actual suspend fun udpConnect(

--- a/ktor-network/web/src/io/ktor/network/sockets/nodejs/node.net.kt
+++ b/ktor-network/web/src/io/ktor/network/sockets/nodejs/node.net.kt
@@ -5,7 +5,6 @@
 package io.ktor.network.sockets.nodejs
 
 import io.ktor.network.sockets.*
-import kotlin.js.JsModule
 
 // js.Error
 internal external interface JsError {
@@ -25,8 +24,7 @@ internal external interface NodeNet {
     fun createServer(options: CreateServerOptions): Server
 }
 
-@JsModule("node:net")
-internal external val nodeNet: NodeNet
+internal expect suspend fun loadNodeNet(): NodeNet
 
 internal fun CreateConnectionOptions(
     remoteAddress: SocketAddress,


### PR DESCRIPTION
**Subsystem**
`ktor-network`

**Motivation**
[KTOR-9595](https://youtrack.jetbrains.com/issue/KTOR-9595) CIO: The engine imports `node:net` statically and breaks wasmJsBrowser webpack build

**Solution**
Use the approach with `await import` similar to [this commit](https://github.com/Kotlin/kotlinx-benchmark/commit/f7248c542778f87a8876e4c91913f6515b3c8368).

