### PR TITLE
KTOR-9788 Fix exception in call handler coroutine due to bad state

### DIFF
--- a/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/HttpTimeoutTest.kt
+++ b/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/HttpTimeoutTest.kt
@@ -273,7 +273,7 @@ class HttpTimeoutTest : ClientLoader(timeout = 30.seconds) {
     @Test
     fun testGetStream() = clientTests(except("Curl")) {
         config {
-            install(HttpTimeout) { requestTimeoutMillis = 1000 }
+            install(HttpTimeout) { requestTimeoutMillis = 2000 }
         }
 
         test { client ->
@@ -281,7 +281,7 @@ class HttpTimeoutTest : ClientLoader(timeout = 30.seconds) {
                 parameter("delay", 10)
             }.body()
 
-            assertEquals("Text", responseBody)
+            assertEquals("TextTextText", responseBody)
         }
     }
 

--- a/ktor-server/ktor-server-core/api/ktor-server-core.api
+++ b/ktor-server/ktor-server-core/api/ktor-server-core.api
@@ -520,6 +520,7 @@ public abstract class io/ktor/server/engine/BaseApplicationResponse : io/ktor/se
 	protected abstract fun respondUpgrade (Lio/ktor/http/content/OutgoingContent$ProtocolUpgrade;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	protected fun respondWriteChannelContent (Lio/ktor/http/content/OutgoingContent$WriteChannelContent;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	protected abstract fun responseChannel (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	protected final fun setSent (Z)V
 	protected abstract fun setStatus (Lio/ktor/http/HttpStatusCode;)V
 	public fun status ()Lio/ktor/http/HttpStatusCode;
 	public fun status (Lio/ktor/http/HttpStatusCode;)V

--- a/ktor-server/ktor-server-core/api/ktor-server-core.klib.api
+++ b/ktor-server/ktor-server-core/api/ktor-server-core.klib.api
@@ -385,6 +385,7 @@ abstract class io.ktor.server.engine/BaseApplicationResponse : io.ktor.server.re
 
     final var isSent // io.ktor.server.engine/BaseApplicationResponse.isSent|{}isSent[0]
         final fun <get-isSent>(): kotlin/Boolean // io.ktor.server.engine/BaseApplicationResponse.isSent.<get-isSent>|<get-isSent>(){}[0]
+        final fun <set-isSent>(kotlin/Boolean) // io.ktor.server.engine/BaseApplicationResponse.isSent.<set-isSent>|<set-isSent>(kotlin.Boolean){}[0]
 
     abstract fun setStatus(io.ktor.http/HttpStatusCode) // io.ktor.server.engine/BaseApplicationResponse.setStatus|setStatus(io.ktor.http.HttpStatusCode){}[0]
     abstract suspend fun respondUpgrade(io.ktor.http.content/OutgoingContent.ProtocolUpgrade) // io.ktor.server.engine/BaseApplicationResponse.respondUpgrade|respondUpgrade(io.ktor.http.content.OutgoingContent.ProtocolUpgrade){}[0]

--- a/ktor-server/ktor-server-core/common/src/io/ktor/server/engine/BaseApplicationResponse.kt
+++ b/ktor-server/ktor-server-core/common/src/io/ktor/server/engine/BaseApplicationResponse.kt
@@ -33,7 +33,7 @@ public abstract class BaseApplicationResponse(
         get() = responded
 
     final override var isSent: Boolean = false
-        private set
+        protected set
 
     override val cookies: ResponseCookies by lazy(LazyThreadSafetyMode.NONE) {
         ResponseCookies(this)

--- a/ktor-server/ktor-server-core/common/src/io/ktor/server/engine/BaseApplicationResponse.kt
+++ b/ktor-server/ktor-server-core/common/src/io/ktor/server/engine/BaseApplicationResponse.kt
@@ -33,6 +33,7 @@ public abstract class BaseApplicationResponse(
         get() = responded
 
     final override var isSent: Boolean = false
+        @InternalAPI
         protected set
 
     override val cookies: ResponseCookies by lazy(LazyThreadSafetyMode.NONE) {
@@ -165,6 +166,7 @@ public abstract class BaseApplicationResponse(
 
             is OutgoingContent.ContentWrapper -> respondOutgoingContent(content.delegate())
         }
+        @OptIn(InternalAPI::class)
         isSent = true
     }
 

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyApplicationCallHandler.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyApplicationCallHandler.kt
@@ -35,14 +35,15 @@ internal fun NettyHttp1ApplicationRequest.isValid(): Boolean {
     return encodings.hasValidTransferEncoding()
 }
 
-internal fun ChannelHandlerContext.respond408RequestTimeoutHttp1() {
+internal fun ChannelHandlerContext.respond408RequestTimeoutHttp1(activeCalls: Collection<NettyHttp1ApplicationCall>) {
+    activeCalls.forEach { it.response.markAsSent() }
     val response = DefaultFullHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.REQUEST_TIMEOUT)
     response.headers().add(HttpHeaders.ContentLength, "0")
     response.headers().add(HttpHeaders.Connection, "close")
     writeAndFlush(response).addListener(ChannelFutureListener.CLOSE)
 }
 
-internal suspend fun NettyHttp1ApplicationCall.respondError400BadRequest() {
+internal fun NettyHttp1ApplicationCall.respondError400BadRequest() {
     logCause()
 
     val causeMessage = failureCause?.message?.toByteArray(charset = Charsets.UTF_8)
@@ -56,6 +57,7 @@ internal suspend fun NettyHttp1ApplicationCall.respondError400BadRequest() {
     }
     response.headers.append(HttpHeaders.Connection, "close", safeOnly = false)
     response.sendResponse(chunked = false, content)
+    response.markAsSent()
     finish()
 }
 

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyApplicationCallHandler.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyApplicationCallHandler.kt
@@ -36,6 +36,8 @@ internal fun NettyHttp1ApplicationRequest.isValid(): Boolean {
 }
 
 internal fun ChannelHandlerContext.respond408RequestTimeoutHttp1(activeCalls: Collection<NettyHttp1ApplicationCall>) {
+    // markAsSent() is required here: the call's engine pipeline may still be running and can reach
+    // NettyApplicationCall.finish() -> ensureResponseSent() after this raw 408 is written
     activeCalls.forEach { it.response.markAsSent() }
     val response = DefaultFullHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.REQUEST_TIMEOUT)
     response.headers().add(HttpHeaders.ContentLength, "0")

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyApplicationResponse.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyApplicationResponse.kt
@@ -150,6 +150,7 @@ public abstract class NettyApplicationResponse(
      */
     internal fun markAsSent() {
         responseMessageSent = true
+        @OptIn(InternalAPI::class)
         isSent = true
     }
 

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyApplicationResponse.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyApplicationResponse.kt
@@ -149,6 +149,7 @@ public abstract class NettyApplicationResponse(
      * the "already completed" guard in [io.ktor.server.netty.http1.NettyHttp1ApplicationResponse].
      */
     internal fun markAsSent() {
+        responseMessageSent = true
         isSent = true
     }
 
@@ -174,7 +175,6 @@ public abstract class NettyApplicationResponse(
         if (!responseMessageSent) {
             responseChannel = ByteReadChannel.Empty
             responseReady.tryFailure(CancellationException("Response was cancelled"))
-            responseMessageSent = true
             markAsSent()
         }
     }

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyApplicationResponse.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyApplicationResponse.kt
@@ -140,6 +140,18 @@ public abstract class NettyApplicationResponse(
         sendResponse(content = ByteReadChannel.Empty)
     }
 
+    /**
+     * Marks the call as answered when the response was completed at the channel level without going
+     * through [respondOutgoingContent] — either because an internal response was sent directly
+     * (for example, the built-in 400 for a malformed request or the built-in 408 for a read timeout),
+     * or because the response was given up on entirely (see [cancel]).
+     * If not called, the response will not be marked as sent, and a later failure could try to respond again and hit
+     * the "already completed" guard in [io.ktor.server.netty.http1.NettyHttp1ApplicationResponse].
+     */
+    internal fun markAsSent() {
+        isSent = true
+    }
+
     internal fun close() {
         val existingChannel = responseChannel
         if (existingChannel is ByteWriteChannel) {
@@ -163,6 +175,7 @@ public abstract class NettyApplicationResponse(
             responseChannel = ByteReadChannel.Empty
             responseReady.tryFailure(CancellationException("Response was cancelled"))
             responseMessageSent = true
+            markAsSent()
         }
     }
 

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http1/NettyHttp1Handler.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http1/NettyHttp1Handler.kt
@@ -144,7 +144,7 @@ internal class NettyHttp1Handler(
                     context.fireExceptionCaught(cause)
                     return
                 }
-                context.respond408RequestTimeoutHttp1()
+                context.respond408RequestTimeoutHttp1(activeCalls)
                 activeCalls.forEach { call ->
                     call.coroutineContext.cancel(CancellationException(cause))
                 }

--- a/ktor-server/ktor-server-netty/jvm/test/io/ktor/tests/server/netty/NettySpecificTest.kt
+++ b/ktor-server/ktor-server-netty/jvm/test/io/ktor/tests/server/netty/NettySpecificTest.kt
@@ -378,6 +378,147 @@ class NettySpecificTest {
     }
 
     @Test
+    fun `handleFailure after engine-level 400 does not double respond`() = runTestWithRealTime {
+        val appStarted = CompletableDeferred<Application>()
+        val thrownAfterBuiltInBadRequest = CompletableDeferred<Throwable?>()
+
+        val serverJob = launch(Dispatchers.IO) {
+            val server = embeddedServer(Netty, port = 0) {
+                routing {
+                    get("/simulate-double-respond") {
+                        // Simulates the engine sending a channel-level 400 (as Netty does for
+                        // malformed requests) followed by an unrelated failure reaching
+                        // handleFailure, without an actual connection-teardown race.
+                        val engineCall = call.pipelineCall.engineCall as NettyHttp1ApplicationCall
+                        engineCall.respondError400BadRequest()
+
+                        val thrown = runCatching {
+                            handleFailure(call, RuntimeException("simulated failure after the built-in 400"))
+                        }.exceptionOrNull()
+                        thrownAfterBuiltInBadRequest.complete(thrown)
+                    }
+                }
+            }
+            server.monitor.subscribe(ApplicationStarted) { app ->
+                appStarted.complete(app)
+            }
+            server.start(wait = true)
+        }
+
+        try {
+            val serverApp = withTimeout(10.seconds) { appStarted.await() }
+            val connector = serverApp.engine.resolvedConnectors()[0]
+
+            HttpClient(CIO).use { client ->
+                runCatching { client.get("http://${connector.host}:${connector.port}/simulate-double-respond") }
+            }
+
+            val thrown = withTimeout(5.seconds) { thrownAfterBuiltInBadRequest.await() }
+            assertNull(
+                thrown,
+                "handleFailure must not attempt to respond again after the engine already sent " +
+                    "a response at the channel level, but threw: $thrown"
+            )
+        } finally {
+            serverJob.cancel()
+        }
+    }
+
+    @Test
+    fun `handleFailure after response cancel does not double respond`() = runTestWithRealTime {
+        val appStarted = CompletableDeferred<Application>()
+        val thrownAfterCancel = CompletableDeferred<Throwable?>()
+
+        val serverJob = launch(Dispatchers.IO) {
+            val server = embeddedServer(Netty, port = 0) {
+                routing {
+                    get("/simulate-cancel-double-respond") {
+                        // Simulates the engine giving up on the response (as Netty does when the
+                        // channel dies mid-response) followed by an unrelated failure reaching
+                        // handleFailure, without an actual connection-teardown race.
+                        val engineCall = call.pipelineCall.engineCall as NettyHttp1ApplicationCall
+                        engineCall.response.cancel()
+
+                        val thrown = runCatching {
+                            handleFailure(call, RuntimeException("simulated failure after response was cancelled"))
+                        }.exceptionOrNull()
+                        thrownAfterCancel.complete(thrown)
+                    }
+                }
+            }
+            server.monitor.subscribe(ApplicationStarted) { app ->
+                appStarted.complete(app)
+            }
+            server.start(wait = true)
+        }
+
+        try {
+            val serverApp = withTimeout(10.seconds) { appStarted.await() }
+            val connector = serverApp.engine.resolvedConnectors()[0]
+
+            HttpClient(CIO).use { client ->
+                runCatching { client.get("http://${connector.host}:${connector.port}/simulate-cancel-double-respond") }
+            }
+
+            val thrown = withTimeout(5.seconds) { thrownAfterCancel.await() }
+            assertNull(
+                thrown,
+                "handleFailure must not attempt to respond again after the response was cancelled, " +
+                    "but threw: $thrown"
+            )
+        } finally {
+            serverJob.cancel()
+        }
+    }
+
+    @Test
+    fun `handleFailure after built-in 408 does not double respond`() = runTestWithRealTime {
+        val appStarted = CompletableDeferred<Application>()
+        val committedAfterBuiltIn408 = CompletableDeferred<Boolean>()
+
+        val serverJob = launch(Dispatchers.IO) {
+            val server = embeddedServer(Netty, port = 0) {
+                routing {
+                    get("/simulate-408-double-respond") {
+                        // Simulates the engine sending a channel-level 408 (as Netty does on a
+                        // read timeout) followed by an unrelated failure reaching handleFailure,
+                        // without relying on an actual read-timeout race.
+                        val engineCall = call.pipelineCall.engineCall as NettyHttp1ApplicationCall
+                        engineCall.context.respond408RequestTimeoutHttp1(listOf(engineCall))
+
+                        runCatching {
+                            handleFailure(call, RuntimeException("simulated failure after the built-in 408"))
+                        }
+                        committedAfterBuiltIn408.complete(call.response.isCommitted)
+                    }
+                }
+            }
+            server.monitor.subscribe(ApplicationStarted) { app ->
+                appStarted.complete(app)
+            }
+            server.start(wait = true)
+        }
+
+        try {
+            val serverApp = withTimeout(10.seconds) { appStarted.await() }
+            val connector = serverApp.engine.resolvedConnectors()[0]
+
+            HttpClient(CIO).use { client ->
+                runCatching { client.get("http://${connector.host}:${connector.port}/simulate-408-double-respond") }
+            }
+
+            val committed = withTimeout(5.seconds) { committedAfterBuiltIn408.await() }
+            assertFalse(
+                committed,
+                "handleFailure must not attempt to respond again after the engine already sent " +
+                    "a 408 at the channel level"
+            )
+        } finally {
+            serverJob.cancel()
+        }
+    }
+
+    @Test
     fun `request handler runs on call event group`() = runTestWithRealTime {
         val handlerThread = AtomicReference<Thread>()
 

--- a/ktor-server/ktor-server-netty/jvm/test/io/ktor/tests/server/netty/NettySpecificTest.kt
+++ b/ktor-server/ktor-server-netty/jvm/test/io/ktor/tests/server/netty/NettySpecificTest.kt
@@ -519,6 +519,56 @@ class NettySpecificTest {
     }
 
     @Test
+    fun `engine pipeline finish after built-in 408 does not stage a second response`() = runTestWithRealTime {
+        val appStarted = CompletableDeferred<Application>()
+        val responseReadySucceededAfterBuiltIn408 = CompletableDeferred<Boolean>()
+
+        val serverJob = launch(Dispatchers.IO) {
+            val server = embeddedServer(Netty, port = 0) {
+                routing {
+                    get("/simulate-408-then-finish") {
+                        // Simulates a read timeout landing while the call's engine pipeline is still
+                        // running: the raw 408 is written first (as NettyHttp1Handler.exceptionCaught
+                        // does), then the cancelled call still reaches
+                        // NettyApplicationCall.finish() -> ensureResponseSent(), since AFTER_CALL_PHASE
+                        // can run to completion before the coroutine cancellation is observed.
+                        val engineCall = call.pipelineCall.engineCall as NettyHttp1ApplicationCall
+                        engineCall.context.respond408RequestTimeoutHttp1(listOf(engineCall))
+
+                        runCatching { engineCall.finish() }
+
+                        // If finish() staged a second response, responseReady flips to success and
+                        // the Netty response pipeline would write it out on top of the 408 already sent.
+                        responseReadySucceededAfterBuiltIn408.complete(engineCall.response.responseReady.isSuccess)
+                    }
+                }
+            }
+            server.monitor.subscribe(ApplicationStarted) { app ->
+                appStarted.complete(app)
+            }
+            server.start(wait = true)
+        }
+
+        try {
+            val serverApp = withTimeout(10.seconds) { appStarted.await() }
+            val connector = serverApp.engine.resolvedConnectors()[0]
+
+            HttpClient(CIO).use { client ->
+                runCatching { client.get("http://${connector.host}:${connector.port}/simulate-408-then-finish") }
+            }
+
+            val succeeded = withTimeout(5.seconds) { responseReadySucceededAfterBuiltIn408.await() }
+            assertFalse(
+                succeeded,
+                "finish() must not stage a second response after the engine already sent a 408 " +
+                    "at the channel level"
+            )
+        } finally {
+            serverJob.cancel()
+        }
+    }
+
+    @Test
     fun `request handler runs on call event group`() = runTestWithRealTime {
         val handlerThread = AtomicReference<Thread>()
 

--- a/ktor-test-server/src/main/kotlin/test/server/tests/Timeout.kt
+++ b/ktor-test-server/src/main/kotlin/test/server/tests/Timeout.kt
@@ -11,25 +11,26 @@ import io.ktor.server.response.*
 import io.ktor.server.routing.*
 import io.ktor.utils.io.*
 import kotlinx.coroutines.delay
+import kotlin.time.Duration.Companion.milliseconds
 
 internal fun Application.timeoutTest() {
     routing {
         route("/timeout") {
             head("/with-delay") {
                 val delay = call.parameters["delay"]!!.toLong()
-                delay(delay)
+                delay(delay.milliseconds)
                 call.respond(HttpStatusCode.OK)
             }
 
             get("/with-delay") {
                 val delay = call.parameters["delay"]!!.toLong()
-                delay(delay)
+                delay(delay.milliseconds)
                 call.respondText { "Text" }
             }
 
             get("/with-stream") {
                 val delay = call.parameters["delay"]!!.toLong()
-                val response = "Text".toByteArray()
+                val response = "TextTextText".toByteArray()
                 call.respond(
                     object : OutgoingContent.WriteChannelContent() {
                         override val contentType = ContentType.Application.OctetStream
@@ -37,7 +38,7 @@ internal fun Application.timeoutTest() {
                             for (offset in response.indices) {
                                 channel.writeFully(response, offset, offset + 1)
                                 channel.flush()
-                                delay(delay)
+                                delay(delay.milliseconds)
                             }
                         }
                     }
@@ -49,7 +50,7 @@ internal fun Application.timeoutTest() {
                 val count = call.parameters["count"]!!.toInt()
                 val url = if (count == 0) "/timeout/with-delay?delay=$delay"
                 else "/timeout/with-redirect?delay=$delay&count=${count - 1}"
-                delay(delay)
+                delay(delay.milliseconds)
                 call.respondRedirect(url)
             }
 
@@ -63,7 +64,7 @@ internal fun Application.timeoutTest() {
                     count += read
                     if (count >= 1024 * 1024) {
                         count = 0
-                        delay(2000)
+                        delay(2000.milliseconds)
                     }
                 }
 


### PR DESCRIPTION
**Subsystem**
Server, Netty

**Motivation**
[KTOR-9788](https://youtrack.jetbrains.com/issue/KTOR-9788) Netty: engine double-responds after its built-in 400, crashing the call-handler coroutine with "Headers can no longer be set because response was already completed"

**Solution**
After using internal response functions, ensure the base response is marked as sent as well.  I also looked around for any other locations where this state could happen and fixed these spots too.