### PR TITLE
KTOR-5577 Support nullable types in receive

### DIFF
--- a/ktor-client/ktor-client-plugins/ktor-client-content-negotiation/ktor-client-content-negotiation-tests/jvm/src/io/ktor/client/plugins/contentnegotiation/tests/JsonContentNegotiationTest.kt
+++ b/ktor-client/ktor-client-plugins/ktor-client-content-negotiation/ktor-client-content-negotiation-tests/jvm/src/io/ktor/client/plugins/contentnegotiation/tests/JsonContentNegotiationTest.kt
@@ -15,8 +15,10 @@ import io.ktor.server.request.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
 import io.ktor.server.testing.*
-import kotlinx.serialization.*
-import kotlin.test.*
+import kotlinx.serialization.Serializable
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
 
 abstract class JsonContentNegotiationTest(val converter: ContentConverter) {
     protected open val extraFieldResult = HttpStatusCode.OK
@@ -171,7 +173,7 @@ abstract class JsonContentNegotiationTest(val converter: ContentConverter) {
         }
         routing {
             post("/") {
-                val request = call.receiveNullable<Wrapper?>()
+                val request = call.receive<Wrapper?>()
                 assertEquals(null, request)
                 call.respondNullable(request)
             }

--- a/ktor-server/ktor-server-core/api/ktor-server-core.api
+++ b/ktor-server/ktor-server-core/api/ktor-server-core.api
@@ -15,8 +15,13 @@ public abstract interface class io/ktor/server/application/ApplicationCall : kot
 	public abstract fun getParameters ()Lio/ktor/http/Parameters;
 	public abstract fun getRequest ()Lio/ktor/server/request/ApplicationRequest;
 	public abstract fun getResponse ()Lio/ktor/server/response/ApplicationResponse;
+	public fun receive (Lio/ktor/util/reflect/TypeInfo;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun receiveNullable (Lio/ktor/util/reflect/TypeInfo;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun respond (Ljava/lang/Object;Lio/ktor/util/reflect/TypeInfo;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class io/ktor/server/application/ApplicationCall$DefaultImpls {
+	public static fun receive (Lio/ktor/server/application/ApplicationCall;Lio/ktor/util/reflect/TypeInfo;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public class io/ktor/server/application/ApplicationCallPipeline : io/ktor/util/pipeline/Pipeline {
@@ -173,6 +178,7 @@ public abstract interface class io/ktor/server/application/PipelineCall : io/kto
 }
 
 public final class io/ktor/server/application/PipelineCall$DefaultImpls {
+	public static fun receive (Lio/ktor/server/application/PipelineCall;Lio/ktor/util/reflect/TypeInfo;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun receiveNullable (Lio/ktor/server/application/PipelineCall;Lio/ktor/util/reflect/TypeInfo;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun respond (Lio/ktor/server/application/PipelineCall;Ljava/lang/Object;Lio/ktor/util/reflect/TypeInfo;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
@@ -469,6 +475,7 @@ public abstract class io/ktor/server/engine/BaseApplicationCall : io/ktor/server
 	public abstract fun getResponse ()Lio/ktor/server/engine/BaseApplicationResponse;
 	protected final fun putResponseAttribute (Lio/ktor/server/engine/BaseApplicationResponse;)V
 	public static synthetic fun putResponseAttribute$default (Lio/ktor/server/engine/BaseApplicationCall;Lio/ktor/server/engine/BaseApplicationResponse;ILjava/lang/Object;)V
+	public fun receive (Lio/ktor/util/reflect/TypeInfo;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun receiveNullable (Lio/ktor/util/reflect/TypeInfo;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun respond (Ljava/lang/Object;Lio/ktor/util/reflect/TypeInfo;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
@@ -1108,7 +1115,7 @@ public final class io/ktor/server/request/ApplicationReceiveFunctionsJvmKt {
 
 public final class io/ktor/server/request/ApplicationReceiveFunctionsKt {
 	public static final fun getFormFieldLimit (Lio/ktor/server/application/ApplicationCall;)J
-	public static final fun receive (Lio/ktor/server/application/ApplicationCall;Lio/ktor/util/reflect/TypeInfo;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final synthetic fun receive (Lio/ktor/server/application/ApplicationCall;Lio/ktor/util/reflect/TypeInfo;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static final fun receive (Lio/ktor/server/application/ApplicationCall;Lkotlin/reflect/KClass;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static final fun receiveChannel (Lio/ktor/server/application/ApplicationCall;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static final fun receiveMultipart (Lio/ktor/server/application/ApplicationCall;JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -1823,6 +1830,7 @@ public final class io/ktor/server/routing/RoutingCall : io/ktor/server/applicati
 	public synthetic fun getResponse ()Lio/ktor/server/response/ApplicationResponse;
 	public fun getResponse ()Lio/ktor/server/routing/RoutingResponse;
 	public final fun getRoute ()Lio/ktor/server/routing/RoutingNode;
+	public fun receive (Lio/ktor/util/reflect/TypeInfo;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun receiveNullable (Lio/ktor/util/reflect/TypeInfo;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun respond (Ljava/lang/Object;Lio/ktor/util/reflect/TypeInfo;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
@@ -1919,6 +1927,7 @@ public final class io/ktor/server/routing/RoutingPipelineCall : io/ktor/server/a
 	public synthetic fun getResponse ()Lio/ktor/server/response/PipelineResponse;
 	public fun getResponse ()Lio/ktor/server/routing/RoutingPipelineResponse;
 	public final fun getRoute ()Lio/ktor/server/routing/RoutingNode;
+	public fun receive (Lio/ktor/util/reflect/TypeInfo;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun receiveNullable (Lio/ktor/util/reflect/TypeInfo;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun respond (Ljava/lang/Object;Lio/ktor/util/reflect/TypeInfo;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun toString ()Ljava/lang/String;

--- a/ktor-server/ktor-server-core/api/ktor-server-core.klib.api
+++ b/ktor-server/ktor-server-core/api/ktor-server-core.klib.api
@@ -70,6 +70,7 @@ abstract interface io.ktor.server.application/ApplicationCall : kotlinx.coroutin
 
     abstract suspend fun <#A1: kotlin/Any?> receiveNullable(io.ktor.util.reflect/TypeInfo): #A1? // io.ktor.server.application/ApplicationCall.receiveNullable|receiveNullable(io.ktor.util.reflect.TypeInfo){0§<kotlin.Any?>}[0]
     abstract suspend fun respond(kotlin/Any?, io.ktor.util.reflect/TypeInfo?) // io.ktor.server.application/ApplicationCall.respond|respond(kotlin.Any?;io.ktor.util.reflect.TypeInfo?){}[0]
+    open suspend fun <#A1: kotlin/Any?> receive(io.ktor.util.reflect/TypeInfo): #A1 // io.ktor.server.application/ApplicationCall.receive|receive(io.ktor.util.reflect.TypeInfo){0§<kotlin.Any?>}[0]
 }
 
 abstract interface io.ktor.server.application/ApplicationEnvironment { // io.ktor.server.application/ApplicationEnvironment|null[0]
@@ -1108,6 +1109,7 @@ final class io.ktor.server.routing/RoutingCall : io.ktor.server.application/Appl
     final val route // io.ktor.server.routing/RoutingCall.route|{}route[0]
         final fun <get-route>(): io.ktor.server.routing/RoutingNode // io.ktor.server.routing/RoutingCall.route.<get-route>|<get-route>(){}[0]
 
+    final suspend fun <#A1: kotlin/Any?> receive(io.ktor.util.reflect/TypeInfo): #A1 // io.ktor.server.routing/RoutingCall.receive|receive(io.ktor.util.reflect.TypeInfo){0§<kotlin.Any?>}[0]
     final suspend fun <#A1: kotlin/Any?> receiveNullable(io.ktor.util.reflect/TypeInfo): #A1? // io.ktor.server.routing/RoutingCall.receiveNullable|receiveNullable(io.ktor.util.reflect.TypeInfo){0§<kotlin.Any?>}[0]
     final suspend fun respond(kotlin/Any?, io.ktor.util.reflect/TypeInfo?) // io.ktor.server.routing/RoutingCall.respond|respond(kotlin.Any?;io.ktor.util.reflect.TypeInfo?){}[0]
 }
@@ -1960,10 +1962,10 @@ final suspend inline fun (io.ktor.server.application/ApplicationCall).io.ktor.se
 final suspend inline fun (io.ktor.server.application/ApplicationCall).io.ktor.server.request/receiveParameters(): io.ktor.http/Parameters // io.ktor.server.request/receiveParameters|receiveParameters@io.ktor.server.application.ApplicationCall(){}[0]
 final suspend inline fun (io.ktor.server.application/ApplicationCall).io.ktor.server.request/receiveText(): kotlin/String // io.ktor.server.request/receiveText|receiveText@io.ktor.server.application.ApplicationCall(){}[0]
 final suspend inline fun (io.ktor.server.application/ApplicationCall).io.ktor.server.response/respondRedirect(kotlin/Boolean = ..., kotlin/Function1<io.ktor.http/URLBuilder, kotlin/Unit>) // io.ktor.server.response/respondRedirect|respondRedirect@io.ktor.server.application.ApplicationCall(kotlin.Boolean;kotlin.Function1<io.ktor.http.URLBuilder,kotlin.Unit>){}[0]
-final suspend inline fun <#A: reified kotlin/Any> (io.ktor.server.application/ApplicationCall).io.ktor.server.request/receive(): #A // io.ktor.server.request/receive|receive@io.ktor.server.application.ApplicationCall(){0§<kotlin.Any>}[0]
 final suspend inline fun <#A: reified kotlin/Any> (io.ktor.server.application/ApplicationCall).io.ktor.server.request/receiveOrNull(): #A? // io.ktor.server.request/receiveOrNull|receiveOrNull@io.ktor.server.application.ApplicationCall(){0§<kotlin.Any>}[0]
 final suspend inline fun <#A: reified kotlin/Any> (io.ktor.server.application/ApplicationCall).io.ktor.server.response/respond(#A) // io.ktor.server.response/respond|respond@io.ktor.server.application.ApplicationCall(0:0){0§<kotlin.Any>}[0]
 final suspend inline fun <#A: reified kotlin/Any> (io.ktor.server.application/ApplicationCall).io.ktor.server.response/respond(io.ktor.http/HttpStatusCode, #A) // io.ktor.server.response/respond|respond@io.ktor.server.application.ApplicationCall(io.ktor.http.HttpStatusCode;0:0){0§<kotlin.Any>}[0]
+final suspend inline fun <#A: reified kotlin/Any?> (io.ktor.server.application/ApplicationCall).io.ktor.server.request/receive(): #A // io.ktor.server.request/receive|receive@io.ktor.server.application.ApplicationCall(){0§<kotlin.Any?>}[0]
 final suspend inline fun <#A: reified kotlin/Any?> (io.ktor.server.application/ApplicationCall).io.ktor.server.request/receiveNullable(): #A? // io.ktor.server.request/receiveNullable|receiveNullable@io.ktor.server.application.ApplicationCall(){0§<kotlin.Any?>}[0]
 final suspend inline fun <#A: reified kotlin/Any?> (io.ktor.server.application/ApplicationCall).io.ktor.server.response/respondNullable(#A) // io.ktor.server.response/respondNullable|respondNullable@io.ktor.server.application.ApplicationCall(0:0){0§<kotlin.Any?>}[0]
 final suspend inline fun <#A: reified kotlin/Any?> (io.ktor.server.application/ApplicationCall).io.ktor.server.response/respondNullable(io.ktor.http/HttpStatusCode, #A) // io.ktor.server.response/respondNullable|respondNullable@io.ktor.server.application.ApplicationCall(io.ktor.http.HttpStatusCode;0:0){0§<kotlin.Any?>}[0]

--- a/ktor-server/ktor-server-core/common/src/io/ktor/server/application/PipelineCall.kt
+++ b/ktor-server/ktor-server-core/common/src/io/ktor/server/application/PipelineCall.kt
@@ -7,14 +7,14 @@ package io.ktor.server.application
 import io.ktor.http.*
 import io.ktor.http.content.*
 import io.ktor.server.plugins.*
+import io.ktor.server.plugins.ContentTransformationException
 import io.ktor.server.request.*
 import io.ktor.server.response.*
 import io.ktor.util.*
 import io.ktor.util.pipeline.*
 import io.ktor.util.reflect.*
 import io.ktor.utils.io.*
-import kotlinx.coroutines.*
-import kotlin.coroutines.*
+import kotlinx.coroutines.CoroutineScope
 
 private val RECEIVE_TYPE_KEY: AttributeKey<TypeInfo> = AttributeKey("ReceiveType")
 
@@ -63,6 +63,27 @@ public interface ApplicationCall : CoroutineScope {
     public val parameters: Parameters
 
     /**
+     * Receives content for this request according to [typeInfo].
+     *
+     * This function returns `null` only when [TypeInfo.isNullable] is `true`.
+     * The caller is responsible for ensuring that [typeInfo] represents the same type as [T].
+     *
+     * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.server.application.ApplicationCall.receive)
+     *
+     * @param typeInfo instance specifying the type to be received.
+     * @return an instance of [T] received from this call.
+     * @throws ContentTransformationException when content cannot be transformed to the requested type.
+     */
+    public suspend fun <T> receive(typeInfo: TypeInfo): T {
+        @Suppress("DEPRECATION")
+        val result = receiveNullable<T>(typeInfo)
+        if (!typeInfo.isNullable && result == null) throw CannotTransformContentToTypeException(typeInfo)
+
+        @Suppress("UNCHECKED_CAST")
+        return result as T
+    }
+
+    /**
      * Receives content for this request.
      *
      * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.server.application.ApplicationCall.receiveNullable)
@@ -71,6 +92,7 @@ public interface ApplicationCall : CoroutineScope {
      * @return instance of [T] received from this call.
      * @throws ContentTransformationException when content cannot be transformed to the requested type.
      */
+    @Deprecated("Use 'receive<T>(typeInfo)' with nullable T instead", ReplaceWith("receive<T?>(typeInfo)"))
     public suspend fun <T> receiveNullable(typeInfo: TypeInfo): T?
 
     /**

--- a/ktor-server/ktor-server-core/common/src/io/ktor/server/application/PipelineCall.kt
+++ b/ktor-server/ktor-server-core/common/src/io/ktor/server/application/PipelineCall.kt
@@ -119,7 +119,7 @@ public interface PipelineCall : ApplicationCall {
         when {
             transformed == NullBody -> return null
             transformed === DoubleReceivePreventionToken -> throw RequestAlreadyConsumedException()
-            !typeInfo.type.isInstance(transformed) -> throw CannotTransformContentToTypeException(typeInfo.kotlinType!!)
+            !typeInfo.type.isInstance(transformed) -> throw CannotTransformContentToTypeException(typeInfo)
         }
 
         @Suppress("UNCHECKED_CAST")

--- a/ktor-server/ktor-server-core/common/src/io/ktor/server/plugins/Errors.kt
+++ b/ktor-server/ktor-server-core/common/src/io/ktor/server/plugins/Errors.kt
@@ -5,11 +5,12 @@
 package io.ktor.server.plugins
 
 import io.ktor.http.*
-import io.ktor.server.application.internal.*
 import io.ktor.util.internal.*
-import kotlinx.coroutines.*
-import kotlinx.io.*
-import kotlin.reflect.*
+import io.ktor.util.reflect.*
+import kotlinx.coroutines.CopyableThrowable
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.io.IOException
+import kotlin.reflect.KType
 
 /**
  * Base exception to indicate that the request is not correct due to
@@ -86,13 +87,21 @@ public class ParameterConversionException(
 public abstract class ContentTransformationException(message: String) : IOException(message)
 
 @OptIn(ExperimentalCoroutinesApi::class)
-public class CannotTransformContentToTypeException(
-    private val type: KType
-) : ContentTransformationException("Cannot transform this request's content to $type"),
+public class CannotTransformContentToTypeException private constructor(
+    private val typeDescription: String
+) : ContentTransformationException("Cannot transform this request's content to $typeDescription"),
     CopyableThrowable<CannotTransformContentToTypeException> {
 
+    public constructor(type: KType) : this(type.toString())
+
+    internal constructor(typeInfo: TypeInfo) : this(
+        typeInfo.kotlinType?.toString()
+            ?: typeInfo.type.simpleName
+            ?: typeInfo.type.toString()
+    )
+
     override fun createCopy(): CannotTransformContentToTypeException =
-        CannotTransformContentToTypeException(type).also {
+        CannotTransformContentToTypeException(typeDescription).also {
             it.initCauseBridge(this)
         }
 }

--- a/ktor-server/ktor-server-core/common/src/io/ktor/server/request/ApplicationReceiveFunctions.kt
+++ b/ktor-server/ktor-server-core/common/src/io/ktor/server/request/ApplicationReceiveFunctions.kt
@@ -15,7 +15,7 @@ import io.ktor.util.reflect.*
 import io.ktor.utils.io.*
 import io.ktor.utils.io.charsets.*
 import io.ktor.utils.io.core.*
-import kotlin.reflect.*
+import kotlin.reflect.KClass
 
 private val FORM_FIELD_LIMIT = AttributeKey<Long>("FormFieldLimit")
 
@@ -86,7 +86,7 @@ public suspend inline fun <reified T : Any> ApplicationCall.receiveOrNull(): T? 
  * @throws ContentTransformationException when content cannot be transformed to the requested type.
  */
 public suspend inline fun <reified T : Any> ApplicationCall.receive(): T = receiveNullable(typeInfo<T>())
-    ?: throw CannotTransformContentToTypeException(typeInfo<T>().kotlinType!!)
+    ?: throw CannotTransformContentToTypeException(typeInfo<T>())
 
 /**
  * Receives content for this request.

--- a/ktor-server/ktor-server-core/common/src/io/ktor/server/request/ApplicationReceiveFunctions.kt
+++ b/ktor-server/ktor-server-core/common/src/io/ktor/server/request/ApplicationReceiveFunctions.kt
@@ -70,9 +70,12 @@ public open class ApplicationReceivePipeline(
  */
 @Deprecated(
     "receiveOrNull is ambiguous with receiveNullable and going to be removed in 3.0.0. " +
-        "Please consider replacing it with runCatching with receive or receiveNullable",
+        "Please consider replacing it with runCatching with receive",
     level = DeprecationLevel.ERROR,
-    replaceWith = ReplaceWith("kotlin.runCatching { this.receiveNullable<T>() }.getOrNull()")
+    replaceWith = ReplaceWith(
+        "kotlin.runCatching { this.receive<T?>() }.getOrNull()",
+        "io.ktor.server.request.receive",
+    )
 )
 @Suppress("DEPRECATION_ERROR")
 public suspend inline fun <reified T : Any> ApplicationCall.receiveOrNull(): T? = receiveOrNull(typeInfo<T>())
@@ -85,8 +88,7 @@ public suspend inline fun <reified T : Any> ApplicationCall.receiveOrNull(): T? 
  * @return instance of [T] received from this call.
  * @throws ContentTransformationException when content cannot be transformed to the requested type.
  */
-public suspend inline fun <reified T : Any> ApplicationCall.receive(): T = receiveNullable(typeInfo<T>())
-    ?: throw CannotTransformContentToTypeException(typeInfo<T>())
+public suspend inline fun <reified T> ApplicationCall.receive(): T = receive(typeInfo<T>())
 
 /**
  * Receives content for this request.
@@ -96,7 +98,11 @@ public suspend inline fun <reified T : Any> ApplicationCall.receive(): T = recei
  * @return instance of [T] received from this call.
  * @throws ContentTransformationException when content cannot be transformed to the requested type.
  */
-public suspend inline fun <reified T> ApplicationCall.receiveNullable(): T? = receiveNullable(typeInfo<T>())
+@Deprecated(
+    "Use 'receive<T>()' with nullable T instead",
+    ReplaceWith("this.receive<T>()", "io.ktor.server.request.receive"),
+)
+public suspend inline fun <reified T> ApplicationCall.receiveNullable(): T? = receive<T>()
 
 /**
  * Receives content for this request.
@@ -109,7 +115,7 @@ public suspend inline fun <reified T> ApplicationCall.receiveNullable(): T? = re
  */
 public suspend fun <T : Any> ApplicationCall.receive(type: KClass<T>): T {
     val kotlinType = starProjectedTypeBridge(type)
-    return receiveNullable(TypeInfo(type, kotlinType))!!
+    return receive(TypeInfo(type = type, kotlinType = kotlinType))
 }
 
 /**
@@ -122,6 +128,11 @@ public suspend fun <T : Any> ApplicationCall.receive(type: KClass<T>): T {
  * @throws ContentTransformationException when content cannot be transformed to the requested type.
  * @throws NullPointerException when content is `null`.
  */
+@Suppress("EXTENSION_SHADOWED_BY_MEMBER", "DEPRECATION")
+@Deprecated(
+    "Maintained for binary compatibility",
+    level = DeprecationLevel.HIDDEN,
+)
 public suspend fun <T> ApplicationCall.receive(typeInfo: TypeInfo): T = receiveNullable(typeInfo)!!
 
 /**
@@ -134,13 +145,13 @@ public suspend fun <T> ApplicationCall.receive(typeInfo: TypeInfo): T = receiveN
  */
 @Deprecated(
     "receiveOrNull is ambiguous with receiveNullable and going to be removed in 3.0.0. " +
-        "Please consider replacing it with runCatching with receive or receiveNullable",
+        "Please consider replacing it with runCatching with receive",
     level = DeprecationLevel.ERROR,
-    replaceWith = ReplaceWith("kotlin.runCatching { this.receiveNullable<T>() }.getOrNull()")
+    replaceWith = ReplaceWith("kotlin.runCatching { this.receive<T?>(typeInfo) }.getOrNull()")
 )
 public suspend fun <T : Any> ApplicationCall.receiveOrNull(typeInfo: TypeInfo): T? {
     return try {
-        receiveNullable(typeInfo)
+        receive(typeInfo)
     } catch (cause: ContentTransformationException) {
         application.log.debug("Conversion failed, null returned", cause)
         null
@@ -157,9 +168,12 @@ public suspend fun <T : Any> ApplicationCall.receiveOrNull(typeInfo: TypeInfo): 
  */
 @Deprecated(
     "receiveOrNull is ambiguous with receiveNullable and going to be removed in 3.0.0. " +
-        "Please consider replacing it with runCatching with receive or receiveNullable",
+        "Please consider replacing it with runCatching with receive",
     level = DeprecationLevel.ERROR,
-    replaceWith = ReplaceWith("kotlin.runCatching { this.receiveNullable<T>() }.getOrNull()")
+    replaceWith = ReplaceWith(
+        "kotlin.runCatching { this.receive(type) }.getOrNull()",
+        "io.ktor.server.request.receive",
+    )
 )
 public suspend fun <T : Any> ApplicationCall.receiveOrNull(type: KClass<T>): T? = try {
     receive(type)

--- a/ktor-server/ktor-server-core/common/src/io/ktor/server/routing/RoutingNode.kt
+++ b/ktor-server/ktor-server-core/common/src/io/ktor/server/routing/RoutingNode.kt
@@ -246,6 +246,12 @@ public class RoutingCall internal constructor(
     public val queryParameters: Parameters = pipelineCall.engineCall.parameters
     public val route: RoutingNode = pipelineCall.route
 
+    override suspend fun <T> receive(typeInfo: TypeInfo): T = pipelineCall.receive(typeInfo)
+
+    @Deprecated(
+        "Use 'receive<T>(typeInfo)' with nullable T instead",
+        replaceWith = ReplaceWith("receive<T?>(typeInfo)")
+    )
     override suspend fun <T> receiveNullable(typeInfo: TypeInfo): T? = pipelineCall.receiveNullable(typeInfo)
 
     override suspend fun respond(message: Any?, typeInfo: TypeInfo?) {

--- a/ktor-server/ktor-server-core/common/src/io/ktor/server/util/Parameters.kt
+++ b/ktor-server/ktor-server-core/common/src/io/ktor/server/util/Parameters.kt
@@ -8,7 +8,7 @@ import io.ktor.http.*
 import io.ktor.server.plugins.*
 import io.ktor.util.converters.*
 import io.ktor.util.reflect.*
-import kotlin.reflect.*
+import kotlin.reflect.KProperty
 
 /**
  * Operator function that allows to delegate variables by call parameters.
@@ -57,13 +57,13 @@ public inline fun <reified R> Parameters.getOrFail(name: String): R =
     getOrFailImpl(name, typeInfo<R>())
 
 @PublishedApi
+@Suppress("UNCHECKED_CAST")
 internal fun <R> Parameters.getOrFailImpl(name: String, typeInfo: TypeInfo): R {
-    return if (typeInfo.kotlinType?.isMarkedNullable == true && get(name) == null) {
+    return if (typeInfo.isNullable && get(name) == null) {
         null as R
     } else {
         val values = getAll(name) ?: throw MissingRequestParameterException(name)
         try {
-            @Suppress("UNCHECKED_CAST")
             DefaultConversionService.fromValues(values, typeInfo) as R
         } catch (cause: Exception) {
             throw ParameterConversionException(name, typeInfo.type.simpleName ?: typeInfo.type.toString(), cause)

--- a/ktor-server/ktor-server-plugins/ktor-server-auth/common/src/io/ktor/server/auth/FormAuth.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-auth/common/src/io/ktor/server/auth/FormAuth.kt
@@ -8,7 +8,7 @@ import io.ktor.http.*
 import io.ktor.server.application.*
 import io.ktor.server.request.*
 import io.ktor.server.response.*
-import io.ktor.utils.io.InternalAPI
+import io.ktor.utils.io.*
 
 /**
  * A form-based authentication provider.
@@ -33,7 +33,7 @@ public class FormAuthenticationProvider internal constructor(config: Config) : A
     @OptIn(InternalAPI::class)
     override suspend fun onAuthenticate(context: AuthenticationContext) {
         val call = context.call
-        val postParameters = runCatching { call.receiveNullable<Parameters>() }.getOrNull()
+        val postParameters = runCatching { call.receive<Parameters?>() }.getOrNull()
         val username = postParameters?.get(userParamName)
         val password = postParameters?.get(passwordParamName)
 

--- a/ktor-server/ktor-server-plugins/ktor-server-auth/common/test/io/ktor/tests/auth/OAuth2Test.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-auth/common/test/io/ktor/tests/auth/OAuth2Test.kt
@@ -1061,9 +1061,7 @@ internal fun createOAuth2Server(server: OAuth2Server): Deferred<HttpClient> {
             routing {
                 route("/oauth/access_token") {
                     handle {
-                        val formData = runCatching {
-                            call.receiveNullable<Parameters>()
-                        }.getOrNull() ?: Parameters.Empty
+                        val formData = runCatching { call.receive<Parameters?>() }.getOrNull() ?: Parameters.Empty
 
                         val values = call.parameters + formData
 

--- a/ktor-server/ktor-server-plugins/ktor-server-content-negotiation/common/src/io/ktor/server/plugins/contentnegotiation/RequestConverter.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-content-negotiation/common/src/io/ktor/server/plugins/contentnegotiation/RequestConverter.kt
@@ -64,7 +64,7 @@ private suspend fun convertBody(
     }
 
     val isEmpty = body.isClosedForRead || !body.awaitContent()
-    val isNullable = receiveType.kotlinType?.isMarkedNullable == true
+    val isNullable = receiveType.isNullable
     if (isEmpty && isNullable) {
         return NullBody
     }

--- a/ktor-server/ktor-server-plugins/ktor-server-di/common/src/io/ktor/server/plugins/di/DependencyInjection.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-di/common/src/io/ktor/server/plugins/di/DependencyInjection.kt
@@ -8,7 +8,7 @@ import io.ktor.server.application.*
 import io.ktor.server.plugins.di.utils.*
 import io.ktor.util.*
 import io.ktor.util.reflect.*
-import io.ktor.utils.io.CancellationException
+import io.ktor.utils.io.*
 import kotlinx.coroutines.CoroutineName
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -318,13 +318,12 @@ public inline fun <reified T> DependencyKey(
 /**
  * Determines if the type associated with a `DependencyKey` is nullable.
  *
- * This function checks whether the `kotlinType` property of the `type` in the `DependencyKey`
- * is marked as nullable. If there is no `kotlinType`, it will return `false`.
+ * This function checks whether the `isNullable` property of the `type` in the `DependencyKey`
+ * is set to `true`.
  *
  * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.server.plugins.di.isNullable)
  */
-public fun DependencyKey.isNullable(): Boolean =
-    type.kotlinType?.isMarkedNullable == true
+public fun DependencyKey.isNullable(): Boolean = type.isNullable
 
 /**
  * Common parent for dependency injection problems.

--- a/ktor-server/ktor-server-plugins/ktor-server-di/common/src/io/ktor/server/plugins/di/utils/Types.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-di/common/src/io/ktor/server/plugins/di/utils/Types.kt
@@ -52,8 +52,11 @@ public expect fun TypeInfo.typeParametersHierarchy(): Sequence<TypeInfo>
  *
  * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.server.plugins.di.utils.toRawType)
  *
- * @return A new [TypeInfo] with [kotlinType] set to null.
+ * @return A new [TypeInfo] with [kotlinType] set to `null` and the original nullability preserved.
  */
 @InternalAPI
-public fun TypeInfo.toRawType(): TypeInfo =
-    TypeInfo(type, kotlinType = null)
+public fun TypeInfo.toRawType(): TypeInfo = TypeInfo(
+    type = type,
+    isNullable = isNullable,
+    kotlinType = null,
+)

--- a/ktor-server/ktor-server-plugins/ktor-server-di/common/test/io/ktor/server/plugins/di/DependencyInjectionTest.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-di/common/test/io/ktor/server/plugins/di/DependencyInjectionTest.kt
@@ -7,6 +7,7 @@ package io.ktor.server.plugins.di
 import io.ktor.client.request.*
 import io.ktor.client.statement.*
 import io.ktor.server.application.*
+import io.ktor.server.plugins.di.utils.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
 import io.ktor.server.testing.*
@@ -15,6 +16,7 @@ import io.ktor.test.dispatcher.*
 import io.ktor.util.logging.*
 import io.ktor.util.reflect.*
 import io.ktor.utils.io.CancellationException
+import io.ktor.utils.io.InternalAPI
 import kotlinx.coroutines.*
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.consumeAsFlow
@@ -559,6 +561,15 @@ class DependencyInjectionTest {
             closed,
             "Expected all dependencies to be closed in the correct order"
         )
+    }
+
+    @Test
+    @OptIn(InternalAPI::class)
+    fun `raw type preserves nullability`() {
+        val rawType = typeInfo<List<String>?>().toRawType()
+
+        assertNull(rawType.kotlinType)
+        assertTrue(rawType.isNullable)
     }
 
     @Test

--- a/ktor-server/ktor-server-plugins/ktor-server-di/jvm/src/io/ktor/server/plugins/di/DependencyReflectionJvm.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-di/jvm/src/io/ktor/server/plugins/di/DependencyReflectionJvm.kt
@@ -85,7 +85,10 @@ public open class DependencyReflectionJvm : DependencyReflection {
         }
 
         return DependencyKey(
-            type = TypeInfo(parameter.type.jvmErasure, parameter.type),
+            type = TypeInfo(
+                type = parameter.type.jvmErasure,
+                kotlinType = parameter.type,
+            ),
             name = name ?: property,
             qualifier = PropertyQualifier.takeIf { property != null }
         )

--- a/ktor-server/ktor-server-plugins/ktor-server-di/jvm/src/io/ktor/server/plugins/di/utils/ClasspathReference.jvm.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-di/jvm/src/io/ktor/server/plugins/di/utils/ClasspathReference.jvm.kt
@@ -25,7 +25,10 @@ internal actual fun Application.installReference(
         // If this is a class reference,
         // treat it as a `create(Object::class)` call
         val kotlinType = clazz.kotlin
-        val classTypeInfo = TypeInfo(kotlinType, kotlinType.starProjectedType)
+        val classTypeInfo = TypeInfo(
+            type = kotlinType,
+            kotlinType = kotlinType.starProjectedType,
+        )
 
         registry.set(DependencyKey(classTypeInfo)) {
             reflection.create(kotlinType, ::get)
@@ -39,7 +42,10 @@ internal actual fun Application.installReference(
             ?: throw InvalidDependencyReferenceException("Missing function reference", reference)
         val returnType = functionCandidates.map { it.returnType }.distinct().singleOrNull()
             ?: throw InvalidDependencyReferenceException("Ambiguous return types", reference)
-        val returnTypeInfo = TypeInfo(returnType.jvmErasure, returnType)
+        val returnTypeInfo = TypeInfo(
+            type = returnType.jvmErasure,
+            kotlinType = returnType,
+        )
 
         registry.set(DependencyKey(returnTypeInfo)) {
             var lastError: Throwable? = null

--- a/ktor-server/ktor-server-plugins/ktor-server-di/jvm/src/io/ktor/server/plugins/di/utils/Types.jvm.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-di/jvm/src/io/ktor/server/plugins/di/utils/Types.jvm.kt
@@ -24,29 +24,32 @@ import kotlin.reflect.full.starProjectedType
 @InternalAPI
 public actual fun TypeInfo.hierarchy(): Sequence<TypeInfo> {
     val supertypes = kotlinType?.hierarchy() ?: type.supertypes.asSequence()
-    return supertypes.mapNotNull { it.toTypeInfo() }
+    return supertypes.mapNotNull { it.toTypeInfo(isNullable) }
 }
 
 /**
  * Converts the current [TypeInfo] into a nullable type representation.
- * If the type is already nullable, returns null.
+ * If the type is already nullable, returns `null`.
  *
  * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.server.plugins.di.utils.toNullable)
  *
- * @return A new [TypeInfo] instance with a nullable type, or null if the type is already nullable.
+ * @return A new [TypeInfo] instance with a nullable type, or `null` if the type is already nullable.
  */
 @InternalAPI
-public actual fun TypeInfo.toNullable(): TypeInfo? =
-    kotlinType?.takeIf { !it.isMarkedNullable }?.let { kType ->
-        TypeInfo(
-            type,
-            type.createType(
-                arguments = kType.arguments,
-                nullable = true,
-                annotations = kType.annotations
-            )
+public actual fun TypeInfo.toNullable(): TypeInfo? {
+    if (isNullable) return null
+
+    val kType = kotlinType ?: return TypeInfo(type = type, isNullable = true)
+    return TypeInfo(
+        type = type,
+        isNullable = true,
+        kotlinType = type.createType(
+            arguments = kType.arguments,
+            nullable = true,
+            annotations = kType.annotations
         )
-    }
+    )
+}
 
 /**
  * Returns a list of the given base implementation for covariant type arguments.
@@ -123,18 +126,21 @@ private fun TypeInfo.parameterizedWith(typeArgReplacements: Map<Int, KType>): Ty
         swappedArguments[paramIndex] = KTypeProjection(KVariance.INVARIANT, paramType)
     }
     return TypeInfo(
-        type,
-        type.createType(
+        type = type,
+        kotlinType = type.createType(
             arguments = swappedArguments,
+            nullable = isNullable,
             annotations = type.annotations
         )
     )
 }
 
-private fun KType.toTypeInfo(): TypeInfo? =
+@OptIn(InternalAPI::class)
+private fun KType.toTypeInfo(isNullable: Boolean): TypeInfo? =
     (classifier as? KClass<*>)?.let {
         TypeInfo(
             type = classifier as KClass<*>,
+            isNullable = isNullable,
             kotlinType = this
         )
     }
@@ -182,7 +188,10 @@ private fun KType.hierarchy(): Sequence<KType> {
 
         // Create a new type with substituted arguments, or fallback to the original
         return supertype.classifier?.let { classifier ->
-            (classifier as? KClass<*>)?.createType(substitutedArguments)
+            (classifier as? KClass<*>)?.createType(
+                arguments = substitutedArguments,
+                nullable = currentType.isMarkedNullable,
+            )
         } ?: supertype
     }
 

--- a/ktor-server/ktor-server-plugins/ktor-server-di/jvm/test/io/ktor/server/plugins/di/utils/TypesTest.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-di/jvm/test/io/ktor/server/plugins/di/utils/TypesTest.kt
@@ -6,8 +6,12 @@ package io.ktor.server.plugins.di.utils
 
 import io.ktor.util.reflect.*
 import io.ktor.utils.io.*
+import kotlin.reflect.typeOf
 import kotlin.test.Test
 import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
 
 interface Companion
 interface Pet : Companion
@@ -29,6 +33,44 @@ class TypesTest {
             ),
             typeInfo<Cat>().hierarchy(),
         )
+    }
+
+    @Test
+    fun `raw hierarchy preserves nullability`() {
+        val hierarchy = TypeInfo(Cat::class, isNullable = true).hierarchy().toList()
+
+        assertTrue(hierarchy.isNotEmpty())
+        assertTrue(hierarchy.all { it.isNullable })
+    }
+
+    @Test
+    fun `hierarchy preserves nullability independent of kotlin type`() {
+        val typeInfo = TypeInfo(
+            type = Cat::class,
+            isNullable = true,
+            kotlinType = typeOf<Cat>(),
+        )
+
+        assertTrue(typeInfo.hierarchy().all { it.isNullable })
+    }
+
+    @Test
+    fun `raw type converts to nullable`() {
+        assertEquals(
+            TypeInfo(Cat::class, isNullable = true),
+            TypeInfo(Cat::class, isNullable = false).toNullable(),
+        )
+    }
+
+    @Test
+    fun `explicitly nullable type is not converted again`() {
+        val typeInfo = TypeInfo(
+            type = Cat::class,
+            isNullable = true,
+            kotlinType = typeOf<Cat>(),
+        )
+
+        assertNull(typeInfo.toNullable())
     }
 
     @Test

--- a/ktor-server/ktor-server-plugins/ktor-server-di/nonJvm/src/io/ktor/server/plugins/di/utils/Types.nonJvm.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-di/nonJvm/src/io/ktor/server/plugins/di/utils/Types.nonJvm.kt
@@ -19,14 +19,15 @@ public actual fun TypeInfo.hierarchy(): Sequence<TypeInfo> =
     sequenceOf(this)
 
 /**
- * This kind of reflection is currently only supported for the JVM platform.
- *
- * For non-JVM platforms, we omit support for resolving covariant types of declared dependencies.
+ * Converts raw types without reflection. Converting [kotlinType] is only supported on the JVM platform.
  *
  * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.server.plugins.di.utils.toNullable)
  */
 @InternalAPI
-public actual fun TypeInfo.toNullable(): TypeInfo? = null
+public actual fun TypeInfo.toNullable(): TypeInfo? {
+    if (isNullable || kotlinType != null) return null
+    return TypeInfo(type = type, isNullable = true)
+}
 
 /**
  * This kind of reflection is currently only supported for the JVM platform.

--- a/ktor-server/ktor-server-test-suites/jvm/src/io/ktor/server/testing/suites/ContentTestSuite.kt
+++ b/ktor-server/ktor-server-test-suites/jvm/src/io/ktor/server/testing/suites/ContentTestSuite.kt
@@ -18,13 +18,13 @@ import io.ktor.server.routing.*
 import io.ktor.server.test.base.*
 import io.ktor.util.logging.*
 import io.ktor.utils.io.*
-import kotlinx.coroutines.*
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import kotlinx.io.asSource
 import kotlinx.io.buffered
-import java.io.*
-import kotlin.io.use
+import java.io.File
+import java.io.InputStream
 import kotlin.test.*
-import kotlin.text.toByteArray
 
 abstract class ContentTestSuite<TEngine : ApplicationEngine, TConfiguration : ApplicationEngine.Configuration>(
     hostFactory: ApplicationEngineFactory<TEngine, TConfiguration>
@@ -260,7 +260,7 @@ abstract class ContentTestSuite<TEngine : ApplicationEngine, TConfiguration : Ap
     fun testRequestContentFormData() = runTest {
         createAndStartServer {
             handle {
-                val parameters = runCatching { call.receiveNullable<Parameters>() }.getOrNull()
+                val parameters = runCatching { call.receive<Parameters?>() }.getOrNull()
                 if (parameters != null) {
                     call.respond(parameters.formUrlEncode())
                 } else {

--- a/ktor-server/ktor-server-tests/common/test/io/ktor/tests/server/http/ApplicationRequestContentTest.kt
+++ b/ktor-server/ktor-server-tests/common/test/io/ktor/tests/server/http/ApplicationRequestContentTest.kt
@@ -170,7 +170,7 @@ class ApplicationRequestContentTest {
 
         routing {
             get("/") {
-                val v = runCatching { call.receiveNullable<IntList>() }.getOrNull()
+                val v = runCatching { call.receive<IntList?>() }.getOrNull()
                 call.respondText(v?.values?.joinToString() ?: "(none)")
             }
         }

--- a/ktor-shared/ktor-serialization/common/src/ContentConverter.kt
+++ b/ktor-shared/ktor-serialization/common/src/ContentConverter.kt
@@ -115,7 +115,7 @@ public suspend fun List<ContentConverter>.deserialize(
     return when {
         result != null -> result
         !body.isClosedForRead -> body
-        typeInfo.kotlinType?.isMarkedNullable == true -> NullBody
+        typeInfo.isNullable -> NullBody
         else -> throw ContentConvertException("No suitable converter found for $typeInfo")
     }
 }

--- a/ktor-shared/ktor-serialization/ktor-serialization-kotlinx/common/src/io/ktor/serialization/kotlinx/SerializerLookup.kt
+++ b/ktor-shared/ktor-serialization/ktor-serialization-kotlinx/common/src/io/ktor/serialization/kotlinx/SerializerLookup.kt
@@ -8,8 +8,9 @@ import io.ktor.util.reflect.*
 import io.ktor.utils.io.*
 import kotlinx.serialization.*
 import kotlinx.serialization.builtins.*
-import kotlinx.serialization.modules.*
-import kotlin.reflect.*
+import kotlinx.serialization.modules.SerializersModule
+import kotlin.reflect.KClass
+import kotlin.reflect.KType
 
 /**
  * Attempts to create a serializer for the given [typeInfo]
@@ -20,7 +21,7 @@ import kotlin.reflect.*
 @ExperimentalSerializationApi
 public fun SerializersModule.serializerForTypeInfo(typeInfo: TypeInfo): KSerializer<*> {
     val module = this
-    return typeInfo.kotlinType
+    val serializer = typeInfo.kotlinType
         ?.let { type ->
             if (type.arguments.isEmpty()) {
                 null // fallback to a simple case because of
@@ -29,8 +30,9 @@ public fun SerializersModule.serializerForTypeInfo(typeInfo: TypeInfo): KSeriali
                 module.serializerOrNull(type) ?: checkTypeParameters(type, typeInfo, module)
             }
         }
-        ?: module.getContextual(typeInfo.type)?.maybeNullable(typeInfo)
-        ?: typeInfo.type.serializer().maybeNullable(typeInfo)
+        ?: module.getContextual(typeInfo.type)
+        ?: typeInfo.type.serializer()
+    return serializer.maybeNullable(typeInfo.isNullable)
 }
 
 /**
@@ -73,10 +75,6 @@ private fun checkTypeParameters(type: KType, typeInfo: TypeInfo, module: Seriali
     )
 }
 
-private fun <T : Any> KSerializer<T>.maybeNullable(typeInfo: TypeInfo): KSerializer<*> {
-    return if (typeInfo.kotlinType?.isMarkedNullable == true) this.nullable else this
-}
-
 @Suppress("UNCHECKED_CAST")
 @InternalAPI
 public fun guessSerializer(value: Any?, module: SerializersModule): KSerializer<Any> = when (value) {
@@ -100,7 +98,7 @@ public fun guessSerializer(value: Any?, module: SerializersModule): KSerializer<
     }
 } as KSerializer<Any>
 
-@OptIn(ExperimentalSerializationApi::class, InternalAPI::class)
+@OptIn(InternalAPI::class)
 private fun Collection<*>.elementSerializer(module: SerializersModule): KSerializer<*> {
     val serializers: List<KSerializer<*>> =
         filterNotNull().map { guessSerializer(it, module) }.distinctBy { it.descriptor.serialName }
@@ -118,12 +116,9 @@ private fun Collection<*>.elementSerializer(module: SerializersModule): KSeriali
         return selected
     }
 
-    @Suppress("UNCHECKED_CAST")
-    selected as KSerializer<Any>
-
-    if (any { it == null }) {
-        return selected.nullable
-    }
-
-    return selected
+    return selected.maybeNullable(nullable = any { it == null })
 }
+
+@Suppress("UNCHECKED_CAST")
+private fun KSerializer<*>.maybeNullable(nullable: Boolean): KSerializer<*> =
+    if (nullable) (this as KSerializer<Any>).nullable else this

--- a/ktor-shared/ktor-serialization/ktor-serialization-kotlinx/common/test/io/ktor/serialization/kotlinx/SerializerLookupTest.kt
+++ b/ktor-shared/ktor-serialization/ktor-serialization-kotlinx/common/test/io/ktor/serialization/kotlinx/SerializerLookupTest.kt
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2014-2026 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.serialization.kotlinx
+
+import io.ktor.util.reflect.TypeInfo
+import io.ktor.utils.io.InternalAPI
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.InternalSerializationApi
+import kotlinx.serialization.modules.EmptySerializersModule
+import kotlin.reflect.typeOf
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+@OptIn(InternalAPI::class, InternalSerializationApi::class, ExperimentalSerializationApi::class)
+class SerializerLookupTest {
+
+    @Test
+    fun `serializer preserves nullability independent of kotlin type`() {
+        val typeInfo = TypeInfo(
+            type = List::class,
+            isNullable = true,
+            kotlinType = typeOf<List<String>>(),
+        )
+
+        val serializer = EmptySerializersModule().serializerForTypeInfo(typeInfo)
+
+        assertTrue(serializer.descriptor.isNullable)
+    }
+}

--- a/ktor-shared/ktor-serialization/ktor-serialization-kotlinx/ktor-serialization-kotlinx-json/common/src/io/ktor/serialization/kotlinx/json/KotlinxSerializationJsonExtensions.kt
+++ b/ktor-shared/ktor-serialization/ktor-serialization-kotlinx/ktor-serialization-kotlinx-json/common/src/io/ktor/serialization/kotlinx/json/KotlinxSerializationJsonExtensions.kt
@@ -99,8 +99,8 @@ private class JsonArraySymbols(charset: Charset) {
 internal fun TypeInfo.argumentTypeInfo(): TypeInfo {
     val elementType = kotlinType!!.arguments[0].type!!
     return TypeInfo(
-        elementType.classifier as KClass<*>,
-        elementType
+        type = elementType.classifier as KClass<*>,
+        kotlinType = elementType,
     )
 }
 

--- a/ktor-shared/ktor-serialization/ktor-serialization-kotlinx/ktor-serialization-kotlinx-json/jvm/test/JsonReceiveNullableWithBodyLimitTest.kt
+++ b/ktor-shared/ktor-serialization/ktor-serialization-kotlinx/ktor-serialization-kotlinx-json/jvm/test/JsonReceiveNullableWithBodyLimitTest.kt
@@ -34,7 +34,7 @@ class JsonReceiveNullableWithBodyLimitTest {
         var receivedWasNull = false
         routing {
             post("/") {
-                val received: Payload? = call.receiveNullable()
+                val received: Payload? = call.receive()
                 receivedWasNull = received == null
                 call.respond(HttpStatusCode.OK, "ok")
             }
@@ -45,7 +45,7 @@ class JsonReceiveNullableWithBodyLimitTest {
         }
         assertEquals(HttpStatusCode.OK, response.status)
         assertEquals("ok", response.bodyAsText())
-        assertTrue(receivedWasNull, "receiveNullable<Payload?>() should return null for an empty body")
+        assertTrue(receivedWasNull, "receive<Payload?>() should return null for an empty body")
     }
 
     @Test
@@ -60,7 +60,7 @@ class JsonReceiveNullableWithBodyLimitTest {
         var receivedWasNull: Boolean
         routing {
             post("/") {
-                val received: Payload? = call.receiveNullable()
+                val received: Payload? = call.receive()
                 receivedWasNull = received == null
                 call.respond(HttpStatusCode.OK, "ok")
             }
@@ -75,7 +75,7 @@ class JsonReceiveNullableWithBodyLimitTest {
             }
             assertEquals(HttpStatusCode.OK, response.status, "iteration #$it returned ${response.status}")
             assertEquals("ok", response.bodyAsText(), "iteration #$it body mismatch")
-            assertTrue(receivedWasNull, "iteration #$it: receiveNullable<Payload?>() should return null")
+            assertTrue(receivedWasNull, "iteration #$it: receive<Payload?>() should return null")
         }
     }
 }

--- a/ktor-shared/ktor-serialization/ktor-serialization-tests/jvm/src/AbstractServerSerializationTest.kt
+++ b/ktor-shared/ktor-serialization/ktor-serialization-tests/jvm/src/AbstractServerSerializationTest.kt
@@ -66,7 +66,7 @@ public abstract class AbstractServerSerializationTest {
                 call.respond(entity)
             }
             post("/null") {
-                val result = call.receiveNullable<NullValues?>() ?: "OK"
+                val result = call.receive<NullValues?>() ?: "OK"
                 call.respondText(result.toString())
             }
         }

--- a/ktor-shared/ktor-websocket-serialization/common/src/io/ktor/websocket/serialization/WebsocketChannelSerialization.kt
+++ b/ktor-shared/ktor-websocket-serialization/common/src/io/ktor/websocket/serialization/WebsocketChannelSerialization.kt
@@ -5,7 +5,6 @@
 package io.ktor.websocket.serialization
 
 import io.ktor.serialization.*
-import io.ktor.util.*
 import io.ktor.util.reflect.*
 import io.ktor.utils.io.*
 import io.ktor.utils.io.charsets.*
@@ -120,18 +119,17 @@ public suspend fun WebSocketSession.receiveDeserializedBase(
         content = frame
     )
 
-    when {
-        typeInfo.type.isInstance(result) -> return result
+    return when {
+        typeInfo.type.isInstance(result) -> result
 
-        result == null -> {
-            if (typeInfo.kotlinType?.isMarkedNullable == true) return null
-            throw WebsocketDeserializeException("Frame has null content", frame = frame)
-        }
+        result == null && typeInfo.isNullable -> null
+
+        result == null -> throw WebsocketDeserializeException("Frame has null content", frame = frame)
+
+        else -> throw WebsocketDeserializeException(
+            "Can't deserialize value: expected value of type ${typeInfo.type.simpleName}," +
+                " got ${result::class.simpleName}",
+            frame = frame,
+        )
     }
-
-    throw WebsocketDeserializeException(
-        "Can't deserialize value: expected value of type ${typeInfo.type.simpleName}," +
-            " got ${result!!::class.simpleName}",
-        frame = frame
-    )
 }

--- a/ktor-utils/api/ktor-utils.api
+++ b/ktor-utils/api/ktor-utils.api
@@ -1080,10 +1080,13 @@ public final class io/ktor/util/reflect/TypeInfo {
 	public synthetic fun <init> (Lkotlin/reflect/KClass;Ljava/lang/reflect/Type;Lkotlin/reflect/KType;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun <init> (Lkotlin/reflect/KClass;Lkotlin/reflect/KType;)V
 	public synthetic fun <init> (Lkotlin/reflect/KClass;Lkotlin/reflect/KType;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lkotlin/reflect/KClass;ZLkotlin/reflect/KType;)V
+	public synthetic fun <init> (Lkotlin/reflect/KClass;ZLkotlin/reflect/KType;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getKotlinType ()Lkotlin/reflect/KType;
 	public final fun getType ()Lkotlin/reflect/KClass;
 	public fun hashCode ()I
+	public final fun isNullable ()Z
 	public fun toString ()Ljava/lang/String;
 }
 

--- a/ktor-utils/api/ktor-utils.klib.api
+++ b/ktor-utils/api/ktor-utils.klib.api
@@ -530,7 +530,10 @@ final class io.ktor.util.pipeline/PipelinePhase { // io.ktor.util.pipeline/Pipel
 
 final class io.ktor.util.reflect/TypeInfo { // io.ktor.util.reflect/TypeInfo|null[0]
     constructor <init>(kotlin.reflect/KClass<*>, kotlin.reflect/KType? = ...) // io.ktor.util.reflect/TypeInfo.<init>|<init>(kotlin.reflect.KClass<*>;kotlin.reflect.KType?){}[0]
+    constructor <init>(kotlin.reflect/KClass<*>, kotlin/Boolean, kotlin.reflect/KType? = ...) // io.ktor.util.reflect/TypeInfo.<init>|<init>(kotlin.reflect.KClass<*>;kotlin.Boolean;kotlin.reflect.KType?){}[0]
 
+    final val isNullable // io.ktor.util.reflect/TypeInfo.isNullable|{}isNullable[0]
+        final fun <get-isNullable>(): kotlin/Boolean // io.ktor.util.reflect/TypeInfo.isNullable.<get-isNullable>|<get-isNullable>(){}[0]
     final val kotlinType // io.ktor.util.reflect/TypeInfo.kotlinType|{}kotlinType[0]
         final fun <get-kotlinType>(): kotlin.reflect/KType? // io.ktor.util.reflect/TypeInfo.kotlinType.<get-kotlinType>|<get-kotlinType>(){}[0]
     final val type // io.ktor.util.reflect/TypeInfo.type|{}type[0]

--- a/ktor-utils/common/src/io/ktor/util/reflect/Type.kt
+++ b/ktor-utils/common/src/io/ktor/util/reflect/Type.kt
@@ -4,11 +4,14 @@
 
 package io.ktor.util.reflect
 
-import io.ktor.utils.io.InternalAPI
+import io.ktor.utils.io.*
 import kotlinx.serialization.InternalSerializationApi
 import kotlinx.serialization.KSerializer
+import kotlinx.serialization.builtins.nullable
 import kotlinx.serialization.serializer
-import kotlin.reflect.*
+import kotlin.reflect.KClass
+import kotlin.reflect.KType
+import kotlin.reflect.typeOf
 
 /**
  * Information about type.
@@ -28,28 +31,52 @@ public expect val KType.platformType: Type
  * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.util.reflect.TypeInfo)
  *
  * @property type Source KClass<*>
- * @property kotlinType Kotlin reified type with all generic type parameters.
+ * @property isNullable `true` when `null` is a valid value for this type. This is stored separately from [kotlinType]
+ * because [kotlinType] can be `null` and we want to preserve nullability in that case.
+ * @property kotlinType Kotlin reified type with all generic type parameters, or `null` when type information is
+ * unavailable.
  */
-public class TypeInfo(
+public class TypeInfo @InternalAPI public constructor(
     public val type: KClass<*>,
-    public val kotlinType: KType? = null
+    public val isNullable: Boolean,
+    public val kotlinType: KType? = null,
 ) {
 
+    @OptIn(InternalAPI::class)
+    public constructor(
+        type: KClass<*>,
+        kotlinType: KType? = null
+    ) : this(
+        type = type,
+        isNullable = kotlinType?.isMarkedNullable == true,
+        kotlinType = kotlinType,
+    )
+
     @Suppress("UNUSED_PARAMETER", "DEPRECATION")
-    @Deprecated("Use constructor without reifiedType parameter.", ReplaceWith("TypeInfo(type, kotlinType)"))
+    @Deprecated(
+        "Use constructor without the reifiedType parameter.",
+        ReplaceWith("TypeInfo(type = type, kotlinType = kotlinType)")
+    )
     public constructor(
         type: KClass<*>,
         reifiedType: Type,
         kotlinType: KType? = null,
     ) : this(type, kotlinType)
 
+    init {
+        require(isNullable || kotlinType?.isMarkedNullable != true) {
+            "TypeInfo for nullable kotlinType $kotlinType must have isNullable set to true"
+        }
+    }
+
     override fun hashCode(): Int {
-        return kotlinType?.hashCode() ?: type.hashCode()
+        return 31 * (kotlinType?.hashCode() ?: type.hashCode()) + isNullable.hashCode()
     }
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (other !is TypeInfo) return false
+        if (isNullable != other.isNullable) return false
 
         return if (kotlinType != null || other.kotlinType != null) {
             kotlinType == other.kotlinType
@@ -66,12 +93,20 @@ public class TypeInfo(
  *
  * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.util.reflect.typeInfo)
  */
-public inline fun <reified T> typeInfo(): TypeInfo = TypeInfo(T::class, typeOfOrNull<T>())
+@OptIn(InternalAPI::class)
+public inline fun <reified T> typeInfo(): TypeInfo = TypeInfo(
+    type = T::class,
+    isNullable = null is T,
+    kotlinType = typeOfOrNull<T>(),
+)
 
 @OptIn(InternalSerializationApi::class)
 @InternalAPI
-public fun TypeInfo.serializer(): KSerializer<out Any?> =
-    kotlinType?.let { serializer(it) } ?: type.serializer()
+@Suppress("UNCHECKED_CAST")
+public fun TypeInfo.serializer(): KSerializer<out Any?> {
+    val serializer = kotlinType?.let { serializer(it) } ?: type.serializer()
+    return if (isNullable) (serializer as KSerializer<Any>).nullable else serializer
+}
 
 /**
  * Check [this] is instance of [type].

--- a/ktor-utils/common/test/io/ktor/util/reflect/TypeInfoTest.kt
+++ b/ktor-utils/common/test/io/ktor/util/reflect/TypeInfoTest.kt
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2014-2026 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.util.reflect
+
+import io.ktor.utils.io.InternalAPI
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlin.reflect.typeOf
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertNotEquals
+import kotlin.test.assertTrue
+
+@OptIn(InternalAPI::class)
+class TypeInfoTest {
+
+    @Test
+    fun `typeInfo preserves nullability`() {
+        assertFalse(typeInfo<String>().isNullable)
+        assertTrue(typeInfo<String?>().isNullable)
+    }
+
+    @Test
+    fun `marked nullable type requires nullable flag`() {
+        assertFailsWith<IllegalArgumentException> {
+            TypeInfo(
+                type = String::class,
+                isNullable = false,
+                kotlinType = typeOf<String?>(),
+            )
+        }
+    }
+
+    @Test
+    fun `raw types with different nullability are not equal`() {
+        val nonNullable = TypeInfo(String::class, isNullable = false)
+        val nullable = TypeInfo(String::class, isNullable = true)
+
+        assertNotEquals(nonNullable, nullable)
+        assertEquals(2, setOf(nonNullable, nullable).size)
+    }
+
+    @Test
+    fun `types with kotlin type and different nullability are not equal`() {
+        val nonNullable = TypeInfo(String::class, isNullable = false, kotlinType = typeOf<String>())
+        val nullable = TypeInfo(String::class, isNullable = true, kotlinType = typeOf<String>())
+
+        assertNotEquals(nonNullable, nullable)
+        assertEquals(2, setOf(nonNullable, nullable).size)
+    }
+
+    @OptIn(InternalAPI::class, ExperimentalSerializationApi::class)
+    @Test
+    fun `serializer preserves explicit nullability`() {
+        val rawSerializer = TypeInfo(String::class, isNullable = true).serializer()
+        val parameterizedSerializer = TypeInfo(
+            type = List::class,
+            isNullable = true,
+            kotlinType = typeOf<List<String>>(),
+        ).serializer()
+
+        assertTrue(rawSerializer.descriptor.isNullable)
+        assertTrue(parameterizedSerializer.descriptor.isNullable)
+    }
+}

--- a/ktor-utils/jvm/src/io/ktor/util/reflect/TypeInfoJvm.kt
+++ b/ktor-utils/jvm/src/io/ktor/util/reflect/TypeInfoJvm.kt
@@ -21,8 +21,14 @@ public val TypeInfo.reifiedType: java.lang.reflect.Type
     get() = kotlinType?.javaType ?: type.java
 
 @Suppress("DEPRECATION")
-@Deprecated("Use TypeInfo constructor instead.", ReplaceWith("TypeInfo(kClass, kType)"))
-public fun typeInfoImpl(reifiedType: Type, kClass: KClass<*>, kType: KType?): TypeInfo = TypeInfo(kClass, kType)
+@Deprecated(
+    "Use TypeInfo constructor instead.",
+    ReplaceWith("TypeInfo(type = kClass, kotlinType = kType)")
+)
+public fun typeInfoImpl(reifiedType: Type, kClass: KClass<*>, kType: KType?): TypeInfo = TypeInfo(
+    type = kClass,
+    kotlinType = kType,
+)
 
 /**
  * Check [this] is instance of [type].

--- a/ktor-utils/posix/src/io/ktor/util/reflect/TypeInfoNative.kt
+++ b/ktor-utils/posix/src/io/ktor/util/reflect/TypeInfoNative.kt
@@ -4,14 +4,18 @@
 
 package io.ktor.util.reflect
 
-import kotlin.reflect.*
+import kotlin.reflect.KClass
+import kotlin.reflect.KType
 
 @Deprecated("Use KType instead.")
 public actual typealias Type = KType
 
 @Suppress("unused", "UNUSED_PARAMETER", "DEPRECATION")
 @Deprecated("Maintained for binary compatibility.", level = DeprecationLevel.HIDDEN)
-internal fun typeInfoImpl(reifiedType: Type, kClass: KClass<*>, kType: KType): TypeInfo = TypeInfo(kClass, kType)
+internal fun typeInfoImpl(reifiedType: Type, kClass: KClass<*>, kType: KType): TypeInfo = TypeInfo(
+    type = kClass,
+    kotlinType = kType,
+)
 
 /**
  * Check [this] is instance of [type].

--- a/ktor-utils/web/src/io/ktor/util/reflect/TypeInfo.web.kt
+++ b/ktor-utils/web/src/io/ktor/util/reflect/TypeInfo.web.kt
@@ -14,8 +14,14 @@ public actual interface Type
 public object JsType : Type
 
 @Suppress("DEPRECATION")
-@Deprecated("Use TypeInfo constructor instead.", ReplaceWith("TypeInfo(kClass, kType)"))
-public fun typeInfoImpl(reifiedType: Type, kClass: KClass<*>, kType: KType?): TypeInfo = TypeInfo(kClass, kType)
+@Deprecated(
+    "Use TypeInfo constructor instead.",
+    ReplaceWith("TypeInfo(type = kClass, kotlinType = kType)")
+)
+public fun typeInfoImpl(reifiedType: Type, kClass: KClass<*>, kType: KType?): TypeInfo = TypeInfo(
+    type = kClass,
+    kotlinType = kType,
+)
 
 /**
  * Check [this] is instance of [type].


### PR DESCRIPTION
**Subsystem**
Server, Serialization, Utils

**Motivation**
[`KTOR-5577`](https://youtrack.jetbrains.com/issue/KTOR-5577) tracks the confusing nullability contract of `ApplicationCall.receiveNullable<T>()`: it accepts a non-nullable `T`, while serializers use the nullability encoded in the requested type. `TypeInfo` also loses nullability when complete `KType` information is unavailable.

**Solution**
The idea is to allow `ApplicationCall.receive<T>()` to use nullable `T`, and deprecate `receiveNullable<T>()` in favor of `receive<T?>()`:

```diff
 post("/") {
-    val payload = call.receiveNullable<Payload?>()
+    val payload = call.receive<Payload?>()
     // use the payload
 }
```

To make nullability inference reliable I had to add `isNullable` property to `TypeInfo` and preserve it through serialization, content negotiation, parameter conversion, WebSocket serialization, and dependency-injection type transformations. The reason behind this is that `typeInfo<T>()` uses `typeOfOrNull` so the information about nullability is not reliably available.

**Backward compatibility**
- Keep the previous `receive(TypeInfo)` extension and `receiveNullable(TypeInfo)` implementation path for source and binary compatibility.
- Add default implementation for the introduced method

It's better to review by commits.