### PR TITLE
Make huge post test less huge

### DIFF
--- a/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/PostTest.kt
+++ b/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/PostTest.kt
@@ -28,7 +28,7 @@ class PostTest : ClientLoader() {
     @Test
     fun testHugePost() = clientTests(except("Js", "Darwin", "CIO", "Curl", "DarwinLegacy", "WinHttp")) {
         test { client ->
-            client.postHelper(makeString(32 * 1024 * 1024))
+            client.postHelper(makeString(2 * 1024 * 1024))
         }
     }
 


### PR DESCRIPTION
Looks like this test is flaky on CI from timeouts on the JVM platform.  I'll see if a smaller payload will resolve the issue - since our default buffer size is 1024^2, exceeding that should be all that's needed for exercising the relevant code.