### PR TITLE
Cherry-pick patch fixes to release/3.x

### DIFF
--- a/ktor-client/ktor-client-plugins/ktor-client-json/jvm/src/io/ktor/client/plugins/json/DefaultJvm.kt
+++ b/ktor-client/ktor-client-plugins/ktor-client-json/jvm/src/io/ktor/client/plugins/json/DefaultJvm.kt
@@ -9,7 +9,7 @@ import io.ktor.utils.io.*
 
 @Suppress("DEPRECATION_ERROR")
 public actual fun defaultSerializer(): JsonSerializer {
-    return serializers.maxByOrNull { it::javaClass.name } ?: error(
+    return serializers.maxByOrNull { it.javaClass.name } ?: error(
         """
         Failed to find serializer. Consider adding one of the following dependencies: 
          - ktor-client-gson

--- a/ktor-io/common/src/io/ktor/utils/io/core/Strings.kt
+++ b/ktor-io/common/src/io/ktor/utils/io/core/Strings.kt
@@ -14,7 +14,7 @@ import kotlin.jvm.JvmMultifileClass
 import kotlin.jvm.JvmName
 
 public fun String.toByteArray(charset: Charset = Charsets.UTF_8): ByteArray {
-    if (charset == Charsets.UTF_8) return encodeToByteArray(throwOnInvalidSequence = true)
+    if (charset == Charsets.UTF_8) return encodeToByteArray()
 
     return charset.newEncoder().encodeToByteArray(this, 0, length)
 }

--- a/ktor-io/common/test/StringsToByteArrayTest.kt
+++ b/ktor-io/common/test/StringsToByteArrayTest.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2014-2026 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+import io.ktor.utils.io.charsets.*
+import io.ktor.utils.io.core.*
+import kotlin.test.*
+
+class StringsToByteArrayTest {
+
+    @Test
+    fun `ascii text encodes to utf8`() {
+        val text = """{"id":42,"name":"Jordan","active":true}"""
+        val bytes = text.toByteArray(Charsets.UTF_8)
+        assertEquals(text.length, bytes.size)
+        assertEquals(text, bytes.decodeToString())
+    }
+
+    @Test
+    fun `multibyte and surrogate pair text round trips`() {
+        val text = "héllo wörld é东京 🚀 tail"
+        assertEquals(text, text.toByteArray(Charsets.UTF_8).decodeToString())
+    }
+
+    @Test
+    fun `surrogate pair at end of string round trips`() {
+        val text = "rocket 🚀"
+        assertEquals(text, text.toByteArray(Charsets.UTF_8).decodeToString())
+    }
+
+    @Test
+    fun `unpaired surrogate is replaced and does not throw`() {
+        // The replacement byte sequence is platform-specific ('?' on JVM via String.getBytes,
+        // U+FFFD elsewhere); the contract is that encoding never throws and the
+        // surrounding characters survive.
+        val decoded = "abc\ud800def".toByteArray(Charsets.UTF_8).decodeToString()
+        assertTrue(decoded.startsWith("abc"))
+        assertTrue(decoded.endsWith("def"))
+    }
+
+    @Test
+    fun `empty string encodes to empty array`() {
+        assertContentEquals(ByteArray(0), "".toByteArray(Charsets.UTF_8))
+    }
+}

--- a/ktor-io/jvm/test/StringsToByteArrayJvmTest.kt
+++ b/ktor-io/jvm/test/StringsToByteArrayJvmTest.kt
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2014-2026 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+import io.ktor.utils.io.charsets.*
+import io.ktor.utils.io.core.*
+import kotlin.test.*
+
+class StringsToByteArrayJvmTest {
+
+    @Test
+    fun `unpaired surrogates are replaced with question mark on jvm`() {
+        // Pins the String.getBytes replacement convention so a change in the
+        // underlying implementation is caught deliberately.
+        assertContentEquals(
+            "abc?def".toByteArray(Charsets.UTF_8),
+            "abc\ud800def".toByteArray(Charsets.UTF_8),
+        )
+        assertContentEquals(
+            "tail?".toByteArray(Charsets.UTF_8),
+            "tail\ude80".toByteArray(Charsets.UTF_8),
+        )
+    }
+}

--- a/ktor-network/common/src/io/ktor/network/sockets/SocketOptions.kt
+++ b/ktor-network/common/src/io/ktor/network/sockets/SocketOptions.kt
@@ -103,7 +103,7 @@ public sealed class SocketOptions(
     ) : SocketOptions(customOptions) {
 
         /**
-         * Socket ougoing buffer size (SO_SNDBUF), `-1` or `0` to make system decide
+         * Socket outgoing buffer size (SO_SNDBUF), `-1` or `0` to make system decide
          *
          * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.network.sockets.SocketOptions.PeerSocketOptions.sendBufferSize)
          */

--- a/ktor-network/ktor-network-tls/jvm/src/io/ktor/network/tls/TLS.kt
+++ b/ktor-network/ktor-network-tls/jvm/src/io/ktor/network/tls/TLS.kt
@@ -17,7 +17,7 @@ import kotlin.coroutines.*
  * in case of a shutdown during a TLS handshake). The context may also be used for cancellation.
  *
  * Note that the context passed here is rarely a child of the scope in which the method is called, because it is not
- * usually a decomposition of the parent task. If it is a child, errors may be propogated to the parent's coroutine
+ * usually a decomposition of the parent task. If it is a child, errors may be propagated to the parent's coroutine
  * exception handler rather than being caught and handled via a try-catch block.
  *
  * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.network.tls.tls)
@@ -46,7 +46,7 @@ public actual suspend fun Socket.tls(
  * in case of a shutdown during a TLS handshake). The context may also be used for cancellation.
  *
  * Note that the context passed here is rarely a child of the scope in which the method is called, because it is not
- * usually a decomposition of the parent task. If it is a child, errors may be propogated to the parent's coroutine
+ * usually a decomposition of the parent task. If it is a child, errors may be propagated to the parent's coroutine
  * exception handler rather than being caught and handled via a try-catch block.
  *
  * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.network.tls.tls)
@@ -71,7 +71,7 @@ public suspend fun Socket.tls(
  * in case of a shutdown during a TLS handshake). The context may also be used for cancellation.
  *
  * Note that the context passed here is rarely a child of the scope in which the method is called, because it is not
- * usually a decomposition of the parent task. If it is a child, errors may be propogated to the parent's coroutine
+ * usually a decomposition of the parent task. If it is a child, errors may be propagated to the parent's coroutine
  * exception handler rather than being caught and handled via a try-catch block.
  *
  * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.network.tls.tls)

--- a/ktor-network/ktor-network-tls/jvm/src/io/ktor/network/tls/TLSConfigBuilder.kt
+++ b/ktor-network/ktor-network-tls/jvm/src/io/ktor/network/tls/TLSConfigBuilder.kt
@@ -21,6 +21,9 @@ public actual class TLSConfigBuilder {
      *
      * The Chain will be used only if the first certificate in the chain is issued by server's certificate.
      *
+     * **Note:** ECDSA certificates are currently not supported for client authentication
+     * (only RSA and DSA are supported). See [KTOR-5391].
+     *
      * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.network.tls.TLSConfigBuilder.certificates)
      */
     public val certificates: MutableList<CertificateAndKey> = mutableListOf()
@@ -97,6 +100,9 @@ public actual fun TLSConfigBuilder.takeFrom(other: TLSConfigBuilder) {
  *
  * It will be used only if the first certificate in the chain is issued by server's certificate.
  *
+ * **Note:** ECDSA certificates are currently not supported for client authentication
+ * (only RSA and DSA are supported). See [KTOR-5391].
+ *
  * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.network.tls.addCertificateChain)
  */
 public fun TLSConfigBuilder.addCertificateChain(chain: Array<X509Certificate>, key: PrivateKey) {
@@ -106,6 +112,9 @@ public fun TLSConfigBuilder.addCertificateChain(chain: Array<X509Certificate>, k
 /**
  * Add client certificates from [store] by using the certificate with specific [alias]
  * or all certificates, if [alias] is null.
+ *
+ * **Note:** ECDSA certificates are currently not supported for client authentication
+ * (only RSA and DSA are supported). See [KTOR-5391].
  *
  * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.network.tls.addKeyStore)
  */

--- a/ktor-server/ktor-server-core/common/src/io/ktor/server/application/ApplicationPlugin.kt
+++ b/ktor-server/ktor-server-core/common/src/io/ktor/server/application/ApplicationPlugin.kt
@@ -238,7 +238,7 @@ public fun <P : RoutingNode, B : Any, F : Any> P.install(
  */
 @Deprecated(
     "This method is misleading and will be removed. " +
-        "If you have use case that requires this functionaity, please add it in KTOR-2696",
+        "If you have use case that requires this functionality, please add it in KTOR-2696",
     level = DeprecationLevel.ERROR
 )
 public fun <A : Pipeline<*, PipelineCall>> A.uninstallAllPlugins() {
@@ -256,7 +256,7 @@ public fun <A : Pipeline<*, PipelineCall>> A.uninstallAllPlugins() {
 @Suppress("DEPRECATION_ERROR")
 @Deprecated(
     "This method is misleading and will be removed. " +
-        "If you have use case that requires this functionaity, please add it in KTOR-2696",
+        "If you have use case that requires this functionality, please add it in KTOR-2696",
     level = DeprecationLevel.ERROR
 )
 public fun <A : Pipeline<*, PipelineCall>, B : Any, F : Any> A.uninstall(

--- a/ktor-server/ktor-server-core/jvm/src/io/ktor/server/engine/ClassLoaders.kt
+++ b/ktor-server/ktor-server-core/jvm/src/io/ktor/server/engine/ClassLoaders.kt
@@ -83,7 +83,7 @@ private fun Class<*>.findURLClassPathField(): Field? {
 }
 
 /**
- * This is auxillary classloader that is not used for loading classes. The purpose is just
+ * This is auxiliary classloader that is not used for loading classes. The purpose is just
  * to get access to [getPackages] function that is unfortunately protected.
  */
 private class ClassLoaderDelegate(delegate: ClassLoader) : ClassLoader(delegate) {


### PR DESCRIPTION
**Subsystem**
Client JSON, ktor-io, ktor-network-tls, Server Core

**Motivation**
Backport patch-compatible fixes from `main` to `release/3.x`.

**Solution**
Cherry-pick the following changes:

- Fix legacy JSON serializer ordering and future Kotlin compilation ([#5739](https://github.com/ktorio/ktor/pull/5739)).
- Document the ECDSA client-certificate limitation in `ktor-network-tls` ([#5234](https://github.com/ktorio/ktor/pull/5234)).
- Use the optimized UTF-8 encoding path ([#5743](https://github.com/ktorio/ktor/pull/5743)).
- Fix KDoc, comment, and deprecation-message typos ([#5759](https://github.com/ktorio/ktor/pull/5759)).

