### PR TITLE
KTOR-9701 Avoid Dispatchers.IO dispatch in Jackson and Gson deserialization

### DIFF
--- a/ktor-shared/ktor-serialization/ktor-serialization-gson/jvm/src/GsonConverter.kt
+++ b/ktor-shared/ktor-serialization/ktor-serialization-gson/jvm/src/GsonConverter.kt
@@ -12,6 +12,7 @@ import io.ktor.util.*
 import io.ktor.util.reflect.*
 import io.ktor.utils.io.*
 import io.ktor.utils.io.charsets.*
+import io.ktor.utils.io.core.*
 import io.ktor.utils.io.jvm.javaio.*
 import kotlinx.coroutines.*
 import kotlinx.coroutines.flow.*
@@ -54,7 +55,7 @@ public class GsonConverter(private val gson: Gson = Gson()) : ContentConverter {
         }
 
         try {
-            val text = String(content.toByteArray(), charset)
+            val text = content.readRemaining().readText(charset)
             return gson.fromJson(text, typeInfo.reifiedType)
         } catch (cause: JsonSyntaxException) {
             throw JsonConvertException("Illegal json parameter found: ${cause.message}", cause)

--- a/ktor-shared/ktor-serialization/ktor-serialization-gson/jvm/src/GsonConverter.kt
+++ b/ktor-shared/ktor-serialization/ktor-serialization-gson/jvm/src/GsonConverter.kt
@@ -54,10 +54,8 @@ public class GsonConverter(private val gson: Gson = Gson()) : ContentConverter {
         }
 
         try {
-            return withContext(Dispatchers.IO) {
-                val reader = content.toInputStream().reader(charset)
-                gson.fromJson(reader, typeInfo.reifiedType)
-            }
+            val text = String(content.toByteArray(), charset)
+            return gson.fromJson(text, typeInfo.reifiedType)
         } catch (cause: JsonSyntaxException) {
             throw JsonConvertException("Illegal json parameter found: ${cause.message}", cause)
         }

--- a/ktor-shared/ktor-serialization/ktor-serialization-jackson/jvm/src/JacksonConverter.kt
+++ b/ktor-shared/ktor-serialization/ktor-serialization-jackson/jvm/src/JacksonConverter.kt
@@ -90,18 +90,17 @@ public class JacksonConverter(
 
     override suspend fun deserialize(charset: Charset, typeInfo: TypeInfo, content: ByteReadChannel): Any? {
         try {
-            return withContext(Dispatchers.IO) {
-                val type = objectMapper.constructType(typeInfo.reifiedType)
-                val objectReader = objectMapper.readerFor(type)
+            val type = objectMapper.constructType(typeInfo.reifiedType)
+            val objectReader = objectMapper.readerFor(type)
 
-                // Jackson handles decoding of Unicode charsets automatically, no need to create a reader.
-                // Additionally, a byte-based source is required for binary format (Smile).
-                if (isUnicode(charset)) {
-                    objectReader.readValue(content.toInputStream())
-                } else {
-                    val reader = content.toInputStream().reader(charset)
-                    objectReader.readValue(reader)
-                }
+            val bytes = content.toByteArray()
+
+            // Jackson decodes Unicode charsets from bytes automatically, and a byte-based
+            // source is required for binary formats (Smile).
+            return if (isUnicode(charset)) {
+                objectReader.readValue(bytes)
+            } else {
+                objectReader.readValue(String(bytes, charset))
             }
         } catch (cause: Exception) {
             val convertException = JsonConvertException("Illegal json parameter found: ${cause.message}", cause)


### PR DESCRIPTION
Resolves [KTOR-9701](https://youtrack.jetbrains.com/issue/KTOR-9701).

**Subsystem**
Serialization: `ktor-serialization-jackson`, `ktor-serialization-gson` (JVM)

**Motivation**
Both converters wrap `deserialize()` in an unconditional `withContext(Dispatchers.IO)`. The dispatch guards against blocking `InputStream` reads, but for request bodies already buffered in the byte channel (the common case for API-sized payloads), the blocking adapter never actually blocks: `ByteReadChannel.toInputStream()` only parks when the channel is empty *and* still open for write. 

The guard itself is the dominant cost: an empty `withContext(Dispatchers.IO) {}` measures **~8.8 µs** (two thread handoffs), out of ~14.6 µs total for a full Jackson deserialize of a small JSON body,  while Jackson's own parsing accounts for only ~2.3 µs.

`KotlinxSerializationConverter` already avoids this: it reads the body with suspending, non-blocking reads and parses inline, which is why it measures ~1.7 µs for the same payload.

**Solution**
Read the body with suspending `toByteArray()` (cooperative, the carrier thread is released while waiting for bytes) and parse inline from memory, in both converters, mirroring the kotlinx converter's approach. The `Dispatchers.IO` dispatch is removed.

Behavior notes:
- Exception mapping is unchanged (`JsonConvertException` wrapping, `MismatchedInputException` for empty bodies, covered by existing tests).
- Jackson still receives a byte-based source (required for binary formats such as Smile); non-Unicode charsets are decoded via `String(bytes, charset)` exactly as the previous `InputStreamReader` did.
- Memory: bodies are now fully buffered before parsing instead of streamed into the parser. This matches the existing behavior of `KotlinxSerializationConverter`; for a 1 MiB body the measured cost is +1.24 MB/op allocation with no time change (parsing dominates).

**Benchmarks**
JMH 1.37, `avgt`, 2 forks × 5 iterations, single thread, `-prof gc`, Corretto 21.0.10, Apple Silicon. Converters invoked directly with prebuffered `ByteReadChannel`s; small payload is a 10-element data-class list (~400 B JSON).

| Benchmark | Before | After | Change |
|---|---|---|---|
| Jackson deserialize, small | 14,608 ± 380 ns | 2,613 ± 45 ns | **−82%** |
| Gson deserialize, small | 12,670 ± 932 ns | 1,768 ± 36 ns | **−86%** |
| kotlinx deserialize, small (unchanged code, control) | 1,686 ± 75 ns | 1,669 ± 35 ns | — |
| Jackson deserialize, 1 MiB — time | 4.69 ± 0.09 ms | 4.61 ± 0.27 ms | within error |
| Jackson deserialize, small — allocation | 13,264 B/op | 11,616 B/op | −12% |
| Gson deserialize, small — allocation | 14,408 B/op | 6,296 B/op | −56% |
| Jackson deserialize, 1 MiB — allocation | 25.05 MB/op | 26.29 MB/op | +1.24 MB (full buffering) |

### Ktor JSON converter throughput — KTOR-9701 fix + `streamBody=false`
Dockerized Netty (4 CPUs, 1 GB), JDK 21, `oha` @ 64 connections, 960 B / 30-field JSON payload.
"Baseline" = Ktor `main` (pre-KTOR-9701); "Patched" = with the KTOR-9701 deserialize fix.

| Endpoint | Converter config | Baseline | Patched | Δ |
|---|---|---:|---:|---:|
| `POST /receive` (deserialize) | Jackson, `streamBody=true` | 45,284 req/s | 59,079 req/s | **+30%** |
| | Jackson, `streamBody=false` | 44,227 req/s | 59,692 req/s | **+35%** |
| | kotlinx (control) | 60,421 req/s | 61,816 req/s | ±2% |
| `POST /echo` (full round trip) | Jackson, `streamBody=true` | 23,225 req/s | 26,272 req/s | +13% |
| | Jackson, `streamBody=false` | 44,516 req/s | **55,466 req/s** | **+25%** |
| | kotlinx (control) | 56,985 req/s | 56,746 req/s | ±0% |
| `GET /object` (serialize) | Jackson, `streamBody=true` | 27,560 req/s | 27,792 req/s | ±1% |
| | Jackson, `streamBody=false` | 63,274 req/s | 62,031 req/s | ±2% |
| | kotlinx (control) | 62,662 req/s | 62,318 req/s | ±1% |



