### PR TITLE
KTOR-9627 Propagate cancellation through blocking bridges

### DIFF
--- a/ktor-client/ktor-client-core/jvm/src/io/ktor/client/plugins/DefaultTransformersJvm.kt
+++ b/ktor-client/ktor-client-core/jvm/src/io/ktor/client/plugins/DefaultTransformersJvm.kt
@@ -11,27 +11,21 @@ import io.ktor.http.*
 import io.ktor.http.content.*
 import io.ktor.utils.io.*
 import io.ktor.utils.io.jvm.javaio.*
-import kotlinx.coroutines.*
-import java.io.*
+import kotlinx.coroutines.job
+import java.io.InputStream
 
+@OptIn(InternalAPI::class)
 internal actual fun HttpClient.platformResponseDefaultTransformers() {
     responsePipeline.intercept(HttpResponsePipeline.Parse) { (info, body) ->
         if (body !is ByteReadChannel) return@intercept
-        when (info.type) {
-            InputStream::class -> {
-                val stream = body.toInputStream(context.coroutineContext[Job])
-                val response = object : InputStream() {
-                    override fun read(): Int = stream.read()
-                    override fun read(b: ByteArray, off: Int, len: Int): Int = stream.read(b, off, len)
-                    override fun available(): Int = stream.available()
 
-                    override fun close() {
-                        super.close()
-                        stream.close()
-                    }
-                }
-                proceedWith(HttpResponseContainer(info, response))
-            }
+        when (info.type) {
+            InputStream::class -> proceedWith(
+                HttpResponseContainer(
+                    expectedType = info,
+                    response = body.asInputStream(context.coroutineContext.job)
+                )
+            )
         }
     }
 }

--- a/ktor-http/jvm/src/io/ktor/http/content/BlockingBridge.kt
+++ b/ktor-http/jvm/src/io/ktor/http/content/BlockingBridge.kt
@@ -7,9 +7,7 @@ package io.ktor.http.content
 import io.ktor.utils.io.*
 import io.ktor.utils.io.charsets.*
 import io.ktor.utils.io.jvm.javaio.*
-import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.withContext
+import kotlinx.coroutines.*
 import java.io.OutputStream
 import java.io.Writer
 
@@ -38,12 +36,13 @@ private val BlockingBridgeDispatcher = Dispatchers.IO.limitedParallelism(
  *
  * The stream passed to [block] is owned by this function and must not be used after [block] returns.
  */
+@OptIn(InternalAPI::class)
 internal suspend inline fun ByteWriteChannel.withBlockingOutputStream(
     dispatcher: CoroutineDispatcher = BlockingBridgeDispatcher,
     crossinline block: suspend (OutputStream) -> Unit,
 ) {
     withContext(dispatcher) {
-        val outputStream = toOutputStream()
+        val outputStream = asOutputStream(coroutineContext.job)
         block(outputStream)
     }
 }
@@ -57,13 +56,14 @@ internal suspend inline fun ByteWriteChannel.withBlockingOutputStream(
  *
  * The writer passed to [block] is owned by this function and must not be used after [block] returns.
  */
+@OptIn(InternalAPI::class)
 internal suspend inline fun ByteWriteChannel.withBlockingWriter(
     charset: Charset,
     dispatcher: CoroutineDispatcher = BlockingBridgeDispatcher,
     crossinline block: suspend (Writer) -> Unit,
 ) {
     withContext(dispatcher) {
-        val writer = toOutputStream().nonClosing().writer(charset)
+        val writer = asOutputStream(coroutineContext.job).nonClosing().writer(charset)
         writer.use { block(it) }
     }
 }

--- a/ktor-http/jvm/src/io/ktor/http/content/OutputStreamContent.kt
+++ b/ktor-http/jvm/src/io/ktor/http/content/OutputStreamContent.kt
@@ -30,7 +30,7 @@ public class OutputStreamContent(
      * Writes the content body directly to the given [stream], bypassing the [ByteWriteChannel] intermediary.
      *
      * Engine implementations that have access to a native blocking [OutputStream] (e.g. servlet engines
-     * backed by a thread-per-request model) should call this method instead of [writeTo(ByteWriteChannel)]
+     * backed by a thread-per-request model) should call this method instead of `writeTo(ByteWriteChannel)`
      * to avoid dispatching to [kotlinx.coroutines.Dispatchers.IO] and the `runBlocking` bridge inside
      * [ByteWriteChannel.toOutputStream].
      *

--- a/ktor-http/jvm/test/io/ktor/tests/http/content/BlockingBridgeTest.kt
+++ b/ktor-http/jvm/test/io/ktor/tests/http/content/BlockingBridgeTest.kt
@@ -8,12 +8,12 @@ import io.ktor.http.content.*
 import io.ktor.test.*
 import io.ktor.util.cio.*
 import io.ktor.utils.io.*
-import kotlinx.coroutines.CompletableDeferred
-import kotlinx.coroutines.CoroutineName
-import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.*
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.debug.junit5.CoroutinesTimeout
-import kotlinx.coroutines.launch
 import kotlin.test.Test
+import kotlin.test.assertFailsWith
+import kotlin.time.Duration.Companion.seconds
 
 @CoroutinesTimeout(testTimeoutMs = 5_000)
 class BlockingBridgeTest {
@@ -41,6 +41,27 @@ class BlockingBridgeTest {
                     stream.write(42)
                 }
             }
+        }
+    }
+
+    @Test
+    fun `withBlockingOutputStream propagates cancellation`() = runTest(timeout = 5.seconds) {
+        val channel = ByteChannel()
+        val writeStarted = CompletableDeferred<Unit>()
+        val writer = async(singleThreadDispatcher + CoroutineName("writer")) {
+            channel.withBlockingOutputStream(singleThreadDispatcher) { stream ->
+                writeStarted.complete(Unit)
+                stream.write(ByteArray(2 * 1024 * 1024))
+            }
+        }
+
+        writeStarted.await()
+        writer.cancel()
+
+        try {
+            assertFailsWith<CancellationException> { writer.await() }
+        } finally {
+            channel.cancel()
         }
     }
 

--- a/ktor-io/api/ktor-io.api
+++ b/ktor-io/api/ktor-io.api
@@ -580,6 +580,8 @@ public final class io/ktor/utils/io/core/internal/NumbersKt {
 }
 
 public final class io/ktor/utils/io/jvm/javaio/BlockingKt {
+	public static final fun asInputStream (Lio/ktor/utils/io/ByteReadChannel;Lkotlinx/coroutines/Job;)Ljava/io/InputStream;
+	public static final fun asOutputStream (Lio/ktor/utils/io/ByteWriteChannel;Lkotlinx/coroutines/Job;)Ljava/io/OutputStream;
 	public static final fun toInputStream (Lio/ktor/utils/io/ByteReadChannel;Lkotlinx/coroutines/Job;)Ljava/io/InputStream;
 	public static synthetic fun toInputStream$default (Lio/ktor/utils/io/ByteReadChannel;Lkotlinx/coroutines/Job;ILjava/lang/Object;)Ljava/io/InputStream;
 	public static final fun toOutputStream (Lio/ktor/utils/io/ByteWriteChannel;)Ljava/io/OutputStream;

--- a/ktor-io/jvm/src/io/ktor/utils/io/jvm/javaio/Blocking.kt
+++ b/ktor-io/jvm/src/io/ktor/utils/io/jvm/javaio/Blocking.kt
@@ -82,7 +82,7 @@ internal class ByteChannelOutputStream(
 
     @OptIn(InternalIoApi::class)
     private fun flushIfNeeded() {
-        if (channelWriteBuffer.buffer.size >= FLUSH_THRESHOLD) {
+        if (channel.autoFlush || channelWriteBuffer.buffer.size >= FLUSH_THRESHOLD) {
             flush()
         }
     }

--- a/ktor-io/jvm/src/io/ktor/utils/io/jvm/javaio/Blocking.kt
+++ b/ktor-io/jvm/src/io/ktor/utils/io/jvm/javaio/Blocking.kt
@@ -10,61 +10,112 @@ import kotlinx.coroutines.runBlocking
 import kotlinx.io.InternalIoApi
 import java.io.InputStream
 import java.io.OutputStream
+import kotlin.coroutines.EmptyCoroutineContext
 import kotlin.math.min
 
 /**
- * Create blocking [java.io.InputStream] for this channel that does block every time the channel suspends at read
- * Similar to do reading in [runBlocking] however you can pass it to regular blocking API
+ * Create blocking [java.io.InputStream] for this channel that does block every time the channel suspends at read.
+ * Similar to do reading in [runBlocking] however you can pass it to regular blocking API.
+ *
+ * - Canceling the [parent] job interrupts blocking reads but leaves [this] channel open.
+ * - Closing the stream closes [this] channel but does not cancel the [parent] job.
+ *
+ * The caller is responsible for closing the stream.
+ *
+ * @param parent a parent job for blocking reads.
  *
  * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.utils.io.jvm.javaio.toInputStream)
  */
-@Suppress("UNUSED_PARAMETER")
+public fun ByteReadChannel.toInputStream(parent: Job? = null): InputStream =
+    ByteChannelInputStream(channel = this, parent = parent)
+
+/**
+ * Creates a blocking [InputStream] parented by the [parent] job.
+ *
+ * - Canceling the [parent] job interrupts blocking reads but leaves [this] channel open.
+ * - Closing the stream closes [this] channel but does not cancel the [parent] job.
+ *
+ * The caller is responsible for closing the stream.
+ *
+ * @param parent a parent job for blocking reads.
+ *
+ * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.utils.io.jvm.javaio.asInputStream)
+ */
+@InternalAPI
+public fun ByteReadChannel.asInputStream(parent: Job): InputStream =
+    ByteChannelInputStream(channel = this, parent = parent)
+
 @OptIn(InternalAPI::class)
-public fun ByteReadChannel.toInputStream(parent: Job? = null): InputStream = object : InputStream() {
+private class ByteChannelInputStream(
+    private val channel: ByteReadChannel,
+    parent: Job?,
+) : InputStream() {
+
+    private val coroutineContext = parent ?: EmptyCoroutineContext
 
     override fun read(): Int {
-        if (isClosedForRead) return -1
-        if (readBuffer.exhausted()) blockingWait()
+        if (channel.isClosedForRead) return -1
+        if (channel.readBuffer.exhausted()) blockingWait()
 
-        if (isClosedForRead) return -1
-        return readBuffer.readByte().toInt() and 0xff
+        if (channel.isClosedForRead) return -1
+        return channel.readBuffer.readByte().toInt() and 0xff
     }
 
     override fun read(b: ByteArray, off: Int, len: Int): Int {
-        if (isClosedForRead) return -1
-        if (readBuffer.exhausted()) blockingWait()
+        if (channel.isClosedForRead) return -1
+        if (channel.readBuffer.exhausted()) blockingWait()
 
-        val count = min(availableForRead, len)
-        val result = readBuffer.readAtMostTo(b, off, off + count)
+        val count = min(channel.availableForRead, len)
+        val result = channel.readBuffer.readAtMostTo(b, off, off + count)
         if (result >= 0) return result
-        return if (isClosedForRead) -1 else 0
+        return if (channel.isClosedForRead) -1 else 0
     }
 
     private fun blockingWait() {
-        runBlocking {
-            awaitContent()
+        runBlocking(coroutineContext) {
+            channel.awaitContent()
         }
     }
 
     override fun close() {
-        cancel()
+        channel.cancel()
     }
 }
 
 /**
- * Create blocking [java.io.OutputStream] for this channel that does block every time the channel suspends at write
- * Similar to do reading in [runBlocking] however you can pass it to regular blocking API
+ * Create blocking [java.io.OutputStream] for this channel that does block every time the channel suspends at write.
+ * Similar to do reading in [runBlocking] however you can pass it to regular blocking API.
  *
  * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.utils.io.jvm.javaio.toOutputStream)
  */
-public fun ByteWriteChannel.toOutputStream(): OutputStream =
-    ByteChannelOutputStream(this)
+public fun ByteWriteChannel.toOutputStream(): OutputStream = ByteChannelOutputStream(channel = this, parent = null)
+
+/**
+ * Creates a blocking [OutputStream] parented by the [parent] job.
+ *
+ * Cancellation propagation:
+ * - Canceling the [parent] job interrupts blocking writes but leaves [this] channel open.
+ * - Closing the stream closes [this] channel but does not cancel the [parent] job.
+ *
+ * The caller is responsible for closing the stream.
+ *
+ * @param parent a parent job for blocking writes.
+ *
+ * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.utils.io.jvm.javaio.asOutputStream)
+ */
+@InternalAPI
+public fun ByteWriteChannel.asOutputStream(parent: Job): OutputStream =
+    ByteChannelOutputStream(channel = this, parent = parent)
 
 private const val FLUSH_THRESHOLD: Long = CHANNEL_MAX_SIZE.toLong()
 
 internal class ByteChannelOutputStream(
-    private val channel: ByteWriteChannel
+    private val channel: ByteWriteChannel,
+    parent: Job? = null,
 ) : OutputStream() {
+
+    private val coroutineContext = parent ?: EmptyCoroutineContext
+
     @OptIn(InternalAPI::class)
     private val channelWriteBuffer = channel.writeBuffer
 
@@ -89,7 +140,7 @@ internal class ByteChannelOutputStream(
 
     override fun flush() {
         throwIfClosed()
-        runBlocking {
+        runBlocking(coroutineContext) {
             channel.flush()
         }
     }
@@ -99,8 +150,13 @@ internal class ByteChannelOutputStream(
     }
 
     override fun close() {
-        runBlocking {
-            channel.flushAndClose()
+        try {
+            runBlocking(coroutineContext) {
+                channel.flushAndClose()
+            }
+        } catch (cause: Throwable) {
+            channel.cancel(cause)
+            throw cause
         }
     }
 }

--- a/ktor-io/jvm/test/io/ktor/utils/io/jvm/javaio/ByteChannelInputStreamTest.kt
+++ b/ktor-io/jvm/test/io/ktor/utils/io/jvm/javaio/ByteChannelInputStreamTest.kt
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2014-2026 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.utils.io.jvm.javaio
+
+import io.ktor.test.*
+import io.ktor.util.cio.*
+import io.ktor.utils.io.*
+import kotlinx.coroutines.*
+import kotlinx.coroutines.CancellationException
+import org.junit.jupiter.api.Test
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import kotlin.concurrent.thread
+import kotlin.test.assertFalse
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.seconds
+
+@OptIn(InternalAPI::class)
+class ByteChannelInputStreamTest {
+
+    @Test
+    fun `read is interrupted when thread is interrupted`() {
+        val channel = ByteChannel()
+        val parent = Job()
+        val inputStream = channel.asInputStream(parent)
+        val readStarted = CountDownLatch(1)
+        val result = CompletableFuture<Throwable?>()
+        val readThread = thread(isDaemon = true) {
+            readStarted.countDown()
+            result.complete(runCatching { inputStream.read() }.exceptionOrNull())
+        }
+
+        try {
+            assertTrue(readStarted.await(5, TimeUnit.SECONDS))
+            assertFalse(result.isDone)
+            readThread.interrupt()
+
+            assertIs<InterruptedException>(result.get(5, TimeUnit.SECONDS))
+            assertTrue(parent.isActive)
+            assertFalse(channel.isClosedForRead)
+        } finally {
+            channel.cancel()
+            parent.cancel()
+            readThread.interrupt()
+            readThread.join(5_000)
+        }
+    }
+
+    @Test
+    fun `read is cancelled with parent`() = runTest(timeout = 5.seconds) {
+        val channel = ByteChannel()
+        val parent = Job(coroutineContext.job)
+        val inputStream = channel.asInputStream(parent)
+        val readStarted = CompletableDeferred<Unit>()
+        val result = async(Dispatchers.IO) {
+            readStarted.complete(Unit)
+            runCatching { inputStream.read() }.exceptionOrNull()
+        }
+
+        channel.use {
+            readStarted.await()
+            parent.cancel()
+
+            assertIs<CancellationException>(result.await())
+        }
+    }
+}

--- a/ktor-io/jvm/test/io/ktor/utils/io/jvm/javaio/ByteChannelOutputStreamTest.kt
+++ b/ktor-io/jvm/test/io/ktor/utils/io/jvm/javaio/ByteChannelOutputStreamTest.kt
@@ -5,16 +5,20 @@
 package io.ktor.utils.io.jvm.javaio
 
 import io.ktor.utils.io.*
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.launch
+import kotlinx.coroutines.*
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
-import kotlin.test.assertContentEquals
-import kotlin.test.assertEquals
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import kotlin.concurrent.thread
+import kotlin.test.*
 import kotlin.time.Duration.Companion.seconds
 
-class ByteByteChannelOutputStreamTest {
+@OptIn(InternalAPI::class)
+class ByteChannelOutputStreamTest {
 
     @Test
     fun `write byte`() = runTest {
@@ -226,6 +230,69 @@ class ByteByteChannelOutputStreamTest {
             writer.join()
 
             assertContentEquals(data, result)
+        } finally {
+            channel.cancel()
+        }
+    }
+
+    @Test
+    fun `write is interrupted when thread is interrupted`() {
+        val channel = ByteChannel()
+        val parent = Job()
+        val outputStream = channel.asOutputStream(parent)
+        val writeStarted = CountDownLatch(1)
+        val result = CompletableFuture<Throwable?>()
+        val writeThread = thread(isDaemon = true) {
+            writeStarted.countDown()
+            result.complete(
+                runCatching { outputStream.write(ByteArray(CHANNEL_MAX_SIZE)) }.exceptionOrNull()
+            )
+        }
+
+        try {
+            assertTrue(writeStarted.await(5, TimeUnit.SECONDS))
+            assertFalse(result.isDone)
+            writeThread.interrupt()
+
+            assertIs<InterruptedException>(result.get(5, TimeUnit.SECONDS))
+            assertTrue(parent.isActive)
+            assertFalse(channel.isClosedForWrite)
+        } finally {
+            channel.cancel()
+            parent.cancel()
+            writeThread.interrupt()
+            writeThread.join(5_000)
+        }
+    }
+
+    @Test
+    fun `close cancels channel when parent is cancelled`() {
+        val channel = ByteChannel()
+        val parent = Job()
+        val outputStream = channel.asOutputStream(parent)
+
+        parent.cancel()
+
+        assertThrows<CancellationException> { outputStream.close() }
+        assertTrue(channel.isClosedForWrite)
+    }
+
+    @Test
+    fun `write is cancelled with parent`() = runTest(timeout = 5.seconds) {
+        val channel = ByteChannel()
+        val parent = Job(coroutineContext.job)
+        val outputStream = channel.asOutputStream(parent)
+        val writeStarted = CompletableDeferred<Unit>()
+        val result = async(Dispatchers.IO) {
+            writeStarted.complete(Unit)
+            runCatching { outputStream.write(ByteArray(CHANNEL_MAX_SIZE)) }.exceptionOrNull()
+        }
+
+        try {
+            writeStarted.await()
+            parent.cancel()
+
+            assertIs<CancellationException>(result.await())
         } finally {
             channel.cancel()
         }

--- a/ktor-io/jvm/test/io/ktor/utils/io/jvm/javaio/ByteChannelOutputStreamTest.kt
+++ b/ktor-io/jvm/test/io/ktor/utils/io/jvm/javaio/ByteChannelOutputStreamTest.kt
@@ -4,7 +4,6 @@
 
 package io.ktor.utils.io.jvm.javaio
 
-import io.ktor.test.dispatcher.runTestWithRealTime
 import io.ktor.utils.io.*
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -13,6 +12,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
+import kotlin.time.Duration.Companion.seconds
 
 class ByteByteChannelOutputStreamTest {
 
@@ -196,20 +196,38 @@ class ByteByteChannelOutputStreamTest {
     }
 
     @Test
-    fun `writes are streamed without explicit flush`() = runTestWithRealTime {
+    fun `writes are streamed without explicit flush`() = runTest {
         val channel = ByteChannel(autoFlush = true)
         val outputStream = ByteChannelOutputStream(channel)
-        val data = ByteArray(2 * 1024 * 1024) { it.toByte() }
+        val data = byteArrayOf(1, 2, 3)
 
-        // Exceeds the internal flush threshold, so it must reach the channel
-        // even though neither flush() nor close() is called
-        launch(Dispatchers.IO) {
-            outputStream.write(data)
-        }
+        outputStream.write(data)
 
+        assertEquals(data.size, channel.availableForRead)
         val result = ByteArray(data.size)
         channel.readFully(result)
         assertContentEquals(data, result)
         outputStream.close()
+    }
+
+    @Test
+    fun `writes are streamed when flush threshold is reached`() = runTest(timeout = 5.seconds) {
+        val channel = ByteChannel(autoFlush = false)
+        val outputStream = ByteChannelOutputStream(channel)
+        val data = ByteArray(2 * CHANNEL_MAX_SIZE) { it.toByte() }
+
+        val writer = launch(Dispatchers.IO) {
+            outputStream.write(data)
+        }
+
+        try {
+            val result = ByteArray(data.size)
+            channel.readFully(result)
+            writer.join()
+
+            assertContentEquals(data, result)
+        } finally {
+            channel.cancel()
+        }
     }
 }

--- a/ktor-server/ktor-server-core/jvm/src/io/ktor/server/engine/DefaultTransformJvm.kt
+++ b/ktor-server/ktor-server-core/jvm/src/io/ktor/server/engine/DefaultTransformJvm.kt
@@ -8,20 +8,17 @@ import io.ktor.server.application.*
 import io.ktor.util.pipeline.*
 import io.ktor.utils.io.*
 import io.ktor.utils.io.jvm.javaio.*
-import io.ktor.utils.io.streams.*
-import java.io.*
+import kotlinx.coroutines.job
+import java.io.InputStream
 
+@OptIn(InternalAPI::class)
 internal actual suspend fun PipelineContext<Any, PipelineCall>.defaultPlatformTransformations(
     query: Any
 ): Any? {
     val channel = query as? ByteReadChannel ?: return null
 
     return when (call.receiveType.type) {
-        InputStream::class -> receiveGuardedInputStream(channel)
+        InputStream::class -> channel.asInputStream(call.coroutineContext.job)
         else -> null
     }
-}
-
-private fun receiveGuardedInputStream(channel: ByteReadChannel): InputStream {
-    return channel.toInputStream()
 }

--- a/ktor-server/ktor-server-core/jvm/test/io/ktor/tests/hosts/ReceiveBlockingPrimitiveTest.kt
+++ b/ktor-server/ktor-server-core/jvm/test/io/ktor/tests/hosts/ReceiveBlockingPrimitiveTest.kt
@@ -66,6 +66,8 @@ class ReceiveBlockingPrimitiveTest {
             }
         }
     ) {
+        private val callJob = Job()
+
         init {
             application.receivePipeline.installDefaultTransformations()
         }
@@ -127,10 +129,10 @@ class ReceiveBlockingPrimitiveTest {
         override val response: BaseApplicationResponse
             get() = error("Shouldn't be invoked")
 
-        override val coroutineContext: CoroutineContext
-            get() = TODO("Not yet implemented")
+        override val coroutineContext: CoroutineContext = callJob
 
         fun close() {
+            callJob.cancel()
             application.dispose()
         }
     }

--- a/ktor-server/ktor-server-test-suites/jvm/src/io/ktor/server/testing/suites/CompressionTestSuite.kt
+++ b/ktor-server/ktor-server-test-suites/jvm/src/io/ktor/server/testing/suites/CompressionTestSuite.kt
@@ -19,9 +19,12 @@ import io.ktor.server.test.base.*
 import io.ktor.util.logging.*
 import io.ktor.utils.io.*
 import io.ktor.utils.io.jvm.javaio.*
-import java.io.*
-import java.util.zip.*
-import kotlin.test.*
+import kotlinx.coroutines.job
+import java.io.ByteArrayInputStream
+import java.util.zip.GZIPInputStream
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 abstract class CompressionTestSuite<TEngine : ApplicationEngine, TConfiguration : ApplicationEngine.Configuration>(
     hostFactory: ApplicationEngineFactory<TEngine, TConfiguration>
@@ -42,7 +45,10 @@ abstract class CompressionTestSuite<TEngine : ApplicationEngine, TConfiguration 
 
         withUrl("/", { header(HttpHeaders.AcceptEncoding, "gzip") }) {
             assertEquals(200, status.value)
-            assertEquals(file.readText(), GZIPInputStream(rawContent.toInputStream()).reader().use { it.readText() })
+            assertEquals(
+                file.readText(),
+                GZIPInputStream(rawContent.asInputStream(coroutineContext.job)).reader().use { it.readText() }
+            )
             assertEquals("gzip", headers[HttpHeaders.ContentEncoding])
         }
     }
@@ -68,7 +74,10 @@ abstract class CompressionTestSuite<TEngine : ApplicationEngine, TConfiguration 
 
         withUrl("/", { header(HttpHeaders.AcceptEncoding, "gzip") }) {
             assertEquals(200, status.value)
-            assertEquals("Hello!", GZIPInputStream(rawContent.toInputStream()).reader().use { it.readText() })
+            assertEquals(
+                "Hello!",
+                GZIPInputStream(rawContent.asInputStream(coroutineContext.job)).reader().use { it.readText() },
+            )
             assertEquals("gzip", headers[HttpHeaders.ContentEncoding])
         }
     }

--- a/ktor-server/ktor-server-test-suites/jvm/src/io/ktor/server/testing/suites/SustainabilityTestSuite.kt
+++ b/ktor-server/ktor-server-test-suites/jvm/src/io/ktor/server/testing/suites/SustainabilityTestSuite.kt
@@ -341,7 +341,7 @@ abstract class SustainabilityTestSuite<TEngine : ApplicationEngine, TConfigurati
             launch(dispatcher) {
                 try {
                     withUrl("/$i") {
-                        rawContent.toInputStream().reader().use { reader ->
+                        rawContent.asInputStream(coroutineContext.job).reader().use { reader ->
                             val firstByte = reader.read()
                             if (firstByte == -1) {
                                 fail("Premature end of response stream at iteration $i")

--- a/ktor-shared/ktor-serialization/ktor-serialization-kotlinx/ktor-serialization-kotlinx-json/common/src/io/ktor/serialization/kotlinx/json/KotlinxSerializationJsonExtensions.kt
+++ b/ktor-shared/ktor-serialization/ktor-serialization-kotlinx/ktor-serialization-kotlinx-json/common/src/io/ktor/serialization/kotlinx/json/KotlinxSerializationJsonExtensions.kt
@@ -12,10 +12,14 @@ import io.ktor.util.reflect.*
 import io.ktor.utils.io.*
 import io.ktor.utils.io.charsets.*
 import io.ktor.utils.io.core.*
-import kotlinx.coroutines.flow.*
-import kotlinx.serialization.*
-import kotlinx.serialization.json.*
-import kotlin.reflect.*
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.collectIndexed
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.InternalSerializationApi
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.SerialFormat
+import kotlinx.serialization.json.Json
+import kotlin.reflect.KClass
 
 /**
  * Adds special handling for receiving [Sequence] and sending [Flow] bodies for the Json format.
@@ -69,7 +73,6 @@ internal class KotlinxSerializationJsonExtensions(private val format: Json) : Ko
         }
     }
 
-    @Suppress("BlockingMethodInNonBlockingContext")
     private suspend fun <T> Flow<T>.serialize(
         serializer: KSerializer<T>,
         charset: Charset,

--- a/ktor-shared/ktor-serialization/ktor-serialization-kotlinx/ktor-serialization-kotlinx-json/jvm/src/io/ktor/serialization/kotlinx/json/JsonExtensionsJvm.kt
+++ b/ktor-shared/ktor-serialization/ktor-serialization-kotlinx/ktor-serialization-kotlinx-json/jvm/src/io/ktor/serialization/kotlinx/json/JsonExtensionsJvm.kt
@@ -8,22 +8,22 @@ import io.ktor.serialization.kotlinx.*
 import io.ktor.util.reflect.*
 import io.ktor.utils.io.*
 import io.ktor.utils.io.jvm.javaio.*
-import kotlinx.coroutines.*
-import kotlinx.serialization.*
-import kotlinx.serialization.json.*
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.InternalSerializationApi
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.decodeToSequence
 
 @OptIn(ExperimentalSerializationApi::class, InternalSerializationApi::class)
 internal actual suspend fun deserializeSequence(
     format: Json,
     content: ByteReadChannel,
     typeInfo: TypeInfo
-): Sequence<Any?>? =
-    withContext(Dispatchers.IO) {
-        val inputStream = content.toInputStream()
-        // kotlinx.serialization provides optimized sequence deserialization
-        // Elements are parsed lazily when the resulting Sequence is evaluated.
-        // The resulting sequence is tied to the stream and can be evaluated only once.
-        val elementTypeInfo = typeInfo.argumentTypeInfo()
-        val serializer = format.serializersModule.serializerForTypeInfo(elementTypeInfo)
-        format.decodeToSequence(inputStream, serializer)
-    }
+): Sequence<Any?>? {
+    val inputStream = content.toInputStream()
+    // kotlinx.serialization provides optimized sequence deserialization
+    // Elements are parsed lazily when the resulting Sequence is evaluated.
+    // The resulting sequence is tied to the stream and can be evaluated only once.
+    val elementTypeInfo = typeInfo.argumentTypeInfo()
+    val serializer = format.serializersModule.serializerForTypeInfo(elementTypeInfo)
+    return format.decodeToSequence(inputStream, serializer)
+}

--- a/ktor-utils/jvm/src/io/ktor/util/cio/OutputStreamAdapters.kt
+++ b/ktor-utils/jvm/src/io/ktor/util/cio/OutputStreamAdapters.kt
@@ -6,8 +6,9 @@ package io.ktor.util.cio
 
 import io.ktor.utils.io.*
 import io.ktor.utils.io.jvm.javaio.*
-import java.io.*
-import java.nio.charset.*
+import java.io.BufferedWriter
+import java.io.Writer
+import java.nio.charset.Charset
 
 /**
  * Open a buffered writer to the channel


### PR DESCRIPTION
**Subsystem**
I/O, Client/Server

**Motivation**
[`KTOR-9627`](https://youtrack.jetbrains.com/issue/KTOR-9627): `ByteReadChannel.toInputStream` and `ByteWriteChannel.toOutputStream` use `runBlocking` internally. Without a parent job, cancellation of the call or coroutine using these bridges does not interrupt a suspended blocking read or write.

**Solution**
Allow blocking channel bridges to receive a parent `Job` and use it for their internal `runBlocking` calls. Ktor-owned call sites now attach bridges to the appropriate client call, server call, or scoped coroutine job.

Add regression coverage for cancellation of blocked input reads, output writes, and HTTP blocking output bridges. Preserve existing JVM binary signatures and update ABI dumps. Related cleanups remove redundant JVM stream wrappers and avoid dispatching construction of a lazy JSON sequence to `Dispatchers.IO`.
