### PR TITLE
Warn KTOR-9705 OpenAPI UI does not support OpenAPI spec 3.1.

### DIFF
--- a/ktor-server/ktor-server-plugins/ktor-server-openapi/jvm/src/io/ktor/server/plugins/openapi/OpenAPI.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-openapi/jvm/src/io/ktor/server/plugins/openapi/OpenAPI.kt
@@ -9,6 +9,7 @@ import io.ktor.server.http.content.*
 import io.ktor.server.routing.*
 import io.ktor.server.routing.openapi.OpenApiDocSource
 import io.ktor.server.routing.openapi.hide
+import io.ktor.util.logging.Logger
 import io.ktor.utils.io.ExperimentalKtorApi
 import io.swagger.codegen.v3.ClientOpts
 import io.swagger.codegen.v3.generators.html.StaticHtml2Codegen
@@ -23,7 +24,11 @@ import java.io.File
  * The documentation is generated using [StaticHtml2Codegen] by default. It can be customized using config in [block].
  * See [OpenAPIConfig] for more details.
  *
- * If source is supplied inside the config [block], the [swaggerFile] argument will take precedence.
+ * HTML generation uses swagger-codegen, which officially supports OpenAPI 3.0.x. OpenAPI 3.1.x specifications may fail
+ * to generate or produce incomplete documentation; prefer [io.ktor.server.plugins.swagger.swaggerUI] with Swagger UI 5+
+ * for browsing 3.1 specs.
+ *
+ * If a source is supplied inside the config [block], the [swaggerFile] argument will take precedence.
  *
  * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.server.plugins.openapi.openAPI)
  *
@@ -47,6 +52,10 @@ public fun Route.openAPI(
  *
  * The documentation is generated using [StaticHtml2Codegen] by default. It can be customized using config in [block].
  * See [OpenAPIConfig] for more details.
+ *
+ * HTML generation uses swagger-codegen, which officially supports OpenAPI 3.0.x. OpenAPI 3.1.x specifications may fail
+ * to generate or produce incomplete documentation; prefer [io.ktor.server.plugins.swagger.swaggerUI] with Swagger UI 5+
+ * for browsing 3.1 specs.
  *
  * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.server.plugins.openapi.openAPI)
  *
@@ -77,11 +86,11 @@ private fun Application.generateFilesBeforeStartup(config: OpenAPIConfig) {
     monitor.subscribe(ApplicationModulesLoaded) {
         val apiDocument = config.source.read(this, config.buildBaseDoc())
             ?: error("Failed to read OpenAPI document from ${config.source}")
-        config.generateFiles(apiDocument.content)
+        config.generateFiles(logger = log, apiDocument = apiDocument.content)
     }
 }
 
-private fun OpenAPIConfig.generateFiles(apiDocument: String) {
+private fun OpenAPIConfig.generateFiles(logger: Logger, apiDocument: String) {
     val swagger = try {
         parser.readContents(apiDocument, null, options)
     } catch (t: Throwable) {
@@ -93,6 +102,16 @@ private fun OpenAPIConfig.generateFiles(apiDocument: String) {
     }
     val openApi = swagger.openAPI
         ?: throw IllegalStateException("Parsed OpenAPI document is missing `openAPI` (messages=${swagger.messages})")
+
+    // See: https://github.com/swagger-api/swagger-codegen/issues/12210
+    val openApiVersion = openApi.openapi
+    if (openApiVersion != null && openApiVersion.startsWith("3.1")) {
+        logger.warn(
+            "OpenAPI document version is $openApiVersion. HTML generation via swagger-codegen " +
+                "officially supports OpenAPI 3.0.x and may fail or produce incomplete docs for 3.1. " +
+                "Prefer swaggerUI with Swagger UI 5+, or use an OpenAPI 3.0.x specification."
+        )
+    }
 
     opts.apply {
         codegen.outputDir = outDir.absolutePath

--- a/ktor-server/ktor-server-plugins/ktor-server-openapi/jvm/src/io/ktor/server/plugins/openapi/OpenAPIConfig.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-openapi/jvm/src/io/ktor/server/plugins/openapi/OpenAPIConfig.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2022 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2014-2026 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package io.ktor.server.plugins.openapi
@@ -70,7 +70,10 @@ public class OpenAPIConfig private constructor(
     /**
      * Specifies a code generator for [OpenAPIConfig].
      *
-     * See also [StaticHtml2Codegen], [StaticHtmlCodegen] and etc.
+     * See also [StaticHtml2Codegen], [StaticHtmlCodegen] etc.
+     *
+     * These swagger-codegen generators officially support OpenAPI 3.0.x. OpenAPI 3.1.x documents may fail to generate
+     * or produce incomplete results.
      *
      * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.server.plugins.openapi.OpenAPIConfig.codegen)
      */

--- a/ktor-server/ktor-server-plugins/ktor-server-openapi/jvm/test/io/ktor/server/plugins/openapi/OpenAPITest.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-openapi/jvm/test/io/ktor/server/plugins/openapi/OpenAPITest.kt
@@ -4,23 +4,24 @@
 
 package io.ktor.server.plugins.openapi
 
+import ch.qos.logback.classic.Level
+import ch.qos.logback.classic.Logger
+import ch.qos.logback.classic.spi.ILoggingEvent
+import ch.qos.logback.core.read.ListAppender
 import io.ktor.client.request.*
 import io.ktor.client.statement.*
 import io.ktor.http.*
 import io.ktor.openapi.*
-import io.ktor.openapi.reflect.ReflectionJsonSchemaInference
+import io.ktor.openapi.reflect.*
 import io.ktor.serialization.kotlinx.json.*
 import io.ktor.server.plugins.contentnegotiation.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
-import io.ktor.server.routing.openapi.OpenApiDocSource
-import io.ktor.server.routing.openapi.describe
+import io.ktor.server.routing.openapi.*
 import io.ktor.server.testing.*
-import io.ktor.utils.io.ExperimentalKtorApi
-import kotlin.test.Test
-import kotlin.test.assertContains
-import kotlin.test.assertEquals
-import kotlin.test.assertFalse
+import io.ktor.utils.io.*
+import org.slf4j.LoggerFactory
+import kotlin.test.*
 
 class OpenAPITest {
 
@@ -106,6 +107,75 @@ class OpenAPITest {
             }
         }
     }
+
+    @Test
+    fun `warns when OpenAPI document is 3_1`() = testApplication {
+        val messages = captureTestLogMessages {
+            routing {
+                openAPI("docs") {
+                    outputPath = "docs/warn-31"
+                }
+            }
+            startApplication()
+        }
+
+        assertTrue(
+            messages.any { it.startsWith("OpenAPI document version is") && it.contains("3.1.1") },
+            "Expected OpenAPI 3.1 codegen warning, got: $messages"
+        )
+    }
+
+    @Test
+    fun `does not warn when OpenAPI document is 3_0`() = testApplication {
+        val messages = captureTestLogMessages {
+            routing {
+                openAPI("docs") {
+                    outputPath = "docs/no-warn-30"
+                    source = OpenApiDocSource.Text(
+                        """
+                        openapi: "3.0.3"
+                        info:
+                          title: Sample
+                          version: "1.0.0"
+                        paths:
+                          /health:
+                            get:
+                              summary: Health check
+                              responses:
+                                "200":
+                                  description: OK
+                        components:
+                          schemas: {}
+                        """.trimIndent(),
+                        contentType = ContentType.Application.Yaml,
+                    )
+                }
+            }
+            startApplication()
+        }
+
+        assertFalse(
+            messages.any { it.startsWith("OpenAPI document version is") },
+            "Did not expect OpenAPI 3.1 codegen warning, got: $messages"
+        )
+    }
+}
+
+private inline fun captureTestLogMessages(block: () -> Unit): List<String> {
+    val logger = LoggerFactory.getLogger("io.ktor.test") as Logger
+    val previousLevel = logger.level
+    logger.level = Level.WARN
+    val listAppender = ListAppender<ILoggingEvent>()
+    logger.addAppender(listAppender)
+    listAppender.start()
+    try {
+        block()
+    } finally {
+        listAppender.stop()
+        logger.detachAppender(listAppender)
+        logger.level = previousLevel
+    }
+    return listAppender.list.map { it.message }
 }
 
 data class Book(

--- a/ktor-server/ktor-server-plugins/ktor-server-swagger/jvm/src/io/ktor/server/plugins/swagger/Swagger.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-swagger/jvm/src/io/ktor/server/plugins/swagger/Swagger.kt
@@ -4,20 +4,56 @@
 
 package io.ktor.server.plugins.swagger
 
+import io.ktor.http.*
+import io.ktor.server.application.*
 import io.ktor.server.html.*
 import io.ktor.server.request.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
-import io.ktor.server.routing.openapi.OpenApiDocSource
-import io.ktor.server.routing.openapi.hide
+import io.ktor.server.routing.openapi.*
 import io.ktor.server.util.*
-import io.ktor.utils.io.ExperimentalKtorApi
+import io.ktor.util.logging.*
+import io.ktor.utils.io.*
 import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.async
 import kotlinx.html.*
 import java.io.File
 
 private val docExpansionValues = listOf("list", "full", "none")
+
+private val openApiVersionJsonRegex = Regex(""""openapi"\s*:\s*"([^"]+)"""")
+private val openApiVersionYamlRegex = Regex("""(?m)^openapi:\s*["']?([^"'#\s]+)["']?""")
+
+internal fun ContentType.isYaml(): Boolean {
+    return contentSubtype.equals("yaml", ignoreCase = true) || contentSubtype.equals("x-yaml", ignoreCase = true)
+}
+
+private fun OpenApiDocSource.Text.openApiVersion(): String? = when {
+    contentType.match(ContentType.Application.Json) ->
+        openApiVersionJsonRegex.find(content)?.groupValues?.get(1)
+
+    contentType.isYaml() ->
+        openApiVersionYamlRegex.find(content)?.groupValues?.get(1)
+
+    else -> null
+}
+
+/**
+ * Warns when an OpenAPI 3.1.x document is served with Swagger UI older than 5.x.
+ */
+internal fun Logger.warnIfIncompatibleOpenApiAndSwaggerUi(
+    document: OpenApiDocSource.Text,
+    swaggerUiVersion: String
+) {
+    val openApiVersion = document.openApiVersion() ?: return
+    if (!openApiVersion.startsWith("3.1")) return
+    val swaggerMajor = swaggerUiVersion.substringBefore('.').toIntOrNull() ?: return
+    if (swaggerMajor >= 5) return
+    warn(
+        "OpenAPI document version is $openApiVersion, but Swagger UI version $swaggerUiVersion " +
+            "does not support OpenAPI 3.1. Use Swagger UI 5.0.0+, or stick to an OpenAPI 3.0.x specification."
+    )
+}
 
 /**
  * Creates a `get` endpoint with [SwaggerUI] at [path] rendered from the OpenAPI file located at [swaggerFile].
@@ -83,6 +119,9 @@ public fun Route.swaggerUI(
 /**
  * Adds a Swagger UI endpoint to the current route.
  *
+ * OpenAPI 3.1.x specifications require Swagger UI 5.0.0 or later ([SwaggerConfig.version]). The default version is
+ * 5.31.0. Pinning a 4.x UI version only works reliably with OpenAPI 3.0.x specifications.
+ *
  * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.server.plugins.swagger.swaggerUI)
  *
  * @param path The root path where the Swagger UI will be available.
@@ -95,10 +134,12 @@ public fun Route.swaggerUI(
     val config = SwaggerConfig().apply(block)
     val source = config.source
     val apiUrl = config.remotePath
+    val log = application.log
     val openApiDoc = with(application) {
         async(start = CoroutineStart.LAZY) {
-            source.read(this@with, config.buildBaseDoc())
+            val doc = source.read(this@with, config.buildBaseDoc())
                 ?: error("Failed to read OpenAPI document from $source")
+            doc.also { log.warnIfIncompatibleOpenApiAndSwaggerUi(document = it, swaggerUiVersion = config.version) }
         }
     }
 

--- a/ktor-server/ktor-server-plugins/ktor-server-swagger/jvm/src/io/ktor/server/plugins/swagger/SwaggerConfig.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-swagger/jvm/src/io/ktor/server/plugins/swagger/SwaggerConfig.kt
@@ -40,6 +40,9 @@ public class SwaggerConfig private constructor(
     /**
      * Specifies a Swagger UI version to use.
      *
+     * Defaults to `5.31.0`. OpenAPI 3.1.x specifications require Swagger UI 5.0.0 or later; versions below 5.x only
+     * support OpenAPI 3.0.x.
+     *
      * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.server.plugins.swagger.SwaggerConfig.version)
      */
     public var version: String = "5.31.0"

--- a/ktor-server/ktor-server-plugins/ktor-server-swagger/jvm/test/io/ktor/server/plugins/swagger/SwaggerTest.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-swagger/jvm/test/io/ktor/server/plugins/swagger/SwaggerTest.kt
@@ -4,6 +4,10 @@
 
 package io.ktor.server.plugins.swagger
 
+import ch.qos.logback.classic.Level
+import ch.qos.logback.classic.Logger
+import ch.qos.logback.classic.spi.ILoggingEvent
+import ch.qos.logback.core.read.ListAppender
 import io.ktor.client.request.*
 import io.ktor.client.statement.*
 import io.ktor.http.*
@@ -15,9 +19,8 @@ import io.ktor.server.routing.openapi.*
 import io.ktor.server.testing.*
 import io.ktor.utils.io.*
 import kotlinx.serialization.Serializable
-import kotlin.test.Test
-import kotlin.test.assertContains
-import kotlin.test.assertEquals
+import org.slf4j.LoggerFactory
+import kotlin.test.*
 
 class SwaggerTest {
 
@@ -357,6 +360,105 @@ class SwaggerTest {
         val response = client.get("/swagger").bodyAsText()
         assertContains(response, "oauth2RedirectUrl: 'https://api.example.com/custom/oauth2-redirect.html'")
     }
+
+    @Test
+    fun `warns when OpenAPI 3_1 document is served with Swagger UI below 5`() = testApplication {
+        val messages = captureTestLogMessages {
+            routing {
+                swaggerUI("swagger") {
+                    version = "4.15.5"
+                    source = OpenApiDocSource.Text(
+                        """
+                        openapi: "3.1.1"
+                        info:
+                          title: Sample
+                          version: "1.0.0"
+                        paths: {}
+                        """.trimIndent(),
+                        contentType = ContentType.Application.Yaml,
+                    )
+                }
+            }
+            client.get("/swagger/documentation.yaml")
+        }
+
+        assertTrue(
+            messages.any {
+                it.contains("3.1.1") && it.contains("4.15.5") && it.contains("does not support OpenAPI 3.1")
+            },
+            "Expected Swagger UI OpenAPI 3.1 warning, got: $messages"
+        )
+    }
+
+    @Test
+    fun `does not warn when OpenAPI 3_0 document is served with Swagger UI below 5`() = testApplication {
+        val messages = captureTestLogMessages {
+            routing {
+                swaggerUI("swagger") {
+                    version = "4.15.5"
+                    source = OpenApiDocSource.Text(
+                        """
+                        openapi: "3.0.3"
+                        info:
+                          title: Sample
+                          version: "1.0.0"
+                        paths: {}
+                        """.trimIndent(),
+                        contentType = ContentType.Application.Yaml,
+                    )
+                }
+            }
+            client.get("/swagger/documentation.yaml")
+        }
+
+        assertFalse(
+            messages.any { it.contains("does not support OpenAPI 3.1") },
+            "Did not expect Swagger UI OpenAPI 3.1 warning, got: $messages"
+        )
+    }
+
+    @Test
+    fun `does not warn when OpenAPI 3_1 document is served with Swagger UI 5 or later`() = testApplication {
+        val messages = captureTestLogMessages {
+            routing {
+                swaggerUI("swagger") {
+                    source = OpenApiDocSource.Text(
+                        """
+                        openapi: "3.1.1"
+                        info:
+                          title: Sample
+                          version: "1.0.0"
+                        paths: {}
+                        """.trimIndent(),
+                        contentType = ContentType.Application.Yaml,
+                    )
+                }
+            }
+            client.get("/swagger/documentation.yaml")
+        }
+
+        assertFalse(
+            messages.any { it.contains("does not support OpenAPI 3.1") },
+            "Did not expect Swagger UI OpenAPI 3.1 warning, got: $messages"
+        )
+    }
+}
+
+private inline fun captureTestLogMessages(block: () -> Unit): List<String> {
+    val logger = LoggerFactory.getLogger("io.ktor.test") as Logger
+    val previousLevel = logger.level
+    logger.level = Level.WARN
+    val listAppender = ListAppender<ILoggingEvent>()
+    logger.addAppender(listAppender)
+    listAppender.start()
+    try {
+        block()
+    } finally {
+        listAppender.stop()
+        logger.detachAppender(listAppender)
+        logger.level = previousLevel
+    }
+    return listAppender.list.map { it.message }
 }
 
 @Serializable


### PR DESCRIPTION
**Subsystem**
Server OpenAPI

**Motivation**
[KTOR-9705](https://youtrack.jetbrains.com/issue/KTOR-9705) OpenAPI UI (ktor-server-openapi) does not support OpenAPI spec 3.1.*

**Solution**
- warn if an older Swagger UI version is used with an OpenAPI 3.1 document
- warn if OpenAPI generation is used with openApiVersion 3.1 (which is the default atm)