### PR TITLE
KTOR-9670: Honor Accept-Encoding q=0 and most-specific matching

### DIFF
--- a/ktor-server/ktor-server-plugins/ktor-server-compression/jvm/src/io/ktor/server/plugins/compression/Compression.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-compression/jvm/src/io/ktor/server/plugins/compression/Compression.kt
@@ -216,16 +216,13 @@ private suspend fun ContentDecoding.Context.decode(
     }
 }
 
+private class AcceptedEncoder(val config: CompressionEncoderConfig, val quality: Double)
+
 private fun ContentEncoding.Context.encode(call: PipelineCall, options: CompressionOptions) {
     if (call.response.isSSEResponse()) {
         LOGGER.trace("Skip compression for sse response ${call.request.uri} ")
         return
     }
-
-    val comparator = compareBy<Pair<CompressionEncoderConfig, HeaderValue>>(
-        { it.second.quality },
-        { it.first.priority }
-    ).reversed()
 
     val acceptEncodingRaw = call.request.acceptEncoding()
     if (acceptEncodingRaw == null) {
@@ -238,16 +235,18 @@ private fun ContentEncoding.Context.encode(call: PipelineCall, options: Compress
         return
     }
 
-    val encoders = parseHeaderValue(acceptEncodingRaw)
-        .filter { it.value == "*" || it.value in options.encoders }
-        .flatMap { header ->
-            when (header.value) {
-                "*" -> options.encoders.values.map { it to header }
-                else -> options.encoders[header.value]?.let { listOf(it to header) } ?: emptyList()
-            }
+    // Each encoder's effective quality comes from its most specific Accept-Encoding entry: an
+    // explicit name overrides a `*` wildcard (RFC 7231 5.3.4). A quality of 0 means "not acceptable".
+    val acceptedEncodings = parseHeaderValue(acceptEncodingRaw)
+    val wildcardQuality = acceptedEncodings.firstOrNull { it.value == "*" }?.quality
+    val encoders = options.encoders.values
+        .mapNotNull { config ->
+            val explicit = acceptedEncodings.firstOrNull { it.value.equals(config.encoder.name, ignoreCase = true) }
+            val quality = (explicit?.quality ?: wildcardQuality)?.takeIf { it > 0.0 }
+            quality?.let { AcceptedEncoder(config, it) }
         }
-        .sortedWith(comparator)
-        .map { it.first }
+        .sortedWith(compareByDescending(AcceptedEncoder::quality).thenByDescending { it.config.priority })
+        .map(AcceptedEncoder::config)
 
     if (encoders.isEmpty()) {
         LOGGER.trace("Skip compression for ${call.request.uri} because no encoders provided.")

--- a/ktor-server/ktor-server-tests/jvm/test/io/ktor/server/plugins/CompressionAcceptEncodingTest.kt
+++ b/ktor-server/ktor-server-tests/jvm/test/io/ktor/server/plugins/CompressionAcceptEncodingTest.kt
@@ -1,0 +1,236 @@
+/*
+ * Copyright 2014-2024 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.server.plugins
+
+import io.ktor.client.request.*
+import io.ktor.client.statement.*
+import io.ktor.http.*
+import io.ktor.server.application.install
+import io.ktor.server.plugins.compression.*
+import io.ktor.server.response.*
+import io.ktor.server.routing.*
+import io.ktor.server.testing.*
+import io.ktor.utils.io.jvm.javaio.*
+import java.util.zip.GZIPInputStream
+import java.util.zip.Inflater
+import java.util.zip.InflaterInputStream
+import kotlin.test.*
+
+/**
+ * Tests for `Accept-Encoding` quality-value negotiation in the [Compression] plugin (RFC 7231 5.3.4):
+ * `q=0` excludes a coding, an explicitly named coding overrides a `*` wildcard, and selection is by
+ * effective quality and then configured priority.
+ */
+class CompressionAcceptEncodingTest {
+    private val textToCompress = "text to be compressed\n".repeat(100)
+
+    @Test
+    fun `q=0 on the only matching coding sends the response uncompressed`() = testApplication {
+        install(Compression) {
+            gzip()
+            deflate()
+        }
+        routing { get("/") { call.respondText(textToCompress) } }
+
+        handleAndAssert("/", "gzip;q=0", null, textToCompress)
+    }
+
+    @Test
+    fun `wildcard q=0 excludes every encoder`() = testApplication {
+        install(Compression) {
+            gzip()
+            deflate()
+        }
+        routing { get("/") { call.respondText(textToCompress) } }
+
+        handleAndAssert("/", "*;q=0", null, textToCompress)
+    }
+
+    @Test
+    fun `explicit q=0 is excluded while the wildcard enables the rest`() = testApplication {
+        install(Compression) {
+            gzip()
+            deflate()
+        }
+        routing { get("/") { call.respondText(textToCompress) } }
+
+        handleAndAssert("/", "gzip;q=0,*;q=0.5", "deflate", textToCompress)
+    }
+
+    @Test
+    fun `explicit coding overrides wildcard q=0`() = testApplication {
+        install(Compression) {
+            gzip { priority = 1.0 }
+            deflate { priority = 10.0 }
+        }
+        routing { get("/") { call.respondText(textToCompress) } }
+
+        // deflate has the higher priority but is forbidden via `*;q=0`; only gzip stays eligible.
+        handleAndAssert("/", "gzip;q=1,*;q=0", "gzip", textToCompress)
+    }
+
+    @Test
+    fun `explicit qvalue overrides the wildcard qvalue for the same coding`() = testApplication {
+        install(Compression) {
+            gzip { priority = 10.0 }
+            deflate { priority = 1.0 }
+        }
+        routing { get("/") { call.respondText(textToCompress) } }
+
+        // gzip's effective quality is its explicit 0.1, not the wildcard 0.9; deflate (0.9 via `*`) wins.
+        handleAndAssert("/", "gzip;q=0.1,*;q=0.9", "deflate", textToCompress)
+    }
+
+    @Test
+    fun `coding match is case-insensitive`() = testApplication {
+        install(Compression) {
+            gzip { priority = 10.0 }
+            deflate { priority = 1.0 }
+        }
+        routing { get("/") { call.respondText(textToCompress) } }
+
+        // `GZIP;q=0` forbids gzip despite the case difference, so deflate (0.5 via `*`) is used.
+        handleAndAssert("/", "GZIP;q=0,*;q=0.5", "deflate", textToCompress)
+    }
+
+    @Test
+    fun `highest qvalue wins`() = testApplication {
+        install(Compression) {
+            gzip()
+            deflate()
+        }
+        routing { get("/") { call.respondText(textToCompress) } }
+
+        handleAndAssert("/", "gzip;q=0.2,deflate;q=0.8", "deflate", textToCompress)
+    }
+
+    @Test
+    fun `equal qvalue falls back to configured priority`() = testApplication {
+        install(Compression) {
+            gzip { priority = 1.0 }
+            deflate { priority = 2.0 }
+        }
+        routing { get("/") { call.respondText(textToCompress) } }
+
+        handleAndAssert("/", "gzip;q=0.5,deflate;q=0.5", "deflate", textToCompress)
+    }
+
+    @Test
+    fun `equal qvalue tie-break uses priority not match specificity`() = testApplication {
+        install(Compression) {
+            gzip { priority = 1.0 }
+            deflate { priority = 10.0 }
+        }
+        routing { get("/") { call.respondText(textToCompress) } }
+
+        // gzip (explicit) and deflate (via `*`) both resolve to 0.5; priority decides, so deflate wins.
+        handleAndAssert("/", "gzip;q=0.5,*;q=0.5", "deflate", textToCompress)
+    }
+
+    @Test
+    fun `wildcard alone selects the highest priority encoder`() = testApplication {
+        install(Compression) {
+            gzip { priority = 1.0 }
+            deflate { priority = 10.0 }
+        }
+        routing { get("/") { call.respondText(textToCompress) } }
+
+        handleAndAssert("/", "*", "deflate", textToCompress)
+    }
+
+    @Test
+    fun `missing q is treated as 1`() = testApplication {
+        install(Compression) {
+            gzip()
+            deflate()
+        }
+        routing { get("/") { call.respondText(textToCompress) } }
+
+        handleAndAssert("/", "gzip,deflate;q=0.5", "gzip", textToCompress)
+    }
+
+    @Test
+    fun `malformed q is treated as 1`() = testApplication {
+        install(Compression) {
+            gzip()
+        }
+        routing { get("/") { call.respondText(textToCompress) } }
+
+        handleAndAssert("/", "gzip;q=abc", "gzip", textToCompress)
+    }
+
+    @Test
+    fun `coding absent from the header is not eligible`() = testApplication {
+        install(Compression) {
+            gzip()
+            deflate()
+        }
+        routing { get("/") { call.respondText(textToCompress) } }
+
+        handleAndAssert("/", "deflate;q=0.5", "deflate", textToCompress)
+    }
+
+    @Test
+    fun `no eligible encoder leaves the response uncompressed`() = testApplication {
+        install(Compression) {
+            gzip()
+        }
+        routing { get("/") { call.respondText(textToCompress) } }
+
+        handleAndAssert("/", "br", null, textToCompress)
+    }
+
+    @Test
+    fun `encoder whose condition fails falls through to the next eligible encoder`() = testApplication {
+        install(Compression) {
+            gzip {
+                condition { parameters["e"] == "1" }
+            }
+            deflate()
+        }
+        routing { get("/") { call.respondText(textToCompress) } }
+
+        handleAndAssert("/?e=0", "gzip;q=1,deflate;q=0.5", "deflate", textToCompress)
+    }
+
+    private suspend fun ApplicationTestBuilder.handleAndAssert(
+        url: String,
+        acceptHeader: String?,
+        expectedEncoding: String?,
+        expectedContent: String,
+    ) {
+        val response = client.get(url) {
+            if (acceptHeader != null) {
+                header(HttpHeaders.AcceptEncoding, acceptHeader)
+            }
+        }
+
+        assertEquals(HttpStatusCode.OK, response.status)
+        if (expectedEncoding != null) {
+            assertEquals(expectedEncoding, response.headers[HttpHeaders.ContentEncoding])
+            when (expectedEncoding) {
+                "gzip" -> {
+                    assertEquals(expectedContent, response.readGzip())
+                    assertNull(response.headers[HttpHeaders.ContentLength])
+                }
+
+                "deflate" -> {
+                    assertEquals(expectedContent, response.readDeflate())
+                    assertNull(response.headers[HttpHeaders.ContentLength])
+                }
+
+                else -> fail("unexpected encoding $expectedEncoding")
+            }
+        } else {
+            assertNull(response.headers[HttpHeaders.ContentEncoding], "content shouldn't be compressed")
+            assertEquals(expectedContent, response.bodyAsText())
+        }
+    }
+
+    private suspend fun HttpResponse.readGzip() = GZIPInputStream(bodyAsChannel().toInputStream()).reader().readText()
+
+    private suspend fun HttpResponse.readDeflate() =
+        InflaterInputStream(bodyAsChannel().toInputStream(), Inflater(true)).reader().readText()
+}


### PR DESCRIPTION
KTOR-9670

## What
The server `Compression` plugin ignored `Accept-Encoding` quality values when choosing a response content-coding. It:
- never excluded a coding the client refused with `q=0`,
- never let an explicitly named coding override a `*` wildcard, and
- matched coding tokens case-sensitively.

For example, a request with `Accept-Encoding: gzip;q=0` still received a gzip-compressed response.

## Why
These contradict HTTP content negotiation (RFC 7231 §5.3.4): `q=0` means "not acceptable", the most specific `Accept-Encoding` entry wins, and coding tokens are case-insensitive.

## How
`encode()` now resolves each configured encoder's *effective* quality from its most specific matching entry (an explicit name overrides `*`, compared case-insensitively), drops codings whose effective quality is `0`, and orders the remaining encoders by quality then configured priority. The existing priority tie-break and the uncompressed fallback (when no encoder is eligible) are preserved. No public API change.

## Tests
New `CompressionAcceptEncodingTest` (15 cases) covers `q=0` exclusion, explicit-over-wildcard precedence (including positive qualities), case-insensitive matching, priority tie-breaks, and the uncompressed fallback. Existing `CompressionTest` (47) and the CIO engine `CompressionTestSuite` remain green.

Pre-flight (`formatKotlin`, `lintKotlin`, `checkKotlinAbi`, `assemble`) all pass; ABI unchanged.

## Risk
Behavior change for clients that send `q=0` or relied on the previous case-sensitive matching. No public API or signature changes.
