### PR TITLE
Fix a hidden bug with javaClass

### DIFF
--- a/ktor-client/ktor-client-plugins/ktor-client-json/jvm/src/io/ktor/client/plugins/json/DefaultJvm.kt
+++ b/ktor-client/ktor-client-plugins/ktor-client-json/jvm/src/io/ktor/client/plugins/json/DefaultJvm.kt
@@ -9,7 +9,7 @@ import io.ktor.utils.io.*
 
 @Suppress("DEPRECATION_ERROR")
 public actual fun defaultSerializer(): JsonSerializer {
-    return serializers.maxByOrNull { it::javaClass.name } ?: error(
+    return serializers.maxByOrNull { it.javaClass.name } ?: error(
         """
         Failed to find serializer. Consider adding one of the following dependencies: 
          - ktor-client-gson


### PR DESCRIPTION
**Subsystem**
Client

**Motivation**
`something::javaClass.name` is not the name of the class of something but `"javaClass"`

**Solution**
Replace property reference with property access.

