### PR TITLE
KTOR-9715 Netty HTTP/3: dispatch application calls via the call event group

### DIFF
--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyApplicationEngine.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyApplicationEngine.kt
@@ -316,6 +316,7 @@ public class NettyApplicationEngine(
                     applicationProvider,
                     pipeline,
                     userContext,
+                    callEventGroup,
                     configuration.runningLimit,
                     quicSslContext,
                     http3Configuration

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http3/NettyHttp3ChannelInitializer.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http3/NettyHttp3ChannelInitializer.kt
@@ -12,6 +12,7 @@ import io.netty.handler.codec.http3.Http3
 import io.netty.handler.codec.http3.Http3ServerConnectionHandler
 import io.netty.handler.codec.quic.QuicChannel
 import io.netty.handler.codec.quic.QuicSslContext
+import io.netty.util.concurrent.EventExecutorGroup
 import java.util.concurrent.TimeUnit
 import kotlin.coroutines.CoroutineContext
 
@@ -26,6 +27,7 @@ internal class NettyHttp3ChannelInitializer(
     private val applicationProvider: () -> Application,
     private val enginePipeline: EnginePipeline,
     private val userContext: CoroutineContext,
+    private val callEventGroup: EventExecutorGroup,
     private val runningLimit: Int,
     private val quicSslContext: QuicSslContext,
     private val http3Configuration: NettyHttp3Configuration
@@ -38,6 +40,7 @@ internal class NettyHttp3ChannelInitializer(
             enginePipeline,
             application,
             userContext,
+            callEventGroup,
             runningLimit
         )
 

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http3/NettyHttp3Handler.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http3/NettyHttp3Handler.kt
@@ -16,6 +16,7 @@ import io.netty.handler.codec.http3.Http3Headers
 import io.netty.handler.codec.http3.Http3HeadersFrame
 import io.netty.handler.codec.http3.Http3RequestStreamInboundHandler
 import io.netty.util.AttributeKey
+import io.netty.util.concurrent.EventExecutorGroup
 import kotlinx.coroutines.*
 import kotlin.coroutines.CoroutineContext
 
@@ -23,6 +24,7 @@ internal class NettyHttp3Handler(
     private val enginePipeline: EnginePipeline,
     private val application: Application,
     private val userCoroutineContext: CoroutineContext,
+    private val callEventGroup: EventExecutorGroup,
     runningLimit: Int
 ) : Http3RequestStreamInboundHandler(), CoroutineScope {
     // Parent [Job] for per-call [Job]s. Cached to avoid re-running `userCoroutineContext[Job]` per request.
@@ -98,8 +100,9 @@ internal class NettyHttp3Handler(
 
     private fun startHttp3(context: ChannelHandlerContext, headers: Http3Headers) {
         val callJob = Job(parent = parentJob)
+        val callExecutor = pinnedCallExecutor(context, callEventGroup)
         // Combine the cached static context with the per-stream dispatcher and per-call [Job] only.
-        val callContext = staticCallContext + NettyDispatcher.CurrentContext(context) + callJob
+        val callContext = staticCallContext + NettyDispatcher.CurrentContext(context, callExecutor) + callJob
         val call = NettyHttp3ApplicationCall(
             application,
             context,
@@ -111,7 +114,9 @@ internal class NettyHttp3Handler(
 
         responseWriter.processResponse(call)
 
-        context.executor().execute {
+        // Dispatching to the call event group keeps user handler code off the QUIC event loop,
+        // which drives every connection and stream of this connector (same model as HTTP/1/2).
+        callExecutor.execute {
             val callScope = CoroutineScope(context = callContext)
             callScope.launch(start = CoroutineStart.UNDISPATCHED) {
                 try {

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http3/NettyHttp3RequestStreamInitializer.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http3/NettyHttp3RequestStreamInitializer.kt
@@ -8,6 +8,7 @@ import io.ktor.server.application.*
 import io.ktor.server.engine.*
 import io.netty.channel.ChannelInitializer
 import io.netty.handler.codec.quic.QuicStreamChannel
+import io.netty.util.concurrent.EventExecutorGroup
 import kotlin.coroutines.CoroutineContext
 
 /**
@@ -23,6 +24,7 @@ internal class NettyHttp3RequestStreamInitializer(
     private val enginePipeline: EnginePipeline,
     private val application: Application,
     private val userCoroutineContext: CoroutineContext,
+    private val callEventGroup: EventExecutorGroup,
     private val runningLimit: Int
 ) : ChannelInitializer<QuicStreamChannel>() {
 
@@ -32,6 +34,7 @@ internal class NettyHttp3RequestStreamInitializer(
                 enginePipeline,
                 application,
                 userCoroutineContext,
+                callEventGroup,
                 runningLimit
             )
         )

--- a/ktor-server/ktor-server-netty/jvm/test/io/ktor/tests/server/netty/NettyHttp3CallExecutorTest.kt
+++ b/ktor-server/ktor-server-netty/jvm/test/io/ktor/tests/server/netty/NettyHttp3CallExecutorTest.kt
@@ -1,0 +1,213 @@
+/*
+ * Copyright 2014-2026 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.tests.server.netty
+
+import io.ktor.server.application.*
+import io.ktor.server.netty.*
+import io.ktor.server.response.*
+import io.ktor.server.routing.*
+import io.ktor.server.test.base.*
+import io.ktor.utils.io.*
+import io.netty.bootstrap.Bootstrap
+import io.netty.channel.*
+import io.netty.channel.nio.NioEventLoopGroup
+import io.netty.channel.socket.nio.NioDatagramChannel
+import io.netty.handler.codec.http3.*
+import io.netty.handler.codec.quic.*
+import java.net.InetSocketAddress
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.LinkedBlockingQueue
+import java.util.concurrent.TimeUnit
+import kotlin.system.measureTimeMillis
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+/**
+ * Regression test: application handler code must not run on the QUIC event loop.
+ *
+ * Without dispatching calls to an executor pinned from the call event group (as HTTP/1 and
+ * HTTP/2 do since KTOR-9542), user handler code runs on the QUIC event loop. All QUIC
+ * connections of a connector share a single DatagramChannel driven by one event loop, so any
+ * blocking user code (JDBC, file IO) stalls the entire HTTP/3 listener, including QUIC
+ * handshakes of unrelated new connections.
+ */
+class NettyHttp3CallExecutorTest :
+    EngineTestBase<NettyApplicationEngine, NettyApplicationEngine.Configuration>(Netty) {
+
+    init {
+        enableSsl = true
+        // FreePorts probes with TCP sockets, but HTTP/3 binds UDP on sslPort; on Windows,
+        // TCP-free ports often fall into Hyper-V/WSL UDP excluded ranges and fail the bind.
+        // Pin ports outside the dynamic range for stability.
+        port = 24430
+        sslPort = 24431
+    }
+
+    @OptIn(ExperimentalKtorApi::class)
+    override fun configure(configuration: NettyApplicationEngine.Configuration) {
+        configuration.enableHttp3()
+    }
+
+    @Test
+    fun `blocking user code on one HTTP3 connection must not stall other connections`() = runTest {
+        val blockEntered = CountDownLatch(1)
+        val blockMillis = 1500L
+
+        createAndStartServer {
+            application.routing {
+                get("/instant") { call.respondText("ok") }
+                get("/block") {
+                    blockEntered.countDown()
+                    Thread.sleep(blockMillis) // deliberately blocking user code (e.g. JDBC, file IO)
+                    call.respondText("done")
+                }
+            }
+        }
+
+        // warmup: the first QUIC connection pays one-time JVM/native initialization costs
+        withHttp3Client { quic -> sendHttp3Request(quic, "/instant") }
+
+        val baselineMs = measureTimeMillis {
+            withHttp3Client { quic -> sendHttp3Request(quic, "/instant") }
+        }
+        println("[repro] fresh connection + GET /instant with idle server: ${baselineMs}ms")
+
+        var stalledMs = 0L
+        withHttp3Client { connectionA ->
+            // fire GET /block on connection A without awaiting the response
+            val pending = Http3ResponseHandler()
+            val stream = Http3.newRequestStream(connectionA, pending).sync().getNow()
+            stream.writeAndFlush(DefaultHttp3HeadersFrame(requestHeaders("/block"))).sync()
+            stream.shutdownOutput().sync()
+            assertTrue(blockEntered.await(5, TimeUnit.SECONDS), "server never entered /block")
+
+            // a brand-new QUIC connection (fresh handshake) on the same connector
+            stalledMs = measureTimeMillis {
+                withHttp3Client { connectionB -> sendHttp3Request(connectionB, "/instant") }
+            }
+            println(
+                "[repro] fresh connection + GET /instant while another connection's handler blocks: ${stalledMs}ms"
+            )
+
+            pending.responseQueue.poll(5, TimeUnit.SECONDS) // drain the /block response
+        }
+
+        assertTrue(
+            stalledMs - baselineMs < 1000,
+            "an unrelated new HTTP/3 connection was stalled (${stalledMs}ms vs ${baselineMs}ms baseline) " +
+                "by blocking user code on another connection: user code runs on the shared QUIC event " +
+                "loop instead of an executor from the call event group (cf. HTTP/1/2, KTOR-9542)"
+        )
+    }
+
+    // --- HTTP/3 client helpers (mirroring NettyHttp3Test, where they are private) ---
+
+    private data class Http3Response(
+        val status: String,
+        val headers: Map<String, String>,
+        val body: String
+    )
+
+    private class Http3ResponseHandler : ChannelInboundHandlerAdapter() {
+        val responseQueue = LinkedBlockingQueue<Http3Response>()
+        private var status: String = ""
+        private var headers: MutableMap<String, String> = mutableMapOf()
+        private val bodyParts = mutableListOf<ByteArray>()
+
+        override fun channelRead(ctx: ChannelHandlerContext, msg: Any) {
+            when (msg) {
+                is Http3HeadersFrame -> {
+                    val h = msg.headers()
+                    status = h.status()?.toString() ?: ""
+                    h.forEach { (name, value) ->
+                        val nameStr = name.toString()
+                        if (!nameStr.startsWith(":")) {
+                            headers[nameStr] = value.toString()
+                        }
+                    }
+                }
+
+                is Http3DataFrame -> {
+                    val content = msg.content()
+                    val bytes = ByteArray(content.readableBytes())
+                    content.readBytes(bytes)
+                    bodyParts.add(bytes)
+                    msg.release()
+                }
+
+                else -> super.channelRead(ctx, msg)
+            }
+        }
+
+        override fun channelInactive(ctx: ChannelHandlerContext) {
+            val body = bodyParts.joinToString("") { String(it, Charsets.UTF_8) }
+            responseQueue.offer(Http3Response(status, headers, body))
+            status = ""
+            headers = mutableMapOf()
+            bodyParts.clear()
+            super.channelInactive(ctx)
+        }
+    }
+
+    private fun requestHeaders(path: String): Http3Headers = DefaultHttp3Headers().apply {
+        method("GET")
+        path(path)
+        scheme("https")
+        authority("localhost:$sslPort")
+    }
+
+    private suspend fun withHttp3Client(block: suspend (QuicChannel) -> Unit) {
+        val group = NioEventLoopGroup(1)
+        try {
+            val quicSslContext = QuicSslContextBuilder.forClient()
+                .trustManager(io.netty.handler.ssl.util.InsecureTrustManagerFactory.INSTANCE)
+                .applicationProtocols(*Http3.supportedApplicationProtocols())
+                .build()
+
+            val quicClientCodec = Http3.newQuicClientCodecBuilder()
+                .sslContext(quicSslContext)
+                .maxIdleTimeout(30_000, TimeUnit.MILLISECONDS)
+                .initialMaxData(10_000_000)
+                .initialMaxStreamDataBidirectionalLocal(1_000_000)
+                .initialMaxStreamDataBidirectionalRemote(1_000_000)
+                .initialMaxStreamsBidirectional(100)
+                .build()
+
+            val udpChannel = Bootstrap()
+                .group(group)
+                .channel(NioDatagramChannel::class.java)
+                .handler(quicClientCodec)
+                .bind(0)
+                .sync()
+                .channel()
+
+            val quicChannel = QuicChannel.newBootstrap(udpChannel)
+                .handler(Http3ClientConnectionHandler())
+                .remoteAddress(InetSocketAddress("127.0.0.1", sslPort))
+                .connect()
+                .get(10, TimeUnit.SECONDS)
+
+            try {
+                block(quicChannel)
+            } finally {
+                runCatching { quicChannel.close().sync() }
+                runCatching { udpChannel.close().sync() }
+            }
+        } finally {
+            group.shutdownGracefully(0, 500, TimeUnit.MILLISECONDS).sync()
+        }
+    }
+
+    private fun sendHttp3Request(quicChannel: QuicChannel, path: String): Http3Response {
+        val responseHandler = Http3ResponseHandler()
+
+        val stream = Http3.newRequestStream(quicChannel, responseHandler).sync().getNow()
+        stream.writeAndFlush(DefaultHttp3HeadersFrame(requestHeaders(path))).sync()
+        stream.shutdownOutput().sync()
+
+        return responseHandler.responseQueue.poll(10, TimeUnit.SECONDS)
+            ?: error("Timed out waiting for HTTP/3 response for $path")
+    }
+}


### PR DESCRIPTION
Fixes [KTOR-9715](https://youtrack.jetbrains.com/issue/KTOR-9715).

## Problem

Since KTOR-9542, HTTP/1 and HTTP/2 dispatch application handler code onto an executor pinned from `callEventGroup`, keeping user code off the Netty I/O threads. The HTTP/3 handler does neither: `startHttp3` builds the call context with the single-argument `NettyDispatcher.CurrentContext(context)` — which defaults to the channel's own event-loop executor — and launches the call coroutine via `context.executor()` as well.

This hurts more on HTTP/3 than it would elsewhere: each SSL connector binds a **single** `DatagramChannel`, and netty-codec-quic drives all QUIC connections and streams of that connector on that one channel's event loop. Blocking user code (JDBC, file IO, CPU-heavy serialization) therefore stalls not just its own stream but the whole HTTP/3 listener, including QUIC handshakes of brand-new, unrelated connections:

```
[repro] fresh connection + GET /instant with idle server: 45ms
[repro] fresh connection + GET /instant while another connection's handler blocks: 1525ms   // ≈ the full 1500 ms Thread.sleep
```

The same application code behaves fine over HTTP/1/2 on the same server, which makes this a confusing performance trap once HTTP/3 is enabled.

## Fix

Mirror the HTTP/1/2 model (KTOR-9542): pass `callEventGroup` down to `NettyHttp3Handler` (via `NettyHttp3ChannelInitializer` / `NettyHttp3RequestStreamInitializer`) and build the call context with `NettyDispatcher.CurrentContext(context, pinnedCallExecutor(context, callEventGroup))`, launching the call coroutine on that executor as `startHttp2` does.

After the fix, the same probe:

```
[repro] fresh connection + GET /instant with idle server: 77ms
[repro] fresh connection + GET /instant while another connection's handler blocks: 68ms   // no stall
```

## Tests

Added `NettyHttp3CallExecutorTest`: one connection's handler blocks in `Thread.sleep`, and the test asserts that a brand-new QUIC connection completes `GET /instant` in roughly baseline time. Fails on current main, passes with this change. The existing HTTP/3 suites (`NettyHttp3Test`, `NettyHttp3MultipleConnectionsTest`, `NettyHttp3ApplicationResponseTest`, `NettyHttp3LocalConnectionPointTest` — 34 tests total) still pass.
