### PR TITLE
KTOR-9819 Curl: Requests leak curl_slist and response StableRef

### DIFF
--- a/ktor-client/ktor-client-curl/desktop/src/io/ktor/client/engine/curl/internal/CurlMultiApiHandler.kt
+++ b/ktor-client/ktor-client-curl/desktop/src/io/ktor/client/engine/curl/internal/CurlMultiApiHandler.kt
@@ -21,10 +21,14 @@ import platform.posix.size_tVar
 @OptIn(ExperimentalForeignApi::class)
 private class RequestHolder(
     val responseCompletable: CompletableDeferred<CurlSuccess>,
+    val requestHeaders: CPointer<curl_slist>,
+    val responseDataRef: StableRef<CurlResponseBuilder>,
     val requestWrapper: StableRef<CurlRequestBodyData>,
     val responseWrapper: StableRef<CurlResponseBodyData>,
 ) {
     fun dispose() {
+        curl_slist_free_all(requestHeaders)
+        responseDataRef.dispose()
         requestWrapper.dispose()
         responseWrapper.dispose()
     }
@@ -82,6 +86,8 @@ internal class CurlMultiApiHandler : Closeable {
         val requestWrapper = setupUploadContent(easyHandle, request)
         val requestHolder = RequestHolder(
             deferred,
+            request.headers,
+            responseDataRef.asStableRef(),
             requestWrapper.asStableRef(),
             responseWrapper.asStableRef()
         )
@@ -317,8 +323,6 @@ internal class CurlMultiApiHandler : Closeable {
         httpStatusCode: Long,
         proxyCode: CURLproxycode,
     ): CurlFail? {
-        curl_slist_free_all(request.headers)
-
         if (message != CURLMSG.CURLMSG_DONE) {
             return CurlFail(
                 IllegalStateException("Request $request failed: $message")

--- a/ktor-client/ktor-client-curl/desktop/src/io/ktor/client/engine/curl/internal/CurlMultiApiHandler.kt
+++ b/ktor-client/ktor-client-curl/desktop/src/io/ktor/client/engine/curl/internal/CurlMultiApiHandler.kt
@@ -127,7 +127,22 @@ internal class CurlMultiApiHandler : Closeable {
             request.caInfo?.let { option(CURLOPT_CAINFO, it) }
         }
 
-        curl_multi_add_handle(multiHandle, easyHandle).verify()
+        try {
+            curl_multi_add_handle(multiHandle, easyHandle).verify()
+        } catch (cause: Throwable) {
+            activeHandles.remove(easyHandle)
+            try {
+                try {
+                    responseData.responseBody.close(cause)
+                } finally {
+                    responseData.headersBytes.close()
+                }
+            } finally {
+                curl_easy_cleanup(easyHandle)
+                requestHolder.dispose()
+            }
+            throw cause
+        }
 
         return easyHandle
     }

--- a/ktor-client/ktor-client-curl/desktop/src/io/ktor/client/engine/curl/internal/CurlMultiApiHandler.kt
+++ b/ktor-client/ktor-client-curl/desktop/src/io/ktor/client/engine/curl/internal/CurlMultiApiHandler.kt
@@ -58,7 +58,10 @@ internal class CurlMultiApiHandler : Closeable {
 
     fun scheduleRequest(request: CurlRequestData, deferred: CompletableDeferred<CurlSuccess>): EasyHandle {
         val easyHandle = curl_easy_init()
-            ?: error("Could not initialize an easy handle")
+            ?: run {
+                curl_slist_free_all(request.headers)
+                error("Could not initialize an easy handle")
+            }
 
         val bodyStartedReceiving = CompletableDeferred<Unit>()
         val responseBody = if (request.isUpgradeRequest) {
@@ -74,63 +77,65 @@ internal class CurlMultiApiHandler : Closeable {
             }
         }
         val responseData = CurlResponseBuilder(request, bodyStartedReceiving, responseBody)
-        val responseDataRef = responseData.asStablePointer()
-        val responseWrapper = responseBody.asStablePointer()
+        val responseDataRef = responseData.toStableRef()
+        val responseWrapper = responseBody.toStableRef()
+        val requestWrapper = CurlRequestBodyData(
+            body = request.content,
+            callContext = request.callContext,
+            onUnpause = { unpauseEasyHandle(easyHandle) },
+        ).toStableRef()
+        val requestHolder = RequestHolder(
+            deferred,
+            request.headers,
+            responseDataRef,
+            requestWrapper,
+            responseWrapper,
+        )
 
         bodyStartedReceiving.invokeOnCompletion {
             val result = collectSuccessResponse(easyHandle) ?: return@invokeOnCompletion
             activeHandles[easyHandle]!!.responseCompletable.complete(result)
         }
 
-        setupMethod(easyHandle, request.method, request.contentLength)
-        val requestWrapper = setupUploadContent(easyHandle, request)
-        val requestHolder = RequestHolder(
-            deferred,
-            request.headers,
-            responseDataRef.asStableRef(),
-            requestWrapper.asStableRef(),
-            responseWrapper.asStableRef()
-        )
-
-        activeHandles[easyHandle] = requestHolder
-
-        easyHandle.apply {
-            option(CURLOPT_URL, request.url)
-            option(CURLOPT_HTTPHEADER, request.headers)
-            option(CURLOPT_HEADERFUNCTION, staticCFunction(::onHeadersReceived))
-            option(CURLOPT_HEADERDATA, responseDataRef)
-            option(CURLOPT_WRITEFUNCTION, staticCFunction(::onBodyChunkReceived))
-            option(CURLOPT_WRITEDATA, responseWrapper)
-            option(CURLOPT_PRIVATE, responseDataRef)
-            option(CURLOPT_ACCEPT_ENCODING, "")
-            request.connectTimeout?.let {
-                if (it != HttpTimeoutConfig.INFINITE_TIMEOUT_MS) {
-                    option(CURLOPT_CONNECTTIMEOUT_MS, request.connectTimeout)
-                } else {
-                    option(CURLOPT_CONNECTTIMEOUT_MS, Long.MAX_VALUE)
-                }
-            }
-
-            request.proxy?.let { proxy ->
-                option(CURLOPT_PROXY, fixProxyUrl(proxy.toString(), proxy.type))
-                option(CURLOPT_SUPPRESS_CONNECT_HEADERS, 1L)
-                if (request.forceProxyTunneling) {
-                    option(CURLOPT_HTTPPROXYTUNNEL, 1L)
-                }
-            }
-
-            if (!request.sslVerify) {
-                option(CURLOPT_SSL_VERIFYPEER, 0L)
-                option(CURLOPT_SSL_VERIFYHOST, 0L)
-            }
-            request.caPath?.let { option(CURLOPT_CAPATH, it) }
-            request.caInfo?.let { option(CURLOPT_CAINFO, it) }
-        }
-
         try {
+            setupMethod(easyHandle, request.method, request.contentLength)
+            setupUploadContent(easyHandle, requestWrapper.asCPointer())
+
+            easyHandle.apply {
+                option(CURLOPT_URL, request.url)
+                option(CURLOPT_HTTPHEADER, request.headers)
+                option(CURLOPT_HEADERFUNCTION, staticCFunction(::onHeadersReceived))
+                option(CURLOPT_HEADERDATA, responseDataRef.asCPointer())
+                option(CURLOPT_WRITEFUNCTION, staticCFunction(::onBodyChunkReceived))
+                option(CURLOPT_WRITEDATA, responseWrapper.asCPointer())
+                option(CURLOPT_PRIVATE, responseDataRef.asCPointer())
+                option(CURLOPT_ACCEPT_ENCODING, "")
+                request.connectTimeout?.let {
+                    if (it != HttpTimeoutConfig.INFINITE_TIMEOUT_MS) {
+                        option(CURLOPT_CONNECTTIMEOUT_MS, request.connectTimeout)
+                    } else {
+                        option(CURLOPT_CONNECTTIMEOUT_MS, Long.MAX_VALUE)
+                    }
+                }
+
+                request.proxy?.let { proxy ->
+                    option(CURLOPT_PROXY, fixProxyUrl(proxy.toString(), proxy.type))
+                    option(CURLOPT_SUPPRESS_CONNECT_HEADERS, 1L)
+                    if (request.forceProxyTunneling) {
+                        option(CURLOPT_HTTPPROXYTUNNEL, 1L)
+                    }
+                }
+
+                if (!request.sslVerify) {
+                    option(CURLOPT_SSL_VERIFYPEER, 0L)
+                    option(CURLOPT_SSL_VERIFYHOST, 0L)
+                }
+                request.caPath?.let { option(CURLOPT_CAPATH, it) }
+                request.caInfo?.let { option(CURLOPT_CAINFO, it) }
+            }
+
             curl_multi_add_handle(multiHandle, easyHandle).verify()
         } catch (cause: Throwable) {
-            activeHandles.remove(easyHandle)
             try {
                 try {
                     responseData.responseBody.close(cause)
@@ -144,6 +149,7 @@ internal class CurlMultiApiHandler : Closeable {
             throw cause
         }
 
+        activeHandles[easyHandle] = requestHolder
         return easyHandle
     }
 
@@ -222,20 +228,11 @@ internal class CurlMultiApiHandler : Closeable {
         }
     }
 
-    private fun setupUploadContent(easyHandle: EasyHandle, request: CurlRequestData): COpaquePointer {
-        val requestPointer = CurlRequestBodyData(
-            body = request.content,
-            callContext = request.callContext,
-            onUnpause = {
-                unpauseEasyHandle(easyHandle)
-            }
-        ).asStablePointer()
-
+    private fun setupUploadContent(easyHandle: EasyHandle, requestPointer: COpaquePointer) {
         easyHandle.apply {
             option(CURLOPT_READDATA, requestPointer)
             option(CURLOPT_READFUNCTION, staticCFunction(::onBodyChunkRequested))
         }
-        return requestPointer
     }
 
     private fun handleCompleted() {

--- a/ktor-client/ktor-client-curl/desktop/src/io/ktor/client/engine/curl/internal/NativeUtils.kt
+++ b/ktor-client/ktor-client-curl/desktop/src/io/ktor/client/engine/curl/internal/NativeUtils.kt
@@ -10,7 +10,10 @@ import kotlinx.cinterop.StableRef
 import kotlinx.cinterop.asStableRef
 
 @OptIn(ExperimentalForeignApi::class)
-internal inline fun <T : Any> T.asStablePointer(): COpaquePointer = StableRef.create(this).asCPointer()
+internal inline fun <T : Any> T.toStableRef(): StableRef<T> = StableRef.create(this)
+
+@OptIn(ExperimentalForeignApi::class)
+internal inline fun <T : Any> T.asStablePointer(): COpaquePointer = toStableRef().asCPointer()
 
 @OptIn(ExperimentalForeignApi::class)
 internal inline fun <reified T : Any> COpaquePointer.fromCPointer(): T = asStableRef<T>().get()

--- a/ktor-client/ktor-client-curl/desktop/test/io/ktor/client/engine/curl/internal/CurlMultiApiHandlerTest.kt
+++ b/ktor-client/ktor-client-curl/desktop/test/io/ktor/client/engine/curl/internal/CurlMultiApiHandlerTest.kt
@@ -20,11 +20,11 @@ import kotlin.native.runtime.GC
 import kotlin.native.runtime.NativeRuntimeApi
 import kotlin.test.Test
 import kotlin.test.assertNull
-import kotlin.test.assertTrue
+import kotlin.test.assertSame
 
-@OptIn(ExperimentalForeignApi::class, ExperimentalNativeApi::class, NativeRuntimeApi::class)
-class CurlMultiApiHandlerTest {
+internal class CurlMultiApiHandlerTest {
 
+    @OptIn(ExperimentalNativeApi::class, NativeRuntimeApi::class)
     @Test
     fun `cancelling a request releases its stable response data`() {
         val handler = CurlMultiApiHandler()
@@ -42,6 +42,7 @@ class CurlMultiApiHandlerTest {
         }
     }
 
+    @OptIn(ExperimentalForeignApi::class, ExperimentalNativeApi::class)
     private fun scheduleAndCancel(handler: CurlMultiApiHandler): WeakReference<CurlRequestData> {
         val request = CurlRequestData(
             protocol = "http",
@@ -63,13 +64,16 @@ class CurlMultiApiHandlerTest {
         val requestReference = WeakReference(request)
         val response = CompletableDeferred<CurlSuccess>()
         val easyHandle = handler.scheduleRequest(request, response)
+        val cancellationCause = CancellationException("Test cancellation")
+        var completionCause: Throwable? = null
+        response.invokeOnCompletion { completionCause = it }
 
-        handler.cancelRequest(easyHandle, CancellationException("Test cancellation"))
+        handler.cancelRequest(easyHandle, cancellationCause)
         memScoped {
             handler.perform(alloc<IntVar>())
         }
 
-        assertTrue(response.isCompleted)
+        assertSame(cancellationCause, completionCause)
         return requestReference
     }
 }

--- a/ktor-client/ktor-client-curl/desktop/test/io/ktor/client/engine/curl/internal/CurlMultiApiHandlerTest.kt
+++ b/ktor-client/ktor-client-curl/desktop/test/io/ktor/client/engine/curl/internal/CurlMultiApiHandlerTest.kt
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2014-2026 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.client.engine.curl.internal
+
+import io.ktor.util.Attributes
+import io.ktor.utils.io.ByteReadChannel
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.IntVar
+import kotlinx.cinterop.alloc
+import kotlinx.cinterop.memScoped
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Job
+import libcurl.curl_slist_append
+import kotlin.coroutines.cancellation.CancellationException
+import kotlin.experimental.ExperimentalNativeApi
+import kotlin.native.ref.WeakReference
+import kotlin.native.runtime.GC
+import kotlin.native.runtime.NativeRuntimeApi
+import kotlin.test.Test
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalForeignApi::class, ExperimentalNativeApi::class, NativeRuntimeApi::class)
+class CurlMultiApiHandlerTest {
+
+    @Test
+    fun `cancelling a request releases its stable response data`() {
+        val handler = CurlMultiApiHandler()
+        try {
+            val requestReference = scheduleAndCancel(handler)
+
+            repeat(10) {
+                GC.collect()
+                if (requestReference.get() == null) return
+            }
+
+            assertNull(requestReference.get())
+        } finally {
+            handler.close()
+        }
+    }
+
+    private fun scheduleAndCancel(handler: CurlMultiApiHandler): WeakReference<CurlRequestData> {
+        val request = CurlRequestData(
+            protocol = "http",
+            url = "http://127.0.0.1:1/",
+            method = "GET",
+            headers = checkNotNull(curl_slist_append(null, "Expect:")),
+            proxy = null,
+            content = ByteReadChannel.Empty,
+            contentLength = 0,
+            connectTimeout = null,
+            callContext = Job(),
+            isUpgradeRequest = false,
+            forceProxyTunneling = false,
+            sslVerify = true,
+            caInfo = null,
+            caPath = null,
+            attributes = Attributes(),
+        )
+        val requestReference = WeakReference(request)
+        val response = CompletableDeferred<CurlSuccess>()
+        val easyHandle = handler.scheduleRequest(request, response)
+
+        handler.cancelRequest(easyHandle, CancellationException("Test cancellation"))
+        memScoped {
+            handler.perform(alloc<IntVar>())
+        }
+
+        assertTrue(response.isCompleted)
+        return requestReference
+    }
+}


### PR DESCRIPTION
**Subsystem**

Client Engine/Curl

**Motivation**

I found that the Curl engine causes memory leak.
[KTOR-9819](https://youtrack.jetbrains.com/issue/KTOR-9819) Curl: Requests leak curl_slist and response StableRef

**Solution**

- Free each request's `curl_slist` correctly.
- Dispose the response `StableRef` correctly.
- Add test for this behavior.