### PR TITLE
KTOR-9620 Some issues related to digest authentication in Ktor 3.5.0

### DIFF
--- a/ktor-client/ktor-client-plugins/ktor-client-auth/common/src/io/ktor/client/plugins/auth/providers/DigestAuthProvider.kt
+++ b/ktor-client/ktor-client-plugins/ktor-client-auth/common/src/io/ktor/client/plugins/auth/providers/DigestAuthProvider.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2014-2026 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package io.ktor.client.plugins.auth.providers
@@ -10,6 +10,7 @@ import io.ktor.client.statement.*
 import io.ktor.http.*
 import io.ktor.http.auth.*
 import io.ktor.util.*
+import io.ktor.util.logging.trace
 import io.ktor.utils.io.*
 import io.ktor.utils.io.charsets.*
 import io.ktor.utils.io.core.*
@@ -129,24 +130,24 @@ public class DigestAuthProvider(
 
     override fun isApplicable(auth: HttpAuthHeader): Boolean {
         if (auth !is HttpAuthHeader.Parameterized || auth.authScheme != AuthScheme.Digest) {
-            LOGGER.trace("Digest Auth Provider is not applicable for $auth")
+            LOGGER.trace { "Digest Auth Provider is not applicable for $auth" }
             return false
         }
 
         val newNonce = auth.parameter("nonce") ?: run {
-            LOGGER.trace("Digest Auth Provider can not handle response without nonce parameter")
+            LOGGER.trace { "Digest Auth Provider can not handle response without nonce parameter" }
             return false
         }
         val newQop = auth.parameter("qop")
         val newOpaque = auth.parameter("opaque")
 
         val newRealm = auth.parameter("realm") ?: run {
-            LOGGER.trace("Digest Auth Provider can not handle response without realm parameter")
+            LOGGER.trace { "Digest Auth Provider can not handle response without realm parameter" }
             return false
         }
         @Suppress("DEPRECATION_ERROR")
         if (newRealm != realm && realm != null) {
-            LOGGER.trace("Digest Auth Provider is not applicable for this realm")
+            LOGGER.trace { "Digest Auth Provider is not applicable for this realm" }
             return false
         }
 
@@ -154,7 +155,7 @@ public class DigestAuthProvider(
         val challengeAlgorithm = auth.parameter("algorithm") ?: "MD5"
         @Suppress("DEPRECATION_ERROR")
         if (!challengeAlgorithm.equals(algorithmName, ignoreCase = true)) {
-            LOGGER.trace("Digest Auth Provider is not applicable for algorithm $challengeAlgorithm")
+            LOGGER.trace { "Digest Auth Provider is not applicable for algorithm $challengeAlgorithm" }
             return false
         }
 

--- a/ktor-client/ktor-client-plugins/ktor-client-auth/common/src/io/ktor/client/plugins/auth/providers/DigestAuthProvider.kt
+++ b/ktor-client/ktor-client-plugins/ktor-client-auth/common/src/io/ktor/client/plugins/auth/providers/DigestAuthProvider.kt
@@ -150,6 +150,14 @@ public class DigestAuthProvider(
             return false
         }
 
+        // Per RFC 7616 §3.3: a missing algorithm parameter defaults to MD5.
+        val challengeAlgorithm = auth.parameter("algorithm") ?: "MD5"
+        @Suppress("DEPRECATION_ERROR")
+        if (!challengeAlgorithm.equals(algorithmName, ignoreCase = true)) {
+            LOGGER.trace("Digest Auth Provider is not applicable for algorithm $challengeAlgorithm")
+            return false
+        }
+
         serverNonce.value = newNonce
         qop.value = newQop
         opaque.value = newOpaque

--- a/ktor-client/ktor-client-plugins/ktor-client-auth/common/test/io/ktor/client/plugins/auth/AuthTest.kt
+++ b/ktor-client/ktor-client-plugins/ktor-client-auth/common/test/io/ktor/client/plugins/auth/AuthTest.kt
@@ -14,11 +14,17 @@ import io.ktor.client.statement.*
 import io.ktor.client.test.base.*
 import io.ktor.http.*
 import io.ktor.http.auth.*
-import io.ktor.test.dispatcher.*
+import io.ktor.util.*
 import io.ktor.utils.io.*
 import kotlinx.coroutines.*
+import kotlinx.coroutines.test.runTest
 import kotlinx.io.IOException
+import kotlin.concurrent.atomics.AtomicInt
+import kotlin.concurrent.atomics.ExperimentalAtomicApi
+import kotlin.concurrent.atomics.incrementAndFetch
+import kotlin.concurrent.atomics.update
 import kotlin.test.*
+import kotlin.time.Duration.Companion.milliseconds
 
 class AuthTest : ClientLoader() {
 
@@ -53,9 +59,7 @@ class AuthTest : ClientLoader() {
             }
         }
         test { client ->
-            client.get("$TEST_SERVER/auth/digest").let {
-                assertTrue(it.status.isSuccess())
-            }
+            assertTrue(client.get("$TEST_SERVER/auth/digest").status.isSuccess())
         }
     }
 
@@ -74,12 +78,8 @@ class AuthTest : ClientLoader() {
             }
         }
         test { client ->
-            client.get("$TEST_SERVER/auth/digest").let {
-                assertTrue(it.status.isSuccess())
-            }
-            client.get("$TEST_SERVER/auth/digest-2").let {
-                assertTrue(it.status.isSuccess())
-            }
+            assertTrue(client.get("$TEST_SERVER/auth/digest").status.isSuccess())
+            assertTrue(client.get("$TEST_SERVER/auth/digest-2").status.isSuccess())
         }
     }
 
@@ -98,6 +98,52 @@ class AuthTest : ClientLoader() {
             assertTrue(client.get("$TEST_SERVER/auth/digest-SHA256").status.isSuccess())
         }
     }
+
+    @Test
+    fun `digest client selects nonce from the challenge matching its configured algorithm`() =
+        testWithEngine(MockEngine) {
+            config {
+                if (!PlatformUtils.IS_NATIVE) {
+                    install(Auth) {
+                        digest {
+                            credentials { DigestAuthCredentials(username = "jetbrains", password = "foobar") }
+                            realm = "realm"
+                        }
+                    }
+                }
+                engine {
+                    addHandler { request ->
+                        if (request.headers[HttpHeaders.Authorization] == null) {
+                            // Initial request: respond with two challenges, SHA-512-256 first, MD5 second.
+                            respond(
+                                content = "",
+                                status = HttpStatusCode.Unauthorized,
+                                headers = Headers.build {
+                                    append(
+                                        HttpHeaders.WWWAuthenticate,
+                                        """Digest realm="realm", nonce="sha-nonce", algorithm=SHA-512-256, qop="auth""""
+                                    )
+                                    append(
+                                        HttpHeaders.WWWAuthenticate,
+                                        """Digest realm="realm", nonce="md5-nonce", algorithm=MD5, qop="auth""""
+                                    )
+                                }
+                            )
+                        } else {
+                            respond("OK", HttpStatusCode.OK)
+                        }
+                    }
+                }
+            }
+
+            if (PlatformUtils.IS_NATIVE) return@testWithEngine
+
+            test { client ->
+                val response = client.get("/")
+                val header = assertNotNull(response.call.request.headers[HttpHeaders.Authorization])
+                assertContains(header, "nonce=\"md5-nonce\"")
+            }
+        }
 
     @Suppress("DEPRECATION_ERROR")
     @Test
@@ -296,9 +342,10 @@ class AuthTest : ClientLoader() {
 
         test { client ->
             client.get("$TEST_SERVER/auth/basic-fixed")
-            client.post("$TEST_SERVER/auth/basic") { expectSuccess = false }.let {
-                assertEquals(HttpStatusCode.Unauthorized, it.status)
-            }
+            assertEquals(
+                HttpStatusCode.Unauthorized,
+                client.post("$TEST_SERVER/auth/basic") { expectSuccess = false }.status
+            )
         }
     }
 
@@ -323,9 +370,9 @@ class AuthTest : ClientLoader() {
     }
 
     @Test
-    fun testUsesFreshTokenIfAvailable() = testSuspend {
-        val request1FinishMonitor = Job()
-        val request2StartMonitor = Job()
+    fun testUsesFreshTokenIfAvailable() = runTest {
+        val request1FinishMonitor = CompletableDeferred<Unit>()
+        val request2StartMonitor = CompletableDeferred<Unit>()
         var refreshCount = 0
         val client = HttpClient(MockEngine) {
             install(Auth) {
@@ -354,12 +401,12 @@ class AuthTest : ClientLoader() {
 
                     when (request.url.encodedPath) {
                         "/url1" -> {
-                            request2StartMonitor.join()
+                            request2StartMonitor.await()
                             respond()
                         }
 
                         "/url2" -> {
-                            request1FinishMonitor.join()
+                            request1FinishMonitor.await()
                             respond()
                         }
 
@@ -368,18 +415,16 @@ class AuthTest : ClientLoader() {
                 }
             }
         }
-
-        val request1 = launch {
-            client.get("/url1")
-            request1FinishMonitor.complete()
+        coroutineScope {
+            launch {
+                client.get("/url1")
+                request1FinishMonitor.complete(Unit)
+            }
+            launch {
+                request2StartMonitor.complete(Unit)
+                client.get("/url2")
+            }
         }
-        val request2 = launch {
-            request2StartMonitor.complete()
-            client.get("/url2")
-        }
-
-        request1.join()
-        request2.join()
         assertEquals(1, refreshCount)
     }
 
@@ -424,7 +469,7 @@ class AuthTest : ClientLoader() {
         }
     }
 
-    // The return of refreshTokenFun is null, cause it should not be called at all, if loadTokensFun returns valid tokens
+    // The return of refreshTokenFun is null, cause it should not be called at all if loadTokensFun returns valid tokens
     @Test
     fun testUnauthorizedBearerAuthWithValidAccessTokenAndInvalidRefreshToken() = clientTests {
         config {
@@ -541,7 +586,6 @@ class AuthTest : ClientLoader() {
         }
     }
 
-    @Suppress("JoinDeclarationAndAssignment")
     @Test
     fun testRefreshWithSameClient() = clientTests {
         lateinit var clientWithAuth: HttpClient
@@ -567,7 +611,6 @@ class AuthTest : ClientLoader() {
         }
     }
 
-    @Suppress("JoinDeclarationAndAssignment")
     @Test
     fun testRefreshReplies401() = clientTests {
         lateinit var clientWithAuth: HttpClient
@@ -616,16 +659,16 @@ class AuthTest : ClientLoader() {
     }
 
     @Test
-    @OptIn(DelicateCoroutinesApi::class)
+    @OptIn(ExperimentalAtomicApi::class)
     fun testMultipleRefreshShouldMakeSingleCall() = clientTests {
-        var refreshRequestsCount = 0
+        val refreshRequestsCount = AtomicInt(0)
         config {
             install(Auth) {
                 bearer {
                     loadTokens { BearerTokens("first", "first") }
 
                     refreshTokens {
-                        refreshRequestsCount++
+                        refreshRequestsCount.incrementAndFetch()
                         val token = client.get("$TEST_SERVER/auth/bearer/token/second?delay=500").bodyAsText()
                         BearerTokens(token, token)
                     }
@@ -633,24 +676,24 @@ class AuthTest : ClientLoader() {
             }
         }
         test { client ->
-            refreshRequestsCount = 0
+            refreshRequestsCount.update { 0 }
             client.get("$TEST_SERVER/auth/bearer/first").bodyAsText()
 
-            val jobs = mutableListOf<Job>()
-            jobs += GlobalScope.launch {
-                val second = client.get("$TEST_SERVER/auth/bearer/second").bodyAsText()
-                assertEquals("OK", second)
+            withContext(Dispatchers.Default) {
+                launch {
+                    val second = client.get("$TEST_SERVER/auth/bearer/second").bodyAsText()
+                    assertEquals("OK", second)
+                }
+                launch {
+                    val second = client.get("$TEST_SERVER/auth/bearer/second").bodyAsText()
+                    assertEquals("OK", second)
+                }
+                launch {
+                    val second = client.get("$TEST_SERVER/auth/bearer/second").bodyAsText()
+                    assertEquals("OK", second)
+                }
             }
-            jobs += GlobalScope.launch {
-                val second = client.get("$TEST_SERVER/auth/bearer/second").bodyAsText()
-                assertEquals("OK", second)
-            }
-            jobs += GlobalScope.launch {
-                val second = client.get("$TEST_SERVER/auth/bearer/second").bodyAsText()
-                assertEquals("OK", second)
-            }
-            jobs.joinAll()
-            assertEquals(1, refreshRequestsCount)
+            assertEquals(1, refreshRequestsCount.load())
         }
     }
 
@@ -1204,7 +1247,7 @@ class AuthTest : ClientLoader() {
                                 serverRefreshToken = new.refresh
 
                                 tokensRenewed.complete(Unit)
-                                delay(250)
+                                delay(250.milliseconds)
 
                                 respond(
                                     content = ByteReadChannel(

--- a/ktor-client/ktor-client-plugins/ktor-client-auth/common/test/io/ktor/client/plugins/auth/DigestProviderTest.kt
+++ b/ktor-client/ktor-client-plugins/ktor-client-auth/common/test/io/ktor/client/plugins/auth/DigestProviderTest.kt
@@ -63,6 +63,17 @@ class DigestProviderTest {
     }
 
     @Test
+    fun `KTOR-9623 isApplicable rejects challenge whose algorithm does not match the configured one`() = runTest {
+        if (!PlatformUtils.IS_JVM) return@runTest
+
+        val sha512Challenge = parseAuthorizationHeader(
+            """Digest algorithm=SHA-512-256, realm="realm", nonce="sha-nonce""""
+        )!!
+
+        assertFalse(digestAuthProvider.isApplicable(sha512Challenge))
+    }
+
+    @Test
     fun addRequestHeadersSetsExpectedAuthHeaderFields() = runTest {
         if (!PlatformUtils.IS_JVM) return@runTest
 

--- a/ktor-client/ktor-client-plugins/ktor-client-auth/common/test/io/ktor/client/plugins/auth/DigestProviderTest.kt
+++ b/ktor-client/ktor-client-plugins/ktor-client-auth/common/test/io/ktor/client/plugins/auth/DigestProviderTest.kt
@@ -74,6 +74,38 @@ class DigestProviderTest {
     }
 
     @Test
+    fun `KTOR-9623 isApplicable accepts challenge with no algorithm parameter treating it as MD5`() = runTest {
+        if (!PlatformUtils.IS_JVM) return@runTest
+
+        val legacyChallenge = parseAuthorizationHeader(
+            """Digest realm="realm", nonce="legacy-nonce""""
+        )!!
+
+        assertTrue(digestAuthProvider.isApplicable(legacyChallenge))
+    }
+
+    @Test
+    fun `KTOR-9623 client uses nonce from the algorithm-matching challenge not from the first challenge`() = runTest {
+        if (!PlatformUtils.IS_JVM) return@runTest
+
+        val provider = DigestAuthProvider({ DigestAuthCredentials("username", "password") }, "realm")
+
+        val sha512Challenge = parseAuthorizationHeader(
+            """Digest algorithm=SHA-512-256, realm="realm", nonce="sha-nonce""""
+        )!!
+        val md5Challenge = parseAuthorizationHeader(
+            """Digest algorithm=MD5, realm="realm", nonce="md5-nonce""""
+        )!!
+
+        assertFalse(provider.isApplicable(sha512Challenge))
+        assertTrue(provider.isApplicable(md5Challenge))
+
+        provider.addRequestHeaders(requestBuilder, md5Challenge)
+
+        assertContains(requestBuilder.headers[HttpHeaders.Authorization]!!, """nonce="md5-nonce"""")
+    }
+
+    @Test
     fun addRequestHeadersSetsExpectedAuthHeaderFields() = runTest {
         if (!PlatformUtils.IS_JVM) return@runTest
 

--- a/ktor-client/ktor-client-plugins/ktor-client-auth/common/test/io/ktor/client/plugins/auth/DigestProviderTest.kt
+++ b/ktor-client/ktor-client-plugins/ktor-client-auth/common/test/io/ktor/client/plugins/auth/DigestProviderTest.kt
@@ -63,46 +63,44 @@ class DigestProviderTest {
     }
 
     @Test
-    fun `KTOR-9623 isApplicable rejects challenge whose algorithm does not match the configured one`() = runTest {
+    fun `isApplicable rejects challenge whose algorithm does not match the configured one`() = runTest {
         if (!PlatformUtils.IS_JVM) return@runTest
 
-        val sha512Challenge = parseAuthorizationHeader(
-            """Digest algorithm=SHA-512-256, realm="realm", nonce="sha-nonce""""
-        )!!
-
+        val sha512Challenge =
+            parseAuthorizationHeader("""Digest algorithm=SHA-512-256, realm="realm", nonce="sha-nonce"""")
+        assertNotNull(sha512Challenge)
         assertFalse(digestAuthProvider.isApplicable(sha512Challenge))
     }
 
     @Test
-    fun `KTOR-9623 isApplicable accepts challenge with no algorithm parameter treating it as MD5`() = runTest {
+    fun `isApplicable accepts challenge with no algorithm parameter treating it as MD5`() = runTest {
         if (!PlatformUtils.IS_JVM) return@runTest
 
-        val legacyChallenge = parseAuthorizationHeader(
-            """Digest realm="realm", nonce="legacy-nonce""""
-        )!!
-
+        val legacyChallenge = parseAuthorizationHeader("""Digest realm="realm", nonce="legacy-nonce"""")
+        assertNotNull(legacyChallenge)
         assertTrue(digestAuthProvider.isApplicable(legacyChallenge))
     }
 
     @Test
-    fun `KTOR-9623 client uses nonce from the algorithm-matching challenge not from the first challenge`() = runTest {
+    fun `client uses nonce from the algorithm-matching challenge not from the first challenge`() = runTest {
         if (!PlatformUtils.IS_JVM) return@runTest
 
         val provider = DigestAuthProvider({ DigestAuthCredentials("username", "password") }, "realm")
 
-        val sha512Challenge = parseAuthorizationHeader(
-            """Digest algorithm=SHA-512-256, realm="realm", nonce="sha-nonce""""
-        )!!
-        val md5Challenge = parseAuthorizationHeader(
-            """Digest algorithm=MD5, realm="realm", nonce="md5-nonce""""
-        )!!
-
+        val sha512Challenge =
+            parseAuthorizationHeader("""Digest algorithm=SHA-512-256, realm="realm", nonce="sha-nonce"""")
+        assertNotNull(sha512Challenge)
         assertFalse(provider.isApplicable(sha512Challenge))
+
+        val md5Challenge =
+            parseAuthorizationHeader("""Digest algorithm=MD5, realm="realm", nonce="md5-nonce"""")
+        assertNotNull(md5Challenge)
         assertTrue(provider.isApplicable(md5Challenge))
 
         provider.addRequestHeaders(requestBuilder, md5Challenge)
 
-        assertContains(requestBuilder.headers[HttpHeaders.Authorization]!!, """nonce="md5-nonce"""")
+        val header = assertNotNull(requestBuilder.headers[HttpHeaders.Authorization])
+        assertContains(header, """nonce="md5-nonce"""")
     }
 
     @Test

--- a/ktor-server/ktor-server-plugins/ktor-server-auth/common/src/io/ktor/server/auth/UnauthorizedResponse.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-auth/common/src/io/ktor/server/auth/UnauthorizedResponse.kt
@@ -21,7 +21,9 @@ public class UnauthorizedResponse(public vararg val challenges: HttpAuthHeader) 
 
     override val headers: Headers
         get() = if (challenges.isNotEmpty()) {
-            headersOf(HttpHeaders.WWWAuthenticate, challenges.joinToString(", ") { it.render() })
+            Headers.build {
+                challenges.forEach { challenge -> append(HttpHeaders.WWWAuthenticate, challenge.render()) }
+            }
         } else {
             Headers.Empty
         }

--- a/ktor-server/ktor-server-plugins/ktor-server-auth/jvm/src/io/ktor/server/auth/DigestCredential.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-auth/jvm/src/io/ktor/server/auth/DigestCredential.kt
@@ -230,7 +230,7 @@ public fun HttpAuthHeader.Parameterized.toDigestCredential(
 
     val charsetParam = parameter("charset")
     // only UTF-8 can be advertised though default charset is not specified in RFC 2617
-    require(charsetParam == null || charsetParam == Charsets.UTF_8.name()) {
+    require(charsetParam == null || charsetParam.equals(Charsets.UTF_8.name(), ignoreCase = true)) {
         "Unsupported charset in digest authentication header"
     }
 

--- a/ktor-server/ktor-server-plugins/ktor-server-auth/jvm/test/io/ktor/tests/auth/DigestRFC7616Test.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-auth/jvm/test/io/ktor/tests/auth/DigestRFC7616Test.kt
@@ -428,16 +428,17 @@ class DigestRFC7616Test {
     }
 
     @Test
-    fun `KTOR-9623 server sends one WWW-Authenticate header per algorithm`() = testApplication {
+    fun `server sends one WWW-Authenticate header per algorithm`() = testApplication {
         setupDigestAuth(algorithms = listOf(DigestAlgorithm.SHA_512_256, DigestAlgorithm.MD5))
 
         val response = client.get("/")
         assertEquals(HttpStatusCode.Unauthorized, response.status)
-        assertEquals(2, response.headers.getAll(HttpHeaders.WWWAuthenticate)?.size)
+        val headers = assertNotNull(response.headers.getAll(HttpHeaders.WWWAuthenticate))
+        assertEquals(2, headers.size)
     }
 
     @Test
-    fun `KTOR-9623 server accepts lowercase charset parameter in Authorization header`() = testApplication {
+    fun `server accepts lowercase charset parameter in Authorization header`() = testApplication {
         setupDigestAuth(algorithms = listOf(DigestAlgorithm.MD5))
 
         val challenge = client.get("/")
@@ -449,11 +450,9 @@ class DigestRFC7616Test {
         val response = credential.expectedDigest(HttpMethod.Get, ha1).toHexString()
 
         val authResponse = client.get("/") {
-            header(
-                HttpHeaders.Authorization,
-                buildAuthHeader("user", "test", nonce, "/", response, "MD5", "00000001", "testcnonce") +
-                    ", charset=utf-8"
-            )
+            val authorization = buildAuthHeader("user", "test", nonce, "/", response, "MD5", "00000001", "testcnonce") +
+                ", charset=utf-8"
+            header(HttpHeaders.Authorization, authorization)
         }
         assertEquals(HttpStatusCode.OK, authResponse.status)
     }

--- a/ktor-server/ktor-server-plugins/ktor-server-auth/jvm/test/io/ktor/tests/auth/DigestRFC7616Test.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-auth/jvm/test/io/ktor/tests/auth/DigestRFC7616Test.kt
@@ -427,6 +427,15 @@ class DigestRFC7616Test {
     }
 
     @Test
+    fun `KTOR-9623 server sends one WWW-Authenticate header per algorithm`() = testApplication {
+        setupDigestAuth(algorithms = listOf(DigestAlgorithm.SHA_512_256, DigestAlgorithm.MD5))
+
+        val response = client.get("/")
+        assertEquals(HttpStatusCode.Unauthorized, response.status)
+        assertEquals(2, response.headers.getAll(HttpHeaders.WWWAuthenticate)?.size)
+    }
+
+    @Test
     fun `KTOR-9623 server accepts lowercase charset parameter in Authorization header`() = testApplication {
         setupDigestAuth(algorithms = listOf(DigestAlgorithm.MD5))
 

--- a/ktor-server/ktor-server-plugins/ktor-server-auth/jvm/test/io/ktor/tests/auth/DigestRFC7616Test.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-auth/jvm/test/io/ktor/tests/auth/DigestRFC7616Test.kt
@@ -427,6 +427,28 @@ class DigestRFC7616Test {
     }
 
     @Test
+    fun `KTOR-9623 server accepts lowercase charset parameter in Authorization header`() = testApplication {
+        setupDigestAuth(algorithms = listOf(DigestAlgorithm.MD5))
+
+        val challenge = client.get("/")
+        assertEquals(HttpStatusCode.Unauthorized, challenge.status)
+        val nonce = Regex("""nonce="([^"]+)"""").find(challenge.headers[HttpHeaders.WWWAuthenticate]!!)!!.groupValues[1]
+
+        val ha1 = computeHA1("user", "test", "pass", DigestAlgorithm.MD5)
+        val credential = createCredential("test", "user", "/", nonce, "MD5", "testcnonce")
+        val response = credential.expectedDigest(HttpMethod.Get, ha1).toHexString()
+
+        val authResponse = client.get("/") {
+            header(
+                HttpHeaders.Authorization,
+                buildAuthHeader("user", "test", nonce, "/", response, "MD5", "00000001", "testcnonce") +
+                    ", charset=utf-8"
+            )
+        }
+        assertEquals(HttpStatusCode.OK, authResponse.status)
+    }
+
+    @Test
     fun testCharsetUTF8InChallenge() = testApplication {
         setupDigestAuth()
 

--- a/ktor-server/ktor-server-plugins/ktor-server-auth/jvm/test/io/ktor/tests/auth/DigestRFC7616Test.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-auth/jvm/test/io/ktor/tests/auth/DigestRFC7616Test.kt
@@ -341,6 +341,7 @@ class DigestRFC7616Test {
         val response = client.get("/")
         assertEquals(HttpStatusCode.Unauthorized, response.status)
         val challenges = response.headers.getAll(HttpHeaders.WWWAuthenticate)!!
+        assertEquals(2, challenges.size)
         assertTrue(challenges.any { it.contains("algorithm=SHA-256") })
         assertTrue(challenges.any { it.contains("algorithm=MD5") })
     }


### PR DESCRIPTION
**Subsystem**
Server

**Motivation**
[KTOR-9620](https://youtrack.jetbrains.com/issue/KTOR-9620) Some issues related to digest authentication in Ktor 3.5.0

[KTOR-9624](https://youtrack.jetbrains.com/issue/KTOR-9624) Digest Auth: "Unsupported charset in digest authentication header" for a charset name in lowercase
The RFC7616 says only the "UTF-8" value is allowed, but parameters in HTTP are case-insensitive

[KTOR-9624](https://youtrack.jetbrains.com/issue/KTOR-9624) Digest Auth: "Unsupported charset in digest authentication header" for a charset name in lowercase

[KTOR-9630](https://youtrack.jetbrains.com/issue/KTOR-9630) Digest Auth: The plugin sends incorrect nonce when server responds with multiple WWW-Authenticate headers

Solution:

- The server now accepts charset=utf-8 in lowercase
- The server now emits a separate WWW-Authenticate header for each Digest algorithm instead of joining them into one ambiguous comma-separated value
- The client now rejects challenges whose algorithm parameter doesn't match its configured algorithmName, so it picks the nonce from the correct challenge rather than the first one.



