### PR TITLE
Make validators phase public

### DIFF
--- a/ktor-server/ktor-server-core/api/ktor-server-core.api
+++ b/ktor-server/ktor-server-core/api/ktor-server-core.api
@@ -36,6 +36,7 @@ public final class io/ktor/server/application/ApplicationCallPipeline$Applicatio
 	public final fun getMonitoring ()Lio/ktor/util/pipeline/PipelinePhase;
 	public final fun getPlugins ()Lio/ktor/util/pipeline/PipelinePhase;
 	public final fun getSetup ()Lio/ktor/util/pipeline/PipelinePhase;
+	public final fun getValidators ()Lio/ktor/util/pipeline/PipelinePhase;
 }
 
 public final class io/ktor/server/application/ApplicationCallPipelineKt {
@@ -198,6 +199,7 @@ public abstract class io/ktor/server/application/PluginBuilder {
 	public final fun onCallReceive (Lkotlin/jvm/functions/Function4;)V
 	public final fun onCallRespond (Lkotlin/jvm/functions/Function3;)V
 	public final fun onCallRespond (Lkotlin/jvm/functions/Function4;)V
+	public final fun onCallValidators (Lkotlin/jvm/functions/Function3;)V
 }
 
 public final class io/ktor/server/application/PluginInstance {

--- a/ktor-server/ktor-server-core/api/ktor-server-core.klib.api
+++ b/ktor-server/ktor-server-core/api/ktor-server-core.klib.api
@@ -306,6 +306,7 @@ abstract class <#A: kotlin/Any> io.ktor.server.application/PluginBuilder { // io
     final fun onCallReceive(kotlin.coroutines/SuspendFunction3<io.ktor.server.application/OnCallReceiveContext<#A>, io.ktor.server.application/PipelineCall, kotlin/Any, kotlin/Unit>) // io.ktor.server.application/PluginBuilder.onCallReceive|onCallReceive(kotlin.coroutines.SuspendFunction3<io.ktor.server.application.OnCallReceiveContext<1:0>,io.ktor.server.application.PipelineCall,kotlin.Any,kotlin.Unit>){}[0]
     final fun onCallRespond(kotlin.coroutines/SuspendFunction2<io.ktor.server.application/OnCallRespondContext<#A>, io.ktor.server.application/PipelineCall, kotlin/Unit>) // io.ktor.server.application/PluginBuilder.onCallRespond|onCallRespond(kotlin.coroutines.SuspendFunction2<io.ktor.server.application.OnCallRespondContext<1:0>,io.ktor.server.application.PipelineCall,kotlin.Unit>){}[0]
     final fun onCallRespond(kotlin.coroutines/SuspendFunction3<io.ktor.server.application/OnCallRespondContext<#A>, io.ktor.server.application/PipelineCall, kotlin/Any, kotlin/Unit>) // io.ktor.server.application/PluginBuilder.onCallRespond|onCallRespond(kotlin.coroutines.SuspendFunction3<io.ktor.server.application.OnCallRespondContext<1:0>,io.ktor.server.application.PipelineCall,kotlin.Any,kotlin.Unit>){}[0]
+    final fun onCallValidators(kotlin.coroutines/SuspendFunction2<io.ktor.server.application/OnCallContext<#A>, io.ktor.server.application/PipelineCall, kotlin/Unit>) // io.ktor.server.application/PluginBuilder.onCallValidators|onCallValidators(kotlin.coroutines.SuspendFunction2<io.ktor.server.application.OnCallContext<1:0>,io.ktor.server.application.PipelineCall,kotlin.Unit>){}[0]
 }
 
 abstract class <#A: kotlin/Any> io.ktor.server.application/RouteScopedPluginBuilder : io.ktor.server.application/PluginBuilder<#A> { // io.ktor.server.application/RouteScopedPluginBuilder|null[0]
@@ -1337,6 +1338,8 @@ open class io.ktor.server.application/ApplicationCallPipeline : io.ktor.util.pip
             final fun <get-Plugins>(): io.ktor.util.pipeline/PipelinePhase // io.ktor.server.application/ApplicationCallPipeline.ApplicationPhase.Plugins.<get-Plugins>|<get-Plugins>(){}[0]
         final val Setup // io.ktor.server.application/ApplicationCallPipeline.ApplicationPhase.Setup|{}Setup[0]
             final fun <get-Setup>(): io.ktor.util.pipeline/PipelinePhase // io.ktor.server.application/ApplicationCallPipeline.ApplicationPhase.Setup.<get-Setup>|<get-Setup>(){}[0]
+        final val Validators // io.ktor.server.application/ApplicationCallPipeline.ApplicationPhase.Validators|{}Validators[0]
+            final fun <get-Validators>(): io.ktor.util.pipeline/PipelinePhase // io.ktor.server.application/ApplicationCallPipeline.ApplicationPhase.Validators.<get-Validators>|<get-Validators>(){}[0]
     }
 }
 

--- a/ktor-server/ktor-server-core/common/src/io/ktor/server/application/ApplicationCallPipeline.kt
+++ b/ktor-server/ktor-server-core/common/src/io/ktor/server/application/ApplicationCallPipeline.kt
@@ -13,7 +13,6 @@ import io.ktor.util.pipeline.*
  *
  * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.server.application.ApplicationCallPipeline)
  */
-@Suppress("PublicApiImplicitType")
 public open class ApplicationCallPipeline public constructor(
     final override val developmentMode: Boolean = false,
     public val environment: ApplicationEnvironment
@@ -21,6 +20,7 @@ public open class ApplicationCallPipeline public constructor(
     Setup,
     Monitoring,
     Plugins,
+    Validators,
     Call,
     Fallback
 ) {
@@ -64,6 +64,15 @@ public open class ApplicationCallPipeline public constructor(
          * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.server.application.ApplicationCallPipeline.ApplicationPhase.Plugins)
          */
         public val Plugins: PipelinePhase = PipelinePhase("Plugins")
+
+        /**
+         * Phase for route-scoped guard plugins such as authentication, rate limiting, CORS, and request body limits.
+         * Interceptors registered in this phase on parent routes run before interceptors
+         * registered on child routes, so the relative order of validators follows route nesting.
+         *
+         * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.server.application.ApplicationCallPipeline.ApplicationPhase.Validators)
+         */
+        internal val Validators: PipelinePhase = PipelinePhase("Validators")
 
         /**
          * Phase for processing a call and sending a response

--- a/ktor-server/ktor-server-core/common/src/io/ktor/server/application/ApplicationCallPipeline.kt
+++ b/ktor-server/ktor-server-core/common/src/io/ktor/server/application/ApplicationCallPipeline.kt
@@ -72,7 +72,7 @@ public open class ApplicationCallPipeline public constructor(
          *
          * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.server.application.ApplicationCallPipeline.ApplicationPhase.Validators)
          */
-        internal val Validators: PipelinePhase = PipelinePhase("Validators")
+        public val Validators: PipelinePhase = PipelinePhase("Validators")
 
         /**
          * Phase for processing a call and sending a response

--- a/ktor-server/ktor-server-core/common/src/io/ktor/server/application/PluginBuilder.kt
+++ b/ktor-server/ktor-server-core/common/src/io/ktor/server/application/PluginBuilder.kt
@@ -105,6 +105,30 @@ public abstract class PluginBuilder<PluginConfig : Any> internal constructor(
     }
 
     /**
+     * Specifies the [block] handler for every incoming [PipelineCall] in the [ApplicationCallPipeline.Validators] phase.
+     *
+     * Use this for route-scoped validator plugins such as authentication, rate limiting, CORS, and request body limits.
+     * Interceptors registered in this phase on parent routes run before interceptors registered on child routes,
+     * so the relative order of validators follows route nesting.
+     *
+     * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.server.application.PluginBuilder.onCallValidators)
+     *
+     * @see [createRouteScopedPlugin]
+     *
+     * @param block An action that needs to be executed when your application receives an HTTP call.
+     */
+    internal fun onCallValidators(block: suspend OnCallContext<PluginConfig>.(call: PipelineCall) -> Unit) {
+        onDefaultPhase(
+            callInterceptions,
+            phase = ApplicationCallPipeline.Validators,
+            handlerName = PHASE_ON_CALL_VALIDATORS,
+            contextInit = ::OnCallContext
+        ) { call, _ ->
+            block(call)
+        }
+    }
+
+    /**
      * Specifies the [block] handler that allows you to obtain and transform data received from the client.
      * This [block] is invoked for every attempt to receive the request body.
      *

--- a/ktor-server/ktor-server-core/common/src/io/ktor/server/application/PluginBuilder.kt
+++ b/ktor-server/ktor-server-core/common/src/io/ktor/server/application/PluginBuilder.kt
@@ -20,7 +20,7 @@ import kotlin.random.*
  * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.server.application.PluginBuilder)
  **/
 @KtorDsl
-@Suppress("UNUSED_PARAMETER", "DEPRECATION")
+@Suppress("UNUSED_PARAMETER")
 public abstract class PluginBuilder<PluginConfig : Any> internal constructor(
     internal val key: AttributeKey<PluginInstance>
 ) {
@@ -117,7 +117,7 @@ public abstract class PluginBuilder<PluginConfig : Any> internal constructor(
      *
      * @param block An action that needs to be executed when your application receives an HTTP call.
      */
-    internal fun onCallValidators(block: suspend OnCallContext<PluginConfig>.(call: PipelineCall) -> Unit) {
+    public fun onCallValidators(block: suspend OnCallContext<PluginConfig>.(call: PipelineCall) -> Unit) {
         onDefaultPhase(
             callInterceptions,
             phase = ApplicationCallPipeline.Validators,

--- a/ktor-server/ktor-server-core/common/src/io/ktor/server/application/debug/DebugPhaseNames.kt
+++ b/ktor-server/ktor-server-core/common/src/io/ktor/server/application/debug/DebugPhaseNames.kt
@@ -5,5 +5,6 @@
 package io.ktor.server.application.debug
 
 internal const val PHASE_ON_CALL = "onCall"
+internal const val PHASE_ON_CALL_VALIDATORS = "onCallValidators"
 internal const val PHASE_ON_CALL_RECEIVE = "onCallReceive"
 internal const val PHASE_ON_CALL_RESPOND = "onCallRespond"

--- a/ktor-server/ktor-server-plugins/ktor-server-auth/common/src/io/ktor/server/auth/AuthenticationInterceptors.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-auth/common/src/io/ktor/server/auth/AuthenticationInterceptors.kt
@@ -19,14 +19,13 @@ import kotlinx.io.readByteArray
 internal val LOGGER = KtorSimpleLogger("io.ktor.server.auth.Authentication")
 
 internal object AuthenticationHook : Hook<suspend (ApplicationCall) -> Unit> {
-    internal val AuthenticatePhase: PipelinePhase = PipelinePhase("Authenticate")
 
     override fun install(
         pipeline: ApplicationCallPipeline,
         handler: suspend (ApplicationCall) -> Unit
     ) {
-        pipeline.insertPhaseAfter(ApplicationCallPipeline.Plugins, AuthenticatePhase)
-        pipeline.intercept(AuthenticatePhase) { handler(call) }
+        @Suppress("INVISIBLE_REFERENCE")
+        pipeline.intercept(ApplicationCallPipeline.Validators) { handler(call) }
     }
 }
 
@@ -44,8 +43,8 @@ public object AuthenticationChecked : Hook<suspend (ApplicationCall) -> Unit> {
         pipeline: ApplicationCallPipeline,
         handler: suspend (ApplicationCall) -> Unit
     ) {
-        pipeline.insertPhaseAfter(ApplicationCallPipeline.Plugins, AuthenticationHook.AuthenticatePhase)
-        pipeline.insertPhaseAfter(AuthenticationHook.AuthenticatePhase, AfterAuthenticationPhase)
+        @Suppress("INVISIBLE_REFERENCE")
+        pipeline.insertPhaseAfter(ApplicationCallPipeline.Validators, AfterAuthenticationPhase)
         pipeline.intercept(AfterAuthenticationPhase) { handler(call) }
     }
 }
@@ -80,7 +79,7 @@ public val AuthenticationInterceptors: RouteScopedPlugin<RouteAuthenticationConf
         if (call.attributes.contains(cacheOAuthFormReceiveKey) && call.receiveType == typeInfo<Parameters>()) {
             if (body is ByteReadChannel) {
                 try {
-                    val array = body.readRemaining().readByteArray()
+                    val array = body.readBuffer.readByteArray()
                     call.attributes.put(formCacheKey, array)
                     newBody = ByteReadChannel(array)
                 } finally {
@@ -276,6 +275,11 @@ public fun Route.authenticate(
 /**
  * Creates a route that allows you to define authorization scope for application resources.
  * This function accepts names of authentication providers defined in the [Authentication] plugin configuration.
+ *
+ * When combined with other route-scoped guard plugins such as [io.ktor.server.plugins.ratelimit.rateLimit],
+ * the relative execution order follows route nesting: interceptors on parent routes run before interceptors
+ * on child routes. To use a principal in a rate limit [io.ktor.server.plugins.ratelimit.RateLimitProviderConfig.requestKey],
+ * nest [rateLimit] inside [authenticate].
  *
  * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.server.auth.authenticate)
  *

--- a/ktor-server/ktor-server-plugins/ktor-server-auth/common/src/io/ktor/server/auth/AuthenticationInterceptors.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-auth/common/src/io/ktor/server/auth/AuthenticationInterceptors.kt
@@ -24,7 +24,6 @@ internal object AuthenticationHook : Hook<suspend (ApplicationCall) -> Unit> {
         pipeline: ApplicationCallPipeline,
         handler: suspend (ApplicationCall) -> Unit
     ) {
-        @Suppress("INVISIBLE_REFERENCE")
         pipeline.intercept(ApplicationCallPipeline.Validators) { handler(call) }
     }
 }

--- a/ktor-server/ktor-server-plugins/ktor-server-body-limit/common/src/io/ktor/server/plugins/bodylimit/RequestBodyLimit.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-body-limit/common/src/io/ktor/server/plugins/bodylimit/RequestBodyLimit.kt
@@ -35,6 +35,7 @@ public class RequestBodyLimitConfig {
  *
  * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.server.plugins.bodylimit.RequestBodyLimit)
  */
+@OptIn(InternalAPI::class)
 public val RequestBodyLimit: RouteScopedPlugin<RequestBodyLimitConfig> = createRouteScopedPlugin(
     "RequestBodyLimit",
     ::RequestBodyLimitConfig
@@ -42,7 +43,8 @@ public val RequestBodyLimit: RouteScopedPlugin<RequestBodyLimitConfig> = createR
 
     val bodyLimit = pluginConfig.bodyLimit
 
-    onCall { call ->
+    @Suppress("INVISIBLE_REFERENCE")
+    onCallValidators { call ->
         val limit = bodyLimit(call)
         val contentLength = call.request.contentLength()
         if (contentLength != null && contentLength > limit) {

--- a/ktor-server/ktor-server-plugins/ktor-server-body-limit/common/src/io/ktor/server/plugins/bodylimit/RequestBodyLimit.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-body-limit/common/src/io/ktor/server/plugins/bodylimit/RequestBodyLimit.kt
@@ -35,7 +35,6 @@ public class RequestBodyLimitConfig {
  *
  * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.server.plugins.bodylimit.RequestBodyLimit)
  */
-@OptIn(InternalAPI::class)
 public val RequestBodyLimit: RouteScopedPlugin<RequestBodyLimitConfig> = createRouteScopedPlugin(
     "RequestBodyLimit",
     ::RequestBodyLimitConfig
@@ -43,7 +42,6 @@ public val RequestBodyLimit: RouteScopedPlugin<RequestBodyLimitConfig> = createR
 
     val bodyLimit = pluginConfig.bodyLimit
 
-    @Suppress("INVISIBLE_REFERENCE")
     onCallValidators { call ->
         val limit = bodyLimit(call)
         val contentLength = call.request.contentLength()

--- a/ktor-server/ktor-server-plugins/ktor-server-cors/common/src/io/ktor/server/plugins/cors/CORS.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-cors/common/src/io/ktor/server/plugins/cors/CORS.kt
@@ -79,9 +79,10 @@ internal fun PluginBuilder<CORSConfig>.buildPlugin() {
      * A plugin's [call] interceptor that does all the job. Usually there is no need to install it as it is done during
      * a plugin installation.
      */
-    onCall { call ->
+    @Suppress("INVISIBLE_REFERENCE")
+    onCallValidators { call ->
         if (call.response.isCommitted) {
-            return@onCall
+            return@onCallValidators
         }
 
         LOGGER.trace { "${call.request.id()}: Start handler" }
@@ -94,7 +95,7 @@ internal fun PluginBuilder<CORSConfig>.buildPlugin() {
 
         if (origin == null) {
             LOGGER.trace { "${call.request.id()}: Skip CORS handler because request lacks the Origin header" }
-            return@onCall
+            return@onCallValidators
         }
 
         val checkOrigin = checkOrigin(
@@ -111,12 +112,12 @@ internal fun PluginBuilder<CORSConfig>.buildPlugin() {
             OriginCheckResult.OK -> {
             }
 
-            OriginCheckResult.SkipCORS -> return@onCall
+            OriginCheckResult.SkipCORS -> return@onCallValidators
 
             OriginCheckResult.Failed -> {
                 LOGGER.trace { "${call.request.id()}: CORS check fails because Origin $origin does not match" }
                 call.respondCorsFailed()
-                return@onCall
+                return@onCallValidators
             }
         }
 
@@ -129,7 +130,7 @@ internal fun PluginBuilder<CORSConfig>.buildPlugin() {
                             "is not in the list of the only allowed simple types ${CORSConfig.CorsSimpleContentTypes}"
                     }
                     call.respondCorsFailed()
-                    return@onCall
+                    return@onCallValidators
                 }
             }
         }
@@ -147,7 +148,7 @@ internal fun PluginBuilder<CORSConfig>.buildPlugin() {
                 headerPredicates,
                 allHeadersSet
             )
-            return@onCall
+            return@onCallValidators
         }
 
         if (!call.corsCheckCurrentMethod(methods)) {
@@ -156,7 +157,7 @@ internal fun PluginBuilder<CORSConfig>.buildPlugin() {
                     "is not allowed. Allowed methods: $methods"
             }
             call.respondCorsFailed()
-            return@onCall
+            return@onCallValidators
         }
 
         LOGGER.trace { "${call.request.id()}: CORS check is succeeded" }

--- a/ktor-server/ktor-server-plugins/ktor-server-cors/common/src/io/ktor/server/plugins/cors/CORS.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-cors/common/src/io/ktor/server/plugins/cors/CORS.kt
@@ -79,7 +79,6 @@ internal fun PluginBuilder<CORSConfig>.buildPlugin() {
      * A plugin's [call] interceptor that does all the job. Usually there is no need to install it as it is done during
      * a plugin installation.
      */
-    @Suppress("INVISIBLE_REFERENCE")
     onCallValidators { call ->
         if (call.response.isCommitted) {
             return@onCallValidators

--- a/ktor-server/ktor-server-plugins/ktor-server-cors/common/src/io/ktor/server/plugins/cors/routing/CORS.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-cors/common/src/io/ktor/server/plugins/cors/routing/CORS.kt
@@ -29,7 +29,7 @@ import io.ktor.server.routing.options
  */
 public val CORS: RouteScopedPlugin<CORSConfig> = createRouteScopedPlugin("CORS", ::CORSConfig) {
     route?.options("{cors-options-wildcard...}") {
-        // Handled by an interceptor of the Call phase added in the plugin
+        // Handled by an interceptor of the Validators phase added in the plugin
     }
 
     buildPlugin()

--- a/ktor-server/ktor-server-plugins/ktor-server-rate-limit/build.gradle.kts
+++ b/ktor-server/ktor-server-plugins/ktor-server-rate-limit/build.gradle.kts
@@ -7,3 +7,11 @@ description = "Rate Limit plugin for Ktor Server"
 plugins {
     id("ktorbuild.project.server-plugin")
 }
+
+kotlin {
+    sourceSets {
+        commonTest.dependencies {
+            implementation(projects.ktorServerAuth)
+        }
+    }
+}

--- a/ktor-server/ktor-server-plugins/ktor-server-rate-limit/common/src/io/ktor/server/plugins/ratelimit/RateLimitInterceptors.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-rate-limit/common/src/io/ktor/server/plugins/ratelimit/RateLimitInterceptors.kt
@@ -11,6 +11,14 @@ import io.ktor.server.response.*
 import io.ktor.util.collections.*
 import io.ktor.util.date.*
 import kotlinx.coroutines.*
+import kotlin.time.Duration.Companion.milliseconds
+
+private object ValidatorsPhase : Hook<suspend (ApplicationCall) -> Unit> {
+    override fun install(pipeline: ApplicationCallPipeline, handler: suspend (ApplicationCall) -> Unit) {
+        @Suppress("INVISIBLE_REFERENCE")
+        pipeline.intercept(ApplicationCallPipeline.Validators) { handler(call) }
+    }
+}
 
 private object PluginsPhase : Hook<suspend (ApplicationCall) -> Unit> {
     override fun install(pipeline: ApplicationCallPipeline, handler: suspend (ApplicationCall) -> Unit) {
@@ -21,15 +29,19 @@ private object PluginsPhase : Hook<suspend (ApplicationCall) -> Unit> {
 internal val RateLimitInterceptors = createRouteScopedPlugin(
     "RateLimitInterceptors",
     ::RateLimitInterceptorsConfig,
-    PluginBuilder<RateLimitInterceptorsConfig>::rateLimiterPluginBuilder
-)
+) {
+    rateLimiterPluginBuilder(ValidatorsPhase)
+}
 internal val RateLimitApplicationInterceptors = createApplicationPlugin(
     "RateLimitApplicationInterceptors",
     ::RateLimitInterceptorsConfig,
-    PluginBuilder<RateLimitInterceptorsConfig>::rateLimiterPluginBuilder
-)
+) {
+    rateLimiterPluginBuilder(PluginsPhase)
+}
 
-private fun PluginBuilder<RateLimitInterceptorsConfig>.rateLimiterPluginBuilder() {
+private fun PluginBuilder<RateLimitInterceptorsConfig>.rateLimiterPluginBuilder(
+    hook: Hook<suspend (ApplicationCall) -> Unit>,
+) {
     val configs = application.attributes.getOrNull(RateLimiterConfigsRegistryKey) ?: emptyMap()
     val providers = pluginConfig.providerNames.map { name ->
         configs[name] ?: throw IllegalStateException(
@@ -40,7 +52,7 @@ private fun PluginBuilder<RateLimitInterceptorsConfig>.rateLimiterPluginBuilder(
     val registry = application.attributes.computeIfAbsent(RateLimiterInstancesRegistryKey) { ConcurrentMap() }
     val clearOnRefillJobs = ConcurrentMap<ProviderKey, Job>()
 
-    on(PluginsPhase) { call ->
+    on(hook) { call ->
         providers.forEach { provider ->
             if (call.isHandled) return@on
 
@@ -70,7 +82,8 @@ private fun PluginBuilder<RateLimitInterceptorsConfig>.rateLimiterPluginBuilder(
                     if (rateLimiterForCall != RateLimiter.Unlimited) {
                         clearOnRefillJobs[providerKey]?.cancel()
                         clearOnRefillJobs[providerKey] = application.launch {
-                            delay(state.refillAtTimeMillis - getTimeMillis())
+                            val duration = state.refillAtTimeMillis - getTimeMillis()
+                            delay(duration.milliseconds)
                             registry.remove(providerKey, rateLimiterForCall)
                             clearOnRefillJobs.remove(providerKey)
                         }

--- a/ktor-server/ktor-server-plugins/ktor-server-rate-limit/common/src/io/ktor/server/plugins/ratelimit/RateLimitInterceptors.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-rate-limit/common/src/io/ktor/server/plugins/ratelimit/RateLimitInterceptors.kt
@@ -15,7 +15,6 @@ import kotlin.time.Duration.Companion.milliseconds
 
 private object ValidatorsPhase : Hook<suspend (ApplicationCall) -> Unit> {
     override fun install(pipeline: ApplicationCallPipeline, handler: suspend (ApplicationCall) -> Unit) {
-        @Suppress("INVISIBLE_REFERENCE")
         pipeline.intercept(ApplicationCallPipeline.Validators) { handler(call) }
     }
 }

--- a/ktor-server/ktor-server-plugins/ktor-server-rate-limit/common/src/io/ktor/server/plugins/ratelimit/Routing.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-rate-limit/common/src/io/ktor/server/plugins/ratelimit/Routing.kt
@@ -11,6 +11,11 @@ import io.ktor.util.*
  * Creates a route with Rate-Limit rules applied to it.
  * This function accepts name of RateLimit providers defined in the [RateLimit] plugin configuration.
  *
+ * When combined with other route-scoped guard plugins such as authentication,
+ * the relative execution order follows route nesting: interceptors on parent routes run before interceptors
+ * on child routes. To use a principal in [RateLimitProviderConfig.requestKey], nest [rateLimit] inside
+ * [io.ktor.server.auth.authenticate].
+ *
  * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.server.plugins.ratelimit.rateLimit)
  *
  * @see [RateLimit]

--- a/ktor-server/ktor-server-plugins/ktor-server-rate-limit/common/test/io/ktor/server/plugins/ratelimit/RateLimitIntegrationTest.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-rate-limit/common/test/io/ktor/server/plugins/ratelimit/RateLimitIntegrationTest.kt
@@ -5,12 +5,12 @@
 package io.ktor.server.plugins.ratelimit
 
 import io.ktor.client.request.*
+import io.ktor.client.statement.*
 import io.ktor.http.*
-import io.ktor.server.application.*
+import io.ktor.server.auth.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
 import io.ktor.server.testing.*
-import io.ktor.util.pipeline.*
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.time.Duration.Companion.seconds
@@ -18,16 +18,21 @@ import kotlin.time.Duration.Companion.seconds
 class RateLimitIntegrationTest {
 
     @Test
-    fun rateLimitRunsBeforeMockAuthWhenRateLimitWrapsAuthenticate() = testApplication {
+    fun `rate limit runs before authentication when rate limit wraps authenticate`() = testApplication {
         install(RateLimit) {
             register(RateLimitName("block-all")) {
                 rateLimiter(limit = 0, refillPeriod = 1.seconds)
             }
         }
+        install(Authentication) {
+            basic("auth") {
+                validate { UserIdPrincipal(it.name) }
+            }
+        }
 
         routing {
             rateLimit(RateLimitName("block-all")) {
-                mockAuthenticate {
+                authenticate("auth") {
                     post("/endpoint") {
                         call.respond(HttpStatusCode.OK)
                     }
@@ -39,15 +44,20 @@ class RateLimitIntegrationTest {
     }
 
     @Test
-    fun rateLimitRunsBeforeMockAuthWhenAuthenticateWrapsRateLimit() = testApplication {
+    fun `rate limit runs after authentication when authenticate wraps rate limit`() = testApplication {
         install(RateLimit) {
             register(RateLimitName("block-all")) {
                 rateLimiter(limit = 0, refillPeriod = 1.seconds)
             }
         }
+        install(Authentication) {
+            basic("auth") {
+                validate { UserIdPrincipal(it.name) }
+            }
+        }
 
         routing {
-            mockAuthenticate {
+            authenticate("auth") {
                 rateLimit(RateLimitName("block-all")) {
                     post("/endpoint") {
                         call.respond(HttpStatusCode.OK)
@@ -56,34 +66,66 @@ class RateLimitIntegrationTest {
             }
         }
 
-        assertEquals(HttpStatusCode.TooManyRequests, client.post("/endpoint").status)
+        assertEquals(HttpStatusCode.Unauthorized, client.post("/endpoint").status)
     }
-}
 
-private val MockAuthenticatePhase = PipelinePhase("Authenticate")
+    @Test
+    fun `rate limit uses principal when authenticate wraps rate limit`() = testApplication {
+        install(RateLimit) {
+            register(RateLimitName("MyRateLimit")) {
+                rateLimiter(limit = 10, refillPeriod = 1.seconds)
+                requestKey { call ->
+                    call.principal<UserIdPrincipal>()?.name ?: error("principal is not available")
+                }
+            }
+        }
+        install(Authentication) {
+            basic("auth") {
+                validate { UserIdPrincipal(it.name) }
+            }
+        }
 
-private object MockAuthenticationHook : Hook<suspend (ApplicationCall) -> Unit> {
-    override fun install(pipeline: ApplicationCallPipeline, handler: suspend (ApplicationCall) -> Unit) {
-        pipeline.insertPhaseAfter(ApplicationCallPipeline.Plugins, MockAuthenticatePhase)
-        pipeline.intercept(MockAuthenticatePhase) { handler(call) }
+        routing {
+            authenticate("auth") {
+                rateLimit(RateLimitName("MyRateLimit")) {
+                    post("/endpoint") {
+                        call.respondText(call.principal<UserIdPrincipal>()?.name ?: "unknown")
+                    }
+                }
+            }
+        }
+
+        val response = client.post("/endpoint") {
+            basicAuth("user", "password")
+        }
+        assertEquals(HttpStatusCode.OK, response.status)
+        assertEquals("user", response.bodyAsText())
     }
-}
 
-private val MockAuthenticationInterceptors = createRouteScopedPlugin("MockAuthenticationInterceptors") {
-    on(MockAuthenticationHook) { call ->
-        if (call.isHandled) return@on
-        call.respond(HttpStatusCode.Unauthorized)
+    @Test
+    fun `rate limit runs before auth when rate limit wraps authenticate`() = testApplication {
+        install(RateLimit) {
+            register(RateLimitName("block-all")) {
+                rateLimiter(limit = 0, refillPeriod = 1.seconds)
+            }
+        }
+        install(Authentication) {
+            basic("auth") {
+                validate { UserIdPrincipal(it.name) }
+            }
+        }
+
+        routing {
+            rateLimit(RateLimitName("block-all")) {
+                authenticate("auth") {
+                    post("/endpoint") {
+                        call.respondText(call.principal<UserIdPrincipal>()?.name ?: "unknown")
+                    }
+                }
+            }
+        }
+
+        val status = client.post("/endpoint") { basicAuth("user", "password") }.status
+        assertEquals(HttpStatusCode.TooManyRequests, status)
     }
-}
-
-private class MockAuthenticationRouteSelector : RouteSelector() {
-    override suspend fun evaluate(context: RoutingResolveContext, segmentIndex: Int): RouteSelectorEvaluation =
-        RouteSelectorEvaluation.Transparent
-}
-
-private fun Route.mockAuthenticate(build: Route.() -> Unit): Route {
-    val authenticatedRoute = createChild(MockAuthenticationRouteSelector())
-    authenticatedRoute.install(MockAuthenticationInterceptors)
-    authenticatedRoute.build()
-    return authenticatedRoute
 }


### PR DESCRIPTION
**Subsystem**
Server

**Motivation**
[KTOR-9716](https://youtrack.jetbrains.com/issue/KTOR-9716) Make ApplicationCallPipeline.ApplicationPhase.Validators public in 3.6.0

**Solution**
- cherry-pick the commit with the new internal phase from `release/3.x`
- make declarations public
