### PR TITLE
KTOR-9643 Enable H2C along with HTTP/2

### DIFF
--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyApplicationEngine.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyApplicationEngine.kt
@@ -137,7 +137,10 @@ public class NettyApplicationEngine(
         public var enableHttp2: Boolean = true
 
         /**
-         * If set to `true` and [enableHttp2] is set to `true`, enables HTTP/2 protocol without TLS for Netty engine
+         * If set to `true` and [enableHttp2] is set to `true`, enables HTTP/2 protocol without TLS (h2c) for
+         * unencrypted connectors. SSL connectors are unaffected and continue to negotiate HTTP/2 via ALPN when
+         * [enableHttp2] is `true`, so this flag can be combined with an SSL connector to serve both HTTP/2 over
+         * TLS and h2c from the same server.
          *
          * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.server.netty.NettyApplicationEngine.Configuration.enableH2c)
          */

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyChannelInitializer.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyChannelInitializer.kt
@@ -144,14 +144,6 @@ public class NettyChannelInitializer(
     override fun initChannel(ch: SocketChannel) {
         with(ch.pipeline()) {
             when {
-                enableHttp2 && enableH2c && connector is EngineSSLConnectorConfig -> {
-                    error("Invalid configuration: H2C (HTTP/2 cleartext) cannot be used with SSL")
-                }
-
-                enableHttp2 && enableH2c -> {
-                    configurePipeline(this, Http2CodecUtil.HTTP_UPGRADE_PROTOCOL_NAME.toString())
-                }
-
                 connector is EngineSSLConnectorConfig -> {
                     val sslEngine = sslContext!!.newEngine(ch.alloc()).apply {
                         if (connector.hasTrustStore()) {
@@ -169,6 +161,10 @@ public class NettyChannelInitializer(
                     } else {
                         configurePipeline(this, ApplicationProtocolNames.HTTP_1_1)
                     }
+                }
+
+                enableHttp2 && enableH2c -> {
+                    configurePipeline(this, Http2CodecUtil.HTTP_UPGRADE_PROTOCOL_NAME.toString())
                 }
 
                 else -> {

--- a/ktor-server/ktor-server-netty/jvm/test/io/ktor/tests/server/netty/NettyEngineTest.kt
+++ b/ktor-server/ktor-server-netty/jvm/test/io/ktor/tests/server/netty/NettyEngineTest.kt
@@ -406,6 +406,42 @@ class NettyH2cEnabledTest :
     }
 }
 
+class NettyH2cWithSslTest :
+    HttpServerJvmTestSuite<NettyApplicationEngine, NettyApplicationEngine.Configuration>(Netty) {
+
+    init {
+        enableSsl = true
+        enableHttp2 = true
+    }
+
+    override fun configure(configuration: NettyApplicationEngine.Configuration) {
+        configuration.enableH2c = true
+    }
+
+    @Test
+    fun testH2cConnectorAndSslConnectorServeConcurrently() = runTest {
+        createAndStartServer {
+            get("/") {
+                call.respondText("Hello, world")
+            }
+        }
+
+        withHttp1("http://127.0.0.1:$port/", port, {}) {
+            assertEquals("Hello, world", bodyAsText())
+            assertEquals(HttpProtocolVersion.HTTP_1_1, version)
+        }
+
+        withHttp1("https://127.0.0.1:$sslPort/", sslPort, {}) {
+            assertEquals("Hello, world", bodyAsText())
+        }
+
+        withHttp2("https://127.0.0.1:$sslPort/", sslPort, {}) {
+            assertEquals("Hello, world", bodyAsText())
+            assertEquals(HttpProtocolVersion.HTTP_2_0, version)
+        }
+    }
+}
+
 class NettyH2cFlushTest :
     EngineTestBase<NettyApplicationEngine, NettyApplicationEngine.Configuration>(Netty) {
 


### PR DESCRIPTION
**Subsystem**
Server, Netty

**Motivation**
[KTOR-9643](https://youtrack.jetbrains.com/issue/KTOR-9643) Allow H2C and HTTP/2 on same server

**Solution**
Allow h2c on cleartext port and http/2 on encrypted port.

