### PR TITLE
Fix Jetty bodyWriter leaking suspended coroutines on aborted writes

### DIFF
--- a/ktor-server/ktor-server-jetty-jakarta/jvm/src/io/ktor/server/jetty/jakarta/JettyResponseBodyWriter.kt
+++ b/ktor-server/ktor-server-jetty-jakarta/jvm/src/io/ktor/server/jetty/jakarta/JettyResponseBodyWriter.kt
@@ -14,6 +14,7 @@ import org.eclipse.jetty.util.Callback
 import org.eclipse.jetty.util.thread.Invocable
 import kotlin.coroutines.Continuation
 import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
 
 internal fun CoroutineScope.bodyWriter(response: Response): ReaderJob =
     reader(CoroutineName("jetty-response-writer")) {
@@ -25,7 +26,13 @@ internal fun CoroutineScope.bodyWriter(response: Response): ReaderJob =
                 continuation?.resume(Unit)
             }
             override fun failed(x: Throwable?) {
-                channel.cancel(x ?: IOException("Failed to write body"))
+                val cause = x ?: IOException("Failed to write body")
+                channel.cancel(cause)
+                // Resume the writer coroutine exceptionally, otherwise it stays suspended
+                // forever when the client aborts mid-write: the reader job never completes,
+                // and structured concurrency then retains the handler job, the application
+                // call, the Jetty exchange and the borrowed buffer for every aborted response.
+                continuation?.resumeWithException(cause)
             }
             override fun getInvocationType(): Invocable.InvocationType? =
                 Invocable.InvocationType.NON_BLOCKING

--- a/ktor-server/ktor-server-jetty-jakarta/jvm/test/io/ktor/tests/server/jetty/jakarta/JettyResponseBodyWriterTest.kt
+++ b/ktor-server/ktor-server-jetty-jakarta/jvm/test/io/ktor/tests/server/jetty/jakarta/JettyResponseBodyWriterTest.kt
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2014-2026 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.tests.server.jetty.jakarta
+
+import io.ktor.server.jetty.jakarta.bodyWriter
+import io.ktor.utils.io.writeByteArray
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withTimeout
+import org.eclipse.jetty.server.Response
+import org.eclipse.jetty.util.Callback
+import java.lang.reflect.Proxy
+import java.nio.ByteBuffer
+import kotlin.test.Test
+import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.seconds
+
+class JettyResponseBodyWriterTest {
+    @Test
+    fun `failed write completes body writer job`() = runTest {
+        val callback = CompletableDeferred<Callback>()
+        val response = responseProxy { buffer, writeCallback ->
+            if (buffer.hasRemaining()) {
+                callback.complete(writeCallback)
+            } else {
+                writeCallback.succeeded()
+            }
+        }
+        val writer = bodyWriter(response)
+
+        writer.channel.writeByteArray(byteArrayOf(1))
+        writer.channel.flush()
+
+        callback.await().failed(Exception("client aborted write"))
+
+        withTimeout(5.seconds) {
+            writer.job.join()
+        }
+        assertTrue(writer.job.isCompleted)
+    }
+}
+
+private fun responseProxy(write: (ByteBuffer, Callback) -> Unit): Response =
+    Proxy.newProxyInstance(
+        Response::class.java.classLoader,
+        arrayOf(Response::class.java)
+    ) { _, method, arguments ->
+        when (method.name) {
+            "write" -> write(arguments!![1] as ByteBuffer, arguments[2] as Callback)
+            "isCommitted" -> true
+            else -> error("Unexpected Response.${method.name} call")
+        }
+    } as Response


### PR DESCRIPTION
 **Subsystem**

  Server, `ktor-server-jetty-jakarta`

  **Motivation**

  When an asynchronous Jetty response write fails, such as when a client
  disconnects mid-response, `Callback.failed()` cancels the channel but does
  not resume the coroutine suspended around `response.write()`.

  As a result, the body writer job never completes and cannot reach its
  cleanup path. This retains the handler job, application call, Jetty
  exchange, and borrowed buffer for every aborted response.

  **Solution**

  Resume the pending write continuation exceptionally with the same failure
  after cancelling the channel. This lets the writer unwind through its
  `catch` and `finally` blocks and recycle the pooled buffer.

  Add a focused regression test that verifies a failed Jetty write completes
  the body writer job. The test times out without the fix and passes with it.

  **Testing**

  - `./gradlew :ktor-server-jetty-jakarta:jvmTest`
  - `./gradlew :ktor-server-jetty-jakarta:assemble`
  - `./gradlew :ktor-server-jetty-jakarta:formatKotlin`
  - `./gradlew :ktor-server-jetty-jakarta:lintKotlin`


