### PR TITLE
KTOR-9774 Serialize CIO pipelined request bodies

### DIFF
--- a/ktor-client/ktor-client-cio/common/src/io/ktor/client/engine/cio/utils.kt
+++ b/ktor-client/ktor-client-cio/common/src/io/ktor/client/engine/cio/utils.kt
@@ -27,7 +27,7 @@ internal suspend fun writeRequest(
     callContext: CoroutineContext,
     overProxy: Boolean,
     closeChannel: Boolean = true
-) = withContext(callContext) {
+): Job? = withContext(callContext) {
     writeHeaders(request, output, overProxy = overProxy, closeChannelOnError = closeChannel)
     writeBody(request, output, callContext, closeChannel)
 }
@@ -108,11 +108,11 @@ internal fun writeBody(
     output: ByteWriteChannel,
     callContext: CoroutineContext,
     closeChannel: Boolean = true
-) {
+): Job? {
     val body = request.body.getUnwrapped()
     if (body is OutgoingContent.NoContent) {
         if (closeChannel) output.close()
-        return
+        return null
     }
     if (body is OutgoingContent.ProtocolUpgrade) {
         throw UnsupportedContentTypeException(body)
@@ -127,7 +127,7 @@ internal fun writeBody(
     val channel = chunkedJob?.channel ?: output
 
     val scope = CoroutineScope(callContext + CoroutineName("cio-client-body-writer"))
-    scope.launch {
+    return scope.launch {
         try {
             processOutgoingContent(request, body, channel)
         } catch (cause: Throwable) {

--- a/ktor-client/ktor-client-cio/jvm/src/io/ktor/client/engine/cio/ConnectionPipeline.kt
+++ b/ktor-client/ktor-client-cio/jvm/src/io/ktor/client/engine/cio/ConnectionPipeline.kt
@@ -53,7 +53,7 @@ internal actual class ConnectionPipeline actual constructor(
                     throw cause
                 }
 
-                writeRequest(task.request, networkOutput, task.context, overProxy, closeChannel = false)
+                writeRequest(task.request, networkOutput, task.context, overProxy, closeChannel = false)?.join()
                 networkOutput.flush()
             }
         } catch (_: ClosedChannelException) {

--- a/ktor-client/ktor-client-cio/jvm/test/io/ktor/client/engine/cio/CIORequestTest.kt
+++ b/ktor-client/ktor-client-cio/jvm/test/io/ktor/client/engine/cio/CIORequestTest.kt
@@ -15,8 +15,10 @@ import io.ktor.http.*
 import io.ktor.http.content.*
 import io.ktor.server.engine.*
 import io.ktor.server.netty.*
+import io.ktor.server.request.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
+import io.ktor.utils.io.*
 import io.mockk.mockkStatic
 import io.mockk.verify
 import kotlinx.coroutines.*
@@ -50,6 +52,9 @@ class CIORequestTest : TestWithKtor() {
             }
             get("/echo") {
                 call.respond("OK")
+            }
+            get("/echo-body") {
+                call.respondText(call.receiveText())
             }
             get("/delay") {
                 delay(1.seconds)
@@ -89,6 +94,59 @@ class CIORequestTest : TestWithKtor() {
                 awaitAll(firstRequest, secondRequest)
             }
             assertEquals(listOf("OK", "OK"), responses)
+        }
+    }
+
+    @Test
+    fun testPipelinedRequestBodiesAreWrittenSequentially() = testWithEngine(CIO) {
+        config {
+            defaultRequest { port = serverPort }
+            engine {
+                pipelining = true
+                endpoint {
+                    maxConnectionsPerRoute = 1
+                }
+            }
+        }
+
+        test { client ->
+            fun HttpRequestBuilder.setBody(value: String, beforeWrite: suspend () -> Unit) {
+                val body = object : OutgoingContent.WriteChannelContent() {
+                    override val contentLength: Long = value.length.toLong()
+
+                    override suspend fun writeTo(channel: ByteWriteChannel) {
+                        beforeWrite()
+                        channel.writeStringUtf8(value)
+                    }
+                }
+                setBody(body)
+            }
+
+            val firstBodyStarted = CompletableDeferred<Unit>()
+            val secondBodyStarted = CompletableDeferred<Unit>()
+
+            val responses = coroutineScope {
+                val firstRequest = async {
+                    client.get("/echo-body") {
+                        setBody("first") {
+                            firstBodyStarted.complete(Unit)
+                            assertNull(
+                                withTimeoutOrNull(1.seconds) { secondBodyStarted.await() },
+                                "Second body write shouldn't be started",
+                            )
+                        }
+                    }.bodyAsText()
+                }
+                firstBodyStarted.await()
+                val secondRequest = async {
+                    client.get("/echo-body") {
+                        setBody("second") { secondBodyStarted.complete(Unit) }
+                    }.bodyAsText()
+                }
+                awaitAll(firstRequest, secondRequest)
+            }
+
+            assertEquals(listOf("first", "second"), responses)
         }
     }
 


### PR DESCRIPTION
**Subsystem**
Client, CIO

**Motivation**
[KTOR-9774](https://youtrack.jetbrains.com/issue/KTOR-9774) CIO can start writing the next pipelined request before the previous request body writer finishes. This allows two request writers to use the same connection concurrently and can corrupt HTTP/1.1 request framing.

**Solution**
Return the asynchronous body writer job from `writeBody` and `writeRequest`, and wait for it in the JVM connection pipeline before advancing to the next request. Response processing and dedicated-connection body writing remain concurrent.

Add a regression test that verifies two non-empty pipelined request bodies are written sequentially and received intact.
