### PR TITLE
Support alternative `fetch` implementations in JS client

### DIFF
--- a/ktor-client/ktor-client-core/api/ktor-client-core.klib.api
+++ b/ktor-client/ktor-client-core/api/ktor-client-core.klib.api
@@ -1948,6 +1948,9 @@ final class io.ktor.client.engine.js/JsError : kotlin/Throwable { // io.ktor.cli
 open class io.ktor.client.engine.js/JsClientEngineConfig : io.ktor.client.engine/HttpClientEngineConfig { // io.ktor.client.engine.js/JsClientEngineConfig|null[0]
     constructor <init>() // io.ktor.client.engine.js/JsClientEngineConfig.<init>|<init>(){}[0]
 
+    final var fetch // io.ktor.client.engine.js/JsClientEngineConfig.fetch|{}fetch[0]
+        final fun <get-fetch>(): kotlin/Function2<kotlin/String, io.ktor.client.fetch/RequestInit?, kotlin.js/Promise<org.w3c.fetch/Response>> // io.ktor.client.engine.js/JsClientEngineConfig.fetch.<get-fetch>|<get-fetch>(){}[0]
+        final fun <set-fetch>(kotlin/Function2<kotlin/String, io.ktor.client.fetch/RequestInit?, kotlin.js/Promise<org.w3c.fetch/Response>>) // io.ktor.client.engine.js/JsClientEngineConfig.fetch.<set-fetch>|<set-fetch>(kotlin.Function2<kotlin.String,io.ktor.client.fetch.RequestInit?,kotlin.js.Promise<org.w3c.fetch.Response>>){}[0]
     final var nodeOptions // io.ktor.client.engine.js/JsClientEngineConfig.nodeOptions|{}nodeOptions[0]
         // Targets: [js]
         final fun <get-nodeOptions>(): dynamic // io.ktor.client.engine.js/JsClientEngineConfig.nodeOptions.<get-nodeOptions>|<get-nodeOptions>(){}[0]

--- a/ktor-client/ktor-client-core/js/src/io/ktor/client/engine/js/Js.kt
+++ b/ktor-client/ktor-client-core/js/src/io/ktor/client/engine/js/Js.kt
@@ -5,7 +5,9 @@
 package io.ktor.client.engine.js
 
 import io.ktor.client.engine.*
+import io.ktor.client.fetch.fetch
 import io.ktor.utils.io.*
+import kotlin.js.Promise
 
 /**
  * A JavaScript client engine that uses the fetch API to execute requests.
@@ -35,6 +37,13 @@ public actual data object Js : HttpClientEngineFactory<JsClientEngineConfig> {
  */
 public actual open class JsClientEngineConfig : HttpClientEngineConfig() {
     internal var requestInit: io.ktor.client.fetch.RequestInit.() -> Unit = {}
+
+    /**
+     * Allows overriding which function is used to execute requests.
+     *
+     * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.client.engine.js.JsClientEngineConfig.fetch)
+     */
+    public var fetch: (String, io.ktor.client.fetch.RequestInit?) -> Promise<org.w3c.fetch.Response> = ::fetch
 
     /**
      * Provides access to the underlying fetch options of the engine.

--- a/ktor-client/ktor-client-core/js/src/io/ktor/client/engine/js/compatibility/Utils.kt
+++ b/ktor-client/ktor-client-core/js/src/io/ktor/client/engine/js/compatibility/Utils.kt
@@ -33,10 +33,10 @@ internal suspend fun commonFetch(
     callJob.invokeOnCompletion(onCancelling = true) { controller.abort() }
 
     val promise: Promise<org.w3c.fetch.Response> = when {
-        PlatformUtils.IS_BROWSER -> fetch(input, init)
+        PlatformUtils.IS_BROWSER -> config.fetch(input, init)
         else -> {
             val options = js("Object").assign(js("Object").create(null), init, config.nodeOptions)
-            fetch(input, options)
+            config.fetch(input, options)
         }
     }
 

--- a/ktor-client/ktor-client-core/wasmJs/src/io/ktor/client/engine/js/Js.kt
+++ b/ktor-client/ktor-client-core/wasmJs/src/io/ktor/client/engine/js/Js.kt
@@ -8,6 +8,7 @@ import io.ktor.client.engine.*
 import io.ktor.client.fetch.*
 import io.ktor.client.utils.*
 import io.ktor.utils.io.*
+import kotlin.js.Promise
 
 /**
  * A JavaScript client engine that uses the fetch API to execute requests.
@@ -37,6 +38,13 @@ public actual data object Js : HttpClientEngineFactory<JsClientEngineConfig> {
  */
 public actual open class JsClientEngineConfig : HttpClientEngineConfig() {
     internal var requestInit: RequestInit.() -> Unit = {}
+
+    /**
+     * Allows overriding which function is used to execute requests.
+     *
+     * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.client.engine.js.JsClientEngineConfig.fetch)
+     */
+    public var fetch: (String, RequestInit?) -> Promise<org.w3c.fetch.Response> = ::fetch
 
     /**
      * Provides access to the underlying fetch options of the engine.

--- a/ktor-client/ktor-client-core/wasmJs/src/io/ktor/client/engine/js/compatibility/Utils.kt
+++ b/ktor-client/ktor-client-core/wasmJs/src/io/ktor/client/engine/js/compatibility/Utils.kt
@@ -35,7 +35,7 @@ internal suspend fun commonFetch(
     callJob.invokeOnCompletion(onCancelling = true) { controller.abort() }
 
     val promise: Promise<org.w3c.fetch.Response> = when {
-        PlatformUtils.IS_BROWSER -> fetch(input, init)
+        PlatformUtils.IS_BROWSER -> config.fetch(input, init)
         else -> {
             val options = makeJsCall<RequestInit>(
                 jsObjectAssign(),
@@ -43,7 +43,7 @@ internal suspend fun commonFetch(
                 init,
                 config.nodeOptions,
             )
-            fetch(input, options)
+            config.fetch(input, options)
         }
     }
 


### PR DESCRIPTION
**Subsystem**
Ktor client `JS` engine

**Motivation**
Some JavaScript libraries, such as [AWS WAF](https://docs.aws.amazon.com/waf/latest/developerguide/waf-javascript-api.html), require using an alternative method (eg, `AwsWafIntegration.fetch`) instead of the global `fetch`. While it's possible to work around this for some libraries by monkey-patching `fetch` to include that call, trying to do this with `AwsWafIntegration` causes an infinite loop because their method calls the global `fetch` internally.

**Solution**
Adds a `fetch` variable to `JsClientEngineConfig`. By default nothing changes and the global `fetch` is used, but you can opt-in to having the client call an alternative wrapper.

