### PR TITLE
Netty engine allocation improvements

### DIFF
--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyApplicationCall.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyApplicationCall.kt
@@ -29,7 +29,35 @@ public abstract class NettyApplicationCall(
      */
     internal lateinit var finishedEvent: ChannelPromise
 
-    public val responseWriteJob: Job = Job()
+    /**
+     * Tracks the lifetime of the response write on the Netty I/O thread.
+     *
+     * This Job is a child of the call's coroutine [Job] (see [coroutineContext]), so the call's
+     * coroutine remains "completing" — and is awaited by the parent application Job during graceful
+     * shutdown — until the response is fully written. This removes the need to suspend on
+     * [Job.join] from the application thread at the end of each call (for example, the
+     * [io.ktor.server.netty.NettyApplicationEngine] AFTER_CALL_PHASE interceptor).
+     *
+     * Initialized via [initResponseWriteJob] on the Netty I/O thread synchronously after call
+     * construction (from `processResponse`) and before the user handler coroutine is launched.
+     * The deferred initialization is required because subclasses bind [coroutineContext] in their
+     * own primary constructor, after the base class constructor has finished.
+     */
+    public lateinit var responseWriteJob: Job
+        private set
+
+    /**
+     * Initializes [responseWriteJob] as a child of the call's coroutine [Job]. Called synchronously
+     * on the Netty I/O thread right after the call is constructed and before the user handler
+     * coroutine is launched, so the field is safely published to all subsequent readers via the
+     * handler-dispatch happens-before edge.
+     */
+    internal fun initResponseWriteJob() {
+        val callJob = coroutineContext[Job]
+        val job = Job(parent = callJob)
+        job.invokeOnCompletion { onResponseWriteCompleted() }
+        responseWriteJob = job
+    }
 
     private val messageReleased = atomic(false)
 
@@ -62,39 +90,32 @@ public abstract class NettyApplicationCall(
 
     internal abstract fun isContextCloseRequired(): Boolean
 
-    internal suspend fun finish() {
+    /**
+     * Marks the call as ready to finish, without suspending the calling coroutine.
+     *
+     * The response writer runs on the Netty I/O thread and signals completion through
+     * [responseWriteJob]; because that job is a child of the call's coroutine [Job], the call
+     * naturally remains "completing" until the write finishes — there is no need to join here.
+     * Per-call cleanup (request close + request message release) is performed by
+     * [onResponseWriteCompleted] when [responseWriteJob] completes (registered as an
+     * `invokeOnCompletion` handler in [initResponseWriteJob]).
+     *
+     * Throws if [NettyApplicationResponse.ensureResponseSent] fails. In that case the failure is
+     * propagated through [finishedEvent] and the response write job is cancelled so cleanup still
+     * runs via the registered completion handler.
+     */
+    internal fun finish() {
         try {
             response.ensureResponseSent()
         } catch (cause: Throwable) {
             finishedEvent.setFailure(cause)
-            finishComplete()
+            // Cancelling the job drives `onResponseWriteCompleted` via invokeOnCompletion.
+            responseWriteJob.cancel()
             throw cause
         }
-
-        if (responseWriteJob.isCompleted) {
-            finishComplete()
-            return
-        }
-
-        return finishSuspend()
     }
 
-    private suspend fun finishSuspend() {
-        try {
-            responseWriteJob.join()
-        } finally {
-            finishComplete()
-        }
-    }
-
-    private fun finishComplete() {
-        // Avoid allocating JobCancellationException on the happy path (responseWriteJob already
-        // completed via finish() or finishSuspend()). On error paths — ensureResponseSent() failure
-        // or outer-coroutine cancellation during join() — the job may still be active and must be
-        // cancelled to release its resources.
-        if (!responseWriteJob.isCompleted) {
-            responseWriteJob.cancel()
-        }
+    private fun onResponseWriteCompleted() {
         request.close()
         releaseRequestMessage()
     }

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyApplicationEngine.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyApplicationEngine.kt
@@ -327,6 +327,11 @@ public class NettyApplicationEngine(
     init {
         pipeline.insertPhaseAfter(EnginePipeline.Call, AFTER_CALL_PHASE)
         pipeline.intercept(AFTER_CALL_PHASE) {
+            // [NettyApplicationCall.finish] is non-suspending: it only ensures the response is
+            // committed (headers + status flushed). The actual write completion is awaited via
+            // structured concurrency — the call's responseWriteJob is a child of the call's
+            // coroutine Job, so the call coroutine remains "completing" until the I/O-thread
+            // writer finishes and cleanup runs from responseWriteJob's invokeOnCompletion handler.
             (call as? NettyApplicationCall)?.finish()
         }
     }

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/cio/NettyHttpResponsePipeline.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/cio/NettyHttpResponsePipeline.kt
@@ -69,6 +69,12 @@ internal class NettyHttpResponsePipeline(
         call.finishedEvent = context.newPromise()
         previousCallHandled = call.finishedEvent
 
+        // Initialize the call's responseWriteJob as a child of the call's coroutineContext Job.
+        // This call happens synchronously on the Netty I/O thread before the user handler coroutine
+        // is dispatched, so the value is safely published to both the call thread and any later
+        // I/O-thread listeners that complete the job.
+        call.initResponseWriteJob()
+
         processElement(call)
     }
 

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/cio/NettyHttpResponsePipeline.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/cio/NettyHttpResponsePipeline.kt
@@ -69,10 +69,6 @@ internal class NettyHttpResponsePipeline(
         call.finishedEvent = context.newPromise()
         previousCallHandled = call.finishedEvent
 
-        // Initialize the call's responseWriteJob as a child of the call's coroutineContext Job.
-        // This call happens synchronously on the Netty I/O thread before the user handler coroutine
-        // is dispatched, so the value is safely published to both the call thread and any later
-        // I/O-thread listeners that complete the job.
         call.initResponseWriteJob()
 
         processElement(call)

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http1/NettyHttp1Handler.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http1/NettyHttp1Handler.kt
@@ -9,6 +9,7 @@ import io.ktor.server.engine.*
 import io.ktor.server.http.*
 import io.ktor.server.netty.*
 import io.ktor.server.netty.NettyApplicationCallHandler.CallHandlerCoroutineName
+import io.ktor.server.netty.NettyDispatcher.CurrentContext
 import io.ktor.server.netty.cio.*
 import io.ktor.util.pipeline.*
 import io.ktor.utils.io.*
@@ -17,7 +18,6 @@ import io.netty.channel.ChannelHandlerContext
 import io.netty.channel.ChannelInboundHandlerAdapter
 import io.netty.handler.codec.http.*
 import io.netty.handler.timeout.ReadTimeoutException
-import io.netty.util.concurrent.EventExecutor
 import io.netty.util.concurrent.EventExecutorGroup
 import kotlinx.coroutines.*
 import java.io.IOException
@@ -51,8 +51,8 @@ internal class NettyHttp1Handler(
     // The dispatcher, user context, application context, and coroutine name are reused across
     // all requests on this connection, so we build them once and combine only with the per-call
     // [Job] on each request.
-    private var cachedApplication: Application? = null
-    private var cachedBaseContext: CoroutineContext = EmptyCoroutineContext
+    private var channelApplication: Application? = null
+    private var channelCoroutineContext: CoroutineContext = EmptyCoroutineContext
 
     override fun channelActive(context: ChannelHandlerContext) {
         // channelActive may be fired more than once on this handler (for example, when the pipeline is
@@ -163,36 +163,24 @@ internal class NettyHttp1Handler(
         super.channelReadComplete(context)
     }
 
-    /**
-     * Returns the connection-stable portion of the per-call coroutine context, building it lazily on
-     * the first request and refreshing it if the running [Application] reference changes (for example,
-     * after a hot reload).
-     *
-     * Combining the application/user/dispatcher/name elements is the same on every request, so caching
-     * them avoids a chain of `CombinedContext` allocations per call; only the per-call [Job] is added
-     * fresh in [handleRequest].
-     */
-    private fun baseCallContext(
-        context: ChannelHandlerContext,
-        callExecutor: EventExecutor
-    ): CoroutineContext {
-        val application = applicationProvider()
-        val cached = cachedBaseContext
-        if (cachedApplication === application && cached !== EmptyCoroutineContext) {
-            return cached
-        }
-        val fresh = application.coroutineContext +
-            userContext +
-            NettyDispatcher.CurrentContext(context, callExecutor) +
-            CallHandlerCoroutineName
-        cachedApplication = application
-        cachedBaseContext = fresh
-        return fresh
-    }
-
     private fun handleRequest(context: ChannelHandlerContext, message: HttpRequest) {
         val callExecutor = pinnedCallExecutor(context, callEventGroup)
-        val baseContext = baseCallContext(context, callExecutor)
+        val application = applicationProvider()
+        // Building the coroutine context is quite expensive, so we cache most of the elements.
+        val baseContext = when {
+            application === channelApplication && channelCoroutineContext !== EmptyCoroutineContext ->
+                channelCoroutineContext
+
+            else -> {
+                val newContext = application.coroutineContext +
+                    userContext +
+                    CurrentContext(context, callExecutor) +
+                    CallHandlerCoroutineName
+                channelApplication = application
+                channelCoroutineContext = newContext
+                newContext
+            }
+        }
         val callJob = Job(parent = baseContext[Job])
 
         // Only the per-call [Job] is combined per request; the rest of the context is cached on the

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http1/NettyHttp1Handler.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http1/NettyHttp1Handler.kt
@@ -17,11 +17,13 @@ import io.netty.channel.ChannelHandlerContext
 import io.netty.channel.ChannelInboundHandlerAdapter
 import io.netty.handler.codec.http.*
 import io.netty.handler.timeout.ReadTimeoutException
+import io.netty.util.concurrent.EventExecutor
 import io.netty.util.concurrent.EventExecutorGroup
 import kotlinx.coroutines.*
 import java.io.IOException
 import java.util.concurrent.ConcurrentLinkedQueue
 import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.EmptyCoroutineContext
 import kotlin.coroutines.cancellation.CancellationException
 
 internal class NettyHttp1Handler(
@@ -44,6 +46,13 @@ internal class NettyHttp1Handler(
     private val activeCalls = ConcurrentLinkedQueue<NettyHttp1ApplicationCall>()
 
     private var activated = false
+
+    // Per-channel cache of the connection-stable portion of the per-call coroutine context.
+    // The dispatcher, user context, application context, and coroutine name are reused across
+    // all requests on this connection, so we build them once and combine only with the per-call
+    // [Job] on each request.
+    private var cachedApplication: Application? = null
+    private var cachedBaseContext: CoroutineContext = EmptyCoroutineContext
 
     override fun channelActive(context: ChannelHandlerContext) {
         // channelActive may be fired more than once on this handler (for example, when the pipeline is
@@ -154,15 +163,41 @@ internal class NettyHttp1Handler(
         super.channelReadComplete(context)
     }
 
-    private fun handleRequest(context: ChannelHandlerContext, message: HttpRequest) {
-        val userAppContext = applicationProvider().coroutineContext + userContext
-        val callJob = Job(parent = userAppContext[Job])
-
-        val callExecutor = pinnedCallExecutor(context, callEventGroup)
-        val callContext = userAppContext +
+    /**
+     * Returns the connection-stable portion of the per-call coroutine context, building it lazily on
+     * the first request and refreshing it if the running [Application] reference changes (for example,
+     * after a hot reload).
+     *
+     * Combining the application/user/dispatcher/name elements is the same on every request, so caching
+     * them avoids a chain of `CombinedContext` allocations per call; only the per-call [Job] is added
+     * fresh in [handleRequest].
+     */
+    private fun baseCallContext(
+        context: ChannelHandlerContext,
+        callExecutor: EventExecutor
+    ): CoroutineContext {
+        val application = applicationProvider()
+        val cached = cachedBaseContext
+        if (cachedApplication === application && cached !== EmptyCoroutineContext) {
+            return cached
+        }
+        val fresh = application.coroutineContext +
+            userContext +
             NettyDispatcher.CurrentContext(context, callExecutor) +
-            callJob +
             CallHandlerCoroutineName
+        cachedApplication = application
+        cachedBaseContext = fresh
+        return fresh
+    }
+
+    private fun handleRequest(context: ChannelHandlerContext, message: HttpRequest) {
+        val callExecutor = pinnedCallExecutor(context, callEventGroup)
+        val baseContext = baseCallContext(context, callExecutor)
+        val callJob = Job(parent = baseContext[Job])
+
+        // Only the per-call [Job] is combined per request; the rest of the context is cached on the
+        // handler instance and reused across all calls on this connection.
+        val callContext = baseContext + callJob
         val call = prepareCallFromRequest(context, message, callContext = callContext)
         activeCalls.add(call)
 

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http2/NettyHttp2Handler.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http2/NettyHttp2Handler.kt
@@ -34,14 +34,14 @@ internal class NettyHttp2Handler(
     private val userCoroutineContext: CoroutineContext,
     runningLimit: Int
 ) : ChannelInboundHandlerAdapter() {
-    private val handlerJob = SupervisorJob(userCoroutineContext[Job])
+    // Parent [Job] for per-call [Job]s. Cached to avoid re-running `userCoroutineContext[Job]` per request.
+    private val parentJob: Job? = userCoroutineContext[Job]
+
+    private val handlerJob = SupervisorJob(parentJob)
 
     // Connection-stable portion of the per-call coroutine context. Cached at construction so each
     // request only needs to combine it with the per-stream dispatcher and the per-call [Job].
     private val staticCallContext: CoroutineContext = userCoroutineContext + CallHandlerCoroutineName
-
-    // Parent [Job] for per-call [Job]s. Cached to avoid re-running `userCoroutineContext[Job]` per request.
-    private val parentJob: Job? = userCoroutineContext[Job]
 
     // Engine context exposed on the [NettyHttp2ApplicationCall]. Constant per handler instance.
     private val callEngineContext: CoroutineContext = handlerJob + Dispatchers.Unconfined

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http2/NettyHttp2Handler.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http2/NettyHttp2Handler.kt
@@ -36,6 +36,16 @@ internal class NettyHttp2Handler(
 ) : ChannelInboundHandlerAdapter() {
     private val handlerJob = SupervisorJob(userCoroutineContext[Job])
 
+    // Connection-stable portion of the per-call coroutine context. Cached at construction so each
+    // request only needs to combine it with the per-stream dispatcher and the per-call [Job].
+    private val staticCallContext: CoroutineContext = userCoroutineContext + CallHandlerCoroutineName
+
+    // Parent [Job] for per-call [Job]s. Cached to avoid re-running `userCoroutineContext[Job]` per request.
+    private val parentJob: Job? = userCoroutineContext[Job]
+
+    // Engine context exposed on the [NettyHttp2ApplicationCall]. Constant per handler instance.
+    private val callEngineContext: CoroutineContext = handlerJob + Dispatchers.Unconfined
+
     private val state = NettyHttpHandlerState(runningLimit)
     private lateinit var responseWriter: NettyHttpResponsePipeline
 
@@ -114,18 +124,18 @@ internal class NettyHttp2Handler(
     }
 
     private fun startHttp2(context: ChannelHandlerContext, headers: Http2Headers) {
-        val callJob = Job(parent = userCoroutineContext[Job])
+        val callJob = Job(parent = parentJob)
         val callExecutor = pinnedCallExecutor(context, callEventGroup)
-        val callContext = userCoroutineContext +
+        // Combine the cached static context with the per-stream dispatcher and per-call [Job] only.
+        val callContext = staticCallContext +
             NettyDispatcher.CurrentContext(context, callExecutor) +
-            callJob +
-            CallHandlerCoroutineName
+            callJob
         val call = NettyHttp2ApplicationCall(
             application = application,
             context = context,
             headers = headers,
             handler = this@NettyHttp2Handler,
-            engineContext = handlerJob + Dispatchers.Unconfined,
+            engineContext = callEngineContext,
             coroutineContext = callContext
         )
         context.applicationCall = call

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http3/NettyHttp3Handler.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http3/NettyHttp3Handler.kt
@@ -25,14 +25,14 @@ internal class NettyHttp3Handler(
     private val userCoroutineContext: CoroutineContext,
     runningLimit: Int
 ) : Http3RequestStreamInboundHandler(), CoroutineScope {
-    private val handlerJob = SupervisorJob(userCoroutineContext[Job])
+    // Parent [Job] for per-call [Job]s. Cached to avoid re-running `userCoroutineContext[Job]` per request.
+    private val parentJob: Job? = userCoroutineContext[Job]
+
+    private val handlerJob = SupervisorJob(parentJob)
 
     // Connection-stable portion of the per-call coroutine context. Cached so each request only needs
     // to combine it with the per-stream dispatcher and the per-call [Job].
     private val staticCallContext: CoroutineContext = userCoroutineContext + CallHandlerCoroutineName
-
-    // Parent [Job] for per-call [Job]s. Cached to avoid re-running `userCoroutineContext[Job]` per request.
-    private val parentJob: Job? = userCoroutineContext[Job]
 
     // Engine context exposed on the [NettyHttp3ApplicationCall]. Constant per handler instance.
     private val callEngineContext: CoroutineContext = handlerJob + Dispatchers.Unconfined

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http3/NettyHttp3Handler.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http3/NettyHttp3Handler.kt
@@ -27,6 +27,16 @@ internal class NettyHttp3Handler(
 ) : Http3RequestStreamInboundHandler(), CoroutineScope {
     private val handlerJob = SupervisorJob(userCoroutineContext[Job])
 
+    // Connection-stable portion of the per-call coroutine context. Cached so each request only needs
+    // to combine it with the per-stream dispatcher and the per-call [Job].
+    private val staticCallContext: CoroutineContext = userCoroutineContext + CallHandlerCoroutineName
+
+    // Parent [Job] for per-call [Job]s. Cached to avoid re-running `userCoroutineContext[Job]` per request.
+    private val parentJob: Job? = userCoroutineContext[Job]
+
+    // Engine context exposed on the [NettyHttp3ApplicationCall]. Constant per handler instance.
+    private val callEngineContext: CoroutineContext = handlerJob + Dispatchers.Unconfined
+
     private val state = NettyHttpHandlerState(runningLimit)
     private lateinit var responseWriter: NettyHttpResponsePipeline
 
@@ -87,14 +97,14 @@ internal class NettyHttp3Handler(
     }
 
     private fun startHttp3(context: ChannelHandlerContext, headers: Http3Headers) {
-        val callJob = Job(parent = userCoroutineContext[Job])
-        val callContext =
-            userCoroutineContext + NettyDispatcher.CurrentContext(context) + callJob + CallHandlerCoroutineName
+        val callJob = Job(parent = parentJob)
+        // Combine the cached static context with the per-stream dispatcher and per-call [Job] only.
+        val callContext = staticCallContext + NettyDispatcher.CurrentContext(context) + callJob
         val call = NettyHttp3ApplicationCall(
             application,
             context,
             headers,
-            handlerJob + Dispatchers.Unconfined,
+            callEngineContext,
             callContext
         )
         context.applicationCall = call

--- a/ktor-server/ktor-server-netty/jvm/test/io/ktor/tests/server/netty/NettyReadRequestTimeoutTest.kt
+++ b/ktor-server/ktor-server-netty/jvm/test/io/ktor/tests/server/netty/NettyReadRequestTimeoutTest.kt
@@ -88,7 +88,6 @@ class NettyReadRequestTimeoutTest :
         client.performAndCheckRequestWithoutTimeout()
     }
 
-    @Ignore
     @Test
     fun `parallel timeout requests`() = requestTimeoutTest(timeout = 1) { _, _ ->
         val client = HttpClient()

--- a/ktor-server/ktor-server-test-suites/common/src/io/ktor/server/testing/suites/HttpServerCommonTestSuite.kt
+++ b/ktor-server/ktor-server-test-suites/common/src/io/ktor/server/testing/suites/HttpServerCommonTestSuite.kt
@@ -345,8 +345,6 @@ abstract class HttpServerCommonTestSuite<TEngine : ApplicationEngine, TConfigura
     }
 
     @Test
-    // Fix [KTOR-7883](https://youtrack.jetbrains.com/issue/KTOR-7883/Fix-flaky-testStatusCodeViaResponseObject)
-    @Ignore
     fun testStatusCodeViaResponseObject() = runTest {
         var completed = false
         createAndStartServer {


### PR DESCRIPTION
**Subsystem**
Server, Netty

**Motivation**
Regular analysis of engine allocations has uncovered a few spots for improvements.

The cleanup of the response writer job seems so be the source of many of our flaky tests.  I've ran the tests a few times now and they pass completely each time. 💪 

**Solution**
- Re-use connection coroutine elements instead of re-allocating every time
- Avoid manual join for writer job in favour of structured concurrency