### PR TITLE
Update dependencies for release/3.x

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -74,7 +74,7 @@ kaml = "0.79.0"
 
 swagger-codegen = "3.0.81"
 swagger-codegen-generators = "1.0.62"
-swagger-parser = "2.1.44"
+swagger-parser = "2.1.45"
 
 tomlj = "1.1.1"
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -52,7 +52,7 @@ typesafe = "1.4.9"
 
 mockk = "1.14.11"
 
-java-jwt = "4.5.2"
+java-jwt = "4.6.0"
 
 jwks-rsa = "0.24.1"
 mustache = "0.9.14"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -15,7 +15,7 @@ kotlinter = "5.6.0"
 kotlinx-browser = "0.5.0"
 
 netty = "4.2.16.Final"
-netty-tcnative = "2.0.79.Final"
+netty-tcnative = "2.0.81.Final"
 
 jetty = "9.4.58.v20250814"
 jetty-jakarta = "12.0.35"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 
 kotlin = "2.3.21"
-android-gradlePlugin = "9.2.1"
+android-gradlePlugin = "9.3.0"
 androidx-test = "1.7.0"
 kotlinx-html = "0.12.0"
 kotlinx-datetime = "0.6.2"
@@ -10,8 +10,8 @@ coroutines = "1.11.0"
 atomicfu = "0.32.1"
 serialization = "1.11.0"
 dokka = "2.2.0"
-kover = "0.9.8"
-kotlinter = "5.5.0"
+kover = "0.9.9"
+kotlinter = "5.6.0"
 kotlinx-browser = "0.5.0"
 
 netty = "4.2.15.Final"
@@ -42,7 +42,7 @@ jackson-annotations = "2.21"
 
 junit = "5.14.4"
 slf4j = "2.0.18"
-logback = "1.5.34"
+logback = "1.5.38"
 
 dropwizard = "4.2.39"
 micrometer = "1.16.5"
@@ -83,7 +83,7 @@ zstd-jni = "1.5.7-11"
 # Keep it in sync with build-settings-logic/settings.gradle.kts
 # TODO: Remove module 'develocity-patched' after updating Develocity plugin to 4.4+
 develocity = "4.3.2" # Should be compatible with our server: ge.jetbrains.com
-develocity-commonCustomUserData = "2.6.0"
+develocity-commonCustomUserData = "2.7.0"
 gradleDoctor = "0.12.1"
 mavenPublishing = "0.37.0"
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,7 +14,7 @@ kover = "0.9.9"
 kotlinter = "5.6.0"
 kotlinx-browser = "0.5.0"
 
-netty = "4.2.15.Final"
+netty = "4.2.16.Final"
 netty-tcnative = "2.0.79.Final"
 
 jetty = "9.4.58.v20250814"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -23,7 +23,7 @@ jetty-alpn-api = "1.1.3.v20160715"
 jetty-alpn-openjdk8 = "9.4.58.v20250814"
 
 tomcat = "9.0.120"
-tomcat-jakarta = "10.1.55"
+tomcat-jakarta = "10.1.57"
 
 stream-webrtc-android = "1.3.10"
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -45,7 +45,7 @@ slf4j = "2.0.18"
 logback = "1.5.38"
 
 dropwizard = "4.2.39"
-micrometer = "1.16.5"
+micrometer = "1.17.0"
 
 jansi = "2.4.3"
 typesafe = "1.4.9"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -22,7 +22,7 @@ jetty-jakarta = "12.0.35"
 jetty-alpn-api = "1.1.3.v20160715"
 jetty-alpn-openjdk8 = "9.4.58.v20250814"
 
-tomcat = "9.0.118"
+tomcat = "9.0.120"
 tomcat-jakarta = "10.1.55"
 
 stream-webrtc-android = "1.3.10"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -36,9 +36,9 @@ okio = "3.17.0"
 json-simple = "1.1.1"
 gson = "2.14.0"
 
-jackson = "2.21.3"
+jackson = "2.22.1"
 jackson3 = "3.1.3"
-jackson-annotations = "2.21"
+jackson-annotations = "2.22"
 
 junit = "5.14.4"
 slf4j = "2.0.18"


### PR DESCRIPTION
Updates dependencies for the upcoming 3.x release.

### Updated

Runtime dependencies:

- Netty `4.2.15.Final` → [`4.2.16.Final`](https://github.com/netty/netty/releases/tag/netty-4.2.16.Final)
- netty-tcnative `2.0.79.Final` → [`2.0.81.Final`](https://github.com/netty/netty-tcnative/compare/netty-tcnative-parent-2.0.79.Final...netty-tcnative-parent-2.0.81.Final)
- Tomcat `9.0.118` → [`9.0.120`](https://tomcat.apache.org/tomcat-9.0-doc/changelog.html#Tomcat_9.0.120)
- Tomcat Jakarta `10.1.55` → [`10.1.57`](https://tomcat.apache.org/tomcat-10.1-doc/changelog.html#Tomcat_10.1.57)
- Jackson `2.21.3` → [`2.22.1`](https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.22)
- Jackson annotations `2.21` → [`2.22`](https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.22)
- Micrometer `1.16.5` → [`1.17.0`](https://github.com/micrometer-metrics/micrometer/releases/tag/v1.17.0)
- java-jwt `4.5.2` → [`4.6.0`](https://github.com/auth0/java-jwt/releases/tag/4.6.0)
- Swagger parser `2.1.44` → [`2.1.45`](https://github.com/swagger-api/swagger-parser/releases/tag/v2.1.45)

Test and build dependencies:

- Android Gradle Plugin `9.2.1` → [`9.3.0`](https://developer.android.com/build/releases/agp-9-3-0-release-notes)
- Kover `0.9.8` → [`0.9.9`](https://github.com/Kotlin/kotlinx-kover/releases/tag/v0.9.9)
- Kotlinter `5.5.0` → [`5.6.0`](https://github.com/jeremymailen/kotlinter-gradle/releases/tag/5.6.0)
- Logback `1.5.34` → [`1.5.38`](https://github.com/qos-ch/logback/releases/tag/v_1.5.38)
- Gradle common custom user data plugin `2.6.0` → [`2.7.0`](https://github.com/gradle/common-custom-user-data-gradle-plugin/releases/tag/v2.7.0)

### Deferred / skipped

- AtomicFU [`0.33.0`](https://github.com/Kotlin/kotlinx-atomicfu/releases/tag/0.33.0): skipped to avoid introducing deprecation warnings for users resolving AtomicFU transitively.
- JUnit `6.1.2`: skipped by maintainer request.
- Eclipse Temurin Docker tag `25.0.3_9-jdk-noble`: skipped by maintainer request.
- Jackson 3 [`3.2.1`](https://github.com/FasterXML/jackson/wiki/Jackson-Release-3.2): skipped because Jackson 3.2 release notes include behavior changes.
- Kotlin `2.4.10`: skipped as a Kotlin feature/minor update, not a release-branch hotfix.
- Gobley `0.3.7`: skipped due to the local policy comment waiting for `0.3.8`.
- Jetty `12.1.11`: skipped because the Renovate PR is blocked/edited.
- `io.ktor:*` catalog update: skipped unless explicitly requested.
- Other production minor/major updates were skipped as release-branch-ineligible.

### Validation

- Targeted JVM validation — successful, 577 tests, 557 passed, 20 skipped, 0 failed: https://ge.jetbrains.com/s/lbv4f7geroaw2
- `./gradlew assemble` — successful: https://ge.jetbrains.com/s/mk45qwjtnih3a
