### PR TITLE
KTOR-9302 Include tag description and externalDocs

### DIFF
--- a/ktor-server/ktor-server-plugins/ktor-server-openapi/api/ktor-server-openapi.api
+++ b/ktor-server/ktor-server-plugins/ktor-server-openapi/api/ktor-server-openapi.api
@@ -25,7 +25,7 @@ public final class io/ktor/server/plugins/openapi/OpenAPIConfig : io/ktor/openap
 	public final fun setOutputPath (Ljava/lang/String;)V
 	public final fun setParser (Lio/swagger/parser/OpenAPIParser;)V
 	public final fun setSource (Lio/ktor/server/routing/openapi/OpenApiDocSource;)V
-	public fun tag (Ljava/lang/String;)V
+	public fun tag (Ljava/lang/String;Ljava/lang/String;Lio/ktor/openapi/ExternalDocs;)V
 }
 
 public final class io/ktor/server/plugins/openapi/OpenAPIKt {

--- a/ktor-server/ktor-server-plugins/ktor-server-swagger/api/ktor-server-swagger.api
+++ b/ktor-server/ktor-server-plugins/ktor-server-swagger/api/ktor-server-swagger.api
@@ -24,7 +24,7 @@ public final class io/ktor/server/plugins/swagger/SwaggerConfig : io/ktor/openap
 	public final fun setRemotePath (Ljava/lang/String;)V
 	public final fun setSource (Lio/ktor/server/routing/openapi/OpenApiDocSource;)V
 	public final fun setVersion (Ljava/lang/String;)V
-	public fun tag (Ljava/lang/String;)V
+	public fun tag (Ljava/lang/String;Ljava/lang/String;Lio/ktor/openapi/ExternalDocs;)V
 }
 
 public final class io/ktor/server/plugins/swagger/SwaggerKt {

--- a/ktor-shared/ktor-openapi-schema/api/ktor-openapi-schema.api
+++ b/ktor-shared/ktor-openapi-schema/api/ktor-openapi-schema.api
@@ -1297,7 +1297,7 @@ public final class io/ktor/openapi/OpenApiDoc$Builder : io/ktor/openapi/OpenApiD
 	public fun setExternalDocs (Lio/ktor/openapi/ExternalDocs;)V
 	public fun setInfo (Lio/ktor/openapi/OpenApiInfo;)V
 	public fun setOpenapiVersion (Ljava/lang/String;)V
-	public fun tag (Ljava/lang/String;)V
+	public fun tag (Ljava/lang/String;Ljava/lang/String;Lio/ktor/openapi/ExternalDocs;)V
 }
 
 public final class io/ktor/openapi/OpenApiDoc$Companion {
@@ -1317,7 +1317,12 @@ public abstract interface class io/ktor/openapi/OpenApiDocDsl {
 	public abstract fun setExternalDocs (Lio/ktor/openapi/ExternalDocs;)V
 	public abstract fun setInfo (Lio/ktor/openapi/OpenApiInfo;)V
 	public abstract fun setOpenapiVersion (Ljava/lang/String;)V
-	public abstract fun tag (Ljava/lang/String;)V
+	public abstract fun tag (Ljava/lang/String;Ljava/lang/String;Lio/ktor/openapi/ExternalDocs;)V
+	public static synthetic fun tag$default (Lio/ktor/openapi/OpenApiDocDsl;Ljava/lang/String;Ljava/lang/String;Lio/ktor/openapi/ExternalDocs;ILjava/lang/Object;)V
+}
+
+public final class io/ktor/openapi/OpenApiDocDsl$DefaultImpls {
+	public static synthetic fun tag$default (Lio/ktor/openapi/OpenApiDocDsl;Ljava/lang/String;Ljava/lang/String;Lio/ktor/openapi/ExternalDocs;ILjava/lang/Object;)V
 }
 
 public final class io/ktor/openapi/OpenApiInfo : io/ktor/openapi/Extensible {
@@ -1538,7 +1543,8 @@ public final class io/ktor/openapi/Operation$Builder : io/ktor/openapi/JsonSchem
 	public final fun setOperationId (Ljava/lang/String;)V
 	public final fun setRequestBody (Lio/ktor/openapi/RequestBody;)V
 	public final fun setSummary (Ljava/lang/String;)V
-	public final fun tag (Ljava/lang/String;)V
+	public final fun tag (Ljava/lang/String;Ljava/lang/String;Lio/ktor/openapi/ExternalDocs;)V
+	public static synthetic fun tag$default (Lio/ktor/openapi/Operation$Builder;Ljava/lang/String;Ljava/lang/String;Lio/ktor/openapi/ExternalDocs;ILjava/lang/Object;)V
 }
 
 public final class io/ktor/openapi/Operation$Companion {

--- a/ktor-shared/ktor-openapi-schema/api/ktor-openapi-schema.klib.api
+++ b/ktor-shared/ktor-openapi-schema/api/ktor-openapi-schema.klib.api
@@ -133,7 +133,7 @@ abstract interface io.ktor.openapi/OpenApiDocDsl { // io.ktor.openapi/OpenApiDoc
 
     abstract fun security(kotlin/Function1<io.ktor.openapi/Security.Builder, kotlin/Unit>) // io.ktor.openapi/OpenApiDocDsl.security|security(kotlin.Function1<io.ktor.openapi.Security.Builder,kotlin.Unit>){}[0]
     abstract fun servers(kotlin/Function1<io.ktor.openapi/Servers.Builder, kotlin/Unit>) // io.ktor.openapi/OpenApiDocDsl.servers|servers(kotlin.Function1<io.ktor.openapi.Servers.Builder,kotlin.Unit>){}[0]
-    abstract fun tag(kotlin/String) // io.ktor.openapi/OpenApiDocDsl.tag|tag(kotlin.String){}[0]
+    abstract fun tag(kotlin/String, kotlin/String? = ..., io.ktor.openapi/ExternalDocs? = ...) // io.ktor.openapi/OpenApiDocDsl.tag|tag(kotlin.String;kotlin.String?;io.ktor.openapi.ExternalDocs?){}[0]
 }
 
 sealed interface <#A: out kotlin/Any?> io.ktor.openapi/ReferenceOr { // io.ktor.openapi/ReferenceOr|null[0]
@@ -1420,7 +1420,7 @@ final class io.ktor.openapi/OpenApiDoc : io.ktor.openapi/Extensible { // io.ktor
         final val servers // io.ktor.openapi/OpenApiDoc.Builder.servers|{}servers[0]
             final fun <get-servers>(): kotlin.collections/List<io.ktor.openapi/Server> // io.ktor.openapi/OpenApiDoc.Builder.servers.<get-servers>|<get-servers>(){}[0]
         final val tags // io.ktor.openapi/OpenApiDoc.Builder.tags|{}tags[0]
-            final fun <get-tags>(): kotlin.collections/List<kotlin/String> // io.ktor.openapi/OpenApiDoc.Builder.tags.<get-tags>|<get-tags>(){}[0]
+            final fun <get-tags>(): kotlin.collections/List<io.ktor.openapi/Tag> // io.ktor.openapi/OpenApiDoc.Builder.tags.<get-tags>|<get-tags>(){}[0]
 
         final var components // io.ktor.openapi/OpenApiDoc.Builder.components|{}components[0]
             final fun <get-components>(): io.ktor.openapi/Components? // io.ktor.openapi/OpenApiDoc.Builder.components.<get-components>|<get-components>(){}[0]
@@ -1438,7 +1438,7 @@ final class io.ktor.openapi/OpenApiDoc : io.ktor.openapi/Extensible { // io.ktor
         final fun build(): io.ktor.openapi/OpenApiDoc // io.ktor.openapi/OpenApiDoc.Builder.build|build(){}[0]
         final fun security(kotlin/Function1<io.ktor.openapi/Security.Builder, kotlin/Unit>) // io.ktor.openapi/OpenApiDoc.Builder.security|security(kotlin.Function1<io.ktor.openapi.Security.Builder,kotlin.Unit>){}[0]
         final fun servers(kotlin/Function1<io.ktor.openapi/Servers.Builder, kotlin/Unit>) // io.ktor.openapi/OpenApiDoc.Builder.servers|servers(kotlin.Function1<io.ktor.openapi.Servers.Builder,kotlin.Unit>){}[0]
-        final fun tag(kotlin/String) // io.ktor.openapi/OpenApiDoc.Builder.tag|tag(kotlin.String){}[0]
+        final fun tag(kotlin/String, kotlin/String?, io.ktor.openapi/ExternalDocs?) // io.ktor.openapi/OpenApiDoc.Builder.tag|tag(kotlin.String;kotlin.String?;io.ktor.openapi.ExternalDocs?){}[0]
         final inline fun <#A2: reified kotlin/Any> extension(kotlin/String, #A2) // io.ktor.openapi/OpenApiDoc.Builder.extension|extension(kotlin.String;0:0){0§<kotlin.Any>}[0]
     }
 
@@ -1612,7 +1612,7 @@ final class io.ktor.openapi/OpenIdConnectSecurityScheme : io.ktor.openapi/Extens
 }
 
 final class io.ktor.openapi/Operation : io.ktor.openapi/Extensible { // io.ktor.openapi/Operation|null[0]
-    constructor <init>(kotlin/String? = ..., kotlin.collections/List<kotlin/String>? = ..., kotlin/String? = ..., kotlin/String? = ..., io.ktor.openapi/ExternalDocs? = ..., kotlin.collections/List<io.ktor.openapi/ReferenceOr<io.ktor.openapi/Parameter>>? = ..., io.ktor.openapi/ReferenceOr<io.ktor.openapi/RequestBody>? = ..., kotlin.collections/Map<kotlin/String, io.ktor.openapi/ReferenceOr<io.ktor.openapi/Callback>>? = ..., io.ktor.openapi/Responses? = ..., kotlin/Boolean? = ..., kotlin.collections/List<kotlin.collections/Map<kotlin/String, kotlin.collections/List<kotlin/String>>>? = ..., kotlin.collections/List<io.ktor.openapi/Server>? = ..., kotlin.collections/Map<kotlin/String, io.ktor.openapi/GenericElement>? = ...) // io.ktor.openapi/Operation.<init>|<init>(kotlin.String?;kotlin.collections.List<kotlin.String>?;kotlin.String?;kotlin.String?;io.ktor.openapi.ExternalDocs?;kotlin.collections.List<io.ktor.openapi.ReferenceOr<io.ktor.openapi.Parameter>>?;io.ktor.openapi.ReferenceOr<io.ktor.openapi.RequestBody>?;kotlin.collections.Map<kotlin.String,io.ktor.openapi.ReferenceOr<io.ktor.openapi.Callback>>?;io.ktor.openapi.Responses?;kotlin.Boolean?;kotlin.collections.List<kotlin.collections.Map<kotlin.String,kotlin.collections.List<kotlin.String>>>?;kotlin.collections.List<io.ktor.openapi.Server>?;kotlin.collections.Map<kotlin.String,io.ktor.openapi.GenericElement>?){}[0]
+    constructor <init>(kotlin/String? = ..., kotlin.collections/List<io.ktor.openapi/Tag>? = ..., kotlin/String? = ..., kotlin/String? = ..., io.ktor.openapi/ExternalDocs? = ..., kotlin.collections/List<io.ktor.openapi/ReferenceOr<io.ktor.openapi/Parameter>>? = ..., io.ktor.openapi/ReferenceOr<io.ktor.openapi/RequestBody>? = ..., kotlin.collections/Map<kotlin/String, io.ktor.openapi/ReferenceOr<io.ktor.openapi/Callback>>? = ..., io.ktor.openapi/Responses? = ..., kotlin/Boolean? = ..., kotlin.collections/List<kotlin.collections/Map<kotlin/String, kotlin.collections/List<kotlin/String>>>? = ..., kotlin.collections/List<io.ktor.openapi/Server>? = ..., kotlin.collections/Map<kotlin/String, io.ktor.openapi/GenericElement>? = ...) // io.ktor.openapi/Operation.<init>|<init>(kotlin.String?;kotlin.collections.List<io.ktor.openapi.Tag>?;kotlin.String?;kotlin.String?;io.ktor.openapi.ExternalDocs?;kotlin.collections.List<io.ktor.openapi.ReferenceOr<io.ktor.openapi.Parameter>>?;io.ktor.openapi.ReferenceOr<io.ktor.openapi.RequestBody>?;kotlin.collections.Map<kotlin.String,io.ktor.openapi.ReferenceOr<io.ktor.openapi.Callback>>?;io.ktor.openapi.Responses?;kotlin.Boolean?;kotlin.collections.List<kotlin.collections.Map<kotlin.String,kotlin.collections.List<kotlin.String>>>?;kotlin.collections.List<io.ktor.openapi.Server>?;kotlin.collections.Map<kotlin.String,io.ktor.openapi.GenericElement>?){}[0]
 
     final val callbacks // io.ktor.openapi/Operation.callbacks|{}callbacks[0]
         final fun <get-callbacks>(): kotlin.collections/Map<kotlin/String, io.ktor.openapi/ReferenceOr<io.ktor.openapi/Callback>>? // io.ktor.openapi/Operation.callbacks.<get-callbacks>|<get-callbacks>(){}[0]
@@ -1639,14 +1639,14 @@ final class io.ktor.openapi/Operation : io.ktor.openapi/Extensible { // io.ktor.
     final val summary // io.ktor.openapi/Operation.summary|{}summary[0]
         final fun <get-summary>(): kotlin/String? // io.ktor.openapi/Operation.summary.<get-summary>|<get-summary>(){}[0]
     final val tags // io.ktor.openapi/Operation.tags|{}tags[0]
-        final fun <get-tags>(): kotlin.collections/List<kotlin/String>? // io.ktor.openapi/Operation.tags.<get-tags>|<get-tags>(){}[0]
+        final fun <get-tags>(): kotlin.collections/List<io.ktor.openapi/Tag>? // io.ktor.openapi/Operation.tags.<get-tags>|<get-tags>(){}[0]
 
     final fun component1(): kotlin/String? // io.ktor.openapi/Operation.component1|component1(){}[0]
     final fun component10(): kotlin/Boolean? // io.ktor.openapi/Operation.component10|component10(){}[0]
     final fun component11(): kotlin.collections/List<kotlin.collections/Map<kotlin/String, kotlin.collections/List<kotlin/String>>>? // io.ktor.openapi/Operation.component11|component11(){}[0]
     final fun component12(): kotlin.collections/List<io.ktor.openapi/Server>? // io.ktor.openapi/Operation.component12|component12(){}[0]
     final fun component13(): kotlin.collections/Map<kotlin/String, io.ktor.openapi/GenericElement>? // io.ktor.openapi/Operation.component13|component13(){}[0]
-    final fun component2(): kotlin.collections/List<kotlin/String>? // io.ktor.openapi/Operation.component2|component2(){}[0]
+    final fun component2(): kotlin.collections/List<io.ktor.openapi/Tag>? // io.ktor.openapi/Operation.component2|component2(){}[0]
     final fun component3(): kotlin/String? // io.ktor.openapi/Operation.component3|component3(){}[0]
     final fun component4(): kotlin/String? // io.ktor.openapi/Operation.component4|component4(){}[0]
     final fun component5(): io.ktor.openapi/ExternalDocs? // io.ktor.openapi/Operation.component5|component5(){}[0]
@@ -1654,7 +1654,7 @@ final class io.ktor.openapi/Operation : io.ktor.openapi/Extensible { // io.ktor.
     final fun component7(): io.ktor.openapi/ReferenceOr<io.ktor.openapi/RequestBody>? // io.ktor.openapi/Operation.component7|component7(){}[0]
     final fun component8(): kotlin.collections/Map<kotlin/String, io.ktor.openapi/ReferenceOr<io.ktor.openapi/Callback>>? // io.ktor.openapi/Operation.component8|component8(){}[0]
     final fun component9(): io.ktor.openapi/Responses? // io.ktor.openapi/Operation.component9|component9(){}[0]
-    final fun copy(kotlin/String? = ..., kotlin.collections/List<kotlin/String>? = ..., kotlin/String? = ..., kotlin/String? = ..., io.ktor.openapi/ExternalDocs? = ..., kotlin.collections/List<io.ktor.openapi/ReferenceOr<io.ktor.openapi/Parameter>>? = ..., io.ktor.openapi/ReferenceOr<io.ktor.openapi/RequestBody>? = ..., kotlin.collections/Map<kotlin/String, io.ktor.openapi/ReferenceOr<io.ktor.openapi/Callback>>? = ..., io.ktor.openapi/Responses? = ..., kotlin/Boolean? = ..., kotlin.collections/List<kotlin.collections/Map<kotlin/String, kotlin.collections/List<kotlin/String>>>? = ..., kotlin.collections/List<io.ktor.openapi/Server>? = ..., kotlin.collections/Map<kotlin/String, io.ktor.openapi/GenericElement>? = ...): io.ktor.openapi/Operation // io.ktor.openapi/Operation.copy|copy(kotlin.String?;kotlin.collections.List<kotlin.String>?;kotlin.String?;kotlin.String?;io.ktor.openapi.ExternalDocs?;kotlin.collections.List<io.ktor.openapi.ReferenceOr<io.ktor.openapi.Parameter>>?;io.ktor.openapi.ReferenceOr<io.ktor.openapi.RequestBody>?;kotlin.collections.Map<kotlin.String,io.ktor.openapi.ReferenceOr<io.ktor.openapi.Callback>>?;io.ktor.openapi.Responses?;kotlin.Boolean?;kotlin.collections.List<kotlin.collections.Map<kotlin.String,kotlin.collections.List<kotlin.String>>>?;kotlin.collections.List<io.ktor.openapi.Server>?;kotlin.collections.Map<kotlin.String,io.ktor.openapi.GenericElement>?){}[0]
+    final fun copy(kotlin/String? = ..., kotlin.collections/List<io.ktor.openapi/Tag>? = ..., kotlin/String? = ..., kotlin/String? = ..., io.ktor.openapi/ExternalDocs? = ..., kotlin.collections/List<io.ktor.openapi/ReferenceOr<io.ktor.openapi/Parameter>>? = ..., io.ktor.openapi/ReferenceOr<io.ktor.openapi/RequestBody>? = ..., kotlin.collections/Map<kotlin/String, io.ktor.openapi/ReferenceOr<io.ktor.openapi/Callback>>? = ..., io.ktor.openapi/Responses? = ..., kotlin/Boolean? = ..., kotlin.collections/List<kotlin.collections/Map<kotlin/String, kotlin.collections/List<kotlin/String>>>? = ..., kotlin.collections/List<io.ktor.openapi/Server>? = ..., kotlin.collections/Map<kotlin/String, io.ktor.openapi/GenericElement>? = ...): io.ktor.openapi/Operation // io.ktor.openapi/Operation.copy|copy(kotlin.String?;kotlin.collections.List<io.ktor.openapi.Tag>?;kotlin.String?;kotlin.String?;io.ktor.openapi.ExternalDocs?;kotlin.collections.List<io.ktor.openapi.ReferenceOr<io.ktor.openapi.Parameter>>?;io.ktor.openapi.ReferenceOr<io.ktor.openapi.RequestBody>?;kotlin.collections.Map<kotlin.String,io.ktor.openapi.ReferenceOr<io.ktor.openapi.Callback>>?;io.ktor.openapi.Responses?;kotlin.Boolean?;kotlin.collections.List<kotlin.collections.Map<kotlin.String,kotlin.collections.List<kotlin.String>>>?;kotlin.collections.List<io.ktor.openapi.Server>?;kotlin.collections.Map<kotlin.String,io.ktor.openapi.GenericElement>?){}[0]
     final fun equals(kotlin/Any?): kotlin/Boolean // io.ktor.openapi/Operation.equals|equals(kotlin.Any?){}[0]
     final fun hashCode(): kotlin/Int // io.ktor.openapi/Operation.hashCode|hashCode(){}[0]
     final fun toString(): kotlin/String // io.ktor.openapi/Operation.toString|toString(){}[0]
@@ -1673,7 +1673,7 @@ final class io.ktor.openapi/Operation : io.ktor.openapi/Extensible { // io.ktor.
         final val servers // io.ktor.openapi/Operation.Builder.servers|{}servers[0]
             final fun <get-servers>(): kotlin.collections/List<io.ktor.openapi/Server> // io.ktor.openapi/Operation.Builder.servers.<get-servers>|<get-servers>(){}[0]
         final val tags // io.ktor.openapi/Operation.Builder.tags|{}tags[0]
-            final fun <get-tags>(): kotlin.collections/List<kotlin/String> // io.ktor.openapi/Operation.Builder.tags.<get-tags>|<get-tags>(){}[0]
+            final fun <get-tags>(): kotlin.collections/List<io.ktor.openapi/Tag> // io.ktor.openapi/Operation.Builder.tags.<get-tags>|<get-tags>(){}[0]
 
         final var deprecated // io.ktor.openapi/Operation.Builder.deprecated|{}deprecated[0]
             final fun <get-deprecated>(): kotlin/Boolean? // io.ktor.openapi/Operation.Builder.deprecated.<get-deprecated>|<get-deprecated>(){}[0]
@@ -1704,7 +1704,7 @@ final class io.ktor.openapi/Operation : io.ktor.openapi/Extensible { // io.ktor.
         final fun responses(kotlin/Function1<io.ktor.openapi/Responses.Builder, kotlin/Unit>) // io.ktor.openapi/Operation.Builder.responses|responses(kotlin.Function1<io.ktor.openapi.Responses.Builder,kotlin.Unit>){}[0]
         final fun security(kotlin/Function1<io.ktor.openapi/Security.Builder, kotlin/Unit>) // io.ktor.openapi/Operation.Builder.security|security(kotlin.Function1<io.ktor.openapi.Security.Builder,kotlin.Unit>){}[0]
         final fun servers(kotlin/Function1<io.ktor.openapi/Servers.Builder, kotlin/Unit>) // io.ktor.openapi/Operation.Builder.servers|servers(kotlin.Function1<io.ktor.openapi.Servers.Builder,kotlin.Unit>){}[0]
-        final fun tag(kotlin/String) // io.ktor.openapi/Operation.Builder.tag|tag(kotlin.String){}[0]
+        final fun tag(kotlin/String, kotlin/String? = ..., io.ktor.openapi/ExternalDocs? = ...) // io.ktor.openapi/Operation.Builder.tag|tag(kotlin.String;kotlin.String?;io.ktor.openapi.ExternalDocs?){}[0]
         final inline fun <#A2: reified kotlin/Any> extension(kotlin/String, #A2) // io.ktor.openapi/Operation.Builder.extension|extension(kotlin.String;0:0){0§<kotlin.Any>}[0]
     }
 

--- a/ktor-shared/ktor-openapi-schema/common/src/io/ktor/openapi/OpenApiDoc.kt
+++ b/ktor-shared/ktor-openapi-schema/common/src/io/ktor/openapi/OpenApiDoc.kt
@@ -66,9 +66,11 @@ public interface OpenApiDocDsl {
      *
      * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.openapi.OpenApiDocDsl.tag)
      *
-     * @param tag The tag name.
+     * @param name The tag name.
+     * @param description The tag description.
+     * @param externalDocs Any external documentation.
      */
-    public fun tag(tag: String)
+    public fun tag(name: String, description: String? = null, externalDocs: ExternalDocs? = null)
 
     /**
      * Optional reusable components for the document (schemas, responses, parameters, request bodies, etc.).
@@ -186,7 +188,7 @@ public data class OpenApiDoc(
         override val extensions: MutableMap<String, GenericElement> = linkedMapOf()
 
         private val _servers = mutableListOf<Server>()
-        private val _tags = mutableListOf<String>()
+        private val _tags = mutableListOf<Tag>()
         private val _securityRequirements = mutableListOf<Map<String, List<String>>>()
 
         /**
@@ -201,7 +203,7 @@ public data class OpenApiDoc(
          *
          * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.openapi.OpenApiDoc.Builder.tags)
          */
-        public val tags: List<String> get() = _tags
+        public val tags: List<Tag> get() = _tags
 
         /**
          * A list of security requirements configured for this API.
@@ -218,8 +220,8 @@ public data class OpenApiDoc(
             Security.Builder().apply(configure).build().requirements.forEach { _securityRequirements.add(it) }
         }
 
-        override fun tag(tag: String) {
-            _tags.add(tag)
+        override fun tag(name: String, description: String?, externalDocs: ExternalDocs?) {
+            _tags.add(Tag(name, description, externalDocs))
         }
 
         /**
@@ -251,7 +253,7 @@ public data class OpenApiDoc(
                 webhooks = emptyMap(),
                 components = components,
                 security = _securityRequirements.ifEmpty { null },
-                tags = _tags.distinct().map(::Tag).ifEmpty { null },
+                tags = _tags.distinctBy { it.name }.ifEmpty { null },
                 externalDocs = externalDocs,
                 extensions = extensions.ifEmpty { null },
             )

--- a/ktor-shared/ktor-openapi-schema/common/src/io/ktor/openapi/Operation.kt
+++ b/ktor-shared/ktor-openapi-schema/common/src/io/ktor/openapi/Operation.kt
@@ -40,7 +40,7 @@ import kotlin.jvm.JvmInline
 @KeepGeneratedSerializer
 public data class Operation(
     public val operationId: String? = null,
-    public val tags: List<String>? = null,
+    public val tags: List<Tag>? = null,
     public val summary: String? = null,
     public val description: String? = null,
     public val externalDocs: ExternalDocs? = null,
@@ -120,7 +120,7 @@ public data class Operation(
         public var externalDocs: ExternalDocs? = null
 
         // TODO remove these after KT-14663 is implemented
-        private val _tags = mutableListOf<String>()
+        private val _tags = mutableListOf<Tag>()
         private val _parameters = mutableListOf<Parameter>()
         private var _responses: Responses? = null
         private val _servers = mutableListOf<Server>()
@@ -132,7 +132,7 @@ public data class Operation(
          *
          * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.openapi.Operation.Builder.tags)
          */
-        public val tags: List<String> get() = _tags
+        public val tags: List<Tag> get() = _tags
 
         /**
          * Collected parameter definitions for this operation.
@@ -190,8 +190,8 @@ public data class Operation(
          *
          * @param tag The tag name to add.
          */
-        public fun tag(tag: String) {
-            _tags.add(tag)
+        public fun tag(tag: String, description: String? = null, externalDocs: ExternalDocs? = null) {
+            _tags.add(Tag(tag, description, externalDocs))
         }
 
         /**
@@ -275,7 +275,7 @@ public data class Operation(
 
         internal fun build(): Operation {
             return Operation(
-                tags = if (_tags.isEmpty()) null else _tags,
+                tags = _tags.distinctBy { it.name }.ifEmpty { null },
                 summary = summary,
                 description = description,
                 externalDocs = externalDocs,

--- a/ktor-shared/ktor-openapi-schema/jvm/test/io/ktor/openapi/GenericElementTest.kt
+++ b/ktor-shared/ktor-openapi-schema/jvm/test/io/ktor/openapi/GenericElementTest.kt
@@ -14,7 +14,6 @@ import kotlin.test.assertEquals
 
 class GenericElementTest {
 
-    @OptIn(ExperimentalSerializationApi::class)
     private val jsonFormat = Json {
         encodeDefaults = false
         prettyPrint = true

--- a/ktor-shared/ktor-openapi-schema/jvm/test/io/ktor/openapi/OperationSerializationTests.kt
+++ b/ktor-shared/ktor-openapi-schema/jvm/test/io/ktor/openapi/OperationSerializationTests.kt
@@ -18,7 +18,6 @@ import kotlin.test.assertEquals
 
 class OperationSerializationTests {
 
-    @OptIn(ExperimentalSerializationApi::class)
     private val jsonFormat = Json {
         encodeDefaults = false
         prettyPrint = true
@@ -219,6 +218,7 @@ class OperationSerializationTests {
     fun `request body with extension properties`() {
         val operation = Operation.build {
             summary = "Create article"
+            tag("Articles", "Endpoints pertaining to articles")
 
             requestBody {
                 description = "Article data"


### PR DESCRIPTION
**Subsystem**
Server, OpenAPI

**Motivation**
[KTOR-9302](https://youtrack.jetbrains.com/issue/KTOR-9302) OpenAPI: No way to set tag description

**Solution**
Added description and external docs to the tag function in the DSL.

There a couple of minor breaking changes here, but the API is still flagged as experimental.