### PR TITLE
KTOR-9683 Close ActorSelectorManager when its job is canceled

### DIFF
--- a/ktor-network/jvm/src/io/ktor/network/selector/ActorSelectorManager.kt
+++ b/ktor-network/jvm/src/io/ktor/network/selector/ActorSelectorManager.kt
@@ -1,16 +1,22 @@
 /*
-* Copyright 2014-2021 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
-*/
+ * Copyright 2014-2026 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
 
 package io.ktor.network.selector
 
 import kotlinx.coroutines.*
-import kotlinx.coroutines.channels.*
-import java.io.*
-import java.nio.channels.*
-import java.util.concurrent.atomic.*
-import kotlin.coroutines.*
-import kotlin.coroutines.intrinsics.*
+import kotlinx.coroutines.channels.ClosedSendChannelException
+import java.io.Closeable
+import java.nio.channels.ClosedChannelException
+import java.nio.channels.ClosedSelectorException
+import java.nio.channels.Selector
+import java.util.concurrent.atomic.AtomicLong
+import java.util.concurrent.atomic.AtomicReference
+import kotlin.coroutines.Continuation
+import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.intrinsics.COROUTINE_SUSPENDED
+import kotlin.coroutines.intrinsics.suspendCoroutineUninterceptedOrReturn
+import kotlin.coroutines.resume
 
 /**
  * Default CIO selector manager implementation
@@ -35,7 +41,15 @@ public class ActorSelectorManager(context: CoroutineContext) : SelectorManagerSu
 
     override val coroutineContext: CoroutineContext = context + CoroutineName("selector")
 
+    @Volatile
+    private var parentCancellationHandler: DisposableHandle? = null
+
     init {
+        @OptIn(InternalCoroutinesApi::class)
+        parentCancellationHandler = context[Job]?.invokeOnCompletion(onCancelling = true) { cause ->
+            if (cause != null) close()
+        }
+
         launch {
             val selector = provider.openSelector() ?: error("openSelector() = null")
             selectorRef = selector
@@ -177,6 +191,8 @@ public class ActorSelectorManager(context: CoroutineContext) : SelectorManagerSu
      * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.network.selector.ActorSelectorManager.close)
      */
     override fun close() {
+        parentCancellationHandler?.dispose()
+        parentCancellationHandler = null
         closed = true
         selectionQueue.close()
         if (!continuation.resume(Unit)) {

--- a/ktor-network/jvm/test/io/ktor/network/selector/ActorSelectorManagerTest.kt
+++ b/ktor-network/jvm/test/io/ktor/network/selector/ActorSelectorManagerTest.kt
@@ -1,43 +1,66 @@
 /*
- * Copyright 2014-2022 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2014-2026 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package io.ktor.network.selector
 
-import io.mockk.*
-import kotlinx.coroutines.*
-import org.junit.jupiter.api.*
-import java.io.*
-import kotlin.test.*
+import io.ktor.test.*
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.job
+import kotlinx.coroutines.test.TestScope
+import kotlinx.io.IOException
+import kotlin.coroutines.CoroutineContext
 import kotlin.test.Test
+import kotlin.test.assertFailsWith
+import kotlin.time.Duration.Companion.seconds
 
 class ActorSelectorManagerTest {
-    private val manager = ActorSelectorManager(Dispatchers.Default)
-
-    @AfterEach
-    fun tearDown() {
-        manager.close()
-    }
 
     @Test
-    fun testSelectableIsClosed(): Unit = runBlocking {
-        val selectable: Selectable = mockk()
-        every { selectable.interestedOps } returns SelectInterest.READ.flag
-        every { selectable.isClosed } returns true
+    fun `selectable is closed`() = runTest {
+        val selectable = mockkSelectable(SelectInterest.READ, isClosed = true)
 
-        assertFailsWith<IOException> {
-            manager.select(selectable, SelectInterest.READ)
+        withSelectorManager { manager ->
+            assertFailsWith<IOException> {
+                manager.select(selectable, SelectInterest.READ)
+            }
         }
     }
 
     @Test
-    fun testSelectOnWrongInterest(): Unit = runBlocking {
-        val selectable: Selectable = mockk()
-        every { selectable.interestedOps } returns SelectInterest.READ.flag
-        every { selectable.isClosed } returns false
+    fun `select on wrong interest`() = runTest {
+        val selectable = mockkSelectable(SelectInterest.READ, isClosed = false)
 
-        assertFailsWith<IllegalStateException> {
-            manager.select(selectable, SelectInterest.WRITE)
+        withSelectorManager { manager ->
+            assertFailsWith<IllegalStateException> {
+                manager.select(selectable, SelectInterest.WRITE)
+            }
         }
     }
+
+    @Test
+    fun `parent job cancellation closes selection manager`() = runTest(timeout = 1.seconds) {
+        val parent = Job(coroutineContext.job)
+
+        withSelectorManager(Dispatchers.Unconfined + parent) {
+            parent.cancelAndJoin()
+        }
+    }
+}
+
+@Suppress("SameParameterValue")
+private fun mockkSelectable(interest: SelectInterest, isClosed: Boolean): Selectable = mockk {
+    every { this@mockk.interestedOps } returns interest.flag
+    every { this@mockk.isClosed } returns isClosed
+}
+
+private inline fun TestScope.withSelectorManager(
+    coroutineContext: CoroutineContext = backgroundScope.coroutineContext,
+    block: (ActorSelectorManager) -> Unit
+) {
+    ActorSelectorManager(coroutineContext).use(block)
 }


### PR DESCRIPTION
**Subsystem**
Network

**Motivation**
[KTOR-9683](https://youtrack.jetbrains.com/issue/KTOR-9683) Sockets: Canceling a SelectorManager job doesn't close it properly

**Solution**
Close `ActorSelectorManager` when its parent job starts cancelling, while preserving the existing unintercepted selector wakeup path. Added a JVM regression test for parent-job cancellation.

Validation: `:ktor-network:jvmTest --tests io.ktor.network.selector.ActorSelectorManagerTest --rerun` passed, 3 tests.
