### PR TITLE
KTOR-9766 Add test case for compiler plugin

### DIFF
--- a/ktor-compiler-plugin/testData/openapi/CallHandlerFunctions.expected.json
+++ b/ktor-compiler-plugin/testData/openapi/CallHandlerFunctions.expected.json
@@ -137,6 +137,23 @@
                     }
                 }
             }
+        },
+        "/suspend-lambda-arguments": {
+            "get": {
+                "summary": "",
+                "responses": {
+                    "200": {
+                        "description": "",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
         }
     },
     "components": {}

--- a/ktor-compiler-plugin/testData/openapi/CallHandlerFunctions.kt
+++ b/ktor-compiler-plugin/testData/openapi/CallHandlerFunctions.kt
@@ -3,6 +3,7 @@
 package openapi
 
 import io.ktor.http.ContentType
+import io.ktor.http.HttpStatusCode
 import io.ktor.serialization.kotlinx.json.json
 import io.ktor.server.application.*
 import io.ktor.server.plugins.contentnegotiation.ContentNegotiation
@@ -43,6 +44,12 @@ fun Application.installCallHandlerFunctions() {
         }
         get("/call-getter-extension") {
             call.respondWithDynamicContentType()
+        }
+        get("/suspend-lambda-arguments") {
+            if (!withAuthorization(call) { authorizeAdmin(call) }) {
+                return@get
+            }
+            call.respond(HttpStatusCode.OK, "ok")
         }
     }
 }
@@ -89,4 +96,28 @@ private fun RoutingCall.includeHeader(key: String, value: String) {
 
 suspend fun ApplicationCall.respondWithDynamicContentType() {
     respondText("data", if (isHandled) ContentType.Text.Html else ContentType.Text.Html)
+}
+
+sealed class AuthorizationResult {
+    data object Success : AuthorizationResult()
+
+    data class Failure(val statusCode: HttpStatusCode, val message: String) : AuthorizationResult()
+}
+
+suspend fun withAuthorization(
+    call: ApplicationCall,
+    block: suspend () -> AuthorizationResult,
+): Boolean {
+    val result = block()
+    if (result is AuthorizationResult.Failure) {
+        // suspend call AND a read of the smart-cast value, in the same branch
+        call.respond(result.statusCode, result.message)
+        return false
+    }
+    return true
+}
+
+suspend fun authorizeAdmin(call: ApplicationCall): AuthorizationResult {
+    call.respond(HttpStatusCode.OK, "checked")
+    return AuthorizationResult.Success
 }


### PR DESCRIPTION
**Subsystem**
Server, OpenAPI

**Motivation**
[KTOR-9766](https://youtrack.jetbrains.com/issue/KTOR-9766) OpenAPI: "has no continuation" AssertionError when a suspend call inside a sealed-type branch reads the smart-cast value

**Solution**
This was also fixed by https://github.com/ktorio/ktor/pull/5807

Just adding a test case here for better coverage.