### PR TITLE
KTOR-9769 Introduce FormFieldLimitExceededException with headers and field name

### DIFF
--- a/ktor-http/api/ktor-http.api
+++ b/ktor-http/api/ktor-http.api
@@ -1477,6 +1477,13 @@ public final class io/ktor/http/content/EntityTagVersion$Companion {
 	public final fun parseSingle (Ljava/lang/String;)Lio/ktor/http/content/EntityTagVersion;
 }
 
+public final class io/ktor/http/content/FormFieldLimitExceededException : java/io/IOException {
+	public fun <init> (Lio/ktor/http/Headers;Ljava/lang/String;Ljava/lang/Throwable;)V
+	public synthetic fun <init> (Lio/ktor/http/Headers;Ljava/lang/String;Ljava/lang/Throwable;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getFieldName ()Ljava/lang/String;
+	public final fun getHeaders ()Lio/ktor/http/Headers;
+}
+
 public final class io/ktor/http/content/LastModifiedVersion : io/ktor/http/content/Version {
 	public fun <init> (Lio/ktor/util/date/GMTDate;)V
 	public fun appendHeadersTo (Lio/ktor/http/HeadersBuilder;)V

--- a/ktor-http/api/ktor-http.klib.api
+++ b/ktor-http/api/ktor-http.klib.api
@@ -370,6 +370,15 @@ final class io.ktor.http.content/EntityTagVersion : io.ktor.http.content/Version
     }
 }
 
+final class io.ktor.http.content/FormFieldLimitExceededException : kotlinx.io/IOException { // io.ktor.http.content/FormFieldLimitExceededException|null[0]
+    constructor <init>(io.ktor.http/Headers, kotlin/String = ..., kotlin/Throwable? = ...) // io.ktor.http.content/FormFieldLimitExceededException.<init>|<init>(io.ktor.http.Headers;kotlin.String;kotlin.Throwable?){}[0]
+
+    final val fieldName // io.ktor.http.content/FormFieldLimitExceededException.fieldName|{}fieldName[0]
+        final fun <get-fieldName>(): kotlin/String? // io.ktor.http.content/FormFieldLimitExceededException.fieldName.<get-fieldName>|<get-fieldName>(){}[0]
+    final val headers // io.ktor.http.content/FormFieldLimitExceededException.headers|{}headers[0]
+        final fun <get-headers>(): io.ktor.http/Headers // io.ktor.http.content/FormFieldLimitExceededException.headers.<get-headers>|<get-headers>(){}[0]
+}
+
 final class io.ktor.http.content/LastModifiedVersion : io.ktor.http.content/Version { // io.ktor.http.content/LastModifiedVersion|null[0]
     constructor <init>(io.ktor.util.date/GMTDate) // io.ktor.http.content/LastModifiedVersion.<init>|<init>(io.ktor.util.date.GMTDate){}[0]
 

--- a/ktor-http/common/src/io/ktor/http/content/FormFieldLimitExceededException.kt
+++ b/ktor-http/common/src/io/ktor/http/content/FormFieldLimitExceededException.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2014-2026 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.http.content
+
+import io.ktor.http.*
+import kotlinx.io.IOException
+
+/**
+ * Exception thrown when a multipart form field exceeds the specified limit.
+ *
+ * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.http.content.FormFieldLimitExceededException)
+ *
+ * @property headers The headers of the part that exceeded the limit.
+ */
+public class FormFieldLimitExceededException(
+    public val headers: Headers,
+    message: String = defaultFormFieldLimitMessage(headers),
+    cause: Throwable? = null
+) : IOException(message, cause) {
+
+    private companion object {
+        private fun defaultFormFieldLimitMessage(headers: Headers): String {
+            val name = headers[HttpHeaders.ContentDisposition]?.let {
+                runCatching { ContentDisposition.parse(it) }.getOrNull()
+            }?.name
+            return if (name != null) {
+                "Form field limit exceeded for field '$name'"
+            } else {
+                "Form field limit exceeded for part with headers: $headers"
+            }
+        }
+    }
+
+    /**
+     * The field name extracted from `Content-Disposition` header, if available.
+     */
+    public val fieldName: String? get() = headers[HttpHeaders.ContentDisposition]?.let {
+        runCatching { ContentDisposition.parse(it) }.getOrNull()
+    }?.name
+}

--- a/ktor-http/common/src/io/ktor/http/content/FormFieldLimitExceededException.kt
+++ b/ktor-http/common/src/io/ktor/http/content/FormFieldLimitExceededException.kt
@@ -12,7 +12,9 @@ import kotlinx.io.IOException
  *
  * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.http.content.FormFieldLimitExceededException)
  *
- * @property headers The headers of the part that exceeded the limit.
+ * @param headers The headers of the part that exceeded the limit.
+ * @param message The exception message.
+ * @param cause The I/O failure that caused this exception, if available.
  */
 public class FormFieldLimitExceededException(
     public val headers: Headers,

--- a/ktor-http/ktor-http-cio/common/src/io/ktor/http/cio/CIOMultipartDataBase.kt
+++ b/ktor-http/ktor-http-cio/common/src/io/ktor/http/cio/CIOMultipartDataBase.kt
@@ -96,10 +96,4 @@ public class CIOMultipartDataBase(
             part::releaseSuspend
         )
     }
-
-    private fun HttpHeadersMap.snapshot(): Headers = Headers.build {
-        for (offset in offsets()) {
-            append(nameAtOffset(offset).toString(), valueAtOffset(offset).toString())
-        }
-    }
 }

--- a/ktor-http/ktor-http-cio/common/src/io/ktor/http/cio/HttpHeadersMap.kt
+++ b/ktor-http/ktor-http-cio/common/src/io/ktor/http/cio/HttpHeadersMap.kt
@@ -4,6 +4,7 @@
 
 package io.ktor.http.cio
 
+import io.ktor.http.*
 import io.ktor.http.cio.internals.*
 import io.ktor.utils.io.pool.*
 import kotlin.math.absoluteValue
@@ -229,6 +230,12 @@ internal fun HttpHeadersMap.dumpTo(indent: String, out: Appendable) {
         out.append(" => ")
         out.append(valueAtOffset(offset))
         out.append("\n")
+    }
+}
+
+internal fun HttpHeadersMap.snapshot(): Headers = Headers.build {
+    for (offset in offsets()) {
+        append(nameAtOffset(offset).toString(), valueAtOffset(offset).toString())
     }
 }
 

--- a/ktor-http/ktor-http-cio/common/src/io/ktor/http/cio/Multipart.kt
+++ b/ktor-http/ktor-http-cio/common/src/io/ktor/http/cio/Multipart.kt
@@ -6,6 +6,7 @@ package io.ktor.http.cio
 
 import io.ktor.http.*
 import io.ktor.http.cio.internals.*
+import io.ktor.http.content.*
 import io.ktor.utils.io.*
 import io.ktor.utils.io.core.*
 import kotlinx.coroutines.CompletableDeferred
@@ -151,10 +152,15 @@ private suspend fun parsePartBodyImpl(
     headers: HttpHeadersMap,
     limit: Long,
 ): Long {
-    val byteCount = when (val contentLength = headers["Content-Length"]?.parseDecLong()) {
-        null -> input.readUntil(boundaryPrefixed, output, limit, ignoreMissing = true)
-        in 0L..limit -> input.copyTo(output, contentLength) + input.skipIfFoundReadCount(boundaryPrefixed)
-        else -> throwLimitExceeded(contentLength, limit)
+    val byteCount = try {
+        when (val contentLength = headers["Content-Length"]?.parseDecLong()) {
+            null -> input.readUntil(boundaryPrefixed, output, limit, ignoreMissing = true)
+            in 0L..limit -> input.copyTo(output, contentLength) + input.skipIfFoundReadCount(boundaryPrefixed)
+            else -> throwLimitExceeded(contentLength, limit)
+        }
+    } catch (cause: IOException) {
+        if (cause is FormFieldLimitExceededException) throw cause
+        throw FormFieldLimitExceededException(headers.snapshot(), cause = cause)
     }
     output.flush()
 

--- a/ktor-server/ktor-server-tests/common/test/io/ktor/tests/server/http/TestEngineMultipartTest.kt
+++ b/ktor-server/ktor-server-tests/common/test/io/ktor/tests/server/http/TestEngineMultipartTest.kt
@@ -184,6 +184,47 @@ class TestEngineMultipartTest {
         }
     }
 
+    @Test
+    fun testMultipartBiggerThanLimitThrowsFormFieldLimitExceededException() {
+        if (!PlatformUtils.IS_JVM) return
+
+        testApplication {
+            routing {
+                post {
+                    call.receiveMultipart(formFieldLimit = 10).readPart()
+                }
+            }
+
+            val exception = assertFailsWith<FormFieldLimitExceededException> {
+                client.post {
+                    setBody(
+                        MultiPartFormDataContent(
+                            formData {
+                                append("longField", "a".repeat(100))
+                            }
+                        )
+                    )
+                }
+            }
+
+            val contentDisposition = exception.headers[HttpHeaders.ContentDisposition]
+            assertNotNull(contentDisposition)
+            assertTrue(contentDisposition.contains("longField"))
+            assertEquals("longField", exception.fieldName)
+            assertEquals("Form field limit exceeded for field 'longField'", exception.message)
+        }
+    }
+
+    @Test
+    fun testFormFieldLimitExceededExceptionMessageFallback() {
+        val headers = Headers.build {
+            append(HttpHeaders.ContentType, "text/plain")
+        }
+        val exception = FormFieldLimitExceededException(headers)
+        assertNull(exception.fieldName)
+        assertEquals("Form field limit exceeded for part with headers: $headers", exception.message)
+    }
+
     private fun testMultiParts(
         asserts: suspend (MultiPartData?) -> Unit,
         setup: HttpRequestBuilder.() -> Unit


### PR DESCRIPTION
### Subsystem
Server, ktor-http-cio

### Motivation

Currently, when calling `call.receiveMultipart(formFieldLimit = ...)` and a form field exceeds the configured limit during stream parsing, Ktor throws a low-level, generic `kotlinx.io.IOException`.

#### Non-Informative Low-Level Error Messages:
When reading a multipart stream, `ByteChannelScanner` previously threw internal scanner errors like:
```text
IOException: Limit of 100 bytes exceeded while searching for "\r\n--boundary..."
```
This error message only reflects internal buffer scanning mechanics and provides zero context about which multipart part or form field caused the limit violation.

#### Practical Use-Cases:
1. **Targeted User Feedback**: Web applications processing multipart forms need to return informative API responses identifying the exact failing field (e.g., `"Form field limit exceeded for field 'photo'"`).
2. **Structured Observability & Logging**: When using Ktor's `StatusPages` plugin or application logging, developers require a strongly-typed exception exposing structured properties (`fieldName` and `headers`) rather than trying to parse uninformative low-level scanner strings.

### Solution
- **New Exception Class**: Introduced `FormFieldLimitExceededException` in `io.ktor.http.content` extending `kotlinx.io.IOException` for backward compatibility.
- **Structured Properties**:
    - `headers: Headers`: Exposes all HTTP headers of the part that exceeded the limit.
    - `fieldName: String?`: Helper property safely extracting the field name from the `Content-Disposition` header.
- **Informative Default Error Message**: Automatically formats the error message to specify the field name when present (`Form field limit exceeded for field '$name'`), falling back to full headers (`Form field limit exceeded for part with headers: $headers`) when unavailable.
- **CIO Parser Integration & Refactoring**:
    - Extracted `HttpHeadersMap.snapshot()` to `HttpHeadersMap.kt` as an internal extension, allowing it to be reused across both `CIOMultipartDataBase.kt` and `Multipart.kt`.
    - Updated M`ultipart.kt` to catch limit exceptions and throw `FormFieldLimitExceededException` populated with the part's Headers snapshot.