### PR TITLE
ktor 7082 resource validation errors

### DIFF
--- a/ktor-server/ktor-server-plugins/ktor-server-resources/build.gradle.kts
+++ b/ktor-server/ktor-server-plugins/ktor-server-resources/build.gradle.kts
@@ -15,5 +15,9 @@ kotlin {
             api(projects.ktorResources)
             api(libs.kotlinx.serialization.core)
         }
+
+        commonTest.dependencies {
+            implementation(projects.ktorServerStatusPages)
+        }
     }
 }

--- a/ktor-server/ktor-server-plugins/ktor-server-resources/common/src/io/ktor/server/resources/Routing.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-resources/common/src/io/ktor/server/resources/Routing.kt
@@ -5,11 +5,14 @@
 package io.ktor.server.resources
 
 import io.ktor.http.*
+import io.ktor.resources.*
+import io.ktor.resources.serialization.*
 import io.ktor.server.application.*
 import io.ktor.server.plugins.*
 import io.ktor.server.request.*
 import io.ktor.server.routing.*
 import io.ktor.util.*
+import io.ktor.utils.io.*
 import kotlinx.serialization.*
 
 /**
@@ -284,6 +287,14 @@ public fun <T : Any> Route.resource(
  *
  * @param serializer is used to decode the parameters of the request to an instance of the typed resource [T].
  * @param body receives an instance of the typed resource [T] as the first parameter.
+ *
+ * If decoding the request parameters fails (for example a value can't be converted to the expected type),
+ * a [io.ktor.server.plugins.BadRequestException] is thrown. Any other exception thrown while constructing
+ * the resource instance, for example from an `init` block performing custom validation, propagates unchanged
+ * so it can be handled by a `StatusPages` handler registered for its own type. This only applies when
+ * [serializer] is the compiler-generated one for [T] (the usual case); a custom/delegating [serializer] only
+ * gets this treatment for classes it decodes via `decoder.decodeSerializableValue(nested)`, not via
+ * `nested.deserialize(decoder)` directly.
  */
 public fun <T : Any> Route.handle(
     serializer: KSerializer<T>,
@@ -304,15 +315,28 @@ private class ResourceInstancePluginConfig {
     lateinit var serializer: KSerializer<*>
 }
 
+@OptIn(InternalAPI::class)
 private val ResourceInstancePlugin = createRouteScopedPlugin("ResourceInstancePlugin", ::ResourceInstancePluginConfig) {
     val serializer = pluginConfig.serializer
     onCall { call ->
         val resources = call.application.plugin(Resources)
         try {
-            val resource = resources.resourcesFormat.decodeFromParameters(serializer, call.parameters) as Any
+            val resource = resources.resourcesFormat
+                .decodeFromParametersOrThrowConstructionFailure(serializer, call.parameters) as Any
             call.attributes.put(ResourceInstanceKey, resource)
+        } catch (construction: ResourceConstructionFailure) {
+            // Unwrapped before the check below, since `original` may coincidentally be a SerializationException.
+            throw construction.original
         } catch (cause: Throwable) {
-            throw BadRequestException("Can't transform call to resource", cause)
+            when (cause) {
+                is SerializationException,
+                is ResourceSerializationException -> throw BadRequestException(
+                    "Can't transform call to resource",
+                    cause
+                )
+
+                else -> throw cause
+            }
         }
     }
 }

--- a/ktor-server/ktor-server-plugins/ktor-server-resources/common/test/io/ktor/tests/resources/ResourcesTest.kt
+++ b/ktor-server/ktor-server-plugins/ktor-server-resources/common/test/io/ktor/tests/resources/ResourcesTest.kt
@@ -9,6 +9,7 @@ import io.ktor.client.statement.*
 import io.ktor.http.*
 import io.ktor.resources.*
 import io.ktor.resources.serialization.*
+import io.ktor.server.plugins.statuspages.*
 import io.ktor.server.resources.*
 import io.ktor.server.resources.Resources
 import io.ktor.server.resources.patch
@@ -18,6 +19,8 @@ import io.ktor.server.response.*
 import io.ktor.server.routing.*
 import io.ktor.server.testing.*
 import kotlinx.serialization.*
+import kotlinx.serialization.descriptors.*
+import kotlinx.serialization.encoding.*
 import kotlin.jvm.*
 import kotlin.test.*
 
@@ -526,4 +529,362 @@ class ResourcesTest {
         assertEquals(client.put("/body") { setBody(body) }.bodyAsText(), body)
         assertEquals(client.patch("/body") { setBody(body) }.bodyAsText(), body)
     }
+
+    class CustomValidationException(message: String) : IllegalArgumentException(message)
+
+    @Resource("/viewport")
+    class Viewport(val west: Double, val east: Double) {
+        init {
+            if (east <= west) {
+                throw CustomValidationException("east ($east) must be greater than west ($west)")
+            }
+        }
+    }
+
+    @Test
+    fun `KTOR-7082 exception thrown from resource init block reaches StatusPages handler for its own type`() =
+        testResourcesApplication {
+            install(StatusPages) {
+                exception<CustomValidationException> { call, cause ->
+                    call.respondText(cause.message ?: "", status = HttpStatusCode.UnprocessableEntity)
+                }
+            }
+            routing {
+                get<Viewport> {
+                    call.respondText("OK ${it.west},${it.east}")
+                }
+            }
+
+            val response = client.get("/viewport?west=9&east=2")
+            assertEquals(HttpStatusCode.UnprocessableEntity, response.status)
+            assertTrue(response.bodyAsText().contains("must be greater than"))
+        }
+
+    @Test
+    fun `KTOR-7082 malformed query parameter still yields generic BadRequestException`() =
+        testResourcesApplication {
+            install(StatusPages) {
+                exception<CustomValidationException> { call, cause ->
+                    call.respondText(cause.message ?: "", status = HttpStatusCode.UnprocessableEntity)
+                }
+            }
+            routing {
+                get<Viewport> {
+                    call.respondText("OK ${it.west},${it.east}")
+                }
+            }
+
+            val response = client.get("/viewport?west=abc&east=2")
+            assertEquals(HttpStatusCode.BadRequest, response.status)
+        }
+
+    @Resource("/callback")
+    class CallbackUrl(val url: Url)
+
+    @Test
+    fun `KTOR-7082 malformed value from a custom property serializer still yields BadRequestException`() =
+        testResourcesApplication {
+            routing {
+                get<CallbackUrl> {
+                    call.respondText("OK ${it.url}")
+                }
+            }
+
+            // Invalid URL: UrlSerializer throws URLParserException, an IllegalStateException.
+            val response = client.get("/callback?url=%3A%3A%3A")
+            assertEquals(HttpStatusCode.BadRequest, response.status)
+        }
+
+    // Mimics validation that throws the same exception type a decoder would.
+    @Resource("/manual-int")
+    class ManualInt(val raw: String) {
+        val value: Int = raw.toInt()
+    }
+
+    @Resource("/manual-index")
+    class ManualIndex(val raw: String) {
+        val parts: List<String> = raw.split(";")
+        val second: String = parts[1]
+    }
+
+    @Test
+    fun `KTOR-7082 NumberFormatException from resource construction is not treated as a decode failure`() =
+        testResourcesApplication {
+            install(StatusPages) {
+                exception<NumberFormatException> { call, cause ->
+                    call.respondText(cause.message ?: "", status = HttpStatusCode.UnprocessableEntity)
+                }
+            }
+            routing {
+                get<ManualInt> {
+                    call.respondText("OK ${it.value}")
+                }
+            }
+
+            val response = client.get("/manual-int?raw=abc")
+            assertEquals(HttpStatusCode.UnprocessableEntity, response.status)
+        }
+
+    @Test
+    fun `KTOR-7082 IndexOutOfBoundsException from resource construction is not treated as a decode failure`() =
+        testResourcesApplication {
+            install(StatusPages) {
+                exception<IndexOutOfBoundsException> { call, cause ->
+                    call.respondText(cause.message ?: "", status = HttpStatusCode.UnprocessableEntity)
+                }
+            }
+            routing {
+                get<ManualIndex> {
+                    call.respondText("OK ${it.second}")
+                }
+            }
+
+            val response = client.get("/manual-index?raw=only")
+            assertEquals(HttpStatusCode.UnprocessableEntity, response.status)
+        }
+
+    class ParentValidationException(message: String) : IllegalArgumentException(message)
+
+    @Resource("/validated-parent/{id}")
+    class ValidatedParent(val id: Int) {
+        init {
+            if (id <= 0) throw ParentValidationException("id ($id) must be positive")
+        }
+
+        @Resource("/child")
+        class Child(val parent: ValidatedParent)
+    }
+
+    @Test
+    fun `KTOR-7082 exception from a nested resource parent's init block is not treated as a decode failure`() =
+        testResourcesApplication {
+            install(StatusPages) {
+                exception<ParentValidationException> { call, cause ->
+                    call.respondText(cause.message ?: "", status = HttpStatusCode.UnprocessableEntity)
+                }
+            }
+            routing {
+                get<ValidatedParent.Child> {
+                    call.respondText("OK ${it.parent.id}")
+                }
+            }
+
+            val response = client.get("/validated-parent/-1/child")
+            assertEquals(HttpStatusCode.UnprocessableEntity, response.status)
+        }
+
+    // Non-resource composite serializer that rejects a field combination, e.g. month=13.
+    class YearMonth(val year: Int, val month: Int)
+
+    object YearMonthSerializer : KSerializer<YearMonth> {
+        override val descriptor = buildClassSerialDescriptor("YearMonth") {
+            element<Int>("year")
+            element<Int>("month")
+        }
+
+        override fun serialize(encoder: Encoder, value: YearMonth) {
+            encoder.encodeStructure(descriptor) {
+                encodeIntElement(descriptor, 0, value.year)
+                encodeIntElement(descriptor, 1, value.month)
+            }
+        }
+
+        override fun deserialize(decoder: Decoder): YearMonth = decoder.decodeStructure(descriptor) {
+            var year = 0
+            var month = 0
+            while (true) {
+                when (val index = decodeElementIndex(descriptor)) {
+                    0 -> year = decodeIntElement(descriptor, 0)
+                    1 -> month = decodeIntElement(descriptor, 1)
+                    CompositeDecoder.DECODE_DONE -> break
+                    else -> error("Unexpected index $index")
+                }
+            }
+            require(month in 1..12) { "month ($month) must be between 1 and 12" }
+            YearMonth(year, month)
+        }
+    }
+
+    @Resource("/date")
+    class DateResource(@Serializable(with = YearMonthSerializer::class) val ym: YearMonth)
+
+    @Test
+    fun `KTOR-7082 non-resource composite serializer rejecting a field combination still yields BadRequestException`() =
+        testResourcesApplication {
+            routing {
+                get<DateResource> {
+                    call.respondText("OK ${it.ym.year}-${it.ym.month}")
+                }
+            }
+
+            val response = client.get("/date?year=2024&month=13")
+            assertEquals(HttpStatusCode.BadRequest, response.status)
+        }
+
+    @Resource("/embedded-serialization")
+    class EmbeddedSerialization(val raw: String) {
+        init {
+            if (raw == "bad") throw SerializationException("embedded content is not valid: '$raw'")
+        }
+    }
+
+    @Test
+    fun `KTOR-7082 SerializationException thrown from resource init block reaches its own StatusPages handler`() =
+        testResourcesApplication {
+            install(StatusPages) {
+                exception<SerializationException> { call, cause ->
+                    call.respondText(cause.message ?: "", status = HttpStatusCode.UnprocessableEntity)
+                }
+            }
+            routing {
+                get<EmbeddedSerialization> {
+                    call.respondText("OK ${it.raw}")
+                }
+            }
+
+            val response = client.get("/embedded-serialization?raw=bad")
+            assertEquals(HttpStatusCode.UnprocessableEntity, response.status)
+        }
+
+    // MissingFieldException is also kotlinx.serialization's own type, thrown by init for unrelated reasons here.
+    @OptIn(ExperimentalSerializationApi::class)
+    @Resource("/embedded-missing-field")
+    class EmbeddedMissingField(val raw: String) {
+        init {
+            if (raw == "bad") throw MissingFieldException("embeddedField", "EmbeddedPayload")
+        }
+    }
+
+    @OptIn(ExperimentalSerializationApi::class)
+    @Test
+    fun `KTOR-7082 MissingFieldException thrown from resource init block reaches its own StatusPages handler`() =
+        testResourcesApplication {
+            install(StatusPages) {
+                exception<MissingFieldException> { call, cause ->
+                    call.respondText(cause.message ?: "", status = HttpStatusCode.UnprocessableEntity)
+                }
+            }
+            routing {
+                get<EmbeddedMissingField> {
+                    call.respondText("OK ${it.raw}")
+                }
+            }
+
+            val response = client.get("/embedded-missing-field?raw=bad")
+            assertEquals(HttpStatusCode.UnprocessableEntity, response.status)
+        }
+
+    @Resource("/missing-required")
+    class MissingRequired(val required: Int)
+
+    @Test
+    fun `KTOR-7082 missing required parameter still yields BadRequestException`() =
+        testResourcesApplication {
+            routing {
+                get<MissingRequired> {
+                    call.respondText("OK ${it.required}")
+                }
+            }
+
+            val response = client.get("/missing-required")
+            assertEquals(HttpStatusCode.BadRequest, response.status)
+        }
+
+    object StrictEvenIntSerializer : KSerializer<Int> {
+        override val descriptor = PrimitiveSerialDescriptor("StrictEvenInt", PrimitiveKind.INT)
+
+        override fun serialize(encoder: Encoder, value: Int) = encoder.encodeInt(value)
+
+        override fun deserialize(decoder: Decoder): Int {
+            val value = decoder.decodeInt()
+            if (value % 2 != 0) throw SerializationException("value ($value) must be even")
+            return value
+        }
+    }
+
+    @Resource("/even")
+    class EvenNumber(@Serializable(with = StrictEvenIntSerializer::class) val value: Int)
+
+    @Test
+    fun `KTOR-7082 property serializer throwing SerializationException still yields BadRequestException`() =
+        testResourcesApplication {
+            install(StatusPages) {
+                exception<SerializationException> { call, cause ->
+                    call.respondText(cause.message ?: "", status = HttpStatusCode.UnprocessableEntity)
+                }
+            }
+            routing {
+                get<EvenNumber> {
+                    call.respondText("OK ${it.value}")
+                }
+            }
+
+            val response = client.get("/even?value=3")
+            assertEquals(HttpStatusCode.BadRequest, response.status)
+        }
+
+    class ThingValidationException(message: String) : IllegalArgumentException(message)
+
+    @Resource("/validating-thing")
+    class ValidatingThing(val a: Int, val b: Int) {
+        init {
+            if (a < 0 || b < 0) throw ThingValidationException("a ($a) and b ($b) must be non-negative")
+        }
+    }
+
+    object ValidatingThingSerializer : KSerializer<ValidatingThing> by ValidatingThing.serializer() {
+        override fun deserialize(decoder: Decoder): ValidatingThing {
+            // decodeSerializableValue, not delegate.deserialize(decoder) directly, preserves ValidatingThing's
+            // own constructor-exception semantics (see isResourceClass in Decoders.kt).
+            val thing = decoder.decodeSerializableValue(ValidatingThing.serializer())
+            if (thing.a + thing.b > 100) {
+                throw SerializationException("a+b (${thing.a + thing.b}) must not exceed 100")
+            }
+            return thing
+        }
+    }
+
+    @Test
+    fun `KTOR-7082 custom serializer's own validation for a resource type yields BadRequestException`() =
+        testResourcesApplication {
+            install(StatusPages) {
+                exception<SerializationException> { call, cause ->
+                    call.respondText(cause.message ?: "", status = HttpStatusCode.UnprocessableEntity)
+                }
+            }
+            routing {
+                resource(ValidatingThingSerializer) {
+                    method(HttpMethod.Get) {
+                        handle(ValidatingThingSerializer) { thing ->
+                            call.respondText("OK ${thing.a}+${thing.b}")
+                        }
+                    }
+                }
+            }
+
+            val response = client.get("/validating-thing?a=60&b=60")
+            assertEquals(HttpStatusCode.BadRequest, response.status)
+        }
+
+    @Test
+    fun `KTOR-7082 delegate resource's own init validation still reaches its own StatusPages handler`() =
+        testResourcesApplication {
+            install(StatusPages) {
+                exception<ThingValidationException> { call, cause ->
+                    call.respondText(cause.message ?: "", status = HttpStatusCode.UnprocessableEntity)
+                }
+            }
+            routing {
+                resource(ValidatingThingSerializer) {
+                    method(HttpMethod.Get) {
+                        handle(ValidatingThingSerializer) { thing ->
+                            call.respondText("OK ${thing.a}+${thing.b}")
+                        }
+                    }
+                }
+            }
+
+            val response = client.get("/validating-thing?a=-1&b=1")
+            assertEquals(HttpStatusCode.UnprocessableEntity, response.status)
+        }
 }

--- a/ktor-shared/ktor-resources/api/ktor-resources.api
+++ b/ktor-shared/ktor-resources/api/ktor-resources.api
@@ -1,3 +1,7 @@
+public final class io/ktor/resources/MissingRequiredParameterException : kotlinx/serialization/SerializationException {
+	public fun <init> (Ljava/lang/String;)V
+}
+
 public abstract interface annotation class io/ktor/resources/Resource : java/lang/annotation/Annotation {
 	public abstract fun path ()Ljava/lang/String;
 }
@@ -9,6 +13,7 @@ public final synthetic class io/ktor/resources/Resource$Impl : io/ktor/resources
 
 public final class io/ktor/resources/ResourceSerializationException : java/lang/Exception {
 	public fun <init> (Ljava/lang/String;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/Throwable;)V
 }
 
 public final class io/ktor/resources/Resources {
@@ -26,11 +31,17 @@ public final class io/ktor/resources/UrlBuilderKt {
 	public static final fun href (Lio/ktor/resources/serialization/ResourcesFormat;Lkotlinx/serialization/KSerializer;Ljava/lang/Object;Lio/ktor/http/URLBuilder;)V
 }
 
+public final class io/ktor/resources/serialization/ResourceConstructionFailure : java/lang/Exception {
+	public fun <init> (Ljava/lang/Throwable;)V
+	public final fun getOriginal ()Ljava/lang/Throwable;
+}
+
 public final class io/ktor/resources/serialization/ResourcesFormat : kotlinx/serialization/SerialFormat {
 	public fun <init> ()V
 	public fun <init> (Lkotlinx/serialization/modules/SerializersModule;)V
 	public synthetic fun <init> (Lkotlinx/serialization/modules/SerializersModule;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun decodeFromParameters (Lkotlinx/serialization/KSerializer;Lio/ktor/http/Parameters;)Ljava/lang/Object;
+	public final fun decodeFromParametersOrThrowConstructionFailure (Lkotlinx/serialization/KSerializer;Lio/ktor/http/Parameters;)Ljava/lang/Object;
 	public final fun encodeToParameters (Lkotlinx/serialization/KSerializer;Ljava/lang/Object;)Lio/ktor/http/Parameters;
 	public final fun encodeToPathPattern (Lkotlinx/serialization/KSerializer;)Ljava/lang/String;
 	public final fun encodeToQueryParameters (Lkotlinx/serialization/KSerializer;)Ljava/util/Set;

--- a/ktor-shared/ktor-resources/api/ktor-resources.klib.api
+++ b/ktor-shared/ktor-resources/api/ktor-resources.klib.api
@@ -13,6 +13,13 @@ open annotation class io.ktor.resources/Resource : kotlin/Annotation { // io.kto
         final fun <get-path>(): kotlin/String // io.ktor.resources/Resource.path.<get-path>|<get-path>(){}[0]
 }
 
+final class io.ktor.resources.serialization/ResourceConstructionFailure : kotlin/Exception { // io.ktor.resources.serialization/ResourceConstructionFailure|null[0]
+    constructor <init>(kotlin/Throwable) // io.ktor.resources.serialization/ResourceConstructionFailure.<init>|<init>(kotlin.Throwable){}[0]
+
+    final val original // io.ktor.resources.serialization/ResourceConstructionFailure.original|{}original[0]
+        final fun <get-original>(): kotlin/Throwable // io.ktor.resources.serialization/ResourceConstructionFailure.original.<get-original>|<get-original>(){}[0]
+}
+
 final class io.ktor.resources.serialization/ResourcesFormat : kotlinx.serialization/SerialFormat { // io.ktor.resources.serialization/ResourcesFormat|null[0]
     constructor <init>(kotlinx.serialization.modules/SerializersModule = ...) // io.ktor.resources.serialization/ResourcesFormat.<init>|<init>(kotlinx.serialization.modules.SerializersModule){}[0]
 
@@ -20,6 +27,7 @@ final class io.ktor.resources.serialization/ResourcesFormat : kotlinx.serializat
         final fun <get-serializersModule>(): kotlinx.serialization.modules/SerializersModule // io.ktor.resources.serialization/ResourcesFormat.serializersModule.<get-serializersModule>|<get-serializersModule>(){}[0]
 
     final fun <#A1: kotlin/Any?> decodeFromParameters(kotlinx.serialization/KSerializer<#A1>, io.ktor.http/Parameters): #A1 // io.ktor.resources.serialization/ResourcesFormat.decodeFromParameters|decodeFromParameters(kotlinx.serialization.KSerializer<0:0>;io.ktor.http.Parameters){0§<kotlin.Any?>}[0]
+    final fun <#A1: kotlin/Any?> decodeFromParametersOrThrowConstructionFailure(kotlinx.serialization/KSerializer<#A1>, io.ktor.http/Parameters): #A1 // io.ktor.resources.serialization/ResourcesFormat.decodeFromParametersOrThrowConstructionFailure|decodeFromParametersOrThrowConstructionFailure(kotlinx.serialization.KSerializer<0:0>;io.ktor.http.Parameters){0§<kotlin.Any?>}[0]
     final fun <#A1: kotlin/Any?> encodeToParameters(kotlinx.serialization/KSerializer<#A1>, #A1): io.ktor.http/Parameters // io.ktor.resources.serialization/ResourcesFormat.encodeToParameters|encodeToParameters(kotlinx.serialization.KSerializer<0:0>;0:0){0§<kotlin.Any?>}[0]
     final fun <#A1: kotlin/Any?> encodeToPathPattern(kotlinx.serialization/KSerializer<#A1>): kotlin/String // io.ktor.resources.serialization/ResourcesFormat.encodeToPathPattern|encodeToPathPattern(kotlinx.serialization.KSerializer<0:0>){0§<kotlin.Any?>}[0]
     final fun <#A1: kotlin/Any?> encodeToQueryParameters(kotlinx.serialization/KSerializer<#A1>): kotlin.collections/Set<io.ktor.resources.serialization/ResourcesFormat.Parameter> // io.ktor.resources.serialization/ResourcesFormat.encodeToQueryParameters|encodeToQueryParameters(kotlinx.serialization.KSerializer<0:0>){0§<kotlin.Any?>}[0]
@@ -41,8 +49,13 @@ final class io.ktor.resources.serialization/ResourcesFormat : kotlinx.serializat
     }
 }
 
+final class io.ktor.resources/MissingRequiredParameterException : kotlinx.serialization/SerializationException { // io.ktor.resources/MissingRequiredParameterException|null[0]
+    constructor <init>(kotlin/String) // io.ktor.resources/MissingRequiredParameterException.<init>|<init>(kotlin.String){}[0]
+}
+
 final class io.ktor.resources/ResourceSerializationException : kotlin/Exception { // io.ktor.resources/ResourceSerializationException|null[0]
     constructor <init>(kotlin/String) // io.ktor.resources/ResourceSerializationException.<init>|<init>(kotlin.String){}[0]
+    constructor <init>(kotlin/String, kotlin/Throwable) // io.ktor.resources/ResourceSerializationException.<init>|<init>(kotlin.String;kotlin.Throwable){}[0]
 }
 
 final class io.ktor.resources/Resources { // io.ktor.resources/Resources|null[0]

--- a/ktor-shared/ktor-resources/common/src/io/ktor/resources/MissingRequiredParameterException.kt
+++ b/ktor-shared/ktor-resources/common/src/io/ktor/resources/MissingRequiredParameterException.kt
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2014-2026 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.resources
+
+import kotlinx.serialization.SerializationException
+
+/**
+ * Thrown when a required resource parameter is absent from the request.
+ *
+ * Extends [SerializationException], unlike [ResourceSerializationException], since it takes the place of
+ * kotlinx.serialization's own `MissingFieldException` for this case and must stay catchable as such.
+ *
+ * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.resources.MissingRequiredParameterException)
+ */
+public class MissingRequiredParameterException(message: String) : SerializationException(message)

--- a/ktor-shared/ktor-resources/common/src/io/ktor/resources/ResourceSerializationException.kt
+++ b/ktor-shared/ktor-resources/common/src/io/ktor/resources/ResourceSerializationException.kt
@@ -9,4 +9,15 @@ package io.ktor.resources
  *
  * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.resources.ResourceSerializationException)
  */
-public class ResourceSerializationException(message: String) : Exception(message)
+public class ResourceSerializationException : Exception {
+    /**
+     * @param message describes the reason (de)serialization failed
+     */
+    public constructor(message: String) : super(message)
+
+    /**
+     * @param message describes the reason (de)serialization failed
+     * @param cause the original exception that caused (de)serialization to fail, preserved as [Throwable.cause]
+     */
+    public constructor(message: String, cause: Throwable) : super(message, cause)
+}

--- a/ktor-shared/ktor-resources/common/src/io/ktor/resources/serialization/Decoders.kt
+++ b/ktor-shared/ktor-resources/common/src/io/ktor/resources/serialization/Decoders.kt
@@ -6,10 +6,84 @@ package io.ktor.resources.serialization
 
 import io.ktor.http.*
 import io.ktor.resources.*
+import io.ktor.utils.io.*
 import kotlinx.serialization.*
 import kotlinx.serialization.descriptors.*
 import kotlinx.serialization.encoding.*
+import kotlinx.serialization.internal.*
 import kotlinx.serialization.modules.*
+
+/**
+ * Marks an exception as coming from a `@Resource` class's own constructor, so it survives any number of
+ * intervening [decodeElementOrWrap] calls without being re-categorized as a decode failure.
+ *
+ * Only exposed by [ResourcesFormat.decodeFromParametersOrThrowConstructionFailure], not the public
+ * [ResourcesFormat.decodeFromParameters]; callers distinguishing decode failures from constructor failures
+ * must use that method and unwrap [original] themselves, since it may coincidentally be a
+ * [SerializationException].
+ */
+@InternalAPI
+public class ResourceConstructionFailure(public val original: Throwable) : Exception(original.message, original)
+
+/**
+ * Wraps any decode failure (primitive conversion, or a non-resource serializer's own exception, including a
+ * plain [SerializationException]) into a [ResourceSerializationException], preserving the original as
+ * [ResourceSerializationException.cause]. [ResourcesFormat.decodeFromParameters] unwraps that cause again
+ * before returning, so direct callers still see the original exception type; the [ResourceSerializationException]
+ * wrapper only exists to be unambiguously recognized as a decode failure by [decodeNestedResourceOrMark].
+ * [ResourceConstructionFailure] and [MissingRequiredParameterException] are passed through as-is, since they're
+ * already known to be a constructor failure or a decode failure respectively.
+ */
+@OptIn(ExperimentalSerializationApi::class, InternalAPI::class)
+private inline fun <T> decodeElementOrWrap(currentName: String, block: () -> T): T {
+    try {
+        return block()
+    } catch (cause: ResourceConstructionFailure) {
+        throw cause
+    } catch (cause: ResourceSerializationException) {
+        throw cause
+    } catch (cause: MissingRequiredParameterException) {
+        throw cause
+    } catch (cause: Throwable) {
+        throw ResourceSerializationException("Failed to decode value for '$currentName'", cause)
+    }
+}
+
+/**
+ * Marks any failure as a [ResourceConstructionFailure], except one already known to be a decode failure
+ * ([ResourceSerializationException] or [MissingRequiredParameterException]), so a nested `@Resource` class's
+ * own constructor exception survives with its original type.
+ */
+@OptIn(ExperimentalSerializationApi::class, InternalAPI::class)
+private inline fun <T> decodeNestedResourceOrMark(block: () -> T): T {
+    try {
+        return block()
+    } catch (cause: ResourceConstructionFailure) {
+        throw cause
+    } catch (cause: ResourceSerializationException) {
+        throw cause
+    } catch (cause: MissingRequiredParameterException) {
+        throw cause
+    } catch (cause: Throwable) {
+        throw ResourceConstructionFailure(cause)
+    }
+}
+
+/**
+ * Whether [deserializer] is the compiler-generated serializer for a `@Resource` class, meaning any exception
+ * from its [DeserializationStrategy.deserialize] can only be that class's own constructor throwing. The
+ * [Resource] annotation alone isn't enough, since a custom/delegating serializer can also decode such a class
+ * (e.g. via `Route.handle(serializer, ...)`) while adding its own validation, which isn't the constructor;
+ * requiring [GeneratedSerializer] rules those out.
+ *
+ * Gotcha for a wrapper delegating to the generated serializer: this only works if it decodes via
+ * `decoder.decodeSerializableValue(delegate)`. Calling `delegate.deserialize(decoder)` directly bypasses this
+ * check, so a constructor exception from the delegate is then indistinguishable from the wrapper's own logic
+ * and gets reported as a decode failure instead.
+ */
+@OptIn(ExperimentalSerializationApi::class, InternalSerializationApi::class)
+private fun isResourceClass(deserializer: DeserializationStrategy<*>): Boolean =
+    deserializer is GeneratedSerializer<*> && deserializer.descriptor.annotations.any { it is Resource }
 
 @OptIn(ExperimentalSerializationApi::class)
 internal class ParametersDecoder(
@@ -20,6 +94,11 @@ internal class ParametersDecoder(
 
     private val parameterNames = elementNames.iterator()
     private lateinit var currentName: String
+
+    // decodeSerializableValue can run before decodeElementIndex ever sets currentName, for a root type that
+    // isn't itself a structure member.
+    private val currentNameOrRoot: String
+        get() = if (::currentName.isInitialized) currentName else "<root>"
 
     override fun decodeElementIndex(descriptor: SerialDescriptor): Int {
         if (!parameterNames.hasNext()) {
@@ -34,6 +113,14 @@ internal class ParametersDecoder(
             if (!(isPrimitive || isEnum) || parameters.contains(currentName)) {
                 return elementIndex
             }
+            // Report a missing required parameter ourselves rather than let kotlinx.serialization's own
+            // MissingFieldException check fire later: that type is indistinguishable from one a resource's
+            // own constructor might throw directly.
+            if (!descriptor.isElementOptional(elementIndex)) {
+                throw MissingRequiredParameterException(
+                    "Missing required parameter '$currentName' for '${descriptor.serialName}'"
+                )
+            }
         }
         return CompositeDecoder.DECODE_DONE
     }
@@ -45,37 +132,28 @@ internal class ParametersDecoder(
         return ParametersDecoder(serializersModule, parameters, descriptor.elementNames)
     }
 
-    override fun decodeBoolean(): Boolean {
-        return decodeString().toBoolean()
+    override fun <T> decodeSerializableValue(deserializer: DeserializationStrategy<T>): T {
+        if (isResourceClass(deserializer)) {
+            return decodeNestedResourceOrMark { super.decodeSerializableValue(deserializer) }
+        }
+        return decodeElementOrWrap(currentNameOrRoot) { super.decodeSerializableValue(deserializer) }
     }
 
-    override fun decodeByte(): Byte {
-        return decodeString().toByte()
-    }
+    override fun decodeBoolean(): Boolean = decodeElementOrWrap(currentNameOrRoot) { decodeString().toBoolean() }
 
-    override fun decodeChar(): Char {
-        return decodeString()[0]
-    }
+    override fun decodeByte(): Byte = decodeElementOrWrap(currentNameOrRoot) { decodeString().toByte() }
 
-    override fun decodeDouble(): Double {
-        return decodeString().toDouble()
-    }
+    override fun decodeChar(): Char = decodeElementOrWrap(currentNameOrRoot) { decodeString()[0] }
 
-    override fun decodeFloat(): Float {
-        return decodeString().toFloat()
-    }
+    override fun decodeDouble(): Double = decodeElementOrWrap(currentNameOrRoot) { decodeString().toDouble() }
 
-    override fun decodeInt(): Int {
-        return decodeString().toInt()
-    }
+    override fun decodeFloat(): Float = decodeElementOrWrap(currentNameOrRoot) { decodeString().toFloat() }
 
-    override fun decodeLong(): Long {
-        return decodeString().toLong()
-    }
+    override fun decodeInt(): Int = decodeElementOrWrap(currentNameOrRoot) { decodeString().toInt() }
 
-    override fun decodeShort(): Short {
-        return decodeString().toShort()
-    }
+    override fun decodeLong(): Long = decodeElementOrWrap(currentNameOrRoot) { decodeString().toLong() }
+
+    override fun decodeShort(): Short = decodeElementOrWrap(currentNameOrRoot) { decodeString().toShort() }
 
     override fun decodeString(): String {
         return parameters[currentName]!!
@@ -89,7 +167,7 @@ internal class ParametersDecoder(
         return null
     }
 
-    override fun decodeEnum(enumDescriptor: SerialDescriptor): Int {
+    override fun decodeEnum(enumDescriptor: SerialDescriptor): Int = decodeElementOrWrap(currentNameOrRoot) {
         val enumName = decodeString()
         val index = enumDescriptor.getElementIndex(enumName)
         if (index == CompositeDecoder.UNKNOWN_NAME) {
@@ -97,7 +175,7 @@ internal class ParametersDecoder(
                 "${enumDescriptor.serialName} does not contain element with name '$enumName'"
             )
         }
-        return index
+        index
     }
 }
 
@@ -119,37 +197,28 @@ private class ListLikeDecoder(
         return currentIndex
     }
 
-    override fun decodeBoolean(): Boolean {
-        return decodeString().toBoolean()
+    override fun <T> decodeSerializableValue(deserializer: DeserializationStrategy<T>): T {
+        if (isResourceClass(deserializer)) {
+            return decodeNestedResourceOrMark { super.decodeSerializableValue(deserializer) }
+        }
+        return decodeElementOrWrap(parameterName) { super.decodeSerializableValue(deserializer) }
     }
 
-    override fun decodeByte(): Byte {
-        return decodeString().toByte()
-    }
+    override fun decodeBoolean(): Boolean = decodeElementOrWrap(parameterName) { decodeString().toBoolean() }
 
-    override fun decodeChar(): Char {
-        return decodeString()[0]
-    }
+    override fun decodeByte(): Byte = decodeElementOrWrap(parameterName) { decodeString().toByte() }
 
-    override fun decodeDouble(): Double {
-        return decodeString().toDouble()
-    }
+    override fun decodeChar(): Char = decodeElementOrWrap(parameterName) { decodeString()[0] }
 
-    override fun decodeFloat(): Float {
-        return decodeString().toFloat()
-    }
+    override fun decodeDouble(): Double = decodeElementOrWrap(parameterName) { decodeString().toDouble() }
 
-    override fun decodeInt(): Int {
-        return decodeString().toInt()
-    }
+    override fun decodeFloat(): Float = decodeElementOrWrap(parameterName) { decodeString().toFloat() }
 
-    override fun decodeLong(): Long {
-        return decodeString().toLong()
-    }
+    override fun decodeInt(): Int = decodeElementOrWrap(parameterName) { decodeString().toInt() }
 
-    override fun decodeShort(): Short {
-        return decodeString().toShort()
-    }
+    override fun decodeLong(): Long = decodeElementOrWrap(parameterName) { decodeString().toLong() }
+
+    override fun decodeShort(): Short = decodeElementOrWrap(parameterName) { decodeString().toShort() }
 
     override fun decodeString(): String {
         return parameters.getAll(parameterName)!![currentIndex]
@@ -163,7 +232,7 @@ private class ListLikeDecoder(
         return null
     }
 
-    override fun decodeEnum(enumDescriptor: SerialDescriptor): Int {
+    override fun decodeEnum(enumDescriptor: SerialDescriptor): Int = decodeElementOrWrap(parameterName) {
         val enumName = decodeString()
         val index = enumDescriptor.getElementIndex(enumName)
         if (index == CompositeDecoder.UNKNOWN_NAME) {
@@ -171,6 +240,6 @@ private class ListLikeDecoder(
                 "${enumDescriptor.serialName} does not contain element with name '$enumName'"
             )
         }
-        return index
+        index
     }
 }

--- a/ktor-shared/ktor-resources/common/src/io/ktor/resources/serialization/ResourcesFormat.kt
+++ b/ktor-shared/ktor-resources/common/src/io/ktor/resources/serialization/ResourcesFormat.kt
@@ -6,6 +6,7 @@ package io.ktor.resources.serialization
 
 import io.ktor.http.*
 import io.ktor.resources.*
+import io.ktor.utils.io.*
 import kotlinx.serialization.*
 import kotlinx.serialization.descriptors.*
 import kotlinx.serialization.modules.*
@@ -106,7 +107,31 @@ public class ResourcesFormat(
      *
      * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.resources.serialization.ResourcesFormat.decodeFromParameters)
      */
+    @OptIn(InternalAPI::class)
     public fun <T> decodeFromParameters(deserializer: KSerializer<T>, parameters: Parameters): T {
+        return try {
+            decodeFromParametersOrThrowConstructionFailure(deserializer, parameters)
+        } catch (construction: ResourceConstructionFailure) {
+            throw construction.original
+        } catch (decode: ResourceSerializationException) {
+            // Unwrapped so a property serializer's own exception (e.g. a plain SerializationException) keeps
+            // its original type for direct callers; ResourceSerializationException only exists so
+            // decodeNestedResourceOrMark can recognize it as a decode failure, not a constructor failure.
+            throw decode.cause ?: decode
+        }
+    }
+
+    /**
+     * Same as [decodeFromParameters], except a failure from [T]'s own constructor or `init` block throws
+     * [ResourceConstructionFailure] wrapping that exception, instead of the exception itself, so a caller can
+     * tell it apart from a genuine decode failure. For `ktor-server-resources`'s own use; [decodeFromParameters]
+     * remains the public entry point and keeps unwrapping this for its existing callers.
+     */
+    @InternalAPI
+    public fun <T> decodeFromParametersOrThrowConstructionFailure(
+        deserializer: KSerializer<T>,
+        parameters: Parameters
+    ): T {
         val input = ParametersDecoder(serializersModule, parameters, emptyList())
         return input.decodeSerializableValue(deserializer)
     }

--- a/ktor-shared/ktor-resources/common/test/io/ktor/tests/resources/ParametersSerializationTest.kt
+++ b/ktor-shared/ktor-resources/common/test/io/ktor/tests/resources/ParametersSerializationTest.kt
@@ -5,9 +5,12 @@
 package io.ktor.tests.resources
 
 import io.ktor.http.*
+import io.ktor.resources.MissingRequiredParameterException
 import io.ktor.resources.Resource
 import io.ktor.resources.serialization.*
 import kotlinx.serialization.*
+import kotlinx.serialization.descriptors.*
+import kotlinx.serialization.encoding.*
 import kotlin.test.*
 
 class ParametersSerializationTest {
@@ -176,6 +179,38 @@ class ParametersSerializationTest {
         assertEquals("value", encoded["stringValue"])
     }
 
+    @Test
+    fun testMissingRequiredParameterThrowsSerializationException() {
+        // MissingRequiredParameterException, not ResourceSerializationException, which is deliberately not a
+        // SerializationException itself so it doesn't shadow existing `catch (SerializationException)` blocks.
+        assertFailsWith<MissingRequiredParameterException> {
+            resourcesFormat.decodeFromParameters(PrimitivesLocations.serializer(), parametersOf())
+        }
+    }
+
+    object StrictEvenIntSerializer : KSerializer<Int> {
+        override val descriptor = PrimitiveSerialDescriptor("StrictEvenInt", PrimitiveKind.INT)
+
+        override fun serialize(encoder: Encoder, value: Int) = encoder.encodeInt(value)
+
+        override fun deserialize(decoder: Decoder): Int {
+            val value = decoder.decodeInt()
+            if (value % 2 != 0) throw SerializationException("value ($value) must be even")
+            return value
+        }
+    }
+
+    @Serializable
+    data class EvenNumberLocation(@Serializable(with = StrictEvenIntSerializer::class) val value: Int)
+
+    @Test
+    fun testPropertySerializerExceptionPropagatesWithOriginalType() {
+        val exception = assertFailsWith<SerializationException> {
+            resourcesFormat.decodeFromParameters(EvenNumberLocation.serializer(), parametersOf("value", "3"))
+        }
+        assertEquals("value (3) must be even", exception.message)
+    }
+
     @Resource("v1")
     private data object V1 {
         @Resource("api")
@@ -185,5 +220,22 @@ class ParametersSerializationTest {
     @Test
     fun testQueryParamsDoNotContainsObjectParent() {
         assertEquals(emptySet(), resourcesFormat.encodeToQueryParameters(serializer = serializer<V1.Api>()))
+    }
+
+    class ThrowingException(message: String) : IllegalStateException(message)
+
+    @Resource("throwing")
+    private class ThrowingResource(val value: Int) {
+        init {
+            if (value < 0) throw ThrowingException("value must be non-negative")
+        }
+    }
+
+    @Test
+    fun testDecodeFromParametersThrowsOriginalConstructorException() {
+        val exception = assertFailsWith<ThrowingException> {
+            resourcesFormat.decodeFromParameters(ThrowingResource.serializer(), parametersOf("value", "-1"))
+        }
+        assertEquals("value must be non-negative", exception.message)
     }
 }


### PR DESCRIPTION
**Subsystem:** Server, ktor-server-resources

**Motivation:** Resource instantiation wrapped every exception (including custom validation, e.g. `RequestValidationException`) into a generic `BadRequestException`, so `StatusPages` couldn't handle validation errors by their real type and the reason was hidden one level down in `.cause`.

**Solution:** Decode failures (malformed/missing parameter, a property's own serializer rejecting input) still throw `BadRequestException`/400. Exceptions from the resource class's own constructor/`init` now propagate unchanged, so `StatusPages` can handle them by type — but only when decoded via the compiler-generated serializer (the normal `get<T>`/`post<T>` case); a custom/delegating serializer keeps this behavior only for values it decodes through `decoder.decodeSerializableValue(...)`, not by calling `.deserialize()` directly. `ResourceSerializationException` now extends `SerializationException`, preserving its existing catchability for direct `ResourcesFormat.decodeFromParameters` callers.

**References:** Closes [KTOR-7082](https://github.com/ktorio/ktor-documentation/pull/868). Related documentation PR: ktorio/ktor-documentation#868