### PR TITLE
KTOR-9661 HttpCache: InvalidCacheStateException is thrown on 304 when…

### DIFF
--- a/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/cache/HttpCache.kt
+++ b/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/cache/HttpCache.kt
@@ -1,6 +1,6 @@
 /*
-* Copyright 2014-2021 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
-*/
+ * Copyright 2014-2026 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
 
 @file:Suppress("DEPRECATION")
 
@@ -43,14 +43,8 @@ internal val LOGGER = KtorSimpleLogger("io.ktor.client.plugins.HttpCache")
  * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.client.plugins.cache.HttpCache)
  */
 public class HttpCache private constructor(
-    @Deprecated(
-        "This will become internal",
-        level = DeprecationLevel.ERROR
-    ) @Suppress("DEPRECATION_ERROR") internal val publicStorage: HttpCacheStorage,
-    @Deprecated(
-        "This will become internal",
-        level = DeprecationLevel.ERROR
-    ) @Suppress("DEPRECATION_ERROR") internal val privateStorage: HttpCacheStorage,
+    @Suppress("DEPRECATION_ERROR") internal val publicStorage: HttpCacheStorage,
+    @Suppress("DEPRECATION_ERROR") internal val privateStorage: HttpCacheStorage,
     private val publicStorageNew: CacheStorage,
     private val privateStorageNew: CacheStorage,
     private val useOldStorage: Boolean,
@@ -236,21 +230,11 @@ public class HttpCache private constructor(
 
                 if (response.status == HttpStatusCode.NotModified) {
                     LOGGER.trace { "Not modified response for ${response.call.request.url}, replying from cache" }
-                    val responseFromCache =
-                        plugin.findAndRefresh(response.call.request, response) ?: throw InvalidCacheStateException(
-                            response.call.request.url
-                        )
-                    if (responseFromCache.varyKeys().size != response.varyKeys().size) {
-                        LOGGER.warn(
-                            "Vary header mismatch on cached response for ${response.call.request.url}. " +
-                                "Received 304 Not Modified with Vary: ${response.varyKeys()} " +
-                                "but cached response has Vary: ${responseFromCache.varyKeys()}. " +
-                                "According to RFC 7232 §4.1 and RFC 9111 §4.1, " +
-                                "the server must include the full Vary header in 304 responses. " +
-                                "Falling back to missing cache logic. " +
-                                "Consider reporting this issue to the server maintainers."
-                        )
-                    }
+                    val responseFromCache = refreshNotModifiedResponse(
+                        response.call.request,
+                        response,
+                        plugin::findAndRefresh,
+                    )
 
                     scope.monitor.raise(HttpResponseFromCache, responseFromCache)
                     proceedWith(responseFromCache)
@@ -340,27 +324,35 @@ public class HttpCache private constructor(
             else -> publicStorageNew
         }
 
-        val cache = findResponse(storage, response.varyKeys(), url, request) ?: return null
-        storage.store(request.url, cache.copy(cache.varyKeys, response.cacheExpires(isSharedClient)))
-        return cache.createResponse(request.call.client, request, response.coroutineContext)
+        val cache = storage.selectResponseToUpdate(response, url, request) ?: return null
+        val newVaryKeys = response.varyKeys().ifEmpty { cache.varyKeys }
+        val mergedHeaders = cache.headers.merge(response.headers)
+        val expires = response.cacheExpires(isSharedClient)
+        val updatedCache = cache.copy(newVaryKeys, expires, mergedHeaders)
+
+        if (cache.varyKeys != newVaryKeys) {
+            storage.remove(url, cache.varyKeys)
+        }
+        storage.store(request.url, updatedCache)
+        return updatedCache.createResponse(request.call.client, request, response.coroutineContext)
     }
 
-    private suspend fun findResponse(
-        storage: CacheStorage,
-        varyKeys: Map<String, String>,
+    private suspend fun CacheStorage.selectResponseToUpdate(
+        response: HttpResponse,
         url: Url,
         request: HttpRequest
-    ): CachedResponseData? = when {
-        varyKeys.isNotEmpty() -> {
-            storage.find(url, varyKeys)
-        }
+    ): CachedResponseData? {
+        response.varyKeys()
+            .takeIf { it.isNotEmpty() }
+            ?.let { return find(url, varyKeys = it) }
 
-        else -> {
-            val requestHeaders = mergedHeadersLookup(request.content, request.headers::get, request.headers::getAll)
-            storage.findAll(url).sortedByDescending { it.responseTime }.firstOrNull { cachedResponse ->
-                cachedResponse.varyKeys.all { (key, value) -> requestHeaders(key) == value }
-            }
-        }
+        val requestHeaders = mergedHeadersLookup(request.content, request.headers::get, request.headers::getAll)
+        val cachedResponses = findAll(url).sortedByDescending { it.responseTime }
+
+        cachedResponses.firstOrNull { it.varyKeys.all { (key, value) -> requestHeaders(key) == value } }
+            ?.let { return it }
+
+        return cachedResponses.selectResponseToFreshen(response) { it.headers }
     }
 
     private suspend fun findResponse(context: HttpRequestBuilder, content: OutgoingContent): CachedResponseData? {

--- a/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/cache/HttpCache.kt
+++ b/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/cache/HttpCache.kt
@@ -342,9 +342,8 @@ public class HttpCache private constructor(
         url: Url,
         request: HttpRequest
     ): CachedResponseData? {
-        response.varyKeys()
-            .takeIf { it.isNotEmpty() }
-            ?.let { return find(url, varyKeys = it) }
+        val varyKeys = response.varyKeys().takeIf { it.isNotEmpty() }
+        varyKeys?.let { find(url, varyKeys) }?.let { return it }
 
         val requestHeaders = mergedHeadersLookup(request.content, request.headers::get, request.headers::getAll)
         val cachedResponses = findAll(url).sortedByDescending { it.responseTime }

--- a/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/cache/HttpCacheEntry.kt
+++ b/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/cache/HttpCacheEntry.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2024 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2014-2026 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package io.ktor.client.plugins.cache
@@ -8,6 +8,7 @@ import io.ktor.client.call.*
 import io.ktor.client.request.*
 import io.ktor.client.statement.*
 import io.ktor.http.*
+import io.ktor.http.content.*
 import io.ktor.util.date.*
 import io.ktor.utils.io.*
 import kotlinx.io.readByteArray
@@ -83,7 +84,7 @@ internal fun HttpResponse.cacheExpires(isShared: Boolean, fallback: () -> GMTDat
 
         return try {
             it.fromHttpToGmtDate()
-        } catch (e: Throwable) {
+        } catch (_: Throwable) {
             fallback()
         }
     } ?: fallback()
@@ -141,4 +142,30 @@ internal enum class ValidateStatus {
     ShouldValidate,
     ShouldNotValidate,
     ShouldWarn,
+}
+
+internal fun etagMatches(cachedEtag: String, validationEtag: String): Boolean {
+    val cached = EntityTagVersion.parseSingle(cachedEtag)
+    val validation = EntityTagVersion.parseSingle(validationEtag)
+    return cached.noneMatch(listOf(validation)) == VersionCheckResult.NOT_MODIFIED
+}
+
+internal fun HttpCacheEntry.withFreshenedMetadata(
+    expires: GMTDate,
+    varyKeys: Map<String, String>,
+    mergedHeaders: Headers,
+): HttpCacheEntry {
+    val freshenedResponse = object : HttpResponse() {
+        override val call: HttpClientCall get() = response.call
+        override val status: HttpStatusCode get() = response.status
+        override val version: HttpProtocolVersion get() = response.version
+        override val requestTime: GMTDate get() = response.requestTime
+        override val responseTime: GMTDate get() = response.responseTime
+        override val headers: Headers = mergedHeaders
+        override val coroutineContext get() = response.coroutineContext
+
+        @OptIn(InternalAPI::class)
+        override val rawContent: ByteReadChannel get() = response.rawContent
+    }
+    return HttpCacheEntry(expires, varyKeys, freshenedResponse, body)
 }

--- a/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/cache/HttpCacheEntry.kt
+++ b/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/cache/HttpCacheEntry.kt
@@ -5,6 +5,7 @@
 package io.ktor.client.plugins.cache
 
 import io.ktor.client.call.*
+import io.ktor.client.plugins.cache.storage.*
 import io.ktor.client.request.*
 import io.ktor.client.statement.*
 import io.ktor.http.*
@@ -30,14 +31,22 @@ public class HttpCacheEntry internal constructor(
     public val response: HttpResponse,
     public val body: ByteArray
 ) {
-    internal val responseHeaders: Headers = Headers.build {
-        appendAll(response.headers)
-    }
+    internal val responseHeaders: Headers = response.headers.filterForCacheStorage()
 
     internal fun produceResponse(): HttpResponse {
-        val currentClient = response.call.client
-        val call = SavedHttpCall(currentClient, response.call.request, response, body)
-        return call.response
+        val filteredResponse = object : HttpResponse() {
+            override val call: HttpClientCall get() = response.call
+            override val status: HttpStatusCode get() = response.status
+            override val version: HttpProtocolVersion get() = response.version
+            override val requestTime: GMTDate get() = response.requestTime
+            override val responseTime: GMTDate get() = response.responseTime
+            override val headers: Headers get() = responseHeaders
+            override val coroutineContext get() = response.coroutineContext
+
+            @OptIn(InternalAPI::class)
+            override val rawContent: ByteReadChannel get() = response.rawContent
+        }
+        return SavedHttpCall(response.call.client, response.call.request, filteredResponse, body).response
     }
 
     override fun equals(other: Any?): Boolean {

--- a/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/cache/HttpCacheEntry.kt
+++ b/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/cache/HttpCacheEntry.kt
@@ -144,11 +144,12 @@ internal enum class ValidateStatus {
     ShouldWarn,
 }
 
-internal fun etagMatches(cachedEtag: String, validationEtag: String): Boolean {
-    val cached = EntityTagVersion.parseSingle(cachedEtag)
-    val validation = EntityTagVersion.parseSingle(validationEtag)
-    return cached.noneMatch(listOf(validation)) == VersionCheckResult.NOT_MODIFIED
-}
+internal fun etagMatches(cachedEtag: String, validationEtag: String): Boolean =
+    runCatching {
+        val cached = EntityTagVersion.parseSingle(cachedEtag)
+        val validation = EntityTagVersion.parseSingle(validationEtag)
+        return cached.noneMatch(listOf(validation)) == VersionCheckResult.NOT_MODIFIED
+    }.getOrDefault(false)
 
 internal fun HttpCacheEntry.withFreshenedMetadata(
     expires: GMTDate,

--- a/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/cache/HttpCacheLegacy.kt
+++ b/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/cache/HttpCacheLegacy.kt
@@ -137,9 +137,8 @@ private fun HttpCacheStorage.selectResponseToUpdate(
     url: Url,
     request: HttpRequest
 ): HttpCacheEntry? {
-    response.varyKeys()
-        .takeIf { it.isNotEmpty() }
-        ?.let { return find(url, varyKeys = it) }
+    val varyKeys = response.varyKeys().takeIf { it.isNotEmpty() }
+    varyKeys?.let { find(url, varyKeys) }?.let { return it }
 
     val requestHeaders = mergedHeadersLookup(request.content, request.headers::get, request.headers::getAll)
     val cachedResponses = findByUrl(url).sortedByDescending { it.response.responseTime }

--- a/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/cache/HttpCacheLegacy.kt
+++ b/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/cache/HttpCacheLegacy.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2022 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2014-2026 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
 @file:Suppress("DEPRECATION", "DEPRECATION_ERROR")
@@ -23,7 +23,7 @@ internal suspend fun PipelineContext<Any, HttpRequestBuilder>.interceptSendLegac
     content: OutgoingContent,
     scope: HttpClient
 ) {
-    val cache = plugin.findResponse(context, content)
+    val cache = plugin.selectResponseToUpdate(context, content)
     if (cache == null) {
         val header = parseHeaderValue(context.headers[HttpHeaders.CacheControl])
         if (CacheControl.ONLY_IF_CACHED in header) {
@@ -64,19 +64,11 @@ internal suspend fun PipelineContext<HttpResponse, Unit>.interceptReceiveLegacy(
     }
 
     if (response.status == HttpStatusCode.NotModified) {
-        val responseFromCache = plugin.findAndRefresh(response.call.request, response)
-            ?: throw InvalidCacheStateException(response.call.request.url)
-        if (responseFromCache.varyKeys().size != response.varyKeys().size) {
-            LOGGER.warn(
-                "Vary header mismatch on cached response for ${response.call.request.url}. " +
-                    "Received 304 Not Modified with Vary: ${response.varyKeys()} " +
-                    "but cached response has Vary: ${responseFromCache.varyKeys()}. " +
-                    "According to RFC 7232 §4.1 and RFC 9111 §4.1, " +
-                    "the server must include the full Vary header in 304 responses. " +
-                    "Proceeding with cached response despite mismatch. " +
-                    "Consider reporting this issue to the server maintainers."
-            )
-        }
+        val responseFromCache = refreshNotModifiedResponse(
+            response.call.request,
+            response,
+            plugin::findAndRefresh,
+        )
 
         scope.monitor.raise(HttpCache.HttpResponseFromCache, responseFromCache)
         proceedWith(responseFromCache)
@@ -127,35 +119,38 @@ private fun HttpCache.findAndRefresh(request: HttpRequest, response: HttpRespons
 
     val storage = if (CacheControl.PRIVATE in cacheControl) privateStorage else publicStorage
 
-    val cache = findResponse(storage, response.varyKeys(), url, request) ?: return null
-    storage.store(
-        url,
-        HttpCacheEntry(response.cacheExpires(isSharedClient), cache.varyKeys, cache.response, cache.body)
-    )
-    return cache.produceResponse()
+    val cache = storage.selectResponseToUpdate(response, url, request) ?: return null
+    val newVaryKeys = response.varyKeys().ifEmpty { cache.varyKeys }
+    val mergedHeaders = cache.responseHeaders.merge(response.headers)
+    val expires = response.cacheExpires(isSharedClient)
+    val updatedCache = cache.withFreshenedMetadata(expires, newVaryKeys, mergedHeaders)
+
+    if (cache.varyKeys != newVaryKeys && storage is UnlimitedCacheStorage) {
+        storage.remove(url, cache.varyKeys)
+    }
+    storage.store(url, updatedCache)
+    return updatedCache.produceResponse()
 }
 
-private fun HttpCache.findResponse(
-    storage: HttpCacheStorage,
-    varyKeys: Map<String, String>,
+private fun HttpCacheStorage.selectResponseToUpdate(
+    response: HttpResponse,
     url: Url,
     request: HttpRequest
-): HttpCacheEntry? = when {
-    varyKeys.isNotEmpty() -> {
-        storage.find(url, varyKeys)
-    }
+): HttpCacheEntry? {
+    response.varyKeys()
+        .takeIf { it.isNotEmpty() }
+        ?.let { return find(url, varyKeys = it) }
 
-    else -> {
-        val requestHeaders = mergedHeadersLookup(request.content, request.headers::get, request.headers::getAll)
-        storage.findByUrl(url)
-            .sortedByDescending { it.response.responseTime }
-            .firstOrNull { cachedResponse ->
-                cachedResponse.varyKeys.all { (key, value) -> requestHeaders(key) == value }
-            }
-    }
+    val requestHeaders = mergedHeadersLookup(request.content, request.headers::get, request.headers::getAll)
+    val cachedResponses = findByUrl(url).sortedByDescending { it.response.responseTime }
+
+    cachedResponses.firstOrNull { it.varyKeys.all { (key, value) -> requestHeaders(key) == value } }
+        ?.let { return it }
+
+    return cachedResponses.selectResponseToFreshen(response) { it.responseHeaders }
 }
 
-private fun HttpCache.findResponse(context: HttpRequestBuilder, content: OutgoingContent): HttpCacheEntry? {
+private fun HttpCache.selectResponseToUpdate(context: HttpRequestBuilder, content: OutgoingContent): HttpCacheEntry? {
     val url = Url(context.url)
     val lookup = mergedHeadersLookup(content, context.headers::get, context.headers::getAll)
 

--- a/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/cache/HttpCacheValidation.kt
+++ b/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/cache/HttpCacheValidation.kt
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2014-2026 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.client.plugins.cache
+
+import io.ktor.client.request.*
+import io.ktor.client.statement.*
+import io.ktor.http.*
+
+internal suspend fun refreshNotModifiedResponse(
+    request: HttpRequest,
+    response: HttpResponse,
+    findAndRefresh: suspend (HttpRequest, HttpResponse) -> HttpResponse?,
+): HttpResponse {
+    val responseFromCache = findAndRefresh(request, response)
+        ?: throw InvalidCacheStateException(request.url)
+
+    if (responseFromCache.varyKeys().size != response.varyKeys().size) {
+        LOGGER.warn(
+            "Vary header mismatch on cached response for ${request.url}. " +
+                "Received 304 Not Modified with Vary: ${response.varyKeys()} " +
+                "but cached response has Vary: ${responseFromCache.varyKeys()}. " +
+                "According to RFC 9110 §15.4.5 and RFC 9111 §4.1, " +
+                "the server must include the full Vary header in 304 responses. " +
+                "Proceeding with cached response despite Vary mismatch. " +
+                "Consider reporting this issue to the server maintainers."
+        )
+    }
+
+    return responseFromCache
+}
+
+internal fun <E> List<E>.selectResponseToFreshen(response: HttpResponse, headers: (E) -> Headers): E? {
+    if (response.headers.haveNoValidator() && size == 1) {
+        return first().takeIf { headers(it).haveNoValidator() }
+    }
+    val etag = response.headers[HttpHeaders.ETag] ?: return null
+    return firstOrNull {
+        val cachedEtag = headers(it)[HttpHeaders.ETag]
+        cachedEtag != null && etagMatches(cachedEtag, etag)
+    }
+}
+
+private fun Headers.haveNoValidator(): Boolean =
+    HttpHeaders.ETag !in this && HttpHeaders.LastModified !in this

--- a/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/cache/storage/HttpCacheStorage.kt
+++ b/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/cache/storage/HttpCacheStorage.kt
@@ -161,7 +161,7 @@ public suspend fun CacheStorage.store(
         url = response.call.request.url,
         statusCode = response.status,
         requestTime = response.requestTime,
-        headers = response.headers,
+        headers = response.headers.filterForCacheStorage(),
         version = response.version,
         body = body,
         responseTime = response.responseTime,
@@ -242,21 +242,60 @@ public class CachedResponseData(
     )
 }
 
-private val mergeCacheExcludedHeaders = setOf(
-    HttpHeaders.ContentLength,
+// RFC 9110 §7.6.1 hop-by-hop headers; RFC 9111 §3.1 excepted from storage / §3.2 excepted from update.
+private val hopByHopHeaders = listOf(
     HttpHeaders.Connection,
+    HttpHeaders.TE,
+    HttpHeaders.TransferEncoding,
+    HttpHeaders.Upgrade,
+    HttpHeaders.ContentRange,
+    "Keep-Alive",
+    "Proxy-Connection",
+)
+
+private val proxyAuthHeaders = listOf(
     HttpHeaders.ProxyAuthenticate,
     HttpHeaders.ProxyAuthenticationInfo,
     HttpHeaders.ProxyAuthorization,
 )
 
+private val staticStorageExcludedHeaders = hopByHopHeaders + proxyAuthHeaders
+
+private val connectionOptionsWithoutFieldNames = listOf("close", "keep-alive", "upgrade")
+
+private fun Headers.connectionOptionFieldNames(): Set<String> {
+    val connection = this[HttpHeaders.Connection] ?: return emptySet()
+    return connection.split(',')
+        .map { it.trim() }
+        .filter { it.isNotEmpty() && it.lowercase() !in connectionOptionsWithoutFieldNames }
+        .toSet()
+}
+
+private fun Headers.excludedNamesForCacheStorage(): List<String> {
+    val names = connectionOptionFieldNames()
+    if (names.isEmpty()) return staticStorageExcludedHeaders
+    return staticStorageExcludedHeaders + names
+}
+
+private fun List<String>.containsIgnoreCase(element: String): Boolean =
+    any { it.equals(element, ignoreCase = true) }
+
+internal fun Headers.filterForCacheStorage(): Headers =
+    filterExcluded(excludedNamesForCacheStorage())
+
+private fun Headers.filterExcluded(excluded: List<String>): Headers = Headers.build {
+    for ((name, values) in this@filterExcluded.entries()) {
+        if (excluded.containsIgnoreCase(name)) continue
+        appendAll(name, values)
+    }
+}
+
 internal fun Headers.merge(other: Headers): Headers = Headers.build {
     appendAll(this@merge)
-    for (name in other.names()) {
-        if (mergeCacheExcludedHeaders.any { it.equals(name, ignoreCase = true) }) {
-            continue
-        }
+    val excluded = other.excludedNamesForCacheStorage() + HttpHeaders.ContentLength
+    for ((name, values) in other.entries()) {
+        if (excluded.containsIgnoreCase(name)) continue
         remove(name)
-        other.getAll(name)?.let { values -> appendAll(name, values) }
+        appendAll(name, values)
     }
 }

--- a/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/cache/storage/HttpCacheStorage.kt
+++ b/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/cache/storage/HttpCacheStorage.kt
@@ -1,6 +1,6 @@
 /*
-* Copyright 2014-2021 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
-*/
+ * Copyright 2014-2026 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
 
 @file:Suppress("DEPRECATION")
 
@@ -79,7 +79,7 @@ internal suspend fun HttpCacheStorage.store(url: Url, value: HttpResponse, isSha
 public interface CacheStorage {
 
     /**
-     * Store [value] in cache storage for [url] key.
+     * Store [data] in cache storage for [url] key.
      *
      * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.client.plugins.cache.storage.CacheStorage.store)
      */
@@ -225,7 +225,11 @@ public class CachedResponseData(
         return result
     }
 
-    internal fun copy(varyKeys: Map<String, String>, expires: GMTDate): CachedResponseData = CachedResponseData(
+    internal fun copy(
+        varyKeys: Map<String, String>,
+        expires: GMTDate,
+        headers: Headers = this.headers,
+    ): CachedResponseData = CachedResponseData(
         url = url,
         statusCode = statusCode,
         requestTime = requestTime,
@@ -236,4 +240,23 @@ public class CachedResponseData(
         varyKeys = varyKeys,
         body = body
     )
+}
+
+private val mergeCacheExcludedHeaders = setOf(
+    HttpHeaders.ContentLength,
+    HttpHeaders.Connection,
+    HttpHeaders.ProxyAuthenticate,
+    HttpHeaders.ProxyAuthenticationInfo,
+    HttpHeaders.ProxyAuthorization,
+)
+
+internal fun Headers.merge(other: Headers): Headers = Headers.build {
+    appendAll(this@merge)
+    for (name in other.names()) {
+        if (mergeCacheExcludedHeaders.any { it.equals(name, ignoreCase = true) }) {
+            continue
+        }
+        remove(name)
+        other.getAll(name)?.let { values -> appendAll(name, values) }
+    }
 }

--- a/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/cache/storage/UnlimitedCacheStorage.kt
+++ b/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/cache/storage/UnlimitedCacheStorage.kt
@@ -30,18 +30,9 @@ internal class UnlimitedCacheStorage : HttpCacheStorage() {
     override fun findByUrl(url: Url): Set<HttpCacheEntry> = store[url] ?: emptySet()
 
     internal fun remove(url: Url, varyKeys: Map<String, String>) =
-        store[url]?.remove(varyKeys) { it.varyKeys }
-}
-
-private inline fun <E> MutableSet<E>.remove(
-    varyKeys: Map<String, String>,
-    crossinline entryVaryKeys: (E) -> Map<String, String>
-) {
-    val entriesToRemove = filter { entry ->
-        val keys = entryVaryKeys(entry)
-        varyKeys.size == keys.size && varyKeys.all { (key, value) -> keys[key] == value }
-    }
-    entriesToRemove.forEach { remove(it) }
+        store[url]?.removeAll { entry ->
+            varyKeys.size == entry.varyKeys.size && varyKeys.all { (key, value) -> entry.varyKeys[key] == value }
+        }
 }
 
 internal class UnlimitedStorage : CacheStorage {
@@ -66,7 +57,9 @@ internal class UnlimitedStorage : CacheStorage {
     override suspend fun findAll(url: Url): Set<CachedResponseData> = store[url] ?: emptySet()
 
     override suspend fun remove(url: Url, varyKeys: Map<String, String>) {
-        store[url]?.remove(varyKeys) { it.varyKeys }
+        store[url]?.removeAll { entry ->
+            varyKeys.size == entry.varyKeys.size && varyKeys.all { (key, value) -> entry.varyKeys[key] == value }
+        }
     }
 
     override suspend fun removeAll(url: Url) {

--- a/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/cache/storage/UnlimitedCacheStorage.kt
+++ b/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/cache/storage/UnlimitedCacheStorage.kt
@@ -1,6 +1,6 @@
 /*
-* Copyright 2014-2021 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
-*/
+ * Copyright 2014-2026 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
 
 package io.ktor.client.plugins.cache.storage
 
@@ -28,6 +28,12 @@ internal class UnlimitedCacheStorage : HttpCacheStorage() {
     }
 
     override fun findByUrl(url: Url): Set<HttpCacheEntry> = store[url] ?: emptySet()
+
+    internal fun remove(url: Url, varyKeys: Map<String, String>) {
+        store[url]?.removeAll { entry ->
+            varyKeys.all { (key, value) -> entry.varyKeys[key] == value } && varyKeys.size == entry.varyKeys.size
+        }
+    }
 }
 
 internal class UnlimitedStorage : CacheStorage {

--- a/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/cache/storage/UnlimitedCacheStorage.kt
+++ b/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/cache/storage/UnlimitedCacheStorage.kt
@@ -29,11 +29,19 @@ internal class UnlimitedCacheStorage : HttpCacheStorage() {
 
     override fun findByUrl(url: Url): Set<HttpCacheEntry> = store[url] ?: emptySet()
 
-    internal fun remove(url: Url, varyKeys: Map<String, String>) {
-        store[url]?.removeAll { entry ->
-            varyKeys.all { (key, value) -> entry.varyKeys[key] == value } && varyKeys.size == entry.varyKeys.size
-        }
+    internal fun remove(url: Url, varyKeys: Map<String, String>) =
+        store[url]?.remove(varyKeys) { it.varyKeys }
+}
+
+private inline fun <E> MutableSet<E>.remove(
+    varyKeys: Map<String, String>,
+    crossinline entryVaryKeys: (E) -> Map<String, String>
+) {
+    val entriesToRemove = filter { entry ->
+        val keys = entryVaryKeys(entry)
+        varyKeys.size == keys.size && varyKeys.all { (key, value) -> keys[key] == value }
     }
+    entriesToRemove.forEach { remove(it) }
 }
 
 internal class UnlimitedStorage : CacheStorage {
@@ -58,9 +66,7 @@ internal class UnlimitedStorage : CacheStorage {
     override suspend fun findAll(url: Url): Set<CachedResponseData> = store[url] ?: emptySet()
 
     override suspend fun remove(url: Url, varyKeys: Map<String, String>) {
-        store[url]?.removeAll { entry ->
-            varyKeys.all { (key, value) -> entry.varyKeys[key] == value } && varyKeys.size == entry.varyKeys.size
-        }
+        store[url]?.remove(varyKeys) { it.varyKeys }
     }
 
     override suspend fun removeAll(url: Url) {

--- a/ktor-client/ktor-client-core/common/test/CacheHeaderFilteringTest.kt
+++ b/ktor-client/ktor-client-core/common/test/CacheHeaderFilteringTest.kt
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2014-2026 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+import io.ktor.client.plugins.cache.storage.*
+import io.ktor.http.*
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class CacheHeaderFilteringTest {
+
+    @Test
+    fun filterForCacheStorageStripsHopByHopAndProxyAuthButKeepsContentLength() {
+        val headers = headersOf(
+            HttpHeaders.ETag to listOf("\"v1\""),
+            HttpHeaders.ContentLength to listOf("4"),
+            HttpHeaders.Connection to listOf("close, Foo"),
+            HttpHeaders.TransferEncoding to listOf("chunked"),
+            "Keep-Alive" to listOf("timeout=5"),
+            "Proxy-Connection" to listOf("keep-alive"),
+            HttpHeaders.TE to listOf("trailers"),
+            HttpHeaders.Upgrade to listOf("websocket"),
+            HttpHeaders.ContentRange to listOf("bytes 0-0/100"),
+            HttpHeaders.ProxyAuthenticate to listOf("Basic"),
+            "Foo" to listOf("bar"),
+            "X-Custom" to listOf("value"),
+        )
+
+        val filtered = headers.filterForCacheStorage()
+
+        assertEquals("\"v1\"", filtered[HttpHeaders.ETag])
+        assertEquals("4", filtered[HttpHeaders.ContentLength])
+        assertEquals("value", filtered["X-Custom"])
+        assertNull(filtered[HttpHeaders.Connection])
+        assertNull(filtered[HttpHeaders.TransferEncoding])
+        assertNull(filtered["Keep-Alive"])
+        assertNull(filtered["Proxy-Connection"])
+        assertNull(filtered[HttpHeaders.TE])
+        assertNull(filtered[HttpHeaders.Upgrade])
+        assertNull(filtered[HttpHeaders.ContentRange])
+        assertNull(filtered[HttpHeaders.ProxyAuthenticate])
+        assertNull(filtered["Foo"])
+    }
+
+    @Test
+    fun mergeExcludesContentLengthFrom304ButPreservesStoredContentLength() {
+        val stored = headersOf(
+            HttpHeaders.ETag to listOf("\"v1\""),
+            HttpHeaders.ContentLength to listOf("4"),
+            HttpHeaders.CacheControl to listOf("max-age=60"),
+        )
+        val notModified = headersOf(
+            HttpHeaders.ETag to listOf("\"v1\""),
+            HttpHeaders.CacheControl to listOf("max-age=120"),
+            HttpHeaders.ContentLength to listOf("0"),
+            HttpHeaders.Connection to listOf("close"),
+        )
+
+        val merged = stored.merge(notModified)
+
+        assertEquals("max-age=120", merged[HttpHeaders.CacheControl])
+        assertEquals("4", merged[HttpHeaders.ContentLength])
+        assertNull(merged[HttpHeaders.Connection])
+    }
+
+    @Test
+    fun mergeExcludesConnectionListedFieldNames() {
+        val stored = headersOf("X-Custom" to listOf("original"))
+        val notModified = headersOf(
+            HttpHeaders.Connection to listOf("Foo"),
+            "Foo" to listOf("bar"),
+            "X-Custom" to listOf("updated"),
+        )
+
+        val merged = stored.merge(notModified)
+
+        assertEquals("updated", merged["X-Custom"])
+        assertNull(merged[HttpHeaders.Connection])
+        assertNull(merged["Foo"])
+    }
+}

--- a/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/plugins/CacheLegacyStorageTest.kt
+++ b/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/plugins/CacheLegacyStorageTest.kt
@@ -1,620 +1,125 @@
 /*
- * Copyright 2014-2025 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2014-2026 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package io.ktor.client.tests.plugins
 
-import io.ktor.client.call.*
-import io.ktor.client.engine.mock.MockEngine
-import io.ktor.client.engine.mock.respond
 import io.ktor.client.plugins.cache.*
-import io.ktor.client.plugins.cache.storage.*
 import io.ktor.client.plugins.logging.*
-import io.ktor.client.request.*
-import io.ktor.client.statement.*
 import io.ktor.client.test.base.*
-import io.ktor.client.utils.*
 import io.ktor.http.*
-import io.ktor.util.*
-import io.ktor.util.date.*
-import io.ktor.utils.io.*
-import kotlinx.coroutines.delay
-import kotlin.test.*
+import kotlin.test.Test
 import kotlin.time.Duration.Companion.milliseconds
 
-@Suppress("DEPRECATION", "DEPRECATION_ERROR")
 class CacheLegacyStorageTest : ClientLoader() {
 
     @Test
     fun testNoStore() = clientTests {
-        val publicStorage = HttpCacheStorage.Unlimited()
-        val privateStorage = HttpCacheStorage.Unlimited()
-        config {
-            install(HttpCache) {
-                this.publicStorage = publicStorage
-                this.privateStorage = privateStorage
-            }
-        }
-
-        test { client ->
-            val url = Url("$TEST_SERVER/cache/no-store")
-
-            val first = client.get(url).body<String>()
-            assertTrue(privateStorage.findByUrl(url).isEmpty())
-            assertTrue(publicStorage.findByUrl(url).isEmpty())
-
-            val second = client.get(url).body<String>()
-            assertTrue(privateStorage.findByUrl(url).isEmpty())
-            assertTrue(publicStorage.findByUrl(url).isEmpty())
-
-            assertNotEquals(first, second)
-        }
+        val cache = CacheTestFixtures.legacy()
+        config { install(cache) }
+        test { client -> testNoStoreScenario(cache, client, Url("$TEST_SERVER/cache/no-store")) }
     }
 
     @Test
     fun testNoCache() = clientTests {
-        val publicStorage = HttpCacheStorage.Unlimited()
-        val privateStorage = HttpCacheStorage.Unlimited()
-        config {
-            install(HttpCache) {
-                this.publicStorage = publicStorage
-                this.privateStorage = privateStorage
-            }
-        }
-
-        test { client ->
-            val url = Url("$TEST_SERVER/cache/no-cache")
-
-            val first = client.get(url).body<String>()
-            assertEquals(1, publicStorage.findByUrl(url).size)
-            assertEquals(0, privateStorage.findByUrl(url).size)
-
-            val second = client.get(url).body<String>()
-            assertEquals(1, publicStorage.findByUrl(url).size)
-            assertEquals(0, privateStorage.findByUrl(url).size)
-
-            assertNotEquals(first, second)
-        }
+        val cache = CacheTestFixtures.legacy()
+        config { install(cache) }
+        test { client -> testNoCacheScenario(cache, client, Url("$TEST_SERVER/cache/no-cache")) }
     }
 
     @Test
     fun testETagCache() = clientTests(except("Js")) {
-        val publicStorage = HttpCacheStorage.Unlimited()
-        val privateStorage = HttpCacheStorage.Unlimited()
-        config {
-            install(HttpCache) {
-                this.publicStorage = publicStorage
-                this.privateStorage = privateStorage
-            }
-        }
-
-        test { client ->
-            val url = Url("$TEST_SERVER/cache/etag")
-
-            val first = client.get(url).body<String>()
-            assertEquals(1, publicStorage.findByUrl(url).size)
-
-            val second = client.get(url).body<String>()
-            assertEquals(1, publicStorage.findByUrl(url).size)
-
-            assertEquals(first, second)
-        }
+        val cache = CacheTestFixtures.legacy()
+        config { install(cache) }
+        test { client -> testETagCacheScenario(cache, client, Url("$TEST_SERVER/cache/etag")) }
     }
 
     @Test
     fun testLastModified() = clientTests(except("Js")) {
-        val publicStorage = HttpCacheStorage.Unlimited()
-        val privateStorage = HttpCacheStorage.Unlimited()
-        config {
-            install(HttpCache) {
-                this.publicStorage = publicStorage
-                this.privateStorage = privateStorage
-            }
-        }
-
-        test { client ->
-            val url = Url("$TEST_SERVER/cache/last-modified")
-
-            val first = client.get(url).body<String>()
-            assertEquals(1, publicStorage.findByUrl(url).size)
-
-            val second = client.get(url).body<String>()
-            assertEquals(1, publicStorage.findByUrl(url).size)
-
-            assertEquals(first, second)
-        }
+        val cache = CacheTestFixtures.legacy()
+        config { install(cache) }
+        test { client -> testETagCacheScenario(cache, client, Url("$TEST_SERVER/cache/last-modified")) }
     }
 
     @Test
     fun testVary() = clientTests(except("Js")) {
-        val publicStorage = HttpCacheStorage.Unlimited()
-        val privateStorage = HttpCacheStorage.Unlimited()
-        config {
-            install(HttpCache) {
-                this.publicStorage = publicStorage
-                this.privateStorage = privateStorage
-            }
-        }
-
-        test { client ->
-            val url = Url("$TEST_SERVER/cache/vary")
-
-            // first header value from Vary
-            val first = client.get(url) {
-                header(HttpHeaders.ContentLanguage, "en")
-            }.body<String>()
-
-            val second = client.get(url) {
-                header(HttpHeaders.ContentLanguage, "en")
-            }.body<String>()
-
-            assertEquals(first, second)
-
-            // second header value from Vary
-            val third = client.get(url) {
-                header(HttpHeaders.ContentLanguage, "ru")
-            }.body<String>()
-
-            assertNotEquals(third, second)
-
-            val fourth = client.get(url) {
-                header(HttpHeaders.ContentLanguage, "ru")
-            }.body<String>()
-
-            assertEquals(third, fourth)
-
-            // first header value from Vary
-            val fifth = client.get(url) {
-                header(HttpHeaders.ContentLanguage, "en")
-            }.body<String>()
-
-            assertEquals(first, fifth)
-
-            // no header value from Vary
-            val sixth = client.get(url).body<String>()
-
-            assertNotEquals(sixth, second)
-            assertNotEquals(sixth, third)
-
-            val seventh = client.get(url).body<String>()
-
-            assertEquals(sixth, seventh)
-        }
+        config { install(cache = CacheTestFixtures.legacy()) }
+        test { client -> testVaryScenario(client, Url("$TEST_SERVER/cache/vary")) }
     }
 
     @Test
     fun testVaryStale() = clientTests(except("Js")) {
-        val publicStorage = HttpCacheStorage.Unlimited()
-        val privateStorage = HttpCacheStorage.Unlimited()
-        config {
-            install(HttpCache) {
-                this.publicStorage = publicStorage
-                this.privateStorage = privateStorage
-            }
-        }
-
-        test { client ->
-            val url = Url("$TEST_SERVER/cache/vary-stale")
-
-            // first header value from Vary
-            val first = client.get(url) {
-                header(HttpHeaders.ContentLanguage, "en")
-            }.body<String>()
-
-            val second = client.get(url) {
-                header(HttpHeaders.ContentLanguage, "en")
-            }.body<String>()
-
-            assertEquals(first, second)
-
-            // second header value from Vary
-            val third = client.get(url) {
-                header(HttpHeaders.ContentLanguage, "ru")
-            }.body<String>()
-
-            assertNotEquals(third, second)
-
-            val fourth = client.get(url) {
-                header(HttpHeaders.ContentLanguage, "ru")
-            }.body<String>()
-
-            assertEquals(third, fourth)
-
-            // first header value from Vary
-            val fifth = client.get(url) {
-                header(HttpHeaders.ContentLanguage, "en")
-            }.body<String>()
-
-            assertEquals(first, fifth)
-
-            // no header value from Vary
-            val sixth = client.get(url).body<String>()
-
-            assertNotEquals(sixth, second)
-            assertNotEquals(sixth, third)
-
-            val seventh = client.get(url).body<String>()
-
-            assertEquals(sixth, seventh)
-        }
+        config { install(cache = CacheTestFixtures.legacy()) }
+        test { client -> testVaryScenario(client, Url("$TEST_SERVER/cache/vary-stale")) }
     }
 
-    @OptIn(InternalAPI::class)
     @Test
     fun testNoVaryIn304() = clientTests(except("Js")) {
-        val publicStorage = HttpCacheStorage.Unlimited()
-        val privateStorage = HttpCacheStorage.Unlimited()
-        config {
-            install(HttpCache) {
-                this.publicStorage = publicStorage
-                this.privateStorage = privateStorage
-            }
-        }
-
-        test { client ->
-            client.receivePipeline.intercept(HttpReceivePipeline.Before) { response ->
-                if (response.status == HttpStatusCode.NotModified) {
-                    val headers = buildHeaders {
-                        response.headers
-                            .filter { name, _ ->
-                                !name.equals(HttpHeaders.Vary, ignoreCase = true)
-                            }
-                            .forEach(::appendAll)
-                    }
-                    proceedWith(
-                        object : HttpResponse() {
-                            override val call get() = response.call
-                            override val rawContent get() = response.rawContent
-                            override val coroutineContext get() = response.coroutineContext
-                            override val headers = headers
-                            override val requestTime get() = response.requestTime
-                            override val responseTime get() = response.responseTime
-                            override val status get() = response.status
-                            override val version get() = response.version
-                        }
-                    )
-                }
-            }
-
-            val url = Url("$TEST_SERVER/cache/vary-stale")
-
-            // first header value from Vary
-            val first = client.get(url) {
-                header(HttpHeaders.ContentLanguage, "en")
-            }.body<String>()
-
-            val second = client.get(url) {
-                header(HttpHeaders.ContentLanguage, "en")
-            }.body<String>()
-
-            assertEquals(first, second)
-
-            // second header value from Vary
-            val third = client.get(url) {
-                header(HttpHeaders.ContentLanguage, "ru")
-            }.body<String>()
-
-            assertNotEquals(third, second)
-
-            val fourth = client.get(url) {
-                header(HttpHeaders.ContentLanguage, "ru")
-            }.body<String>()
-
-            assertEquals(third, fourth)
-
-            // first header value from Vary
-            val fifth = client.get(url) {
-                header(HttpHeaders.ContentLanguage, "en")
-            }.body<String>()
-
-            assertEquals(first, fifth)
-
-            // no header value from Vary
-            val sixth = client.get(url).body<String>()
-
-            assertNotEquals(sixth, second)
-            assertNotEquals(sixth, third)
-
-            val seventh = client.get(url).body<String>()
-
-            assertEquals(sixth, seventh)
-        }
+        config { install(cache = CacheTestFixtures.legacy()) }
+        test { client -> testNoVaryIn304Scenario(client, Url("$TEST_SERVER/cache/vary-stale")) }
     }
 
     @Test
     fun testMaxAge() = clientTests(except("native:CIO")) {
-        val publicStorage = HttpCacheStorage.Unlimited()
-        val privateStorage = HttpCacheStorage.Unlimited()
-        config {
-            install(HttpCache) {
-                this.publicStorage = publicStorage
-                this.privateStorage = privateStorage
-            }
-        }
-
-        test { client ->
-            val url = Url("$TEST_SERVER/cache/max-age")
-
-            val first = client.get(url).body<String>()
-            val cache = publicStorage.findByUrl(url)
-            assertEquals(1, cache.size)
-
-            val second = client.get(url).body<String>()
-
-            assertEquals(first, second)
-            delay(2500.milliseconds)
-
-            val third = client.get(url).body<String>()
-            assertNotEquals(first, third)
-        }
+        val cache = CacheTestFixtures.legacy()
+        config { install(cache) }
+        test { client -> testMaxAgeScenario(cache, client, Url("$TEST_SERVER/cache/max-age")) }
     }
 
     @Test
     fun testOnlyIfCached() = clientTests {
-        val publicStorage = HttpCacheStorage.Unlimited()
-        val privateStorage = HttpCacheStorage.Unlimited()
-        config {
-            install(HttpCache) {
-                this.publicStorage = publicStorage
-                this.privateStorage = privateStorage
-            }
-        }
-
-        test { client ->
-            val url = Url("$TEST_SERVER/cache/etag?max-age=10")
-
-            val responseNoCache = client.get(url) {
-                header(HttpHeaders.CacheControl, "only-if-cached")
-            }
-            assertEquals(HttpStatusCode.GatewayTimeout, responseNoCache.status)
-
-            val bodyOriginal = client.get(url).bodyAsText()
-
-            val responseCached = client.get(url) {
-                header(HttpHeaders.CacheControl, "only-if-cached")
-            }
-            val bodyCached = responseCached.bodyAsText()
-            assertEquals(HttpStatusCode.OK, responseCached.status)
-            assertEquals(bodyOriginal, bodyCached)
-        }
+        config { install(cache = CacheTestFixtures.legacy()) }
+        test { client -> testOnlyIfCachedScenario(client, Url("$TEST_SERVER/cache/etag?max-age=10")) }
     }
 
     @Test
     fun testMaxStale() = clientTests(retries = 3) {
-        val publicStorage = HttpCacheStorage.Unlimited()
-        val privateStorage = HttpCacheStorage.Unlimited()
-        config {
-            install(HttpCache) {
-                this.publicStorage = publicStorage
-                this.privateStorage = privateStorage
-            }
-        }
-
-        test { client ->
-            val url = Url("$TEST_SERVER/cache/max-age")
-
-            val original = client.get(url).body<String>()
-            val cache = publicStorage.findByUrl(url)
-            assertEquals(1, cache.size)
-
-            delay(2500.milliseconds)
-
-            val stale = client.get(url) {
-                header(HttpHeaders.CacheControl, "max-stale=4")
-            }
-            assertEquals("110", stale.headers[HttpHeaders.Warning])
-            val staleBody = stale.body<String>()
-            assertEquals(original, staleBody)
-
-            val staleMaxInt = client.get(url) {
-                header(HttpHeaders.CacheControl, "max-stale=${Int.MAX_VALUE}")
-            }
-            assertEquals("110", stale.headers[HttpHeaders.Warning])
-            val staleMaxIntBody = staleMaxInt.body<String>()
-            assertEquals(original, staleMaxIntBody)
-
-            val notStale = client.get(url)
-            val notStaleBody = notStale.body<String>()
-            assertNull(notStale.headers[HttpHeaders.Warning])
-            assertNotEquals(original, notStaleBody)
-        }
+        val cache = CacheTestFixtures.legacy()
+        config { install(cache) }
+        test { client -> testMaxStaleScenario(cache, client, Url("$TEST_SERVER/cache/max-age")) }
     }
 
     @Test
     fun testNoStoreRequest() = clientTests(except("Js")) {
-        val publicStorage = HttpCacheStorage.Unlimited()
-        val privateStorage = HttpCacheStorage.Unlimited()
-        config {
-            install(HttpCache) {
-                this.publicStorage = publicStorage
-                this.privateStorage = privateStorage
-            }
-        }
-
-        test { client ->
-            val url = Url("$TEST_SERVER/cache/etag")
-
-            val first = client.get(url) {
-                header(HttpHeaders.CacheControl, "no-store")
-            }.body<String>()
-            assertEquals(0, publicStorage.findByUrl(url).size)
-
-            val second = client.get(url).body<String>()
-            assertEquals(1, publicStorage.findByUrl(url).size)
-
-            assertNotEquals(first, second)
-        }
+        val cache = CacheTestFixtures.legacy()
+        config { install(cache) }
+        test { client -> testNoStoreRequestScenario(cache, client, Url("$TEST_SERVER/cache/etag")) }
     }
 
     @Test
     fun testNoCacheRequest() = clientTests(except("Js")) {
-        val publicStorage = HttpCacheStorage.Unlimited()
-        val privateStorage = HttpCacheStorage.Unlimited()
-        config {
-            install(HttpCache) {
-                this.publicStorage = publicStorage
-                this.privateStorage = privateStorage
-            }
-        }
-
-        test { client ->
-            var requestsCount = 0
-            client.sendPipeline.intercept(HttpSendPipeline.Engine) {
-                requestsCount++
-            }
-
-            val url = Url("$TEST_SERVER/cache/etag?max-age=30")
-
-            val first = client.get(url).body<String>()
-            assertEquals(1, publicStorage.findByUrl(url).size)
-
-            val second = client.get(url) {
-                header(HttpHeaders.CacheControl, "no-cache")
-            }.body<String>()
-            assertEquals(1, publicStorage.findByUrl(url).size)
-
-            assertEquals(2, requestsCount)
-            assertEquals(first, second)
-        }
+        val cache = CacheTestFixtures.legacy()
+        config { install(cache) }
+        test { client -> testNoCacheRequestScenario(cache, client, Url("$TEST_SERVER/cache/etag?max-age=30")) }
     }
 
     @Test
     fun testRequestWithMaxAge0() = clientTests(except("Js")) {
-        val publicStorage = HttpCacheStorage.Unlimited()
-        val privateStorage = HttpCacheStorage.Unlimited()
-        config {
-            install(HttpCache) {
-                this.publicStorage = publicStorage
-                this.privateStorage = privateStorage
-            }
-        }
-
-        test { client ->
-            var requestsCount = 0
-            client.sendPipeline.intercept(HttpSendPipeline.Engine) {
-                requestsCount++
-            }
-
-            val url = Url("$TEST_SERVER/cache/etag?max-age=30")
-
-            val first = client.get(url).body<String>()
-            assertEquals(1, publicStorage.findByUrl(url).size)
-
-            val second = client.get(url) {
-                header(HttpHeaders.CacheControl, "max-age=0")
-            }.body<String>()
-            assertEquals(1, publicStorage.findByUrl(url).size)
-
-            assertEquals(2, requestsCount)
-            assertEquals(first, second)
-        }
+        val cache = CacheTestFixtures.legacy()
+        config { install(cache) }
+        test { client -> testRequestWithMaxAge0Scenario(cache, client, Url("$TEST_SERVER/cache/etag?max-age=30")) }
     }
 
     @Test
     fun testExpires() = clientTests {
-        val publicStorage = HttpCacheStorage.Unlimited()
-        val privateStorage = HttpCacheStorage.Unlimited()
-        config {
-            install(HttpCache) {
-                this.publicStorage = publicStorage
-                this.privateStorage = privateStorage
-            }
-        }
-
+        val cache = CacheTestFixtures.legacy()
+        config { install(cache) }
         test { client ->
-            val now = GMTDate() + 4000L
-            val url = Url("$TEST_SERVER/cache/expires")
-
-            suspend fun getWithHeader(expires: String): String {
-                delayGMTDate(1)
-
-                return client.get(url) {
-                    header("X-Expires", expires)
-                }.body()
-            }
-
-            val first = getWithHeader(now.toHttpDate())
-            val cache = publicStorage.findByUrl(url)
-            assertEquals(1, cache.size)
-
-            // this should be from the cache
-            val second = client.get(url).body<String>()
-
-            assertEquals(first, second)
-            delay(5000.milliseconds)
-
-            // now it should be already expired
-            val third = client.get(url).body<String>()
-            assertNotEquals(first, third)
-
-            // illegal values: broken, "0" and blank should be treated as already expired
-            // so shouldn't be cached
-            var previous = third
-            getWithHeader("broken-date").let { result ->
-                assertNotEquals(previous, result)
-                previous = result
-            }
-
-            getWithHeader("0").let { result ->
-                assertNotEquals(previous, result)
-                previous = result
-            }
-
-            getWithHeader(" ").let { result ->
-                assertNotEquals(previous, result)
-                previous = result
-            }
-
-            delayGMTDate(1)
-            val last = client.get(url).body<String>()
-            assertNotEquals(previous, last)
+            testExpiresScenario(
+                cache,
+                client,
+                Url("$TEST_SERVER/cache/expires"),
+                expiresOffset = 4000.milliseconds,
+                expireDelay = 5000.milliseconds,
+            )
         }
     }
 
     @Test
     fun testPublicAndPrivateCache() = clientTests(except("native:*")) {
-        val publicStorage = HttpCacheStorage.Unlimited()
-        val privateStorage = HttpCacheStorage.Unlimited()
-        config {
-            install(HttpCache) {
-                this.publicStorage = publicStorage
-                this.privateStorage = privateStorage
-            }
-        }
-
-        test { client ->
-            val privateUrl = Url("$TEST_SERVER/cache/private")
-            val publicUrl = Url("$TEST_SERVER/cache/public")
-
-            fun publicCache() = publicStorage.findByUrl(publicUrl)
-            fun privateCache() = privateStorage.findByUrl(privateUrl)
-
-            val firstPrivate = client.get(privateUrl).body<String>()
-            assertEquals(firstPrivate, "private")
-            assertEquals(1, privateCache().size)
-            assertEquals(0, publicCache().size)
-            val privateCacheEntry = privateCache().first()
-
-            val firstPublic = client.get(publicUrl).body<String>()
-            assertEquals(firstPublic, "public")
-            assertEquals(1, publicCache().size)
-            assertEquals(1, privateCache().size)
-            val publicCacheEntry = publicCache().first()
-
-            val secondPrivate = client.get(privateUrl).body<String>()
-            assertEquals(secondPrivate, "private")
-
-            assertSame(privateCacheEntry, privateCache().first())
-
-            // Public from cache.
-            val secondPublic = client.get(publicUrl).body<String>()
-            assertEquals(secondPublic, "public")
-
-            assertEquals(1, privateCache().size)
-            assertEquals(1, publicCache().size)
-
-            assertSame(publicCacheEntry, publicCache().first())
-        }
+        val cache = CacheTestFixtures.legacy()
+        config { install(cache) }
+        test { client -> testPublicAndPrivateCacheScenario(cache, client) }
     }
 
     @Test
@@ -626,74 +131,20 @@ class CacheLegacyStorageTest : ClientLoader() {
             }
             install(HttpCache)
         }
-        test { client ->
-            client.receivePipeline.intercept(HttpReceivePipeline.State) { response ->
-                val savedResponse = response.call.save().response
-                proceedWith(savedResponse)
-            }
-            val result = client.get("$TEST_SERVER/content/chunked-data?size=5000").bodyAsText()
-            assertEquals(5000, result.length)
-        }
+        test { client -> testWithLoggingScenario(client) }
     }
 
     @Test
-    fun test304WithoutVaryMatchesByEtag() = testWithEngine(MockEngine) {
-        val etag = "\"v1\""
-        val url = Url("https://example.com/x")
-        val publicStorage = HttpCacheStorage.Unlimited()
-        config {
-            install(HttpCache) {
-                this.publicStorage = publicStorage
-            }
-            engine {
-                addHandler { request ->
-                    if (request.headers.contains(HttpHeaders.IfNoneMatch)) {
-                        // The server omits Vary in the 304 but provides a matching validator.
-                        // The legacy storage must locate the entry by ETag and reply from cache
-                        // instead of throwing InvalidCacheStateException.
-                        respond("", HttpStatusCode.NotModified, headersOf(HttpHeaders.ETag, etag))
-                    } else {
-                        val headers = headersOf(
-                            HttpHeaders.ETag to listOf(etag),
-                            HttpHeaders.Vary to listOf("Origin"),
-                            HttpHeaders.CacheControl to listOf("max-age=0, must-revalidate"),
-                        )
-                        respond("body", HttpStatusCode.OK, headers)
-                    }
-                }
-            }
-        }
-
-        test { client ->
-            val first = client.get(url).bodyAsText()
-            assertEquals("body", first)
-
-            val second = client.get(url).bodyAsText()
-            assertEquals("body", second)
-
-            assertEquals(1, publicStorage.findByUrl(url).size)
-        }
-    }
-
-    /**
-     * Does delay and ensures that the [GMTDate] measurements report at least
-     * the specified number of [milliseconds].
-     * The reason why it's not the same is that on some platforms time granularity of GMTDate
-     * is not that high and could be even larger than a millisecond.
-     */
-    private suspend fun delayGMTDate(milliseconds: Long) {
-        var delayValue = milliseconds
-
-        do {
-            val start = GMTDate()
-            delay(delayValue.milliseconds)
-            val end = GMTDate()
-            if (end > start + milliseconds) {
-                break
-            }
-            if (delayValue != 1L) {
-                delayValue = 1L
-            }
-        } while (true)
+    fun test304WithoutVaryMatchesByEtag() = mockCacheTest(
+        url = Url("https://example.com/x"),
+        fixtures = CacheTestFixtures.legacy(),
+    ) {
+        revalidateHandler(
+            initialHeaders = defaultRevalidateInitialHeaders(
+                extra = headersOf(HttpHeaders.Vary to listOf("Origin")),
+            ),
+            notModifiedHeaders = headersOf(HttpHeaders.ETag, DEFAULT_ETAG),
+        )
+        testBody = { client -> test304WithoutVaryMatchesByEtagScenario(fixtures, client, url) }
     }
 }

--- a/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/plugins/CacheLegacyStorageTest.kt
+++ b/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/plugins/CacheLegacyStorageTest.kt
@@ -5,6 +5,8 @@
 package io.ktor.client.tests.plugins
 
 import io.ktor.client.call.*
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
 import io.ktor.client.plugins.cache.*
 import io.ktor.client.plugins.cache.storage.*
 import io.ktor.client.plugins.logging.*
@@ -18,6 +20,7 @@ import io.ktor.util.date.*
 import io.ktor.utils.io.*
 import kotlinx.coroutines.delay
 import kotlin.test.*
+import kotlin.time.Duration.Companion.milliseconds
 
 @Suppress("DEPRECATION", "DEPRECATION_ERROR")
 class CacheLegacyStorageTest : ClientLoader() {
@@ -339,7 +342,7 @@ class CacheLegacyStorageTest : ClientLoader() {
             val second = client.get(url).body<String>()
 
             assertEquals(first, second)
-            delay(2500)
+            delay(2500.milliseconds)
 
             val third = client.get(url).body<String>()
             assertNotEquals(first, third)
@@ -394,7 +397,7 @@ class CacheLegacyStorageTest : ClientLoader() {
             val cache = publicStorage.findByUrl(url)
             assertEquals(1, cache.size)
 
-            delay(2500)
+            delay(2500.milliseconds)
 
             val stale = client.get(url) {
                 header(HttpHeaders.CacheControl, "max-stale=4")
@@ -538,7 +541,7 @@ class CacheLegacyStorageTest : ClientLoader() {
             val second = client.get(url).body<String>()
 
             assertEquals(first, second)
-            delay(5000)
+            delay(5000.milliseconds)
 
             // now it should be already expired
             val third = client.get(url).body<String>()
@@ -633,6 +636,45 @@ class CacheLegacyStorageTest : ClientLoader() {
         }
     }
 
+    @Test
+    fun test304WithoutVaryMatchesByEtag() = testWithEngine(MockEngine) {
+        val etag = "\"v1\""
+        val url = Url("https://example.com/x")
+        val publicStorage = HttpCacheStorage.Unlimited()
+        config {
+            install(HttpCache) {
+                this.publicStorage = publicStorage
+            }
+            engine {
+                addHandler { request ->
+                    if (request.headers.contains(HttpHeaders.IfNoneMatch)) {
+                        // The server omits Vary in the 304 but provides a matching validator.
+                        // The legacy storage must locate the entry by ETag and reply from cache
+                        // instead of throwing InvalidCacheStateException.
+                        respond("", HttpStatusCode.NotModified, headersOf(HttpHeaders.ETag, etag))
+                    } else {
+                        val headers = headersOf(
+                            HttpHeaders.ETag to listOf(etag),
+                            HttpHeaders.Vary to listOf("Origin"),
+                            HttpHeaders.CacheControl to listOf("max-age=0, must-revalidate"),
+                        )
+                        respond("body", HttpStatusCode.OK, headers)
+                    }
+                }
+            }
+        }
+
+        test { client ->
+            val first = client.get(url).bodyAsText()
+            assertEquals("body", first)
+
+            val second = client.get(url).bodyAsText()
+            assertEquals("body", second)
+
+            assertEquals(1, publicStorage.findByUrl(url).size)
+        }
+    }
+
     /**
      * Does delay and ensures that the [GMTDate] measurements report at least
      * the specified number of [milliseconds].
@@ -644,7 +686,7 @@ class CacheLegacyStorageTest : ClientLoader() {
 
         do {
             val start = GMTDate()
-            delay(delayValue)
+            delay(delayValue.milliseconds)
             val end = GMTDate()
             if (end > start + milliseconds) {
                 break

--- a/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/plugins/CacheTest.kt
+++ b/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/plugins/CacheTest.kt
@@ -990,13 +990,8 @@ class CacheTest : ClientLoader() {
                 addHandler { request ->
                     if (request.headers.contains(HttpHeaders.IfModifiedSince)) {
                         // 304 with no validator while several variants are stored:
-                        // the lenient single-entry rule must NOT apply, so this is treated
-                        // as a fresh response instead of an arbitrary cached entry.
-                        respond(
-                            "fresh",
-                            HttpStatusCode.OK,
-                            headersOf(HttpHeaders.LastModified, "Mon, 01 Jan 2024 00:00:00 GMT")
-                        )
+                        // the lenient single-entry rule must NOT apply.
+                        respond("", HttpStatusCode.NotModified)
                     } else {
                         val variant = request.headers[HttpHeaders.AcceptLanguage] ?: "default"
                         val headers = headersOf(
@@ -1018,10 +1013,14 @@ class CacheTest : ClientLoader() {
             assertEquals("es", es)
             assertEquals(2, publicStorage.findAll(url).size)
 
-            // A request whose variant is not stored revalidates; the 304 has no validator, and
-            // there are multiple stored responses, so it must not be served from cache.
-            val fresh = client.get(url) { header(HttpHeaders.AcceptLanguage, "fr") }.bodyAsText()
-            assertEquals("fresh", fresh)
+            // Revalidate cached variants; the 304 has no validator and multiple stored
+            // responses exist, so the lenient single-entry rule must not apply — each
+            // response is matched by its request Vary keys instead.
+            val enAgain = client.get(url) { header(HttpHeaders.AcceptLanguage, "en") }.bodyAsText()
+            assertEquals("en", enAgain)
+
+            val esAgain = client.get(url) { header(HttpHeaders.AcceptLanguage, "es") }.bodyAsText()
+            assertEquals("es", esAgain)
         }
     }
 

--- a/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/plugins/CacheTest.kt
+++ b/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/plugins/CacheTest.kt
@@ -19,6 +19,7 @@ import io.ktor.util.date.*
 import io.ktor.utils.io.*
 import kotlinx.coroutines.delay
 import kotlin.test.*
+import kotlin.time.Duration.Companion.milliseconds
 
 class CacheTest : ClientLoader() {
 
@@ -417,7 +418,7 @@ class CacheTest : ClientLoader() {
             val second = client.get(url).body<String>()
 
             assertEquals(first, second)
-            delay(2500)
+            delay(2500.milliseconds)
 
             val third = client.get(url).body<String>()
             assertNotEquals(first, third)
@@ -521,7 +522,7 @@ class CacheTest : ClientLoader() {
             val cache = publicStorage.findAll(url)
             assertEquals(1, cache.size)
 
-            delay(2500)
+            delay(2500.milliseconds)
 
             val stale = client.get(url) {
                 header(HttpHeaders.CacheControl, "max-stale=4")
@@ -665,7 +666,7 @@ class CacheTest : ClientLoader() {
             val second = client.get(url).body<String>()
 
             assertEquals(first, second)
-            delay(2500)
+            delay(2500.milliseconds)
 
             // now it should be already expired
             val third = client.get(url).body<String>()
@@ -857,6 +858,174 @@ class CacheTest : ClientLoader() {
     }
 
     @Test
+    fun test304WithNewlyAddedVaryHeader() = testWithEngine(MockEngine) {
+        val etag = "\"v1\""
+        val url = Url("https://example.com/x")
+        val publicStorage = CacheStorage.Unlimited()
+        config {
+            install(HttpCache) {
+                publicStorage(publicStorage)
+            }
+            engine {
+                addHandler { request ->
+                    if (request.headers.contains(HttpHeaders.IfNoneMatch)) {
+                        val headers = headersOf(
+                            HttpHeaders.ETag to listOf(etag),
+                            HttpHeaders.Vary to listOf("Origin"),
+                        )
+                        respond("", HttpStatusCode.NotModified, headers)
+                    } else {
+                        val headers = headersOf(
+                            HttpHeaders.ETag to listOf(etag),
+                            HttpHeaders.CacheControl to listOf("max-age=0, must-revalidate"),
+                        )
+                        respond("body", HttpStatusCode.OK, headers)
+                    }
+                }
+            }
+        }
+
+        test { client ->
+            val first = client.get(url).bodyAsText()
+            assertEquals("body", first)
+
+            val second = client.get(url).bodyAsText()
+            assertEquals("body", second)
+
+            val cached = publicStorage.findAll(url)
+            assertEquals(1, cached.size)
+            assertEquals(mapOf("origin" to ""), cached.single().varyKeys)
+            assertEquals("Origin", cached.single().headers[HttpHeaders.Vary])
+        }
+    }
+
+    @Test
+    fun test304WithoutVaryMatchesByEtag() = testWithEngine(MockEngine) {
+        val etag = "\"v1\""
+        val url = Url("https://example.com/x")
+        val publicStorage = CacheStorage.Unlimited()
+        config {
+            install(HttpCache) {
+                publicStorage(publicStorage)
+            }
+            engine {
+                addHandler { request ->
+                    if (request.headers.contains(HttpHeaders.IfNoneMatch)) {
+                        // The server omits Vary in the 304 but provides a matching validator.
+                        // The cached entry must be found by its ETag instead of failing with
+                        // InvalidCacheStateException.
+                        respond("", HttpStatusCode.NotModified, headersOf(HttpHeaders.ETag, etag))
+                    } else {
+                        val headers = headersOf(
+                            HttpHeaders.ETag to listOf(etag),
+                            HttpHeaders.Vary to listOf("Origin"),
+                            HttpHeaders.CacheControl to listOf("max-age=0, must-revalidate"),
+                        )
+                        respond("body", HttpStatusCode.OK, headers)
+                    }
+                }
+            }
+        }
+
+        test { client ->
+            val first = client.get(url).bodyAsText()
+            assertEquals("body", first)
+
+            // Triggers a conditional request that gets a 304 without the Vary header.
+            // Should not throw and should reply from cache.
+            val second = client.get(url).bodyAsText()
+            assertEquals("body", second)
+
+            assertEquals(1, publicStorage.findAll(url).size)
+        }
+    }
+
+    @Test
+    fun test304WithoutValidatorMatchesSingleStoredResponse() = testWithEngine(MockEngine) {
+        val url = Url("https://example.com/x")
+        val publicStorage = CacheStorage.Unlimited()
+        config {
+            install(HttpCache) {
+                publicStorage(publicStorage)
+            }
+            engine {
+                addHandler { request ->
+                    if (request.headers.contains(HttpHeaders.IfModifiedSince)) {
+                        // 304 carries no validator at all (no ETag, no Last-Modified).
+                        // Per RFC 9111 §4.3.4, since there is a single stored response that
+                        // also lacks a validator, that response is identified for update.
+                        respond("", HttpStatusCode.NotModified)
+                    } else {
+                        val headers = headersOf(
+                            HttpHeaders.LastModified to listOf("Mon, 01 Jan 2024 00:00:00 GMT"),
+                            HttpHeaders.CacheControl to listOf("max-age=0, must-revalidate"),
+                        )
+                        respond("body", HttpStatusCode.OK, headers)
+                    }
+                }
+            }
+        }
+
+        test { client ->
+            val first = client.get(url).bodyAsText()
+            assertEquals("body", first)
+
+            // The 304 has no validator, but the single stored response is freshened.
+            val second = client.get(url).bodyAsText()
+            assertEquals("body", second)
+
+            assertEquals(1, publicStorage.findAll(url).size)
+        }
+    }
+
+    @Test
+    fun test304WithoutValidatorIsNotMatchedWhenMultipleStoredResponses() = testWithEngine(MockEngine) {
+        val url = Url("https://example.com/x")
+        val publicStorage = CacheStorage.Unlimited()
+        config {
+            install(HttpCache) {
+                publicStorage(publicStorage)
+            }
+            engine {
+                addHandler { request ->
+                    if (request.headers.contains(HttpHeaders.IfModifiedSince)) {
+                        // 304 with no validator while several variants are stored:
+                        // the lenient single-entry rule must NOT apply, so this is treated
+                        // as a fresh response instead of an arbitrary cached entry.
+                        respond(
+                            "fresh",
+                            HttpStatusCode.OK,
+                            headersOf(HttpHeaders.LastModified, "Mon, 01 Jan 2024 00:00:00 GMT")
+                        )
+                    } else {
+                        val variant = request.headers[HttpHeaders.AcceptLanguage] ?: "default"
+                        val headers = headersOf(
+                            HttpHeaders.LastModified to listOf("Mon, 01 Jan 2024 00:00:00 GMT"),
+                            HttpHeaders.Vary to listOf(HttpHeaders.AcceptLanguage),
+                            HttpHeaders.CacheControl to listOf("max-age=0, must-revalidate"),
+                        )
+                        respond(variant, HttpStatusCode.OK, headers)
+                    }
+                }
+            }
+        }
+
+        test { client ->
+            // Store two different variants, so more than one stored response exists for the URL.
+            val en = client.get(url) { header(HttpHeaders.AcceptLanguage, "en") }.bodyAsText()
+            val es = client.get(url) { header(HttpHeaders.AcceptLanguage, "es") }.bodyAsText()
+            assertEquals("en", en)
+            assertEquals("es", es)
+            assertEquals(2, publicStorage.findAll(url).size)
+
+            // A request whose variant is not stored revalidates; the 304 has no validator, and
+            // there are multiple stored responses, so it must not be served from cache.
+            val fresh = client.get(url) { header(HttpHeaders.AcceptLanguage, "fr") }.bodyAsText()
+            assertEquals("fresh", fresh)
+        }
+    }
+
+    @Test
     fun testVaryHeader() = clientTests {
         val publicStorage = CacheStorage.Unlimited()
         val privateStorage = CacheStorage.Unlimited()
@@ -932,7 +1101,7 @@ class CacheTest : ClientLoader() {
 
         do {
             val start = GMTDate()
-            delay(delayValue)
+            delay(delayValue.milliseconds)
             val end = GMTDate()
             if (end > start + milliseconds) {
                 break

--- a/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/plugins/CacheTest.kt
+++ b/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/plugins/CacheTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2014-2026 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package io.ktor.client.tests.plugins
@@ -7,17 +7,12 @@ package io.ktor.client.tests.plugins
 import io.ktor.client.call.*
 import io.ktor.client.engine.mock.*
 import io.ktor.client.plugins.cache.*
-import io.ktor.client.plugins.cache.storage.*
 import io.ktor.client.plugins.logging.*
 import io.ktor.client.request.*
 import io.ktor.client.statement.*
 import io.ktor.client.test.base.*
 import io.ktor.client.utils.*
 import io.ktor.http.*
-import io.ktor.util.*
-import io.ktor.util.date.*
-import io.ktor.utils.io.*
-import kotlinx.coroutines.delay
 import kotlin.test.*
 import kotlin.time.Duration.Companion.milliseconds
 
@@ -25,90 +20,29 @@ class CacheTest : ClientLoader() {
 
     @Test
     fun testNoStore() = clientTests {
-        val publicStorage = CacheStorage.Unlimited()
-        val privateStorage = CacheStorage.Unlimited()
-        config {
-            install(HttpCache) {
-                publicStorage(publicStorage)
-                privateStorage(privateStorage)
-            }
-        }
-
-        test { client ->
-            val url = Url("$TEST_SERVER/cache/no-store")
-
-            val first = client.get(url).body<String>()
-            assertTrue(privateStorage.findAll(url).isEmpty())
-            assertTrue(publicStorage.findAll(url).isEmpty())
-
-            val second = client.get(url).body<String>()
-            assertTrue(privateStorage.findAll(url).isEmpty())
-            assertTrue(publicStorage.findAll(url).isEmpty())
-
-            assertNotEquals(first, second)
-        }
+        val cache = CacheTestFixtures.modern()
+        config { install(cache) }
+        test { client -> testNoStoreScenario(cache, client, Url("$TEST_SERVER/cache/no-store")) }
     }
 
     @Test
     fun testNoCache() = clientTests {
-        val publicStorage = CacheStorage.Unlimited()
-        val privateStorage = CacheStorage.Unlimited()
-        config {
-            install(HttpCache) {
-                publicStorage(publicStorage)
-                privateStorage(privateStorage)
-            }
-        }
-
-        test { client ->
-            val url = Url("$TEST_SERVER/cache/no-cache")
-
-            val first = client.get(url).body<String>()
-            assertEquals(1, publicStorage.findAll(url).size)
-            assertEquals(0, privateStorage.findAll(url).size)
-
-            val second = client.get(url).body<String>()
-            assertEquals(1, publicStorage.findAll(url).size)
-            assertEquals(0, privateStorage.findAll(url).size)
-
-            assertNotEquals(first, second)
-        }
+        val cache = CacheTestFixtures.modern()
+        config { install(cache) }
+        test { client -> testNoCacheScenario(cache, client, Url("$TEST_SERVER/cache/no-cache")) }
     }
 
     @Test
     fun testETagCache() = clientTests(except("Js")) {
-        val publicStorage = CacheStorage.Unlimited()
-        val privateStorage = CacheStorage.Unlimited()
-        config {
-            install(HttpCache) {
-                publicStorage(publicStorage)
-                privateStorage(privateStorage)
-            }
-        }
-
-        test { client ->
-            val url = Url("$TEST_SERVER/cache/etag")
-
-            val first = client.get(url).body<String>()
-            assertEquals(1, publicStorage.findAll(url).size)
-
-            val second = client.get(url).body<String>()
-            assertEquals(1, publicStorage.findAll(url).size)
-
-            assertEquals(first, second)
-        }
+        val cache = CacheTestFixtures.modern()
+        config { install(cache) }
+        test { client -> testETagCacheScenario(cache, client, Url("$TEST_SERVER/cache/etag")) }
     }
 
     @Test
     fun testReuseCacheStorage() = clientTests(except("Js")) {
-        val publicStorage = CacheStorage.Unlimited()
-        val privateStorage = CacheStorage.Unlimited()
-        config {
-            install(HttpCache) {
-                publicStorage(publicStorage)
-                privateStorage(privateStorage)
-            }
-        }
+        val cache = CacheTestFixtures.modern()
+        config { install(cache) }
 
         test { client ->
             val client1 = client.config { }
@@ -126,251 +60,45 @@ class CacheTest : ClientLoader() {
 
     @Test
     fun testLastModified() = clientTests(except("Js")) {
-        val publicStorage = CacheStorage.Unlimited()
-        val privateStorage = CacheStorage.Unlimited()
-        config {
-            install(HttpCache) {
-                publicStorage(publicStorage)
-                privateStorage(privateStorage)
-            }
-        }
-
-        test { client ->
-            val url = Url("$TEST_SERVER/cache/last-modified")
-
-            val first = client.get(url).body<String>()
-            assertEquals(1, publicStorage.findAll(url).size)
-
-            val second = client.get(url).body<String>()
-            assertEquals(1, publicStorage.findAll(url).size)
-
-            assertEquals(first, second)
-        }
+        val cache = CacheTestFixtures.modern()
+        config { install(cache) }
+        test { client -> testETagCacheScenario(cache, client, Url("$TEST_SERVER/cache/last-modified")) }
     }
 
     @Test
     fun testVary() = clientTests(except("Js")) {
-        val publicStorage = CacheStorage.Unlimited()
-        val privateStorage = CacheStorage.Unlimited()
-        config {
-            install(HttpCache) {
-                publicStorage(publicStorage)
-                privateStorage(privateStorage)
-            }
-        }
-
-        test { client ->
-            val url = Url("$TEST_SERVER/cache/vary")
-
-            // first header value from Vary
-            val first = client.get(url) {
-                header(HttpHeaders.ContentLanguage, "en")
-            }.body<String>()
-
-            val second = client.get(url) {
-                header(HttpHeaders.ContentLanguage, "en")
-            }.body<String>()
-
-            assertEquals(first, second)
-
-            // second header value from Vary
-            val third = client.get(url) {
-                header(HttpHeaders.ContentLanguage, "ru")
-            }.body<String>()
-
-            assertNotEquals(third, second)
-
-            val fourth = client.get(url) {
-                header(HttpHeaders.ContentLanguage, "ru")
-            }.body<String>()
-
-            assertEquals(third, fourth)
-
-            // first header value from Vary
-            val fifth = client.get(url) {
-                header(HttpHeaders.ContentLanguage, "en")
-            }.body<String>()
-
-            assertEquals(first, fifth)
-
-            // no header value from Vary
-            val sixth = client.get(url).body<String>()
-
-            assertNotEquals(sixth, second)
-            assertNotEquals(sixth, third)
-
-            val seventh = client.get(url).body<String>()
-
-            assertEquals(sixth, seventh)
-        }
+        val cache = CacheTestFixtures.modern()
+        config { install(cache) }
+        test { client -> testVaryScenario(client, Url("$TEST_SERVER/cache/vary")) }
     }
 
     @Test
     fun testVaryStale() = clientTests(except("Js")) {
-        val publicStorage = CacheStorage.Unlimited()
-        val privateStorage = CacheStorage.Unlimited()
-        config {
-            install(HttpCache) {
-                publicStorage(publicStorage)
-                privateStorage(privateStorage)
-            }
-        }
-
-        test { client ->
-            val url = Url("$TEST_SERVER/cache/vary-stale")
-
-            // first header value from Vary
-            val first = client.get(url) {
-                header(HttpHeaders.ContentLanguage, "en")
-            }.body<String>()
-
-            val second = client.get(url) {
-                header(HttpHeaders.ContentLanguage, "en")
-            }.body<String>()
-
-            assertEquals(first, second)
-
-            // second header value from Vary
-            val third = client.get(url) {
-                header(HttpHeaders.ContentLanguage, "ru")
-            }.body<String>()
-
-            assertNotEquals(third, second)
-
-            val fourth = client.get(url) {
-                header(HttpHeaders.ContentLanguage, "ru")
-            }.body<String>()
-
-            assertEquals(third, fourth)
-
-            // first header value from Vary
-            val fifth = client.get(url) {
-                header(HttpHeaders.ContentLanguage, "en")
-            }.body<String>()
-
-            assertEquals(first, fifth)
-
-            // no header value from Vary
-            val sixth = client.get(url).body<String>()
-
-            assertNotEquals(sixth, second)
-            assertNotEquals(sixth, third)
-
-            val seventh = client.get(url).body<String>()
-
-            assertEquals(sixth, seventh)
-        }
+        val cache = CacheTestFixtures.modern()
+        config { install(cache) }
+        test { client -> testVaryScenario(client, Url("$TEST_SERVER/cache/vary-stale")) }
     }
 
-    @OptIn(InternalAPI::class)
     @Test
     fun testNoVaryIn304() = clientTests(except("Js")) {
-        val publicStorage = CacheStorage.Unlimited()
-        val privateStorage = CacheStorage.Unlimited()
-        config {
-            install(HttpCache) {
-                publicStorage(publicStorage)
-                privateStorage(privateStorage)
-            }
-        }
-
-        test { client ->
-            client.receivePipeline.intercept(HttpReceivePipeline.Before) { response ->
-                if (response.status == HttpStatusCode.NotModified) {
-                    val headers = buildHeaders {
-                        response.headers
-                            .filter { name, _ ->
-                                !name.equals(HttpHeaders.Vary, ignoreCase = true)
-                            }
-                            .forEach(::appendAll)
-                    }
-                    proceedWith(
-                        object : HttpResponse() {
-                            override val call get() = response.call
-                            override val rawContent get() = response.rawContent
-                            override val coroutineContext get() = response.coroutineContext
-                            override val headers = headers
-                            override val requestTime get() = response.requestTime
-                            override val responseTime get() = response.responseTime
-                            override val status get() = response.status
-                            override val version get() = response.version
-                        }
-                    )
-                }
-            }
-
-            val url = Url("$TEST_SERVER/cache/vary-stale")
-
-            // first header value from Vary
-            val first = client.get(url) {
-                header(HttpHeaders.ContentLanguage, "en")
-            }.body<String>()
-
-            val second = client.get(url) {
-                header(HttpHeaders.ContentLanguage, "en")
-            }.body<String>()
-
-            assertEquals(first, second)
-
-            // second header value from Vary
-            val third = client.get(url) {
-                header(HttpHeaders.ContentLanguage, "ru")
-            }.body<String>()
-
-            assertNotEquals(third, second)
-
-            val fourth = client.get(url) {
-                header(HttpHeaders.ContentLanguage, "ru")
-            }.body<String>()
-
-            assertEquals(third, fourth)
-
-            // first header value from Vary
-            val fifth = client.get(url) {
-                header(HttpHeaders.ContentLanguage, "en")
-            }.body<String>()
-
-            assertEquals(first, fifth)
-
-            // no header value from Vary
-            val sixth = client.get(url).body<String>()
-
-            assertNotEquals(sixth, second)
-            assertNotEquals(sixth, third)
-
-            val seventh = client.get(url).body<String>()
-
-            assertEquals(sixth, seventh)
-        }
+        val cache = CacheTestFixtures.modern()
+        config { install(cache) }
+        test { client -> testNoVaryIn304Scenario(client, Url("$TEST_SERVER/cache/vary-stale")) }
     }
 
     @Test
     fun testSingleVaryAndMultipleVaryWithSameValues() = testWithEngine(MockEngine) {
-        class FakeResponse {
-            var content: String = ""
-            var status: HttpStatusCode = HttpStatusCode.OK
-            var headers: Headers = headersOf()
-        }
-
         val fakeResponse = FakeResponse()
-        val publicStorage = CacheStorage.Unlimited()
-        val privateStorage = CacheStorage.Unlimited()
+        val cache = CacheTestFixtures.modern()
         config {
-            install(HttpCache) {
-                publicStorage(publicStorage)
-                privateStorage(privateStorage)
-            }
-
+            install(cache)
             engine {
                 addHandler {
-                    respond(
-                        content = fakeResponse.content,
-                        status = fakeResponse.status,
-                        headers = buildHeaders {
-                            fakeResponse.headers.forEach(::appendAll)
-                            append(HttpHeaders.ETag, "W/\"ETAG\"")
-                        },
-                    )
+                    val headers = buildHeaders {
+                        fakeResponse.headers.forEach(::appendAll)
+                        append(HttpHeaders.ETag, "W/\"ETAG\"")
+                    }
+                    respond(fakeResponse.content, fakeResponse.status, headers)
                 }
             }
         }
@@ -379,70 +107,35 @@ class CacheTest : ClientLoader() {
             val url = Url("$TEST_SERVER/cache/vary-multiple")
             val vary = listOf(HttpHeaders.Origin, HttpHeaders.Accept)
 
-            // multiple Vary keys
             fakeResponse.content = "Cache"
             fakeResponse.status = HttpStatusCode.OK
             fakeResponse.headers = buildHeaders {
                 vary.forEach { append(HttpHeaders.Vary, it) }
             }
             val okBody = client.get(url).body<String>()
-            assertEquals(okBody, "Cache")
+            assertEquals("Cache", okBody)
 
-            // single Vary key with comma separated multiple values
             fakeResponse.content = ""
             fakeResponse.status = HttpStatusCode.NotModified
             fakeResponse.headers = headersOf(HttpHeaders.Vary, vary.joinToString(","))
             val notModifiedBody = client.get(url).body<String>()
-            assertEquals(notModifiedBody, okBody)
+            assertEquals(okBody, notModifiedBody)
         }
     }
 
     @Test
     fun testMaxAge() = clientTests {
-        val publicStorage = CacheStorage.Unlimited()
-        val privateStorage = CacheStorage.Unlimited()
-        config {
-            install(HttpCache) {
-                publicStorage(publicStorage)
-                privateStorage(privateStorage)
-            }
-        }
-
-        test { client ->
-            val url = Url("$TEST_SERVER/cache/max-age")
-
-            val first = client.get(url).body<String>()
-            val cache = publicStorage.findAll(url)
-            assertEquals(1, cache.size)
-
-            val second = client.get(url).body<String>()
-
-            assertEquals(first, second)
-            delay(2500.milliseconds)
-
-            val third = client.get(url).body<String>()
-            assertNotEquals(first, third)
-        }
+        val cache = CacheTestFixtures.modern()
+        config { install(cache) }
+        test { client -> testMaxAgeScenario(cache, client, Url("$TEST_SERVER/cache/max-age")) }
     }
 
     @Test
     fun testSMaxAgeWhenIsSharedTrue() = testWithEngine(MockEngine) {
-        class FakeResponse {
-            var content: String = ""
-            var status: HttpStatusCode = HttpStatusCode.OK
-        }
-
         val fakeResponse = FakeResponse()
-        val publicStorage = CacheStorage.Unlimited()
-        val privateStorage = CacheStorage.Unlimited()
+        val cache = CacheTestFixtures.modern()
         config {
-            install(HttpCache) {
-                publicStorage(publicStorage)
-                privateStorage(privateStorage)
-
-                isShared = true
-            }
-
+            install(cache) { isShared = true }
             engine {
                 addHandler {
                     respond(
@@ -463,349 +156,108 @@ class CacheTest : ClientLoader() {
             fakeResponse.content = "First"
             fakeResponse.status = HttpStatusCode.OK
             val firstBody = client.get(url).body<String>()
-            assertEquals(firstBody, "First")
+            assertEquals("First", firstBody)
 
-            // When isShared = true, s-maxage is in used as expiration.
-            // s-maxage doesn't expires yet, therefore this response should not be reflected.
             fakeResponse.content = "Second"
             fakeResponse.status = HttpStatusCode.OK
             val secondBody = client.get(url).body<String>()
-            assertEquals(secondBody, firstBody)
+            assertEquals(firstBody, secondBody)
         }
     }
 
     @Test
     fun testOnlyIfCached() = clientTests {
-        val publicStorage = CacheStorage.Unlimited()
-        val privateStorage = CacheStorage.Unlimited()
-        config {
-            install(HttpCache) {
-                publicStorage(publicStorage)
-                privateStorage(privateStorage)
-            }
-        }
-
-        test { client ->
-            val url = Url("$TEST_SERVER/cache/etag?max-age=10")
-
-            val responseNoCache = client.get(url) {
-                header(HttpHeaders.CacheControl, "only-if-cached")
-            }
-            assertEquals(HttpStatusCode.GatewayTimeout, responseNoCache.status)
-
-            val bodyOriginal = client.get(url).bodyAsText()
-
-            val responseCached = client.get(url) {
-                header(HttpHeaders.CacheControl, "only-if-cached")
-            }
-            val bodyCached = responseCached.bodyAsText()
-            assertEquals(HttpStatusCode.OK, responseCached.status)
-            assertEquals(bodyOriginal, bodyCached)
-        }
+        val cache = CacheTestFixtures.modern()
+        config { install(cache) }
+        test { client -> testOnlyIfCachedScenario(client, Url("$TEST_SERVER/cache/etag?max-age=10")) }
     }
 
     @Test
     fun testMaxStale() = clientTests {
-        val publicStorage = CacheStorage.Unlimited()
-        val privateStorage = CacheStorage.Unlimited()
-        config {
-            install(HttpCache) {
-                publicStorage(publicStorage)
-                privateStorage(privateStorage)
-            }
-        }
-
-        test { client ->
-            val url = Url("$TEST_SERVER/cache/max-age")
-
-            val original = client.get(url).body<String>()
-            val cache = publicStorage.findAll(url)
-            assertEquals(1, cache.size)
-
-            delay(2500.milliseconds)
-
-            val stale = client.get(url) {
-                header(HttpHeaders.CacheControl, "max-stale=4")
-            }
-            assertEquals("110", stale.headers[HttpHeaders.Warning])
-            val staleBody = stale.body<String>()
-            assertEquals(original, staleBody)
-
-            val staleMaxInt = client.get(url) {
-                header(HttpHeaders.CacheControl, "max-stale=${Int.MAX_VALUE}")
-            }
-            assertEquals("110", stale.headers[HttpHeaders.Warning])
-            val staleMaxIntBody = staleMaxInt.body<String>()
-            assertEquals(original, staleMaxIntBody)
-
-            val notStale = client.get(url)
-            val notStaleBody = notStale.body<String>()
-            assertNull(notStale.headers[HttpHeaders.Warning])
-            assertNotEquals(original, notStaleBody)
-        }
+        val cache = CacheTestFixtures.modern()
+        config { install(cache) }
+        test { client -> testMaxStaleScenario(cache, client, Url("$TEST_SERVER/cache/max-age")) }
     }
 
     @Test
     fun testNoStoreRequest() = clientTests(except("Js")) {
-        val publicStorage = CacheStorage.Unlimited()
-        val privateStorage = CacheStorage.Unlimited()
-        config {
-            install(HttpCache) {
-                publicStorage(publicStorage)
-                privateStorage(privateStorage)
-            }
-        }
-
-        test { client ->
-            val url = Url("$TEST_SERVER/cache/etag")
-
-            val first = client.get(url) {
-                header(HttpHeaders.CacheControl, "no-store")
-            }.body<String>()
-            assertEquals(0, publicStorage.findAll(url).size)
-
-            val second = client.get(url).body<String>()
-            assertEquals(1, publicStorage.findAll(url).size)
-
-            assertNotEquals(first, second)
-        }
+        val cache = CacheTestFixtures.modern()
+        config { install(cache) }
+        test { client -> testNoStoreRequestScenario(cache, client, Url("$TEST_SERVER/cache/etag")) }
     }
 
     @Test
     fun testNoCacheRequest() = clientTests(except("Js")) {
-        val publicStorage = CacheStorage.Unlimited()
-        val privateStorage = CacheStorage.Unlimited()
-        config {
-            install(HttpCache) {
-                publicStorage(publicStorage)
-                privateStorage(privateStorage)
-            }
-        }
-
-        test { client ->
-            var requestsCount = 0
-            client.sendPipeline.intercept(HttpSendPipeline.Engine) {
-                requestsCount++
-            }
-
-            val url = Url("$TEST_SERVER/cache/etag?max-age=30")
-
-            val first = client.get(url).body<String>()
-            assertEquals(1, publicStorage.findAll(url).size)
-
-            val second = client.get(url) {
-                header(HttpHeaders.CacheControl, "no-cache")
-            }.body<String>()
-            assertEquals(1, publicStorage.findAll(url).size)
-
-            assertEquals(2, requestsCount)
-            assertEquals(first, second)
-        }
+        val cache = CacheTestFixtures.modern()
+        config { install(cache) }
+        test { client -> testNoCacheRequestScenario(cache, client, Url("$TEST_SERVER/cache/etag?max-age=30")) }
     }
 
     @Test
     fun testRequestWithMaxAge0() = clientTests(except("Js")) {
-        val publicStorage = CacheStorage.Unlimited()
-        val privateStorage = CacheStorage.Unlimited()
-        config {
-            install(HttpCache) {
-                publicStorage(publicStorage)
-                privateStorage(privateStorage)
-            }
-        }
-
-        test { client ->
-            var requestsCount = 0
-            client.sendPipeline.intercept(HttpSendPipeline.Engine) {
-                requestsCount++
-            }
-
-            val url = Url("$TEST_SERVER/cache/etag?max-age=30")
-
-            val first = client.get(url).body<String>()
-            assertEquals(1, publicStorage.findAll(url).size)
-
-            val second = client.get(url) {
-                header(HttpHeaders.CacheControl, "max-age=0")
-            }.body<String>()
-            assertEquals(1, publicStorage.findAll(url).size)
-
-            assertEquals(2, requestsCount)
-            assertEquals(first, second)
-        }
+        val cache = CacheTestFixtures.modern()
+        config { install(cache) }
+        test { client -> testRequestWithMaxAge0Scenario(cache, client, Url("$TEST_SERVER/cache/etag?max-age=30")) }
     }
 
     @Test
     fun testExpires() = clientTests {
-        val publicStorage = CacheStorage.Unlimited()
-        val privateStorage = CacheStorage.Unlimited()
-        config {
-            install(HttpCache) {
-                publicStorage(publicStorage)
-                privateStorage(privateStorage)
-            }
-        }
-
+        val cache = CacheTestFixtures.modern()
+        config { install(cache) }
         test { client ->
-            val now = GMTDate() + 2000L
-            val url = Url("$TEST_SERVER/cache/expires")
-
-            suspend fun getWithHeader(expires: String): String {
-                delayGMTDate(1)
-
-                return client.get(url) {
-                    header("X-Expires", expires)
-                }.body()
-            }
-
-            val first = getWithHeader(now.toHttpDate())
-            val cache = publicStorage.findAll(url)
-            assertEquals(1, cache.size)
-
-            // this should be from the cache
-            val second = client.get(url).body<String>()
-
-            assertEquals(first, second)
-            delay(2500.milliseconds)
-
-            // now it should be already expired
-            val third = client.get(url).body<String>()
-            assertNotEquals(first, third)
-
-            // illegal values: broken, "0" and blank should be treated as already expired
-            // so shouldn't be cached
-            var previous = third
-            getWithHeader("broken-date").let { result ->
-                assertNotEquals(previous, result)
-                previous = result
-            }
-
-            getWithHeader("0").let { result ->
-                assertNotEquals(previous, result)
-                previous = result
-            }
-
-            getWithHeader(" ").let { result ->
-                assertNotEquals(previous, result)
-                previous = result
-            }
-
-            delayGMTDate(1)
-            val last = client.get(url).body<String>()
-            assertNotEquals(previous, last)
+            testExpiresScenario(
+                cache,
+                client,
+                Url("$TEST_SERVER/cache/expires"),
+                expiresOffset = 2000.milliseconds,
+                expireDelay = 2500.milliseconds,
+            )
         }
     }
 
     @Test
     fun testPublicAndPrivateCache() = clientTests {
-        val publicStorage = CacheStorage.Unlimited()
-        val privateStorage = CacheStorage.Unlimited()
-        config {
-            install(HttpCache) {
-                publicStorage(publicStorage)
-                privateStorage(privateStorage)
-            }
-        }
-
-        test { client ->
-            val privateUrl = Url("$TEST_SERVER/cache/private")
-            val publicUrl = Url("$TEST_SERVER/cache/public")
-
-            suspend fun publicCache() = publicStorage.findAll(publicUrl)
-            suspend fun privateCache() = privateStorage.findAll(privateUrl)
-
-            val firstPrivate = client.get(privateUrl).body<String>()
-            assertEquals(firstPrivate, "private")
-            assertEquals(1, privateCache().size)
-            assertEquals(0, publicCache().size)
-            val privateCacheEntry = privateCache().first()
-
-            val firstPublic = client.get(publicUrl).body<String>()
-            assertEquals(firstPublic, "public")
-            assertEquals(1, publicCache().size)
-            assertEquals(1, privateCache().size)
-            val publicCacheEntry = publicCache().first()
-
-            val secondPrivate = client.get(privateUrl).body<String>()
-            assertEquals(secondPrivate, "private")
-
-            assertSame(privateCacheEntry, privateCache().first())
-
-            // Public from cache.
-            val secondPublic = client.get(publicUrl).body<String>()
-            assertEquals(secondPublic, "public")
-
-            assertEquals(1, privateCache().size)
-            assertEquals(1, publicCache().size)
-
-            assertSame(publicCacheEntry, publicCache().first())
-        }
+        val cache = CacheTestFixtures.modern()
+        config { install(cache) }
+        test { client -> testPublicAndPrivateCacheScenario(cache, client) }
     }
 
     @Test
     fun testWithLogging() = clientTests {
-        val publicStorage = CacheStorage.Unlimited()
-        val privateStorage = CacheStorage.Unlimited()
+        val cache = CacheTestFixtures.modern()
         config {
             install(Logging) {
                 level = LogLevel.ALL
                 logger = Logger.EMPTY
             }
-            install(HttpCache) {
-                publicStorage(publicStorage)
-                privateStorage(privateStorage)
-            }
+            install(cache)
         }
-        test { client ->
-            client.receivePipeline.intercept(HttpReceivePipeline.State) { response ->
-                val savedResponse = response.call.save().response
-                proceedWith(savedResponse)
-            }
-            val result = client.get("$TEST_SERVER/content/chunked-data?size=5000").bodyAsText()
-            assertEquals(5000, result.length)
-        }
+        test { client -> testWithLoggingScenario(client) }
     }
 
     @Test
     fun testCachesPrivateByDefault() = clientTests {
-        val publicStorage = CacheStorage.Unlimited()
-        val privateStorage = CacheStorage.Unlimited()
-        config {
-            install(HttpCache) {
-                publicStorage(publicStorage)
-                privateStorage(privateStorage)
-            }
-        }
+        val cache = CacheTestFixtures.modern()
+        config { install(cache) }
         test { client ->
             val privateUrl = Url("$TEST_SERVER/cache/private")
 
-            suspend fun privateCache() = privateStorage.findAll(privateUrl)
-
             val firstPrivate = client.get(privateUrl).body<String>()
-            assertEquals(firstPrivate, "private")
-            assertEquals(1, privateCache().size)
+            assertEquals("private", firstPrivate)
+            assertEquals(1, cache.privateEntries(privateUrl).size)
         }
     }
 
     @Test
     fun testDoesntCachesPrivateWhenShared() = clientTests {
-        val publicStorage = CacheStorage.Unlimited()
-        val privateStorage = CacheStorage.Unlimited()
-        config {
-            install(HttpCache) {
-                publicStorage(publicStorage)
-                privateStorage(privateStorage)
-                isShared = true
-            }
-        }
+        val cache = CacheTestFixtures.modern()
+        config { install(cache) { isShared = true } }
         test { client ->
             val privateUrl = Url("$TEST_SERVER/cache/private")
 
-            suspend fun privateCache() = privateStorage.findAll(privateUrl)
-
             val firstPrivate = client.get(privateUrl).body<String>()
-            assertEquals(firstPrivate, "private")
-            assertEquals(0, privateCache().size)
+            assertEquals("private", firstPrivate)
+            assertEquals(0, cache.privateEntries(privateUrl).size)
         }
     }
 
@@ -838,12 +290,8 @@ class CacheTest : ClientLoader() {
 
     @Test
     fun testDifferentVaryHeaders() = clientTests {
-        val storage = CacheStorage.Unlimited()
-        config {
-            install(HttpCache) {
-                publicStorage(storage)
-            }
-        }
+        val cache = CacheTestFixtures.modern()
+        config { install(cache) }
 
         test { client ->
             val url = "$TEST_SERVER/cache/different-vary"
@@ -853,46 +301,32 @@ class CacheTest : ClientLoader() {
             val second = client.get(url)
 
             assertEquals(first.bodyAsText(), second.bodyAsText())
-            assertEquals(storage.findAll(Url("$TEST_SERVER/cache/different-vary")).size, 1)
+            assertEquals(1, cache.publicEntries(Url(url)).size)
         }
     }
 
     @Test
-    fun test304WithNewlyAddedVaryHeader() = testWithEngine(MockEngine) {
-        val etag = "\"v1\""
-        val url = Url("https://example.com/x")
-        val publicStorage = CacheStorage.Unlimited()
-        config {
-            install(HttpCache) {
-                publicStorage(publicStorage)
-            }
-            engine {
-                addHandler { request ->
-                    if (request.headers.contains(HttpHeaders.IfNoneMatch)) {
-                        val headers = headersOf(
-                            HttpHeaders.ETag to listOf(etag),
-                            HttpHeaders.Vary to listOf("Origin"),
-                        )
-                        respond("", HttpStatusCode.NotModified, headers)
-                    } else {
-                        val headers = headersOf(
-                            HttpHeaders.ETag to listOf(etag),
-                            HttpHeaders.CacheControl to listOf("max-age=0, must-revalidate"),
-                        )
-                        respond("body", HttpStatusCode.OK, headers)
-                    }
-                }
-            }
-        }
+    fun test304WithNewlyAddedVaryHeader() = mockCacheTest(url = Url("https://example.com/x")) {
+        val etags = listOf(DEFAULT_ETAG)
+        revalidateHandler(
+            initialHeaders = headersOf(
+                HttpHeaders.ETag to etags,
+                HttpHeaders.CacheControl to listOf(REVALIDATE_CACHE_CONTROL),
+            ),
+            notModifiedHeaders = headersOf(
+                HttpHeaders.ETag to etags,
+                HttpHeaders.Vary to listOf("Origin"),
+            ),
+        )
 
-        test { client ->
+        testBody = { client ->
             val first = client.get(url).bodyAsText()
             assertEquals("body", first)
 
             val second = client.get(url).bodyAsText()
             assertEquals("body", second)
 
-            val cached = publicStorage.findAll(url)
+            val cached = fixtures.publicEntries(url)
             assertEquals(1, cached.size)
             assertEquals(mapOf("origin" to ""), cached.single().varyKeys)
             assertEquals("Origin", cached.single().headers[HttpHeaders.Vary])
@@ -900,122 +334,123 @@ class CacheTest : ClientLoader() {
     }
 
     @Test
-    fun test304WithoutVaryMatchesByEtag() = testWithEngine(MockEngine) {
-        val etag = "\"v1\""
-        val url = Url("https://example.com/x")
-        val publicStorage = CacheStorage.Unlimited()
-        config {
-            install(HttpCache) {
-                publicStorage(publicStorage)
-            }
-            engine {
-                addHandler { request ->
-                    if (request.headers.contains(HttpHeaders.IfNoneMatch)) {
-                        // The server omits Vary in the 304 but provides a matching validator.
-                        // The cached entry must be found by its ETag instead of failing with
-                        // InvalidCacheStateException.
-                        respond("", HttpStatusCode.NotModified, headersOf(HttpHeaders.ETag, etag))
-                    } else {
-                        val headers = headersOf(
-                            HttpHeaders.ETag to listOf(etag),
-                            HttpHeaders.Vary to listOf("Origin"),
-                            HttpHeaders.CacheControl to listOf("max-age=0, must-revalidate"),
-                        )
-                        respond("body", HttpStatusCode.OK, headers)
-                    }
-                }
-            }
-        }
+    fun test304HopByHopHeadersAreNotMerged() = mockCacheTest(url = Url("https://example.com/hop-by-hop")) {
+        revalidateHandler(
+            initialBody = "data",
+            initialHeaders = defaultRevalidateInitialHeaders(
+                extra = headersOf("X-Custom" to listOf("original")),
+            ),
+            notModifiedHeaders = hopByHop304Headers(),
+        )
+        testBody = { client ->
+            val first = client.get(url)
+            assertEquals("data", first.bodyAsText())
+            assertEquals(REVALIDATE_CACHE_CONTROL, first.headers[HttpHeaders.CacheControl])
+            assertEquals("original", first.headers["X-Custom"])
 
-        test { client ->
-            val first = client.get(url).bodyAsText()
-            assertEquals("body", first)
+            val second = client.get(url)
+            assertEquals("data", second.bodyAsText())
+            assertEquals("max-age=120", second.headers[HttpHeaders.CacheControl])
+            assertEquals("original", second.headers["X-Custom"])
+            assertHopByHopAbsent(second.headers)
 
-            // Triggers a conditional request that gets a 304 without the Vary header.
-            // Should not throw and should reply from cache.
-            val second = client.get(url).bodyAsText()
-            assertEquals("body", second)
-
-            assertEquals(1, publicStorage.findAll(url).size)
+            val cached = fixtures.publicEntries(url)
+            assertEquals(1, cached.size)
+            assertEquals("max-age=120", cached.single().headers[HttpHeaders.CacheControl])
+            assertNull(cached.single().headers[HttpHeaders.Connection])
+            assertNull(cached.single().headers["Foo"])
         }
     }
 
     @Test
-    fun test304WithoutValidatorMatchesSingleStoredResponse() = testWithEngine(MockEngine) {
-        val url = Url("https://example.com/x")
-        val publicStorage = CacheStorage.Unlimited()
-        config {
-            install(HttpCache) {
-                publicStorage(publicStorage)
-            }
-            engine {
-                addHandler { request ->
-                    if (request.headers.contains(HttpHeaders.IfModifiedSince)) {
-                        // 304 carries no validator at all (no ETag, no Last-Modified).
-                        // Per RFC 9111 §4.3.4, since there is a single stored response that
-                        // also lacks a validator, that response is identified for update.
-                        respond("", HttpStatusCode.NotModified)
-                    } else {
-                        val headers = headersOf(
-                            HttpHeaders.LastModified to listOf("Mon, 01 Jan 2024 00:00:00 GMT"),
-                            HttpHeaders.CacheControl to listOf("max-age=0, must-revalidate"),
-                        )
-                        respond("body", HttpStatusCode.OK, headers)
-                    }
-                }
-            }
+    fun testHopByHopHeadersAreNotStoredOnInitialCache() = mockCacheTest(
+        url = Url("https://example.com/store-hop-by-hop")
+    ) {
+        handler = {
+            respond(
+                "data",
+                HttpStatusCode.OK,
+                hopByHopOkHeaders(extra = headersOf("X-Custom" to listOf("original")), includeProxyAuth = true),
+            )
         }
+        testBody = { client ->
+            val first = client.get(url)
+            assertEquals("data", first.bodyAsText())
+            assertEquals("original", first.headers["X-Custom"])
+            assertEquals("4", first.headers[HttpHeaders.ContentLength])
+            assertHopByHopAbsent(first.headers, includeProxyAuth = true)
 
-        test { client ->
-            val first = client.get(url).bodyAsText()
-            assertEquals("body", first)
+            val cached = fixtures.publicEntries(url)
+            assertEquals(1, cached.size)
+            assertEquals("original", cached.single().headers["X-Custom"])
+            assertEquals("4", cached.single().headers[HttpHeaders.ContentLength])
+            assertNull(cached.single().headers[HttpHeaders.Connection])
+            assertNull(cached.single().headers["Foo"])
 
-            // The 304 has no validator, but the single stored response is freshened.
-            val second = client.get(url).bodyAsText()
-            assertEquals("body", second)
-
-            assertEquals(1, publicStorage.findAll(url).size)
+            val second = client.get(url)
+            assertEquals("data", second.bodyAsText())
+            assertNull(second.headers[HttpHeaders.Connection])
+            assertEquals("4", second.headers[HttpHeaders.ContentLength])
         }
     }
 
     @Test
-    fun test304WithoutValidatorIsNotMatchedWhenMultipleStoredResponses() = testWithEngine(MockEngine) {
-        val url = Url("https://example.com/x")
-        val publicStorage = CacheStorage.Unlimited()
-        config {
-            install(HttpCache) {
-                publicStorage(publicStorage)
-            }
-            engine {
-                addHandler { request ->
-                    if (request.headers.contains(HttpHeaders.IfModifiedSince)) {
-                        // 304 with no validator while several variants are stored:
-                        // the lenient single-entry rule must NOT apply.
-                        respond("", HttpStatusCode.NotModified)
-                    } else {
-                        val variant = request.headers[HttpHeaders.AcceptLanguage] ?: "default"
-                        val headers = headersOf(
-                            HttpHeaders.LastModified to listOf("Mon, 01 Jan 2024 00:00:00 GMT"),
-                            HttpHeaders.Vary to listOf(HttpHeaders.AcceptLanguage),
-                            HttpHeaders.CacheControl to listOf("max-age=0, must-revalidate"),
-                        )
-                        respond(variant, HttpStatusCode.OK, headers)
-                    }
-                }
+    fun test304WithoutVaryMatchesByEtag() = mockCacheTest(url = Url("https://example.com/x")) {
+        revalidateHandler(
+            initialHeaders = defaultRevalidateInitialHeaders(
+                extra = headersOf(HttpHeaders.Vary to listOf("Origin")),
+            ),
+            notModifiedHeaders = headersOf(HttpHeaders.ETag, DEFAULT_ETAG),
+        )
+        testBody = { client -> test304WithoutVaryMatchesByEtagScenario(fixtures, client, url) }
+    }
+
+    @Test
+    fun test304WithoutValidatorMatchesSingleStoredResponse() = mockCacheTest(url = Url("https://example.com/x")) {
+        revalidateHandler(
+            match = RevalidationMatch.LastModified,
+            initialHeaders = defaultRevalidateInitialHeaders(match = RevalidationMatch.LastModified),
+            notModifiedHeaders = headersOf(HttpHeaders.CacheControl, "max-age=120"),
+        )
+        testBody = { client ->
+            val first = client.get(url)
+            assertEquals("body", first.bodyAsText())
+            assertEquals(REVALIDATE_CACHE_CONTROL, first.headers[HttpHeaders.CacheControl])
+
+            val second = client.get(url)
+            assertEquals("body", second.bodyAsText())
+            assertEquals("max-age=120", second.headers[HttpHeaders.CacheControl])
+
+            val cached = fixtures.publicEntries(url)
+            assertEquals(1, cached.size)
+            assertEquals("max-age=120", cached.single().headers[HttpHeaders.CacheControl])
+        }
+    }
+
+    @Test
+    fun test304WithoutValidatorIsNotMatchedWhenMultipleStoredResponses() = mockCacheTest(
+        url = Url("https://example.com/x")
+    ) {
+        handler = { request ->
+            if (HttpHeaders.IfModifiedSince !in request.headers) {
+                val variant = request.headers[HttpHeaders.AcceptLanguage] ?: "default"
+                val headers = headersOf(
+                    HttpHeaders.LastModified to listOf(DEFAULT_LAST_MODIFIED),
+                    HttpHeaders.Vary to listOf(HttpHeaders.AcceptLanguage),
+                    HttpHeaders.CacheControl to listOf(REVALIDATE_CACHE_CONTROL),
+                )
+                respond(variant, HttpStatusCode.OK, headers)
+            } else {
+                respond("", HttpStatusCode.NotModified)
             }
         }
-
-        test { client ->
-            // Store two different variants, so more than one stored response exists for the URL.
+        testBody = { client ->
             val en = client.get(url) { header(HttpHeaders.AcceptLanguage, "en") }.bodyAsText()
             val es = client.get(url) { header(HttpHeaders.AcceptLanguage, "es") }.bodyAsText()
             assertEquals("en", en)
             assertEquals("es", es)
-            assertEquals(2, publicStorage.findAll(url).size)
+            assertEquals(2, fixtures.publicEntries(url).size)
 
-            // Revalidate cached variants; the 304 has no validator and multiple stored
-            // responses exist, so the lenient single-entry rule must not apply — each
-            // response is matched by its request Vary keys instead.
             val enAgain = client.get(url) { header(HttpHeaders.AcceptLanguage, "en") }.bodyAsText()
             assertEquals("en", enAgain)
 
@@ -1026,14 +461,8 @@ class CacheTest : ClientLoader() {
 
     @Test
     fun testVaryHeader() = clientTests {
-        val publicStorage = CacheStorage.Unlimited()
-        val privateStorage = CacheStorage.Unlimited()
-        config {
-            install(HttpCache) {
-                publicStorage(publicStorage)
-                privateStorage(privateStorage)
-            }
-        }
+        val cache = CacheTestFixtures.modern()
+        config { install(cache) }
 
         test { client ->
             val url = Url("$TEST_SERVER/cache/vary-header")
@@ -1046,20 +475,13 @@ class CacheTest : ClientLoader() {
                 header("Accept", "application/cbor")
             }
 
-            assertEquals(2, publicStorage.findAll(url).size)
+            assertEquals(2, cache.publicEntries(url).size)
         }
     }
 
     @Test
     fun testCaseSensitiveInVary() = clientTests {
-        val publicStorage = CacheStorage.Unlimited()
-        val privateStorage = CacheStorage.Unlimited()
-        config {
-            install(HttpCache) {
-                publicStorage(publicStorage)
-                privateStorage(privateStorage)
-            }
-        }
+        config { install(cache = CacheTestFixtures.modern()) }
 
         test { client ->
             val url = Url("$TEST_SERVER/cache/vary-header-case-sensitive")
@@ -1087,27 +509,5 @@ class CacheTest : ClientLoader() {
             assertEquals("2", response2)
             assertEquals("2", response3)
         }
-    }
-
-    /**
-     * Does delay and ensures that the [GMTDate] measurements report at least
-     * the specified number of [milliseconds].
-     * The reason why it's not the same is that on some platforms time granularity of GMTDate
-     * is not that high and could be even larger than a millisecond.
-     */
-    private suspend fun delayGMTDate(milliseconds: Long) {
-        var delayValue = milliseconds
-
-        do {
-            val start = GMTDate()
-            delay(delayValue.milliseconds)
-            val end = GMTDate()
-            if (end > start + milliseconds) {
-                break
-            }
-            if (delayValue != 1L) {
-                delayValue = 1L
-            }
-        } while (true)
     }
 }

--- a/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/plugins/CacheTestUtils.kt
+++ b/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/plugins/CacheTestUtils.kt
@@ -410,7 +410,7 @@ internal suspend fun testMaxStaleScenario(cache: CacheTestFixtures, client: Http
     val staleMaxInt = client.get(url) {
         header(HttpHeaders.CacheControl, "max-stale=${Int.MAX_VALUE}")
     }
-    assertEquals("110", stale.headers[HttpHeaders.Warning])
+    assertEquals("110", staleMaxInt.headers[HttpHeaders.Warning])
     val staleMaxIntBody = staleMaxInt.body<String>()
     assertEquals(original, staleMaxIntBody)
 
@@ -521,7 +521,7 @@ internal suspend fun testPublicAndPrivateCacheScenario(cache: CacheTestFixtures,
     val firstPrivate = client.get(privateUrl).body<String>()
     assertEquals("private", firstPrivate)
     assertEquals(1, cache.privateEntries(privateUrl).size)
-    assertEquals(0, cache.publicEntries(publicUrl).size)
+    assertEquals(0, cache.publicEntries(privateUrl).size)
     val privateCacheEntry = cache.privateEntries(privateUrl).first().raw
 
     val firstPublic = client.get(publicUrl).body<String>()

--- a/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/plugins/CacheTestUtils.kt
+++ b/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/plugins/CacheTestUtils.kt
@@ -1,0 +1,564 @@
+/*
+ * Copyright 2014-2026 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+@file:Suppress("DEPRECATION", "DEPRECATION_ERROR")
+
+package io.ktor.client.tests.plugins
+
+import io.ktor.client.*
+import io.ktor.client.call.*
+import io.ktor.client.engine.mock.*
+import io.ktor.client.plugins.cache.*
+import io.ktor.client.plugins.cache.storage.*
+import io.ktor.client.request.*
+import io.ktor.client.statement.*
+import io.ktor.client.test.base.*
+import io.ktor.client.utils.*
+import io.ktor.http.*
+import io.ktor.util.*
+import io.ktor.util.date.*
+import io.ktor.utils.io.*
+import kotlinx.coroutines.*
+import kotlin.test.*
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
+import io.ktor.client.plugins.cache.HttpCache.Config as HttpCacheConfig
+
+internal const val REVALIDATE_CACHE_CONTROL = "max-age=0, must-revalidate"
+internal const val DEFAULT_ETAG = "\"v1\""
+internal const val DEFAULT_LAST_MODIFIED = "Mon, 01 Jan 2024 00:00:00 GMT"
+
+enum class CacheStorageKind {
+    Modern,
+    Legacy,
+}
+
+enum class RevalidationMatch {
+    ETag,
+    LastModified,
+}
+
+data class CacheEntryProbe(
+    val headers: Headers,
+    val varyKeys: Map<String, String>,
+    val raw: Any,
+)
+
+class CacheEntriesProbe(
+    private val entries: List<CacheEntryProbe>,
+) {
+    val size: Int get() = entries.size
+
+    fun isEmpty(): Boolean = entries.isEmpty()
+
+    fun single(): CacheEntryProbe = entries.single()
+
+    fun first(): CacheEntryProbe = entries.first()
+}
+
+class CacheTestFixtures private constructor(
+    val kind: CacheStorageKind,
+    internal val publicModern: CacheStorage?,
+    internal val privateModern: CacheStorage?,
+    internal val publicLegacy: HttpCacheStorage?,
+    internal val privateLegacy: HttpCacheStorage?,
+) {
+    companion object {
+        fun modern(): CacheTestFixtures = CacheTestFixtures(
+            kind = CacheStorageKind.Modern,
+            publicModern = CacheStorage.Unlimited(),
+            privateModern = CacheStorage.Unlimited(),
+            publicLegacy = null,
+            privateLegacy = null,
+        )
+
+        fun legacy(): CacheTestFixtures = CacheTestFixtures(
+            kind = CacheStorageKind.Legacy,
+            publicModern = null,
+            privateModern = null,
+            publicLegacy = HttpCacheStorage.Unlimited(),
+            privateLegacy = HttpCacheStorage.Unlimited(),
+        )
+    }
+
+    suspend fun publicEntries(url: Url): CacheEntriesProbe = when (kind) {
+        CacheStorageKind.Modern -> CacheEntriesProbe(
+            publicModern!!.findAll(url).map { it.toProbe() },
+        )
+
+        CacheStorageKind.Legacy -> CacheEntriesProbe(
+            publicLegacy!!.findByUrl(url).map { it.toProbe() },
+        )
+    }
+
+    suspend fun privateEntries(url: Url): CacheEntriesProbe = when (kind) {
+        CacheStorageKind.Modern -> CacheEntriesProbe(
+            privateModern!!.findAll(url).map { it.toProbe() },
+        )
+
+        CacheStorageKind.Legacy -> CacheEntriesProbe(
+            privateLegacy!!.findByUrl(url).map { it.toProbe() },
+        )
+    }
+}
+
+fun HttpClientConfig<*>.install(cache: CacheTestFixtures, configure: HttpCacheConfig.() -> Unit = {}) {
+    install(HttpCache) {
+        when (cache.kind) {
+            CacheStorageKind.Modern -> {
+                publicStorage(cache.publicModern!!)
+                privateStorage(cache.privateModern!!)
+            }
+
+            CacheStorageKind.Legacy -> {
+                publicStorage = cache.publicLegacy!!
+                privateStorage = cache.privateLegacy!!
+            }
+        }
+        configure()
+    }
+}
+
+private fun CachedResponseData.toProbe(): CacheEntryProbe = CacheEntryProbe(headers, varyKeys, raw = this)
+
+private fun HttpCacheEntry.toProbe(): CacheEntryProbe = CacheEntryProbe(response.headers, varyKeys, raw = this)
+
+internal class FakeResponse {
+    var content: String = ""
+    var status: HttpStatusCode = HttpStatusCode.OK
+    var headers: Headers = headersOf()
+}
+
+internal class MockCacheTestScope(
+    val url: Url,
+    val fixtures: CacheTestFixtures,
+) {
+    lateinit var handler: suspend MockRequestHandleScope.(HttpRequestData) -> HttpResponseData
+    var testBody: suspend CoroutineScope.(HttpClient) -> Unit = {}
+}
+
+internal fun mockCacheTest(
+    url: Url = Url("https://example.com/test"),
+    fixtures: CacheTestFixtures = CacheTestFixtures.modern(),
+    configureCache: HttpCacheConfig.() -> Unit = {},
+    block: MockCacheTestScope.() -> Unit,
+) = testWithEngine(MockEngine) {
+    val scope = MockCacheTestScope(url, fixtures).apply(block)
+
+    config {
+        install(fixtures, configureCache)
+        engine {
+            addHandler { request -> scope.handler(this, request) }
+        }
+    }
+
+    test { client -> scope.testBody(this, client) }
+}
+
+internal fun defaultRevalidateInitialHeaders(
+    etag: String = DEFAULT_ETAG,
+    lastModified: String = DEFAULT_LAST_MODIFIED,
+    match: RevalidationMatch = RevalidationMatch.ETag,
+    extra: Headers = headersOf(),
+): Headers = buildHeaders {
+    when (match) {
+        RevalidationMatch.ETag -> append(HttpHeaders.ETag, etag)
+        RevalidationMatch.LastModified -> append(HttpHeaders.LastModified, lastModified)
+    }
+    append(HttpHeaders.CacheControl, REVALIDATE_CACHE_CONTROL)
+    extra.forEach { name, values -> appendAll(name, values) }
+}
+
+internal fun MockCacheTestScope.revalidateHandler(
+    match: RevalidationMatch = RevalidationMatch.ETag,
+    etag: String = DEFAULT_ETAG,
+    lastModified: String = DEFAULT_LAST_MODIFIED,
+    initialBody: String = "body",
+    initialHeaders: Headers = defaultRevalidateInitialHeaders(etag, lastModified, match),
+    notModifiedHeaders: Headers = headersOf(),
+) {
+    handler = { request ->
+        val isRevalidation = when (match) {
+            RevalidationMatch.ETag -> HttpHeaders.IfNoneMatch in request.headers
+            RevalidationMatch.LastModified -> HttpHeaders.IfModifiedSince in request.headers
+        }
+        if (isRevalidation) {
+            respond("", HttpStatusCode.NotModified, notModifiedHeaders)
+        } else {
+            respond(initialBody, HttpStatusCode.OK, initialHeaders)
+        }
+    }
+}
+
+internal fun hopByHopHeaderValues(includeProxyAuth: Boolean = false): Headers = buildHeaders {
+    append(HttpHeaders.Connection, "close, Foo")
+    append(HttpHeaders.TransferEncoding, "chunked")
+    append("Keep-Alive", "timeout=5")
+    append("Proxy-Connection", "keep-alive")
+    append(HttpHeaders.TE, "trailers")
+    append(HttpHeaders.Upgrade, "websocket")
+    append(HttpHeaders.ContentRange, "bytes 0-0/100")
+    append("Foo", "bar")
+    if (includeProxyAuth) {
+        append(HttpHeaders.ProxyAuthenticate, "Basic")
+    }
+}
+
+internal fun hopByHop304Headers(etag: String = DEFAULT_ETAG): Headers = buildHeaders {
+    append(HttpHeaders.ETag, etag)
+    append(HttpHeaders.CacheControl, "max-age=120")
+    hopByHopHeaderValues().forEach { name, values -> appendAll(name, values) }
+}
+
+internal fun hopByHopOkHeaders(
+    etag: String = DEFAULT_ETAG,
+    cacheControl: String = "max-age=60",
+    contentLength: String? = "4",
+    extra: Headers = headersOf(),
+    includeProxyAuth: Boolean = false,
+): Headers = buildHeaders {
+    append(HttpHeaders.ETag, etag)
+    append(HttpHeaders.CacheControl, cacheControl)
+    if (contentLength != null) {
+        append(HttpHeaders.ContentLength, contentLength)
+    }
+    hopByHopHeaderValues(includeProxyAuth).forEach { name, values -> appendAll(name, values) }
+    extra.forEach { name, values -> appendAll(name, values) }
+}
+
+internal fun assertHopByHopAbsent(headers: Headers, includeProxyAuth: Boolean = false) {
+    assertNull(headers[HttpHeaders.Connection])
+    assertNull(headers[HttpHeaders.TransferEncoding])
+    assertNull(headers["Keep-Alive"])
+    assertNull(headers["Proxy-Connection"])
+    assertNull(headers[HttpHeaders.TE])
+    assertNull(headers[HttpHeaders.Upgrade])
+    assertNull(headers[HttpHeaders.ContentRange])
+    assertNull(headers["Foo"])
+    if (includeProxyAuth) {
+        assertNull(headers[HttpHeaders.ProxyAuthenticate])
+    }
+}
+
+/**
+ * Does delay and ensures that the [GMTDate] measurements report at least
+ * the specified number of [milliseconds].
+ */
+internal suspend fun delayGMTDate(milliseconds: Long) {
+    var delayValue = milliseconds
+
+    do {
+        val start = GMTDate()
+        delay(delayValue.milliseconds)
+        val end = GMTDate()
+        if (end > start + milliseconds) {
+            break
+        }
+        if (delayValue != 1L) {
+            delayValue = 1L
+        }
+    } while (true)
+}
+
+internal suspend fun testNoStoreScenario(cache: CacheTestFixtures, client: HttpClient, url: Url) {
+    val first = client.get(url).body<String>()
+    assertTrue(cache.privateEntries(url).isEmpty())
+    assertTrue(cache.publicEntries(url).isEmpty())
+
+    val second = client.get(url).body<String>()
+    assertTrue(cache.privateEntries(url).isEmpty())
+    assertTrue(cache.publicEntries(url).isEmpty())
+
+    assertNotEquals(first, second)
+}
+
+internal suspend fun testNoCacheScenario(cache: CacheTestFixtures, client: HttpClient, url: Url) {
+    val first = client.get(url).body<String>()
+    assertEquals(1, cache.publicEntries(url).size)
+    assertEquals(0, cache.privateEntries(url).size)
+
+    val second = client.get(url).body<String>()
+    assertEquals(1, cache.publicEntries(url).size)
+    assertEquals(0, cache.privateEntries(url).size)
+
+    assertNotEquals(first, second)
+}
+
+internal suspend fun testETagCacheScenario(cache: CacheTestFixtures, client: HttpClient, url: Url) {
+    val first = client.get(url).body<String>()
+    assertEquals(1, cache.publicEntries(url).size)
+
+    val second = client.get(url).body<String>()
+    assertEquals(1, cache.publicEntries(url).size)
+
+    assertEquals(first, second)
+}
+
+internal suspend fun testVaryScenario(client: HttpClient, url: Url) {
+    val first = client.get(url) {
+        header(HttpHeaders.ContentLanguage, "en")
+    }.bodyAsText()
+
+    val second = client.get(url) {
+        header(HttpHeaders.ContentLanguage, "en")
+    }.bodyAsText()
+
+    assertEquals(first, second)
+
+    val third = client.get(url) {
+        header(HttpHeaders.ContentLanguage, "ru")
+    }.bodyAsText()
+
+    assertNotEquals(third, second)
+
+    val fourth = client.get(url) {
+        header(HttpHeaders.ContentLanguage, "ru")
+    }.bodyAsText()
+
+    assertEquals(third, fourth)
+
+    val fifth = client.get(url) {
+        header(HttpHeaders.ContentLanguage, "en")
+    }.bodyAsText()
+
+    assertEquals(first, fifth)
+
+    val sixth = client.get(url).bodyAsText()
+
+    assertNotEquals(sixth, second)
+    assertNotEquals(sixth, third)
+
+    val seventh = client.get(url).bodyAsText()
+
+    assertEquals(sixth, seventh)
+}
+
+@OptIn(InternalAPI::class)
+internal fun setupNoVaryIn304Client(client: HttpClient) {
+    client.receivePipeline.intercept(HttpReceivePipeline.Before) { response ->
+        if (response.status != HttpStatusCode.NotModified) {
+            return@intercept
+        }
+        val headers = buildHeaders {
+            response.headers
+                .filter { name, _ -> !name.equals(HttpHeaders.Vary, ignoreCase = true) }
+                .forEach(::appendAll)
+        }
+        proceedWith(
+            object : HttpResponse() {
+                override val call get() = response.call
+                override val rawContent get() = response.rawContent
+                override val coroutineContext get() = response.coroutineContext
+                override val headers = headers
+                override val requestTime get() = response.requestTime
+                override val responseTime get() = response.responseTime
+                override val status get() = response.status
+                override val version get() = response.version
+            }
+        )
+    }
+}
+
+internal suspend fun testNoVaryIn304Scenario(client: HttpClient, url: Url) {
+    setupNoVaryIn304Client(client)
+    testVaryScenario(client, url)
+}
+
+internal suspend fun testMaxAgeScenario(cache: CacheTestFixtures, client: HttpClient, url: Url) {
+    val first = client.get(url).body<String>()
+    assertEquals(1, cache.publicEntries(url).size)
+
+    val second = client.get(url).body<String>()
+
+    assertEquals(first, second)
+    delay(2500.milliseconds)
+
+    val third = client.get(url).body<String>()
+    assertNotEquals(first, third)
+}
+
+internal suspend fun testOnlyIfCachedScenario(client: HttpClient, url: Url) {
+    val responseNoCache = client.get(url) {
+        header(HttpHeaders.CacheControl, "only-if-cached")
+    }
+    assertEquals(HttpStatusCode.GatewayTimeout, responseNoCache.status)
+
+    val bodyOriginal = client.get(url).bodyAsText()
+
+    val responseCached = client.get(url) {
+        header(HttpHeaders.CacheControl, "only-if-cached")
+    }
+    val bodyCached = responseCached.bodyAsText()
+    assertEquals(HttpStatusCode.OK, responseCached.status)
+    assertEquals(bodyOriginal, bodyCached)
+}
+
+internal suspend fun testMaxStaleScenario(cache: CacheTestFixtures, client: HttpClient, url: Url) {
+    val original = client.get(url).body<String>()
+    assertEquals(1, cache.publicEntries(url).size)
+
+    delay(2500.milliseconds)
+
+    val stale = client.get(url) {
+        header(HttpHeaders.CacheControl, "max-stale=4")
+    }
+    assertEquals("110", stale.headers[HttpHeaders.Warning])
+    val staleBody = stale.body<String>()
+    assertEquals(original, staleBody)
+
+    val staleMaxInt = client.get(url) {
+        header(HttpHeaders.CacheControl, "max-stale=${Int.MAX_VALUE}")
+    }
+    assertEquals("110", stale.headers[HttpHeaders.Warning])
+    val staleMaxIntBody = staleMaxInt.body<String>()
+    assertEquals(original, staleMaxIntBody)
+
+    val notStale = client.get(url)
+    val notStaleBody = notStale.body<String>()
+    assertNull(notStale.headers[HttpHeaders.Warning])
+    assertNotEquals(original, notStaleBody)
+}
+
+internal suspend fun testNoStoreRequestScenario(cache: CacheTestFixtures, client: HttpClient, url: Url) {
+    val first = client.get(url) {
+        header(HttpHeaders.CacheControl, "no-store")
+    }.body<String>()
+    assertEquals(0, cache.publicEntries(url).size)
+
+    val second = client.get(url).body<String>()
+    assertEquals(1, cache.publicEntries(url).size)
+
+    assertNotEquals(first, second)
+}
+
+internal suspend fun testNoCacheRequestScenario(cache: CacheTestFixtures, client: HttpClient, url: Url) {
+    var requestsCount = 0
+    client.sendPipeline.intercept(HttpSendPipeline.Engine) {
+        requestsCount++
+    }
+
+    val first = client.get(url).body<String>()
+    assertEquals(1, cache.publicEntries(url).size)
+
+    val second = client.get(url) {
+        header(HttpHeaders.CacheControl, "no-cache")
+    }.body<String>()
+    assertEquals(1, cache.publicEntries(url).size)
+
+    assertEquals(2, requestsCount)
+    assertEquals(first, second)
+}
+
+internal suspend fun testRequestWithMaxAge0Scenario(cache: CacheTestFixtures, client: HttpClient, url: Url) {
+    var requestsCount = 0
+    client.sendPipeline.intercept(HttpSendPipeline.Engine) {
+        requestsCount++
+    }
+
+    val first = client.get(url).body<String>()
+    assertEquals(1, cache.publicEntries(url).size)
+
+    val second = client.get(url) {
+        header(HttpHeaders.CacheControl, "max-age=0")
+    }.body<String>()
+    assertEquals(1, cache.publicEntries(url).size)
+
+    assertEquals(2, requestsCount)
+    assertEquals(first, second)
+}
+
+internal suspend fun testExpiresScenario(
+    cache: CacheTestFixtures,
+    client: HttpClient,
+    url: Url,
+    expiresOffset: Duration,
+    expireDelay: Duration,
+) {
+    val now = GMTDate() + expiresOffset
+
+    suspend fun getWithHeader(expires: String): String {
+        delayGMTDate(1)
+        return client.get(url) { header("X-Expires", expires) }.body()
+    }
+
+    val first = getWithHeader(now.toHttpDate())
+    assertEquals(1, cache.publicEntries(url).size)
+
+    val second = client.get(url).body<String>()
+
+    assertEquals(first, second)
+    delay(expireDelay)
+
+    val third = client.get(url).body<String>()
+    assertNotEquals(first, third)
+
+    var previous = third
+    getWithHeader("broken-date").let { result ->
+        assertNotEquals(previous, result)
+        previous = result
+    }
+
+    getWithHeader("0").let { result ->
+        assertNotEquals(previous, result)
+        previous = result
+    }
+
+    getWithHeader(" ").let { result ->
+        assertNotEquals(previous, result)
+        previous = result
+    }
+
+    delayGMTDate(1)
+    val last = client.get(url).body<String>()
+    assertNotEquals(previous, last)
+}
+
+internal suspend fun testPublicAndPrivateCacheScenario(cache: CacheTestFixtures, client: HttpClient) {
+    val privateUrl = Url("$TEST_SERVER/cache/private")
+    val publicUrl = Url("$TEST_SERVER/cache/public")
+
+    val firstPrivate = client.get(privateUrl).body<String>()
+    assertEquals("private", firstPrivate)
+    assertEquals(1, cache.privateEntries(privateUrl).size)
+    assertEquals(0, cache.publicEntries(publicUrl).size)
+    val privateCacheEntry = cache.privateEntries(privateUrl).first().raw
+
+    val firstPublic = client.get(publicUrl).body<String>()
+    assertEquals("public", firstPublic)
+    assertEquals(1, cache.publicEntries(publicUrl).size)
+    assertEquals(1, cache.privateEntries(privateUrl).size)
+    val publicCacheEntry = cache.publicEntries(publicUrl).first().raw
+
+    val secondPrivate = client.get(privateUrl).body<String>()
+    assertEquals("private", secondPrivate)
+
+    assertSame(privateCacheEntry, cache.privateEntries(privateUrl).first().raw)
+
+    val secondPublic = client.get(publicUrl).body<String>()
+    assertEquals("public", secondPublic)
+
+    assertEquals(1, cache.privateEntries(privateUrl).size)
+    assertEquals(1, cache.publicEntries(publicUrl).size)
+
+    assertSame(publicCacheEntry, cache.publicEntries(publicUrl).first().raw)
+}
+
+internal suspend fun testWithLoggingScenario(client: HttpClient) {
+    client.receivePipeline.intercept(HttpReceivePipeline.State) { response ->
+        val savedResponse = response.call.save().response
+        proceedWith(savedResponse)
+    }
+    val result = client.get("$TEST_SERVER/content/chunked-data?size=5000").bodyAsText()
+    assertEquals(5000, result.length)
+}
+
+internal suspend fun test304WithoutVaryMatchesByEtagScenario(cache: CacheTestFixtures, client: HttpClient, url: Url) {
+    val first = client.get(url).bodyAsText()
+    assertEquals("body", first)
+
+    val second = client.get(url).bodyAsText()
+    assertEquals("body", second)
+
+    assertEquals(1, cache.publicEntries(url).size)
+}

--- a/ktor-utils/common/src/io/ktor/util/collections/ConcurrentSet.kt
+++ b/ktor-utils/common/src/io/ktor/util/collections/ConcurrentSet.kt
@@ -20,7 +20,7 @@ public fun <Key : Any> ConcurrentSet(): MutableSet<Key> = object : MutableSet<Ke
     }
 
     override fun addAll(elements: Collection<Key>): Boolean =
-        fold(false) { modified, element -> add(element) || modified }
+        elements.fold(false) { modified, element -> add(element) || modified }
 
     override fun clear() {
         delegate.clear()
@@ -44,7 +44,7 @@ public fun <Key : Any> ConcurrentSet(): MutableSet<Key> = object : MutableSet<Ke
     override fun remove(element: Key): Boolean = delegate.remove(element) != null
 
     override fun removeAll(elements: Collection<Key>): Boolean =
-        fold(false) { modified, element -> remove(element) || modified }
+        elements.fold(false) { modified, element -> remove(element) || modified }
 
     override fun retainAll(elements: Collection<Key>): Boolean {
         val removeList = mutableSetOf<Key>()

--- a/ktor-utils/common/src/io/ktor/util/collections/ConcurrentSet.kt
+++ b/ktor-utils/common/src/io/ktor/util/collections/ConcurrentSet.kt
@@ -14,22 +14,37 @@ public fun <Key : Any> ConcurrentSet(): MutableSet<Key> = object : MutableSet<Ke
     private val delegate = ConcurrentMap<Key, Unit>()
 
     override fun add(element: Key): Boolean {
-        if (delegate.containsKey(element)) return false
-        delegate[element] = Unit
-        return true
+        var added = false
+        delegate.computeIfAbsent(element) { added = true }
+        return added
     }
 
-    override fun addAll(elements: Collection<Key>): Boolean = elements.all { add(it) }
+    override fun addAll(elements: Collection<Key>): Boolean =
+        fold(false) { modified, element -> add(element) || modified }
 
     override fun clear() {
         delegate.clear()
     }
 
-    override fun iterator(): MutableIterator<Key> = delegate.keys.iterator()
+    override fun iterator(): MutableIterator<Key> = object : MutableIterator<Key> {
+        private val keys = delegate.keys.iterator()
+        private var current: Key? = null
+
+        override fun hasNext(): Boolean = keys.hasNext()
+
+        override fun next(): Key = keys.next().also { current = it }
+
+        override fun remove() {
+            val key = current ?: error("next() has not been called")
+            delegate.remove(key)
+            current = null
+        }
+    }
 
     override fun remove(element: Key): Boolean = delegate.remove(element) != null
 
-    override fun removeAll(elements: Collection<Key>): Boolean = elements.all { remove(it) }
+    override fun removeAll(elements: Collection<Key>): Boolean =
+        fold(false) { modified, element -> remove(element) || modified }
 
     override fun retainAll(elements: Collection<Key>): Boolean {
         val removeList = mutableSetOf<Key>()
@@ -45,7 +60,7 @@ public fun <Key : Any> ConcurrentSet(): MutableSet<Key> = object : MutableSet<Ke
 
     override fun contains(element: Key): Boolean = delegate.containsKey(element)
 
-    override fun containsAll(elements: Collection<Key>): Boolean = elements.containsAll(delegate.keys)
+    override fun containsAll(elements: Collection<Key>): Boolean = elements.all { contains(it) }
 
     override fun isEmpty(): Boolean = delegate.isEmpty()
 }

--- a/ktor-utils/common/test/io/ktor/util/collections/ConcurrentSetTest.kt
+++ b/ktor-utils/common/test/io/ktor/util/collections/ConcurrentSetTest.kt
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2014-2026 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.util.collections
+
+import kotlin.test.*
+
+class ConcurrentSetTest {
+
+    @Test
+    fun `add remove and clear`() {
+        val set = ConcurrentSet<String>()
+
+        assertTrue(set.add("a"))
+        assertFalse(set.add("a"))
+        assertEquals(1, set.size)
+        assertTrue(set.contains("a"))
+
+        assertTrue(set.remove("a"))
+        assertFalse(set.remove("a"))
+        assertTrue(set.isEmpty())
+
+        assertTrue(set.addAll(listOf("x", "y")))
+        set.clear()
+        assertTrue(set.isEmpty())
+    }
+
+    @Test
+    fun `addAll returns true when set was modified`() {
+        val set = ConcurrentSet<String>()
+        assertTrue(set.addAll(listOf("existing")))
+        assertTrue(set.addAll(listOf("existing", "new")))
+        assertEquals(setOf("existing", "new"), set.toSet())
+    }
+
+    @Test
+    fun `addAll returns false when nothing was added`() {
+        val set = ConcurrentSet<String>()
+        assertTrue(set.addAll(listOf("a", "b")))
+        assertFalse(set.addAll(listOf("a", "b")))
+        assertFalse(set.addAll(emptyList()))
+    }
+
+    @Test
+    fun `removeAll collection returns true when set was modified`() {
+        val set = ConcurrentSet<String>()
+        set.addAll(listOf("a", "b", "c"))
+
+        assertTrue(set.removeAll(listOf("missing", "b")))
+        assertEquals(setOf("a", "c"), set.toSet())
+    }
+
+    @Test
+    fun `removeAll collection returns false when nothing was removed`() {
+        val set = ConcurrentSet<String>()
+        set.addAll(listOf("a", "b"))
+
+        assertFalse(set.removeAll(listOf("missing")))
+    }
+
+    @Test
+    fun `removeAll with predicate removes matching elements`() {
+        val set = ConcurrentSet<String>()
+        set.addAll(listOf("keep-1", "remove-1", "keep-2", "remove-2"))
+
+        assertTrue(set.removeAll { it.startsWith("remove") })
+        assertEquals(setOf("keep-1", "keep-2"), set.toSet())
+    }
+
+    @Test
+    fun `iterator remove removes from delegate not snapshot`() {
+        val set = ConcurrentSet<String>()
+        set.addAll(listOf("a", "b", "c"))
+
+        val iterator = set.iterator()
+        while (iterator.hasNext()) {
+            if (iterator.next() == "b") {
+                iterator.remove()
+            }
+        }
+
+        assertEquals(setOf("a", "c"), set.toSet())
+        assertEquals(2, set.size)
+    }
+
+    @Test
+    fun `retainAll keeps only matching elements`() {
+        val set = ConcurrentSet<String>()
+        set.addAll(listOf("a", "b", "c", "d"))
+
+        assertTrue(set.retainAll(setOf("b", "d", "missing")))
+        assertEquals(setOf("b", "d"), set.toSet())
+    }
+
+    @Test
+    fun `containsAll checks set contains requested elements`() {
+        val set = ConcurrentSet<String>()
+        set.addAll(listOf("a", "b", "c"))
+
+        assertTrue(set.containsAll(listOf("a", "c")))
+        assertFalse(set.containsAll(listOf("a", "missing")))
+    }
+
+    @Test
+    fun `remove and readd same instance`() {
+        val set = ConcurrentSet<String>()
+        val value = "entry"
+
+        assertTrue(set.add(value))
+        assertFalse(set.add(value))
+
+        set.remove(value)
+        assertTrue(set.add(value))
+
+        assertEquals(1, set.size)
+        assertTrue(set.contains(value))
+    }
+}

--- a/ktor-utils/web/src/io/ktor/util/collections/ConcurrentMap.web.kt
+++ b/ktor-utils/web/src/io/ktor/util/collections/ConcurrentMap.web.kt
@@ -39,7 +39,7 @@ public actual class ConcurrentMap<Key, Value> public actual constructor(initialC
         get() = delegate.entries
 
     actual override val keys: MutableSet<Key>
-        get() = delegate.keys
+        get() = LinkedHashSet(delegate.keys)
 
     actual override val values: MutableCollection<Value>
         get() = delegate.values


### PR DESCRIPTION
**Subsystem**
Client HttpCache

**Motivation**
[KTOR-9661](https://youtrack.jetbrains.com/issue/KTOR-9661) HttpCache: InvalidCacheStateException is thrown on 304 when no cached entry matches varyKeys

**Solution**
- Added a validator-based fallback when matching a 304 to a stored entry https://www.rfc-editor.org/info/rfc9111/#section-4.3.4
- Freshen stored entries by merging the 304 response headers and updating `varyKeys/expiry`; remove the stale entry when `varyKeys` change

