### PR TITLE
Fix/content negotiation accept header

### DIFF
--- a/ktor-client/ktor-client-plugins/ktor-client-content-negotiation/build.gradle.kts
+++ b/ktor-client/ktor-client-plugins/ktor-client-content-negotiation/build.gradle.kts
@@ -14,5 +14,8 @@ kotlin {
         commonMain.dependencies {
             api(projects.ktorSerialization)
         }
+        commonTest.dependencies {
+            implementation(projects.ktorSerializationKotlinxJson)
+        }
     }
 }

--- a/ktor-client/ktor-client-plugins/ktor-client-content-negotiation/common/src/io/ktor/client/plugins/contentnegotiation/ContentNegotiation.kt
+++ b/ktor-client/ktor-client-plugins/ktor-client-content-negotiation/common/src/io/ktor/client/plugins/contentnegotiation/ContentNegotiation.kt
@@ -76,10 +76,13 @@ public fun interface ContentTypeMergeStrategy {
          * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.client.plugins.contentnegotiation.ContentTypeMergeStrategy.Companion.Default)
          */
         public val Default: ContentTypeMergeStrategy = ContentTypeMergeStrategy { registered, headers ->
+            val parsedHeaders = headers.asSequence().flatMap { parseHeaderValue(it) }
             registered.asSequence().filter { contentType ->
-                headers.none { h ->
+                parsedHeaders.none { header ->
                     try {
-                        ContentType.parse(h).match(contentType)
+                        val acceptedType = ContentType.parse(header.value)
+                        ContentType(acceptedType.contentType, acceptedType.contentSubtype, header.params)
+                            .match(contentType)
                     } catch (e: BadContentTypeFormatException) {
                         false
                     }

--- a/ktor-client/ktor-client-plugins/ktor-client-content-negotiation/common/test/io/ktor/client/plugins/AcceptHeaderTest.kt
+++ b/ktor-client/ktor-client-plugins/ktor-client-content-negotiation/common/test/io/ktor/client/plugins/AcceptHeaderTest.kt
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2014-2026 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.client.plugins
+
+import io.ktor.client.*
+import io.ktor.client.engine.mock.*
+import io.ktor.client.plugins.contentnegotiation.*
+import io.ktor.client.request.*
+import io.ktor.http.*
+import io.ktor.serialization.kotlinx.json.*
+import kotlinx.coroutines.test.runTest
+import kotlin.test.*
+
+class AcceptHeaderTest {
+    // Ktor's duplicate check uses ContentType.parse, which retains only the last media range.
+    // The explicit JSON exclusion conflicts with the implicit q=1 added by ContentNegotiation.
+    @Test
+    fun honorCombinedHeaderContent() = runTest {
+        val combinedAcceptHeader = "application/json;q=0, text/plain;q=0.5"
+        val mockEngine = MockEngine { respondOk() }
+        HttpClient(mockEngine) {
+            this.install(ContentNegotiation) { json() }
+        }.use { client ->
+            client.get("https://example.com") {
+                header(HttpHeaders.Accept, combinedAcceptHeader)
+            }
+        }
+        val receivedAcceptHeader = mockEngine.requestHistory.single().headers.getAll(HttpHeaders.Accept)
+        assertNotNull(receivedAcceptHeader)
+        val jsonQualities = parseHeaderValue(receivedAcceptHeader.joinToString(", "))
+            .filter { it.value == "application/json" }
+            .map { it.quality }
+        assertEquals(listOf(0.0), jsonQualities)
+    }
+}

--- a/ktor-client/ktor-client-plugins/ktor-client-content-negotiation/common/test/io/ktor/client/plugins/AcceptHeaderTest.kt
+++ b/ktor-client/ktor-client-plugins/ktor-client-content-negotiation/common/test/io/ktor/client/plugins/AcceptHeaderTest.kt
@@ -14,8 +14,7 @@ import kotlinx.coroutines.test.runTest
 import kotlin.test.*
 
 class AcceptHeaderTest {
-    // Ktor's duplicate check uses ContentType.parse, which retains only the last media range.
-    // The explicit JSON exclusion conflicts with the implicit q=1 added by ContentNegotiation.
+    // An explicit JSON exclusion in a combined Accept header must not be overridden by an implicit q=1.
     @Test
     fun honorCombinedHeaderContent() = runTest {
         val combinedAcceptHeader = "application/json;q=0, text/plain;q=0.5"
@@ -25,6 +24,28 @@ class AcceptHeaderTest {
         }.use { client ->
             client.get("https://example.com") {
                 header(HttpHeaders.Accept, combinedAcceptHeader)
+            }
+        }
+        val receivedAcceptHeader = mockEngine.requestHistory.single().headers.getAll(HttpHeaders.Accept)
+        assertNotNull(receivedAcceptHeader)
+        val jsonQualities = parseHeaderValue(receivedAcceptHeader.joinToString(", "))
+            .filter { it.value == "application/json" }
+            .map { it.quality }
+        assertEquals(listOf(0.0), jsonQualities)
+    }
+
+    // Dropping the parsed profile parameter may add a duplicate JSON entry with implicit q=1 despite the explicit q=0.
+    @Test
+    fun honorHeaderContentWithParameters() = runTest {
+        val acceptHeaderWithParameters = "application/json;profile=\"a,b\";q=0"
+        val mockEngine = MockEngine { respondOk() }
+        HttpClient(mockEngine) {
+            this.install(ContentNegotiation) {
+                json(contentType = ContentType.Application.Json.withParameter("profile", "a,b"))
+            }
+        }.use { client ->
+            client.get("https://example.com") {
+                header(HttpHeaders.Accept, acceptHeaderWithParameters)
             }
         }
         val receivedAcceptHeader = mockEngine.requestHistory.single().headers.getAll(HttpHeaders.Accept)


### PR DESCRIPTION
**Subsystem**
Ktor Client ContentNegotiation

**Motivation**
Ktor's duplicate check uses ContentType.parse, which retains only the last media range. If an AcceptHeader is set by the user in the form of a combined header then only the last element is checked. In my example the explicit JSON exclusion (q=0) conflicts with the implicit q=1 added by ContentNegotiation.

**Solution**
Parse all elements of the Header via parseHeaderValue. Since this splits the header into value and params they need to be re-assembled so that it is correctly identified as duplicate.

For both instances test cases were added.
(Closed #5861 to rebase to `release/3.x` after reading #5852)