### PR TITLE
KTOR-9698 Include discriminator property in sealed subtype schemas

### DIFF
--- a/ktor-server/ktor-server-plugins/ktor-server-routing-openapi/jvm/test-resources/expected/openapi.json
+++ b/ktor-server/ktor-server-plugins/ktor-server-routing-openapi/jvm/test-resources/expected/openapi.json
@@ -54,11 +54,18 @@
         "type": "object",
         "title": "DM",
         "required": [
+          "type",
           "id",
           "content",
           "timestamp"
         ],
         "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "io.ktor.server.routing.openapi.Message.DM"
+            ]
+          },
           "id": {
             "type": "integer"
           },
@@ -74,11 +81,18 @@
         "type": "object",
         "title": "Post",
         "required": [
+          "type",
           "id",
           "content",
           "timestamp"
         ],
         "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "io.ktor.server.routing.openapi.Message.Post"
+            ]
+          },
           "id": {
             "type": "integer"
           },

--- a/ktor-server/ktor-server-plugins/ktor-server-routing-openapi/jvm/test-resources/expected/openapi.yaml
+++ b/ktor-server/ktor-server-plugins/ktor-server-routing-openapi/jvm/test-resources/expected/openapi.yaml
@@ -36,10 +36,15 @@ components:
       type: "object"
       title: "DM"
       required:
+      - "type"
       - "id"
       - "content"
       - "timestamp"
       properties:
+        "type":
+          type: "string"
+          enum:
+          - "io.ktor.server.routing.openapi.Message.DM"
         "id":
           type: "integer"
         "content":
@@ -50,10 +55,15 @@ components:
       type: "object"
       title: "Post"
       required:
+      - "type"
       - "id"
       - "content"
       - "timestamp"
       properties:
+        "type":
+          type: "string"
+          enum:
+          - "io.ktor.server.routing.openapi.Message.Post"
         "id":
           type: "integer"
         "content":

--- a/ktor-server/ktor-server-plugins/ktor-server-routing-openapi/jvm/test/io/ktor/server/routing/openapi/DescribeRouteTest.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-routing-openapi/jvm/test/io/ktor/server/routing/openapi/DescribeRouteTest.kt
@@ -27,6 +27,7 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.builtins.serializer
 import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonClassDiscriminator
 import kotlin.reflect.typeOf
@@ -227,9 +228,11 @@ class DescribeRouteTest {
         assertNotNull(okResponse, "OK response is missing")
         assertEquals("A list of messages", okResponse.description)
         assertEquals("child", okResponse.extensions?.get("x-bonus")?.deserialize(String.serializer()))
+        val actualOkSchema = okResponse.content?.get(ContentType.Application.Json)?.schema?.valueOrNull()
+        assertNotNull(actualOkSchema, "OK response schema is missing")
         assertEquals(
-            KotlinxJsonSchemaInference.jsonSchema<List<Message>>(),
-            okResponse.content?.get(ContentType.Application.Json)?.schema?.valueOrNull()
+            jsonFormat.encodeToString(KotlinxJsonSchemaInference.jsonSchema<List<Message>>()),
+            jsonFormat.encodeToString(actualOkSchema),
         )
         val badRequestResponse = responses.responses?.get(HttpStatusCode.BadRequest.value)?.valueOrNull()
         assertNotNull(badRequestResponse, "Bad request response is missing")

--- a/ktor-shared/ktor-openapi-schema/common/src/io/ktor/openapi/JsonSchemaInference.kt
+++ b/ktor-shared/ktor-openapi-schema/common/src/io/ktor/openapi/JsonSchemaInference.kt
@@ -459,7 +459,7 @@ public class KotlinxSerializerJsonSchemaInference(
                             )
                         )
                     ) +
-                        schema.value.properties.orEmpty(),
+                        (schema.value.properties.orEmpty() - discriminatorProperty),
             )
         )
     }

--- a/ktor-shared/ktor-openapi-schema/common/src/io/ktor/openapi/JsonSchemaInference.kt
+++ b/ktor-shared/ktor-openapi-schema/common/src/io/ktor/openapi/JsonSchemaInference.kt
@@ -219,13 +219,14 @@ public class KotlinxSerializerJsonSchemaInference(
                                         subclassDescriptor = subclassDescriptor,
                                         serialName = serialName,
                                     )
-                            buildSchemaOrReference(
+                            buildSealedSubclassSchema(
+                                discriminatorProperty = discriminatorProperty,
+                                discriminatorValue = serialName,
                                 descriptor = subclassDescriptor,
-                                referenceName = componentName,
+                                componentName = componentName,
                                 visiting = visiting,
                                 annotations = sealedElementsDescriptor.getElementAnnotations(i),
                                 serializer = subclassSerializer,
-                                schemaTitleOverride = componentName,
                             )
                         }
                     val discriminatorMapping = (0..<sealedElementsDescriptor.elementsCount)
@@ -424,6 +425,43 @@ public class KotlinxSerializerJsonSchemaInference(
         } else {
             subclassName
         }
+    }
+
+    private fun buildSealedSubclassSchema(
+        discriminatorProperty: String,
+        discriminatorValue: String,
+        descriptor: SerialDescriptor,
+        componentName: String,
+        visiting: MutableSet<String>,
+        annotations: List<Annotation>,
+        serializer: KSerializer<*>?,
+    ): ReferenceOr<JsonSchema> {
+        val schema = buildSchemaOrReference(
+            descriptor = descriptor,
+            referenceName = componentName,
+            visiting = visiting,
+            annotations = annotations,
+            serializer = serializer,
+            schemaTitleOverride = componentName,
+        )
+
+        if (schema !is Value) return schema
+
+        return Value(
+            schema.value.copy(
+                required = (listOf(discriminatorProperty) + schema.value.required.orEmpty()).distinct(),
+                properties =
+                    mapOf(
+                        discriminatorProperty to Value(
+                            JsonSchema(
+                                type = JsonType.STRING,
+                                enum = listOf(GenericElement(discriminatorValue)),
+                            )
+                        )
+                    ) +
+                        schema.value.properties.orEmpty(),
+            )
+        )
     }
 }
 

--- a/ktor-shared/ktor-openapi-schema/common/src/io/ktor/openapi/JsonSchemaInference.kt
+++ b/ktor-shared/ktor-openapi-schema/common/src/io/ktor/openapi/JsonSchemaInference.kt
@@ -451,15 +451,15 @@ public class KotlinxSerializerJsonSchemaInference(
             schema.value.copy(
                 required = (listOf(discriminatorProperty) + schema.value.required.orEmpty()).distinct(),
                 properties =
-                    mapOf(
-                        discriminatorProperty to Value(
-                            JsonSchema(
-                                type = JsonType.STRING,
-                                enum = listOf(GenericElement(discriminatorValue)),
-                            )
+                mapOf(
+                    discriminatorProperty to Value(
+                        JsonSchema(
+                            type = JsonType.STRING,
+                            enum = listOf(GenericElement(discriminatorValue)),
                         )
-                    ) +
-                        (schema.value.properties.orEmpty() - discriminatorProperty),
+                    )
+                ) +
+                    (schema.value.properties.orEmpty() - discriminatorProperty),
             )
         )
     }

--- a/ktor-shared/ktor-openapi-schema/ktor-openapi-schema-reflect/jvm/src/io/ktor/openapi/reflect/JsonSchemaInference.jvm.kt
+++ b/ktor-shared/ktor-openapi-schema/ktor-openapi-schema-reflect/jvm/src/io/ktor/openapi/reflect/JsonSchemaInference.jvm.kt
@@ -224,9 +224,6 @@ public class ReflectionJsonSchemaInference(
         try {
             if (kClass.isSealed) {
                 val sealedSubclasses = kClass.sealedSubclasses
-                val sealedSubclassSchema = sealedSubclasses.map {
-                    buildSchemaOrRef(it.starProjectedType, visiting)
-                }
                 val discriminatorMapping = sealedSubclasses
                     .filter { it.qualifiedName != null }
                     .associate { subclass ->
@@ -234,6 +231,14 @@ public class ReflectionJsonSchemaInference(
                     }
 
                 val discriminatorProperty = adapter.getDiscriminatorProperty(kClass)
+                val sealedSubclassSchema = sealedSubclasses.map {
+                    buildSealedSubclassSchema(
+                        type = it.starProjectedType,
+                        visiting = visiting,
+                        discriminatorProperty = discriminatorProperty,
+                        discriminatorValue = it.qualifiedName ?: it.simpleName.orEmpty(),
+                    )
+                }
                 return jsonSchemaFromAnnotations(
                     title = typeName,
                     annotations = includeAnnotations + kClass.annotations,
@@ -302,6 +307,32 @@ public class ReflectionJsonSchemaInference(
                 visiting.remove(name)
             }
         }
+    }
+
+    private fun buildSealedSubclassSchema(
+        type: KType,
+        visiting: MutableSet<String>,
+        discriminatorProperty: String,
+        discriminatorValue: String,
+    ): ReferenceOr<JsonSchema> {
+        val schema = buildSchemaOrRef(type, visiting)
+        if (schema !is ReferenceOr.Value) return schema
+
+        return ReferenceOr.Value(
+            schema.value.copy(
+                required = (listOf(discriminatorProperty) + schema.value.required.orEmpty()).distinct(),
+                properties =
+                mapOf(
+                    discriminatorProperty to ReferenceOr.Value(
+                        JsonSchema(
+                            type = JsonType.STRING,
+                            enum = listOf(GenericElement(discriminatorValue)),
+                        )
+                    )
+                ) +
+                    schema.value.properties.orEmpty(),
+            )
+        )
     }
 
     private fun KClass<*>.underlyingValueClassTypeOrNull(ownerType: KType): KType? {

--- a/ktor-shared/ktor-openapi-schema/ktor-openapi-schema-reflect/jvm/src/io/ktor/openapi/reflect/JsonSchemaInference.jvm.kt
+++ b/ktor-shared/ktor-openapi-schema/ktor-openapi-schema-reflect/jvm/src/io/ktor/openapi/reflect/JsonSchemaInference.jvm.kt
@@ -330,7 +330,7 @@ public class ReflectionJsonSchemaInference(
                         )
                     )
                 ) +
-                    schema.value.properties.orEmpty(),
+                    (schema.value.properties.orEmpty() - discriminatorProperty),
             )
         )
     }

--- a/ktor-shared/ktor-openapi-schema/ktor-openapi-schema-reflect/jvm/test-resources/schema/BinaryExpression.yaml
+++ b/ktor-shared/ktor-openapi-schema/ktor-openapi-schema-reflect/jvm/test-resources/schema/BinaryExpression.yaml
@@ -13,15 +13,25 @@ properties:
       - type: object
         title: io.ktor.openapi.reflect.IntLiteral
         required:
+          - type
           - value
         properties:
+          type:
+            type: string
+            enum:
+              - io.ktor.openapi.reflect.IntLiteral
           value:
             type: integer
       - type: object
         title: io.ktor.openapi.reflect.StringLiteral
         required:
+          - type
           - value
         properties:
+          type:
+            type: string
+            enum:
+              - io.ktor.openapi.reflect.StringLiteral
           value:
             type: string
     discriminator:
@@ -40,15 +50,25 @@ properties:
       - type: object
         title: io.ktor.openapi.reflect.IntLiteral
         required:
+          - type
           - value
         properties:
+          type:
+            type: string
+            enum:
+              - io.ktor.openapi.reflect.IntLiteral
           value:
             type: integer
       - type: object
         title: io.ktor.openapi.reflect.StringLiteral
         required:
+          - type
           - value
         properties:
+          type:
+            type: string
+            enum:
+              - io.ktor.openapi.reflect.StringLiteral
           value:
             type: string
     discriminator:

--- a/ktor-shared/ktor-openapi-schema/ktor-openapi-schema-reflect/jvm/test-resources/schema/KindShape.kotlinx.yaml
+++ b/ktor-shared/ktor-openapi-schema/ktor-openapi-schema-reflect/jvm/test-resources/schema/KindShape.kotlinx.yaml
@@ -4,16 +4,26 @@ oneOf:
   - type: object
     title: io.ktor.openapi.reflect.KindShape.Circle
     required:
+      - kind
       - radius
     properties:
+      kind:
+        type: string
+        enum:
+          - circle
       radius:
         type: number
   - type: object
     title: io.ktor.openapi.reflect.KindShape.Rectangle
     required:
+      - kind
       - width
       - height
     properties:
+      kind:
+        type: string
+        enum:
+          - rectangle
       width:
         type: number
       height:

--- a/ktor-shared/ktor-openapi-schema/ktor-openapi-schema-reflect/jvm/test-resources/schema/KindShape.yaml
+++ b/ktor-shared/ktor-openapi-schema/ktor-openapi-schema-reflect/jvm/test-resources/schema/KindShape.yaml
@@ -4,16 +4,26 @@ oneOf:
   - type: object
     title: io.ktor.openapi.reflect.KindShape.Circle
     required:
+      - kind
       - radius
     properties:
+      kind:
+        type: string
+        enum:
+          - io.ktor.openapi.reflect.KindShape.Circle
       radius:
         type: number
   - type: object
     title: io.ktor.openapi.reflect.KindShape.Rectangle
     required:
+      - kind
       - width
       - height
     properties:
+      kind:
+        type: string
+        enum:
+          - io.ktor.openapi.reflect.KindShape.Rectangle
       width:
         type: number
       height:

--- a/ktor-shared/ktor-openapi-schema/ktor-openapi-schema-reflect/jvm/test-resources/schema/Shape.yaml
+++ b/ktor-shared/ktor-openapi-schema/ktor-openapi-schema-reflect/jvm/test-resources/schema/Shape.yaml
@@ -4,16 +4,26 @@ oneOf:
   - type: object
     title: io.ktor.openapi.reflect.Shape.Circle
     required:
+      - type
       - radius
     properties:
+      type:
+        type: string
+        enum:
+          - io.ktor.openapi.reflect.Shape.Circle
       radius:
         type: number
   - type: object
     title: io.ktor.openapi.reflect.Shape.Rectangle
     required:
+      - type
       - width
       - height
     properties:
+      type:
+        type: string
+        enum:
+          - io.ktor.openapi.reflect.Shape.Rectangle
       width:
         type: number
       height:


### PR DESCRIPTION
**Subsystem**
OpenAPI schema inference

**Motivation**
Sealed types include their discriminator field in serialized JSON, but the generated subtype schemas only included the regular subtype properties. This made each `oneOf` variant miss the discriminator property that is present in the payload.

**Solution**
When building schemas for sealed types, add the discriminator property to each inline subtype schema as a single-value string enum. Kotlinx serialization uses the sealed element serial name, and reflection uses the same subclass name that is already used in the discriminator mapping.

Existing subtype properties are preserved, and schemas that are emitted as references remain references.

**Tests**
- Updated schema snapshots for sealed types with default and custom discriminators.

**Issue**
KTOR-9698
