### PR TITLE
KTOR-9671 Allow clients to configure URL allowed characters for darwin platform

### DIFF
--- a/ktor-client/ktor-client-darwin/api/ktor-client-darwin.klib.api
+++ b/ktor-client/ktor-client-darwin/api/ktor-client-darwin.klib.api
@@ -49,6 +49,7 @@ final class io.ktor.client.engine.darwin/DarwinClientEngineConfig : io.ktor.clie
 
     final fun configureRequest(kotlin/Function1<platform.Foundation/NSMutableURLRequest, kotlin/Unit>) // io.ktor.client.engine.darwin/DarwinClientEngineConfig.configureRequest|configureRequest(kotlin.Function1<platform.Foundation.NSMutableURLRequest,kotlin.Unit>){}[0]
     final fun configureSession(kotlin/Function1<platform.Foundation/NSURLSessionConfiguration, kotlin/Unit>) // io.ktor.client.engine.darwin/DarwinClientEngineConfig.configureSession|configureSession(kotlin.Function1<platform.Foundation.NSURLSessionConfiguration,kotlin.Unit>){}[0]
+    final fun configureUrlAllowedCharacters(kotlin/Function1<io.ktor.client.engine.darwin/UrlAllowedCharactersConfig, kotlin/Unit>) // io.ktor.client.engine.darwin/DarwinClientEngineConfig.configureUrlAllowedCharacters|configureUrlAllowedCharacters(kotlin.Function1<io.ktor.client.engine.darwin.UrlAllowedCharactersConfig,kotlin.Unit>){}[0]
     final fun usePreconfiguredSession(platform.Foundation/NSURLSession, io.ktor.client.engine.darwin/KtorNSURLSessionDelegate) // io.ktor.client.engine.darwin/DarwinClientEngineConfig.usePreconfiguredSession|usePreconfiguredSession(platform.Foundation.NSURLSession;io.ktor.client.engine.darwin.KtorNSURLSessionDelegate){}[0]
     final fun usePreconfiguredSession(platform.Foundation/NSURLSession?) // io.ktor.client.engine.darwin/DarwinClientEngineConfig.usePreconfiguredSession|usePreconfiguredSession(platform.Foundation.NSURLSession?){}[0]
 
@@ -163,6 +164,26 @@ final class io.ktor.client.engine.darwin/KtorNSURLSessionDelegate : platform.Fou
 
     // Targets: [watchosArm32, watchosArm64]
     final fun hash(): kotlin/UInt // io.ktor.client.engine.darwin/KtorNSURLSessionDelegate.hash|objc:hash[0]
+}
+
+final class io.ktor.client.engine.darwin/UrlAllowedCharactersConfig { // io.ktor.client.engine.darwin/UrlAllowedCharactersConfig|null[0]
+    constructor <init>() // io.ktor.client.engine.darwin/UrlAllowedCharactersConfig.<init>|<init>(){}[0]
+
+    final var fragmentAllowedCharacterSet // io.ktor.client.engine.darwin/UrlAllowedCharactersConfig.fragmentAllowedCharacterSet|{}fragmentAllowedCharacterSet[0]
+        final fun <get-fragmentAllowedCharacterSet>(): platform.Foundation/NSCharacterSet // io.ktor.client.engine.darwin/UrlAllowedCharactersConfig.fragmentAllowedCharacterSet.<get-fragmentAllowedCharacterSet>|<get-fragmentAllowedCharacterSet>(){}[0]
+        final fun <set-fragmentAllowedCharacterSet>(platform.Foundation/NSCharacterSet) // io.ktor.client.engine.darwin/UrlAllowedCharactersConfig.fragmentAllowedCharacterSet.<set-fragmentAllowedCharacterSet>|<set-fragmentAllowedCharacterSet>(platform.Foundation.NSCharacterSet){}[0]
+    final var hostAllowedCharacterSet // io.ktor.client.engine.darwin/UrlAllowedCharactersConfig.hostAllowedCharacterSet|{}hostAllowedCharacterSet[0]
+        final fun <get-hostAllowedCharacterSet>(): platform.Foundation/NSCharacterSet // io.ktor.client.engine.darwin/UrlAllowedCharactersConfig.hostAllowedCharacterSet.<get-hostAllowedCharacterSet>|<get-hostAllowedCharacterSet>(){}[0]
+        final fun <set-hostAllowedCharacterSet>(platform.Foundation/NSCharacterSet) // io.ktor.client.engine.darwin/UrlAllowedCharactersConfig.hostAllowedCharacterSet.<set-hostAllowedCharacterSet>|<set-hostAllowedCharacterSet>(platform.Foundation.NSCharacterSet){}[0]
+    final var pathAllowedCharacterSet // io.ktor.client.engine.darwin/UrlAllowedCharactersConfig.pathAllowedCharacterSet|{}pathAllowedCharacterSet[0]
+        final fun <get-pathAllowedCharacterSet>(): platform.Foundation/NSCharacterSet // io.ktor.client.engine.darwin/UrlAllowedCharactersConfig.pathAllowedCharacterSet.<get-pathAllowedCharacterSet>|<get-pathAllowedCharacterSet>(){}[0]
+        final fun <set-pathAllowedCharacterSet>(platform.Foundation/NSCharacterSet) // io.ktor.client.engine.darwin/UrlAllowedCharactersConfig.pathAllowedCharacterSet.<set-pathAllowedCharacterSet>|<set-pathAllowedCharacterSet>(platform.Foundation.NSCharacterSet){}[0]
+    final var queryAllowedCharacterSet // io.ktor.client.engine.darwin/UrlAllowedCharactersConfig.queryAllowedCharacterSet|{}queryAllowedCharacterSet[0]
+        final fun <get-queryAllowedCharacterSet>(): platform.Foundation/NSCharacterSet // io.ktor.client.engine.darwin/UrlAllowedCharactersConfig.queryAllowedCharacterSet.<get-queryAllowedCharacterSet>|<get-queryAllowedCharacterSet>(){}[0]
+        final fun <set-queryAllowedCharacterSet>(platform.Foundation/NSCharacterSet) // io.ktor.client.engine.darwin/UrlAllowedCharactersConfig.queryAllowedCharacterSet.<set-queryAllowedCharacterSet>|<set-queryAllowedCharacterSet>(platform.Foundation.NSCharacterSet){}[0]
+    final var userAllowedCharacterSet // io.ktor.client.engine.darwin/UrlAllowedCharactersConfig.userAllowedCharacterSet|{}userAllowedCharacterSet[0]
+        final fun <get-userAllowedCharacterSet>(): platform.Foundation/NSCharacterSet // io.ktor.client.engine.darwin/UrlAllowedCharactersConfig.userAllowedCharacterSet.<get-userAllowedCharacterSet>|<get-userAllowedCharacterSet>(){}[0]
+        final fun <set-userAllowedCharacterSet>(platform.Foundation/NSCharacterSet) // io.ktor.client.engine.darwin/UrlAllowedCharactersConfig.userAllowedCharacterSet.<set-userAllowedCharacterSet>|<set-userAllowedCharacterSet>(platform.Foundation.NSCharacterSet){}[0]
 }
 
 final object io.ktor.client.engine.darwin/Darwin : io.ktor.client.engine/HttpClientEngineFactory<io.ktor.client.engine.darwin/DarwinClientEngineConfig> { // io.ktor.client.engine.darwin/Darwin|null[0]

--- a/ktor-client/ktor-client-darwin/darwin/src/io/ktor/client/engine/darwin/DarwinClientEngineConfig.kt
+++ b/ktor-client/ktor-client-darwin/darwin/src/io/ktor/client/engine/darwin/DarwinClientEngineConfig.kt
@@ -6,6 +6,7 @@ package io.ktor.client.engine.darwin
 
 import io.ktor.client.engine.*
 import io.ktor.client.engine.darwin.internal.*
+import io.ktor.utils.io.KtorDsl
 import kotlinx.cinterop.*
 import platform.Foundation.*
 import platform.Foundation.NSCharacterSet
@@ -32,6 +33,7 @@ public typealias ChallengeHandler = (
  *
  * By default, the configuration uses `NSCharacterSet.URL*AllowedCharacterSet` values.
  */
+@KtorDsl
 public class UrlAllowedCharactersConfig {
 
     /**

--- a/ktor-client/ktor-client-darwin/darwin/src/io/ktor/client/engine/darwin/DarwinClientEngineConfig.kt
+++ b/ktor-client/ktor-client-darwin/darwin/src/io/ktor/client/engine/darwin/DarwinClientEngineConfig.kt
@@ -8,6 +8,7 @@ import io.ktor.client.engine.*
 import io.ktor.client.engine.darwin.internal.*
 import kotlinx.cinterop.*
 import platform.Foundation.*
+import platform.Foundation.NSCharacterSet
 
 /**
  * A challenge handler type for [NSURLSession].
@@ -21,6 +22,58 @@ public typealias ChallengeHandler = (
     challenge: NSURLAuthenticationChallenge,
     completionHandler: (NSURLSessionAuthChallengeDisposition, NSURLCredential?) -> Unit
 ) -> Unit
+
+/**
+ * Configuration of allowed character sets used for URL percent-encoding.
+ *
+ * Each property defines the set of characters that can appear unescaped
+ * in the corresponding URL component. Characters not included in the
+ * configured set will be percent-encoded during URL construction.
+ *
+ * By default, the configuration uses `NSCharacterSet.URL*AllowedCharacterSet` values.
+ */
+public class UrlAllowedCharactersConfig {
+
+    /**
+     * Allowed characters for the user information component of a URL
+     * (for example, the username in `https://user@example.com`).
+     *
+     * Defaults to [NSCharacterSet.URLUserAllowedCharacterSet].
+     */
+    public var userAllowedCharacterSet: NSCharacterSet = NSCharacterSet.URLUserAllowedCharacterSet
+
+    /**
+     * Allowed characters for the host component of a URL
+     * (for example, `example.com`).
+     *
+     * Defaults to [NSCharacterSet.URLHostAllowedCharacterSet].
+     */
+    public var hostAllowedCharacterSet: NSCharacterSet = NSCharacterSet.URLHostAllowedCharacterSet
+
+    /**
+     * Allowed characters for the path component of a URL
+     * (for example, `/api/v1/users`).
+     *
+     * Defaults to [NSCharacterSet.URLPathAllowedCharacterSet].
+     */
+    public var pathAllowedCharacterSet: NSCharacterSet = NSCharacterSet.URLPathAllowedCharacterSet
+
+    /**
+     * Allowed characters for the query component of a URL
+     * (for example, `page=1&sort=name`).
+     *
+     * Defaults to [NSCharacterSet.URLQueryAllowedCharacterSet].
+     */
+    public var queryAllowedCharacterSet: NSCharacterSet = NSCharacterSet.URLQueryAllowedCharacterSet
+
+    /**
+     * Allowed characters for the fragment component of a URL
+     * (for example, `section-1` in `https://example.com#section-1`).
+     *
+     * Defaults to [NSCharacterSet.URLFragmentAllowedCharacterSet].
+     */
+    public var fragmentAllowedCharacterSet: NSCharacterSet = NSCharacterSet.URLFragmentAllowedCharacterSet
+}
 
 /**
  * A configuration for the [Darwin] client engine.
@@ -70,6 +123,11 @@ public class DarwinClientEngineConfig : HttpClientEngineConfig() {
      */
     public var preconfiguredSession: NSURLSession? = null
         private set
+
+    /**
+     * Specifies allowed character sets used for URL percent-encoding.
+     */
+    internal val urlAllowedCharactersConfig: UrlAllowedCharactersConfig = UrlAllowedCharactersConfig()
 
     /**
      * Specifies a session to use for making HTTP requests.
@@ -161,5 +219,12 @@ public class DarwinClientEngineConfig : HttpClientEngineConfig() {
     @OptIn(UnsafeNumber::class)
     public fun handleChallenge(block: ChallengeHandler) {
         challengeHandler = block
+    }
+
+    /**
+     * Configures the set of allowed URL characters using the provided [block].
+     */
+    public fun configureUrlAllowedCharacters(block: UrlAllowedCharactersConfig.() -> Unit) {
+        urlAllowedCharactersConfig.block()
     }
 }

--- a/ktor-client/ktor-client-darwin/darwin/src/io/ktor/client/engine/darwin/internal/DarwinRequestUtils.kt
+++ b/ktor-client/ktor-client-darwin/darwin/src/io/ktor/client/engine/darwin/internal/DarwinRequestUtils.kt
@@ -11,8 +11,8 @@ import kotlinx.cinterop.UnsafeNumber
 import platform.Foundation.*
 
 @OptIn(InternalAPI::class, UnsafeNumber::class)
-internal suspend fun HttpRequestData.toNSUrlRequest(): NSMutableURLRequest {
-    val url = url.toNSUrl()
+internal suspend fun HttpRequestData.toNSUrlRequest(config: UrlAllowedCharactersConfig): NSMutableURLRequest {
+    val url = url.toNSUrl(config)
     val nativeRequest = NSMutableURLRequest.requestWithURL(url).apply {
         setupSocketTimeout(this@toNSUrlRequest)
         body.toDataOrStream()?.let {

--- a/ktor-client/ktor-client-darwin/darwin/src/io/ktor/client/engine/darwin/internal/DarwinSession.kt
+++ b/ktor-client/ktor-client-darwin/darwin/src/io/ktor/client/engine/darwin/internal/DarwinSession.kt
@@ -34,7 +34,7 @@ internal class DarwinSession(
 
     @OptIn(InternalAPI::class, ExperimentalForeignApi::class)
     internal suspend fun execute(request: HttpRequestData, callContext: CoroutineContext): HttpResponseData {
-        val nativeRequest = request.toNSUrlRequest()
+        val nativeRequest = request.toNSUrlRequest(config.urlAllowedCharactersConfig)
             .apply(config.requestConfig)
         val (task, response) = if (request.isUpgradeRequest()) {
             val task = withSession { webSocketTaskWithRequest(nativeRequest) }

--- a/ktor-client/ktor-client-darwin/darwin/src/io/ktor/client/engine/darwin/internal/DarwinUrlUtils.kt
+++ b/ktor-client/ktor-client-darwin/darwin/src/io/ktor/client/engine/darwin/internal/DarwinUrlUtils.kt
@@ -4,17 +4,18 @@
 
 package io.ktor.client.engine.darwin.internal
 
+import io.ktor.client.engine.darwin.*
 import io.ktor.http.*
 import io.ktor.util.*
 import platform.Foundation.*
 
-internal fun Url.toNSUrl(): NSURL {
-    val userEncoded = encodedUser.orEmpty().isEncoded(NSCharacterSet.URLUserAllowedCharacterSet)
-    val passwordEncoded = encodedPassword.orEmpty().isEncoded(NSCharacterSet.URLUserAllowedCharacterSet)
-    val hostEncoded = host.isEncoded(NSCharacterSet.URLHostAllowedCharacterSet)
-    val pathEncoded = encodedPath.isEncoded(NSCharacterSet.URLPathAllowedCharacterSet)
-    val queryEncoded = encodedQuery.isEncoded(NSCharacterSet.URLQueryAllowedCharacterSet)
-    val fragmentEncoded = encodedFragment.isEncoded(NSCharacterSet.URLFragmentAllowedCharacterSet)
+internal fun Url.toNSUrl(config: UrlAllowedCharactersConfig = UrlAllowedCharactersConfig()): NSURL {
+    val userEncoded = encodedUser.orEmpty().isEncoded(config.userAllowedCharacterSet)
+    val passwordEncoded = encodedPassword.orEmpty().isEncoded(config.userAllowedCharacterSet)
+    val hostEncoded = host.isEncoded(config.hostAllowedCharacterSet)
+    val pathEncoded = encodedPath.isEncoded(config.pathAllowedCharacterSet)
+    val queryEncoded = encodedQuery.isEncoded(config.queryAllowedCharacterSet)
+    val fragmentEncoded = encodedFragment.isEncoded(config.fragmentAllowedCharacterSet)
     if (userEncoded && passwordEncoded && hostEncoded && pathEncoded && queryEncoded && fragmentEncoded) {
         return NSURL(string = toString())
     }
@@ -26,16 +27,16 @@ internal fun Url.toNSUrl(): NSURL {
 
         components.percentEncodedUser = when {
             userEncoded -> encodedUser
-            else -> user?.sanitize(NSCharacterSet.URLUserAllowedCharacterSet)
+            else -> user?.sanitize(config.userAllowedCharacterSet)
         }
         components.percentEncodedPassword = when {
             passwordEncoded -> encodedPassword
-            else -> password?.sanitize(NSCharacterSet.URLUserAllowedCharacterSet)
+            else -> password?.sanitize(config.userAllowedCharacterSet)
         }
 
         components.percentEncodedHost = when {
             hostEncoded -> host
-            else -> host.sanitize(NSCharacterSet.URLHostAllowedCharacterSet)
+            else -> host.sanitize(config.hostAllowedCharacterSet)
         }
         if (port != DEFAULT_PORT && port != protocol.defaultPort) {
             components.port = NSNumber(int = port)
@@ -43,7 +44,7 @@ internal fun Url.toNSUrl(): NSURL {
 
         components.percentEncodedPath = when {
             pathEncoded -> encodedPath
-            else -> rawSegments.joinToString("/").sanitize(NSCharacterSet.URLPathAllowedCharacterSet)
+            else -> rawSegments.joinToString("/").sanitize(config.pathAllowedCharacterSet)
         }
 
         when {
@@ -51,13 +52,13 @@ internal fun Url.toNSUrl(): NSURL {
             queryEncoded -> components.percentEncodedQuery = encodedQuery
             else -> components.percentEncodedQueryItems = parameters.toMap()
                 .flatMap { (key, value) -> if (value.isEmpty()) listOf(key to null) else value.map { key to it } }
-                .map { NSURLQueryItem(it.first.encodeQueryKey(), it.second?.encodeQueryValue()) }
+                .map { NSURLQueryItem(it.first.encodeQueryKey(config), it.second?.encodeQueryValue(config)) }
         }
 
         components.percentEncodedFragment = when {
             encodedFragment.isEmpty() -> null
             fragmentEncoded -> encodedFragment
-            else -> fragment.sanitize(NSCharacterSet.URLFragmentAllowedCharacterSet)
+            else -> fragment.sanitize(config.fragmentAllowedCharacterSet)
         }
 
         return components.URL ?: error("Invalid url: $this")
@@ -67,11 +68,11 @@ internal fun Url.toNSUrl(): NSURL {
 private fun String.sanitize(allowed: NSCharacterSet): String =
     asNSString().stringByAddingPercentEncodingWithAllowedCharacters(allowed)!!
 
-private fun String.encodeQueryKey(): String =
-    encodeQueryValue().replace("=", "%3D")
+private fun String.encodeQueryKey(config: UrlAllowedCharactersConfig): String =
+    encodeQueryValue(config).replace("=", "%3D")
 
-private fun String.encodeQueryValue(): String =
-    asNSString().stringByAddingPercentEncodingWithAllowedCharacters(NSCharacterSet.URLQueryAllowedCharacterSet)!!
+private fun String.encodeQueryValue(config: UrlAllowedCharactersConfig): String =
+    asNSString().stringByAddingPercentEncodingWithAllowedCharacters(config.queryAllowedCharacterSet)!!
         .replace("&", "%26")
         .replace(";", "%3B")
 


### PR DESCRIPTION
**Subsystem**
ktor-client-darwin

**Motivation**
[KTOR-9671](https://youtrack.jetbrains.com/issue/KTOR-9671) Darwin: Semicolons in URL path are sanitized

I faced an issue, when the url like `https://example.com/segment1;param=value/segment2/` was encoded on darwin platform and become `https://example.com/segment1%3Bparam=value/segment2/`. Android/jvm platform work correctly, they don't sanitize the semicolon character (which actually is a valid character according to [RFC-3986](https://www.rfc-editor.org/info/rfc3986/#section-3.3)) for url path.

Firstly, I tried to write a test to check if ktor makes incorrect sanitazion. But, it worked just fine in tests. However, it worked incorrectly on my iOS 16.4 (at least). 

**Solution**
I decided to allow client to modify allowed characters for url encoding for darwin platform, since different OS versions can suggest different allowed characters. For my case it fixed the issue.

