### PR TITLE
KTOR-4110: Fix WebSocket session structured concurrency

### DIFF
--- a/ktor-server/ktor-server-plugins/ktor-server-websockets/jvm/test/io/ktor/tests/websocket/WebSocketTest.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-websockets/jvm/test/io/ktor/tests/websocket/WebSocketTest.kt
@@ -24,6 +24,7 @@ import kotlinx.io.readByteArray
 import kotlin.random.Random
 import kotlin.test.*
 import kotlin.time.Duration.Companion.seconds
+import kotlin.use
 
 @CoroutinesTimeout(30_000)
 class WebSocketTest {
@@ -503,6 +504,34 @@ class WebSocketTest {
             val wsRawRoute: Route = webSocketRaw("/ws-raw") {}
             assertNotNull(wsRawRoute)
         }
+    }
+
+    @Test
+    fun `WebSocket session structured concurrency`() {
+        val messages = mutableListOf<String>()
+        testApplication {
+            install(WebSockets)
+            routing {
+                webSocket("/ws") {
+                    launch(CoroutineName("/ws handler")) {
+                        for (message in incoming) {
+                            // we need to block non-cooperatively while the whole application gets canceled
+                            // application shutdown should pause until this coroutine is terminated
+                            Thread.sleep(200)
+                            messages.add(message.data.toString(Charsets.UTF_8))
+                        }
+                    }
+                }
+            }
+            client.config {
+                install(io.ktor.client.plugins.websocket.WebSockets)
+            }.use {
+                it.webSocket("/ws") {
+                    outgoing.send(Frame.Text("Hello"))
+                }
+            }
+        }
+        assertContentEquals(expected = listOf("Hello"), actual = messages)
     }
 }
 

--- a/ktor-shared/ktor-websockets/common/src/io/ktor/websocket/DefaultWebSocketSession.kt
+++ b/ktor-shared/ktor-websockets/common/src/io/ktor/websocket/DefaultWebSocketSession.kt
@@ -146,7 +146,7 @@ internal class DefaultWebSocketSessionImpl(
     private val pinger = atomic<SendChannel<Frame.Pong>?>(null)
     private val closeReasonRef = CompletableDeferred<CloseReason>()
 
-    private val context = Job(raw.coroutineContext.job)
+    private val context = Job(raw.coroutineContext[Job])
     override val coroutineContext: CoroutineContext =
         raw.coroutineContext + context + CoroutineName("ws-default")
 

--- a/ktor-shared/ktor-websockets/common/src/io/ktor/websocket/DefaultWebSocketSession.kt
+++ b/ktor-shared/ktor-websockets/common/src/io/ktor/websocket/DefaultWebSocketSession.kt
@@ -146,9 +146,9 @@ internal class DefaultWebSocketSessionImpl(
     private val pinger = atomic<SendChannel<Frame.Pong>?>(null)
     private val closeReasonRef = CompletableDeferred<CloseReason>()
 
-    private val context = Job()
+    private val context = Job(raw.coroutineContext.job)
     override val coroutineContext: CoroutineContext =
-        raw.coroutineContext.minusKey(Job) + context + CoroutineName("ws-default")
+        raw.coroutineContext + context + CoroutineName("ws-default")
 
     private val filtered = Channel.from<Frame>(incomingFramesConfig)
 


### PR DESCRIPTION
Make DefaultWebSocketSessionImpl treat the Job of the session it wraps as a parent for its own Job.
Also add a test for it.

**Subsystem**
Client, Server (WebSockets shared module)

**Motivation**
[KTOR-4110](https://youtrack.jetbrains.com/issue/KTOR-4110) Websockets: Websocket handler doesn't support structured concurrency

**Solution**
Make DefaultWebSocketSessionImpl treat the Job of the session it wraps as a parent for its own Job.
