### PR TITLE
Fix KTOR-9722  cannot be initialized with a congested  pool

### DIFF
--- a/ktor-client/ktor-client-plugins/ktor-client-auth/common/src/io/ktor/client/plugins/auth/providers/DigestAuthProvider.kt
+++ b/ktor-client/ktor-client-plugins/ktor-client-auth/common/src/io/ktor/client/plugins/auth/providers/DigestAuthProvider.kt
@@ -120,7 +120,7 @@ public class DigestAuthProvider(
 
     private val qop = atomic<String?>(null)
     private val opaque = atomic<String?>(null)
-    private val clientNonce = generateNonceBlocking()
+    private var clientNonce: String? = null
 
     private val requestCounter = atomic(0)
 
@@ -181,6 +181,7 @@ public class DigestAuthProvider(
         }
 
         val credentials = tokenHolder.loadToken() ?: return
+        val cnonce = clientNonce ?: generateNonceSuspend().also { clientNonce = it }
         val credential = makeDigest("${credentials.username}:$realm:${credentials.password}")
 
         val start = credential.toHexString()
@@ -188,7 +189,7 @@ public class DigestAuthProvider(
         val tokenSequence = if (actualQop == null) {
             listOf(start, nonce, end)
         } else {
-            listOf(start, nonce, nonceCount, clientNonce, actualQop, end)
+            listOf(start, nonce, nonceCount, cnonce, actualQop, end)
         }
 
         val token = makeDigest(tokenSequence.joinToString(":"))
@@ -200,7 +201,7 @@ public class DigestAuthProvider(
                 serverOpaque?.let { this["opaque"] = it.quote() }
                 this["username"] = credentials.username.quote()
                 this["nonce"] = nonce.quote()
-                this["cnonce"] = clientNonce.quote()
+                this["cnonce"] = cnonce.quote()
                 this["response"] = token.toHexString().quote()
                 this["uri"] = url.fullPath.quote()
                 actualQop?.let { this["qop"] = it }

--- a/ktor-client/ktor-client-plugins/ktor-client-auth/common/src/io/ktor/client/plugins/auth/providers/DigestAuthProvider.kt
+++ b/ktor-client/ktor-client-plugins/ktor-client-auth/common/src/io/ktor/client/plugins/auth/providers/DigestAuthProvider.kt
@@ -120,7 +120,7 @@ public class DigestAuthProvider(
 
     private val qop = atomic<String?>(null)
     private val opaque = atomic<String?>(null)
-    private var clientNonce: String? = null
+    private val clientNonce = atomic<String?>(null)
 
     private val requestCounter = atomic(0)
 
@@ -166,6 +166,13 @@ public class DigestAuthProvider(
         return true
     }
 
+    private suspend inline fun getNonce(): String {
+        clientNonce.value?.let { return it }
+        val newNonce = generateNonceSuspend()
+        val prevNonce = clientNonce.getAndSet(newNonce)
+        return prevNonce ?: newNonce
+    }
+
     override suspend fun addRequestHeaders(request: HttpRequestBuilder, authHeader: HttpAuthHeader?) {
         val nonceCount = requestCounter.incrementAndGet().toString(radix = 16).padStart(length = 8, padChar = '0')
         val methodName = request.method.value.uppercase()
@@ -181,7 +188,7 @@ public class DigestAuthProvider(
         }
 
         val credentials = tokenHolder.loadToken() ?: return
-        val cnonce = clientNonce ?: generateNonceSuspend().also { clientNonce = it }
+        val cnonce = getNonce()
         val credential = makeDigest("${credentials.username}:$realm:${credentials.password}")
 
         val start = credential.toHexString()

--- a/ktor-client/ktor-client-plugins/ktor-client-auth/jvm/test/io/ktor/client/plugins/auth/DigestProviderJvmTest.kt
+++ b/ktor-client/ktor-client-plugins/ktor-client-auth/jvm/test/io/ktor/client/plugins/auth/DigestProviderJvmTest.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2014-2026 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.client.plugins.auth
+
+import io.ktor.client.plugins.auth.providers.*
+import kotlinx.coroutines.*
+import java.util.concurrent.CountDownLatch
+import kotlin.test.Test
+
+class DigestProviderJvmTest {
+
+    @Test
+    fun `constructor does not block when Dispatchers Default is saturated`() {
+        val processors = Runtime.getRuntime().availableProcessors()
+        val latch = CountDownLatch(processors)
+        val jobs = List(processors) {
+            @OptIn(DelicateCoroutinesApi::class)
+            GlobalScope.launch(Dispatchers.Default) {
+                latch.countDown()
+                Thread.sleep(10_000)
+            }
+        }
+        latch.await()
+        try {
+            DigestAuthProvider({ DigestAuthCredentials("username", "password") }, "realm")
+        } finally {
+            jobs.forEach { it.cancel() }
+        }
+    }
+}

--- a/ktor-client/ktor-client-plugins/ktor-client-auth/jvm/test/io/ktor/client/plugins/auth/DigestProviderJvmTest.kt
+++ b/ktor-client/ktor-client-plugins/ktor-client-auth/jvm/test/io/ktor/client/plugins/auth/DigestProviderJvmTest.kt
@@ -7,6 +7,7 @@ package io.ktor.client.plugins.auth
 import io.ktor.client.plugins.auth.providers.*
 import kotlinx.coroutines.*
 import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
 import kotlin.test.Test
 
 class DigestProviderJvmTest {
@@ -14,18 +15,20 @@ class DigestProviderJvmTest {
     @Test
     fun `constructor does not block when Dispatchers Default is saturated`() {
         val processors = Runtime.getRuntime().availableProcessors()
-        val latch = CountDownLatch(processors)
+        val startLatch = CountDownLatch(processors)
+        val releaseLatch = CountDownLatch(1)
         val jobs = List(processors) {
             @OptIn(DelicateCoroutinesApi::class)
             GlobalScope.launch(Dispatchers.Default) {
-                latch.countDown()
-                Thread.sleep(10_000)
+                startLatch.countDown()
+                releaseLatch.await(10, TimeUnit.SECONDS)
             }
         }
-        latch.await()
+        startLatch.await()
         try {
             DigestAuthProvider({ DigestAuthCredentials("username", "password") }, "realm")
         } finally {
+            releaseLatch.countDown()
             jobs.forEach { it.cancel() }
         }
     }

--- a/ktor-utils/api/ktor-utils.api
+++ b/ktor-utils/api/ktor-utils.api
@@ -339,10 +339,14 @@ public final class io/ktor/util/RangesKt {
 }
 
 public final class io/ktor/util/StatelessHmacNonceManager : io/ktor/util/NonceManager {
-	public fun <init> (Ljavax/crypto/spec/SecretKeySpec;Ljava/lang/String;JLkotlin/jvm/functions/Function0;)V
+	public synthetic fun <init> (Ljavax/crypto/spec/SecretKeySpec;Ljava/lang/String;JLkotlin/jvm/functions/Function0;)V
 	public synthetic fun <init> (Ljavax/crypto/spec/SecretKeySpec;Ljava/lang/String;JLkotlin/jvm/functions/Function0;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public fun <init> ([BLjava/lang/String;JLkotlin/jvm/functions/Function0;)V
+	public fun <init> (Ljavax/crypto/spec/SecretKeySpec;Ljava/lang/String;JLkotlin/jvm/functions/Function1;)V
+	public synthetic fun <init> (Ljavax/crypto/spec/SecretKeySpec;Ljava/lang/String;JLkotlin/jvm/functions/Function1;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> ([BLjava/lang/String;JLkotlin/jvm/functions/Function0;)V
 	public synthetic fun <init> ([BLjava/lang/String;JLkotlin/jvm/functions/Function0;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> ([BLjava/lang/String;JLkotlin/jvm/functions/Function1;)V
+	public synthetic fun <init> ([BLjava/lang/String;JLkotlin/jvm/functions/Function1;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getAlgorithm ()Ljava/lang/String;
 	public final fun getKeySpec ()Ljavax/crypto/spec/SecretKeySpec;
 	public final fun getNonceGenerator ()Lkotlin/jvm/functions/Function0;

--- a/ktor-utils/common/test/io/ktor/util/NonceTest.kt
+++ b/ktor-utils/common/test/io/ktor/util/NonceTest.kt
@@ -4,14 +4,37 @@
 
 package io.ktor.util
 
+import kotlinx.coroutines.test.runTest
 import kotlin.test.*
 
 class NonceTest {
 
     @Test
-    fun testGenerateNonce() {
-        val nonce1 = generateNonceBlocking()
-        val nonce2 = generateNonceBlocking()
-        assertNotEquals(nonce1, nonce2)
+    fun `generates distinct nonces`() = runTest {
+        assertNotEquals(generateNonceBlocking(), generateNonceBlocking())
+        assertNotEquals(generateNonceSuspend(), generateNonceSuspend())
+    }
+
+    @Test
+    fun `returns nonce of requested length`() = runTest {
+        assertEquals(NONCE_SIZE_IN_CHARS, generateNonceBlocking().length)
+        assertEquals(NONCE_SIZE_IN_CHARS, generateNonceSuspend().length)
+
+        val biggerLength = 64
+        assertEquals(biggerLength, generateNonceBlocking(biggerLength).length)
+        assertEquals(biggerLength, generateNonceSuspend(biggerLength).length)
+
+        val smallerLength = 13
+        assertEquals(smallerLength, generateNonceBlocking(smallerLength).length)
+        assertEquals(smallerLength, generateNonceSuspend(smallerLength).length)
+    }
+
+    @Test
+    fun `contains only hex characters`() = runTest {
+        assertTrue(generateNonceBlocking().all { it.isHexDigit() })
+        assertTrue(generateNonceSuspend().all { it.isHexDigit() })
+        assertTrue(generateNonceBlocking(64).all { it.isHexDigit() })
     }
 }
+
+private fun Char.isHexDigit(): Boolean = this in '0'..'9' || this in 'a'..'f'

--- a/ktor-utils/jvm/src/io/ktor/util/CryptoJvm.kt
+++ b/ktor-utils/jvm/src/io/ktor/util/CryptoJvm.kt
@@ -8,7 +8,7 @@
 
 package io.ktor.util
 
-import java.security.*
+import java.security.MessageDigest
 
 /**
  * Create a digest function with the specified [algorithm] and [salt] provider.
@@ -62,18 +62,15 @@ private value class DigestImpl(val delegate: MessageDigest) : Digest {
  * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.util.generateNonceSuspend)
  */
 public actual suspend fun generateNonceSuspend(length: Int): String {
-    ensureNonceGeneratorRunning()
-
-    val nonce = nonceChannel.receive()
-
-    if (nonce.length >= length) {
-        return nonce.substring(0, length)
+    val nonce = tryGenerateNonceFromChannel(length)
+    if (nonce is String) {
+        return nonce
     }
-
-    return if (length <= NONCE_SIZE_IN_CHARS) {
+    ensureNonceGeneratorRunning()
+    return if (nonce == null) {
         nonceChannel.receive().substring(0, length)
     } else {
-        generateNonceLong(nonce, length)
+        generateNonceLong(nonce as StringBuilder, length)
     }
 }
 
@@ -83,21 +80,46 @@ public actual suspend fun generateNonceSuspend(length: Int): String {
  * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.util.generateNonceBlocking)
  */
 public actual fun generateNonceBlocking(length: Int): String {
-    nonceChannel.tryReceive().getOrNull()?.let { nonce ->
-        if (nonce.length == length) return nonce
-        if (nonce.length > length) return nonce.substring(0, length)
+    val nonce = tryGenerateNonceFromChannel(length)
+    if (nonce is String) {
+        return nonce
     }
     ensureNonceGeneratorRunning()
-    return generateNonceSynchronously(length)
+    val acc = if (nonce == null) StringBuilder(length) else nonce as StringBuilder
+    return generateNonceSynchronously(acc, length)
 }
 
-private suspend fun generateNonceLong(initial: CharSequence?, length: Int) = buildString(length) {
-    if (initial != null) {
-        append(initial)
+/**
+ * Attempts to read a nonce from [nonceChannel] without blocking or suspending.
+ *
+ * The return type is [Any] to avoid wrapper allocations on the hot path when [length]
+ * equals [NONCE_SIZE_IN_CHARS] and the channel contains a prefetched nonce.
+ *
+ * Return value semantics:
+ * - [String] — a complete nonce of the requested [length]; callers may return it directly.
+ * - `null` — only when [length] equals [NONCE_SIZE_IN_CHARS] and the channel is empty.
+ * - [StringBuilder] — for non-default lengths, a partial accumulation when the channel was drained
+ *   before [length] characters were collected; may be empty if nothing was received.
+ */
+private fun tryGenerateNonceFromChannel(length: Int): Any? {
+    if (length == NONCE_SIZE_IN_CHARS) {
+        return nonceChannel.tryReceive().getOrNull()
     }
+    val builder = StringBuilder(length)
+    while (true) {
+        val nonce = nonceChannel.tryReceive().getOrNull()
+            ?: return builder
+        builder.append(nonce, 0, (length - builder.length).coerceAtMost(nonce.length))
+        if (builder.length == length) {
+            return builder.toString()
+        }
+    }
+}
 
-    while (length > this.length) {
+private suspend fun generateNonceLong(acc: StringBuilder, length: Int): String {
+    while (length > acc.length) {
         val toAppend = nonceChannel.receive()
-        append(toAppend, 0, (length - this.length).coerceAtMost(toAppend.length))
+        acc.append(toAppend, 0, (length - acc.length).coerceAtMost(toAppend.length))
     }
+    return acc.toString()
 }

--- a/ktor-utils/jvm/src/io/ktor/util/CryptoJvm.kt
+++ b/ktor-utils/jvm/src/io/ktor/util/CryptoJvm.kt
@@ -2,13 +2,12 @@
 * Copyright 2014-2021 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
 */
 
-@file:kotlin.jvm.JvmMultifileClass
-@file:kotlin.jvm.JvmName("CryptoKt")
+@file:JvmMultifileClass
+@file:JvmName("CryptoKt")
 @file:Suppress("FunctionName")
 
 package io.ktor.util
 
-import kotlinx.coroutines.*
 import java.security.*
 
 /**
@@ -84,21 +83,12 @@ public actual suspend fun generateNonceSuspend(length: Int): String {
  * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.util.generateNonceBlocking)
  */
 public actual fun generateNonceBlocking(length: Int): String {
-    val nonce = nonceChannel.tryReceive().getOrNull()
-
-    if (nonce != null && nonce.length >= length) {
-        return nonce.substring(0, length)
+    nonceChannel.tryReceive().getOrNull()?.let { nonce ->
+        if (nonce.length == length) return nonce
+        if (nonce.length > length) return nonce.substring(0, length)
     }
-
     ensureNonceGeneratorRunning()
-
-    return runBlocking {
-        if (length <= NONCE_SIZE_IN_CHARS) {
-            nonceChannel.receive().substring(0, length)
-        } else {
-            generateNonceLong(nonce, length)
-        }
-    }
+    return generateNonceSynchronously(length)
 }
 
 private suspend fun generateNonceLong(initial: CharSequence?, length: Int) = buildString(length) {
@@ -110,4 +100,4 @@ private suspend fun generateNonceLong(initial: CharSequence?, length: Int) = bui
         val toAppend = nonceChannel.receive()
         append(toAppend, 0, (length - this.length).coerceAtMost(toAppend.length))
     }
-}.substring(0, length)
+}

--- a/ktor-utils/jvm/src/io/ktor/util/Nonce.kt
+++ b/ktor-utils/jvm/src/io/ktor/util/Nonce.kt
@@ -8,6 +8,7 @@ import kotlinx.coroutines.*
 import kotlinx.coroutines.channels.*
 import org.slf4j.*
 import java.security.*
+import java.util.concurrent.Executors
 import kotlin.random.*
 
 private val logger = LoggerFactory.getLogger("io.ktor.util.random")
@@ -36,10 +37,14 @@ internal val nonceChannel: Channel<String> = Channel(getSystemPropertyInt("nonce
 
 private val NonceGeneratorCoroutineName = CoroutineName("nonce-generator")
 
+private val nonceGeneratorDispatcher = Executors.newSingleThreadExecutor { runnable ->
+    Thread(runnable, "ktor-nonce-generator").apply { isDaemon = true }
+}.asCoroutineDispatcher()
+
 @OptIn(DelicateCoroutinesApi::class)
 @Suppress("CoroutineContextWithJob")
 private val nonceGeneratorJob = GlobalScope.launch(
-    context = Dispatchers.Default + NonCancellable + NonceGeneratorCoroutineName,
+    context = nonceGeneratorDispatcher + NonCancellable + NonceGeneratorCoroutineName,
     start = CoroutineStart.LAZY
 ) {
     val nonceChannel = nonceChannel
@@ -120,14 +125,15 @@ internal fun ensureNonceGeneratorRunning() {
     nonceGeneratorJob.start()
 }
 
-internal fun generateNonceSynchronously(length: Int): String = buildString(length) {
+internal fun generateNonceSynchronously(acc: StringBuilder, length: Int): String {
     val random = lookupSecureRandom()
     val bytes = ByteArray(NONCE_SIZE_IN_BYTES)
-    while (this.length < length) {
+    while (acc.length < length) {
         random.nextBytes(bytes)
         val hex = bytes.toHexString()
-        append(hex, 0, (length - this.length).coerceAtMost(hex.length))
+        acc.append(hex, 0, (length - acc.length).coerceAtMost(hex.length))
     }
+    return acc.toString()
 }
 
 private fun lookupSecureRandom(): SecureRandom {

--- a/ktor-utils/jvm/src/io/ktor/util/Nonce.kt
+++ b/ktor-utils/jvm/src/io/ktor/util/Nonce.kt
@@ -125,9 +125,11 @@ internal fun ensureNonceGeneratorRunning() {
     nonceGeneratorJob.start()
 }
 
+private val secureRandom: SecureRandom by lazy { lookupSecureRandom() }
+
 internal fun generateNonceSynchronously(acc: StringBuilder, length: Int): String {
-    val random = lookupSecureRandom()
     val bytes = ByteArray(NONCE_SIZE_IN_BYTES)
+    val random = secureRandom
     while (acc.length < length) {
         random.nextBytes(bytes)
         val hex = bytes.toHexString()

--- a/ktor-utils/jvm/src/io/ktor/util/Nonce.kt
+++ b/ktor-utils/jvm/src/io/ktor/util/Nonce.kt
@@ -120,6 +120,16 @@ internal fun ensureNonceGeneratorRunning() {
     nonceGeneratorJob.start()
 }
 
+internal fun generateNonceSynchronously(length: Int): String = buildString(length) {
+    val random = lookupSecureRandom()
+    val bytes = ByteArray(NONCE_SIZE_IN_BYTES)
+    while (this.length < length) {
+        random.nextBytes(bytes)
+        val hex = bytes.toHexString()
+        append(hex, 0, (length - this.length).coerceAtMost(hex.length))
+    }
+}
+
 private fun lookupSecureRandom(): SecureRandom {
     System.getProperty("$SYSTEM_PROPERTY_PREFIX.random.provider")?.let { name ->
         getInstanceOrNull(name)?.let { return it }

--- a/ktor-utils/jvm/src/io/ktor/util/StatelessHmacNonceManager.kt
+++ b/ktor-utils/jvm/src/io/ktor/util/StatelessHmacNonceManager.kt
@@ -4,13 +4,14 @@
 
 package io.ktor.util
 
+import kotlinx.coroutines.runBlocking
 import java.util.concurrent.*
 import javax.crypto.*
 import javax.crypto.spec.*
 
 /**
  * Stateless nonce manager implementation with HMAC verification and timeout.
- * Every nonce provided by this manager consist of a random part, timestamp and HMAC.
+ * Every nonce provided by this manager consists of a random part, timestamp, and HMAC.
  *
  * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.util.StatelessHmacNonceManager)
  *
@@ -19,12 +20,22 @@ import javax.crypto.spec.*
  * @property timeoutMillis specifies the amount of time for a nonce to be considered valid
  * @property nonceGenerator function that produces random values
  */
-public class StatelessHmacNonceManager(
-    public val keySpec: SecretKeySpec,
-    public val algorithm: String = "HmacSHA256",
-    public val timeoutMillis: Long = 60000,
-    public val nonceGenerator: () -> String = { generateNonceBlocking() }
+public class StatelessHmacNonceManager private constructor(
+    @Deprecated("This will become private") public val keySpec: SecretKeySpec,
+    @Deprecated("This will become private") public val algorithm: String = "HmacSHA256",
+    @Deprecated("This will become private") public val timeoutMillis: Long = 6000,
+    private val suspendNonceGenerator: suspend () -> String,
+    @Suppress("UNUSED_PARAMETER")
+    dummy: Unit
 ) : NonceManager {
+
+    public constructor(
+        keySpec: SecretKeySpec,
+        algorithm: String = "HmacSHA256",
+        timeoutMillis: Long = 6000,
+        nonceGenerator: suspend () -> String = { generateNonceSuspend() },
+    ) : this (keySpec, algorithm, timeoutMillis, suspendNonceGenerator = nonceGenerator, dummy = Unit)
+
     /**
      * Helper constructor that makes a secret key from [key] ByteArray
      *
@@ -34,27 +45,74 @@ public class StatelessHmacNonceManager(
         key: ByteArray,
         algorithm: String = "HmacSHA256",
         timeoutMillis: Long = 60000,
-        nonceGenerator: () -> String = { generateNonceBlocking() }
+        nonceGenerator: suspend () -> String = { generateNonceSuspend() },
     ) : this(
-        SecretKeySpec(
-            key,
-            algorithm
-        ),
+        SecretKeySpec(key, algorithm),
         algorithm,
         timeoutMillis,
-        nonceGenerator
+        suspendNonceGenerator = nonceGenerator,
+        dummy = Unit
     )
+
+    @Deprecated("Non-suspend nonce generator is deprecated", level = DeprecationLevel.HIDDEN)
+    public constructor(
+        keySpec: SecretKeySpec,
+        algorithm: String = "HmacSHA256",
+        timeoutMillis: Long = 60000,
+        nonceGenerator: () -> String = DEFAULT_LEGACY_NONCE_GENERATOR,
+    ) : this(
+        keySpec,
+        algorithm,
+        timeoutMillis,
+        suspendNonceGenerator = if (nonceGenerator === DEFAULT_LEGACY_NONCE_GENERATOR) {
+            { generateNonceSuspend() }
+        } else {
+            { nonceGenerator() }
+        },
+        dummy = Unit
+    )
+
+    /**
+     * Helper constructor that makes a secret key from [key] ByteArray
+     *
+     * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.util.StatelessHmacNonceManager.StatelessHmacNonceManager)
+     */
+    @Deprecated("Non-suspend nonce generator is deprecated", level = DeprecationLevel.HIDDEN)
+    public constructor(
+        key: ByteArray,
+        algorithm: String = "HmacSHA256",
+        timeoutMillis: Long = 60000,
+        nonceGenerator: () -> String = DEFAULT_LEGACY_NONCE_GENERATOR,
+    ) : this(
+        SecretKeySpec(key, algorithm),
+        algorithm,
+        timeoutMillis,
+        suspendNonceGenerator = if (nonceGenerator === DEFAULT_LEGACY_NONCE_GENERATOR) {
+            { generateNonceSuspend() }
+        } else {
+            { nonceGenerator() }
+        },
+        dummy = Unit
+    )
+
+    @Deprecated("This will become private")
+    public val nonceGenerator: () -> String = {
+        // blocking, but legacy nonceGenerator shouldn't be used much
+        runBlocking { suspendNonceGenerator() }
+    }
 
     /**
      * MAC length in bytes
      */
+    @Suppress("DEPRECATION")
     private val macLength = Mac.getInstance(algorithm).let { mac ->
         mac.init(keySpec)
         mac.macLength
     }
 
+    @Suppress("DEPRECATION")
     override suspend fun newNonce(): String {
-        val random = nonceGenerator()
+        val random = suspendNonceGenerator()
         val time = System.nanoTime().toString(16).padStart(16, '0')
 
         val mac = Mac.getInstance(algorithm).apply {
@@ -65,6 +123,7 @@ public class StatelessHmacNonceManager(
         return "$random+$time+$mac"
     }
 
+    @Suppress("DEPRECATION")
     override suspend fun verifyNonce(nonce: String): Boolean {
         val parts = nonce.split('+')
         if (parts.size != 3) return false
@@ -90,5 +149,9 @@ public class StatelessHmacNonceManager(
         }
 
         return validCount == macLength * 2
+    }
+
+    private companion object {
+        private val DEFAULT_LEGACY_NONCE_GENERATOR: () -> String = { generateNonceBlocking() }
     }
 }

--- a/ktor-utils/jvm/test/io/ktor/tests/utils/NonceSmokeTest.kt
+++ b/ktor-utils/jvm/test/io/ktor/tests/utils/NonceSmokeTest.kt
@@ -4,44 +4,64 @@
 
 package io.ktor.tests.utils
 
+import io.ktor.test.*
 import io.ktor.util.*
 import kotlinx.coroutines.*
 import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
 import kotlin.test.Test
 import kotlin.test.assertTrue
 import kotlin.time.Duration.Companion.seconds
 
 class NonceSmokeTest {
     @Test
-    fun test() {
+    fun test() = runTest {
         val nonceSet = HashSet<String>(4096)
 
-        repeat(4096) {
+        // start nonce background generation here to reduce noice in profiler
+        ensureNonceGeneratorRunning()
+
+        repeat(4098) {
             nonceSet.add(generateNonceBlocking())
         }
 
-        assertTrue { nonceSet.size == 4096 }
+        assertTrue { nonceSet.size == 4098 }
     }
 
     @Test
-    fun `test generate nonce blocking does not deadlock when Default Dispatcher is saturated`() {
+    fun `test generateNonceBlocking completes when Default Dispatcher is saturated`() {
+        saturateDefaultDispatcher {
+            generateNonceBlocking()
+        }
+    }
+
+    @Test
+    fun `test generateNonceSuspend completes when Default Dispatcher is saturated`() {
+        saturateDefaultDispatcher {
+            generateNonceSuspend()
+        }
+    }
+
+    private fun saturateDefaultDispatcher(block: suspend () -> Unit) {
         val processors = Runtime.getRuntime().availableProcessors()
-        val latch = CountDownLatch(processors)
+        val startLatch = CountDownLatch(processors)
+        val releaseLatch = CountDownLatch(1)
         val jobs = List(processors) {
             @OptIn(DelicateCoroutinesApi::class)
             GlobalScope.launch(Dispatchers.Default) {
-                latch.countDown()
-                Thread.sleep(10_000)
+                startLatch.countDown()
+                releaseLatch.await(10, TimeUnit.SECONDS)
             }
         }
-        latch.await()
+        startLatch.await()
         try {
             runBlocking {
                 withTimeout(5.seconds) {
-                    generateNonceBlocking()
+                    block()
                 }
             }
         } finally {
+            releaseLatch.countDown()
             jobs.forEach { it.cancel() }
         }
     }

--- a/ktor-utils/jvm/test/io/ktor/tests/utils/NonceSmokeTest.kt
+++ b/ktor-utils/jvm/test/io/ktor/tests/utils/NonceSmokeTest.kt
@@ -5,7 +5,11 @@
 package io.ktor.tests.utils
 
 import io.ktor.util.*
-import kotlin.test.*
+import kotlinx.coroutines.*
+import java.util.concurrent.CountDownLatch
+import kotlin.test.Test
+import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.seconds
 
 class NonceSmokeTest {
     @Test
@@ -17,5 +21,28 @@ class NonceSmokeTest {
         }
 
         assertTrue { nonceSet.size == 4096 }
+    }
+
+    @Test
+    fun `test generate nonce blocking does not deadlock when Default Dispatcher is saturated`() {
+        val processors = Runtime.getRuntime().availableProcessors()
+        val latch = CountDownLatch(processors)
+        val jobs = List(processors) {
+            @OptIn(DelicateCoroutinesApi::class)
+            GlobalScope.launch(Dispatchers.Default) {
+                latch.countDown()
+                Thread.sleep(10_000)
+            }
+        }
+        latch.await()
+        try {
+            runBlocking {
+                withTimeout(5.seconds) {
+                    generateNonceBlocking()
+                }
+            }
+        } finally {
+            jobs.forEach { it.cancel() }
+        }
     }
 }


### PR DESCRIPTION
**Subsystem**
Client

**Motivation**
[KTOR-9722](https://youtrack.jetbrains.com/issue/KTOR-9722) `DigestAuthProvider` cannot be initialized with a congested `Dispatchers.Default` pool

**Solution**
- generate a nonce in `DigestAuthProvider` lazily using suspend version
- generate nonce sequentially in `generateNonceBlocking` if there are no already generated 

The second change is questionable. Depending on what we expect from "Blocking" functions. 
`generateNonceBlocking` was still using coroutines and could cause a deadlock.
I tried profiling `NonceSmokeTest`, and it shows a slight increase in memory usage (~7.2 MB -> 8 MB).

