### PR TITLE
KTOR-9762 Disconnect Android connections on cancellation

### DIFF
--- a/ktor-client/ktor-client-android/jvm/src/io/ktor/client/engine/android/AndroidClientEngine.kt
+++ b/ktor-client/ktor-client-android/jvm/src/io/ktor/client/engine/android/AndroidClientEngine.kt
@@ -6,7 +6,7 @@ package io.ktor.client.engine.android
 
 import io.ktor.client.call.*
 import io.ktor.client.engine.*
-import io.ktor.client.io.configurePlatform
+import io.ktor.client.io.*
 import io.ktor.client.plugins.*
 import io.ktor.client.plugins.sse.*
 import io.ktor.client.request.*
@@ -49,6 +49,8 @@ public class AndroidClientEngine(override val config: AndroidEngineConfig) : Htt
             ?: outgoingContent.contentLength
 
         val connection: HttpURLConnection = getProxyAwareConnection(url).apply {
+            disconnectOnCancellation(callContext)
+
             connectTimeout = config.connectTimeout
             readTimeout = config.socketTimeout
 

--- a/ktor-client/ktor-client-android/jvm/src/io/ktor/client/engine/android/AndroidURLConnectionUtils.kt
+++ b/ktor-client/ktor-client-android/jvm/src/io/ktor/client/engine/android/AndroidURLConnectionUtils.kt
@@ -66,6 +66,13 @@ internal suspend fun <T> HttpURLConnection.timeoutAwareConnection(
     }
 }
 
+@OptIn(InternalCoroutinesApi::class)
+internal fun HttpURLConnection.disconnectOnCancellation(callContext: CoroutineContext) {
+    callContext.job.invokeOnCompletion(onCancelling = true) { cause ->
+        if (cause != null) disconnect()
+    }
+}
+
 /**
  * Establish connection and return correspondent [ByteReadChannel].
  */

--- a/ktor-client/ktor-client-android/jvm/test/io/ktor/client/engine/android/UrlConnectionUtilsTest.kt
+++ b/ktor-client/ktor-client-android/jvm/test/io/ktor/client/engine/android/UrlConnectionUtilsTest.kt
@@ -6,16 +6,23 @@ package io.ktor.client.engine.android
 
 import io.ktor.client.request.*
 import kotlinx.coroutines.*
-import java.net.*
-import kotlin.test.*
+import kotlinx.coroutines.test.runTest
+import java.net.ConnectException
+import java.net.HttpURLConnection
+import java.net.SocketTimeoutException
+import java.net.URL
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
 
 class UrlConnectionUtilsTest {
 
     private val data = HttpRequestBuilder().build()
 
     @Test
-    fun testTimeoutAwareConnectionCatchesErrorInConnect(): Unit = runBlocking {
-        val connection = TestConnection(true, false)
+    fun `timeout-aware connection catches error in connect`(): Unit = runTest {
+        val connection = TestConnection(throwInConnect = true)
         assertFailsWith<Throwable>("Connect timeout has expired") {
             connection.timeoutAwareConnection(data) {
                 it.connect()
@@ -24,20 +31,51 @@ class UrlConnectionUtilsTest {
     }
 
     @Test
-    fun testTimeoutAwareConnectionCatchesErrorInResponseStatusCode(): Unit = runBlocking {
-        val connection = TestConnection(false, true)
+    fun `timeout-aware connection catches error in response status code`(): Unit = runTest {
+        val connection = TestConnection(throwInResponseCode = true)
         assertFailsWith<Throwable>("Connect timeout has expired") {
             connection.timeoutAwareConnection(data) {
                 it.responseCode
             }
         }
     }
+
+    @Test
+    fun `disconnects immediately on cancellation`(): Unit = runTest {
+        val job = Job(coroutineContext.job)
+        val connection = TestConnection()
+        connection.disconnectOnCancellation(job)
+
+        // Keep the job cancelling while asserting that disconnect runs before child completion.
+        CoroutineScope(coroutineContext + job).launch(start = CoroutineStart.UNDISPATCHED) {
+            awaitCancellation()
+        }
+
+        job.cancel()
+
+        assertFalse(job.isCompleted)
+        assertEquals(1, connection.disconnectCount)
+    }
+
+    @Test
+    fun `does not disconnect on completion`() {
+        val job = Job()
+        val connection = TestConnection()
+        connection.disconnectOnCancellation(job)
+
+        job.complete()
+
+        assertEquals(0, connection.disconnectCount)
+    }
 }
 
 private class TestConnection(
-    private val throwInConnect: Boolean,
-    private val throwInResponseCode: Boolean,
+    private val throwInConnect: Boolean = false,
+    private val throwInResponseCode: Boolean = false,
 ) : HttpURLConnection(URL("https://example.com")) {
+
+    var disconnectCount: Int = 0
+        private set
 
     override fun getResponseCode(): Int {
         if (throwInResponseCode) throw ConnectException("Connect timed out")
@@ -49,7 +87,7 @@ private class TestConnection(
     }
 
     override fun disconnect() {
-        throw NotImplementedError()
+        disconnectCount++
     }
 
     override fun usingProxy(): Boolean {


### PR DESCRIPTION
**Subsystem**
Client, Android engine

**Motivation**
Fix [KTOR-9762](https://youtrack.jetbrains.com/issue/KTOR-9762), where cancelling a streaming response can wait for a blocking `HttpURLConnection` read to complete.

**Solution**
Disconnect the `HttpURLConnection` when the call context starts cancelling, before creating the response body channel. Normal completion does not disconnect the connection, preserving connection reuse.

Add focused tests for immediate disconnection during cancellation and no disconnection after normal completion.
