### PR TITLE
KTOR-8524 Trigger application lifecycle events for ServletApplicationEngine in WAR deployments

### DIFF
--- a/ktor-server/ktor-server-jetty-jakarta/jvm/test-resources/application-lifecycle.conf
+++ b/ktor-server/ktor-server-jetty-jakarta/jvm/test-resources/application-lifecycle.conf
@@ -1,0 +1,5 @@
+ktor {
+    application {
+        modules = [ io.ktor.tests.server.jetty.jakarta.LifecycleProbeKt.lifecycleProbeModule ]
+    }
+}

--- a/ktor-server/ktor-server-jetty-jakarta/jvm/test/io/ktor/tests/server/jetty/jakarta/ApplicationLifecycleEventsTest.kt
+++ b/ktor-server/ktor-server-jetty-jakarta/jvm/test/io/ktor/tests/server/jetty/jakarta/ApplicationLifecycleEventsTest.kt
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2014-2026 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.tests.server.jetty.jakarta
+
+import io.ktor.server.servlet.jakarta.KtorServletContextListener
+import io.ktor.server.servlet.jakarta.ServletApplicationEngine
+import org.eclipse.jetty.ee10.servlet.ServletContextHandler
+import org.eclipse.jetty.ee10.servlet.ServletHolder
+import org.eclipse.jetty.server.Server
+import org.eclipse.jetty.server.ServerConnector
+import java.net.HttpURLConnection
+import java.net.URI
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+/**
+ * Regression test for KTOR-8524: when `ServletApplicationEngine` bootstraps itself from configuration
+ * (the WAR deployment scenario), the application lifecycle is bound to the web application context via
+ * [KtorServletContainerInitializer] instead of the servlet's lazy `init()` / `destroy()` callbacks.
+ *
+ * As a result, regardless of `load-on-startup`:
+ *  - `ApplicationStarted` is triggered at deployment time, before any request, and
+ *  - `ApplicationStopped` is triggered on undeploy even if no request was ever served.
+ *
+ * The servlet is mounted like a real WAR — no engine attributes are injected and no `load-on-startup`
+ * is configured. [KtorServletContextListener] is registered directly, mirroring what
+ * [io.ktor.server.servlet.jakarta.KtorServletContainerInitializer] does when a container auto-discovers
+ * it via `META-INF/services` (validated separately below).
+ */
+class ApplicationLifecycleEventsTest {
+
+    @BeforeTest
+    fun resetProbe() {
+        LifecycleProbe.reset()
+    }
+
+    @AfterTest
+    fun clearProbe() {
+        LifecycleProbe.reset()
+    }
+
+    @Test
+    fun applicationStartedIsTriggeredAtDeploymentBeforeAnyRequest() {
+        val server = startServer()
+        try {
+            assertTrue(
+                "started" in LifecycleProbe.events,
+                "ApplicationStarted must be triggered when the application is deployed, before any request is made"
+            )
+
+            // Managed mode still serves requests: the servlet reuses the listener-started server.
+            httpGet(server.localPort())
+        } finally {
+            server.stop()
+        }
+    }
+
+    @Test
+    fun applicationStoppedIsTriggeredOnUndeployWithoutAnyRequest() {
+        val server = startServer()
+        server.stop()
+
+        assertTrue(
+            "stopped" in LifecycleProbe.events,
+            "ApplicationStopped must be triggered on undeploy even if no request was ever served"
+        )
+    }
+
+    @Test
+    fun containerInitializerIsRegisteredViaServiceFile() {
+        val resource = javaClass.classLoader
+            .getResource("META-INF/services/jakarta.servlet.ServletContainerInitializer")
+        assertNotNull(resource, "ServletContainerInitializer service file must be present for auto-registration")
+
+        val registered = resource.readText().lineSequence()
+            .map { it.substringBefore('#').trim() }
+            .filter { it.isNotEmpty() }
+            .toList()
+        assertTrue(
+            "io.ktor.server.servlet.jakarta.KtorServletContainerInitializer" in registered,
+            "KtorServletContainerInitializer must be registered as a ServletContainerInitializer service"
+        )
+    }
+
+    private fun startServer(): Server {
+        val server = Server()
+        server.addConnector(ServerConnector(server).apply { port = 0 })
+
+        val context = ServletContextHandler().apply {
+            classLoader = this@ApplicationLifecycleEventsTest::class.java.classLoader
+            contextPath = "/"
+            addServlet(
+                ServletHolder("ktor-servlet", ServletApplicationEngine::class.java).apply {
+                    isAsyncSupported = false
+                    // Self-bootstrap mode: no ApplicationAttributeKey injection, configuration only.
+                    setInitParameter("io.ktor.ktor.config", "application-lifecycle.conf")
+                    // Intentionally NO load-on-startup configured — mirror a default WAR (lazy init).
+                },
+                "/*"
+            )
+            // Mirror what KtorServletContainerInitializer does when auto-discovered via META-INF/services.
+            addEventListener(KtorServletContextListener())
+        }
+        server.handler = context
+
+        server.start()
+        return server
+    }
+
+    private fun Server.localPort(): Int = (connectors.first() as ServerConnector).localPort
+
+    private fun httpGet(port: Int) {
+        val connection = URI("http://localhost:$port/").toURL().openConnection() as HttpURLConnection
+        try {
+            connection.connectTimeout = 5_000
+            connection.readTimeout = 5_000
+            connection.responseCode // triggers the request
+        } finally {
+            connection.disconnect()
+        }
+    }
+}

--- a/ktor-server/ktor-server-jetty-jakarta/jvm/test/io/ktor/tests/server/jetty/jakarta/LifecycleProbe.kt
+++ b/ktor-server/ktor-server-jetty-jakarta/jvm/test/io/ktor/tests/server/jetty/jakarta/LifecycleProbe.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2014-2026 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.tests.server.jetty.jakarta
+
+import io.ktor.server.application.*
+import java.util.concurrent.CopyOnWriteArrayList
+
+/**
+ * Records Ktor application lifecycle events observed from within an application module.
+ *
+ * The probe is a JVM-wide singleton so that the events recorded by the module loaded inside the
+ * servlet container can be asserted from the test that started the container.
+ */
+internal object LifecycleProbe {
+    val events: MutableList<String> = CopyOnWriteArrayList()
+
+    fun reset() {
+        events.clear()
+    }
+}
+
+/**
+ * Application module referenced from `application-lifecycle.conf`.
+ *
+ * It mirrors what a user does in their own application: subscribe to lifecycle events via the
+ * application monitor. This is the only realistic way to observe these events for a servlet that
+ * bootstraps itself from configuration (the WAR deployment scenario).
+ */
+fun Application.lifecycleProbeModule() {
+    monitor.subscribe(ApplicationStarted) { LifecycleProbe.events += "started" }
+    monitor.subscribe(ApplicationStopping) { LifecycleProbe.events += "stopping" }
+    monitor.subscribe(ApplicationStopped) { LifecycleProbe.events += "stopped" }
+}

--- a/ktor-server/ktor-server-jetty/jvm/test-resources/application-lifecycle.conf
+++ b/ktor-server/ktor-server-jetty/jvm/test-resources/application-lifecycle.conf
@@ -1,0 +1,5 @@
+ktor {
+    application {
+        modules = [ io.ktor.tests.server.jetty.LifecycleProbeKt.lifecycleProbeModule ]
+    }
+}

--- a/ktor-server/ktor-server-jetty/jvm/test/io/ktor/tests/server/jetty/ApplicationLifecycleEventsTest.kt
+++ b/ktor-server/ktor-server-jetty/jvm/test/io/ktor/tests/server/jetty/ApplicationLifecycleEventsTest.kt
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2014-2026 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.tests.server.jetty
+
+import io.ktor.server.servlet.KtorServletContextListener
+import io.ktor.server.servlet.ServletApplicationEngine
+import org.eclipse.jetty.server.Server
+import org.eclipse.jetty.server.ServerConnector
+import org.eclipse.jetty.servlet.ServletContextHandler
+import org.eclipse.jetty.servlet.ServletHolder
+import java.net.HttpURLConnection
+import java.net.URI
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+/**
+ * Regression test for KTOR-8524: when `ServletApplicationEngine` bootstraps itself from configuration
+ * (the WAR deployment scenario), the application lifecycle is bound to the web application context via
+ * [KtorServletContextListener] instead of the servlet's lazy `init()` / `destroy()` callbacks.
+ *
+ * As a result, regardless of `load-on-startup`:
+ *  - `ApplicationStarted` is triggered at deployment time, before any request, and
+ *  - `ApplicationStopped` is triggered on undeploy even if no request was ever served.
+ *
+ * The servlet is mounted like a real WAR — no engine attributes are injected and no `load-on-startup`
+ * is configured. [KtorServletContextListener] is registered directly, mirroring what
+ * [io.ktor.server.servlet.KtorServletContainerInitializer] does when a container auto-discovers it via
+ * `META-INF/services` (validated separately below).
+ */
+class ApplicationLifecycleEventsTest {
+
+    @BeforeTest
+    fun resetProbe() {
+        LifecycleProbe.reset()
+    }
+
+    @AfterTest
+    fun clearProbe() {
+        LifecycleProbe.reset()
+    }
+
+    @Test
+    fun applicationStartedIsTriggeredAtDeploymentBeforeAnyRequest() {
+        val server = startServer()
+        try {
+            assertTrue(
+                "started" in LifecycleProbe.events,
+                "ApplicationStarted must be triggered when the application is deployed, before any request is made"
+            )
+
+            // Managed mode still serves requests: the servlet reuses the listener-started server.
+            httpGet(server.localPort())
+        } finally {
+            server.stop()
+        }
+    }
+
+    @Test
+    fun applicationStoppedIsTriggeredOnUndeployWithoutAnyRequest() {
+        val server = startServer()
+        server.stop()
+
+        assertTrue(
+            "stopped" in LifecycleProbe.events,
+            "ApplicationStopped must be triggered on undeploy even if no request was ever served"
+        )
+    }
+
+    @Test
+    fun containerInitializerIsRegisteredViaServiceFile() {
+        val resource = javaClass.classLoader
+            .getResource("META-INF/services/javax.servlet.ServletContainerInitializer")
+        assertNotNull(resource, "ServletContainerInitializer service file must be present for auto-registration")
+
+        val registered = resource.readText().lineSequence()
+            .map { it.substringBefore('#').trim() }
+            .filter { it.isNotEmpty() }
+            .toList()
+        assertTrue(
+            "io.ktor.server.servlet.KtorServletContainerInitializer" in registered,
+            "KtorServletContainerInitializer must be registered as a ServletContainerInitializer service"
+        )
+    }
+
+    private fun startServer(): Server {
+        val server = Server()
+        server.addConnector(ServerConnector(server).apply { port = 0 })
+
+        val context = ServletContextHandler().apply {
+            classLoader = this@ApplicationLifecycleEventsTest::class.java.classLoader
+            contextPath = "/"
+            addServlet(
+                ServletHolder("ktor-servlet", ServletApplicationEngine::class.java).apply {
+                    isAsyncSupported = false
+                    // Self-bootstrap mode: no ApplicationAttributeKey injection, configuration only.
+                    setInitParameter("io.ktor.ktor.config", "application-lifecycle.conf")
+                    // Intentionally NO load-on-startup configured — mirror a default WAR (lazy init).
+                },
+                "/*"
+            )
+            // Mirror what KtorServletContainerInitializer does when auto-discovered via META-INF/services.
+            addEventListener(KtorServletContextListener())
+        }
+        server.handler = context
+
+        server.start()
+        return server
+    }
+
+    private fun Server.localPort(): Int = (connectors.first() as ServerConnector).localPort
+
+    private fun httpGet(port: Int) {
+        val connection = URI("http://localhost:$port/").toURL().openConnection() as HttpURLConnection
+        try {
+            connection.connectTimeout = 5_000
+            connection.readTimeout = 5_000
+            connection.responseCode // triggers the request
+        } finally {
+            connection.disconnect()
+        }
+    }
+}

--- a/ktor-server/ktor-server-jetty/jvm/test/io/ktor/tests/server/jetty/LifecycleProbe.kt
+++ b/ktor-server/ktor-server-jetty/jvm/test/io/ktor/tests/server/jetty/LifecycleProbe.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2014-2026 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.tests.server.jetty
+
+import io.ktor.server.application.*
+import java.util.concurrent.CopyOnWriteArrayList
+
+/**
+ * Records Ktor application lifecycle events observed from within an application module.
+ *
+ * The probe is a JVM-wide singleton so that the events recorded by the module loaded inside the
+ * servlet container can be asserted from the test that started the container.
+ */
+internal object LifecycleProbe {
+    val events: MutableList<String> = CopyOnWriteArrayList()
+
+    fun reset() {
+        events.clear()
+    }
+}
+
+/**
+ * Application module referenced from `application-lifecycle.conf`.
+ *
+ * It mirrors what a user does in their own application: subscribe to lifecycle events via the
+ * application monitor. This is the only realistic way to observe these events for a servlet that
+ * bootstraps itself from configuration (the WAR deployment scenario).
+ */
+fun Application.lifecycleProbeModule() {
+    monitor.subscribe(ApplicationStarted) { LifecycleProbe.events += "started" }
+    monitor.subscribe(ApplicationStopping) { LifecycleProbe.events += "stopping" }
+    monitor.subscribe(ApplicationStopped) { LifecycleProbe.events += "stopped" }
+}

--- a/ktor-server/ktor-server-servlet-jakarta/api/ktor-server-servlet-jakarta.api
+++ b/ktor-server/ktor-server-servlet-jakarta/api/ktor-server-servlet-jakarta.api
@@ -61,6 +61,17 @@ public abstract class io/ktor/server/servlet/jakarta/KtorServlet : jakarta/servl
 	protected fun service (Ljakarta/servlet/http/HttpServletRequest;Ljakarta/servlet/http/HttpServletResponse;)V
 }
 
+public final class io/ktor/server/servlet/jakarta/KtorServletContainerInitializer : jakarta/servlet/ServletContainerInitializer {
+	public fun <init> ()V
+	public fun onStartup (Ljava/util/Set;Ljakarta/servlet/ServletContext;)V
+}
+
+public final class io/ktor/server/servlet/jakarta/KtorServletContextListener : jakarta/servlet/ServletContextListener {
+	public fun <init> ()V
+	public fun contextDestroyed (Ljakarta/servlet/ServletContextEvent;)V
+	public fun contextInitialized (Ljakarta/servlet/ServletContextEvent;)V
+}
+
 public final class io/ktor/server/servlet/jakarta/KtorServletKt {
 	public static final fun getServletContextAttribute ()Lio/ktor/util/AttributeKey;
 }

--- a/ktor-server/ktor-server-servlet-jakarta/jvm/resources/META-INF/services/jakarta.servlet.ServletContainerInitializer
+++ b/ktor-server/ktor-server-servlet-jakarta/jvm/resources/META-INF/services/jakarta.servlet.ServletContainerInitializer
@@ -1,0 +1,1 @@
+io.ktor.server.servlet.jakarta.KtorServletContainerInitializer

--- a/ktor-server/ktor-server-servlet-jakarta/jvm/src/io/ktor/server/servlet/jakarta/KtorServletContainerInitializer.kt
+++ b/ktor-server/ktor-server-servlet-jakarta/jvm/src/io/ktor/server/servlet/jakarta/KtorServletContainerInitializer.kt
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2014-2026 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.server.servlet.jakarta
+
+import io.ktor.server.application.*
+import io.ktor.server.servlet.jakarta.ServletApplicationEngine.Companion.ApplicationAttributeKey
+import io.ktor.server.servlet.jakarta.ServletApplicationEngine.Companion.ApplicationEnginePipelineAttributeKey
+import io.ktor.utils.io.InternalAPI
+import jakarta.servlet.ServletContainerInitializer
+import jakarta.servlet.ServletContext
+import jakarta.servlet.ServletContextEvent
+import jakarta.servlet.ServletContextListener
+
+/**
+ * Registers [KtorServletContextListener] so a servlet-hosted Ktor application is started and stopped in
+ * lockstep with the web application context lifecycle.
+ *
+ * Registered automatically via `META-INF/services/jakarta.servlet.ServletContainerInitializer`, so no
+ * user configuration is required. It is a no-op when the application is driven by an embedded engine,
+ * which injects [ServletApplicationEngine.ApplicationAttributeKey] and owns the lifecycle itself.
+ *
+ * It must be `public` so the servlet container can instantiate it via `ServiceLoader`, but it is
+ * internal infrastructure and not intended to be referenced directly.
+ *
+ * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.server.servlet.jakarta.KtorServletContainerInitializer)
+ */
+@InternalAPI
+public class KtorServletContainerInitializer : ServletContainerInitializer {
+    override fun onStartup(classes: MutableSet<Class<*>>?, ctx: ServletContext) {
+        // Embedded engine mode owns the lifecycle; do not register the listener.
+        if (ctx.getAttribute(ApplicationAttributeKey) != null) return
+        ctx.addListener(KtorServletContextListener::class.java)
+    }
+}
+
+/**
+ * Starts and stops a servlet-hosted Ktor application together with the web application context, so the
+ * lifecycle events fire at deploy/undeploy regardless of `load-on-startup` (see KTOR-8524).
+ *
+ * Registered automatically by [KtorServletContainerInitializer]; it can also be added as a `<listener>`
+ * in `web.xml`.
+ *
+ * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.server.servlet.jakarta.KtorServletContextListener)
+ */
+public class KtorServletContextListener : ServletContextListener {
+    override fun contextInitialized(sce: ServletContextEvent) {
+        val ctx = sce.servletContext
+        // Embedded engine mode owns the lifecycle.
+        if (ctx.getAttribute(ApplicationAttributeKey) != null) return
+        // Defensive: never start the application twice.
+        if (ctx.managedEmbeddedServer() != null) return
+
+        val registrations = ctx.servletRegistrations?.values?.filter { registration ->
+            val className = registration.className ?: return@filter false
+            val servletClass = runCatching { ctx.classLoader.loadClass(className) }.getOrNull()
+            servletClass != null && ServletApplicationEngine::class.java.isAssignableFrom(servletClass)
+        }.orEmpty()
+
+        // Context-managed lifecycle assumes a single Ktor application per web application context.
+        // With more than one ServletApplicationEngine, fall back to per-servlet self-bootstrap so each
+        // servlet keeps its own application (matching the pre-listener behavior) instead of sharing one.
+        val registration = registrations.singleOrNull() ?: run {
+            if (registrations.size > 1) {
+                ctx.log(
+                    "Multiple ServletApplicationEngine registrations found; context-managed application " +
+                        "lifecycle is disabled. Each servlet bootstraps its own application on init()."
+                )
+            }
+            return
+        }
+
+        val initParameters = registration.initParameters.toList() + ctx.contextInitParameters()
+
+        val bootstrap = bootstrapServletApplication(ctx, initParameters)
+        bootstrap.server.start()
+
+        ctx.setAttribute(ManagedServerKey, bootstrap.server)
+        ctx.setAttribute(ApplicationEnginePipelineAttributeKey, bootstrap.enginePipeline)
+    }
+
+    override fun contextDestroyed(sce: ServletContextEvent) {
+        val ctx = sce.servletContext
+        val server = ctx.managedEmbeddedServer() ?: return
+
+        server.application.monitor.raise(ApplicationStopPreparing, server.environment)
+        server.stop()
+        ctx.removeAttribute(ManagedServerKey)
+    }
+}
+
+private fun ServletContext.contextInitParameters(): List<Pair<String, String>> =
+    initParameterNames?.toList().orEmpty().mapNotNull { name ->
+        getInitParameter(name)?.let { name to it }
+    }

--- a/ktor-server/ktor-server-servlet-jakarta/jvm/src/io/ktor/server/servlet/jakarta/KtorServletContainerInitializer.kt
+++ b/ktor-server/ktor-server-servlet-jakarta/jvm/src/io/ktor/server/servlet/jakarta/KtorServletContainerInitializer.kt
@@ -36,8 +36,14 @@ public class KtorServletContainerInitializer : ServletContainerInitializer {
 }
 
 /**
- * Starts and stops a servlet-hosted Ktor application together with the web application context, so the
- * lifecycle events fire at deploy/undeploy regardless of `load-on-startup` (see KTOR-8524).
+ * Starts and stops a servlet-hosted Ktor application together with the web application context,
+ * independently of when (or whether) the [ServletApplicationEngine] servlet is initialized.
+ *
+ * In a WAR deployment without `load-on-startup` the servlet container initializes the servlet lazily on
+ * the first request. Binding the application lifecycle to `contextInitialized` / `contextDestroyed`
+ * makes `ApplicationStarted` fire at deployment time instead of only after the first request, and
+ * guarantees `ApplicationStopped` fires on undeploy even when no request was ever served (otherwise
+ * resources released by `ApplicationStopped` handlers would leak).
  *
  * Registered automatically by [KtorServletContainerInitializer]; it can also be added as a `<listener>`
  * in `web.xml`.
@@ -87,6 +93,7 @@ public class KtorServletContextListener : ServletContextListener {
         server.application.monitor.raise(ApplicationStopPreparing, server.environment)
         server.stop()
         ctx.removeAttribute(ManagedServerKey)
+        ctx.removeAttribute(ApplicationEnginePipelineAttributeKey)
     }
 }
 

--- a/ktor-server/ktor-server-servlet-jakarta/jvm/src/io/ktor/server/servlet/jakarta/ServletApplicationEngine.kt
+++ b/ktor-server/ktor-server-servlet-jakarta/jvm/src/io/ktor/server/servlet/jakarta/ServletApplicationEngine.kt
@@ -105,8 +105,8 @@ public open class ServletApplicationEngine : KtorServlet() {
     }
 
     override fun destroy() {
-        // In managed mode the server is stopped by KtorManagedServerStopListener on context
-        // destruction, which also guarantees the stop events fire even if no request was ever served.
+        // In managed mode the server is stopped by KtorServletContextListener on context destruction,
+        // which also guarantees the stop events fire even if no request was ever served.
         if (servletContext.managedEmbeddedServer() == null) {
             application.monitor.raise(ApplicationStopPreparing, environment)
             super.destroy()
@@ -205,7 +205,7 @@ internal fun bootstrapServletApplication(
     initParameters: List<Pair<String, String>>
 ): ServletApplicationBootstrap {
     val parameters = initParameters
-        .filter { (name, _) -> name.startsWith("io.ktor") }
+        .filter { (name, _) -> name.startsWith("io.ktor.") }
         .map { (name, value) -> name.removePrefix("io.ktor.") to value }
 
     val parametersConfig = MapApplicationConfig(parameters)

--- a/ktor-server/ktor-server-servlet-jakarta/jvm/src/io/ktor/server/servlet/jakarta/ServletApplicationEngine.kt
+++ b/ktor-server/ktor-server-servlet-jakarta/jvm/src/io/ktor/server/servlet/jakarta/ServletApplicationEngine.kt
@@ -32,48 +32,33 @@ public open class ServletApplicationEngine : KtorServlet() {
             emptySet()
         }
 
-    private val embeddedServer: EmbeddedServer<ApplicationEngine, ApplicationEngine.Configuration>? by lazy {
-        servletContext.getAttribute(ApplicationAttributeKey)?.let {
-            return@lazy null
+    private val bootstrap: ServletApplicationBootstrap? by lazy {
+        // External injection mode: the embedded engine (Jetty/Tomcat) owns the application lifecycle.
+        if (servletContext.getAttribute(ApplicationAttributeKey) != null) return@lazy null
+
+        // Managed mode: KtorServletContainerInitializer already created and started the server at
+        // deployment time. Reuse that instance instead of bootstrapping (and starting) a second one.
+        servletContext.managedEmbeddedServer()?.let { server ->
+            return@lazy ServletApplicationBootstrap(
+                server,
+                servletContext.getAttribute(ApplicationEnginePipelineAttributeKey) as EnginePipeline
+            )
         }
 
-        val servletContext = servletContext
-        val servletConfig = servletConfig
+        // Fallback (no ServletContainerInitializer ran): self-bootstrap from servlet init parameters.
+        bootstrapServletApplication(servletContext, collectInitParameters())
+    }
 
-        val parameterNames = (
+    private val embeddedServer: ServletEmbeddedServer?
+        get() = bootstrap?.server
+
+    private fun collectInitParameters(): List<Pair<String, String>> {
+        val names = (
             servletContext.initParameterNames?.toList().orEmpty() +
                 servletConfig.initParameterNames?.toList().orEmpty()
-            ).filter { it.startsWith("io.ktor") }.distinct()
-        val parameters = parameterNames.map {
-            it.removePrefix("io.ktor.") to
-                (servletConfig.getInitParameter(it) ?: servletContext.getInitParameter(it))
-        }
-
-        val parametersConfig = MapApplicationConfig(parameters)
-        val configPath = "ktor.config"
-        val applicationIdPath = "ktor.application.id"
-
-        val combinedConfig = parametersConfig
-            .withFallback(load(parametersConfig.tryGetString(configPath)))
-
-        val applicationId = combinedConfig.tryGetString(applicationIdPath) ?: "Application"
-
-        val environment = applicationEnvironment {
-            config = combinedConfig
-            log = LoggerFactory.getLogger(applicationId)
-            classLoader = servletContext.classLoader
-        }
-        val applicationProperties = serverConfig(environment) {
-            rootPath = servletContext.contextPath ?: "/"
-        }
-        val server = EmbeddedServer(applicationProperties, EmptyEngineFactory)
-        server.apply {
-            monitor.subscribe(ApplicationStarting) {
-                it.receivePipeline.merge(enginePipeline.receivePipeline)
-                it.sendPipeline.merge(enginePipeline.sendPipeline)
-                it.receivePipeline.installDefaultTransformations()
-                it.sendPipeline.installDefaultTransformations()
-            }
+            ).distinct()
+        return names.mapNotNull { name ->
+            (servletConfig.getInitParameter(name) ?: servletContext.getInitParameter(name))?.let { name to it }
         }
     }
 
@@ -91,9 +76,7 @@ public open class ServletApplicationEngine : KtorServlet() {
     override val enginePipeline: EnginePipeline by lazy {
         servletContext.getAttribute(ApplicationEnginePipelineAttributeKey)?.let { return@lazy it as EnginePipeline }
 
-        defaultEnginePipeline(environment.config, application.developmentMode).also {
-            BaseApplicationResponse.setupSendPipeline(it.sendPipeline)
-        }
+        bootstrap!!.enginePipeline
     }
 
     override val upgrade: ServletUpgrade by lazy {
@@ -113,14 +96,24 @@ public open class ServletApplicationEngine : KtorServlet() {
      * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.server.servlet.jakarta.ServletApplicationEngine.init)
      */
     override fun init() {
-        embeddedServer?.start()
+        // In managed mode the server is already started by KtorServletContainerInitializer at
+        // deployment time, so it must not be started again (a second start would recreate the app).
+        if (servletContext.managedEmbeddedServer() == null) {
+            embeddedServer?.start()
+        }
         super.init()
     }
 
     override fun destroy() {
-        application.monitor.raise(ApplicationStopPreparing, environment)
-        super.destroy()
-        embeddedServer?.stop()
+        // In managed mode the server is stopped by KtorManagedServerStopListener on context
+        // destruction, which also guarantees the stop events fire even if no request was ever served.
+        if (servletContext.managedEmbeddedServer() == null) {
+            application.monitor.raise(ApplicationStopPreparing, environment)
+            super.destroy()
+            embeddedServer?.stop()
+        } else {
+            super.destroy()
+        }
     }
 
     public companion object {
@@ -177,3 +170,70 @@ private object EmptyEngineFactory : ApplicationEngineFactory<ApplicationEngine, 
 
 internal fun ServletContext.isTomcat() =
     getAttribute(ApplicationAttributeKey) == null && serverInfo.contains("tomcat", ignoreCase = true)
+
+/**
+ * Internal context attribute holding the listener-managed [EmbeddedServer].
+ *
+ * Kept separate from [ServletApplicationEngine.ApplicationAttributeKey] so it does not flip
+ * [ServletContext.isTomcat] detection.
+ */
+internal const val ManagedServerKey: String = "_ktor_managed_embedded_server"
+
+internal typealias ServletEmbeddedServer = EmbeddedServer<ApplicationEngine, ApplicationEngine.Configuration>
+
+@Suppress("UNCHECKED_CAST")
+internal fun ServletContext.managedEmbeddedServer(): ServletEmbeddedServer? =
+    getAttribute(ManagedServerKey) as? ServletEmbeddedServer
+
+internal class ServletApplicationBootstrap(
+    val server: ServletEmbeddedServer,
+    val enginePipeline: EnginePipeline
+)
+
+/**
+ * Builds (but does not start) an [EmbeddedServer] for a servlet-hosted Ktor application together with
+ * its [EnginePipeline], wiring the pipeline into the application on [ApplicationStarting].
+ *
+ * Shared by [ServletApplicationEngine] (the self-bootstrap fallback) and [KtorServletContainerInitializer]
+ * (the WAR deployment path) so the bootstrap logic lives in a single place.
+ *
+ * @param initParameters servlet/context init parameters as raw `name to value` pairs; only those
+ * prefixed with `io.ktor.` are considered, with the prefix stripped to form the configuration keys.
+ */
+internal fun bootstrapServletApplication(
+    servletContext: ServletContext,
+    initParameters: List<Pair<String, String>>
+): ServletApplicationBootstrap {
+    val parameters = initParameters
+        .filter { (name, _) -> name.startsWith("io.ktor") }
+        .map { (name, value) -> name.removePrefix("io.ktor.") to value }
+
+    val parametersConfig = MapApplicationConfig(parameters)
+    val combinedConfig = parametersConfig
+        .withFallback(load(parametersConfig.tryGetString("ktor.config")))
+
+    val applicationId = combinedConfig.tryGetString("ktor.application.id") ?: "Application"
+
+    val environment = applicationEnvironment {
+        config = combinedConfig
+        log = LoggerFactory.getLogger(applicationId)
+        classLoader = servletContext.classLoader
+    }
+    val applicationProperties = serverConfig(environment) {
+        rootPath = servletContext.contextPath ?: "/"
+    }
+    val server = EmbeddedServer(applicationProperties, EmptyEngineFactory)
+
+    val enginePipeline = defaultEnginePipeline(environment.config, server.application.developmentMode).also {
+        BaseApplicationResponse.setupSendPipeline(it.sendPipeline)
+    }
+
+    server.monitor.subscribe(ApplicationStarting) {
+        it.receivePipeline.merge(enginePipeline.receivePipeline)
+        it.sendPipeline.merge(enginePipeline.sendPipeline)
+        it.receivePipeline.installDefaultTransformations()
+        it.sendPipeline.installDefaultTransformations()
+    }
+
+    return ServletApplicationBootstrap(server, enginePipeline)
+}

--- a/ktor-server/ktor-server-servlet-jakarta/jvm/test/io/ktor/tests/servlet/jakarta/ConfigTest.kt
+++ b/ktor-server/ktor-server-servlet-jakarta/jvm/test/io/ktor/tests/servlet/jakarta/ConfigTest.kt
@@ -36,6 +36,7 @@ class ConfigTest {
             every { contextPath } returns "/"
             every { getAttribute(ApplicationAttributeKey) } returns null
             every { getAttribute(EnvironmentAttributeKey) } returns null
+            every { getAttribute(ManagedServerKey) } returns null
             every { serverInfo } returns ""
         }
 
@@ -72,6 +73,7 @@ class ConfigTest {
             every { contextPath } returns "/"
             every { getAttribute(ApplicationAttributeKey) } returns null
             every { getAttribute(EnvironmentAttributeKey) } returns null
+            every { getAttribute(ManagedServerKey) } returns null
             every { serverInfo } returns ""
         }
 

--- a/ktor-server/ktor-server-servlet-jakarta/jvm/test/io/ktor/tests/servlet/jakarta/KtorServletContainerInitializerTest.kt
+++ b/ktor-server/ktor-server-servlet-jakarta/jvm/test/io/ktor/tests/servlet/jakarta/KtorServletContainerInitializerTest.kt
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2014-2026 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.tests.servlet.jakarta
+
+import io.ktor.server.servlet.jakarta.KtorServletContainerInitializer
+import io.ktor.server.servlet.jakarta.KtorServletContextListener
+import io.ktor.server.servlet.jakarta.ManagedServerKey
+import io.ktor.server.servlet.jakarta.ServletApplicationEngine
+import io.ktor.server.servlet.jakarta.ServletApplicationEngine.Companion.ApplicationAttributeKey
+import io.ktor.utils.io.InternalAPI
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import jakarta.servlet.ServletContext
+import jakarta.servlet.ServletContextEvent
+import jakarta.servlet.ServletRegistration
+import kotlin.test.Test
+
+@OptIn(InternalAPI::class)
+class KtorServletContainerInitializerTest {
+
+    @Test
+    fun registersLifecycleListenerWhenNotEmbedded() {
+        val ctx = mockk<ServletContext>(relaxed = true) {
+            every { getAttribute(ApplicationAttributeKey) } returns null
+        }
+
+        KtorServletContainerInitializer().onStartup(null, ctx)
+
+        verify { ctx.addListener(KtorServletContextListener::class.java) }
+    }
+
+    @Test
+    fun doesNotRegisterListenerInEmbeddedMode() {
+        val ctx = mockk<ServletContext>(relaxed = true) {
+            every { getAttribute(ApplicationAttributeKey) } returns Any()
+        }
+
+        KtorServletContainerInitializer().onStartup(null, ctx)
+
+        verify(exactly = 0) { ctx.addListener(KtorServletContextListener::class.java) }
+    }
+
+    @Test
+    fun skipsContextManagementWhenMultipleEngineRegistrations() {
+        val registration = mockk<ServletRegistration> {
+            every { className } returns ServletApplicationEngine::class.java.name
+        }
+        val ctx = mockk<ServletContext>(relaxed = true) {
+            every { getAttribute(ApplicationAttributeKey) } returns null
+            every { getAttribute(ManagedServerKey) } returns null
+            every { classLoader } returns this@KtorServletContainerInitializerTest::class.java.classLoader
+            every { servletRegistrations } returns mapOf("first" to registration, "second" to registration)
+        }
+        val event = mockk<ServletContextEvent> { every { servletContext } returns ctx }
+
+        KtorServletContextListener().contextInitialized(event)
+
+        // Falls back to per-servlet self-bootstrap: warns and does not take over the lifecycle.
+        verify { ctx.log(any()) }
+        verify(exactly = 0) { ctx.setAttribute(ManagedServerKey, any()) }
+    }
+}

--- a/ktor-server/ktor-server-servlet/api/ktor-server-servlet.api
+++ b/ktor-server/ktor-server-servlet/api/ktor-server-servlet.api
@@ -61,6 +61,17 @@ public abstract class io/ktor/server/servlet/KtorServlet : javax/servlet/http/Ht
 	protected fun service (Ljavax/servlet/http/HttpServletRequest;Ljavax/servlet/http/HttpServletResponse;)V
 }
 
+public final class io/ktor/server/servlet/KtorServletContainerInitializer : javax/servlet/ServletContainerInitializer {
+	public fun <init> ()V
+	public fun onStartup (Ljava/util/Set;Ljavax/servlet/ServletContext;)V
+}
+
+public final class io/ktor/server/servlet/KtorServletContextListener : javax/servlet/ServletContextListener {
+	public fun <init> ()V
+	public fun contextDestroyed (Ljavax/servlet/ServletContextEvent;)V
+	public fun contextInitialized (Ljavax/servlet/ServletContextEvent;)V
+}
+
 public final class io/ktor/server/servlet/KtorServletKt {
 	public static final fun getServletContextAttribute ()Lio/ktor/util/AttributeKey;
 }

--- a/ktor-server/ktor-server-servlet/jvm/resources/META-INF/services/javax.servlet.ServletContainerInitializer
+++ b/ktor-server/ktor-server-servlet/jvm/resources/META-INF/services/javax.servlet.ServletContainerInitializer
@@ -1,0 +1,1 @@
+io.ktor.server.servlet.KtorServletContainerInitializer

--- a/ktor-server/ktor-server-servlet/jvm/src/io/ktor/server/servlet/KtorServletContainerInitializer.kt
+++ b/ktor-server/ktor-server-servlet/jvm/src/io/ktor/server/servlet/KtorServletContainerInitializer.kt
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2014-2026 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.server.servlet
+
+import io.ktor.server.application.*
+import io.ktor.server.servlet.ServletApplicationEngine.Companion.ApplicationAttributeKey
+import io.ktor.server.servlet.ServletApplicationEngine.Companion.ApplicationEnginePipelineAttributeKey
+import io.ktor.utils.io.InternalAPI
+import javax.servlet.ServletContainerInitializer
+import javax.servlet.ServletContext
+import javax.servlet.ServletContextEvent
+import javax.servlet.ServletContextListener
+
+/**
+ * Registers [KtorServletContextListener] so a servlet-hosted Ktor application is started and stopped in
+ * lockstep with the web application context lifecycle.
+ *
+ * Registered automatically via `META-INF/services/javax.servlet.ServletContainerInitializer`, so no
+ * user configuration is required. It is a no-op when the application is driven by an embedded engine,
+ * which injects [ServletApplicationEngine.ApplicationAttributeKey] and owns the lifecycle itself.
+ *
+ * It must be `public` so the servlet container can instantiate it via `ServiceLoader`, but it is
+ * internal infrastructure and not intended to be referenced directly.
+ *
+ * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.server.servlet.KtorServletContainerInitializer)
+ */
+@InternalAPI
+public class KtorServletContainerInitializer : ServletContainerInitializer {
+    override fun onStartup(classes: MutableSet<Class<*>>?, ctx: ServletContext) {
+        // Embedded engine mode owns the lifecycle; do not register the listener.
+        if (ctx.getAttribute(ApplicationAttributeKey) != null) return
+        ctx.addListener(KtorServletContextListener::class.java)
+    }
+}
+
+/**
+ * Starts and stops a servlet-hosted Ktor application together with the web application context, so the
+ * lifecycle events fire at deploy/undeploy regardless of `load-on-startup` (see KTOR-8524).
+ *
+ * Registered automatically by [KtorServletContainerInitializer]; it can also be added as a `<listener>`
+ * in `web.xml`.
+ *
+ * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.server.servlet.KtorServletContextListener)
+ */
+public class KtorServletContextListener : ServletContextListener {
+    override fun contextInitialized(sce: ServletContextEvent) {
+        val ctx = sce.servletContext
+        // Embedded engine mode owns the lifecycle.
+        if (ctx.getAttribute(ApplicationAttributeKey) != null) return
+        // Defensive: never start the application twice.
+        if (ctx.managedEmbeddedServer() != null) return
+
+        val registrations = ctx.servletRegistrations?.values?.filter { registration ->
+            val className = registration.className ?: return@filter false
+            val servletClass = runCatching { ctx.classLoader.loadClass(className) }.getOrNull()
+            servletClass != null && ServletApplicationEngine::class.java.isAssignableFrom(servletClass)
+        }.orEmpty()
+
+        // Context-managed lifecycle assumes a single Ktor application per web application context.
+        // With more than one ServletApplicationEngine, fall back to per-servlet self-bootstrap so each
+        // servlet keeps its own application (matching the pre-listener behavior) instead of sharing one.
+        val registration = registrations.singleOrNull() ?: run {
+            if (registrations.size > 1) {
+                ctx.log(
+                    "Multiple ServletApplicationEngine registrations found; context-managed application " +
+                        "lifecycle is disabled. Each servlet bootstraps its own application on init()."
+                )
+            }
+            return
+        }
+
+        val initParameters = registration.initParameters.toList() + ctx.contextInitParameters()
+
+        val bootstrap = bootstrapServletApplication(ctx, initParameters)
+        bootstrap.server.start()
+
+        ctx.setAttribute(ManagedServerKey, bootstrap.server)
+        ctx.setAttribute(ApplicationEnginePipelineAttributeKey, bootstrap.enginePipeline)
+    }
+
+    override fun contextDestroyed(sce: ServletContextEvent) {
+        val ctx = sce.servletContext
+        val server = ctx.managedEmbeddedServer() ?: return
+
+        server.application.monitor.raise(ApplicationStopPreparing, server.environment)
+        server.stop()
+        ctx.removeAttribute(ManagedServerKey)
+    }
+}
+
+private fun ServletContext.contextInitParameters(): List<Pair<String, String>> =
+    initParameterNames?.toList().orEmpty().mapNotNull { name ->
+        getInitParameter(name)?.let { name to it }
+    }

--- a/ktor-server/ktor-server-servlet/jvm/src/io/ktor/server/servlet/KtorServletContainerInitializer.kt
+++ b/ktor-server/ktor-server-servlet/jvm/src/io/ktor/server/servlet/KtorServletContainerInitializer.kt
@@ -36,8 +36,14 @@ public class KtorServletContainerInitializer : ServletContainerInitializer {
 }
 
 /**
- * Starts and stops a servlet-hosted Ktor application together with the web application context, so the
- * lifecycle events fire at deploy/undeploy regardless of `load-on-startup` (see KTOR-8524).
+ * Starts and stops a servlet-hosted Ktor application together with the web application context,
+ * independently of when (or whether) the [ServletApplicationEngine] servlet is initialized.
+ *
+ * In a WAR deployment without `load-on-startup` the servlet container initializes the servlet lazily on
+ * the first request. Binding the application lifecycle to `contextInitialized` / `contextDestroyed`
+ * makes `ApplicationStarted` fire at deployment time instead of only after the first request, and
+ * guarantees `ApplicationStopped` fires on undeploy even when no request was ever served (otherwise
+ * resources released by `ApplicationStopped` handlers would leak).
  *
  * Registered automatically by [KtorServletContainerInitializer]; it can also be added as a `<listener>`
  * in `web.xml`.
@@ -87,6 +93,7 @@ public class KtorServletContextListener : ServletContextListener {
         server.application.monitor.raise(ApplicationStopPreparing, server.environment)
         server.stop()
         ctx.removeAttribute(ManagedServerKey)
+        ctx.removeAttribute(ApplicationEnginePipelineAttributeKey)
     }
 }
 

--- a/ktor-server/ktor-server-servlet/jvm/src/io/ktor/server/servlet/ServletApplicationEngine.kt
+++ b/ktor-server/ktor-server-servlet/jvm/src/io/ktor/server/servlet/ServletApplicationEngine.kt
@@ -204,7 +204,7 @@ internal fun bootstrapServletApplication(
     initParameters: List<Pair<String, String>>
 ): ServletApplicationBootstrap {
     val parameters = initParameters
-        .filter { (name, _) -> name.startsWith("io.ktor") }
+        .filter { (name, _) -> name.startsWith("io.ktor.") }
         .map { (name, value) -> name.removePrefix("io.ktor.") to value }
 
     val parametersConfig = MapApplicationConfig(parameters)

--- a/ktor-server/ktor-server-servlet/jvm/src/io/ktor/server/servlet/ServletApplicationEngine.kt
+++ b/ktor-server/ktor-server-servlet/jvm/src/io/ktor/server/servlet/ServletApplicationEngine.kt
@@ -32,48 +32,33 @@ public open class ServletApplicationEngine : KtorServlet() {
             emptySet()
         }
 
-    private val embeddedServer: EmbeddedServer<ApplicationEngine, ApplicationEngine.Configuration>? by lazy {
-        servletContext.getAttribute(ApplicationAttributeKey)?.let {
-            return@lazy null
+    private val bootstrap: ServletApplicationBootstrap? by lazy {
+        // External injection mode: the embedded engine (Jetty/Tomcat) owns the application lifecycle.
+        if (servletContext.getAttribute(ApplicationAttributeKey) != null) return@lazy null
+
+        // Managed mode: KtorServletContainerInitializer already created and started the server at
+        // deployment time. Reuse that instance instead of bootstrapping (and starting) a second one.
+        servletContext.managedEmbeddedServer()?.let { server ->
+            return@lazy ServletApplicationBootstrap(
+                server,
+                servletContext.getAttribute(ApplicationEnginePipelineAttributeKey) as EnginePipeline
+            )
         }
 
-        val servletContext = servletContext
-        val servletConfig = servletConfig
+        // Fallback (no ServletContainerInitializer ran): self-bootstrap from servlet init parameters.
+        bootstrapServletApplication(servletContext, collectInitParameters())
+    }
 
-        val parameterNames = (
+    private val embeddedServer: ServletEmbeddedServer?
+        get() = bootstrap?.server
+
+    private fun collectInitParameters(): List<Pair<String, String>> {
+        val names = (
             servletContext.initParameterNames?.toList().orEmpty() +
                 servletConfig.initParameterNames?.toList().orEmpty()
-            ).filter { it.startsWith("io.ktor") }.distinct()
-        val parameters = parameterNames.map {
-            it.removePrefix("io.ktor.") to
-                (servletConfig.getInitParameter(it) ?: servletContext.getInitParameter(it))
-        }
-
-        val parametersConfig = MapApplicationConfig(parameters)
-        val configPath = "ktor.config"
-        val applicationIdPath = "ktor.application.id"
-
-        val combinedConfig = parametersConfig
-            .withFallback(load(parametersConfig.tryGetString(configPath)))
-
-        val applicationId = combinedConfig.tryGetString(applicationIdPath) ?: "Application"
-
-        val environment = applicationEnvironment {
-            config = combinedConfig
-            log = LoggerFactory.getLogger(applicationId)
-            classLoader = servletContext.classLoader
-        }
-        val applicationProperties = serverConfig(environment) {
-            rootPath = servletContext.contextPath ?: "/"
-        }
-        val server = EmbeddedServer(applicationProperties, EmptyEngineFactory)
-        server.apply {
-            monitor.subscribe(ApplicationStarting) {
-                it.receivePipeline.merge(enginePipeline.receivePipeline)
-                it.sendPipeline.merge(enginePipeline.sendPipeline)
-                it.receivePipeline.installDefaultTransformations()
-                it.sendPipeline.installDefaultTransformations()
-            }
+            ).distinct()
+        return names.mapNotNull { name ->
+            (servletConfig.getInitParameter(name) ?: servletContext.getInitParameter(name))?.let { name to it }
         }
     }
 
@@ -91,9 +76,7 @@ public open class ServletApplicationEngine : KtorServlet() {
     override val enginePipeline: EnginePipeline by lazy {
         servletContext.getAttribute(ApplicationEnginePipelineAttributeKey)?.let { return@lazy it as EnginePipeline }
 
-        defaultEnginePipeline(environment.config, application.developmentMode).also {
-            BaseApplicationResponse.setupSendPipeline(it.sendPipeline)
-        }
+        bootstrap!!.enginePipeline
     }
 
     override val upgrade: ServletUpgrade by lazy {
@@ -113,14 +96,24 @@ public open class ServletApplicationEngine : KtorServlet() {
      * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.server.servlet.ServletApplicationEngine.init)
      */
     override fun init() {
-        embeddedServer?.start()
+        // In managed mode the server is already started by KtorServletContainerInitializer at
+        // deployment time, so it must not be started again (a second start would recreate the app).
+        if (servletContext.managedEmbeddedServer() == null) {
+            embeddedServer?.start()
+        }
         super.init()
     }
 
     override fun destroy() {
-        application.monitor.raise(ApplicationStopPreparing, environment)
-        super.destroy()
-        embeddedServer?.stop()
+        // In managed mode the server is stopped by KtorServletContextListener on context destruction,
+        // which also guarantees the stop events fire even if no request was ever served.
+        if (servletContext.managedEmbeddedServer() == null) {
+            application.monitor.raise(ApplicationStopPreparing, environment)
+            super.destroy()
+            embeddedServer?.stop()
+        } else {
+            super.destroy()
+        }
     }
 
     public companion object {
@@ -176,3 +169,70 @@ private object EmptyEngineFactory : ApplicationEngineFactory<ApplicationEngine, 
 
 internal fun ServletContext.isTomcat() =
     getAttribute(ApplicationAttributeKey) == null && serverInfo.contains("tomcat", ignoreCase = true)
+
+/**
+ * Internal context attribute holding the listener-managed [EmbeddedServer].
+ *
+ * Kept separate from [ServletApplicationEngine.ApplicationAttributeKey] so it does not flip
+ * [ServletContext.isTomcat] detection.
+ */
+internal const val ManagedServerKey: String = "_ktor_managed_embedded_server"
+
+internal typealias ServletEmbeddedServer = EmbeddedServer<ApplicationEngine, ApplicationEngine.Configuration>
+
+@Suppress("UNCHECKED_CAST")
+internal fun ServletContext.managedEmbeddedServer(): ServletEmbeddedServer? =
+    getAttribute(ManagedServerKey) as? ServletEmbeddedServer
+
+internal class ServletApplicationBootstrap(
+    val server: ServletEmbeddedServer,
+    val enginePipeline: EnginePipeline
+)
+
+/**
+ * Builds (but does not start) an [EmbeddedServer] for a servlet-hosted Ktor application together with
+ * its [EnginePipeline], wiring the pipeline into the application on [ApplicationStarting].
+ *
+ * Shared by [ServletApplicationEngine] (the self-bootstrap fallback) and [KtorServletContainerInitializer]
+ * (the WAR deployment path) so the bootstrap logic lives in a single place.
+ *
+ * @param initParameters servlet/context init parameters as raw `name to value` pairs; only those
+ * prefixed with `io.ktor.` are considered, with the prefix stripped to form the configuration keys.
+ */
+internal fun bootstrapServletApplication(
+    servletContext: ServletContext,
+    initParameters: List<Pair<String, String>>
+): ServletApplicationBootstrap {
+    val parameters = initParameters
+        .filter { (name, _) -> name.startsWith("io.ktor") }
+        .map { (name, value) -> name.removePrefix("io.ktor.") to value }
+
+    val parametersConfig = MapApplicationConfig(parameters)
+    val combinedConfig = parametersConfig
+        .withFallback(load(parametersConfig.tryGetString("ktor.config")))
+
+    val applicationId = combinedConfig.tryGetString("ktor.application.id") ?: "Application"
+
+    val environment = applicationEnvironment {
+        config = combinedConfig
+        log = LoggerFactory.getLogger(applicationId)
+        classLoader = servletContext.classLoader
+    }
+    val applicationProperties = serverConfig(environment) {
+        rootPath = servletContext.contextPath ?: "/"
+    }
+    val server = EmbeddedServer(applicationProperties, EmptyEngineFactory)
+
+    val enginePipeline = defaultEnginePipeline(environment.config, server.application.developmentMode).also {
+        BaseApplicationResponse.setupSendPipeline(it.sendPipeline)
+    }
+
+    server.monitor.subscribe(ApplicationStarting) {
+        it.receivePipeline.merge(enginePipeline.receivePipeline)
+        it.sendPipeline.merge(enginePipeline.sendPipeline)
+        it.receivePipeline.installDefaultTransformations()
+        it.sendPipeline.installDefaultTransformations()
+    }
+
+    return ServletApplicationBootstrap(server, enginePipeline)
+}

--- a/ktor-server/ktor-server-servlet/jvm/test/io/ktor/tests/servlet/ConfigTest.kt
+++ b/ktor-server/ktor-server-servlet/jvm/test/io/ktor/tests/servlet/ConfigTest.kt
@@ -36,6 +36,7 @@ class ConfigTest {
             every { contextPath } returns "/"
             every { getAttribute(ApplicationAttributeKey) } returns null
             every { getAttribute(EnvironmentAttributeKey) } returns null
+            every { getAttribute(ManagedServerKey) } returns null
             every { serverInfo } returns ""
         }
 
@@ -71,6 +72,7 @@ class ConfigTest {
             every { contextPath } returns "/"
             every { getAttribute(ApplicationAttributeKey) } returns null
             every { getAttribute(EnvironmentAttributeKey) } returns null
+            every { getAttribute(ManagedServerKey) } returns null
             every { serverInfo } returns ""
         }
 

--- a/ktor-server/ktor-server-servlet/jvm/test/io/ktor/tests/servlet/KtorServletContainerInitializerTest.kt
+++ b/ktor-server/ktor-server-servlet/jvm/test/io/ktor/tests/servlet/KtorServletContainerInitializerTest.kt
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2014-2026 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.tests.servlet
+
+import io.ktor.server.servlet.KtorServletContainerInitializer
+import io.ktor.server.servlet.KtorServletContextListener
+import io.ktor.server.servlet.ManagedServerKey
+import io.ktor.server.servlet.ServletApplicationEngine
+import io.ktor.server.servlet.ServletApplicationEngine.Companion.ApplicationAttributeKey
+import io.ktor.utils.io.InternalAPI
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import javax.servlet.ServletContext
+import javax.servlet.ServletContextEvent
+import javax.servlet.ServletRegistration
+import kotlin.test.Test
+
+@OptIn(InternalAPI::class)
+class KtorServletContainerInitializerTest {
+
+    @Test
+    fun registersLifecycleListenerWhenNotEmbedded() {
+        val ctx = mockk<ServletContext>(relaxed = true) {
+            every { getAttribute(ApplicationAttributeKey) } returns null
+        }
+
+        KtorServletContainerInitializer().onStartup(null, ctx)
+
+        verify { ctx.addListener(KtorServletContextListener::class.java) }
+    }
+
+    @Test
+    fun doesNotRegisterListenerInEmbeddedMode() {
+        val ctx = mockk<ServletContext>(relaxed = true) {
+            every { getAttribute(ApplicationAttributeKey) } returns Any()
+        }
+
+        KtorServletContainerInitializer().onStartup(null, ctx)
+
+        verify(exactly = 0) { ctx.addListener(KtorServletContextListener::class.java) }
+    }
+
+    @Test
+    fun skipsContextManagementWhenMultipleEngineRegistrations() {
+        val registration = mockk<ServletRegistration> {
+            every { className } returns ServletApplicationEngine::class.java.name
+        }
+        val ctx = mockk<ServletContext>(relaxed = true) {
+            every { getAttribute(ApplicationAttributeKey) } returns null
+            every { getAttribute(ManagedServerKey) } returns null
+            every { classLoader } returns this@KtorServletContainerInitializerTest::class.java.classLoader
+            every { servletRegistrations } returns mapOf("first" to registration, "second" to registration)
+        }
+        val event = mockk<ServletContextEvent> { every { servletContext } returns ctx }
+
+        KtorServletContextListener().contextInitialized(event)
+
+        // Falls back to per-servlet self-bootstrap: warns and does not take over the lifecycle.
+        verify { ctx.log(any()) }
+        verify(exactly = 0) { ctx.setAttribute(ManagedServerKey, any()) }
+    }
+}


### PR DESCRIPTION
**Subsystem**
 Server: ktor-server-servlet, ktor-server-servlet-jakarta
(regression tests in ktor-server-jetty, ktor-server-jetty-jakarta)

**Motivation**
[KTOR-8524](https://youtrack.jetbrains.com/issue/KTOR-8524/ServletApplicationEngine-Application-events-arent-triggered)  

`ApplicationStarted` / `ApplicationStopped` are meant to fire when the application starts and stops, consistently across deployment modes. In the embedded modes (`embeddedServer(...)`) this already works: the events fire when Ktor calls `start()` / `stop()`.

In a WAR deployment, however, `ServletApplicationEngine` self-bootstraps an `EmbeddedServer` and ties its lifecycle to the servlet's `init()` / `destroy()` callbacks. Because a servlet is initialized lazily (without `load-on-startup`, on the first request), the application lifecycle ends up bound to the wrong moment:

- `ApplicationStarted` fires only after the first request, not at deployment time.
- `ApplicationStopped` is never fired if the application is undeployed without serving any request, so resources released in `ApplicationStopped` handlers leak.

In a WAR, "the application starts" is the web application context being initialized (deploy time) — not the first request. `load-on-startup` would work around this, but it is a deployment-descriptor setting owned by the user, so the library cannot guarantee it; the lifecycle has to be correct by default.


**Solution**
Bind the application lifecycle to the servletContext instead of the servlet's lazy `init()` / `destroy()`:
- `KtorServletContextListener` starts/stops the embedded server on `contextInitialized` / `contextDestroyed`, so `ApplicationStarted` /`ApplicationStopped` fire at deploy/undeploy regardless of `load-on-startup`.
- `KtorServletContainerInitializer` (auto-registered via `META-INF/services`) registers the listener, so no user configuration is required. Marked `@InternalAPI`.
- `ServletApplicationEngine` reuses the listener-managed server and skips its own start/stop. The servlet stays lazily initialized, falls back to self-bootstrapping when no initializer ran, and the whole thing is a no-op when an embedded engine owns the lifecycle.

Applied to both `ktor-server-servlet` (javax) and `ktor-server-servlet-jakarta` with regression tests in the servlet and Jetty modules.
