### PR TITLE
KTOR-8524 Fix lifecycle events in Tomcat ServletApplicationEngine

### DIFF
--- a/ktor-server/ktor-server-jetty-jakarta/jvm/test/io/ktor/tests/server/jetty/jakarta/ApplicationLifecycleEventsTest.kt
+++ b/ktor-server/ktor-server-jetty-jakarta/jvm/test/io/ktor/tests/server/jetty/jakarta/ApplicationLifecycleEventsTest.kt
@@ -4,12 +4,14 @@
 
 package io.ktor.tests.server.jetty.jakarta
 
-import io.ktor.server.servlet.jakarta.KtorServletContextListener
+import io.ktor.server.servlet.jakarta.KtorServletContainerInitializer
 import io.ktor.server.servlet.jakarta.ServletApplicationEngine
+import io.ktor.utils.io.InternalAPI
 import org.eclipse.jetty.ee10.servlet.ServletContextHandler
 import org.eclipse.jetty.ee10.servlet.ServletHolder
 import org.eclipse.jetty.server.Server
 import org.eclipse.jetty.server.ServerConnector
+import org.eclipse.jetty.util.component.LifeCycle
 import java.net.HttpURLConnection
 import java.net.URI
 import kotlin.test.AfterTest
@@ -28,9 +30,8 @@ import kotlin.test.assertTrue
  *  - `ApplicationStopped` is triggered on undeploy even if no request was ever served.
  *
  * The servlet is mounted like a real WAR — no engine attributes are injected and no `load-on-startup`
- * is configured. [KtorServletContextListener] is registered directly, mirroring what
- * [io.ktor.server.servlet.jakarta.KtorServletContainerInitializer] does when a container auto-discovers
- * it via `META-INF/services` (validated separately below).
+ * is configured. [KtorServletContainerInitializer.onStartup] is invoked directly, mirroring what a
+ * container does when it auto-discovers it via `META-INF/services` (validated separately below).
  */
 class ApplicationLifecycleEventsTest {
 
@@ -87,6 +88,7 @@ class ApplicationLifecycleEventsTest {
         )
     }
 
+    @OptIn(InternalAPI::class)
     private fun startServer(): Server {
         val server = Server()
         server.addConnector(ServerConnector(server).apply { port = 0 })
@@ -103,9 +105,14 @@ class ApplicationLifecycleEventsTest {
                 },
                 "/*"
             )
-            // Mirror what KtorServletContainerInitializer does when auto-discovered via META-INF/services.
-            addEventListener(KtorServletContextListener())
         }
+        // Mirror what KtorServletContainerInitializer does when auto-discovered via META-INF/services.
+        context.addEventListener(object : LifeCycle.Listener {
+            override fun lifeCycleStarting(event: LifeCycle) {
+                (context.servletContext as ServletContextHandler.ServletContextApi).setExtendedListenerTypes(true)
+                KtorServletContainerInitializer().onStartup(null, context.servletContext)
+            }
+        })
         server.handler = context
 
         server.start()

--- a/ktor-server/ktor-server-jetty/jvm/test/io/ktor/tests/server/jetty/ApplicationLifecycleEventsTest.kt
+++ b/ktor-server/ktor-server-jetty/jvm/test/io/ktor/tests/server/jetty/ApplicationLifecycleEventsTest.kt
@@ -4,12 +4,14 @@
 
 package io.ktor.tests.server.jetty
 
-import io.ktor.server.servlet.KtorServletContextListener
+import io.ktor.server.servlet.KtorServletContainerInitializer
 import io.ktor.server.servlet.ServletApplicationEngine
+import io.ktor.utils.io.InternalAPI
 import org.eclipse.jetty.server.Server
 import org.eclipse.jetty.server.ServerConnector
 import org.eclipse.jetty.servlet.ServletContextHandler
 import org.eclipse.jetty.servlet.ServletHolder
+import org.eclipse.jetty.util.component.LifeCycle
 import java.net.HttpURLConnection
 import java.net.URI
 import kotlin.test.AfterTest
@@ -28,9 +30,8 @@ import kotlin.test.assertTrue
  *  - `ApplicationStopped` is triggered on undeploy even if no request was ever served.
  *
  * The servlet is mounted like a real WAR — no engine attributes are injected and no `load-on-startup`
- * is configured. [KtorServletContextListener] is registered directly, mirroring what
- * [io.ktor.server.servlet.KtorServletContainerInitializer] does when a container auto-discovers it via
- * `META-INF/services` (validated separately below).
+ * is configured. [KtorServletContainerInitializer.onStartup] is invoked directly, mirroring what a
+ * container does when it auto-discovers it via `META-INF/services` (validated separately below).
  */
 class ApplicationLifecycleEventsTest {
 
@@ -87,6 +88,7 @@ class ApplicationLifecycleEventsTest {
         )
     }
 
+    @OptIn(InternalAPI::class)
     private fun startServer(): Server {
         val server = Server()
         server.addConnector(ServerConnector(server).apply { port = 0 })
@@ -103,9 +105,13 @@ class ApplicationLifecycleEventsTest {
                 },
                 "/*"
             )
-            // Mirror what KtorServletContainerInitializer does when auto-discovered via META-INF/services.
-            addEventListener(KtorServletContextListener())
         }
+        context.addLifeCycleListener(object : LifeCycle.Listener {
+            override fun lifeCycleStarting(event: LifeCycle) {
+                context.servletContext.setExtendedListenerTypes(true)
+                KtorServletContainerInitializer().onStartup(null, context.servletContext)
+            }
+        })
         server.handler = context
 
         server.start()

--- a/ktor-server/ktor-server-servlet-jakarta/jvm/src/io/ktor/server/servlet/jakarta/KtorServletContainerInitializer.kt
+++ b/ktor-server/ktor-server-servlet-jakarta/jvm/src/io/ktor/server/servlet/jakarta/KtorServletContainerInitializer.kt
@@ -31,33 +31,8 @@ public class KtorServletContainerInitializer : ServletContainerInitializer {
     override fun onStartup(classes: MutableSet<Class<*>>?, ctx: ServletContext) {
         // Embedded engine mode owns the lifecycle; do not register the listener.
         if (ctx.getAttribute(ApplicationAttributeKey) != null) return
-        ctx.addListener(KtorServletContextListener::class.java)
-    }
-}
-
-/**
- * Starts and stops a servlet-hosted Ktor application together with the web application context,
- * independently of when (or whether) the [ServletApplicationEngine] servlet is initialized.
- *
- * In a WAR deployment without `load-on-startup` the servlet container initializes the servlet lazily on
- * the first request. Binding the application lifecycle to `contextInitialized` / `contextDestroyed`
- * makes `ApplicationStarted` fire at deployment time instead of only after the first request, and
- * guarantees `ApplicationStopped` fires on undeploy even when no request was ever served (otherwise
- * resources released by `ApplicationStopped` handlers would leak).
- *
- * Registered automatically by [KtorServletContainerInitializer]; it can also be added as a `<listener>`
- * in `web.xml`.
- *
- * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.server.servlet.jakarta.KtorServletContextListener)
- */
-public class KtorServletContextListener : ServletContextListener {
-    override fun contextInitialized(sce: ServletContextEvent) {
-        val ctx = sce.servletContext
-        // Embedded engine mode owns the lifecycle.
-        if (ctx.getAttribute(ApplicationAttributeKey) != null) return
-        // Defensive: never start the application twice.
-        if (ctx.managedEmbeddedServer() != null) return
-
+        
+        // Required for lifecycle events in Tomcat
         val registrations = ctx.servletRegistrations?.values?.filter { registration ->
             val className = registration.className ?: return@filter false
             val servletClass = runCatching { ctx.classLoader.loadClass(className) }.getOrNull()
@@ -84,6 +59,30 @@ public class KtorServletContextListener : ServletContextListener {
 
         ctx.setAttribute(ManagedServerKey, bootstrap.server)
         ctx.setAttribute(ApplicationEnginePipelineAttributeKey, bootstrap.enginePipeline)
+
+        ctx.addListener(KtorServletContextListener::class.java)
+    }
+}
+
+/**
+ * Starts and stops a servlet-hosted Ktor application together with the web application context,
+ * independently of when (or whether) the [ServletApplicationEngine] servlet is initialized.
+ *
+ * In a WAR deployment without `load-on-startup` the servlet container initializes the servlet lazily on
+ * the first request. Binding the application lifecycle to `contextInitialized` / `contextDestroyed`
+ * makes `ApplicationStarted` fire at deployment time instead of only after the first request, and
+ * guarantees `ApplicationStopped` fires on undeploy even when no request was ever served (otherwise
+ * resources released by `ApplicationStopped` handlers would leak).
+ *
+ * Registered automatically by [KtorServletContainerInitializer]; it can also be added as a `<listener>`
+ * in `web.xml`.
+ *
+ * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.server.servlet.jakarta.KtorServletContextListener)
+ */
+public class KtorServletContextListener : ServletContextListener {
+    override fun contextInitialized(sce: ServletContextEvent) {
+        // The application is already started by KtorServletContainerInitializer.onStartup() at
+        // deployment time; this listener only exists to hook contextDestroyed().
     }
 
     override fun contextDestroyed(sce: ServletContextEvent) {

--- a/ktor-server/ktor-server-servlet-jakarta/jvm/src/io/ktor/server/servlet/jakarta/KtorServletContainerInitializer.kt
+++ b/ktor-server/ktor-server-servlet-jakarta/jvm/src/io/ktor/server/servlet/jakarta/KtorServletContainerInitializer.kt
@@ -31,7 +31,7 @@ public class KtorServletContainerInitializer : ServletContainerInitializer {
     override fun onStartup(classes: MutableSet<Class<*>>?, ctx: ServletContext) {
         // Embedded engine mode owns the lifecycle; do not register the listener.
         if (ctx.getAttribute(ApplicationAttributeKey) != null) return
-        
+
         // Required for lifecycle events in Tomcat
         val registrations = ctx.servletRegistrations?.values?.filter { registration ->
             val className = registration.className ?: return@filter false
@@ -54,11 +54,8 @@ public class KtorServletContainerInitializer : ServletContainerInitializer {
 
         val initParameters = registration.initParameters.toList() + ctx.contextInitParameters()
 
-        val bootstrap = bootstrapServletApplication(ctx, initParameters)
-        bootstrap.server.start()
-
-        ctx.setAttribute(ManagedServerKey, bootstrap.server)
-        ctx.setAttribute(ApplicationEnginePipelineAttributeKey, bootstrap.enginePipeline)
+        // Deferred to KtorServletContextListener.contextInitialized()
+        ctx.setAttribute(ResolvedConfigKey, ResolvedServletConfig(ctx.classLoader, initParameters))
 
         ctx.addListener(KtorServletContextListener::class.java)
     }
@@ -81,8 +78,15 @@ public class KtorServletContainerInitializer : ServletContainerInitializer {
  */
 public class KtorServletContextListener : ServletContextListener {
     override fun contextInitialized(sce: ServletContextEvent) {
-        // The application is already started by KtorServletContainerInitializer.onStartup() at
-        // deployment time; this listener only exists to hook contextDestroyed().
+        val ctx = sce.servletContext
+        val resolvedConfig = ctx.getAttribute(ResolvedConfigKey) as? ResolvedServletConfig ?: return
+        ctx.removeAttribute(ResolvedConfigKey)
+
+        val bootstrap = bootstrapServletApplication(ctx, resolvedConfig.initParameters, resolvedConfig.classLoader)
+        bootstrap.server.start()
+
+        ctx.setAttribute(ManagedServerKey, bootstrap.server)
+        ctx.setAttribute(ApplicationEnginePipelineAttributeKey, bootstrap.enginePipeline)
     }
 
     override fun contextDestroyed(sce: ServletContextEvent) {
@@ -95,6 +99,13 @@ public class KtorServletContextListener : ServletContextListener {
         ctx.removeAttribute(ApplicationEnginePipelineAttributeKey)
     }
 }
+
+internal const val ResolvedConfigKey: String = "_ktor_resolved_servlet_config"
+
+internal class ResolvedServletConfig(
+    val classLoader: ClassLoader,
+    val initParameters: List<Pair<String, String>>
+)
 
 private fun ServletContext.contextInitParameters(): List<Pair<String, String>> =
     initParameterNames?.toList().orEmpty().mapNotNull { name ->

--- a/ktor-server/ktor-server-servlet-jakarta/jvm/src/io/ktor/server/servlet/jakarta/ServletApplicationEngine.kt
+++ b/ktor-server/ktor-server-servlet-jakarta/jvm/src/io/ktor/server/servlet/jakarta/ServletApplicationEngine.kt
@@ -202,7 +202,8 @@ internal class ServletApplicationBootstrap(
  */
 internal fun bootstrapServletApplication(
     servletContext: ServletContext,
-    initParameters: List<Pair<String, String>>
+    initParameters: List<Pair<String, String>>,
+    classLoader: ClassLoader = servletContext.classLoader
 ): ServletApplicationBootstrap {
     val parameters = initParameters
         .filter { (name, _) -> name.startsWith("io.ktor.") }
@@ -217,7 +218,7 @@ internal fun bootstrapServletApplication(
     val environment = applicationEnvironment {
         config = combinedConfig
         log = LoggerFactory.getLogger(applicationId)
-        classLoader = servletContext.classLoader
+        this.classLoader = classLoader
     }
     val applicationProperties = serverConfig(environment) {
         rootPath = servletContext.contextPath ?: "/"

--- a/ktor-server/ktor-server-servlet-jakarta/jvm/test/io/ktor/tests/servlet/jakarta/KtorServletContainerInitializerTest.kt
+++ b/ktor-server/ktor-server-servlet-jakarta/jvm/test/io/ktor/tests/servlet/jakarta/KtorServletContainerInitializerTest.kt
@@ -14,7 +14,6 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
 import jakarta.servlet.ServletContext
-import jakarta.servlet.ServletContextEvent
 import jakarta.servlet.ServletRegistration
 import kotlin.test.Test
 
@@ -23,8 +22,13 @@ class KtorServletContainerInitializerTest {
 
     @Test
     fun registersLifecycleListenerWhenNotEmbedded() {
+        val registration = mockk<ServletRegistration>(relaxed = true) {
+            every { className } returns ServletApplicationEngine::class.java.name
+        }
         val ctx = mockk<ServletContext>(relaxed = true) {
             every { getAttribute(ApplicationAttributeKey) } returns null
+            every { classLoader } returns this@KtorServletContainerInitializerTest::class.java.classLoader
+            every { servletRegistrations } returns mapOf("ktor-servlet" to registration)
         }
 
         KtorServletContainerInitializer().onStartup(null, ctx)
@@ -54,12 +58,12 @@ class KtorServletContainerInitializerTest {
             every { classLoader } returns this@KtorServletContainerInitializerTest::class.java.classLoader
             every { servletRegistrations } returns mapOf("first" to registration, "second" to registration)
         }
-        val event = mockk<ServletContextEvent> { every { servletContext } returns ctx }
 
-        KtorServletContextListener().contextInitialized(event)
+        KtorServletContainerInitializer().onStartup(null, ctx)
 
         // Falls back to per-servlet self-bootstrap: warns and does not take over the lifecycle.
         verify { ctx.log(any()) }
         verify(exactly = 0) { ctx.setAttribute(ManagedServerKey, any()) }
+        verify(exactly = 0) { ctx.addListener(KtorServletContextListener::class.java) }
     }
 }

--- a/ktor-server/ktor-server-servlet/jvm/src/io/ktor/server/servlet/KtorServletContainerInitializer.kt
+++ b/ktor-server/ktor-server-servlet/jvm/src/io/ktor/server/servlet/KtorServletContainerInitializer.kt
@@ -54,11 +54,8 @@ public class KtorServletContainerInitializer : ServletContainerInitializer {
 
         val initParameters = registration.initParameters.toList() + ctx.contextInitParameters()
 
-        val bootstrap = bootstrapServletApplication(ctx, initParameters)
-        bootstrap.server.start()
-
-        ctx.setAttribute(ManagedServerKey, bootstrap.server)
-        ctx.setAttribute(ApplicationEnginePipelineAttributeKey, bootstrap.enginePipeline)
+        // Deferred to KtorServletContextListener.contextInitialized()
+        ctx.setAttribute(ResolvedConfigKey, ResolvedServletConfig(ctx.classLoader, initParameters))
 
         ctx.addListener(KtorServletContextListener::class.java)
     }
@@ -81,8 +78,15 @@ public class KtorServletContainerInitializer : ServletContainerInitializer {
  */
 public class KtorServletContextListener : ServletContextListener {
     override fun contextInitialized(sce: ServletContextEvent) {
-        // The application is already started by KtorServletContainerInitializer.onStartup() at
-        // deployment time; this listener only exists to hook contextDestroyed().
+        val ctx = sce.servletContext
+        val resolvedConfig = ctx.getAttribute(ResolvedConfigKey) as? ResolvedServletConfig ?: return
+        ctx.removeAttribute(ResolvedConfigKey)
+
+        val bootstrap = bootstrapServletApplication(ctx, resolvedConfig.initParameters, resolvedConfig.classLoader)
+        bootstrap.server.start()
+
+        ctx.setAttribute(ManagedServerKey, bootstrap.server)
+        ctx.setAttribute(ApplicationEnginePipelineAttributeKey, bootstrap.enginePipeline)
     }
 
     override fun contextDestroyed(sce: ServletContextEvent) {
@@ -95,6 +99,13 @@ public class KtorServletContextListener : ServletContextListener {
         ctx.removeAttribute(ApplicationEnginePipelineAttributeKey)
     }
 }
+
+internal const val ResolvedConfigKey: String = "_ktor_resolved_servlet_config"
+
+internal class ResolvedServletConfig(
+    val classLoader: ClassLoader,
+    val initParameters: List<Pair<String, String>>
+)
 
 private fun ServletContext.contextInitParameters(): List<Pair<String, String>> =
     initParameterNames?.toList().orEmpty().mapNotNull { name ->

--- a/ktor-server/ktor-server-servlet/jvm/src/io/ktor/server/servlet/KtorServletContainerInitializer.kt
+++ b/ktor-server/ktor-server-servlet/jvm/src/io/ktor/server/servlet/KtorServletContainerInitializer.kt
@@ -31,33 +31,8 @@ public class KtorServletContainerInitializer : ServletContainerInitializer {
     override fun onStartup(classes: MutableSet<Class<*>>?, ctx: ServletContext) {
         // Embedded engine mode owns the lifecycle; do not register the listener.
         if (ctx.getAttribute(ApplicationAttributeKey) != null) return
-        ctx.addListener(KtorServletContextListener::class.java)
-    }
-}
 
-/**
- * Starts and stops a servlet-hosted Ktor application together with the web application context,
- * independently of when (or whether) the [ServletApplicationEngine] servlet is initialized.
- *
- * In a WAR deployment without `load-on-startup` the servlet container initializes the servlet lazily on
- * the first request. Binding the application lifecycle to `contextInitialized` / `contextDestroyed`
- * makes `ApplicationStarted` fire at deployment time instead of only after the first request, and
- * guarantees `ApplicationStopped` fires on undeploy even when no request was ever served (otherwise
- * resources released by `ApplicationStopped` handlers would leak).
- *
- * Registered automatically by [KtorServletContainerInitializer]; it can also be added as a `<listener>`
- * in `web.xml`.
- *
- * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.server.servlet.KtorServletContextListener)
- */
-public class KtorServletContextListener : ServletContextListener {
-    override fun contextInitialized(sce: ServletContextEvent) {
-        val ctx = sce.servletContext
-        // Embedded engine mode owns the lifecycle.
-        if (ctx.getAttribute(ApplicationAttributeKey) != null) return
-        // Defensive: never start the application twice.
-        if (ctx.managedEmbeddedServer() != null) return
-
+        // Required for lifecycle events in Tomcat
         val registrations = ctx.servletRegistrations?.values?.filter { registration ->
             val className = registration.className ?: return@filter false
             val servletClass = runCatching { ctx.classLoader.loadClass(className) }.getOrNull()
@@ -84,6 +59,30 @@ public class KtorServletContextListener : ServletContextListener {
 
         ctx.setAttribute(ManagedServerKey, bootstrap.server)
         ctx.setAttribute(ApplicationEnginePipelineAttributeKey, bootstrap.enginePipeline)
+
+        ctx.addListener(KtorServletContextListener::class.java)
+    }
+}
+
+/**
+ * Starts and stops a servlet-hosted Ktor application together with the web application context,
+ * independently of when (or whether) the [ServletApplicationEngine] servlet is initialized.
+ *
+ * In a WAR deployment without `load-on-startup` the servlet container initializes the servlet lazily on
+ * the first request. Binding the application lifecycle to `contextInitialized` / `contextDestroyed`
+ * makes `ApplicationStarted` fire at deployment time instead of only after the first request, and
+ * guarantees `ApplicationStopped` fires on undeploy even when no request was ever served (otherwise
+ * resources released by `ApplicationStopped` handlers would leak).
+ *
+ * Registered automatically by [KtorServletContainerInitializer]; it can also be added as a `<listener>`
+ * in `web.xml`.
+ *
+ * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.server.servlet.KtorServletContextListener)
+ */
+public class KtorServletContextListener : ServletContextListener {
+    override fun contextInitialized(sce: ServletContextEvent) {
+        // The application is already started by KtorServletContainerInitializer.onStartup() at
+        // deployment time; this listener only exists to hook contextDestroyed().
     }
 
     override fun contextDestroyed(sce: ServletContextEvent) {

--- a/ktor-server/ktor-server-servlet/jvm/src/io/ktor/server/servlet/ServletApplicationEngine.kt
+++ b/ktor-server/ktor-server-servlet/jvm/src/io/ktor/server/servlet/ServletApplicationEngine.kt
@@ -201,7 +201,8 @@ internal class ServletApplicationBootstrap(
  */
 internal fun bootstrapServletApplication(
     servletContext: ServletContext,
-    initParameters: List<Pair<String, String>>
+    initParameters: List<Pair<String, String>>,
+    classLoader: ClassLoader = servletContext.classLoader
 ): ServletApplicationBootstrap {
     val parameters = initParameters
         .filter { (name, _) -> name.startsWith("io.ktor.") }
@@ -216,7 +217,7 @@ internal fun bootstrapServletApplication(
     val environment = applicationEnvironment {
         config = combinedConfig
         log = LoggerFactory.getLogger(applicationId)
-        classLoader = servletContext.classLoader
+        this.classLoader = classLoader
     }
     val applicationProperties = serverConfig(environment) {
         rootPath = servletContext.contextPath ?: "/"

--- a/ktor-server/ktor-server-servlet/jvm/test/io/ktor/tests/servlet/KtorServletContainerInitializerTest.kt
+++ b/ktor-server/ktor-server-servlet/jvm/test/io/ktor/tests/servlet/KtorServletContainerInitializerTest.kt
@@ -14,7 +14,6 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
 import javax.servlet.ServletContext
-import javax.servlet.ServletContextEvent
 import javax.servlet.ServletRegistration
 import kotlin.test.Test
 
@@ -23,8 +22,13 @@ class KtorServletContainerInitializerTest {
 
     @Test
     fun registersLifecycleListenerWhenNotEmbedded() {
+        val registration = mockk<ServletRegistration>(relaxed = true) {
+            every { className } returns ServletApplicationEngine::class.java.name
+        }
         val ctx = mockk<ServletContext>(relaxed = true) {
             every { getAttribute(ApplicationAttributeKey) } returns null
+            every { classLoader } returns this@KtorServletContainerInitializerTest::class.java.classLoader
+            every { servletRegistrations } returns mapOf("ktor-servlet" to registration)
         }
 
         KtorServletContainerInitializer().onStartup(null, ctx)
@@ -54,12 +58,12 @@ class KtorServletContainerInitializerTest {
             every { classLoader } returns this@KtorServletContainerInitializerTest::class.java.classLoader
             every { servletRegistrations } returns mapOf("first" to registration, "second" to registration)
         }
-        val event = mockk<ServletContextEvent> { every { servletContext } returns ctx }
 
-        KtorServletContextListener().contextInitialized(event)
+        KtorServletContainerInitializer().onStartup(null, ctx)
 
         // Falls back to per-servlet self-bootstrap: warns and does not take over the lifecycle.
         verify { ctx.log(any()) }
         verify(exactly = 0) { ctx.setAttribute(ManagedServerKey, any()) }
+        verify(exactly = 0) { ctx.addListener(KtorServletContextListener::class.java) }
     }
 }


### PR DESCRIPTION
**Subsystem**
Server, Tomcat

**Motivation**
[KTOR-8524](https://youtrack.jetbrains.com/issue/KTOR-8524) ServletApplicationEngine: Application events aren't triggered

This ticket was fixed for Jetty, but failed to resolve the problem for Tomcat.

**Solution**
KtorServletContextListener.contextInitialized() called ctx.servletRegistrations, but Tomcat wraps the ServletContext handed to dynamically-added listeners (NoPluggabilityServletContext) and throws UnsupportedOperationException for that method. Jetty doesn't enforce this same restriction as strictly, which is why the original PR worked there but silently failed on Tomcat.
