### PR TITLE
renovate: Change base branch and enable dependency dashboard approval

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,9 +3,10 @@
   "extends": [
     "config:recommended",
     ":semanticCommitsDisabled",
-    ":label(dependencies)",
-    "schedule:automergeNonOfficeHours"
+    ":label(dependencies)"
   ],
+  "baseBranchPatterns": ["/^release\\/.*/"],
+  "dependencyDashboardApproval": true,
   "rebaseWhen": "conflicted",
   "packageRules": [
     {


### PR DESCRIPTION
**Subsystem**
Build Infrastructure

**Motivation**
Reduce noise from Renovate.

**Solution**
1. Do not create PRs automatically so Renovate PRs doesn't occupy all CI resources  
2. Change the base branch to release branch so Renovate shows an up-to-date list of dependencies to be updated
