### PR TITLE
Remove workaround for KT-83710

### DIFF
--- a/build-logic/src/main/kotlin/ktorbuild.kmp.gradle.kts
+++ b/build-logic/src/main/kotlin/ktorbuild.kmp.gradle.kts
@@ -73,12 +73,6 @@ if (targets.hasNative) {
     // A workaround for KT-77609
     tasks.matching { it::class.simpleName?.startsWith("CInteropCommonizerTask") == true }
         .configureEach { withLimitedParallelism("native-tools", maxParallelTasks = 3) }
-
-    // A workaround for KT-83710
-    tasks.named { it == "commonizeNativeDistribution" }
-        .configureEach { dependsOn("downloadKotlinNativeDistribution") }
-    tasks.named { it == "downloadKotlinNativeDistribution" }
-        .configureEach { outputs.upToDateWhen { false } }
 }
 
 if (ktorBuild.isCI.get()) configureTestTasksOnCi()


### PR DESCRIPTION
**Subsystem**

Build logic

**Motivation**

The build file contained a workaround for [KT-83710](https://youtrack.jetbrains.com/issue/KT-83710) (though, more accurately, a workaround for [KTOR-9190](https://youtrack.jetbrains.com/issue/KTOR-9190)). The main issue requiring this workaround was fixed in [KT-83598](https://youtrack.jetbrains.com/issue/KT-83598) (and released in Kotlin 2.3.20-Beta2), so the workaround can be removed now.

**Solution**

The solution simply removes the build code that's not needed anymore. I verified that the project builds correctly without the workaround using the following steps (as outlined in [KTOR-9190](https://youtrack.jetbrains.com/issue/KTOR-9190)):

1. Syncing the project in the IDE (IDEA 2026.2.1), both with the `~/.konan` directory already primed and deleted.
2. Running `./gradlew :ktor-io:commonizeCInterop`, similarly with and without the `~/.konan` directory.

