### PR TITLE
KTOR-9701 Jackson 3: Avoid Dispatcher.IO in deserialization

### DIFF
--- a/ktor-shared/ktor-serialization/ktor-serialization-jackson3/jvm/src/JacksonConverter.kt
+++ b/ktor-shared/ktor-serialization/ktor-serialization-jackson3/jvm/src/JacksonConverter.kt
@@ -10,16 +10,18 @@ import io.ktor.serialization.*
 import io.ktor.util.reflect.*
 import io.ktor.utils.io.*
 import io.ktor.utils.io.charsets.*
-import io.ktor.utils.io.jvm.javaio.*
-import kotlinx.coroutines.*
-import kotlinx.coroutines.flow.*
-import tools.jackson.core.*
+import kotlinx.coroutines.flow.Flow
+import tools.jackson.core.JacksonException
+import tools.jackson.core.JsonEncoding
+import tools.jackson.core.JsonGenerator
 import tools.jackson.core.StreamWriteFeature
-import tools.jackson.core.util.*
-import tools.jackson.databind.*
+import tools.jackson.core.util.DefaultIndenter
+import tools.jackson.core.util.DefaultPrettyPrinter
+import tools.jackson.databind.ObjectMapper
 import tools.jackson.databind.json.JsonMapper
-import tools.jackson.module.kotlin.*
-import java.io.*
+import tools.jackson.module.kotlin.KotlinModule
+import tools.jackson.module.kotlin.jacksonObjectMapper
+import java.io.Flushable
 import kotlin.text.*
 
 /**
@@ -92,18 +94,17 @@ public class JacksonConverter(
 
     override suspend fun deserialize(charset: Charset, typeInfo: TypeInfo, content: ByteReadChannel): Any? {
         try {
-            return withContext(Dispatchers.IO) {
-                val type = objectMapper.constructType(typeInfo.reifiedType)
-                val objectReader = objectMapper.readerFor(type)
+            val type = objectMapper.constructType(typeInfo.reifiedType)
+            val objectReader = objectMapper.readerFor(type)
 
-                // Jackson handles decoding of Unicode charsets automatically, no need to create a reader.
-                // Additionally, a byte-based source is required for binary format (Smile).
-                if (isUnicode(charset)) {
-                    objectReader.readValue(content.toInputStream())
-                } else {
-                    val reader = content.toInputStream().reader(charset)
-                    objectReader.readValue(reader)
-                }
+            val bytes = content.toByteArray()
+
+            // Jackson decodes Unicode charsets from bytes automatically, and a byte-based
+            // source is required for binary formats (Smile).
+            return if (isUnicode(charset)) {
+                objectReader.readValue(bytes)
+            } else {
+                objectReader.readValue(String(bytes, charset))
             }
         } catch (cause: Exception) {
             val convertException = JsonConvertException("Illegal json parameter found: ${cause.message}", cause)


### PR DESCRIPTION
**Subsystem**
Serialization, Jackson 3

**Motivation**
[KTOR-9701](https://youtrack.jetbrains.com/issue/KTOR-9701) Jackson/Gson converters waste time on unnecessary Dispatchers.IO dispatch

**Solution**
The fix (https://github.com/ktorio/ktor/pull/5740) was applied only to Jackson 2, so I ported it to Jackson 3.

