### PR TITLE
Ignore malformed Max-Age values when parsing Set-Cookie

### DIFF
--- a/ktor-http/common/src/io/ktor/http/Cookie.kt
+++ b/ktor-http/common/src/io/ktor/http/Cookie.kt
@@ -108,7 +108,7 @@ public fun parseServerSetCookieHeader(cookiesHeader: String): Cookie {
         name = first.key,
         value = decodeCookieValue(first.value, encoding),
         encoding = encoding,
-        maxAge = loweredMap["max-age"]?.toIntClamping(),
+        maxAge = loweredMap["max-age"]?.toMaxAgeOrNull(),
         expires = runCatching { loweredMap["expires"]?.fromCookieToGmtDate() }.getOrNull(),
         domain = loweredMap["domain"],
         path = loweredMap["path"],
@@ -268,4 +268,18 @@ private inline fun cookiePartFlag(name: String, value: Boolean) =
 private inline fun cookiePartExt(name: String, value: String?) =
     if (value == null) cookiePartFlag(name, true) else cookiePart(name, value, CookieEncoding.RAW)
 
-private fun String.toIntClamping(): Int = toLong().coerceIn(0L, Int.MAX_VALUE.toLong()).toInt()
+/**
+ * Parses the `Max-Age` attribute value as a number of seconds clamped to the [Int] range.
+ *
+ * Returns `null` when the value is not a decimal number, as RFC 6265 (section 5.2.2) requires such
+ * an attribute to be ignored. A negative value means the cookie expires immediately, so it maps to `0`.
+ */
+private fun String.toMaxAgeOrNull(): Int? {
+    val digitsStart = if (startsWith('-')) 1 else 0
+    if (digitsStart > lastIndex) return null
+    for (index in digitsStart..lastIndex) {
+        if (this[index] !in '0'..'9') return null
+    }
+    if (digitsStart == 1) return 0
+    return toLongOrNull()?.coerceAtMost(Int.MAX_VALUE.toLong())?.toInt() ?: Int.MAX_VALUE
+}

--- a/ktor-server/ktor-server-tests/common/test/io/ktor/tests/server/plugins/ParserServerSetCookieTest.kt
+++ b/ktor-server/ktor-server-tests/common/test/io/ktor/tests/server/plugins/ParserServerSetCookieTest.kt
@@ -120,6 +120,36 @@ class ParserServerSetCookieTest {
     }
 
     @Test
+    fun testMaxAgeAboveLongRange() {
+        val header = "key=aaa; max-age=99999999999999999999"
+        val parsed = parseServerSetCookieHeader(header)
+
+        assertEquals("key", parsed.name)
+        assertEquals("aaa", parsed.value)
+        assertEquals(Int.MAX_VALUE, parsed.maxAge)
+    }
+
+    @Test
+    fun testMaxAgeNotANumber() {
+        val header = "key=aaa; max-age=abc"
+        val parsed = parseServerSetCookieHeader(header)
+
+        assertEquals("key", parsed.name)
+        assertEquals("aaa", parsed.value)
+        assertNull(parsed.maxAge)
+    }
+
+    @Test
+    fun testMaxAgeEmpty() {
+        val header = "key=aaa; max-age="
+        val parsed = parseServerSetCookieHeader(header)
+
+        assertEquals("key", parsed.name)
+        assertEquals("aaa", parsed.value)
+        assertNull(parsed.maxAge)
+    }
+
+    @Test
     fun testSlash() {
         val header = "384f8bdb/sessid=GLU787LwmQa9uLqnM7nWHzBm; path=/"
         val parsed = parseServerSetCookieHeader(header)


### PR DESCRIPTION
### Problem

`parseServerSetCookieHeader` reads `Max-Age` with `String.toLong()`, so a non-numeric value, or one above the `Long` range, throws `NumberFormatException`. RFC 6265 5.2.2 requires ignoring it.

`HttpCookies` runs the parser on every `Set-Cookie` header via `HttpResponse.setCookie()`, so one bad value breaks response handling. `expires` here is already guarded (KTOR-9235).

### Fix

Return `null` for a non-numeric `Max-Age`. Negatives still map to `0` and large values still clamp to `Int.MAX_VALUE`, now beyond the `Long` range.

### Verification

The three added tests fail on unmodified `release/3.x` (`NumberFormatException` for `abc`, the empty value, a 20-digit number) while the other 11 pass. All 14 pass with the fix. `:ktor-http:jvmTest` is 295/0, lint is clean, and the private helper leaves the ABI intact.
