### PR TITLE
KTOR-9817 Retain borrowed CF references in CertificatePinner before bridging

### DIFF
--- a/ktor-client/ktor-client-darwin-legacy/darwin/src/io/ktor/client/engine/darwin/certificates/LegacyCertificatePinner.kt
+++ b/ktor-client/ktor-client-darwin-legacy/darwin/src/io/ktor/client/engine/darwin/certificates/LegacyCertificatePinner.kt
@@ -303,9 +303,9 @@ public data class LegacyCertificatePinner(
         return publicKeyRef.use {
             val publicKeyAttributes = SecKeyCopyAttributes(publicKeyRef)
             val publicKeyTypePointer = CFDictionaryGetValue(publicKeyAttributes, kSecAttrKeyType)
-            val publicKeyType = CFBridgingRelease(publicKeyTypePointer) as NSString
+            val publicKeyType = CFBridgingRelease(CFRetain(publicKeyTypePointer)) as NSString
             val publicKeySizePointer = CFDictionaryGetValue(publicKeyAttributes, kSecAttrKeySizeInBits)
-            val publicKeySize = CFBridgingRelease(publicKeySizePointer) as NSNumber
+            val publicKeySize = CFBridgingRelease(CFRetain(publicKeySizePointer)) as NSNumber
 
             CFBridgingRelease(publicKeyAttributes)
 
@@ -332,8 +332,8 @@ public data class LegacyCertificatePinner(
      */
     @OptIn(ExperimentalForeignApi::class)
     private fun checkValidKeyType(publicKeyType: NSString, publicKeySize: NSNumber): Boolean {
-        val keyTypeRSA = CFBridgingRelease(kSecAttrKeyTypeRSA) as NSString
-        val keyTypeECSECPrimeRandom = CFBridgingRelease(kSecAttrKeyTypeECSECPrimeRandom) as NSString
+        val keyTypeRSA = CFBridgingRelease(CFRetain(kSecAttrKeyTypeRSA)) as NSString
+        val keyTypeECSECPrimeRandom = CFBridgingRelease(CFRetain(kSecAttrKeyTypeECSECPrimeRandom)) as NSString
 
         val size: Int = publicKeySize.intValue.toInt()
         val keys = when (publicKeyType) {
@@ -351,8 +351,8 @@ public data class LegacyCertificatePinner(
      */
     @OptIn(ExperimentalForeignApi::class)
     private fun getAsn1HeaderBytes(publicKeyType: NSString, publicKeySize: NSNumber): IntArray {
-        val keyTypeRSA = CFBridgingRelease(kSecAttrKeyTypeRSA) as NSString
-        val keyTypeECSECPrimeRandom = CFBridgingRelease(kSecAttrKeyTypeECSECPrimeRandom) as NSString
+        val keyTypeRSA = CFBridgingRelease(CFRetain(kSecAttrKeyTypeRSA)) as NSString
+        val keyTypeECSECPrimeRandom = CFBridgingRelease(CFRetain(kSecAttrKeyTypeECSECPrimeRandom)) as NSString
 
         val size: Int = publicKeySize.intValue.toInt()
         val keys = when (publicKeyType) {

--- a/ktor-client/ktor-client-darwin/darwin/src/io/ktor/client/engine/darwin/certificates/CertificatePinner.kt
+++ b/ktor-client/ktor-client-darwin/darwin/src/io/ktor/client/engine/darwin/certificates/CertificatePinner.kt
@@ -13,6 +13,7 @@ import platform.CoreCrypto.CC_SHA1_DIGEST_LENGTH
 import platform.CoreCrypto.CC_SHA256
 import platform.CoreCrypto.CC_SHA256_DIGEST_LENGTH
 import platform.CoreFoundation.CFDictionaryGetValue
+import platform.CoreFoundation.CFRetain
 import platform.CoreFoundation.CFStringCreateWithCString
 import platform.CoreFoundation.kCFStringEncodingUTF8
 import platform.Foundation.*
@@ -294,9 +295,9 @@ public data class CertificatePinner(
         return publicKeyRef.use {
             val publicKeyAttributes = SecKeyCopyAttributes(publicKeyRef)
             val publicKeyTypePointer = CFDictionaryGetValue(publicKeyAttributes, kSecAttrKeyType)
-            val publicKeyType = CFBridgingRelease(publicKeyTypePointer) as NSString
+            val publicKeyType = CFBridgingRelease(CFRetain(publicKeyTypePointer)) as NSString
             val publicKeySizePointer = CFDictionaryGetValue(publicKeyAttributes, kSecAttrKeySizeInBits)
-            val publicKeySize = CFBridgingRelease(publicKeySizePointer) as NSNumber
+            val publicKeySize = CFBridgingRelease(CFRetain(publicKeySizePointer)) as NSNumber
 
             CFBridgingRelease(publicKeyAttributes)
 
@@ -323,8 +324,8 @@ public data class CertificatePinner(
      */
     @OptIn(ExperimentalForeignApi::class)
     private fun checkValidKeyType(publicKeyType: NSString, publicKeySize: NSNumber): Boolean {
-        val keyTypeRSA = CFBridgingRelease(kSecAttrKeyTypeRSA) as NSString
-        val keyTypeECSECPrimeRandom = CFBridgingRelease(kSecAttrKeyTypeECSECPrimeRandom) as NSString
+        val keyTypeRSA = CFBridgingRelease(CFRetain(kSecAttrKeyTypeRSA)) as NSString
+        val keyTypeECSECPrimeRandom = CFBridgingRelease(CFRetain(kSecAttrKeyTypeECSECPrimeRandom)) as NSString
 
         val size: Int = publicKeySize.intValue.toInt()
         val keys = when (publicKeyType) {
@@ -342,8 +343,8 @@ public data class CertificatePinner(
      */
     @OptIn(ExperimentalForeignApi::class)
     private fun getAsn1HeaderBytes(publicKeyType: NSString, publicKeySize: NSNumber): IntArray {
-        val keyTypeRSA = CFBridgingRelease(kSecAttrKeyTypeRSA) as NSString
-        val keyTypeECSECPrimeRandom = CFBridgingRelease(kSecAttrKeyTypeECSECPrimeRandom) as NSString
+        val keyTypeRSA = CFBridgingRelease(CFRetain(kSecAttrKeyTypeRSA)) as NSString
+        val keyTypeECSECPrimeRandom = CFBridgingRelease(CFRetain(kSecAttrKeyTypeECSECPrimeRandom)) as NSString
 
         val size: Int = publicKeySize.intValue.toInt()
         val keys = when (publicKeyType) {


### PR DESCRIPTION
`CertificatePinner` passes six references it does not own to `CFBridgingRelease` on every TLS handshake:

- `publicKeyType` and `publicKeySize` come from `CFDictionaryGetValue`, which follows the Core Foundation Get Rule — the dictionary owns them.
- `kSecAttrKeyTypeRSA` and `kSecAttrKeyTypeECSECPrimeRandom` are Security framework constants, released twice each (`checkValidKeyType` and `getAsn1HeaderBytes`).

The corrupted objects are values of the `SecKeyCopyAttributes` dictionary, so nothing fails at the handshake. The process dies later, when the Kotlin/Native GC finalizes that dictionary and `-[__NSDictionaryM dealloc]` releases values that are already gone:

```
objc_object::release  <-  cow_cleanup  <-  -[__NSDictionaryM dealloc]
  <-  Kotlin_ObjCExport_releaseAssociatedObject  <-  GC finalizer processor
```

This reproduces reliably on watchOS (`arm64_32`): a few seconds after any pinned request, on an Apple Watch Series 8 running watchOS 26.6, with Ktor 3.5.1. It is masked on `arm64`, where those values land on tagged pointers and `release` is a no-op, and it never appears in the simulator if the pinner is not installed there. Verified fixed on-device with this patch.

Each call now retains the borrowed reference before handing ownership to `CFBridgingRelease`, leaving the retain count balanced. No behaviour or API change.