### PR TITLE
Fix KTOR-9760 Digest Auth: URI and HA2 are empty for a URL without a …

### DIFF
--- a/ktor-client/ktor-client-plugins/ktor-client-auth/common/src/io/ktor/client/plugins/auth/providers/DigestAuthProvider.kt
+++ b/ktor-client/ktor-client-plugins/ktor-client-auth/common/src/io/ktor/client/plugins/auth/providers/DigestAuthProvider.kt
@@ -183,8 +183,11 @@ public class DigestAuthProvider(
         val credentials = tokenHolder.loadToken() ?: return
         val credential = makeDigest("${credentials.username}:$realm:${credentials.password}")
 
+        // Clients send "/" when the URL path is empty (RFC 9112); digest uri/HA2 must match that target.
+        val requestTarget = if (url.rawSegments.isEmpty()) "/${url.fullPath}" else url.fullPath
+
         val start = credential.toHexString()
-        val end = makeDigest("$methodName:${url.fullPath}").toHexString()
+        val end = makeDigest("$methodName:$requestTarget").toHexString()
         val tokenSequence = if (actualQop == null) {
             listOf(start, nonce, end)
         } else {
@@ -202,7 +205,7 @@ public class DigestAuthProvider(
                 this["nonce"] = nonce.quote()
                 this["cnonce"] = clientNonce.quote()
                 this["response"] = token.toHexString().quote()
-                this["uri"] = url.fullPath.quote()
+                this["uri"] = requestTarget.quote()
                 actualQop?.let { this["qop"] = it }
                 this["nc"] = nonceCount
                 @Suppress("DEPRECATION_ERROR")

--- a/ktor-client/ktor-client-plugins/ktor-client-auth/common/test/io/ktor/client/plugins/auth/DigestProviderTest.kt
+++ b/ktor-client/ktor-client-plugins/ktor-client-auth/common/test/io/ktor/client/plugins/auth/DigestProviderTest.kt
@@ -170,6 +170,36 @@ class DigestProviderTest {
         assertEquals("d51dd4b72db592e321b80d006d24c34c", response)
     }
 
+    @Test
+    fun `empty path treated as slash for uri and hash`() = runTest {
+        if (!PlatformUtils.IS_JVM) return@runTest
+
+        val provider = DigestAuthProvider(
+            credentials = { DigestAuthCredentials("username", "pass") },
+            realm = null
+        )
+        val authHeader = parseAuthorizationHeader(authMissingQopAndOpaque)!!
+
+        val expectedResponses = mapOf(
+            "" to "59371c611ceaf1d6d76c6da3136e7f59",
+            "?x=1" to "1313e773fecf0751fc8222d164931909",
+        )
+
+        for (queryParameters in expectedResponses.keys) {
+            val pathRequest = HttpRequestBuilder {
+                takeFrom("https://example.com$queryParameters")
+            }
+
+            assertTrue(provider.isApplicable(authHeader))
+            provider.addRequestHeaders(pathRequest, authHeader)
+
+            val headerValue = checkNotNull(pathRequest.headers[HttpHeaders.Authorization])
+            val resultAuthHeader = parseAuthorizationHeader(headerValue) as HttpAuthHeader.Parameterized
+            assertEquals("/$queryParameters", resultAuthHeader.parameter("uri"))
+            assertEquals(expectedResponses[queryParameters], resultAuthHeader.parameter("response"))
+        }
+    }
+
     private fun runIsApplicable(headerValue: String) =
         digestAuthProvider.isApplicable(parseAuthorizationHeader(headerValue)!!)
 


### PR DESCRIPTION
**Subsystem**
Client

**Motivation**
[KTOR-9760](https://youtrack.jetbrains.com/issue/KTOR-9760) Digest Auth: URI and HA2 are empty for a URL without a path

**Solution**
Use the request target that is actually sent by the client

