### PR TITLE
KTOR-9702 Resolve duplication between readRemaining and readBuffer

### DIFF
--- a/ktor-io/api/ktor-io.api
+++ b/ktor-io/api/ktor-io.api
@@ -79,6 +79,7 @@ public final class io/ktor/utils/io/ByteReadChannelOperationsKt {
 	public static final fun readAvailable (Lio/ktor/utils/io/ByteReadChannel;[BIILkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun readAvailable$default (Lio/ktor/utils/io/ByteReadChannel;[BIILkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public static final fun readBuffer (Lio/ktor/utils/io/ByteReadChannel;ILkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun readBuffer (Lio/ktor/utils/io/ByteReadChannel;JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static final fun readBuffer (Lio/ktor/utils/io/ByteReadChannel;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static final fun readByte (Lio/ktor/utils/io/ByteReadChannel;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static final fun readByteArray (Lio/ktor/utils/io/ByteReadChannel;ILkotlin/coroutines/Continuation;)Ljava/lang/Object;

--- a/ktor-io/api/ktor-io.klib.api
+++ b/ktor-io/api/ktor-io.klib.api
@@ -497,6 +497,7 @@ final suspend fun (io.ktor.utils.io/ByteReadChannel).io.ktor.utils.io/peek(kotli
 final suspend fun (io.ktor.utils.io/ByteReadChannel).io.ktor.utils.io/readAvailable(kotlin/ByteArray, kotlin/Int = ..., kotlin/Int = ...): kotlin/Int // io.ktor.utils.io/readAvailable|readAvailable@io.ktor.utils.io.ByteReadChannel(kotlin.ByteArray;kotlin.Int;kotlin.Int){}[0]
 final suspend fun (io.ktor.utils.io/ByteReadChannel).io.ktor.utils.io/readBuffer(): kotlinx.io/Buffer // io.ktor.utils.io/readBuffer|readBuffer@io.ktor.utils.io.ByteReadChannel(){}[0]
 final suspend fun (io.ktor.utils.io/ByteReadChannel).io.ktor.utils.io/readBuffer(kotlin/Int): kotlinx.io/Buffer // io.ktor.utils.io/readBuffer|readBuffer@io.ktor.utils.io.ByteReadChannel(kotlin.Int){}[0]
+final suspend fun (io.ktor.utils.io/ByteReadChannel).io.ktor.utils.io/readBuffer(kotlin/Long): kotlinx.io/Buffer // io.ktor.utils.io/readBuffer|readBuffer@io.ktor.utils.io.ByteReadChannel(kotlin.Long){}[0]
 final suspend fun (io.ktor.utils.io/ByteReadChannel).io.ktor.utils.io/readByte(): kotlin/Byte // io.ktor.utils.io/readByte|readByte@io.ktor.utils.io.ByteReadChannel(){}[0]
 final suspend fun (io.ktor.utils.io/ByteReadChannel).io.ktor.utils.io/readByteArray(kotlin/Int): kotlin/ByteArray // io.ktor.utils.io/readByteArray|readByteArray@io.ktor.utils.io.ByteReadChannel(kotlin.Int){}[0]
 final suspend fun (io.ktor.utils.io/ByteReadChannel).io.ktor.utils.io/readDouble(): kotlin/Double // io.ktor.utils.io/readDouble|readDouble@io.ktor.utils.io.ByteReadChannel(){}[0]

--- a/ktor-io/common/src/io/ktor/utils/io/ByteReadChannelOperations.kt
+++ b/ktor-io/common/src/io/ktor/utils/io/ByteReadChannelOperations.kt
@@ -119,7 +119,7 @@ public suspend fun ByteReadChannel.readBuffer(): Buffer {
  * @param max The maximum number of bytes to read from the channel.
  * @return A [Buffer] containing the data read from the channel.
  */
-@Deprecated("Use Long parameter", ReplaceWith("readBuffer(Long)"), DeprecationLevel.WARNING)
+@Deprecated("Use Long parameter", ReplaceWith("readBuffer(max.toLong())"), DeprecationLevel.WARNING)
 @OptIn(InternalAPI::class)
 public suspend fun ByteReadChannel.readBuffer(max: Int): Buffer =
     readBuffer(max.toLong())
@@ -141,7 +141,7 @@ public suspend fun ByteReadChannel.readBuffer(max: Long): Buffer {
 
         val size = minOf(remaining, readBuffer.remaining)
         result.write(readBuffer, size)
-        remaining -= size.toInt()
+        remaining -= size
     }
 
     return result
@@ -250,12 +250,12 @@ public suspend fun ByteReadChannel.readByteArray(count: Int): ByteArray = buildP
     }
 }.readByteArray()
 
-@Deprecated("Use readBuffer()", ReplaceWith("readBuffer(Long)"), DeprecationLevel.WARNING)
+@Deprecated("Use readBuffer()", ReplaceWith("readBuffer()"), DeprecationLevel.WARNING)
 @OptIn(InternalAPI::class, InternalIoApi::class)
 public suspend fun ByteReadChannel.readRemaining(): Source =
     readBuffer()
 
-@Deprecated("Use readBuffer(Long)", ReplaceWith("readBuffer(Long)"), DeprecationLevel.WARNING)
+@Deprecated("Use readBuffer(Long)", ReplaceWith("readBuffer(max)"), DeprecationLevel.WARNING)
 @OptIn(InternalAPI::class, InternalIoApi::class)
 public suspend fun ByteReadChannel.readRemaining(max: Long): Source =
     readBuffer(max)

--- a/ktor-io/common/src/io/ktor/utils/io/ByteReadChannelOperations.kt
+++ b/ktor-io/common/src/io/ktor/utils/io/ByteReadChannelOperations.kt
@@ -112,7 +112,14 @@ public suspend fun ByteReadChannel.readBuffer(): Buffer {
     return result
 }
 
-@Deprecated("Use Long parameter", ReplaceWith("readBuffer(Long)"), DeprecationLevel.HIDDEN)
+/**
+ * Reads data from the current [ByteReadChannel] into a new [Buffer] up to the specified maximum number of bytes.
+ * This function suspends until data becomes available or the channel is closed.
+ *
+ * @param max The maximum number of bytes to read from the channel.
+ * @return A [Buffer] containing the data read from the channel.
+ */
+@Deprecated("Use Long parameter", ReplaceWith("readBuffer(Long)"), DeprecationLevel.WARNING)
 @OptIn(InternalAPI::class)
 public suspend fun ByteReadChannel.readBuffer(max: Int): Buffer =
     readBuffer(max.toLong())

--- a/ktor-io/common/src/io/ktor/utils/io/ByteReadChannelOperations.kt
+++ b/ktor-io/common/src/io/ktor/utils/io/ByteReadChannelOperations.kt
@@ -94,29 +94,46 @@ private suspend fun ByteReadChannel.awaitUntilReadable(numberOfBytes: Int) {
     }
 }
 
+/**
+ * Reads the entire channel to an in-memory [Buffer].
+ * This function suspends until data becomes available or the channel is closed.
+ *
+ * @return the entire contents of the [ByteReadChannel]
+ */
 @OptIn(InternalAPI::class)
 public suspend fun ByteReadChannel.readBuffer(): Buffer {
     val result = Buffer()
     while (!isClosedForRead) {
+        if (readBuffer.exhausted()) awaitContent()
         result.transferFrom(readBuffer)
-        awaitContent()
     }
 
-    closedCause?.let { throw it }
-
+    rethrowCloseCauseIfNeeded()
     return result
 }
 
+@Deprecated("Use Long parameter", ReplaceWith("readBuffer(Long)"), DeprecationLevel.HIDDEN)
 @OptIn(InternalAPI::class)
-public suspend fun ByteReadChannel.readBuffer(max: Int): Buffer {
+public suspend fun ByteReadChannel.readBuffer(max: Int): Buffer =
+    readBuffer(max.toLong())
+
+/**
+ * Reads data from the current [ByteReadChannel] into a new [Buffer] up to the specified maximum number of bytes.
+ * This function suspends until data becomes available or the channel is closed.
+ *
+ * @param max The maximum number of bytes to read from the channel.
+ * @return A [Buffer] containing the data read from the channel.
+ */
+@OptIn(InternalAPI::class)
+public suspend fun ByteReadChannel.readBuffer(max: Long): Buffer {
     val result = Buffer()
     var remaining = max
 
     while (remaining > 0 && !isClosedForRead) {
         if (readBuffer.exhausted()) awaitContent()
 
-        val size = minOf(remaining.toLong(), readBuffer.remaining)
-        readBuffer.readTo(result, size)
+        val size = minOf(remaining, readBuffer.remaining)
+        result.write(readBuffer, size)
         remaining -= size.toInt()
     }
 
@@ -226,36 +243,15 @@ public suspend fun ByteReadChannel.readByteArray(count: Int): ByteArray = buildP
     }
 }.readByteArray()
 
+@Deprecated("Use readBuffer()", ReplaceWith("readBuffer(Long)"), DeprecationLevel.WARNING)
 @OptIn(InternalAPI::class, InternalIoApi::class)
-public suspend fun ByteReadChannel.readRemaining(): Source {
-    val result = BytePacketBuilder()
-    while (!isClosedForRead) {
-        result.transferFrom(readBuffer)
-        awaitContent()
-    }
+public suspend fun ByteReadChannel.readRemaining(): Source =
+    readBuffer()
 
-    rethrowCloseCauseIfNeeded()
-    return result.buffer
-}
-
+@Deprecated("Use readBuffer(Long)", ReplaceWith("readBuffer(Long)"), DeprecationLevel.WARNING)
 @OptIn(InternalAPI::class, InternalIoApi::class)
-public suspend fun ByteReadChannel.readRemaining(max: Long): Source {
-    val result = BytePacketBuilder()
-    var remaining = max
-    while (!isClosedForRead && remaining > 0) {
-        if (remaining >= readBuffer.remaining) {
-            remaining -= readBuffer.remaining
-            readBuffer.transferTo(result)
-        } else {
-            readBuffer.readTo(result, remaining)
-            remaining = 0
-        }
-
-        awaitContent()
-    }
-
-    return result.buffer
-}
+public suspend fun ByteReadChannel.readRemaining(max: Long): Source =
+    readBuffer(max)
 
 /**
  * Reads all available bytes to [buffer] and returns immediately or suspends if no bytes available

--- a/ktor-io/jvm/test/ByteChannelConcurrentTest.kt
+++ b/ktor-io/jvm/test/ByteChannelConcurrentTest.kt
@@ -45,7 +45,7 @@ class ByteChannelConcurrentTest {
             while (!contentReady) {
                 delay(100)
             }
-            channel.readBuffer(CHANNEL_MAX_SIZE * 2)
+            channel.readBuffer(CHANNEL_MAX_SIZE * 2L)
             channel.close()
         }
 

--- a/ktor-utils/common/src/io/ktor/util/ByteChannels.kt
+++ b/ktor-utils/common/src/io/ktor/util/ByteChannels.kt
@@ -61,7 +61,7 @@ public fun ByteReadChannel.copyToBoth(first: ByteWriteChannel, second: ByteWrite
     GlobalScope.launch(Dispatchers.Default) {
         try {
             while (!isClosedForRead && (!first.isClosedForWrite || !second.isClosedForWrite)) {
-                readRemaining(CHUNK_BUFFER_SIZE).use {
+                readBuffer(CHUNK_BUFFER_SIZE).use {
                     try {
                         first.writePacket(it.peek())
                         second.writePacket(it.peek())

--- a/ktor-utils/common/src/io/ktor/util/cio/Readers.kt
+++ b/ktor-utils/common/src/io/ktor/util/cio/Readers.kt
@@ -16,7 +16,7 @@ import kotlin.contracts.*
  */
 
 public suspend fun ByteReadChannel.toByteArray(limit: Int = Int.MAX_VALUE): ByteArray =
-    readRemaining(limit.toLong()).readByteArray()
+    readBuffer(limit.toLong()).readByteArray()
 
 /**
  * Executes [block] on [ByteWriteChannel] and close it down correctly whether an exception


### PR DESCRIPTION
**Subsystem**
Core, I/O

**Motivation**
[KTOR-9702](https://youtrack.jetbrains.com/issue/KTOR-9702) Duplicate code in ByteReadChannel

**Solution**
We have `readRemaining` and `readBuffer` that do the exact same thing.  Since `readBuffer()` returns `Buffer`, it's slightly more useful, though the naming is a bit confusing with the `readBuffer` property.  Alternatively, we could use `readRemaining` as the implementation and change its return type to `Buffer` since it's a sub-type.

Also, I looked through either implementation and chose the one that's a bit faster, and inlined a couple of functions after reading through the code in `kotlinx-io`.