### PR TITLE
KTOR-9827 Authorization header removed from refresh token request

### DIFF
--- a/ktor-client/ktor-client-plugins/ktor-client-auth/common/src/io/ktor/client/plugins/auth/providers/BearerAuthProvider.kt
+++ b/ktor-client/ktor-client-plugins/ktor-client-auth/common/src/io/ktor/client/plugins/auth/providers/BearerAuthProvider.kt
@@ -52,6 +52,9 @@ public class RefreshTokensParams(
     /**
      * Marks that this request is for refreshing auth tokens, resulting in a special handling of it.
      *
+     * When a request is marked no additional Authorization headers are included and any custom
+     * Authorization headers are kept.
+     *
      * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.client.plugins.auth.providers.RefreshTokensParams.markAsRefreshTokenRequest)
      */
     public fun HttpRequestBuilder.markAsRefreshTokenRequest() {
@@ -228,16 +231,12 @@ public class BearerAuthProvider(
      * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.client.plugins.auth.providers.BearerAuthProvider.addRequestHeaders)
      */
     override suspend fun addRequestHeaders(request: HttpRequestBuilder, authHeader: HttpAuthHeader?) {
+        if (request.attributes.contains(AuthCircuitBreaker)) return
         val token = tokensHolder.loadToken() ?: return
 
         request.headers {
-            if (request.attributes.contains(AuthCircuitBreaker).not()) {
-                val tokenValue = "Bearer ${token.accessToken}"
-                if (contains(HttpHeaders.Authorization)) {
-                    remove(HttpHeaders.Authorization)
-                }
-                append(HttpHeaders.Authorization, tokenValue)
-            }
+            val tokenValue = "Bearer ${token.accessToken}"
+            this[HttpHeaders.Authorization] = tokenValue
         }
     }
 

--- a/ktor-client/ktor-client-plugins/ktor-client-auth/common/src/io/ktor/client/plugins/auth/providers/BearerAuthProvider.kt
+++ b/ktor-client/ktor-client-plugins/ktor-client-auth/common/src/io/ktor/client/plugins/auth/providers/BearerAuthProvider.kt
@@ -52,7 +52,7 @@ public class RefreshTokensParams(
     /**
      * Marks that this request is for refreshing auth tokens, resulting in a special handling of it.
      *
-     * When a request is marked no additional Authorization headers are included and any custom
+     * When a request is marked, no additional Authorization headers are included, and any custom
      * Authorization headers are kept.
      *
      * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.client.plugins.auth.providers.RefreshTokensParams.markAsRefreshTokenRequest)

--- a/ktor-client/ktor-client-plugins/ktor-client-auth/common/src/io/ktor/client/plugins/auth/providers/BearerAuthProvider.kt
+++ b/ktor-client/ktor-client-plugins/ktor-client-auth/common/src/io/ktor/client/plugins/auth/providers/BearerAuthProvider.kt
@@ -231,11 +231,11 @@ public class BearerAuthProvider(
         val token = tokensHolder.loadToken() ?: return
 
         request.headers {
-            val tokenValue = "Bearer ${token.accessToken}"
-            if (contains(HttpHeaders.Authorization)) {
-                remove(HttpHeaders.Authorization)
-            }
             if (request.attributes.contains(AuthCircuitBreaker).not()) {
+                val tokenValue = "Bearer ${token.accessToken}"
+                if (contains(HttpHeaders.Authorization)) {
+                    remove(HttpHeaders.Authorization)
+                }
                 append(HttpHeaders.Authorization, tokenValue)
             }
         }

--- a/ktor-client/ktor-client-plugins/ktor-client-auth/common/test/io/ktor/client/plugins/auth/AuthTest.kt
+++ b/ktor-client/ktor-client-plugins/ktor-client-auth/common/test/io/ktor/client/plugins/auth/AuthTest.kt
@@ -866,13 +866,8 @@ class AuthTest : ClientLoader() {
             engine {
                 addHandler { request ->
                     val authHeader = request.headers[HttpHeaders.Authorization]
-                    if (authHeader == null) {
-                        // no header - this is expected for refresh token requests
-                        respond("OK", HttpStatusCode.OK)
-                    } else {
-                        // header is invalid throw unauthorized
-                        respond("No Auth Header", HttpStatusCode.Unauthorized)
-                    }
+                    // Respond with the authorization header as body so it can be checked in this test.
+                    respond(authHeader.orEmpty())
                 }
             }
         }
@@ -880,14 +875,23 @@ class AuthTest : ClientLoader() {
         test { client ->
             // Test without circuit breaker - should add auth header with invalid token
             val response1 = client.get("/")
-            assertEquals(HttpStatusCode.Unauthorized, response1.status)
+            assertEquals("Bearer invalid", response1.bodyAsText())
 
             // Test with circuit breaker - should not add auth header
             val response2 = client.get("/") {
                 // add AuthCircuitBreaker like any refresh token request would have
                 attributes.put(AuthCircuitBreaker, Unit)
             }
-            assertEquals(HttpStatusCode.OK, response2.status)
+            assertEquals("", response2.bodyAsText())
+
+            // Test with circuit breaker - should keep custom auth header
+            val response3 = client.get("/") {
+                // add AuthCircuitBreaker like any refresh token request would have
+                attributes.put(AuthCircuitBreaker, Unit)
+                // Add a different auth header which could be needed for the token refresh request
+                header(HttpHeaders.Authorization, "token refresh")
+            }
+            assertEquals("token refresh", response3.bodyAsText())
         }
     }
 


### PR DESCRIPTION
**Subsystem**
ktor-client-auth

**Motivation**
https://youtrack.jetbrains.com/issue/KTOR-9827

**Solution**
Authorization header is no longer removed for refresh token requests.