### PR TITLE
KTOR-9787 Remove experimental flag for HTMX

### DIFF
--- a/ktor-server/ktor-server-plugins/ktor-server-htmx/common/src/io/ktor/server/htmx/HxHeaders.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-htmx/common/src/io/ktor/server/htmx/HxHeaders.kt
@@ -8,12 +8,34 @@ import io.ktor.util.collections.*
 import io.ktor.utils.io.*
 import kotlin.jvm.JvmInline
 
+/**
+ * Provides typed access to the HTMX request headers of this request.
+ *
+ * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.server.htmx.hx)
+ */
 public val RoutingRequest.hx: HXRequestHeaders get() = HXRequestHeaders(headers)
 
+/**
+ * Provides typed access to the HTMX response headers that will be sent with this response.
+ *
+ * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.server.htmx.hx)
+ */
 public val RoutingResponse.hx: HXResponseHeaders get() = HXResponseHeaders(headers)
 
+/**
+ * Whether this request was made by htmx, i.e. the `HX-Request` header is set to `true`.
+ *
+ * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.server.htmx.isHtmx)
+ */
 public val RoutingRequest.isHtmx: Boolean get() = headers[HxRequestHeaders.Request] == "true"
 
+/**
+ * Typed accessors for the HTMX request headers sent by the htmx.org client library.
+ *
+ * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.server.htmx.HXRequestHeaders)
+ *
+ * @see [Official documentation](https://htmx.org/reference/#request_headers)
+ */
 @JvmInline
 public value class HXRequestHeaders(private val headers: Headers) {
 
@@ -67,13 +89,49 @@ public value class HXRequestHeaders(private val headers: Headers) {
     public val triggerName: String? get() = headers[HxRequestHeaders.TriggerName]
 }
 
+/**
+ * Typed accessors for setting the HTMX response headers understood by the htmx.org client library.
+ *
+ * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.server.htmx.HXResponseHeaders)
+ *
+ * @see [Official documentation](https://htmx.org/reference/#response_headers)
+ */
 @OptIn(InternalAPI::class)
 public class HXResponseHeaders(private val headers: ResponseHeaders) : StringMap {
 
+    /**
+     * Allows you to do a client-side redirect that does not do a full page reload.
+     *
+     * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.server.htmx.HXResponseHeaders.location)
+     */
     public var location: String? by HxResponseHeaders.Location
+
+    /**
+     * Pushes a new URL into the history stack.
+     *
+     * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.server.htmx.HXResponseHeaders.pushUrl)
+     */
     public var pushUrl: String? by HxResponseHeaders.PushUrl
+
+    /**
+     * Can be used to do a client-side redirect to a new location.
+     *
+     * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.server.htmx.HXResponseHeaders.redirect)
+     */
     public var redirect: String? by HxResponseHeaders.Redirect
+
+    /**
+     * If set to `true`, the client-side will do a full refresh of the page.
+     *
+     * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.server.htmx.HXResponseHeaders.refresh)
+     */
     public var refresh: Boolean? by HxResponseHeaders.Refresh.asBoolean()
+
+    /**
+     * Replaces the current URL in the location bar.
+     *
+     * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.server.htmx.HXResponseHeaders.replaceUrl)
+     */
     public val replaceUrl: String? by HxResponseHeaders.ReplaceUrl
 
     override fun set(key: String, value: String): Unit =

--- a/ktor-server/ktor-server-plugins/ktor-server-htmx/common/src/io/ktor/server/htmx/HxHeaders.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-htmx/common/src/io/ktor/server/htmx/HxHeaders.kt
@@ -8,15 +8,12 @@ import io.ktor.util.collections.*
 import io.ktor.utils.io.*
 import kotlin.jvm.JvmInline
 
-@ExperimentalKtorApi
 public val RoutingRequest.hx: HXRequestHeaders get() = HXRequestHeaders(headers)
 
-@ExperimentalKtorApi
 public val RoutingResponse.hx: HXResponseHeaders get() = HXResponseHeaders(headers)
 
 public val RoutingRequest.isHtmx: Boolean get() = headers[HxRequestHeaders.Request] == "true"
 
-@ExperimentalKtorApi
 @JvmInline
 public value class HXRequestHeaders(private val headers: Headers) {
 
@@ -70,7 +67,6 @@ public value class HXRequestHeaders(private val headers: Headers) {
     public val triggerName: String? get() = headers[HxRequestHeaders.TriggerName]
 }
 
-@ExperimentalKtorApi
 @OptIn(InternalAPI::class)
 public class HXResponseHeaders(private val headers: ResponseHeaders) : StringMap {
 

--- a/ktor-server/ktor-server-plugins/ktor-server-htmx/common/src/io/ktor/server/htmx/HxRouting.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-htmx/common/src/io/ktor/server/htmx/HxRouting.kt
@@ -14,7 +14,6 @@ import kotlin.jvm.JvmInline
  *
  * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.server.htmx.hx)
  */
-@ExperimentalKtorApi
 public val Route.hx: HxRoute get() = HxRoute.wrap(this)
 
 /**
@@ -22,7 +21,6 @@ public val Route.hx: HxRoute get() = HxRoute.wrap(this)
  *
  * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.server.htmx.hx)
  */
-@ExperimentalKtorApi
 public fun Route.hx(configuration: HxRoute.() -> Unit): Route = hx.apply(configuration)
 
 /**
@@ -30,7 +28,6 @@ public fun Route.hx(configuration: HxRoute.() -> Unit): Route = hx.apply(configu
  *
  * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.server.htmx.HxRoute)
  */
-@ExperimentalKtorApi
 @KtorDsl
 @JvmInline
 public value class HxRoute internal constructor(private val route: Route) : Route by route {

--- a/ktor-server/ktor-server-plugins/ktor-server-htmx/common/test/io/ktor/server/htmx/HxRoutingTest.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-htmx/common/test/io/ktor/server/htmx/HxRoutingTest.kt
@@ -11,7 +11,6 @@ import io.ktor.server.html.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
 import io.ktor.server.testing.*
-import io.ktor.utils.io.ExperimentalKtorApi
 import kotlinx.html.body
 import kotlinx.html.h1
 import kotlin.test.Test
@@ -19,7 +18,6 @@ import kotlin.test.assertEquals
 
 class HxRoutingTest {
 
-    @OptIn(ExperimentalKtorApi::class)
     @Test
     fun routing() = testApplication {
         val responseTemplate: (String) -> String = { header ->

--- a/ktor-shared/ktor-htmx/ktor-htmx-html/common/src/io/ktor/htmx/html/HxAttributes.kt
+++ b/ktor-shared/ktor-htmx/ktor-htmx-html/common/src/io/ktor/htmx/html/HxAttributes.kt
@@ -11,58 +11,292 @@ import kotlinx.html.HtmlTagMarker
 import kotlinx.html.impl.DelegatingMap
 import kotlin.jvm.JvmInline
 
+/**
+ * Provides typed access to the HTMX (`hx-*`) attributes of this tag.
+ *
+ * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.htmx.html.hx)
+ */
 public val DelegatingMap.hx: HxAttributes get() = HxAttributes(this)
 
+/**
+ * Configures the HTMX (`hx-*`) attributes of this tag.
+ *
+ * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.htmx.html.hx)
+ */
 public inline fun DelegatingMap.hx(block: HxAttributes.() -> Unit) {
     hx.block()
 }
 
+/**
+ * Typed accessors for the HTMX (`hx-*`) attributes understood by the htmx.org client library.
+ *
+ * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.htmx.html.HxAttributes)
+ *
+ * @see [Official documentation](https://htmx.org/reference/#attributes-additional)
+ */
 @HtmlTagMarker
 @OptIn(InternalAPI::class)
 public class HxAttributes(override val map: DelegatingMap) : StringMapDelegate {
+    /**
+     * Issues a GET to the specified URL.
+     *
+     * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.htmx.html.HxAttributes.get)
+     */
     public var get: String? by HxAttributeKeys.Get
+
+    /**
+     * Issues a POST to the specified URL.
+     *
+     * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.htmx.html.HxAttributes.post)
+     */
     public var post: String? by HxAttributeKeys.Post
+
+    /**
+     * Pushes a URL into the browser location bar to create history.
+     *
+     * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.htmx.html.HxAttributes.pushUrl)
+     */
     public var pushUrl: String? by HxAttributeKeys.PushUrl
+
+    /**
+     * Selects content to swap in from a response.
+     *
+     * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.htmx.html.HxAttributes.select)
+     */
     public var select: String? by HxAttributeKeys.Select
+
+    /**
+     * Selects content to swap in from a response, somewhere other than the target (out of band).
+     *
+     * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.htmx.html.HxAttributes.selectOob)
+     */
     public var selectOob: String? by HxAttributeKeys.SelectOob
+
+    /**
+     * Controls how content will swap in (outerHTML, beforeend, afterend, …).
+     *
+     * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.htmx.html.HxAttributes.swap)
+     */
     public var swap: String? by HxAttributeKeys.Swap
+
+    /**
+     * Marks element to swap in from a response (out of band).
+     *
+     * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.htmx.html.HxAttributes.swapOob)
+     */
     public var swapOob: String? by HxAttributeKeys.SwapOob
+
+    /**
+     * Specifies the target element to be swapped.
+     *
+     * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.htmx.html.HxAttributes.target)
+     */
     public var target: String? by HxAttributeKeys.Target
+
+    /**
+     * Specifies the event that triggers the request.
+     *
+     * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.htmx.html.HxAttributes.trigger)
+     */
     public var trigger: String? by HxAttributeKeys.Trigger
+
+    /**
+     * Adds values to submit with the request (JSON format).
+     *
+     * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.htmx.html.HxAttributes.vals)
+     */
     public var vals: String? by HxAttributeKeys.Vals
+
+    /**
+     * Adds progressive enhancement for links and forms.
+     *
+     * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.htmx.html.HxAttributes.boost)
+     */
     public var boost: Boolean? by HxAttributeKeys.Boost.asBoolean()
+
+    /**
+     * Shows a confirm() dialog before issuing a request.
+     *
+     * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.htmx.html.HxAttributes.confirm)
+     */
     public var confirm: String? by HxAttributeKeys.Confirm
+
+    /**
+     * Issues a DELETE to the specified URL.
+     *
+     * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.htmx.html.HxAttributes.delete)
+     */
     public var delete: String? by HxAttributeKeys.Delete
+
+    /**
+     * Disables htmx processing for the given node and any children nodes.
+     *
+     * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.htmx.html.HxAttributes.disable)
+     */
     public var disable: Boolean? by HxAttributeKeys.Disable.asPresenceBoolean()
+
+    /**
+     * Adds the disabled attribute to the specified elements while a request is in flight.
+     *
+     * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.htmx.html.HxAttributes.disabledElt)
+     */
     public var disabledElt: String? by HxAttributeKeys.DisabledElt
+
+    /**
+     * Controls and disables automatic attribute inheritance for child nodes.
+     *
+     * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.htmx.html.HxAttributes.disinherit)
+     */
     public var disinherit: String? by HxAttributeKeys.Disinherit
+
+    /**
+     * Changes the request encoding type.
+     *
+     * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.htmx.html.HxAttributes.encoding)
+     */
     public var encoding: String? by HxAttributeKeys.Encoding
+
+    /**
+     * Extensions to use for this element.
+     *
+     * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.htmx.html.HxAttributes.ext)
+     */
     public var ext: String? by HxAttributeKeys.Ext
+
+    /**
+     * Prevents sensitive data from being saved to the history cache.
+     *
+     * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.htmx.html.HxAttributes.history)
+     */
     public var history: String? by HxAttributeKeys.History
+
+    /**
+     * Specifies the element to snapshot and restore during history navigation.
+     *
+     * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.htmx.html.HxAttributes.historyElt)
+     */
     public var historyElt: String? by HxAttributeKeys.HistoryElt
+
+    /**
+     * Includes additional data in requests.
+     *
+     * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.htmx.html.HxAttributes.include)
+     */
     public var include: String? by HxAttributeKeys.Include
+
+    /**
+     * Specifies the element to put the htmx-request class on during the request.
+     *
+     * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.htmx.html.HxAttributes.indicator)
+     */
     public var indicator: String? by HxAttributeKeys.Indicator
+
+    /**
+     * Controls and enables automatic attribute inheritance for child nodes if it has been disabled by default.
+     *
+     * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.htmx.html.HxAttributes.inherit)
+     */
     public var inherit: String? by HxAttributeKeys.Inherit
+
+    /**
+     * Filters the parameters that will be submitted with a request.
+     *
+     * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.htmx.html.HxAttributes.params)
+     */
     public var params: String? by HxAttributeKeys.Params
+
+    /**
+     * Issues a PATCH to the specified URL.
+     *
+     * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.htmx.html.HxAttributes.patch)
+     */
     public var patch: String? by HxAttributeKeys.Patch
+
+    /**
+     * Specifies elements to keep unchanged between requests.
+     *
+     * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.htmx.html.HxAttributes.preserve)
+     */
     public var preserve: Boolean? by HxAttributeKeys.Preserve.asBoolean()
+
+    /**
+     * Shows a prompt() before submitting a request.
+     *
+     * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.htmx.html.HxAttributes.prompt)
+     */
     public var prompt: String? by HxAttributeKeys.Prompt
+
+    /**
+     * Issues a PUT to the specified URL.
+     *
+     * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.htmx.html.HxAttributes.put)
+     */
     public var put: String? by HxAttributeKeys.Put
+
+    /**
+     * Replaces the URL in the browser location bar.
+     *
+     * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.htmx.html.HxAttributes.replaceUrl)
+     */
     public var replaceUrl: String? by HxAttributeKeys.ReplaceUrl
+
+    /**
+     * Configures various aspects of the request.
+     *
+     * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.htmx.html.HxAttributes.request)
+     */
     public var request: String? by HxAttributeKeys.Request
+
+    /**
+     * Controls how requests made by different elements are synchronized.
+     *
+     * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.htmx.html.HxAttributes.sync)
+     */
     public var sync: String? by HxAttributeKeys.Sync
+
+    /**
+     * Forces elements to validate themselves before a request.
+     *
+     * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.htmx.html.HxAttributes.validate)
+     */
     public var validate: Boolean? by HxAttributeKeys.Validate.asBoolean()
+
+    /**
+     * Adds values dynamically to the parameters to submit with the request (deprecated, please use hx-vals).
+     *
+     * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.htmx.html.HxAttributes.vars)
+     */
     public var vars: String? by HxAttributeKeys.Vars
 
+    /**
+     * Provides typed access to the `hx-on:*` event handler attributes of this tag.
+     *
+     * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.htmx.html.HxAttributes.on)
+     */
     public val on: On
         get() = On(map)
 
+    /**
+     * Handles the given [event] with the inline [script] on this tag.
+     *
+     * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.htmx.html.HxAttributes.on)
+     */
     public fun on(event: String, script: String) {
         map["hx-on::$event"] = script
     }
 
+    /**
+     * Typed access to the `hx-on:*` event handler attributes of a tag.
+     *
+     * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.htmx.html.HxAttributes.On)
+     */
     @JvmInline
     public value class On(private val attributes: MutableMap<String, String>) {
+        /**
+         * Sets the inline [script] to run when [event] fires, or removes the handler if [script] is `null`.
+         *
+         * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.htmx.html.HxAttributes.On.set)
+         */
         public operator fun set(event: String, script: String?) {
             if (script == null) {
                 attributes.remove("${HxAttributeKeys.On}::$event")
@@ -71,6 +305,11 @@ public class HxAttributes(override val map: DelegatingMap) : StringMapDelegate {
             }
         }
 
+        /**
+         * Returns the inline script configured for [event], if any.
+         *
+         * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.htmx.html.HxAttributes.On.get)
+         */
         public operator fun get(event: String): String? = attributes["${HxAttributeKeys.On}:$event"]
     }
 }

--- a/ktor-shared/ktor-htmx/ktor-htmx-html/common/src/io/ktor/htmx/html/HxAttributes.kt
+++ b/ktor-shared/ktor-htmx/ktor-htmx-html/common/src/io/ktor/htmx/html/HxAttributes.kt
@@ -11,15 +11,12 @@ import kotlinx.html.HtmlTagMarker
 import kotlinx.html.impl.DelegatingMap
 import kotlin.jvm.JvmInline
 
-@ExperimentalKtorApi
 public val DelegatingMap.hx: HxAttributes get() = HxAttributes(this)
 
-@ExperimentalKtorApi
 public inline fun DelegatingMap.hx(block: HxAttributes.() -> Unit) {
     hx.block()
 }
 
-@ExperimentalKtorApi
 @HtmlTagMarker
 @OptIn(InternalAPI::class)
 public class HxAttributes(override val map: DelegatingMap) : StringMapDelegate {

--- a/ktor-shared/ktor-htmx/ktor-htmx-html/common/test/io/ktor/htmx/html/HxAttributesTest.kt
+++ b/ktor-shared/ktor-htmx/ktor-htmx-html/common/test/io/ktor/htmx/html/HxAttributesTest.kt
@@ -5,7 +5,6 @@
 package io.ktor.htmx.html
 
 import io.ktor.htmx.*
-import io.ktor.utils.io.*
 import kotlinx.html.body
 import kotlinx.html.button
 import kotlinx.html.html
@@ -15,7 +14,6 @@ import kotlin.test.assertEquals
 
 class HxAttributesTest {
 
-    @OptIn(ExperimentalKtorApi::class)
     @Test
     fun htmxAttributes() {
         val actual = buildString {


### PR DESCRIPTION
**Subsystem**
Server, HTMX

**Motivation**
[KTOR-9787](https://youtrack.jetbrains.com/issue/KTOR-9787) Remove experimental flag for HTMX

Since this hasn't changed much at all since its introduction, I think we can safely remove the experimental flag now.

**Solution**
Removed the experimental flag.

