### PR TITLE
Add support for Byte, UByte, UShort, UInt, ULong, and Kotlin Uuid conversions in DefaultConversionService

### DIFF
--- a/ktor-utils/common/src/io/ktor/util/converters/ConversionService.kt
+++ b/ktor-utils/common/src/io/ktor/util/converters/ConversionService.kt
@@ -36,6 +36,7 @@ public interface ConversionService {
  * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.util.converters.DefaultConversionService)
  */
 public object DefaultConversionService : ConversionService {
+    @OptIn(ExperimentalUuidApi::class)
     override fun toValues(value: Any?): List<String> {
         if (value == null) {
             return emptyList()
@@ -54,8 +55,14 @@ public object DefaultConversionService : ConversionService {
                     Double::class,
                     Long::class,
                     Short::class,
+                    Byte::class,
                     Char::class,
                     Boolean::class,
+                    Uuid::class,
+                    UShort::class,
+                    UInt::class,
+                    ULong::class,
+                    UByte::class,
                     String::class -> listOf(value.toString())
 
                     else -> throw DataConversionException(
@@ -110,6 +117,11 @@ public object DefaultConversionService : ConversionService {
         Double::class -> value.toDouble()
         Long::class -> value.toLong()
         Short::class -> value.toShort()
+        Byte::class -> value.toByte()
+        UShort::class -> value.toUShort()
+        UInt::class -> value.toUInt()
+        ULong::class -> value.toULong()
+        UByte::class -> value.toUByte()
         Char::class -> value.single()
         Boolean::class -> value.toBoolean()
         Uuid::class -> Uuid.parse(value)

--- a/ktor-utils/common/test/io/ktor/util/converters/DataConversionTest.kt
+++ b/ktor-utils/common/test/io/ktor/util/converters/DataConversionTest.kt
@@ -76,7 +76,7 @@ class DataConversionTest {
     @OptIn(ExperimentalUuidApi::class)
     @Test
     fun testDefaultConversionUuid() {
-        val id = Uuid.random()
+        val id = Uuid.parse("a1b2c3d4-e5f6-7890-abcd-ef1234567890")
         val converted = DefaultConversionService.fromValues(listOf(id.toString()), typeInfo<Uuid>())
         assertEquals(id, converted)
 

--- a/ktor-utils/common/test/io/ktor/util/converters/DataConversionTest.kt
+++ b/ktor-utils/common/test/io/ktor/util/converters/DataConversionTest.kt
@@ -6,6 +6,7 @@ package io.ktor.util.converters
 
 import io.ktor.util.reflect.*
 import kotlin.test.*
+import kotlin.uuid.*
 
 class DataConversionTest {
 
@@ -25,6 +26,62 @@ class DataConversionTest {
 
         val converted = DefaultConversionService.toValues(1)
         assertEquals(listOf("1"), converted)
+    }
+
+    @Test
+    fun testDefaultConversionByte() {
+        val id = DefaultConversionService.fromValues(listOf("1"), typeInfo<Byte>())
+        assertEquals(1.toByte(), id)
+
+        val converted = DefaultConversionService.toValues(1.toByte())
+        assertEquals(listOf("1"), converted)
+    }
+
+    @Test
+    fun testDefaultConversionUByte() {
+        val id = DefaultConversionService.fromValues(listOf("1"), typeInfo<UByte>())
+        assertEquals(1.toUByte(), id)
+
+        val converted = DefaultConversionService.toValues(1.toUByte())
+        assertEquals(listOf("1"), converted)
+    }
+
+    @Test
+    fun testDefaultConversionUShort() {
+        val id = DefaultConversionService.fromValues(listOf("1"), typeInfo<UShort>())
+        assertEquals(1.toUShort(), id)
+
+        val converted = DefaultConversionService.toValues(1.toUShort())
+        assertEquals(listOf("1"), converted)
+    }
+
+    @Test
+    fun testDefaultConversionUInt() {
+        val id = DefaultConversionService.fromValues(listOf("1"), typeInfo<UInt>())
+        assertEquals(1.toUInt(), id)
+
+        val converted = DefaultConversionService.toValues(1.toUInt())
+        assertEquals(listOf("1"), converted)
+    }
+
+    @Test
+    fun testDefaultConversionULong() {
+        val id = DefaultConversionService.fromValues(listOf("1"), typeInfo<ULong>())
+        assertEquals(1.toULong(), id)
+
+        val converted = DefaultConversionService.toValues(1.toULong())
+        assertEquals(listOf("1"), converted)
+    }
+
+    @OptIn(ExperimentalUuidApi::class)
+    @Test
+    fun testDefaultConversionUuid() {
+        val id = Uuid.random()
+        val converted = DefaultConversionService.fromValues(listOf(id.toString()), typeInfo<Uuid>())
+        assertEquals(id, converted)
+
+        val toValues = DefaultConversionService.toValues(converted)
+        assertEquals(listOf(id.toString()), toValues)
     }
 
     @Test

--- a/ktor-utils/jvm/src/io/ktor/util/converters/ConversionServiceJvm.kt
+++ b/ktor-utils/jvm/src/io/ktor/util/converters/ConversionServiceJvm.kt
@@ -29,6 +29,7 @@ private fun convertSimpleTypes(value: String, klass: KClass<*>): Any? = when (kl
     java.lang.Double::class -> value.toDouble()
     java.lang.Long::class -> value.toLong()
     java.lang.Short::class -> value.toShort()
+    java.lang.Byte::class -> value.toByte()
     java.lang.Boolean::class -> value.toBoolean()
     java.lang.String::class -> value
     Character::class -> value[0]
@@ -49,6 +50,7 @@ internal actual fun platformDefaultToValues(value: Any): List<String>? {
         is java.lang.Double -> listOf(value.toString())
         is java.lang.Long -> listOf(value.toString())
         is java.lang.Boolean -> listOf(value.toString())
+        is java.lang.Byte -> listOf(value.toString())
         is java.lang.Short -> listOf(value.toString())
         is java.lang.String -> listOf(value.toString())
         is Character -> listOf(value.toString())

--- a/ktor-utils/jvm/test/io/ktor/tests/utils/converters/DataConversionTest.kt
+++ b/ktor-utils/jvm/test/io/ktor/tests/utils/converters/DataConversionTest.kt
@@ -58,6 +58,16 @@ class DataConversionTest {
         assertEquals(listOf("B"), toValues)
     }
 
+    @Suppress("PLATFORM_CLASS_MAPPED_TO_KOTLIN")
+    @Test
+    fun testDefaultConversionByte() {
+        val converted = DefaultConversionService.fromValues(listOf("1"), typeInfo<java.lang.Byte>())
+        assertEquals(1.toByte(), converted)
+
+        val toValues = DefaultConversionService.toValues(converted)
+        assertEquals(listOf("1"), toValues)
+    }
+
     @Test
     fun testDefaultConversionUUID() {
         val id = UUID.randomUUID()


### PR DESCRIPTION
**Subsystem**
Server

**Motivation**
Currently in `DefaultConversionService` we did not support `Byte`, `java.lang.Byte`, `UByte`, `UShort`, `UInt` or `ULong`.
We were also missing `Uuid` in `toValues` in #5679

**Solution**
Added support for these types in the existing `DefaultConversionService`.
