### PR TITLE
Fix KTOR-9523 OAuth2: fallback handler not invoked when token endpoint...

### DIFF
--- a/ktor-server/ktor-server-plugins/ktor-server-auth/api/ktor-server-auth.api
+++ b/ktor-server/ktor-server-plugins/ktor-server-auth/api/ktor-server-auth.api
@@ -358,6 +358,11 @@ public final class io/ktor/server/auth/OAuth2Exception$UnsupportedGrantType : io
 	public final fun getGrantType ()Ljava/lang/String;
 }
 
+public final class io/ktor/server/auth/OAuth2InvalidGrantError : io/ktor/server/auth/AuthenticationFailedCause$Error {
+	public fun <init> (Lio/ktor/server/auth/OAuth2Exception$InvalidGrant;)V
+	public final fun getCause ()Lio/ktor/server/auth/OAuth2Exception$InvalidGrant;
+}
+
 public final class io/ktor/server/auth/OAuth2Kt {
 	public static final fun verifyWithOAuth2 (Lio/ktor/server/auth/UserPasswordCredential;Lio/ktor/client/HttpClient;Lio/ktor/server/auth/OAuthServerSettings$OAuth2ServerSettings;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }

--- a/ktor-server/ktor-server-plugins/ktor-server-auth/api/ktor-server-auth.klib.api
+++ b/ktor-server/ktor-server-plugins/ktor-server-auth/api/ktor-server-auth.klib.api
@@ -251,6 +251,13 @@ final class io.ktor.server.auth/FormAuthenticationProvider : io.ktor.server.auth
     }
 }
 
+final class io.ktor.server.auth/OAuth2InvalidGrantError : io.ktor.server.auth/AuthenticationFailedCause.Error { // io.ktor.server.auth/OAuth2InvalidGrantError|null[0]
+    constructor <init>(io.ktor.server.auth/OAuth2Exception.InvalidGrant) // io.ktor.server.auth/OAuth2InvalidGrantError.<init>|<init>(io.ktor.server.auth.OAuth2Exception.InvalidGrant){}[0]
+
+    final val cause // io.ktor.server.auth/OAuth2InvalidGrantError.cause|{}cause[0]
+        final fun <get-cause>(): io.ktor.server.auth/OAuth2Exception.InvalidGrant // io.ktor.server.auth/OAuth2InvalidGrantError.cause.<get-cause>|<get-cause>(){}[0]
+}
+
 final class io.ktor.server.auth/OAuth2RedirectError : io.ktor.server.auth/AuthenticationFailedCause.Error { // io.ktor.server.auth/OAuth2RedirectError|null[0]
     constructor <init>(kotlin/String, kotlin/String?) // io.ktor.server.auth/OAuth2RedirectError.<init>|<init>(kotlin.String;kotlin.String?){}[0]
 

--- a/ktor-server/ktor-server-plugins/ktor-server-auth/common/src/io/ktor/server/auth/OAuthProcedure.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-auth/common/src/io/ktor/server/auth/OAuthProcedure.kt
@@ -9,6 +9,7 @@ import io.ktor.server.application.*
 import io.ktor.util.*
 import io.ktor.util.logging.*
 import io.ktor.utils.io.InternalAPI
+import kotlinx.coroutines.CancellationException
 
 private val Logger: Logger = KtorSimpleLogger("io.ktor.auth.oauth")
 
@@ -80,8 +81,14 @@ public class OAuthAuthenticationProvider internal constructor(config: Config) : 
 
         /**
          * Specifies a fallback function invoked when OAuth flow fails
-         * with an [AuthenticationFailedCause.Error], e.g., a token exchange error, network/parse failure, etc.
-         * If call is not handled in the fallback, `401 Unauthorized` will be responded.
+         * with an [AuthenticationFailedCause.Error], e.g., a token exchange error, network/parse failure, or `invalid_grant` error.
+         *
+         * If `invalid_grant` occurs, this fallback is invoked. If the fallback handles the call (e.g., by responding),
+         * Ktor completes the authentication flow. If the fallback does not handle the call, Ktor falls back to
+         * the redirect challenge to try to automatically recover the authentication flow.
+         *
+         * For other errors, or if the fallback handles the call, Ktor will not execute the redirect challenge and
+         * will respond with `401 Unauthorized` if the call remains unhandled by the fallback.
          *
          * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.server.auth.OAuthAuthenticationProvider.Config.fallback)
          */
@@ -140,6 +147,16 @@ public fun AuthenticationConfig.oauth(
 public class OAuth2RedirectError(public val error: String, public val errorDescription: String?) :
     AuthenticationFailedCause.Error(if (errorDescription == null) error else "$error: $errorDescription")
 
+/**
+ * Error container for when the token endpoint responds with an `invalid_grant` error.
+ *
+ * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.server.auth.OAuth2InvalidGrantError)
+ *
+ * @property cause the original [OAuth2Exception.InvalidGrant] exception thrown during token request.
+ */
+public class OAuth2InvalidGrantError(public val cause: OAuth2Exception.InvalidGrant) :
+    AuthenticationFailedCause.Error("Failed to request OAuth2 access token due to invalid_grant: ${cause.message}")
+
 internal suspend fun OAuthAuthenticationProvider.oauth2(authProviderName: String?, context: AuthenticationContext) {
     val call = context.call
     val provider = providerLookup?.invoke(call) ?: settings
@@ -163,7 +180,13 @@ internal suspend fun OAuthAuthenticationProvider.oauth2(authProviderName: String
 
     cause ?: return
 
-    if (cause is AuthenticationFailedCause.Error) {
+    if (cause is OAuth2InvalidGrantError) {
+        this@oauth2.fallback.invoke(call, cause)
+        if (call.isHandled) {
+            context.error(OAuthKey, cause)
+            return
+        }
+    } else if (cause is AuthenticationFailedCause.Error) {
         this@oauth2.fallback.invoke(call, cause)
         context.error(OAuthKey, cause)
         return
@@ -202,7 +225,9 @@ private suspend fun OAuthAuthenticationProvider.oauth2RequestToken(
     null
 } catch (cause: OAuth2Exception.InvalidGrant) {
     Logger.trace("OAuth invalid grant reported: {}", cause)
-    AuthenticationFailedCause.InvalidCredentials
+    OAuth2InvalidGrantError(cause)
+} catch (cause: CancellationException) {
+    throw cause
 } catch (cause: Throwable) {
     Logger.trace("OAuth2 request access token failed", cause)
     AuthenticationFailedCause.Error("Failed to request OAuth2 access token due to $cause")

--- a/ktor-server/ktor-server-plugins/ktor-server-auth/common/test/io/ktor/tests/auth/OAuth2Test.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-auth/common/test/io/ktor/tests/auth/OAuth2Test.kt
@@ -435,6 +435,47 @@ class OAuth2Test {
     }
 
     @Test
+    fun testFallbackCalledOnInvalidGrant() = testApplication {
+        var fallbackCalled = false
+        install(Authentication) {
+            oauth("login") {
+                client = this@testApplication.client
+                urlProvider = { "http://localhost/login" }
+                settings = OAuthServerSettings.OAuth2ServerSettings(
+                    name = "oauth2",
+                    authorizeUrl = "http://localhost/authorize",
+                    accessTokenUrl = "http://localhost/access_token",
+                    clientId = "clientId1",
+                    clientSecret = "clientSecret1",
+                    requestMethod = HttpMethod.Post,
+                    passParamsInURL = true
+                )
+                fallback = { _ ->
+                    fallbackCalled = true
+                    respond(HttpStatusCode.Forbidden, "Invalid grant")
+                }
+            }
+        }
+
+        routing {
+            post("/access_token") {
+                call.respondText(
+                    "error=invalid_grant&error_description=Token+has+expired",
+                    ContentType.Application.FormUrlEncoded
+                )
+            }
+            authenticate("login") {
+                get("/login") { }
+            }
+        }
+
+        noRedirectsClient().get("/login?code=code&state=state").apply {
+            assertEquals(HttpStatusCode.Forbidden, status)
+            assertTrue(fallbackCalled, "Fallback should be called when OAuth2Exception.InvalidGrant is thrown")
+        }
+    }
+
+    @Test
     fun testRequestToken() = testApplication {
         application { module() }
         val result = client.get(

--- a/ktor-server/ktor-server-plugins/ktor-server-auth/jvm/src/io/ktor/server/auth/OAuth.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-auth/jvm/src/io/ktor/server/auth/OAuth.kt
@@ -5,6 +5,7 @@
 package io.ktor.server.auth
 
 import io.ktor.server.application.*
+import kotlinx.coroutines.CancellationException
 import kotlinx.io.IOException
 
 internal actual suspend fun OAuthAuthenticationProvider.oauth1a(
@@ -60,6 +61,8 @@ private suspend fun OAuthAuthenticationProvider.oauth1RequestToken(
     null
 } catch (_: OAuth1aException.MissingTokenException) {
     AuthenticationFailedCause.InvalidCredentials
+} catch (cause: CancellationException) {
+    throw cause
 } catch (cause: Throwable) {
     AuthenticationFailedCause.Error("OAuth1a failed to get OAuth1 access token due to $cause")
 }


### PR DESCRIPTION
**Subsystem**
Server

**Motivation**
[KTOR-9523](https://youtrack.jetbrains.com/issue/KTOR-9523) OAuth2: fallback handler not invoked when token endpoint returns invalid_grant

**Solution**
- Invoke fallback on invalid_grant and pass `OAuth2InvalidGrantError` as a cause
- We might want to change the default behaviour on invalid grant and respond with 401 instead of redirecting, but it's a breaking change

Also, we were catching some cancellation exceptions