### PR TITLE
KTOR-9574 Use response charset for content negotiation

### DIFF
--- a/ktor-client/ktor-client-plugins/ktor-client-content-negotiation/common/src/io/ktor/client/plugins/contentnegotiation/ContentNegotiation.kt
+++ b/ktor-client/ktor-client-plugins/ktor-client-content-negotiation/common/src/io/ktor/client/plugins/contentnegotiation/ContentNegotiation.kt
@@ -294,7 +294,7 @@ public val ContentNegotiation: ClientPlugin<ContentNegotiationConfig> = createCl
 
     transformResponseBody { response, body, info ->
         val contentType = response.contentType() ?: return@transformResponseBody null
-        val charset = response.request.headers.suitableCharset()
+        val charset = contentType.charset() ?: Charsets.UTF_8
 
         convertResponse(response.request.url, info, body, contentType, charset)
     }

--- a/ktor-client/ktor-client-plugins/ktor-client-content-negotiation/common/test/io/ktor/client/plugins/ContentNegotiationTests.kt
+++ b/ktor-client/ktor-client-plugins/ktor-client-content-negotiation/common/test/io/ktor/client/plugins/ContentNegotiationTests.kt
@@ -14,6 +14,7 @@ import io.ktor.http.*
 import io.ktor.http.content.*
 import io.ktor.util.*
 import io.ktor.utils.io.*
+import io.ktor.utils.io.charsets.*
 import io.ktor.utils.io.core.*
 import kotlin.test.*
 
@@ -388,6 +389,37 @@ class ContentNegotiationTests {
                     }
                 }
             }
+        }
+    }
+
+    @Test
+    fun responseContentTypeCharsetUsedForResponseDeserialization() = testWithEngine(MockEngine) {
+        val responseContentType = ContentType.Application.Xml.withCharset(Charsets.ISO_8859_1)
+        val responseBody = "<response>café</response>"
+
+        config {
+            install(ContentNegotiation) {
+                register(ContentType.Application.Xml, TestContentConverter()) {
+                    deserializeFn = { charset, _, body ->
+                        assertEquals(Charsets.ISO_8859_1, charset)
+                        StringWrapper(body.readRemaining().readText(charset = charset))
+                    }
+                }
+            }
+            engine {
+                addHandler {
+                    respond(
+                        content = ByteReadChannel(responseBody.toByteArray(Charsets.ISO_8859_1)),
+                        headers = headersOf(HttpHeaders.ContentType, responseContentType.toString())
+                    )
+                }
+            }
+        }
+
+        test { client ->
+            val response = client.get("https://test.com/").body<StringWrapper>()
+
+            assertEquals(StringWrapper(responseBody), response)
         }
     }
 


### PR DESCRIPTION
**Subsystem**
Client, `ktor-client-content-negotiation`

**Motivation**
Fix [KTOR-9574](https://youtrack.jetbrains.com/issue/KTOR-9574): client `ContentNegotiation` used the outgoing request headers when selecting a charset for response deserialization, ignoring the charset declared by the response `Content-Type` header.

**Solution**
Use `response.contentType().charset()` for response deserialization and fall back to UTF-8 when the response does not declare a charset. Added a regression test that verifies a response with `Content-Type: application/xml; charset=ISO-8859-1` is deserialized with `ISO-8859-1` without relying on request `Accept-Charset`.

Validation:

```text
:ktor-client-content-negotiation:clean :ktor-client-content-negotiation:jvmTest --tests io.ktor.client.plugins.ContentNegotiationTests.responseContentTypeCharsetUsedForResponseDeserialization
```
