### PR TITLE
KTOR-9882 Update ktor-client-java disallowed headers

### DIFF
--- a/ktor-client/ktor-client-java/jvm/src/io/ktor/client/engine/java/JavaHttpRequest.kt
+++ b/ktor-client/ktor-client-java/jvm/src/io/ktor/client/engine/java/JavaHttpRequest.kt
@@ -18,17 +18,23 @@ import java.time.*
 import java.util.*
 import kotlin.coroutines.*
 
+/**
+ * Headers managed or restricted by `java.net.http.HttpClient` itself. Passing any of these to
+ * `HttpRequest.Builder.header(...)` throws `IllegalArgumentException`, so the engine omits them:
+ * [HttpHeaders.ContentLength] is derived from the [HttpRequest.BodyPublisher], and the JDK controls
+ * the transport headers [HttpHeaders.Connection], [HttpHeaders.Expect] and [HttpHeaders.Upgrade].
+ *
+ * Other headers the JDK once restricted (`Date`, `From`, `Via`, `Warning`) are intentionally absent:
+ * since [JDK-8213189](https://bugs.openjdk.org/browse/JDK-8213189) the JDK accepts them, so the
+ * engine delegates to it rather than silently dropping caller-supplied values.
+ */
 internal val DISALLOWED_HEADERS = TreeSet(String.CASE_INSENSITIVE_ORDER).apply {
     addAll(
         setOf(
             HttpHeaders.Connection,
             HttpHeaders.ContentLength,
-            HttpHeaders.Date,
             HttpHeaders.Expect,
-            HttpHeaders.From,
-            HttpHeaders.Upgrade,
-            HttpHeaders.Via,
-            HttpHeaders.Warning
+            HttpHeaders.Upgrade
         )
     )
 }

--- a/ktor-client/ktor-client-java/jvm/test/io/ktor/client/engine/java/RequestHeadersTest.kt
+++ b/ktor-client/ktor-client-java/jvm/test/io/ktor/client/engine/java/RequestHeadersTest.kt
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2014-2026 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.client.engine.java
+
+import io.ktor.client.*
+import io.ktor.client.call.*
+import io.ktor.client.request.*
+import io.ktor.client.tests.utils.*
+import io.ktor.http.*
+import io.ktor.server.cio.*
+import io.ktor.server.engine.*
+import io.ktor.server.request.*
+import io.ktor.server.response.*
+import io.ktor.server.routing.*
+import io.ktor.server.util.*
+import kotlinx.coroutines.runBlocking
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Verifies that headers the JDK `HttpClient` no longer restricts are delegated to it and reach the
+ * server, rather than being silently dropped by the engine's `DISALLOWED_HEADERS` filter.
+ */
+class RequestHeadersTest : TestWithKtor() {
+
+    override val server = embeddedServer(CIO, serverPort) {
+        routing {
+            get("/echo-header") {
+                val name = call.parameters.getOrFail("name")
+                call.respondText(call.request.header(name) ?: ABSENT)
+            }
+        }
+    }
+
+    @Test
+    fun `caller-supplied Date header reaches the server`() =
+        assertHeaderReachesServer(HttpHeaders.Date, "Wed, 21 Oct 2015 07:28:00 GMT")
+
+    @Test
+    fun `caller-supplied From header reaches the server`() =
+        assertHeaderReachesServer(HttpHeaders.From, "user@example.com")
+
+    @Test
+    fun `caller-supplied Via header reaches the server`() =
+        assertHeaderReachesServer(HttpHeaders.Via, "1.1 ktor")
+
+    @Test
+    fun `caller-supplied Warning header reaches the server`() =
+        assertHeaderReachesServer(HttpHeaders.Warning, "199 ktor test")
+
+    private fun assertHeaderReachesServer(name: String, value: String) = runBlocking {
+        HttpClient(Java).use { client ->
+            val received = client.get("$testUrl/echo-header?name=$name") {
+                header(name, value)
+            }.body<String>()
+            assertEquals(value, received, "$name header should reach the server unchanged")
+        }
+    }
+
+    private companion object {
+        private const val ABSENT = "<absent>"
+    }
+}

--- a/ktor-client/ktor-client-java/jvm/test/io/ktor/client/engine/java/RequestProducerTest.kt
+++ b/ktor-client/ktor-client-java/jvm/test/io/ktor/client/engine/java/RequestProducerTest.kt
@@ -69,6 +69,38 @@ class RequestProducerTest {
         assertEquals(2, request.bodyPublisher().get().contentLength())
     }
 
+    @OptIn(InternalAPI::class)
+    @Test
+    fun `JDK-allowed headers are delegated while JDK-managed headers are dropped`() {
+        val request = HttpRequestData(
+            Url("http://127.0.0.1/"),
+            HttpMethod.Get,
+            Headers.build {
+                append(HttpHeaders.Date, "Wed, 21 Oct 2015 07:28:00 GMT")
+                append(HttpHeaders.From, "user@example.com")
+                append(HttpHeaders.Via, "1.1 ktor")
+                append(HttpHeaders.Warning, "199 ktor test")
+                append(HttpHeaders.Connection, "close")
+                append(HttpHeaders.Expect, "100-continue")
+                append(HttpHeaders.Upgrade, "websocket")
+            },
+            EmptyContent,
+            Job(),
+            Attributes()
+        ).convertToHttpRequest(EmptyCoroutineContext)
+
+        val headers = request.headers()
+        // Delegated to the JDK, which accepts them (JDK-8213189).
+        assertEquals("Wed, 21 Oct 2015 07:28:00 GMT", headers.firstValue(HttpHeaders.Date).get())
+        assertEquals("user@example.com", headers.firstValue(HttpHeaders.From).get())
+        assertEquals("1.1 ktor", headers.firstValue(HttpHeaders.Via).get())
+        assertEquals("199 ktor test", headers.firstValue(HttpHeaders.Warning).get())
+        // Still managed/restricted by the JDK, so omitted by the engine.
+        assertFalse(headers.firstValue(HttpHeaders.Connection).isPresent)
+        assertFalse(headers.firstValue(HttpHeaders.Expect).isPresent)
+        assertFalse(headers.firstValue(HttpHeaders.Upgrade).isPresent)
+    }
+
     @Test
     fun testByteReadChannelWriter() {
         val publisher = JavaHttpRequestBodyPublisher(EmptyCoroutineContext) {


### PR DESCRIPTION
[KTOR-9882](https://youtrack.jetbrains.com/issue/KTOR-9882) Java client engine silently drops caller-supplied Date

**Subsystem**
Client, Java engine

**Motivation**
The Java client engine keeps an internal `DISALLOWED_HEADERS` denylist and silently omits any matching header when building the JDK request. That list includes `Date`,  `From`, `Via` and `Warning`. Since [JDK-8213189](https://bugs.openjdk.org/browse/JDK-8213189) the JDK's `HttpClient` no longer restricts these, and every other Ktor engine (CIO, Apache) already preserves them; so a caller-supplied `Date` was dropped with no error and no log, only on the Java engine.

The denylist was preserving an obsolete JDK policy.

**Solution**
Remove `Date`, `From`, `Via` and `Warning` from `DISALLOWED_HEADERS`, delegating them to the JDK, which accepts them.
The genuinely JDK-managed headers stay filtered.