### PR TITLE
KTOR-9575 Native. Fix utf-16 decoding BOM

### DIFF
--- a/ktor-io/darwin/src/CharsetDarwin.kt
+++ b/ktor-io/darwin/src/CharsetDarwin.kt
@@ -12,7 +12,7 @@ import platform.posix.*
 public actual object Charsets {
     public actual val UTF_8: Charset = CharsetDarwin("UTF-8")
     public actual val ISO_8859_1: Charset = CharsetDarwin("ISO-8859-1")
-    internal val UTF_16: Charset = CharsetDarwin(platformUtf16)
+    internal val UTF_16: Charset = CharsetDarwin("UTF-16")
 }
 
 internal actual fun findCharset(name: String): Charset {
@@ -24,7 +24,6 @@ internal actual fun findCharset(name: String): Charset {
 }
 
 private class CharsetDarwin(name: String) : Charset(name) {
-    @OptIn(UnsafeNumber::class)
     val encoding: NSStringEncoding = when (name.uppercase()) {
         "UTF-8" -> NSUTF8StringEncoding
         "ISO-8859-1" -> NSISOLatin1StringEncoding
@@ -38,7 +37,7 @@ private class CharsetDarwin(name: String) : Charset(name) {
         "NEXTSTEP" -> NSNEXTSTEPStringEncoding
         "JAPANESE_EUC" -> NSJapaneseEUCStringEncoding
         "LATIN1" -> NSISOLatin1StringEncoding
-        else -> throw IllegalArgumentException("Charset $name is not supported by darwin.")
+        else -> throw IllegalArgumentException("Charset $name is not supported by Darwin.")
     }
 
     override fun newEncoder(): CharsetEncoder = object : CharsetEncoder(this) {
@@ -48,9 +47,8 @@ private class CharsetDarwin(name: String) : Charset(name) {
     }
 }
 
-@OptIn(UnsafeNumber::class)
 internal actual fun CharsetEncoder.encodeImpl(input: CharSequence, fromIndex: Int, toIndex: Int, dst: Sink): Int {
-    val charset = _charset as? CharsetDarwin ?: error("Charset $this is not supported by darwin.")
+    val charset = _charset as? CharsetDarwin ?: error("Charset $this is not supported by Darwin.")
 
     @Suppress("CAST_NEVER_SUCCEEDS")
     val content = input.substring(fromIndex, toIndex) as? NSString ?: error("Failed to convert input to NSString.")
@@ -64,13 +62,13 @@ internal actual fun CharsetEncoder.encodeImpl(input: CharSequence, fromIndex: In
 }
 
 @Suppress("CAST_NEVER_SUCCEEDS")
-@OptIn(UnsafeNumber::class, BetaInteropApi::class)
+@OptIn(BetaInteropApi::class)
 public actual fun CharsetDecoder.decode(input: Source, dst: Appendable, max: Int): Int {
     if (max != Int.MAX_VALUE) {
         throw IOException("Max argument is deprecated")
     }
 
-    val charset = _charset as? CharsetDarwin ?: error("Charset $this is not supported by darwin.")
+    val charset = _charset as? CharsetDarwin ?: error("Charset $this is not supported by Darwin.")
     val source: ByteArray = input.readByteArray()
 
     val data = source.toNSData()
@@ -81,13 +79,12 @@ public actual fun CharsetDecoder.decode(input: Source, dst: Appendable, max: Int
     return content.length
 }
 
-@OptIn(UnsafeNumber::class)
 internal actual fun CharsetEncoder.encodeToByteArrayImpl(
     input: CharSequence,
     fromIndex: Int,
     toIndex: Int
 ): ByteArray {
-    val charset = _charset as? CharsetDarwin ?: error("Charset $this is not supported by darwin.")
+    val charset = _charset as? CharsetDarwin ?: error("Charset $this is not supported by Darwin.")
 
     @Suppress("CAST_NEVER_SUCCEEDS")
     val content = input.substring(fromIndex, toIndex) as? NSString ?: error("Failed to convert input to NSString.")
@@ -97,7 +94,7 @@ internal actual fun CharsetEncoder.encodeToByteArrayImpl(
         ?: throw MalformedInputException("Failed to convert String to Bytes using $charset")
 }
 
-@OptIn(UnsafeNumber::class, ExperimentalForeignApi::class)
+@OptIn(ExperimentalForeignApi::class)
 private fun ByteArray.toNSData(): NSData = NSMutableData().apply {
     if (isEmpty()) return@apply
     this@toNSData.usePinned {
@@ -105,7 +102,7 @@ private fun ByteArray.toNSData(): NSData = NSMutableData().apply {
     }
 }
 
-@OptIn(UnsafeNumber::class, ExperimentalForeignApi::class)
+@OptIn(ExperimentalForeignApi::class)
 private fun NSData.toByteArray(): ByteArray {
     val result = ByteArray(length.toInt())
     if (result.isEmpty()) return result

--- a/ktor-io/jvmAndPosix/test/CharsetUtf16Test.kt
+++ b/ktor-io/jvmAndPosix/test/CharsetUtf16Test.kt
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2014-2026 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+import io.ktor.utils.io.charsets.*
+import io.ktor.utils.io.core.*
+import kotlin.test.*
+
+class CharsetUtf16Test {
+
+    @Test
+    fun `decoding UTF-16 with BE BOM produces correct text`() {
+        val bytes = byteArrayOf(
+            0xFE.toByte(), 0xFF.toByte(),
+            0x00, 0x48,
+            0x00, 0x65,
+            0x00, 0x6C,
+            0x00, 0x6C,
+            0x00, 0x6F,
+            0x00, 0x2C,
+            0x00, 0x20,
+            0x00, 0x57,
+            0x00, 0x6F,
+            0x00, 0x72,
+            0x00, 0x6C,
+            0x00, 0x64,
+            0x00, 0x21,
+        )
+        val source = buildPacket { writeFully(bytes) }
+
+        val text = Charsets.forName("UTF-16").newDecoder().decode(source)
+
+        assertEquals("Hello, World!", text)
+    }
+
+    @Test
+    fun `decoding UTF-16 with LE BOM produces correct text`() {
+        val bytes = byteArrayOf(
+            0xFF.toByte(), 0xFE.toByte(),
+            0x48, 0x00,
+            0x65, 0x00,
+            0x6C, 0x00,
+            0x6C, 0x00,
+            0x6F, 0x00,
+            0x2C, 0x00,
+            0x20, 0x00,
+            0x57, 0x00,
+            0x6F, 0x00,
+            0x72, 0x00,
+            0x6C, 0x00,
+            0x64, 0x00,
+            0x21, 0x00,
+        )
+        val source = buildPacket { writeFully(bytes) }
+
+        val text = Charsets.forName("UTF-16").newDecoder().decode(source)
+
+        assertEquals("Hello, World!", text)
+    }
+
+    @Test
+    fun `UTF-16BE and UTF-16LE are supported`() {
+        assertTrue(Charsets.isSupported("UTF-16BE"))
+        assertTrue(Charsets.isSupported("UTF-16LE"))
+    }
+
+    @Test
+    fun `explicit UTF-16LE decodes without BOM`() {
+        val bytes = byteArrayOf(
+            0x48,
+            0x00,
+            0x69,
+            0x00,
+        )
+        val source = buildPacket { writeFully(bytes) }
+
+        val text = Charsets.forName("UTF-16LE").newDecoder().decode(source)
+
+        assertEquals("Hi", text)
+    }
+
+    @Test
+    fun `unsupported charset`() {
+        assertFalse(Charsets.isSupported("NOT-A-CHARSET"))
+        assertFailsWith<IllegalArgumentException> {
+            Charsets.forName("NOT-A-CHARSET")
+        }
+    }
+
+    @Test
+    fun `UTF-16LE does not decode big-endian bytes correctly`() {
+        val beBytes = byteArrayOf(0x00, 0x48, 0x00, 0x69)
+        val source = buildPacket { writeFully(beBytes) }
+
+        val text = Charsets.forName("UTF-16LE").newDecoder().decode(source)
+
+        assertNotEquals("Hi", text)
+    }
+
+    @Test
+    fun `decoding truncated UTF-16 should not hang`() {
+        val truncated = byteArrayOf(0x00)
+        val source = buildPacket { writeFully(truncated) }
+        val result = runCatching { Charsets.forName("UTF-16").newDecoder().decode(source) }
+        assertDecodeFailed(result)
+    }
+
+    @Test
+    fun `decoding truncated UTF-16LE should not hang`() {
+        val truncated = byteArrayOf(0x48)
+        val source = buildPacket { writeFully(truncated) }
+        val result = runCatching { Charsets.forName("UTF-16LE").newDecoder().decode(source) }
+        assertDecodeFailed(result)
+    }
+}
+
+private fun assertDecodeFailed(result: Result<String>) {
+    when {
+        result.isFailure && result.exceptionOrNull() is MalformedInputException -> Unit
+        result.isSuccess && result.getOrNull() == "\uFFFD" -> Unit
+        result.isSuccess -> fail("Expected decode to fail but got: ${result.getOrNull()}")
+        else -> fail("Unexpected failure: ${result.exceptionOrNull()}")
+    }
+}

--- a/ktor-io/linux/src/CharsetLinux.kt
+++ b/ktor-io/linux/src/CharsetLinux.kt
@@ -17,7 +17,7 @@ private const val DECODING_BUFFER_SIZE = 8192
 public actual object Charsets {
     public actual val UTF_8: Charset by lazy { CharsetIconv("UTF-8") }
     public actual val ISO_8859_1: Charset by lazy { CharsetIconv("ISO-8859-1") }
-    internal val UTF_16: Charset by lazy { CharsetIconv(platformUtf16) }
+    internal val UTF_16: Charset by lazy { CharsetIconv("UTF-16") }
 }
 
 internal actual fun findCharset(name: String): Charset {
@@ -40,10 +40,7 @@ private class CharsetIconv(name: String) : Charset(name) {
     override fun newDecoder(): CharsetDecoder = CharsetDecoderImpl(this)
 }
 
-internal fun iconvCharsetName(name: String) = when (name) {
-    "UTF-16" -> platformUtf16
-    else -> name
-}
+internal fun iconvCharsetName(name: String) = name
 
 @OptIn(ExperimentalForeignApi::class)
 private val negativePointer = (-1L).toCPointer<IntVar>()

--- a/ktor-io/mingwX64/src/CharsetMingw.kt
+++ b/ktor-io/mingwX64/src/CharsetMingw.kt
@@ -17,7 +17,7 @@ private const val DECODING_BUFFER_SIZE = 8192
 public actual object Charsets {
     public actual val UTF_8: Charset by lazy { CharsetIconv("UTF-8") }
     public actual val ISO_8859_1: Charset by lazy { CharsetIconv("ISO-8859-1") }
-    internal val UTF_16: Charset by lazy { CharsetIconv(platformUtf16) }
+    internal val UTF_16: Charset by lazy { CharsetIconv("UTF-16") }
 }
 
 @OptIn(ExperimentalForeignApi::class)
@@ -40,10 +40,7 @@ internal actual fun findCharset(name: String): Charset {
     return CharsetIconv(name)
 }
 
-internal fun iconvCharsetName(name: String) = when (name) {
-    "UTF-16" -> platformUtf16
-    else -> name
-}
+internal fun iconvCharsetName(name: String) = name
 
 @OptIn(ExperimentalForeignApi::class)
 private val negativePointer = (-1L).toCPointer<IntVar>()

--- a/ktor-io/posix/src/io/ktor/utils/io/charsets/CharsetNative.kt
+++ b/ktor-io/posix/src/io/ktor/utils/io/charsets/CharsetNative.kt
@@ -27,11 +27,11 @@ public actual abstract class Charset(internal val _name: String) {
     public companion object {
         public fun forName(name: String): Charset = findCharset(name)
 
-        public fun isSupported(charset: String): Boolean = when (charset) {
-            "UTF-8", "utf-8", "UTF8", "utf8" -> true
-            "ISO-8859-1", "iso-8859-1" -> true
-            "UTF-16", "utf-16", "UTF16", "utf16" -> true
-            else -> false
+        public fun isSupported(charset: String): Boolean = try {
+            findCharset(charset)
+            true
+        } catch (_: IllegalArgumentException) {
+            false
         }
     }
 
@@ -72,7 +72,7 @@ internal data class CharsetDecoderImpl(private val charset: Charset) : CharsetDe
 public actual val CharsetDecoder.charset: Charset get() = _charset
 
 internal val platformUtf16: String =
-    if (ByteOrder.nativeOrder() == io.ktor.utils.io.core.ByteOrder.BIG_ENDIAN) "UTF-16BE" else "UTF-16LE"
+    if (ByteOrder.nativeOrder() == ByteOrder.BIG_ENDIAN) "UTF-16BE" else "UTF-16LE"
 
 // -----------------------------------------------------------
 public actual open class MalformedInputException actual constructor(message: String) : kotlinx.io.IOException(message)


### PR DESCRIPTION
**Subsystem**
Ktor IO

**Motivation**
[KTOR-9575](https://youtrack.jetbrains.com/issue/KTOR-9575) Darwin: findCharset("UTF-16") maps to NSUTF16LittleEndianStringEncoding causing decoding failure for UTF-16 content with BOM

**Solution**
- Fixes UTF-16 decoding on POSIX targets (Darwin, Linux, Mingw) when the byte stream includes a BOM
- The canonical UTF-16 charset now uses BOM-aware encodings (NSUTF16StringEncoding on Darwin, iconv UTF-16 on Linux/Mingw), matching JVM behaviour
- Aligns Charsets.isSupported() with an actual platform support

