### PR TITLE
KTOR-9657 Fix shortening recursive refs in schema

### DIFF
--- a/ktor-server/ktor-server-plugins/ktor-server-routing-openapi/common/src/io/ktor/server/routing/openapi/OperationMapping.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-routing-openapi/common/src/io/ktor/server/routing/openapi/OperationMapping.kt
@@ -8,6 +8,7 @@ import io.ktor.http.*
 import io.ktor.openapi.*
 
 private val StringReference: ReferenceOr<JsonSchema> = ReferenceOr.Value(JsonSchema(type = JsonType.STRING))
+private const val SchemaComponentPrefix: String = "#/components/schemas/"
 
 /**
  * Mapping function for [Operation].
@@ -222,7 +223,8 @@ public class CollectSchemaReferences(private val schemaToComponent: (JsonSchema)
     }
 
     private fun mapSchemaReferences(refRef: ReferenceOr.Reference): ReferenceOr<JsonSchema> {
-        val schemaName = refRef.ref.removePrefix("#/components/schemas/")
+        if (!refRef.ref.startsWith(SchemaComponentPrefix)) return refRef
+        val schemaName = refRef.ref.removePrefix(SchemaComponentPrefix)
         val targetComponent = titleToComponent[schemaName]
             ?: titleToComponent[schemaName.substringAfterLast('.')]
             ?: schemaName.substringAfterLast('.')

--- a/ktor-server/ktor-server-plugins/ktor-server-routing-openapi/common/src/io/ktor/server/routing/openapi/OperationMapping.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-routing-openapi/common/src/io/ktor/server/routing/openapi/OperationMapping.kt
@@ -126,34 +126,64 @@ public val PopulateMediaTypeDefaults: OperationMapping = OperationMapping { oper
  * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.server.routing.openapi.CollectSchemaReferences)
  */
 public class CollectSchemaReferences(private val schemaToComponent: (JsonSchema) -> String?) : OperationMapping {
+    private val titleToComponent = mutableMapOf<String, String>()
+
     override fun map(operation: Operation): Operation =
         operation.copy(
-            requestBody = operation.requestBody?.mapValue {
-                it.copy(content = it.content?.let(::collectSchemaReferences))
+            requestBody = operation.requestBody?.mapValue { reqBody ->
+                reqBody.copy(content = reqBody.content?.let(::mapSchemaReferences))
             },
             responses = operation.responses?.let { responses ->
                 responses.copy(
+                    default = responses.default?.mapValue { mapSchemaReferences(it) },
                     responses = responses.responses?.mapValues { (_, response) ->
-                        response.mapValue {
-                            it.copy(content = it.content?.let(::collectSchemaReferences))
-                        }
+                        response.mapValue { mapSchemaReferences(it) }
                     }
                 )
             },
             parameters = operation.parameters?.map { parameter ->
-                parameter.mapValue {
-                    it.copy(
-                        schema = it.schema?.mapToReference(::collectSchema),
-                        content = it.content?.let(::collectSchemaReferences)
+                parameter.mapValue { param ->
+                    param.copy(
+                        schema = param.schema?.mapToSchemaReference(::mapSchemaReferences, ::mapSchemaReferences),
+                        content = param.content?.let(::mapSchemaReferences)
                     )
                 }
             },
+            callbacks = operation.callbacks?.mapValues { (_, callbackRef) ->
+                callbackRef.mapValue { callback ->
+                    Callback(
+                        callback.value.mapValues { (_, pathItem) ->
+                            pathItem.copy(
+                                parameters = pathItem.parameters?.map { parameter ->
+                                    parameter.mapValue { param ->
+                                        param.copy(
+                                            schema = param.schema?.mapToSchemaReference(
+                                                ::mapSchemaReferences,
+                                                ::mapSchemaReferences
+                                            ),
+                                            content = param.content?.let(::mapSchemaReferences)
+                                        )
+                                    }
+                                },
+                                get = pathItem.get?.let(::map),
+                                put = pathItem.put?.let(::map),
+                                post = pathItem.post?.let(::map),
+                                delete = pathItem.delete?.let(::map),
+                                options = pathItem.options?.let(::map),
+                                head = pathItem.head?.let(::map),
+                                patch = pathItem.patch?.let(::map),
+                                trace = pathItem.trace?.let(::map),
+                            )
+                        }
+                    )
+                }
+            }
         )
 
-    private fun collectSchemaReferences(content: Map<ContentType, MediaType>): Map<ContentType, MediaType> =
+    private fun mapSchemaReferences(content: Map<ContentType, MediaType>): Map<ContentType, MediaType> =
         content.mapValues { (_, mediaType) ->
             mediaType.copy(
-                schema = mediaType.schema?.mapToReference(::collectSchema),
+                schema = mediaType.schema?.mapToSchemaReference(::mapSchemaReferences, ::mapSchemaReferences),
             )
         }
 
@@ -162,27 +192,67 @@ public class CollectSchemaReferences(private val schemaToComponent: (JsonSchema)
      *
      * This applies a "depth-first" transformation on the schema to extract all nested references first.
      */
-    private fun collectSchema(schema: JsonSchema): ReferenceOr<JsonSchema> {
+    private fun mapSchemaReferences(schema: JsonSchema): ReferenceOr<JsonSchema> {
         val nestedSchema = schema.copy(
-            allOf = schema.allOf?.map { it.mapToReference(::collectSchema) },
-            anyOf = schema.anyOf?.map { it.mapToReference(::collectSchema) },
-            oneOf = schema.oneOf?.map { it.mapToReference(::collectSchema) },
-            not = schema.not?.mapToReference(::collectSchema),
-            properties = schema.properties?.mapValues { (_, value) -> value.mapToReference(::collectSchema) },
-            items = schema.items?.mapToReference(::collectSchema),
+            allOf = schema.allOf?.map { it.mapToSchemaReference(::mapSchemaReferences, ::mapSchemaReferences) },
+            anyOf = schema.anyOf?.map { it.mapToSchemaReference(::mapSchemaReferences, ::mapSchemaReferences) },
+            oneOf = schema.oneOf?.map { it.mapToSchemaReference(::mapSchemaReferences, ::mapSchemaReferences) },
+            not = schema.not?.mapToSchemaReference(::mapSchemaReferences, ::mapSchemaReferences),
+            properties = schema.properties?.mapValues { (_, value) ->
+                value.mapToSchemaReference(::mapSchemaReferences, ::mapSchemaReferences)
+            },
+            items = schema.items?.mapToSchemaReference(::mapSchemaReferences, ::mapSchemaReferences),
             additionalProperties = when (val ap = schema.additionalProperties) {
                 is AdditionalProperties.PSchema -> AdditionalProperties.PSchema(
-                    ap.value.mapToReference(::collectSchema)
+                    ap.value.mapToSchemaReference(::mapSchemaReferences, ::mapSchemaReferences)
                 )
 
                 else -> ap
             },
         )
-        return schemaToComponent(nestedSchema)
+        val title = nestedSchema.title
+        val componentName = schemaToComponent(nestedSchema)
+        if (title != null && componentName != null) {
+            titleToComponent[title] = componentName
+            titleToComponent[title.substringAfterLast('.')] = componentName
+        }
+        return componentName
             ?.let(::schemaRef)
             ?: ReferenceOr.value(nestedSchema)
     }
 
+    private fun mapSchemaReferences(refRef: ReferenceOr.Reference): ReferenceOr<JsonSchema> {
+        val schemaName = refRef.ref.removePrefix("#/components/schemas/")
+        val targetComponent = titleToComponent[schemaName]
+            ?: titleToComponent[schemaName.substringAfterLast('.')]
+            ?: schemaName.substringAfterLast('.')
+        return ReferenceOr.schema(targetComponent, refRef.isDynamic)
+    }
+
+    private fun mapSchemaReferences(response: Response): Response = response.copy(
+        content = response.content?.let(this::mapSchemaReferences),
+        headers = response.headers?.mapValues { (_, headerRef) ->
+            headerRef.mapValue { header ->
+                header.copy(
+                    schema = header.schema?.mapToSchemaReference(
+                        ::mapSchemaReferences,
+                        ::mapSchemaReferences
+                    ),
+                    content = header.content?.let(::mapSchemaReferences)
+                )
+            }
+        }
+    )
+
     private fun schemaRef(title: String): ReferenceOr<JsonSchema> =
         ReferenceOr.schema(title)
 }
+
+private fun ReferenceOr<JsonSchema>.mapToSchemaReference(
+    mappingFunction: (JsonSchema) -> ReferenceOr<JsonSchema>,
+    referenceMapping: (ReferenceOr.Reference) -> ReferenceOr<JsonSchema>
+): ReferenceOr<JsonSchema> =
+    when (this) {
+        is ReferenceOr.Reference -> referenceMapping(this)
+        is ReferenceOr.Value -> mappingFunction(value)
+    }

--- a/ktor-server/ktor-server-plugins/ktor-server-routing-openapi/jvm/test/io/ktor/server/routing/openapi/CollectSchemaReferencesTest.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-routing-openapi/jvm/test/io/ktor/server/routing/openapi/CollectSchemaReferencesTest.kt
@@ -1,0 +1,182 @@
+/*
+ * Copyright 2014-2026 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.server.routing.openapi
+
+import io.ktor.http.*
+import io.ktor.openapi.*
+import kotlin.test.*
+
+class CollectSchemaReferencesTest {
+
+    @Test
+    fun `schema references on recursive properties`() {
+        val operation = Operation(
+            parameters = listOf(
+                ReferenceOr.Value(
+                    Parameter(
+                        name = "param",
+                        `in` = ParameterType.query,
+                        schema = ReferenceOr.Value(
+                            JsonSchema(
+                                type = JsonType.OBJECT,
+                                title = "com.acme.openapi.Value",
+                                properties = mapOf(
+                                    "name" to ReferenceOr.Value(JsonSchema(type = JsonType.STRING)),
+                                    "children" to ReferenceOr.Value(
+                                        JsonSchema(
+                                            type = JsonType.ARRAY,
+                                            items = ReferenceOr.Reference(
+                                                "#/components/schemas/com.acme.openapi.Value"
+                                            )
+                                        )
+                                    )
+                                )
+                            )
+                        )
+                    )
+                )
+            ),
+            requestBody = ReferenceOr.Value(
+                RequestBody(
+                    content = mapOf(
+                        ContentType.Application.Json to MediaType(
+                            schema = ReferenceOr.Value(
+                                JsonSchema(
+                                    type = JsonType.OBJECT,
+                                    title = "com.acme.openapi.Value",
+                                    properties = mapOf(
+                                        "name" to ReferenceOr.Value(JsonSchema(type = JsonType.STRING)),
+                                        "children" to ReferenceOr.Value(
+                                            JsonSchema(
+                                                type = JsonType.ARRAY,
+                                                items = ReferenceOr.Reference(
+                                                    "#/components/schemas/com.acme.openapi.Value"
+                                                )
+                                            )
+                                        )
+                                    )
+                                )
+                            )
+                        )
+                    )
+                )
+            ),
+            responses = Responses(
+                default = ReferenceOr.Value(
+                    Response(
+                        description = "Default response",
+                        headers = mapOf(
+                            "X-Header" to ReferenceOr.Value(
+                                Header(
+                                    schema = ReferenceOr.Value(
+                                        JsonSchema(
+                                            type = JsonType.STRING,
+                                            title = "com.acme.openapi.HeaderType"
+                                        )
+                                    )
+                                )
+                            )
+                        )
+                    )
+                ),
+                responses = mapOf(
+                    200 to ReferenceOr.Value(
+                        Response(
+                            description = "Success",
+                            content = mapOf(
+                                ContentType.Application.Json to MediaType(
+                                    schema = ReferenceOr.Value(
+                                        JsonSchema(
+                                            type = JsonType.OBJECT,
+                                            title = "com.acme.openapi.Value"
+                                        )
+                                    )
+                                )
+                            )
+                        )
+                    )
+                )
+            )
+        )
+
+        val collector = CollectSchemaReferences { schema ->
+            schema.title?.substringAfterLast('.')
+        }
+
+        val mapped = collector.map(operation)
+
+        // Verify parameter schema is referenced
+        val paramSchema = mapped.parameters?.get(0)?.valueOrNull()?.schema
+        assertNotNull(paramSchema)
+        assertTrue(paramSchema is ReferenceOr.Reference)
+        assertEquals("#/components/schemas/Value", paramSchema.ref)
+
+        // Verify requestBody schema is referenced
+        val reqBodyContent = mapped.requestBody?.valueOrNull()?.content?.get(ContentType.Application.Json)
+        assertNotNull(reqBodyContent)
+        val reqBodySchemaRef = reqBodyContent.schema
+        assertNotNull(reqBodySchemaRef)
+        assertTrue(reqBodySchemaRef is ReferenceOr.Reference)
+        assertEquals("#/components/schemas/Value", reqBodySchemaRef.ref)
+
+        // Verify responses default header schema
+        val defaultResp = mapped.responses?.default?.valueOrNull()
+        assertNotNull(defaultResp)
+        val headerSchema = defaultResp.headers?.get("X-Header")?.valueOrNull()?.schema
+        assertNotNull(headerSchema)
+        assertTrue(headerSchema is ReferenceOr.Reference)
+        assertEquals("#/components/schemas/HeaderType", headerSchema.ref)
+    }
+
+    @Test
+    fun `recursive reference substitution`() {
+        val schemaWithRef = JsonSchema(
+            type = JsonType.OBJECT,
+            title = "com.acme.openapi.Value",
+            properties = mapOf(
+                "children" to ReferenceOr.Value(
+                    JsonSchema(
+                        type = JsonType.ARRAY,
+                        items = ReferenceOr.Reference(
+                            "#/components/schemas/com.acme.openapi.Value"
+                        )
+                    )
+                )
+            )
+        )
+
+        val collector = CollectSchemaReferences { schema ->
+            schema.title?.substringAfterLast('.')
+        }
+
+        val containerSchema = JsonSchema(
+            type = JsonType.OBJECT,
+            title = "com.acme.openapi.Container",
+            properties = mapOf(
+                "value" to ReferenceOr.Value(schemaWithRef)
+            )
+        )
+
+        val opContainer = Operation(
+            requestBody = ReferenceOr.Value(
+                RequestBody(
+                    content = mapOf(
+                        ContentType.Application.Json to MediaType(
+                            schema = ReferenceOr.Value(containerSchema)
+                        )
+                    )
+                )
+            )
+        )
+
+        val mappedContainer = collector.map(opContainer)
+        val containerRef = mappedContainer.requestBody?.valueOrNull()?.content?.get(
+            ContentType.Application.Json
+        )?.schema
+        assertNotNull(containerRef)
+        assertTrue(containerRef is ReferenceOr.Reference)
+        assertEquals("#/components/schemas/Container", containerRef.ref)
+    }
+}

--- a/ktor-shared/ktor-openapi-schema/ktor-openapi-schema-reflect/jvm/test/io/ktor/openapi/reflect/ReflectionJsonSchemaInferenceTest.kt
+++ b/ktor-shared/ktor-openapi-schema/ktor-openapi-schema-reflect/jvm/test/io/ktor/openapi/reflect/ReflectionJsonSchemaInferenceTest.kt
@@ -4,7 +4,6 @@
 
 package io.ktor.openapi.reflect
 
-import io.ktor.openapi.*
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.json.JsonClassDiscriminator
 import kotlin.reflect.KClass


### PR DESCRIPTION
**Subsystem**
Server, OpenAPI

**Motivation**
[KTOR-9657](https://youtrack.jetbrains.com/issue/KTOR-9657) OpenAPI: generated schema for recursive types uses invalid schemaRef with ReflectionJsonSchemaInference

**Solution**
There were still a few missing paths for swapping references.  They should be fixed now.  Added tests for better validation.
