### PR TITLE
KTOR-9679 Fix reading incomplete UTF-8 strings from the buffer

### DIFF
--- a/ktor-io/common/src/io/ktor/utils/io/ByteReadChannelOperations.kt
+++ b/ktor-io/common/src/io/ktor/utils/io/ByteReadChannelOperations.kt
@@ -760,6 +760,23 @@ private suspend fun ByteReadChannel.internalReadLineTo(
             transferString(1) // transfer the CR
         } else {
             // No new line separator
+            if (count in 1..4 && !isClosedForRead) {
+                val tempSource = readBuffer.peek()
+                val incompleteCp = try {
+                    tempSource.readCodePointValue()
+                    false
+                } catch (_: EOFException) {
+                    true
+                } finally {
+                    tempSource.close()
+                }
+
+                if (incompleteCp) {
+                    awaitContent((count + 1).toInt())
+                    continue
+                }
+            }
+
             transferString(count)
         }
 

--- a/ktor-io/common/src/io/ktor/utils/io/ByteReadChannelOperations.kt
+++ b/ktor-io/common/src/io/ktor/utils/io/ByteReadChannelOperations.kt
@@ -687,12 +687,12 @@ private suspend fun ByteReadChannel.internalReadLineTo(
     if (isClosedForRead) return -1
 
     var consumed = 0L
+    val outBuffer = Buffer()
 
-    fun transferString(count: Long) {
+    fun transferBytes(count: Long) {
         if (count > 0L) {
-            val string = readBuffer.readString(count)
-            out.append(string)
-            consumed += string.length
+            outBuffer.write(readBuffer, count)
+            consumed += count
         }
     }
 
@@ -735,49 +735,40 @@ private suspend fun ByteReadChannel.internalReadLineTo(
 
         // Sole CR in the buffer
         if (crIndex >= 0) {
-            transferString(count = crIndex)
+            transferBytes(crIndex)
             readBuffer.discard(1)
+            out.append(outBuffer.readString())
             return consumed
         }
 
         // Fast path. LF or CRLF in the buffer
         if (lfIndex == 0L) {
             readBuffer.discard(1)
+            out.append(outBuffer.readString())
             return consumed
         }
         if (lfIndex > 0) {
             val isCrlf = if (readBuffer.buffer[lfIndex - 1] == CR) 1L else 0L
-            transferString(count = lfIndex - isCrlf)
+            transferBytes(lfIndex - isCrlf)
             readBuffer.discard(1 + isCrlf)
+            out.append(outBuffer.readString())
             return consumed
         }
 
         val count = minOf(limitLeft, readBuffer.remaining)
         // Check for the corner case when the last byte in the buffer is CR, and LF is in the next buffer
         if (readBuffer.buffer[count - 1] == CR) {
-            transferString(count = count - 1)
-            if (readBuffer.discardCrlfOrCr()) return consumed
-            transferString(1) // transfer the CR
+            transferBytes(count - 1)
+
+            if (readBuffer.discardCrlfOrCr()) {
+                out.append(outBuffer.readString())
+                return consumed
+            } else {
+                transferBytes(1)
+            }
         } else {
             // No new line separator
-            if (count in 1..4 && !isClosedForRead) {
-                val tempSource = readBuffer.peek()
-                val incompleteCp = try {
-                    tempSource.readCodePointValue()
-                    false
-                } catch (_: EOFException) {
-                    true
-                } finally {
-                    tempSource.close()
-                }
-
-                if (incompleteCp) {
-                    awaitContent((count + 1).toInt())
-                    continue
-                }
-            }
-
-            transferString(count)
+            transferBytes(count)
         }
 
         if (consumed < limit && readBuffer.remaining == 0L && !awaitContent()) break
@@ -798,14 +789,20 @@ private suspend fun ByteReadChannel.internalReadLineTo(
         when (readBuffer.buffer[0]) {
             LF -> {
                 readBuffer.discard(1)
+                out.append(outBuffer.readString())
                 return consumed
             }
 
-            CR -> if (readBuffer.discardCrlfOrCr()) return consumed
+            CR -> if (readBuffer.discardCrlfOrCr()) {
+                out.append(outBuffer.readString())
+                return consumed
+            }
         }
 
         throwTooLongLineException(limit)
     }
+
+    out.append(outBuffer.readString())
 
     if (throwOnIncompleteLine) throwEndOfStreamException(consumed)
     return consumed

--- a/ktor-io/common/src/io/ktor/utils/io/ByteReadChannelOperations.kt
+++ b/ktor-io/common/src/io/ktor/utils/io/ByteReadChannelOperations.kt
@@ -687,21 +687,21 @@ private suspend fun ByteReadChannel.internalReadLineTo(
     if (isClosedForRead) return -1
 
     var consumed = 0L
-    var outBufferCreated = false
-    val outBuffer: Buffer by lazy {
-        outBufferCreated = true
-        Buffer()
-    }
+    var outBuffer: Buffer? = null
 
     fun transferBytes(count: Long) {
         if (count > 0L) {
+            if (outBuffer == null) {
+                outBuffer = Buffer()
+            }
+
             outBuffer.write(readBuffer, count)
             consumed += count
         }
     }
 
-    fun completeLine(count: Long) {
-        if (!outBufferCreated) {
+    fun transferLine(count: Long) {
+        if (outBuffer == null) {
             if (count > 0L) {
                 out.append(readBuffer.readString(count))
                 consumed += count
@@ -751,7 +751,7 @@ private suspend fun ByteReadChannel.internalReadLineTo(
 
         // Sole CR in the buffer
         if (crIndex >= 0) {
-            completeLine(crIndex)
+            transferLine(crIndex)
             readBuffer.discard(1)
 
             return consumed
@@ -759,13 +759,13 @@ private suspend fun ByteReadChannel.internalReadLineTo(
 
         // Fast path. LF or CRLF in the buffer
         if (lfIndex == 0L) {
-            completeLine(lfIndex)
+            transferLine(lfIndex)
             readBuffer.discard(1)
             return consumed
         }
         if (lfIndex > 0) {
             val isCrlf = if (readBuffer.buffer[lfIndex - 1] == CR) 1L else 0L
-            completeLine(lfIndex - isCrlf)
+            transferLine(lfIndex - isCrlf)
             readBuffer.discard(1 + isCrlf)
             return consumed
         }
@@ -773,7 +773,7 @@ private suspend fun ByteReadChannel.internalReadLineTo(
         val count = minOf(limitLeft, readBuffer.remaining)
         // Check for the corner case when the last byte in the buffer is CR, and LF is in the next buffer
         if (readBuffer.buffer[count - 1] == CR) {
-            completeLine(count - 1)
+            transferLine(count - 1)
 
             if (readBuffer.discardCrlfOrCr()) {
                 return consumed
@@ -803,12 +803,17 @@ private suspend fun ByteReadChannel.internalReadLineTo(
         when (readBuffer.buffer[0]) {
             LF -> {
                 readBuffer.discard(1)
-                out.append(outBuffer.readString())
+                if (outBuffer != null) {
+                    out.append(outBuffer.readString())
+                }
+
                 return consumed
             }
 
             CR -> if (readBuffer.discardCrlfOrCr()) {
-                out.append(outBuffer.readString())
+                if (outBuffer != null) {
+                    out.append(outBuffer.readString())
+                }
                 return consumed
             }
         }
@@ -816,7 +821,9 @@ private suspend fun ByteReadChannel.internalReadLineTo(
         throwTooLongLineException(limit)
     }
 
-    out.append(outBuffer.readString())
+    if (outBuffer != null) {
+        out.append(outBuffer.readString())
+    }
 
     if (throwOnIncompleteLine) throwEndOfStreamException(consumed)
     return consumed

--- a/ktor-io/common/src/io/ktor/utils/io/ByteReadChannelOperations.kt
+++ b/ktor-io/common/src/io/ktor/utils/io/ByteReadChannelOperations.kt
@@ -687,12 +687,28 @@ private suspend fun ByteReadChannel.internalReadLineTo(
     if (isClosedForRead) return -1
 
     var consumed = 0L
-    val outBuffer = Buffer()
+    var outBufferCreated = false
+    val outBuffer: Buffer by lazy {
+        outBufferCreated = true
+        Buffer()
+    }
 
     fun transferBytes(count: Long) {
         if (count > 0L) {
             outBuffer.write(readBuffer, count)
             consumed += count
+        }
+    }
+
+    fun completeLine(count: Long) {
+        if (!outBufferCreated) {
+            if (count > 0L) {
+                out.append(readBuffer.readString(count))
+                consumed += count
+            }
+        } else {
+            transferBytes(count)
+            out.append(outBuffer.readString())
         }
     }
 
@@ -735,33 +751,31 @@ private suspend fun ByteReadChannel.internalReadLineTo(
 
         // Sole CR in the buffer
         if (crIndex >= 0) {
-            transferBytes(crIndex)
+            completeLine(crIndex)
             readBuffer.discard(1)
-            out.append(outBuffer.readString())
+
             return consumed
         }
 
         // Fast path. LF or CRLF in the buffer
         if (lfIndex == 0L) {
+            completeLine(lfIndex)
             readBuffer.discard(1)
-            out.append(outBuffer.readString())
             return consumed
         }
         if (lfIndex > 0) {
             val isCrlf = if (readBuffer.buffer[lfIndex - 1] == CR) 1L else 0L
-            transferBytes(lfIndex - isCrlf)
+            completeLine(lfIndex - isCrlf)
             readBuffer.discard(1 + isCrlf)
-            out.append(outBuffer.readString())
             return consumed
         }
 
         val count = minOf(limitLeft, readBuffer.remaining)
         // Check for the corner case when the last byte in the buffer is CR, and LF is in the next buffer
         if (readBuffer.buffer[count - 1] == CR) {
-            transferBytes(count - 1)
+            completeLine(count - 1)
 
             if (readBuffer.discardCrlfOrCr()) {
-                out.append(outBuffer.readString())
                 return consumed
             } else {
                 transferBytes(1)

--- a/ktor-io/common/test/ReadLineTest.kt
+++ b/ktor-io/common/test/ReadLineTest.kt
@@ -132,6 +132,13 @@ class ReadLineTest {
     }
 
     @Test
+    fun `limit - exact limit with LF immediately after unicode`() = runTest {
+        val channel = ByteReadChannel("привет\n")
+        val line = channel.readLineStrict(12)
+        assertEquals("привет", line)
+    }
+
+    @Test
     fun `limit - exact limit with CRLF immediately after`() = runTest {
         val channel = ByteReadChannel("12345\r\n")
         channel.assertLines("12345", limit = 5)
@@ -376,5 +383,37 @@ class ReadLineTest {
             channel.close()
         }
         assertEquals("\uD83D\uDE00", channel.readLine())
+    }
+
+    @Test
+    fun `1k chunk before code point boundary`() = runTest {
+        val channel = ByteChannel()
+        backgroundScope.launch {
+            channel.writeFully(ByteArray(1024) { 'a'.code.toByte() })
+            channel.writeFully(byteArrayOf(0xE3.toByte(), 0x83.toByte()))
+            channel.flush()
+            yield()
+            channel.writeFully(byteArrayOf(0xB3.toByte(), '\n'.code.toByte()))
+            channel.flush()
+
+            channel.close()
+        }
+        assertEquals("a".repeat(1024) + "ン", channel.readLine())
+    }
+
+    @Test
+    fun `4k chunk before code point boundary`() = runTest {
+        val channel = ByteChannel()
+        backgroundScope.launch {
+            channel.writeFully(ByteArray(4094) { 'b'.code.toByte() })
+            channel.writeFully(byteArrayOf(0xE3.toByte(), 0x83.toByte()))
+            channel.flush()
+            yield()
+            channel.writeFully(byteArrayOf(0xB3.toByte(), '\n'.code.toByte()))
+            channel.flush()
+
+            channel.close()
+        }
+        assertEquals("b".repeat(4094) + "ン", channel.readLine())
     }
 }

--- a/ktor-io/common/test/ReadLineTest.kt
+++ b/ktor-io/common/test/ReadLineTest.kt
@@ -6,6 +6,8 @@ import io.ktor.test.*
 import io.ktor.utils.io.*
 import io.ktor.utils.io.charsets.*
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.yield
 import kotlinx.io.EOFException
 import kotlin.test.*
 
@@ -325,5 +327,54 @@ class ReadLineTest {
             assertEquals(line, buffer.toString(), "Unexpected line content")
         }
         assertTrue(exhausted(), "Not all lines were read")
+    }
+
+    @Test
+    fun `code point boundary`() = runTest {
+        val channel = ByteChannel()
+        backgroundScope.launch {
+            channel.writeFully(byteArrayOf(0xE3.toByte(), 0x83.toByte()))
+            channel.flush()
+            yield()
+            channel.writeByte(0xB3.toByte())
+            channel.flush()
+            yield()
+            channel.writeByte('\n'.code.toByte())
+
+            channel.close()
+        }
+        assertEquals("ン", channel.readLine())
+    }
+
+    @Test
+    fun `incomplete code point boundary`() = runTest {
+        val channel = ByteChannel()
+        backgroundScope.launch {
+            channel.writeFully(byteArrayOf(0xE3.toByte(), 0x83.toByte()))
+            channel.flush()
+            yield()
+            channel.writeByte('\n'.code.toByte())
+
+            channel.close()
+        }
+        assertEquals("�", channel.readLine())
+    }
+
+    @Test
+    fun `4-byte code point boundary`() = runTest {
+        val channel = ByteChannel()
+        backgroundScope.launch {
+            channel.writeFully(byteArrayOf(0xF0.toByte(), 0x9F.toByte()))
+            channel.flush()
+            yield()
+            channel.writeByte(0x98.toByte())
+            channel.flush()
+            yield()
+            channel.writeFully(byteArrayOf(0x80.toByte(), '\n'.code.toByte()))
+            channel.flush()
+
+            channel.close()
+        }
+        assertEquals("\uD83D\uDE00", channel.readLine())
     }
 }


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KTOR-9679
The current implementation now uses the number of bytes as the limit instead of the number of characters. This could be a breaking change, although the current implementation does not work properly with multi-byte characters and the limit, for example:
```kt
val channel = ByteReadChannel("привет\n")
println(channel.readLineStrict(6)) // throws TooLongLineException
```

