### PR TITLE
KTOR-9741 Prevent CIO request handler leak

### DIFF
--- a/ktor-server/ktor-server-cio/common/src/io/ktor/server/cio/backend/ServerPipeline.kt
+++ b/ktor-server/ktor-server-cio/common/src/io/ktor/server/cio/backend/ServerPipeline.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2014-2026 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package io.ktor.server.cio.backend
@@ -16,11 +16,7 @@ import kotlinx.coroutines.*
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.channels.ReceiveChannel
-import kotlinx.io.Buffer
-import kotlinx.io.IOException
-import kotlinx.io.InternalIoApi
-import kotlinx.io.Source
-import kotlinx.io.readByteArray
+import kotlinx.io.*
 import kotlin.time.Duration
 
 private val LOGGER = KtorSimpleLogger("io.ktor.server.cio.backend.ServerPipeline")
@@ -46,19 +42,7 @@ public fun CoroutineScope.startServerConnectionPipeline(
     handler: HttpRequestHandler
 ): Job = launch(HttpPipelineCoroutine) {
     val actorChannel = Channel<ByteReadChannel>(capacity = 3)
-
-    launch(
-        context = HttpPipelineWriterCoroutine,
-        start = CoroutineStart.UNDISPATCHED
-    ) {
-        try {
-            pipelineWriterLoop(actorChannel, timeout, connection)
-        } catch (cause: Throwable) {
-            connection.output.close(cause)
-        } finally {
-            connection.output.close()
-        }
-    }
+    startServerPipelineWriter(actorChannel, timeout, connection)
 
     val requestContext = RequestHandlerCoroutine + Dispatchers.Unconfined
 
@@ -97,7 +81,8 @@ public fun CoroutineScope.startServerConnectionPipeline(
                 actorChannel.send(response)
             } catch (cause: Throwable) {
                 request.release()
-                throw cause
+                response.cancel(cause)
+                break // end pipeline loop
             }
 
             try {
@@ -192,6 +177,38 @@ public fun CoroutineScope.startServerConnectionPipeline(
         // the call coroutine with proper ConnectionClosedException cause.
         handlerScope?.onClose?.invoke()
         actorChannel.close()
+    }
+}
+
+@OptIn(InternalAPI::class)
+internal fun CoroutineScope.startServerPipelineWriter(
+    actorChannel: Channel<ByteReadChannel>,
+    timeout: Duration,
+    connection: ServerIncomingConnection
+): Job = launch(
+    context = HttpPipelineWriterCoroutine,
+    start = CoroutineStart.UNDISPATCHED
+) {
+    var failure: Throwable? = null
+    try {
+        pipelineWriterLoop(actorChannel, timeout, connection)
+    } catch (cause: Throwable) {
+        failure = cause
+    } finally {
+        actorChannel.close(failure)
+        connection.output.close(failure)
+        actorChannel.cancelPendingResponses(failure)
+    }
+}
+
+private fun Channel<ByteReadChannel>.cancelPendingResponses(cause: Throwable?) {
+    while (true) {
+        val response = tryReceive().getOrNull() ?: break
+        if (cause == null) {
+            response.cancel()
+        } else {
+            response.cancel(cause)
+        }
     }
 }
 

--- a/ktor-server/ktor-server-cio/jvm/test/io/ktor/tests/server/cio/ServerPipelineTest.kt
+++ b/ktor-server/ktor-server-cio/jvm/test/io/ktor/tests/server/cio/ServerPipelineTest.kt
@@ -9,18 +9,17 @@ import io.ktor.server.cio.backend.*
 import io.ktor.utils.io.*
 import io.ktor.utils.io.core.*
 import kotlinx.coroutines.*
+import kotlinx.coroutines.channels.Channel
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.TestInfo
 import java.util.concurrent.CountDownLatch
 import kotlin.coroutines.AbstractCoroutineContextElement
 import kotlin.coroutines.CoroutineContext
-import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertNotNull
-import kotlin.test.assertNull
+import kotlin.test.*
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
 
 @OptIn(InternalAPI::class)
 class ServerPipelineTest : CoroutineScope {
@@ -182,6 +181,91 @@ class ServerPipelineTest : CoroutineScope {
                 }
             }
         }
+    }
+
+    @Test
+    fun testRequestAfterIdleTimeoutIsNotHandled(): Unit = runBlocking(coroutineContext) {
+        val input = ByteChannel()
+        val output = ByteChannel()
+        val lateRequestHandled = CompletableDeferred<Unit>()
+
+        val pipelineJob = startServerConnectionPipeline(
+            ServerIncomingConnection(input, output, null, null),
+            timeout = 100.milliseconds
+        ) { request ->
+            val isFirstRequest = request.uri.toString() == "/first"
+            request.release()
+            if (isFirstRequest) {
+                this.output.writeStringUtf8("OK")
+            } else {
+                lateRequestHandled.complete(Unit)
+            }
+        }
+        val outputReader = launch { output.discard() }
+
+        input.writeStringUtf8("GET /first HTTP/1.1\r\nConnection: keep-alive\r\n\r\n")
+        input.flush()
+        withTimeout(1.seconds) { outputReader.join() }
+
+        input.writeStringUtf8("GET /second HTTP/1.1\r\nConnection: keep-alive\r\n\r\n")
+        input.flush()
+        input.close()
+
+        withTimeout(1.seconds) { pipelineJob.join() }
+        assertFalse(lateRequestHandled.isCompleted, "Request should not be handled after the idle timeout")
+        assertFalse(pipelineJob.isCancelled, "Pipeline job should complete gracefully")
+    }
+
+    @Test
+    fun testWriterTimeoutCancelsQueuedResponses(): Unit = runBlocking(coroutineContext) {
+        val responses = List(3) { ByteChannel() }
+        val actorChannel = Channel<ByteReadChannel>(3)
+        responses.forEach { assertTrue(actorChannel.trySend(it).isSuccess) }
+
+        startServerPipelineWriter(
+            actorChannel,
+            timeout = Duration.ZERO,
+            connection = ServerIncomingConnection(ByteChannel(), ByteChannel(), null, null)
+        ).join()
+
+        responses.forEach { assertTrue(it.isClosedForRead) }
+    }
+
+    @Test
+    fun testIdleTimeoutDoesNotCancelActiveRequest(): Unit = runBlocking(coroutineContext) {
+        val input = ByteChannel()
+        val output = ByteChannel()
+        val responseSent = CompletableDeferred<Unit>()
+        val finishRequest = CompletableDeferred<Unit>()
+        val requestJob = CompletableDeferred<Job>()
+
+        val pipelineJob = startServerConnectionPipeline(
+            ServerIncomingConnection(input, output, null, null),
+            timeout = 100.milliseconds
+        ) { request ->
+            request.release()
+            requestJob.complete(currentCoroutineContext().job)
+            this.output.writeStringUtf8("OK")
+            this.output.flushAndClose()
+            responseSent.complete(Unit)
+            finishRequest.await()
+        }
+        val outputReader = launch { output.discard() }
+
+        input.writeStringUtf8("GET / HTTP/1.1\r\nConnection: keep-alive\r\n\r\n")
+        input.flush()
+        responseSent.await()
+        withTimeout(1.seconds) { outputReader.join() }
+
+        input.writeStringUtf8("GET /late HTTP/1.1\r\nConnection: keep-alive\r\n\r\n")
+        input.flush()
+        input.close()
+
+        assertNull(withTimeoutOrNull(500.milliseconds) { requestJob.await().join() }, "Request should not be cancelled")
+        finishRequest.complete(Unit)
+        withTimeout(1.seconds) { requestJob.await().join() }
+        withTimeout(1.seconds) { pipelineJob.join() }
+        assertFalse(pipelineJob.isCancelled, "Pipeline job should complete gracefully")
     }
 
     @Test


### PR DESCRIPTION
**Subsystem**
Server, CIO

**Motivation**
Fix [KTOR-9741](https://youtrack.jetbrains.com/issue/KTOR-9741), where CIO can leak a request-handler coroutine when a client reuses a connection after the server's idle timeout. The response writer has already stopped, but the response queue can still accept a new response; a response exceeding the channel capacity then suspends forever without a reader.

**Solution**
When the pipeline writer exits, close the response queue before closing the connection output, then drain and cancel responses that won the race and were already queued. If enqueueing loses the race, release the request, cancel its unqueued response channel, and stop parsing gracefully without cancelling request handlers that are still performing work after sending their responses.

Add regression tests for rejecting requests after idle timeout, cancelling responses already queued when the writer times out, and preserving an active request handler during graceful pipeline shutdown.
