### PR TITLE
KTOR-9711 Fix canceled stream connection corruption

### DIFF
--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/cio/NettyHttpResponsePipeline.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/cio/NettyHttpResponsePipeline.kt
@@ -26,12 +26,26 @@ import kotlin.coroutines.CoroutineContext
 private const val UNFLUSHED_LIMIT = 65536
 
 /**
- * Contains methods for handling http request with Netty
+ * Contains methods for handling HTTP responses with Netty.
+ *
+ * The pipeline serializes response writes in request order, tracks active and streaming responses,
+ * and flushes pending writes when the channel read cycle is complete and no non-streaming responses
+ * are still active.
+ *
+ * @property context Netty channel context used to write, flush, read from, and close the channel.
+ * @property httpHandlerState Shared state used to coordinate request counters, streaming counters,
+ *                            read-completion state, and back-pressure decisions for the handler.
+ * @property coroutineContext Coroutine context used to launch response body writer coroutines.
+ * @property onFailure Optional action invoked after a failed call's counters are decremented. For HTTP/2, this is
+ *                     used to trigger [flushIfNeeded] on the most-recently-created pipeline (which may differ from
+ *                     `this` due to the shared-handler-per-stream design), so that a pending flush blocked by the
+ *                     stale counter is unblocked regardless of thread-scheduling order.
  */
 internal class NettyHttpResponsePipeline(
     private val context: ChannelHandlerContext,
     private val httpHandlerState: NettyHttpHandlerState,
-    override val coroutineContext: CoroutineContext
+    override val coroutineContext: CoroutineContext,
+    private val onFailure: (() -> Unit)? = null
 ) : CoroutineScope {
     /**
      * True if there is unflushed written data in channel
@@ -111,7 +125,13 @@ internal class NettyHttpResponsePipeline(
             else -> actualException
         }
 
+        if (call.isStreamingResponse) {
+            httpHandlerState.streamingResponses.decrementAndGet()
+        }
+        httpHandlerState.activeRequests.decrementAndGet()
+
         flushIfNeeded()
+        onFailure?.invoke()
         call.response.responseChannel.cancel(t)
         call.responseWriteJob.cancel()
         call.response.cancel()

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http2/NettyHttp2Handler.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http2/NettyHttp2Handler.kt
@@ -85,7 +85,8 @@ internal class NettyHttp2Handler(
         responseWriter = NettyHttpResponsePipeline(
             context = context,
             httpHandlerState = state,
-            coroutineContext = handlerJob
+            coroutineContext = handlerJob,
+            onFailure = { responseWriter.flushIfNeeded() }
         )
 
         // Append a tail sink that consumes NettyHttp2ApplicationCall messages forwarded by this handler

--- a/ktor-server/ktor-server-netty/jvm/test/io/ktor/tests/server/netty/NettyEngineTest.kt
+++ b/ktor-server/ktor-server-netty/jvm/test/io/ktor/tests/server/netty/NettyEngineTest.kt
@@ -12,6 +12,7 @@ import io.ktor.http.*
 import io.ktor.network.selector.*
 import io.ktor.network.sockets.*
 import io.ktor.server.application.*
+import io.ktor.server.http.*
 import io.ktor.server.netty.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
@@ -19,6 +20,7 @@ import io.ktor.server.test.base.*
 import io.ktor.server.testing.suites.*
 import io.ktor.server.websocket.*
 import io.ktor.utils.io.*
+import io.ktor.utils.io.InternalAPI
 import io.ktor.websocket.*
 import io.netty.buffer.ByteBuf
 import io.netty.buffer.Unpooled
@@ -31,6 +33,7 @@ import kotlin.test.Ignore
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.milliseconds
 
 class NettyCompressionTest : CompressionTestSuite<NettyApplicationEngine, NettyApplicationEngine.Configuration>(Netty) {
     init {
@@ -464,7 +467,7 @@ class NettyH2cFlushTest :
                     // Wait for SSE DATA on the wire — once we receive it, the SSE's
                     // writeAndFlush on the child channel is complete and respondWithBigBody
                     // is suspended in awaitContent(). No more flushes from SSE.
-                    withTimeout(5_000) {
+                    withTimeout(5_000.milliseconds) {
                         waitForDataOnStream(reader, SSE_STREAM_ID)
                     }
 
@@ -475,11 +478,87 @@ class NettyH2cFlushTest :
                     // Without the fix, this hangs: the regular response is written to the
                     // channel but never flushed because flushIfNeeded() checks
                     // activeRequests == 0, which is false (SSE stream is still active).
-                    val regularData = withTimeout(3_000) {
+                    val regularData = withTimeout(3_000.milliseconds) {
                         readResponseForStream(reader, REGULAR_STREAM_ID)
                     }
 
                     assertEquals("ok", regularData)
+                }
+            }
+        } finally {
+            server.stop()
+        }
+    }
+
+    @OptIn(InternalAPI::class)
+    @Test
+    fun testH2RstStreamDoesNotPoisonConnection() = runTest {
+        val requestReceived = CompletableDeferred<Unit>()
+        // Completed by HttpRequestCloseHandlerKey when stream 3's channel becomes inactive
+        val stream3ChannelClosed = CompletableDeferred<Unit>()
+
+        val server = createServer {
+            routing {
+                get("/slow") {
+                    // Register a close callback so we know when the channel is truly gone
+                    @OptIn(InternalAPI::class)
+                    call.attributes.put(HttpRequestCloseHandlerKey) {
+                        stream3ChannelClosed.complete(Unit)
+                    }
+                    requestReceived.complete(Unit)
+                    // Suspend until the channel is closed (by the client's RST_STREAM), then attempt
+                    // to respond — this exercises the failure path in respondWithFailure.
+                    stream3ChannelClosed.await()
+                    runCatching { call.respondText("slow ok") }
+                }
+                get("/data") {
+                    call.respondText("data ok")
+                }
+            }
+        }
+        server.start(wait = false)
+
+        try {
+            SelectorManager().use { selector ->
+                aSocket(selector).tcp().connect("127.0.0.1", port).use { socket ->
+                    val writer = socket.openWriteChannel()
+                    val reader = socket.openReadChannel()
+
+                    writer.writeStringUtf8("PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n")
+                    writer.flush()
+                    writer.writeFully(h2Frame(null, Http2FrameTypes.SETTINGS, Http2Flags(), 0))
+                    writer.flush()
+
+                    val serverSettings = reader.readH2Frame()
+                    assertEquals(Http2FrameTypes.SETTINGS, serverSettings.frameType)
+                    val serverAck = reader.readH2Frame()
+                    assertEquals(Http2FrameTypes.SETTINGS, serverAck.frameType)
+                    assertTrue(serverAck.flags.ack())
+
+                    writer.writeFully(h2Frame(null, Http2FrameTypes.SETTINGS, Http2Flags().ack(true), 0))
+                    writer.flush()
+
+                    // Phase 1: send /slow, wait for the server to receive it, then cancel with RST_STREAM
+                    writer.writeFully(h2HeadersFrame("/slow", 3))
+                    writer.flush()
+                    withTimeout(5_000.milliseconds) { requestReceived.await() }
+
+                    val rstPayload = Unpooled.buffer(4)
+                    rstPayload.writeInt(Http2Error.CANCEL.code().toInt())
+                    writer.writeFully(h2Frame(rstPayload, Http2FrameTypes.RST_STREAM, Http2Flags(), 3))
+                    writer.flush()
+
+                    // Wait until stream 3's channel is fully closed server-side; at this point
+                    // the server handler resumes and will call respondWithFailure, decrementing
+                    // activeRequests back to zero.
+                    withTimeout(5_000.milliseconds) { stream3ChannelClosed.await() }
+
+                    // Phase 2: same connection must still work after the cancelled stream
+                    writer.writeFully(h2HeadersFrame("/data", 5))
+                    writer.flush()
+
+                    val body = withTimeout(3_000.milliseconds) { readResponseForStream(reader, 5) }
+                    assertEquals("data ok", body)
                 }
             }
         } finally {

--- a/ktor-server/ktor-server-netty/jvm/test/io/ktor/tests/server/netty/NettyEngineTest.kt
+++ b/ktor-server/ktor-server-netty/jvm/test/io/ktor/tests/server/netty/NettyEngineTest.kt
@@ -32,6 +32,7 @@ import kotlinx.coroutines.flow.consumeAsFlow
 import kotlin.test.Ignore
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 import kotlin.time.Duration.Companion.milliseconds
 
@@ -490,12 +491,15 @@ class NettyH2cFlushTest :
         }
     }
 
-    @OptIn(InternalAPI::class)
     @Test
-    fun testH2RstStreamDoesNotPoisonConnection() = runTest {
+    fun `H2 RST stream does not poison connection`() = runTest {
         val requestReceived = CompletableDeferred<Unit>()
         // Completed by HttpRequestCloseHandlerKey when stream 3's channel becomes inactive
         val stream3ChannelClosed = CompletableDeferred<Unit>()
+        // Completed by the /data handler just before calling respondText
+        val dataReachedResponse = CompletableDeferred<Unit>()
+        // Completed by the test to allow /slow to proceed with its (failing) respondText call
+        val slowCanRespond = CompletableDeferred<Unit>()
 
         val server = createServer {
             routing {
@@ -506,12 +510,17 @@ class NettyH2cFlushTest :
                         stream3ChannelClosed.complete(Unit)
                     }
                     requestReceived.complete(Unit)
-                    // Suspend until the channel is closed (by the client's RST_STREAM), then attempt
-                    // to respond — this exercises the failure path in respondWithFailure.
+                    // Suspend until the channel is closed (by the client's RST_STREAM), then wait
+                    // for the test to send /data and reach the response path before allowing
+                    // respondWithFailure to run and decrement activeRequests.
                     stream3ChannelClosed.await()
+                    slowCanRespond.await()
                     runCatching { call.respondText("slow ok") }
                 }
                 get("/data") {
+                    // Signal that /data has reached the response/flush path before handing off
+                    // to respondText, so the test can assert the flush is still blocked.
+                    dataReachedResponse.complete(Unit)
                     call.respondText("data ok")
                 }
             }
@@ -548,16 +557,36 @@ class NettyH2cFlushTest :
                     writer.writeFully(h2Frame(rstPayload, Http2FrameTypes.RST_STREAM, Http2Flags(), 3))
                     writer.flush()
 
-                    // Wait until stream 3's channel is fully closed server-side; at this point
-                    // the server handler resumes and will call respondWithFailure, decrementing
-                    // activeRequests back to zero.
+                    // Wait until stream 3's channel is fully closed server-side; the /slow handler
+                    // has resumed from stream3ChannelClosed.await() and is now suspended on
+                    // slowCanRespond — activeRequests is still 1 from /slow's increment.
                     withTimeout(5_000.milliseconds) { stream3ChannelClosed.await() }
 
-                    // Phase 2: same connection must still work after the cancelled stream
+                    // Phase 2: send /data while /slow has not yet run its failure path.
+                    // activeRequests == 1 (from /slow); /data's response will be written to Netty's
+                    // outbound buffer but flushIfNeeded() cannot fire until activeRequests drops to 0.
                     writer.writeFully(h2HeadersFrame("/data", 5))
                     writer.flush()
 
-                    val body = withTimeout(3_000.milliseconds) { readResponseForStream(reader, 5) }
+                    // Read /data response concurrently — this will block until the flush fires.
+                    val dataResponseDeferred = async { readResponseForStream(reader, 5) }
+
+                    // Wait until /data's handler has been invoked and is about to call respondText.
+                    withTimeout(3_000.milliseconds) { dataReachedResponse.await() }
+
+                    // The /data response is not yet on the wire: /slow still holds activeRequests at
+                    // a non-zero value, preventing flushIfNeeded() from issuing context.flush().
+                    assertFalse(
+                        dataResponseDeferred.isCompleted,
+                        "/data response should be blocked until /slow cleanup"
+                    )
+
+                    // Release /slow → it calls respondText on a closed channel → respondWithFailure
+                    // → activeRequests.decrementAndGet() → flushIfNeeded() → context.flush()
+                    // → /data response delivered.
+                    slowCanRespond.complete(Unit)
+
+                    val body = withTimeout(3_000.milliseconds) { dataResponseDeferred.await() }
                     assertEquals("data ok", body)
                 }
             }


### PR DESCRIPTION
**Subsystem**
Server, Netty

**Motivation**
[KTOR-9711](https://youtrack.jetbrains.com/issue/KTOR-9711) Netty HTTP/2: a single client-canceled stream (RST_STREAM) breaks response flushing for the whole connection

**Solution**
1. Added counter decrements in respondWithFailure + a postFailureFlush callback parameter.
2. Pass postFailureFlush = { responseWriter.flushIfNeeded() } when creating the pipeline. The lambda always reads the current responseWriter field, so it retriggers flush on the latest stream's pipeline — handling the race where a new stream's flush may have already run before the failed stream's counters were decremented.

Note, this will probable require a little rework in main after the HTTP/3 updates.