### PR TITLE
KTOR-9816 Escape $ in application.yaml file

### DIFF
--- a/ktor-server/ktor-server-config-yaml/jvmAndPosix/src/io/ktor/server/config/yaml/YamlConfig.kt
+++ b/ktor-server/ktor-server-config-yaml/jvmAndPosix/src/io/ktor/server/config/yaml/YamlConfig.kt
@@ -43,6 +43,7 @@ public expect fun YamlConfig(path: String?): YamlConfig?
 /**
  * Implements [ApplicationConfig] by loading a configuration from a YAML file.
  * Values can reference to environment variables with `$ENV_VAR`, `${ENV_VAR}`, or `"$ENV_VAR:default_value"` syntax.
+ * Prefix an extra `$` to keep a literal dollar: `$$ENV` is `$ENV`.
  *
  * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.server.config.yaml.YamlConfig)
  */
@@ -200,6 +201,8 @@ private fun YamlScalar.resolveReferences(rootNode: YamlMap): YamlNode {
 }
 
 private fun resolveReference(rootNode: YamlMap, value: String, visited: MutableSet<String>): String? {
+    if (value.startsWith("$$")) return value.drop(1)
+
     if (value.startsWith("$") && !visited.add(value)) {
         throw ApplicationConfigurationException("Cycle detected in references: $visited")
     }

--- a/ktor-server/ktor-server-config-yaml/jvmAndPosix/src/io/ktor/server/config/yaml/YamlConfig.kt
+++ b/ktor-server/ktor-server-config-yaml/jvmAndPosix/src/io/ktor/server/config/yaml/YamlConfig.kt
@@ -122,15 +122,7 @@ public class YamlConfig private constructor(yamlMap: YamlMap) : ApplicationConfi
 
     @Deprecated("Redundant; handled automatically")
     public fun checkEnvironmentVariables() {
-        fun check(element: YamlNode?) {
-            when (element) {
-                is YamlScalar -> resolveReference(rootNode, element.content, visited = mutableSetOf())
-                is YamlMap -> element.entries.forEach { entry -> check(entry.value) }
-                is YamlList -> element.items.forEach { check(it) }
-                else -> return
-            }
-        }
-        check(rootNode)
+        // Substitution already ran at construction; re-resolving would treat escaped $$ as a new reference.
     }
 
     private inner class YamlNodeConfigValue(

--- a/ktor-server/ktor-server-config-yaml/jvmAndPosix/test/YamlConfigTest.kt
+++ b/ktor-server/ktor-server-config-yaml/jvmAndPosix/test/YamlConfigTest.kt
@@ -74,7 +74,6 @@ class YamlConfigTest {
 
         val keys = config.keys()
         assertEquals(
-            keys,
             setOf(
                 "auth.hashAlgorithm",
                 "auth.salt",
@@ -83,7 +82,8 @@ class YamlConfigTest {
                 "auth.listValues",
                 "auth.data.value1",
                 "auth.data.value2"
-            )
+            ),
+            keys
         )
     }
 
@@ -369,19 +369,19 @@ class YamlConfigTest {
         val yaml = Yaml.default.decodeFromString<YamlMap>(content)
         val config = YamlConfig.from(yaml)
 
-        assertEquals("\${FOO}", config.property("ktor.variable").getString())
+        assertEquals($$"${FOO}", config.property("ktor.variable").getString())
     }
 
     @Test
     fun testEscapedDollarOnly() {
-        val content = $$$"""
+        val content = """
             ktor:
                 variable: $$
         """.trimIndent()
         val yaml = Yaml.default.decodeFromString<YamlMap>(content)
         val config = YamlConfig.from(yaml)
 
-        assertEquals("\$", config.property("ktor.variable").getString())
+        assertEquals("$", config.property("ktor.variable").getString())
     }
 
     @Test
@@ -394,7 +394,22 @@ class YamlConfigTest {
         val yaml = Yaml.default.decodeFromString<YamlMap>(content)
         val config = YamlConfig.from(yaml)
 
-        assertEquals(listOf("\$foo"), config.property("ktor.values").getList())
+        assertEquals(listOf($$"$foo"), config.property("ktor.values").getList())
+    }
+
+    @Test
+    fun testEscapedDollarWithCheckEnvironmentVariables() {
+        val content = $$$"""
+            ktor:
+                variable: $$NON_EXISTENT
+        """.trimIndent()
+        val yaml = Yaml.default.decodeFromString<YamlMap>(content)
+        val config = YamlConfig.from(yaml)
+
+        @Suppress("DEPRECATION")
+        config.checkEnvironmentVariables()
+
+        assertEquals($$"$NON_EXISTENT", config.property("ktor.variable").getString())
     }
 
     @Test

--- a/ktor-server/ktor-server-config-yaml/jvmAndPosix/test/YamlConfigTest.kt
+++ b/ktor-server/ktor-server-config-yaml/jvmAndPosix/test/YamlConfigTest.kt
@@ -345,6 +345,59 @@ class YamlConfigTest {
     }
 
     @Test
+    fun testEscapedDollarPrefix() {
+        val content = $$$$"""
+            ktor:
+                variable1: $$PATH
+                variable2: "$$PATH"
+                variable3: $$$PATH
+        """.trimIndent()
+        val yaml = Yaml.default.decodeFromString<YamlMap>(content)
+        val config = YamlConfig.from(yaml)
+
+        assertEquals($$"$PATH", config.property("ktor.variable1").getString())
+        assertEquals($$"$PATH", config.property("ktor.variable2").getString())
+        assertEquals($$$"$$PATH", config.property("ktor.variable3").getString())
+    }
+
+    @Test
+    fun testEscapedDollarCurlyBraces() {
+        val content = $$$"""
+            ktor:
+                variable: "$${FOO}"
+        """.trimIndent()
+        val yaml = Yaml.default.decodeFromString<YamlMap>(content)
+        val config = YamlConfig.from(yaml)
+
+        assertEquals("\${FOO}", config.property("ktor.variable").getString())
+    }
+
+    @Test
+    fun testEscapedDollarOnly() {
+        val content = $$$"""
+            ktor:
+                variable: $$
+        """.trimIndent()
+        val yaml = Yaml.default.decodeFromString<YamlMap>(content)
+        val config = YamlConfig.from(yaml)
+
+        assertEquals("\$", config.property("ktor.variable").getString())
+    }
+
+    @Test
+    fun testEscapedDollarInList() {
+        val content = $$$"""
+            ktor:
+                values:
+                    - $$foo
+        """.trimIndent()
+        val yaml = Yaml.default.decodeFromString<YamlMap>(content)
+        val config = YamlConfig.from(yaml)
+
+        assertEquals(listOf("\$foo"), config.property("ktor.values").getList())
+    }
+
+    @Test
     fun testMalformedVarCurlyBraces() {
         val content = $$"""
             ktor:


### PR DESCRIPTION
**Subsystem**
Server Configuration

**Motivation**
[KTOR-9816](https://youtrack.jetbrains.com/issue/KTOR-9816) Escape `$` in application.yaml file

**Solution**
- A leading $$ now drops one $ and leaves the rest as-is

