### PR TITLE
Ignore letter case of the q parameter in accept route selectors

### DIFF
--- a/ktor-http/common/src/io/ktor/http/HttpHeaderValueParser.kt
+++ b/ktor-http/common/src/io/ktor/http/HttpHeaderValueParser.kt
@@ -43,7 +43,7 @@ public data class HeaderValue(val value: String, val params: List<HeaderValuePar
      *
      * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.http.HeaderValue.quality)
      */
-    val quality: Double = params.firstOrNull { it.name == "q" }
+    val quality: Double = params.firstOrNull { it.name.equals("q", ignoreCase = true) }
         ?.value
         ?.toDoubleOrNull()
         ?.takeIf { it in 0.0..1.0 }

--- a/ktor-http/common/test/io/ktor/tests/http/CommonHeadersTest.kt
+++ b/ktor-http/common/test/io/ktor/tests/http/CommonHeadersTest.kt
@@ -27,6 +27,15 @@ class CommonHeadersTest {
     }
 
     @Test
+    fun parseQualityParameterCaseInsensitive() {
+        val items = parseAndSortContentTypeHeader("audio/*; Q=0.2, audio/basic")
+        assertEquals(2, items.count())
+        assertEquals("audio/basic", items[0].value)
+        assertEquals("audio/*", items[1].value)
+        assertEquals(0.2, items[1].quality)
+    }
+
+    @Test
     fun parseAcceptHeaderWithPreference() {
         val items = parseAndSortContentTypeHeader("text/plain; q=0.5, text/html,text/x-dvi; q=0.8, text/x-c")
         assertEquals(4, items.count())

--- a/ktor-server/ktor-server-core/common/src/io/ktor/server/routing/RouteSelector.kt
+++ b/ktor-server/ktor-server-core/common/src/io/ktor/server/routing/RouteSelector.kt
@@ -840,7 +840,7 @@ private fun HeaderValue.toContentType(): ContentType {
         ContentType(
             contentType.contentType,
             contentType.contentSubtype,
-            params.filter { it.name != "q" }
+            params.filter { !it.name.equals("q", ignoreCase = true) }
         )
     }
 }

--- a/ktor-server/ktor-server-tests/common/test/io/ktor/tests/server/routing/RoutingProcessingTest.kt
+++ b/ktor-server/ktor-server-tests/common/test/io/ktor/tests/server/routing/RoutingProcessingTest.kt
@@ -544,6 +544,12 @@ class RoutingProcessingTest {
         }
 
         client.get("/") {
+            header(HttpHeaders.Accept, "text/plain; Q=0.1, application/json; q=0.9")
+        }.let {
+            assertEquals("{\"status\": \"OK\"}", it.bodyAsText())
+        }
+
+        client.get("/") {
             header(HttpHeaders.Accept, "text/html")
         }.let {
             assertEquals(HttpStatusCode.NotAcceptable, it.status)

--- a/ktor-server/ktor-server-tests/common/test/io/ktor/tests/server/routing/RoutingProcessingTest.kt
+++ b/ktor-server/ktor-server-tests/common/test/io/ktor/tests/server/routing/RoutingProcessingTest.kt
@@ -710,6 +710,12 @@ class RoutingProcessingTest {
         }.let {
             assertEquals("matched", it.bodyAsText())
         }
+
+        client.get("/") {
+            header(HttpHeaders.Accept, "application/soap+xml; action=foo; Q=0.5")
+        }.let {
+            assertEquals("matched", it.bodyAsText())
+        }
     }
 
     @Test


### PR DESCRIPTION
**Subsystem**
Ktor-Server, Routing

**Motivation**
[RFC 9110, 5.6.6](https://datatracker.ietf.org/doc/html/rfc9110#section-5.6.6) makes parameter names case-insensitive, so the weight may arrive as `Q=`. `HeaderValue.toContentType()` strips only the lowercase `q`, so `Q=0.5` leaks into the media type parameters and `ContentType.match` fails. An `accept(ContentType.parse("application/soap+xml; action=foo"))` route answers 406 to `Accept: application/soap+xml; action=foo; Q=0.5` but matches `q=0.5`. #5794 fixed the same class in `HeaderValue.quality`; this site was missed.

**Solution**
Compare the parameter name with `ignoreCase = true`.

**Verification**
Extended `testAcceptHeaderWithParameters` with the uppercase form; it fails without the fix. `:ktor-server-core:jvmTest` (215) and `:ktor-server-tests:jvmTest` (588) pass.
