### PR TITLE
OAuth 2.0 Protected Resource Metadata to the OIDC plugin

### DIFF
--- a/ktor-server/ktor-server-plugins/ktor-server-auth-oidc/api/ktor-server-auth-oidc.api
+++ b/ktor-server/ktor-server-plugins/ktor-server-auth-oidc/api/ktor-server-auth-oidc.api
@@ -1,3 +1,12 @@
+public abstract class io/ktor/server/auth/oidc/CodeChallengeMethod {
+	public abstract fun getName ()Ljava/lang/String;
+}
+
+public final class io/ktor/server/auth/oidc/CodeChallengeMethod$S256 : io/ktor/server/auth/oidc/CodeChallengeMethod {
+	public static final field INSTANCE Lio/ktor/server/auth/oidc/CodeChallengeMethod$S256;
+	public fun getName ()Ljava/lang/String;
+}
+
 public final class io/ktor/server/auth/oidc/Oidc {
 	public static final field Companion Lio/ktor/server/auth/oidc/Oidc$Companion;
 	public final fun provider (Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -17,18 +26,9 @@ public final class io/ktor/server/auth/oidc/OidcAccessTokenConfig {
 	public final fun setOpaqueToken (Lio/ktor/server/auth/oidc/OpaqueTokenStrategy;)V
 }
 
-public final class io/ktor/server/auth/oidc/OidcAuthenticatedContextKt {
-	public static final fun getProvider (Lio/ktor/server/auth/oidc/OidcProviderContext;)Lio/ktor/server/auth/oidc/OidcProvider;
-}
-
 public final class io/ktor/server/auth/oidc/OidcBearerConfig {
 	public final fun getTokenExtractor ()Lkotlin/jvm/functions/Function1;
 	public final fun setTokenExtractor (Lkotlin/jvm/functions/Function1;)V
-}
-
-public final class io/ktor/server/auth/oidc/OidcBearerContext : io/ktor/server/auth/oidc/OidcProviderContext, io/ktor/server/auth/typesafe/AuthenticatedContext {
-	public fun principal (Lio/ktor/server/routing/RoutingContext;)Ljava/lang/Object;
-	public fun provider ()Lio/ktor/server/auth/oidc/OidcProvider;
 }
 
 public final class io/ktor/server/auth/oidc/OidcJwtConfig {
@@ -66,9 +66,9 @@ public final class io/ktor/server/auth/oidc/OidcMetadataRefreshFailure {
 public final class io/ktor/server/auth/oidc/OidcOAuthConfig {
 	public field clientId Ljava/lang/String;
 	public field clientSecret Ljava/lang/String;
-	public final fun disablePkce ()V
 	public final fun getClientId ()Ljava/lang/String;
 	public final fun getClientSecret ()Ljava/lang/String;
+	public final fun getCodeChallengeMethod ()Lio/ktor/server/auth/oidc/CodeChallengeMethod;
 	public final fun getFetchUserInfo ()Z
 	public final fun getIdTokenAudience ()Ljava/lang/String;
 	public final fun getLoginUri ()Lkotlin/jvm/functions/Function1;
@@ -81,6 +81,7 @@ public final class io/ktor/server/auth/oidc/OidcOAuthConfig {
 	public final fun onSuccess (Lkotlin/jvm/functions/Function3;)V
 	public final fun setClientId (Ljava/lang/String;)V
 	public final fun setClientSecret (Ljava/lang/String;)V
+	public final fun setCodeChallengeMethod (Lio/ktor/server/auth/oidc/CodeChallengeMethod;)V
 	public final fun setFetchUserInfo (Z)V
 	public final fun setIdTokenAudience (Ljava/lang/String;)V
 	public final fun setLoginUri (Lkotlin/jvm/functions/Function1;)V
@@ -98,6 +99,8 @@ public final class io/ktor/server/auth/oidc/OidcPluginConfig {
 	public final fun getHttpClient ()Lio/ktor/client/HttpClient;
 	public final fun getInitialDiscoveryAttempts ()I
 	public final fun getInitialDiscoveryRetryDelay-UwyO8pc ()J
+	public final fun protectedResource (Ljava/lang/String;)V
+	public final fun protectedResource (Ljava/lang/String;Lkotlin/jvm/functions/Function1;)V
 	public final fun setDiscoveryRefreshFailureDelay-LRDsOJo (J)V
 	public final fun setDiscoveryRefreshInterval-LRDsOJo (J)V
 	public final fun setHttpClient (Lio/ktor/client/HttpClient;)V
@@ -134,10 +137,6 @@ public final class io/ktor/server/auth/oidc/OidcProviderConfig {
 	public final fun setMetadata (Lio/ktor/server/auth/oidc/OpenIdProviderMetadata;)V
 }
 
-public abstract interface class io/ktor/server/auth/oidc/OidcProviderContext {
-	public abstract fun provider ()Lio/ktor/server/auth/oidc/OidcProvider;
-}
-
 public final class io/ktor/server/auth/oidc/OidcSessionConfig {
 	public final fun cookie (Lkotlin/jvm/functions/Function1;)V
 	public final fun csrfProtection (Lkotlin/jvm/functions/Function1;)V
@@ -152,18 +151,6 @@ public final class io/ktor/server/auth/oidc/OidcSessionConfig {
 	public final fun setRefreshUri (Lkotlin/jvm/functions/Function1;)V
 	public final fun setStorage (Lio/ktor/server/sessions/SessionStorage;)V
 	public final fun setTokenRefreshStrategy (Lio/ktor/server/auth/oidc/OidcTokenRefreshStrategy;)V
-}
-
-public final class io/ktor/server/auth/oidc/OidcSessionsContext : io/ktor/server/auth/oidc/OidcProviderContext, io/ktor/server/auth/typesafe/SessionAuthenticatedContext {
-	public fun clearSession (Lio/ktor/server/routing/RoutingContext;)V
-	public fun principal (Lio/ktor/server/routing/RoutingContext;)Ljava/lang/Object;
-	public fun provider ()Lio/ktor/server/auth/oidc/OidcProvider;
-	public fun session (Lio/ktor/server/routing/RoutingContext;)Lio/ktor/server/auth/oidc/OidcToken$Id;
-	public synthetic fun session (Lio/ktor/server/routing/RoutingContext;)Ljava/lang/Object;
-	public fun setSession (Lio/ktor/server/routing/RoutingContext;Lio/ktor/server/auth/oidc/OidcToken$Id;)V
-	public synthetic fun setSession (Lio/ktor/server/routing/RoutingContext;Ljava/lang/Object;)V
-	public fun updateSession (Lio/ktor/server/routing/RoutingContext;Lkotlin/jvm/functions/Function1;)Lio/ktor/server/auth/oidc/OidcToken$Id;
-	public synthetic fun updateSession (Lio/ktor/server/routing/RoutingContext;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
 }
 
 public final class io/ktor/server/auth/oidc/OidcStateEncryptionKey {
@@ -500,6 +487,71 @@ public abstract class io/ktor/server/auth/oidc/OpenIdTestTokenBuilder {
 	public final fun setName (Ljava/lang/String;)V
 	public final fun setNotBefore (Lkotlin/time/Instant;)V
 	public final fun setSubject (Ljava/lang/String;)V
+}
+
+public final class io/ktor/server/auth/oidc/ProtectedResourceMetadata {
+	public static final field Companion Lio/ktor/server/auth/oidc/ProtectedResourceMetadata$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/util/List;Ljava/util/List;Ljava/lang/Boolean;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/util/List;Ljava/util/List;Ljava/lang/Boolean;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getAuthorizationDetailsTypesSupported ()Ljava/util/List;
+	public final fun getAuthorizationServers ()Ljava/util/List;
+	public final fun getBearerMethodsSupported ()Ljava/util/List;
+	public final fun getDpopBoundAccessTokensRequired ()Ljava/lang/Boolean;
+	public final fun getDpopSigningAlgValuesSupported ()Ljava/util/List;
+	public final fun getJwksUri ()Ljava/lang/String;
+	public final fun getResource ()Ljava/lang/String;
+	public final fun getResourceDocumentation ()Ljava/lang/String;
+	public final fun getResourceName ()Ljava/lang/String;
+	public final fun getResourcePolicyUri ()Ljava/lang/String;
+	public final fun getResourceSigningAlgValuesSupported ()Ljava/util/List;
+	public final fun getResourceTosUri ()Ljava/lang/String;
+	public final fun getScopesSupported ()Ljava/util/List;
+	public final fun getTlsClientCertificateBoundAccessTokens ()Ljava/lang/Boolean;
+}
+
+public final synthetic class io/ktor/server/auth/oidc/ProtectedResourceMetadata$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/ktor/server/auth/oidc/ProtectedResourceMetadata$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/ktor/server/auth/oidc/ProtectedResourceMetadata;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/ktor/server/auth/oidc/ProtectedResourceMetadata;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/ktor/server/auth/oidc/ProtectedResourceMetadata$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/ktor/server/auth/oidc/ProtectedResourceMetadataConfig {
+	public final fun getAuthorizationDetailsTypesSupported ()Ljava/util/List;
+	public final fun getAuthorizationServers ()Ljava/util/List;
+	public final fun getBearerMethodsSupported ()Ljava/util/List;
+	public final fun getDpopBoundAccessTokensRequired ()Ljava/lang/Boolean;
+	public final fun getDpopSigningAlgValuesSupported ()Ljava/util/List;
+	public final fun getJwksUri ()Ljava/lang/String;
+	public final fun getResource ()Ljava/lang/String;
+	public final fun getResourceDocumentation ()Ljava/lang/String;
+	public final fun getResourceName ()Ljava/lang/String;
+	public final fun getResourcePolicyUri ()Ljava/lang/String;
+	public final fun getResourceSigningAlgValuesSupported ()Ljava/util/List;
+	public final fun getResourceTosUri ()Ljava/lang/String;
+	public final fun getScopesSupported ()Ljava/util/List;
+	public final fun getTlsClientCertificateBoundAccessTokens ()Ljava/lang/Boolean;
+	public final fun setAuthorizationDetailsTypesSupported (Ljava/util/List;)V
+	public final fun setAuthorizationServers (Ljava/util/List;)V
+	public final fun setBearerMethodsSupported (Ljava/util/List;)V
+	public final fun setDpopBoundAccessTokensRequired (Ljava/lang/Boolean;)V
+	public final fun setDpopSigningAlgValuesSupported (Ljava/util/List;)V
+	public final fun setJwksUri (Ljava/lang/String;)V
+	public final fun setResourceDocumentation (Ljava/lang/String;)V
+	public final fun setResourceName (Ljava/lang/String;)V
+	public final fun setResourcePolicyUri (Ljava/lang/String;)V
+	public final fun setResourceSigningAlgValuesSupported (Ljava/util/List;)V
+	public final fun setResourceTosUri (Ljava/lang/String;)V
+	public final fun setScopesSupported (Ljava/util/List;)V
+	public final fun setTlsClientCertificateBoundAccessTokens (Ljava/lang/Boolean;)V
 }
 
 public final class io/ktor/server/auth/oidc/TokenClaims {

--- a/ktor-server/ktor-server-plugins/ktor-server-auth-oidc/build.gradle.kts
+++ b/ktor-server/ktor-server-plugins/ktor-server-auth-oidc/build.gradle.kts
@@ -19,12 +19,12 @@ kotlin {
             api(projects.ktorServerAuthJwt)
             api(projects.ktorClientCore)
             api(projects.ktorClientContentNegotiation)
+            api(projects.ktorServerContentNegotiation)
             api(projects.ktorSerializationKotlinxJson)
             api(libs.kotlinx.serialization.json)
         }
         jvmTest.dependencies {
             implementation(projects.ktorServerTestHost)
-            implementation(projects.ktorServerContentNegotiation)
             implementation(projects.ktorServerCio)
             implementation(projects.ktorClientMock)
         }

--- a/ktor-server/ktor-server-plugins/ktor-server-auth-oidc/jvm/src/io/ktor/server/auth/oidc/Oidc.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-auth-oidc/jvm/src/io/ktor/server/auth/oidc/Oidc.kt
@@ -36,8 +36,9 @@ private val ProviderNameRegex = Regex("[a-z0-9]+(?:-[a-z0-9]+)*")
  *   Registered internally as `"$name-oauth"` and used only for the auto-registered routes;
  *   browser session authentication is exposed as [OidcProvider.sessions].
  *
- * This plugin implements the Authorization Code Flow with PKCE (RFC 6749 §4.1, OIDC Core §3.1) and resource-server
- * Bearer / RFC 7662 introspection. Implicit and Hybrid flows are not supported.
+ * This plugin implements the Authorization Code Flow with PKCE (RFC 6749 §4.1, OIDC Core §3.1), resource-server
+ * Bearer / RFC 7662 introspection, and optional OAuth 2.0 Protected Resource Metadata (RFC 9728) via
+ * [OidcPluginConfig.protectedResource]. Implicit and Hybrid flows are not supported.
  *
  * Provider metadata is fetched automatically from the issuer's discovery document
  * (`<issuer>/.well-known/openid-configuration`) and periodically refreshed unless a provider configures static
@@ -297,8 +298,25 @@ public class Oidc internal constructor(
         return provider
     }
 
+    internal fun configureProtectedResourceRoute() {
+        config.protectedResourceConfig?.let { protectedResourceConfig ->
+            application.configureProtectedResourceRoute(protectedResourceConfig) {
+                providers.values.map { it.config }
+            }
+        }
+    }
+
+    private fun resourceMetadataUrl(): String? =
+        config.protectedResourceConfig?.let { protectedResourceConfig ->
+            require(protectedResourceConfig.resource.isNotBlank()) {
+                "protectedResource(resource) must be set to the resource server's identifier URL"
+            }
+            buildResourceMetadataUrl(protectedResourceConfig.resource)
+        }
+
     private suspend fun commitProvider(provider: OidcProvider<*>) = providerRegistrationMutex.withLock {
         checkProductionEnvironment(provider)
+        provider.resourceMetadataUrl = resourceMetadataUrl()
         if (provider.config.oauthConfig != null) {
             application.configureOAuthRoute(provider)
         }
@@ -444,6 +462,7 @@ public class Oidc internal constructor(
                 client = managedClient,
             )
             plugin.loadConfigFromEnvironment()
+            plugin.configureProtectedResourceRoute()
 
             pipeline.monitor.subscribe(ApplicationModulesLoaded) {
                 if (plugin.providers.isEmpty()) {

--- a/ktor-server/ktor-server-plugins/ktor-server-auth-oidc/jvm/src/io/ktor/server/auth/oidc/OidcBearer.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-auth-oidc/jvm/src/io/ktor/server/auth/oidc/OidcBearer.kt
@@ -23,7 +23,9 @@ import org.slf4j.Logger
 private const val HEADER_LOG_LIMIT: Int = 96
 
 @OptIn(InternalAPI::class)
-internal fun <P : Any> OidcProvider<P>.createBearerScheme(): DefaultAuthScheme<P, AuthenticatedContext<P>> {
+internal fun <P : Any> OidcProvider<P>.createBearerScheme(
+    resourceMetadataUrl: String?,
+): DefaultAuthScheme<P, AuthenticatedContext<P>> {
     val extractor = bearerConfig.tokenExtractor
     return bearer(
         name = "$name-bearer",
@@ -45,7 +47,8 @@ internal fun <P : Any> OidcProvider<P>.createBearerScheme(): DefaultAuthScheme<P
         }
 
         onUnauthorized = {
-            val challenge = HttpAuthHeader.Parameterized(AuthScheme.Bearer, parameters = emptyMap())
+            val parameters = resourceMetadataUrl?.let { mapOf("resource_metadata" to it) }.orEmpty()
+            val challenge = HttpAuthHeader.Parameterized(AuthScheme.Bearer, parameters = parameters)
             call.respond(UnauthorizedResponse(challenge))
         }
     }

--- a/ktor-server/ktor-server-plugins/ktor-server-auth-oidc/jvm/src/io/ktor/server/auth/oidc/OidcConfig.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-auth-oidc/jvm/src/io/ktor/server/auth/oidc/OidcConfig.kt
@@ -31,6 +31,8 @@ import kotlin.time.Duration.Companion.seconds
  */
 @KtorDsl
 public class OidcPluginConfig {
+    internal var protectedResourceConfig: ProtectedResourceMetadataConfig? = null
+
     /**
      * Optional HTTP client used for discovery and userinfo requests.
      * If not configured, the plugin installs an internal client.
@@ -66,6 +68,28 @@ public class OidcPluginConfig {
      * The delay is applied only between attempts. It is not used after the final failed attempt.
      */
     public var initialDiscoveryRetryDelay: Duration = 5.seconds
+
+    /**
+     * Configures OAuth 2.0 Protected Resource Metadata (RFC 9728) with defaults.
+     *
+     * When configured, the plugin serves a `/.well-known/oauth-protected-resource` endpoint with
+     * metadata for this resource and includes a `resource_metadata` parameter in `WWW-Authenticate`
+     * headers on Bearer authentication failures.
+     */
+    public fun protectedResource(resource: String) {
+        protectedResource(resource) {}
+    }
+
+    /**
+     * Configures OAuth 2.0 Protected Resource Metadata (RFC 9728).
+     *
+     * When configured, the plugin serves a `/.well-known/oauth-protected-resource` endpoint with
+     * metadata for this resource and includes a `resource_metadata` parameter in `WWW-Authenticate`
+     * headers on Bearer authentication failures.
+     */
+    public fun protectedResource(resource: String, configure: ProtectedResourceMetadataConfig.() -> Unit) {
+        protectedResourceConfig = ProtectedResourceMetadataConfig(resource).apply(configure)
+    }
 
     internal fun validate() {
         require(initialDiscoveryAttempts >= 1) {

--- a/ktor-server/ktor-server-plugins/ktor-server-auth-oidc/jvm/src/io/ktor/server/auth/oidc/OidcProtectedResource.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-auth-oidc/jvm/src/io/ktor/server/auth/oidc/OidcProtectedResource.kt
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2014-2026 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.server.auth.oidc
+
+import io.ktor.serialization.kotlinx.json.*
+import io.ktor.server.application.*
+import io.ktor.server.plugins.contentnegotiation.*
+import io.ktor.server.response.*
+import io.ktor.server.routing.*
+import kotlinx.serialization.json.Json
+import java.net.URI
+
+internal fun Application.configureProtectedResourceRoute(
+    config: ProtectedResourceMetadataConfig,
+    providers: () -> List<OidcProviderConfig<*>>,
+) = routing {
+    install(ContentNegotiation) {
+        val format = Json {
+            explicitNulls = false
+            encodeDefaults = true
+        }
+        json(format)
+    }
+
+    val metadata by lazy { buildProtectedResourceMetadata(config, providers()) }
+    val path = buildResourceMetadataRoutePath(config.resource)
+    get(path) { call.respond(metadata) }
+}
+
+internal fun buildProtectedResourceMetadata(
+    config: ProtectedResourceMetadataConfig,
+    providers: Collection<OidcProviderConfig<*>>,
+): ProtectedResourceMetadata {
+    val authorizationServers = config.authorizationServers
+        ?: providers.map { it.issuer }.distinct().ifEmpty { null }
+
+    val scopesSupported = config.scopesSupported
+        ?: providers
+            .mapNotNull { it.oauthConfig?.scopes }
+            .flatten()
+            .distinct()
+            .ifEmpty { null }
+
+    val bearerMethodsSupported = config.bearerMethodsSupported
+        ?: listOf("header").takeIf {
+            providers.any { provider ->
+                val bearerConfig = provider.bearerConfig ?: return@any false
+                bearerConfig.tokenExtractor == null
+            }
+        }
+
+    return ProtectedResourceMetadata(
+        resource = config.resource,
+        authorizationServers = authorizationServers,
+        jwksUri = config.jwksUri,
+        scopesSupported = scopesSupported,
+        bearerMethodsSupported = bearerMethodsSupported,
+        resourceSigningAlgValuesSupported = config.resourceSigningAlgValuesSupported,
+        resourceName = config.resourceName,
+        resourceDocumentation = config.resourceDocumentation,
+        resourcePolicyUri = config.resourcePolicyUri,
+        resourceTosUri = config.resourceTosUri,
+        tlsClientCertificateBoundAccessTokens = config.tlsClientCertificateBoundAccessTokens,
+        authorizationDetailsTypesSupported = config.authorizationDetailsTypesSupported,
+        dpopSigningAlgValuesSupported = config.dpopSigningAlgValuesSupported,
+        dpopBoundAccessTokensRequired = config.dpopBoundAccessTokensRequired,
+    )
+}
+
+internal fun buildResourceMetadataUrl(resource: String): String {
+    val uri = parseProtectedResourceUri(resource)
+    val port = if (uri.port == -1) "" else ":${uri.port}"
+    val resourcePath = uri.path?.trimEnd('/') ?: ""
+    return "${uri.scheme}://${uri.host}$port/.well-known/oauth-protected-resource$resourcePath"
+}
+
+private fun buildResourceMetadataRoutePath(resource: String): String {
+    val resourcePath = parseProtectedResourceUri(resource).path?.trimEnd('/') ?: ""
+    return "/.well-known/oauth-protected-resource$resourcePath"
+}
+
+private fun parseProtectedResourceUri(resource: String): URI = URI(resource).apply {
+    require(scheme?.equals("https", ignoreCase = true) == true) {
+        "protectedResource(resource) must use the https scheme: $resource"
+    }
+    require(!host.isNullOrBlank()) { "protectedResource(resource) must include a host: $resource" }
+    require(rawUserInfo == null) { "protectedResource(resource) must not include userinfo: $resource" }
+    require(rawQuery == null) { "protectedResource(resource) must not include a query: $resource" }
+    require(rawFragment == null) { "protectedResource(resource) must not include a fragment: $resource" }
+}

--- a/ktor-server/ktor-server-plugins/ktor-server-auth-oidc/jvm/src/io/ktor/server/auth/oidc/OidcProtectedResource.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-auth-oidc/jvm/src/io/ktor/server/auth/oidc/OidcProtectedResource.kt
@@ -16,17 +16,19 @@ internal fun Application.configureProtectedResourceRoute(
     config: ProtectedResourceMetadataConfig,
     providers: () -> List<OidcProviderConfig<*>>,
 ) = routing {
-    install(ContentNegotiation) {
-        val format = Json {
-            explicitNulls = false
-            encodeDefaults = true
-        }
-        json(format)
-    }
-
     val metadata by lazy { buildProtectedResourceMetadata(config, providers()) }
     val path = buildResourceMetadataRoutePath(config.resource)
-    get(path) { call.respond(metadata) }
+    route(path) {
+        install(ContentNegotiation) {
+            val format = Json {
+                explicitNulls = false
+                encodeDefaults = true
+            }
+            json(format)
+        }
+
+        get { call.respond(metadata) }
+    }
 }
 
 internal fun buildProtectedResourceMetadata(

--- a/ktor-server/ktor-server-plugins/ktor-server-auth-oidc/jvm/src/io/ktor/server/auth/oidc/OidcProtectedResource.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-auth-oidc/jvm/src/io/ktor/server/auth/oidc/OidcProtectedResource.kt
@@ -16,7 +16,6 @@ internal fun Application.configureProtectedResourceRoute(
     config: ProtectedResourceMetadataConfig,
     providers: () -> List<OidcProviderConfig<*>>,
 ) = routing {
-    val metadata by lazy { buildProtectedResourceMetadata(config, providers()) }
     val path = buildResourceMetadataRoutePath(config.resource)
     route(path) {
         install(ContentNegotiation) {
@@ -27,7 +26,7 @@ internal fun Application.configureProtectedResourceRoute(
             json(format)
         }
 
-        get { call.respond(metadata) }
+        get { call.respond(buildProtectedResourceMetadata(config, providers())) }
     }
 }
 
@@ -35,11 +34,13 @@ internal fun buildProtectedResourceMetadata(
     config: ProtectedResourceMetadataConfig,
     providers: Collection<OidcProviderConfig<*>>,
 ): ProtectedResourceMetadata {
+    val bearerProviders = providers.filter { it.bearerConfig != null }
+
     val authorizationServers = config.authorizationServers
-        ?: providers.map { it.issuer }.distinct().ifEmpty { null }
+        ?: bearerProviders.map { it.issuer }.distinct().ifEmpty { null }
 
     val scopesSupported = config.scopesSupported
-        ?: providers
+        ?: bearerProviders
             .mapNotNull { it.oauthConfig?.scopes }
             .flatten()
             .distinct()
@@ -74,8 +75,14 @@ internal fun buildProtectedResourceMetadata(
 internal fun buildResourceMetadataUrl(resource: String): String {
     val uri = parseProtectedResourceUri(resource)
     val port = if (uri.port == -1) "" else ":${uri.port}"
+    val authority = uri.hostAuthorityWithoutPort()
     val resourcePath = uri.path?.trimEnd('/') ?: ""
-    return "${uri.scheme}://${uri.host}$port/.well-known/oauth-protected-resource$resourcePath"
+    return "${uri.scheme}://$authority$port/.well-known/oauth-protected-resource$resourcePath"
+}
+
+private fun URI.hostAuthorityWithoutPort(): String {
+    val authority = rawAuthority?.substringAfter('@') ?: host
+    return if (port == -1) authority else authority.removeSuffix(":$port")
 }
 
 private fun buildResourceMetadataRoutePath(resource: String): String {

--- a/ktor-server/ktor-server-plugins/ktor-server-auth-oidc/jvm/src/io/ktor/server/auth/oidc/OidcProvider.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-auth-oidc/jvm/src/io/ktor/server/auth/oidc/OidcProvider.kt
@@ -69,6 +69,8 @@ public class OidcProvider<P : Any> internal constructor(
     internal val accessTokenConfig: OidcAccessTokenConfig
         get() = checkNotNull(config.accessTokenConfig) { "Access token is not enabled for provider $name" }
 
+    internal var resourceMetadataUrl: String? = null
+
     internal val bearerConfig: OidcBearerConfig
         get() = checkNotNull(config.bearerConfig) {
             "Bearer scheme is not enabled. Call bearer { } in the provider $name."
@@ -251,7 +253,9 @@ public class OidcProvider<P : Any> internal constructor(
      *
      * @throws IllegalStateException when the provider was not configured with `bearer { }`.
      */
-    public val bearer: DefaultAuthScheme<P, AuthenticatedContext<P>> by lazy { createBearerScheme() }
+    public val bearer: DefaultAuthScheme<P, AuthenticatedContext<P>> by lazy {
+        createBearerScheme(resourceMetadataUrl)
+    }
 
     /**
      * Typed browser session authentication scheme.

--- a/ktor-server/ktor-server-plugins/ktor-server-auth-oidc/jvm/src/io/ktor/server/auth/oidc/ProtectedResourceMetadata.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-auth-oidc/jvm/src/io/ktor/server/auth/oidc/ProtectedResourceMetadata.kt
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2014-2026 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.server.auth.oidc
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * OAuth 2.0 Protected Resource Metadata as defined in RFC 9728.
+ *
+ * Served at the `/.well-known/oauth-protected-resource` endpoint when
+ * [OidcPluginConfig.protectedResource] is configured.
+ *
+ * @property resource The protected resource's identifier URL.
+ * @property authorizationServers OAuth authorization server issuer identifiers trusted by this resource.
+ * @property jwksUri URL of the resource server's JWK Set document containing its public keys.
+ * @property scopesSupported OAuth 2.0 scope values that this resource server understands.
+ * @property bearerMethodsSupported Methods supported for presenting Bearer tokens: `header`, `body`, `query`.
+ * @property resourceSigningAlgValuesSupported JWS algorithms supported by this resource, excluding `none`.
+ * @property resourceName Human-readable name of the protected resource.
+ * @property resourceDocumentation URL of developer documentation for this resource.
+ * @property resourcePolicyUri URL describing the resource's data usage requirements.
+ * @property resourceTosUri URL of the resource's terms of service.
+ * @property tlsClientCertificateBoundAccessTokens Whether this resource requires TLS client certificate-bound
+ * access tokens.
+ * @property authorizationDetailsTypesSupported Authorization details types supported per RFC 9396.
+ * @property dpopSigningAlgValuesSupported JWS algorithms supported for DPoP proof validation.
+ * @property dpopBoundAccessTokensRequired Whether DPoP-bound access tokens are required.
+ *
+ * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.server.auth.oidc.ProtectedResourceMetadata)
+ */
+@Serializable
+public class ProtectedResourceMetadata(
+    public val resource: String,
+    @SerialName("authorization_servers")
+    public val authorizationServers: List<String>? = null,
+    @SerialName("jwks_uri")
+    public val jwksUri: String? = null,
+    @SerialName("scopes_supported")
+    public val scopesSupported: List<String>? = null,
+    @SerialName("bearer_methods_supported")
+    public val bearerMethodsSupported: List<String>? = null,
+    @SerialName("resource_signing_alg_values_supported")
+    public val resourceSigningAlgValuesSupported: List<String>? = null,
+    @SerialName("resource_name")
+    public val resourceName: String? = null,
+    @SerialName("resource_documentation")
+    public val resourceDocumentation: String? = null,
+    @SerialName("resource_policy_uri")
+    public val resourcePolicyUri: String? = null,
+    @SerialName("resource_tos_uri")
+    public val resourceTosUri: String? = null,
+    @SerialName("tls_client_certificate_bound_access_tokens")
+    public val tlsClientCertificateBoundAccessTokens: Boolean? = null,
+    @SerialName("authorization_details_types_supported")
+    public val authorizationDetailsTypesSupported: List<String>? = null,
+    @SerialName("dpop_signing_alg_values_supported")
+    public val dpopSigningAlgValuesSupported: List<String>? = null,
+    @SerialName("dpop_bound_access_tokens_required")
+    public val dpopBoundAccessTokensRequired: Boolean? = null,
+)

--- a/ktor-server/ktor-server-plugins/ktor-server-auth-oidc/jvm/src/io/ktor/server/auth/oidc/ProtectedResourceMetadataConfig.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-auth-oidc/jvm/src/io/ktor/server/auth/oidc/ProtectedResourceMetadataConfig.kt
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2014-2026 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.server.auth.oidc
+
+import io.ktor.utils.io.*
+
+/**
+ * Configuration for OAuth 2.0 Protected Resource Metadata (RFC 9728).
+ *
+ * Fields that can be auto-derived from provider configuration, such as [authorizationServers],
+ * [scopesSupported], and [bearerMethodsSupported], are populated automatically unless explicitly overridden.
+ *
+ * @param resource The protected resource's identifier URL. It must be an HTTPS URL with a host,
+ * no userinfo, no query, and no fragment.
+ *
+ * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.server.auth.oidc.ProtectedResourceMetadataConfig)
+ */
+@KtorDsl
+public class ProtectedResourceMetadataConfig internal constructor(
+    public val resource: String,
+) {
+    /**
+     * OAuth authorization server issuer identifiers trusted by this resource.
+     *
+     * When `null`, auto-derived from all configured provider issuers.
+     */
+    public var authorizationServers: List<String>? = null
+
+    /**
+     * URL of the resource server's JWK Set document.
+     *
+     * When `null`, omitted from the metadata response.
+     */
+    public var jwksUri: String? = null
+
+    /**
+     * OAuth 2.0 scope values that this resource server understands.
+     *
+     * When `null`, auto-derived from the union of all provider OAuth scopes.
+     */
+    public var scopesSupported: List<String>? = null
+
+    /**
+     * Methods supported for presenting Bearer tokens: `header`, `body`, `query`.
+     *
+     * When `null`, auto-derived as `header` when at least one provider uses the default
+     * `Authorization: Bearer` header extractor. Custom token extractors cannot be inferred; set this value
+     * explicitly when a custom extractor reads tokens from another RFC 6750 location.
+     */
+    public var bearerMethodsSupported: List<String>? = null
+
+    /**
+     * JWS algorithms supported by this resource server, excluding `none`.
+     *
+     * When `null`, omitted from the metadata response.
+     */
+    public var resourceSigningAlgValuesSupported: List<String>? = null
+
+    /**
+     * Human-readable name of the protected resource.
+     */
+    public var resourceName: String? = null
+
+    /**
+     * URL of developer documentation for this resource.
+     */
+    public var resourceDocumentation: String? = null
+
+    /**
+     * URL describing the resource's data usage requirements.
+     */
+    public var resourcePolicyUri: String? = null
+
+    /**
+     * URL of the resource's terms of service.
+     */
+    public var resourceTosUri: String? = null
+
+    /**
+     * Whether this resource requires TLS client certificate-bound access tokens.
+     */
+    public var tlsClientCertificateBoundAccessTokens: Boolean? = null
+
+    /**
+     * Authorization details types supported per RFC 9396.
+     */
+    public var authorizationDetailsTypesSupported: List<String>? = null
+
+    /**
+     * JWS algorithms supported for DPoP proof validation.
+     */
+    public var dpopSigningAlgValuesSupported: List<String>? = null
+
+    /**
+     * Whether this resource requires DPoP-bound access tokens.
+     */
+    public var dpopBoundAccessTokensRequired: Boolean? = null
+}

--- a/ktor-server/ktor-server-plugins/ktor-server-auth-oidc/jvm/test/io/ktor/server/auth/oidc/OidcBrowserFlowTest.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-auth-oidc/jvm/test/io/ktor/server/auth/oidc/OidcBrowserFlowTest.kt
@@ -1,0 +1,297 @@
+/*
+ * Copyright 2014-2026 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+@file:OptIn(ExperimentalKtorApi::class)
+
+package io.ktor.server.auth.oidc
+
+import io.ktor.client.request.*
+import io.ktor.client.statement.*
+import io.ktor.http.*
+import io.ktor.server.auth.oidc.utils.*
+import io.ktor.server.auth.typesafe.*
+import io.ktor.server.request.*
+import io.ktor.server.response.*
+import io.ktor.server.routing.*
+import io.ktor.server.testing.*
+import io.ktor.utils.io.*
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.atomic.AtomicReference
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+class OidcBrowserFlowTest {
+
+    @Test
+    fun `browser can sign in use session refresh and logout`() = testApplication {
+        val keys = testRsaKeys
+        val idTokensByState = ConcurrentHashMap<String, String>()
+        val tokenGrantTypes = mutableListOf<String>()
+        val userInfoCalls = AtomicInteger()
+        val refreshedIdToken = AtomicReference<String>()
+
+        openIdBrowserFlowProvider(keys, idTokensByState, tokenGrantTypes, userInfoCalls, refreshedIdToken)
+
+        val openIdClient = openIdHttpClient()
+        application {
+            val oidc = openIdConnect {
+                httpClient = openIdClient
+            }
+            val oidcProvider = oidc.provider("auth0") {
+                testIssuer(metadata = browserFlowMetadata())
+                jwt(keys)
+                accessToken {
+                    audiences = setOf("api")
+                }
+                bearer()
+                sessions {
+                    name = OIDC_TEST_SESSION_NAME
+                    cookie {
+                        cookie.secure = false
+                        cookie.httpOnly = true
+                    }
+                }
+                oauth {
+                    clientId = "client-id"
+                    clientSecret = "client-secret"
+                    fetchUserInfo = true
+                    onSuccess { principal ->
+                        val idToken = principal as OidcToken.Id
+                        call.respondText("signed in ${idToken.userInfo.subject}")
+                    }
+                }
+            }
+
+            routing {
+                authenticateWithAnyOf(oidcProvider.bearer, oidcProvider.sessions) {
+                    get("/either") {
+                        val subject = when (val currentPrincipal = principal) {
+                            is OidcToken.Access -> "bearer:${currentPrincipal.userInfo?.subject}"
+                            is OidcToken.Id -> "session:${currentPrincipal.userInfo.subject}"
+                            is OidcToken.Opaque -> "opaque"
+                        }
+                        call.respondText(subject)
+                    }
+                }
+                authenticateWith(oidcProvider.sessions) {
+                    get("/me") {
+                        val idToken = principal as OidcToken.Id
+                        call.respondText("${idToken.userInfo.subject}:${idToken.userInfo.name}")
+                    }
+                    post("/me") {
+                        val idToken = principal as OidcToken.Id
+                        call.respondText("updated ${idToken.userInfo.subject}")
+                    }
+                }
+            }
+        }
+
+        var sessionCookie: String? = null
+
+        fun HttpRequestBuilder.sessionCookie() {
+            sessionCookie?.let { header(HttpHeaders.Cookie, it) }
+        }
+
+        val browser = noRedirectsClient()
+
+        val apiToken = keys.accessToken {
+            subject = "api-user"
+        }
+        val bearerOnly = browser.get("/either") {
+            header(HttpHeaders.Authorization, "Bearer $apiToken")
+        }
+        assertEquals(HttpStatusCode.OK, bearerOnly.status)
+        assertEquals("bearer:api-user", bearerOnly.bodyAsText())
+
+        val login = browser.get("/oidc/auth0/login")
+        assertEquals(HttpStatusCode.Found, login.status)
+        val authorizeUrl = Url(assertNotNull(login.headers[HttpHeaders.Location]))
+        val stateCookie = assertNotNull(login.oidcStateCookieHeader())
+        val state = assertNotNull(authorizeUrl.parameters["state"])
+        val nonce = assertNotNull(authorizeUrl.parameters["nonce"])
+        assertNotNull(authorizeUrl.parameters["code_challenge"])
+        assertEquals("S256", authorizeUrl.parameters["code_challenge_method"])
+        assertEquals("auth0.example.com", authorizeUrl.host)
+        assertEquals("/authorize", authorizeUrl.encodedPath)
+
+        idTokensByState[state] = keys.idToken(subject = "browser-user") {
+            audience = "client-id"
+            this.nonce = nonce
+        }
+
+        val callback = browser.get("/oidc/auth0/callback?code=login-code&state=$state") {
+            header(HttpHeaders.Cookie, stateCookie)
+        }
+        assertEquals(HttpStatusCode.OK, callback.status)
+        assertEquals("signed in browser-user", callback.bodyAsText())
+        assertEquals(listOf("authorization_code"), tokenGrantTypes)
+        assertEquals(1, userInfoCalls.get())
+        sessionCookie = assertNotNull(callback.oidcSessionCookieHeader())
+        val setSessionCookie = assertNotNull(
+            callback.headers.getAll(HttpHeaders.SetCookie)
+                .orEmpty()
+                .firstOrNull { it.startsWith("$OIDC_TEST_SESSION_NAME=") }
+        )
+        val parsedSessionCookie = parseServerSetCookieHeader(setSessionCookie)
+        assertTrue(parsedSessionCookie.httpOnly)
+        assertEquals("lax", parsedSessionCookie.extensions["SameSite"])
+
+        val sessionOnly = browser.get("/either") {
+            sessionCookie()
+        }
+        assertEquals(HttpStatusCode.OK, sessionOnly.status)
+        assertEquals("session:browser-user", sessionOnly.bodyAsText())
+
+        val bearerPreferred = browser.get("/either") {
+            sessionCookie()
+            header(HttpHeaders.Authorization, "Bearer $apiToken")
+        }
+        assertEquals(HttpStatusCode.OK, bearerPreferred.status)
+        assertEquals("bearer:api-user", bearerPreferred.bodyAsText())
+
+        val profile = browser.get("/me") {
+            sessionCookie()
+        }
+        assertEquals(HttpStatusCode.OK, profile.status)
+        assertEquals("browser-user:Browser User", profile.bodyAsText())
+
+        val blockedProfileUpdate = browser.post("/me") {
+            sessionCookie()
+        }
+        assertEquals(HttpStatusCode.BadRequest, blockedProfileUpdate.status)
+
+        val allowedProfileUpdate = browser.post("/me") {
+            sessionCookie()
+            header(HttpHeaders.Host, "localhost")
+            header(HttpHeaders.Origin, "http://localhost")
+        }
+        assertEquals(HttpStatusCode.OK, allowedProfileUpdate.status)
+        assertEquals("updated browser-user", allowedProfileUpdate.bodyAsText())
+
+        val blockedRefresh = browser.post("/oidc/auth0/refresh") {
+            sessionCookie()
+        }
+        assertEquals(HttpStatusCode.BadRequest, blockedRefresh.status)
+
+        val refresh = browser.post("/oidc/auth0/refresh") {
+            sessionCookie()
+            header(HttpHeaders.Host, "localhost")
+            header(HttpHeaders.Origin, "http://localhost")
+        }
+        assertEquals(HttpStatusCode.OK, refresh.status)
+        assertEquals(listOf("authorization_code", "refresh_token"), tokenGrantTypes)
+        assertEquals(2, userInfoCalls.get())
+        refresh.oidcSessionCookieHeader()?.let { sessionCookie = it }
+
+        val refreshedProfile = browser.get("/me") {
+            sessionCookie()
+        }
+        assertEquals(HttpStatusCode.OK, refreshedProfile.status)
+        assertEquals("refreshed-user:Refreshed User", refreshedProfile.bodyAsText())
+
+        val logout = browser.post("/oidc/auth0/logout") {
+            sessionCookie()
+            header(HttpHeaders.Host, "localhost")
+            header(HttpHeaders.Origin, "http://localhost")
+        }
+        assertEquals(HttpStatusCode.SeeOther, logout.status)
+        val logoutUrl = Url(assertNotNull(logout.headers[HttpHeaders.Location]))
+        assertEquals("/logout", logoutUrl.encodedPath)
+        assertEquals(logoutUrl.parameters["id_token_hint"], refreshedIdToken.get())
+        assertEquals("http://localhost/", logoutUrl.parameters["post_logout_redirect_uri"])
+        assertEquals("client-id", logoutUrl.parameters["client_id"])
+
+        val afterLogout = browser.get("/me") {
+            sessionCookie()
+        }
+        assertEquals(HttpStatusCode.Unauthorized, afterLogout.status)
+    }
+
+    private fun TestApplicationBuilder.openIdBrowserFlowProvider(
+        keys: OpenIdTestKeys,
+        idTokensByState: Map<String, String>,
+        tokenGrantTypes: MutableList<String>,
+        userInfoCalls: AtomicInteger,
+        refreshedIdToken: AtomicReference<String>,
+    ) {
+        externalServices {
+            hosts(ISSUER_URL) {
+                routing {
+                    tokenEndpoint(keys, idTokensByState, tokenGrantTypes, refreshedIdToken)
+                    userInfoEndpoint(userInfoCalls)
+                }
+            }
+        }
+    }
+
+    private fun Route.tokenEndpoint(
+        keys: OpenIdTestKeys,
+        idTokensByState: Map<String, String>,
+        tokenGrantTypes: MutableList<String>,
+        refreshedIdToken: AtomicReference<String>,
+    ) {
+        post("/token") {
+            val parameters = call.receiveParameters()
+            val grantType = assertNotNull(parameters["grant_type"])
+            tokenGrantTypes += grantType
+
+            when (grantType) {
+                "authorization_code" -> {
+                    respondAuthorizationCodeWithIdToken(
+                        parameters = parameters,
+                        idTokensByState = idTokensByState,
+                        accessToken = "access-token-1",
+                    )
+                }
+
+                "refresh_token" -> {
+                    assertEquals(parameters["refresh_token"], "refresh-token-1")
+                    assertEquals("client-id", parameters["client_id"])
+                    assertEquals("client-secret", parameters["client_secret"])
+
+                    val idToken = keys.idToken(subject = "refreshed-user") {
+                        audience = "client-id"
+                        name = "Refreshed Token Subject"
+                    }
+                    refreshedIdToken.set(idToken)
+                    call.respondText(
+                        openIdTestJson.encodeToString(
+                            TokenRefreshResponse(
+                                accessToken = "access-token-2",
+                                tokenType = "Bearer",
+                                expiresIn = 3600,
+                                refreshToken = "refresh-token-2",
+                                idToken = idToken,
+                            )
+                        ),
+                        ContentType.Application.Json,
+                    )
+                }
+
+                else -> call.respond(HttpStatusCode.BadRequest)
+            }
+        }
+    }
+
+    private fun Route.userInfoEndpoint(userInfoCalls: AtomicInteger) {
+        get("/userinfo") {
+            userInfoCalls.incrementAndGet()
+            val body = when (call.request.headers[HttpHeaders.Authorization]) {
+                "Bearer access-token-1" -> {
+                    """{"sub":"browser-user","name":"Browser User","email":"browser@example.com"}"""
+                }
+
+                "Bearer access-token-2" -> {
+                    """{"sub":"refreshed-user","name":"Refreshed User","email":"refresh@example.com"}"""
+                }
+
+                else -> return@get call.respond(HttpStatusCode.Unauthorized)
+            }
+            call.respondText(body, ContentType.Application.Json)
+        }
+    }
+}

--- a/ktor-server/ktor-server-plugins/ktor-server-auth-oidc/jvm/test/io/ktor/server/auth/oidc/OidcOpaqueIntrospectionTest.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-auth-oidc/jvm/test/io/ktor/server/auth/oidc/OidcOpaqueIntrospectionTest.kt
@@ -1,0 +1,148 @@
+/*
+ * Copyright 2014-2026 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+@file:OptIn(ExperimentalKtorApi::class, ExperimentalTime::class)
+
+package io.ktor.server.auth.oidc
+
+import io.ktor.client.request.*
+import io.ktor.client.statement.*
+import io.ktor.http.*
+import io.ktor.server.auth.oidc.utils.*
+import io.ktor.server.auth.typesafe.*
+import io.ktor.server.request.*
+import io.ktor.server.response.*
+import io.ktor.server.routing.*
+import io.ktor.server.testing.*
+import io.ktor.utils.io.*
+import java.util.*
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.time.Clock
+import kotlin.time.ExperimentalTime
+
+class OidcOpaqueIntrospectionTest {
+
+    @Test
+    fun `opaque introspection validates active audience lifetime and issuer with basic auth`() = testApplication {
+        val now = Clock.System.now().toEpochMilliseconds() / 1000
+        openIdIntrospectionProvider { parameters ->
+            assertNull(parameters["client_id"])
+            assertNull(parameters["client_secret"])
+            assertEquals("access_token", parameters["token_type_hint"])
+            assertEquals(
+                "Basic ${Base64.getEncoder().encodeToString("resource-server:secret".toByteArray())}",
+                call.request.headers[HttpHeaders.Authorization],
+            )
+            when (parameters["token"]) {
+                "active-token" -> """{"active":true,"sub":"opaque-user","aud":["api"],"scope":"read"}"""
+                "primitive-audience-token" -> """{"active":true,"sub":"primitive-user","aud":"api","scope":"read"}"""
+                "inactive-token" -> """{"active":false,"aud":["api"]}"""
+                "wrong-audience-token" -> """{"active":true,"sub":"opaque-user","aud":["other-api"]}"""
+                "missing-audience-token" -> """{"active":true,"sub":"opaque-user"}"""
+                "expired-token" -> """{"active":true,"aud":["api"],"exp":${now - 120}}"""
+                "not-yet-valid-token" -> """{"active":true,"aud":["api"],"nbf":${now + 120}}"""
+                "wrong-issuer-token" -> """{"active":true,"aud":["api"],"iss":"https://issuer.example.net"}"""
+                else -> """{"active":false}"""
+            }
+        }
+
+        installOpaqueBearer("api")
+
+        assertOpaqueToken("active-token", HttpStatusCode.OK, "opaque-user")
+        assertOpaqueToken("primitive-audience-token", HttpStatusCode.OK, "primitive-user")
+        for (token in listOf(
+            "inactive-token",
+            "wrong-audience-token",
+            "missing-audience-token",
+            "expired-token",
+            "not-yet-valid-token",
+            "wrong-issuer-token",
+        )) {
+            assertOpaqueToken(token, HttpStatusCode.Unauthorized)
+        }
+    }
+
+    @Test
+    fun `opaque introspection post auth treats primitive audience as a single value`() = testApplication {
+        openIdIntrospectionProvider { parameters ->
+            assertEquals("resource-server", parameters["client_id"])
+            assertEquals("secret", parameters["client_secret"])
+            assertEquals("access_token", parameters["token_type_hint"])
+            assertNull(call.request.headers[HttpHeaders.Authorization])
+            when (parameters["token"]) {
+                "spaced-audience-token" -> """{"active":true,"sub":"primitive-user","aud":"my api","scope":"read"}"""
+                else -> """{"active":false}"""
+            }
+        }
+
+        installOpaqueBearer(
+            audience = "my api",
+            authMethod = OpaqueTokenIntrospectionAuthMethod.ClientSecretPost,
+        )
+
+        assertOpaqueToken("spaced-audience-token", HttpStatusCode.OK, "primitive-user")
+    }
+
+    private fun TestApplicationBuilder.openIdIntrospectionProvider(
+        responseForToken: suspend RoutingContext.(Parameters) -> String,
+    ) {
+        externalServices {
+            hosts(ISSUER_URL) {
+                routing {
+                    post("/introspect") {
+                        call.respondText(responseForToken(call.receiveParameters()), ContentType.Application.Json)
+                    }
+                }
+            }
+        }
+    }
+
+    private fun ApplicationTestBuilder.installOpaqueBearer(
+        audience: String,
+        authMethod: OpaqueTokenIntrospectionAuthMethod = OpaqueTokenIntrospectionAuthMethod.ClientSecretBasic,
+    ) {
+        val openIdClient = openIdHttpClient()
+        application {
+            val oidc = openIdConnect {
+                httpClient = openIdClient
+            }
+            val oidcProvider = oidc.provider("auth0") {
+                testIssuer()
+                accessToken {
+                    audiences = setOf(audience)
+                    opaqueToken = OpaqueTokenStrategy.Introspect(
+                        endpoint = "$ISSUER_URL/introspect",
+                        clientId = "resource-server",
+                        clientSecret = "secret",
+                        authMethod = authMethod,
+                    )
+                }
+                bearer()
+            }
+
+            routing {
+                authenticateWith(oidcProvider.bearer) {
+                    get("/opaque") {
+                        val opaque = principal as OidcToken.Opaque
+                        call.respondText(opaque.introspection.subject ?: "missing")
+                    }
+                }
+            }
+        }
+    }
+
+    private suspend fun ApplicationTestBuilder.assertOpaqueToken(
+        token: String,
+        status: HttpStatusCode,
+        body: String? = null,
+    ) {
+        val response = client.get("/opaque") {
+            header(HttpHeaders.Authorization, "Bearer $token")
+        }
+        assertEquals(status, response.status)
+        body?.let { assertEquals(it, response.bodyAsText()) }
+    }
+}

--- a/ktor-server/ktor-server-plugins/ktor-server-auth-oidc/jvm/test/io/ktor/server/auth/oidc/OidcProviderOperationsTest.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-auth-oidc/jvm/test/io/ktor/server/auth/oidc/OidcProviderOperationsTest.kt
@@ -1,0 +1,322 @@
+/*
+ * Copyright 2014-2026 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+@file:OptIn(ExperimentalKtorApi::class)
+
+package io.ktor.server.auth.oidc
+
+import io.ktor.client.request.*
+import io.ktor.client.statement.*
+import io.ktor.http.*
+import io.ktor.http.auth.*
+import io.ktor.server.auth.oidc.utils.*
+import io.ktor.server.auth.typesafe.*
+import io.ktor.server.request.*
+import io.ktor.server.response.*
+import io.ktor.server.routing.*
+import io.ktor.server.testing.*
+import io.ktor.utils.io.*
+import kotlin.test.*
+
+class OidcProviderOperationsTest {
+
+    @Test
+    fun `refreshToken returns raw fields and verified principal when id token is present`() = testApplication {
+        val keys = testRsaKeys
+
+        openIdProvider(keys)
+
+        val openIdClient = openIdHttpClient()
+        application {
+            val oidc = openIdConnect {
+                httpClient = openIdClient
+            }
+            val oidcProvider = oidc.provider("auth0") {
+                testIssuer(metadata = browserFlowMetadata())
+                jwt(keys)
+                accessToken {
+                    audiences = setOf("api")
+                }
+                bearer()
+                oauth {
+                    clientId = "client-id"
+                    clientSecret = "client-secret"
+                    resourceIndicators = listOf("https://api.example.com")
+                }
+            }
+            routing {
+                get("/refresh") {
+                    val result = oidcProvider.refreshToken("refresh-token-1")
+                    val principal = assertNotNull(result.idToken)
+                    call.respondText(
+                        listOf(
+                            result.accessToken,
+                            result.refreshToken,
+                            principal.value,
+                            result.expiresIn?.inWholeSeconds.toString(),
+                            result.tokenType,
+                            result.scope,
+                            principal.userInfo.subject,
+                        ).joinToString(":")
+                    )
+                }
+                get("/refresh/access-only") {
+                    val result = oidcProvider.refreshToken("access-only-refresh-token")
+                    call.respondText("${result.accessToken}:${result.refreshToken}:${result.idToken}")
+                }
+                get("/refresh/not-rotated") {
+                    val result = oidcProvider.refreshToken("refresh-token-not-rotated")
+                    val principal = assertNotNull(result.idToken)
+                    call.respondText("${result.refreshToken}:${principal.refreshToken}:${principal.userInfo.subject}")
+                }
+                get("/refresh/bad-token-type") {
+                    val failure = assertFailsWith<OidcTokenRejectedException> {
+                        oidcProvider.refreshToken("refresh-token-dpop")
+                    }
+                    call.respondText(failure.message.orEmpty())
+                }
+                get("/logout-url") {
+                    val url = oidcProvider.buildLogoutUrl(
+                        idTokenHint = "id-token-hint",
+                        postLogoutRedirectUri = "https://app.example.com/signed-out",
+                    )
+                    call.respondText(url)
+                }
+                authenticateWith(oidcProvider.bearer) {
+                    get("/context-refresh") {
+                        val result = oidcProvider.refreshToken("refresh-token-1")
+                        val principal = assertNotNull(result.idToken)
+                        call.respondText("${result.accessToken}:${principal.userInfo.subject}")
+                    }
+                    get("/context-logout-url") {
+                        val url = oidcProvider.buildLogoutUrl(
+                            idTokenHint = "id-token-hint",
+                            postLogoutRedirectUri = "https://app.example.com/signed-out",
+                        )
+                        call.respondText(url)
+                    }
+                }
+            }
+        }
+
+        val routeToken = keys.accessToken {
+            subject = "api-user"
+        }
+        val refresh = client.get("/refresh")
+        assertEquals(HttpStatusCode.OK, refresh.status)
+        val parts = refresh.bodyAsText().split(":")
+        assertEquals("access-token-2", parts[0])
+        assertEquals("refresh-token-2", parts[1])
+        assertEquals("3600", parts[3])
+        assertEquals("Bearer", parts[4])
+        assertEquals("openid profile", parts[5])
+        assertEquals("refreshed-user", parts[6])
+
+        val accessOnlyRefresh = client.get("/refresh/access-only")
+        assertEquals(HttpStatusCode.OK, accessOnlyRefresh.status)
+        assertEquals(accessOnlyRefresh.bodyAsText(), "access-token-only:null:null")
+
+        val notRotatedRefresh = client.get("/refresh/not-rotated")
+        assertEquals(HttpStatusCode.OK, notRotatedRefresh.status)
+        assertEquals("null:refresh-token-not-rotated:non-rotated-user", notRotatedRefresh.bodyAsText())
+
+        val badTokenType = client.get("/refresh/bad-token-type")
+        assertEquals(HttpStatusCode.OK, badTokenType.status)
+        assertContains(badTokenType.bodyAsText(), "token_type")
+
+        val logoutUrl = Url(client.get("/logout-url").bodyAsText())
+        assertEquals("/logout", logoutUrl.encodedPath)
+        assertEquals(logoutUrl.parameters["id_token_hint"], "id-token-hint")
+        assertEquals("https://app.example.com/signed-out", logoutUrl.parameters["post_logout_redirect_uri"])
+        assertEquals("client-id", logoutUrl.parameters["client_id"])
+
+        val contextRefresh = client.get("/context-refresh") {
+            header(HttpHeaders.Authorization, "Bearer $routeToken")
+        }
+        assertEquals(HttpStatusCode.OK, contextRefresh.status)
+        assertEquals(contextRefresh.bodyAsText(), "access-token-2:refreshed-user")
+
+        val contextLogoutUrl = Url(
+            client.get("/context-logout-url") {
+                header(HttpHeaders.Authorization, "Bearer $routeToken")
+            }.bodyAsText()
+        )
+        assertEquals("/logout", contextLogoutUrl.encodedPath)
+        assertEquals(contextLogoutUrl.parameters["id_token_hint"], "id-token-hint")
+        assertEquals("https://app.example.com/signed-out", contextLogoutUrl.parameters["post_logout_redirect_uri"])
+        assertEquals("client-id", contextLogoutUrl.parameters["client_id"])
+    }
+
+    @Test
+    fun `buildVerifiedPrincipal validates at hash when present`() = testApplication {
+        val accessToken = "access-token"
+        val keysByAlgorithm = testRsaKeysByAlgorithm
+        val algorithms = keysByAlgorithm.keys
+
+        application {
+            val oidc = openIdConnect { }
+            val oidcProvider = oidc.provider("auth0") {
+                testIssuer()
+                jwt {
+                    jwkProviderFactory = { jwkProviderWithMultipleKeys(*keysByAlgorithm.values.toTypedArray()) }
+                }
+                oauth {
+                    clientId = "client-id"
+                    clientSecret = "client-secret"
+                }
+            }
+            routing {
+                algorithms.forEach { algorithm ->
+                    val algorithmName = algorithm.testJwaName
+                    get("/at-hash/valid/$algorithmName") {
+                        val keys = keysByAlgorithm.getValue(algorithm)
+                        val idToken = keys.idToken(subject = "hash-user") {
+                            audience = "client-id"
+                            atHash = keys.algorithm.hashAccessToken(accessToken)
+                        }
+                        val principal = oidcProvider.buildIdToken(
+                            idToken = idToken,
+                            accessToken = accessToken,
+                            refreshToken = null,
+                            expectedAudience = "client-id",
+                        )
+                        call.respondText(principal.userInfo.subject)
+                    }
+                }
+                get("/at-hash/invalid") {
+                    val keys = keysByAlgorithm.getValue(SignatureAlgorithm.RSA_SHA_256)
+                    val failure = assertFailsWith<OidcTokenRejectedException> {
+                        oidcProvider.buildIdToken(
+                            idToken = keys.idToken(subject = "hash-user") {
+                                audience = "client-id"
+                                atHash = "invalid"
+                            },
+                            accessToken = accessToken,
+                            refreshToken = null,
+                            expectedAudience = "client-id",
+                        )
+                    }
+                    call.respondText(failure.message.orEmpty())
+                }
+            }
+        }
+
+        algorithms.forEach { algorithm ->
+            val valid = client.get("/at-hash/valid/${algorithm.testJwaName}")
+            assertEquals(HttpStatusCode.OK, valid.status)
+            assertEquals("hash-user", valid.bodyAsText())
+        }
+
+        val invalid = client.get("/at-hash/invalid")
+        assertEquals(HttpStatusCode.OK, invalid.status)
+        assertContains(invalid.bodyAsText(), "at_hash")
+    }
+
+    @Test
+    fun `buildLogoutUrl returns null when provider has no logout endpoint`() = testApplication {
+        application {
+            val oidc = openIdConnect { }
+            val oidcProvider = oidc.provider("auth0") {
+                testIssuer(metadata = openIdProviderMetadata)
+                oauth {
+                    clientId = "client-id"
+                    clientSecret = "client-secret"
+                }
+            }
+            routing {
+                get("/logout-url") {
+                    val failure = assertFailsWith<IllegalArgumentException> {
+                        oidcProvider.buildLogoutUrl("id-token-hint", null)
+                    }
+                    call.respondText(failure.message.orEmpty())
+                }
+            }
+        }
+
+        assertContains(client.get("/logout-url").bodyAsText(), "endSessionEndpoint")
+    }
+
+    private fun TestApplicationBuilder.openIdProvider(keys: OpenIdTestKeys) {
+        externalServices {
+            hosts(ISSUER_URL) {
+                routing {
+                    post("/token") {
+                        val parameters = call.receiveParameters()
+                        assertEquals("refresh_token", parameters["grant_type"])
+                        assertEquals("client-id", parameters["client_id"])
+                        assertEquals("client-secret", parameters["client_secret"])
+                        assertEquals(listOf("https://api.example.com"), parameters.getAll("resource"))
+
+                        when (parameters["refresh_token"]) {
+                            "refresh-token-1" -> {
+                                val idToken = keys.idToken(subject = "refreshed-user") {
+                                    audience = "client-id"
+                                }
+                                call.respondText(
+                                    openIdTestJson.encodeToString(
+                                        TokenRefreshResponse(
+                                            accessToken = "access-token-2",
+                                            tokenType = "Bearer",
+                                            expiresIn = 3600,
+                                            refreshToken = "refresh-token-2",
+                                            idToken = idToken,
+                                            scope = "openid profile",
+                                        )
+                                    ),
+                                    ContentType.Application.Json,
+                                )
+                            }
+
+                            "access-only-refresh-token" -> {
+                                call.respondText(
+                                    openIdTestJson.encodeToString(
+                                        TokenRefreshResponse(
+                                            accessToken = "access-token-only",
+                                            tokenType = "Bearer",
+                                        )
+                                    ),
+                                    ContentType.Application.Json,
+                                )
+                            }
+
+                            "refresh-token-not-rotated" -> {
+                                val idToken = keys.idToken(subject = "non-rotated-user") {
+                                    audience = "client-id"
+                                }
+                                call.respondText(
+                                    openIdTestJson.encodeToString(
+                                        TokenRefreshResponse(
+                                            accessToken = "access-token-not-rotated",
+                                            tokenType = "Bearer",
+                                            idToken = idToken,
+                                        )
+                                    ),
+                                    ContentType.Application.Json,
+                                )
+                            }
+
+                            "refresh-token-dpop" -> {
+                                val idToken = keys.idToken(subject = "bad-token-type-user") {
+                                    audience = "client-id"
+                                }
+                                call.respondText(
+                                    openIdTestJson.encodeToString(
+                                        TokenRefreshResponse(
+                                            accessToken = "access-token-bad-type",
+                                            tokenType = "DPoP",
+                                            idToken = idToken,
+                                        )
+                                    ),
+                                    ContentType.Application.Json,
+                                )
+                            }
+
+                            else -> call.respond(HttpStatusCode.BadRequest)
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/ktor-server/ktor-server-plugins/ktor-server-auth-oidc/jvm/test/io/ktor/server/auth/oidc/OidcTypedAuthenticationTest.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-auth-oidc/jvm/test/io/ktor/server/auth/oidc/OidcTypedAuthenticationTest.kt
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2014-2026 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+@file:OptIn(ExperimentalKtorApi::class)
+
+package io.ktor.server.auth.oidc
+
+import io.ktor.client.request.*
+import io.ktor.client.statement.*
+import io.ktor.http.*
+import io.ktor.server.auth.*
+import io.ktor.server.auth.oidc.utils.*
+import io.ktor.server.auth.typesafe.*
+import io.ktor.server.response.*
+import io.ktor.server.routing.*
+import io.ktor.server.testing.*
+import io.ktor.utils.io.*
+import java.util.concurrent.ConcurrentHashMap
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+
+class OidcTypedAuthenticationTest {
+
+    @Test
+    fun `typed bearer and session schemes share provider principal type`() = testApplication {
+        val keys = testRsaKeys
+        val idTokensByState = ConcurrentHashMap<String, String>()
+
+        openIdProvider(keys, idTokensByState)
+        val openIdClient = openIdHttpClient()
+        application {
+            val oidc = openIdConnect {
+                httpClient = openIdClient
+            }
+            val google = oidc.provider(
+                name = "google",
+                transformPrincipal = { principal ->
+                    when (principal) {
+                        is OidcToken.Id -> UserIdPrincipal(principal.userInfo.subject)
+                        is OidcToken.Access -> principal.userInfo?.subject?.let(::UserIdPrincipal)
+                        is OidcToken.Opaque -> principal.introspection.subject?.let(::UserIdPrincipal)
+                    }
+                },
+            ) {
+                testIssuer()
+                jwt(keys)
+                accessToken {
+                    audiences = setOf("api")
+                }
+                bearer()
+                sessions {
+                    name = OIDC_TEST_SESSION_NAME
+                    cookie {
+                        cookie.secure = false
+                    }
+                }
+                oauth {
+                    clientId = "client-id"
+                    clientSecret = "client-secret"
+                }
+            }
+
+            routing {
+                authenticateWithAnyOf<UserIdPrincipal>(google.bearer, google.sessions) {
+                    get("/both") {
+                        call.respondText(principal.name)
+                    }
+                }
+            }
+        }
+
+        val bearerToken = keys.accessToken {
+            subject = "bearer-user"
+        }
+        val bearerResponse = client.get("/both") {
+            header(HttpHeaders.Authorization, "Bearer $bearerToken")
+        }
+        assertEquals("bearer-user", bearerResponse.bodyAsText())
+
+        val browser = noRedirectsClient()
+        val login = browser.prepareOidcLogin("google")
+        idTokensByState[login.state] = keys.idToken(subject = "session-user") {
+            audience = "client-id"
+            nonce = login.nonce
+        }
+
+        val callback = browser.completeOidcCallback(login, providerName = "google")
+        val sessionCookie = assertNotNull(callback.oidcSessionCookieHeader())
+        val sessionResponse = client.get("/both") {
+            header(HttpHeaders.Cookie, sessionCookie)
+        }
+        assertEquals("session-user", sessionResponse.bodyAsText())
+    }
+}

--- a/ktor-server/ktor-server-plugins/ktor-server-auth-oidc/jvm/test/io/ktor/server/auth/oidc/ProtectedResourceMetadataTest.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-auth-oidc/jvm/test/io/ktor/server/auth/oidc/ProtectedResourceMetadataTest.kt
@@ -1,0 +1,350 @@
+/*
+ * Copyright 2014-2026 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+@file:OptIn(ExperimentalKtorApi::class)
+
+package io.ktor.server.auth.oidc
+
+import io.ktor.client.request.*
+import io.ktor.client.statement.*
+import io.ktor.http.*
+import io.ktor.server.auth.oidc.utils.*
+import io.ktor.server.auth.typesafe.*
+import io.ktor.server.response.*
+import io.ktor.server.routing.*
+import io.ktor.server.testing.*
+import io.ktor.utils.io.*
+import kotlin.test.*
+
+class ProtectedResourceMetadataTest {
+
+    @Test
+    fun `protected resource metadata endpoint returns correct JSON`() = testApplication {
+        application {
+            val oidc = openIdConnect {
+                protectedResource("https://api.example.com") {
+                    resourceName = "My API"
+                }
+            }
+            oidc.provider("auth0") {
+                testIssuer()
+                accessToken {
+                    audiences = setOf("api")
+                }
+                bearer()
+            }
+        }
+        val response = client.get("/.well-known/oauth-protected-resource")
+        assertEquals(HttpStatusCode.OK, response.status)
+        assertEquals(ContentType.Application.Json, response.contentType()?.withoutParameters())
+        val body = response.bodyAsText()
+        val metadata = discoveryJson.decodeFromString<ProtectedResourceMetadata>(body)
+        assertEquals("https://api.example.com", metadata.resource)
+        assertEquals(listOf(ISSUER_URL), metadata.authorizationServers)
+        assertEquals("My API", metadata.resourceName)
+    }
+
+    @Test
+    fun `protected resource metadata can be enabled with defaults`() = testApplication {
+        application {
+            val oidc = openIdConnect {
+                protectedResource("https://api.example.com")
+            }
+            oidc.provider("auth0") {
+                testIssuer()
+                accessToken {
+                    audiences = setOf("api")
+                }
+                bearer()
+            }
+        }
+        val metadata = discoveryJson.decodeFromString<ProtectedResourceMetadata>(
+            client.get("/.well-known/oauth-protected-resource").bodyAsText()
+        )
+        assertEquals("https://api.example.com", metadata.resource)
+        assertEquals(listOf("header"), metadata.bearerMethodsSupported)
+    }
+
+    @Test
+    fun `protected resource metadata supports explicit scopes`() = testApplication {
+        application {
+            val oidc = openIdConnect {
+                protectedResource("https://api.example.com") {
+                    scopesSupported = listOf("openid", "profile", "custom-scope")
+                }
+            }
+            oidc.provider("auth0") {
+                testIssuer()
+                accessToken {
+                    audiences = setOf("api")
+                }
+                bearer()
+            }
+        }
+        val response = client.get("/.well-known/oauth-protected-resource")
+        val metadata = discoveryJson.decodeFromString<ProtectedResourceMetadata>(response.bodyAsText())
+        assertEquals(listOf("openid", "profile", "custom-scope"), metadata.scopesSupported)
+    }
+
+    @Test
+    fun `protected resource metadata explicit overrides take precedence`() = testApplication {
+        application {
+            val oidc = openIdConnect {
+                protectedResource("https://api.example.com") {
+                    authorizationServers = listOf("https://custom-as.example.com")
+                    scopesSupported = listOf("read", "write")
+                }
+            }
+            oidc.provider("auth0") {
+                testIssuer()
+                accessToken {
+                    audiences = setOf("api")
+                }
+                bearer()
+            }
+        }
+        val response = client.get("/.well-known/oauth-protected-resource")
+        val metadata = discoveryJson.decodeFromString<ProtectedResourceMetadata>(response.bodyAsText())
+        assertEquals(listOf("https://custom-as.example.com"), metadata.authorizationServers)
+        assertEquals(listOf("read", "write"), metadata.scopesSupported)
+    }
+
+    @Test
+    fun `protected resource metadata disabled by default`() = testApplication {
+        application {
+            val oidc = openIdConnect { }
+            oidc.provider("auth0") {
+                testIssuer()
+                accessToken {
+                    audiences = setOf("api")
+                }
+                bearer()
+            }
+        }
+        val response = client.get("/.well-known/oauth-protected-resource")
+        assertEquals(HttpStatusCode.NotFound, response.status)
+    }
+
+    @Test
+    fun `WWW-Authenticate includes resource_metadata when protected resource configured`() = testApplication {
+        application {
+            val oidc = openIdConnect {
+                protectedResource("https://api.example.com") {}
+            }
+            val provider = oidc.provider("auth0") {
+                testIssuer()
+                accessToken {
+                    audiences = setOf("my-api")
+                }
+                bearer()
+            }
+
+            routing {
+                authenticateWith(provider.bearer) {
+                    get("/protected") { call.respondText("ok") }
+                }
+            }
+        }
+        val response = client.get("/protected")
+        assertEquals(HttpStatusCode.Unauthorized, response.status)
+        val wwwAuth = response.headers[HttpHeaders.WWWAuthenticate]
+        assertNotNull(wwwAuth)
+        assertContains(wwwAuth, "resource_metadata=")
+        assertContains(wwwAuth, "https://api.example.com/.well-known/oauth-protected-resource")
+    }
+
+    @Test
+    fun `WWW-Authenticate omits resource_metadata when protected resource not configured`() = testApplication {
+        application {
+            val oidc = openIdConnect { }
+            val provider = oidc.provider("auth0") {
+                testIssuer()
+                accessToken {
+                    audiences = setOf("my-api")
+                }
+                bearer()
+            }
+            routing {
+                authenticateWith(provider.bearer) {
+                    get("/protected") { call.respondText("ok") }
+                }
+            }
+        }
+        val response = client.get("/protected")
+        assertEquals(HttpStatusCode.Unauthorized, response.status)
+        val wwwAuth = response.headers[HttpHeaders.WWWAuthenticate] ?: ""
+        assertFalse(wwwAuth.contains("resource_metadata"))
+    }
+
+    @Test
+    fun `protected resource metadata routes follow resource path and port`() {
+        val cases = listOf(
+            "https://api.example.com" to "/.well-known/oauth-protected-resource",
+            "https://api.example.com/v1/" to "/.well-known/oauth-protected-resource/v1",
+            "https://api.example.com/v1" to "/.well-known/oauth-protected-resource/v1",
+            "https://api.example.com:8443/v1" to "/.well-known/oauth-protected-resource/v1",
+        )
+
+        cases.forEach { (resource, routePath) ->
+            testApplication {
+                configureProtectedResourceApplication(resource, protectedPath = "/protected")
+
+                val response = client.get(routePath)
+                assertEquals(HttpStatusCode.OK, response.status, resource)
+                val metadata = discoveryJson.decodeFromString<ProtectedResourceMetadata>(response.bodyAsText())
+                assertEquals(resource, metadata.resource)
+
+                val expectedMetadataUrl = buildResourceMetadataUrl(resource)
+                assertContains(expectedMetadataUrl, routePath)
+                val wwwAuth = client.get("/protected").headers[HttpHeaders.WWWAuthenticate]
+                assertNotNull(wwwAuth)
+                assertContains(wwwAuth, expectedMetadataUrl)
+
+                if (routePath != "/.well-known/oauth-protected-resource") {
+                    assertEquals(HttpStatusCode.NotFound, client.get("/.well-known/oauth-protected-resource").status)
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `protected resource metadata omits null fields`() = testApplication {
+        application {
+            val oidc = openIdConnect {
+                protectedResource("https://api.example.com") {}
+            }
+            oidc.provider("auth0") {
+                testIssuer()
+                accessToken {
+                    audiences = setOf("api")
+                }
+                bearer()
+            }
+        }
+        val body = client.get("/.well-known/oauth-protected-resource").bodyAsText()
+        assertFalse(body.contains("\"jwks_uri\""))
+        assertFalse(body.contains("\"resource_name\""))
+        assertFalse(body.contains("\"dpop_bound_access_tokens_required\""))
+        assertContains(body, "\"resource\"")
+        assertContains(body, "\"authorization_servers\"")
+    }
+
+    @Test
+    fun `protected resource metadata does not infer custom bearer extractors`() = testApplication {
+        application {
+            val oidc = openIdConnect {
+                protectedResource("https://api.example.com") {}
+            }
+            oidc.provider("auth0") {
+                testIssuer()
+                accessToken {
+                    audiences = setOf("api")
+                }
+                bearer {
+                    tokenExtractor = { call -> call.request.headers["X-Token"] }
+                }
+            }
+        }
+        val metadata = discoveryJson.decodeFromString<ProtectedResourceMetadata>(
+            client.get("/.well-known/oauth-protected-resource").bodyAsText()
+        )
+        assertNull(metadata.bearerMethodsSupported)
+    }
+
+    @Test
+    fun `protected resource metadata uses explicit bearer methods with custom extractor`() = testApplication {
+        application {
+            val oidc = openIdConnect {
+                protectedResource("https://api.example.com") {
+                    bearerMethodsSupported = listOf("body")
+                }
+            }
+            oidc.provider("auth0") {
+                testIssuer()
+                accessToken {
+                    audiences = setOf("api")
+                }
+                bearer {
+                    tokenExtractor = { call -> call.request.headers["X-Token"] }
+                }
+            }
+        }
+        val metadata = discoveryJson.decodeFromString<ProtectedResourceMetadata>(
+            client.get("/.well-known/oauth-protected-resource").bodyAsText()
+        )
+        assertEquals(listOf("body"), metadata.bearerMethodsSupported)
+    }
+
+    @Test
+    fun `protected resource metadata derives bearer methods from token sources`() = testApplication {
+        application {
+            val oidc = openIdConnect {
+                protectedResource("https://api.example.com") {}
+            }
+            oidc.provider("auth0") {
+                testIssuer()
+                accessToken {
+                    audiences = setOf("api")
+                }
+                bearer()
+            }
+        }
+        val metadata = discoveryJson.decodeFromString<ProtectedResourceMetadata>(
+            client.get("/.well-known/oauth-protected-resource").bodyAsText()
+        )
+        assertEquals(listOf("header"), metadata.bearerMethodsSupported)
+    }
+
+    @Test
+    fun `protected resource metadata rejects unsupported resource URLs`() {
+        val invalidResources = listOf(
+            "https://user@api.example.com" to "userinfo",
+            "https://api.example.com?foo=bar" to "query",
+            "https://api.example.com#metadata" to "fragment",
+            "http://api.example.com" to "https",
+            "https:///v1" to "host",
+        )
+
+        invalidResources.forEach { (resource, expectedMessage) ->
+            val failure = assertFailsWith<IllegalArgumentException> {
+                testApplication {
+                    application {
+                        openIdConnect {
+                            protectedResource(resource)
+                        }
+                    }
+                    startApplication()
+                }
+            }
+            assertContains(failure.message.orEmpty(), "protectedResource(resource)")
+            assertContains(failure.message.orEmpty(), expectedMessage)
+        }
+    }
+
+    private suspend fun ApplicationTestBuilder.configureProtectedResourceApplication(
+        resource: String,
+        protectedPath: String? = null,
+    ) {
+        application {
+            val oidc = openIdConnect {
+                protectedResource(resource) {}
+            }
+            val provider = oidc.provider("auth0") {
+                testIssuer()
+                accessToken {
+                    audiences = setOf("api")
+                }
+                bearer()
+            }
+
+            if (protectedPath != null) {
+                routing {
+                    authenticateWith(provider.bearer) {
+                        get(protectedPath) { call.respondText("ok") }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/ktor-server/ktor-server-plugins/ktor-server-auth-oidc/jvm/test/io/ktor/server/auth/oidc/ProtectedResourceMetadataTest.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-auth-oidc/jvm/test/io/ktor/server/auth/oidc/ProtectedResourceMetadataTest.kt
@@ -67,6 +67,36 @@ class ProtectedResourceMetadataTest {
     }
 
     @Test
+    fun `protected resource metadata reflects providers registered after first request`() = testApplication {
+        lateinit var oidc: Oidc
+        application {
+            oidc = openIdConnect {
+                protectedResource("https://api.example.com")
+            }
+        }
+
+        val firstMetadata = discoveryJson.decodeFromString<ProtectedResourceMetadata>(
+            client.get("/.well-known/oauth-protected-resource").bodyAsText()
+        )
+        assertNull(firstMetadata.authorizationServers)
+        assertNull(firstMetadata.bearerMethodsSupported)
+
+        oidc.provider("auth0") {
+            testIssuer()
+            accessToken {
+                audiences = setOf("api")
+            }
+            bearer()
+        }
+
+        val secondMetadata = discoveryJson.decodeFromString<ProtectedResourceMetadata>(
+            client.get("/.well-known/oauth-protected-resource").bodyAsText()
+        )
+        assertEquals(listOf(ISSUER_URL), secondMetadata.authorizationServers)
+        assertEquals(listOf("header"), secondMetadata.bearerMethodsSupported)
+    }
+
+    @Test
     fun `protected resource metadata supports explicit scopes`() = testApplication {
         application {
             val oidc = openIdConnect {
@@ -109,6 +139,41 @@ class ProtectedResourceMetadataTest {
         assertEquals(listOf("https://custom-as.example.com"), metadata.authorizationServers)
         assertEquals(listOf("read", "write"), metadata.scopesSupported)
     }
+
+    @Test
+    fun `protected resource metadata derives authorization servers and scopes from bearer providers only`() =
+        testApplication {
+            application {
+                val oidc = openIdConnect {
+                    protectedResource("https://api.example.com")
+                }
+                oidc.provider("browser") {
+                    testIssuer("https://login.example.com")
+                    oauth {
+                        clientId = "browser-client"
+                        clientSecret = "browser-secret"
+                        scopes = listOf("openid", "browser")
+                    }
+                }
+                oidc.provider("api") {
+                    testIssuer("https://issuer.example.com")
+                    accessToken {
+                        audiences = setOf("api")
+                    }
+                    bearer()
+                    oauth {
+                        clientId = "api-client"
+                        clientSecret = "api-secret"
+                        scopes = listOf("openid", "api.read")
+                    }
+                }
+            }
+
+            val response = client.get("/.well-known/oauth-protected-resource")
+            val metadata = discoveryJson.decodeFromString<ProtectedResourceMetadata>(response.bodyAsText())
+            assertEquals(listOf("https://issuer.example.com"), metadata.authorizationServers)
+            assertEquals(listOf("openid", "api.read"), metadata.scopesSupported)
+        }
 
     @Test
     fun `protected resource metadata disabled by default`() = testApplication {
@@ -206,6 +271,14 @@ class ProtectedResourceMetadataTest {
                 }
             }
         }
+    }
+
+    @Test
+    fun `protected resource metadata URL preserves IPv6 brackets`() {
+        assertEquals(
+            "https://[::1]:8443/.well-known/oauth-protected-resource/v1",
+            buildResourceMetadataUrl("https://[::1]:8443/v1")
+        )
     }
 
     @Test

--- a/ktor-server/ktor-server-plugins/ktor-server-auth-oidc/jvm/test/io/ktor/server/auth/oidc/utils/OidcSessionTestUtils.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-auth-oidc/jvm/test/io/ktor/server/auth/oidc/utils/OidcSessionTestUtils.kt
@@ -17,7 +17,6 @@ import io.ktor.server.response.*
 import io.ktor.server.routing.*
 import io.ktor.server.testing.*
 import io.ktor.utils.io.*
-import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import java.util.concurrent.atomic.AtomicInteger
 import kotlin.test.assertEquals


### PR DESCRIPTION
**Subsystem**
Server OIDC

**Motivation**
[KTOR-5001](https://youtrack.jetbrains.com/issue/KTOR-5001) Add OpenID Connect (OIDC) support on client and server

**Solution**
- New `protectedResource(resource) { }` DSL
- Serves metadata at `/.well-known/oauth-protected-resource{path}` derived from the resource identifier URL
- Auto-derives authorization_servers, scopes_supported, and bearer_methods_supported from configured providers unless explicitly overridden
- Bearer authentication failures include a resource_metadata parameter in WWW-Authenticate when protected resource metadata is enabled

This should be the last PR for the OIDC plugin

