### PR TITLE
KTOR-7468 - Add Kotlin Uuid conversion support to DefaultConversionService

### DIFF
--- a/ktor-server/ktor-server-tests/common/test/io/ktor/tests/server/plugins/DataConversionTest.kt
+++ b/ktor-server/ktor-server-tests/common/test/io/ktor/tests/server/plugins/DataConversionTest.kt
@@ -8,6 +8,8 @@ import io.ktor.server.plugins.dataconversion.*
 import io.ktor.server.testing.*
 import io.ktor.util.reflect.*
 import kotlin.test.*
+import kotlin.uuid.ExperimentalUuidApi
+import kotlin.uuid.Uuid
 
 class DataConversionTest {
     @Test
@@ -15,6 +17,16 @@ class DataConversionTest {
         application {
             val id = conversionService.fromValues(listOf("1"), typeInfo<Int>())
             assertEquals(1, id)
+        }
+    }
+
+    @OptIn(ExperimentalUuidApi::class)
+    @Test
+    fun testDefaultUUidConversion() = testApplication {
+        application {
+            val actual = Uuid.generateV7()
+            val id = conversionService.fromValues(listOf(actual.toString()), typeInfo<Uuid>())
+            assertEquals(actual, id)
         }
     }
 
@@ -26,6 +38,18 @@ class DataConversionTest {
             val type = typeInfo<List<Int>>()
             val id = conversionService.fromValues(listOf("1", "2"), type)
             assertEquals(expectedList, id)
+        }
+    }
+
+    @OptIn(ExperimentalUuidApi::class)
+    @Test
+    fun testDefaultUUidConversionList() = testApplication {
+        application {
+            val type = typeInfo<List<Uuid>>()
+            val values = listOf(Uuid.generateV7(), Uuid.generateV7())
+            val id =
+                conversionService.fromValues(values.map { it.toString() }, type)
+            assertEquals(values, id)
         }
     }
 

--- a/ktor-server/ktor-server-tests/common/test/io/ktor/tests/server/plugins/DataConversionTest.kt
+++ b/ktor-server/ktor-server-tests/common/test/io/ktor/tests/server/plugins/DataConversionTest.kt
@@ -24,7 +24,7 @@ class DataConversionTest {
     @Test
     fun testDefaultUUidConversion() = testApplication {
         application {
-            val actual = Uuid.generateV7()
+            val actual = Uuid.random()
             val id = conversionService.fromValues(listOf(actual.toString()), typeInfo<Uuid>())
             assertEquals(actual, id)
         }
@@ -46,7 +46,7 @@ class DataConversionTest {
     fun testDefaultUUidConversionList() = testApplication {
         application {
             val type = typeInfo<List<Uuid>>()
-            val values = listOf(Uuid.generateV7(), Uuid.generateV7())
+            val values = listOf(Uuid.random(), Uuid.random())
             val id =
                 conversionService.fromValues(values.map { it.toString() }, type)
             assertEquals(values, id)

--- a/ktor-utils/common/src/io/ktor/util/converters/ConversionService.kt
+++ b/ktor-utils/common/src/io/ktor/util/converters/ConversionService.kt
@@ -6,6 +6,8 @@ package io.ktor.util.converters
 
 import io.ktor.util.reflect.*
 import kotlin.reflect.*
+import kotlin.uuid.ExperimentalUuidApi
+import kotlin.uuid.Uuid
 
 /**
  * Data conversion service that does serialization and deserialization to/from list of strings
@@ -97,6 +99,7 @@ public object DefaultConversionService : ConversionService {
         throwConversionException(klass.toString())
     }
 
+    @OptIn(ExperimentalUuidApi::class)
     private fun convertPrimitives(klass: KClass<*>, value: String) = when (klass) {
         Int::class -> value.toInt()
         Float::class -> value.toFloat()
@@ -105,6 +108,7 @@ public object DefaultConversionService : ConversionService {
         Short::class -> value.toShort()
         Char::class -> value.single()
         Boolean::class -> value.toBoolean()
+        Uuid::class -> Uuid.parse(value)
         String::class -> value
         else -> null
     }


### PR DESCRIPTION
**Subsystem**
ktor-utils

**Motivation**
Currently we do not support Kotlin Uuid in `DefaultConversionService`.

**Solution**
Add support for Kotlin Uuid in `DefaultConversionService`.

~Created as draft since this should await Kotlin 2.4.0 version bump, and before merging we should remove `@OptIn(ExperimentalUuidApi::class)`~