### PR TITLE
KTOR-9648 Add reflection support for custom discriminator values

### DIFF
--- a/ktor-shared/ktor-openapi-schema/ktor-openapi-schema-reflect/api/ktor-openapi-schema-reflect.api
+++ b/ktor-shared/ktor-openapi-schema/ktor-openapi-schema-reflect/api/ktor-openapi-schema-reflect.api
@@ -12,6 +12,8 @@ public final class io/ktor/openapi/reflect/ReflectionJsonSchemaInference$Compani
 
 public abstract interface class io/ktor/openapi/reflect/SchemaReflectionAdapter {
 	public fun getDiscriminatorProperty (Lkotlin/reflect/KClass;)Ljava/lang/String;
+	public fun getDiscriminatorValue (Lkotlin/reflect/KClass;)Ljava/lang/String;
+	public fun getDiscriminatorValue (Lkotlin/reflect/KClass;Lkotlin/reflect/KClass;)Ljava/lang/String;
 	public fun getName (Lkotlin/reflect/KProperty1;)Ljava/lang/String;
 	public fun getName (Lkotlin/reflect/KType;)Ljava/lang/String;
 	public fun getProperties (Lkotlin/reflect/KClass;)Ljava/util/Collection;
@@ -21,6 +23,8 @@ public abstract interface class io/ktor/openapi/reflect/SchemaReflectionAdapter 
 
 public final class io/ktor/openapi/reflect/SchemaReflectionAdapter$DefaultImpls {
 	public static fun getDiscriminatorProperty (Lio/ktor/openapi/reflect/SchemaReflectionAdapter;Lkotlin/reflect/KClass;)Ljava/lang/String;
+	public static fun getDiscriminatorValue (Lio/ktor/openapi/reflect/SchemaReflectionAdapter;Lkotlin/reflect/KClass;)Ljava/lang/String;
+	public static fun getDiscriminatorValue (Lio/ktor/openapi/reflect/SchemaReflectionAdapter;Lkotlin/reflect/KClass;Lkotlin/reflect/KClass;)Ljava/lang/String;
 	public static fun getName (Lio/ktor/openapi/reflect/SchemaReflectionAdapter;Lkotlin/reflect/KProperty1;)Ljava/lang/String;
 	public static fun getName (Lio/ktor/openapi/reflect/SchemaReflectionAdapter;Lkotlin/reflect/KType;)Ljava/lang/String;
 	public static fun getProperties (Lio/ktor/openapi/reflect/SchemaReflectionAdapter;Lkotlin/reflect/KClass;)Ljava/util/Collection;

--- a/ktor-shared/ktor-openapi-schema/ktor-openapi-schema-reflect/jvm/src/io/ktor/openapi/reflect/JsonSchemaInference.jvm.kt
+++ b/ktor-shared/ktor-openapi-schema/ktor-openapi-schema-reflect/jvm/src/io/ktor/openapi/reflect/JsonSchemaInference.jvm.kt
@@ -94,6 +94,23 @@ public interface SchemaReflectionAdapter {
      * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.openapi.reflect.SchemaReflectionAdapter.getDiscriminatorProperty)
      */
     public fun getDiscriminatorProperty(kClass: KClass<*>): String = "type"
+
+    /**
+     * Returns the discriminator value for the given [subclass] of [kClass].
+     * By default, delegates to [getDiscriminatorValue] with a single parameter, which returns `null`.
+     *
+     * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.openapi.reflect.SchemaReflectionAdapter.getDiscriminatorValue)
+     */
+    public fun getDiscriminatorValue(kClass: KClass<*>, subclass: KClass<*>): String? =
+        getDiscriminatorValue(subclass)
+
+    /**
+     * Returns the discriminator value for the given [subclass].
+     * By default, returns `null`.
+     *
+     * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.openapi.reflect.SchemaReflectionAdapter.getDiscriminatorValue)
+     */
+    public fun getDiscriminatorValue(subclass: KClass<*>): String? = null
 }
 
 /**
@@ -230,7 +247,10 @@ public class ReflectionJsonSchemaInference(
                 val discriminatorMapping = sealedSubclasses
                     .filter { it.qualifiedName != null }
                     .associate { subclass ->
-                        subclass.qualifiedName!! to "#/components/schemas/${subclass.qualifiedName}"
+                        val fqName = subclass.qualifiedName!!
+                        val discriminatorValue = adapter.getDiscriminatorValue(kClass, subclass) ?: fqName
+                        val subclassSchemaName = adapter.getName(subclass.starProjectedType) ?: fqName
+                        discriminatorValue to "#/components/schemas/$subclassSchemaName"
                     }
 
                 val discriminatorProperty = adapter.getDiscriminatorProperty(kClass)

--- a/ktor-shared/ktor-openapi-schema/ktor-openapi-schema-reflect/jvm/test/io/ktor/openapi/reflect/ReflectionJsonSchemaInferenceTest.kt
+++ b/ktor-shared/ktor-openapi-schema/ktor-openapi-schema-reflect/jvm/test/io/ktor/openapi/reflect/ReflectionJsonSchemaInferenceTest.kt
@@ -11,6 +11,23 @@ import kotlin.reflect.KClass
 import kotlin.reflect.KProperty1
 import kotlin.reflect.full.memberProperties
 import kotlin.reflect.full.primaryConstructor
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+
+annotation class CustomTypesDiscriminator(val property: String)
+annotation class CustomSubTypes(vararg val value: CustomSubType)
+annotation class CustomSubType(val value: KClass<*>, val name: String)
+
+@CustomTypesDiscriminator("kind")
+@CustomSubTypes(
+    CustomSubType(CustomDiscriminatorShape.Circle::class, "CIRCLE"),
+    CustomSubType(CustomDiscriminatorShape.Square::class, "SQUARE")
+)
+sealed interface CustomDiscriminatorShape {
+    data class Circle(val radius: Int) : CustomDiscriminatorShape
+    data class Square(val length: Int) : CustomDiscriminatorShape
+}
 
 class ReflectionJsonSchemaInferenceTest : AbstractSchemaInferenceTest(
     ReflectionJsonSchemaInference(object : SchemaReflectionAdapter {
@@ -25,8 +42,26 @@ class ReflectionJsonSchemaInferenceTest : AbstractSchemaInferenceTest(
 
         @OptIn(ExperimentalSerializationApi::class)
         override fun getDiscriminatorProperty(kClass: KClass<*>): String =
-            kClass.annotations.filterIsInstance<JsonClassDiscriminator>().firstOrNull()?.discriminator
+            kClass.annotations.filterIsInstance<CustomTypesDiscriminator>().firstOrNull()?.property
+                ?: kClass.annotations.filterIsInstance<JsonClassDiscriminator>().firstOrNull()?.discriminator
                 ?: super.getDiscriminatorProperty(kClass)
+
+        override fun getDiscriminatorValue(kClass: KClass<*>, subclass: KClass<*>): String? {
+            val subTypes = kClass.annotations.filterIsInstance<CustomSubTypes>().firstOrNull()
+            return subTypes?.value?.firstOrNull { it.value == subclass }?.name
+                ?: super.getDiscriminatorValue(kClass, subclass)
+        }
     }),
     "reflect"
-)
+) {
+    @Test
+    fun `custom discriminator values test`() {
+        val schema = inference.jsonSchema<CustomDiscriminatorShape>()
+        assertNotNull(schema.discriminator)
+        assertEquals("kind", schema.discriminator?.propertyName)
+        val mapping = schema.discriminator?.mapping
+        assertNotNull(mapping)
+        assertEquals("#/components/schemas/io.ktor.openapi.reflect.CustomDiscriminatorShape.Circle", mapping["CIRCLE"])
+        assertEquals("#/components/schemas/io.ktor.openapi.reflect.CustomDiscriminatorShape.Square", mapping["SQUARE"])
+    }
+}


### PR DESCRIPTION
**Subsystem**
Shared, JSON schema inference

**Motivation**
[KTOR-9648](https://youtrack.jetbrains.com/issue/KTOR-9648) OpenAPI: reflection schema inference produces incorrect discriminator mapping for Jackson-annotated and nested sealed hierarchies

**Solution**
Added support for overriding discriminator values for sealed types in JSON schema reflection (i.e., Jackson / Gson annotations).

