### PR TITLE
Update webrtc-java version and unlock ignored tests

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -25,7 +25,7 @@ jetty-alpn-openjdk8 = "9.4.58.v20250814"
 tomcat = "9.0.120"
 tomcat-jakarta = "10.1.57"
 
-webrtc-java = "0.14.0"
+webrtc-java = "0.16.0"
 stream-webrtc-android = "1.3.10"
 
 apache = "4.1.5"

--- a/ktor-client/ktor-client-webrtc/androidDevice/test/io/ktor/client/webrtc/utils/Ignore.android.kt
+++ b/ktor-client/ktor-client-webrtc/androidDevice/test/io/ktor/client/webrtc/utils/Ignore.android.kt
@@ -1,8 +1,0 @@
-/*
- * Copyright 2014-2025 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
- */
-
-package io.ktor.client.webrtc.utils
-
-@Target(AnnotationTarget.CLASS, AnnotationTarget.FUNCTION)
-actual annotation class IgnoreJvm

--- a/ktor-client/ktor-client-webrtc/androidNative/test/io/ktor/client/webrtc/utils/Ignore.android.kt
+++ b/ktor-client/ktor-client-webrtc/androidNative/test/io/ktor/client/webrtc/utils/Ignore.android.kt
@@ -1,8 +1,0 @@
-/*
- * Copyright 2014-2025 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
- */
-
-package io.ktor.client.webrtc.utils
-
-@Target(AnnotationTarget.CLASS, AnnotationTarget.FUNCTION)
-actual annotation class IgnoreJvm

--- a/ktor-client/ktor-client-webrtc/build.gradle.kts
+++ b/ktor-client/ktor-client-webrtc/build.gradle.kts
@@ -1,12 +1,8 @@
 /*
  * Copyright 2014-2026 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
-@file:OptIn(ExperimentalWasmDsl::class, ExperimentalKotlinGradlePluginApi::class)
-
 import ktorbuild.disableNativeCompileConfigurationCache
 import ktorbuild.targets.*
-import org.jetbrains.kotlin.gradle.*
-import org.jetbrains.kotlin.gradle.tasks.KotlinCompilationTask
 
 description = "Ktor WebRTC Client"
 
@@ -121,8 +117,8 @@ configurations.named { it.startsWith("androidDeviceTest") }.configureEach {
     exclude(group = "org.junit.platform")
 }
 
-tasks.withType<KotlinCompilationTask<*>>().configureEach {
-    if (name.contains("Test", ignoreCase = true)) {
+kotlin {
+    sourceSets.matching { it.name.contains("Test", ignoreCase = true) }.configureEach {
         compilerOptions {
             freeCompilerArgs.add("-Xcontext-parameters")
         }

--- a/ktor-client/ktor-client-webrtc/common/test/io/ktor/client/webrtc/WebRtcDataChannelTest.kt
+++ b/ktor-client/ktor-client-webrtc/common/test/io/ktor/client/webrtc/WebRtcDataChannelTest.kt
@@ -243,9 +243,6 @@ class WebRtcDataChannelTest {
         assertEquals(null, dataChannel2.tryReceive())
     }
 
-    // Ignored on JVM: webrtc-java’s onBufferedAmountChange/bufferedAmountLow callback isn’t fired
-    // See https://github.com/devopvoid/webrtc-java/issues/214
-    // Remove this annotation once the issue is resolved
     @Test
     fun testCloseIsIdempotent() = testDataChannel { pc1, pc2 ->
         val ch1 = pc1.createDataChannel("idempotent-close")
@@ -269,9 +266,7 @@ class WebRtcDataChannelTest {
         ch2.close()
     }
 
-    // Ignored on JVM: webrtc-java's onBufferedAmountChange/bufferedAmountLow callback isn't fired
     @Test
-    @IgnoreJvm
     fun testDataChannelBufferedAmountLowEvent() = testDataChannel { pc1, pc2 ->
         val dataChannelEvents1 = pc1.dataChannelEvents.collectToChannel()
         val dataChannelEvents2 = pc2.dataChannelEvents.collectToChannel()

--- a/ktor-client/ktor-client-webrtc/common/test/io/ktor/client/webrtc/utils/Ignore.kt
+++ b/ktor-client/ktor-client-webrtc/common/test/io/ktor/client/webrtc/utils/Ignore.kt
@@ -1,8 +1,0 @@
-/*
- * Copyright 2014-2025 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
- */
-
-package io.ktor.client.webrtc.utils
-
-@Target(AnnotationTarget.CLASS, AnnotationTarget.FUNCTION)
-expect annotation class IgnoreJvm()

--- a/ktor-client/ktor-client-webrtc/ios/test/io/ktor/client/webrtc/utils/Ignore.ios.kt
+++ b/ktor-client/ktor-client-webrtc/ios/test/io/ktor/client/webrtc/utils/Ignore.ios.kt
@@ -1,8 +1,0 @@
-/*
- * Copyright 2014-2025 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
- */
-
-package io.ktor.client.webrtc.utils
-
-@Target(AnnotationTarget.CLASS, AnnotationTarget.FUNCTION)
-actual annotation class IgnoreJvm

--- a/ktor-client/ktor-client-webrtc/jvm/test/io/ktor/client/webrtc/utils/Ignore.jvm.kt
+++ b/ktor-client/ktor-client-webrtc/jvm/test/io/ktor/client/webrtc/utils/Ignore.jvm.kt
@@ -1,7 +1,0 @@
-/*
- * Copyright 2014-2026 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
- */
-
-package io.ktor.client.webrtc.utils
-
-actual typealias IgnoreJvm = org.junit.jupiter.api.Disabled

--- a/ktor-client/ktor-client-webrtc/web/test/io/ktor/client/webrtc/utils/Ignore.web.kt
+++ b/ktor-client/ktor-client-webrtc/web/test/io/ktor/client/webrtc/utils/Ignore.web.kt
@@ -1,8 +1,0 @@
-/*
- * Copyright 2014-2025 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
- */
-
-package io.ktor.client.webrtc.utils
-
-@Target(AnnotationTarget.CLASS, AnnotationTarget.FUNCTION)
-actual annotation class IgnoreJvm


### PR DESCRIPTION
**Subsystem**
WebRTC Client

**Motivation**
`DataChannelEvent.BufferedAmountLow` was not emitted because of a bug in `webrtc-java`, so the corresponding tests were ignored

**Solution**
Updated it to the new version that was released a couple of days ago.
Also, updated `build.gradle.kts` because the IDE was complaining about context parameters in tests.
Removed now redundant IgnoreJvm annotation.
