### PR TITLE
KTOR-9614 Zstd: Use streaming API for encoding

### DIFF
--- a/ktor-shared/ktor-encoding-zstd/jvm/src/io/ktor/encoding/zstd/Zstd.jvm.kt
+++ b/ktor-shared/ktor-encoding-zstd/jvm/src/io/ktor/encoding/zstd/Zstd.jvm.kt
@@ -4,6 +4,7 @@
 
 package io.ktor.encoding.zstd
 
+import com.github.luben.zstd.EndDirective
 import com.github.luben.zstd.ZstdCompressCtx
 import com.github.luben.zstd.ZstdDecompressCtx
 import io.ktor.util.*
@@ -102,15 +103,26 @@ public class Zstd(private val compressionLevel: Int) : Encoder {
         try {
             while (!isClosedForRead) {
                 inputBuf.clear()
-                outputBuf.clear()
                 val bytesRead = readAvailable(inputBuf)
                 if (bytesRead <= 0) continue
                 inputBuf.flip()
 
-                ctx.compress(outputBuf, inputBuf)
-                outputBuf.flip()
-                destination.writeFully(outputBuf)
+                while (inputBuf.hasRemaining()) {
+                    outputBuf.clear()
+                    ctx.compressDirectByteBufferStream(outputBuf, inputBuf, EndDirective.CONTINUE)
+                    outputBuf.flip()
+                    if (outputBuf.hasRemaining()) destination.writeFully(outputBuf)
+                }
             }
+
+            inputBuf.clear()
+            inputBuf.flip()
+            do {
+                outputBuf.clear()
+                val finished = ctx.compressDirectByteBufferStream(outputBuf, inputBuf, EndDirective.END)
+                outputBuf.flip()
+                if (outputBuf.hasRemaining()) destination.writeFully(outputBuf)
+            } while (!finished)
         } finally {
             ctx.close()
             pool.recycle(inputBuf)

--- a/ktor-shared/ktor-encoding-zstd/jvm/test/io/ktor/encoding/zstd/ZstdTest.kt
+++ b/ktor-shared/ktor-encoding-zstd/jvm/test/io/ktor/encoding/zstd/ZstdTest.kt
@@ -9,7 +9,10 @@ import io.ktor.util.cio.*
 import io.ktor.utils.io.*
 import io.ktor.utils.io.pool.*
 import kotlinx.coroutines.test.runTest
+import kotlinx.io.readByteArray
+import kotlin.random.Random
 import kotlin.test.Test
+import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
 
 /**
@@ -20,9 +23,26 @@ private const val DEFAULT_BUFFER_SIZE = 4098
 class ZstdTest {
 
     @Test
+    fun `encode handles incompressible payload close to buffer size`() = runTest {
+        val bytes = Random(0).nextBytes(DEFAULT_BUFFER_SIZE)
+
+        val encodedReadChannel = encodeBytes(bytes)
+        val decodedReadChannel = ZstdEncoder().decode(encodedReadChannel)
+        val decodedBytes = decodedReadChannel.readRemaining().readByteArray()
+
+        assertContentEquals(bytes, decodedBytes)
+    }
+
+    @Test
     fun `decode handles payload split into multiple zstd frames`() = runTest {
-        val string = "zstd".repeat(DEFAULT_BUFFER_SIZE)
-        val encodedReadChannel = ZstdEncoder().encode(ByteReadChannel(string.toByteArray()))
+        val firstPart = "zstd".repeat(DEFAULT_BUFFER_SIZE)
+        val secondPart = "ktor".repeat(DEFAULT_BUFFER_SIZE)
+        val string = firstPart + secondPart
+
+        val firstFrame = encodeString(firstPart).readRemaining().readByteArray()
+        val secondFrame = encodeString(secondPart).readRemaining().readByteArray()
+
+        val encodedReadChannel = ByteReadChannel(firstFrame + secondFrame)
         val decodedReadChannel = ZstdEncoder().decode(encodedReadChannel)
         val decodedString = decodedReadChannel.readRemaining().readText()
 
@@ -33,7 +53,7 @@ class ZstdTest {
     fun `decode handles zstd frames that span multiple buffer reads`() = runTest {
         val string = "zstd".repeat(DEFAULT_BUFFER_SIZE)
 
-        val encodedReadChannel = Zstd(DEFAULT_COMPRESSION_LEVEL).encode(ByteReadChannel(string.toByteArray()))
+        val encodedReadChannel = encodeString(string)
         val decodedReadChannel = ByteChannel()
         with(Zstd(DEFAULT_COMPRESSION_LEVEL)) {
             // the absolute smallest possible zstd frame is 6 bytes,
@@ -46,3 +66,6 @@ class ZstdTest {
         assertEquals(string, decodedString)
     }
 }
+
+private fun encodeString(string: String): ByteReadChannel = encodeBytes(string.toByteArray())
+private fun encodeBytes(bytes: ByteArray): ByteReadChannel = ZstdEncoder().encode(ByteReadChannel(bytes))


### PR DESCRIPTION
**Subsystem**
`ktor-encoding-zstd`

**Motivation**
[KTOR-9614](https://youtrack.jetbrains.com/issue/KTOR-9614) Zstd Compression: "Destination buffer is too small" exception for a particular sequence of bytes

**Solution**
Use zstd-jni streaming compression API instead of one-shot compression into a fixed-size direct buffer. This allows compressed output to span multiple pooled buffers and avoids `Destination buffer is too small` for incompressible chunks.

Also added regression coverage for near-buffer-size incompressible payloads and improved the test for concatenated zstd frames.