### PR TITLE
Fail fast when CIO client engine is configured with a SOCKS proxy

### DIFF
--- a/ktor-client/ktor-client-cio/common/src/io/ktor/client/engine/cio/CIOEngine.kt
+++ b/ktor-client/ktor-client-cio/common/src/io/ktor/client/engine/cio/CIOEngine.kt
@@ -33,6 +33,15 @@ internal class CIOEngine(
         UnixSocketCapability
     )
 
+    // Kept above selectorManager: an exception here must abort construction before
+    // the selector below is opened, or its coroutine/thread would leak with no
+    // engine reference left to close it.
+    private val proxy: ProxyConfig? = when (val type = config.proxy?.type) {
+        null -> null
+        ProxyType.HTTP -> config.proxy
+        else -> throw IllegalStateException("CIO engine does not currently support $type proxies.")
+    }
+
     private val endpoints = ConcurrentMap<String, Endpoint>()
 
     private val selectorManager = SelectorManager(dispatcher)
@@ -46,12 +55,6 @@ internal class CIOEngine(
     private val requestsJob: CoroutineContext
 
     override val coroutineContext: CoroutineContext
-
-    private val proxy: ProxyConfig? = when (val type = config.proxy?.type) {
-        null -> null
-        ProxyType.HTTP -> config.proxy
-        else -> throw IllegalStateException("CIO engine does not currently support $type proxies.")
-    }
 
     init {
         configurePlatform()

--- a/ktor-client/ktor-client-cio/common/src/io/ktor/client/engine/cio/CIOEngine.kt
+++ b/ktor-client/ktor-client-cio/common/src/io/ktor/client/engine/cio/CIOEngine.kt
@@ -48,11 +48,8 @@ internal class CIOEngine(
     override val coroutineContext: CoroutineContext
 
     private val proxy: ProxyConfig? = when (val type = config.proxy?.type) {
-        ProxyType.SOCKS,
         null -> null
-
         ProxyType.HTTP -> config.proxy
-
         else -> throw IllegalStateException("CIO engine does not currently support $type proxies.")
     }
 

--- a/ktor-client/ktor-client-cio/jvm/test/io/ktor/client/engine/cio/ProxyTest.kt
+++ b/ktor-client/ktor-client-cio/jvm/test/io/ktor/client/engine/cio/ProxyTest.kt
@@ -1,0 +1,34 @@
+/*
+* Copyright 2014-2026 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+*/
+
+package io.ktor.client.engine.cio
+
+import io.ktor.client.*
+import io.ktor.client.engine.*
+import io.ktor.http.*
+import kotlin.test.*
+
+class ProxyTest {
+
+    @Test
+    fun testSocksProxyThrowsInsteadOfBeingSilentlyIgnored() {
+        assertFailsWith<IllegalStateException> {
+            HttpClient(CIO) {
+                engine {
+                    proxy = ProxyBuilder.socks("localhost", 1080)
+                }
+            }
+        }
+    }
+
+    @Test
+    fun testHttpProxyIsAccepted() {
+        val client = HttpClient(CIO) {
+            engine {
+                proxy = ProxyBuilder.http(Url("http://localhost:8080"))
+            }
+        }
+        client.close()
+    }
+}


### PR DESCRIPTION
Previously, ProxyType.SOCKS was silently mapped to null in CIOEngine, so an HttpClient(CIO) configured with
ProxyBuilder.socks(...) would connect directly without the proxy and without any warning. Every other unrecognized proxy type already throws IllegalStateException; SOCKS now follows the same path so the failure is explicit and immediate instead of a silent, hard-to-diagnose behavior difference from the configured proxy.

Claude-Session: https://claude.ai/code/session_01G9Bj3CsqRznjLANFwoV2nW

**Subsystem**
Client/Server, related modules

**Motivation**
Describe what problem this PR solves and why it is important. Refer to a bug/ticket #.

**Solution**
Describe your solution.

