### PR TITLE
Fix bottleneck in Netty pipelining

### DIFF
--- a/ktor-server/ktor-server-netty/api/ktor-server-netty.api
+++ b/ktor-server/ktor-server-netty/api/ktor-server-netty.api
@@ -85,6 +85,7 @@ public final class io/ktor/server/netty/NettyApplicationEngine$Configuration : i
 	public static synthetic fun enableHttp3$default (Lio/ktor/server/netty/NettyApplicationEngine$Configuration;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
 	public final fun getChannelPipelineConfig ()Lkotlin/jvm/functions/Function1;
 	public final fun getConfigureBootstrap ()Lkotlin/jvm/functions/Function1;
+	public final fun getDispatchCallStartOnIoExecutor ()Z
 	public final fun getEnableH2c ()Z
 	public final fun getEnableHttp2 ()Z
 	public final fun getHttpServerCodec ()Lkotlin/jvm/functions/Function0;
@@ -98,6 +99,7 @@ public final class io/ktor/server/netty/NettyApplicationEngine$Configuration : i
 	public final fun getTcpKeepAlive ()Z
 	public final fun setChannelPipelineConfig (Lkotlin/jvm/functions/Function1;)V
 	public final fun setConfigureBootstrap (Lkotlin/jvm/functions/Function1;)V
+	public final fun setDispatchCallStartOnIoExecutor (Z)V
 	public final fun setEnableH2c (Z)V
 	public final fun setEnableHttp2 (Z)V
 	public final fun setHttpServerCodec (Lkotlin/jvm/functions/Function0;)V
@@ -164,6 +166,7 @@ public final class io/ktor/server/netty/NettyChannelInitializer : io/netty/chann
 	public static final field Companion Lio/ktor/server/netty/NettyChannelInitializer$Companion;
 	public fun <init> (Lkotlin/jvm/functions/Function0;Lio/ktor/server/engine/EnginePipeline;Lio/ktor/server/application/ApplicationEnvironment;Lio/netty/util/concurrent/EventExecutorGroup;Lkotlin/coroutines/CoroutineContext;Lkotlin/coroutines/CoroutineContext;Lio/ktor/server/engine/EngineConnectorConfig;IIILkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;Z)V
 	public fun <init> (Lkotlin/jvm/functions/Function0;Lio/ktor/server/engine/EnginePipeline;Lio/ktor/server/application/ApplicationEnvironment;Lio/netty/util/concurrent/EventExecutorGroup;Lkotlin/coroutines/CoroutineContext;Lkotlin/coroutines/CoroutineContext;Lio/ktor/server/engine/EngineConnectorConfig;IIILkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;ZZ)V
+	public fun <init> (Lkotlin/jvm/functions/Function0;Lio/ktor/server/engine/EnginePipeline;Lio/ktor/server/application/ApplicationEnvironment;Lio/netty/util/concurrent/EventExecutorGroup;Lkotlin/coroutines/CoroutineContext;Lkotlin/coroutines/CoroutineContext;Lio/ktor/server/engine/EngineConnectorConfig;IIILkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;ZZZ)V
 	public synthetic fun initChannel (Lio/netty/channel/Channel;)V
 }
 

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyApplicationCall.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyApplicationCall.kt
@@ -62,7 +62,6 @@ public abstract class NettyApplicationCall(
     private val messageReleased = atomic(false)
 
     internal var isByteBufferContent = false
-    internal var isStreamingResponse = false
 
     /**
      * Returns http content object with [buf] content if [isByteBufferContent] is false,

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyApplicationCall.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyApplicationCall.kt
@@ -46,6 +46,8 @@ public abstract class NettyApplicationCall(
     public lateinit var responseWriteJob: Job
         private set
 
+    private lateinit var completableResponseWriteJob: CompletableJob
+
     /**
      * Initializes [responseWriteJob] as a child of the call's coroutine [Job]. Called synchronously
      * on the Netty I/O thread right after the call is constructed and before the user handler
@@ -56,7 +58,17 @@ public abstract class NettyApplicationCall(
         val callJob = coroutineContext[Job]
         val job = Job(parent = callJob)
         job.invokeOnCompletion { onResponseWriteCompleted() }
+        completableResponseWriteJob = job
         responseWriteJob = job
+    }
+
+    /**
+     * Marks [responseWriteJob] as successfully completed. Used on the normal (non-error) path once the
+     * response write has been dispatched, so completion goes through [CompletableJob.complete]'s fast
+     * path instead of the cancellation machinery that [Job.cancel] always incurs.
+     */
+    internal fun completeResponseWriteJob() {
+        completableResponseWriteJob.complete()
     }
 
     private val messageReleased = atomic(false)

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyApplicationEngine.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyApplicationEngine.kt
@@ -35,7 +35,6 @@ import io.netty.handler.codec.quic.QuicSslContext
 import io.netty.handler.codec.quic.QuicSslContextBuilder
 import kotlinx.coroutines.CompletableJob
 import kotlinx.coroutines.asCoroutineDispatcher
-import java.net.BindException
 import java.net.SocketOption
 import java.net.StandardSocketOptions
 import java.security.PrivateKey

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyApplicationEngine.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyApplicationEngine.kt
@@ -82,6 +82,16 @@ public class NettyApplicationEngine(
         public var shareWorkGroup: Boolean = false
 
         /**
+         * If set to `true`, the initial dispatch of a call's coroutine is scheduled directly on the
+         * channel's own I/O executor instead of the dedicated call event group, skipping a cross-thread
+         * hop for calls that complete without suspending.
+         *
+         * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.server.netty.NettyApplicationEngine.Configuration.dispatchCallStartOnIoExecutor)
+         */
+        @ExperimentalKtorApi
+        public var dispatchCallStartOnIoExecutor: Boolean = false
+
+        /**
          * User-provided function to configure Netty's [ServerBootstrap]
          *
          * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.server.netty.NettyApplicationEngine.Configuration.configureBootstrap)
@@ -272,6 +282,7 @@ public class NettyApplicationEngine(
                     NettyDispatcher +
                     DefaultUncaughtExceptionHandler(environment.log)
 
+            @OptIn(ExperimentalKtorApi::class)
             childHandler(
                 NettyChannelInitializer(
                     applicationProvider,
@@ -287,7 +298,8 @@ public class NettyApplicationEngine(
                     configuration.httpServerCodec,
                     configuration.channelPipelineConfig,
                     configuration.enableHttp2,
-                    configuration.enableH2c
+                    configuration.enableH2c,
+                    configuration.dispatchCallStartOnIoExecutor
                 )
             )
             if (configuration.tcpKeepAlive) {
@@ -402,6 +414,7 @@ public class NettyApplicationEngine(
             if (http3Configuration.udpSendBufferSize > 0) {
                 option(ChannelOption.SO_SNDBUF, http3Configuration.udpSendBufferSize)
             }
+            @OptIn(ExperimentalKtorApi::class)
             handler(
                 NettyHttp3ChannelInitializer(
                     applicationProvider,
@@ -411,7 +424,8 @@ public class NettyApplicationEngine(
                     configuration.runningLimit,
                     quicSslContext,
                     http3Configuration,
-                    useCodecDispatcher = http3SocketCount > 1
+                    useCodecDispatcher = http3SocketCount > 1,
+                    dispatchCallStartOnIoExecutor = configuration.dispatchCallStartOnIoExecutor
                 )
             )
         }

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyChannelInitializer.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyChannelInitializer.kt
@@ -193,7 +193,10 @@ public class NettyChannelInitializer(
             // handler is most effective as the first in the pipeline.
             addLast(
                 "flushConsolidation",
-                FlushConsolidationHandler(FlushConsolidationHandler.DEFAULT_EXPLICIT_FLUSH_AFTER_FLUSHES, true)
+                FlushConsolidationHandler(
+                    FlushConsolidationHandler.DEFAULT_EXPLICIT_FLUSH_AFTER_FLUSHES,
+                    false
+                )
             )
 
             when {

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyChannelInitializer.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyChannelInitializer.kt
@@ -187,18 +187,6 @@ public class NettyChannelInitializer(
 
     override fun initChannel(ch: SocketChannel) {
         with(ch.pipeline()) {
-            // Consolidates back-to-back flush() calls (e.g. from pipelined responses) into a
-            // single transport write. Added first so it sees every flush regardless of which
-            // protocol handler further up the pipeline issues it. See Netty's own KDoc: this
-            // handler is most effective as the first in the pipeline.
-            addLast(
-                "flushConsolidation",
-                FlushConsolidationHandler(
-                    FlushConsolidationHandler.DEFAULT_EXPLICIT_FLUSH_AFTER_FLUSHES,
-                    false
-                )
-            )
-
             when {
                 connector is EngineSSLConnectorConfig -> {
                     val sslEngine = sslContext!!.newEngine(ch.alloc()).apply {

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyChannelInitializer.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyChannelInitializer.kt
@@ -22,6 +22,7 @@ import io.netty.handler.codec.http2.Http2CodecUtil
 import io.netty.handler.codec.http2.Http2MultiplexCodecBuilder
 import io.netty.handler.codec.http2.Http2SecurityUtil
 import io.netty.handler.codec.http2.Http2ServerUpgradeCodec
+import io.netty.handler.flush.FlushConsolidationHandler
 import io.netty.handler.ssl.ApplicationProtocolConfig
 import io.netty.handler.ssl.ApplicationProtocolNames
 import io.netty.handler.ssl.ApplicationProtocolNegotiationHandler
@@ -143,6 +144,15 @@ public class NettyChannelInitializer(
 
     override fun initChannel(ch: SocketChannel) {
         with(ch.pipeline()) {
+            // Consolidates back-to-back flush() calls (e.g. from pipelined responses) into a
+            // single transport write. Added first so it sees every flush regardless of which
+            // protocol handler further up the pipeline issues it. See Netty's own KDoc: this
+            // handler is most effective as the first in the pipeline.
+            addLast(
+                "flushConsolidation",
+                FlushConsolidationHandler(FlushConsolidationHandler.DEFAULT_EXPLICIT_FLUSH_AFTER_FLUSHES, true)
+            )
+
             when {
                 connector is EngineSSLConnectorConfig -> {
                     val sslEngine = sslContext!!.newEngine(ch.alloc()).apply {

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyChannelInitializer.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyChannelInitializer.kt
@@ -202,17 +202,18 @@ public class NettyChannelInitializer(
                 // would reach Netty's tail handler and trigger "Discarded inbound message" warnings.
                 pipeline.addLast(NettyHttp2ConnectionSink)
                 pipeline.channel().closeFuture().addListener {
-                    handler.cancel()
+                    handler.onConnectionClose()
                 }
                 channelPipelineConfig(pipeline)
             }
 
             Http2CodecUtil.HTTP_UPGRADE_PROTOCOL_NAME.toString() -> {
+                val application = applicationProvider()
                 val handler = NettyHttp2Handler(
                     enginePipeline,
-                    applicationProvider(),
+                    application,
                     callEventGroup,
-                    userContext,
+                    application.coroutineContext + userContext,
                     runningLimit
                 )
 
@@ -271,7 +272,7 @@ public class NettyChannelInitializer(
                 })
 
                 pipeline.channel().closeFuture().addListener {
-                    handler.cancel()
+                    handler.onConnectionClose()
                 }
                 channelPipelineConfig(pipeline)
             }

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyChannelInitializer.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyChannelInitializer.kt
@@ -62,7 +62,8 @@ public class NettyChannelInitializer(
     private val httpServerCodec: () -> HttpServerCodec,
     private val channelPipelineConfig: ChannelPipeline.() -> Unit,
     private val enableHttp2: Boolean,
-    private val enableH2c: Boolean
+    private val enableH2c: Boolean,
+    private val dispatchCallStartOnIoExecutor: Boolean
 ) : ChannelInitializer<SocketChannel>() {
     private var sslContext: SslContext? = null
 
@@ -104,6 +105,48 @@ public class NettyChannelInitializer(
         channelPipelineConfig = channelPipelineConfig,
         enableHttp2 = enableHttp2,
         enableH2c = false
+    )
+
+    @Deprecated(
+        message = "Use main constructor",
+        replaceWith = ReplaceWith(
+            "NettyChannelInitializer(" +
+                "applicationProvider, enginePipeline, environment, callEventGroup, engineContext, " +
+                "userContext, connector, runningLimit, responseWriteTimeout, requestReadTimeout, " +
+                "httpServerCodec, channelPipelineConfig, enableHttp2, enableH2c, dispatchCallStartOnIoExecutor)"
+        )
+    )
+    public constructor(
+        applicationProvider: () -> Application,
+        enginePipeline: EnginePipeline,
+        environment: ApplicationEnvironment,
+        callEventGroup: EventExecutorGroup,
+        engineContext: CoroutineContext,
+        userContext: CoroutineContext,
+        connector: EngineConnectorConfig,
+        runningLimit: Int,
+        responseWriteTimeout: Int,
+        requestReadTimeout: Int,
+        httpServerCodec: () -> HttpServerCodec,
+        channelPipelineConfig: ChannelPipeline.() -> Unit,
+        enableHttp2: Boolean,
+        enableH2c: Boolean,
+    ) : this(
+        applicationProvider = applicationProvider,
+        enginePipeline = enginePipeline,
+        environment = environment,
+        callEventGroup = callEventGroup,
+        engineContext = engineContext,
+        userContext = userContext,
+        connector = connector,
+        runningLimit = runningLimit,
+        responseWriteTimeout = responseWriteTimeout,
+        requestReadTimeout = requestReadTimeout,
+        httpServerCodec = httpServerCodec,
+        channelPipelineConfig = channelPipelineConfig,
+        enableHttp2 = enableHttp2,
+        enableH2c = enableH2c,
+        dispatchCallStartOnIoExecutor = false
     )
 
     init {
@@ -193,7 +236,8 @@ public class NettyChannelInitializer(
                     application,
                     callEventGroup,
                     application.coroutineContext + userContext,
-                    runningLimit
+                    runningLimit,
+                    dispatchCallStartOnIoExecutor
                 )
 
                 pipeline.addLast(Http2MultiplexCodecBuilder.forServer(handler).build())
@@ -214,7 +258,8 @@ public class NettyChannelInitializer(
                     application,
                     callEventGroup,
                     application.coroutineContext + userContext,
-                    runningLimit
+                    runningLimit,
+                    dispatchCallStartOnIoExecutor
                 )
 
                 val multiplexHandler = Http2MultiplexCodecBuilder.forServer(handler).build()
@@ -251,7 +296,8 @@ public class NettyChannelInitializer(
                             callEventGroup,
                             engineContext,
                             userContext,
-                            runningLimit
+                            runningLimit,
+                            dispatchCallStartOnIoExecutor
                         )
 
                         if (requestReadTimeout > 0) {
@@ -285,7 +331,8 @@ public class NettyChannelInitializer(
                     callEventGroup,
                     engineContext,
                     userContext,
-                    runningLimit
+                    runningLimit,
+                    dispatchCallStartOnIoExecutor
                 )
 
                 with(pipeline) {

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyChannelInitializer.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyChannelInitializer.kt
@@ -287,7 +287,9 @@ public class NettyChannelInitializer(
                 // sink is a no-op.
                 pipeline.addLast(NettyHttp2ConnectionSink)
 
-                pipeline.addLast(object : SimpleChannelInboundHandler<HttpMessage>() {
+                // autoRelease = false: channelRead0 always forwards msg via fireChannelRead without
+                // retaining it first, so the default auto-release would drop its refCnt a second time.
+                pipeline.addLast(object : SimpleChannelInboundHandler<HttpMessage>(false) {
                     @Throws(Exception::class)
                     override fun channelRead0(ctx: ChannelHandlerContext, msg: HttpMessage) {
                         val pipe = ctx.pipeline()

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyHttpHandlerState.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyHttpHandlerState.kt
@@ -15,10 +15,12 @@ internal class NettyHttpHandlerState(private val runningLimit: Int) {
     internal val skippedRead: AtomicBoolean = atomic(false)
 
     internal fun onLastResponseMessage(context: ChannelHandlerContext) {
-        activeRequests.decrementAndGet()
-
-        if (skippedRead.compareAndSet(expect = false, update = true) && activeRequests.value < runningLimit) {
+        // always skip read when over limit
+        if (activeRequests.decrementAndGet() >= runningLimit) return
+        // read when skipped earlier
+        if (skippedRead.compareAndSet(expect = true, update = false)) {
             context.read()
         }
     }
+
 }

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyHttpHandlerState.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyHttpHandlerState.kt
@@ -7,7 +7,10 @@ package io.ktor.server.netty
 import io.netty.channel.*
 import kotlinx.atomicfu.*
 
-internal class NettyHttpHandlerState(private val runningLimit: Int) {
+internal class NettyHttpHandlerState(
+    private val runningLimit: Int,
+    private val onCapacityAvailable: (ChannelHandlerContext) -> Unit = {}
+) {
 
     internal val activeRequests: AtomicLong = atomic(0L)
     internal val isCurrentRequestFullyRead: AtomicBoolean = atomic(false)
@@ -21,6 +24,6 @@ internal class NettyHttpHandlerState(private val runningLimit: Int) {
         if (skippedRead.compareAndSet(expect = true, update = false)) {
             context.read()
         }
+        onCapacityAvailable(context)
     }
-
 }

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyHttpHandlerState.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyHttpHandlerState.kt
@@ -10,7 +10,6 @@ import kotlinx.atomicfu.*
 internal class NettyHttpHandlerState(private val runningLimit: Int) {
 
     internal val activeRequests: AtomicLong = atomic(0L)
-    internal val streamingResponses: AtomicLong = atomic(0L)
     internal val isCurrentRequestFullyRead: AtomicBoolean = atomic(false)
     internal val isChannelReadCompleted: AtomicBoolean = atomic(false)
     internal val skippedRead: AtomicBoolean = atomic(false)

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/cio/NettyHttpResponsePipeline.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/cio/NettyHttpResponsePipeline.kt
@@ -95,7 +95,11 @@ internal class NettyHttpResponsePipeline(
         } catch (actualException: Throwable) {
             respondWithFailure(call, actualException)
         } finally {
-            call.responseWriteJob.cancel()
+            // On the failure path above, responseWriteJob is already cancelled by respondWithFailure;
+            // completing it here again is then a no-op. On the (overwhelmingly common) success path,
+            // this is the actual completion signal, so it goes through complete()'s fast path rather
+            // than cancel()'s always-slow-path Finishing/exception-aggregation machinery.
+            call.completeResponseWriteJob()
         }
     }
 

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/cio/NettyHttpResponsePipeline.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/cio/NettyHttpResponsePipeline.kt
@@ -29,18 +29,17 @@ private const val UNFLUSHED_LIMIT = 65536
 /**
  * Contains methods for handling HTTP responses with Netty.
  *
- * The pipeline serializes response writes in request order, tracks active and streaming responses,
- * and flushes pending writes when the channel read cycle is complete and no non-streaming responses
- * are still active.
+ * The pipeline serializes response writes in request order and flushes pending writes once the
+ * channel read cycle is complete.
  *
  * @property context Netty channel context used to write, flush, read from, and close the channel.
- * @property httpHandlerState Shared state used to coordinate request counters, streaming counters,
- *                            read-completion state, and back-pressure decisions for the handler.
+ * @property httpHandlerState Shared state used to coordinate request counters, read-completion state,
+ *                            and back-pressure decisions for the handler.
  * @property coroutineContext Coroutine context used to launch response body writer coroutines.
  * @property onFailure Optional action invoked after a failed call's counters are decremented. For HTTP/2, this is
  *                     used to trigger [flushIfNeeded] on the most-recently-created pipeline (which may differ from
- *                     `this` due to the shared-handler-per-stream design), so that a pending flush blocked by the
- *                     stale counter is unblocked regardless of thread-scheduling order.
+ *                     `this` due to the shared-handler-per-stream design), so that any of its pending writes are
+ *                     flushed regardless of thread-scheduling order.
  */
 internal class NettyHttpResponsePipeline(
     private val context: ChannelHandlerContext,
@@ -65,14 +64,16 @@ internal class NettyHttpResponsePipeline(
     /** Flush if all is true:
      * - there is some unflushed data
      * - nothing to read from the channel
-     * - there are no active non-streaming requests
+     *
+     * Flushing never reorders already-written data (Netty's outbound buffer is FIFO), so it is always safe
+     * to flush as soon as the current read cycle is done, regardless of how many other requests on this
+     * connection are still being computed or written. Gating this on other requests being finished as well
+     * previously caused an already fully-written response to sit unflushed indefinitely whenever a
+     * still-pending sibling request (e.g. a pipelined HTTP/1.1 request, or a concurrent HTTP/2 stream) took
+     * a long time to complete.
      */
     internal fun flushIfNeeded() {
-        if (
-            isDataNotFlushed.value &&
-            httpHandlerState.isChannelReadCompleted.value &&
-            httpHandlerState.activeRequests.value == httpHandlerState.streamingResponses.value
-        ) {
+        if (isDataNotFlushed.value && httpHandlerState.isChannelReadCompleted.value) {
             context.flush()
             isDataNotFlushed.compareAndSet(expect = true, update = false)
         }
@@ -126,9 +127,6 @@ internal class NettyHttpResponsePipeline(
             else -> actualException
         }
 
-        if (call.isStreamingResponse) {
-            httpHandlerState.streamingResponses.decrementAndGet()
-        }
         httpHandlerState.activeRequests.decrementAndGet()
 
         flushIfNeeded()
@@ -170,9 +168,6 @@ internal class NettyHttpResponsePipeline(
             null
         }
 
-        if (call.isStreamingResponse) {
-            httpHandlerState.streamingResponses.decrementAndGet()
-        }
         httpHandlerState.onLastResponseMessage(context)
         call.finishedEvent.setSuccess()
 
@@ -224,9 +219,6 @@ internal class NettyHttpResponsePipeline(
             responseMessage is Http3HeadersFrame -> responseMessage.headers().getInt("content-length", -1)
             else -> -1
         }
-
-        call.isStreamingResponse = true
-        httpHandlerState.streamingResponses.incrementAndGet()
 
         launch(context.executor().asCoroutineDispatcher(), start = CoroutineStart.UNDISPATCHED) {
             respondWithBodyAndTrailerMessage(

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http1/NettyHttp1Handler.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http1/NettyHttp1Handler.kt
@@ -34,7 +34,8 @@ internal class NettyHttp1Handler(
     private val callEventGroup: EventExecutorGroup,
     private val engineContext: CoroutineContext,
     private val userContext: CoroutineContext,
-    private val runningLimit: Int
+    private val runningLimit: Int,
+    private val dispatchCallStartOnIoExecutor: Boolean = false
 ) : ChannelInboundHandlerAdapter() {
     private lateinit var handlerJob: CompletableJob
 
@@ -262,8 +263,12 @@ internal class NettyHttp1Handler(
         // early instead of buffering them, which is required when the client waits for response headers
         // before sending the request body.
         // Dispatching to the call event group also ensures user handler code does not run on the I/O worker
-        // event loop.
-        callExecutor.execute {
+        // event loop. When dispatchCallStartOnIoExecutor is enabled, calls that never suspend skip that
+        // hop entirely and run on the I/O thread instead; calls that do suspend still resume on
+        // callExecutor via NettyDispatcher, since callExecutor above is unconditionally what's captured
+        // in CurrentContext.
+        val startExecutor = if (dispatchCallStartOnIoExecutor) context.executor() else callExecutor
+        startExecutor.execute {
             val callScope = CoroutineScope(context = callContext)
             callScope.launch(start = CoroutineStart.UNDISPATCHED) {
                 try {

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http1/NettyHttp1Handler.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http1/NettyHttp1Handler.kt
@@ -18,6 +18,7 @@ import io.netty.channel.ChannelHandlerContext
 import io.netty.channel.ChannelInboundHandlerAdapter
 import io.netty.handler.codec.http.*
 import io.netty.handler.timeout.ReadTimeoutException
+import io.netty.util.ReferenceCountUtil
 import io.netty.util.concurrent.EventExecutorGroup
 import kotlinx.coroutines.*
 import java.io.IOException
@@ -35,13 +36,20 @@ internal class NettyHttp1Handler(
     private val userContext: CoroutineContext,
     private val runningLimit: Int
 ) : ChannelInboundHandlerAdapter() {
-    private val handlerJob = CompletableDeferred<Nothing>()
+    private lateinit var handlerJob: CompletableJob
 
     private var skipEmpty = false
 
     private lateinit var responseWriter: NettyHttpResponsePipeline
 
-    private val state = NettyHttpHandlerState(runningLimit)
+    private val state = NettyHttpHandlerState(runningLimit, onCapacityAvailable = ::drainPending)
+
+    // Decoded messages that arrived while activeRequests >= runningLimit. Netty's HTTP codec can decode
+    // and deliver many complete pipelined HttpRequest (and follow-up HttpContent) messages from a single
+    // physical socket read, all before callReadIfNeeded ever gets a chance to gate anything - so the only
+    // way to make runningLimit an actual hard cap is to buffer messages here instead of dispatching them,
+    // and replay them in order once a slot frees up. Access is confined to this channel's event loop.
+    private val pendingMessages = ArrayDeque<Any>()
 
     private val activeCalls = ConcurrentLinkedQueue<NettyHttp1ApplicationCall>()
 
@@ -65,6 +73,8 @@ internal class NettyHttp1Handler(
         }
         activated = true
 
+        handlerJob = SupervisorJob(applicationProvider().coroutineContext[Job])
+
         responseWriter = NettyHttpResponsePipeline(
             context = context,
             httpHandlerState = state,
@@ -86,16 +96,41 @@ internal class NettyHttp1Handler(
     }
 
     override fun channelRead(context: ChannelHandlerContext, message: Any) {
+        // These flags track the state of the *live* physical read cycle currently in progress, so they must
+        // only be touched here, for messages as they are actually decoded - never from drainPending, which
+        // replays messages decoded during a past, already-completed read cycle.
         if (message is LastHttpContent) {
             state.isCurrentRequestFullyRead.compareAndSet(expect = false, update = true)
         }
+        if (message is HttpRequest) {
+            if (message !is LastHttpContent) {
+                state.isCurrentRequestFullyRead.compareAndSet(expect = true, update = false)
+            }
+            state.isChannelReadCompleted.compareAndSet(expect = true, update = false)
+        }
 
+        // A pipelined connection can have several complete requests (and their body content) decoded from
+        // one physical read. HTTP/1.1 requests on a connection never interleave on the wire, so once one
+        // message has been deferred, every message after it - whether it's the rest of that request's body
+        // or the start of the next pipelined request - must stay queued in order until we catch up.
+        if (pendingMessages.isNotEmpty()) {
+            pendingMessages.addLast(message)
+            return
+        }
+        dispatchOrDefer(context, message)
+    }
+
+    private fun dispatchOrDefer(context: ChannelHandlerContext, message: Any) {
+        if (message is HttpRequest && state.activeRequests.value >= runningLimit) {
+            pendingMessages.addLast(message)
+            return
+        }
+        dispatchMessage(context, message)
+    }
+
+    private fun dispatchMessage(context: ChannelHandlerContext, message: Any) {
         when (message) {
             is HttpRequest -> {
-                if (message !is LastHttpContent) {
-                    state.isCurrentRequestFullyRead.compareAndSet(expect = true, update = false)
-                }
-                state.isChannelReadCompleted.compareAndSet(expect = true, update = false)
                 state.activeRequests.incrementAndGet()
 
                 handleRequest(context, message)
@@ -114,6 +149,20 @@ internal class NettyHttp1Handler(
         }
     }
 
+    /**
+     * Replays messages that were buffered by [dispatchOrDefer] while over [runningLimit], now that a slot
+     * has freed up. Stops as soon as the next queued message is a new request that would exceed the limit
+     * again, leaving it (and everything after it) queued for the next call.
+     */
+    private fun drainPending(context: ChannelHandlerContext) {
+        while (true) {
+            val next = pendingMessages.firstOrNull() ?: return
+            if (next is HttpRequest && state.activeRequests.value >= runningLimit) return
+            pendingMessages.removeFirst()
+            dispatchMessage(context, next)
+        }
+    }
+
     override fun channelInactive(context: ChannelHandlerContext) {
         onConnectionClose(context)
         context.fireChannelInactive()
@@ -123,19 +172,31 @@ internal class NettyHttp1Handler(
         if (context.channel().isActive) {
             return
         }
+        while (pendingMessages.isNotEmpty()) {
+            ReferenceCountUtil.release(pendingMessages.removeFirst())
+        }
         while (true) {
             val call = activeCalls.poll() ?: break
             @OptIn(InternalAPI::class)
             call.attributes.getOrNull(HttpRequestCloseHandlerKey)?.invoke()
         }
+        // Marks handlerJob as completing rather than cancelling it: calls that didn't opt into
+        // HttpRequestLifecycle's cancelCallOnClose (invoked above) are allowed to keep running to
+        // completion — only once every in-flight callJob finishes does handlerJob actually complete
+        // and detach from applicationJob's children list.
+        handlerJob.complete()
     }
 
     @Suppress("OverridingDeprecatedMember")
     override fun exceptionCaught(context: ChannelHandlerContext, cause: Throwable) {
         when (cause) {
             is IOException -> {
+                // Cancellation of in-flight calls and completion of handlerJob is left to
+                // onConnectionClose(), triggered by the channelInactive() that follows this close():
+                // that path invokes each call's HttpRequestCloseHandlerKey callback (giving opted-in
+                // calls their specific ConnectionClosedException cause) before touching handlerJob,
+                // so doing it here too would race a generic cause against that specific one.
                 environment.log.trace("I/O operation failed", cause)
-                handlerJob.cancel()
                 context.close()
             }
 
@@ -151,7 +212,8 @@ internal class NettyHttp1Handler(
             }
 
             else -> {
-                handlerJob.completeExceptionally(cause)
+                // See the IOException branch above: cleanup is left to the channelInactive()/
+                // onConnectionClose() that follows this close().
                 context.close()
             }
         }
@@ -181,7 +243,7 @@ internal class NettyHttp1Handler(
                 newContext
             }
         }
-        val callJob = Job(parent = baseContext[Job])
+        val callJob = Job(parent = handlerJob)
 
         // Only the per-call [Job] is combined per request; the rest of the context is cached on the
         // handler instance and reused across all calls on this connection.

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http2/NettyHttp2Handler.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http2/NettyHttp2Handler.kt
@@ -32,7 +32,8 @@ internal class NettyHttp2Handler(
     private val application: Application,
     private val callEventGroup: EventExecutorGroup,
     private val userCoroutineContext: CoroutineContext,
-    runningLimit: Int
+    runningLimit: Int,
+    private val dispatchCallStartOnIoExecutor: Boolean = false
 ) : ChannelInboundHandlerAdapter() {
     // Parent [Job] for per-call [Job]s. Cached to avoid re-running `userCoroutineContext[Job]` per request.
     private val parentJob: Job? = userCoroutineContext[Job]
@@ -151,8 +152,12 @@ internal class NettyHttp2Handler(
         // deliver subsequent Http2DataFrame messages. Without this, the coroutine runs on the event loop,
         // blocking data frame delivery and causing EOFException.
         // Dispatching to the call event group also ensures user handler code does not run on the I/O worker
-        // event loop.
-        callExecutor.execute {
+        // event loop. When dispatchCallStartOnIoExecutor is enabled, calls that never suspend skip that
+        // hop entirely and run on the I/O thread instead; calls that do suspend still resume on
+        // callExecutor via NettyDispatcher, since callExecutor above is unconditionally what's captured
+        // in CurrentContext.
+        val startExecutor = if (dispatchCallStartOnIoExecutor) context.executor() else callExecutor
+        startExecutor.execute {
             val callScope = CoroutineScope(context = callContext)
             callScope.launch(start = CoroutineStart.UNDISPATCHED) {
                 try {

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http2/NettyHttp2Handler.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http2/NettyHttp2Handler.kt
@@ -56,6 +56,12 @@ internal class NettyHttp2Handler(
                 state.isChannelReadCompleted.compareAndSet(expect = true, update = false)
                 state.activeRequests.incrementAndGet()
                 startHttp2(context, message.headers())
+                if (message.isEndStream) {
+                    context.applicationCall?.request?.apply {
+                        contentActor.close()
+                        state.isCurrentRequestFullyRead.compareAndSet(expect = false, update = true)
+                    }
+                }
             }
 
             is Http2DataFrame -> {

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http2/NettyHttp2Handler.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http2/NettyHttp2Handler.kt
@@ -125,7 +125,7 @@ internal class NettyHttp2Handler(
     }
 
     private fun startHttp2(context: ChannelHandlerContext, headers: Http2Headers) {
-        val callJob = Job(parent = parentJob)
+        val callJob = Job(parent = handlerJob)
         val callExecutor = pinnedCallExecutor(context, callEventGroup)
         // Combine the cached static context with the per-stream dispatcher and per-call [Job] only.
         val callContext = staticCallContext +
@@ -274,8 +274,14 @@ internal class NettyHttp2Handler(
         }
     }
 
-    internal fun cancel() {
-        handlerJob.cancel()
+    // Marks handlerJob as completing rather than cancelling it: individual streams already get
+    // their specific cancellation cause (if any) via onStreamClose()'s HttpRequestCloseHandlerKey
+    // invocation as each Http2StreamChannel becomes inactive during connection teardown. Forcibly
+    // cancelling handlerJob here would race a generic cause against that specific one, and would
+    // also kill calls that never opted into cancelCallOnClose. complete() still lets handlerJob
+    // detach from its parent once every in-flight callJob finishes, avoiding a leak.
+    internal fun onConnectionClose() {
+        handlerJob.complete()
     }
 
     companion object {

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http3/NettyHttp3ChannelInitializer.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http3/NettyHttp3ChannelInitializer.kt
@@ -20,6 +20,8 @@ import io.netty.handler.codec.quic.QuicCodecDispatcher
 import io.netty.handler.codec.quic.QuicConnectionIdGenerator
 import io.netty.handler.codec.quic.QuicSslContext
 import io.netty.util.concurrent.EventExecutorGroup
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
 import java.util.concurrent.TimeUnit
 import kotlin.coroutines.CoroutineContext
 
@@ -118,6 +120,12 @@ internal class NettyHttp3ChannelInitializer(
         // Http3ServerConnectionHandler is not sharable: one instance per connection
         builder.handler(object : ChannelInitializer<QuicChannel>() {
             override fun initChannel(ch: QuicChannel) {
+                // One [SupervisorJob] per QUIC connection, parented to the application's job so that
+                // per-request [Job]s fan out across many small per-connection children lists instead
+                // of contending on the single shared `Application.applicationJob` list.
+                val connectionJob = SupervisorJob(application.coroutineContext[Job])
+                ch.attr(NettyHttp3Handler.ConnectionJobKey).set(connectionJob)
+                ch.closeFuture().addListener { connectionJob.cancel() }
                 ch.pipeline().addLast(Http3ServerConnectionHandler(streamInitializer))
             }
         })

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http3/NettyHttp3ChannelInitializer.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http3/NettyHttp3ChannelInitializer.kt
@@ -47,6 +47,7 @@ internal class NettyHttp3ChannelInitializer(
     private val quicSslContext: QuicSslContext,
     private val http3Configuration: NettyHttp3Configuration,
     useCodecDispatcher: Boolean,
+    private val dispatchCallStartOnIoExecutor: Boolean = false,
 ) : ChannelInitializer<DatagramChannel>() {
 
     /**
@@ -87,7 +88,8 @@ internal class NettyHttp3ChannelInitializer(
             application,
             userContext,
             callEventGroup,
-            runningLimit
+            runningLimit,
+            dispatchCallStartOnIoExecutor
         )
 
         val builder = Http3.newQuicServerCodecBuilder()

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http3/NettyHttp3Handler.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http3/NettyHttp3Handler.kt
@@ -100,7 +100,7 @@ internal class NettyHttp3Handler(
     }
 
     private fun startHttp3(context: ChannelHandlerContext, headers: Http3Headers) {
-        val callJob = Job(parent = parentJob)
+        val callJob = Job(parent = handlerJob)
         val callExecutor = pinnedCallExecutor(context, callEventGroup)
         // Combine the cached static context with the per-stream dispatcher and per-call [Job] only.
         val callContext = staticCallContext + NettyDispatcher.CurrentContext(context, callExecutor) + callJob
@@ -132,6 +132,12 @@ internal class NettyHttp3Handler(
     }
 
     companion object {
+        // Attribute holding the per-[QuicChannel] connection-scoped [Job] that connection-level
+        // [SupervisorJob]s are parented to, so per-call [Job]s fan out across many small
+        // per-connection children lists instead of contending on the single shared
+        // `Application.applicationJob` list.
+        internal val ConnectionJobKey: AttributeKey<Job> = AttributeKey.valueOf("ktor.Http3ConnectionJob")
+
         private val ApplicationCallKey = AttributeKey.valueOf<NettyHttp3ApplicationCall>("ktor.Http3ApplicationCall")
 
         private var ChannelHandlerContext.applicationCall: NettyHttp3ApplicationCall?

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http3/NettyHttp3Handler.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http3/NettyHttp3Handler.kt
@@ -25,7 +25,8 @@ internal class NettyHttp3Handler(
     private val application: Application,
     private val callEventGroup: EventExecutorGroup,
     private val userCoroutineContext: CoroutineContext,
-    runningLimit: Int
+    runningLimit: Int,
+    private val dispatchCallStartOnIoExecutor: Boolean = false
 ) : Http3RequestStreamInboundHandler(), CoroutineScope {
     // Parent [Job] for per-call [Job]s. Cached to avoid re-running `userCoroutineContext[Job]` per request.
     private val parentJob: Job? = userCoroutineContext[Job]
@@ -117,7 +118,12 @@ internal class NettyHttp3Handler(
 
         // Dispatching to the call event group keeps user handler code off the QUIC event loop,
         // which drives every connection and stream of this connector (same model as HTTP/1/2).
-        callExecutor.execute {
+        // When dispatchCallStartOnIoExecutor is enabled, calls that never suspend skip that hop
+        // entirely and run on the QUIC event loop instead; calls that do suspend still resume on
+        // callExecutor via NettyDispatcher, since callExecutor above is unconditionally what's
+        // captured in CurrentContext.
+        val startExecutor = if (dispatchCallStartOnIoExecutor) context.executor() else callExecutor
+        startExecutor.execute {
             val callScope = CoroutineScope(context = callContext)
             callScope.launch(start = CoroutineStart.UNDISPATCHED) {
                 try {

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http3/NettyHttp3RequestStreamInitializer.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http3/NettyHttp3RequestStreamInitializer.kt
@@ -29,12 +29,17 @@ internal class NettyHttp3RequestStreamInitializer(
 ) : ChannelInitializer<QuicStreamChannel>() {
 
     override fun initChannel(ch: QuicStreamChannel) {
+        // The connection-scoped Job attached in NettyHttp3ChannelInitializer's per-QuicChannel
+        // initializer; folded in here so NettyHttp3Handler's parentJob resolves to it instead of
+        // bypassing straight to the application's job.
+        val connectionJob = ch.parent()?.attr(NettyHttp3Handler.ConnectionJobKey)?.get()
+        val context = if (connectionJob != null) userCoroutineContext + connectionJob else userCoroutineContext
         ch.pipeline().addLast(
             NettyHttp3Handler(
                 enginePipeline,
                 application,
                 callEventGroup,
-                userCoroutineContext,
+                context,
                 runningLimit
             )
         )

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http3/NettyHttp3RequestStreamInitializer.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http3/NettyHttp3RequestStreamInitializer.kt
@@ -25,7 +25,8 @@ internal class NettyHttp3RequestStreamInitializer(
     private val application: Application,
     private val userCoroutineContext: CoroutineContext,
     private val callEventGroup: EventExecutorGroup,
-    private val runningLimit: Int
+    private val runningLimit: Int,
+    private val dispatchCallStartOnIoExecutor: Boolean = false
 ) : ChannelInitializer<QuicStreamChannel>() {
 
     override fun initChannel(ch: QuicStreamChannel) {
@@ -40,7 +41,8 @@ internal class NettyHttp3RequestStreamInitializer(
                 application,
                 callEventGroup,
                 context,
-                runningLimit
+                runningLimit,
+                dispatchCallStartOnIoExecutor
             )
         )
     }

--- a/ktor-server/ktor-server-netty/jvm/test/io/ktor/tests/server/netty/NettyPipelinedResponseFlushTest.kt
+++ b/ktor-server/ktor-server-netty/jvm/test/io/ktor/tests/server/netty/NettyPipelinedResponseFlushTest.kt
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2014-2026 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.tests.server.netty
+
+import io.ktor.http.*
+import io.ktor.network.selector.*
+import io.ktor.network.sockets.*
+import io.ktor.server.engine.*
+import io.ktor.server.netty.*
+import io.ktor.server.response.*
+import io.ktor.server.routing.*
+import io.ktor.server.test.base.*
+import io.ktor.utils.io.*
+import kotlinx.coroutines.*
+import kotlin.test.*
+import kotlin.time.Duration.Companion.seconds
+
+class NettyPipelinedResponseFlushTest :
+    EngineTestBase<NettyApplicationEngine, NettyApplicationEngine.Configuration>(Netty) {
+
+    companion object {
+        private const val TEST_SERVER_HOST = "127.0.0.1"
+    }
+
+    @Test
+    fun `completed pipelined response is flushed without waiting for a later request to finish`() = runTest {
+        val slowRequestStarted = CompletableDeferred<Unit>()
+        val releaseSlowResponse = CompletableDeferred<Unit>()
+
+        val server = embeddedServer(
+            Netty,
+            module = {
+                routing {
+                    get("/fast") {
+                        call.respondText("fast-response")
+                    }
+                    get("/slow") {
+                        slowRequestStarted.complete(Unit)
+                        releaseSlowResponse.await()
+                        call.respondText("slow-response")
+                    }
+                }
+            },
+            configure = {
+                connector {
+                    port = this@NettyPipelinedResponseFlushTest.port
+                    host = TEST_SERVER_HOST
+                }
+            }
+        )
+        server.start(wait = false)
+
+        try {
+            SelectorManager().use { selector ->
+                aSocket(selector).tcp().connect(TEST_SERVER_HOST, port).use { socket ->
+                    val writeChannel = socket.openWriteChannel()
+                    val readChannel = socket.openReadChannel()
+
+                    // Pipeline both requests on the same connection without waiting for a response to either.
+                    writeChannel.writeStringUtf8(pipelinedRequest("/fast") + pipelinedRequest("/slow"))
+                    writeChannel.flush()
+
+                    // Confirm /slow is genuinely still in flight -- its handler is suspended independently
+                    // of /fast, which was already first in line and had nothing left to compute.
+                    withTimeout(5.seconds) { slowRequestStarted.await() }
+
+                    // /fast has no ordering dependency left to satisfy: it must reach the client promptly
+                    // instead of being held back by the still-pending /slow request sharing the connection.
+                    val fastResponse = withTimeout(2.seconds) { readChannel.readHttpResponse() }
+                    assertTrue(fastResponse.contains("fast-response"), "Expected fast response, got:\n$fastResponse")
+
+                    releaseSlowResponse.complete(Unit)
+
+                    val slowResponse = withTimeout(5.seconds) { readChannel.readHttpResponse() }
+                    assertTrue(slowResponse.contains("slow-response"), "Expected slow response, got:\n$slowResponse")
+                }
+            }
+        } finally {
+            server.stop()
+        }
+    }
+
+    private fun pipelinedRequest(path: String): String =
+        "GET $path HTTP/1.1\r\nHost: $TEST_SERVER_HOST\r\nConnection: keep-alive\r\n\r\n"
+
+    private suspend fun ByteReadChannel.readHttpResponse(): String {
+        val builder = StringBuilder()
+        var contentLength = 0
+        while (true) {
+            val line = readLine() ?: error("Unexpected end of stream while reading response headers")
+            builder.append(line).append("\r\n")
+            if (line.isEmpty()) break
+
+            val separator = line.indexOf(':')
+            if (separator > 0 && line.take(separator).equals(HttpHeaders.ContentLength, ignoreCase = true)) {
+                contentLength = line.substring(separator + 1).trim().toInt()
+            }
+        }
+        if (contentLength > 0) {
+            val body = ByteArray(contentLength)
+            readFully(body)
+            builder.append(body.decodeToString())
+        }
+        return builder.toString()
+    }
+}

--- a/ktor-server/ktor-server-netty/jvm/test/io/ktor/tests/server/netty/NettyRunningLimitResumeTest.kt
+++ b/ktor-server/ktor-server-netty/jvm/test/io/ktor/tests/server/netty/NettyRunningLimitResumeTest.kt
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2014-2026 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.tests.server.netty
+
+import io.ktor.http.*
+import io.ktor.network.selector.*
+import io.ktor.network.sockets.*
+import io.ktor.server.engine.*
+import io.ktor.server.netty.*
+import io.ktor.server.response.*
+import io.ktor.server.routing.*
+import io.ktor.server.test.base.*
+import io.ktor.utils.io.*
+import kotlinx.coroutines.*
+import kotlin.test.*
+import kotlin.time.Duration.Companion.seconds
+
+class NettyRunningLimitResumeTest :
+    EngineTestBase<NettyApplicationEngine, NettyApplicationEngine.Configuration>(Netty) {
+
+    companion object {
+        private const val TEST_SERVER_HOST = "127.0.0.1"
+    }
+
+    @Test
+    fun `reading resumes once in-flight requests drop back below the running limit`() = runTest {
+        val firstRequestStarted = CompletableDeferred<Unit>()
+        val releaseFirstResponse = CompletableDeferred<Unit>()
+
+        val server = embeddedServer(
+            Netty,
+            module = {
+                routing {
+                    get("/first") {
+                        firstRequestStarted.complete(Unit)
+                        releaseFirstResponse.await()
+                        call.respondText("first-response")
+                    }
+                    get("/second") {
+                        call.respondText("second-response")
+                    }
+                }
+            },
+            configure = {
+                runningLimit = 1
+                connector {
+                    port = this@NettyRunningLimitResumeTest.port
+                    host = TEST_SERVER_HOST
+                }
+            }
+        )
+        server.start(wait = false)
+
+        try {
+            SelectorManager().use { selector ->
+                aSocket(selector).tcp().connect(TEST_SERVER_HOST, port).use { socket ->
+                    val writeChannel = socket.openWriteChannel()
+                    val readChannel = socket.openReadChannel()
+
+                    // Send the first request alone so the server genuinely reads and starts handling it
+                    // (rather than decoding both requests out of one buffered chunk).
+                    writeChannel.writeStringUtf8(pipelinedRequest("/first"))
+                    writeChannel.flush()
+                    withTimeout(5.seconds) { firstRequestStarted.await() }
+
+                    // With runningLimit = 1, the server already stopped arming further socket reads once
+                    // /first was accepted. This second request now sits unread in the socket buffer until
+                    // /first completes and the engine resumes reading.
+                    writeChannel.writeStringUtf8(pipelinedRequest("/second"))
+                    writeChannel.flush()
+
+                    releaseFirstResponse.complete(Unit)
+
+                    val firstResponse = withTimeout(5.seconds) { readChannel.readHttpResponse() }
+                    assertTrue(
+                        firstResponse.contains("first-response"),
+                        "Expected first response, got:\n$firstResponse"
+                    )
+
+                    // This read hangs forever if the engine never resumes reading past the running limit.
+                    val secondResponse = withTimeout(5.seconds) { readChannel.readHttpResponse() }
+                    assertTrue(
+                        secondResponse.contains("second-response"),
+                        "Expected second response, got:\n$secondResponse"
+                    )
+                }
+            }
+        } finally {
+            server.stop()
+        }
+    }
+
+    private fun pipelinedRequest(path: String): String =
+        "GET $path HTTP/1.1\r\nHost: $TEST_SERVER_HOST\r\nConnection: keep-alive\r\n\r\n"
+
+    private suspend fun ByteReadChannel.readHttpResponse(): String {
+        val builder = StringBuilder()
+        var contentLength = 0
+        while (true) {
+            val line = readLine() ?: error("Unexpected end of stream while reading response headers")
+            builder.append(line).append("\r\n")
+            if (line.isEmpty()) break
+
+            val separator = line.indexOf(':')
+            if (separator > 0 && line.take(separator).equals(HttpHeaders.ContentLength, ignoreCase = true)) {
+                contentLength = line.substring(separator + 1).trim().toInt()
+            }
+        }
+        if (contentLength > 0) {
+            val body = ByteArray(contentLength)
+            readFully(body)
+            builder.append(body.decodeToString())
+        }
+        return builder.toString()
+    }
+}

--- a/ktor-server/ktor-server-netty/jvm/test/io/ktor/tests/server/netty/NettyRunningLimitResumeTest.kt
+++ b/ktor-server/ktor-server-netty/jvm/test/io/ktor/tests/server/netty/NettyRunningLimitResumeTest.kt
@@ -92,6 +92,77 @@ class NettyRunningLimitResumeTest :
         }
     }
 
+    @Test
+    fun `pipelined burst does not exceed running limit even when decoded in a single read`() = runTest {
+        val firstRequestStarted = CompletableDeferred<Unit>()
+        val secondRequestStarted = CompletableDeferred<Unit>()
+        val releaseFirstResponse = CompletableDeferred<Unit>()
+
+        val server = embeddedServer(
+            Netty,
+            module = {
+                routing {
+                    get("/first") {
+                        firstRequestStarted.complete(Unit)
+                        releaseFirstResponse.await()
+                        call.respondText("first-response")
+                    }
+                    get("/second") {
+                        secondRequestStarted.complete(Unit)
+                        call.respondText("second-response")
+                    }
+                }
+            },
+            configure = {
+                runningLimit = 1
+                connector {
+                    port = this@NettyRunningLimitResumeTest.port
+                    host = TEST_SERVER_HOST
+                }
+            }
+        )
+        server.start(wait = false)
+
+        try {
+            SelectorManager().use { selector ->
+                aSocket(selector).tcp().connect(TEST_SERVER_HOST, port).use { socket ->
+                    val writeChannel = socket.openWriteChannel()
+                    val readChannel = socket.openReadChannel()
+
+                    // Write both requests before the server has read anything, so Netty's HTTP codec
+                    // decodes and delivers both HttpRequest messages from a single physical socket read,
+                    // in one dispatch batch, before the running-limit check ever runs.
+                    writeChannel.writeStringUtf8(pipelinedRequest("/first") + pipelinedRequest("/second"))
+                    writeChannel.flush()
+
+                    withTimeout(5.seconds) { firstRequestStarted.await() }
+
+                    // With runningLimit = 1, /second must stay queued until /first completes, even though
+                    // both requests were already decoded together in the same read.
+                    delay(200)
+                    assertFalse(secondRequestStarted.isCompleted, "second request started before first completed")
+
+                    releaseFirstResponse.complete(Unit)
+
+                    val firstResponse = withTimeout(5.seconds) { readChannel.readHttpResponse() }
+                    assertTrue(
+                        firstResponse.contains("first-response"),
+                        "Expected first response, got:\n$firstResponse"
+                    )
+
+                    withTimeout(5.seconds) { secondRequestStarted.await() }
+                    val secondResponse = withTimeout(5.seconds) { readChannel.readHttpResponse() }
+                    assertTrue(
+                        secondResponse.contains("second-response"),
+                        "Expected second response, got:\n$secondResponse"
+                    )
+                }
+            }
+        } finally {
+            server.stop()
+        }
+    }
+
     private fun pipelinedRequest(path: String): String =
         "GET $path HTTP/1.1\r\nHost: $TEST_SERVER_HOST\r\nConnection: keep-alive\r\n\r\n"
 

--- a/ktor-server/ktor-server-netty/jvm/test/io/ktor/tests/server/netty/NettySpecificTest.kt
+++ b/ktor-server/ktor-server-netty/jvm/test/io/ktor/tests/server/netty/NettySpecificTest.kt
@@ -421,6 +421,50 @@ class NettySpecificTest {
         }
     }
 
+    @OptIn(ExperimentalKtorApi::class)
+    @Test
+    fun `request handler runs on io executor when dispatchCallStartOnIoExecutor is enabled`() = runTestWithRealTime {
+        val handlerThread = AtomicReference<Thread>()
+
+        val server = embeddedServer(
+            factory = Netty,
+            rootConfig = serverConfig {
+                module {
+                    routing {
+                        get("/") {
+                            handlerThread.set(Thread.currentThread())
+                            call.respondText("ok")
+                        }
+                    }
+                }
+            },
+            configure = {
+                connector { port = 0 }
+                shareWorkGroup = false
+                dispatchCallStartOnIoExecutor = true
+            }
+        )
+        server.startSuspend(wait = false)
+
+        try {
+            val connector = server.engine.resolvedConnectors().first()
+            HttpClient(CIO).use { it.get("http://${connector.host}:${connector.port}/") }
+
+            val callEventGroup = NettyApplicationEngine::class.java
+                .getDeclaredMethod("getCallEventGroup")
+                .apply { isAccessible = true }
+                .invoke(server.engine) as EventLoopGroup
+
+            val thread = handlerThread.get()
+            assertFalse(
+                callEventGroup.any { it.inEventLoop(thread) },
+                "Handler ran on '${thread.name}', which is in the call event group"
+            )
+        } finally {
+            server.stopSuspend()
+        }
+    }
+
     @Test
     fun `no messages are discarded from the netty pipeline for HTTP1`() = noDiscardedMessagesTest(enableH2c = false) {
         val connector = engine.resolvedConnectors().first()

--- a/ktor-server/ktor-server-test-suites/jvm/src/io/ktor/server/testing/suites/HttpServerJvmTestSuite.kt
+++ b/ktor-server/ktor-server-test-suites/jvm/src/io/ktor/server/testing/suites/HttpServerJvmTestSuite.kt
@@ -64,12 +64,19 @@ abstract class HttpServerJvmTestSuite<TEngine : ApplicationEngine, TConfiguratio
                 flush()
             }
 
+            // Pipelined responses may arrive as several separate TCP segments rather than a single one,
+            // so read until all expected bytes have been received instead of relying on one socket read.
             val bb = ByteBuffer.allocate(1911)
-            s.getInputStream().readPacketAtLeast(1).readFully(bb)
+            val input = s.getInputStream()
+            while (bb.hasRemaining()) {
+                val read = input.read(bb.array(), bb.position(), bb.remaining())
+                if (read == -1) break
+                bb.position(bb.position() + read)
+            }
             val bytes = bb.array()
             assertEquals(
                 pipelinedResponses,
-                clearSocketResponses(bytes.decodeToString(0, 0 + bytes.size).lineSequence())
+                clearSocketResponses(bytes.decodeToString(0, bb.position()).lineSequence())
             )
         }
     }


### PR DESCRIPTION
**Subsystem**
Server, Netty

**Motivation**
Observed that pipelined requests were hitting lower throughput than non-pipelined when under benchmark tests.  This was caused by a condition `activeRequests == streamingResponses` likely never being satisfied due to many connections being constantly active.

**Solution**
`flushIfNeeded()` now flushes whenever there's unflushed data and the current read cycle is complete, with no dependency on sibling request state — flush is always safe since Netty's outbound buffer is strictly FIFO.  Removed the now-dead `isStreamingResponse` counters entirely and updated stale KDoc.

