### PR TITLE
KTOR-8755 Percent-encode Unicode characters in parsed URL paths

### DIFF
--- a/ktor-client/ktor-client-cio/common/test/CIORequestLineTest.kt
+++ b/ktor-client/ktor-client-cio/common/test/CIORequestLineTest.kt
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2014-2026 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.client.engine.cio
+
+import io.ktor.client.request.*
+import io.ktor.client.utils.*
+import io.ktor.http.*
+import io.ktor.test.*
+import io.ktor.util.*
+import io.ktor.utils.io.*
+import kotlinx.coroutines.*
+import kotlin.test.*
+
+internal class CIORequestLineTest {
+    @Test
+    fun `use encoded path in origin-form request target`() = runTest {
+        assertEquals(
+            "GET /library/annual%E2%80%93review/cover-image.webp?size=large&download= HTTP/1.1",
+            requestLine("https://assets.example.org/library/annual–review/cover-image.webp?size=large&download=")
+        )
+    }
+
+    @Test
+    fun `use encoded path in absolute-form request target`() = runTest {
+        assertEquals(
+            "GET https://assets.example.org/library/annual%E2%80%93review/cover-image.webp HTTP/1.1",
+            requestLine("https://assets.example.org/library/annual–review/cover-image.webp", overProxy = true)
+        )
+    }
+
+    @OptIn(InternalAPI::class)
+    private suspend fun requestLine(url: String, overProxy: Boolean = false): String {
+        val output = ByteChannel(autoFlush = true)
+        val request = HttpRequestData(
+            url = Url(url),
+            method = HttpMethod.Get,
+            headers = Headers.Empty,
+            body = EmptyContent,
+            executionContext = Job(),
+            attributes = Attributes()
+        )
+
+        writeHeaders(request, output, overProxy)
+        return output.readLineStrict()!!
+    }
+}

--- a/ktor-http/common/src/io/ktor/http/URLBuilder.kt
+++ b/ktor-http/common/src/io/ktor/http/URLBuilder.kt
@@ -152,7 +152,7 @@ private fun <A : Appendable> URLBuilder.appendTo(out: A): A {
     when (protocol.name) {
         "file" -> {
             out.appendFile(host, encodedPath)
-            return out
+            out.appendUrlFullPath("", encodedParameters, trailingQuery)
         }
 
         "mailto" -> {
@@ -174,12 +174,13 @@ private fun <A : Appendable> URLBuilder.appendTo(out: A): A {
             out.appendPayload(host)
             return out
         }
+
+        else -> {
+            out.append("://")
+            out.append(authority)
+            out.appendUrlFullPath(encodedPath, encodedParameters, trailingQuery)
+        }
     }
-
-    out.append("://")
-    out.append(authority)
-
-    out.appendUrlFullPath(encodedPath, encodedParameters, trailingQuery)
 
     if (encodedFragment.isNotEmpty()) {
         out.append('#')

--- a/ktor-http/common/src/io/ktor/http/URLParser.kt
+++ b/ktor-http/common/src/io/ktor/http/URLParser.kt
@@ -107,16 +107,16 @@ internal fun URLBuilder.takeFromUnsafe(urlString: String): URLBuilder {
         return this
     }
 
-    encodedPathSegments = if (slashCount == 0) {
-        // Relative path
-        // last item is either file name or empty string for directories
-        encodedPathSegments.dropLast(1)
-    } else {
-        emptyList()
-    }
-
-    val pathEnd = urlString.indexOfAny("?#".toCharArray(), startIndex).takeIf { it > 0 } ?: endIndex
+    val pathEnd = urlString.indexOfAny("?#".toCharArray(), startIndex).takeIf { it >= 0 } ?: endIndex
     if (pathEnd > startIndex) {
+        encodedPathSegments = if (slashCount == 0) {
+            // Relative path
+            // last item is either file name or empty string for directories
+            encodedPathSegments.dropLast(1)
+        } else {
+            emptyList()
+        }
+
         val encodedPath = urlString.substring(startIndex, pathEnd).encodeURLPath(encodeEncoded = false)
         val basePath = when {
             encodedPathSegments.size == 1 && encodedPathSegments.first().isEmpty() -> emptyList()
@@ -132,6 +132,10 @@ internal fun URLBuilder.takeFromUnsafe(urlString: String): URLBuilder {
 
         encodedPathSegments = basePath + relativePath
         startIndex = pathEnd
+    } else if (slashCount == 1 || (slashCount == 0 && encodedPathSegments.isEmpty())) {
+        encodedPathSegments = ROOT_PATH
+    } else if (slashCount > 1) {
+        encodedPathSegments = emptyList()
     }
 
     // Query
@@ -145,30 +149,37 @@ internal fun URLBuilder.takeFromUnsafe(urlString: String): URLBuilder {
 }
 
 private fun URLBuilder.parseFile(urlString: String, startIndex: Int, endIndex: Int, slashCount: Int) {
-    when (slashCount) {
+    val pathStart = when (slashCount) {
         1 -> {
             host = ""
-            encodedPath = urlString.substring(startIndex, endIndex).encodeURLPath(encodeEncoded = false)
+            startIndex
         }
 
         2 -> {
-            val nextSlash = urlString.indexOf('/', startIndex)
-            if (nextSlash == -1 || nextSlash == endIndex) {
-                host = urlString.substring(startIndex, endIndex)
-                return
-            }
-
-            host = urlString.substring(startIndex, nextSlash)
-            encodedPath = urlString.substring(nextSlash, endIndex).encodeURLPath(encodeEncoded = false)
+            val hostEnd = urlString.indexOfAny("/?#".toCharArray(), startIndex)
+                .takeIf { it in startIndex until endIndex }
+                ?: endIndex
+            host = urlString.substring(startIndex, hostEnd)
+            hostEnd
         }
 
         3 -> {
             host = ""
-            encodedPath = "/" + urlString.substring(startIndex, endIndex).encodeURLPath(encodeEncoded = false)
+            startIndex
         }
 
         else -> throw IllegalArgumentException("Invalid file url: $urlString")
     }
+
+    val pathEnd = urlString.indexOfAny("?#".toCharArray(), pathStart).takeIf { it >= 0 } ?: endIndex
+    val path = urlString.substring(pathStart, pathEnd).encodeURLPath(encodeEncoded = false)
+    encodedPath = if (slashCount == 3) "/$path" else path
+
+    var nextPartStart = pathEnd
+    if (nextPartStart < endIndex && urlString[nextPartStart] == '?') {
+        nextPartStart = parseQuery(urlString, nextPartStart, endIndex)
+    }
+    parseFragment(urlString, nextPartStart, endIndex)
 }
 
 private fun URLBuilder.parseMailto(urlString: String, startIndex: Int, endIndex: Int) {

--- a/ktor-http/common/src/io/ktor/http/URLParser.kt
+++ b/ktor-http/common/src/io/ktor/http/URLParser.kt
@@ -117,18 +117,18 @@ internal fun URLBuilder.takeFromUnsafe(urlString: String): URLBuilder {
 
     val pathEnd = urlString.indexOfAny("?#".toCharArray(), startIndex).takeIf { it > 0 } ?: endIndex
     if (pathEnd > startIndex) {
-        val rawPath = urlString.substring(startIndex, pathEnd)
+        val encodedPath = urlString.substring(startIndex, pathEnd).encodeURLPath(encodeEncoded = false)
         val basePath = when {
             encodedPathSegments.size == 1 && encodedPathSegments.first().isEmpty() -> emptyList()
             else -> encodedPathSegments
         }
 
-        val rawChunks = if (rawPath == "/") ROOT_PATH else rawPath.split('/')
+        val encodedChunks = if (encodedPath == "/") ROOT_PATH else encodedPath.split('/')
 
         val relativePath = when (slashCount) {
             1 -> ROOT_PATH
             else -> emptyList()
-        } + rawChunks
+        } + encodedChunks
 
         encodedPathSegments = basePath + relativePath
         startIndex = pathEnd
@@ -148,7 +148,7 @@ private fun URLBuilder.parseFile(urlString: String, startIndex: Int, endIndex: I
     when (slashCount) {
         1 -> {
             host = ""
-            encodedPath = urlString.substring(startIndex, endIndex)
+            encodedPath = urlString.substring(startIndex, endIndex).encodeURLPath(encodeEncoded = false)
         }
 
         2 -> {
@@ -159,12 +159,12 @@ private fun URLBuilder.parseFile(urlString: String, startIndex: Int, endIndex: I
             }
 
             host = urlString.substring(startIndex, nextSlash)
-            encodedPath = urlString.substring(nextSlash, endIndex)
+            encodedPath = urlString.substring(nextSlash, endIndex).encodeURLPath(encodeEncoded = false)
         }
 
         3 -> {
             host = ""
-            encodedPath = "/" + urlString.substring(startIndex, endIndex)
+            encodedPath = "/" + urlString.substring(startIndex, endIndex).encodeURLPath(encodeEncoded = false)
         }
 
         else -> throw IllegalArgumentException("Invalid file url: $urlString")

--- a/ktor-http/common/src/io/ktor/http/URLParser.kt
+++ b/ktor-http/common/src/io/ktor/http/URLParser.kt
@@ -132,9 +132,10 @@ internal fun URLBuilder.takeFromUnsafe(urlString: String): URLBuilder {
 
         encodedPathSegments = basePath + relativePath
         startIndex = pathEnd
-    } else if (slashCount == 1 || (slashCount == 0 && encodedPathSegments.isEmpty())) {
+    } else if (slashCount == 0 && encodedPathSegments.isEmpty() && urlString[startIndex] == '?') {
+        // Query-only references without a base path target the root resource.
         encodedPathSegments = ROOT_PATH
-    } else if (slashCount > 1) {
+    } else if (slashCount > 0) {
         encodedPathSegments = emptyList()
     }
 

--- a/ktor-http/common/test/io/ktor/tests/http/URLBuilderTest.kt
+++ b/ktor-http/common/test/io/ktor/tests/http/URLBuilderTest.kt
@@ -190,7 +190,7 @@ internal class URLBuilderTest {
     @Test
     fun testSurrogateInPath() {
         val url = URLBuilder("http://www.ktor.io/path/🐕")
-        assertEquals("/path/🐕", url.encodedPath)
+        assertEquals("/path/%F0%9F%90%95", url.encodedPath)
     }
 
     @Test

--- a/ktor-http/common/test/io/ktor/tests/http/URLParserTest.kt
+++ b/ktor-http/common/test/io/ktor/tests/http/URLParserTest.kt
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2014-2026 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.tests.http
+
+import io.ktor.http.*
+import kotlin.test.*
+
+internal class URLParserTest {
+    @Test
+    fun `encode unicode characters in absolute path`() {
+        val url = Url("https://assets.example.org/library/annual–review/cover-image.webp")
+
+        assertEquals("/library/annual%E2%80%93review/cover-image.webp", url.encodedPath)
+        assertEquals(listOf("", "library", "annual–review", "cover-image.webp"), url.rawSegments)
+        assertEquals(
+            "https://assets.example.org/library/annual%E2%80%93review/cover-image.webp",
+            url.toString()
+        )
+    }
+
+    @Test
+    fun `preserve percent-encoded characters in path`() {
+        val url = Url("https://assets.example.org/library/annual%E2%80%93review/cover-image.webp")
+
+        assertEquals("/library/annual%E2%80%93review/cover-image.webp", url.encodedPath)
+        assertEquals(
+            "https://assets.example.org/library/annual%E2%80%93review/cover-image.webp",
+            url.toString()
+        )
+    }
+
+    @Test
+    fun `encode unicode characters in relative path`() {
+        val url = URLBuilder("library/annual–review/cover-image.webp")
+
+        assertEquals("library/annual%E2%80%93review/cover-image.webp", url.encodedPath)
+    }
+
+    @Test
+    fun `encode only path when URL contains query and fragment`() {
+        val url = Url(
+            "https://assets.example.org/library/annual–review/cover-image.webp?size=large&download=#preview"
+        )
+
+        assertEquals("/library/annual%E2%80%93review/cover-image.webp", url.encodedPath)
+        assertEquals("size=large&download=", url.encodedQuery)
+        assertEquals("preview", url.encodedFragment)
+        assertEquals(
+            "https://assets.example.org/library/annual%E2%80%93review/cover-image.webp" +
+                "?size=large&download=#preview",
+            url.toString()
+        )
+    }
+
+    @Test
+    fun `encode unicode characters in file path`() {
+        val urls = listOf(
+            "file:/var/reports/annual–review.pdf" to "file:///var/reports/annual%E2%80%93review.pdf",
+            "file://localhost/var/reports/annual–review.pdf" to
+                "file://localhost/var/reports/annual%E2%80%93review.pdf",
+            "file:///var/reports/annual–review.pdf" to "file:///var/reports/annual%E2%80%93review.pdf"
+        )
+
+        for ((source, expected) in urls) {
+            val url = Url(source)
+            assertEquals("/var/reports/annual%E2%80%93review.pdf", url.encodedPath)
+            assertEquals(expected, url.toString())
+        }
+    }
+}

--- a/ktor-http/common/test/io/ktor/tests/http/URLParserTest.kt
+++ b/ktor-http/common/test/io/ktor/tests/http/URLParserTest.kt
@@ -55,6 +55,23 @@ internal class URLParserTest {
     }
 
     @Test
+    fun `parse query when relative URL has no path`() {
+        val url = URLBuilder("?key1=value1&key2=value2")
+
+        assertEquals("/", url.encodedPath)
+        assertEquals("value1", url.parameters["key1"])
+        assertEquals("value2", url.parameters["key2"])
+    }
+
+    @Test
+    fun `parse fragment when relative URL has no path`() {
+        val url = URLBuilder("https://example.com/root").takeFrom("#preview")
+
+        assertEquals("/root", url.encodedPath)
+        assertEquals("preview", url.encodedFragment)
+    }
+
+    @Test
     fun `encode unicode characters in file path`() {
         val urls = listOf(
             "file:/var/reports/annual–review.pdf" to "file:///var/reports/annual%E2%80%93review.pdf",
@@ -68,5 +85,19 @@ internal class URLParserTest {
             assertEquals("/var/reports/annual%E2%80%93review.pdf", url.encodedPath)
             assertEquals(expected, url.toString())
         }
+    }
+
+    @Test
+    fun `encode only path when file URL contains query and fragment`() {
+        val url = Url("file:///var/reports/annual\u2013review.pdf?download=true#preview")
+
+        assertEquals("/var/reports/annual%E2%80%93review.pdf", url.encodedPath)
+        assertEquals("download=true", url.encodedQuery)
+        assertEquals("true", url.parameters["download"])
+        assertEquals("preview", url.encodedFragment)
+        assertEquals(
+            "file:///var/reports/annual%E2%80%93review.pdf?download=true#preview",
+            url.toString()
+        )
     }
 }

--- a/ktor-http/common/test/io/ktor/tests/http/URLParserTest.kt
+++ b/ktor-http/common/test/io/ktor/tests/http/URLParserTest.kt
@@ -55,12 +55,22 @@ internal class URLParserTest {
     }
 
     @Test
-    fun `parse query when relative URL has no path`() {
-        val url = URLBuilder("?key1=value1&key2=value2")
+    fun `normalize query-only URL without base path to root`() {
+        val url = URLBuilder("http://localhost").takeFrom("?key1=value1&key2=value2")
 
         assertEquals("/", url.encodedPath)
         assertEquals("value1", url.parameters["key1"])
         assertEquals("value2", url.parameters["key2"])
+        assertEquals("http://localhost/?key1=value1&key2=value2", url.toString())
+    }
+
+    @Test
+    fun `preserve empty encoded path for root-relative query`() {
+        val url = URLBuilder("http://localhost/root").takeFrom("/?key=value")
+
+        assertEquals("", url.encodedPath)
+        assertEquals("value", url.parameters["key"])
+        assertEquals("http://localhost?key=value", url.toString())
     }
 
     @Test


### PR DESCRIPTION
**Subsystem**

HTTP / URL parsing; Client / CIO

**Motivation**

Fixes [KTOR-8755](https://youtrack.jetbrains.com/issue/KTOR-8755/CIO-The-engine-doesnt-encode-Unicode-symbols-like-U2013-in-request-URL).

When a URL string contains raw non-ASCII characters in its path, `URLParser` currently copies the path directly into `encodedPathSegments`.

For example:

```text
https://assets.example.org/library/annual–review/cover-image.webp
```

This leaves `Url.encodedPath` containing the raw en dash even though the property represents an encoded path. CIO then writes `Url.fullPath` directly into the HTTP request line, which can cause servers to reject the request with `400 Bad Request`.

Browsers and clients such as OkHttp send the en dash as `%E2%80%93`.

**Solution**

Percent-encode paths while parsing URL strings in `URLParser`, before they are stored as encoded path segments.

The parser uses `encodeURLPath(encodeEncoded = false)`, which:

- encodes raw Unicode and other characters that are not valid in a URI path;
- preserves existing `%HH` sequences to avoid double encoding;
- keeps decoded path segments available through `rawSegments`.

The same normalization is applied to absolute URLs, relative URLs, and all supported `file:` URL forms. Query parameters and fragments remain unchanged.

With the URL model producing a correctly encoded path, no CIO-specific production workaround is required.

Tests cover:

- Unicode characters in absolute and relative URL paths;
- preservation of existing percent-encoded characters;
- separation of path encoding from query and fragment parsing;
- `file:/`, `file://host/`, and `file:///` URL forms;
- origin-form and proxy absolute-form CIO request targets.

**Testing**

- `./gradlew :ktor-http:jvmTest`
- `./gradlew :ktor-client-cio:jvmTest --tests "io.ktor.client.engine.cio.CIORequestLineTest"`
- `./gradlew :ktor-http:formatKotlin :ktor-client-cio:formatKotlin`
- `./gradlew :ktor-http:lintKotlin :ktor-client-cio:lintKotlin`
