### PR TITLE
KTOR-9870 Optimize OkHttp request/response handling

### DIFF
--- a/ktor-client/ktor-client-okhttp/jvm/src/io/ktor/client/engine/okhttp/OkHttpEngine.kt
+++ b/ktor-client/ktor-client-okhttp/jvm/src/io/ktor/client/engine/okhttp/OkHttpEngine.kt
@@ -6,7 +6,7 @@ package io.ktor.client.engine.okhttp
 
 import io.ktor.client.call.*
 import io.ktor.client.engine.*
-import io.ktor.client.io.configurePlatform
+import io.ktor.client.io.*
 import io.ktor.client.plugins.*
 import io.ktor.client.plugins.sse.*
 import io.ktor.client.plugins.websocket.*
@@ -171,25 +171,31 @@ public class OkHttpEngine(override val config: OkHttpConfig) : HttpClientEngineB
     }
 }
 
-@OptIn(DelicateCoroutinesApi::class, InternalCoroutinesApi::class)
-private fun BufferedSource.toChannel(context: CoroutineContext, requestData: HttpRequestData): ByteReadChannel =
-    GlobalScope.writer(context) {
+@OptIn(DelicateCoroutinesApi::class, InternalCoroutinesApi::class, InternalAPI::class)
+private fun BufferedSource.toChannel(context: CoroutineContext, requestData: HttpRequestData): ByteReadChannel {
+    val responseChannel = ByteChannel()
+    return GlobalScope.writer(context, responseChannel) {
         use { source ->
             var lastRead = 0
             while (source.isOpen && context.isActive && lastRead >= 0) {
-                channel.write { buffer ->
+                val bytesWritten = responseChannel.writeAvailable { buffer ->
                     lastRead = try {
                         source.read(buffer)
                     } catch (cause: Throwable) {
                         val cancelOrCloseCause =
-                            kotlin.runCatching { context.job.getCancellationException() }.getOrNull() ?: cause
+                            runCatching { context.job.getCancellationException() }.getOrDefault(cause)
                         throw mapExceptions(cancelOrCloseCause, requestData)
                     }
                 }
-                channel.flush()
+                responseChannel.rethrowCloseCauseIfNeeded()
+                if (bytesWritten == -1) break
+
+                responseChannel.flushWriteBuffer()
+                if (!responseChannel.hasFreeSpace) responseChannel.flush()
             }
         }
     }.channel
+}
 
 private fun mapExceptions(cause: Throwable, request: HttpRequestData): Throwable = when (cause) {
     is java.net.SocketTimeoutException -> SocketTimeoutException(request, cause)

--- a/ktor-client/ktor-client-okhttp/jvm/src/io/ktor/client/engine/okhttp/StreamRequestBody.kt
+++ b/ktor-client/ktor-client-okhttp/jvm/src/io/ktor/client/engine/okhttp/StreamRequestBody.kt
@@ -5,13 +5,15 @@
 package io.ktor.client.engine.okhttp
 
 import io.ktor.utils.io.*
-import io.ktor.utils.io.jvm.javaio.toInputStream
-import io.ktor.utils.io.streams.asByteWriteChannel
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.launch
-import okhttp3.*
-import okio.*
+import io.ktor.utils.io.CancellationException
+import io.ktor.utils.io.jvm.javaio.*
+import io.ktor.utils.io.streams.*
+import kotlinx.coroutines.*
+import okhttp3.MediaType
+import okhttp3.RequestBody
+import okio.BufferedSink
+import okio.IOException
+import okio.use
 import kotlin.coroutines.CoroutineContext
 
 internal class StreamAdapterIOException(cause: Throwable) : IOException(cause)
@@ -49,8 +51,14 @@ internal class StreamRequestBody(
             }
         } else {
             try {
-                block().toInputStream().source().use {
-                    sink.writeAll(it)
+                val channel = block()
+                try {
+                    runBlocking(callContext.job) {
+                        channel.copyTo(sink.outputStream())
+                    }
+                } catch (cause: Throwable) {
+                    channel.cancel(cause)
+                    throw cause
                 }
             } catch (cause: IOException) {
                 throw cause

--- a/ktor-client/ktor-client-okhttp/jvm/test/io/ktor/client/engine/okhttp/OkHttpEngineTests.kt
+++ b/ktor-client/ktor-client-okhttp/jvm/test/io/ktor/client/engine/okhttp/OkHttpEngineTests.kt
@@ -7,13 +7,20 @@ package io.ktor.client.engine.okhttp
 import io.ktor.client.*
 import io.ktor.client.call.*
 import io.ktor.client.request.*
+import io.ktor.client.statement.*
 import io.ktor.test.*
+import io.ktor.utils.io.*
 import kotlinx.coroutines.*
 import okhttp3.*
+import okhttp3.ResponseBody.Companion.asResponseBody
 import okio.Buffer
 import okio.BufferedSource
-import java.util.concurrent.*
+import okio.Pipe
+import okio.buffer
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
 import kotlin.test.*
+import kotlin.time.Duration.Companion.seconds
 
 class OkHttpEngineTests {
     @Test
@@ -46,18 +53,51 @@ class OkHttpEngineTests {
     @Test
     fun testPreconfigured() = runBlocking {
         var preconfiguredClientCalled = false
-        val okHttpClient = OkHttpClient().newBuilder().addInterceptor(
-            Interceptor { chain ->
+        val okHttpClient = OkHttpClient.Builder()
+            .addInterceptor { chain ->
                 preconfiguredClientCalled = true
                 chain.proceed(chain.request())
             }
-        ).connectTimeout(1, TimeUnit.MILLISECONDS).build()
+            .connectTimeout(1, TimeUnit.MILLISECONDS)
+            .build()
 
         HttpClient(OkHttp) {
             engine { preconfigured = okHttpClient }
         }.use { client ->
             runCatching { client.get("http://localhost:1234").body<String>() }
             assertTrue(preconfiguredClientCalled)
+        }
+    }
+
+    @Test
+    fun testResponseBodyIsStreamedBeforeEof() = runTest(timeout = 5.seconds) {
+        val pipe = Pipe(1024)
+        val sink = pipe.sink.buffer()
+        val source = pipe.source.buffer()
+
+        val client = HttpClient(OkHttp) {
+            engine {
+                preconfigured = OkHttpClient.Builder()
+                    .addResponseInterceptor(source.asResponseBody())
+                    .build()
+            }
+        }
+
+        client.use { client ->
+            sink.use { sink ->
+                client.prepareGet("http://localhost/").execute { response ->
+                    sink.writeByte(42)
+                    sink.flush()
+
+                    val channel = response.bodyAsChannel()
+                    assertEquals(42, channel.readByte().toInt())
+                    assertFalse(channel.isClosedForRead)
+
+                    sink.close()
+                    assertFalse(channel.awaitContent())
+                    assertFalse(source.isOpen)
+                }
+            }
         }
     }
 
@@ -86,21 +126,11 @@ class OkHttpEngineTests {
                 }
             }
 
-            val okHttpClient = OkHttpClient.Builder()
-                .addInterceptor { chain ->
-                    Response.Builder()
-                        .request(chain.request())
-                        .protocol(Protocol.HTTP_1_1)
-                        .code(200)
-                        .message("OK")
-                        .body(responseBody)
-                        .build()
-                }
-                .build()
-
             val client = HttpClient(OkHttp) {
                 engine {
-                    preconfigured = okHttpClient
+                    preconfigured = OkHttpClient.Builder()
+                        .addResponseInterceptor(responseBody)
+                        .build()
                     dispatcher = engineDispatcher
                 }
             }
@@ -139,3 +169,14 @@ class OkHttpEngineTests {
         }
     }
 }
+
+private fun OkHttpClient.Builder.addResponseInterceptor(responseBody: ResponseBody): OkHttpClient.Builder =
+    addInterceptor { chain ->
+        Response.Builder()
+            .request(chain.request())
+            .protocol(Protocol.HTTP_1_1)
+            .code(200)
+            .message("OK")
+            .body(responseBody)
+            .build()
+    }


### PR DESCRIPTION
**Subsystem**
Client, `ktor-client-okhttp`

**Motivation**
[KTOR-9870](https://youtrack.jetbrains.com/issue/KTOR-9870) tracks unnecessary coroutine dispatching and allocations in OkHttp request and response streaming.

For responses, `BufferedSource.toChannel` copied approximately one 4–8 KiB chunk per iteration through a producer coroutine and an intermediate `ByteChannel`. `ByteWriteChannel.write(ByteBuffer)` already flushed on every iteration, and the caller performed a second redundant flush. A 2 MiB response produced about 513 iterations; allocation measurements attributed approximately 24.6 KiB to each flush continuation site.

After optimizing the response path, reading a 2 MiB streaming response allocates **63,605 fewer bytes** than the baseline. Approximately 49.2 KiB corresponds to the two flush continuation sites; the remaining reduction is consistent with removing the suspend `write()` continuation on each iteration. This GET response benchmark does not exercise the request-body change.

The non-duplex request path similarly adapted a `ByteReadChannel` through `InputStream` and Okio `Source` before writing it to the request sink.

**Solution**
- Copy non-duplex request bodies directly from `ByteReadChannel` to the OkHttp sink output stream under the call job, cancelling the channel if the copy fails.
- Create the response `ByteChannel` explicitly and read into it with non-suspending `writeAvailable`.
- Preserve immediate streaming by publishing every response chunk with `flushWriteBuffer()`.
- Invoke suspending `flush()` only when the response channel reaches its backpressure limit.
- Recheck the channel failure after a potentially blocking OkHttp read and before publishing bytes.
- Add a focused test proving that response data is available before source EOF and that the source closes after EOF.

Blocking OkHttp reads remain on the engine dispatcher. Call cancellation, exception mapping, response adapters, source closure, bounded buffering, and single-reader channel semantics are preserved.
