### PR TITLE
KTOR-9796 Add flaky-test quarantine infrastructure and transient-only retry

### DIFF
--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -22,6 +22,18 @@ dependencies {
     implementation(files(libs.javaClass.superclass.protectionDomain.codeSource.location))
 }
 
+// The flaky-test selectors are driven by one property with one set of values, read here to
+// configure the test tasks and in `ktor-test-base` to decide whether a `@Flaky` test runs. Compiling
+// `ktor-test-constants` into build-logic keeps that a single declaration instead of two that have to
+// be kept in sync by hand.
+//
+// The module is added as a source directory rather than as a project dependency because it is a
+// Kotlin Multiplatform project built by the `ktorbuild.project.internal` convention plugin — which
+// this build produces, so including it here would be circular.
+sourceSets.main {
+    kotlin.srcDir("../ktor-shared/ktor-test-constants/common/src")
+}
+
 // Should be synced with gradle/gradle-daemon-jvm.properties
 kotlin {
     jvmToolchain(21)

--- a/build-logic/src/main/kotlin/ktorbuild.kmp.gradle.kts
+++ b/build-logic/src/main/kotlin/ktorbuild.kmp.gradle.kts
@@ -44,6 +44,7 @@ kotlin {
 val targets = ktorBuild.targets
 
 configureCommon()
+configureFlakyTests()
 if (targets.hasJvm) configureJvm()
 if (targets.hasJs) configureJs()
 if (targets.hasWasmJs) configureWasmJs()

--- a/build-logic/src/main/kotlin/ktorbuild/targets/FlakyTestsConfig.kt
+++ b/build-logic/src/main/kotlin/ktorbuild/targets/FlakyTestsConfig.kt
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2014-2026 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package ktorbuild.targets
+
+import org.gradle.api.Project
+import org.gradle.api.tasks.testing.AbstractTestTask
+import org.gradle.api.tasks.testing.Test
+import org.gradle.kotlin.dsl.withType
+
+/**
+ * Name token marking a test as flaky on every target.
+ *
+ * The `@Flaky` annotation is enforced by a JUnit `ExecutionCondition`, and there is no JUnit
+ * Platform on Native/JS/Wasm. A token in the test or class name is the one selector that works
+ * everywhere, because Gradle test filtering applies to every `AbstractTestTask`.
+ */
+const val FLAKY_NAME_TOKEN = "_flaky"
+
+/** Matches the token anywhere in the test name, which also covers the `[target]` name suffixes. */
+private const val FLAKY_TEST_PATTERN = "*$FLAKY_NAME_TOKEN*"
+
+/**
+ * Selects how test tasks treat flaky tests, as a Gradle property (`-P`).
+ *
+ * The same name and the same values are used for the system property that JVM test tasks pass to
+ * `io.ktor.test.junit.FlakyTestCondition`, so there is one spelling to remember for both selectors.
+ */
+internal const val FLAKY_MODE_PROPERTY = "ktor.tests.flaky"
+
+/** How test tasks treat tests marked with [FLAKY_NAME_TOKEN]. Selected by [FLAKY_MODE_PROPERTY]. */
+internal enum class FlakyTestsMode {
+    /** The default: flaky tests don't run. */
+    EXCLUDE,
+
+    /** Nightly: run flaky tests and nothing else, to track whether they still flip. */
+    ONLY,
+
+    /** Run everything, flaky included. */
+    ALL;
+
+    /** The [FLAKY_MODE_PROPERTY] value denoting this mode, as accepted by [of]. */
+    val propertyValue: String get() = name.lowercase()
+
+    companion object {
+        fun of(value: String?): FlakyTestsMode = when (value) {
+            null, "", "exclude" -> EXCLUDE
+            "only" -> ONLY
+            "all" -> ALL
+            else -> error(
+                "Unexpected value '$value' of '$FLAKY_MODE_PROPERTY'. Expected one of: exclude, only, all."
+            )
+        }
+    }
+}
+
+internal fun Project.flakyTestsMode(): FlakyTestsMode =
+    FlakyTestsMode.of(providers.gradleProperty(FLAKY_MODE_PROPERTY).orNull)
+
+/**
+ * Applies the [FLAKY_MODE_PROPERTY] mode to the test tasks that have no other way to select flaky
+ * tests, which is every target except the JVM.
+ *
+ * JVM test tasks are left alone on purpose. They select `@Flaky` by annotation through
+ * `FlakyTestCondition`, which receives the same mode as a system property (see `JvmConfig`), and the
+ * two selectors would *intersect* rather than agree: [FlakyTestsMode.ONLY] would run only the tests
+ * that are both annotated **and** named `*_flaky*`, silently skipping every `@Flaky` test that
+ * carries no name token. The name token exists only because Native/JS/Wasm have no JUnit Platform.
+ */
+internal fun Project.configureFlakyTests() {
+    val mode = flakyTestsMode()
+
+    tasks.withType<AbstractTestTask>().configureEach {
+        if (this !is Test) selectFlakyTests(mode)
+    }
+}
+
+internal const val FLAKY_TEST_TASK = "flakyTest"
+
+private fun AbstractTestTask.selectFlakyTests(mode: FlakyTestsMode) {
+    when (mode) {
+        FlakyTestsMode.EXCLUDE -> filter.excludeTestsMatching(FLAKY_TEST_PATTERN)
+
+        FlakyTestsMode.ONLY -> {
+            filter.includeTestsMatching(FLAKY_TEST_PATTERN)
+            // Most modules have no flaky tests at all, and that isn't a failure.
+            filter.isFailOnNoMatchingTests = false
+        }
+
+        FlakyTestsMode.ALL -> Unit
+    }
+}

--- a/build-logic/src/main/kotlin/ktorbuild/targets/FlakyTestsConfig.kt
+++ b/build-logic/src/main/kotlin/ktorbuild/targets/FlakyTestsConfig.kt
@@ -4,79 +4,47 @@
 
 package ktorbuild.targets
 
+import io.ktor.test.constants.FLAKY_MODE_PROPERTY
+import io.ktor.test.constants.FLAKY_NAME_TOKEN
+import io.ktor.test.constants.FlakyTestsMode
 import org.gradle.api.Project
 import org.gradle.api.tasks.testing.AbstractTestTask
-import org.gradle.api.tasks.testing.Test
 import org.gradle.kotlin.dsl.withType
-
-/**
- * Name token marking a test as flaky on every target.
- *
- * The `@Flaky` annotation is enforced by a JUnit `ExecutionCondition`, and there is no JUnit
- * Platform on Native/JS/Wasm. A token in the test or class name is the one selector that works
- * everywhere, because Gradle test filtering applies to every `AbstractTestTask`.
- */
-const val FLAKY_NAME_TOKEN = "_flaky"
 
 /** Matches the token anywhere in the test name, which also covers the `[target]` name suffixes. */
 private const val FLAKY_TEST_PATTERN = "*$FLAKY_NAME_TOKEN*"
 
-/**
- * Selects how test tasks treat flaky tests, as a Gradle property (`-P`).
- *
- * The same name and the same values are used for the system property that JVM test tasks pass to
- * `io.ktor.test.junit.FlakyTestCondition`, so there is one spelling to remember for both selectors.
- */
-internal const val FLAKY_MODE_PROPERTY = "ktor.tests.flaky"
-
-/** How test tasks treat tests marked with [FLAKY_NAME_TOKEN]. Selected by [FLAKY_MODE_PROPERTY]. */
-internal enum class FlakyTestsMode {
-    /** The default: flaky tests don't run. */
-    EXCLUDE,
-
-    /** Nightly: run flaky tests and nothing else, to track whether they still flip. */
-    ONLY,
-
-    /** Run everything, flaky included. */
-    ALL;
-
-    /** The [FLAKY_MODE_PROPERTY] value denoting this mode, as accepted by [of]. */
-    val propertyValue: String get() = name.lowercase()
-
-    companion object {
-        fun of(value: String?): FlakyTestsMode = when (value) {
-            null, "", "exclude" -> EXCLUDE
-            "only" -> ONLY
-            "all" -> ALL
-            else -> error(
-                "Unexpected value '$value' of '$FLAKY_MODE_PROPERTY'. Expected one of: exclude, only, all."
-            )
-        }
-    }
-}
+internal const val FLAKY_TEST_TASK = "flakyTest"
 
 internal fun Project.flakyTestsMode(): FlakyTestsMode =
     FlakyTestsMode.of(providers.gradleProperty(FLAKY_MODE_PROPERTY).orNull)
 
 /**
- * Applies the [FLAKY_MODE_PROPERTY] mode to the test tasks that have no other way to select flaky
- * tests, which is every target except the JVM.
+ * Test tasks that select `@Flaky` by annotation and must therefore *not* also get the name filter.
  *
- * JVM test tasks are left alone on purpose. They select `@Flaky` by annotation through
- * `FlakyTestCondition`, which receives the same mode as a system property (see `JvmConfig`), and the
- * two selectors would *intersect* rather than agree: [FlakyTestsMode.ONLY] would run only the tests
- * that are both annotated **and** named `*_flaky*`, silently skipping every `@Flaky` test that
- * carries no name token. The name token exists only because Native/JS/Wasm have no JUnit Platform.
+ * Exactly the tasks `JvmConfig` gives [FLAKY_MODE_PROPERTY] and the JUnit autodetection that
+ * registers `FlakyTestCondition`. Stacking both selectors on them would *intersect* rather than
+ * agree: [FlakyTestsMode.ONLY] would run only the tests that are both annotated **and** named
+ * `*_flaky*`, silently skipping every `@Flaky` test that carries no name token.
+ *
+ * Matching by name rather than by task type matters: Android host tests are `Test` tasks too, but
+ * they never receive the condition, so exempting them by type would leave them with no selector at
+ * all and run quarantined tests in the default Android suite.
+ */
+private val ANNOTATION_DRIVEN_TEST_TASKS = setOf("jvmTest", "stressTest", FLAKY_TEST_TASK)
+
+/**
+ * Applies the [FLAKY_MODE_PROPERTY] mode to every test task that cannot select `@Flaky` by
+ * annotation — every target without a JUnit Platform, plus JVM tasks outside
+ * [ANNOTATION_DRIVEN_TEST_TASKS]. The name token exists only for those.
  */
 internal fun Project.configureFlakyTests() {
     val mode = flakyTestsMode()
 
     tasks.withType<AbstractTestTask>().configureEach {
-        if (this !is Test) selectFlakyTests(mode)
+        if (name !in ANNOTATION_DRIVEN_TEST_TASKS) selectFlakyTests(mode)
     }
 }
-
-internal const val FLAKY_TEST_TASK = "flakyTest"
 
 private fun AbstractTestTask.selectFlakyTests(mode: FlakyTestsMode) {
     when (mode) {

--- a/build-logic/src/main/kotlin/ktorbuild/targets/JvmConfig.kt
+++ b/build-logic/src/main/kotlin/ktorbuild/targets/JvmConfig.kt
@@ -4,6 +4,8 @@
 
 package ktorbuild.targets
 
+import io.ktor.test.constants.FLAKY_MODE_PROPERTY
+import io.ktor.test.constants.FlakyTestsMode
 import ktorbuild.ProjectTag
 import ktorbuild.addProjectTag
 import ktorbuild.internal.java
@@ -12,12 +14,20 @@ import ktorbuild.internal.ktorBuild
 import ktorbuild.internal.libs
 import org.gradle.api.Project
 import org.gradle.api.provider.Provider
+import org.gradle.api.tasks.TaskProvider
 import org.gradle.api.tasks.testing.Test
 import org.gradle.jvm.tasks.Jar
 import org.gradle.jvm.toolchain.JavaLanguageVersion
 import org.gradle.jvm.toolchain.JavaToolchainService
 import org.gradle.kotlin.dsl.*
 import org.jetbrains.kotlin.gradle.targets.jvm.tasks.KotlinJvmTest
+
+/**
+ * Identifies `ktor-test-base` on a test runtime classpath, where it appears either as this build's
+ * output directories or as a resolved jar. It is the module shipping `FlakyTestCondition` — and the
+ * `@Flaky` annotation the condition looks for.
+ */
+private const val TEST_BASE_MODULE = "ktor-test-base"
 
 internal fun Project.configureJvm() {
     addProjectTag(ProjectTag.Jvm)
@@ -54,7 +64,7 @@ private fun Project.configureTests() {
     )
     val jvmTestClassesDirs = files(jvmTestCompilation.map { it.output.classesDirs })
 
-    tasks.named<KotlinJvmTest>("jvmTest") {
+    val jvmTest = tasks.named<KotlinJvmTest>("jvmTest") {
         maxHeapSize = "2g"
         exclude("**/*StressTest*")
         // Auto-register FlakyTestCondition so @Flaky tests are excluded from the default run (they
@@ -90,17 +100,49 @@ private fun Project.configureTests() {
     tasks.register<Test>(FLAKY_TEST_TASK) {
         classpath = jvmTestRuntimeClasspath
         testClassesDirs = jvmTestClassesDirs
+        // Per-module `jvmTest` tweaks decide how a module's tests behave — Netty and the Jetty HTTP/2
+        // modules set `enable.http2`, the Android client sets `http.maxConnections`. Without them a
+        // quarantined test would run under different conditions here than in the suite it was
+        // quarantined from, corrupting the very flip rate this task exists to measure.
+        inheritExecutionSettingsFrom(jvmTest)
+
+        // Selection here is by annotation, and the condition that applies it ships in
+        // `ktor-test-base`. A module that doesn't have it on the test runtime classpath has nothing
+        // deselecting its ordinary tests, so this task would run the module's whole suite — with
+        // `ignoreFailures` below hiding every failure it produced. Such a module can't have @Flaky
+        // tests in the first place, since the annotation ships in the same module, so skipping is
+        // the correct outcome rather than a missed sample.
+        onlyIf("FlakyTestCondition is on the test runtime classpath") {
+            jvmTestRuntimeClasspath.any { it.invariantSeparatorsPath.contains(TEST_BASE_MODULE) }
+        }
 
         maxHeapSize = "2g"
         // A quarantined test flipping is the expected outcome here, not a regression to block on.
         // Failures still land in the test reports and in Develocity, which is where the flip rate is tracked.
         ignoreFailures = true
+        // Each run is a fresh sample of whether the test still flips, so an unchanged input tree is
+        // no reason to skip it — up-to-date checking would report the previous run's verdict forever.
+        outputs.upToDateWhen { false }
         systemProperty(FLAKY_MODE_PROPERTY, FlakyTestsMode.ONLY.propertyValue)
         systemProperty("junit.jupiter.extensions.autodetection.enabled", "true")
         exclude("**/*StressTest*")
         useJUnitPlatform()
         configureJavaToolchain(java.toolchain.languageVersion, ktorBuild.jvmTestToolchain)
     }
+}
+
+/**
+ * Copies the execution environment of [source] onto this task: the system properties and JVM
+ * arguments a module set on its own `jvmTest`, which decide how that module's tests behave.
+ *
+ * `get()` realizes the task to read its configuration, which does *not* make this task depend on
+ * running it — unlike deriving a `FileCollection` from the provider, which does. Anything this task
+ * sets afterwards wins, so the flaky mode and the toolchain settings still override what is copied.
+ */
+private fun Test.inheritExecutionSettingsFrom(source: TaskProvider<KotlinJvmTest>) {
+    val jvmTest = source.get()
+    systemProperties(jvmTest.systemProperties)
+    jvmArgs(jvmTest.jvmArgs.orEmpty())
 }
 
 private fun Project.configureJarManifest() {

--- a/build-logic/src/main/kotlin/ktorbuild/targets/JvmConfig.kt
+++ b/build-logic/src/main/kotlin/ktorbuild/targets/JvmConfig.kt
@@ -41,22 +41,63 @@ internal fun Project.configureJvm() {
 }
 
 private fun Project.configureTests() {
-    val jvmTest = tasks.named<KotlinJvmTest>("jvmTest") {
+    val flakyTestsMode = flakyTestsMode()
+
+    // Take the test classpath from the JVM test *compilation*, not from the `jvmTest` task. A
+    // provider derived from `tasks.named("jvmTest")` carries that task as its producer, so depending
+    // on it makes Gradle run the whole default suite before `stressTest` or `flakyTest`. The
+    // compilation's own file collections are built by the compile tasks, which is all these need.
+    val jvmTestCompilation = kotlin.jvm().compilations.named("test")
+    val jvmTestRuntimeClasspath = files(
+        jvmTestCompilation.map { it.output.allOutputs },
+        jvmTestCompilation.map { it.runtimeDependencyFiles },
+    )
+    val jvmTestClassesDirs = files(jvmTestCompilation.map { it.output.classesDirs })
+
+    tasks.named<KotlinJvmTest>("jvmTest") {
         maxHeapSize = "2g"
         exclude("**/*StressTest*")
+        // Auto-register FlakyTestCondition so @Flaky tests are excluded from the default run (they
+        // run only in the `flakyTest` task below, or with -Pktor.tests.flaky=only|all).
+        systemProperty("junit.jupiter.extensions.autodetection.enabled", "true")
+        systemProperty(FLAKY_MODE_PROPERTY, flakyTestsMode.propertyValue)
         useJUnitPlatform()
         configureJavaToolchain(java.toolchain.languageVersion, ktorBuild.jvmTestToolchain)
     }
 
     tasks.register<Test>("stressTest") {
-        classpath = files(jvmTest.map { it.classpath })
-        testClassesDirs = files(jvmTest.map { it.testClassesDirs })
+        classpath = jvmTestRuntimeClasspath
+        testClassesDirs = jvmTestClassesDirs
 
         maxHeapSize = "2g"
         jvmArgs("-XX:+HeapDumpOnOutOfMemoryError")
         setForkEvery(1)
         systemProperty("enable.stress.tests", "true")
+        // JVM test tasks are exempt from the `_flaky` name filter (see `configureFlakyTests`), so
+        // the condition is what keeps @Flaky tests out of this task too.
+        systemProperty("junit.jupiter.extensions.autodetection.enabled", "true")
+        systemProperty(FLAKY_MODE_PROPERTY, flakyTestsMode.propertyValue)
         include("**/*StressTest*")
+        useJUnitPlatform()
+        configureJavaToolchain(java.toolchain.languageVersion, ktorBuild.jvmTestToolchain)
+    }
+
+    // Runs ONLY @Flaky-annotated tests (excluded from the default `jvmTest`). Intended for a
+    // nightly/dedicated job that publishes to Develocity so quarantined tests stay tracked.
+    // (Selection is by annotation, resolved at execution time; the `_flaky` name token — same
+    // property, applied by `configureFlakyTests` — is the equivalent for Native/JS/Wasm, which have
+    // no JUnit Platform.)
+    tasks.register<Test>(FLAKY_TEST_TASK) {
+        classpath = jvmTestRuntimeClasspath
+        testClassesDirs = jvmTestClassesDirs
+
+        maxHeapSize = "2g"
+        // A quarantined test flipping is the expected outcome here, not a regression to block on.
+        // Failures still land in the test reports and in Develocity, which is where the flip rate is tracked.
+        ignoreFailures = true
+        systemProperty(FLAKY_MODE_PROPERTY, FlakyTestsMode.ONLY.propertyValue)
+        systemProperty("junit.jupiter.extensions.autodetection.enabled", "true")
+        exclude("**/*StressTest*")
         useJUnitPlatform()
         configureJavaToolchain(java.toolchain.languageVersion, ktorBuild.jvmTestToolchain)
     }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -42,6 +42,7 @@ jackson3 = "3.1.3"
 jackson-annotations = "2.21"
 
 junit = "5.14.4"
+konsist = "0.17.3"
 slf4j = "2.0.18"
 logback = "1.5.34"
 
@@ -212,6 +213,7 @@ slf4j-api = { module = "org.slf4j:slf4j-api", version.ref = "slf4j" }
 slf4j-simple = { module = "org.slf4j:slf4j-simple", version.ref = "slf4j" }
 logback-classic = { module = "ch.qos.logback:logback-classic", version.ref = "logback" }
 junit = { module = "org.junit.jupiter:junit-jupiter", version.ref = "junit" }
+konsist = { module = "com.lemonappdev:konsist", version.ref = "konsist" }
 
 apache-httpasyncclient = { module = "org.apache.httpcomponents:httpasyncclient", version.ref = "apache" }
 apache-client5 = { module = "org.apache.httpcomponents.client5:httpclient5", version.ref = "apache5" }

--- a/ktor-server/ktor-server-test-base/common/src/io/ktor/server/test/base/BaseTest.kt
+++ b/ktor-server/ktor-server-test-base/common/src/io/ktor/server/test/base/BaseTest.kt
@@ -23,3 +23,35 @@ expect abstract class BaseTest() {
         block: suspend CoroutineScope.() -> Unit
     ): TestResult
 }
+
+/**
+ * The retry, guard and lifecycle scaffolding shared by the [BaseTest.runTest] actuals.
+ *
+ * Only the coroutine context differs between targets, so that part stays in the actual and arrives
+ * here as [runAttempt] — the platform's `runTestWithRealTime` call. Everything else is identical:
+ * an assertion failure is recorded and replayed rather than retried, so a deterministic failure is
+ * reported by the attempt that produced it instead of being masked as flakiness. `runTest`'s own
+ * timeout error stays retryable, being thrown around [block] rather than by it.
+ */
+internal fun BaseTest.runTestAttempts(
+    retries: Int,
+    runAttempt: (block: suspend CoroutineScope.() -> Unit) -> TestResult,
+    block: suspend CoroutineScope.() -> Unit,
+): TestResult {
+    val guard = DeterministicFailureGuard()
+    return retryTest(retries) { retry ->
+        guard.failFast()
+        runAttempt {
+            if (retry > 0) println("[Retry $retry/$retries]")
+            beforeTest()
+            try {
+                block()
+            } catch (cause: Throwable) {
+                guard.record(cause)
+                throw cause
+            } finally {
+                afterTest()
+            }
+        }
+    }
+}

--- a/ktor-server/ktor-server-test-base/common/src/io/ktor/server/test/base/BaseTest.kt
+++ b/ktor-server/ktor-server-test-base/common/src/io/ktor/server/test/base/BaseTest.kt
@@ -29,9 +29,10 @@ expect abstract class BaseTest() {
  *
  * Only the coroutine context differs between targets, so that part stays in the actual and arrives
  * here as [runAttempt] — the platform's `runTestWithRealTime` call. Everything else is identical:
- * an assertion failure is recorded and replayed rather than retried, so a deterministic failure is
- * reported by the attempt that produced it instead of being masked as flakiness. `runTest`'s own
- * timeout error stays retryable, being thrown around [block] rather than by it.
+ * an assertion failure thrown by [block] is recorded and ends the retry loop, so a deterministic
+ * failure is reported by the attempt that produced it instead of being masked as flakiness.
+ * `runTest`'s own timeout error is an `AssertionError` too, but stays retryable because it is thrown
+ * around [block] rather than by it, so the guard never sees it.
  */
 internal fun BaseTest.runTestAttempts(
     retries: Int,
@@ -39,8 +40,7 @@ internal fun BaseTest.runTestAttempts(
     block: suspend CoroutineScope.() -> Unit,
 ): TestResult {
     val guard = DeterministicFailureGuard()
-    return retryTest(retries) { retry ->
-        guard.failFast()
+    return retryTest(retries, shouldRetry = { !guard.hasFailure }) { retry ->
         runAttempt {
             if (retry > 0) println("[Retry $retry/$retries]")
             beforeTest()

--- a/ktor-server/ktor-server-test-base/common/test/io/ktor/server/test/base/BaseTestTest.kt
+++ b/ktor-server/ktor-server-test-base/common/test/io/ktor/server/test/base/BaseTestTest.kt
@@ -15,7 +15,7 @@ class BaseTestTest : BaseTest() {
     fun `runTest - retry test by default on non-JVM platform`(): TestResult {
         var retryCount = 0
         return runTest {
-            if (!PlatformUtils.IS_JVM && retryCount++ < 1) fail("This test should be retried")
+            if (!PlatformUtils.IS_JVM && retryCount++ < 1) transientFailure("This test should be retried")
         }
     }
 
@@ -31,7 +31,7 @@ class BaseTestTest : BaseTest() {
     fun `runTest - more than one retry`(): TestResult {
         var retryCount = 0
         return runTest(retries = 3) {
-            if (retryCount++ < 3) fail("This test should be retried")
+            if (retryCount++ < 3) transientFailure("This test should be retried")
         }
     }
 
@@ -43,3 +43,6 @@ class BaseTestTest : BaseTest() {
         }
     }
 }
+
+/** Simulates a transient (retryable) failure, as opposed to a deterministic assertion failure. */
+private fun transientFailure(message: String): Nothing = throw IllegalStateException(message)

--- a/ktor-server/ktor-server-test-base/jvm/src/io/ktor/server/test/base/BaseTestJvm.kt
+++ b/ktor-server/ktor-server-test-base/jvm/src/io/ktor/server/test/base/BaseTestJvm.kt
@@ -49,14 +49,21 @@ actual abstract class BaseTest actual constructor() {
         timeout: Duration,
         retries: Int,
         block: suspend CoroutineScope.() -> Unit
-    ): TestResult = retryTest(retries) { retry ->
-        runTestWithRealTime(CoroutineName("test-$testName"), timeout) {
-            if (retry > 0) println("[Retry $retry/$retries]")
-            beforeTest()
-            try {
-                block()
-            } finally {
-                afterTest()
+    ): TestResult {
+        val guard = DeterministicFailureGuard()
+        return retryTest(retries) { retry ->
+            guard.failFast()
+            runTestWithRealTime(CoroutineName("test-$testName"), timeout) {
+                if (retry > 0) println("[Retry $retry/$retries]")
+                beforeTest()
+                try {
+                    block()
+                } catch (cause: Throwable) {
+                    guard.record(cause)
+                    throw cause
+                } finally {
+                    afterTest()
+                }
             }
         }
     }

--- a/ktor-server/ktor-server-test-base/jvm/src/io/ktor/server/test/base/BaseTestJvm.kt
+++ b/ktor-server/ktor-server-test-base/jvm/src/io/ktor/server/test/base/BaseTestJvm.kt
@@ -49,22 +49,9 @@ actual abstract class BaseTest actual constructor() {
         timeout: Duration,
         retries: Int,
         block: suspend CoroutineScope.() -> Unit
-    ): TestResult {
-        val guard = DeterministicFailureGuard()
-        return retryTest(retries) { retry ->
-            guard.failFast()
-            runTestWithRealTime(CoroutineName("test-$testName"), timeout) {
-                if (retry > 0) println("[Retry $retry/$retries]")
-                beforeTest()
-                try {
-                    block()
-                } catch (cause: Throwable) {
-                    guard.record(cause)
-                    throw cause
-                } finally {
-                    afterTest()
-                }
-            }
-        }
-    }
+    ): TestResult = runTestAttempts(
+        retries,
+        runAttempt = { attempt -> runTestWithRealTime(CoroutineName("test-$testName"), timeout, attempt) },
+        block = block,
+    )
 }

--- a/ktor-server/ktor-server-test-base/jvm/test/io/ktor/server/test/base/BaseTestRetryJvmTest.kt
+++ b/ktor-server/ktor-server-test-base/jvm/test/io/ktor/server/test/base/BaseTestRetryJvmTest.kt
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2014-2026 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.server.test.base
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.fail
+
+/**
+ * Verifies how [BaseTest.runTest] classifies failures for retries.
+ *
+ * These assertions live in the JVM source set because there `TestResult` is `Unit`, so a failing
+ * test propagates its failure synchronously and can be asserted on. On Web the same call returns
+ * a `Promise`, which would reject asynchronously instead.
+ */
+class BaseTestRetryJvmTest {
+
+    private class Fixture : BaseTest()
+
+    @Test
+    fun `assertion failure is not retried`() {
+        var attempts = 0
+
+        assertFailsWith<AssertionError> {
+            Fixture().runTest(retries = 3) {
+                attempts++
+                fail("Deterministic failure")
+            }
+        }
+
+        assertEquals(1, attempts, "An assertion failure is deterministic and must not be retried")
+    }
+
+    @Test
+    fun `transient failure is retried`() {
+        var attempts = 0
+
+        Fixture().runTest(retries = 3) {
+            if (attempts++ < 3) throw IllegalStateException("Transient failure")
+        }
+
+        assertEquals(4, attempts, "Transient failures should be retried until they pass")
+    }
+}

--- a/ktor-server/ktor-server-test-base/nonJvm/src/io/ktor/server/test/base/BaseTest.nonJvm.kt
+++ b/ktor-server/ktor-server-test-base/nonJvm/src/io/ktor/server/test/base/BaseTest.nonJvm.kt
@@ -50,14 +50,21 @@ actual abstract class BaseTest actual constructor() {
         timeout: Duration,
         retries: Int,
         block: suspend CoroutineScope.() -> Unit
-    ): TestResult = retryTest(retries) { retry ->
-        runTestWithRealTime(timeout = timeout) {
-            if (retry > 0) println("[Retry $retry/$retries]")
-            beforeTest()
-            try {
-                block()
-            } finally {
-                afterTest()
+    ): TestResult {
+        val guard = DeterministicFailureGuard()
+        return retryTest(retries) { retry ->
+            guard.failFast()
+            runTestWithRealTime(timeout = timeout) {
+                if (retry > 0) println("[Retry $retry/$retries]")
+                beforeTest()
+                try {
+                    block()
+                } catch (cause: Throwable) {
+                    guard.record(cause)
+                    throw cause
+                } finally {
+                    afterTest()
+                }
             }
         }
     }

--- a/ktor-server/ktor-server-test-base/nonJvm/src/io/ktor/server/test/base/BaseTest.nonJvm.kt
+++ b/ktor-server/ktor-server-test-base/nonJvm/src/io/ktor/server/test/base/BaseTest.nonJvm.kt
@@ -50,24 +50,11 @@ actual abstract class BaseTest actual constructor() {
         timeout: Duration,
         retries: Int,
         block: suspend CoroutineScope.() -> Unit
-    ): TestResult {
-        val guard = DeterministicFailureGuard()
-        return retryTest(retries) { retry ->
-            guard.failFast()
-            runTestWithRealTime(timeout = timeout) {
-                if (retry > 0) println("[Retry $retry/$retries]")
-                beforeTest()
-                try {
-                    block()
-                } catch (cause: Throwable) {
-                    guard.record(cause)
-                    throw cause
-                } finally {
-                    afterTest()
-                }
-            }
-        }
-    }
+    ): TestResult = runTestAttempts(
+        retries,
+        runAttempt = { attempt -> runTestWithRealTime(timeout = timeout, testBody = attempt) },
+        block = block,
+    )
 }
 
 private class UnhandledErrorsException(override val message: String) : Exception()

--- a/ktor-shared/ktor-test-base/build.gradle.kts
+++ b/ktor-shared/ktor-test-base/build.gradle.kts
@@ -14,12 +14,18 @@ kotlin {
             api(libs.kotlin.test)
             api(projects.ktorUtils)
             api(projects.ktorTestDispatcher)
+            api(projects.ktorTestConstants)
         }
 
         jvmMain.dependencies {
             api(libs.kotlin.test.junit5)
             api(libs.junit)
             api(libs.kotlinx.coroutines.debug)
+        }
+
+        jvmTest.dependencies {
+            // Enforces the `@Flaky` / `_flaky` naming convention across the repository's sources.
+            implementation(libs.konsist)
         }
     }
 }

--- a/ktor-shared/ktor-test-base/common/src/io/ktor/test/DeterministicFailureGuard.kt
+++ b/ktor-shared/ktor-test-base/common/src/io/ktor/test/DeterministicFailureGuard.kt
@@ -8,9 +8,9 @@ package io.ktor.test
  * Keeps a retry loop from retrying deterministic failures.
  *
  * Assertion failures are deterministic, so retrying them cannot turn them green — it only hides a
- * real bug behind a "flaky" verdict. Once one is recorded, the enclosing retry loop stops: either by
- * calling [failFast] to replay it in place of another attempt, or by checking [hasFailure] and
- * reporting instead of retrying.
+ * real bug behind a "flaky" verdict. Once one is recorded, [hasFailure] tells the enclosing retry
+ * loop to stop — as `retryTest`'s `shouldRetry` predicate, or as part of a `recover` callback's
+ * decision whether to rethrow.
  *
  * Only failures passed to [record] are classified, which must be exactly those thrown by the test
  * body. The timeout error of `runTest` is an [AssertionError] as well, but is worth retrying, and
@@ -22,11 +22,6 @@ class DeterministicFailureGuard {
 
     /** `true` once a deterministic failure has been recorded, so further attempts are pointless. */
     val hasFailure: Boolean get() = failure != null
-
-    /** Re-throws the recorded failure, if any, to skip another attempt of the test body. */
-    fun failFast() {
-        failure?.let { throw it }
-    }
 
     /** Records [cause] as deterministic when it is an [AssertionError]. */
     fun record(cause: Throwable) {

--- a/ktor-shared/ktor-test-base/common/src/io/ktor/test/DeterministicFailureGuard.kt
+++ b/ktor-shared/ktor-test-base/common/src/io/ktor/test/DeterministicFailureGuard.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2014-2026 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.test
+
+/**
+ * Keeps a retry loop from retrying deterministic failures.
+ *
+ * Assertion failures are deterministic, so retrying them cannot turn them green — it only hides a
+ * real bug behind a "flaky" verdict. Once one is recorded, the enclosing retry loop stops: either by
+ * calling [failFast] to replay it in place of another attempt, or by checking [hasFailure] and
+ * reporting instead of retrying.
+ *
+ * Only failures passed to [record] are classified, which must be exactly those thrown by the test
+ * body. The timeout error of `runTest` is an [AssertionError] as well, but is worth retrying, and
+ * stays retryable because it is thrown around the body rather than by it.
+ * Used by [runTestWithData] and by `BaseTest.runTest`.
+ */
+class DeterministicFailureGuard {
+    private var failure: Throwable? = null
+
+    /** `true` once a deterministic failure has been recorded, so further attempts are pointless. */
+    val hasFailure: Boolean get() = failure != null
+
+    /** Re-throws the recorded failure, if any, to skip another attempt of the test body. */
+    fun failFast() {
+        failure?.let { throw it }
+    }
+
+    /** Records [cause] as deterministic when it is an [AssertionError]. */
+    fun record(cause: Throwable) {
+        if (cause is AssertionError) failure = cause
+    }
+}

--- a/ktor-shared/ktor-test-base/common/src/io/ktor/test/Eventually.kt
+++ b/ktor-shared/ktor-test-base/common/src/io/ktor/test/Eventually.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2014-2026 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.test
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.withContext
+import kotlin.test.fail
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.TimeSource
+
+/**
+ * Waits until [condition] holds, polling it every [interval], and fails if it doesn't hold within
+ * [timeout].
+ *
+ * @param description What is being waited for, phrased to read after "Timed out waiting for".
+ * @param timeout Upper bound on the total wait.
+ * @param interval How often [condition] is evaluated.
+ * @param condition The awaited condition. Evaluated at least once, even with a zero [timeout].
+ */
+suspend fun assertEventually(
+    description: String,
+    timeout: Duration = DEFAULT_EVENTUALLY_TIMEOUT,
+    interval: Duration = (timeout / 20).coerceIn(1.milliseconds, 100.milliseconds),
+    condition: suspend () -> Boolean,
+) {
+    val deadline = TimeSource.Monotonic.markNow() + timeout
+    while (true) {
+        if (condition()) return
+        if (deadline.hasPassedNow()) fail("Timed out after $timeout waiting for $description")
+        realTimeDelay(interval)
+    }
+}
+
+/** Delays in real time, so the wait isn't skipped by the virtual clock of `runTest`. */
+private suspend fun realTimeDelay(duration: Duration) {
+    withContext(Dispatchers.Default) { delay(duration) }
+}

--- a/ktor-shared/ktor-test-base/common/src/io/ktor/test/Eventually.kt
+++ b/ktor-shared/ktor-test-base/common/src/io/ktor/test/Eventually.kt
@@ -7,19 +7,33 @@ package io.ktor.test
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.withContext
-import kotlin.test.fail
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.TimeSource
+
+/**
+ * Thrown by [assertEventually] when [assertEventually]'s condition doesn't hold in time.
+ *
+ * Deliberately **not** an [AssertionError]: [DeterministicFailureGuard] classifies those as
+ * deterministic and stops the retry loop, which is right for an assertion the test body evaluated
+ * and wrong here. Running out of time waiting for a condition is the transient, load-dependent
+ * failure that retrying exists for, so this stays an ordinary exception and remains retryable.
+ *
+ * It is also not a `CancellationException`, which the coroutine machinery would treat as normal
+ * cancellation and swallow instead of failing the test.
+ */
+class EventuallyTimeoutException(message: String) : Exception(message)
 
 /**
  * Waits until [condition] holds, polling it every [interval], and fails if it doesn't hold within
  * [timeout].
  *
  * @param description What is being waited for, phrased to read after "Timed out waiting for".
- * @param timeout Upper bound on the total wait.
+ * @param timeout Upper bound on the total wait, honored even if [interval] is larger.
  * @param interval How often [condition] is evaluated.
  * @param condition The awaited condition. Evaluated at least once, even with a zero [timeout].
+ * @throws EventuallyTimeoutException if [condition] doesn't hold within [timeout]. Retryable on
+ *  purpose — see the exception's own documentation.
  */
 suspend fun assertEventually(
     description: String,
@@ -30,8 +44,14 @@ suspend fun assertEventually(
     val deadline = TimeSource.Monotonic.markNow() + timeout
     while (true) {
         if (condition()) return
-        if (deadline.hasPassedNow()) fail("Timed out after $timeout waiting for $description")
-        realTimeDelay(interval)
+        val remaining = -deadline.elapsedNow()
+        if (remaining <= Duration.ZERO) {
+            throw EventuallyTimeoutException("Timed out after $timeout waiting for $description")
+        }
+        // Never sleep past the deadline: `timeout` is documented as the upper bound on the wait, so
+        // an interval larger than what is left would overshoot it (`interval = 1s` with a 100ms
+        // timeout would fail after a second).
+        realTimeDelay(minOf(interval, remaining))
     }
 }
 

--- a/ktor-shared/ktor-test-base/common/src/io/ktor/test/Flaky.kt
+++ b/ktor-shared/ktor-test-base/common/src/io/ktor/test/Flaky.kt
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2014-2026 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.test
+
+/**
+ * Marks a test (method or class) as flaky (non-deterministic).
+ *
+ * Flaky tests are **excluded from the default test run** and executed only by the dedicated
+ * flaky/nightly task, so they stay tracked in Develocity instead of being deleted or silently
+ * retried.
+ *
+ * On JVM this is enforced by `io.ktor.test.junit.FlakyTestCondition` (auto-registered via JUnit
+ * extension autodetection). There is no JUnit Platform on Native/JS/Wasm, so annotations can't be
+ * used for selection there. **For a test in common code, also add the `_flaky` token to its name**,
+ * which the build filters out on every target:
+ *
+ * ```
+ * @Flaky("KTOR-1234")
+ * @Test
+ * fun testReconnectsAfterClose_flaky() { ... }
+ * ```
+ *
+ * Both selectors are driven by one property, `ktor.tests.flaky`, applied to every target:
+ *
+ * | Command                                                   | Runs                    |
+ * |-----------------------------------------------------------|-------------------------|
+ * | `./gradlew :module:jvmTest`                               | everything except flaky |
+ * | `./gradlew :module:jsNodeTest -Pktor.tests.flaky=only`    | flaky only              |
+ * | `./gradlew :module:macosArm64Test -Pktor.tests.flaky=all` | everything              |
+ *
+ * The JVM-only `flakyTest` task runs **only** the `@Flaky` tests: it pins the same property to
+ * `only` for the test JVM, so `FlakyTestCondition` skips everything else. It exists because the
+ * annotation is resolved at execution time rather than during selection, which is what lets it
+ * catch JVM tests that carry no `_flaky` token.
+ *
+ * ### Flakiness confined to one engine
+ *
+ * This annotation quarantines a whole test method. Both selectors act on the method — the JUnit
+ * condition before the body runs, the name token during Gradle's test selection — so neither can see
+ * which engine `clientTests` would have picked. Annotating a `clientTests` method that only flips on
+ * one engine therefore drops the coverage for every *other* engine and every other target too.
+ *
+ * Until `ClientLoader` can express the scope directly, split the test and quarantine only the
+ * affected engine:
+ *
+ * ```
+ * @Test
+ * fun testEcho() = clientTests(except("WinHttp")) { echo() }
+ *
+ * @Flaky("KTOR-1234")
+ * @Test
+ * fun testEcho_flaky() = clientTests(only("WinHttp")) { echo() }
+ *
+ * private fun TestClientBuilder<*>.echo() { test { client -> /* ... */ } }
+ * ```
+ *
+ * Use `platform:Engine` patterns (`only("jvm:CIO")`) when the flakiness is specific to one platform's
+ * build of an engine, so the others keep running.
+ *
+ * Prefer fixing flakiness over marking; when marking, always link the tracking issue.
+ *
+ * @property ticket The YouTrack issue tracking the flakiness, e.g. `"KTOR-1234"`.
+ */
+@Retention(AnnotationRetention.RUNTIME)
+@Target(AnnotationTarget.CLASS, AnnotationTarget.FUNCTION)
+annotation class Flaky(val ticket: String)

--- a/ktor-shared/ktor-test-base/common/src/io/ktor/test/Flaky.kt
+++ b/ktor-shared/ktor-test-base/common/src/io/ktor/test/Flaky.kt
@@ -65,4 +65,7 @@ package io.ktor.test
  */
 @Retention(AnnotationRetention.RUNTIME)
 @Target(AnnotationTarget.CLASS, AnnotationTarget.FUNCTION)
+// Inherited so that a test class extending an annotated base class is quarantined too — the shared
+// test suite pattern used across Ktor. JUnit walks superclasses only for inherited annotations.
+@JvmInherited
 annotation class Flaky(val ticket: String)

--- a/ktor-shared/ktor-test-base/common/src/io/ktor/test/JvmInherited.kt
+++ b/ktor-shared/ktor-test-base/common/src/io/ktor/test/JvmInherited.kt
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2014-2026 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.test
+
+/**
+ * Meta-annotation making an annotation inherited by subclasses on the JVM, and doing nothing
+ * elsewhere.
+ *
+ * On the JVM this is `java.lang.annotation.Inherited`, which is what JUnit's annotation lookup
+ * consults before walking up a superclass chain (see `AnnotationSupport.findAnnotation`). A Kotlin
+ * annotation declared in common code cannot apply the Java annotation directly, so it goes through
+ * this alias; every other target has no such concept and gets an annotation with no effect.
+ */
+@Target(AnnotationTarget.ANNOTATION_CLASS)
+@Retention(AnnotationRetention.RUNTIME)
+expect annotation class JvmInherited()

--- a/ktor-shared/ktor-test-base/common/src/io/ktor/test/TestDefaults.kt
+++ b/ktor-shared/ktor-test-base/common/src/io/ktor/test/TestDefaults.kt
@@ -23,3 +23,11 @@ val DEFAULT_TEST_TIMEOUT: Duration = 30.seconds
  * On JVM retries are disabled as we use test-retry Gradle plugin instead.
  */
 val DEFAULT_RETRIES: Int = if (PlatformUtils.IS_JVM) 0 else 1
+
+/**
+ * Default upper bound on the wait of [assertEventually].
+ *
+ * Deliberately generous: a condition that holds quickly is detected quickly, so a large value only
+ * affects how long a genuinely broken test takes to fail.
+ */
+val DEFAULT_EVENTUALLY_TIMEOUT: Duration = 10.seconds

--- a/ktor-shared/ktor-test-base/common/src/io/ktor/test/TestResult.kt
+++ b/ktor-shared/ktor-test-base/common/src/io/ktor/test/TestResult.kt
@@ -38,7 +38,14 @@ internal expect inline fun <T> runTestForEach(items: Iterable<T>, crossinline te
  * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.test.retryTest)
  *
  * @param retries The number of retries to attempt after an initial failure. Must be a non-negative integer.
+ * @param shouldRetry Decides whether a failure is worth another attempt. Returning `false` stops the
+ *  loop and re-throws that failure immediately, instead of burning the remaining attempts on a
+ *  verdict that is already known. Defaults to retrying every failure.
  * @param test A test to execute, which accepts the current retry attempt (starting at 0) as an argument.
  * @return A [TestResult] representing the outcome of the test after all attempts.
  */
-expect inline fun retryTest(retries: Int, crossinline test: (Int) -> TestResult): TestResult
+expect inline fun retryTest(
+    retries: Int,
+    crossinline shouldRetry: (Throwable) -> Boolean = { true },
+    crossinline test: (Int) -> TestResult,
+): TestResult

--- a/ktor-shared/ktor-test-base/common/src/io/ktor/test/runTestWithData.kt
+++ b/ktor-shared/ktor-test-base/common/src/io/ktor/test/runTestWithData.kt
@@ -87,6 +87,8 @@ sealed interface TestExecutionResult<T> {
  * @param context Optional coroutine context for test execution. Defaults to [EmptyCoroutineContext].
  * @param timeout Maximum duration allowed for each test attempt. Defaults to 1 minute.
  * @param retries Number of additional attempts after initial failure (`0` means no retries).
+ *  Only transient failures are retried: an assertion failed by the test body is deterministic,
+ *  so it is reported immediately instead of being retried and masked.
  * @param afterEach Called after each test case attempt, regardless of success or failure.
  *  Receives the test case and error (if any occurred).
  * @param handleFailures Called after all tests finished if any failures occurred.
@@ -112,6 +114,8 @@ fun <T> runTestWithData(
 
     val failures = mutableListOf<TestFailure<T>>()
     return runTestForEach(testCases) { data ->
+        val guard = DeterministicFailureGuard()
+
         retryTest(retries) { retry ->
             val testCase = TestCase(data, retry)
 
@@ -119,15 +123,21 @@ fun <T> runTestWithData(
                 recover = { cause ->
                     val failure = TestFailure(testCase, cause, start?.elapsedNow() ?: Duration.ZERO)
                     afterEach(failure)
-                    // Don't rethrow the exception on the last retry,
-                    // save it instead to pass in handleFailures later
-                    if (retry == retries) failures += failure else throw cause
+                    // Record and stop (as on the last retry) to let the failure surface.
+                    // Not rethrowing is what ends the retry loop; handleFailures reports the failure.
+                    if (retry == retries || guard.hasFailure) failures += failure else throw cause
                 }
             ) {
                 runTest(context, timeout = timeout) {
-                    start = timeSource.markNow()
-                    test(testCase)
-                    afterEach(TestSuccess(testCase, start.elapsedNow()))
+                    val mark = timeSource.markNow()
+                    start = mark
+                    try {
+                        test(testCase)
+                    } catch (cause: Throwable) {
+                        guard.record(cause)
+                        throw cause
+                    }
+                    afterEach(TestSuccess(testCase, mark.elapsedNow()))
                 }
             }
         }

--- a/ktor-shared/ktor-test-base/common/src/io/ktor/test/runTestWithData.kt
+++ b/ktor-shared/ktor-test-base/common/src/io/ktor/test/runTestWithData.kt
@@ -87,8 +87,8 @@ sealed interface TestExecutionResult<T> {
  * @param context Optional coroutine context for test execution. Defaults to [EmptyCoroutineContext].
  * @param timeout Maximum duration allowed for each test attempt. Defaults to 1 minute.
  * @param retries Number of additional attempts after initial failure (`0` means no retries).
- *  Only transient failures are retried: an assertion failed by the test body is deterministic,
- *  so it is reported immediately instead of being retried and masked.
+ *  Only transient failures are retried: an assertion failure thrown by the test body is
+ *  deterministic, so it is reported immediately instead of being retried and masked.
  * @param afterEach Called after each test case attempt, regardless of success or failure.
  *  Receives the test case and error (if any occurred).
  * @param handleFailures Called after all tests finished if any failures occurred.

--- a/ktor-shared/ktor-test-base/common/test/io/ktor/test/DeterministicFailureGuardTest.kt
+++ b/ktor-shared/ktor-test-base/common/test/io/ktor/test/DeterministicFailureGuardTest.kt
@@ -5,23 +5,18 @@
 package io.ktor.test
 
 import kotlin.test.Test
-import kotlin.test.assertFails
 import kotlin.test.assertFalse
-import kotlin.test.assertSame
 import kotlin.test.assertTrue
 
 class DeterministicFailureGuardTest {
 
     @Test
-    fun `assertion failure is replayed instead of retried`() {
+    fun `assertion failure stops the retry loop`() {
         val guard = DeterministicFailureGuard()
-        val cause = AssertionError("deterministic")
 
-        guard.record(cause)
+        guard.record(AssertionError("deterministic"))
 
         assertTrue(guard.hasFailure)
-        val replayed = assertFails { guard.failFast() }
-        assertSame(cause, replayed, "The recorded failure should be re-thrown as is")
     }
 
     @Test
@@ -31,6 +26,5 @@ class DeterministicFailureGuardTest {
         guard.record(IllegalStateException("connection reset"))
 
         assertFalse(guard.hasFailure)
-        guard.failFast() // Doesn't throw, so the next attempt runs the test body again.
     }
 }

--- a/ktor-shared/ktor-test-base/common/test/io/ktor/test/DeterministicFailureGuardTest.kt
+++ b/ktor-shared/ktor-test-base/common/test/io/ktor/test/DeterministicFailureGuardTest.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2014-2026 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.test
+
+import kotlin.test.Test
+import kotlin.test.assertFails
+import kotlin.test.assertFalse
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
+
+class DeterministicFailureGuardTest {
+
+    @Test
+    fun `assertion failure is replayed instead of retried`() {
+        val guard = DeterministicFailureGuard()
+        val cause = AssertionError("deterministic")
+
+        guard.record(cause)
+
+        assertTrue(guard.hasFailure)
+        val replayed = assertFails { guard.failFast() }
+        assertSame(cause, replayed, "The recorded failure should be re-thrown as is")
+    }
+
+    @Test
+    fun `transient failure stays retryable`() {
+        val guard = DeterministicFailureGuard()
+
+        guard.record(IllegalStateException("connection reset"))
+
+        assertFalse(guard.hasFailure)
+        guard.failFast() // Doesn't throw, so the next attempt runs the test body again.
+    }
+}

--- a/ktor-shared/ktor-test-base/common/test/io/ktor/test/EventuallyTest.kt
+++ b/ktor-shared/ktor-test-base/common/test/io/ktor/test/EventuallyTest.kt
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2014-2026 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.test
+
+import kotlinx.coroutines.test.TestResult
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertContains
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
+import kotlin.time.TimeSource
+
+class EventuallyTest {
+
+    @Test
+    fun `returns without waiting when the condition already holds`(): TestResult = runTest {
+        var evaluations = 0
+
+        assertEventually("an already satisfied condition") { evaluations++ >= 0 }
+
+        assertEquals(1, evaluations, "The condition should be evaluated once and not polled again")
+    }
+
+    @Test
+    fun `polls until the condition becomes true`(): TestResult = runTest {
+        var remaining = 3
+
+        assertEventually("the counter to reach zero", timeout = 5.seconds, interval = 1.milliseconds) {
+            remaining-- == 0
+        }
+
+        assertEquals(-1, remaining, "Polling should stop on the attempt that satisfies the condition")
+    }
+
+    @Test
+    fun `fails with the description when the condition never holds`(): TestResult = runTest {
+        val error = assertFailsWith<AssertionError> {
+            assertEventually("something that never happens", timeout = 50.milliseconds, interval = 1.milliseconds) {
+                false
+            }
+        }
+
+        assertContains(error.message.orEmpty(), "something that never happens")
+    }
+
+    @Test
+    fun `evaluates the condition at least once with a zero timeout`(): TestResult = runTest {
+        var evaluations = 0
+
+        assertEventually("an immediately satisfied condition", timeout = Duration.ZERO) { evaluations++ >= 0 }
+
+        assertEquals(1, evaluations)
+    }
+
+    @Test
+    fun `waits in real time so the virtual clock does not skip the poll interval`(): TestResult = runTest {
+        val start = TimeSource.Monotonic.markNow()
+
+        val error = assertFailsWith<AssertionError> {
+            assertEventually("never", timeout = 100.milliseconds, interval = 20.milliseconds) { false }
+        }
+
+        // Inside `runTest` a virtual `delay` would return instantly, making this a busy loop that
+        // still eventually fails. Asserting real elapsed time is what distinguishes the two.
+        val elapsed = start.elapsedNow()
+        assertContains(error.message.orEmpty(), "never")
+        assertTrue(elapsed >= 100.milliseconds, "Expected a real wait, but only $elapsed elapsed")
+    }
+}

--- a/ktor-shared/ktor-test-base/common/test/io/ktor/test/EventuallyTest.kt
+++ b/ktor-shared/ktor-test-base/common/test/io/ktor/test/EventuallyTest.kt
@@ -4,12 +4,12 @@
 
 package io.ktor.test
 
-import kotlinx.coroutines.test.TestResult
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertContains
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
@@ -19,7 +19,7 @@ import kotlin.time.TimeSource
 class EventuallyTest {
 
     @Test
-    fun `returns without waiting when the condition already holds`(): TestResult = runTest {
+    fun `returns without waiting when the condition already holds`() = runTest {
         var evaluations = 0
 
         assertEventually("an already satisfied condition") { evaluations++ >= 0 }
@@ -28,7 +28,7 @@ class EventuallyTest {
     }
 
     @Test
-    fun `polls until the condition becomes true`(): TestResult = runTest {
+    fun `polls until the condition becomes true`() = runTest {
         var remaining = 3
 
         assertEventually("the counter to reach zero", timeout = 5.seconds, interval = 1.milliseconds) {
@@ -39,8 +39,8 @@ class EventuallyTest {
     }
 
     @Test
-    fun `fails with the description when the condition never holds`(): TestResult = runTest {
-        val error = assertFailsWith<AssertionError> {
+    fun `fails with the description when the condition never holds`() = runTest {
+        val error = assertFailsWith<EventuallyTimeoutException> {
             assertEventually("something that never happens", timeout = 50.milliseconds, interval = 1.milliseconds) {
                 false
             }
@@ -50,7 +50,7 @@ class EventuallyTest {
     }
 
     @Test
-    fun `evaluates the condition at least once with a zero timeout`(): TestResult = runTest {
+    fun `evaluates the condition at least once with a zero timeout`() = runTest {
         var evaluations = 0
 
         assertEventually("an immediately satisfied condition", timeout = Duration.ZERO) { evaluations++ >= 0 }
@@ -59,10 +59,35 @@ class EventuallyTest {
     }
 
     @Test
-    fun `waits in real time so the virtual clock does not skip the poll interval`(): TestResult = runTest {
+    fun `honors the timeout even when the interval is larger`() = runTest {
         val start = TimeSource.Monotonic.markNow()
 
-        val error = assertFailsWith<AssertionError> {
+        assertFailsWith<EventuallyTimeoutException> {
+            assertEventually("never", timeout = 100.milliseconds, interval = 5.seconds) { false }
+        }
+
+        // Without clamping the poll to the time remaining, the first delay would run the full 5s
+        // interval and blow through the 100ms upper bound this helper documents.
+        val elapsed = start.elapsedNow()
+        assertTrue(elapsed < 1.seconds, "Expected the wait to stop near the timeout, but $elapsed elapsed")
+    }
+
+    @Test
+    fun `timing out stays retryable rather than being classified deterministic`() {
+        val guard = DeterministicFailureGuard()
+
+        guard.record(EventuallyTimeoutException("Timed out after 1s waiting for something"))
+
+        // Waiting for a condition and running out of time is load-dependent, so the retry loop must
+        // get another attempt. An AssertionError here would make the guard replay it immediately.
+        assertFalse(guard.hasFailure, "An assertEventually timeout should not stop the retry loop")
+    }
+
+    @Test
+    fun `waits in real time so the virtual clock does not skip the poll interval`() = runTest {
+        val start = TimeSource.Monotonic.markNow()
+
+        val error = assertFailsWith<EventuallyTimeoutException> {
             assertEventually("never", timeout = 100.milliseconds, interval = 20.milliseconds) { false }
         }
 

--- a/ktor-shared/ktor-test-base/common/test/io/ktor/test/FlakyNameConventionTest.kt
+++ b/ktor-shared/ktor-test-base/common/test/io/ktor/test/FlakyNameConventionTest.kt
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2014-2026 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.test
+
+import kotlin.test.Test
+
+/**
+ * Fixture for the cross-platform `_flaky` name convention (see [Flaky]).
+ *
+ * Unlike the `@Flaky` annotation, which only JUnit can act on, the name token is filtered by Gradle
+ * on every target. This test therefore has no body: its purpose is to be *selected*, so that the
+ * filtering can be verified on Native/JS/Wasm as well as JVM.
+ *
+ * It must not run in a default test run, and must be the only test selected by
+ * `-Pktor.tests.flaky=only`.
+ */
+class FlakyNameConventionTest {
+
+    @Flaky("KTOR-9796")
+    @Test
+    fun nameTokenIsFilteredOnEveryTarget_flaky() = Unit
+}

--- a/ktor-shared/ktor-test-base/common/test/io/ktor/test/RunTestWithDataTest.kt
+++ b/ktor-shared/ktor-test-base/common/test/io/ktor/test/RunTestWithDataTest.kt
@@ -52,10 +52,27 @@ class RunTestWithDataTest {
             singleTestCase,
             retries = 3,
             test = { (_, retry) ->
-                if (retry < 3) fail("Retry #$retry")
+                if (retry < 3) transientFailure("Retry #$retry")
                 successfulRetry = retry
             },
             afterAll = { assertEquals(3, successfulRetry) },
+        )
+    }
+
+    @Test
+    fun testAssertionFailuresAreNotRetried(): TestResult {
+        var attempts = 0
+        return runTestWithData(
+            singleTestCase,
+            retries = 3,
+            test = {
+                attempts++
+                fail("Deterministic failure")
+            },
+            handleFailures = {
+                assertEquals(1, it.size)
+                assertEquals(1, attempts, "Assertion failures should not be retried")
+            },
         )
     }
 
@@ -107,7 +124,7 @@ class RunTestWithDataTest {
         timeout = singleTestDuration * 1.75,
         test = { (_, retry) ->
             realTimeDelay(singleTestDuration)
-            if (retry == 0) fail("Try again, please")
+            if (retry == 0) transientFailure("Try again, please")
         },
     )
 
@@ -151,7 +168,7 @@ class RunTestWithDataTest {
             },
             test = { (id, retry) ->
                 when (id) {
-                    1 -> if (retry == 0) fail("First attempt failed")
+                    1 -> if (retry == 0) transientFailure("First attempt failed")
                     2 -> if (retry == 0) realTimeDelay(singleTestDuration * 2)
                 }
             },
@@ -179,6 +196,9 @@ class RunTestWithDataTest {
 }
 
 private val singleTestCase = listOf(1)
+
+/** Simulates a transient (retryable) failure, as opposed to an assertion failure. */
+private fun transientFailure(message: String): Nothing = throw IllegalStateException(message)
 
 private suspend fun realTimeDelay(duration: Duration) {
     withContext(Dispatchers.Default.limitedParallelism(1)) { delay(duration) }

--- a/ktor-shared/ktor-test-base/jvm/resources/META-INF/services/org.junit.jupiter.api.extension.Extension
+++ b/ktor-shared/ktor-test-base/jvm/resources/META-INF/services/org.junit.jupiter.api.extension.Extension
@@ -1,0 +1,1 @@
+io.ktor.test.junit.FlakyTestCondition

--- a/ktor-shared/ktor-test-base/jvm/src/io/ktor/test/JvmInherited.jvm.kt
+++ b/ktor-shared/ktor-test-base/jvm/src/io/ktor/test/JvmInherited.jvm.kt
@@ -1,0 +1,7 @@
+/*
+ * Copyright 2014-2026 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.test
+
+actual typealias JvmInherited = java.lang.annotation.Inherited

--- a/ktor-shared/ktor-test-base/jvm/src/io/ktor/test/junit/FlakyTestCondition.kt
+++ b/ktor-shared/ktor-test-base/jvm/src/io/ktor/test/junit/FlakyTestCondition.kt
@@ -5,47 +5,12 @@
 package io.ktor.test.junit
 
 import io.ktor.test.Flaky
+import io.ktor.test.constants.FLAKY_MODE_PROPERTY
+import io.ktor.test.constants.FlakyTestsMode
 import org.junit.jupiter.api.extension.ConditionEvaluationResult
 import org.junit.jupiter.api.extension.ExecutionCondition
 import org.junit.jupiter.api.extension.ExtensionContext
 import org.junit.platform.commons.support.AnnotationSupport
-
-/** System property selecting how this run treats `@Flaky` tests. See [FlakyTestsMode]. */
-internal const val FLAKY_MODE_PROPERTY = "ktor.tests.flaky"
-
-/**
- * How a test run treats `@Flaky` tests, taken from the [FLAKY_MODE_PROPERTY] system property.
- *
- * Mirrors `FlakyTestsMode` in build-logic, which reads the same values from the Gradle property of
- * the same name and forwards them to test JVMs. The values are spelled out in both places because
- * build-logic isn't on the test classpath.
- */
-internal enum class FlakyTestsMode {
-    /** The default: `@Flaky` tests don't run. */
-    EXCLUDE,
-
-    /** Nightly: run `@Flaky` tests and nothing else, to track whether they still flip. */
-    ONLY,
-
-    /** Run everything, flaky included. */
-    ALL;
-
-    internal companion object {
-        fun of(value: String?): FlakyTestsMode = when (value) {
-            null, "", "exclude" -> EXCLUDE
-
-            "only" -> ONLY
-
-            "all" -> ALL
-
-            else -> error(
-                "Unexpected value '$value' of '$FLAKY_MODE_PROPERTY'. Expected one of: exclude, only, all."
-            )
-        }
-
-        fun current(): FlakyTestsMode = of(System.getProperty(FLAKY_MODE_PROPERTY))
-    }
-}
 
 /**
  * Excludes [Flaky]-annotated tests from the default run and includes them only when the
@@ -61,8 +26,14 @@ internal enum class FlakyTestsMode {
  * `@Flaky` on a common-source test method is honored without a per-test `@ExtendWith`.
  */
 class FlakyTestCondition : ExecutionCondition {
+
+    /**
+     * Read once: the property is fixed for the lifetime of the test JVM, and the condition is
+     * evaluated for every test in the module.
+     */
+    private val mode = FlakyTestsMode.of(System.getProperty(FLAKY_MODE_PROPERTY))
+
     override fun evaluateExecutionCondition(context: ExtensionContext): ConditionEvaluationResult {
-        val mode = FlakyTestsMode.current()
         val flaky = context.findFlaky()
 
         if (flaky == null) {
@@ -84,26 +55,15 @@ class FlakyTestCondition : ExecutionCondition {
         }
     }
 
-    /** Finds [Flaky] on the current test method, or on its class or any of its base classes. */
+    /**
+     * Finds [Flaky] on the current test method, or on its class or any of its base classes.
+     *
+     * The superclass lookup works because [Flaky] is meta-annotated `@JvmInherited`, which expands
+     * to `java.lang.annotation.Inherited` here: JUnit walks the superclass chain only for
+     * annotations carrying it. Without that, a test inheriting from an annotated base class — the
+     * shared test suite pattern used across Ktor — would silently keep running.
+     */
     private fun ExtensionContext.findFlaky(): Flaky? =
         AnnotationSupport.findAnnotation(element, Flaky::class.java).orElse(null)
-            ?: testClass.orElse(null)?.findFlakyInHierarchy()
-
-    /**
-     * Searches [Flaky] up the superclass chain.
-     *
-     * JUnit walks superclasses only for annotations meta-annotated with
-     * `java.lang.annotation.Inherited` (see `AnnotationUtils.findAnnotation`), which a Kotlin
-     * annotation declared in common code cannot be. That is why `@ExtendWith` on a base class is
-     * inherited but `@Flaky` isn't. Without this walk, tests inheriting from an annotated base
-     * class — the shared test suite pattern used across Ktor — would silently keep running.
-     */
-    private fun Class<*>.findFlakyInHierarchy(): Flaky? {
-        var type: Class<*>? = this
-        while (type != null && type != Any::class.java) {
-            AnnotationSupport.findAnnotation(type, Flaky::class.java).orElse(null)?.let { return it }
-            type = type.superclass
-        }
-        return null
-    }
+            ?: testClass.orElse(null)?.let { AnnotationSupport.findAnnotation(it, Flaky::class.java).orElse(null) }
 }

--- a/ktor-shared/ktor-test-base/jvm/src/io/ktor/test/junit/FlakyTestCondition.kt
+++ b/ktor-shared/ktor-test-base/jvm/src/io/ktor/test/junit/FlakyTestCondition.kt
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2014-2026 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.test.junit
+
+import io.ktor.test.Flaky
+import org.junit.jupiter.api.extension.ConditionEvaluationResult
+import org.junit.jupiter.api.extension.ExecutionCondition
+import org.junit.jupiter.api.extension.ExtensionContext
+import org.junit.platform.commons.support.AnnotationSupport
+
+/** System property selecting how this run treats `@Flaky` tests. See [FlakyTestsMode]. */
+internal const val FLAKY_MODE_PROPERTY = "ktor.tests.flaky"
+
+/**
+ * How a test run treats `@Flaky` tests, taken from the [FLAKY_MODE_PROPERTY] system property.
+ *
+ * Mirrors `FlakyTestsMode` in build-logic, which reads the same values from the Gradle property of
+ * the same name and forwards them to test JVMs. The values are spelled out in both places because
+ * build-logic isn't on the test classpath.
+ */
+internal enum class FlakyTestsMode {
+    /** The default: `@Flaky` tests don't run. */
+    EXCLUDE,
+
+    /** Nightly: run `@Flaky` tests and nothing else, to track whether they still flip. */
+    ONLY,
+
+    /** Run everything, flaky included. */
+    ALL;
+
+    internal companion object {
+        fun of(value: String?): FlakyTestsMode = when (value) {
+            null, "", "exclude" -> EXCLUDE
+
+            "only" -> ONLY
+
+            "all" -> ALL
+
+            else -> error(
+                "Unexpected value '$value' of '$FLAKY_MODE_PROPERTY'. Expected one of: exclude, only, all."
+            )
+        }
+
+        fun current(): FlakyTestsMode = of(System.getProperty(FLAKY_MODE_PROPERTY))
+    }
+}
+
+/**
+ * Excludes [Flaky]-annotated tests from the default run and includes them only when the
+ * [FLAKY_MODE_PROPERTY] system property asks for them:
+ *  - `exclude` (the default) — skip `@Flaky` tests, run everything else.
+ *  - `only` — run **only** `@Flaky` tests, skipping everything else (the `flakyTest` nightly task,
+ *    so it samples the quarantined tests without dragging the whole JVM suite along).
+ *  - `all` — run the full suite with `@Flaky` tests included.
+ *
+ * Mirrors `StressTestCondition`, but is annotation-driven and auto-registered via JUnit
+ * extension autodetection (see `META-INF/services/org.junit.jupiter.api.extension.Extension`
+ * and `junit.jupiter.extensions.autodetection.enabled` in build-logic `JvmConfig`), so
+ * `@Flaky` on a common-source test method is honored without a per-test `@ExtendWith`.
+ */
+class FlakyTestCondition : ExecutionCondition {
+    override fun evaluateExecutionCondition(context: ExtensionContext): ConditionEvaluationResult {
+        val mode = FlakyTestsMode.current()
+        val flaky = context.findFlaky()
+
+        if (flaky == null) {
+            return when {
+                mode != FlakyTestsMode.ONLY -> ConditionEvaluationResult.enabled("Not a @Flaky test")
+
+                context.testMethod.isPresent ->
+                    ConditionEvaluationResult.disabled("Only @Flaky tests requested ($FLAKY_MODE_PROPERTY=only)")
+
+                else ->
+                    ConditionEvaluationResult.enabled("Container kept for its @Flaky tests ($FLAKY_MODE_PROPERTY=only)")
+            }
+        }
+
+        return if (mode == FlakyTestsMode.EXCLUDE) {
+            ConditionEvaluationResult.disabled("@Flaky test excluded (${flaky.ticket})")
+        } else {
+            ConditionEvaluationResult.enabled("Flaky tests enabled (${flaky.ticket})")
+        }
+    }
+
+    /** Finds [Flaky] on the current test method, or on its class or any of its base classes. */
+    private fun ExtensionContext.findFlaky(): Flaky? =
+        AnnotationSupport.findAnnotation(element, Flaky::class.java).orElse(null)
+            ?: testClass.orElse(null)?.findFlakyInHierarchy()
+
+    /**
+     * Searches [Flaky] up the superclass chain.
+     *
+     * JUnit walks superclasses only for annotations meta-annotated with
+     * `java.lang.annotation.Inherited` (see `AnnotationUtils.findAnnotation`), which a Kotlin
+     * annotation declared in common code cannot be. That is why `@ExtendWith` on a base class is
+     * inherited but `@Flaky` isn't. Without this walk, tests inheriting from an annotated base
+     * class — the shared test suite pattern used across Ktor — would silently keep running.
+     */
+    private fun Class<*>.findFlakyInHierarchy(): Flaky? {
+        var type: Class<*>? = this
+        while (type != null && type != Any::class.java) {
+            AnnotationSupport.findAnnotation(type, Flaky::class.java).orElse(null)?.let { return it }
+            type = type.superclass
+        }
+        return null
+    }
+}

--- a/ktor-shared/ktor-test-base/jvm/test/io/ktor/test/FlakyConventionTest.kt
+++ b/ktor-shared/ktor-test-base/jvm/test/io/ktor/test/FlakyConventionTest.kt
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2014-2026 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.test
+
+import com.lemonappdev.konsist.api.Konsist
+import com.lemonappdev.konsist.api.declaration.KoFunctionDeclaration
+import com.lemonappdev.konsist.api.verify.assertTrue
+import io.ktor.test.constants.FLAKY_NAME_TOKEN
+import kotlin.test.Test
+
+/** Simple name of [Flaky], matched textually — see [isFlaky]. */
+private const val FLAKY_ANNOTATION = "Flaky"
+
+/**
+ * Enforces that the two flaky-test selectors agree wherever both apply.
+ *
+ * `@Flaky` is acted on by `FlakyTestCondition`, which needs a JUnit Platform and so exists only on
+ * the JVM; the [FLAKY_NAME_TOKEN] suffix is filtered by Gradle on every target. A test compiled for
+ * any non-JVM target therefore needs both, and one without the other silently does the wrong thing:
+ * an annotation alone leaves the test running in the default Native/JS/Wasm suites, and a name token
+ * alone leaves it running in the default JVM suite.
+ *
+ * Only `jvm/test` is exempt, because nothing there is compiled for another target. Everything else —
+ * `common/test`, `jvmAndPosix/test`, `android/test` and the rest — is checked. Android host tests
+ * are `Test` tasks that never receive the condition, so they need the token as well.
+ */
+class FlakyConventionTest {
+
+    @Test
+    fun `Flaky annotation and name token agree outside jvm-only test sources`() {
+        val functions = nonJvmTestFunctions()
+
+        functions
+            .filter { it.isFlaky() }
+            .assertTrue(
+                additionalMessage = "A @Flaky test compiled for a non-JVM target also needs the " +
+                    "'$FLAKY_NAME_TOKEN' name token, which is the only selector those targets have.",
+            ) { it.name.endsWith(FLAKY_NAME_TOKEN) }
+
+        functions
+            .filter { it.name.endsWith(FLAKY_NAME_TOKEN) }
+            .assertTrue(
+                additionalMessage = "A test named '*$FLAKY_NAME_TOKEN' also needs @Flaky, which is " +
+                    "what keeps it out of the default JVM run and records the tracking ticket.",
+            ) { it.isFlaky() }
+    }
+
+    /**
+     * Test functions from every test source set except the JVM-only one.
+     *
+     * The repository uses a flattened, platform-centric source layout (`<module>/<platform>/test`),
+     * so source sets are selected by path rather than by Konsist's `scopeFromSourceSet`, which
+     * expects the conventional `src/<name>` directories.
+     */
+    private fun nonJvmTestFunctions(): List<KoFunctionDeclaration> = Konsist
+        .scopeFromProject()
+        .files
+        .filter { "/test/" in it.path && "/jvm/test/" !in it.path }
+        .flatMap { it.functions(includeNested = true) }
+}
+
+/**
+ * Whether the function carries [Flaky], matched by simple name.
+ *
+ * Konsist's `hasAnnotationOf` resolves the annotation through the file's imports, so it misses uses
+ * that need no import — such as the tests in this module, which share [Flaky]'s package.
+ */
+private fun KoFunctionDeclaration.isFlaky(): Boolean = annotations.any { it.name == FLAKY_ANNOTATION }

--- a/ktor-shared/ktor-test-base/jvm/test/io/ktor/test/junit/FlakyTestConditionTest.kt
+++ b/ktor-shared/ktor-test-base/jvm/test/io/ktor/test/junit/FlakyTestConditionTest.kt
@@ -5,6 +5,8 @@
 package io.ktor.test.junit
 
 import io.ktor.test.Flaky
+import io.ktor.test.constants.FLAKY_MODE_PROPERTY
+import io.ktor.test.constants.FlakyTestsMode
 import kotlin.test.Test
 import kotlin.test.assertTrue
 
@@ -25,7 +27,7 @@ private const val SELF_TEST_TICKET = "KTOR-9796"
 private fun assertDisabledUnlessFlakyEnabled() {
     // Mirrors FlakyTestCondition: a @Flaky test runs only in `only` mode (the flakyTest task) or
     // `all` mode (the full suite, flaky included).
-    val mode = FlakyTestsMode.current()
+    val mode = FlakyTestsMode.of(System.getProperty(FLAKY_MODE_PROPERTY))
     assertTrue(
         mode != FlakyTestsMode.EXCLUDE,
         "This test is annotated @Flaky, so FlakyTestCondition must have disabled it, but it ran " +
@@ -40,7 +42,7 @@ abstract class FlakyBaseClassFixture {
     fun `class-level Flaky is inherited by subclasses`() = assertDisabledUnlessFlakyEnabled()
 }
 
-/** Kotlin annotations aren't `@Inherited`, so this case needs JUnit's annotation lookup. */
+/** Covers `@Flaky` being meta-annotated `@JvmInherited`, which is what makes JUnit look here. */
 class FlakyInheritedClassTest : FlakyBaseClassFixture()
 
 class FlakyAnnotatedMethodTest {

--- a/ktor-shared/ktor-test-base/jvm/test/io/ktor/test/junit/FlakyTestConditionTest.kt
+++ b/ktor-shared/ktor-test-base/jvm/test/io/ktor/test/junit/FlakyTestConditionTest.kt
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2014-2026 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.test.junit
+
+import io.ktor.test.Flaky
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+/**
+ * Ticket used by the fixtures below. These tests aren't actually flaky: they exist to verify that
+ * [FlakyTestCondition] disables `@Flaky` tests, so they need the annotation to be under test.
+ */
+private const val SELF_TEST_TICKET = "KTOR-9796"
+
+/**
+ * Asserts that this test runs only when flaky tests are enabled.
+ *
+ * Each fixture below is annotated `@Flaky`, so [FlakyTestCondition] must disable it in the default
+ * `jvmTest` run and enable it in `flakyTest`. Asserting the property is set therefore succeeds in
+ * `flakyTest` and, should the condition ever stop recognizing the annotation, fails in `jvmTest`
+ * with the message below instead of passing silently.
+ */
+private fun assertDisabledUnlessFlakyEnabled() {
+    // Mirrors FlakyTestCondition: a @Flaky test runs only in `only` mode (the flakyTest task) or
+    // `all` mode (the full suite, flaky included).
+    val mode = FlakyTestsMode.current()
+    assertTrue(
+        mode != FlakyTestsMode.EXCLUDE,
+        "This test is annotated @Flaky, so FlakyTestCondition must have disabled it, but it ran " +
+            "with $FLAKY_MODE_PROPERTY=${System.getProperty(FLAKY_MODE_PROPERTY)}. Is the Extension " +
+            "service file in jvm/resources/META-INF/services missing?",
+    )
+}
+
+@Flaky(SELF_TEST_TICKET)
+abstract class FlakyBaseClassFixture {
+    @Test
+    fun `class-level Flaky is inherited by subclasses`() = assertDisabledUnlessFlakyEnabled()
+}
+
+/** Kotlin annotations aren't `@Inherited`, so this case needs JUnit's annotation lookup. */
+class FlakyInheritedClassTest : FlakyBaseClassFixture()
+
+class FlakyAnnotatedMethodTest {
+    @Flaky(SELF_TEST_TICKET)
+    @Test
+    fun `method-level Flaky is honored`() = assertDisabledUnlessFlakyEnabled()
+}

--- a/ktor-shared/ktor-test-base/jvmAndPosix/src/io/ktor/test/TestResult.jvmAndPosix.kt
+++ b/ktor-shared/ktor-test-base/jvmAndPosix/src/io/ktor/test/TestResult.jvmAndPosix.kt
@@ -25,7 +25,11 @@ internal actual inline fun <T> runTestForEach(items: Iterable<T>, test: (T) -> T
     return DummyTestResult
 }
 
-actual inline fun retryTest(retries: Int, test: (Int) -> TestResult): TestResult {
+actual inline fun retryTest(
+    retries: Int,
+    shouldRetry: (Throwable) -> Boolean,
+    test: (Int) -> TestResult,
+): TestResult {
     check(retries >= 0) { "Retries count shouldn't be negative but it is $retries" }
 
     lateinit var lastCause: Throwable
@@ -33,6 +37,7 @@ actual inline fun retryTest(retries: Int, test: (Int) -> TestResult): TestResult
         try {
             return test(attempt)
         } catch (cause: Throwable) {
+            if (!shouldRetry(cause)) throw cause
             lastCause = cause
         }
     }

--- a/ktor-shared/ktor-test-base/jvmAndPosix/test/io/ktor/test/RetryTestTest.kt
+++ b/ktor-shared/ktor-test-base/jvmAndPosix/test/io/ktor/test/RetryTestTest.kt
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2014-2026 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.test
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFails
+import kotlin.test.assertSame
+
+/**
+ * Covers `retryTest`'s loop control on the targets whose actual runs the attempts synchronously.
+ *
+ * The web actual chains promises instead, so a test lambda that throws synchronously — the only way
+ * to provoke a failure without a real `runTest` — never reaches its `catch` links and would prove
+ * nothing there. Its behavior is exercised through `BaseTest` in the server test suites.
+ */
+class RetryTestTest {
+
+    @Test
+    fun `stops on the attempt that recorded a deterministic failure`() {
+        val guard = DeterministicFailureGuard()
+        val cause = AssertionError("deterministic")
+        var attempts = 0
+
+        val thrown = assertFails {
+            retryTest(retries = 3, shouldRetry = { !guard.hasFailure }) { _ ->
+                attempts++
+                guard.record(cause)
+                throw cause
+            }
+        }
+
+        // Without the predicate the loop would run all four attempts to reach a verdict the first
+        // one already produced.
+        assertEquals(1, attempts, "A deterministic failure should not be attempted again")
+        assertSame(cause, thrown, "The recorded failure should surface as is")
+    }
+
+    @Test
+    fun `keeps retrying transient failures`() {
+        var attempts = 0
+
+        retryTest(retries = 3) { _ ->
+            attempts++
+            if (attempts < 3) throw IllegalStateException("connection reset")
+            DummyTestResult
+        }
+
+        assertEquals(3, attempts, "Transient failures should be retried until one succeeds")
+    }
+
+    @Test
+    fun `exhausts the retries and rethrows the last failure`() {
+        var attempts = 0
+
+        val thrown = assertFails {
+            retryTest(retries = 2) { attempt ->
+                attempts++
+                throw IllegalStateException("attempt $attempt")
+            }
+        }
+
+        assertEquals(3, attempts, "One initial attempt plus two retries")
+        assertEquals("attempt 2", thrown.message)
+    }
+}

--- a/ktor-shared/ktor-test-base/nonJvm/src/io/ktor/test/JvmInherited.nonJvm.kt
+++ b/ktor-shared/ktor-test-base/nonJvm/src/io/ktor/test/JvmInherited.nonJvm.kt
@@ -1,0 +1,10 @@
+/*
+ * Copyright 2014-2026 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.test
+
+/** No target outside the JVM has a notion of annotation inheritance, so this carries no behavior. */
+@Target(AnnotationTarget.ANNOTATION_CLASS)
+@Retention(AnnotationRetention.RUNTIME)
+actual annotation class JvmInherited actual constructor()

--- a/ktor-shared/ktor-test-base/web/src/io/ktor/test/TestResult.web.kt
+++ b/ktor-shared/ktor-test-base/web/src/io/ktor/test/TestResult.web.kt
@@ -14,9 +14,17 @@ internal actual inline fun testWithRecover(
 internal actual inline fun <T> runTestForEach(items: Iterable<T>, crossinline test: (T) -> TestResult): TestResult =
     items.fold(DummyTestResult) { acc, item -> acc.andThen { test(item) } }
 
-actual inline fun retryTest(retries: Int, crossinline test: (Int) -> TestResult): TestResult {
+actual inline fun retryTest(
+    retries: Int,
+    crossinline shouldRetry: (Throwable) -> Boolean,
+    crossinline test: (Int) -> TestResult,
+): TestResult {
     check(retries >= 0) { "Retries count shouldn't be negative but it is $retries" }
-    return (1..retries).fold(test(0)) { acc, retry -> acc.catch { test(retry) } }
+    // Rethrowing rejects the promise, which the remaining `catch` links pass along untouched — the
+    // web equivalent of breaking out of the loop.
+    return (1..retries).fold(test(0)) { acc, retry ->
+        acc.catch { cause -> if (shouldRetry(cause)) test(retry) else throw cause }
+    }
 }
 
 @PublishedApi

--- a/ktor-shared/ktor-test-constants/build.gradle.kts
+++ b/ktor-shared/ktor-test-constants/build.gradle.kts
@@ -1,0 +1,9 @@
+/*
+ * Copyright 2014-2026 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+description = "Constants shared between the Ktor build and the Ktor test infrastructure"
+
+plugins {
+    id("ktorbuild.project.internal")
+}

--- a/ktor-shared/ktor-test-constants/common/src/io/ktor/test/constants/FlakyTestsMode.kt
+++ b/ktor-shared/ktor-test-constants/common/src/io/ktor/test/constants/FlakyTestsMode.kt
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2014-2026 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.test.constants
+
+/**
+ * Name token marking a test as flaky on every target.
+ *
+ * The `@Flaky` annotation is enforced by a JUnit `ExecutionCondition`, and there is no JUnit
+ * Platform on Native/JS/Wasm. A token in the test or class name is the one selector that works
+ * everywhere, because Gradle test filtering applies to every test task.
+ */
+const val FLAKY_NAME_TOKEN = "_flaky"
+
+/**
+ * Selects how a test run treats flaky tests.
+ *
+ * The build reads it as a Gradle property (`-Pktor.tests.flaky=only`) and forwards it to test JVMs
+ * as a system property of the same name, so there is one spelling to remember for both selectors.
+ */
+const val FLAKY_MODE_PROPERTY = "ktor.tests.flaky"
+
+/** How a test run treats flaky tests, as selected by [FLAKY_MODE_PROPERTY]. */
+enum class FlakyTestsMode {
+    /** The default: flaky tests don't run. */
+    EXCLUDE,
+
+    /** Nightly: run flaky tests and nothing else, to track whether they still flip. */
+    ONLY,
+
+    /** Run everything, flaky included. */
+    ALL;
+
+    /** The [FLAKY_MODE_PROPERTY] value denoting this mode, as accepted by [of]. */
+    val propertyValue: String get() = name.lowercase()
+
+    companion object {
+        /** Parses a [FLAKY_MODE_PROPERTY] value, treating a missing or blank one as [EXCLUDE]. */
+        fun of(value: String?): FlakyTestsMode = when (value) {
+            null, "", "exclude" -> EXCLUDE
+
+            "only" -> ONLY
+
+            "all" -> ALL
+
+            else -> error(
+                "Unexpected value '$value' of '$FLAKY_MODE_PROPERTY'. Expected one of: exclude, only, all."
+            )
+        }
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -184,6 +184,7 @@ projects {
         +"ktor-websocket-serialization"
         +"ktor-websockets"
         +"ktor-test-base"
+        +"ktor-test-constants"
         +"ktor-openapi-schema" including {
             +"ktor-openapi-schema-reflect"
         }


### PR DESCRIPTION
**Subsystem**

 Test Infrastructure — `build-logic`, `ktor-test-base` (`common`, `jvm`), `ktor-server-test-base`                                                                  
  (`common`, `jvm`, `nonJvm`).

**Motivation**

  KTOR-9796, part of the epic KTOR-9789.                                                                                                                            
                                                                                                                                                                    
  A 28-day cross-source analysis found ~840 flaky and 619 failed test-executions across ~4,091 builds. 
  They collapse into ~8 cross-cutting patterns rather than ~50 independent bad tests, and two habits kept them alive:                                                                                            
                                                                                                                                                                    
  - **`@Ignore("flaky")`** — the test disappears from every report, so nobody learns whether it still                                                               
    flips or whether the underlying bug got fixed. Several had been disabled for over a year.                                                                       
  - **Blanket `retries = 3..10`** — retries apply to *any* failure, so a deterministic assertion                                                                    
    failure is re-run and eventually reported as "flaky", masking a real bug.                                                                                       
                                                                                                                                                                    
  There was also no shared primitive for "wait until", so liveness assertions checked state the instant                                                             
  a call returned.                                                                                                                                                  
                                                                                                                                                                    
  This is the infrastructure half of #5833, extracted on review request so it can be reviewed and                                                                   
  merged ahead of the per-test changes. It adds primitives and build wiring only — **no test is                                                                     
  quarantined by this PR**, so `flakyTest` currently selects just the three self-test fixtures.
  
  **Solution**

  Covers the five work items of KTOR-9796.                                                                                                                          
                                                                                                                                                                    
  *1. Transient-only retry*                                                                                                                                         
                                                                                                                                                                    
  `DeterministicFailureGuard` classifies an `AssertionError` thrown by the test body as deterministic:                                                              
  it is reported by the first attempt instead of being retried. `runTest`'s own timeout error stays                                                                 
  retryable, since it is thrown *around* the body rather than by it. Wired into `runTestWithData` and                                                               
  into `BaseTest.runTest` on both JVM and non-JVM. `DEFAULT_RETRIES` is unchanged (`0` on JVM, `1`                                                                  
  elsewhere).                                                                                                                                                       
                                                                                                                                                                    
  *2. `@Flaky(ticket)`*                                                                                                                                             
                                                                                                                                                                    
  New annotation in `ktor-test-base`, requiring a YouTrack issue. Flaky tests are excluded from the                                                                 
  default run but still **executed and reported** by a dedicated task, so they stay visible. Enforced                                                               
  on JVM by `FlakyTestCondition` (an `ExecutionCondition` modelled on the existing                                                                                  
  `StressTestCondition`), auto-registered through JUnit extension autodetection so `@Flaky` works on                                                                
  common-source tests without a per-test `@ExtendWith`. 

*3. Cross-platform selection by name*                                                                                                                             
                                                                                                                                                                    
  Native/JS/Wasm have no JUnit Platform, so selection there uses a `_flaky` name token, applied by                                                                  
  `FlakyTestsConfig` to every `AbstractTestTask`. `FlakyNameConventionTest` guards the convention.                                                                  
                                                                                                                                                                    
  *4. `flakyTest` task*                                                                                                                                             
                                                                                                                                                                    
  JVM-only, pins the mode to `only`, and sets `ignoreFailures = true`: a quarantined test flipping is                                                               
  the expected outcome, not a regression to block on. Failures still land in the reports and in                                                                     
  Develocity, which is where the flip rate is tracked.                                                                                                              
                                                                                                                                                                    
  Both selectors are driven by **one property, `ktor.tests.flaky`**, with the same three values as a                                                                
  Gradle property and as the system property JVM test tasks forward to the condition:

  | Invocation                                                | Runs                                |                                                               
  |-----------------------------------------------------------|-------------------------------------|                                                               
  | `./gradlew :module:jvmTest`                                | everything except flaky            |                                                               
  | `./gradlew :module:jsNodeTest -Pktor.tests.flaky=only`     | flaky only                         |                                                               
  | `./gradlew :module:macosArm64Test -Pktor.tests.flaky=all`  | everything, flaky included         |                                                               
  | `./gradlew :module:flakyTest`                              | `@Flaky` only, JVM (pins `only`)   |                                                               
                                                                                                                                                                    
  An unrecognized value fails at configuration time with the accepted values listed.                                                                                
                                                                                                                                                                    
  *5. `assertEventually`*                                                                                                                                           
                                                                                                                                                                    
  A real-time-delay polling helper in `ktor-test-base`, available to client and server tests alike,                                                                 
  with `DEFAULT_EVENTUALLY_TIMEOUT = 10s`. `waitForCondition` is left in place here; its call sites                                                                 
  migrate in the follow-up PR. 

**Known follow-ups** (kept out to keep this reviewable, all raised in #5833 review) 
                                                                              
  Cache the system property in `FlakyTestCondition`; express `@Flaky` as `expect`/`actual` or add a                                                                 
  `@JvmInherited` alias instead of walking the superclass chain by hand; use Konsist for the naming                                                                 
  rule; share `FLAKY_NAME_TOKEN`/`FlakyTestsMode` between build-logic and `ktor-test-base` via an                                                                   
  included module; `outputs.upToDateWhen { false }` on `flakyTest`; extract the JVM/nonJvm `BaseTest`                                                               
  duplication; and an engine-scoped `clientTests(flaky = ...)` so a flake confined to one engine no                                                                 
  longer needs a duplicated test.


