### PR TITLE
WS Common. Validate control frame size

### DIFF
--- a/ktor-shared/ktor-websockets/common/src/io/ktor/websocket/CloseReason.kt
+++ b/ktor-shared/ktor-websockets/common/src/io/ktor/websocket/CloseReason.kt
@@ -12,10 +12,19 @@ import kotlin.jvm.*
  *
  * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.websocket.CloseReason)
  *
- * @property code - close reason code as per RFC 6455, recommended to be one of [CloseReason.Codes]
- * @property message - a close reason message, could be empty
+ * @property code - close reason code as per RFC 6455, recommended to be one of [Codes]
+ * @property message - a close reason message; could be empty
+ * @throws IllegalArgumentException if [message] is longer than 123 bytes when UTF-8-encoded
  */
 public data class CloseReason(val code: Short, val message: String) {
+    init {
+        val size = message.utf8Size()
+        require(size <= MAX_CLOSE_REASON_MESSAGE_SIZE) {
+            "Close reason message is too long: $size bytes, but must not exceed " +
+                "$MAX_CLOSE_REASON_MESSAGE_SIZE bytes when UTF-8-encoded"
+        }
+    }
+
     public constructor(code: Codes, message: String) : this(code.code, message)
 
     /**
@@ -78,5 +87,10 @@ public data class CloseReason(val code: Short, val message: String) {
              */
             public fun byCode(code: Short): Codes? = byCodeMap[code]
         }
+    }
+
+    internal companion object {
+        fun truncated(code: Codes, message: String): CloseReason =
+            CloseReason(code, message.utf8Truncate(MAX_CLOSE_REASON_MESSAGE_SIZE))
     }
 }

--- a/ktor-shared/ktor-websockets/common/src/io/ktor/websocket/ControlFrames.kt
+++ b/ktor-shared/ktor-websockets/common/src/io/ktor/websocket/ControlFrames.kt
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2014-2026 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.websocket
+
+/**
+ * Maximum payload size of a WebSocket control frame (`Close`, `Ping`, `Pong`), in bytes.
+ *
+ * Per [RFC 6455 §5.5](https://datatracker.ietf.org/doc/html/rfc6455#section-5.5) control frames
+ * must carry a payload of 125 bytes or fewer, otherwise the peer treats it as a protocol violation.
+ */
+internal const val MAX_CONTROL_FRAME_PAYLOAD_SIZE: Int = 125
+
+/**
+ * Maximum size of a [CloseReason] message, in UTF-8 bytes.
+ *
+ * A `Close` frame payload is the 2-byte close code followed by the UTF-8-encoded message, so the
+ * message may occupy at most [MAX_CONTROL_FRAME_PAYLOAD_SIZE] minus the code size.
+ */
+internal const val MAX_CLOSE_REASON_MESSAGE_SIZE: Int = MAX_CONTROL_FRAME_PAYLOAD_SIZE - Short.SIZE_BYTES
+
+/**
+ * Validates that a control frame does not exceed [MAX_CONTROL_FRAME_PAYLOAD_SIZE].
+ * Non-control frames are not checked.
+ *
+ * @throws IllegalArgumentException if a control frame payload is larger than [MAX_CONTROL_FRAME_PAYLOAD_SIZE].
+ */
+internal fun Frame.validateSize() {
+    require(!frameType.controlFrame || data.size <= MAX_CONTROL_FRAME_PAYLOAD_SIZE) {
+        "Control frames must not exceed $MAX_CONTROL_FRAME_PAYLOAD_SIZE bytes per RFC 6455, " +
+            "but $frameType frame has ${data.size} bytes"
+    }
+}
+
+/**
+ * UTF-8 byte length of the character at [index], treating a valid surrogate pair (whose low half is
+ * at `index + 1`) as a single 4-byte code point. Matches [String.encodeToByteArray]: a lone surrogate
+ * counts as the 3-byte replacement character. A returned value of `4` therefore means the character
+ * spans two code units (advance the index by 2); any other value means one (advance by 1).
+ */
+private fun String.utf8ByteCountAt(index: Int): Int {
+    val code = this[index].code
+    return when {
+        code < 0x80 -> 1
+        code < 0x800 -> 2
+        this[index].isHighSurrogate() && index + 1 < length && this[index + 1].isLowSurrogate() -> 4
+        else -> 3
+    }
+}
+
+/**
+ * Number of bytes [this] string occupies when UTF-8-encoded, computed without allocating an
+ * intermediate byte array (unlike `encodeToByteArray().size`).
+ */
+internal fun String.utf8Size(): Int {
+    var size = 0
+    var index = 0
+    while (index < length) {
+        val bytes = utf8ByteCountAt(index)
+        size += bytes
+        index += if (bytes == 4) 2 else 1
+    }
+    return size
+}
+
+/**
+ * Returns unchanged string if it shorter than [maxSize] UTF-8 bytes, otherwise drops trailing characters
+ * until the UTF-8 encoding fits. Truncation happens on whole characters, so multibyte characters are never split,
+ * and the result stays decodable.
+ */
+internal fun String.utf8Truncate(maxSize: Int): String {
+    var size = 0
+    var index = 0
+    while (index < length) {
+        val bytes = utf8ByteCountAt(index)
+        if (size + bytes > maxSize) break
+        size += bytes
+        index += if (bytes == 4) 2 else 1
+    }
+    return if (index == length) this else substring(0, index)
+}

--- a/ktor-shared/ktor-websockets/common/src/io/ktor/websocket/FrameCommon.kt
+++ b/ktor-shared/ktor-websockets/common/src/io/ktor/websocket/FrameCommon.kt
@@ -103,6 +103,9 @@ public expect sealed class Frame private constructor(
      * Represents a low-level level close frame. It could be sent to indicate WebSocket session end.
      * Usually there is no need to send/handle it unless you have a RAW WebSocket session.
      *
+     * Note: a control frame payload must not exceed 125 bytes (RFC 6455 §5.5);
+     * constructing a larger one throws [IllegalArgumentException].
+     *
      * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.websocket.Frame.Close)
      */
     public class Close(data: ByteArray) : Frame {
@@ -115,6 +118,9 @@ public expect sealed class Frame private constructor(
      * Represents a low-level ping frame. Could be sent to test connection (peer should reply with [Pong]).
      * Usually there is no need to send/handle it unless you have a RAW WebSocket session.
      *
+     * Note: a control frame payload must not exceed 125 bytes (RFC 6455 §5.5);
+     * constructing a larger one throws [IllegalArgumentException].
+     *
      * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.websocket.Frame.Ping)
      */
     public class Ping(data: ByteArray) : Frame {
@@ -124,6 +130,9 @@ public expect sealed class Frame private constructor(
     /**
      * Represents a low-level pong frame. Should be sent in reply to a [Ping] frame.
      * Usually there is no need to send/handle it unless you have a RAW WebSocket session.
+     *
+     * Note: a control frame payload must not exceed 125 bytes (RFC 6455 §5.5);
+     * constructing a larger one throws [IllegalArgumentException].
      *
      * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.websocket.Frame.Pong)
      */

--- a/ktor-shared/ktor-websockets/common/src/io/ktor/websocket/RawWebSocketCommon.kt
+++ b/ktor-shared/ktor-websockets/common/src/io/ktor/websocket/RawWebSocketCommon.kt
@@ -105,11 +105,13 @@ internal class RawWebSocketCommon(
                 }
             } catch (cause: FrameTooBigException) {
                 _incoming.close(cause)
-                outgoing.send(Frame.Close(CloseReason(CloseReason.Codes.TOO_BIG, cause.message)))
+                val reason = CloseReason.truncated(CloseReason.Codes.TOO_BIG, cause.message)
+                outgoing.send(Frame.Close(reason))
             } catch (cause: ProtocolViolationException) {
                 // same as above
                 _incoming.close(cause)
-                outgoing.send(Frame.Close(CloseReason(CloseReason.Codes.PROTOCOL_ERROR, cause.message)))
+                val reason = CloseReason.truncated(CloseReason.Codes.PROTOCOL_ERROR, cause.message)
+                outgoing.send(Frame.Close(reason))
             } catch (_: CancellationException) {
                 _incoming.cancel()
             } catch (_: EOFException) {
@@ -250,8 +252,8 @@ public suspend fun ByteReadChannel.readFrame(maxFrameSize: Long, lastOpcode: Int
         127 -> readLong()
         else -> length.toLong()
     }
-    if (frameType.controlFrame && length > 125) {
-        throw ProtocolViolationException("control frames can't be larger than 125 bytes")
+    if (frameType.controlFrame && length > MAX_CONTROL_FRAME_PAYLOAD_SIZE) {
+        throw ProtocolViolationException("control frames can't be larger than $MAX_CONTROL_FRAME_PAYLOAD_SIZE bytes")
     }
 
     val maskKey = when (maskAndLength and 0x80 != 0) {

--- a/ktor-shared/ktor-websockets/common/src/io/ktor/websocket/WebSocketSession.kt
+++ b/ktor-shared/ktor-websockets/common/src/io/ktor/websocket/WebSocketSession.kt
@@ -173,12 +173,17 @@ public suspend fun WebSocketSession.close(cause: Throwable?) {
 /**
  * Closes a session with normal or error close reason, depending on whether [cause] is cancellation or not.
  *
+ * The [cause] message is truncated if needed so that the resulting close frame stays within the
+ * WebSocket control-frame size limit.
+ *
  * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.websocket.closeExceptionally)
  */
 public suspend fun WebSocketSession.closeExceptionally(cause: Throwable) {
-    val reason = when (cause) {
-        is CancellationException -> CloseReason(CloseReason.Codes.NORMAL, "")
-        else -> CloseReason(CloseReason.Codes.INTERNAL_ERROR, cause.toString())
+    val reason = if (cause is CancellationException) {
+        CloseReason(CloseReason.Codes.NORMAL, "")
+    } else {
+        val message = cause.toString().utf8Truncate(MAX_CLOSE_REASON_MESSAGE_SIZE)
+        CloseReason(CloseReason.Codes.INTERNAL_ERROR, message)
     }
 
     close(reason)

--- a/ktor-shared/ktor-websockets/common/test/io/ktor/websockets/ControlFrameSizeTest.kt
+++ b/ktor-shared/ktor-websockets/common/test/io/ktor/websockets/ControlFrameSizeTest.kt
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2014-2026 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.websockets
+
+import io.ktor.websocket.CloseReason
+import io.ktor.websocket.Frame
+import io.ktor.websocket.MAX_CLOSE_REASON_MESSAGE_SIZE
+import io.ktor.websocket.MAX_CONTROL_FRAME_PAYLOAD_SIZE
+import io.ktor.websocket.utf8Size
+import io.ktor.websocket.utf8Truncate
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+class ControlFrameSizeTest {
+
+    @Test
+    fun closeReasonAcceptsMessageAtLimit() {
+        val message = "a".repeat(MAX_CLOSE_REASON_MESSAGE_SIZE) // 123 ASCII bytes
+        val reason = CloseReason(CloseReason.Codes.NORMAL, message)
+        assertEquals(message, reason.message)
+
+        // The resulting close frame occupies the control-frame limit exactly.
+        assertEquals(MAX_CONTROL_FRAME_PAYLOAD_SIZE, Frame.Close(reason).data.size)
+    }
+
+    @Test
+    fun closeReasonRejectsTooLongMessage() {
+        val message = "a".repeat(MAX_CLOSE_REASON_MESSAGE_SIZE + 1)
+        assertFailsWith<IllegalArgumentException> {
+            CloseReason(CloseReason.Codes.NORMAL, message)
+        }
+    }
+
+    @Test
+    fun closeReasonRejectsTooLongUnicodeMessage() {
+        // Each 'я' is 2 UTF-8 bytes, so 62 of them = 124 bytes > limit.
+        val message = "я".repeat(62)
+        assertFailsWith<IllegalArgumentException> {
+            CloseReason(CloseReason.Codes.NORMAL, message)
+        }
+    }
+
+    @Test
+    fun controlFramesRejectOversizePayload() {
+        val tooBig = ByteArray(MAX_CONTROL_FRAME_PAYLOAD_SIZE + 1)
+        assertFailsWith<IllegalArgumentException> { Frame.Ping(tooBig) }
+        assertFailsWith<IllegalArgumentException> { Frame.Pong(tooBig) }
+        assertFailsWith<IllegalArgumentException> { Frame.Close(tooBig) }
+    }
+
+    @Test
+    fun controlFramesAcceptPayloadAtLimit() {
+        val atLimit = ByteArray(MAX_CONTROL_FRAME_PAYLOAD_SIZE)
+        assertEquals(MAX_CONTROL_FRAME_PAYLOAD_SIZE, Frame.Ping(atLimit).data.size)
+        assertEquals(MAX_CONTROL_FRAME_PAYLOAD_SIZE, Frame.Pong(atLimit).data.size)
+        assertEquals(MAX_CONTROL_FRAME_PAYLOAD_SIZE, Frame.Close(atLimit).data.size)
+    }
+
+    @Test
+    fun dataFramesAreNotSizeLimited() {
+        val big = ByteArray(MAX_CONTROL_FRAME_PAYLOAD_SIZE + 1000)
+        assertEquals(big.size, Frame.Text(true, big).data.size)
+        assertEquals(big.size, Frame.Binary(true, big).data.size)
+    }
+
+    @Test
+    fun truncationFitsWithinLimit() {
+        val truncated = "a".repeat(500).utf8Truncate(10)
+        assertEquals(10, truncated.encodeToByteArray().size)
+        // A truncated reason must be constructible as a valid close reason.
+        assertEquals(12, Frame.Close(CloseReason(1000, truncated)).data.size)
+    }
+
+    @Test
+    fun truncationDoesNotSplitMultibyteCharacters() {
+        // 122 ASCII bytes + a 2-byte character would be 124 bytes; the trailing character must be dropped whole.
+        val message = "a".repeat(4) + "я"
+        val truncated = message.utf8Truncate(5)
+
+        assertEquals("a".repeat(4), truncated)
+        assertTrue(truncated.encodeToByteArray().size <= MAX_CLOSE_REASON_MESSAGE_SIZE)
+    }
+
+    @Test
+    fun utf8SizeMatchesEncoder() {
+        // Covers 1-, 2-, 3-byte characters and a 4-byte surrogate pair (😀) for well-formed text.
+        val samples = listOf("", "ascii", "я".repeat(3), "日本語", "a😀b", "mix: aя日😀")
+        for (sample in samples) {
+            sample.encodeToByteArray()
+            assertEquals(sample.encodeToByteArray().size, sample.utf8Size(), "utf8Size mismatch for \"$sample\"")
+        }
+    }
+
+    @Test
+    fun utf8SizeNeverUnderestimatesForLoneSurrogate() {
+        // A lone surrogate is malformed; the platform encoder's replacement-byte count is not fixed.
+        // utf8Size must never underestimate, so the close-frame size guarantee always holds.
+        val loneSurrogate = "\uD83D"
+        assertTrue(loneSurrogate.utf8Size() >= loneSurrogate.encodeToByteArray().size)
+    }
+
+    @Test
+    fun truncationOfMultibyteOnlyMessageStaysDecodable() {
+        val truncated = "я".repeat(200).utf8Truncate(MAX_CLOSE_REASON_MESSAGE_SIZE)
+        val bytes = truncated.encodeToByteArray()
+        assertTrue(bytes.size <= MAX_CLOSE_REASON_MESSAGE_SIZE)
+        // No replacement characters: re-decoding yields the same string (no split multibyte char).
+        assertEquals(truncated, bytes.decodeToString())
+        assertTrue(truncated.all { it == 'я' })
+    }
+}

--- a/ktor-shared/ktor-websockets/common/test/io/ktor/websockets/FrameCloseTest.kt
+++ b/ktor-shared/ktor-websockets/common/test/io/ktor/websockets/FrameCloseTest.kt
@@ -1,10 +1,14 @@
 /*
-* Copyright 2014-2021 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
-*/
+ * Copyright 2014-2026 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
 
-package io.ktor.websocket
+package io.ktor.websockets
 
-import kotlin.test.*
+import io.ktor.websocket.*
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
 
 class FrameCloseTest {
     @Test

--- a/ktor-shared/ktor-websockets/common/test/io/ktor/websockets/WebSocketExtensionHeaderTest.kt
+++ b/ktor-shared/ktor-websockets/common/test/io/ktor/websockets/WebSocketExtensionHeaderTest.kt
@@ -2,7 +2,7 @@
  * Copyright 2014-2022 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
-package io.ktor.tests.http.cio.websocket
+package io.ktor.websockets
 
 import io.ktor.websocket.*
 import kotlin.test.*

--- a/ktor-shared/ktor-websockets/jvm/src/io/ktor/websocket/Frame.kt
+++ b/ktor-shared/ktor-websockets/jvm/src/io/ktor/websocket/Frame.kt
@@ -30,6 +30,10 @@ public actual sealed class Frame actual constructor(
     public actual val rsv2: Boolean,
     public actual val rsv3: Boolean
 ) {
+    init {
+        validateSize()
+    }
+
     /**
      * Frame content
      *

--- a/ktor-shared/ktor-websockets/jvm/src/io/ktor/websocket/FrameParser.kt
+++ b/ktor-shared/ktor-websockets/jvm/src/io/ktor/websocket/FrameParser.kt
@@ -106,8 +106,10 @@ public class FrameParser {
         mask = maskAndLength1 and 0x80 != 0
         val length1 = maskAndLength1 and 0x7f
 
-        if (frameType.controlFrame && length1 > 125) {
-            throw ProtocolViolationException("control frames can't be larger than 125 bytes")
+        if (frameType.controlFrame && length1 > MAX_CONTROL_FRAME_PAYLOAD_SIZE) {
+            throw ProtocolViolationException(
+                "control frames can't be larger than $MAX_CONTROL_FRAME_PAYLOAD_SIZE bytes"
+            )
         }
 
         lengthLength = when (length1) {

--- a/ktor-shared/ktor-websockets/jvm/src/io/ktor/websocket/RawWebSocketJvm.kt
+++ b/ktor-shared/ktor-websockets/jvm/src/io/ktor/websocket/RawWebSocketJvm.kt
@@ -108,10 +108,12 @@ internal class RawWebSocketJvm(
                     filtered.send(frame)
                 }
             } catch (cause: FrameTooBigException) {
-                outgoing.trySend(Frame.Close(CloseReason(CloseReason.Codes.TOO_BIG, cause.message)))
+                val reason = CloseReason.truncated(CloseReason.Codes.TOO_BIG, cause.message)
+                outgoing.trySend(Frame.Close(reason))
                 filtered.close(cause)
             } catch (cause: ProtocolViolationException) {
-                outgoing.trySend(Frame.Close(CloseReason(CloseReason.Codes.PROTOCOL_ERROR, cause.message)))
+                val reason = CloseReason.truncated(CloseReason.Codes.PROTOCOL_ERROR, cause.message)
+                outgoing.trySend(Frame.Close(reason))
                 filtered.close(cause)
             } catch (cause: CancellationException) {
                 reader.incoming.cancel(cause)

--- a/ktor-shared/ktor-websockets/jvm/test/WebSocketReaderTest.kt
+++ b/ktor-shared/ktor-websockets/jvm/test/WebSocketReaderTest.kt
@@ -28,8 +28,11 @@ class WebSocketReaderTest {
         val channel = ByteChannel(true)
         runBlocking {
             val reader = WebSocketReader(channel, coroutineContext, 1000)
-            val frame = Frame.Ping(ByteArray(126))
-            writeFrame(channel, frame)
+            channel.write { buffer: ByteBuffer ->
+                buffer.put(0x89.toByte())
+                buffer.put(0x7E.toByte())
+            }
+            channel.flush()
             assertFailsWith<ProtocolViolationException> {
                 reader.incoming.receive()
             }

--- a/ktor-shared/ktor-websockets/posix/src/io/ktor/websocket/FrameNative.kt
+++ b/ktor-shared/ktor-websockets/posix/src/io/ktor/websocket/FrameNative.kt
@@ -28,6 +28,10 @@ public actual sealed class Frame actual constructor(
     public actual val rsv2: Boolean,
     public actual val rsv3: Boolean
 ) {
+    init {
+        validateSize()
+    }
+
     /**
      * Represents an application level binary frame.
      * In a RAW web socket session a big text frame could be fragmented

--- a/ktor-shared/ktor-websockets/web/src/io/ktor/websocket/Frame.web.kt
+++ b/ktor-shared/ktor-websockets/web/src/io/ktor/websocket/Frame.web.kt
@@ -28,6 +28,10 @@ public actual sealed class Frame actual constructor(
     public actual val rsv2: Boolean,
     public actual val rsv3: Boolean
 ) {
+    init {
+        validateSize()
+    }
+
     /**
      * Represents an application level binary frame.
      * In a RAW web socket session a big text frame could be fragmented


### PR DESCRIPTION
**Subsystem**
Common WebSockets

**Motivation**
[KTOR-9501](https://youtrack.jetbrains.com/issue/KTOR-9501) Websockets: Closing WebSocketSession with a long message leads to ProtocolViolationException

**Solution**
- CloseReason now validates its message in the constructor and throws an IllegalArgumentException if it exceeds 123 UTF-8 bytes (125 minus the 2-byte close code)
- Raw Frame control types validate payload size
- Ktor's internal error paths (closeExceptionally, the RawWebSocket* catch blocks) truncate caught exception text on whole-character boundaries before building a CloseReason


