### PR TITLE
Fix Swagger test required fields ordering

### DIFF
--- a/ktor-server/ktor-server-plugins/ktor-server-swagger/jvm/test/io/ktor/server/plugins/swagger/SwaggerTest.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-swagger/jvm/test/io/ktor/server/plugins/swagger/SwaggerTest.kt
@@ -309,18 +309,27 @@ class SwaggerTest {
             val responseText = response.bodyAsText()
             assertContains(responseText, "Books API from routes")
             assertContains(
-                responseText,
-                """
-              required:
-              - author
-              - title
-                """.trimIndent().prependIndent("      ")
+                responseText.requiredFieldBlocks(),
+                setOf("author", "title"),
+                message = "Response should declare 'author' and 'title' as required fields, in any order"
             )
             for (description in descriptions) {
                 assertContains(responseText, description, message = "Response should contain '$description'")
             }
         }
     }
+}
+private fun String.requiredFieldBlocks(): List<Set<String>> {
+    val lines = lines()
+    return lines.indices
+        .filter { lines[it].trim() == "required:" }
+        .map { start ->
+            lines.asSequence()
+                .drop(start + 1)
+                .takeWhile { it.trim().startsWith("- ") }
+                .map { it.trim().removePrefix("- ") }
+                .toSet()
+        }
 }
 
 @Serializable


### PR DESCRIPTION
Fix test failing from Kotlin compiler updates changing property traversal order in serialization:
https://buildserver.labs.intellij.net/buildConfiguration/Kotlin_KotlinDev_KotlinxTrainKtorK2/1008677451

