### PR TITLE
KTOR-9646 Update compiler plugin to 2.4.0

### DIFF
--- a/ktor-compiler-plugin/build.gradle.kts
+++ b/ktor-compiler-plugin/build.gradle.kts
@@ -36,15 +36,20 @@ sourceSets {
 
 idea.module.generatedSourceDirs.add(projectDir.resolve("test-gen"))
 
+// This module compiles against a newer Kotlin compiler API than the rest of the project.
+// The project-wide Kotlin version (and Kotlin Gradle plugin) is kept on `libs.versions.kotlin`,
+// but the compiler API artifacts this plugin links against are overridden here.
+val kotlinCompilerVersion = "2.4.0"
+
 dependencies {
-    compileOnly(libs.kotlin.compilerEmbeddable)
+    compileOnly("org.jetbrains.kotlin:kotlin-compiler-embeddable:$kotlinCompilerVersion")
     implementation(libs.kotlinx.serialization.json)
 
-    testFixturesApi(libs.kotlin.test.junit5)
-    testFixturesApi(libs.kotlin.compilerTestFramework)
-    testFixturesApi(libs.kotlin.compiler)
+    testFixturesApi("org.jetbrains.kotlin:kotlin-test-junit5:$kotlinCompilerVersion")
+    testFixturesApi("org.jetbrains.kotlin:kotlin-compiler-internal-test-framework:$kotlinCompilerVersion")
+    testFixturesApi("org.jetbrains.kotlin:kotlin-compiler:$kotlinCompilerVersion")
     testFixturesApi(libs.kotlinx.serialization.json)
-    testFixturesApi(libs.kotlinx.serialization.compiler.embedded)
+    testFixturesApi("org.jetbrains.kotlin:kotlin-serialization-compiler-plugin-embeddable:$kotlinCompilerVersion")
 
     testSamples(projects.ktorServerCore)
     testSamples(projects.ktorServerCio)
@@ -58,13 +63,13 @@ dependencies {
     testSamples(projects.ktorClientApache)
     testSamples(projects.ktorSerializationKotlinxJson)
     testSamples(projects.ktorOpenapiSchema)
-    testSamples(libs.kotlin.test)
+    testSamples("org.jetbrains.kotlin:kotlin-test:$kotlinCompilerVersion")
 
-    testRuntimeOnly(libs.kotlin.test.junit5)
-    testRuntimeOnly(libs.kotlin.test)
-    testRuntimeOnly(libs.kotlin.reflect)
-    testRuntimeOnly(libs.kotlin.script.runtime)
-    testRuntimeOnly(libs.kotlin.annotations.jvm)
+    testRuntimeOnly("org.jetbrains.kotlin:kotlin-test-junit5:$kotlinCompilerVersion")
+    testRuntimeOnly("org.jetbrains.kotlin:kotlin-test:$kotlinCompilerVersion")
+    testRuntimeOnly("org.jetbrains.kotlin:kotlin-reflect:$kotlinCompilerVersion")
+    testRuntimeOnly("org.jetbrains.kotlin:kotlin-script-runtime:$kotlinCompilerVersion")
+    testRuntimeOnly("org.jetbrains.kotlin:kotlin-annotations-jvm:$kotlinCompilerVersion")
 }
 
 buildConfig {
@@ -111,6 +116,16 @@ tasks {
     }
 
     test(configureCompilerPluginTest)
+
+    // This module uses the bare `kotlin.jvm` plugin (not KMP), so it only exposes a `test` task.
+    // The rest of the repository — and CI — follows the KMP convention of running `:module:jvmTest`.
+    // Register a `jvmTest` alias that depends on `test` so this module participates in the standard
+    // CI test suite and matches the conventions documented in AGENTS.md.
+    val jvmTest by registering {
+        group = "verification"
+        description = "Alias for the `test` task to match the KMP `jvmTest` convention used across the repository."
+        dependsOn(test)
+    }
 
     val updateSnapshots by registering(Test::class) {
         group = "verification"

--- a/ktor-compiler-plugin/src/io/ktor/compiler/KtorCompilerPluginRegistrar.kt
+++ b/ktor-compiler-plugin/src/io/ktor/compiler/KtorCompilerPluginRegistrar.kt
@@ -7,13 +7,9 @@ import io.ktor.openapi.ir.OpenApiCodeGenerationExtension
 import io.ktor.openapi.OpenApiProcessorConfig
 import io.ktor.openapi.routing.RouteCallLookup
 import org.jetbrains.kotlin.backend.common.extensions.IrGenerationExtension
-import org.jetbrains.kotlin.cli.common.messages.MessageCollector
 import org.jetbrains.kotlin.compiler.plugin.CompilerPluginRegistrar
-import org.jetbrains.kotlin.config.CommonConfigurationKeys
 import org.jetbrains.kotlin.config.CompilerConfiguration
 import org.jetbrains.kotlin.fir.extensions.FirExtensionRegistrarAdapter
-import java.nio.file.Paths
-import kotlin.io.path.absolutePathString
 
 class KtorCompilerPluginRegistrar : CompilerPluginRegistrar() {
 
@@ -26,8 +22,7 @@ class KtorCompilerPluginRegistrar : CompilerPluginRegistrar() {
             return
         }
 
-        val messageCollector = configuration.get(CommonConfigurationKeys.MESSAGE_COLLECTOR_KEY, MessageCollector.NONE)
-        val logger = Logger.wrap(messageCollector, openApiConfig.debug, openApiConfig.logDir)
+        val logger = Logger.wrap(configuration, openApiConfig.debug, openApiConfig.logDir)
         val routes: RouteCallLookup = mutableMapOf()
         // Analysis FIR plugin reads the comments and caches them to the routes graph
         FirExtensionRegistrarAdapter.registerExtension(

--- a/ktor-compiler-plugin/src/io/ktor/compiler/KtorCompilerPluginRegistrar.kt
+++ b/ktor-compiler-plugin/src/io/ktor/compiler/KtorCompilerPluginRegistrar.kt
@@ -6,7 +6,6 @@ import io.ktor.openapi.fir.OpenApiAnalysisExtension
 import io.ktor.openapi.ir.OpenApiCodeGenerationExtension
 import io.ktor.openapi.OpenApiProcessorConfig
 import io.ktor.openapi.routing.RouteCallLookup
-import kotlinx.serialization.ExperimentalSerializationApi
 import org.jetbrains.kotlin.backend.common.extensions.IrGenerationExtension
 import org.jetbrains.kotlin.cli.common.messages.MessageCollector
 import org.jetbrains.kotlin.compiler.plugin.CompilerPluginRegistrar
@@ -16,7 +15,6 @@ import org.jetbrains.kotlin.fir.extensions.FirExtensionRegistrarAdapter
 import java.nio.file.Paths
 import kotlin.io.path.absolutePathString
 
-@OptIn(ExperimentalSerializationApi::class)
 class KtorCompilerPluginRegistrar : CompilerPluginRegistrar() {
 
     override val pluginId: String get() = PLUGIN_ID

--- a/ktor-compiler-plugin/src/io/ktor/openapi/Logger.kt
+++ b/ktor-compiler-plugin/src/io/ktor/openapi/Logger.kt
@@ -1,12 +1,11 @@
 package io.ktor.openapi
 
 import org.jetbrains.kotlin.cli.common.messages.CompilerMessageLocation
-import org.jetbrains.kotlin.cli.common.messages.CompilerMessageSeverity
-import org.jetbrains.kotlin.cli.common.messages.MessageCollector
+import org.jetbrains.kotlin.cli.reportLog
+import org.jetbrains.kotlin.config.CompilerConfiguration
 import java.nio.file.Paths
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
-import kotlin.io.path.appendText
 import kotlin.io.path.bufferedWriter
 
 fun interface Logger {
@@ -14,7 +13,7 @@ fun interface Logger {
         const val DEBUG_LOG_FILE = "ktor-compiler-debug.log"
         private val LOG_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSS: ")
 
-        fun wrap(messageCollector: MessageCollector, debug: Boolean, logDir: String?): Logger {
+        fun wrap(configuration: CompilerConfiguration, debug: Boolean, logDir: String?): Logger {
             val debugFileWriter = if (debug && logDir != null) {
                 Paths.get(logDir, DEBUG_LOG_FILE).bufferedWriter().also {
                     it.append(LocalDateTime.now().format(LOG_FORMATTER))
@@ -24,16 +23,12 @@ fun interface Logger {
             } else null
 
             return Logger { message, cause, location ->
-                // Always log messages to message collector
+                // Always log messages via the compiler configuration's reporter
                 val fullMessage = if (debug && cause != null) {
                     "$message\n${cause.stackTraceToString()}"
                 } else message
 
-                messageCollector.report(
-                    severity = CompilerMessageSeverity.LOGGING,
-                    message = fullMessage,
-                    location = location,
-                )
+                configuration.reportLog(fullMessage, location)
 
                 debugFileWriter?.appendLine(buildString {
                     append(LocalDateTime.now().format(LOG_FORMATTER))

--- a/ktor-compiler-plugin/test-gen/io/ktor/compiler/runners/OpenapiTestGenerated.java
+++ b/ktor-compiler-plugin/test-gen/io/ktor/compiler/runners/OpenapiTestGenerated.java
@@ -15,6 +15,10 @@ import java.util.regex.Pattern;
 @TestMetadata("ktor-compiler-plugin/testData/openapi")
 @TestDataPath("$PROJECT_ROOT")
 public class OpenapiTestGenerated extends AbstractOpenapiTest {
+  private void run(String fileName) {
+    runTest("ktor-compiler-plugin/testData/openapi/" + fileName);
+  }
+
   @Test
   public void testAllFilesPresentInOpenapi() {
     KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("ktor-compiler-plugin/testData/openapi"), Pattern.compile("^(.+)\\.kt$"), null, true);
@@ -23,78 +27,78 @@ public class OpenapiTestGenerated extends AbstractOpenapiTest {
   @Test
   @TestMetadata("CallHandlerFunctions.kt")
   public void testCallHandlerFunctions() {
-    runTest("ktor-compiler-plugin/testData/openapi/CallHandlerFunctions.kt");
+    run("CallHandlerFunctions.kt");
   }
 
   @Test
   @TestMetadata("KDocOptions.kt")
   public void testKDocOptions() {
-    runTest("ktor-compiler-plugin/testData/openapi/KDocOptions.kt");
+    run("KDocOptions.kt");
   }
 
   @Test
   @TestMetadata("MarkdownOptions.kt")
   public void testMarkdownOptions() {
-    runTest("ktor-compiler-plugin/testData/openapi/MarkdownOptions.kt");
+    run("MarkdownOptions.kt");
   }
 
   @Test
   @TestMetadata("Nesting.kt")
   public void testNesting() {
-    runTest("ktor-compiler-plugin/testData/openapi/Nesting.kt");
+    run("Nesting.kt");
   }
 
   @Test
   @TestMetadata("NullableValueClasses.kt")
   public void testNullableValueClasses() {
-    runTest("ktor-compiler-plugin/testData/openapi/NullableValueClasses.kt");
+    run("NullableValueClasses.kt");
   }
 
   @Test
   @TestMetadata("OddReferences.kt")
   public void testOddReferences() {
-    runTest("ktor-compiler-plugin/testData/openapi/OddReferences.kt");
+    run("OddReferences.kt");
   }
 
   @Test
   @TestMetadata("Parameters.kt")
   public void testParameters() {
-    runTest("ktor-compiler-plugin/testData/openapi/Parameters.kt");
+    run("Parameters.kt");
   }
 
   @Test
   @TestMetadata("RareCalls.kt")
   public void testRareCalls() {
-    runTest("ktor-compiler-plugin/testData/openapi/RareCalls.kt");
+    run("RareCalls.kt");
   }
 
   @Test
   @TestMetadata("Recursion.kt")
   public void testRecursion() {
-    runTest("ktor-compiler-plugin/testData/openapi/Recursion.kt");
+    run("Recursion.kt");
   }
 
   @Test
   @TestMetadata("Resources.kt")
   public void testResources() {
-    runTest("ktor-compiler-plugin/testData/openapi/Resources.kt");
+    run("Resources.kt");
   }
 
   @Test
   @TestMetadata("Responses.kt")
   public void testResponses() {
-    runTest("ktor-compiler-plugin/testData/openapi/Responses.kt");
+    run("Responses.kt");
   }
 
   @Test
   @TestMetadata("RouteFunctions.kt")
   public void testRouteFunctions() {
-    runTest("ktor-compiler-plugin/testData/openapi/RouteFunctions.kt");
+    run("RouteFunctions.kt");
   }
 
   @Test
   @TestMetadata("TypeParameters.kt")
   public void testTypeParameters() {
-    runTest("ktor-compiler-plugin/testData/openapi/TypeParameters.kt");
+    run("TypeParameters.kt");
   }
 }

--- a/ktor-compiler-plugin/testData/openapi/KDocOptions.expected.json
+++ b/ktor-compiler-plugin/testData/openapi/KDocOptions.expected.json
@@ -172,7 +172,10 @@
     "components": {
         "schemas": {
             "Contact": {
-                "type": "object",
+                "type": [
+                    "object",
+                    "null"
+                ],
                 "title": "Contact",
                 "properties": {
                     "name": {
@@ -196,7 +199,10 @@
                 }
             },
             "License": {
-                "type": "object",
+                "type": [
+                    "object",
+                    "null"
+                ],
                 "title": "License",
                 "required": [
                     "name"
@@ -246,24 +252,10 @@
                         ]
                     },
                     "contact": {
-                        "oneOf": [
-                            {
-                                "$ref": "#/components/schemas/Contact"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ]
+                        "$ref": "#/components/schemas/Contact"
                     },
                     "license": {
-                        "oneOf": [
-                            {
-                                "$ref": "#/components/schemas/License"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ]
+                        "$ref": "#/components/schemas/License"
                     },
                     "extensions": {
                         "type": [

--- a/ktor-compiler-plugin/testData/openapi/MarkdownOptions.expected.json
+++ b/ktor-compiler-plugin/testData/openapi/MarkdownOptions.expected.json
@@ -196,7 +196,10 @@
     "components": {
         "schemas": {
             "Contact": {
-                "type": "object",
+                "type": [
+                    "object",
+                    "null"
+                ],
                 "title": "Contact",
                 "properties": {
                     "name": {
@@ -220,7 +223,10 @@
                 }
             },
             "License": {
-                "type": "object",
+                "type": [
+                    "object",
+                    "null"
+                ],
                 "title": "License",
                 "required": [
                     "name"
@@ -270,24 +276,10 @@
                         ]
                     },
                     "contact": {
-                        "oneOf": [
-                            {
-                                "$ref": "#/components/schemas/Contact"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ]
+                        "$ref": "#/components/schemas/Contact"
                     },
                     "license": {
-                        "oneOf": [
-                            {
-                                "$ref": "#/components/schemas/License"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ]
+                        "$ref": "#/components/schemas/License"
                     },
                     "extensions": {
                         "type": [

--- a/ktor-compiler-plugin/testData/openapi/Recursion.expected.json
+++ b/ktor-compiler-plugin/testData/openapi/Recursion.expected.json
@@ -47,7 +47,7 @@
                     "parent": {
                         "oneOf": [
                             {
-                                "$ref": "#/components/schemas/openapi.Node"
+                                "$ref": "#/components/schemas/Node"
                             },
                             {
                                 "type": "null"


### PR DESCRIPTION
Looks like there were no breaking changes in the compiler plugin itself this time, but instead some binary incompatibility within the compiler instrumentation itself.

I noticed the test snapshots were out of date and that CI was not running the compiler plugin tests automatically, so I just added a task that will trigger during the normal suite.

Note, I'm only updating to 2.4.0 for the compiler plugin, so we can be more deliberate about updating it project-wide.  I'll also test this against 2.3.21 to see if it's backwards compatible.