### PR TITLE
KTOR-9770 Preserve CIO exceptions during timeout mapping

### DIFF
--- a/ktor-client/ktor-client-cio/jvm/src/io/ktor/client/engine/cio/Exceptions.kt
+++ b/ktor-client/ktor-client-cio/jvm/src/io/ktor/client/engine/cio/Exceptions.kt
@@ -1,5 +1,5 @@
 /*
-* Copyright 2014-2021 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+* Copyright 2014-2026 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
 */
 
 package io.ktor.client.engine.cio
@@ -10,7 +10,7 @@ import io.ktor.util.*
 import io.ktor.utils.io.*
 
 @OptIn(InternalAPI::class)
-internal actual fun Throwable.mapToKtor(request: HttpRequestData): Throwable = when (cause?.rootCause) {
-    is java.net.SocketTimeoutException -> SocketTimeoutException(request, cause)
-    else -> cause
-} ?: this
+internal actual fun Throwable.mapToKtor(request: HttpRequestData): Throwable = when (rootCause) {
+    is java.net.SocketTimeoutException -> SocketTimeoutException(request, this)
+    else -> this
+}

--- a/ktor-client/ktor-client-cio/jvm/test/io/ktor/client/engine/cio/ConnectErrorsTest.kt
+++ b/ktor-client/ktor-client-cio/jvm/test/io/ktor/client/engine/cio/ConnectErrorsTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2014-2026 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package io.ktor.client.engine.cio
@@ -20,10 +20,12 @@ import io.ktor.server.routing.*
 import io.ktor.test.*
 import io.ktor.utils.io.*
 import org.junit.jupiter.api.assertThrows
+import java.io.EOFException
 import java.io.File
 import java.net.ConnectException
 import java.net.ServerSocket
 import java.net.SocketException
+import java.net.SocketTimeoutException
 import java.util.concurrent.TimeUnit
 import javax.net.ssl.TrustManagerFactory
 import javax.net.ssl.X509TrustManager
@@ -202,6 +204,21 @@ class ConnectErrorsTest {
                 thread.join()
             }
         }
+    }
+
+    @Test
+    fun testMapToKtorPreservesNonTimeoutException() {
+        val exception = ClosedReadChannelException(EOFException())
+
+        assertSame(exception, exception.mapToKtor(HttpRequestBuilder().build()))
+    }
+
+    @Test
+    fun testMapToKtorMapsSocketTimeoutException() {
+        val exception = ClosedReadChannelException(SocketTimeoutException())
+
+        val mappedException = assertIs<SocketTimeoutException>(exception.mapToKtor(HttpRequestBuilder().build()))
+        assertSame(exception, mappedException.cause)
     }
 
     @Test


### PR DESCRIPTION
**Subsystem**
Client, CIO JVM

**Motivation**
[KTOR-9770](https://youtrack.jetbrains.com/issue/KTOR-9770)

CIO's JVM exception mapper unintentionally unwraps non-timeout exceptions to their immediate cause. This can discard contextual exceptions and may explain the renewed sole-`EOFException` reports in [KTOR-8205](https://youtrack.jetbrains.com/issue/KTOR-8205).

**Solution**
Preserve the original throwable unless its root cause is a JVM socket timeout. For socket timeouts, retain the original throwable as the cause of the request-aware timeout exception.

Add focused tests for both mapping branches.
