### PR TITLE
KTOR-9759 Reject whitespace in URL host during parsing

### DIFF
--- a/ktor-http/common/src/io/ktor/http/URLParser.kt
+++ b/ktor-http/common/src/io/ktor/http/URLParser.kt
@@ -206,7 +206,11 @@ private fun URLBuilder.parseFragment(urlString: String, startIndex: Int, endInde
 private fun URLBuilder.fillHost(urlString: String, startIndex: Int, endIndex: Int) {
     val colonIndex = urlString.indexOfColonInHostPort(startIndex, endIndex).takeIf { it > 0 } ?: endIndex
 
-    host = urlString.substring(startIndex, colonIndex)
+    val hostValue = urlString.substring(startIndex, colonIndex)
+    require(hostValue.none { it.isWhitespace() }) {
+        "Host cannot contain whitespace characters: \"$hostValue\""
+    }
+    host = hostValue
 
     port = if (colonIndex + 1 < endIndex) {
         urlString.substring(colonIndex + 1, endIndex).toInt()

--- a/ktor-http/common/test/io/ktor/tests/http/UrlTest.kt
+++ b/ktor-http/common/test/io/ktor/tests/http/UrlTest.kt
@@ -364,6 +364,13 @@ class UrlTest {
     }
 
     @Test
+    fun testParseUrlWithSpaceInHost() {
+        assertEquals(null, parseUrl("http:// example.com"))
+        assertEquals(null, parseUrl("http://exa mple.com"))
+        assertEquals(null, parseUrl("http://example.com :8080"))
+    }
+
+    @Test
     fun testAboutUrl() {
         val aboutBlankUrl = Url("about:blank")
         assertEquals("about:blank", aboutBlankUrl.toString())


### PR DESCRIPTION
**Subsystem**
Ktor HTTP (ktor-http) — URL parsing (URLParser / parseUrl, URLBuilder.takeFrom). Affects both client and server since both rely on this shared URL parsing.

**Motivation**
parseUrl accepted malformed URLs whose host component contained whitespace (e.g. http:// example.com, http://exa mple.com, http://example.com :8080), returning a Url instead of rejecting them. A host with spaces is not a valid authority, and silently accepting it can lead to surprising downstream behavior (bad requests, unexpected host values). parseUrl is documented to return null for invalid URLs, so these inputs should be rejected rather than parsed.

Fixes KTOR-9718.

**Solution**
In URLParser.fillHost, validate the extracted host and reject it if it contains any whitespace character:

val hostValue = urlString.substring(startIndex, colonIndex)
require(hostValue.none { it.isWhitespace() }) {
    "Host cannot contain whitespace characters: $hostValue"
}
host = hostValue
The thrown IllegalArgumentException is caught by parseUrl, which then returns null as documented. Added UrlTest.testParseUrlWithSpaceInHost covering a space before the host, inside the host, and before the port.

