### PR TITLE
Fixup decode return in JVM and add KDoc for function

### DIFF
--- a/ktor-io/common/src/io/ktor/utils/io/charsets/Encoding.kt
+++ b/ktor-io/common/src/io/ktor/utils/io/charsets/Encoding.kt
@@ -77,6 +77,14 @@ public fun CharsetDecoder.decode(input: Source, max: Int = Int.MAX_VALUE): Strin
     decode(input, this, max)
 }
 
+/**
+ * Decodes the data from the given source and appends the result to the specified destination.
+ *
+ * @param input The source from which the data is read.
+ * @param dst The Appendable instance where the decoded data is appended.
+ * @param max The maximum number of bytes to decode.
+ * @return The number of bytes consumed from the source.
+ */
 public expect fun CharsetDecoder.decode(input: Source, dst: Appendable, max: Int): Int
 
 // ----------------------------- REGISTRY ------------------------------------------------------------------------------

--- a/ktor-io/common/src/io/ktor/utils/io/charsets/Encoding.kt
+++ b/ktor-io/common/src/io/ktor/utils/io/charsets/Encoding.kt
@@ -83,7 +83,7 @@ public fun CharsetDecoder.decode(input: Source, max: Int = Int.MAX_VALUE): Strin
  * @param input The source from which the data is read.
  * @param dst The Appendable instance where the decoded data is appended.
  * @param max The maximum number of bytes to decode.
- * @return The number of bytes consumed from the source.
+ * @return The number of characters consumed from the source.
  */
 public expect fun CharsetDecoder.decode(input: Source, dst: Appendable, max: Int): Int
 

--- a/ktor-io/jvm/src/io/ktor/utils/io/charsets/CharsetJVM.kt
+++ b/ktor-io/jvm/src/io/ktor/utils/io/charsets/CharsetJVM.kt
@@ -83,8 +83,9 @@ public actual fun CharsetDecoder.decode(input: Source, dst: Appendable, max: Int
     // ensure buffer is filled
     input.request(maxBytes)
     val count = minOf(input.remaining, maxBytes)
-    dst.append(input.readString(count, charset))
-    return count.toInt()
+    val csq = input.readString(count, charset)
+    dst.append(csq)
+    return csq.length
 }
 
 // ----------------------------------

--- a/ktor-io/jvm/src/io/ktor/utils/io/charsets/CharsetJVM.kt
+++ b/ktor-io/jvm/src/io/ktor/utils/io/charsets/CharsetJVM.kt
@@ -79,11 +79,8 @@ public actual typealias CharsetDecoder = java.nio.charset.CharsetDecoder
 public actual val CharsetDecoder.charset: Charset get() = charset()!!
 
 public actual fun CharsetDecoder.decode(input: Source, dst: Appendable, max: Int): Int {
-    if (charset == Charsets.UTF_8) {
-        return input.readString().also { dst.append(it) }.length
-    }
-    // ensure buffer is filled
     val maxBytes = max.toLong()
+    // ensure buffer is filled
     input.request(maxBytes)
     val count = minOf(input.remaining, maxBytes)
     dst.append(input.readString(count, charset))

--- a/ktor-io/jvm/src/io/ktor/utils/io/charsets/CharsetJVM.kt
+++ b/ktor-io/jvm/src/io/ktor/utils/io/charsets/CharsetJVM.kt
@@ -6,7 +6,6 @@ package io.ktor.utils.io.charsets
 
 import io.ktor.utils.io.core.*
 import kotlinx.io.*
-import kotlinx.io.bytestring.*
 import java.nio.*
 
 @Suppress("ACTUAL_CLASSIFIER_MUST_HAVE_THE_SAME_MEMBERS_AS_NON_FINAL_EXPECT_CLASSIFIER_WARNING")
@@ -82,8 +81,11 @@ public actual fun CharsetDecoder.decode(input: Source, dst: Appendable, max: Int
     val maxBytes = max.toLong()
     // ensure buffer is filled
     input.request(maxBytes)
-    val count = minOf(input.remaining, maxBytes)
-    val csq = input.readString(count, charset)
+    val byteCount = minOf(input.remaining, maxBytes)
+    val csq = when (charset) {
+        Charsets.UTF_8 -> input.readString(byteCount)
+        else -> input.readString(byteCount, charset)
+    }
     dst.append(csq)
     return csq.length
 }


### PR DESCRIPTION
**Subsystem**
Shared, I/O

**Motivation**
Fixed missed comment https://github.com/ktorio/ktor/pull/5824/changes#r3870996103

**Solution**
Dropped the short-circuit condition so we always return the size of the buffered source (i.e. bytes consumed)