### PR TITLE
KT-84955: suppress deprecated native targets warning

### DIFF
--- a/build-logic/src/main/kotlin/ktorbuild/targets/KtorTargets.kt
+++ b/build-logic/src/main/kotlin/ktorbuild/targets/KtorTargets.kt
@@ -262,6 +262,7 @@ internal fun KotlinMultiplatformExtension.addTargets(targets: KtorTargets, isCI:
     // See: https://kotlinlang.org/docs/native-target-support.html
 
     // Tier 1
+    @Suppress("DEPRECATION_ERROR") // See KT-84955.
     if (targets.isEnabled("macosX64")) macosX64()
     if (targets.isEnabled("macosArm64")) macosArm64()
     if (targets.isEnabled("iosArm64")) iosArm64()
@@ -272,9 +273,11 @@ internal fun KotlinMultiplatformExtension.addTargets(targets: KtorTargets, isCI:
     if (targets.isEnabled("linuxArm64")) linuxArm64()
     if (targets.isEnabled("linuxX64")) linuxX64()
     if (targets.isEnabled("watchosArm64")) watchosArm64()
+    @Suppress("DEPRECATION_ERROR") // See KT-84955.
     if (targets.isEnabled("watchosX64")) watchosX64()
     if (targets.isEnabled("watchosSimulatorArm64")) watchosSimulatorArm64()
     if (targets.isEnabled("tvosArm64")) tvosArm64()
+    @Suppress("DEPRECATION_ERROR") // See KT-84955.
     if (targets.isEnabled("tvosX64")) tvosX64()
     if (targets.isEnabled("tvosSimulatorArm64")) tvosSimulatorArm64()
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -69,6 +69,8 @@ kotlin.suppressGradlePluginWarnings=ConfigurationOnDemandNotSupported
 kotlin.daemon.useFallbackStrategy=false
 # Disable Klibs x-compilation due to problem with abiCheck in 2.2.20
 kotlin.native.enableKlibsCrossCompilation=false
+# macosX64, tvosX64 and watchosX64 are deprecated since 2.5.0, see KT-84955
+kotlin.internal.suppressGradlePluginErrors=DeprecatedKotlinNativeTargetsDiagnostic
 
 # Android
 android.useAndroidX=true


### PR DESCRIPTION
**Subsystem**
Build logic

**Motivation**
KT-84955 deprecated a number of native targets (macosX64, tvosX64, watchosX64).

**Solution**
This change suppresses the errors temporarily in the kotlin-community/dev branch.

