### PR TITLE
KTOR-8766 Fix multiple invocations of close from DI

### DIFF
--- a/ktor-server/ktor-server-plugins/ktor-server-di/common/src/io/ktor/server/plugins/di/DependencyInjection.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-di/common/src/io/ktor/server/plugins/di/DependencyInjection.kt
@@ -163,18 +163,23 @@ public val DI: ApplicationPlugin<DependencyInjectionConfig> =
             }
             monitor.subscribe(ApplicationStopping) {
                 for ((key, initializer) in dependencyMap.entries.reversed()) {
-                    if (initializer is DependencyInitializer.Ambiguous ||
-                        initializer is DependencyInitializer.Missing
-                    ) {
-                        continue
-                    }
-                    try {
-                        val instance = registry.getDeferred<Any?>(key).tryGetCompleted() ?: continue
-                        registry.shutdownHooks[key]?.invoke(instance)
-                        onShutdown(key, instance)
-                    } catch (e: Throwable) {
-                        if (e !is CancellationException) {
-                            environment.log.warn("Exception during cleanup for $key; continuing", e)
+                    when (initializer) {
+                        is DependencyInitializer.Ambiguous,
+                        is DependencyInitializer.Missing,
+                        is DependencyInitializer.Null,
+                        is DependencyInitializer.Implicit -> continue
+
+                        is DependencyInitializer.Explicit,
+                        is DependencyInitializer.Value -> {
+                            try {
+                                val instance = registry.getDeferred<Any?>(key).tryGetCompleted() ?: continue
+                                registry.shutdownHooks[key]?.invoke(instance)
+                                onShutdown(key, instance)
+                            } catch (e: Throwable) {
+                                if (e is CancellationException) throw e
+
+                                environment.log.warn("Exception during cleanup for $key; continuing", e)
+                            }
                         }
                     }
                 }

--- a/ktor-server/ktor-server-plugins/ktor-server-di/common/test/io/ktor/server/plugins/di/DependencyInjectionTest.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-di/common/test/io/ktor/server/plugins/di/DependencyInjectionTest.kt
@@ -510,7 +510,7 @@ class DependencyInjectionTest {
 
     @Test
     fun cleanup() = runTest {
-        val closed = mutableSetOf<Any>()
+        val closed = mutableListOf<Any>()
         val closer1 = object : Closer {
             override fun closeMe() {
                 closed += this
@@ -556,7 +556,7 @@ class DependencyInjectionTest {
 
         assertEquals(
             listOf(closer2, closer1, autoCloseable),
-            closed.toList(),
+            closed,
             "Expected all dependencies to be closed in the correct order"
         )
     }


### PR DESCRIPTION
**Subsystem**
Server, DI

**Motivation**
[KTOR-8766](https://youtrack.jetbrains.com/issue/KTOR-8766) DI: The close method is called twice on cleanup of AutoCloseable

**Solution**
The multiple invocations were caused by iterating on "implicit" keys in the DI registry map.  Replaced the instance check with an exhaustive when so that we can be more explicit here, importantly avoiding all non-source keys.

