### PR TITLE
KTOR-8355 Map malformed query parameter encoding to 400 Bad Request

### DIFF
--- a/ktor-server/ktor-server-core/common/src/io/ktor/server/request/PipelineRequest.kt
+++ b/ktor-server/ktor-server-core/common/src/io/ktor/server/request/PipelineRequest.kt
@@ -6,6 +6,7 @@ package io.ktor.server.request
 
 import io.ktor.http.*
 import io.ktor.server.application.*
+import io.ktor.server.plugins.*
 import io.ktor.utils.io.*
 
 /**
@@ -120,10 +121,14 @@ public interface PipelineRequest : ApplicationRequest {
  * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.server.request.encodeParameters)
  */
 public fun ApplicationRequest.encodeParameters(parameters: Parameters): Parameters {
-    return ParametersBuilder().apply {
-        rawQueryParameters.names().forEach { key ->
-            val values = parameters.getAll(key)?.map { it.decodeURLQueryComponent(plusIsSpace = true) }.orEmpty()
-            appendAll(key.decodeURLQueryComponent(), values)
-        }
-    }.build()
+    try {
+        return ParametersBuilder().apply {
+            rawQueryParameters.names().forEach { key ->
+                val values = parameters.getAll(key)?.map { it.decodeURLQueryComponent(plusIsSpace = true) }.orEmpty()
+                appendAll(key.decodeURLQueryComponent(), values)
+            }
+        }.build()
+    } catch (cause: URLDecodeException) {
+        throw BadRequestException("Url decode failed for query parameters of $uri", cause)
+    }
 }

--- a/ktor-server/ktor-server-test-suites/jvm/src/io/ktor/server/testing/suites/HttpServerJvmTestSuite.kt
+++ b/ktor-server/ktor-server-test-suites/jvm/src/io/ktor/server/testing/suites/HttpServerJvmTestSuite.kt
@@ -460,6 +460,35 @@ abstract class HttpServerJvmTestSuite<TEngine : ApplicationEngine, TConfiguratio
         }
     }
 
+    @Test
+    fun testMalformedQueryParameterEncodingReturnsBadRequest() = runTest {
+        createAndStartServer {
+            get("/") {
+                call.respond(HttpStatusCode.OK)
+            }
+        }
+
+        val request = buildString {
+            append("GET /?foo=%nope HTTP/1.1\r\n")
+            append("Host: localhost\r\n")
+            append("Connection: close\r\n")
+            append("\r\n")
+        }.toByteArray()
+
+        socket {
+            outputStream.apply {
+                write(request)
+                flush()
+            }
+
+            val statusLine = inputStream.bufferedReader().readLine()
+            assertTrue(
+                statusLine != null && "400" in statusLine,
+                "Expected 400 Bad Request but got: $statusLine"
+            )
+        }
+    }
+
     private val pipelinedResponses = """
                     HTTP/1.1 200
                     Response for 1


### PR DESCRIPTION
**Subsystem**
Server, HTTP

**Motivation**
[KTOR-8355](https://youtrack.jetbrains.com/issue/KTOR-8355) Bad percentage encoding in URL query causes uncaught exception and 500 status

**Solution**
- `ApplicationRequest.encodeParameters` (shared by all of these engines) decoded query parameter names/values without catching `URLDecodeException`, and `defaultExceptionStatusCode` has no mapping for it, so it fell back to `InternalServerError`. Netty was unaffected because it uses its own `QueryStringDecoder` and already wraps failures into `BadRequestException`.
- Fix wraps the decode calls in `encodeParameters` and rethrows as `BadRequestException`, mirroring the existing pattern used for malformed path segments in `RoutingResolveContext`. This fixes CIO, Jetty(-Jakarta), Servlet(-Jakarta), and Tomcat(-Jakarta) in one shared location.