### PR TITLE
KTOR-9818 Performance improvements for Netty HTTP/3

### DIFF
--- a/ktor-server/ktor-server-netty/api/ktor-server-netty.api
+++ b/ktor-server/ktor-server-netty/api/ktor-server-netty.api
@@ -174,6 +174,15 @@ public final class io/ktor/server/netty/cio/NettyResponsePipelineException : jav
 	public fun <init> (Ljava/lang/String;)V
 }
 
+public final class io/ktor/server/netty/http3/HmacQuicTokenHandler : io/netty/handler/codec/quic/QuicTokenHandler {
+	public fun <init> ()V
+	public fun <init> (Lkotlin/jvm/functions/Function0;J)V
+	public synthetic fun <init> (Lkotlin/jvm/functions/Function0;JILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun maxTokenLength ()I
+	public fun validateToken (Lio/netty/buffer/ByteBuf;Ljava/net/InetSocketAddress;)I
+	public fun writeToken (Lio/netty/buffer/ByteBuf;Lio/netty/buffer/ByteBuf;Ljava/net/InetSocketAddress;)Z
+}
+
 public final class io/ktor/server/netty/http3/NettyHttp3Configuration {
 	public fun <init> ()V
 	public final fun getConfigureQuicServerCodec ()Lkotlin/jvm/functions/Function1;
@@ -183,6 +192,9 @@ public final class io/ktor/server/netty/http3/NettyHttp3Configuration {
 	public final fun getQuicInitialMaxStreamsBidirectional ()J
 	public final fun getQuicMaxIdleTimeout-UwyO8pc ()J
 	public final fun getQuicTokenHandler ()Lio/netty/handler/codec/quic/QuicTokenHandler;
+	public final fun getUdpReceiveBufferSize ()I
+	public final fun getUdpSendBufferSize ()I
+	public final fun getUdpSocketCount ()Ljava/lang/Integer;
 	public final fun setConfigureQuicServerCodec (Lkotlin/jvm/functions/Function1;)V
 	public final fun setQuicInitialMaxData (J)V
 	public final fun setQuicInitialMaxStreamDataBidirectionalLocal (J)V
@@ -190,5 +202,8 @@ public final class io/ktor/server/netty/http3/NettyHttp3Configuration {
 	public final fun setQuicInitialMaxStreamsBidirectional (J)V
 	public final fun setQuicMaxIdleTimeout-LRDsOJo (J)V
 	public final fun setQuicTokenHandler (Lio/netty/handler/codec/quic/QuicTokenHandler;)V
+	public final fun setUdpReceiveBufferSize (I)V
+	public final fun setUdpSendBufferSize (I)V
+	public final fun setUdpSocketCount (Ljava/lang/Integer;)V
 }
 

--- a/ktor-server/ktor-server-netty/api/ktor-server-netty.api
+++ b/ktor-server/ktor-server-netty/api/ktor-server-netty.api
@@ -175,9 +175,8 @@ public final class io/ktor/server/netty/cio/NettyResponsePipelineException : jav
 }
 
 public final class io/ktor/server/netty/http3/HmacQuicTokenHandler : io/netty/handler/codec/quic/QuicTokenHandler {
-	public fun <init> ()V
-	public fun <init> (Lkotlin/jvm/functions/Function0;J)V
 	public synthetic fun <init> (Lkotlin/jvm/functions/Function0;JILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Lkotlin/jvm/functions/Function0;JLkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun maxTokenLength ()I
 	public fun validateToken (Lio/netty/buffer/ByteBuf;Ljava/net/InetSocketAddress;)I
 	public fun writeToken (Lio/netty/buffer/ByteBuf;Lio/netty/buffer/ByteBuf;Ljava/net/InetSocketAddress;)Z

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyApplicationCall.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyApplicationCall.kt
@@ -91,6 +91,14 @@ public abstract class NettyApplicationCall(
     internal abstract fun isContextCloseRequired(): Boolean
 
     /**
+     * Flushes written response data right before the channel is closed by the response pipeline.
+     * Protocol-specific implementations may piggyback their end-of-stream signal on this flush.
+     */
+    internal open fun flushBeforeClose(context: ChannelHandlerContext) {
+        context.flush()
+    }
+
+    /**
      * Marks the call as ready to finish, without suspending the calling coroutine.
      *
      * The response writer runs on the Netty I/O thread and signals completion through

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyApplicationCall.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyApplicationCall.kt
@@ -93,8 +93,13 @@ public abstract class NettyApplicationCall(
     /**
      * Flushes written response data right before the channel is closed by the response pipeline.
      * Protocol-specific implementations may piggyback their end-of-stream signal on this flush.
+     *
+     * [lastFuture] is the future of the last response write. It may still be pending (for example,
+     * queued behind flow control) when this is called, so implementations that send an explicit
+     * end-of-stream signal on the underlying channel (rather than through this context) must wait
+     * for it to complete first, or risk racing ahead of not-yet-transmitted data.
      */
-    internal open fun flushBeforeClose(context: ChannelHandlerContext) {
+    internal open fun flushBeforeClose(context: ChannelHandlerContext, lastFuture: ChannelFuture) {
         context.flush()
     }
 

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyApplicationEngine.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyApplicationEngine.kt
@@ -41,6 +41,7 @@ import java.net.StandardSocketOptions
 import java.security.PrivateKey
 import java.security.cert.X509Certificate
 import java.util.concurrent.TimeUnit
+import kotlin.getValue
 import kotlin.reflect.KClass
 import kotlin.system.measureTimeMillis
 
@@ -303,39 +304,40 @@ public class NettyApplicationEngine(
      * channels reject the option) — an actual NIO `DatagramChannel`'s `supportedOptions()` is
      * probed to confirm real support before the option is used.
      */
-    private val reusePortOption: ChannelOption<Boolean>? get() = reusePortResolution.option
+    private val reusePortOption: ChannelOption<Boolean>? get() = reusePortResolution.getOrNull()
 
     /**
      * Explains why [reusePortOption] is `null`, distinguishing "this JDK doesn't have the
      * `SO_REUSEPORT` constant" (needs Java 9+) from "this JDK has it, but the platform's NIO
      * provider rejects it anyway" (for example, Windows) — the two require different advice.
      */
-    private val reusePortResolution: ReusePortResolution by lazy {
+    private val reusePortResolution: Result<ChannelOption<Boolean>> by lazy {
         if (KQueue.isAvailable() || Epoll.isAvailable()) {
-            return@lazy ReusePortResolution(UnixChannelOption.SO_REUSEPORT, null)
-        }
-        try {
-            @Suppress("UNCHECKED_CAST")
-            val soReusePort = StandardSocketOptions::class.java.getField("SO_REUSEPORT")
-                .get(null) as SocketOption<Boolean>
-            val supported = java.nio.channels.DatagramChannel.open().use { channel ->
-                channel.supportedOptions().contains(soReusePort)
+            Result.success(UnixChannelOption.SO_REUSEPORT)
+        } else {
+            try {
+                @Suppress("UNCHECKED_CAST")
+                val soReusePort = StandardSocketOptions::class.java.getField("SO_REUSEPORT")
+                    .get(null) as SocketOption<Boolean>
+                val supported = java.nio.channels.DatagramChannel.open().use { channel ->
+                    channel.supportedOptions().contains(soReusePort)
+                }
+                if (!supported) {
+                    Result.failure(
+                        IllegalArgumentException(
+                            "the current platform's NIO datagram provider does not support SO_REUSEPORT"
+                        )
+                    )
+                } else {
+                    Result.success(NioChannelOption.of(soReusePort))
+                }
+            } catch (_: ReflectiveOperationException) {
+                Result.failure(IllegalArgumentException("SO_REUSEPORT requires running on Java 9 or newer"))
+            } catch (_: java.io.IOException) {
+                Result.failure(IllegalArgumentException("SO_REUSEPORT support could not be determined"))
             }
-            if (!supported) {
-                return@lazy ReusePortResolution(
-                    null,
-                    "the current platform's NIO datagram provider does not support SO_REUSEPORT"
-                )
-            }
-            ReusePortResolution(NioChannelOption.of(soReusePort), null)
-        } catch (_: ReflectiveOperationException) {
-            ReusePortResolution(null, "SO_REUSEPORT requires running on Java 9 or newer")
-        } catch (_: java.io.IOException) {
-            ReusePortResolution(null, "SO_REUSEPORT support could not be determined")
         }
     }
-
-    private class ReusePortResolution(val option: ChannelOption<Boolean>?, val unsupportedReason: String?)
 
     /**
      * The number of UDP sockets bound per HTTP/3 connector.
@@ -352,7 +354,7 @@ public class NettyApplicationEngine(
             configured != null -> {
                 check(configured == 1 || reusePortOption != null) {
                     "udpSocketCount = $configured requires SO_REUSEPORT support, but " +
-                        "${reusePortResolution.unsupportedReason}. " +
+                        "${reusePortResolution.exceptionOrNull()?.message}. " +
                         "Use a native transport (epoll/kqueue) or set udpSocketCount = 1."
                 }
                 configured

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyApplicationEngine.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyApplicationEngine.kt
@@ -25,6 +25,7 @@ import io.netty.channel.kqueue.KQueueDatagramChannel
 import io.netty.channel.kqueue.KQueueServerSocketChannel
 import io.netty.channel.socket.DatagramChannel
 import io.netty.channel.socket.ServerSocketChannel
+import io.netty.channel.socket.nio.NioChannelOption
 import io.netty.channel.socket.nio.NioDatagramChannel
 import io.netty.channel.socket.nio.NioServerSocketChannel
 import io.netty.channel.unix.UnixChannelOption
@@ -35,6 +36,8 @@ import io.netty.handler.codec.quic.QuicSslContextBuilder
 import kotlinx.coroutines.CompletableJob
 import kotlinx.coroutines.asCoroutineDispatcher
 import java.net.BindException
+import java.net.SocketOption
+import java.net.StandardSocketOptions
 import java.security.PrivateKey
 import java.security.cert.X509Certificate
 import java.util.concurrent.TimeUnit
@@ -290,17 +293,50 @@ public class NettyApplicationEngine(
     }
 
     /**
+     * The `SO_REUSEPORT` [ChannelOption] matching the datagram transport selected by
+     * [getDatagramChannelClass], or `null` when unsupported: native transports use
+     * [UnixChannelOption.SO_REUSEPORT], while NIO requires the JDK socket option
+     * `StandardSocketOptions.SO_REUSEPORT`, which is resolved reflectively because it is only
+     * available since Java 9 while this module compiles against the Java 8 API.
+     */
+    private val reusePortOption: ChannelOption<Boolean>? by lazy {
+        if (KQueue.isAvailable() || Epoll.isAvailable()) {
+            return@lazy UnixChannelOption.SO_REUSEPORT
+        }
+        try {
+            @Suppress("UNCHECKED_CAST")
+            val soReusePort = StandardSocketOptions::class.java.getField("SO_REUSEPORT")
+                .get(null) as SocketOption<Boolean>
+            NioChannelOption.of(soReusePort)
+        } catch (_: ReflectiveOperationException) {
+            null
+        }
+    }
+
+    /**
      * The number of UDP sockets bound per HTTP/3 connector.
      *
      * Every QUIC channel (and all its streams) is served by the event loop of the datagram socket
      * that received it, so a single socket pins the entire HTTP/3 endpoint to one thread. Binding
      * multiple sockets with `SO_REUSEPORT` lets the kernel spread connections across event loops.
-     * Kernel-side UDP load balancing across `SO_REUSEPORT` sockets is only effective on Linux,
-     * so the automatic default stays at 1 elsewhere.
+     * Kernel-side UDP load balancing across `SO_REUSEPORT` sockets is a Linux kernel feature
+     * (available with both epoll and NIO transports), so the automatic default stays at 1 elsewhere.
      */
     private val http3SocketCount: Int by lazy {
-        configuration.http3Configuration?.udpSocketCount
-            ?: if (Epoll.isAvailable()) configuration.workerGroupSize else 1
+        val configured = configuration.http3Configuration?.udpSocketCount
+        when {
+            configured != null -> {
+                check(configured == 1 || reusePortOption != null) {
+                    "udpSocketCount = $configured requires SO_REUSEPORT support: " +
+                        "use a native transport (epoll/kqueue) or run on Java 9+ for NIO support"
+                }
+                configured
+            }
+
+            isLinux && reusePortOption != null -> configuration.workerGroupSize
+
+            else -> 1
+        }
     }
 
     @Suppress("UNCHECKED_CAST")
@@ -327,7 +363,8 @@ public class NettyApplicationEngine(
             group(workerEventGroup)
             channel(getDatagramChannelClass().java)
             if (http3SocketCount > 1) {
-                option(UnixChannelOption.SO_REUSEPORT, true)
+                // Non-null is guaranteed by the http3SocketCount initializer check.
+                option(checkNotNull(reusePortOption), true)
             }
             if (http3Configuration.udpReceiveBufferSize > 0) {
                 option(ChannelOption.SO_RCVBUF, http3Configuration.udpReceiveBufferSize)
@@ -343,7 +380,8 @@ public class NettyApplicationEngine(
                     callEventGroup,
                     configuration.runningLimit,
                     quicSslContext,
-                    http3Configuration
+                    http3Configuration,
+                    useCodecDispatcher = http3SocketCount > 1
                 )
             )
         }
@@ -490,3 +528,5 @@ internal fun getDatagramChannelClass(): KClass<out DatagramChannel> = when {
     Epoll.isAvailable() -> EpollDatagramChannel::class
     else -> NioDatagramChannel::class
 }
+
+private val isLinux: Boolean = System.getProperty("os.name", "").contains("linux", ignoreCase = true)

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyApplicationEngine.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyApplicationEngine.kt
@@ -27,6 +27,7 @@ import io.netty.channel.socket.DatagramChannel
 import io.netty.channel.socket.ServerSocketChannel
 import io.netty.channel.socket.nio.NioDatagramChannel
 import io.netty.channel.socket.nio.NioServerSocketChannel
+import io.netty.channel.unix.UnixChannelOption
 import io.netty.handler.codec.http.HttpObjectDecoder
 import io.netty.handler.codec.http.HttpServerCodec
 import io.netty.handler.codec.quic.QuicSslContext
@@ -288,6 +289,20 @@ public class NettyApplicationEngine(
         }
     }
 
+    /**
+     * The number of UDP sockets bound per HTTP/3 connector.
+     *
+     * Every QUIC channel (and all its streams) is served by the event loop of the datagram socket
+     * that received it, so a single socket pins the entire HTTP/3 endpoint to one thread. Binding
+     * multiple sockets with `SO_REUSEPORT` lets the kernel spread connections across event loops.
+     * Kernel-side UDP load balancing across `SO_REUSEPORT` sockets is only effective on Linux,
+     * so the automatic default stays at 1 elsewhere.
+     */
+    private val http3SocketCount: Int by lazy {
+        configuration.http3Configuration?.udpSocketCount
+            ?: if (Epoll.isAvailable()) configuration.workerGroupSize else 1
+    }
+
     @Suppress("UNCHECKED_CAST")
     private fun createHttp3Bootstrap(
         connector: EngineSSLConnectorConfig,
@@ -311,6 +326,15 @@ public class NettyApplicationEngine(
         return Bootstrap().apply {
             group(workerEventGroup)
             channel(getDatagramChannelClass().java)
+            if (http3SocketCount > 1) {
+                option(UnixChannelOption.SO_REUSEPORT, true)
+            }
+            if (http3Configuration.udpReceiveBufferSize > 0) {
+                option(ChannelOption.SO_RCVBUF, http3Configuration.udpReceiveBufferSize)
+            }
+            if (http3Configuration.udpSendBufferSize > 0) {
+                option(ChannelOption.SO_SNDBUF, http3Configuration.udpSendBufferSize)
+            }
             handler(
                 NettyHttp3ChannelInitializer(
                     applicationProvider,
@@ -348,11 +372,15 @@ public class NettyApplicationEngine(
 
             // Bind HTTP/3 (QUIC/UDP) on the same resolved port as the TCP SSL connector.
             // TCP and UDP can share the same port number since they are different protocols.
+            // Multiple sockets per connector (SO_REUSEPORT) spread QUIC connections across
+            // event loops; see [http3SocketCount].
             val resolvedSslConnectors = channels!!.zip(configuration.connectors)
                 .filter { it.second is EngineSSLConnectorConfig }
                 .map { it.second.host to (it.first.localAddress() as java.net.InetSocketAddress).port }
             http3Channels = http3Bootstraps.zip(resolvedSslConnectors)
-                .map { (bootstrap, hostPort) -> bootstrap.bind(hostPort.first, hostPort.second) }
+                .flatMap { (bootstrap, hostPort) ->
+                    List(http3SocketCount) { bootstrap.bind(hostPort.first, hostPort.second) }
+                }
                 .map { it.sync().channel() }
 
             resolvedConnectorsDeferred.complete(connectors)

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyApplicationEngine.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyApplicationEngine.kt
@@ -297,21 +297,45 @@ public class NettyApplicationEngine(
      * [getDatagramChannelClass], or `null` when unsupported: native transports use
      * [UnixChannelOption.SO_REUSEPORT], while NIO requires the JDK socket option
      * `StandardSocketOptions.SO_REUSEPORT`, which is resolved reflectively because it is only
-     * available since Java 9 while this module compiles against the Java 8 API.
+     * available since Java 9 while this module compiles against the Java 8 API. The field's mere
+     * presence only proves the JDK version supports the constant, not that the platform's NIO
+     * provider actually implements it (for example, Windows exposes the field but its datagram
+     * channels reject the option) — an actual NIO `DatagramChannel`'s `supportedOptions()` is
+     * probed to confirm real support before the option is used.
      */
-    private val reusePortOption: ChannelOption<Boolean>? by lazy {
+    private val reusePortOption: ChannelOption<Boolean>? get() = reusePortResolution.option
+
+    /**
+     * Explains why [reusePortOption] is `null`, distinguishing "this JDK doesn't have the
+     * `SO_REUSEPORT` constant" (needs Java 9+) from "this JDK has it, but the platform's NIO
+     * provider rejects it anyway" (for example, Windows) — the two require different advice.
+     */
+    private val reusePortResolution: ReusePortResolution by lazy {
         if (KQueue.isAvailable() || Epoll.isAvailable()) {
-            return@lazy UnixChannelOption.SO_REUSEPORT
+            return@lazy ReusePortResolution(UnixChannelOption.SO_REUSEPORT, null)
         }
         try {
             @Suppress("UNCHECKED_CAST")
             val soReusePort = StandardSocketOptions::class.java.getField("SO_REUSEPORT")
                 .get(null) as SocketOption<Boolean>
-            NioChannelOption.of(soReusePort)
+            val supported = java.nio.channels.DatagramChannel.open().use { channel ->
+                channel.supportedOptions().contains(soReusePort)
+            }
+            if (!supported) {
+                return@lazy ReusePortResolution(
+                    null,
+                    "the current platform's NIO datagram provider does not support SO_REUSEPORT"
+                )
+            }
+            ReusePortResolution(NioChannelOption.of(soReusePort), null)
         } catch (_: ReflectiveOperationException) {
-            null
+            ReusePortResolution(null, "SO_REUSEPORT requires running on Java 9 or newer")
+        } catch (_: java.io.IOException) {
+            ReusePortResolution(null, "SO_REUSEPORT support could not be determined")
         }
     }
+
+    private class ReusePortResolution(val option: ChannelOption<Boolean>?, val unsupportedReason: String?)
 
     /**
      * The number of UDP sockets bound per HTTP/3 connector.
@@ -327,13 +351,14 @@ public class NettyApplicationEngine(
         when {
             configured != null -> {
                 check(configured == 1 || reusePortOption != null) {
-                    "udpSocketCount = $configured requires SO_REUSEPORT support: " +
-                        "use a native transport (epoll/kqueue) or run on Java 9+ for NIO support"
+                    "udpSocketCount = $configured requires SO_REUSEPORT support, but " +
+                        "${reusePortResolution.unsupportedReason}. " +
+                        "Use a native transport (epoll/kqueue) or set udpSocketCount = 1."
                 }
                 configured
             }
 
-            isLinux && reusePortOption != null -> configuration.workerGroupSize
+            isLinux && reusePortOption != null && configuration.workerGroupSize > 1 -> configuration.workerGroupSize
 
             else -> 1
         }

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/cio/NettyHttpResponsePipeline.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/cio/NettyHttpResponsePipeline.kt
@@ -184,7 +184,7 @@ internal class NettyHttpResponsePipeline(
     }
 
     fun close(call: NettyApplicationCall, lastFuture: ChannelFuture) {
-        call.flushBeforeClose(context)
+        call.flushBeforeClose(context, lastFuture)
         isDataNotFlushed.compareAndSet(expect = true, update = false)
         lastFuture.addListener {
             context.close()

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/cio/NettyHttpResponsePipeline.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/cio/NettyHttpResponsePipeline.kt
@@ -176,21 +176,15 @@ internal class NettyHttpResponsePipeline(
         httpHandlerState.onLastResponseMessage(context)
         call.finishedEvent.setSuccess()
 
-        lastMessageFuture?.addListener {
-            if (prepareForClose) {
-                close(lastFuture)
-                return@addListener
-            }
-        }
         if (prepareForClose) {
-            close(lastFuture)
+            close(call, lastMessageFuture ?: lastFuture)
             return
         }
         scheduleFlush()
     }
 
-    fun close(lastFuture: ChannelFuture) {
-        context.flush()
+    fun close(call: NettyApplicationCall, lastFuture: ChannelFuture) {
+        call.flushBeforeClose(context)
         isDataNotFlushed.compareAndSet(expect = true, update = false)
         lastFuture.addListener {
             context.close()

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http3/HmacQuicTokenHandler.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http3/HmacQuicTokenHandler.kt
@@ -38,6 +38,11 @@ private const val TIMESTAMP_LENGTH = 8
  * and are cryptographically signed to prevent forgery. Expired tokens are
  * rejected to mitigate replay attacks.
  *
+ * Assign an instance to [NettyHttp3Configuration.quicTokenHandler] to enable
+ * QUIC address validation via stateless Retry. Note that this adds one round trip
+ * to every connection handshake; see [NettyHttp3Configuration.quicTokenHandler]
+ * for the trade-offs.
+ *
  * Token format:
  * ```
  * [timestamp (8 bytes)] [HMAC-SHA256 (32 bytes)] [dcid (variable)]
@@ -52,15 +57,22 @@ private const val TIMESTAMP_LENGTH = 8
  * implementation can extract it at the offset returned by [validateToken].
  *
  * @param keyGen a function for providing the secret key used in HMAC signing and validation.
- *   If not provided, a random 256-bit key is generated.
+ *   If not provided, a random 256-bit key is generated. Provide a shared key when tokens
+ *   must validate across multiple server instances.
  * @param tokenLifetimeMillis maximum age of a valid token in milliseconds.
  */
-internal class HmacQuicTokenHandler(
+public class HmacQuicTokenHandler(
     keyGen: () -> SecretKey = ::generateDefaultKey,
     private val tokenLifetimeMillis: Long = TOKEN_LIFETIME_MS,
 ) : QuicTokenHandler {
 
     private val secretKey: SecretKey by lazy(keyGen)
+
+    // Mac instances are not thread-safe and are relatively expensive to instantiate and key,
+    // so keep one initialized instance per thread. doFinal() resets the Mac for reuse.
+    private val macs: ThreadLocal<Mac> = ThreadLocal.withInitial {
+        Mac.getInstance("HmacSHA256").apply { init(secretKey) }
+    }
 
     override fun writeToken(out: ByteBuf, dcid: ByteBuf, address: InetSocketAddress): Boolean {
         val timestamp = System.currentTimeMillis()
@@ -111,8 +123,7 @@ internal class HmacQuicTokenHandler(
     override fun maxTokenLength(): Int = TIMESTAMP_LENGTH + HMAC_LENGTH + Quic.MAX_CONN_ID_LEN
 
     private fun computeHmac(timestamp: Long, address: InetSocketAddress, dcidBytes: ByteBuffer): ByteArray {
-        val mac = Mac.getInstance("HmacSHA256")
-        mac.init(secretKey)
+        val mac = macs.get()
 
         KtorDefaultPool.useInstance { timestampBuffer ->
             timestampBuffer.limit(TIMESTAMP_LENGTH)

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http3/HmacQuicTokenHandler.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http3/HmacQuicTokenHandler.kt
@@ -16,6 +16,8 @@ import java.security.SecureRandom
 import javax.crypto.KeyGenerator
 import javax.crypto.Mac
 import javax.crypto.SecretKey
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
 
 /**
  * Maximum age of a valid token in milliseconds (default: 60 seconds).
@@ -59,12 +61,18 @@ private const val TIMESTAMP_LENGTH = 8
  * @param keyGen a function for providing the secret key used in HMAC signing and validation.
  *   If not provided, a random 256-bit key is generated. Provide a shared key when tokens
  *   must validate across multiple server instances.
- * @param tokenLifetimeMillis maximum age of a valid token in milliseconds.
+ * @param tokenLifetime maximum age of a valid token.
  */
 public class HmacQuicTokenHandler(
     keyGen: () -> SecretKey = ::generateDefaultKey,
-    private val tokenLifetimeMillis: Long = TOKEN_LIFETIME_MS,
+    private val tokenLifetime: Duration = TOKEN_LIFETIME_MS.milliseconds,
 ) : QuicTokenHandler {
+
+    init {
+        require(tokenLifetime.isPositive()) {
+            "tokenLifetimeMillis must be strictly positive, but was $tokenLifetime"
+        }
+    }
 
     private val secretKey: SecretKey by lazy(keyGen)
 
@@ -100,7 +108,7 @@ public class HmacQuicTokenHandler(
         val timestamp = token.getLong(token.readerIndex())
 
         val now = System.currentTimeMillis()
-        if (now - timestamp > tokenLifetimeMillis || timestamp > now) return -1
+        if (now - timestamp > tokenLifetime.inWholeMilliseconds || timestamp > now) return -1
 
         val receivedMac = ByteArray(HMAC_LENGTH)
         token.getBytes(token.readerIndex() + TIMESTAMP_LENGTH, receivedMac)

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http3/NettyHttp3ApplicationCall.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http3/NettyHttp3ApplicationCall.kt
@@ -44,15 +44,19 @@ internal class NettyHttp3ApplicationCall(
         return null
     }
 
-    override fun flushBeforeClose(context: ChannelHandlerContext) {
+    override fun flushBeforeClose(context: ChannelHandlerContext, lastFuture: ChannelFuture) {
         if (isByteBufferContent) {
-            return super.flushBeforeClose(context)
+            return super.flushBeforeClose(context, lastFuture)
         }
-        // shutdownOutput() enqueues the QUIC stream FIN behind the pending response frames and then
-        // flushes, so the FIN coalesces with the final data packet instead of being sent separately
-        // by the subsequent channel close.
         val channel = context.channel() as? QuicStreamChannel
-        channel?.shutdownOutput() ?: context.flush()
+        if (channel == null) {
+            context.flush()
+            return
+        }
+        // required to ensure the final write has actually reached the wire before the FIN is sent
+        lastFuture.addListener {
+            channel.shutdownOutput()
+        }
     }
 
     override fun upgrade(dst: ChannelHandlerContext) {

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http3/NettyHttp3ApplicationCall.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http3/NettyHttp3ApplicationCall.kt
@@ -53,7 +53,9 @@ internal class NettyHttp3ApplicationCall(
             context.flush()
             return
         }
-        // required to ensure the final write has actually reached the wire before the FIN is sent
+        // lastFuture is the future of a queued write and won't complete until flushed; flush now
+        // so the write actually reaches the wire before the FIN is sent via shutdownOutput()
+        context.flush()
         lastFuture.addListener {
             channel.shutdownOutput()
         }

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http3/NettyHttp3ApplicationCall.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http3/NettyHttp3ApplicationCall.kt
@@ -9,6 +9,7 @@ import io.ktor.server.netty.*
 import io.netty.buffer.*
 import io.netty.channel.*
 import io.netty.handler.codec.http3.*
+import io.netty.handler.codec.quic.QuicStreamChannel
 import kotlin.coroutines.*
 
 internal class NettyHttp3ApplicationCall(
@@ -41,6 +42,17 @@ internal class NettyHttp3ApplicationCall(
         }
         // HTTP/3 signals end of stream by closing the QUIC stream, not via a frame flag
         return null
+    }
+
+    override fun flushBeforeClose(context: ChannelHandlerContext) {
+        if (isByteBufferContent) {
+            return super.flushBeforeClose(context)
+        }
+        // shutdownOutput() enqueues the QUIC stream FIN behind the pending response frames and then
+        // flushes, so the FIN coalesces with the final data packet instead of being sent separately
+        // by the subsequent channel close.
+        val channel = context.channel() as? QuicStreamChannel
+        channel?.shutdownOutput() ?: context.flush()
     }
 
     override fun upgrade(dst: ChannelHandlerContext) {

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http3/NettyHttp3ChannelInitializer.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http3/NettyHttp3ChannelInitializer.kt
@@ -6,6 +6,8 @@ package io.ktor.server.netty.http3
 
 import io.ktor.server.application.*
 import io.ktor.server.engine.*
+import io.netty.channel.Channel
+import io.netty.channel.ChannelHandler
 import io.netty.channel.ChannelInitializer
 import io.netty.channel.epoll.Epoll
 import io.netty.channel.socket.DatagramChannel
@@ -14,6 +16,8 @@ import io.netty.handler.codec.http3.Http3ServerConnectionHandler
 import io.netty.handler.codec.quic.EpollQuicUtils
 import io.netty.handler.codec.quic.QuicChannel
 import io.netty.handler.codec.quic.QuicChannelOption
+import io.netty.handler.codec.quic.QuicCodecDispatcher
+import io.netty.handler.codec.quic.QuicConnectionIdGenerator
 import io.netty.handler.codec.quic.QuicSslContext
 import io.netty.util.concurrent.EventExecutorGroup
 import java.util.concurrent.TimeUnit
@@ -22,6 +26,12 @@ import kotlin.coroutines.CoroutineContext
 /**
  * A [ChannelInitializer] for QUIC/HTTP3 that configures the [DatagramChannel] pipeline
  * with the QUIC server codec and HTTP/3 connection handler.
+ *
+ * When [useCodecDispatcher] is `true` (more than one `SO_REUSEPORT` socket is bound), a single
+ * shared [QuicCodecDispatcher] is installed on every socket instead of a bare codec. The dispatcher
+ * encodes the socket index into server-issued connection IDs and re-dispatches datagrams that the
+ * kernel's 4-tuple hash delivered to the wrong socket (for example, after connection migration or
+ * NAT rebinding), so connection-ID routing stays correct across sockets.
  *
  * [Http3ServerConnectionHandler] is created per incoming [QuicChannel], since HTTP/3
  * connection handlers are not sharable.
@@ -33,10 +43,41 @@ internal class NettyHttp3ChannelInitializer(
     private val callEventGroup: EventExecutorGroup,
     private val runningLimit: Int,
     private val quicSslContext: QuicSslContext,
-    private val http3Configuration: NettyHttp3Configuration
+    private val http3Configuration: NettyHttp3Configuration,
+    useCodecDispatcher: Boolean,
 ) : ChannelInitializer<DatagramChannel>() {
 
+    /**
+     * Shared across all bound sockets: [QuicCodecDispatcher.handlerAdded] assigns each socket an
+     * index and calls back into [newQuicServerCodec] with an index-aware connection-id generator.
+     */
+    private val codecDispatcher: QuicCodecDispatcher? = if (useCodecDispatcher) {
+        object : QuicCodecDispatcher() {
+            override fun initChannel(
+                channel: Channel,
+                localConnectionIdLength: Int,
+                idGenerator: QuicConnectionIdGenerator
+            ) {
+                channel.pipeline().addLast(newQuicServerCodec(localConnectionIdLength, idGenerator))
+            }
+        }
+    } else {
+        null
+    }
+
     override fun initChannel(ch: DatagramChannel) {
+        val dispatcher = codecDispatcher
+        if (dispatcher != null) {
+            ch.pipeline().addLast(dispatcher)
+        } else {
+            ch.pipeline().addLast(newQuicServerCodec(localConnectionIdLength = null, idGenerator = null))
+        }
+    }
+
+    private fun newQuicServerCodec(
+        localConnectionIdLength: Int?,
+        idGenerator: QuicConnectionIdGenerator?
+    ): ChannelHandler {
         val application = applicationProvider()
 
         val streamInitializer = NettyHttp3RequestStreamInitializer(
@@ -47,7 +88,7 @@ internal class NettyHttp3ChannelInitializer(
             runningLimit
         )
 
-        val quicServerCodec = Http3.newQuicServerCodecBuilder()
+        return Http3.newQuicServerCodecBuilder()
             .sslContext(quicSslContext)
             .maxIdleTimeout(http3Configuration.quicMaxIdleTimeout.inWholeMilliseconds, TimeUnit.MILLISECONDS)
             .initialMaxData(http3Configuration.quicInitialMaxData)
@@ -68,6 +109,12 @@ internal class NettyHttp3ChannelInitializer(
                 }
             }
             .apply(http3Configuration.configureQuicServerCodec)
+            .apply {
+                // Applied after user configuration on purpose: with multiple sockets, the dispatcher
+                // owns connection-id generation, and overriding it would break cross-socket routing.
+                if (localConnectionIdLength != null) localConnectionIdLength(localConnectionIdLength)
+                if (idGenerator != null) connectionIdAddressGenerator(idGenerator)
+            }
             // Http3ServerConnectionHandler is not sharable: one instance per connection
             .handler(object : ChannelInitializer<QuicChannel>() {
                 override fun initChannel(ch: QuicChannel) {
@@ -75,7 +122,5 @@ internal class NettyHttp3ChannelInitializer(
                 }
             })
             .build()
-
-        ch.pipeline().addLast(quicServerCodec)
     }
 }

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http3/NettyHttp3ChannelInitializer.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http3/NettyHttp3ChannelInitializer.kt
@@ -7,10 +7,13 @@ package io.ktor.server.netty.http3
 import io.ktor.server.application.*
 import io.ktor.server.engine.*
 import io.netty.channel.ChannelInitializer
+import io.netty.channel.epoll.Epoll
 import io.netty.channel.socket.DatagramChannel
 import io.netty.handler.codec.http3.Http3
 import io.netty.handler.codec.http3.Http3ServerConnectionHandler
+import io.netty.handler.codec.quic.EpollQuicUtils
 import io.netty.handler.codec.quic.QuicChannel
+import io.netty.handler.codec.quic.QuicChannelOption
 import io.netty.handler.codec.quic.QuicSslContext
 import io.netty.util.concurrent.EventExecutorGroup
 import java.util.concurrent.TimeUnit
@@ -46,12 +49,24 @@ internal class NettyHttp3ChannelInitializer(
 
         val quicServerCodec = Http3.newQuicServerCodecBuilder()
             .sslContext(quicSslContext)
-            .tokenHandler(http3Configuration.quicTokenHandler)
             .maxIdleTimeout(http3Configuration.quicMaxIdleTimeout.inWholeMilliseconds, TimeUnit.MILLISECONDS)
             .initialMaxData(http3Configuration.quicInitialMaxData)
             .initialMaxStreamDataBidirectionalLocal(http3Configuration.quicInitialMaxStreamDataBidirectionalLocal)
             .initialMaxStreamDataBidirectionalRemote(http3Configuration.quicInitialMaxStreamDataBidirectionalRemote)
             .initialMaxStreamsBidirectional(http3Configuration.quicInitialMaxStreamsBidirectional)
+            .apply {
+                // When no token handler is configured, Netty accepts connections on the first Initial
+                // packet; a configured handler enables stateless Retry (address validation).
+                http3Configuration.quicTokenHandler?.let { tokenHandler(it) }
+                // GSO: send up to 10 UDP packets per syscall where the kernel supports it.
+                // newSegmentedAllocator falls back to SegmentedDatagramPacketAllocator.NONE otherwise.
+                if (Epoll.isAvailable()) {
+                    option(
+                        QuicChannelOption.SEGMENTED_DATAGRAM_PACKET_ALLOCATOR,
+                        EpollQuicUtils.newSegmentedAllocator(10)
+                    )
+                }
+            }
             .apply(http3Configuration.configureQuicServerCodec)
             // Http3ServerConnectionHandler is not sharable: one instance per connection
             .handler(object : ChannelInitializer<QuicChannel>() {

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http3/NettyHttp3ChannelInitializer.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http3/NettyHttp3ChannelInitializer.kt
@@ -88,39 +88,40 @@ internal class NettyHttp3ChannelInitializer(
             runningLimit
         )
 
-        return Http3.newQuicServerCodecBuilder()
+        val builder = Http3.newQuicServerCodecBuilder()
             .sslContext(quicSslContext)
             .maxIdleTimeout(http3Configuration.quicMaxIdleTimeout.inWholeMilliseconds, TimeUnit.MILLISECONDS)
             .initialMaxData(http3Configuration.quicInitialMaxData)
             .initialMaxStreamDataBidirectionalLocal(http3Configuration.quicInitialMaxStreamDataBidirectionalLocal)
             .initialMaxStreamDataBidirectionalRemote(http3Configuration.quicInitialMaxStreamDataBidirectionalRemote)
             .initialMaxStreamsBidirectional(http3Configuration.quicInitialMaxStreamsBidirectional)
-            .apply {
-                // When no token handler is configured, Netty accepts connections on the first Initial
-                // packet; a configured handler enables stateless Retry (address validation).
-                http3Configuration.quicTokenHandler?.let { tokenHandler(it) }
-                // GSO: send up to 10 UDP packets per syscall where the kernel supports it.
-                // newSegmentedAllocator falls back to SegmentedDatagramPacketAllocator.NONE otherwise.
-                if (Epoll.isAvailable()) {
-                    option(
-                        QuicChannelOption.SEGMENTED_DATAGRAM_PACKET_ALLOCATOR,
-                        EpollQuicUtils.newSegmentedAllocator(10)
-                    )
-                }
+        // When no token handler is configured, Netty accepts connections on the first Initial
+        // packet; a configured handler enables stateless Retry (address validation).
+        http3Configuration.quicTokenHandler?.let(builder::tokenHandler)
+
+        // GSO: send up to 10 UDP packets per syscall where the kernel supports it.
+        // newSegmentedAllocator falls back to SegmentedDatagramPacketAllocator.NONE otherwise.
+        if (Epoll.isAvailable()) {
+            builder.option(
+                QuicChannelOption.SEGMENTED_DATAGRAM_PACKET_ALLOCATOR,
+                EpollQuicUtils.newSegmentedAllocator(10)
+            )
+        }
+        // Custom configuration for codecs lambda
+        builder.apply(http3Configuration.configureQuicServerCodec)
+
+        // Applied after user configuration on purpose: with multiple sockets, the dispatcher
+        // owns connection-id generation, and overriding it would break cross-socket routing.
+        localConnectionIdLength?.let(builder::localConnectionIdLength)
+        idGenerator?.let(builder::connectionIdAddressGenerator)
+
+        // Http3ServerConnectionHandler is not sharable: one instance per connection
+        builder.handler(object : ChannelInitializer<QuicChannel>() {
+            override fun initChannel(ch: QuicChannel) {
+                ch.pipeline().addLast(Http3ServerConnectionHandler(streamInitializer))
             }
-            .apply(http3Configuration.configureQuicServerCodec)
-            .apply {
-                // Applied after user configuration on purpose: with multiple sockets, the dispatcher
-                // owns connection-id generation, and overriding it would break cross-socket routing.
-                if (localConnectionIdLength != null) localConnectionIdLength(localConnectionIdLength)
-                if (idGenerator != null) connectionIdAddressGenerator(idGenerator)
-            }
-            // Http3ServerConnectionHandler is not sharable: one instance per connection
-            .handler(object : ChannelInitializer<QuicChannel>() {
-                override fun initChannel(ch: QuicChannel) {
-                    ch.pipeline().addLast(Http3ServerConnectionHandler(streamInitializer))
-                }
-            })
-            .build()
+        })
+
+        return builder.build()
     }
 }

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http3/NettyHttp3Configuration.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http3/NettyHttp3Configuration.kt
@@ -116,12 +116,17 @@ public class NettyHttp3Configuration {
      * with `SO_REUSEPORT` lets the kernel distribute connections across sockets (and therefore across
      * event loops) by hashing the client address.
      *
-     * When `null` (the default), the number of worker event loops is used on transports where
-     * `SO_REUSEPORT` balances UDP traffic across sockets (Linux/epoll), and a single socket elsewhere.
-     * Values greater than 1 require a native transport (epoll or kqueue).
+     * When `null` (the default), the number of worker event loops is used on Linux, where the
+     * kernel balances UDP traffic across `SO_REUSEPORT` sockets (with both epoll and NIO
+     * transports), and a single socket elsewhere. Values greater than 1 require `SO_REUSEPORT`
+     * support from the platform (Linux, macOS/BSD; not available on Windows). On platforms
+     * without kernel load balancing, all traffic is delivered to one of the sockets.
      *
-     * Note: kernel hashing is based on the client address, so QUIC connection migration across
-     * client addresses is not supported when more than one socket is bound.
+     * With more than one socket, the socket index is encoded into server-issued connection IDs
+     * (via Netty's [io.netty.handler.codec.quic.QuicCodecDispatcher]), and datagrams that the
+     * kernel's address hash delivers to the wrong socket (for example, after connection migration
+     * or NAT rebinding) are re-dispatched to the owning socket. Connection-id generation is managed
+     * by the engine in this mode and must not be overridden via [configureQuicServerCodec].
      */
     public var udpSocketCount: Int? = null
         set(value) {

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http3/NettyHttp3Configuration.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http3/NettyHttp3Configuration.kt
@@ -23,14 +23,20 @@ import kotlin.time.Duration.Companion.seconds
 public class NettyHttp3Configuration {
 
     /**
-     * The [QuicTokenHandler] used to generate and validate QUIC retry tokens.
-     * By default, a secure HMAC-SHA256-based handler is used that cryptographically
-     * signs tokens with a randomly generated key and rejects forged or expired tokens.
+     * The [QuicTokenHandler] used to generate and validate QUIC address-validation (Retry) tokens.
      *
-     * Callers may replace this with a custom [QuicTokenHandler] implementation
-     * to use a different signing strategy or integrate with external token services.
+     * When `null` (the default), no address validation is performed and connections are accepted
+     * on the first Initial packet. Setting a handler enables stateless Retry: every new connection
+     * without a token receives a Retry packet and must restart the handshake, which adds one full
+     * round trip and roughly doubles the Initial packet processing per connection. Enable it when
+     * the endpoint is exposed to untrusted networks and needs protection against source-address
+     * spoofing and amplification attacks.
+     *
+     * [HmacQuicTokenHandler] is provided as a secure implementation that signs tokens
+     * with HMAC-SHA256 and rejects forged or expired tokens. Callers may also supply a custom
+     * [QuicTokenHandler] to use a different signing strategy or integrate with external token services.
      */
-    public var quicTokenHandler: QuicTokenHandler = HmacQuicTokenHandler()
+    public var quicTokenHandler: QuicTokenHandler? = null
 
     /**
      * Maximum idle timeout for QUIC connections.
@@ -98,6 +104,56 @@ public class NettyHttp3Configuration {
         set(value) {
             require(value > 0) {
                 "quicInitialMaxStreamsBidirectional must be > 0, but was $value"
+            }
+            field = value
+        }
+
+    /**
+     * The number of UDP sockets to bind for the HTTP/3 endpoint.
+     *
+     * All QUIC channels of a socket are served by the single event loop the socket is registered on,
+     * so binding one socket pins the entire HTTP/3 endpoint to one thread. Binding multiple sockets
+     * with `SO_REUSEPORT` lets the kernel distribute connections across sockets (and therefore across
+     * event loops) by hashing the client address.
+     *
+     * When `null` (the default), the number of worker event loops is used on transports where
+     * `SO_REUSEPORT` balances UDP traffic across sockets (Linux/epoll), and a single socket elsewhere.
+     * Values greater than 1 require a native transport (epoll or kqueue).
+     *
+     * Note: kernel hashing is based on the client address, so QUIC connection migration across
+     * client addresses is not supported when more than one socket is bound.
+     */
+    public var udpSocketCount: Int? = null
+        set(value) {
+            require(value == null || value > 0) {
+                "udpSocketCount must be > 0, but was $value"
+            }
+            field = value
+        }
+
+    /**
+     * The `SO_RCVBUF` size in bytes for the HTTP/3 UDP sockets, or `0` to use the system default.
+     *
+     * Under load, an undersized receive buffer causes dropped datagrams, which QUIC treats as packet
+     * loss and recovers from at a significant throughput cost. Consider raising this (for example,
+     * to a few megabytes) for high-throughput deployments; the effective value may be capped by the
+     * operating system.
+     */
+    public var udpReceiveBufferSize: Int = 0
+        set(value) {
+            require(value >= 0) {
+                "udpReceiveBufferSize must be >= 0, but was $value"
+            }
+            field = value
+        }
+
+    /**
+     * The `SO_SNDBUF` size in bytes for the HTTP/3 UDP sockets, or `0` to use the system default.
+     */
+    public var udpSendBufferSize: Int = 0
+        set(value) {
+            require(value >= 0) {
+                "udpSendBufferSize must be >= 0, but was $value"
             }
             field = value
         }

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http3/NettyHttp3Handler.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http3/NettyHttp3Handler.kt
@@ -94,7 +94,9 @@ internal class NettyHttp3Handler(
 
     @Suppress("OverridingDeprecatedMember")
     override fun exceptionCaught(ctx: ChannelHandlerContext, cause: Throwable) {
-        application.log.error("HTTP/3 stream exception", cause)
+        // Stream-level failures (client resets, aborted downloads) are routine under load;
+        // log at debug to keep error logging out of the hot path, matching the HTTP/2 handler.
+        application.log.debug("HTTP/3 stream exception", cause)
         ctx.close()
     }
 

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http3/NettyHttp3Handler.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http3/NettyHttp3Handler.kt
@@ -92,7 +92,6 @@ internal class NettyHttp3Handler(
         context.fireChannelReadComplete()
     }
 
-    @Suppress("OverridingDeprecatedMember")
     override fun exceptionCaught(ctx: ChannelHandlerContext, cause: Throwable) {
         // Stream-level failures (client resets, aborted downloads) are routine under load;
         // log at debug to keep error logging out of the hot path, matching the HTTP/2 handler.

--- a/ktor-server/ktor-server-netty/jvm/test/io/ktor/tests/server/netty/HmacQuicTokenHandlerTest.kt
+++ b/ktor-server/ktor-server-netty/jvm/test/io/ktor/tests/server/netty/HmacQuicTokenHandlerTest.kt
@@ -8,6 +8,7 @@ import io.ktor.server.netty.http3.*
 import io.netty.buffer.*
 import java.net.*
 import kotlin.test.*
+import kotlin.time.Duration.Companion.milliseconds
 
 class HmacQuicTokenHandlerTest {
 
@@ -87,7 +88,7 @@ class HmacQuicTokenHandlerTest {
     fun `expired token is rejected`() {
         val shortLivedHandler = HmacQuicTokenHandler(
             keyGen = HmacQuicTokenHandler::generateDefaultKey,
-            tokenLifetimeMillis = 1
+            tokenLifetime = 1.milliseconds
         )
 
         val out = Unpooled.buffer()

--- a/ktor-server/ktor-server-netty/jvm/test/io/ktor/tests/server/netty/NettyEngineTest.kt
+++ b/ktor-server/ktor-server-netty/jvm/test/io/ktor/tests/server/netty/NettyEngineTest.kt
@@ -12,6 +12,7 @@ import io.ktor.http.*
 import io.ktor.network.selector.*
 import io.ktor.network.sockets.*
 import io.ktor.server.application.*
+import io.ktor.server.http.content.*
 import io.ktor.server.http.*
 import io.ktor.server.netty.*
 import io.ktor.server.request.*
@@ -26,7 +27,8 @@ import io.ktor.websocket.*
 import io.netty.bootstrap.Bootstrap
 import io.netty.buffer.ByteBuf
 import io.netty.buffer.Unpooled
-import io.netty.channel.*
+import io.netty.channel.ChannelHandlerContext
+import io.netty.channel.ChannelInboundHandlerAdapter
 import io.netty.channel.epoll.Epoll
 import io.netty.channel.kqueue.KQueue
 import io.netty.channel.nio.NioEventLoopGroup
@@ -35,10 +37,14 @@ import io.netty.handler.codec.http.HttpResponseStatus
 import io.netty.handler.codec.http2.*
 import io.netty.handler.codec.http2.Http2CodecUtil.readUnsignedInt
 import io.netty.handler.codec.http3.*
-import io.netty.handler.codec.quic.*
-import kotlinx.coroutines.*
+import io.netty.handler.codec.quic.QuicChannel
+import io.netty.handler.codec.quic.QuicSslContextBuilder
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.consumeAsFlow
+import kotlinx.coroutines.withTimeout
 import org.junit.jupiter.api.Assumptions.assumeTrue
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
 import java.net.InetSocketAddress
 import java.net.StandardSocketOptions
 import java.util.concurrent.LinkedBlockingQueue
@@ -50,6 +56,9 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 import kotlin.time.Duration.Companion.milliseconds
+import kotlin.test.*
+import kotlin.time.Duration.Companion.seconds
+import kotlin.time.measureTime
 
 class NettyCompressionTest : CompressionTestSuite<NettyApplicationEngine, NettyApplicationEngine.Configuration>(Netty) {
     init {
@@ -846,6 +855,41 @@ open class NettyHttp3Test :
                 ?: error("Timed out waiting for HTTP/3 response")
             assertEquals("200", response.status)
             assertEquals(body, response.body)
+        }
+    }
+
+    /**
+     * Reproduces a reported bottleneck serving files via [staticFiles] over HTTP/3.
+     * Not an assertion-heavy test: run/profile this method directly (for example with the
+     * IntelliJ profiler) to see where time goes when a [io.ktor.server.http.content.LocalFileContent]
+     * response is streamed over a QUIC stream instead of a TCP socket.
+     */
+    @Test
+    fun `staticFiles high volume GET requests`(@TempDir tempDir: File) = runTest(timeout = 60.seconds) {
+        val fileContent = "0123456789".repeat(100_000) // 1,000,000 bytes of ASCII content
+        File(tempDir, "asset.txt").writeText(fileContent)
+
+        createAndStartServer {
+            application.routing {
+                staticFiles("/static", tempDir)
+            }
+        }
+
+        val requestCount = 200
+        withHttp3Client { quicChannel ->
+            val elapsed = measureTime {
+                repeat(requestCount) {
+                    val response = sendHttp3Request(quicChannel, "GET", "/static/asset.txt")
+                    assertEquals("200", response.status)
+                    assertEquals(fileContent.length, response.body.length)
+                }
+            }
+            val totalBytes = requestCount.toLong() * fileContent.length
+            println(
+                "Served $requestCount HTTP/3 staticFiles requests " +
+                    "(${fileContent.length} bytes each, ${totalBytes / (1024 * 1024)} MiB total) in $elapsed, " +
+                    "${elapsed.inWholeMilliseconds.toDouble() / requestCount} ms/request"
+            )
         }
     }
 

--- a/ktor-server/ktor-server-netty/jvm/test/io/ktor/tests/server/netty/NettyEngineTest.kt
+++ b/ktor-server/ktor-server-netty/jvm/test/io/ktor/tests/server/netty/NettyEngineTest.kt
@@ -12,7 +12,6 @@ import io.ktor.http.*
 import io.ktor.network.selector.*
 import io.ktor.network.sockets.*
 import io.ktor.server.application.*
-import io.ktor.server.http.content.*
 import io.ktor.server.http.*
 import io.ktor.server.netty.*
 import io.ktor.server.request.*
@@ -22,16 +21,17 @@ import io.ktor.server.test.base.*
 import io.ktor.server.testing.suites.*
 import io.ktor.server.websocket.*
 import io.ktor.utils.io.*
-import io.ktor.utils.io.InternalAPI
 import io.ktor.websocket.*
 import io.netty.bootstrap.Bootstrap
 import io.netty.buffer.ByteBuf
 import io.netty.buffer.Unpooled
 import io.netty.channel.ChannelHandlerContext
 import io.netty.channel.ChannelInboundHandlerAdapter
+import io.netty.channel.MultiThreadIoEventLoopGroup
 import io.netty.channel.epoll.Epoll
 import io.netty.channel.kqueue.KQueue
 import io.netty.channel.nio.NioEventLoopGroup
+import io.netty.channel.nio.NioIoHandler
 import io.netty.channel.socket.nio.NioDatagramChannel
 import io.netty.handler.codec.http.HttpResponseStatus
 import io.netty.handler.codec.http2.*
@@ -39,26 +39,20 @@ import io.netty.handler.codec.http2.Http2CodecUtil.readUnsignedInt
 import io.netty.handler.codec.http3.*
 import io.netty.handler.codec.quic.QuicChannel
 import io.netty.handler.codec.quic.QuicSslContextBuilder
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.consumeAsFlow
+import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeout
 import org.junit.jupiter.api.Assumptions.assumeTrue
-import org.junit.jupiter.api.io.TempDir
-import java.io.File
 import java.net.InetSocketAddress
 import java.net.StandardSocketOptions
 import java.util.concurrent.LinkedBlockingQueue
 import java.util.concurrent.TimeUnit
-import kotlin.test.BeforeTest
-import kotlin.test.Ignore
-import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertFalse
-import kotlin.test.assertTrue
-import kotlin.time.Duration.Companion.milliseconds
 import kotlin.test.*
-import kotlin.time.Duration.Companion.seconds
-import kotlin.time.measureTime
+import kotlin.time.Duration.Companion.milliseconds
 
 class NettyCompressionTest : CompressionTestSuite<NettyApplicationEngine, NettyApplicationEngine.Configuration>(Netty) {
     init {
@@ -858,41 +852,6 @@ open class NettyHttp3Test :
         }
     }
 
-    /**
-     * Reproduces a reported bottleneck serving files via [staticFiles] over HTTP/3.
-     * Not an assertion-heavy test: run/profile this method directly (for example with the
-     * IntelliJ profiler) to see where time goes when a [io.ktor.server.http.content.LocalFileContent]
-     * response is streamed over a QUIC stream instead of a TCP socket.
-     */
-    @Test
-    fun `staticFiles high volume GET requests`(@TempDir tempDir: File) = runTest(timeout = 60.seconds) {
-        val fileContent = "0123456789".repeat(100_000) // 1,000,000 bytes of ASCII content
-        File(tempDir, "asset.txt").writeText(fileContent)
-
-        createAndStartServer {
-            application.routing {
-                staticFiles("/static", tempDir)
-            }
-        }
-
-        val requestCount = 200
-        withHttp3Client { quicChannel ->
-            val elapsed = measureTime {
-                repeat(requestCount) {
-                    val response = sendHttp3Request(quicChannel, "GET", "/static/asset.txt")
-                    assertEquals("200", response.status)
-                    assertEquals(fileContent.length, response.body.length)
-                }
-            }
-            val totalBytes = requestCount.toLong() * fileContent.length
-            println(
-                "Served $requestCount HTTP/3 staticFiles requests " +
-                    "(${fileContent.length} bytes each, ${totalBytes / (1024 * 1024)} MiB total) in $elapsed, " +
-                    "${elapsed.inWholeMilliseconds.toDouble() / requestCount} ms/request"
-            )
-        }
-    }
-
     private data class Http3Response(
         val status: String,
         val headers: Map<String, String>,
@@ -943,41 +902,43 @@ open class NettyHttp3Test :
     }
 
     private suspend fun withHttp3Client(block: suspend (QuicChannel) -> Unit) {
-        val group = NioEventLoopGroup(1)
+        val group = MultiThreadIoEventLoopGroup(NioIoHandler.newFactory())
         try {
-            val quicSslContext = QuicSslContextBuilder.forClient()
-                .trustManager(io.netty.handler.ssl.util.InsecureTrustManagerFactory.INSTANCE)
-                .applicationProtocols(*Http3.supportedApplicationProtocols())
-                .build()
+            withContext(Dispatchers.IO) {
+                val quicSslContext = QuicSslContextBuilder.forClient()
+                    .trustManager(io.netty.handler.ssl.util.InsecureTrustManagerFactory.INSTANCE)
+                    .applicationProtocols(*Http3.supportedApplicationProtocols())
+                    .build()
 
-            val quicClientCodec = Http3.newQuicClientCodecBuilder()
-                .sslContext(quicSslContext)
-                .maxIdleTimeout(30_000, TimeUnit.MILLISECONDS)
-                .initialMaxData(10_000_000)
-                .initialMaxStreamDataBidirectionalLocal(1_000_000)
-                .initialMaxStreamDataBidirectionalRemote(1_000_000)
-                .initialMaxStreamsBidirectional(100)
-                .build()
+                val quicClientCodec = Http3.newQuicClientCodecBuilder()
+                    .sslContext(quicSslContext)
+                    .maxIdleTimeout(30_000, TimeUnit.MILLISECONDS)
+                    .initialMaxData(10_000_000)
+                    .initialMaxStreamDataBidirectionalLocal(1_000_000)
+                    .initialMaxStreamDataBidirectionalRemote(1_000_000)
+                    .initialMaxStreamsBidirectional(100)
+                    .build()
 
-            val udpChannel = Bootstrap()
-                .group(group)
-                .channel(NioDatagramChannel::class.java)
-                .handler(quicClientCodec)
-                .bind(0)
-                .sync()
-                .channel()
+                val udpChannel = Bootstrap()
+                    .group(group)
+                    .channel(NioDatagramChannel::class.java)
+                    .handler(quicClientCodec)
+                    .bind(0)
+                    .sync()
+                    .channel()
 
-            val quicChannel = QuicChannel.newBootstrap(udpChannel)
-                .handler(Http3ClientConnectionHandler())
-                .remoteAddress(InetSocketAddress("127.0.0.1", sslPort))
-                .connect()
-                .get()
+                val quicChannel = QuicChannel.newBootstrap(udpChannel)
+                    .handler(Http3ClientConnectionHandler())
+                    .remoteAddress(InetSocketAddress("127.0.0.1", sslPort))
+                    .connect()
+                    .get()
 
-            try {
-                block(quicChannel)
-            } finally {
-                quicChannel.close().sync()
-                udpChannel.close().sync()
+                try {
+                    block(quicChannel)
+                } finally {
+                    quicChannel.close().sync()
+                    udpChannel.close().sync()
+                }
             }
         } finally {
             group.shutdownGracefully().sync()

--- a/ktor-server/ktor-server-netty/jvm/test/io/ktor/tests/server/netty/NettyEngineTest.kt
+++ b/ktor-server/ktor-server-netty/jvm/test/io/ktor/tests/server/netty/NettyEngineTest.kt
@@ -27,6 +27,8 @@ import io.netty.bootstrap.Bootstrap
 import io.netty.buffer.ByteBuf
 import io.netty.buffer.Unpooled
 import io.netty.channel.*
+import io.netty.channel.epoll.Epoll
+import io.netty.channel.kqueue.KQueue
 import io.netty.channel.nio.NioEventLoopGroup
 import io.netty.channel.socket.nio.NioDatagramChannel
 import io.netty.handler.codec.http.HttpResponseStatus
@@ -36,9 +38,12 @@ import io.netty.handler.codec.http3.*
 import io.netty.handler.codec.quic.*
 import kotlinx.coroutines.*
 import kotlinx.coroutines.flow.consumeAsFlow
+import org.junit.jupiter.api.Assumptions.assumeTrue
 import java.net.InetSocketAddress
+import java.net.StandardSocketOptions
 import java.util.concurrent.LinkedBlockingQueue
 import java.util.concurrent.TimeUnit
+import kotlin.test.BeforeTest
 import kotlin.test.Ignore
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -681,7 +686,7 @@ class NettyH2cFlushTest :
     )
 }
 
-class NettyHttp3Test :
+open class NettyHttp3Test :
     EngineTestBase<NettyApplicationEngine, NettyApplicationEngine.Configuration>(Netty) {
 
     init {
@@ -962,6 +967,33 @@ class NettyHttp3Test :
 
         return responseHandler.responseQueue.poll(10, TimeUnit.SECONDS)
             ?: error("Timed out waiting for HTTP/3 response")
+    }
+}
+
+/**
+ * Runs the full [NettyHttp3Test] suite with multiple `SO_REUSEPORT` datagram sockets, exercising
+ * the [io.netty.handler.codec.quic.QuicCodecDispatcher] path where the socket index is encoded
+ * into server connection IDs. On platforms without kernel-side UDP reuseport balancing (macOS),
+ * all datagrams land on one of the sockets, which still validates dispatcher-managed connection-id
+ * generation end to end.
+ *
+ * Skipped when `SO_REUSEPORT` is unavailable: the NIO transport needs the Java 9+ socket option,
+ * so on Java 8 the tests only run with a native transport (epoll/kqueue) on the classpath.
+ */
+class NettyHttp3MultiSocketTest : NettyHttp3Test() {
+
+    @BeforeTest
+    fun assumeReusePortSupported() {
+        val reusePortSupported = Epoll.isAvailable() || KQueue.isAvailable() ||
+            runCatching { StandardSocketOptions::class.java.getField("SO_REUSEPORT") }.isSuccess
+        assumeTrue(reusePortSupported, "SO_REUSEPORT is not supported in this environment")
+    }
+
+    @OptIn(ExperimentalKtorApi::class)
+    override fun configure(configuration: NettyApplicationEngine.Configuration) {
+        configuration.enableHttp3 {
+            udpSocketCount = 2
+        }
     }
 }
 


### PR DESCRIPTION
**Subsystem**
Server, Netty

**Motivation**
[KTOR-9818](https://youtrack.jetbrains.com/issue/KTOR-9818) Netty HTTP/3 Performance Improvements

**Solution**

Benchmarks showed the HTTP/3 connector running about 25x slower than HTTP/2. The main cause was that the whole endpoint ran on a single thread: Netty registers every QUIC connection and stream on the event loop of the datagram socket that received it, so with one bound UDP socket all packet I/O, TLS crypto and QPACK for every connection ran on one event loop (150-200% CPU on a 64 thread box, vs 5000%+ for HTTP/2). A few per-connection and per-response overheads sat on top of that.

Changes:

* Bind multiple UDP sockets per SSL connector with SO_REUSEPORT so the kernel spreads connections across event loops. Defaults to workerGroupSize sockets on Linux, which is the only OS that load balances unicast UDP this way, and 1 elsewhere. Configurable via the new `udpSocketCount` option. On the NIO transport the JDK socket option is used instead of UnixChannelOption (which NIO silently ignores); it's resolved reflectively because the field is Java 9+ and we compile against the Java 8 API.
* When more than one socket is bound, a shared `QuicCodecDispatcher` is installed on all of them. It encodes the socket index into server connection ids and re-dispatches datagrams that the kernel hashed to the wrong socket, e.g. after connection migration or NAT rebinding. It's applied after `configureQuicServerCodec` so user config can't break the routing.
* Address validation (stateless Retry) is now opt-in. `quicTokenHandler` defaults to null, matching Netty's own default. Previously every handshake paid an extra round trip plus a second Initial processing pass. HmacQuicTokenHandler is now public for anyone who wants validation back, and it caches Mac instances per thread instead of creating one per token.
* HTTP/3 responses now end the stream with QuicStreamChannel.shutdownOutput() instead of flush + close, so the FIN coalesces with the last data packet instead of going out as a separate datagram. This also fixed a latent double close in handleLastResponseMessage that would have queued a second FIN under the new scheme.
* New `udpReceiveBufferSize` / `udpSendBufferSize` options (SO_RCVBUF / SO_SNDBUF), and GSO is enabled on epoll (up to 10 packets per syscall, falls back to NONE without kernel support).
* Stream exceptions are logged at debug instead of error, same as the HTTP/2 handler. Client resets during load tests were producing a stack trace per stream.

Testing: NettyHttp3MultiSocketTest runs the whole NettyHttp3Test suite with udpSocketCount = 2, covering the dispatcher and the NIO reuseport path. On macOS all traffic lands on one socket, but the double bind and dispatcher-managed connection id generation are still exercised; on Linux CI the kernel actually balances. Full jvmTest, lint and ABI checks pass.

API surface (all new in 3.6.0): the new NettyHttp3Configuration options, quicTokenHandler made nullable, and HmacQuicTokenHandler promoted from internal to public.

Background reading for the less obvious parts:
* SO_REUSEPORT balancing: https://lwn.net/Articles/542629/
* Retry / address validation trade-off: RFC 9000 section 8.1
  https://www.rfc-editor.org/rfc/rfc9000.html#section-8.1
* QuicCodecDispatcher (added in Netty QUIC 0.0.59): see Http3ServerExample and
  QuicServerSoReusePortExample in the netty repo
* UDP GSO: https://blog.cloudflare.com/accelerating-udp-packet-transmission-for-quic/