### PR TITLE
Keep only one Application running in Hot Reload

### DIFF
--- a/ktor-server/ktor-server-core/jvm/src/io/ktor/server/engine/EmbeddedServerJvm.kt
+++ b/ktor-server/ktor-server-core/jvm/src/io/ktor/server/engine/EmbeddedServerJvm.kt
@@ -2,6 +2,8 @@
  * Copyright 2014-2025 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
+@file:OptIn(InternalAPI::class)
+
 package io.ktor.server.engine
 
 import io.ktor.events.*
@@ -27,6 +29,7 @@ import java.util.concurrent.locks.ReentrantReadWriteLock
 import kotlin.concurrent.getOrSet
 import kotlin.concurrent.read
 import kotlin.concurrent.write
+import kotlin.time.Duration.Companion.milliseconds
 
 private typealias ApplicationModule = suspend Application.() -> Unit
 
@@ -61,9 +64,10 @@ actual constructor(
     private val moduleInjector: ModuleParametersInjector by lazy {
         loadServiceOrNull() ?: ModuleParametersInjector.Disabled
     }
-    private val modules: List<DynamicApplicationModule> get() =
-        environment.moduleConfigReferences.map(::dynamicModule) +
-            rootConfig.modules.map { module -> module.toDynamicModuleOrNull() ?: module.wrapWithDynamicModule() }
+    private val modules: List<DynamicApplicationModule>
+        get() =
+            environment.moduleConfigReferences.map(::dynamicModule) +
+                rootConfig.modules.map { module -> module.toDynamicModuleOrNull() ?: module.wrapWithDynamicModule() }
 
     private var applicationInstance: Application? = Application(
         environment,
@@ -91,10 +95,11 @@ actual constructor(
     }
 
     /**
-     * Reload application: build a new instance first, then dispose of the previous one.
+     * Reload application: stop the current instance first, then create a replacement.
      *
-     * If the new application cannot be created (for example, because the user code throws during
-     * module loading), the previous instance is preserved and the failure is rethrown.
+     * If creation fails (for example, because the user code throws during module loading),
+     * the engine and file watcher keep running without an application. Another explicit
+     * [reload] call may retry; auto-reload retries only after another watched-file change.
      *
      * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.server.engine.EmbeddedServer.reload)
      */
@@ -105,24 +110,22 @@ actual constructor(
     }
 
     private fun currentApplication(): Application = applicationInstanceLock.read {
-        val currentApplication = applicationInstance ?: error("EmbeddedServer was stopped")
-
         if (!rootConfig.developmentMode) {
-            return@read currentApplication
+            return@read applicationInstance ?: error("EmbeddedServer was stopped")
         }
 
+        // Poll for changes even when no application is loaded, so a failed reload can recover
+        // after the next filesystem event.
         if (getFileChanges().isNullOrEmpty()) {
-            return@read currentApplication
+            return@read applicationInstance ?: error("EmbeddedServer was stopped")
         }
 
         applicationInstanceLock.write {
             try {
                 reloadApplication()
             } catch (cause: Throwable) {
-                environment.log.error(
-                    "Auto-reload failed; continuing to serve the previously loaded application.",
-                    cause,
-                )
+                environment.log.error("Auto-reload failed.", cause)
+                throw cause
             }
         }
 
@@ -130,10 +133,10 @@ actual constructor(
     }
 
     /**
-     * Build a new application and swap it in, disposing of the previous one only on success.
+     * Stop the current application (if any), then create and install a replacement.
      *
-     * On failure the previous application, its class loader, and the registered watch keys
-     * are left intact so the server keeps serving requests against the last known-good code.
+     * On failure the engine keeps running, [applicationInstance] stays null, watch keys from
+     * the failed attempt are retained, and a partially initialized replacement is disposed of.
      *
      * Must be called while holding the write lock on [applicationInstanceLock].
      */
@@ -142,39 +145,36 @@ actual constructor(
         val previousClassLoader = applicationClassLoader
         val previousWatchKeys = packageWatchKeys
 
-        val (newApplication, newClassLoader) = try {
-            createApplication()
-        } catch (cause: Throwable) {
-            // createClassLoader -> watchUrls() may have already replaced packageWatchKeys before
-            // instantiateAndConfigureApplication() failed. Cancel those freshly-registered keys
-            // (they belong to a class loader we are discarding) and restore the previous ones.
-            if (packageWatchKeys !== previousWatchKeys) {
-                packageWatchKeys.forEach { it.cancel() }
-                packageWatchKeys = previousWatchKeys
-            }
-            throw cause
-        }
+        applicationInstance = null
+        applicationClassLoader = null
 
         if (previousApplication != null) {
-            safeRaiseEvent(ApplicationStopping, previousApplication)
-            try {
-                destroyBlocking(previousApplication, previousClassLoader)
-            } catch (e: Throwable) {
-                environment.log.error("Failed to destroy previous application instance.", e)
-            }
-            safeRaiseEvent(ApplicationStopped, previousApplication)
-        }
-        if (packageWatchKeys !== previousWatchKeys) {
-            previousWatchKeys.forEach { it.cancel() }
+            disposeApplication(previousApplication, previousClassLoader)
         }
 
-        applicationInstance = newApplication
-        applicationClassLoader = newClassLoader
+        try {
+            val (newApplication, newClassLoader) = createApplication()
+            applicationInstance = newApplication
+            applicationClassLoader = newClassLoader
+        } catch (cause: Throwable) {
+            environment.log.error("Application reload failed.", cause)
+            throw cause
+        } finally {
+            // Keep watch keys from the latest creation attempt (or the previous ones if create
+            // failed before watchUrls). Drop only obsolete previous-only keys.
+            for (watchKey in previousWatchKeys) {
+                if (watchKey !in packageWatchKeys) {
+                    watchKey.cancel()
+                }
+            }
+        }
     }
 
     private fun getFileChanges(): List<WatchEvent<*>>? {
         try {
-            val changes = packageWatchKeys.flatMap { it.pollEvents() }
+            val changes = packageWatchKeys.flatMap { key ->
+                key.pollEvents().also { key.reset() }
+            }
             if (changes.isEmpty()) {
                 return changes
             }
@@ -184,7 +184,9 @@ actual constructor(
             var count = changes.size
             while (true) {
                 Thread.sleep(200)
-                val moreChanges = packageWatchKeys.flatMap { it.pollEvents() }
+                val moreChanges = packageWatchKeys.flatMap { key ->
+                    key.pollEvents().also { key.reset() }
+                }
                 if (moreChanges.isEmpty()) {
                     break
                 }
@@ -213,6 +215,11 @@ actual constructor(
 
         try {
             return instantiateAndConfigureApplication(classLoader) to classLoader
+        } catch (cause: Throwable) {
+            // Application cleanup (if a new instance was created) happens in
+            // instantiateAndConfigureApplication. Always close a discarded overriding loader.
+            (classLoader as? OverridingClassLoader)?.close()
+            throw cause
         } finally {
             currentThread.contextClassLoader = oldThreadClassLoader
         }
@@ -245,7 +252,11 @@ actual constructor(
         val jre = File(System.getProperty("java.home")).parent
         val debugUrls = allUrls.map { it.file }
         environment.log.debug("Java Home: $jre")
-        environment.log.debug("Class Loader: $baseClassLoader: ${debugUrls.filter { !it.toString().startsWith(jre) }}")
+        environment.log.debug(
+            "Class Loader: {}: {}",
+            baseClassLoader,
+            debugUrls.filter { !it.toString().startsWith(jre) }
+        )
 
         // we shouldn't watch URL for ktor-server classes, even if they match patterns,
         // because otherwise it loads two ApplicationEnvironment (and other) types which do not match
@@ -292,23 +303,16 @@ actual constructor(
         applicationClassLoader = null
 
         if (currentApplication != null) {
-            safeRaiseEvent(ApplicationStopping, currentApplication)
-            try {
-                destroyBlocking(currentApplication, currentApplicationClassLoader)
-            } catch (e: Throwable) {
-                environment.log.error("Failed to destroy application instance.", e)
-            }
-            safeRaiseEvent(ApplicationStopped, currentApplication)
+            disposeApplication(currentApplication, currentApplicationClassLoader)
         }
         packageWatchKeys.forEach { it.cancel() }
         packageWatchKeys = mutableListOf()
     }
 
-    @OptIn(InternalAPI::class)
     private fun destroyBlocking(application: Application, classLoader: ClassLoader?) {
         try {
             runBlocking {
-                withTimeout(engineConfig.shutdownTimeout) {
+                withTimeout(engineConfig.shutdownTimeout.milliseconds) {
                     application.disposeAndJoin()
                 }
             }
@@ -350,7 +354,7 @@ actual constructor(
         }
 
         paths.forEach { path ->
-            environment.log.debug("Watching $path for changes.")
+            environment.log.debug("Watching {} for changes.", path)
         }
 
         val modifiers = get_com_sun_nio_file_SensitivityWatchEventModifier_HIGH()?.let { arrayOf(it) } ?: emptyArray()
@@ -418,7 +422,8 @@ actual constructor(
     }
 
     private fun instantiateAndConfigureApplication(currentClassLoader: ClassLoader): Application {
-        val newInstance = if (recreateInstance || applicationInstance == null) {
+        val createdNewInstance = recreateInstance || applicationInstance == null
+        val newInstance = if (createdNewInstance) {
             Application(
                 environment,
                 rootConfig.developmentMode,
@@ -432,22 +437,42 @@ actual constructor(
             applicationInstance!!
         }
 
-        safeRaiseEvent(ApplicationStarting, newInstance)
+        try {
+            safeRaiseEvent(ApplicationStarting, newInstance)
 
-        avoidingDoubleStartup {
-            withTimeout(environment.startupTimeout) {
-                environment.moduleLoader.loadModules(
-                    newInstance,
-                    currentClassLoader,
-                    modules,
-                )
+            avoidingDoubleStartup {
+                withTimeout(environment.startupTimeout) {
+                    environment.moduleLoader.loadModules(
+                        newInstance,
+                        currentClassLoader,
+                        modules,
+                    )
+                }
             }
+
+            monitor.raise(ApplicationModulesLoaded, newInstance)
+            monitor.raise(ApplicationStarted, newInstance)
+
+            return newInstance
+        } catch (cause: Throwable) {
+            // Dispose of orphaned replacement instances. The pre-start reused instance is cleaned by
+            // start()'s destroyApplication() path instead to avoid double disposal.
+            if (createdNewInstance) {
+                // Class loader is closed by createApplication()'s failure path.
+                disposeApplication(newInstance, classLoader = null)
+            }
+            throw cause
         }
+    }
 
-        monitor.raise(ApplicationModulesLoaded, newInstance)
-        monitor.raise(ApplicationStarted, newInstance)
-
-        return newInstance
+    private fun disposeApplication(application: Application, classLoader: ClassLoader?) {
+        safeRaiseEvent(ApplicationStopping, application)
+        try {
+            destroyBlocking(application, classLoader)
+        } catch (e: Throwable) {
+            environment.log.error("Failed to destroy application instance.", e)
+        }
+        safeRaiseEvent(ApplicationStopped, application)
     }
 
     private fun dynamicModule(name: String): DynamicApplicationModule {
@@ -479,8 +504,8 @@ actual constructor(
     }
 
     /**
-     * Method name getting might fail if method signature has been changed after compilation
-     * (for example by R8 or ProGuard).
+     * Method name getting might fail if the method signature has been changed after compilation
+     * (for example, by R8 or ProGuard).
      *
      * We must also filter out function names with $, assuming they are anonymous.
      */

--- a/ktor-server/ktor-server-core/jvm/src/io/ktor/server/engine/EmbeddedServerJvm.kt
+++ b/ktor-server/ktor-server-core/jvm/src/io/ktor/server/engine/EmbeddedServerJvm.kt
@@ -57,6 +57,9 @@ actual constructor(
     private var applicationClassLoader: ClassLoader? = null
     private var packageWatchKeys = emptyList<WatchKey>()
 
+    /** Bumped after each successful reload; used to skip duplicate auto-reloads. */
+    private var applicationGeneration: Int = 0
+
     private val configuredWatchPath = environment.config.propertyOrNull("ktor.deployment.watch")?.getList().orEmpty()
     private val watchPatterns: List<String> = configuredWatchPath + rootConfig.watchPaths
 
@@ -65,9 +68,8 @@ actual constructor(
         loadServiceOrNull() ?: ModuleParametersInjector.Disabled
     }
     private val modules: List<DynamicApplicationModule>
-        get() =
-            environment.moduleConfigReferences.map(::dynamicModule) +
-                rootConfig.modules.map { module -> module.toDynamicModuleOrNull() ?: module.wrapWithDynamicModule() }
+        get() = environment.moduleConfigReferences.map(::dynamicModule) +
+            rootConfig.modules.map { module -> module.toDynamicModuleOrNull() ?: module.wrapWithDynamicModule() }
 
     private var applicationInstance: Application? = Application(
         environment,
@@ -106,30 +108,42 @@ actual constructor(
     public fun reload() {
         applicationInstanceLock.write {
             reloadApplication()
+            applicationGeneration++
         }
     }
 
-    private fun currentApplication(): Application = applicationInstanceLock.read {
+    private fun getApplicationOrThrow(): Application {
+        return applicationInstance ?: error("Application is not loaded; check logs for details")
+    }
+
+    private fun currentApplication(): Application {
         if (!rootConfig.developmentMode) {
-            return@read applicationInstance ?: error("EmbeddedServer was stopped")
+            return applicationInstanceLock.read { getApplicationOrThrow() }
         }
 
-        // Poll for changes even when no application is loaded, so a failed reload can recover
-        // after the next filesystem event.
-        if (getFileChanges().isNullOrEmpty()) {
-            return@read applicationInstance ?: error("EmbeddedServer was stopped")
-        }
-
-        applicationInstanceLock.write {
-            try {
-                reloadApplication()
-            } catch (cause: Throwable) {
-                environment.log.error("Auto-reload failed.", cause)
-                throw cause
+        // Poll under the read lock only. Later write-lock re-poll can be empty even when this thread must still reload.
+        // Track generation instead.
+        val generationBefore = applicationInstanceLock.read {
+            if (drainFileChanges().isNullOrEmpty()) {
+                return getApplicationOrThrow()
             }
+            applicationGeneration
         }
 
-        return@read applicationInstance ?: error("EmbeddedServer was stopped")
+        return applicationInstanceLock.write {
+            if (applicationGeneration == generationBefore) {
+                // Drain any leftover events from the same change wave
+                drainFileChanges()
+                try {
+                    reloadApplication()
+                    applicationGeneration++
+                } catch (cause: Throwable) {
+                    environment.log.error("Auto-reload failed.", cause)
+                    throw cause
+                }
+            }
+            getApplicationOrThrow()
+        }
     }
 
     /**
@@ -170,7 +184,7 @@ actual constructor(
         }
     }
 
-    private fun getFileChanges(): List<WatchEvent<*>>? {
+    private fun drainFileChanges(): List<WatchEvent<*>>? {
         try {
             val changes = packageWatchKeys.flatMap { key ->
                 key.pollEvents().also { key.reset() }
@@ -264,7 +278,7 @@ actual constructor(
             ApplicationEnvironment::class.java, // ktor-server
             Pipeline::class.java, // ktor-parsing
             HttpStatusCode::class.java, // ktor-http
-            kotlin.jvm.functions.Function1::class.java, // kotlin-stdlib
+            Function1::class.java, // kotlin-stdlib
             Logger::class.java, // slf4j
             ByteReadChannel::class.java,
             Input::class.java, // kotlinx-io

--- a/ktor-server/ktor-server-core/jvm/test/io/ktor/tests/hosts/EmbeddedServerReloadingTests.kt
+++ b/ktor-server/ktor-server-core/jvm/test/io/ktor/tests/hosts/EmbeddedServerReloadingTests.kt
@@ -18,14 +18,22 @@ import io.ktor.server.testing.*
 import io.ktor.tests.hosts.EmbeddedServerReloadingTests.Companion.addLoadedModule
 import io.ktor.util.*
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
 import kotlinx.coroutines.runBlocking
 import org.slf4j.helpers.NOPLogger
+import java.io.File
+import java.net.URLClassLoader
+import kotlin.io.path.createTempDirectory
 import kotlin.reflect.KClass
 import kotlin.reflect.KFunction
 import kotlin.reflect.KFunction0
 import kotlin.reflect.jvm.javaMethod
 import kotlin.reflect.jvm.jvmName
 import kotlin.test.*
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
 
 class EmbeddedServerReloadingTests {
 
@@ -502,7 +510,6 @@ class EmbeddedServerReloadingTests {
     }
 
     class ClassModuleFunctionHolder {
-        @Suppress("UNUSED")
         fun Application.classExtensionFunction() {
             attributes.put(TestKey, "classExtensionFunction")
         }
@@ -513,7 +520,6 @@ class EmbeddedServerReloadingTests {
     }
 
     object ObjectModuleFunctionHolder {
-        @Suppress("UNUSED")
         fun Application.objectExtensionFunction() {
             attributes.put(TestKey, "objectExtensionFunction")
         }
@@ -540,7 +546,6 @@ class EmbeddedServerReloadingTests {
 
         private fun KClass<*>.functionFqName(name: String) = "$jvmName.$name"
 
-        @Suppress("UNUSED")
         fun Application.companionObjectExtensionFunction() {
             attributes.put(TestKey, "companionObjectExtensionFunction")
         }
@@ -549,7 +554,6 @@ class EmbeddedServerReloadingTests {
             app.attributes.put(TestKey, "companionObjectFunction")
         }
 
-        @Suppress("UNUSED")
         @JvmStatic
         fun Application.companionObjectJvmStaticExtensionFunction() {
             attributes.put(TestKey, "companionObjectJvmStaticExtensionFunction")
@@ -604,33 +608,189 @@ class EmbeddedServerReloadingTests {
         server.stop()
     }
 
+    class AppEvent(val app: Application, val type: Type) {
+        enum class Type {
+            Starting,
+            Stopping,
+            Stopped
+        }
+    }
+
     @Test
-    fun `reload preserves previous application when module fails to load`() {
+    fun `failed explicit reload stops application and allows retry`() {
         var moduleCallCount = 0
-        val props = serverConfig {
+        var appShouldFailToStart = false
+        val lifecycle = mutableListOf<AppEvent>()
+
+        val environment = applicationEnvironment {
+            classLoader = this::class.java.classLoader
+            log = NOPLogger.NOP_LOGGER
+            config = MapApplicationConfig()
+        }
+
+        val props = serverConfig(environment) {
             developmentMode = false
             module {
                 val callIndex = moduleCallCount++
-                if (callIndex == 0) {
-                    attributes.put(TestKey, "first-load")
-                } else {
+                attributes.put(TestKey, "load-$callIndex")
+                if (appShouldFailToStart) {
                     error("Simulated reload failure on call #$callIndex")
                 }
             }
         }
-        val server = EmbeddedServer(props, DummyEngineFactory)
+        val server = EmbeddedServer(props, DummyEngineFactory).apply {
+            monitor.subscribe(ApplicationStarting) { lifecycle += AppEvent(app = it, type = AppEvent.Type.Starting) }
+            monitor.subscribe(ApplicationStopping) { lifecycle += AppEvent(app = it, type = AppEvent.Type.Stopping) }
+            monitor.subscribe(ApplicationStopped) { lifecycle += AppEvent(app = it, type = AppEvent.Type.Stopped) }
+            start()
+        }
 
-        server.start()
         val initialApp = server.application
-        assertEquals("first-load", initialApp.attributes[TestKey])
+        assertEquals("load-0", initialApp.attributes[TestKey])
+        assertTrue(initialApp.isActive)
 
+        appShouldFailToStart = true
         assertFailsWith<IllegalStateException> { server.reload() }
         assertEquals(2, moduleCallCount)
+        assertFalse(initialApp.isActive)
 
-        val appAfterFailedReload = server.application
-        assertEquals("first-load", appAfterFailedReload.attributes[TestKey])
+        assertFailsWith<IllegalStateException> { server.application }
+
+        val stoppedIndex = lifecycle.indexOfFirst { it.type == AppEvent.Type.Stopped && it.app === initialApp }
+        val nextStartingIndex = lifecycle.indexOfFirst { it.type == AppEvent.Type.Starting && it.app !== initialApp }
+        assertTrue(
+            stoppedIndex in 0..<nextStartingIndex,
+            "Expected old generation to stop before the replacement starts: $lifecycle"
+        )
+
+        val failedApp = lifecycle.first { it.type == AppEvent.Type.Starting && it.app !== initialApp }.app
+        assertEquals(
+            1,
+            lifecycle.count { it.type == AppEvent.Type.Stopping && it.app === failedApp },
+            "Failed generation should be cleaned exactly once: $lifecycle"
+        )
+        assertTrue(
+            lifecycle.any { it.type == AppEvent.Type.Stopped && it.app === failedApp },
+            "Expected failed partial generation to be cleaned up: $lifecycle"
+        )
+
+        appShouldFailToStart = false
+        server.reload()
+        assertEquals(3, moduleCallCount)
+        assertEquals("load-2", server.application.attributes[TestKey])
+        assertTrue(server.application.isActive)
 
         server.stop()
+    }
+
+    @Test
+    fun `auto-reload retries only after another watched file change`() {
+        val watchDir = createTempDirectory(prefix = "ktor-autoreload-watch-").toFile().also { it.deleteOnExit() }
+        val marker = File(watchDir, "marker.txt").also { it.writeText("initial") }
+        val watchToken = watchDir.name
+
+        val parentLoader = EmbeddedServerReloadingTests::class.java.classLoader
+        val reloadClassLoader = URLClassLoader(arrayOf(watchDir.toURI().toURL()), parentLoader)
+
+        assertTrue(
+            checkUrlMatches(watchDir.toURI().toURL(), watchToken),
+            "Watch token must match the temp directory URL"
+        )
+        assertTrue(reloadClassLoader.urLs.toList().any { checkUrlMatches(it, watchToken) })
+
+        var generation = 0
+        var appShouldFailToStart = false
+        val lifecycle = mutableListOf<AppEvent>()
+
+        val environment = applicationEnvironment {
+            classLoader = reloadClassLoader
+            log = NOPLogger.NOP_LOGGER
+            config = HoconApplicationConfig(
+                ConfigFactory.parseMap(
+                    mapOf("ktor.deployment.watch" to listOf(watchToken))
+                )
+            )
+        }
+
+        val props = serverConfig(environment) {
+            developmentMode = true
+            watchPaths = listOf(watchToken)
+            module {
+                val current = ++generation
+                attributes.put(TestKey, "gen-$current")
+                if (appShouldFailToStart) {
+                    error("Simulated auto-reload failure for generation $current")
+                }
+            }
+        }
+        val server = EmbeddedServer(props, DummyEngineFactory).apply {
+            monitor.subscribe(ApplicationStarting) { lifecycle += AppEvent(app = it, type = AppEvent.Type.Starting) }
+            monitor.subscribe(ApplicationStopping) { lifecycle += AppEvent(app = it, type = AppEvent.Type.Stopping) }
+            monitor.subscribe(ApplicationStopped) { lifecycle += AppEvent(app = it, type = AppEvent.Type.Stopped) }
+        }
+
+        try {
+            server.start()
+            val firstApp = server.application
+            assertEquals("gen-1", firstApp.attributes[TestKey])
+            assertEquals(1, generation)
+
+            appShouldFailToStart = true
+            marker.writeText("change-1-${System.nanoTime()}")
+            awaitUntil {
+                server.probeApplication()
+                generation > 1
+            }
+            assertEquals(2, generation)
+            assertFalse(firstApp.isActive)
+
+            val stoppedIndex = lifecycle.indexOfFirst { it.type == AppEvent.Type.Stopped && it.app === firstApp }
+            val failedStartingIndex = lifecycle.indexOfFirst {
+                it.type == AppEvent.Type.Starting && it.app !== firstApp
+            }
+            assertTrue(
+                stoppedIndex in 0..<failedStartingIndex,
+                "Expected no application overlap on failed auto-reload: $lifecycle"
+            )
+
+            val failedApp = lifecycle[failedStartingIndex].app
+            assertEquals(
+                1,
+                lifecycle.count { it.type == AppEvent.Type.Stopping && it.app === failedApp },
+                "Failed partial generation should be cleaned exactly once: $lifecycle"
+            )
+
+            assertFailsWith<IllegalStateException> { server.application }
+            assertEquals(2, generation, "Must not retry creation without another file change")
+
+            appShouldFailToStart = false
+            marker.writeText("change-2-${System.nanoTime()}")
+            awaitUntil {
+                server.probeApplication()
+                generation > 2
+            }
+
+            assertEquals("gen-3", server.application.attributes[TestKey])
+            assertEquals(3, generation)
+            assertTrue(server.application.isActive)
+        } finally {
+            server.stop()
+            reloadClassLoader.close()
+            watchDir.deleteRecursively()
+        }
+    }
+
+    // Triggers change detection via application lookup; ignores failures while none is loaded.
+    private fun EmbeddedServer<*, *>.probeApplication() {
+        runCatching { application }
+    }
+
+    private fun awaitUntil(timeout: Duration = 10.seconds, condition: () -> Boolean) {
+        val deadline = System.currentTimeMillis() + timeout.inWholeMilliseconds
+        while (!condition()) {
+            check(System.currentTimeMillis() < deadline) { "Timed out waiting for condition" }
+            Thread.sleep(100)
+        }
     }
 
     @Test
@@ -729,6 +889,7 @@ fun Application.topLevelExtensionFunction() {
 }
 
 suspend fun Application.topLevelSuspendExtensionFunction() {
+    delay(0.milliseconds)
     attributes.put(EmbeddedServerReloadingTests.TestKey2, "topLevelSuspendExtensionFunction")
 }
 


### PR DESCRIPTION
**Subsystem**
Server Hot Reload

**Motivation**
[KTOR-9792](https://youtrack.jetbrains.com/issue/KTOR-9792) Application lifecycle events affect other reload generations

https://github.com/ktorio/ktor/issues/4717

**Previous Solution**
The solution for https://github.com/ktorio/ktor/issues/4717 unnecessarily had 2 applications running during hot reload, which is breaking application monitoring, because most of them don't filter the target event application.

**Proposed Solution**
Revert the previous fix; first, stop the current app and then try to start the new one; if it fails, the server should still be active and watch for changes, though failing all incoming requests.