### PR TITLE
Make quality parameter case-insensitive

### DIFF
--- a/ktor-http/common/src/io/ktor/http/HttpHeaderValueParser.kt
+++ b/ktor-http/common/src/io/ktor/http/HttpHeaderValueParser.kt
@@ -43,7 +43,7 @@ public data class HeaderValue(val value: String, val params: List<HeaderValuePar
      *
      * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.http.HeaderValue.quality)
      */
-    val quality: Double = params.firstOrNull { it.name == "q" }
+    val quality: Double = params.firstOrNull { it.name.equals("q", ignoreCase = true) }
         ?.value
         ?.toDoubleOrNull()
         ?.takeIf { it in 0.0..1.0 }

--- a/ktor-http/common/test/io/ktor/tests/http/CommonHeadersTest.kt
+++ b/ktor-http/common/test/io/ktor/tests/http/CommonHeadersTest.kt
@@ -32,6 +32,7 @@ class CommonHeadersTest {
         assertEquals(2, items.count())
         assertEquals("audio/basic", items[0].value)
         assertEquals("audio/*", items[1].value)
+        assertEquals(0.2, items[1].quality)
     }
 
     @Test

--- a/ktor-http/common/test/io/ktor/tests/http/CommonHeadersTest.kt
+++ b/ktor-http/common/test/io/ktor/tests/http/CommonHeadersTest.kt
@@ -27,6 +27,14 @@ class CommonHeadersTest {
     }
 
     @Test
+    fun parseQualityParameterCaseInsensitive() {
+        val items = parseAndSortContentTypeHeader("audio/*; Q=0.2, audio/basic")
+        assertEquals(2, items.count())
+        assertEquals("audio/basic", items[0].value)
+        assertEquals("audio/*", items[1].value)
+    }
+
+    @Test
     fun parseAcceptHeaderWithPreference() {
         val items = parseAndSortContentTypeHeader("text/plain; q=0.5, text/html,text/x-dvi; q=0.8, text/x-c")
         assertEquals(4, items.count())


### PR DESCRIPTION
**Subsystem**
Ktor-Http

**Motivation**
According to [RFC 9110, 12.4.2](https://datatracker.ietf.org/doc/html/rfc9110#section-12.4.2) the parameter "q" is case-insensitive.

**Solution**
Make equality check case-insensitive.

