### PR TITLE
KTOR-9639 Darwin: WebSocket crashes when a frame arrives after the session is closed

### DIFF
--- a/ktor-client/ktor-client-darwin/darwin/src/io/ktor/client/engine/darwin/internal/DarwinWebsocketSession.kt
+++ b/ktor-client/ktor-client-darwin/darwin/src/io/ktor/client/engine/darwin/internal/DarwinWebsocketSession.kt
@@ -70,13 +70,13 @@ internal class DarwinWebsocketSession(
         launch {
             sendMessages()
         }
-        coroutineContext[Job]!!.invokeOnCompletion { cause ->
-            if (cause != null) {
+        coroutineContext.job.invokeOnCompletion { cause ->
+            if (cause != null && cause !is CancellationException) {
                 val code = CloseReason.Codes.INTERNAL_ERROR.code.convert<NSInteger>()
                 task.cancelWithCloseCode(code, "Client failed".toByteArray().toNSData())
             }
             _incoming.close(cause)
-            _outgoing.cancel(cause = CancellationException(cause))
+            _outgoing.cancel(cause = cause as? CancellationException ?: CancellationException(cause))
         }
     }
 
@@ -98,12 +98,10 @@ internal class DarwinWebsocketSession(
 
     private fun receiveFrame(frame: Frame) {
         val result = _incoming.trySend(frame)
-        when {
-            result.isSuccess -> return
-            result.isClosed -> result.exceptionOrNull()?.let { throw it }
-            else -> launch(start = CoroutineStart.UNDISPATCHED) {
-                _incoming.send(frame)
-            }
+        if (result.isSuccess || result.isClosed) return
+
+        launch(start = CoroutineStart.UNDISPATCHED) {
+            _incoming.send(frame)
         }
     }
 


### PR DESCRIPTION
**Subsystem**
`ktor-client-darwin`

**Motivation**
[KTOR-9639](https://youtrack.jetbrains.com/issue/KTOR-9639) Darwin: WebSocket client crashes the process when a PONG arrives after the session is closed

**Solution**
We shouldn't throw from functions that are used from callbacks passed into ObjC world.