### PR TITLE
KTOR-9825 Unescape quoted-pair at the end of a header parameter value

### DIFF
--- a/ktor-http/common/src/io/ktor/http/HttpHeaderValueParser.kt
+++ b/ktor-http/common/src/io/ktor/http/HttpHeaderValueParser.kt
@@ -217,7 +217,7 @@ private fun parseHeaderValueParameterValueQuoted(value: String, start: Int): Pai
                 return position + 1 to builder.toString()
             }
 
-            currentChar == '\\' && position < value.lastIndex - 2 -> {
+            currentChar == '\\' && position < value.lastIndex -> {
                 builder.append(value[position + 1])
                 position += 2
                 continue@loop

--- a/ktor-http/common/src/io/ktor/http/HttpHeaderValueParser.kt
+++ b/ktor-http/common/src/io/ktor/http/HttpHeaderValueParser.kt
@@ -229,7 +229,7 @@ private fun parseHeaderValueParameterValueQuoted(value: String, start: Int): Pai
     }
 
     // The value is unquoted here
-    return position to '"' + builder.toString()
+    return position to value.substring(start - 1, position)
 }
 
 private fun String.nextIsDelimiterOrEnd(start: Int): Boolean {

--- a/ktor-http/common/test/io/ktor/tests/http/CommonHeadersTest.kt
+++ b/ktor-http/common/test/io/ktor/tests/http/CommonHeadersTest.kt
@@ -163,6 +163,10 @@ class CommonHeadersTest {
             listOf(HeaderValue("justValue", listOf(HeaderValueParam("x", "\"abc\\")))),
             parseHeaderValue("justValue;x=\"abc\\")
         )
+        assertEquals(
+            listOf(HeaderValue("justValue", listOf(HeaderValueParam("x", "\"abc\\q")))),
+            parseHeaderValue("justValue;x=\"abc\\q")
+        )
     }
 
     @Test

--- a/ktor-http/common/test/io/ktor/tests/http/CommonHeadersTest.kt
+++ b/ktor-http/common/test/io/ktor/tests/http/CommonHeadersTest.kt
@@ -166,6 +166,32 @@ class CommonHeadersTest {
     }
 
     @Test
+    fun `parse quoted parameter value with escaped character at the end`() {
+        assertEquals(
+            listOf(HeaderValue("justValue", listOf(HeaderValueParam("a", "quoted\"")))),
+            parseHeaderValue("justValue; a=\"quoted\\\"\"")
+        )
+        assertEquals(
+            listOf(HeaderValue("justValue", listOf(HeaderValueParam("a", "quoted\\")))),
+            parseHeaderValue("justValue; a=\"quoted\\\\\"")
+        )
+        assertEquals(
+            listOf(HeaderValue("justValue", listOf(HeaderValueParam("a", "\"")))),
+            parseHeaderValue("justValue; a=\"\\\"\"")
+        )
+    }
+
+    @Test
+    fun `parse round trips a rendered parameter value ending with a quote`() {
+        val rendered = ContentDisposition.File.withParameter("filename", "a\"").toString()
+        assertEquals("file; filename=\"a\\\"\"", rendered)
+        assertEquals(
+            listOf(HeaderValue("file", listOf(HeaderValueParam("filename", "a\"")))),
+            parseHeaderValue(rendered)
+        )
+    }
+
+    @Test
     fun parseRealLifeHeadersShouldntFail() {
         val examples = listOf(
             "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",


### PR DESCRIPTION
**Subsystem**
Core (ktor-http)

**Motivation**
`parseHeaderValue` unescaped a backslash in a quoted parameter value only when it sat more than two characters from the end of the header, so an escaped character in the tail kept its backslash. A header Ktor renders itself then does not survive a round trip:

```kotlin
val rendered = ContentDisposition.File.withParameter("filename", "a\"").toString()
// file; filename="a\""
parseHeaderValue(rendered)  // filename=a\"  (expected a")
```

**Solution**
Unescape whenever a character follows the backslash. An unterminated quoted value still falls back to the raw substring, so `justValue;x="abc\q` parses to `"abc\q` as before.

Verified on JDK 21: `:ktor-http:jvmTest` (new tests fail before the change), `:ktor-client-core:jvmTest`, `:ktor-server-core:jvmTest`, four affected server plugins, `formatKotlin`/`lintKotlin`.
