### PR TITLE
KTOR-9775 Close request body sink after duplex streaming request to release the connection for OkHttp

### DIFF
--- a/ktor-client/ktor-client-okhttp/jvm/src/io/ktor/client/engine/okhttp/StreamRequestBody.kt
+++ b/ktor-client/ktor-client-okhttp/jvm/src/io/ktor/client/engine/okhttp/StreamRequestBody.kt
@@ -33,7 +33,7 @@ internal class StreamRequestBody(
                     sink.use {
                         try {
                             channel.copyTo(it.outputStream().asByteWriteChannel())
-                        } catch (cause: Throwable) {
+                        } catch (cause: CancellationException) {
                             // A failing flush() completes the request body, while close() alone would
                             // throw ProtocolException for a partially written fixed-length body
                             // without releasing the connection.

--- a/ktor-client/ktor-client-okhttp/jvm/src/io/ktor/client/engine/okhttp/StreamRequestBody.kt
+++ b/ktor-client/ktor-client-okhttp/jvm/src/io/ktor/client/engine/okhttp/StreamRequestBody.kt
@@ -31,7 +31,15 @@ internal class StreamRequestBody(
                 try {
                     val channel = block()
                     sink.use {
-                        channel.copyTo(it.outputStream().asByteWriteChannel())
+                        try {
+                            channel.copyTo(it.outputStream().asByteWriteChannel())
+                        } catch (cause: Throwable) {
+                            // A failing flush() completes the request body, while close() alone would
+                            // throw ProtocolException for a partially written fixed-length body
+                            // without releasing the connection.
+                            runCatching { it.flush() }
+                            throw cause
+                        }
                     }
                 } catch (cause: IOException) {
                     throw cause

--- a/ktor-client/ktor-client-okhttp/jvm/src/io/ktor/client/engine/okhttp/StreamRequestBody.kt
+++ b/ktor-client/ktor-client-okhttp/jvm/src/io/ktor/client/engine/okhttp/StreamRequestBody.kt
@@ -30,7 +30,9 @@ internal class StreamRequestBody(
             CoroutineScope(callContext).launch(Dispatchers.IO) {
                 try {
                     val channel = block()
-                    channel.copyTo(sink.outputStream().asByteWriteChannel())
+                    sink.use {
+                        channel.copyTo(it.outputStream().asByteWriteChannel())
+                    }
                 } catch (cause: IOException) {
                     throw cause
                 } catch (cause: Throwable) {

--- a/ktor-client/ktor-client-okhttp/jvm/test/io/ktor/client/engine/okhttp/OkHttpHttp2Test.kt
+++ b/ktor-client/ktor-client-okhttp/jvm/test/io/ktor/client/engine/okhttp/OkHttpHttp2Test.kt
@@ -11,11 +11,17 @@ import io.ktor.client.tests.*
 import io.ktor.http.content.*
 import io.ktor.utils.io.*
 import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.withTimeoutOrNull
+import okhttp3.ConnectionPool
 import okhttp3.Protocol
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
 import kotlin.test.fail
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
 
 class OkHttpHttp2Test : Http2Test<OkHttpConfig>(OkHttp) {
     override fun OkHttpConfig.enableHttp2() {
@@ -53,6 +59,45 @@ class OkHttpHttp2Test : Http2Test<OkHttpConfig>(OkHttp) {
                 """.trimIndent(),
                 response.trim()
             )
+        }
+    }
+
+    @Test
+    fun testDuplexStreamingConnectionReleasedAfterRequest() = testClient {
+        val connectionPool = ConnectionPool()
+        configureClient {
+            engine {
+                duplexStreamingEnabled = true
+                config { connectionPool(connectionPool) }
+            }
+        }
+
+        test { client ->
+            val inputChannel = ByteChannel(true)
+            client
+                .preparePost("/echo/stream") {
+                    setBody(inputChannel)
+                }
+                .execute {
+                    val outputChannel = it.bodyAsChannel()
+                    val buffer = StringBuilder()
+                    (0..2).forEach { i ->
+                        inputChannel.writeStringUtf8("client: $i\n")
+                        inputChannel.flush()
+                        outputChannel.readLineStrictTo(buffer)
+                        buffer.append('\n')
+                    }
+                    buffer.toString()
+                }
+
+            assertTrue(connectionPool.connectionCount() > 0, "Expected the request to use the injected pool")
+
+            val released = withTimeoutOrNull(5.seconds) {
+                while (connectionPool.idleConnectionCount() < connectionPool.connectionCount()) {
+                    delay(50.milliseconds)
+                }
+            } != null
+            assertTrue(released, "Connection should be released after request")
         }
     }
 

--- a/ktor-client/ktor-client-okhttp/jvm/test/io/ktor/client/engine/okhttp/OkHttpHttp2Test.kt
+++ b/ktor-client/ktor-client-okhttp/jvm/test/io/ktor/client/engine/okhttp/OkHttpHttp2Test.kt
@@ -11,15 +11,12 @@ import io.ktor.client.tests.*
 import io.ktor.http.content.*
 import io.ktor.utils.io.*
 import kotlinx.coroutines.CompletableDeferred
-import kotlinx.coroutines.delay
-import kotlinx.coroutines.withTimeoutOrNull
 import okhttp3.ConnectionPool
 import okhttp3.Protocol
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.fail
-import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 
 class OkHttpHttp2Test : Http2Test<OkHttpConfig>(OkHttp) {
@@ -79,25 +76,56 @@ class OkHttpHttp2Test : Http2Test<OkHttpConfig>(OkHttp) {
                 }
                 .execute {
                     val outputChannel = it.bodyAsChannel()
-                    val buffer = StringBuilder()
-                    (0..2).forEach { i ->
-                        inputChannel.writeStringUtf8("client: $i\n")
+                    repeat(3) { index ->
+                        inputChannel.writeStringUtf8("client: $index\n")
                         inputChannel.flush()
-                        outputChannel.readLineStrictTo(buffer)
-                        buffer.append('\n')
+                        assertEquals("server: client: $index", outputChannel.readLineStrict())
                     }
-                    buffer.toString()
                 }
 
-            assertEquals(connectionPool.connectionCount(), 1, "Expected the request to use the injected pool")
+            assertEquals(1, connectionPool.connectionCount(), "Expected the request to use the injected pool")
 
-            val idleConnections = withTimeoutOrNull(5.seconds) {
-                while (connectionPool.idleConnectionCount() < connectionPool.connectionCount()) {
-                    delay(50.milliseconds)
+            waitForCondition("connection to be released", timeout = 5.seconds) {
+                connectionPool.idleConnectionCount() == connectionPool.connectionCount()
+            }
+            assertEquals(1, connectionPool.idleConnectionCount(), "Connection should be released after request")
+        }
+    }
+
+    @Test
+    fun testDuplexStreamingFixedLengthConnectionReleasedAfterRequest() = testClient {
+        val connectionPool = ConnectionPool()
+        configureClient {
+            engine {
+                duplexStreamingEnabled = true
+                config { connectionPool(connectionPool) }
+            }
+        }
+
+        test { client ->
+            val inputChannel = ByteChannel(true)
+            val partialBody = object : OutgoingContent.ReadChannelContent() {
+                override val contentLength: Long = 1024
+                override fun readFrom(): ByteReadChannel = inputChannel
+            }
+
+            client
+                .preparePost("/echo/stream") {
+                    setBody(partialBody)
                 }
-                connectionPool.idleConnectionCount()
-            } ?: 0
-            assertEquals(idleConnections, 1, "Connection should be released after request")
+                .execute {
+                    val outputChannel = it.bodyAsChannel()
+                    inputChannel.writeStringUtf8("client: 0\n")
+                    inputChannel.flush()
+                    assertEquals("server: client: 0", outputChannel.readLineStrict())
+                }
+
+            assertEquals(1, connectionPool.connectionCount(), "Expected the request to use the injected pool")
+
+            waitForCondition("connection to be released", timeout = 5.seconds) {
+                connectionPool.idleConnectionCount() == connectionPool.connectionCount()
+            }
+            assertEquals(1, connectionPool.idleConnectionCount(), "Connection should be released after request")
         }
     }
 

--- a/ktor-client/ktor-client-okhttp/jvm/test/io/ktor/client/engine/okhttp/OkHttpHttp2Test.kt
+++ b/ktor-client/ktor-client-okhttp/jvm/test/io/ktor/client/engine/okhttp/OkHttpHttp2Test.kt
@@ -18,7 +18,6 @@ import okhttp3.Protocol
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
-import kotlin.test.assertTrue
 import kotlin.test.fail
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
@@ -90,14 +89,15 @@ class OkHttpHttp2Test : Http2Test<OkHttpConfig>(OkHttp) {
                     buffer.toString()
                 }
 
-            assertTrue(connectionPool.connectionCount() > 0, "Expected the request to use the injected pool")
+            assertEquals(connectionPool.connectionCount(), 1, "Expected the request to use the injected pool")
 
-            val released = withTimeoutOrNull(5.seconds) {
+            val idleConnections = withTimeoutOrNull(5.seconds) {
                 while (connectionPool.idleConnectionCount() < connectionPool.connectionCount()) {
                     delay(50.milliseconds)
                 }
-            } != null
-            assertTrue(released, "Connection should be released after request")
+                connectionPool.idleConnectionCount()
+            } ?: 0
+            assertEquals(idleConnections, 1, "Connection should be released after request")
         }
     }
 

--- a/ktor-client/ktor-client-test-base/common/src/io/ktor/client/test/base/WaitUtils.kt
+++ b/ktor-client/ktor-client-test-base/common/src/io/ktor/client/test/base/WaitUtils.kt
@@ -2,7 +2,7 @@
  * Copyright 2014-2025 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
-package io.ktor.client.tests.utils
+package io.ktor.client.test.base
 
 import kotlinx.coroutines.delay
 import kotlin.test.assertTrue

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -130,7 +130,7 @@ projects {
         +"ktor-client-test-base"
         +"ktor-client-tests"
 
-        +"ktor-client-webrtc" including {
+        /*+"ktor-client-webrtc" including {
             // Include `ktor-client-webrtc-rs` if rust compilation is enabled in `gradle.properties` for local builds
             // or if the `RUST_COMPILATION` environment variable is set to `true` for the CI.
             val compileRust = providers.environmentVariable("KTOR_RUST_COMPILATION")
@@ -139,7 +139,7 @@ projects {
             if (compileRust) {
                 +"ktor-client-webrtc-rs" // requires `cargo` to be installed
             }
-        }
+        }*/
 
         nested("ktor-client-plugins") {
             +"ktor-client-auth"

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -130,7 +130,7 @@ projects {
         +"ktor-client-test-base"
         +"ktor-client-tests"
 
-        /*+"ktor-client-webrtc" including {
+        +"ktor-client-webrtc" including {
             // Include `ktor-client-webrtc-rs` if rust compilation is enabled in `gradle.properties` for local builds
             // or if the `RUST_COMPILATION` environment variable is set to `true` for the CI.
             val compileRust = providers.environmentVariable("KTOR_RUST_COMPILATION")
@@ -139,7 +139,7 @@ projects {
             if (compileRust) {
                 +"ktor-client-webrtc-rs" // requires `cargo` to be installed
             }
-        }*/
+        }
 
         nested("ktor-client-plugins") {
             +"ktor-client-auth"


### PR DESCRIPTION
**Subsystem**
OkHttpClient

**Motivation**
When `duplexStreamingEnabled = true` in the OkHttp engine, the connection used by a duplex streaming request is never released back to the connection pool. The exchange never completes from OkHttp's perspective, so the connection never becomes idle, and the next request that reuses the pooled HTTP/2 connection hangs indefinitely.

**Solution**
Close the request body sink (`sink.use { ... }`) once the body has been fully written or the writer coroutine is cancelled. This  lets OkHttp complete the exchange and return the connection to the pool. `RequestBody.writeTo` has no defined semantics for closing the sink, but for duplex bodies OkHttp doesn't close it itself (in contrast to non-duplex requests), so closing it in `writeTo` seems the only mechanism available.

For reference `aws.smithy.kotlin.runtime.http.engine.okhttp.StreamingRequestBody` uses the same approach.

