### PR TITLE
KTOR-7009 Keep CIO pipeline connection open

### DIFF
--- a/ktor-client/ktor-client-cio/common/src/io/ktor/client/engine/cio/utils.kt
+++ b/ktor-client/ktor-client-cio/common/src/io/ktor/client/engine/cio/utils.kt
@@ -6,7 +6,7 @@ package io.ktor.client.engine.cio
 
 import io.ktor.client.call.*
 import io.ktor.client.engine.*
-import io.ktor.client.plugins.websocket.WEBSOCKETS_KEY
+import io.ktor.client.plugins.websocket.*
 import io.ktor.client.request.*
 import io.ktor.client.utils.*
 import io.ktor.http.*
@@ -28,8 +28,8 @@ internal suspend fun writeRequest(
     overProxy: Boolean,
     closeChannel: Boolean = true
 ) = withContext(callContext) {
-    writeHeaders(request, output, overProxy, closeChannel)
-    writeBody(request, output, callContext)
+    writeHeaders(request, output, overProxy = overProxy, closeChannelOnError = closeChannel)
+    writeBody(request, output, callContext, closeChannel)
 }
 
 @OptIn(InternalAPI::class)
@@ -37,7 +37,7 @@ internal suspend fun writeHeaders(
     request: HttpRequestData,
     output: ByteWriteChannel,
     overProxy: Boolean,
-    closeChannel: Boolean = true
+    closeChannelOnError: Boolean = true
 ) {
     val builder = RequestResponseBuilder()
 
@@ -93,7 +93,7 @@ internal suspend fun writeHeaders(
         output.writePacket(builder.build())
         output.flush()
     } catch (cause: Throwable) {
-        if (closeChannel) {
+        if (closeChannelOnError) {
             output.flushAndClose()
         }
         throw cause
@@ -102,8 +102,8 @@ internal suspend fun writeHeaders(
     }
 }
 
-@Suppress("TYPEALIAS_EXPANSION_DEPRECATION", "DEPRECATION")
-internal suspend fun writeBody(
+@Suppress("DEPRECATION")
+internal fun writeBody(
     request: HttpRequestData,
     output: ByteWriteChannel,
     callContext: CoroutineContext,

--- a/ktor-client/ktor-client-cio/jvm/test/io/ktor/client/engine/cio/CIORequestTest.kt
+++ b/ktor-client/ktor-client-cio/jvm/test/io/ktor/client/engine/cio/CIORequestTest.kt
@@ -19,15 +19,19 @@ import io.ktor.server.response.*
 import io.ktor.server.routing.*
 import io.mockk.mockkStatic
 import io.mockk.verify
+import kotlinx.coroutines.*
 import kotlinx.coroutines.debug.junit5.CoroutinesTimeout
-import kotlinx.coroutines.delay
 import java.net.InetAddress
 import java.nio.channels.UnresolvedAddressException
 import kotlin.test.*
+import kotlin.time.Duration.Companion.seconds
 
 @CoroutinesTimeout(60_000)
 class CIORequestTest : TestWithKtor() {
     private val testSize = 2 * 1024
+
+    private val firstPipelineRequestReceived = CompletableDeferred<Unit>()
+    private val secondPipelineRequestReceived = CompletableDeferred<Unit>()
 
     override val server: EmbeddedServer<*, *> = embeddedServer(Netty, serverPort) {
         routing {
@@ -48,9 +52,43 @@ class CIORequestTest : TestWithKtor() {
                 call.respond("OK")
             }
             get("/delay") {
-                delay(1000)
+                delay(1.seconds)
                 call.respond("OK")
             }
+            get("/pipeline") {
+                when (call.parameters["request"]) {
+                    "first" -> {
+                        firstPipelineRequestReceived.complete(Unit)
+                        secondPipelineRequestReceived.await()
+                    }
+
+                    "second" -> secondPipelineRequestReceived.complete(Unit)
+                }
+                call.respond("OK")
+            }
+        }
+    }
+
+    @Test
+    fun testTwoPipelinedRequests() = testWithEngine(CIO) {
+        config {
+            defaultRequest { port = serverPort }
+            engine {
+                pipelining = true
+                endpoint {
+                    maxConnectionsPerRoute = 1
+                }
+            }
+        }
+
+        test { client ->
+            val responses = coroutineScope {
+                val firstRequest = async { client.get("/pipeline?request=first").bodyAsText() }
+                firstPipelineRequestReceived.await()
+                val secondRequest = async { client.get("/pipeline?request=second").bodyAsText() }
+                awaitAll(firstRequest, secondRequest)
+            }
+            assertEquals(listOf("OK", "OK"), responses)
         }
     }
 


### PR DESCRIPTION
**Subsystem**
CIO client engine

**Motivation**
[KTOR-7009](https://youtrack.jetbrains.com/issue/KTOR-7009) With HTTP pipelining enabled, CIO closes the connection output after writing a request and can fail to parse the response with an unexpected EOF.

**Solution**
Propagate the pipeline's `closeChannel` setting when writing the request body so the connection remains open for subsequent requests. Add a regression test that sends two requests through the same pipeline before receiving the first response.
