### PR TITLE
KTOR-9707 Do not cancel body erroneously

### DIFF
--- a/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/SaveBody.kt
+++ b/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/SaveBody.kt
@@ -30,7 +30,6 @@ private val LOGGER by lazy { KtorSimpleLogger("io.ktor.client.plugins.SaveBody")
  *
  * @see HttpClientCall.save
  */
-@OptIn(InternalAPI::class)
 internal val SaveBody: ClientPlugin<Unit> = createClientPlugin("SaveBody") {
     client.receivePipeline.intercept(HttpReceivePipeline.Before) { response ->
         val call = response.call
@@ -40,14 +39,15 @@ internal val SaveBody: ClientPlugin<Unit> = createClientPlugin("SaveBody") {
             return@intercept
         }
 
+        var failure: Throwable? = null
         val savedResponse = try {
             LOGGER.trace { "Saving body for ${call.request.url}" }
             call.save().response
         } catch (e: Throwable) {
-            response.tryCancelBody(e)
+            failure = e
             throw e
         } finally {
-            response.tryCancelBody()
+            response.tryCancelBody(failure)
         }
 
         attributes.put(RESPONSE_BODY_SAVED, Unit)
@@ -57,9 +57,15 @@ internal val SaveBody: ClientPlugin<Unit> = createClientPlugin("SaveBody") {
 
 @OptIn(InternalAPI::class)
 internal fun HttpResponse.tryCancelBody(e: Throwable? = null) {
-    if (!rawContent.isClosedForRead) {
-        runCatching { rawContent.cancel(e) }
-            .onFailure { LOGGER.debug("Failed to cancel response body", it) }
+    val byteChannel = rawContent
+    if (!byteChannel.isClosedForRead) {
+        try {
+            byteChannel.cancel(e)
+        } catch (cause: CancellationException) {
+            throw cause
+        } catch (cause: Exception) {
+            LOGGER.debug("Failed to cancel response body", cause)
+        }
     }
 }
 

--- a/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/SaveBody.kt
+++ b/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/SaveBody.kt
@@ -43,13 +43,23 @@ internal val SaveBody: ClientPlugin<Unit> = createClientPlugin("SaveBody") {
         val savedResponse = try {
             LOGGER.trace { "Saving body for ${call.request.url}" }
             call.save().response
+        } catch (e: Throwable) {
+            response.tryCancelBody(e)
+            throw e
         } finally {
-            runCatching { response.rawContent.cancel() }
-                .onFailure { LOGGER.debug("Failed to cancel response body", it) }
+            response.tryCancelBody()
         }
 
         attributes.put(RESPONSE_BODY_SAVED, Unit)
         proceedWith(savedResponse)
+    }
+}
+
+@OptIn(InternalAPI::class)
+internal fun HttpResponse.tryCancelBody(e: Throwable? = null) {
+    if (!rawContent.isClosedForRead) {
+        runCatching { rawContent.cancel(e) }
+            .onFailure { LOGGER.debug("Failed to cancel response body", it) }
     }
 }
 


### PR DESCRIPTION
**Subsystem**
Client

**Motivation**
[KTOR-9707](https://youtrack.jetbrains.com/issue/KTOR-9707) SaveBody performance regression

**Solution**
This kind stranger ran some client benchmarks against the underlying engine implementations and found this issue:

https://github.com/ragboyjr/ktor-benchmarks/tree/dockerized-benchmarks/docker-benchmark#high-level-results

Calling cancel on the response body is creating a new `IOException` every time which was eating up a lot of resources.  We can instead just check if it's already closed / reuse the original cause if there was some I/O error.