### PR TITLE
Fix KTOR-9621 RateLimit plugin is bypassed

### DIFF
--- a/ktor-server/ktor-server-plugins/ktor-server-rate-limit/common/src/io/ktor/server/plugins/ratelimit/RateLimitInterceptors.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-rate-limit/common/src/io/ktor/server/plugins/ratelimit/RateLimitInterceptors.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2022 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2014-2026 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package io.ktor.server.plugins.ratelimit
@@ -10,14 +10,11 @@ import io.ktor.server.request.*
 import io.ktor.server.response.*
 import io.ktor.util.collections.*
 import io.ktor.util.date.*
-import io.ktor.util.pipeline.*
 import kotlinx.coroutines.*
 
-private object BeforeCall : Hook<suspend (ApplicationCall) -> Unit> {
+private object PluginsPhase : Hook<suspend (ApplicationCall) -> Unit> {
     override fun install(pipeline: ApplicationCallPipeline, handler: suspend (ApplicationCall) -> Unit) {
-        val beforeCallPhase = PipelinePhase("BeforeCall")
-        pipeline.insertPhaseBefore(ApplicationCallPipeline.Call, beforeCallPhase)
-        pipeline.intercept(beforeCallPhase) { handler(call) }
+        pipeline.intercept(ApplicationCallPipeline.Plugins) { handler(call) }
     }
 }
 
@@ -43,7 +40,7 @@ private fun PluginBuilder<RateLimitInterceptorsConfig>.rateLimiterPluginBuilder(
     val registry = application.attributes.computeIfAbsent(RateLimiterInstancesRegistryKey) { ConcurrentMap() }
     val clearOnRefillJobs = ConcurrentMap<ProviderKey, Job>()
 
-    on(BeforeCall) { call ->
+    on(PluginsPhase) { call ->
         providers.forEach { provider ->
             if (call.isHandled) return@on
 

--- a/ktor-server/ktor-server-plugins/ktor-server-rate-limit/common/test/io/ktor/server/plugins/ratelimit/RateLimitIntegrationTest.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-rate-limit/common/test/io/ktor/server/plugins/ratelimit/RateLimitIntegrationTest.kt
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2014-2026 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.server.plugins.ratelimit
+
+import io.ktor.client.request.*
+import io.ktor.http.*
+import io.ktor.server.application.*
+import io.ktor.server.response.*
+import io.ktor.server.routing.*
+import io.ktor.server.testing.*
+import io.ktor.util.pipeline.*
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.time.Duration.Companion.seconds
+
+class RateLimitIntegrationTest {
+
+    @Test
+    fun rateLimitRunsBeforeMockAuthWhenRateLimitWrapsAuthenticate() = testApplication {
+        install(RateLimit) {
+            register(RateLimitName("block-all")) {
+                rateLimiter(limit = 0, refillPeriod = 1.seconds)
+            }
+        }
+
+        routing {
+            rateLimit(RateLimitName("block-all")) {
+                mockAuthenticate {
+                    post("/endpoint") {
+                        call.respond(HttpStatusCode.OK)
+                    }
+                }
+            }
+        }
+
+        assertEquals(HttpStatusCode.TooManyRequests, client.post("/endpoint").status)
+    }
+
+    @Test
+    fun rateLimitRunsBeforeMockAuthWhenAuthenticateWrapsRateLimit() = testApplication {
+        install(RateLimit) {
+            register(RateLimitName("block-all")) {
+                rateLimiter(limit = 0, refillPeriod = 1.seconds)
+            }
+        }
+
+        routing {
+            mockAuthenticate {
+                rateLimit(RateLimitName("block-all")) {
+                    post("/endpoint") {
+                        call.respond(HttpStatusCode.OK)
+                    }
+                }
+            }
+        }
+
+        assertEquals(HttpStatusCode.TooManyRequests, client.post("/endpoint").status)
+    }
+}
+
+private val MockAuthenticatePhase = PipelinePhase("Authenticate")
+
+private object MockAuthenticationHook : Hook<suspend (ApplicationCall) -> Unit> {
+    override fun install(pipeline: ApplicationCallPipeline, handler: suspend (ApplicationCall) -> Unit) {
+        pipeline.insertPhaseAfter(ApplicationCallPipeline.Plugins, MockAuthenticatePhase)
+        pipeline.intercept(MockAuthenticatePhase) { handler(call) }
+    }
+}
+
+private val MockAuthenticationInterceptors = createRouteScopedPlugin("MockAuthenticationInterceptors") {
+    on(MockAuthenticationHook) { call ->
+        if (call.isHandled) return@on
+        call.respond(HttpStatusCode.Unauthorized)
+    }
+}
+
+private class MockAuthenticationRouteSelector : RouteSelector() {
+    override suspend fun evaluate(context: RoutingResolveContext, segmentIndex: Int): RouteSelectorEvaluation =
+        RouteSelectorEvaluation.Transparent
+}
+
+private fun Route.mockAuthenticate(build: Route.() -> Unit): Route {
+    val authenticatedRoute = createChild(MockAuthenticationRouteSelector())
+    authenticatedRoute.install(MockAuthenticationInterceptors)
+    authenticatedRoute.build()
+    return authenticatedRoute
+}

--- a/ktor-server/ktor-server-plugins/ktor-server-rate-limit/common/test/io/ktor/server/plugins/ratelimit/RateLimitTest.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-rate-limit/common/test/io/ktor/server/plugins/ratelimit/RateLimitTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2024 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2014-2026 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package io.ktor.server.plugins.ratelimit


### PR DESCRIPTION
**Subsystem**
Server

**Motivation**
[KTOR-9621](https://youtrack.jetbrains.com/issue/KTOR-9621) RateLimit plugin is bypassed when the nested authenticate block rejects the request

**Solution**
- Auth ran in the Authenticate phase (after Plugins) while rate limit ran in a BeforeCall phase (before Call). 
- Failed auth responded with 401 and set call.isHandled, so the rate limiter’s guard exited early
- Move the rate-limit hook to the Plugins phase, so it always runs before authentication, regardless of DSL nesting (`rateLimit { authenticate { … } }` or the reverse)

