### PR TITLE
Fixes from codex for 3.6

### DIFF
--- a/ktor-io/common/src/io/ktor/utils/io/core/Strings.kt
+++ b/ktor-io/common/src/io/ktor/utils/io/core/Strings.kt
@@ -86,15 +86,101 @@ public fun Source.readTextExact(charset: Charset = Charsets.UTF_8, n: Int): Stri
 /**
  * Read exactly [charactersCount] characters interpreting bytes in the specified [charset].
  *
+ * @throws IllegalArgumentException if [charset] is not either ISO_8859_1 or UTF_8
+ *
  * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.utils.io.core.readTextExactCharacters)
  */
 public fun Source.readTextExactCharacters(charactersCount: Int, charset: Charset = Charsets.UTF_8): String {
-    val s = readText(charset, charactersCount)
-    if (s.length < charactersCount) {
-        prematureEndOfStreamToReadChars(charactersCount)
+    require(charactersCount >= 0) { "charactersCount shouldn't be negative: $charactersCount" }
+    if (charactersCount == 0) return ""
+
+    return when (charset) {
+        Charsets.UTF_8 -> readUtf8ExactCharacters(charactersCount)
+        Charsets.ISO_8859_1 -> readIso88591ExactCharacters(charactersCount)
+        else -> throw IllegalArgumentException("Unsupported charset: $charset")
     }
-    return s
 }
+
+private fun Source.readIso88591ExactCharacters(charactersCount: Int): String {
+    val result = CharArray(charactersCount)
+    repeat(charactersCount) { index ->
+        val b = readByteOrFail()
+        result[index] = (b.toInt() and 0xFF).toChar()
+    }
+    return result.concatToString()
+}
+
+private fun Source.readUtf8ExactCharacters(charactersCount: Int): String {
+    val out = StringBuilder(charactersCount)
+    var remainingUnits = charactersCount
+
+    while (remainingUnits > 0) {
+        val nextUnits = peekNextUtf8CodePointUtf16UnitsOrFail(charactersCount)
+        if (nextUnits > remainingUnits) {
+            throw MalformedInputException(
+                "Unable to read exactly $charactersCount UTF-16 characters: next UTF-8 code point requires $nextUnits units."
+            )
+        }
+
+        val codePoint = try {
+            readCodePointValue()
+        } catch (_: EOFException) {
+            prematureEndOfStreamToReadChars(charactersCount)
+        }
+
+        if (codePoint <= 0xFFFF) {
+            out.append(codePoint.toChar())
+        } else {
+            val cp = codePoint - 0x10000
+            val high = ((cp ushr 10) + 0xD800).toChar()
+            val low = ((cp and 0x3FF) + 0xDC00).toChar()
+            out.append(high)
+            out.append(low)
+        }
+
+        remainingUnits -= nextUnits
+    }
+
+    return out.toString()
+}
+
+@OptIn(InternalIoApi::class)
+private fun Source.peekNextUtf8CodePointUtf16UnitsOrFail(charactersCount: Int): Int {
+    request(1)
+    if (buffer.size < 1L) prematureEndOfStreamToReadChars(charactersCount)
+
+    val b0 = (buffer[0].toInt() and 0xFF)
+    return when {
+        (b0 and 0b1000_0000) == 0 -> 1
+
+        (b0 and 0b1110_0000) == 0b1100_0000 -> {
+            request(2)
+            if (buffer.size < 2L) prematureEndOfStreamToReadChars(charactersCount)
+            1
+        }
+
+        (b0 and 0b1111_0000) == 0b1110_0000 -> {
+            request(3)
+            if (buffer.size < 3L) prematureEndOfStreamToReadChars(charactersCount)
+            1
+        }
+
+        (b0 and 0b1111_1000) == 0b1111_0000 -> {
+            request(4)
+            if (buffer.size < 4L) prematureEndOfStreamToReadChars(charactersCount)
+            2
+        }
+
+        else -> throw MalformedInputException("Invalid UTF-8 leading byte")
+    }
+}
+
+private fun Source.readByteOrFail(): Byte =
+    try {
+        readByte()
+    } catch (_: EOFException) {
+        prematureEndOfStreamToReadChars(1)
+    }
 
 /**
  * Writes [text] characters in range \[[fromIndex] .. [toIndex]) with the specified [charset]

--- a/ktor-io/common/src/io/ktor/utils/io/core/Strings.kt
+++ b/ktor-io/common/src/io/ktor/utils/io/core/Strings.kt
@@ -106,12 +106,12 @@ private fun Source.readSingleByteExactCharacters(charactersCount: Int, charset: 
         throw IllegalArgumentException("Unsupported charset: $charset")
     }
 
-    val result = readText(charset, charactersCount)
-    if (result.length < charactersCount) {
-        prematureEndOfStreamToReadChars(charactersCount)
+    val bytes = ByteArray(charactersCount)
+    repeat(charactersCount) { index ->
+        bytes[index] = readByteOrFail()
     }
 
-    return result
+    return String(bytes, charset = charset)
 }
 
 private fun Source.readIso88591ExactCharacters(charactersCount: Int): String {
@@ -232,7 +232,7 @@ public fun Sink.writeText(
     charset: Charset = Charsets.UTF_8
 ) {
     if (charset === Charsets.UTF_8) {
-        val string = text.concatToString(fromIndex, fromIndex + toIndex)
+        val string = text.concatToString(fromIndex, toIndex)
         return writeString(string, 0, toIndex - fromIndex)
     }
 

--- a/ktor-io/common/src/io/ktor/utils/io/core/Strings.kt
+++ b/ktor-io/common/src/io/ktor/utils/io/core/Strings.kt
@@ -62,13 +62,12 @@ public fun Source.readBytes(): ByteArray = readByteArray()
 public fun Source.readBytes(count: Int): ByteArray = readByteArray(count)
 
 /**
- * Reads at most [max] characters decoding bytes with specified [charset]. Extra character bytes will remain unconsumed
+ * Reads at most [max] bytes with specified [charset]. Extra character bytes will remain unconsumed
  *
  * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.utils.io.core.readText)
  *
  * @return a decoded string
  */
-@OptIn(InternalIoApi::class)
 public expect fun Source.readText(charset: Charset = Charsets.UTF_8, max: Int = Int.MAX_VALUE): String
 
 /**

--- a/ktor-io/common/src/io/ktor/utils/io/core/Strings.kt
+++ b/ktor-io/common/src/io/ktor/utils/io/core/Strings.kt
@@ -86,7 +86,7 @@ public fun Source.readTextExact(charset: Charset = Charsets.UTF_8, n: Int): Stri
 /**
  * Read exactly [charactersCount] characters interpreting bytes in the specified [charset].
  *
- * @throws IllegalArgumentException if [charset] is not either ISO_8859_1 or UTF_8
+ * @throws IllegalArgumentException if [charset] is not UTF_8 and is not a supported single-byte charset
  *
  * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.utils.io.core.readTextExactCharacters)
  */
@@ -97,8 +97,21 @@ public fun Source.readTextExactCharacters(charactersCount: Int, charset: Charset
     return when (charset) {
         Charsets.UTF_8 -> readUtf8ExactCharacters(charactersCount)
         Charsets.ISO_8859_1 -> readIso88591ExactCharacters(charactersCount)
-        else -> throw IllegalArgumentException("Unsupported charset: $charset")
+        else -> readSingleByteExactCharacters(charactersCount, charset)
     }
+}
+
+private fun Source.readSingleByteExactCharacters(charactersCount: Int, charset: Charset): String {
+    if (!charset.supportsReadTextExactCharacters()) {
+        throw IllegalArgumentException("Unsupported charset: $charset")
+    }
+
+    val result = readText(charset, charactersCount)
+    if (result.length < charactersCount) {
+        prematureEndOfStreamToReadChars(charactersCount)
+    }
+
+    return result
 }
 
 private fun Source.readIso88591ExactCharacters(charactersCount: Int): String {
@@ -128,6 +141,11 @@ private fun Source.readUtf8ExactCharacters(charactersCount: Int): String {
             prematureEndOfStreamToReadChars(charactersCount)
         }
 
+        val decodedUnits = if (codePoint <= 0xFFFF) 1 else 2
+        if (decodedUnits != nextUnits) {
+            throw MalformedInputException("Invalid UTF-8 code point")
+        }
+
         if (codePoint <= 0xFFFF) {
             out.append(codePoint.toChar())
         } else {
@@ -138,7 +156,7 @@ private fun Source.readUtf8ExactCharacters(charactersCount: Int): String {
             out.append(low)
         }
 
-        remainingUnits -= nextUnits
+        remainingUnits -= decodedUnits
     }
 
     return out.toString()
@@ -181,6 +199,8 @@ private fun Source.readByteOrFail(): Byte =
     } catch (_: EOFException) {
         prematureEndOfStreamToReadChars(1)
     }
+
+internal expect fun Charset.supportsReadTextExactCharacters(): Boolean
 
 /**
  * Writes [text] characters in range \[[fromIndex] .. [toIndex]) with the specified [charset]

--- a/ktor-io/common/src/io/ktor/utils/io/core/internal/CharArraySequence.kt
+++ b/ktor-io/common/src/io/ktor/utils/io/core/internal/CharArraySequence.kt
@@ -20,11 +20,13 @@ internal class CharArraySequence(
     final override fun subSequence(startIndex: Int, endIndex: Int): CharSequence {
         require(startIndex >= 0) { "startIndex shouldn't be negative: $startIndex" }
         require(startIndex <= length) { "startIndex is too large: $startIndex > $length" }
-        require(startIndex + endIndex <= length) { "endIndex is too large: $endIndex > $length" }
+        require(endIndex <= length) { "endIndex is too large: $endIndex > $length" }
         require(endIndex >= startIndex) { "endIndex should be greater or equal to startIndex: $startIndex > $endIndex" }
 
         return CharArraySequence(array, offset + startIndex, endIndex - startIndex)
     }
+
+    override fun toString(): String = array.concatToString(offset, offset + length)
 
     private fun indexOutOfBounds(index: Int): Nothing {
         throw IndexOutOfBoundsException("String index out of bounds: $index > $length")

--- a/ktor-io/common/test/StringsTest.kt
+++ b/ktor-io/common/test/StringsTest.kt
@@ -122,7 +122,26 @@ class StringsTest {
     }
 
     @Test
+    fun `readTextExactCharacters supports single-byte charset decoding`() {
+        val charsetName = when {
+            Charsets.isSupported("windows-1252") -> "windows-1252"
+            Charsets.isSupported("US-ASCII") -> "US-ASCII"
+            else -> return
+        }
+        val charset = Charsets.forName(charsetName)
+
+        val packet = buildPacket {
+            writeText("ABCZ", charset = charset)
+        }
+
+        assertEquals("ABC", packet.readTextExactCharacters(3, charset))
+        assertEquals("Z", packet.readText(charset))
+    }
+
+    @Test
     fun `readTextExactCharacters rejects unsupported charset`() {
+        if (!Charsets.isSupported("UTF-16")) return
+
         val packet = buildPacket {
             writeText("abc")
         }
@@ -173,6 +192,17 @@ class StringsTest {
 
         assertFailsWith<MalformedInputException> {
             packet.readTextExactCharacters(1, Charsets.UTF_8)
+        }
+    }
+
+    @Test
+    fun `readTextExactCharacters utf8 fails on malformed four-byte out-of-range code point`() {
+        val packet = buildPacket {
+            writeFully(byteArrayOf(0xF4.toByte(), 0x90.toByte(), 0x80.toByte(), 0x80.toByte()))
+        }
+
+        assertFailsWith<MalformedInputException> {
+            packet.readTextExactCharacters(2, Charsets.UTF_8)
         }
     }
 

--- a/ktor-io/common/test/StringsTest.kt
+++ b/ktor-io/common/test/StringsTest.kt
@@ -1,0 +1,214 @@
+/*
+ * Copyright 2014-2026 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+import io.ktor.utils.io.charsets.*
+import io.ktor.utils.io.core.*
+import kotlinx.io.EOFException
+import kotlin.test.*
+
+class StringsTest {
+
+    @Test
+    fun `toByteArray uses non utf8 encoder when charset differs`() {
+        val text = "AéB"
+
+        val bytes = text.toByteArray(Charsets.ISO_8859_1)
+
+        assertContentEquals(byteArrayOf(0x41, 0xE9.toByte(), 0x42), bytes)
+    }
+
+    @Suppress("DEPRECATION")
+    @Test
+    fun `deprecated String constructor decodes utf8 byte range`() {
+        val bytes = "prefix-é-middle-suffix".encodeToByteArray()
+
+        val text = String(bytes, offset = 7, length = 9, charset = Charsets.UTF_8)
+
+        assertEquals("é-middle", text)
+    }
+
+    @Suppress("DEPRECATION")
+    @Test
+    fun `deprecated String constructor decodes non utf8 bytes`() {
+        val bytes = byteArrayOf(0x41, 0xE9.toByte(), 0x42)
+
+        val text = String(bytes, charset = Charsets.ISO_8859_1)
+
+        assertEquals("AéB", text)
+    }
+
+    @Suppress("DEPRECATION")
+    @Test
+    fun `readBytes reads all remaining bytes`() {
+        val packet = buildPacket {
+            writeFully(byteArrayOf(1, 2, 3, 4))
+        }
+
+        assertContentEquals(byteArrayOf(1, 2, 3, 4), packet.readBytes())
+    }
+
+    @Suppress("DEPRECATION")
+    @Test
+    fun `readBytes count reads exact amount and leaves rest`() {
+        val packet = buildPacket {
+            writeFully(byteArrayOf(1, 2, 3, 4))
+        }
+
+        assertContentEquals(byteArrayOf(1, 2), packet.readBytes(2))
+        assertContentEquals(byteArrayOf(3, 4), packet.readBytes())
+    }
+
+    @Suppress("DEPRECATION")
+    @Test
+    fun `readTextExact delegates to readTextExactCharacters`() {
+        val packet = buildPacket {
+            writeText("abcdef")
+        }
+
+        assertEquals("abcd", packet.readTextExact(n = 4))
+    }
+
+    @Test
+    fun `readTextExactCharacters returns requested count with utf8`() {
+        val packet = buildPacket {
+            writeText("éßabc")
+        }
+
+        assertEquals("éß", packet.readTextExactCharacters(2))
+    }
+
+    @Test
+    fun `readTextExactCharacters with ISO-8859-1 leaves trailing bytes`() {
+        val packet = buildPacket {
+            writeFully(byteArrayOf(0x41, 0xE9.toByte(), 0x42, 0x43))
+        }
+
+        assertEquals("Aé", packet.readTextExactCharacters(2, Charsets.ISO_8859_1))
+        assertEquals("BC", packet.readText(Charsets.ISO_8859_1))
+    }
+
+    @Test
+    fun `readTextExactCharacters throws on premature eof`() {
+        val packet = buildPacket {
+            writeText("hi")
+        }
+
+        assertFailsWith<EOFException> {
+            packet.readTextExactCharacters(3)
+        }
+    }
+
+    @Test
+    fun `readTextExactCharacters with zero count returns empty and keeps source intact`() {
+        val packet = buildPacket {
+            writeText("abc")
+        }
+
+        assertEquals("", packet.readTextExactCharacters(0))
+        assertEquals("abc", packet.readText())
+    }
+
+    @Test
+    fun `readTextExactCharacters rejects negative count`() {
+        val packet = buildPacket {
+            writeText("abc")
+        }
+
+        val cause = assertFailsWith<IllegalArgumentException> {
+            packet.readTextExactCharacters(-1)
+        }
+        assertContains(cause.message.orEmpty(), "shouldn't be negative")
+    }
+
+    @Test
+    fun `readTextExactCharacters rejects unsupported charset`() {
+        val packet = buildPacket {
+            writeText("abc")
+        }
+
+        val cause = assertFailsWith<IllegalArgumentException> {
+            packet.readTextExactCharacters(1, Charsets.forName("UTF-16"))
+        }
+        assertContains(cause.message.orEmpty(), "Unsupported charset")
+    }
+
+    @Test
+    fun `readTextExactCharacters utf8 does not overconsume source`() {
+        val packet = buildPacket {
+            writeText("eéX")
+        }
+
+        assertEquals("eé", packet.readTextExactCharacters(2, Charsets.UTF_8))
+        assertEquals("X", packet.readText(Charsets.UTF_8))
+    }
+
+    @Test
+    fun `readTextExactCharacters utf8 reads supplementary code point for two utf16 units`() {
+        val packet = buildPacket {
+            writeText("😀X")
+        }
+
+        assertEquals("😀", packet.readTextExactCharacters(2, Charsets.UTF_8))
+        assertEquals("X", packet.readText(Charsets.UTF_8))
+    }
+
+    @Test
+    fun `readTextExactCharacters utf8 fails when next code point exceeds requested utf16 units`() {
+        val packet = buildPacket {
+            writeText("😀X")
+        }
+
+        assertFailsWith<MalformedInputException> {
+            packet.readTextExactCharacters(1, Charsets.UTF_8)
+        }
+        assertEquals("😀X", packet.readText(Charsets.UTF_8))
+    }
+
+    @Test
+    fun `readTextExactCharacters utf8 fails on invalid leading byte`() {
+        val packet = buildPacket {
+            writeFully(byteArrayOf(0x80.toByte()))
+        }
+
+        assertFailsWith<MalformedInputException> {
+            packet.readTextExactCharacters(1, Charsets.UTF_8)
+        }
+    }
+
+    @Test
+    fun `writeText CharSequence writes selected utf8 range`() {
+        val packet = buildPacket {
+            writeText("prefix-middle-suffix", fromIndex = 7, toIndex = 13)
+        }
+
+        assertEquals("middle", packet.readText())
+    }
+
+    @Test
+    fun `writeText CharSequence writes selected range with non utf8 charset`() {
+        val packet = buildPacket {
+            writeText("AéBÇ", fromIndex = 1, toIndex = 3, charset = Charsets.ISO_8859_1)
+        }
+
+        assertEquals("éB", packet.readText(Charsets.ISO_8859_1))
+    }
+
+    @Test
+    fun `writeText CharArray writes selected utf8 range`() {
+        val packet = buildPacket {
+            writeText(charArrayOf('a', 'b', 'c', 'd', 'e'), fromIndex = 1, toIndex = 4)
+        }
+
+        assertEquals("bcd", packet.readText())
+    }
+
+    @Test
+    fun `writeText CharArray writes selected range with non utf8 charset`() {
+        val packet = buildPacket {
+            writeText(charArrayOf('A', 'é', 'B', 'Ç'), fromIndex = 1, toIndex = 3, charset = Charsets.ISO_8859_1)
+        }
+
+        assertEquals("éB", packet.readText(Charsets.ISO_8859_1))
+    }
+}

--- a/ktor-io/js/src/io/ktor/utils/io/charsets/Charset.js.kt
+++ b/ktor-io/js/src/io/ktor/utils/io/charsets/Charset.js.kt
@@ -130,6 +130,8 @@ internal actual fun CharsetEncoder.encodeToByteArrayImpl(
 public actual fun CharsetDecoder.decode(input: Source, dst: Appendable, max: Int): Int {
     val decoder = Decoder(charset.name, true)
 
+    // ensure buffer is filled
+    input.request(max.toLong())
     val count = minOf(input.buffer.size, max.toLong())
     val array = input.readByteArray(count.toInt())
     val result = try {

--- a/ktor-io/jvm/src/io/ktor/utils/io/charsets/CharsetJVM.kt
+++ b/ktor-io/jvm/src/io/ktor/utils/io/charsets/CharsetJVM.kt
@@ -83,10 +83,11 @@ public actual fun CharsetDecoder.decode(input: Source, dst: Appendable, max: Int
         return input.readString().also { dst.append(it) }.length
     }
     // ensure buffer is filled
-    input.request(max.toLong())
-    val count = minOf(input.remaining.toInt(), max)
-    dst.append(input.readByteString(count).decodeToString(charset))
-    return count
+    val maxBytes = max.toLong()
+    input.request(maxBytes)
+    val count = minOf(input.remaining, maxBytes)
+    dst.append(input.readString(count, charset))
+    return count.toInt()
 }
 
 // ----------------------------------

--- a/ktor-io/jvm/src/io/ktor/utils/io/charsets/CharsetJVM.kt
+++ b/ktor-io/jvm/src/io/ktor/utils/io/charsets/CharsetJVM.kt
@@ -82,10 +82,11 @@ public actual fun CharsetDecoder.decode(input: Source, dst: Appendable, max: Int
     if (charset == Charsets.UTF_8) {
         return input.readString().also { dst.append(it) }.length
     }
-
-    val result = input.remaining
-    dst.append(input.readByteString().decodeToString(charset))
-    return result.toInt()
+    // ensure buffer is filled
+    input.request(max.toLong())
+    val count = minOf(input.remaining.toInt(), max)
+    dst.append(input.readByteString(count).decodeToString(charset))
+    return count
 }
 
 // ----------------------------------

--- a/ktor-io/jvm/src/io/ktor/utils/io/core/Strings.jvm.kt
+++ b/ktor-io/jvm/src/io/ktor/utils/io/core/Strings.jvm.kt
@@ -16,5 +16,9 @@ import kotlinx.io.readString
 public actual fun Source.readText(charset: Charset, max: Int): String =
     when (max) {
         Int.MAX_VALUE -> readString(charset)
-        else -> readString(minOf(buffer.size, max.toLong()), charset)
+        else -> {
+            // ensure buffer is filled
+            request(max.toLong())
+            readString(minOf(buffer.size, max.toLong()), charset)
+        }
     }

--- a/ktor-io/jvm/src/io/ktor/utils/io/core/Strings.jvm.kt
+++ b/ktor-io/jvm/src/io/ktor/utils/io/core/Strings.jvm.kt
@@ -23,3 +23,9 @@ public actual fun Source.readText(charset: Charset, max: Int): String =
             readString(minOf(buffer.size, max.toLong()), charset)
         }
     }
+
+internal actual fun Charset.supportsReadTextExactCharacters(): Boolean {
+    val encoder = newEncoder()
+    val decoder = newDecoder()
+    return encoder.maxBytesPerChar() == 1f && decoder.maxCharsPerByte() == 1f
+}

--- a/ktor-io/jvm/src/io/ktor/utils/io/core/Strings.jvm.kt
+++ b/ktor-io/jvm/src/io/ktor/utils/io/core/Strings.jvm.kt
@@ -16,6 +16,7 @@ import kotlinx.io.readString
 public actual fun Source.readText(charset: Charset, max: Int): String =
     when (max) {
         Int.MAX_VALUE -> readString(charset)
+
         else -> {
             // ensure buffer is filled
             request(max.toLong())

--- a/ktor-io/nonJvm/src/io/ktor/utils/io/core/Strings.nonJvm.kt
+++ b/ktor-io/nonJvm/src/io/ktor/utils/io/core/Strings.nonJvm.kt
@@ -7,6 +7,7 @@ package io.ktor.utils.io.core
 import io.ktor.utils.io.charsets.Charset
 import io.ktor.utils.io.charsets.Charsets
 import io.ktor.utils.io.charsets.decode
+import io.ktor.utils.io.charsets.name
 import kotlinx.io.InternalIoApi
 import kotlinx.io.Source
 import kotlinx.io.readString
@@ -23,4 +24,11 @@ public actual fun Source.readText(charset: Charset, max: Int): String {
     }
 
     return charset.newDecoder().decode(this, max)
+}
+
+internal actual fun Charset.supportsReadTextExactCharacters(): Boolean {
+    val normalized = name.uppercase()
+    return normalized == "US-ASCII" || normalized == "ASCII" || normalized == "WINDOWS-1252" ||
+        normalized == "CP1252" || normalized == "ISO-8859-1" || normalized == "ISO_8859-1" ||
+        normalized == "LATIN1"
 }

--- a/ktor-io/nonJvm/src/io/ktor/utils/io/core/Strings.nonJvm.kt
+++ b/ktor-io/nonJvm/src/io/ktor/utils/io/core/Strings.nonJvm.kt
@@ -16,6 +16,8 @@ import kotlin.math.min
 public actual fun Source.readText(charset: Charset, max: Int): String {
     if (charset == Charsets.UTF_8) {
         if (max == Int.MAX_VALUE) return readString()
+        // ensure buffer is filled
+        request(max.toLong())
         val count = min(buffer.size, max.toLong())
         return readString(count)
     }

--- a/ktor-shared/ktor-openapi-schema/ktor-openapi-schema-reflect/jvm/src/io/ktor/openapi/reflect/JsonSchemaInference.jvm.kt
+++ b/ktor-shared/ktor-openapi-schema/ktor-openapi-schema-reflect/jvm/src/io/ktor/openapi/reflect/JsonSchemaInference.jvm.kt
@@ -241,13 +241,15 @@ public class ReflectionJsonSchemaInference(
         try {
             if (kClass.isSealed) {
                 val sealedSubclasses = kClass.sealedSubclasses
+                val discriminatorValues = sealedSubclasses.associateWith { subclass ->
+                    val fqName = subclass.qualifiedName
+                    adapter.getDiscriminatorValue(kClass, subclass) ?: fqName ?: subclass.simpleName.orEmpty()
+                }
                 val discriminatorMapping = sealedSubclasses
                     .filter { it.qualifiedName != null }
                     .associate { subclass ->
-                        val fqName = subclass.qualifiedName!!
-                        val discriminatorValue = adapter.getDiscriminatorValue(kClass, subclass) ?: fqName
-                        val subclassSchemaName = adapter.getName(subclass.starProjectedType) ?: fqName
-                        discriminatorValue to "#/components/schemas/$subclassSchemaName"
+                        val subclassSchemaName = adapter.getName(subclass.starProjectedType) ?: subclass.qualifiedName!!
+                        discriminatorValues.getValue(subclass) to "#/components/schemas/$subclassSchemaName"
                     }
 
                 val discriminatorProperty = adapter.getDiscriminatorProperty(kClass)
@@ -256,7 +258,7 @@ public class ReflectionJsonSchemaInference(
                         type = it.starProjectedType,
                         visiting = visiting,
                         discriminatorProperty = discriminatorProperty,
-                        discriminatorValue = it.qualifiedName ?: it.simpleName.orEmpty(),
+                        discriminatorValue = discriminatorValues.getValue(it),
                     )
                 }
                 return jsonSchemaFromAnnotations(


### PR DESCRIPTION
**Subsystem**
Core / JSON schema

**Motivation**
https://github.com/ktorio/ktor/pull/5821

**Solution**
The max arg was inconsistently but always using bytes prior to changes in 3.6, so I updated the KDoc and made this argument apply consistently.

I also noticed that in many places, we're using `buffer.size` as a proxy for `Source.size`, but it is actually `buffer.size <= Source.size` for implementations that are not `Buffer`.  I fixed the spots relevant to the change here, but there could be other problems abound that we've not noticed due to our codebase generally only referencing `Buffer`.

