### PR TITLE
KTOR-9671: Fix semicolon character encoding for old darwin versions

### DIFF
--- a/ktor-client/ktor-client-darwin-legacy/darwin/src/io/ktor/client/engine/darwin/internal/legacy/DarwinLegacyUrlUtils.kt
+++ b/ktor-client/ktor-client-darwin-legacy/darwin/src/io/ktor/client/engine/darwin/internal/legacy/DarwinLegacyUrlUtils.kt
@@ -8,11 +8,22 @@ import io.ktor.http.*
 import io.ktor.util.*
 import platform.Foundation.*
 
+// Old version of macOS/iOS might not allow semicolon ';' in path for
+// compatibility with RFC 1808 (obsolete). However, ';' is a valid character according to RFC-3986.
+private val pathAllowedCharacters =
+    if (NSCharacterSet.URLPathAllowedCharacterSet.characterIsMember(';'.code.toUShort())) {
+        NSCharacterSet.URLPathAllowedCharacterSet
+    } else {
+        (NSCharacterSet.URLPathAllowedCharacterSet.mutableCopy() as NSMutableCharacterSet).apply {
+            addCharactersInString(";")
+        }
+    }
+
 internal fun Url.toNSUrl(): NSURL {
     val userEncoded = encodedUser.orEmpty().isEncoded(NSCharacterSet.URLUserAllowedCharacterSet)
     val passwordEncoded = encodedPassword.orEmpty().isEncoded(NSCharacterSet.URLUserAllowedCharacterSet)
     val hostEncoded = host.isEncoded(NSCharacterSet.URLHostAllowedCharacterSet)
-    val pathEncoded = encodedPath.isEncoded(NSCharacterSet.URLPathAllowedCharacterSet)
+    val pathEncoded = encodedPath.isEncoded(pathAllowedCharacters)
     val queryEncoded = encodedQuery.isEncoded(NSCharacterSet.URLQueryAllowedCharacterSet)
     val fragmentEncoded = encodedFragment.isEncoded(NSCharacterSet.URLFragmentAllowedCharacterSet)
     if (userEncoded && passwordEncoded && hostEncoded && pathEncoded && queryEncoded && fragmentEncoded) {
@@ -43,7 +54,7 @@ internal fun Url.toNSUrl(): NSURL {
 
         components.percentEncodedPath = when {
             pathEncoded -> encodedPath
-            else -> rawSegments.joinToString("/").sanitize(NSCharacterSet.URLPathAllowedCharacterSet)
+            else -> rawSegments.joinToString("/").sanitize(pathAllowedCharacters)
         }
 
         when {

--- a/ktor-client/ktor-client-darwin-legacy/darwin/test/DarwinLegacyEngineTest.kt
+++ b/ktor-client/ktor-client-darwin-legacy/darwin/test/DarwinLegacyEngineTest.kt
@@ -73,6 +73,10 @@ class DarwinLegacyEngineTest : ClientEngineTest<DarwinLegacyClientEngineConfig>(
         assertTrue(
             stringToNSUrlString("http://привет.привет/") in possibleResults
         )
+        assertEquals(
+            "https://example.com/path;param=my%3Bvalue/segment",
+            stringToNSUrlString("https://example.com/path;param=my%3Bvalue/segment")
+        )
     }
 
     @Test

--- a/ktor-client/ktor-client-darwin/darwin/src/io/ktor/client/engine/darwin/internal/DarwinUrlUtils.kt
+++ b/ktor-client/ktor-client-darwin/darwin/src/io/ktor/client/engine/darwin/internal/DarwinUrlUtils.kt
@@ -8,11 +8,21 @@ import io.ktor.http.*
 import io.ktor.util.*
 import platform.Foundation.*
 
+// Old version of macOS/iOS might not allow semicolon ';' in path for
+// compatibility with RFC 1808 (obsolete). However, ';' is a valid character according to RFC-3986.
+private val pathAllowedCharacters = if (NSCharacterSet.URLPathAllowedCharacterSet.characterIsMember(';'.code.toUShort())) {
+    NSCharacterSet.URLPathAllowedCharacterSet
+} else {
+    (NSCharacterSet.URLPathAllowedCharacterSet.mutableCopy() as NSMutableCharacterSet).apply {
+        addCharactersInString(";")
+    }
+}
+
 internal fun Url.toNSUrl(): NSURL {
     val userEncoded = encodedUser.orEmpty().isEncoded(NSCharacterSet.URLUserAllowedCharacterSet)
     val passwordEncoded = encodedPassword.orEmpty().isEncoded(NSCharacterSet.URLUserAllowedCharacterSet)
     val hostEncoded = host.isEncoded(NSCharacterSet.URLHostAllowedCharacterSet)
-    val pathEncoded = encodedPath.isEncoded(NSCharacterSet.URLPathAllowedCharacterSet)
+    val pathEncoded = encodedPath.isEncoded(pathAllowedCharacters)
     val queryEncoded = encodedQuery.isEncoded(NSCharacterSet.URLQueryAllowedCharacterSet)
     val fragmentEncoded = encodedFragment.isEncoded(NSCharacterSet.URLFragmentAllowedCharacterSet)
     if (userEncoded && passwordEncoded && hostEncoded && pathEncoded && queryEncoded && fragmentEncoded) {
@@ -43,7 +53,7 @@ internal fun Url.toNSUrl(): NSURL {
 
         components.percentEncodedPath = when {
             pathEncoded -> encodedPath
-            else -> rawSegments.joinToString("/").sanitize(NSCharacterSet.URLPathAllowedCharacterSet)
+            else -> rawSegments.joinToString("/").sanitize(pathAllowedCharacters)
         }
 
         when {

--- a/ktor-client/ktor-client-darwin/darwin/src/io/ktor/client/engine/darwin/internal/DarwinUrlUtils.kt
+++ b/ktor-client/ktor-client-darwin/darwin/src/io/ktor/client/engine/darwin/internal/DarwinUrlUtils.kt
@@ -10,13 +10,14 @@ import platform.Foundation.*
 
 // Old version of macOS/iOS might not allow semicolon ';' in path for
 // compatibility with RFC 1808 (obsolete). However, ';' is a valid character according to RFC-3986.
-private val pathAllowedCharacters = if (NSCharacterSet.URLPathAllowedCharacterSet.characterIsMember(';'.code.toUShort())) {
-    NSCharacterSet.URLPathAllowedCharacterSet
-} else {
-    (NSCharacterSet.URLPathAllowedCharacterSet.mutableCopy() as NSMutableCharacterSet).apply {
-        addCharactersInString(";")
+private val pathAllowedCharacters =
+    if (NSCharacterSet.URLPathAllowedCharacterSet.characterIsMember(';'.code.toUShort())) {
+        NSCharacterSet.URLPathAllowedCharacterSet
+    } else {
+        (NSCharacterSet.URLPathAllowedCharacterSet.mutableCopy() as NSMutableCharacterSet).apply {
+            addCharactersInString(";")
+        }
     }
-}
 
 internal fun Url.toNSUrl(): NSURL {
     val userEncoded = encodedUser.orEmpty().isEncoded(NSCharacterSet.URLUserAllowedCharacterSet)

--- a/ktor-client/ktor-client-darwin/darwin/test/DarwinEngineTest.kt
+++ b/ktor-client/ktor-client-darwin/darwin/test/DarwinEngineTest.kt
@@ -100,6 +100,10 @@ class DarwinEngineTest : ClientEngineTest<DarwinClientEngineConfig>(Darwin) {
         assertTrue(
             stringToNSUrlString("http://привет.привет/") in possibleResults
         )
+        assertEquals(
+            "https://example.com/path;param=my%3Bvalue/segment",
+            stringToNSUrlString("https://example.com/path;param=my%3Bvalue/segment")
+        )
     }
 
     @Test


### PR DESCRIPTION
**Subsystem**
ktor-client-darwin

**Motivation**
[KTOR-9671](https://youtrack.jetbrains.com/issue/KTOR-9671) Darwin: Semicolons in URL path are sanitized

I faced an issue, when the url like `https://example.com/segment1;param=value/segment2/` was encoded on darwin platform and become `https://example.com/segment1%3Bparam=value/segment2/`. Android/jvm platform work correctly, they don't sanitize the semicolon character (which actually is a valid character according to [RFC-3986](https://www.rfc-editor.org/info/rfc3986/#section-3.3)) for url path.

@osipxd reproduced it on old CI; I reproduced it when running ktor on 16.4 iOS simulator.

**Solution**
Just extend allowed character set with semicolon if it is not there (based on a [suggestion](https://github.com/ktorio/ktor/pull/5699#pullrequestreview-4545410108)).

