### PR TITLE
KTOR-9690 Fix graceful shutdown regression in Netty

### DIFF
--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyApplicationEngine.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyApplicationEngine.kt
@@ -307,26 +307,36 @@ public class NettyApplicationEngine(
         // Netty's EventLoopGroup accepts new tasks during the gracePeriod
         // and always waits at least gracePeriod, even if there are no tasks to complete.
         val noQuietPeriod = 0L
-        val timeoutMillis = (timeoutMillis - channelsCloseTime).coerceAtLeast(gracePeriodMillis)
-        val shutdownConnections = connectionEventGroup.shutdownGracefully(
-            noQuietPeriod,
-            timeoutMillis,
-            TimeUnit.MILLISECONDS
-        )
-        val shutdownWorkers = workerEventGroup.shutdownGracefully(
-            gracePeriodMillis,
-            timeoutMillis,
-            TimeUnit.MILLISECONDS
-        )
-        val workersShutdownTime = measureTimeMillis {
-            withStopException { shutdownConnections.sync() }
-            withStopException { shutdownWorkers.sync() }
+
+        var remainingTimeoutMillis = (timeoutMillis - channelsCloseTime).coerceAtLeast(100L)
+
+        val connectionsShutdownTime = measureTimeMillis {
+            withStopException {
+                connectionEventGroup.shutdownGracefully(
+                    noQuietPeriod,
+                    remainingTimeoutMillis,
+                    TimeUnit.MILLISECONDS
+                ).sync()
+            }
         }
+
+        remainingTimeoutMillis = (remainingTimeoutMillis - connectionsShutdownTime).coerceAtLeast(100L)
+
+        val workersShutdownTime = measureTimeMillis {
+            withStopException {
+                workerEventGroup.shutdownGracefully(
+                    gracePeriodMillis.coerceAtMost(remainingTimeoutMillis),
+                    remainingTimeoutMillis,
+                    TimeUnit.MILLISECONDS
+                ).sync()
+            }
+        }
+
         if (!configuration.shareWorkGroup) {
             withStopException {
                 // There should be no new tasks to be scheduled at this point; no quiet period is needed.
-                val timeoutMillis = (timeoutMillis - workersShutdownTime).coerceAtLeast(100L)
-                callEventGroup.shutdownGracefully(noQuietPeriod, timeoutMillis, TimeUnit.MILLISECONDS).sync()
+                remainingTimeoutMillis = (remainingTimeoutMillis - workersShutdownTime).coerceAtLeast(100L)
+                callEventGroup.shutdownGracefully(noQuietPeriod, remainingTimeoutMillis, TimeUnit.MILLISECONDS).sync()
             }
         }
     }

--- a/ktor-server/ktor-server-netty/jvm/test/io/ktor/tests/server/netty/NettyConfigurationTest.kt
+++ b/ktor-server/ktor-server-netty/jvm/test/io/ktor/tests/server/netty/NettyConfigurationTest.kt
@@ -62,8 +62,8 @@ class NettyConfigurationTest {
 
         engine.start(wait = false)
         engine.stop(10, 10)
-        verify { parentGroup.shutdownGracefully(0, 10, TimeUnit.MILLISECONDS) }
-        verify { childGroup.shutdownGracefully(10, 10, TimeUnit.MILLISECONDS) }
+        verify { parentGroup.shutdownGracefully(0, match { it >= 10 }, TimeUnit.MILLISECONDS) }
+        verify { childGroup.shutdownGracefully(10, match { it >= 10 }, TimeUnit.MILLISECONDS) }
     }
 
     @Test


### PR DESCRIPTION
**Subsystem**
Server, Netty

**Motivation**
[KTOR-9690](https://youtrack.jetbrains.com/issue/KTOR-9690) Netty: in-flight requests are aborted on stop(), ignoring shutdown grace period

**Solution**
Wait for connection event group to shutdown before moving onto the other event groups.  This should prevent live request handlers from being needlessly aborted.
