### PR TITLE
Cherry-pick patch fixes to release/3.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,66 @@
+# 3.5.0
+> Published 14 May 2026
+
+### Features
+* [KTOR-8421](https://youtrack.jetbrains.com/issue/KTOR-8421) Route.contentType should support multiple ContentType
+* [KTOR-7961](https://youtrack.jetbrains.com/issue/KTOR-7961) Add known TDM headers to the HttpHeaders object
+* [KTOR-9418](https://youtrack.jetbrains.com/issue/KTOR-9418) Support getAs from the root ApplicationConfig
+* [KTOR-9559](https://youtrack.jetbrains.com/issue/KTOR-9559) DNS configuration for the Apache5 client
+* [KTOR-9554](https://youtrack.jetbrains.com/issue/KTOR-9554) DNS configuration for OkHttp client engine
+* [KTOR-9555](https://youtrack.jetbrains.com/issue/KTOR-9555) Custom SSE heartbeat function
+* [KTOR-8914](https://youtrack.jetbrains.com/issue/KTOR-8914) Dependency injection: read annotations in function references
+* [KTOR-8300](https://youtrack.jetbrains.com/issue/KTOR-8300) Sessions: Add a way to create a user session shared for all user devices or look up sessions of the same user
+* [KTOR-9521](https://youtrack.jetbrains.com/issue/KTOR-9521) Upgrade to Kotlin 2.3.21
+* [KTOR-9276](https://youtrack.jetbrains.com/issue/KTOR-9276) Make DynamicProviderConfig.authenticateFunction suspend
+* [KTOR-9491](https://youtrack.jetbrains.com/issue/KTOR-9491) Provide parameter validation convenience functions
+* [KTOR-9506](https://youtrack.jetbrains.com/issue/KTOR-9506) OpenAPI: Support prefixItems in JsonSchema for tuple type definitions
+* [KTOR-470](https://youtrack.jetbrains.com/issue/KTOR-470) Add an option to not resend the session cookie if the session data wasn't changed.
+* [KTOR-9355](https://youtrack.jetbrains.com/issue/KTOR-9355) Deprecate HttpHeaders.AcceptCharset
+* [KTOR-7659](https://youtrack.jetbrains.com/issue/KTOR-7659) Make ktor-network compatible with ES modules for nodejs
+* [KTOR-9350](https://youtrack.jetbrains.com/issue/KTOR-9350) JS: Make ES2015 the default target for tests
+* [KTOR-7578](https://youtrack.jetbrains.com/issue/KTOR-7578) Update Digest authentication implementation according to RFC 7616
+
+### Improvements
+* [KTOR-9503](https://youtrack.jetbrains.com/issue/KTOR-9503) The JacksonConverter.streamRequestBody property name is confusing
+* [KTOR-9552](https://youtrack.jetbrains.com/issue/KTOR-9552) Deprecation notice for io.ktor.server.auth.Principal does not explain what to use instead
+* [KTOR-7458](https://youtrack.jetbrains.com/issue/KTOR-7458) Jetty Jakarta: Provide an easy way to disable SNI hostname validation
+* [KTOR-9354](https://youtrack.jetbrains.com/issue/KTOR-9354) Websockets: webSocket builder function should return a Route to be describable
+* [KTOR-9488](https://youtrack.jetbrains.com/issue/KTOR-9488) Nonce and hex function performance optimizations
+
+### Bugfixes
+* [KTOR-9524](https://youtrack.jetbrains.com/issue/KTOR-9524) Netty response hangs after connection lost
+* [KTOR-9542](https://youtrack.jetbrains.com/issue/KTOR-9542) Netty: The request handler runs on worker event loop instead of call event loop since 3.4.3
+* [KTOR-9531](https://youtrack.jetbrains.com/issue/KTOR-9531) Netty server intermittently drops requests after upgrading to 3.4.3
+* [KTOR-8151](https://youtrack.jetbrains.com/issue/KTOR-8151) MicrometerMetrics: "MeterFilters configured after a Meter has been registered" warning when a metric is registered before installing the plugin
+* [KTOR-9411](https://youtrack.jetbrains.com/issue/KTOR-9411) Darwin throws DarwinHttpRequestException instead of FrameTooBigException
+* [KTOR-8320](https://youtrack.jetbrains.com/issue/KTOR-8320) CallLogging: plugin usage in testApplication breaks console standard output
+* [KTOR-8906](https://youtrack.jetbrains.com/issue/KTOR-8906) Jackson, with request body streaming on, exhausts Dispatchers.IO
+* [KTOR-8709](https://youtrack.jetbrains.com/issue/KTOR-8709) Websockets: Unable to close session with a custom CloseReason
+* [KTOR-9567](https://youtrack.jetbrains.com/issue/KTOR-9567) Flaky UnixSockets on Windows: WSAEOPNOTSUPP from bind()
+* [KTOR-9183](https://youtrack.jetbrains.com/issue/KTOR-9183) A client call wrapped with `withTimeout` throws a generic CancellationException instead of TimeoutCancellationException
+* [KTOR-8199](https://youtrack.jetbrains.com/issue/KTOR-8199) Autoreloading: default watch patterns don't match anything when project path contain spaces
+* [KTOR-9549](https://youtrack.jetbrains.com/issue/KTOR-9549) Kotlin/JS: ktor-ktor-client-core.mjs is incompatible with Vite: toRaw naming conflict
+* [KTOR-9544](https://youtrack.jetbrains.com/issue/KTOR-9544) Apache: body channel not cancelled when caller scope is cancelled
+* [KTOR-9546](https://youtrack.jetbrains.com/issue/KTOR-9546) HttpClient: cancelling ByteReadChannel body does not propagate to engine
+* [KTOR-455](https://youtrack.jetbrains.com/issue/KTOR-455) Content-Disposition additional parameters should be inside quotes
+* [KTOR-9500](https://youtrack.jetbrains.com/issue/KTOR-9500) RawSourceChannel returns false positive on awaitContent
+* [KTOR-646](https://youtrack.jetbrains.com/issue/KTOR-646) Netty engine still print annoying exceptions
+* [KTOR-9527](https://youtrack.jetbrains.com/issue/KTOR-9527) Curl: Freeze when receiving large responses
+* [KTOR-9460](https://youtrack.jetbrains.com/issue/KTOR-9460) Curl: Can't build shared library with Ktor 3.4.2
+* [KTOR-9483](https://youtrack.jetbrains.com/issue/KTOR-9483) Curl: backpressure implementation is never used
+* [KTOR-9545](https://youtrack.jetbrains.com/issue/KTOR-9545) Curl: body channel not cancelled when caller scope is cancelled
+* [KTOR-9540](https://youtrack.jetbrains.com/issue/KTOR-9540) Curl: CancelWebSocket task may cancel a new HTTP request due to easy handle pointer reuse
+* [KTOR-9539](https://youtrack.jetbrains.com/issue/KTOR-9539) Curl: WebSocket bearer token refresh fails due to stale native handle reuse
+* [KTOR-9536](https://youtrack.jetbrains.com/issue/KTOR-9536) Netty call hang when channel becomes inactive before response is sent
+* [KTOR-4752](https://youtrack.jetbrains.com/issue/KTOR-4752) OkHttp: Websockets pinging doesn't work
+* [KTOR-9409](https://youtrack.jetbrains.com/issue/KTOR-9409) call.respond performance regression caused by transitive kotlin-reflect:2.3.0
+* [KTOR-9487](https://youtrack.jetbrains.com/issue/KTOR-9487) ZSTD decoder fails if the compressed frame is larger than 4096 bytes
+* [KTOR-8271](https://youtrack.jetbrains.com/issue/KTOR-8271) MockEngine, HttpTimeout: the virtual clock of kotlinx coroutines isn't respected
+* [KTOR-6683](https://youtrack.jetbrains.com/issue/KTOR-6683) Plugin onCallReceive/transformBody is not called for receive<ByteArray>()
+* [KTOR-7416](https://youtrack.jetbrains.com/issue/KTOR-7416) Jetty, Java: Custom Host header doesn't override the default value
+* [KTOR-9203](https://youtrack.jetbrains.com/issue/KTOR-9203) CIOMultipartDataBase: Call thread is blocked when releasing file parts
+
+
 # 3.4.3
 > Published 22 April 2026
 

--- a/ktor-server/ktor-server-plugins/ktor-server-sessions/jvm/src/io/ktor/server/sessions/SessionTransportTransformerEncrypt.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-sessions/jvm/src/io/ktor/server/sessions/SessionTransportTransformerEncrypt.kt
@@ -56,9 +56,16 @@ public class SessionTransportTransformerEncrypt(
      */
     public val encryptionKeySize: Int get() = encryptionKeySpec.encoded.size
 
+    // AES CBC IV length always equals the cipher block size (16 bytes for AES),
+    // regardless of the key length. Using encryptionKeySize here used to break AES-256.
+    private val ivSize: Int = when (encryptionKeySpec.algorithm.uppercase()) {
+        "AES" -> 16
+        else -> Cipher.getInstance("$encryptAlgorithm/CBC/PKCS5PADDING").blockSize
+    }
+
     // Check that input keys are right
     init {
-        encrypt(ivGenerator(encryptionKeySize), byteArrayOf())
+        encrypt(ivGenerator(ivSize), byteArrayOf())
         mac(byteArrayOf())
     }
 
@@ -105,7 +112,7 @@ public class SessionTransportTransformerEncrypt(
     }
 
     override fun transformWrite(transportValue: String): String {
-        val iv = ivGenerator(encryptionKeySize)
+        val iv = ivGenerator(ivSize)
         val decrypted = transportValue.toByteArray(charset)
         val encrypted = encrypt(iv, decrypted)
         val mac = mac(encrypted)

--- a/ktor-server/ktor-server-plugins/ktor-server-sessions/jvm/test/io/ktor/tests/sessions/SessionTransportTransformerEncryptTest.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-sessions/jvm/test/io/ktor/tests/sessions/SessionTransportTransformerEncryptTest.kt
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2014-2026 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.tests.sessions
+
+import io.ktor.server.sessions.*
+import javax.crypto.spec.SecretKeySpec
+import kotlin.test.*
+
+class SessionTransportTransformerEncryptTest {
+
+    @Test
+    fun `accepts 32-byte AES-256 encryption key`() {
+        // AES-CBC requires a 16-byte IV regardless of key length. Constructing the transformer
+        // with a 32-byte key used to fail with InvalidAlgorithmParameterException because the
+        // IV was generated using the key size instead of the cipher block size.
+        SessionTransportTransformerEncrypt(ByteArray(32), ByteArray(32))
+    }
+
+    @Test
+    fun `transformWrite generates 16-byte IV for AES-256`() {
+        val transformer = SessionTransportTransformerEncrypt(ByteArray(32), ByteArray(32))
+        val encoded = transformer.transformWrite("hello")
+        val iv = encoded.substringBefore('/').hexToByteArray()
+        assertEquals(16, iv.size)
+    }
+
+    @Test
+    fun `round-trip preserves payload for AES-128, AES-192 and AES-256`() {
+        for (keyLength in intArrayOf(16, 24, 32)) {
+            val transformer = SessionTransportTransformerEncrypt(ByteArray(keyLength), ByteArray(32))
+            val original = "session-value-$keyLength"
+            val encoded = transformer.transformWrite(original)
+            val decoded = transformer.transformRead(encoded)
+            assertEquals(original, decoded, "round-trip failed for AES-${keyLength * 8}")
+        }
+    }
+
+    @Test
+    fun `uses cipher block size for non-AES algorithm (DESede)`() {
+        val encryptionKeySpec = SecretKeySpec(ByteArray(24), "DESede")
+        val signKeySpec = SecretKeySpec(ByteArray(32), "HmacSHA256")
+
+        val transformer = SessionTransportTransformerEncrypt(
+            encryptionKeySpec = encryptionKeySpec,
+            signKeySpec = signKeySpec,
+        )
+
+        val original = "non-aes-session-value"
+        val encoded = transformer.transformWrite(original)
+        val iv = encoded.substringBefore('/').hexToByteArray()
+
+        assertEquals(8, iv.size, "DESede should use an 8-byte IV matching its block size")
+        assertEquals(original, transformer.transformRead(encoded))
+    }
+}

--- a/ktor-shared/ktor-openapi-schema/common/src/io/ktor/openapi/JsonSchemaInference.kt
+++ b/ktor-shared/ktor-openapi-schema/common/src/io/ktor/openapi/JsonSchemaInference.kt
@@ -11,6 +11,7 @@ import io.ktor.utils.io.*
 import kotlinx.serialization.*
 import kotlinx.serialization.descriptors.*
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonClassDiscriminator
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.modules.EmptySerializersModule
 import kotlinx.serialization.modules.SerializersModule
@@ -192,7 +193,10 @@ public class KotlinxSerializerJsonSchemaInference(
 
             PolymorphicKind.SEALED -> {
                 if (descriptor.elementsCount == 2) {
-                    val discriminatorProperty = descriptor.getElementName(0)
+                    val discriminatorProperty = descriptor.annotations
+                        .filterIsInstance<JsonClassDiscriminator>()
+                        .firstOrNull()?.discriminator
+                        ?: descriptor.getElementName(0)
                     val sealedElementsDescriptor = descriptor.getElementDescriptor(1)
                     val sealedSubclassComponentNames = sealedSubclassComponentNameMapping(serializer)
                     val sealedElementsSchema = (0..<sealedElementsDescriptor.elementsCount)

--- a/ktor-shared/ktor-openapi-schema/ktor-openapi-schema-reflect/api/ktor-openapi-schema-reflect.api
+++ b/ktor-shared/ktor-openapi-schema/ktor-openapi-schema-reflect/api/ktor-openapi-schema-reflect.api
@@ -11,6 +11,7 @@ public final class io/ktor/openapi/reflect/ReflectionJsonSchemaInference$Compani
 }
 
 public abstract interface class io/ktor/openapi/reflect/SchemaReflectionAdapter {
+	public fun getDiscriminatorProperty (Lkotlin/reflect/KClass;)Ljava/lang/String;
 	public fun getName (Lkotlin/reflect/KProperty1;)Ljava/lang/String;
 	public fun getName (Lkotlin/reflect/KType;)Ljava/lang/String;
 	public fun getProperties (Lkotlin/reflect/KClass;)Ljava/util/Collection;
@@ -19,6 +20,7 @@ public abstract interface class io/ktor/openapi/reflect/SchemaReflectionAdapter 
 }
 
 public final class io/ktor/openapi/reflect/SchemaReflectionAdapter$DefaultImpls {
+	public static fun getDiscriminatorProperty (Lio/ktor/openapi/reflect/SchemaReflectionAdapter;Lkotlin/reflect/KClass;)Ljava/lang/String;
 	public static fun getName (Lio/ktor/openapi/reflect/SchemaReflectionAdapter;Lkotlin/reflect/KProperty1;)Ljava/lang/String;
 	public static fun getName (Lio/ktor/openapi/reflect/SchemaReflectionAdapter;Lkotlin/reflect/KType;)Ljava/lang/String;
 	public static fun getProperties (Lio/ktor/openapi/reflect/SchemaReflectionAdapter;Lkotlin/reflect/KClass;)Ljava/util/Collection;

--- a/ktor-shared/ktor-openapi-schema/ktor-openapi-schema-reflect/build.gradle.kts
+++ b/ktor-shared/ktor-openapi-schema/ktor-openapi-schema-reflect/build.gradle.kts
@@ -20,6 +20,7 @@ kotlin {
         }
         jvmTest.dependencies {
             implementation(libs.kaml.serialization)
+            implementation(libs.kotlinx.serialization.json)
         }
     }
 }

--- a/ktor-shared/ktor-openapi-schema/ktor-openapi-schema-reflect/jvm/src/io/ktor/openapi/reflect/JsonSchemaInference.jvm.kt
+++ b/ktor-shared/ktor-openapi-schema/ktor-openapi-schema-reflect/jvm/src/io/ktor/openapi/reflect/JsonSchemaInference.jvm.kt
@@ -83,6 +83,17 @@ public interface SchemaReflectionAdapter {
      */
     public fun isNullable(type: KType): Boolean =
         type.isMarkedNullable
+
+    /**
+     * Returns the discriminator property name for the given sealed [kClass].
+     * By default, returns `"type"`.
+     *
+     * Override this to support serialization-framework-specific discriminator annotations,
+     * for example `@JsonClassDiscriminator` from kotlinx.serialization.
+     *
+     * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.openapi.reflect.SchemaReflectionAdapter.getDiscriminatorProperty)
+     */
+    public fun getDiscriminatorProperty(kClass: KClass<*>): String = "type"
 }
 
 /**
@@ -222,13 +233,14 @@ public class ReflectionJsonSchemaInference(
                         subclass.qualifiedName!! to "#/components/schemas/${subclass.qualifiedName}"
                     }
 
+                val discriminatorProperty = adapter.getDiscriminatorProperty(kClass)
                 return jsonSchemaFromAnnotations(
                     title = typeName,
                     annotations = includeAnnotations + kClass.annotations,
                     reflectSchema = ::schemaRefForClass,
                     type = JsonType.OBJECT.wrapIfNullable(nullable),
                     oneOf = sealedSubclassSchema,
-                    discriminator = JsonSchemaDiscriminator("type", discriminatorMapping),
+                    discriminator = JsonSchemaDiscriminator(discriminatorProperty, discriminatorMapping),
                 )
             }
 

--- a/ktor-shared/ktor-openapi-schema/ktor-openapi-schema-reflect/jvm/test-resources/schema/KindShape.kotlinx.yaml
+++ b/ktor-shared/ktor-openapi-schema/ktor-openapi-schema-reflect/jvm/test-resources/schema/KindShape.kotlinx.yaml
@@ -1,0 +1,25 @@
+type: object
+title: io.ktor.openapi.reflect.KindShape
+oneOf:
+  - type: object
+    title: io.ktor.openapi.reflect.KindShape.Circle
+    required:
+      - radius
+    properties:
+      radius:
+        type: number
+  - type: object
+    title: io.ktor.openapi.reflect.KindShape.Rectangle
+    required:
+      - width
+      - height
+    properties:
+      width:
+        type: number
+      height:
+        type: number
+discriminator:
+  propertyName: kind
+  mapping:
+    circle: "#/components/schemas/io.ktor.openapi.reflect.KindShape.Circle"
+    rectangle: "#/components/schemas/io.ktor.openapi.reflect.KindShape.Rectangle"

--- a/ktor-shared/ktor-openapi-schema/ktor-openapi-schema-reflect/jvm/test-resources/schema/KindShape.yaml
+++ b/ktor-shared/ktor-openapi-schema/ktor-openapi-schema-reflect/jvm/test-resources/schema/KindShape.yaml
@@ -1,0 +1,25 @@
+type: object
+title: io.ktor.openapi.reflect.KindShape
+oneOf:
+  - type: object
+    title: io.ktor.openapi.reflect.KindShape.Circle
+    required:
+      - radius
+    properties:
+      radius:
+        type: number
+  - type: object
+    title: io.ktor.openapi.reflect.KindShape.Rectangle
+    required:
+      - width
+      - height
+    properties:
+      width:
+        type: number
+      height:
+        type: number
+discriminator:
+  propertyName: kind
+  mapping:
+    io.ktor.openapi.reflect.KindShape.Circle: "#/components/schemas/io.ktor.openapi.reflect.KindShape.Circle"
+    io.ktor.openapi.reflect.KindShape.Rectangle: "#/components/schemas/io.ktor.openapi.reflect.KindShape.Rectangle"

--- a/ktor-shared/ktor-openapi-schema/ktor-openapi-schema-reflect/jvm/test/io/ktor/openapi/reflect/AbstractSchemaInferenceTest.kt
+++ b/ktor-shared/ktor-openapi-schema/ktor-openapi-schema-reflect/jvm/test/io/ktor/openapi/reflect/AbstractSchemaInferenceTest.kt
@@ -9,8 +9,11 @@ import com.charleskorn.kaml.Yaml
 import com.charleskorn.kaml.YamlConfiguration
 import io.ktor.openapi.*
 import io.ktor.openapi.JsonSchema.*
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.JsonClassDiscriminator
 import kotlin.reflect.typeOf
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -45,6 +48,10 @@ abstract class AbstractSchemaInferenceTest(
     @Test
     fun `sealed type inference`() =
         assertSchemaMatches<Shape>()
+
+    @Test
+    fun `custom discriminator annotation with serial names`() =
+        assertSchemaMatches<KindShape>()
 
     @Test
     fun `advanced container annotations`() =
@@ -413,3 +420,16 @@ data class Page<out E>(
     val items: List<E>,
     val total: Int,
 )
+
+@OptIn(ExperimentalSerializationApi::class)
+@JsonClassDiscriminator("kind")
+@Serializable
+sealed interface KindShape {
+    @Serializable
+    @SerialName("circle")
+    data class Circle(val radius: Double) : KindShape
+
+    @Serializable
+    @SerialName("rectangle")
+    data class Rectangle(val width: Double, val height: Double) : KindShape
+}

--- a/ktor-shared/ktor-openapi-schema/ktor-openapi-schema-reflect/jvm/test/io/ktor/openapi/reflect/ReflectionJsonSchemaInferenceTest.kt
+++ b/ktor-shared/ktor-openapi-schema/ktor-openapi-schema-reflect/jvm/test/io/ktor/openapi/reflect/ReflectionJsonSchemaInferenceTest.kt
@@ -4,6 +4,9 @@
 
 package io.ktor.openapi.reflect
 
+import io.ktor.openapi.*
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.json.JsonClassDiscriminator
 import kotlin.reflect.KClass
 import kotlin.reflect.KProperty1
 import kotlin.reflect.full.memberProperties
@@ -19,6 +22,11 @@ class ReflectionJsonSchemaInferenceTest : AbstractSchemaInferenceTest(
             val props = kClass.memberProperties.associateBy { it.name }
             return constructorParams.mapNotNull { props[it] }
         }
+
+        @OptIn(ExperimentalSerializationApi::class)
+        override fun getDiscriminatorProperty(kClass: KClass<*>): String =
+            kClass.annotations.filterIsInstance<JsonClassDiscriminator>().firstOrNull()?.discriminator
+                ?: super.getDiscriminatorProperty(kClass)
     }),
     "reflect"
 )


### PR DESCRIPTION
## Changes

Cherry-picks to `release/3.x`:

- Add changelog for 3.5.0 (#5621)
- KTOR-9425 Use cipher block size for session IV (#5636)
- KTOR-9591 Fix @JsonClassDiscriminator being ignored for sealed types in OpenAPI schema (#5628)

KTOR-9425 is targeted to 3.6.0 in YouTrack, but included for 3.5.1 because it is a localized bug fix for AES-192/AES-256 session encryption, does not touch API files, and existing readable session values remain compatible because the IV is stored in the transport value.

KTOR-9591 touches OpenAPI `.api` files; included because OpenAPI is experimental and the change is a bug fix. Its expected schema was adjusted for compatibility with the release branch KTOR-9597 sealed-subtype schema naming fix.

## Validation

- `:ktor-server-sessions:jvmTest` — passed, 26 tests
- `:ktor-openapi-schema-reflect:jvmTest` — passed, 40 tests
