### PR TITLE
KTOR-9477 Fix mac comparison to prevent session forgery

### DIFF
--- a/ktor-server/ktor-server-plugins/ktor-server-sessions/jvm/src/io/ktor/server/sessions/SessionTransportTransformerEncrypt.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-sessions/jvm/src/io/ktor/server/sessions/SessionTransportTransformerEncrypt.kt
@@ -88,7 +88,8 @@ public class SessionTransportTransformerEncrypt(
             val encryptedAndMac = transportValue.substringAfterLast('/', "")
             val macHex = encryptedAndMac.substringAfterLast(':', "")
             val encrypted = encryptedAndMac.substringBeforeLast(':').hexToByteArray()
-            val macCheck = mac(encrypted).toHexString() == macHex
+            val expectedMac = macHex.hexToByteArray()
+            val macCheck = MessageDigest.isEqual(mac(encrypted), expectedMac)
             if (!macCheck && !backwardCompatibleRead) {
                 return null
             }
@@ -96,7 +97,7 @@ public class SessionTransportTransformerEncrypt(
             val iv = transportValue.substringBeforeLast('/').hexToByteArray()
             val decrypted = decrypt(iv, encrypted)
 
-            if (!macCheck && mac(decrypted).toHexString() != macHex) {
+            if (!macCheck && !MessageDigest.isEqual(mac(decrypted), expectedMac)) {
                 return null
             }
 


### PR DESCRIPTION
**Subsystem**
Server, Sessions

**Motivation**
[KTOR-9477](https://youtrack.jetbrains.com/issue/KTOR-9477) Sessions: Session forgery vulnerability in the SessionTransportTransformerEncrypt component

**Solution**
Both MAC checks now decode the expected MAC to bytes and compare with MessageDigest.isEqual (JDK's constant-time comparison), matching the pattern already used correctly in the sibling SessionTransportTransformerMessageAuthentication class.
