### PR TITLE
KTOR-9875 Netty performance issues fixes

### DIFF
--- a/ktor-server/ktor-server-netty/api/ktor-server-netty.api
+++ b/ktor-server/ktor-server-netty/api/ktor-server-netty.api
@@ -164,6 +164,7 @@ public final class io/ktor/server/netty/NettyChannelInitializer : io/netty/chann
 	public static final field Companion Lio/ktor/server/netty/NettyChannelInitializer$Companion;
 	public fun <init> (Lkotlin/jvm/functions/Function0;Lio/ktor/server/engine/EnginePipeline;Lio/ktor/server/application/ApplicationEnvironment;Lio/netty/util/concurrent/EventExecutorGroup;Lkotlin/coroutines/CoroutineContext;Lkotlin/coroutines/CoroutineContext;Lio/ktor/server/engine/EngineConnectorConfig;IIILkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;Z)V
 	public fun <init> (Lkotlin/jvm/functions/Function0;Lio/ktor/server/engine/EnginePipeline;Lio/ktor/server/application/ApplicationEnvironment;Lio/netty/util/concurrent/EventExecutorGroup;Lkotlin/coroutines/CoroutineContext;Lkotlin/coroutines/CoroutineContext;Lio/ktor/server/engine/EngineConnectorConfig;IIILkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;ZZ)V
+	public fun <init> (Lkotlin/jvm/functions/Function0;Lio/ktor/server/engine/EnginePipeline;Lio/ktor/server/application/ApplicationEnvironment;Lio/netty/util/concurrent/EventExecutorGroup;Lkotlin/coroutines/CoroutineContext;Lkotlin/coroutines/CoroutineContext;Lio/ktor/server/engine/EngineConnectorConfig;IIILkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;ZZZ)V
 	public synthetic fun initChannel (Lio/netty/channel/Channel;)V
 }
 

--- a/ktor-server/ktor-server-netty/api/ktor-server-netty.api
+++ b/ktor-server/ktor-server-netty/api/ktor-server-netty.api
@@ -85,6 +85,7 @@ public final class io/ktor/server/netty/NettyApplicationEngine$Configuration : i
 	public static synthetic fun enableHttp3$default (Lio/ktor/server/netty/NettyApplicationEngine$Configuration;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
 	public final fun getChannelPipelineConfig ()Lkotlin/jvm/functions/Function1;
 	public final fun getConfigureBootstrap ()Lkotlin/jvm/functions/Function1;
+	public final fun getEnableFlushConsolidation ()Z
 	public final fun getEnableH2c ()Z
 	public final fun getEnableHttp2 ()Z
 	public final fun getHttpServerCodec ()Lkotlin/jvm/functions/Function0;
@@ -98,6 +99,7 @@ public final class io/ktor/server/netty/NettyApplicationEngine$Configuration : i
 	public final fun getTcpKeepAlive ()Z
 	public final fun setChannelPipelineConfig (Lkotlin/jvm/functions/Function1;)V
 	public final fun setConfigureBootstrap (Lkotlin/jvm/functions/Function1;)V
+	public final fun setEnableFlushConsolidation (Z)V
 	public final fun setEnableH2c (Z)V
 	public final fun setEnableHttp2 (Z)V
 	public final fun setHttpServerCodec (Lkotlin/jvm/functions/Function0;)V
@@ -164,7 +166,7 @@ public final class io/ktor/server/netty/NettyChannelInitializer : io/netty/chann
 	public static final field Companion Lio/ktor/server/netty/NettyChannelInitializer$Companion;
 	public fun <init> (Lkotlin/jvm/functions/Function0;Lio/ktor/server/engine/EnginePipeline;Lio/ktor/server/application/ApplicationEnvironment;Lio/netty/util/concurrent/EventExecutorGroup;Lkotlin/coroutines/CoroutineContext;Lkotlin/coroutines/CoroutineContext;Lio/ktor/server/engine/EngineConnectorConfig;IIILkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;Z)V
 	public fun <init> (Lkotlin/jvm/functions/Function0;Lio/ktor/server/engine/EnginePipeline;Lio/ktor/server/application/ApplicationEnvironment;Lio/netty/util/concurrent/EventExecutorGroup;Lkotlin/coroutines/CoroutineContext;Lkotlin/coroutines/CoroutineContext;Lio/ktor/server/engine/EngineConnectorConfig;IIILkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;ZZ)V
-	public fun <init> (Lkotlin/jvm/functions/Function0;Lio/ktor/server/engine/EnginePipeline;Lio/ktor/server/application/ApplicationEnvironment;Lio/netty/util/concurrent/EventExecutorGroup;Lkotlin/coroutines/CoroutineContext;Lkotlin/coroutines/CoroutineContext;Lio/ktor/server/engine/EngineConnectorConfig;IIILkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;ZZZ)V
+	public fun <init> (Lkotlin/jvm/functions/Function0;Lio/ktor/server/engine/EnginePipeline;Lio/ktor/server/application/ApplicationEnvironment;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/CoroutineContext;Lkotlin/coroutines/CoroutineContext;Lio/ktor/server/engine/EngineConnectorConfig;IIILkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;ZZZ)V
 	public synthetic fun initChannel (Lio/netty/channel/Channel;)V
 }
 

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyApplicationCall.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyApplicationCall.kt
@@ -62,7 +62,6 @@ public abstract class NettyApplicationCall(
     private val messageReleased = atomic(false)
 
     internal var isByteBufferContent = false
-    internal var isStreamingResponse = false
 
     /**
      * Returns http content object with [buf] content if [isByteBufferContent] is false,

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyApplicationCall.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyApplicationCall.kt
@@ -46,6 +46,8 @@ public abstract class NettyApplicationCall(
     public lateinit var responseWriteJob: Job
         private set
 
+    private lateinit var completableResponseWriteJob: CompletableJob
+
     /**
      * Initializes [responseWriteJob] as a child of the call's coroutine [Job]. Called synchronously
      * on the Netty I/O thread right after the call is constructed and before the user handler
@@ -56,7 +58,17 @@ public abstract class NettyApplicationCall(
         val callJob = coroutineContext[Job]
         val job = Job(parent = callJob)
         job.invokeOnCompletion { onResponseWriteCompleted() }
+        completableResponseWriteJob = job
         responseWriteJob = job
+    }
+
+    /**
+     * Marks [responseWriteJob] as successfully completed. Used on the normal (non-error) path once the
+     * response write has been dispatched, so completion goes through [CompletableJob.complete]'s fast
+     * path instead of the cancellation machinery that [Job.cancel] always incurs.
+     */
+    internal fun completeResponseWriteJob() {
+        completableResponseWriteJob.complete()
     }
 
     private val messageReleased = atomic(false)

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyApplicationEngine.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyApplicationEngine.kt
@@ -75,7 +75,8 @@ public class NettyApplicationEngine(
         public var runningLimit: Int = 32
 
         /**
-         * Do not create separate call event group and reuse worker group for processing calls
+         * All tasks use a common event group, and call dispatchers wrap this event group without thread pinning.
+         * This setting reduces some overhead in scheduling at the expense of the safety provided by segregating the work and call groups.
          *
          * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.server.netty.NettyApplicationEngine.Configuration.shareWorkGroup)
          */
@@ -240,6 +241,15 @@ public class NettyApplicationEngine(
         workerEventGroup.asCoroutineDispatcher()
     }
 
+    /**
+     * Resolves the [io.netty.util.concurrent.EventExecutor] a call's coroutine should be dispatched onto
+     * and resumed on, for a given channel. Built once since [callEventGroup] and
+     * [Configuration.shareWorkGroup] are both stable for the lifetime of this engine.
+     */
+    private val resolveCallExecutor by lazy {
+        callExecutorResolver(callEventGroup, configuration.shareWorkGroup)
+    }
+
     private var cancellationJob: CompletableJob? = null
 
     private var channels: List<Channel>? = null
@@ -277,7 +287,7 @@ public class NettyApplicationEngine(
                     applicationProvider,
                     pipeline,
                     environment,
-                    callEventGroup,
+                    resolveCallExecutor,
                     workerDispatcher,
                     userContext,
                     connector,
@@ -407,7 +417,7 @@ public class NettyApplicationEngine(
                     applicationProvider,
                     pipeline,
                     userContext,
-                    callEventGroup,
+                    resolveCallExecutor,
                     configuration.runningLimit,
                     quicSslContext,
                     http3Configuration,

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyApplicationEngine.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyApplicationEngine.kt
@@ -167,6 +167,16 @@ public class NettyApplicationEngine(
         public var channelPipelineConfig: ChannelPipeline.() -> Unit = {}
 
         /**
+         * If set to `true`, adds Netty's [io.netty.handler.flush.FlushConsolidationHandler] as the first
+         * handler in the channel pipeline. It batches back-to-back `flush()` calls (for example, from
+         * pipelined responses) into a single transport write, which can improve throughput under
+         * concurrent load at the cost of slightly delaying individual flushes.
+         *
+         * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.server.netty.NettyApplicationEngine.Configuration.enableFlushConsolidation)
+         */
+        public var enableFlushConsolidation: Boolean = false
+
+        /**
          * Holds the HTTP/3 configuration when HTTP/3 is enabled, or `null` when disabled.
          *
          * Configured via [enableHttp3].
@@ -297,7 +307,8 @@ public class NettyApplicationEngine(
                     configuration.httpServerCodec,
                     configuration.channelPipelineConfig,
                     configuration.enableHttp2,
-                    configuration.enableH2c
+                    configuration.enableH2c,
+                    configuration.enableFlushConsolidation
                 )
             )
             if (configuration.tcpKeepAlive) {

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyChannelInitializer.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyChannelInitializer.kt
@@ -315,7 +315,9 @@ public class NettyChannelInitializer(
                 // sink is a no-op.
                 pipeline.addLast(NettyHttp2ConnectionSink)
 
-                pipeline.addLast(object : SimpleChannelInboundHandler<HttpMessage>() {
+                // autoRelease = false: channelRead0 always forwards msg via fireChannelRead without
+                // retaining it first, so the default auto-release would drop its refCnt a second time.
+                pipeline.addLast(object : SimpleChannelInboundHandler<HttpMessage>(false) {
                     @Throws(Exception::class)
                     override fun channelRead0(ctx: ChannelHandlerContext, msg: HttpMessage) {
                         val pipe = ctx.pipeline()

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyChannelInitializer.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyChannelInitializer.kt
@@ -192,17 +192,18 @@ public class NettyChannelInitializer(
                 // would reach Netty's tail handler and trigger "Discarded inbound message" warnings.
                 pipeline.addLast(NettyHttp2ConnectionSink)
                 pipeline.channel().closeFuture().addListener {
-                    handler.cancel()
+                    handler.onConnectionClose()
                 }
                 channelPipelineConfig(pipeline)
             }
 
             Http2CodecUtil.HTTP_UPGRADE_PROTOCOL_NAME.toString() -> {
+                val application = applicationProvider()
                 val handler = NettyHttp2Handler(
                     enginePipeline,
-                    applicationProvider(),
+                    application,
                     callEventGroup,
-                    userContext,
+                    application.coroutineContext + userContext,
                     runningLimit
                 )
 
@@ -261,7 +262,7 @@ public class NettyChannelInitializer(
                 })
 
                 pipeline.channel().closeFuture().addListener {
-                    handler.cancel()
+                    handler.onConnectionClose()
                 }
                 channelPipelineConfig(pipeline)
             }

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyChannelInitializer.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyChannelInitializer.kt
@@ -22,6 +22,7 @@ import io.netty.handler.codec.http2.Http2CodecUtil
 import io.netty.handler.codec.http2.Http2MultiplexCodecBuilder
 import io.netty.handler.codec.http2.Http2SecurityUtil
 import io.netty.handler.codec.http2.Http2ServerUpgradeCodec
+import io.netty.handler.flush.FlushConsolidationHandler
 import io.netty.handler.ssl.ApplicationProtocolConfig
 import io.netty.handler.ssl.ApplicationProtocolNames
 import io.netty.handler.ssl.ApplicationProtocolNegotiationHandler
@@ -63,6 +64,7 @@ public class NettyChannelInitializer(
     private val channelPipelineConfig: ChannelPipeline.() -> Unit,
     private val enableHttp2: Boolean,
     private val enableH2c: Boolean,
+    private val enableFlushConsolidation: Boolean,
 ) : ChannelInitializer<SocketChannel>() {
     private var sslContext: SslContext? = null
 
@@ -110,9 +112,10 @@ public class NettyChannelInitializer(
         message = "Use main constructor",
         replaceWith = ReplaceWith(
             "NettyChannelInitializer(" +
-                "applicationProvider, enginePipeline, environment, callEventGroup, engineContext, " +
-                "userContext, connector, runningLimit, responseWriteTimeout, requestReadTimeout, " +
-                "httpServerCodec, channelPipelineConfig, enableHttp2, enableH2c, shareWorkGroup)"
+                "applicationProvider, enginePipeline, environment, " +
+                "callExecutorResolver(callEventGroup, false), engineContext, userContext, connector, " +
+                "runningLimit, responseWriteTimeout, requestReadTimeout, httpServerCodec, " +
+                "channelPipelineConfig, enableHttp2, enableH2c, false)"
         )
     )
     public constructor(
@@ -134,7 +137,7 @@ public class NettyChannelInitializer(
         applicationProvider = applicationProvider,
         enginePipeline = enginePipeline,
         environment = environment,
-        callEventGroup = callEventGroup,
+        resolveCallExecutor = callExecutorResolver(callEventGroup, false),
         engineContext = engineContext,
         userContext = userContext,
         connector = connector,
@@ -145,50 +148,7 @@ public class NettyChannelInitializer(
         channelPipelineConfig = channelPipelineConfig,
         enableHttp2 = enableHttp2,
         enableH2c = enableH2c,
-        shareWorkGroup = false
-    )
-
-    @Deprecated(
-        message = "Use main constructor",
-        replaceWith = ReplaceWith(
-            "NettyChannelInitializer(" +
-                "applicationProvider, enginePipeline, environment, " +
-                "callExecutorResolver(callEventGroup, shareWorkGroup), engineContext, userContext, " +
-                "connector, runningLimit, responseWriteTimeout, requestReadTimeout, httpServerCodec, " +
-                "channelPipelineConfig, enableHttp2, enableH2c)"
-        )
-    )
-    public constructor(
-        applicationProvider: () -> Application,
-        enginePipeline: EnginePipeline,
-        environment: ApplicationEnvironment,
-        callEventGroup: EventExecutorGroup,
-        engineContext: CoroutineContext,
-        userContext: CoroutineContext,
-        connector: EngineConnectorConfig,
-        runningLimit: Int,
-        responseWriteTimeout: Int,
-        requestReadTimeout: Int,
-        httpServerCodec: () -> HttpServerCodec,
-        channelPipelineConfig: ChannelPipeline.() -> Unit,
-        enableHttp2: Boolean,
-        enableH2c: Boolean,
-        shareWorkGroup: Boolean,
-    ) : this(
-        applicationProvider = applicationProvider,
-        enginePipeline = enginePipeline,
-        environment = environment,
-        resolveCallExecutor = callExecutorResolver(callEventGroup, shareWorkGroup),
-        engineContext = engineContext,
-        userContext = userContext,
-        connector = connector,
-        runningLimit = runningLimit,
-        responseWriteTimeout = responseWriteTimeout,
-        requestReadTimeout = requestReadTimeout,
-        httpServerCodec = httpServerCodec,
-        channelPipelineConfig = channelPipelineConfig,
-        enableHttp2 = enableHttp2,
-        enableH2c = enableH2c
+        enableFlushConsolidation = false
     )
 
     init {
@@ -229,6 +189,16 @@ public class NettyChannelInitializer(
 
     override fun initChannel(ch: SocketChannel) {
         with(ch.pipeline()) {
+            if (enableFlushConsolidation) {
+                addLast(
+                    "flushConsolidation",
+                    FlushConsolidationHandler(
+                        FlushConsolidationHandler.DEFAULT_EXPLICIT_FLUSH_AFTER_FLUSHES,
+                        false
+                    )
+                )
+            }
+
             when {
                 connector is EngineSSLConnectorConfig -> {
                     val sslEngine = sslContext!!.newEngine(ch.alloc()).apply {

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyChannelInitializer.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyChannelInitializer.kt
@@ -33,6 +33,7 @@ import io.netty.handler.ssl.SupportedCipherSuiteFilter
 import io.netty.handler.timeout.ReadTimeoutException
 import io.netty.handler.timeout.ReadTimeoutHandler
 import io.netty.handler.timeout.WriteTimeoutHandler
+import io.netty.util.concurrent.EventExecutor
 import io.netty.util.concurrent.EventExecutorGroup
 import java.io.FileInputStream
 import java.nio.channels.ClosedChannelException
@@ -51,7 +52,7 @@ public class NettyChannelInitializer(
     private val applicationProvider: () -> Application,
     private val enginePipeline: EnginePipeline,
     private val environment: ApplicationEnvironment,
-    private val callEventGroup: EventExecutorGroup,
+    private val resolveCallExecutor: (ChannelHandlerContext) -> EventExecutor,
     private val engineContext: CoroutineContext,
     private val userContext: CoroutineContext,
     private val connector: EngineConnectorConfig,
@@ -61,7 +62,7 @@ public class NettyChannelInitializer(
     private val httpServerCodec: () -> HttpServerCodec,
     private val channelPipelineConfig: ChannelPipeline.() -> Unit,
     private val enableHttp2: Boolean,
-    private val enableH2c: Boolean
+    private val enableH2c: Boolean,
 ) : ChannelInitializer<SocketChannel>() {
     private var sslContext: SslContext? = null
 
@@ -103,6 +104,91 @@ public class NettyChannelInitializer(
         channelPipelineConfig = channelPipelineConfig,
         enableHttp2 = enableHttp2,
         enableH2c = false
+    )
+
+    @Deprecated(
+        message = "Use main constructor",
+        replaceWith = ReplaceWith(
+            "NettyChannelInitializer(" +
+                "applicationProvider, enginePipeline, environment, callEventGroup, engineContext, " +
+                "userContext, connector, runningLimit, responseWriteTimeout, requestReadTimeout, " +
+                "httpServerCodec, channelPipelineConfig, enableHttp2, enableH2c, shareWorkGroup)"
+        )
+    )
+    public constructor(
+        applicationProvider: () -> Application,
+        enginePipeline: EnginePipeline,
+        environment: ApplicationEnvironment,
+        callEventGroup: EventExecutorGroup,
+        engineContext: CoroutineContext,
+        userContext: CoroutineContext,
+        connector: EngineConnectorConfig,
+        runningLimit: Int,
+        responseWriteTimeout: Int,
+        requestReadTimeout: Int,
+        httpServerCodec: () -> HttpServerCodec,
+        channelPipelineConfig: ChannelPipeline.() -> Unit,
+        enableHttp2: Boolean,
+        enableH2c: Boolean,
+    ) : this(
+        applicationProvider = applicationProvider,
+        enginePipeline = enginePipeline,
+        environment = environment,
+        callEventGroup = callEventGroup,
+        engineContext = engineContext,
+        userContext = userContext,
+        connector = connector,
+        runningLimit = runningLimit,
+        responseWriteTimeout = responseWriteTimeout,
+        requestReadTimeout = requestReadTimeout,
+        httpServerCodec = httpServerCodec,
+        channelPipelineConfig = channelPipelineConfig,
+        enableHttp2 = enableHttp2,
+        enableH2c = enableH2c,
+        shareWorkGroup = false
+    )
+
+    @Deprecated(
+        message = "Use main constructor",
+        replaceWith = ReplaceWith(
+            "NettyChannelInitializer(" +
+                "applicationProvider, enginePipeline, environment, " +
+                "callExecutorResolver(callEventGroup, shareWorkGroup), engineContext, userContext, " +
+                "connector, runningLimit, responseWriteTimeout, requestReadTimeout, httpServerCodec, " +
+                "channelPipelineConfig, enableHttp2, enableH2c)"
+        )
+    )
+    public constructor(
+        applicationProvider: () -> Application,
+        enginePipeline: EnginePipeline,
+        environment: ApplicationEnvironment,
+        callEventGroup: EventExecutorGroup,
+        engineContext: CoroutineContext,
+        userContext: CoroutineContext,
+        connector: EngineConnectorConfig,
+        runningLimit: Int,
+        responseWriteTimeout: Int,
+        requestReadTimeout: Int,
+        httpServerCodec: () -> HttpServerCodec,
+        channelPipelineConfig: ChannelPipeline.() -> Unit,
+        enableHttp2: Boolean,
+        enableH2c: Boolean,
+        shareWorkGroup: Boolean,
+    ) : this(
+        applicationProvider = applicationProvider,
+        enginePipeline = enginePipeline,
+        environment = environment,
+        resolveCallExecutor = callExecutorResolver(callEventGroup, shareWorkGroup),
+        engineContext = engineContext,
+        userContext = userContext,
+        connector = connector,
+        runningLimit = runningLimit,
+        responseWriteTimeout = responseWriteTimeout,
+        requestReadTimeout = requestReadTimeout,
+        httpServerCodec = httpServerCodec,
+        channelPipelineConfig = channelPipelineConfig,
+        enableHttp2 = enableHttp2,
+        enableH2c = enableH2c
     )
 
     init {
@@ -181,7 +267,7 @@ public class NettyChannelInitializer(
                 val handler = NettyHttp2Handler(
                     enginePipeline,
                     application,
-                    callEventGroup,
+                    resolveCallExecutor,
                     application.coroutineContext + userContext,
                     runningLimit
                 )
@@ -202,7 +288,7 @@ public class NettyChannelInitializer(
                 val handler = NettyHttp2Handler(
                     enginePipeline,
                     application,
-                    callEventGroup,
+                    resolveCallExecutor,
                     application.coroutineContext + userContext,
                     runningLimit
                 )
@@ -238,7 +324,7 @@ public class NettyChannelInitializer(
                             applicationProvider,
                             enginePipeline,
                             environment,
-                            callEventGroup,
+                            resolveCallExecutor,
                             engineContext,
                             userContext,
                             runningLimit
@@ -272,7 +358,7 @@ public class NettyChannelInitializer(
                     applicationProvider,
                     enginePipeline,
                     environment,
-                    callEventGroup,
+                    resolveCallExecutor,
                     engineContext,
                     userContext,
                     runningLimit

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyHttpHandlerState.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyHttpHandlerState.kt
@@ -10,7 +10,6 @@ import kotlinx.atomicfu.*
 internal class NettyHttpHandlerState(private val runningLimit: Int) {
 
     internal val activeRequests: AtomicLong = atomic(0L)
-    internal val streamingResponses: AtomicLong = atomic(0L)
     internal val isCurrentRequestFullyRead: AtomicBoolean = atomic(false)
     internal val isChannelReadCompleted: AtomicBoolean = atomic(false)
     internal val skippedRead: AtomicBoolean = atomic(false)

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyHttpHandlerState.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyHttpHandlerState.kt
@@ -7,7 +7,10 @@ package io.ktor.server.netty
 import io.netty.channel.*
 import kotlinx.atomicfu.*
 
-internal class NettyHttpHandlerState(private val runningLimit: Int) {
+internal class NettyHttpHandlerState(
+    private val runningLimit: Int,
+    private val onCapacityAvailable: (ChannelHandlerContext) -> Unit = {}
+) {
 
     internal val activeRequests: AtomicLong = atomic(0L)
     internal val isCurrentRequestFullyRead: AtomicBoolean = atomic(false)
@@ -20,5 +23,6 @@ internal class NettyHttpHandlerState(private val runningLimit: Int) {
         if (skippedRead.compareAndSet(expect = false, update = true) && activeRequests.value < runningLimit) {
             context.read()
         }
+        onCapacityAvailable(context)
     }
 }

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/PinnedCallExecutor.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/PinnedCallExecutor.kt
@@ -13,20 +13,38 @@ private val PinnedCallExecutorKey: AttributeKey<EventExecutor> =
     AttributeKey.valueOf("ktor.netty.pinnedCallExecutor")
 
 /**
- * Returns the [EventExecutor] from [callEventGroup] pinned to the given Netty channel.
+ * Builds a function resolving the [EventExecutor] a call's coroutine should be dispatched onto and
+ * resumed on, for a given [ChannelHandlerContext].
  *
- * The executor is selected once per channel and cached as a channel attribute, so all calls on a given
- * connection (HTTP/1) or stream (HTTP/2) are dispatched onto a single thread for the lifetime of the
- * channel. This preserves thread affinity across coroutine suspensions, allowing user code to observe
- * the same thread before and after `withContext` / other suspension points.
+ * When [shareWorkGroup] is `true`, [callEventGroup] is the same group that drives the channel's own I/O.
+ * [EventExecutorGroup.next] could still pick a different thread within that group than the channel's own
+ * event loop, so the resolver is pinned directly to [ChannelHandlerContext.executor] instead: this
+ * guarantees the initial, un-suspended dispatch and any post-suspension resumption land on the exact same
+ * thread.
+ *
+ * Otherwise, the resolver selects an [EventExecutor] from [callEventGroup] once per channel and caches it
+ * as a channel attribute, so all calls on a given connection (HTTP/1) or stream (HTTP/2) are dispatched
+ * onto a single thread for the lifetime of the channel. This preserves thread affinity across coroutine
+ * suspensions, allowing user code to observe the same thread before and after `withContext` / other
+ * suspension points.
  */
-internal fun pinnedCallExecutor(
-    context: ChannelHandlerContext,
-    callEventGroup: EventExecutorGroup
-): EventExecutor {
-    val attr = context.channel().attr(PinnedCallExecutorKey)
-    val existing = attr.get()
-    if (existing != null) return existing
-    val picked = callEventGroup.next()
-    return if (attr.compareAndSet(null, picked)) picked else attr.get()
+internal fun callExecutorResolver(
+    callEventGroup: EventExecutorGroup,
+    shareWorkGroup: Boolean
+): (ChannelHandlerContext) -> EventExecutor {
+    if (shareWorkGroup) return ChannelHandlerContext::executor
+    return { context ->
+        val attr = context.channel().attr(PinnedCallExecutorKey)
+        val existing = attr.get()
+        if (existing != null) {
+            existing
+        } else {
+            val picked = callEventGroup.next()
+            if (attr.compareAndSet(null, picked)) {
+                picked
+            } else {
+                attr.get()
+            }
+        }
+    }
 }

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/cio/NettyHttpResponsePipeline.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/cio/NettyHttpResponsePipeline.kt
@@ -44,7 +44,7 @@ private const val UNFLUSHED_LIMIT = 65536
 internal class NettyHttpResponsePipeline(
     private val context: ChannelHandlerContext,
     private val httpHandlerState: NettyHttpHandlerState,
-    override val coroutineContext: CoroutineContext,
+    override var coroutineContext: CoroutineContext,
     private val onFailure: (() -> Unit)? = null
 ) : CoroutineScope {
     /**

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/cio/NettyHttpResponsePipeline.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/cio/NettyHttpResponsePipeline.kt
@@ -29,18 +29,17 @@ private const val UNFLUSHED_LIMIT = 65536
 /**
  * Contains methods for handling HTTP responses with Netty.
  *
- * The pipeline serializes response writes in request order, tracks active and streaming responses,
- * and flushes pending writes when the channel read cycle is complete and no non-streaming responses
- * are still active.
+ * The pipeline serializes response writes in request order and flushes pending writes once the
+ * channel read cycle is complete.
  *
  * @property context Netty channel context used to write, flush, read from, and close the channel.
- * @property httpHandlerState Shared state used to coordinate request counters, streaming counters,
- *                            read-completion state, and back-pressure decisions for the handler.
+ * @property httpHandlerState Shared state used to coordinate request counters, read-completion state,
+ *                            and back-pressure decisions for the handler.
  * @property coroutineContext Coroutine context used to launch response body writer coroutines.
  * @property onFailure Optional action invoked after a failed call's counters are decremented. For HTTP/2, this is
  *                     used to trigger [flushIfNeeded] on the most-recently-created pipeline (which may differ from
- *                     `this` due to the shared-handler-per-stream design), so that a pending flush blocked by the
- *                     stale counter is unblocked regardless of thread-scheduling order.
+ *                     `this` due to the shared-handler-per-stream design), so that any of its pending writes are
+ *                     flushed regardless of thread-scheduling order.
  */
 internal class NettyHttpResponsePipeline(
     private val context: ChannelHandlerContext,
@@ -65,14 +64,13 @@ internal class NettyHttpResponsePipeline(
     /** Flush if all is true:
      * - there is some unflushed data
      * - nothing to read from the channel
-     * - there are no active non-streaming requests
+     *
+     * Flushing never reorders already-written data (Netty's outbound buffer is FIFO), so it is always safe
+     * to flush as soon as the current read cycle is done, regardless of how many other requests on this
+     * connection are still being computed or written.
      */
     internal fun flushIfNeeded() {
-        if (
-            isDataNotFlushed.value &&
-            httpHandlerState.isChannelReadCompleted.value &&
-            httpHandlerState.activeRequests.value == httpHandlerState.streamingResponses.value
-        ) {
+        if (isDataNotFlushed.value && httpHandlerState.isChannelReadCompleted.value) {
             context.flush()
             isDataNotFlushed.compareAndSet(expect = true, update = false)
         }
@@ -126,9 +124,6 @@ internal class NettyHttpResponsePipeline(
             else -> actualException
         }
 
-        if (call.isStreamingResponse) {
-            httpHandlerState.streamingResponses.decrementAndGet()
-        }
         httpHandlerState.activeRequests.decrementAndGet()
 
         flushIfNeeded()
@@ -170,9 +165,6 @@ internal class NettyHttpResponsePipeline(
             null
         }
 
-        if (call.isStreamingResponse) {
-            httpHandlerState.streamingResponses.decrementAndGet()
-        }
         httpHandlerState.onLastResponseMessage(context)
         call.finishedEvent.setSuccess()
 
@@ -224,9 +216,6 @@ internal class NettyHttpResponsePipeline(
             responseMessage is Http3HeadersFrame -> responseMessage.headers().getInt("content-length", -1)
             else -> -1
         }
-
-        call.isStreamingResponse = true
-        httpHandlerState.streamingResponses.incrementAndGet()
 
         launch(context.executor().asCoroutineDispatcher(), start = CoroutineStart.UNDISPATCHED) {
             respondWithBodyAndTrailerMessage(

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/cio/NettyHttpResponsePipeline.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/cio/NettyHttpResponsePipeline.kt
@@ -92,7 +92,11 @@ internal class NettyHttpResponsePipeline(
         } catch (actualException: Throwable) {
             respondWithFailure(call, actualException)
         } finally {
-            call.responseWriteJob.cancel()
+            // On the failure path above, responseWriteJob is already cancelled by respondWithFailure;
+            // completing it here again is then a no-op. On the (overwhelmingly common) success path,
+            // this is the actual completion signal, so it goes through complete()'s fast path rather
+            // than cancel()'s always-slow-path Finishing/exception-aggregation machinery.
+            call.completeResponseWriteJob()
         }
     }
 

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http1/NettyHttp1Handler.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http1/NettyHttp1Handler.kt
@@ -71,7 +71,9 @@ internal class NettyHttp1Handler(
             return
         }
         activated = true
-        handlerJob = SupervisorJob(applicationProvider().coroutineContext[Job])
+        val application = applicationProvider()
+        handlerJob = SupervisorJob(application.coroutineContext[Job])
+        channelApplication = application
         responseWriter = NettyHttpResponsePipeline(
             context = context,
             httpHandlerState = state,
@@ -221,6 +223,13 @@ internal class NettyHttp1Handler(
     private fun handleRequest(context: ChannelHandlerContext, message: HttpRequest) {
         val callExecutor = resolveCallExecutor(context)
         val application = applicationProvider()
+
+        // check for reload before re-using handlerJob
+        if (application !== channelApplication) {
+            handlerJob = SupervisorJob(application.coroutineContext[Job])
+            responseWriter.coroutineContext = handlerJob
+        }
+
         // Building the coroutine context is quite expensive, so we cache most of the elements.
         val baseContext = when {
             application === channelApplication && channelCoroutineContext !== EmptyCoroutineContext ->

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http1/NettyHttp1Handler.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http1/NettyHttp1Handler.kt
@@ -19,7 +19,7 @@ import io.netty.channel.ChannelInboundHandlerAdapter
 import io.netty.handler.codec.http.*
 import io.netty.handler.timeout.ReadTimeoutException
 import io.netty.util.ReferenceCountUtil
-import io.netty.util.concurrent.EventExecutorGroup
+import io.netty.util.concurrent.EventExecutor
 import kotlinx.coroutines.*
 import java.io.IOException
 import java.util.concurrent.ConcurrentLinkedQueue
@@ -31,7 +31,7 @@ internal class NettyHttp1Handler(
     private val applicationProvider: () -> Application,
     private val enginePipeline: EnginePipeline,
     private val environment: ApplicationEnvironment,
-    private val callEventGroup: EventExecutorGroup,
+    private val resolveCallExecutor: (ChannelHandlerContext) -> EventExecutor,
     private val engineContext: CoroutineContext,
     private val userContext: CoroutineContext,
     private val runningLimit: Int
@@ -219,7 +219,7 @@ internal class NettyHttp1Handler(
     }
 
     private fun handleRequest(context: ChannelHandlerContext, message: HttpRequest) {
-        val callExecutor = pinnedCallExecutor(context, callEventGroup)
+        val callExecutor = resolveCallExecutor(context)
         val application = applicationProvider()
         // Building the coroutine context is quite expensive, so we cache most of the elements.
         val baseContext = when {
@@ -254,8 +254,10 @@ internal class NettyHttp1Handler(
         // This allows the response pipeline to detect that the request body is still being received and flush headers
         // early instead of buffering them, which is required when the client waits for response headers
         // before sending the request body.
-        // Dispatching to the call event group also ensures user handler code does not run on the I/O worker
-        // event loop.
+        // Dispatching to the call executor also ensures user handler code does not run on the I/O worker
+        // event loop. When resolveCallExecutor is pinned directly to context.executor() (shareWorkGroup),
+        // calls that never suspend skip that hop entirely and run on the I/O thread instead; calls that do
+        // suspend still resume on that same thread via NettyDispatcher.
         callExecutor.execute {
             val callScope = CoroutineScope(context = callContext)
             callScope.launch(start = CoroutineStart.UNDISPATCHED) {

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http1/NettyHttp1Handler.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http1/NettyHttp1Handler.kt
@@ -18,6 +18,7 @@ import io.netty.channel.ChannelHandlerContext
 import io.netty.channel.ChannelInboundHandlerAdapter
 import io.netty.handler.codec.http.*
 import io.netty.handler.timeout.ReadTimeoutException
+import io.netty.util.ReferenceCountUtil
 import io.netty.util.concurrent.EventExecutorGroup
 import kotlinx.coroutines.*
 import java.io.IOException
@@ -35,13 +36,19 @@ internal class NettyHttp1Handler(
     private val userContext: CoroutineContext,
     private val runningLimit: Int
 ) : ChannelInboundHandlerAdapter() {
-    private val handlerJob = CompletableDeferred<Nothing>()
-
     private var skipEmpty = false
 
     private lateinit var responseWriter: NettyHttpResponsePipeline
 
-    private val state = NettyHttpHandlerState(runningLimit)
+    private val state = NettyHttpHandlerState(runningLimit, onCapacityAvailable = ::drainPending)
+
+    private lateinit var handlerJob: CompletableJob
+
+    // Decoded messages that arrived while activeRequests >= runningLimit.
+    // Netty's HTTP codec can decode and deliver many complete pipelined HttpRequest from a single read
+    // so the only way to make runningLimit an actual hard cap is to buffer messages here instead of dispatching them,
+    // and replay them in order once a slot frees up. Access is confined to this channel's event loop.
+    private val pendingMessages = ArrayDeque<Any>()
 
     private val activeCalls = ConcurrentLinkedQueue<NettyHttp1ApplicationCall>()
 
@@ -64,7 +71,7 @@ internal class NettyHttp1Handler(
             return
         }
         activated = true
-
+        handlerJob = SupervisorJob(applicationProvider().coroutineContext[Job])
         responseWriter = NettyHttpResponsePipeline(
             context = context,
             httpHandlerState = state,
@@ -86,16 +93,41 @@ internal class NettyHttp1Handler(
     }
 
     override fun channelRead(context: ChannelHandlerContext, message: Any) {
+        // These flags track the state of the *live* physical read cycle currently in progress, so they must
+        // only be touched here, for messages as they are actually decoded - never from drainPending, which
+        // replays messages decoded during a past, already-completed read cycle.
         if (message is LastHttpContent) {
             state.isCurrentRequestFullyRead.compareAndSet(expect = false, update = true)
         }
+        if (message is HttpRequest) {
+            if (message !is LastHttpContent) {
+                state.isCurrentRequestFullyRead.compareAndSet(expect = true, update = false)
+            }
+            state.isChannelReadCompleted.compareAndSet(expect = true, update = false)
+        }
 
+        // A pipelined connection can have several complete requests (and their body content) decoded from
+        // one physical read. HTTP/1.1 requests on a connection never interleave on the wire, so once one
+        // message has been deferred, every message after it - whether it's the rest of that request's body
+        // or the start of the next pipelined request - must stay queued in order until we catch up.
+        if (pendingMessages.isNotEmpty()) {
+            pendingMessages.addLast(message)
+            return
+        }
+        dispatchOrDefer(context, message)
+    }
+
+    private fun dispatchOrDefer(context: ChannelHandlerContext, message: Any) {
+        if (message is HttpRequest && state.activeRequests.value >= runningLimit) {
+            pendingMessages.addLast(message)
+            return
+        }
+        dispatchMessage(context, message)
+    }
+
+    private fun dispatchMessage(context: ChannelHandlerContext, message: Any) {
         when (message) {
             is HttpRequest -> {
-                if (message !is LastHttpContent) {
-                    state.isCurrentRequestFullyRead.compareAndSet(expect = true, update = false)
-                }
-                state.isChannelReadCompleted.compareAndSet(expect = true, update = false)
                 state.activeRequests.incrementAndGet()
 
                 handleRequest(context, message)
@@ -114,6 +146,20 @@ internal class NettyHttp1Handler(
         }
     }
 
+    /**
+     * Replays messages that were buffered by [dispatchOrDefer] while over [runningLimit], now that a slot
+     * has freed up. Stops as soon as the next queued message is a new request that would exceed the limit
+     * again, leaving it (and everything after it) queued for the next call.
+     */
+    private fun drainPending(context: ChannelHandlerContext) {
+        while (true) {
+            val next = pendingMessages.firstOrNull() ?: return
+            if (next is HttpRequest && state.activeRequests.value >= runningLimit) return
+            pendingMessages.removeFirst()
+            dispatchMessage(context, next)
+        }
+    }
+
     override fun channelInactive(context: ChannelHandlerContext) {
         onConnectionClose(context)
         context.fireChannelInactive()
@@ -123,19 +169,27 @@ internal class NettyHttp1Handler(
         if (context.channel().isActive) {
             return
         }
+        while (pendingMessages.isNotEmpty()) {
+            ReferenceCountUtil.release(pendingMessages.removeFirst())
+        }
         while (true) {
             val call = activeCalls.poll() ?: break
             @OptIn(InternalAPI::class)
             call.attributes.getOrNull(HttpRequestCloseHandlerKey)?.invoke()
         }
+        handlerJob.complete()
     }
 
     @Suppress("OverridingDeprecatedMember")
     override fun exceptionCaught(context: ChannelHandlerContext, cause: Throwable) {
         when (cause) {
             is IOException -> {
+                // Cancellation of in-flight calls and completion of handlerJob is left to
+                // onConnectionClose(), triggered by the channelInactive() that follows this close():
+                // that path invokes each call's HttpRequestCloseHandlerKey callback (giving opted-in
+                // calls their specific ConnectionClosedException cause) before touching handlerJob,
+                // so doing it here too would race a generic cause against that specific one.
                 environment.log.trace("I/O operation failed", cause)
-                handlerJob.cancel()
                 context.close()
             }
 
@@ -151,7 +205,8 @@ internal class NettyHttp1Handler(
             }
 
             else -> {
-                handlerJob.completeExceptionally(cause)
+                // See the IOException branch above: cleanup is left to the channelInactive()/
+                // onConnectionClose() that follows this close().
                 context.close()
             }
         }
@@ -181,7 +236,7 @@ internal class NettyHttp1Handler(
                 newContext
             }
         }
-        val callJob = Job(parent = baseContext[Job])
+        val callJob = Job(parent = handlerJob)
 
         // Only the per-call [Job] is combined per request; the rest of the context is cached on the
         // handler instance and reused across all calls on this connection.

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http2/NettyHttp2Handler.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http2/NettyHttp2Handler.kt
@@ -125,7 +125,7 @@ internal class NettyHttp2Handler(
     }
 
     private fun startHttp2(context: ChannelHandlerContext, headers: Http2Headers) {
-        val callJob = Job(parent = parentJob)
+        val callJob = Job(parent = handlerJob)
         val callExecutor = pinnedCallExecutor(context, callEventGroup)
         // Combine the cached static context with the per-stream dispatcher and per-call [Job] only.
         val callContext = staticCallContext +
@@ -274,8 +274,8 @@ internal class NettyHttp2Handler(
         }
     }
 
-    internal fun cancel() {
-        handlerJob.cancel()
+    internal fun onConnectionClose() {
+        handlerJob.complete()
     }
 
     companion object {

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http2/NettyHttp2Handler.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http2/NettyHttp2Handler.kt
@@ -55,6 +55,12 @@ internal class NettyHttp2Handler(
                 state.isChannelReadCompleted.compareAndSet(expect = true, update = false)
                 state.activeRequests.incrementAndGet()
                 startHttp2(context, message.headers())
+                if (message.isEndStream) {
+                    context.applicationCall?.request?.apply {
+                        contentActor.close()
+                        state.isCurrentRequestFullyRead.compareAndSet(expect = false, update = true)
+                    }
+                }
             }
 
             is Http2DataFrame -> {

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http2/NettyHttp2Handler.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http2/NettyHttp2Handler.kt
@@ -20,7 +20,7 @@ import io.netty.channel.ChannelInboundHandlerAdapter
 import io.netty.handler.codec.http2.*
 import io.netty.util.AttributeKey
 import io.netty.util.ReferenceCountUtil
-import io.netty.util.concurrent.EventExecutorGroup
+import io.netty.util.concurrent.EventExecutor
 import kotlinx.coroutines.*
 import java.lang.reflect.Field
 import java.nio.channels.ClosedChannelException
@@ -30,7 +30,7 @@ import kotlin.coroutines.CoroutineContext
 internal class NettyHttp2Handler(
     private val enginePipeline: EnginePipeline,
     private val application: Application,
-    private val callEventGroup: EventExecutorGroup,
+    private val resolveCallExecutor: (ChannelHandlerContext) -> EventExecutor,
     private val userCoroutineContext: CoroutineContext,
     runningLimit: Int
 ) : ChannelInboundHandlerAdapter() {
@@ -126,7 +126,7 @@ internal class NettyHttp2Handler(
 
     private fun startHttp2(context: ChannelHandlerContext, headers: Http2Headers) {
         val callJob = Job(parent = handlerJob)
-        val callExecutor = pinnedCallExecutor(context, callEventGroup)
+        val callExecutor = resolveCallExecutor(context)
         // Combine the cached static context with the per-stream dispatcher and per-call [Job] only.
         val callContext = staticCallContext +
             NettyDispatcher.CurrentContext(context, callExecutor) +
@@ -150,8 +150,10 @@ internal class NettyHttp2Handler(
         // Defer coroutine start to the next event loop tick so that channelRead returns and Netty can
         // deliver subsequent Http2DataFrame messages. Without this, the coroutine runs on the event loop,
         // blocking data frame delivery and causing EOFException.
-        // Dispatching to the call event group also ensures user handler code does not run on the I/O worker
-        // event loop.
+        // Dispatching to the call executor also ensures user handler code does not run on the I/O worker
+        // event loop. When resolveCallExecutor is pinned directly to context.executor() (shareWorkGroup),
+        // calls that never suspend skip that hop entirely and run on the I/O thread instead; calls that do
+        // suspend still resume on that same thread via NettyDispatcher.
         callExecutor.execute {
             val callScope = CoroutineScope(context = callContext)
             callScope.launch(start = CoroutineStart.UNDISPATCHED) {

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http3/NettyHttp3ChannelInitializer.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http3/NettyHttp3ChannelInitializer.kt
@@ -20,6 +20,8 @@ import io.netty.handler.codec.quic.QuicCodecDispatcher
 import io.netty.handler.codec.quic.QuicConnectionIdGenerator
 import io.netty.handler.codec.quic.QuicSslContext
 import io.netty.util.concurrent.EventExecutorGroup
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
 import java.util.concurrent.TimeUnit
 import kotlin.coroutines.CoroutineContext
 
@@ -118,6 +120,12 @@ internal class NettyHttp3ChannelInitializer(
         // Http3ServerConnectionHandler is not sharable: one instance per connection
         builder.handler(object : ChannelInitializer<QuicChannel>() {
             override fun initChannel(ch: QuicChannel) {
+                // One [SupervisorJob] per QUIC connection, parented to the application's job so that
+                // per-request [Job]s fan out across many small per-connection children lists instead
+                // of contending on the single shared `Application.applicationJob` list.
+                val connectionJob = SupervisorJob(application.coroutineContext[Job])
+                ch.attr(NettyHttp3Handler.ConnectionJobKey).set(connectionJob)
+                ch.closeFuture().addListener { connectionJob.cancel() }
                 ch.pipeline().addLast(Http3ServerConnectionHandler(streamInitializer))
             }
         })

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http3/NettyHttp3ChannelInitializer.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http3/NettyHttp3ChannelInitializer.kt
@@ -8,6 +8,7 @@ import io.ktor.server.application.*
 import io.ktor.server.engine.*
 import io.netty.channel.Channel
 import io.netty.channel.ChannelHandler
+import io.netty.channel.ChannelHandlerContext
 import io.netty.channel.ChannelInitializer
 import io.netty.channel.epoll.Epoll
 import io.netty.channel.socket.DatagramChannel
@@ -19,7 +20,7 @@ import io.netty.handler.codec.quic.QuicChannelOption
 import io.netty.handler.codec.quic.QuicCodecDispatcher
 import io.netty.handler.codec.quic.QuicConnectionIdGenerator
 import io.netty.handler.codec.quic.QuicSslContext
-import io.netty.util.concurrent.EventExecutorGroup
+import io.netty.util.concurrent.EventExecutor
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import java.util.concurrent.TimeUnit
@@ -42,7 +43,7 @@ internal class NettyHttp3ChannelInitializer(
     private val applicationProvider: () -> Application,
     private val enginePipeline: EnginePipeline,
     private val userContext: CoroutineContext,
-    private val callEventGroup: EventExecutorGroup,
+    private val resolveCallExecutor: (ChannelHandlerContext) -> EventExecutor,
     private val runningLimit: Int,
     private val quicSslContext: QuicSslContext,
     private val http3Configuration: NettyHttp3Configuration,
@@ -86,7 +87,7 @@ internal class NettyHttp3ChannelInitializer(
             enginePipeline,
             application,
             userContext,
-            callEventGroup,
+            resolveCallExecutor,
             runningLimit
         )
 

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http3/NettyHttp3Handler.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http3/NettyHttp3Handler.kt
@@ -100,7 +100,7 @@ internal class NettyHttp3Handler(
     }
 
     private fun startHttp3(context: ChannelHandlerContext, headers: Http3Headers) {
-        val callJob = Job(parent = parentJob)
+        val callJob = Job(parent = handlerJob)
         val callExecutor = pinnedCallExecutor(context, callEventGroup)
         // Combine the cached static context with the per-stream dispatcher and per-call [Job] only.
         val callContext = staticCallContext + NettyDispatcher.CurrentContext(context, callExecutor) + callJob
@@ -132,6 +132,12 @@ internal class NettyHttp3Handler(
     }
 
     companion object {
+        // Attribute holding the per-[QuicChannel] connection-scoped [Job] that connection-level
+        // [SupervisorJob]s are parented to, so per-call [Job]s fan out across many small
+        // per-connection children lists instead of contending on the single shared
+        // `Application.applicationJob` list.
+        internal val ConnectionJobKey: AttributeKey<Job> = AttributeKey.valueOf("ktor.Http3ConnectionJob")
+
         private val ApplicationCallKey = AttributeKey.valueOf<NettyHttp3ApplicationCall>("ktor.Http3ApplicationCall")
 
         private var ChannelHandlerContext.applicationCall: NettyHttp3ApplicationCall?

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http3/NettyHttp3Handler.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http3/NettyHttp3Handler.kt
@@ -16,14 +16,14 @@ import io.netty.handler.codec.http3.Http3Headers
 import io.netty.handler.codec.http3.Http3HeadersFrame
 import io.netty.handler.codec.http3.Http3RequestStreamInboundHandler
 import io.netty.util.AttributeKey
-import io.netty.util.concurrent.EventExecutorGroup
+import io.netty.util.concurrent.EventExecutor
 import kotlinx.coroutines.*
 import kotlin.coroutines.CoroutineContext
 
 internal class NettyHttp3Handler(
     private val enginePipeline: EnginePipeline,
     private val application: Application,
-    private val callEventGroup: EventExecutorGroup,
+    private val resolveCallExecutor: (ChannelHandlerContext) -> EventExecutor,
     private val userCoroutineContext: CoroutineContext,
     runningLimit: Int
 ) : Http3RequestStreamInboundHandler(), CoroutineScope {
@@ -101,7 +101,7 @@ internal class NettyHttp3Handler(
 
     private fun startHttp3(context: ChannelHandlerContext, headers: Http3Headers) {
         val callJob = Job(parent = handlerJob)
-        val callExecutor = pinnedCallExecutor(context, callEventGroup)
+        val callExecutor = resolveCallExecutor(context)
         // Combine the cached static context with the per-stream dispatcher and per-call [Job] only.
         val callContext = staticCallContext + NettyDispatcher.CurrentContext(context, callExecutor) + callJob
         val call = NettyHttp3ApplicationCall(
@@ -115,8 +115,11 @@ internal class NettyHttp3Handler(
 
         responseWriter.processResponse(call)
 
-        // Dispatching to the call event group keeps user handler code off the QUIC event loop,
+        // Dispatching to the call executor keeps user handler code off the QUIC event loop,
         // which drives every connection and stream of this connector (same model as HTTP/1/2).
+        // When resolveCallExecutor is pinned directly to context.executor() (shareWorkGroup), calls that
+        // never suspend skip that hop entirely and run on the QUIC event loop instead; calls that do
+        // suspend still resume on that same thread via NettyDispatcher.
         callExecutor.execute {
             val callScope = CoroutineScope(context = callContext)
             callScope.launch(start = CoroutineStart.UNDISPATCHED) {

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http3/NettyHttp3RequestStreamInitializer.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http3/NettyHttp3RequestStreamInitializer.kt
@@ -29,12 +29,17 @@ internal class NettyHttp3RequestStreamInitializer(
 ) : ChannelInitializer<QuicStreamChannel>() {
 
     override fun initChannel(ch: QuicStreamChannel) {
+        // The connection-scoped Job attached in NettyHttp3ChannelInitializer's per-QuicChannel
+        // initializer; folded in here so NettyHttp3Handler's parentJob resolves to it instead of
+        // bypassing straight to the application's job.
+        val connectionJob = ch.parent()?.attr(NettyHttp3Handler.ConnectionJobKey)?.get()
+        val context = if (connectionJob != null) userCoroutineContext + connectionJob else userCoroutineContext
         ch.pipeline().addLast(
             NettyHttp3Handler(
                 enginePipeline,
                 application,
                 callEventGroup,
-                userCoroutineContext,
+                context,
                 runningLimit
             )
         )

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http3/NettyHttp3RequestStreamInitializer.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http3/NettyHttp3RequestStreamInitializer.kt
@@ -6,9 +6,10 @@ package io.ktor.server.netty.http3
 
 import io.ktor.server.application.*
 import io.ktor.server.engine.*
+import io.netty.channel.ChannelHandlerContext
 import io.netty.channel.ChannelInitializer
 import io.netty.handler.codec.quic.QuicStreamChannel
-import io.netty.util.concurrent.EventExecutorGroup
+import io.netty.util.concurrent.EventExecutor
 import kotlin.coroutines.CoroutineContext
 
 /**
@@ -24,7 +25,7 @@ internal class NettyHttp3RequestStreamInitializer(
     private val enginePipeline: EnginePipeline,
     private val application: Application,
     private val userCoroutineContext: CoroutineContext,
-    private val callEventGroup: EventExecutorGroup,
+    private val resolveCallExecutor: (ChannelHandlerContext) -> EventExecutor,
     private val runningLimit: Int
 ) : ChannelInitializer<QuicStreamChannel>() {
 
@@ -38,7 +39,7 @@ internal class NettyHttp3RequestStreamInitializer(
             NettyHttp3Handler(
                 enginePipeline,
                 application,
-                callEventGroup,
+                resolveCallExecutor,
                 context,
                 runningLimit
             )

--- a/ktor-server/ktor-server-netty/jvm/test/io/ktor/tests/server/netty/NettyPipeliningTest.kt
+++ b/ktor-server/ktor-server-netty/jvm/test/io/ktor/tests/server/netty/NettyPipeliningTest.kt
@@ -15,6 +15,7 @@ import io.ktor.server.test.base.*
 import io.ktor.utils.io.*
 import kotlinx.coroutines.*
 import kotlin.test.*
+import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 
 class NettyPipeliningTest :
@@ -75,6 +76,77 @@ class NettyPipeliningTest :
 
                     val slowResponse = withTimeout(5.seconds) { readChannel.readHttpResponse() }
                     assertTrue(slowResponse.contains("slow-response"), "Expected slow response, got:\n$slowResponse")
+                }
+            }
+        } finally {
+            server.stop()
+        }
+    }
+
+    @Test
+    fun `pipelined burst does not exceed running limit even when decoded in a single read`() = runTest {
+        val firstRequestStarted = CompletableDeferred<Unit>()
+        val secondRequestStarted = CompletableDeferred<Unit>()
+        val releaseFirstResponse = CompletableDeferred<Unit>()
+
+        val server = embeddedServer(
+            Netty,
+            module = {
+                routing {
+                    get("/first") {
+                        firstRequestStarted.complete(Unit)
+                        releaseFirstResponse.await()
+                        call.respondText("first-response")
+                    }
+                    get("/second") {
+                        secondRequestStarted.complete(Unit)
+                        call.respondText("second-response")
+                    }
+                }
+            },
+            configure = {
+                runningLimit = 1
+                connector {
+                    port = this@NettyPipeliningTest.port
+                    host = TEST_SERVER_HOST
+                }
+            }
+        )
+        server.start(wait = false)
+
+        try {
+            SelectorManager().use { selector ->
+                aSocket(selector).tcp().connect(TEST_SERVER_HOST, port).use { socket ->
+                    val writeChannel = socket.openWriteChannel()
+                    val readChannel = socket.openReadChannel()
+
+                    // Write both requests before the server has read anything, so Netty's HTTP codec
+                    // decodes and delivers both HttpRequest messages from a single physical socket read,
+                    // in one dispatch batch, before the running-limit check ever runs.
+                    writeChannel.writeStringUtf8(pipelinedRequest("/first") + pipelinedRequest("/second"))
+                    writeChannel.flush()
+
+                    withTimeout(5.seconds) { firstRequestStarted.await() }
+
+                    // With runningLimit = 1, /second must stay queued until /first completes, even though
+                    // both requests were already decoded together in the same read.
+                    delay(200.milliseconds)
+                    assertFalse(secondRequestStarted.isCompleted, "second request started before first completed")
+
+                    releaseFirstResponse.complete(Unit)
+
+                    val firstResponse = withTimeout(5.seconds) { readChannel.readHttpResponse() }
+                    assertTrue(
+                        firstResponse.contains("first-response"),
+                        "Expected first response, got:\n$firstResponse"
+                    )
+
+                    withTimeout(5.seconds) { secondRequestStarted.await() }
+                    val secondResponse = withTimeout(5.seconds) { readChannel.readHttpResponse() }
+                    assertTrue(
+                        secondResponse.contains("second-response"),
+                        "Expected second response, got:\n$secondResponse"
+                    )
                 }
             }
         } finally {

--- a/ktor-server/ktor-server-netty/jvm/test/io/ktor/tests/server/netty/NettyPipeliningTest.kt
+++ b/ktor-server/ktor-server-netty/jvm/test/io/ktor/tests/server/netty/NettyPipeliningTest.kt
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2014-2026 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.tests.server.netty
+
+import io.ktor.http.*
+import io.ktor.network.selector.*
+import io.ktor.network.sockets.*
+import io.ktor.server.engine.*
+import io.ktor.server.netty.*
+import io.ktor.server.response.*
+import io.ktor.server.routing.*
+import io.ktor.server.test.base.*
+import io.ktor.utils.io.*
+import kotlinx.coroutines.*
+import kotlin.test.*
+import kotlin.time.Duration.Companion.seconds
+
+class NettyPipeliningTest :
+    EngineTestBase<NettyApplicationEngine, NettyApplicationEngine.Configuration>(Netty) {
+
+    companion object {
+        private const val TEST_SERVER_HOST = "127.0.0.1"
+    }
+
+    @Test
+    fun `completed pipelined response is flushed without waiting for a later request to finish`() = runTest {
+        val slowRequestStarted = CompletableDeferred<Unit>()
+        val releaseSlowResponse = CompletableDeferred<Unit>()
+
+        val server = embeddedServer(
+            Netty,
+            module = {
+                routing {
+                    get("/fast") {
+                        call.respondText("fast-response")
+                    }
+                    get("/slow") {
+                        slowRequestStarted.complete(Unit)
+                        releaseSlowResponse.await()
+                        call.respondText("slow-response")
+                    }
+                }
+            },
+            configure = {
+                connector {
+                    port = this@NettyPipeliningTest.port
+                    host = TEST_SERVER_HOST
+                }
+            }
+        )
+        server.start(wait = false)
+
+        try {
+            SelectorManager().use { selector ->
+                aSocket(selector).tcp().connect(TEST_SERVER_HOST, port).use { socket ->
+                    val writeChannel = socket.openWriteChannel()
+                    val readChannel = socket.openReadChannel()
+
+                    // Pipeline both requests on the same connection without waiting for a response to either.
+                    writeChannel.writeStringUtf8(pipelinedRequest("/fast") + pipelinedRequest("/slow"))
+                    writeChannel.flush()
+
+                    // Confirm /slow is genuinely still in flight -- its handler is suspended independently
+                    // of /fast, which was already first in line and had nothing left to compute.
+                    withTimeout(5.seconds) { slowRequestStarted.await() }
+
+                    // /fast has no ordering dependency left to satisfy: it must reach the client promptly
+                    // instead of being held back by the still-pending /slow request sharing the connection.
+                    val fastResponse = withTimeout(2.seconds) { readChannel.readHttpResponse() }
+                    assertTrue(fastResponse.contains("fast-response"), "Expected fast response, got:\n$fastResponse")
+
+                    releaseSlowResponse.complete(Unit)
+
+                    val slowResponse = withTimeout(5.seconds) { readChannel.readHttpResponse() }
+                    assertTrue(slowResponse.contains("slow-response"), "Expected slow response, got:\n$slowResponse")
+                }
+            }
+        } finally {
+            server.stop()
+        }
+    }
+
+    private fun pipelinedRequest(path: String): String =
+        "GET $path HTTP/1.1\r\nHost: $TEST_SERVER_HOST\r\nConnection: keep-alive\r\n\r\n"
+
+    private suspend fun ByteReadChannel.readHttpResponse(): String {
+        val builder = StringBuilder()
+        var contentLength = 0
+        while (true) {
+            val line = readLine() ?: error("Unexpected end of stream while reading response headers")
+            builder.append(line).append("\r\n")
+            if (line.isEmpty()) break
+
+            val separator = line.indexOf(':')
+            if (separator > 0 && line.take(separator).equals(HttpHeaders.ContentLength, ignoreCase = true)) {
+                contentLength = line.substring(separator + 1).trim().toInt()
+            }
+        }
+        if (contentLength > 0) {
+            val body = ByteArray(contentLength)
+            readFully(body)
+            builder.append(body.decodeToString())
+        }
+        return builder.toString()
+    }
+}

--- a/ktor-server/ktor-server-netty/jvm/test/io/ktor/tests/server/netty/NettySpecificTest.kt
+++ b/ktor-server/ktor-server-netty/jvm/test/io/ktor/tests/server/netty/NettySpecificTest.kt
@@ -12,7 +12,7 @@ import io.ktor.client.*
 import io.ktor.client.engine.cio.*
 import io.ktor.client.plugins.*
 import io.ktor.client.request.*
-import io.ktor.client.statement.bodyAsText
+import io.ktor.client.statement.*
 import io.ktor.http.*
 import io.ktor.http.content.*
 import io.ktor.network.selector.*
@@ -22,7 +22,7 @@ import io.ktor.server.application.hooks.*
 import io.ktor.server.engine.*
 import io.ktor.server.netty.*
 import io.ktor.server.netty.http1.*
-import io.ktor.server.request.receive
+import io.ktor.server.request.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
 import io.ktor.test.dispatcher.*
@@ -39,12 +39,10 @@ import java.io.IOException
 import java.net.BindException
 import java.net.ServerSocket
 import java.util.concurrent.ExecutorService
-import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.atomic.AtomicReference
 import kotlin.coroutines.EmptyCoroutineContext
 import kotlin.test.*
 import kotlin.time.Duration.Companion.milliseconds
-import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Duration.Companion.seconds
 
 class NettySpecificTest {

--- a/ktor-server/ktor-server-netty/jvm/test/io/ktor/tests/server/netty/NettySpecificTest.kt
+++ b/ktor-server/ktor-server-netty/jvm/test/io/ktor/tests/server/netty/NettySpecificTest.kt
@@ -29,6 +29,8 @@ import io.ktor.test.dispatcher.*
 import io.ktor.utils.io.*
 import io.mockk.mockk
 import io.netty.channel.Channel
+import io.netty.channel.ChannelHandlerContext
+import io.netty.channel.ChannelInboundHandlerAdapter
 import io.netty.channel.EventLoopGroup
 import io.netty.channel.embedded.EmbeddedChannel
 import io.netty.channel.nio.NioEventLoopGroup
@@ -285,7 +287,7 @@ class NettySpecificTest {
             applicationProvider = { mockk(relaxed = true) },
             enginePipeline = mockk(relaxed = true),
             environment = environment,
-            callEventGroup = callEventGroup,
+            resolveCallExecutor = callExecutorResolver(callEventGroup, shareWorkGroup = false),
             engineContext = EmptyCoroutineContext,
             userContext = EmptyCoroutineContext,
             runningLimit = 32
@@ -413,6 +415,52 @@ class NettySpecificTest {
             assertTrue(
                 callEventGroup.any { it.inEventLoop(thread) },
                 "Handler ran on '${thread.name}', not on any call event group thread"
+            )
+        } finally {
+            server.stopSuspend()
+        }
+    }
+
+    @Test
+    fun `request handler runs on channel event loop when shareWorkGroup is enabled`() = runTestWithRealTime {
+        val ioThread = AtomicReference<Thread>()
+        val handlerThread = AtomicReference<Thread>()
+
+        val server = embeddedServer(
+            factory = Netty,
+            rootConfig = serverConfig {
+                module {
+                    routing {
+                        get("/") {
+                            handlerThread.set(Thread.currentThread())
+                            call.respondText("ok")
+                        }
+                    }
+                }
+            },
+            configure = {
+                connector { port = 0 }
+                shareWorkGroup = true
+                channelPipelineConfig = {
+                    addLast(object : ChannelInboundHandlerAdapter() {
+                        override fun channelRead(ctx: ChannelHandlerContext, msg: Any) {
+                            ioThread.set(Thread.currentThread())
+                            ctx.fireChannelRead(msg)
+                        }
+                    })
+                }
+            }
+        )
+        server.startSuspend(wait = false)
+
+        try {
+            val connector = server.engine.resolvedConnectors().first()
+            HttpClient(CIO).use { it.get("http://${connector.host}:${connector.port}/") }
+
+            assertSame(
+                ioThread.get(),
+                handlerThread.get(),
+                "Expected the call to start on the channel's own event loop thread when shareWorkGroup is enabled"
             )
         } finally {
             server.stopSuspend()

--- a/ktor-server/ktor-server-test-suites/jvm/src/io/ktor/server/testing/suites/HttpServerJvmTestSuite.kt
+++ b/ktor-server/ktor-server-test-suites/jvm/src/io/ktor/server/testing/suites/HttpServerJvmTestSuite.kt
@@ -64,12 +64,19 @@ abstract class HttpServerJvmTestSuite<TEngine : ApplicationEngine, TConfiguratio
                 flush()
             }
 
+            // Pipelined responses may arrive as several separate TCP segments rather than a single one,
+            // so read until all expected bytes have been received instead of relying on one socket read.
             val bb = ByteBuffer.allocate(1911)
-            s.getInputStream().readPacketAtLeast(1).readFully(bb)
+            val input = s.getInputStream()
+            while (bb.hasRemaining()) {
+                val read = input.read(bb.array(), bb.position(), bb.remaining())
+                if (read == -1) break
+                bb.position(bb.position() + read)
+            }
             val bytes = bb.array()
             assertEquals(
                 pipelinedResponses,
-                clearSocketResponses(bytes.decodeToString(0, 0 + bytes.size).lineSequence())
+                clearSocketResponses(bytes.decodeToString(0, bb.position()).lineSequence())
             )
         }
     }


### PR DESCRIPTION
**Subsystem**
Server, Netty

**Motivation**
[KTOR-9875](https://youtrack.jetbrains.com/issue/KTOR-9875) Netty performance issues

Investigations into Ktor's benchmark statistics have revealed a few problems that appear when a Netty server is under load.

1. Pipelined responses are not flushed while other requests are queued in the same connection.  This leads to a memory leak on the connection which could crash the server.
2. The runningLimit config item is not properly enforced due to a mistake in the logic when checking if reads on pipelined requests should continue.  This can lead to poisoning of connections after the threshold is reached.
3. Call jobs are all direct children of the application job.  When processing connections on a server with high parallelism and many connections, this causes major contention on the coroutine internals.
4. The `shareWorkGroup` flag shares the same overhead as the default configuration due to the thread-pinning logic.  This ought to be circumvented to allow for higher throughput.
5. Write jobs are cancelled instead of completed on happy path requests.  This allocates an exception each time, which is very bad for the allocation rate.
6. Empty HTTP/2 requests cause a leak from not being finished

**Solution**
Each fix required it's own investigation and fix, generally by running specific benchmarks with profiling and letting Claude comb over the results.  With everything combined, we're seeing a pretty significant improvement in Netty's performance https://github.com/MDA2AV/HttpArena/pull/1204#issuecomment-5551945825

Best to review this commit-by-commit.

