### PR TITLE
KTOR-5009 Add a way to prevent automatic Accept header injection

### DIFF
--- a/ktor-client/ktor-client-plugins/ktor-client-content-negotiation/api/ktor-client-content-negotiation.api
+++ b/ktor-client/ktor-client-plugins/ktor-client-content-negotiation/api/ktor-client-content-negotiation.api
@@ -5,11 +5,13 @@ public final class io/ktor/client/plugins/contentnegotiation/ContentConverterExc
 public final class io/ktor/client/plugins/contentnegotiation/ContentNegotiationConfig : io/ktor/serialization/Configuration {
 	public fun <init> ()V
 	public final fun clearIgnoredTypes ()V
+	public final fun getAddAcceptHeaderOnlyIfNonePresent ()Z
 	public final fun getDefaultAcceptHeaderQValue ()Ljava/lang/Double;
 	public final fun ignoreType (Lkotlin/reflect/KClass;)V
 	public final fun register (Lio/ktor/http/ContentType;Lio/ktor/serialization/ContentConverter;Lio/ktor/http/ContentTypeMatcher;Lkotlin/jvm/functions/Function1;)V
 	public fun register (Lio/ktor/http/ContentType;Lio/ktor/serialization/ContentConverter;Lkotlin/jvm/functions/Function1;)V
 	public final fun removeIgnoredType (Lkotlin/reflect/KClass;)V
+	public final fun setAddAcceptHeaderOnlyIfNonePresent (Z)V
 	public final fun setDefaultAcceptHeaderQValue (Ljava/lang/Double;)V
 }
 

--- a/ktor-client/ktor-client-plugins/ktor-client-content-negotiation/api/ktor-client-content-negotiation.api
+++ b/ktor-client/ktor-client-plugins/ktor-client-content-negotiation/api/ktor-client-content-negotiation.api
@@ -5,19 +5,29 @@ public final class io/ktor/client/plugins/contentnegotiation/ContentConverterExc
 public final class io/ktor/client/plugins/contentnegotiation/ContentNegotiationConfig : io/ktor/serialization/Configuration {
 	public fun <init> ()V
 	public final fun clearIgnoredTypes ()V
-	public final fun getAddAcceptHeaderOnlyIfNonePresent ()Z
+	public final fun getAcceptHeaderMergeStrategy ()Lio/ktor/client/plugins/contentnegotiation/ContentTypeMergeStrategy;
 	public final fun getDefaultAcceptHeaderQValue ()Ljava/lang/Double;
 	public final fun ignoreType (Lkotlin/reflect/KClass;)V
 	public final fun register (Lio/ktor/http/ContentType;Lio/ktor/serialization/ContentConverter;Lio/ktor/http/ContentTypeMatcher;Lkotlin/jvm/functions/Function1;)V
 	public fun register (Lio/ktor/http/ContentType;Lio/ktor/serialization/ContentConverter;Lkotlin/jvm/functions/Function1;)V
 	public final fun removeIgnoredType (Lkotlin/reflect/KClass;)V
-	public final fun setAddAcceptHeaderOnlyIfNonePresent (Z)V
+	public final fun setAcceptHeaderMergeStrategy (Lio/ktor/client/plugins/contentnegotiation/ContentTypeMergeStrategy;)V
 	public final fun setDefaultAcceptHeaderQValue (Ljava/lang/Double;)V
 }
 
 public final class io/ktor/client/plugins/contentnegotiation/ContentNegotiationKt {
 	public static final fun exclude (Lio/ktor/client/request/HttpRequestBuilder;[Lio/ktor/http/ContentType;)V
 	public static final fun getContentNegotiation ()Lio/ktor/client/plugins/api/ClientPlugin;
+}
+
+public abstract interface class io/ktor/client/plugins/contentnegotiation/ContentTypeMergeStrategy {
+	public static final field Companion Lio/ktor/client/plugins/contentnegotiation/ContentTypeMergeStrategy$Companion;
+	public abstract fun mergeContentTypes (Ljava/util/List;Ljava/util/List;)Lkotlin/sequences/Sequence;
+}
+
+public final class io/ktor/client/plugins/contentnegotiation/ContentTypeMergeStrategy$Companion {
+	public final fun getDefault ()Lio/ktor/client/plugins/contentnegotiation/ContentTypeMergeStrategy;
+	public final fun getSkipIfPresent ()Lio/ktor/client/plugins/contentnegotiation/ContentTypeMergeStrategy;
 }
 
 public final class io/ktor/client/plugins/contentnegotiation/JsonContentTypeMatcher : io/ktor/http/ContentTypeMatcher {

--- a/ktor-client/ktor-client-plugins/ktor-client-content-negotiation/api/ktor-client-content-negotiation.klib.api
+++ b/ktor-client/ktor-client-plugins/ktor-client-content-negotiation/api/ktor-client-content-negotiation.klib.api
@@ -13,6 +13,9 @@ final class io.ktor.client.plugins.contentnegotiation/ContentConverterException 
 final class io.ktor.client.plugins.contentnegotiation/ContentNegotiationConfig : io.ktor.serialization/Configuration { // io.ktor.client.plugins.contentnegotiation/ContentNegotiationConfig|null[0]
     constructor <init>() // io.ktor.client.plugins.contentnegotiation/ContentNegotiationConfig.<init>|<init>(){}[0]
 
+    final var addAcceptHeaderOnlyIfNonePresent // io.ktor.client.plugins.contentnegotiation/ContentNegotiationConfig.addAcceptHeaderOnlyIfNonePresent|{}addAcceptHeaderOnlyIfNonePresent[0]
+        final fun <get-addAcceptHeaderOnlyIfNonePresent>(): kotlin/Boolean // io.ktor.client.plugins.contentnegotiation/ContentNegotiationConfig.addAcceptHeaderOnlyIfNonePresent.<get-addAcceptHeaderOnlyIfNonePresent>|<get-addAcceptHeaderOnlyIfNonePresent>(){}[0]
+        final fun <set-addAcceptHeaderOnlyIfNonePresent>(kotlin/Boolean) // io.ktor.client.plugins.contentnegotiation/ContentNegotiationConfig.addAcceptHeaderOnlyIfNonePresent.<set-addAcceptHeaderOnlyIfNonePresent>|<set-addAcceptHeaderOnlyIfNonePresent>(kotlin.Boolean){}[0]
     final var defaultAcceptHeaderQValue // io.ktor.client.plugins.contentnegotiation/ContentNegotiationConfig.defaultAcceptHeaderQValue|{}defaultAcceptHeaderQValue[0]
         final fun <get-defaultAcceptHeaderQValue>(): kotlin/Double? // io.ktor.client.plugins.contentnegotiation/ContentNegotiationConfig.defaultAcceptHeaderQValue.<get-defaultAcceptHeaderQValue>|<get-defaultAcceptHeaderQValue>(){}[0]
         final fun <set-defaultAcceptHeaderQValue>(kotlin/Double?) // io.ktor.client.plugins.contentnegotiation/ContentNegotiationConfig.defaultAcceptHeaderQValue.<set-defaultAcceptHeaderQValue>|<set-defaultAcceptHeaderQValue>(kotlin.Double?){}[0]

--- a/ktor-client/ktor-client-plugins/ktor-client-content-negotiation/api/ktor-client-content-negotiation.klib.api
+++ b/ktor-client/ktor-client-plugins/ktor-client-content-negotiation/api/ktor-client-content-negotiation.klib.api
@@ -6,6 +6,17 @@
 // - Show declarations: true
 
 // Library unique name: <io.ktor:ktor-client-content-negotiation>
+abstract fun interface io.ktor.client.plugins.contentnegotiation/ContentTypeMergeStrategy { // io.ktor.client.plugins.contentnegotiation/ContentTypeMergeStrategy|null[0]
+    abstract fun mergeContentTypes(kotlin.collections/List<io.ktor.http/ContentType>, kotlin.collections/List<kotlin/String>): kotlin.sequences/Sequence<io.ktor.http/ContentType> // io.ktor.client.plugins.contentnegotiation/ContentTypeMergeStrategy.mergeContentTypes|mergeContentTypes(kotlin.collections.List<io.ktor.http.ContentType>;kotlin.collections.List<kotlin.String>){}[0]
+
+    final object Companion { // io.ktor.client.plugins.contentnegotiation/ContentTypeMergeStrategy.Companion|null[0]
+        final val Default // io.ktor.client.plugins.contentnegotiation/ContentTypeMergeStrategy.Companion.Default|{}Default[0]
+            final fun <get-Default>(): io.ktor.client.plugins.contentnegotiation/ContentTypeMergeStrategy // io.ktor.client.plugins.contentnegotiation/ContentTypeMergeStrategy.Companion.Default.<get-Default>|<get-Default>(){}[0]
+        final val SkipIfPresent // io.ktor.client.plugins.contentnegotiation/ContentTypeMergeStrategy.Companion.SkipIfPresent|{}SkipIfPresent[0]
+            final fun <get-SkipIfPresent>(): io.ktor.client.plugins.contentnegotiation/ContentTypeMergeStrategy // io.ktor.client.plugins.contentnegotiation/ContentTypeMergeStrategy.Companion.SkipIfPresent.<get-SkipIfPresent>|<get-SkipIfPresent>(){}[0]
+    }
+}
+
 final class io.ktor.client.plugins.contentnegotiation/ContentConverterException : kotlin/Exception { // io.ktor.client.plugins.contentnegotiation/ContentConverterException|null[0]
     constructor <init>(kotlin/String) // io.ktor.client.plugins.contentnegotiation/ContentConverterException.<init>|<init>(kotlin.String){}[0]
 }
@@ -13,9 +24,9 @@ final class io.ktor.client.plugins.contentnegotiation/ContentConverterException 
 final class io.ktor.client.plugins.contentnegotiation/ContentNegotiationConfig : io.ktor.serialization/Configuration { // io.ktor.client.plugins.contentnegotiation/ContentNegotiationConfig|null[0]
     constructor <init>() // io.ktor.client.plugins.contentnegotiation/ContentNegotiationConfig.<init>|<init>(){}[0]
 
-    final var addAcceptHeaderOnlyIfNonePresent // io.ktor.client.plugins.contentnegotiation/ContentNegotiationConfig.addAcceptHeaderOnlyIfNonePresent|{}addAcceptHeaderOnlyIfNonePresent[0]
-        final fun <get-addAcceptHeaderOnlyIfNonePresent>(): kotlin/Boolean // io.ktor.client.plugins.contentnegotiation/ContentNegotiationConfig.addAcceptHeaderOnlyIfNonePresent.<get-addAcceptHeaderOnlyIfNonePresent>|<get-addAcceptHeaderOnlyIfNonePresent>(){}[0]
-        final fun <set-addAcceptHeaderOnlyIfNonePresent>(kotlin/Boolean) // io.ktor.client.plugins.contentnegotiation/ContentNegotiationConfig.addAcceptHeaderOnlyIfNonePresent.<set-addAcceptHeaderOnlyIfNonePresent>|<set-addAcceptHeaderOnlyIfNonePresent>(kotlin.Boolean){}[0]
+    final var acceptHeaderMergeStrategy // io.ktor.client.plugins.contentnegotiation/ContentNegotiationConfig.acceptHeaderMergeStrategy|{}acceptHeaderMergeStrategy[0]
+        final fun <get-acceptHeaderMergeStrategy>(): io.ktor.client.plugins.contentnegotiation/ContentTypeMergeStrategy // io.ktor.client.plugins.contentnegotiation/ContentNegotiationConfig.acceptHeaderMergeStrategy.<get-acceptHeaderMergeStrategy>|<get-acceptHeaderMergeStrategy>(){}[0]
+        final fun <set-acceptHeaderMergeStrategy>(io.ktor.client.plugins.contentnegotiation/ContentTypeMergeStrategy) // io.ktor.client.plugins.contentnegotiation/ContentNegotiationConfig.acceptHeaderMergeStrategy.<set-acceptHeaderMergeStrategy>|<set-acceptHeaderMergeStrategy>(io.ktor.client.plugins.contentnegotiation.ContentTypeMergeStrategy){}[0]
     final var defaultAcceptHeaderQValue // io.ktor.client.plugins.contentnegotiation/ContentNegotiationConfig.defaultAcceptHeaderQValue|{}defaultAcceptHeaderQValue[0]
         final fun <get-defaultAcceptHeaderQValue>(): kotlin/Double? // io.ktor.client.plugins.contentnegotiation/ContentNegotiationConfig.defaultAcceptHeaderQValue.<get-defaultAcceptHeaderQValue>|<get-defaultAcceptHeaderQValue>(){}[0]
         final fun <set-defaultAcceptHeaderQValue>(kotlin/Double?) // io.ktor.client.plugins.contentnegotiation/ContentNegotiationConfig.defaultAcceptHeaderQValue.<set-defaultAcceptHeaderQValue>|<set-defaultAcceptHeaderQValue>(kotlin.Double?){}[0]

--- a/ktor-client/ktor-client-plugins/ktor-client-content-negotiation/common/src/io/ktor/client/plugins/contentnegotiation/ContentNegotiation.kt
+++ b/ktor-client/ktor-client-plugins/ktor-client-content-negotiation/common/src/io/ktor/client/plugins/contentnegotiation/ContentNegotiation.kt
@@ -65,7 +65,13 @@ public fun interface ContentTypeMergeStrategy {
          */
         public val Default: ContentTypeMergeStrategy = ContentTypeMergeStrategy { registered, headers ->
             registered.asSequence().filter { contentType ->
-                headers.none { h -> ContentType.parse(h).match(contentType) }
+                headers.none { h ->
+                    try {
+                        ContentType.parse(h).match(contentType)
+                    } catch (e: BadContentTypeFormatException) {
+                        false
+                    }
+                }
             }
         }
 

--- a/ktor-client/ktor-client-plugins/ktor-client-content-negotiation/common/src/io/ktor/client/plugins/contentnegotiation/ContentNegotiation.kt
+++ b/ktor-client/ktor-client-plugins/ktor-client-content-negotiation/common/src/io/ktor/client/plugins/contentnegotiation/ContentNegotiation.kt
@@ -67,6 +67,16 @@ public class ContentNegotiationConfig : Configuration {
     public var defaultAcceptHeaderQValue: Double? = null
 
     /**
+     * If set to true, the plugin will not add Accept headers for registered content types
+     * if the request already has any Accept header set.
+     * Useful when working with APIs that are strict about Accept header values.
+     * Default is false to preserve backward compatibility.
+     *
+     * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.client.plugins.contentnegotiation.ContentNegotiationConfig.addAcceptHeaderOnlyIfNonePresent)
+     */
+    public var addAcceptHeaderOnlyIfNonePresent: Boolean = false
+
+    /**
      * Registers a [contentType] to a specified [converter] with an optional [configuration] script for a converter.
      *
      * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.client.plugins.contentnegotiation.ContentNegotiationConfig.register)
@@ -184,16 +194,18 @@ public val ContentNegotiation: ClientPlugin<ContentNegotiationConfig> = createCl
         }
 
         val acceptHeaders = request.headers.getAll(HttpHeaders.Accept).orEmpty()
-        requestRegistrations.forEach {
-            if (acceptHeaders.none { h -> ContentType.parse(h).match(it.contentTypeToSend) }) {
-                // automatically added headers get a lower content type priority, so user-specified accept headers
-                //  with higher q or implicit q=1 will take precedence
-                val contentTypeToSend = when (val qValue = pluginConfig.defaultAcceptHeaderQValue) {
-                    null -> it.contentTypeToSend
-                    else -> it.contentTypeToSend.withParameter("q", qValue.toString())
+        if (!(pluginConfig.addAcceptHeaderOnlyIfNonePresent && acceptHeaders.isNotEmpty())) {
+            requestRegistrations.forEach {
+                if (acceptHeaders.none { h -> ContentType.parse(h).match(it.contentTypeToSend) }) {
+                    // automatically added headers get a lower content type priority, so user-specified accept headers
+                    //  with higher q or implicit q=1 will take precedence
+                    val contentTypeToSend = when (val qValue = pluginConfig.defaultAcceptHeaderQValue) {
+                        null -> it.contentTypeToSend
+                        else -> it.contentTypeToSend.withParameter("q", qValue.toString())
+                    }
+                    LOGGER.trace("Adding Accept=$contentTypeToSend header for ${request.url}")
+                    request.accept(contentTypeToSend)
                 }
-                LOGGER.trace("Adding Accept=$contentTypeToSend header for ${request.url}")
-                request.accept(contentTypeToSend)
             }
         }
 

--- a/ktor-client/ktor-client-plugins/ktor-client-content-negotiation/common/src/io/ktor/client/plugins/contentnegotiation/ContentNegotiation.kt
+++ b/ktor-client/ktor-client-plugins/ktor-client-content-negotiation/common/src/io/ktor/client/plugins/contentnegotiation/ContentNegotiation.kt
@@ -40,6 +40,53 @@ internal expect val DefaultIgnoredTypes: Set<KClass<*>>
 internal val ExcludedContentTypes: AttributeKey<List<ContentType>> = AttributeKey("ExcludedContentTypesAttr")
 
 /**
+ * Defines how registered content types are merged into the request's Accept header.
+ *
+ * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.client.plugins.contentnegotiation.ContentTypeMergeStrategy)
+ */
+public fun interface ContentTypeMergeStrategy {
+    /**
+     * Returns the content types that should be appended to the Accept header.
+     *
+     * @param registeredContentTypes the content types from all active converter registrations
+     * @param acceptHeaders the Accept header values already present on the request
+     */
+    public fun mergeContentTypes(
+        registeredContentTypes: List<ContentType>,
+        acceptHeaders: List<String>
+    ): Sequence<ContentType>
+
+    public companion object {
+        /**
+         * Default behavior: appends each registered content type that is not already
+         * represented in the existing Accept headers. Preserves backward compatibility.
+         *
+         * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.client.plugins.contentnegotiation.ContentTypeMergeStrategy.Default)
+         */
+        public val Default: ContentTypeMergeStrategy = ContentTypeMergeStrategy { registered, headers ->
+            registered.asSequence().filter { contentType ->
+                headers.none { h -> ContentType.parse(h).match(contentType) }
+            }
+        }
+
+        /**
+         * Skips Accept header injection entirely when at least one Accept header is already
+         * present on the request. Falls back to [Default] behavior when none are present.
+         * Useful when working with APIs that are strict about which Accept values they accept.
+         *
+         * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.client.plugins.contentnegotiation.ContentTypeMergeStrategy.SkipIfPresent)
+         */
+        public val SkipIfPresent: ContentTypeMergeStrategy = ContentTypeMergeStrategy { registered, headers ->
+            if (headers.isNotEmpty()) {
+                emptySequence()
+            } else {
+                Default.mergeContentTypes(registered, headers)
+            }
+        }
+    }
+}
+
+/**
  * A [ContentNegotiation] configuration that is used during installation.
  *
  * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.client.plugins.contentnegotiation.ContentNegotiationConfig)
@@ -67,14 +114,12 @@ public class ContentNegotiationConfig : Configuration {
     public var defaultAcceptHeaderQValue: Double? = null
 
     /**
-     * If set to true, the plugin will not add Accept headers for registered content types
-     * if the request already has any Accept header set.
-     * Useful when working with APIs that are strict about Accept header values.
-     * Default is false to preserve backward compatibility.
+     * Controls how registered content types are merged into the Accept header.
+     * Defaults to [ContentTypeMergeStrategy.Default], which preserves backward-compatible behavior.
      *
-     * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.client.plugins.contentnegotiation.ContentNegotiationConfig.addAcceptHeaderOnlyIfNonePresent)
+     * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.client.plugins.contentnegotiation.ContentNegotiationConfig.acceptHeaderMergeStrategy)
      */
-    public var addAcceptHeaderOnlyIfNonePresent: Boolean = false
+    public var acceptHeaderMergeStrategy: ContentTypeMergeStrategy = ContentTypeMergeStrategy.Default
 
     /**
      * Registers a [contentType] to a specified [converter] with an optional [configuration] script for a converter.
@@ -171,7 +216,7 @@ public class ContentNegotiationConfig : Configuration {
  * A plugin that serves two primary purposes:
  * - Negotiating media types between the client and server. For this, it uses the `Accept` and `Content-Type` headers.
  * - Serializing/deserializing the content in a specific format when sending requests and receiving responses.
- *    Ktor supports the following formats out-of-the-box: `JSON`, `XML`, and `CBOR`.
+ * Ktor supports the following formats out-of-the-box: `JSON`, `XML`, and `CBOR`.
  *
  * You can learn more from [Content negotiation and serialization](https://ktor.io/docs/serialization-client.html).
  *
@@ -194,20 +239,16 @@ public val ContentNegotiation: ClientPlugin<ContentNegotiationConfig> = createCl
         }
 
         val acceptHeaders = request.headers.getAll(HttpHeaders.Accept).orEmpty()
-        if (!(pluginConfig.addAcceptHeaderOnlyIfNonePresent && acceptHeaders.isNotEmpty())) {
-            requestRegistrations.forEach {
-                if (acceptHeaders.none { h -> ContentType.parse(h).match(it.contentTypeToSend) }) {
-                    // automatically added headers get a lower content type priority, so user-specified accept headers
-                    //  with higher q or implicit q=1 will take precedence
-                    val contentTypeToSend = when (val qValue = pluginConfig.defaultAcceptHeaderQValue) {
-                        null -> it.contentTypeToSend
-                        else -> it.contentTypeToSend.withParameter("q", qValue.toString())
-                    }
-                    LOGGER.trace("Adding Accept=$contentTypeToSend header for ${request.url}")
-                    request.accept(contentTypeToSend)
+        pluginConfig.acceptHeaderMergeStrategy
+            .mergeContentTypes(requestRegistrations.map { it.contentTypeToSend }, acceptHeaders)
+            .forEach { contentType ->
+                val contentTypeToSend = when (val qValue = pluginConfig.defaultAcceptHeaderQValue) {
+                    null -> contentType
+                    else -> contentType.withParameter("q", qValue.toString())
                 }
+                LOGGER.trace("Adding Accept=$contentTypeToSend header for ${request.url}")
+                request.accept(contentTypeToSend)
             }
-        }
 
         if (body is OutgoingContent || ignoredTypes.any { it.isInstance(body) }) {
             LOGGER.trace(

--- a/ktor-client/ktor-client-plugins/ktor-client-content-negotiation/common/test/io/ktor/client/plugins/ContentNegotiationTests.kt
+++ b/ktor-client/ktor-client-plugins/ktor-client-content-negotiation/common/test/io/ktor/client/plugins/ContentNegotiationTests.kt
@@ -232,6 +232,49 @@ class ContentNegotiationTests {
     }
 
     @Test
+    fun doesNotAddAcceptHeadersWhenUserHeaderPresentAndOptionEnabled() {
+        testWithEngine(MockEngine) {
+            setupWithContentNegotiation {
+                register(ContentType.Application.Json, TestContentConverter())
+                addAcceptHeaderOnlyIfNonePresent = true
+            }
+
+            test { client ->
+                client.get("https://test.com/") {
+                    accept(ContentType.Application.OctetStream)
+                }.apply {
+                    val sentHeaders = call.request.headers.getAll(HttpHeaders.Accept)
+                        ?.map { ContentType.parse(it) }
+                        ?: emptyList()
+
+                    assertEquals(1, sentHeaders.size)
+                    assertContains(sentHeaders, ContentType.Application.OctetStream)
+                }
+            }
+        }
+    }
+
+    @Test
+    fun addsAcceptHeadersWhenNoUserHeaderPresentEvenIfOptionEnabled() {
+        testWithEngine(MockEngine) {
+            setupWithContentNegotiation {
+                register(ContentType.Application.Json, TestContentConverter())
+                addAcceptHeaderOnlyIfNonePresent = true
+            }
+
+            test { client ->
+                client.get("https://test.com/").apply {
+                    val sentHeaders = call.request.headers.getAll(HttpHeaders.Accept)
+                        ?.map { ContentType.parse(it) }
+                        ?: emptyList()
+
+                    assertContains(sentHeaders, ContentType.Application.Json)
+                }
+            }
+        }
+    }
+
+    @Test
     fun testKeepsContentType() {
         testWithEngine(MockEngine) {
             setupWithContentNegotiation {

--- a/ktor-client/ktor-client-plugins/ktor-client-content-negotiation/common/test/io/ktor/client/plugins/ContentNegotiationTests.kt
+++ b/ktor-client/ktor-client-plugins/ktor-client-content-negotiation/common/test/io/ktor/client/plugins/ContentNegotiationTests.kt
@@ -275,6 +275,29 @@ class ContentNegotiationTests {
     }
 
     @Test
+    fun testDefaultMergeStrategyWithMalformedAcceptHeader() {
+        testWithEngine(MockEngine) {
+            setupWithContentNegotiation {
+                register(ContentType.Application.Json, TestContentConverter())
+            }
+            test { client ->
+                client.get("https://test.com/") {
+                    header(HttpHeaders.Accept, "malformed-header-value-without-slash")
+                }.apply {
+                    val sentHeaders = call.request.headers.getAll(HttpHeaders.Accept)
+                        ?: emptyList()
+
+                    val containsJson = sentHeaders.any { it.contains("application/json") }
+                    assertTrue(
+                        containsJson,
+                        "It should inject application/json because the existing header is invalid."
+                    )
+                }
+            }
+        }
+    }
+
+    @Test
     fun testKeepsContentType() {
         testWithEngine(MockEngine) {
             setupWithContentNegotiation {

--- a/ktor-client/ktor-client-plugins/ktor-client-content-negotiation/common/test/io/ktor/client/plugins/ContentNegotiationTests.kt
+++ b/ktor-client/ktor-client-plugins/ktor-client-content-negotiation/common/test/io/ktor/client/plugins/ContentNegotiationTests.kt
@@ -236,7 +236,7 @@ class ContentNegotiationTests {
         testWithEngine(MockEngine) {
             setupWithContentNegotiation {
                 register(ContentType.Application.Json, TestContentConverter())
-                addAcceptHeaderOnlyIfNonePresent = true
+                acceptHeaderMergeStrategy = ContentTypeMergeStrategy.SkipIfPresent
             }
 
             test { client ->
@@ -259,7 +259,7 @@ class ContentNegotiationTests {
         testWithEngine(MockEngine) {
             setupWithContentNegotiation {
                 register(ContentType.Application.Json, TestContentConverter())
-                addAcceptHeaderOnlyIfNonePresent = true
+                acceptHeaderMergeStrategy = ContentTypeMergeStrategy.SkipIfPresent
             }
 
             test { client ->


### PR DESCRIPTION
### Target Ticket
Refers to YouTrack issue: [KTOR-5009](https://youtrack.jetbrains.com/issue/KTOR-5009) (ContentNegotiation: Add a way to prevent changing Accept and Content-Type headers)

### Description
This PR introduces a way to opt-out of automatic `Accept` header injection performed by the `ContentNegotiation` client plugin. 

Currently, the plugin appends registered content types to the request's `Accept` header even if the user has explicitly specified a custom `Accept` header. 

To resolve this, a new configuration property `addAcceptHeaderOnlyIfNonePresent` has been added to `ContentNegotiationConfig`. 
- When set to `true`, the plugin will completely bypass appending fallback headers if any `Accept` header is already configured on the outgoing request.
- The default value is set to `false` to maintain backward compatibility and preserve original behavior.

### Changes
- **`ContentNegotiation.kt`**: Added the `addAcceptHeaderOnlyIfNonePresent` property and wrapped the request registration block in a guard condition inside `convertRequest()`.
- **API Dumps**: Updated JVM and KLIB api files to reflect binary compatibility for the new public API property.
- **`ContentNegotiationTests.kt`**: Added two unit tests covering cases where the option is enabled, one when a user header is present (skips injection) and one when it is missing (performs default injection).