### PR TITLE
Accept optional whitespace around commas in the Range header

### DIFF
--- a/ktor-http/common/src/io/ktor/http/Ranges.kt
+++ b/ktor-http/common/src/io/ktor/http/Ranges.kt
@@ -75,12 +75,18 @@ public sealed class ContentRange {
  * Parse `Range` header value
  *
  * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.http.parseRangesSpecifier)
+ *
+ * @param rangeSpec the raw `Range` header value, for example `bytes=0-499, 1000-1499`.
+ * Optional whitespace (space or horizontal tab) around the commas separating the range set is accepted,
+ * as allowed by the list syntax of RFC 9110 5.6.1.
+ * @return the parsed specifier, or `null` if [rangeSpec] is syntactically incorrect or unsatisfiable
  */
 public fun parseRangesSpecifier(rangeSpec: String): RangesSpecifier? {
     try {
         val (unit, allRangesString) = rangeSpec.chomp("=") { return null }
-        // A range set is a comma-separated list, and RFC 9110 5.6.1 allows optional whitespace around the commas
-        val allRanges = allRangesString.split(',').map { it.trim() }.map {
+        // A range set is a comma-separated list, and RFC 9110 5.6.1 allows optional whitespace (SP / HTAB)
+        // around the commas
+        val allRanges = allRangesString.split(',').map { it.trim(' ', '\t') }.map {
             if (it.startsWith("-")) {
                 ContentRange.Suffix(it.removePrefix("-").toLong())
             } else {

--- a/ktor-http/common/src/io/ktor/http/Ranges.kt
+++ b/ktor-http/common/src/io/ktor/http/Ranges.kt
@@ -79,7 +79,8 @@ public sealed class ContentRange {
 public fun parseRangesSpecifier(rangeSpec: String): RangesSpecifier? {
     try {
         val (unit, allRangesString) = rangeSpec.chomp("=") { return null }
-        val allRanges = allRangesString.split(',').map {
+        // A range set is a comma-separated list, and RFC 9110 5.6.1 allows optional whitespace around the commas
+        val allRanges = allRangesString.split(',').map { it.trim() }.map {
             if (it.startsWith("-")) {
                 ContentRange.Suffix(it.removePrefix("-").toLong())
             } else {

--- a/ktor-http/common/src/io/ktor/http/Ranges.kt
+++ b/ktor-http/common/src/io/ktor/http/Ranges.kt
@@ -77,20 +77,17 @@ public sealed class ContentRange {
  * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.http.parseRangesSpecifier)
  *
  * @param rangeSpec the raw `Range` header value, for example `bytes=0-499, 1000-1499`.
- * Optional whitespace (space or horizontal tab) around the commas separating the range set is accepted,
- * as allowed by the list syntax of RFC 9110 5.6.1.
  * @return the parsed specifier, or `null` if [rangeSpec] is syntactically incorrect or unsatisfiable
  */
 public fun parseRangesSpecifier(rangeSpec: String): RangesSpecifier? {
     try {
         val (unit, allRangesString) = rangeSpec.chomp("=") { return null }
-        // A range set is a comma-separated list, and RFC 9110 5.6.1 allows optional whitespace (SP / HTAB)
-        // around the commas
-        val allRanges = allRangesString.split(',').map { it.trim(' ', '\t') }.map {
-            if (it.startsWith("-")) {
-                ContentRange.Suffix(it.removePrefix("-").toLong())
+        val allRanges = allRangesString.split(',').map { segment ->
+            val range = segment.trim(' ', '\t')
+            if (range.startsWith("-")) {
+                ContentRange.Suffix(range.removePrefix("-").toLong())
             } else {
-                val (from, to) = it.chomp("-") { "" to "" }
+                val (from, to) = range.chomp("-") { "" to "" }
                 when {
                     to.isNotEmpty() -> ContentRange.Bounded(from.toLong(), to.toLong())
                     else -> ContentRange.TailFrom(from.toLong())

--- a/ktor-http/common/test/io/ktor/tests/http/RangesTest.kt
+++ b/ktor-http/common/test/io/ktor/tests/http/RangesTest.kt
@@ -55,6 +55,34 @@ class RangesTest {
     }
 
     @Test
+    fun testParseWhitespaceAfterComma() {
+        assertEquals(
+            RangesSpecifier(
+                RangeUnits.Bytes,
+                listOf(
+                    ContentRange.Bounded(0, 499),
+                    ContentRange.Bounded(1000, 1499)
+                )
+            ),
+            parseRangesSpecifier("bytes=0-499, 1000-1499")
+        )
+    }
+
+    @Test
+    fun testParseWhitespaceAroundComma() {
+        assertEquals(
+            RangesSpecifier(
+                RangeUnits.Bytes,
+                listOf(
+                    ContentRange.TailFrom(9500),
+                    ContentRange.Suffix(500)
+                )
+            ),
+            parseRangesSpecifier("bytes=9500-\t, -500")
+        )
+    }
+
+    @Test
     fun testParseEmpty() {
         assertNull(parseRangesSpecifier(""))
     }

--- a/ktor-http/common/test/io/ktor/tests/http/RangesTest.kt
+++ b/ktor-http/common/test/io/ktor/tests/http/RangesTest.kt
@@ -55,7 +55,7 @@ class RangesTest {
     }
 
     @Test
-    fun testParseWhitespaceAfterComma() {
+    fun `parse whitespace after comma`() {
         assertEquals(
             RangesSpecifier(
                 RangeUnits.Bytes,
@@ -69,7 +69,7 @@ class RangesTest {
     }
 
     @Test
-    fun testParseWhitespaceAroundComma() {
+    fun `parse whitespace around comma`() {
         assertEquals(
             RangesSpecifier(
                 RangeUnits.Bytes,
@@ -80,6 +80,20 @@ class RangesTest {
             ),
             parseRangesSpecifier("bytes=9500-\t, -500")
         )
+    }
+
+    @Test
+    fun `reject line breaks around comma`() {
+        assertNull(parseRangesSpecifier("bytes=0-499,\n1000-1499"))
+        assertNull(parseRangesSpecifier("bytes=0-499\r, 1000-1499"))
+    }
+
+    @Test
+    fun `reject empty range set elements`() {
+        assertNull(parseRangesSpecifier("bytes=,0-499"))
+        assertNull(parseRangesSpecifier("bytes=0-499,"))
+        assertNull(parseRangesSpecifier("bytes=0-499,,1000-1499"))
+        assertNull(parseRangesSpecifier("bytes=0-499, ,1000-1499"))
     }
 
     @Test


### PR DESCRIPTION
**Subsystem**

Server / `ktor-http` (`parseRangesSpecifier`), which is what `PartialContent` uses to read the `Range` header.

**Motivation**

`Range` carries a comma-separated list, and RFC 9110 [5.6.1](https://www.rfc-editor.org/rfc/rfc9110#section-5.6.1)
expands `1#element` to `element *( OWS "," OWS element )`, so `bytes=0-499, 1000-1499` is well-formed.

`parseRangesSpecifier` splits on `,` and hands each element to `toLong()` untrimmed:

```kotlin
val allRanges = allRangesString.split(',').map {
    ...
    ContentRange.Bounded(from.toLong(), to.toLong())
```

`" 1000"` throws `NumberFormatException`, the surrounding `catch (e: Throwable)` classifies the header as
syntactically incorrect, and the whole header is dropped rather than the one element.

Measured on `release/3.x` with the `PartialContentTest` harness (1100 byte body), the only difference between
the two requests being the space after the comma:

| `Range` | status | `Content-Range` |
| --- | --- | --- |
| `bytes=0-0,1-2` | 206 Partial Content | `bytes 0-2/1100` |
| `bytes=0-0, 1-2` | 200 OK | absent |

So a client that writes a space after the comma silently gets the full body instead of a 206.

No YouTrack ticket exists for this one, so there is no `KTOR-{NUM}` prefix.

**Solution**

Trim each list element before parsing it, and cover it with two tests in `RangesTest`
(space after the comma, and tab/space on both sides).

This covers only the OWS of the list rule. Empty list elements (`bytes=0-0,,1-2`) are still rejected;
that is a separate leniency and out of scope here.

Verification, with `JAVA_HOME` set to JDK 21:

- `./gradlew :ktor-http:jvmTest` — 294 tests, 0 failures.
- `./gradlew :ktor-http:lintKotlin` and `./gradlew :ktor-http:compileKotlinJs` pass.
- No public signature change, so there is no `api/*.api` update in the diff.

Reverting only the production hunk and keeping the tests fails, so the tests do pin the fix:

```
RangesTest[jvm] > testParseWhitespaceAfterComma()[jvm] FAILED
    org.opentest4j.AssertionFailedError: expected: <bytes=0-499,1000-1499> but was: <null>
RangesTest[jvm] > testParseWhitespaceAroundComma()[jvm] FAILED
    org.opentest4j.AssertionFailedError: expected: <bytes=9500-,-500> but was: <null>
```

Bug fix without API changes, so the base branch is `release/3.x` per the branching strategy in CONTRIBUTING.
The affected line is identical on `main`.
