### PR TITLE
KTOR-9252 Incomplete gzip response causes client/server to hang

### DIFF
--- a/ktor-utils/jvm/src/io/ktor/util/EncodersJvm.kt
+++ b/ktor-utils/jvm/src/io/ktor/util/EncodersJvm.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2014-2026 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package io.ktor.util
@@ -10,6 +10,7 @@ import io.ktor.utils.io.core.*
 import kotlinx.coroutines.CoroutineName
 import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.GlobalScope
+import kotlinx.io.EOFException
 import java.nio.ByteBuffer
 import java.util.zip.CRC32
 import java.util.zip.Checksum
@@ -139,7 +140,9 @@ private fun inflate(
         readBuffer.flip()
 
         while (!inflater.finished()) {
-            totalSize += inflater.inflateTo(channel, writeBuffer, checksum)
+            val inflated = inflater.inflateTo(channel, writeBuffer, checksum)
+            if (inflated == 0 && inflater.needsInput()) throw EOFException("Compressed input is incomplete.")
+            totalSize += inflated
             readBuffer.position(readBuffer.limit() - inflater.remaining)
         }
 
@@ -170,6 +173,7 @@ private suspend fun Inflater.inflateTo(channel: ByteWriteChannel, buffer: ByteBu
     buffer.clear()
 
     val inflated = inflate(buffer.array(), buffer.position(), buffer.remaining())
+    check(inflated > 0 || needsInput() || finished()) { "Inflater made no progress." }
     buffer.position(buffer.position() + inflated)
     buffer.flip()
 

--- a/ktor-utils/jvm/test/io/ktor/tests/utils/EncodersJvmTest.kt
+++ b/ktor-utils/jvm/test/io/ktor/tests/utils/EncodersJvmTest.kt
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2014-2026 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.tests.utils
+
+import io.ktor.test.*
+import io.ktor.util.*
+import io.ktor.util.cio.*
+import io.ktor.utils.io.*
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.io.readByteArray
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertFails
+import kotlin.time.Duration.Companion.seconds
+
+class EncodersJvmTest {
+
+    @Test
+    fun `malformed gzip fails`() = runTest(timeout = 1.seconds) {
+        @Suppress("ktlint:standard:no-multi-spaces")
+        val malformedGzip = byteArrayOf(
+            0x1f, 0x8b.toByte(),    // Magic
+            0x08,                   // Deflate method
+            0x00,                   // Flags
+            0x00, 0x00, 0x00, 0x00, // Timestamp
+            0x00,                   // Extra flags
+            0xff.toByte(),          // OS
+            // Incomplete deflate stream
+            0x01, 0x00, 0x00,
+        )
+
+        val failure = assertFails("Malformed gzip should fail") { GZip.decodeBytes(malformedGzip) }
+        assertEquals("Compressed input is incomplete.", failure.message)
+    }
+
+    @Test
+    fun `deflate with full output buffer`() = runTest(timeout = 1.seconds) {
+        val bytes = ByteArray(DEFAULT_BUFFER_SIZE + 1) { 1 }
+        val compressed = Deflate.encodeBytes(bytes)
+        val decoded = Deflate.decodeBytes(compressed)
+
+        assertContentEquals(bytes, decoded)
+    }
+}
+
+private suspend fun Encoder.encodeBytes(bytes: ByteArray): ByteArray =
+    encode(ByteReadChannel(bytes), currentCoroutineContext()).readRemaining().readByteArray()
+
+private suspend fun Encoder.decodeBytes(bytes: ByteArray): ByteArray =
+    decode(ByteReadChannel(bytes), currentCoroutineContext()).readRemaining().readByteArray()


### PR DESCRIPTION
**Subsystem**
ktor-utils, content encoding

**Motivation**
[KTOR-9252](https://youtrack.jetbrains.com/issue/KTOR-9252): malformed or incomplete gzip content can leave the JVM `Inflater` waiting for more input after the source channel has already reached EOF. The decoder then keeps trying to inflate without making progress, which can hang client/server content decoding and burn CPU.

**Solution**
Detect incomplete compressed input after EOF and fail with `EOFException` instead of continuing the inflate loop. Added a focused JVM regression test that decodes malformed gzip directly through `GZip.decode`.

Validation: `:ktor-utils:jvmTest --tests io.ktor.tests.utils.EncodersJvmTest.testMalformedGzipFails --rerun` passed, 1 test executed.
