### PR TITLE
KTOR-8903 Fix timeout response on closed connection

### DIFF
--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyApplicationCallHandler.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyApplicationCallHandler.kt
@@ -8,6 +8,7 @@ import io.ktor.http.*
 import io.ktor.server.application.*
 import io.ktor.server.netty.http1.*
 import io.ktor.utils.io.*
+import io.netty.channel.ChannelFutureListener
 import io.netty.channel.ChannelHandlerContext
 import io.netty.handler.codec.http.DefaultFullHttpResponse
 import io.netty.handler.codec.http.HttpResponseStatus
@@ -38,8 +39,7 @@ internal fun ChannelHandlerContext.respond408RequestTimeoutHttp1() {
     val response = DefaultFullHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.REQUEST_TIMEOUT)
     response.headers().add(HttpHeaders.ContentLength, "0")
     response.headers().add(HttpHeaders.Connection, "close")
-    writeAndFlush(response)
-    close()
+    writeAndFlush(response).addListener(ChannelFutureListener.CLOSE)
 }
 
 internal suspend fun NettyHttp1ApplicationCall.respondError400BadRequest() {

--- a/ktor-server/ktor-server-netty/jvm/test/io/ktor/tests/server/netty/NettyReadRequestTimeoutTest.kt
+++ b/ktor-server/ktor-server-netty/jvm/test/io/ktor/tests/server/netty/NettyReadRequestTimeoutTest.kt
@@ -22,6 +22,7 @@ import io.ktor.utils.io.core.*
 import kotlinx.coroutines.*
 import kotlin.io.use
 import kotlin.test.*
+import kotlin.time.Duration.Companion.milliseconds
 
 class NettyReadRequestTimeoutTest :
     EngineTestBase<NettyApplicationEngine, NettyApplicationEngine.Configuration>(Netty) {
@@ -95,12 +96,36 @@ class NettyReadRequestTimeoutTest :
         client.performAndCheckRequestWithTimeout()
     }
 
+    @Test
+    fun `request timeout response is written before connection is closed`() =
+        requestTimeoutTest(timeout = 1) { writer, reader ->
+            writer.writeHeaders("/echo")
+
+            val response = withTimeout(5000.milliseconds) {
+                reader.readRemaining().readText()
+            }
+
+            assertTrue(
+                response.contains(REQUEST_TIMEOUT_RESPONSE),
+                "Expected 408 response, but got:\n$response"
+            )
+            assertTrue(
+                response.contains("Content-Length: 0"),
+                "Expected zero-length response, but got:\n$response"
+            )
+            assertTrue(
+                response.contains("Connection: close"),
+                "Expected connection close header, but got:\n$response"
+            )
+            assertTrue(reader.isClosedForRead)
+        }
+
     private suspend fun HttpClient.performAndCheckRequestWithTimeout() {
         get {
             url(host = TEST_SERVER_HOST, path = "/echo", port = this@NettyReadRequestTimeoutTest.port)
             setBody(object : OutgoingContent.WriteChannelContent() {
                 override suspend fun writeTo(channel: ByteWriteChannel) {
-                    delay(1100)
+                    delay(1100.milliseconds)
                     channel.writeFully("Hello world".toByteArray())
                 }
             })


### PR DESCRIPTION
**Subsystem**
Server, Netty

**Motivation**
[KTOR-8903](https://youtrack.jetbrains.com/issue/KTOR-8903) Netty: Close channel connection on errors properly

**Solution**
Previously, we'd close the channel immediately after calling `writeAndFlush`, but this can be asyncronous.  As a result, we'd try to write to a closed socket and hit broken pipe errors.  The fix is to add a close listener to the `ChannelFuture` returned from the `writeAndFlush` call.