### PR TITLE
KTOR-9735 Use SystemFileSystem default in cache file storage

### DIFF
--- a/ktor-client/ktor-client-core/api/ktor-client-core.api
+++ b/ktor-client/ktor-client-core/api/ktor-client-core.api
@@ -712,8 +712,8 @@ public final class io/ktor/client/plugins/cache/storage/FileCacheStorageKt {
 }
 
 public final class io/ktor/client/plugins/cache/storage/FileStorageKt {
-	public static final fun FileStorage (Lkotlinx/io/files/FileSystem;Lkotlinx/io/files/Path;Lkotlinx/coroutines/CoroutineDispatcher;)Lio/ktor/client/plugins/cache/storage/CacheStorage;
-	public static synthetic fun FileStorage$default (Lkotlinx/io/files/FileSystem;Lkotlinx/io/files/Path;Lkotlinx/coroutines/CoroutineDispatcher;ILjava/lang/Object;)Lio/ktor/client/plugins/cache/storage/CacheStorage;
+	public static final fun FileStorage (Lkotlinx/io/files/Path;Lkotlinx/io/files/FileSystem;Lkotlinx/coroutines/CoroutineDispatcher;)Lio/ktor/client/plugins/cache/storage/CacheStorage;
+	public static synthetic fun FileStorage$default (Lkotlinx/io/files/Path;Lkotlinx/io/files/FileSystem;Lkotlinx/coroutines/CoroutineDispatcher;ILjava/lang/Object;)Lio/ktor/client/plugins/cache/storage/CacheStorage;
 }
 
 public abstract class io/ktor/client/plugins/cache/storage/HttpCacheStorage {

--- a/ktor-client/ktor-client-core/api/ktor-client-core.klib.api
+++ b/ktor-client/ktor-client-core/api/ktor-client-core.klib.api
@@ -1694,7 +1694,7 @@ final suspend inline fun <#A: reified kotlin/Any?> (io.ktor.client.plugins.webso
 final suspend inline fun <#A: reified kotlin/Any?> (io.ktor.client.statement/HttpResponse).io.ktor.client.call/body(): #A // io.ktor.client.call/body|body@io.ktor.client.statement.HttpResponse(){0§<kotlin.Any?>}[0]
 
 // Targets: [native]
-final fun io.ktor.client.plugins.cache.storage/FileStorage(kotlinx.io.files/FileSystem, kotlinx.io.files/Path, kotlinx.coroutines/CoroutineDispatcher = ...): io.ktor.client.plugins.cache.storage/CacheStorage // io.ktor.client.plugins.cache.storage/FileStorage|FileStorage(kotlinx.io.files.FileSystem;kotlinx.io.files.Path;kotlinx.coroutines.CoroutineDispatcher){}[0]
+final fun io.ktor.client.plugins.cache.storage/FileStorage(kotlinx.io.files/Path, kotlinx.io.files/FileSystem = ..., kotlinx.coroutines/CoroutineDispatcher = ...): io.ktor.client.plugins.cache.storage/CacheStorage // io.ktor.client.plugins.cache.storage/FileStorage|FileStorage(kotlinx.io.files.Path;kotlinx.io.files.FileSystem;kotlinx.coroutines.CoroutineDispatcher){}[0]
 
 // Targets: [js, wasmJs]
 abstract interface io.ktor.client.fetch/AbortSignal : io.ktor.client.fetch/EventTarget { // io.ktor.client.fetch/AbortSignal|null[0]

--- a/ktor-client/ktor-client-core/jvm/src/io/ktor/client/plugins/cache/storage/FileCacheStorage.kt
+++ b/ktor-client/ktor-client-core/jvm/src/io/ktor/client/plugins/cache/storage/FileCacheStorage.kt
@@ -7,7 +7,6 @@ package io.ktor.client.plugins.cache.storage
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.io.files.Path
-import kotlinx.io.files.SystemFileSystem
 import java.io.File
 
 /**
@@ -24,7 +23,6 @@ public fun FileStorage(
     directory: File,
     dispatcher: CoroutineDispatcher = Dispatchers.IO
 ): CacheStorage = FileStorage(
-    fileSystem = SystemFileSystem,
     directory = Path(directory.path),
     dispatcher = dispatcher,
 )

--- a/ktor-client/ktor-client-core/jvmAndPosix/src/io/ktor/client/plugins/cache/storage/FileStorage.kt
+++ b/ktor-client/ktor-client-core/jvmAndPosix/src/io/ktor/client/plugins/cache/storage/FileStorage.kt
@@ -25,21 +25,21 @@ import kotlinx.io.files.*
  *
  * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.client.plugins.cache.storage.FileStorage)
  *
- * @param fileSystem file system to use for file operations.
  * @param directory directory to store cache data.
+ * @param fileSystem file system to use for file operations.
  * @param dispatcher dispatcher to use for file operations.
  */
 @Suppress("FunctionName")
 public fun FileStorage(
-    fileSystem: FileSystem,
     directory: Path,
+    fileSystem: FileSystem = SystemFileSystem,
     dispatcher: CoroutineDispatcher = ioDispatcher()
-): CacheStorage = CachingCacheStorage(FileCacheStorage(fileSystem, directory, dispatcher))
+): CacheStorage = CachingCacheStorage(FileCacheStorage(directory, fileSystem, dispatcher))
 
 private class FileCacheStorage(
-    private val fileSystem: FileSystem,
     private val directoryPath: Path,
-    private val dispatcher: CoroutineDispatcher = ioDispatcher()
+    private val fileSystem: FileSystem,
+    private val dispatcher: CoroutineDispatcher
 ) : CacheStorage {
 
     private val mutexes = ConcurrentMap<String, Mutex>()

--- a/ktor-client/ktor-client-core/jvmAndPosix/test/FileStorageTest.kt
+++ b/ktor-client/ktor-client-core/jvmAndPosix/test/FileStorageTest.kt
@@ -39,7 +39,7 @@ class FileStorageTest {
 
     @Test
     fun testFindAll() = runTest {
-        val storage = FileStorage(SystemFileSystem, tempDirectory)
+        val storage = FileStorage(tempDirectory)
 
         storage.store(Url("http://example.com"), data())
         storage.store(Url("http://example.com"), data(mapOf("key" to "value")))
@@ -49,7 +49,7 @@ class FileStorageTest {
 
     @Test
     fun testFind() = runTest {
-        val storage = FileStorage(SystemFileSystem, tempDirectory)
+        val storage = FileStorage(tempDirectory)
 
         storage.store(Url("http://example.com"), data())
         // Use an uppercase key to test case insensitivity
@@ -60,7 +60,7 @@ class FileStorageTest {
 
     @Test
     fun testStore() = runTest {
-        val storage = FileStorage(SystemFileSystem, tempDirectory)
+        val storage = FileStorage(tempDirectory)
         storage.store(Url("http://example.com"), data())
 
         assertEquals(1, storage.findAll(Url("http://example.com")).size)
@@ -72,7 +72,7 @@ class FileStorageTest {
 
     @Test
     fun testRemove() = runTest {
-        val storage = FileStorage(SystemFileSystem, tempDirectory)
+        val storage = FileStorage(tempDirectory)
         storage.store(Url("http://example.com"), data())
         storage.store(Url("http://example.com"), data(mapOf("key" to "value")))
 
@@ -85,7 +85,7 @@ class FileStorageTest {
 
     @Test
     fun testRemoveAll() = runTest {
-        val storage = FileStorage(SystemFileSystem, tempDirectory)
+        val storage = FileStorage(tempDirectory)
         storage.store(Url("http://example.com"), data())
         storage.store(Url("http://example.com"), data(mapOf("key" to "value")))
 
@@ -97,7 +97,7 @@ class FileStorageTest {
 
     @Test
     fun `clear removes entries for all cached URLs`() = runTest {
-        val storage = FileStorage(SystemFileSystem, tempDirectory)
+        val storage = FileStorage(tempDirectory)
         storage.store(Url("http://example.com"), data())
         storage.store(Url("http://example.com"), data(mapOf("key" to "value")))
         storage.store(Url("http://other.com"), data())

--- a/ktor-client/ktor-client-tests/jvmAndPosix/test/io/ktor/client/tests/FileCacheTest.kt
+++ b/ktor-client/ktor-client-tests/jvmAndPosix/test/io/ktor/client/tests/FileCacheTest.kt
@@ -25,8 +25,8 @@ import kotlin.uuid.Uuid
 
 class FileCacheTest : ClientLoader() {
     private val tmpDirPath = temporaryDirectoryPath()
-    private val publicStorage = FileStorage(SystemFileSystem, Path(tmpDirPath, "cache-test-public"))
-    private val privateStorage = FileStorage(SystemFileSystem, Path(tmpDirPath, "cache-test-private"))
+    private val publicStorage = FileStorage(Path(tmpDirPath, "cache-test-public"))
+    private val privateStorage = FileStorage(Path(tmpDirPath, "cache-test-private"))
 
     @Test
     fun testVaryHeader() = clientTests {
@@ -126,7 +126,7 @@ class FileCacheTest : ClientLoader() {
     @Test
     fun testSkipCacheIfException() = clientTests {
         val path = Path(SystemTemporaryDirectory, "cache-test-public-deleted")
-        val publicStorage = FileStorage(SystemFileSystem, path)
+        val publicStorage = FileStorage(path)
         config {
             install(HttpCache) {
                 publicStorage(publicStorage)
@@ -146,7 +146,7 @@ class FileCacheTest : ClientLoader() {
     @Test
     fun testUpgradeOldCacheVersionWithCaseSensitiveVary() = clientTests {
         val path = Path(SystemTemporaryDirectory, "cache-test-public-upgrade")
-        val publicStorage = FileStorage(SystemFileSystem, path)
+        val publicStorage = FileStorage(path)
         config {
             install(HttpCache) {
                 publicStorage(publicStorage)


### PR DESCRIPTION
**Subsystem**
Client, HttpCache

**Motivation**
[KTOR-9735](https://youtrack.jetbrains.com/issue/KTOR-9735) Commonize HttpCache FileCacheStorage

I noticed in https://github.com/ktorio/ktor/pull/4940 that there was a required `FileSystem` argument, which can be replaced with the default `SystemFileSystem` for the sake of convenience.

**Solution**
Updated the function signature to include a default argument.

This API has not been released yet, so we can ignore the breaking change in the ABI here.

