### PR TITLE
KTOR-9607 Handle NoSuchMethodError for SecureRandom.getInstanceStrong() on older Android API levels

### DIFF
--- a/ktor-utils/jvm/src/io/ktor/util/Nonce.kt
+++ b/ktor-utils/jvm/src/io/ktor/util/Nonce.kt
@@ -137,6 +137,8 @@ private fun lookupSecureRandom(): SecureRandom {
         return SecureRandom.getInstanceStrong()
     } catch (_: NoSuchAlgorithmException) {
         // ignored
+    } catch (_: NoSuchMethodError) {
+        // SecureRandom.getInstanceStrong() is unavailable on older Android API levels
     }
 
     logger.warn("None of the JDK determined strong SecureRandom providers were available, falling back to the default")


### PR DESCRIPTION
**Subsystem**

ktor-utils

**Motivation**

https://youtrack.jetbrains.com/issue/KTOR-9607

