### PR TITLE
Cherry-pick KTOR-9671 and 3.5.1 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,56 @@
+# 3.5.1
+> Published 25 June 2026
+
+### Improvements
+* [KTOR-9492](https://youtrack.jetbrains.com/issue/KTOR-9492) OpenAPI plugin: handle requireXxx functions in compiler plugin
+* [KTOR-9569](https://youtrack.jetbrains.com/issue/KTOR-9569) Add more details for KDoc of BearerAuthConfig.sendWithoutRequest
+* [KTOR-9571](https://youtrack.jetbrains.com/issue/KTOR-9571) Add KDoc for BearerAuthConfig.realm
+* [KTOR-9570](https://youtrack.jetbrains.com/issue/KTOR-9570) Add Kdoc for BearerAuthConfig.refreshTokens
+
+### Bugfixes
+* [KTOR-9646](https://youtrack.jetbrains.com/issue/KTOR-9646) Fix Kotlin 2.4.0 compiler plugin breaking changes
+* [KTOR-9585](https://youtrack.jetbrains.com/issue/KTOR-9585) OpenAPI: JsonSchema title is truncated when it contains a dot
+* [KTOR-9591](https://youtrack.jetbrains.com/issue/KTOR-9591) OpenAPI: `@JsonClassDiscriminator` on sealed types is ignored when generating OpenAPI discriminator schema
+* [KTOR-9597](https://youtrack.jetbrains.com/issue/KTOR-9597) OpenAPI: Schema name collisions because`@SerialName` of sealed subtypes is used as `components.schemas` key
+* [KTOR-9601](https://youtrack.jetbrains.com/issue/KTOR-9601) OpenAPI: nullable @JvmInline value class loses nullability in generated schema
+* [KTOR-9620](https://youtrack.jetbrains.com/issue/KTOR-9620) Some issues related to digest authentication in 3.5.0
+* [KTOR-9623](https://youtrack.jetbrains.com/issue/KTOR-9623) Digest Auth: server must respond with one WWW-Authenticate header for each supported algorithm
+* [KTOR-9624](https://youtrack.jetbrains.com/issue/KTOR-9624) Digest Auth: "Unsupported charset in digest authentication header" for a charset name in lowercase
+* [KTOR-9630](https://youtrack.jetbrains.com/issue/KTOR-9630) Digest Auth: The plugin sends incorrect nonce when server responds with multiple WWW-Authenticate headers
+* [KTOR-9565](https://youtrack.jetbrains.com/issue/KTOR-9565) WebRTC: Peer stops receiving messages after a while on iOS
+* [KTOR-9610](https://youtrack.jetbrains.com/issue/KTOR-9610) WebRtcPeerConnection::close causes ClosedReceiveChannelException for other peer
+* [KTOR-9633](https://youtrack.jetbrains.com/issue/KTOR-9633) WebRTC statistics fetching race condition
+* [KTOR-9603](https://youtrack.jetbrains.com/issue/KTOR-9603) Structured concurrency is violated in WebRTC tests
+* [KTOR-9671](https://youtrack.jetbrains.com/issue/KTOR-9671) Darwin: Semicolons in URL path are sanitized
+* [KTOR-9639](https://youtrack.jetbrains.com/issue/KTOR-9639) Darwin: WebSocket client crashes the process when a PONG arrives after the session is closed
+* [KTOR-9575](https://youtrack.jetbrains.com/issue/KTOR-9575) Darwin: findCharset("UTF-16") maps to NSUTF16LittleEndianStringEncoding causing decoding failure for UTF-16 content with BOM
+* [KTOR-9661](https://youtrack.jetbrains.com/issue/KTOR-9661) HttpCache: InvalidCacheStateException is thrown on 304 when no cached entry matches varyKeys
+* [KTOR-9673](https://youtrack.jetbrains.com/issue/KTOR-9673) Caching always missing with Content Negotiation
+* [KTOR-9596](https://youtrack.jetbrains.com/issue/KTOR-9596) HttpTimeout: HttpRequestTimeoutException on any request with runTest and request timeout defined since 3.5.0
+* [KTOR-9632](https://youtrack.jetbrains.com/issue/KTOR-9632) HttpRequestBuilder.timeout call removes capabilities set in DefaultRequest
+* [KTOR-9252](https://youtrack.jetbrains.com/issue/KTOR-9252) ContentEncoding: Incomplete gzip response causes client/server to hang indefinitely
+* [KTOR-9670](https://youtrack.jetbrains.com/issue/KTOR-9670) Compression: The plugin ignores Accept-Encoding q=0 and most-specific matching
+* [KTOR-9614](https://youtrack.jetbrains.com/issue/KTOR-9614) Zstd Compression: "Destination buffer is too small" exception for a particular sequence of bytes
+* [KTOR-9636](https://youtrack.jetbrains.com/issue/KTOR-9636) CORS plugin drops OPTIONS preflight requests when allowSameOrigin is on
+* [KTOR-9659](https://youtrack.jetbrains.com/issue/KTOR-9659) CORS is skipped when the Origin header contains an IPv6 address
+* [KTOR-9574](https://youtrack.jetbrains.com/issue/KTOR-9574) ContentNegotiation: The charset of `Accept-Charset` header is used for response deserialization
+* [KTOR-9606](https://youtrack.jetbrains.com/issue/KTOR-9606) KotlinxSerializationConverter: it fails to deserialize an empty channel closed with a delay
+* [KTOR-9617](https://youtrack.jetbrains.com/issue/KTOR-9617) OutputStreamContent and WriterContent can exhaust Dispatchers.IO
+* [KTOR-9629](https://youtrack.jetbrains.com/issue/KTOR-9629) RawSourceChannel: coroutine cancellation is not propagated to the RawSource
+* [KTOR-8870](https://youtrack.jetbrains.com/issue/KTOR-8870) File.readChannel: do not close a non-opened file and ignore closing exceptions
+* [KTOR-9460](https://youtrack.jetbrains.com/issue/KTOR-9460) Curl: Can't build shared library with Ktor 3.4.2
+* [KTOR-9607](https://youtrack.jetbrains.com/issue/KTOR-9607) Crash on Android 7: NoSuchMethodError getInstanceStrong() since 3.5.0
+* [KTOR-9595](https://youtrack.jetbrains.com/issue/KTOR-9595) CIO: The engine imports `node:net` statically and breaks wasmJsBrowser webpack build
+* [KTOR-9615](https://youtrack.jetbrains.com/issue/KTOR-9615) Apache5: The underlying request is not aborted when coroutine Job is cancelled
+* [KTOR-8443](https://youtrack.jetbrains.com/issue/KTOR-8443) RoutingBuilder.contentType does not use parameters when matching
+* [KTOR-9425](https://youtrack.jetbrains.com/issue/KTOR-9425) SessionTransportTransformerEncrypt init block uses wrong IV size for AES-256 (regression of KTOR-661)
+* [KTOR-9621](https://youtrack.jetbrains.com/issue/KTOR-9621) RateLimit plugin is bypassed when the nested authenticate block rejects the request
+* [KTOR-8766](https://youtrack.jetbrains.com/issue/KTOR-8766) DI: The close method is called twice on cleanup of AutoCloseable
+* [KTOR-8695](https://youtrack.jetbrains.com/issue/KTOR-8695) GMTDate() being offset by 369 years on Windows
+* [KTOR-9589](https://youtrack.jetbrains.com/issue/KTOR-9589) Duplicate PROPERTY_SETTER target in @InternalAPI annotation
+* [KTOR-9602](https://youtrack.jetbrains.com/issue/KTOR-9602) Gradle plugin environment variable is not included in the image
+
+
 # 3.5.0
 > Published 14 May 2026
 

--- a/ktor-client/ktor-client-darwin-legacy/darwin/src/io/ktor/client/engine/darwin/internal/legacy/DarwinLegacyUrlUtils.kt
+++ b/ktor-client/ktor-client-darwin-legacy/darwin/src/io/ktor/client/engine/darwin/internal/legacy/DarwinLegacyUrlUtils.kt
@@ -8,11 +8,22 @@ import io.ktor.http.*
 import io.ktor.util.*
 import platform.Foundation.*
 
+// Old version of macOS/iOS might not allow semicolon ';' in path for
+// compatibility with RFC 1808 (obsolete). However, ';' is a valid character according to RFC-3986.
+private val pathAllowedCharacters =
+    if (NSCharacterSet.URLPathAllowedCharacterSet.characterIsMember(';'.code.toUShort())) {
+        NSCharacterSet.URLPathAllowedCharacterSet
+    } else {
+        (NSCharacterSet.URLPathAllowedCharacterSet.mutableCopy() as NSMutableCharacterSet).apply {
+            addCharactersInString(";")
+        }
+    }
+
 internal fun Url.toNSUrl(): NSURL {
     val userEncoded = encodedUser.orEmpty().isEncoded(NSCharacterSet.URLUserAllowedCharacterSet)
     val passwordEncoded = encodedPassword.orEmpty().isEncoded(NSCharacterSet.URLUserAllowedCharacterSet)
     val hostEncoded = host.isEncoded(NSCharacterSet.URLHostAllowedCharacterSet)
-    val pathEncoded = encodedPath.isEncoded(NSCharacterSet.URLPathAllowedCharacterSet)
+    val pathEncoded = encodedPath.isEncoded(pathAllowedCharacters)
     val queryEncoded = encodedQuery.isEncoded(NSCharacterSet.URLQueryAllowedCharacterSet)
     val fragmentEncoded = encodedFragment.isEncoded(NSCharacterSet.URLFragmentAllowedCharacterSet)
     if (userEncoded && passwordEncoded && hostEncoded && pathEncoded && queryEncoded && fragmentEncoded) {
@@ -43,7 +54,7 @@ internal fun Url.toNSUrl(): NSURL {
 
         components.percentEncodedPath = when {
             pathEncoded -> encodedPath
-            else -> rawSegments.joinToString("/").sanitize(NSCharacterSet.URLPathAllowedCharacterSet)
+            else -> rawSegments.joinToString("/").sanitize(pathAllowedCharacters)
         }
 
         when {

--- a/ktor-client/ktor-client-darwin-legacy/darwin/test/DarwinLegacyEngineTest.kt
+++ b/ktor-client/ktor-client-darwin-legacy/darwin/test/DarwinLegacyEngineTest.kt
@@ -73,6 +73,10 @@ class DarwinLegacyEngineTest : ClientEngineTest<DarwinLegacyClientEngineConfig>(
         assertTrue(
             stringToNSUrlString("http://привет.привет/") in possibleResults
         )
+        assertEquals(
+            "https://example.com/path;param=my%3Bvalue/segment",
+            stringToNSUrlString("https://example.com/path;param=my%3Bvalue/segment")
+        )
     }
 
     @Test

--- a/ktor-client/ktor-client-darwin/darwin/src/io/ktor/client/engine/darwin/internal/DarwinUrlUtils.kt
+++ b/ktor-client/ktor-client-darwin/darwin/src/io/ktor/client/engine/darwin/internal/DarwinUrlUtils.kt
@@ -8,11 +8,22 @@ import io.ktor.http.*
 import io.ktor.util.*
 import platform.Foundation.*
 
+// Old version of macOS/iOS might not allow semicolon ';' in path for
+// compatibility with RFC 1808 (obsolete). However, ';' is a valid character according to RFC-3986.
+private val pathAllowedCharacters =
+    if (NSCharacterSet.URLPathAllowedCharacterSet.characterIsMember(';'.code.toUShort())) {
+        NSCharacterSet.URLPathAllowedCharacterSet
+    } else {
+        (NSCharacterSet.URLPathAllowedCharacterSet.mutableCopy() as NSMutableCharacterSet).apply {
+            addCharactersInString(";")
+        }
+    }
+
 internal fun Url.toNSUrl(): NSURL {
     val userEncoded = encodedUser.orEmpty().isEncoded(NSCharacterSet.URLUserAllowedCharacterSet)
     val passwordEncoded = encodedPassword.orEmpty().isEncoded(NSCharacterSet.URLUserAllowedCharacterSet)
     val hostEncoded = host.isEncoded(NSCharacterSet.URLHostAllowedCharacterSet)
-    val pathEncoded = encodedPath.isEncoded(NSCharacterSet.URLPathAllowedCharacterSet)
+    val pathEncoded = encodedPath.isEncoded(pathAllowedCharacters)
     val queryEncoded = encodedQuery.isEncoded(NSCharacterSet.URLQueryAllowedCharacterSet)
     val fragmentEncoded = encodedFragment.isEncoded(NSCharacterSet.URLFragmentAllowedCharacterSet)
     if (userEncoded && passwordEncoded && hostEncoded && pathEncoded && queryEncoded && fragmentEncoded) {
@@ -43,7 +54,7 @@ internal fun Url.toNSUrl(): NSURL {
 
         components.percentEncodedPath = when {
             pathEncoded -> encodedPath
-            else -> rawSegments.joinToString("/").sanitize(NSCharacterSet.URLPathAllowedCharacterSet)
+            else -> rawSegments.joinToString("/").sanitize(pathAllowedCharacters)
         }
 
         when {

--- a/ktor-client/ktor-client-darwin/darwin/test/DarwinEngineTest.kt
+++ b/ktor-client/ktor-client-darwin/darwin/test/DarwinEngineTest.kt
@@ -100,6 +100,10 @@ class DarwinEngineTest : ClientEngineTest<DarwinClientEngineConfig>(Darwin) {
         assertTrue(
             stringToNSUrlString("http://привет.привет/") in possibleResults
         )
+        assertEquals(
+            "https://example.com/path;param=my%3Bvalue/segment",
+            stringToNSUrlString("https://example.com/path;param=my%3Bvalue/segment")
+        )
     }
 
     @Test


### PR DESCRIPTION
**Subsystem**
Client / Darwin, release notes

**Motivation**
Weekly maintenance cherry-pick of patch-eligible fixes from `main` to `release/3.x`.

KTOR-9671 is targeted to 3.5.2 and fixes semicolon URL path encoding on Darwin. The 3.5.1 changelog entry also belongs on the release branch.

Merge with `--ff-only` after CI passes.

**Solution**
Cherry-picked:
- `d8502fceb` / `de59131c9` — `KTOR-9671: Fix semicolon character encoding for old darwin versions (#5712)`
- `888e7ebdd` / `8ab20cc16` — `Add changelog for 3.5.1 (#5721)`

Skipped from current `main` scan:
- Already in release by patch-id: `e22ac185f` CORS fix.
- 3.6.0 features/refactors: KTOR-6610, KTOR-9590, KTOR-8953, KTOR-9674, source-set move, HTTP auth constants.
- `4d0093218` UNIX socket tests/source-set changes: touches `.api` files and source-set declarations, so not a patch cherry-pick candidate.
- KTOR-9561 is a bug fix but YouTrack target release is 3.6.0, so left for human review per weekly-maintenance rules.

Validation:
- `:ktor-client-darwin:macosArm64Test :ktor-client-darwin-legacy:macosArm64Test` — passed, 10 tests.
- `CHANGELOG.md` change only for the second cherry-pick; no additional tests run.
