### PR TITLE
KTOR-9784 Support multipart on non-JVM server targets

### DIFF
--- a/ktor-server/ktor-server-core/common/src/io/ktor/server/engine/DefaultTransform.kt
+++ b/ktor-server/ktor-server-core/common/src/io/ktor/server/engine/DefaultTransform.kt
@@ -5,6 +5,8 @@
 package io.ktor.server.engine
 
 import io.ktor.http.*
+import io.ktor.http.cio.*
+import io.ktor.http.cio.internals.*
 import io.ktor.http.content.*
 import io.ktor.server.application.*
 import io.ktor.server.http.content.*
@@ -16,6 +18,7 @@ import io.ktor.util.pipeline.*
 import io.ktor.utils.io.*
 import io.ktor.utils.io.charsets.*
 import io.ktor.utils.io.core.*
+import kotlinx.coroutines.*
 import kotlinx.io.*
 
 internal val LOGGER = KtorSimpleLogger("io.ktor.server.engine.DefaultTransform")
@@ -45,6 +48,8 @@ public fun ApplicationReceivePipeline.installDefaultTransformations() {
             ByteReadChannel::class -> null
 
             ByteArray::class -> channel.toByteArray()
+
+            MultiPartData::class -> multiPartData(channel)
 
             Parameters::class -> {
                 val contentType = withContentType(call) { call.request.contentType() }
@@ -99,7 +104,25 @@ internal expect suspend fun PipelineContext<Any, PipelineCall>.defaultPlatformTr
     query: Any
 ): Any?
 
-internal expect fun PipelineContext<*, PipelineCall>.multiPartData(rc: ByteReadChannel): MultiPartData
+@OptIn(InternalAPI::class)
+internal fun PipelineContext<*, PipelineCall>.multiPartData(rc: ByteReadChannel): MultiPartData {
+    val contentType = call.request.header(HttpHeaders.ContentType)
+        ?: throw UnsupportedMediaTypeException(null)
+
+    val contentLength = call.request.header(HttpHeaders.ContentLength)?.toLong()
+
+    try {
+        return CIOMultipartDataBase(
+            coroutineContext + Dispatchers.Unconfined,
+            rc,
+            contentType,
+            contentLength,
+            formFieldLimit = call.formFieldLimit
+        )
+    } catch (_: UnsupportedMediaTypeExceptionCIO) {
+        throw UnsupportedMediaTypeException(ContentType.parse(contentType))
+    }
+}
 
 internal inline fun <R> withContentType(call: PipelineCall, block: () -> R): R = try {
     block()

--- a/ktor-server/ktor-server-core/jvm/src/io/ktor/server/engine/DefaultTransformJvm.kt
+++ b/ktor-server/ktor-server-core/jvm/src/io/ktor/server/engine/DefaultTransformJvm.kt
@@ -4,19 +4,13 @@
 
 package io.ktor.server.engine
 
-import io.ktor.http.*
-import io.ktor.http.cio.*
-import io.ktor.http.cio.internals.*
-import io.ktor.http.content.*
 import io.ktor.server.application.*
-import io.ktor.server.plugins.UnsupportedMediaTypeException
 import io.ktor.server.request.*
 import io.ktor.util.pipeline.*
 import io.ktor.utils.io.*
 import io.ktor.utils.io.charsets.*
 import io.ktor.utils.io.jvm.javaio.*
 import io.ktor.utils.io.streams.*
-import kotlinx.coroutines.*
 import kotlinx.io.*
 import java.io.*
 
@@ -27,28 +21,7 @@ internal actual suspend fun PipelineContext<Any, PipelineCall>.defaultPlatformTr
 
     return when (call.receiveType.type) {
         InputStream::class -> receiveGuardedInputStream(channel)
-        MultiPartData::class -> multiPartData(channel)
         else -> null
-    }
-}
-
-@OptIn(InternalAPI::class)
-internal actual fun PipelineContext<*, PipelineCall>.multiPartData(rc: ByteReadChannel): MultiPartData {
-    val contentType = call.request.header(HttpHeaders.ContentType)
-        ?: throw UnsupportedMediaTypeException(null)
-
-    val contentLength = call.request.header(HttpHeaders.ContentLength)?.toLong()
-
-    try {
-        return CIOMultipartDataBase(
-            coroutineContext + Dispatchers.Unconfined,
-            rc,
-            contentType,
-            contentLength,
-            formFieldLimit = call.formFieldLimit
-        )
-    } catch (_: UnsupportedMediaTypeExceptionCIO) {
-        throw UnsupportedMediaTypeException(ContentType.parse(contentType))
     }
 }
 

--- a/ktor-server/ktor-server-core/nonJvm/src/io/ktor/server/engine/DefaultTransform.nonJvm.kt
+++ b/ktor-server/ktor-server-core/nonJvm/src/io/ktor/server/engine/DefaultTransform.nonJvm.kt
@@ -4,19 +4,14 @@
 
 package io.ktor.server.engine
 
-import io.ktor.http.content.*
 import io.ktor.server.application.*
 import io.ktor.util.pipeline.*
-import io.ktor.utils.io.*
 import io.ktor.utils.io.charsets.*
 import kotlinx.io.*
 
 internal actual suspend fun PipelineContext<Any, PipelineCall>.defaultPlatformTransformations(
     query: Any
 ): Any? = null
-
-internal actual fun PipelineContext<*, PipelineCall>.multiPartData(rc: ByteReadChannel): MultiPartData =
-    error("Multipart is not supported on non JVM platforms")
 
 internal actual fun Source.readTextWithCustomCharset(charset: Charset): String =
     error("Charset $charset is not supported on non JVM platforms")

--- a/ktor-server/ktor-server-tests/common/test/io/ktor/tests/server/http/TestEngineMultipartTest.kt
+++ b/ktor-server/ktor-server-tests/common/test/io/ktor/tests/server/http/TestEngineMultipartTest.kt
@@ -6,6 +6,7 @@ package io.ktor.tests.server.http
 
 import io.ktor.client.request.*
 import io.ktor.client.request.forms.*
+import io.ktor.client.statement.*
 import io.ktor.http.*
 import io.ktor.http.content.*
 import io.ktor.server.application.*
@@ -109,6 +110,38 @@ class TestEngineMultipartTest {
     }
 
     @Test
+    fun testReceiveMultipartFormItem() = testApplication {
+        routing {
+            post {
+                val part = call.receiveMultipart().readPart() as PartData.FormItem
+                call.respondText("${part.name}=${part.value}")
+            }
+        }
+
+        val response = client.post {
+            setBody(MultiPartFormDataContent(formData { append("data", "value") }))
+        }
+
+        assertEquals(HttpStatusCode.OK, response.status)
+        assertEquals("data=value", response.bodyAsText())
+    }
+
+    @Test
+    fun testReceiveParametersFromMultipart() = testApplication {
+        routing {
+            post {
+                call.respondText(call.receiveParameters()["data"] ?: "missing")
+            }
+        }
+
+        val response = client.post {
+            setBody(MultiPartFormDataContent(formData { append("data", "value") }))
+        }
+
+        assertEquals("value", response.bodyAsText())
+    }
+
+    @Test
     fun testMultipartIsNotTruncated() {
         if (!PlatformUtils.IS_JVM) return
 
@@ -160,8 +193,6 @@ class TestEngineMultipartTest {
 
     @Test
     fun testMultipartBiggerThanLimitFails() {
-        if (!PlatformUtils.IS_JVM) return
-
         testApplication {
             routing {
                 post {

--- a/ktor-server/ktor-server-tests/common/test/io/ktor/tests/server/http/TestEngineMultipartTest.kt
+++ b/ktor-server/ktor-server-tests/common/test/io/ktor/tests/server/http/TestEngineMultipartTest.kt
@@ -114,7 +114,10 @@ class TestEngineMultipartTest {
         routing {
             post {
                 val part = call.receiveMultipart().readPart() as PartData.FormItem
-                call.respondText("${part.name}=${part.value}")
+                val name = part.name
+                val value = part.value
+                part.release()
+                call.respondText("$name=$value")
             }
         }
 
@@ -138,6 +141,7 @@ class TestEngineMultipartTest {
             setBody(MultiPartFormDataContent(formData { append("data", "value") }))
         }
 
+        assertEquals(HttpStatusCode.OK, response.status)
         assertEquals("value", response.bodyAsText())
     }
 


### PR DESCRIPTION
**Subsystem**
Server, `ktor-server-core`

**Motivation**

KTOR-9784, reported as #5694.

`call.receiveMultipart()` fails on non-JVM server targets:

```
io.ktor.server.plugins.CannotTransformContentToTypeException:
Cannot transform this request's content to io.ktor.http.content.MultiPartData
```

The default receive transformation has no `MultiPartData` branch in `commonMain`;
it falls through to `defaultPlatformTransformations`, whose non-JVM actual returns
`null`. The body then stays a `ByteReadChannel`, and `PipelineCall` throws. This is
a server-core wiring gap rather than an engine problem: the Content-Type is parsed
correctly and `call.receiveChannel()` works.

The same root cause produces a second symptom: `call.receiveParameters()` with a
`multipart/form-data` body reaches the common `Parameters::class` branch, which calls
`multiPartData(channel)` directly and hits
`error("Multipart is not supported on non JVM platforms")`, failing with
`IllegalStateException`.

The non-JVM stub used to be accurate. When the Native CIO server was added
(`0de7948fb`, KTOR-746), the CIO multipart parser lived in `ktor-http-cio/jvm/` only,
and the same was still true when JS/Wasm server targets were commonized
(`1115fae6f`). `4933074bb` (KTOR-6632, shipped in 3.1.0) moved
`CIOMultipartDataBase` and `parseMultipart` to `ktor-http-cio/common/`, leaving only
`discardBlocking()` as expect/actual, so that the **client** could receive multipart
data on every target. The server side was not updated, and the stub was later
relocated to `nonJvm` (`d0d6a7e83`) without being re-evaluated.

**Solution**

Move the JVM `multiPartData` implementation to `commonMain` and add a
`MultiPartData::class` branch to the common transformation.

- No new dependency: `ktor-server-core` already has `api(projects.ktorHttpCio)` in
  `commonMain`.
- No public API changes: every declaration involved is `internal`, so ABI dumps are
  unaffected.
- The parser this now reaches is the same one `ktor-client-core` has used from
  `commonMain` since 3.1.0.

**Tests**

The existing multipart tests in `TestEngineMultipartTest` run assertions inside a
call interceptor, where the pipeline swallows failures, so they passed on non-JVM
targets despite multipart being broken. Two tests were added that assert on the
response instead:

- `testReceiveMultipartFormItem` — the `receiveMultipart()` path
- `testReceiveParametersFromMultipart` — the `receiveParameters()` path

Both fail on `jsNodeTest` without this change and pass with it.

`testMultipartBiggerThanLimitFails` had an `if (!PlatformUtils.IS_JVM) return` guard,
an artifact of multipart being JVM-only; it is removed so the `formFieldLimit` path
is covered on the newly working targets. The guard on `testMultipartIsNotTruncated`
is kept, since that test allocates 42 MB.

Verified locally:

- `:ktor-server-tests:jsNodeTest` — RED before the change, GREEN after
- `:ktor-server-core:jvmTest`, `:ktor-server-tests:jvmTest` — pass
- `:ktor-server-tests:linuxX64TestKlibrary`, `:ktor-server-core:linuxX64MainKlibrary` — compile
- `:ktor-server-core:lintKotlin`, `:ktor-server-tests:lintKotlin` — pass

Kotlin/Native tests were not executed: no Kotlin/Native-capable host was available
(the machine used lacks Xcode, and a Linux aarch64 host is not a supported
Kotlin/Native host platform). Native coverage here is compile-only, and CI should be
the deciding signal for `linuxX64Test`. `checkKotlinAbi` could not run for the same
Xcode reason; the change is `internal`-only, so no dump updates are expected.
