### PR TITLE
Fix KTOR-9729: Expose Response Body for Failed Websocket Connections

### DIFF
--- a/ktor-client/ktor-client-core/api/ktor-client-core.api
+++ b/ktor-client/ktor-client-core/api/ktor-client-core.api
@@ -1073,6 +1073,8 @@ public final class io/ktor/client/plugins/websocket/WebSocketCapability : io/kto
 public final class io/ktor/client/plugins/websocket/WebSocketException : java/lang/IllegalStateException {
 	public fun <init> (Ljava/lang/String;)V
 	public fun <init> (Ljava/lang/String;Ljava/lang/Throwable;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/Throwable;Lio/ktor/client/statement/HttpResponse;)V
+	public final fun getResponse ()Lio/ktor/client/statement/HttpResponse;
 }
 
 public final class io/ktor/client/plugins/websocket/WebSocketExtensionsCapability : io/ktor/client/engine/HttpClientEngineCapability {

--- a/ktor-client/ktor-client-core/api/ktor-client-core.klib.api
+++ b/ktor-client/ktor-client-core/api/ktor-client-core.klib.api
@@ -632,6 +632,10 @@ final class io.ktor.client.plugins.websocket/DefaultClientWebSocketSession : io.
 final class io.ktor.client.plugins.websocket/WebSocketException : kotlin/IllegalStateException { // io.ktor.client.plugins.websocket/WebSocketException|null[0]
     constructor <init>(kotlin/String) // io.ktor.client.plugins.websocket/WebSocketException.<init>|<init>(kotlin.String){}[0]
     constructor <init>(kotlin/String, kotlin/Throwable?) // io.ktor.client.plugins.websocket/WebSocketException.<init>|<init>(kotlin.String;kotlin.Throwable?){}[0]
+    constructor <init>(kotlin/String, kotlin/Throwable?, io.ktor.client.statement/HttpResponse?) // io.ktor.client.plugins.websocket/WebSocketException.<init>|<init>(kotlin.String;kotlin.Throwable?;io.ktor.client.statement.HttpResponse?){}[0]
+
+    final val response // io.ktor.client.plugins.websocket/WebSocketException.response|{}response[0]
+        final fun <get-response>(): io.ktor.client.statement/HttpResponse? // io.ktor.client.plugins.websocket/WebSocketException.response.<get-response>|<get-response>(){}[0]
 }
 
 final class io.ktor.client.plugins.websocket/WebSockets { // io.ktor.client.plugins.websocket/WebSockets|null[0]

--- a/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/websocket/WebSockets.kt
+++ b/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/websocket/WebSockets.kt
@@ -293,6 +293,10 @@ public class WebSockets internal constructor(
 public class WebSocketException(
     message: String,
     cause: Throwable?,
+    /**
+     * The HTTP response from a failed handshake, exposing the status, headers, and body returned
+     * by the server. Availability varies by engine.
+     */
     public val response: HttpResponse?,
 ) : IllegalStateException(message, cause) {
     // required for backwards binary compatibility

--- a/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/websocket/WebSockets.kt
+++ b/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/websocket/WebSockets.kt
@@ -229,9 +229,17 @@ public class WebSockets internal constructor(
                     return@intercept
                 }
                 if (status != HttpStatusCode.SwitchingProtocols) {
+                    val failedResponse = try {
+                        context.save().response
+                    } catch (cause: Exception) {
+                        LOGGER.trace { "Failed to read response body of failed WebSocket handshake: $cause" }
+                        null
+                    }
                     @Suppress("ktlint:standard:max-line-length")
                     throw WebSocketException(
-                        "Handshake exception, expected status code ${HttpStatusCode.SwitchingProtocols.value} but was ${status.value}"
+                        "Handshake exception, expected status code ${HttpStatusCode.SwitchingProtocols.value} but was ${status.value}",
+                        cause = null,
+                        response = failedResponse,
                     )
                 }
                 if (session !is WebSocketSession) {
@@ -273,7 +281,12 @@ public class WebSockets internal constructor(
     }
 }
 
-public class WebSocketException(message: String, cause: Throwable?) : IllegalStateException(message, cause) {
+public class WebSocketException(
+    message: String,
+    cause: Throwable?,
+    public val response: HttpResponse?,
+) : IllegalStateException(message, cause) {
     // required for backwards binary compatibility
-    public constructor(message: String) : this(message, cause = null)
+    public constructor(message: String) : this(message, cause = null, response = null)
+    public constructor(message: String, cause: Throwable?) : this(message, cause, response = null)
 }

--- a/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/websocket/WebSockets.kt
+++ b/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/websocket/WebSockets.kt
@@ -24,6 +24,10 @@ public val WEBSOCKETS_KEY: AttributeKey<WebSockets> = AttributeKey<WebSockets>("
 
 internal val LOGGER = KtorSimpleLogger("io.ktor.client.plugins.websocket.WebSockets")
 
+// Marks a call whose failed-handshake response has already been captured, so reading that
+// response's body (via WebSocketException.response) doesn't re-enter the handshake handling below.
+private val FAILED_HANDSHAKE_RESPONSE_KEY = AttributeKey<Unit>("WebSocketFailedHandshakeResponse")
+
 /**
  * Indicates if a client engine supports WebSockets.
  *
@@ -228,9 +232,14 @@ public class WebSockets internal constructor(
                     LOGGER.trace { "Skipping non-websocket response from ${context.request.url}: $requestContent" }
                     return@intercept
                 }
+                if (context.attributes.contains(FAILED_HANDSHAKE_RESPONSE_KEY)) {
+                    // Reading the body of an already-captured failed handshake (WebSocketException.response);
+                    // let the default transformers produce the body instead of handling the handshake again.
+                    return@intercept
+                }
                 if (status != HttpStatusCode.SwitchingProtocols) {
                     val failedResponse = try {
-                        context.save().response
+                        context.save().also { it.attributes.put(FAILED_HANDSHAKE_RESPONSE_KEY, Unit) }.response
                     } catch (cause: Exception) {
                         LOGGER.trace { "Failed to read response body of failed WebSocket handshake: $cause" }
                         null

--- a/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/websocket/WebSockets.kt
+++ b/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/websocket/WebSockets.kt
@@ -294,6 +294,8 @@ public class WebSockets internal constructor(
 }
 
 /**
+ * This exception is thrown when a WebSocket handshake fails.
+ *
  * @property response the HTTP response from a failed handshake, exposing the status, headers, and body returned
  * by the server. Availability varies by engine.
  */

--- a/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/websocket/WebSockets.kt
+++ b/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/websocket/WebSockets.kt
@@ -247,9 +247,9 @@ public class WebSockets internal constructor(
                         LOGGER.trace { "Failed to read response body of failed WebSocket handshake: $cause" }
                         null
                     }
-                    @Suppress("ktlint:standard:max-line-length")
                     throw WebSocketException(
-                        "Handshake exception, expected status code ${HttpStatusCode.SwitchingProtocols.value} but was ${status.value}",
+                        "Handshake exception, expected status code ${HttpStatusCode.SwitchingProtocols.value} " +
+                            "but was ${status.value}",
                         cause = null,
                         response = failedResponse,
                     )

--- a/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/websocket/WebSockets.kt
+++ b/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/websocket/WebSockets.kt
@@ -16,6 +16,7 @@ import io.ktor.util.*
 import io.ktor.util.logging.*
 import io.ktor.utils.io.*
 import io.ktor.websocket.*
+import kotlin.coroutines.cancellation.CancellationException
 
 private val REQUEST_EXTENSIONS_KEY = AttributeKey<List<WebSocketExtension<*>>>("Websocket extensions")
 
@@ -240,6 +241,8 @@ public class WebSockets internal constructor(
                 if (status != HttpStatusCode.SwitchingProtocols) {
                     val failedResponse = try {
                         context.save().also { it.attributes.put(FAILED_HANDSHAKE_RESPONSE_KEY, Unit) }.response
+                    } catch (cause: CancellationException) {
+                        throw cause
                     } catch (cause: Exception) {
                         LOGGER.trace { "Failed to read response body of failed WebSocket handshake: $cause" }
                         null

--- a/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/websocket/WebSockets.kt
+++ b/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/websocket/WebSockets.kt
@@ -293,13 +293,13 @@ public class WebSockets internal constructor(
     }
 }
 
+/**
+ * @property response the HTTP response from a failed handshake, exposing the status, headers, and body returned
+ * by the server. Availability varies by engine.
+ */
 public class WebSocketException(
     message: String,
     cause: Throwable?,
-    /**
-     * The HTTP response from a failed handshake, exposing the status, headers, and body returned
-     * by the server. Availability varies by engine.
-     */
     public val response: HttpResponse?,
 ) : IllegalStateException(message, cause) {
     // required for backwards binary compatibility

--- a/ktor-client/ktor-client-java/jvm/src/io/ktor/client/engine/java/JavaHttpWebSocket.kt
+++ b/ktor-client/ktor-client-java/jvm/src/io/ktor/client/engine/java/JavaHttpWebSocket.kt
@@ -170,17 +170,20 @@ internal class JavaHttpWebSocket(
 
         var status = HttpStatusCode.SwitchingProtocols
         var headers: Headers
+        var body: Any = this
         try {
             webSocket = builder.buildAsync(requestData.url.toURI(), this).await()
             val protocol = webSocket.subprotocol?.takeIf { it.isNotEmpty() }
             headers = if (protocol != null) headersOf(HttpHeaders.SecWebSocketProtocol, protocol) else Headers.Empty
         } catch (cause: WebSocketHandshakeException) {
-            if (cause.response.statusCode() == HttpStatusCode.Unauthorized.value) {
-                status = HttpStatusCode.Unauthorized
-                headers = headersOf(cause.response.headers().map())
-            } else {
-                throw cause
-            }
+            // A failed handshake - expose the response.
+            val response = cause.response ?: throw cause
+            status = HttpStatusCode.fromValue(response.statusCode())
+            headers = headersOf(response.headers().map())
+
+            // NOTE: For current OpenJDKs, response.body() is either null or String, but this isn't part of the
+            // public API and could theoretically change in the future.
+            (response.body() as? String)?.let { body = ByteReadChannel(it.toByteArray()) }
         }
 
         return HttpResponseData(
@@ -188,7 +191,7 @@ internal class JavaHttpWebSocket(
             requestTime,
             headers,
             HttpProtocolVersion.HTTP_1_1,
-            this,
+            body,
             callContext
         )
     }

--- a/ktor-client/ktor-client-okhttp/jvm/src/io/ktor/client/engine/okhttp/OkHttpEngine.kt
+++ b/ktor-client/ktor-client-okhttp/jvm/src/io/ktor/client/engine/okhttp/OkHttpEngine.kt
@@ -94,7 +94,12 @@ public class OkHttpEngine(override val config: OkHttpConfig) : HttpClientEngineB
         ).apply { start() }
 
         val originResponse = session.originResponse.await()
-        return buildResponseData(originResponse, requestTime, session, callContext, requestData)
+
+        // On a failed handshake, expose the materialized response body. Otherwise the
+        // response body is the session itself.
+        val responseBody: Any = session.failedHandshakeBody?.let { ByteReadChannel(it) } ?: session
+
+        return buildResponseData(originResponse, requestTime, responseBody, callContext, requestData)
     }
 
     private suspend fun executeHttpRequest(

--- a/ktor-client/ktor-client-okhttp/jvm/src/io/ktor/client/engine/okhttp/OkHttpWebsocketSession.kt
+++ b/ktor-client/ktor-client-okhttp/jvm/src/io/ktor/client/engine/okhttp/OkHttpWebsocketSession.kt
@@ -14,6 +14,7 @@ import kotlinx.coroutines.channels.*
 import okhttp3.*
 import okio.ByteString
 import okio.ByteString.Companion.toByteString
+import java.io.IOException
 import kotlin.coroutines.CoroutineContext
 
 @OptIn(InternalAPI::class)
@@ -28,6 +29,10 @@ internal class OkHttpWebsocketSession(
     private val self = CompletableDeferred<OkHttpWebsocketSession>()
 
     internal val originResponse: CompletableDeferred<Response> = CompletableDeferred()
+
+    // Body of a failed-handshake response.
+    internal var failedHandshakeBody: ByteArray? = null
+        private set
 
     private val channelsConfig: WebSocketChannelsConfig = wsConfig.channelsConfig
 
@@ -144,17 +149,23 @@ internal class OkHttpWebsocketSession(
 
     override fun onFailure(webSocket: WebSocket, t: Throwable, response: Response?) {
         super.onFailure(webSocket, t, response)
-        val statusCode = response?.code
 
-        if (statusCode == HttpStatusCode.Unauthorized.value) {
-            originResponse.complete(response)
-            _incoming.close()
-            outgoing.close()
-        } else {
+        if (response == null || response.code == HttpStatusCode.SwitchingProtocols.value) {
+            // Network error or post-handshake failure.
             originResponse.completeExceptionally(t)
             _closeReason.completeExceptionally(t)
             _incoming.close(t)
             outgoing.close(t)
+        } else {
+            // A failed handshake. Materialize the handshake response so it can be exposed.
+            failedHandshakeBody = try {
+                response.body.bytes()
+            } catch (_: IOException) {
+                null
+            }
+            originResponse.complete(response)
+            _incoming.close()
+            outgoing.close()
         }
     }
 

--- a/ktor-client/ktor-client-okhttp/jvm/src/io/ktor/client/engine/okhttp/OkHttpWebsocketSession.kt
+++ b/ktor-client/ktor-client-okhttp/jvm/src/io/ktor/client/engine/okhttp/OkHttpWebsocketSession.kt
@@ -151,7 +151,7 @@ internal class OkHttpWebsocketSession(
         super.onFailure(webSocket, t, response)
 
         if (response == null || response.code == HttpStatusCode.SwitchingProtocols.value) {
-            // Network error or post-handshake failure.
+            // Network error (no response) or post-handshake failure (status code 101).
             originResponse.completeExceptionally(t)
             _closeReason.completeExceptionally(t)
             _incoming.close(t)

--- a/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/WebSocketTest.kt
+++ b/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/WebSocketTest.kt
@@ -579,6 +579,25 @@ class WebSocketTest : ClientLoader(except(ENGINES_WITHOUT_WS)) {
     }
 
     @Test
+    fun testFailedHandshakeExposesResponse() = clientTests(only("CIO")) {
+        config {
+            install(WebSockets)
+        }
+
+        test { client ->
+            val exception = assertFailsWith<WebSocketException> {
+                client.webSocket("$TEST_WEBSOCKET_SERVER/websockets/handshake-403") {
+                    fail("Unreachable")
+                }
+            }
+
+            val response = assertNotNull(exception.response)
+            assertEquals(HttpStatusCode.Forbidden, response.status)
+            assertEquals("handshake forbidden", response.bodyAsText())
+        }
+    }
+
+    @Test
     fun testWebSocketHeaders() = clientTests {
         config {
             install(WebSockets)

--- a/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/WebSocketTest.kt
+++ b/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/WebSocketTest.kt
@@ -598,6 +598,26 @@ class WebSocketTest : ClientLoader(except(ENGINES_WITHOUT_WS)) {
     }
 
     @Test
+    fun testFailedHandshakeExposesResponseStatus() = clientTests(only("CIO", "OkHttp", "Java")) {
+        // The OkHttp and Java engines only surface the failed-handshake response for 401 Unauthorized;
+        // CIO surfaces it for any non-101 status (and additionally exposes the body, see the test above).
+        config {
+            install(WebSockets)
+        }
+
+        test { client ->
+            val exception = assertFailsWith<WebSocketException> {
+                client.webSocket("$TEST_WEBSOCKET_SERVER/websockets/handshake-401") {
+                    fail("Unreachable")
+                }
+            }
+
+            val response = assertNotNull(exception.response)
+            assertEquals(HttpStatusCode.Unauthorized, response.status)
+        }
+    }
+
+    @Test
     fun testWebSocketHeaders() = clientTests {
         config {
             install(WebSockets)

--- a/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/WebSocketTest.kt
+++ b/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/WebSocketTest.kt
@@ -593,6 +593,7 @@ class WebSocketTest : ClientLoader(except(ENGINES_WITHOUT_WS)) {
 
             val response = assertNotNull(exception.response)
             assertEquals(HttpStatusCode.Forbidden, response.status)
+            assertEquals("forbidden", response.headers["X-Handshake-Reason"])
             assertEquals("handshake forbidden", response.bodyAsText())
         }
     }
@@ -614,6 +615,7 @@ class WebSocketTest : ClientLoader(except(ENGINES_WITHOUT_WS)) {
 
             val response = assertNotNull(exception.response)
             assertEquals(HttpStatusCode.Unauthorized, response.status)
+            assertEquals("unauthorized", response.headers["X-Handshake-Reason"])
         }
     }
 

--- a/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/WebSocketTest.kt
+++ b/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/WebSocketTest.kt
@@ -599,25 +599,6 @@ class WebSocketTest : ClientLoader(except(ENGINES_WITHOUT_WS)) {
     }
 
     @Test
-    fun testFailedHandshakeExposesResponseStatus() = clientTests(only("CIO", "OkHttp", "Java")) {
-        config {
-            install(WebSockets)
-        }
-
-        test { client ->
-            val exception = assertFailsWith<WebSocketException> {
-                client.webSocket("$TEST_WEBSOCKET_SERVER/websockets/handshake-401") {
-                    fail("Unreachable")
-                }
-            }
-
-            val response = assertNotNull(exception.response)
-            assertEquals(HttpStatusCode.Unauthorized, response.status)
-            assertEquals("unauthorized", response.headers["X-Handshake-Reason"])
-        }
-    }
-
-    @Test
     fun testWebSocketHeaders() = clientTests {
         config {
             install(WebSockets)

--- a/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/WebSocketTest.kt
+++ b/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/WebSocketTest.kt
@@ -579,7 +579,7 @@ class WebSocketTest : ClientLoader(except(ENGINES_WITHOUT_WS)) {
     }
 
     @Test
-    fun testFailedHandshakeExposesResponse() = clientTests(only("CIO")) {
+    fun testFailedHandshakeExposesResponse() = clientTests(only("CIO", "OkHttp")) {
         config {
             install(WebSockets)
         }
@@ -600,8 +600,8 @@ class WebSocketTest : ClientLoader(except(ENGINES_WITHOUT_WS)) {
 
     @Test
     fun testFailedHandshakeExposesResponseStatus() = clientTests(only("CIO", "OkHttp", "Java")) {
-        // The OkHttp and Java engines only surface the failed-handshake response for 401 Unauthorized;
-        // CIO surfaces it for any non-101 status (and additionally exposes the body, see the test above).
+        // The Java engine only surfaces the failed-handshake response for 401 Unauthorized;
+        // CIO and OkHttp surface it for any non-101 status (and additionally expose the body, see the test above).
         config {
             install(WebSockets)
         }

--- a/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/WebSocketTest.kt
+++ b/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/WebSocketTest.kt
@@ -579,7 +579,7 @@ class WebSocketTest : ClientLoader(except(ENGINES_WITHOUT_WS)) {
     }
 
     @Test
-    fun testFailedHandshakeExposesResponse() = clientTests(only("CIO", "OkHttp")) {
+    fun testFailedHandshakeExposesResponse() = clientTests(only("CIO", "OkHttp", "Java")) {
         config {
             install(WebSockets)
         }
@@ -600,8 +600,6 @@ class WebSocketTest : ClientLoader(except(ENGINES_WITHOUT_WS)) {
 
     @Test
     fun testFailedHandshakeExposesResponseStatus() = clientTests(only("CIO", "OkHttp", "Java")) {
-        // The Java engine only surfaces the failed-handshake response for 401 Unauthorized;
-        // CIO and OkHttp surface it for any non-101 status (and additionally expose the body, see the test above).
         config {
             install(WebSockets)
         }

--- a/ktor-test-server/src/main/kotlin/test/server/tests/WebSockets.kt
+++ b/ktor-test-server/src/main/kotlin/test/server/tests/WebSockets.kt
@@ -85,6 +85,9 @@ internal fun Application.webSockets() {
             get("500") {
                 call.respond(HttpStatusCode.InternalServerError)
             }
+            get("handshake-403") {
+                call.respondText("handshake forbidden", status = HttpStatusCode.Forbidden)
+            }
         }
     }
 }

--- a/ktor-test-server/src/main/kotlin/test/server/tests/WebSockets.kt
+++ b/ktor-test-server/src/main/kotlin/test/server/tests/WebSockets.kt
@@ -86,9 +86,11 @@ internal fun Application.webSockets() {
                 call.respond(HttpStatusCode.InternalServerError)
             }
             get("handshake-403") {
+                call.response.header("X-Handshake-Reason", "forbidden")
                 call.respondText("handshake forbidden", status = HttpStatusCode.Forbidden)
             }
             get("handshake-401") {
+                call.response.header("X-Handshake-Reason", "unauthorized")
                 call.respond(HttpStatusCode.Unauthorized)
             }
         }

--- a/ktor-test-server/src/main/kotlin/test/server/tests/WebSockets.kt
+++ b/ktor-test-server/src/main/kotlin/test/server/tests/WebSockets.kt
@@ -88,6 +88,9 @@ internal fun Application.webSockets() {
             get("handshake-403") {
                 call.respondText("handshake forbidden", status = HttpStatusCode.Forbidden)
             }
+            get("handshake-401") {
+                call.respond(HttpStatusCode.Unauthorized)
+            }
         }
     }
 }

--- a/ktor-test-server/src/main/kotlin/test/server/tests/WebSockets.kt
+++ b/ktor-test-server/src/main/kotlin/test/server/tests/WebSockets.kt
@@ -89,10 +89,6 @@ internal fun Application.webSockets() {
                 call.response.header("X-Handshake-Reason", "forbidden")
                 call.respondText("handshake forbidden", status = HttpStatusCode.Forbidden)
             }
-            get("handshake-401") {
-                call.response.header("X-Handshake-Reason", "unauthorized")
-                call.respond(HttpStatusCode.Unauthorized)
-            }
         }
     }
 }


### PR DESCRIPTION
**Subsystem**
Websocket Client

**Motivation**
This fixes [KTOR-9729](https://youtrack.jetbrains.com/issue/KTOR-9729/Expose-HTTP-status-response-body-on-failed-WebSocket-handshake), which I reported. The gist is that there's no way to read the response body from a rejected WebSocket connection. It's typical for servers to send information about why the request was rejected in the body.

**Solution**
- Added a nullable `response: HttpResponse?` property to `WebSocketException`, mirroring `SSEClientException`.
- On a failed handshake, the response-pipeline interceptor now `save()`s the call and attaches it to the exception.
  - The saved call is tagged with an internal attribute so that reading `exception.response.bodyAsText()` doesn't re-enter the interceptor and throw again.
- This solution works on CIO, with the status code and body being preserved.
  -  For OkHTTP and Java engines, it only works for 401 responses, and only returns the status code / headers with the body being lost.

