### PR TITLE
Add KDoc annotator to build logic

### DIFF
--- a/build-logic/kdoc-annotator/README.md
+++ b/build-logic/kdoc-annotator/README.md
@@ -8,6 +8,8 @@ This tool was originally developed in [e5l/kdoc-annotator](https://github.com/e5
 
 ## Usage
 
+Run from the Ktor repository root:
+
 ```shell
-./gradlew run --args="path/to/project link"
+./gradlew annotateKDocs
 ```

--- a/build-logic/kdoc-annotator/README.md
+++ b/build-logic/kdoc-annotator/README.md
@@ -1,0 +1,13 @@
+# KDoc Annotator
+
+Add a feedback link to public API KDocs in production source sets and remove it from test source sets.
+
+## Origin
+
+This tool was originally developed in [e5l/kdoc-annotator](https://github.com/e5l/kdoc-annotator).
+
+## Usage
+
+```shell
+./gradlew run --args="path/to/project link"
+```

--- a/build-logic/kdoc-annotator/build.gradle.kts
+++ b/build-logic/kdoc-annotator/build.gradle.kts
@@ -1,0 +1,21 @@
+plugins {
+    kotlin("jvm")
+    application
+}
+
+application {
+    mainClass.set("MainKt")
+}
+
+dependencies {
+    implementation(kotlin("compiler-embeddable"))
+    testImplementation(kotlin("test"))
+}
+
+tasks.test {
+    useJUnitPlatform()
+}
+
+kotlin {
+    jvmToolchain(21)
+}

--- a/build-logic/kdoc-annotator/build.gradle.kts
+++ b/build-logic/kdoc-annotator/build.gradle.kts
@@ -20,8 +20,17 @@ tasks.test {
     useJUnitPlatform()
 }
 
+val excludedPathPatterns = listOf(
+    ".gradle/**",
+    "build-logic/**",
+    "build-settings-logic/**",
+    "ktor-test-server/**",
+    "**/build/**",
+)
+
 tasks.run.configure {
     args(rootProject.projectDir.parentFile, "https://ktor.io/feedback/")
+    args(excludedPathPatterns.map { "--exclude=$it" })
 }
 
 kotlin {

--- a/build-logic/kdoc-annotator/build.gradle.kts
+++ b/build-logic/kdoc-annotator/build.gradle.kts
@@ -1,10 +1,14 @@
+/*
+ * Copyright 2014-2026 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
 plugins {
     kotlin("jvm")
     application
 }
 
 application {
-    mainClass.set("MainKt")
+    mainClass.set("ktorbuild.kdoc.MainKt")
 }
 
 dependencies {

--- a/build-logic/kdoc-annotator/build.gradle.kts
+++ b/build-logic/kdoc-annotator/build.gradle.kts
@@ -16,6 +16,10 @@ tasks.test {
     useJUnitPlatform()
 }
 
+tasks.run.configure {
+    args(rootProject.projectDir.parentFile, "https://ktor.io/feedback/")
+}
+
 kotlin {
     jvmToolchain(21)
 }

--- a/build-logic/kdoc-annotator/src/main/kotlin/CompilerUtils.kt
+++ b/build-logic/kdoc-annotator/src/main/kotlin/CompilerUtils.kt
@@ -1,3 +1,9 @@
+/*
+ * Copyright 2014-2026 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package ktorbuild.kdoc
+
 import org.jetbrains.kotlin.K1Deprecation
 import org.jetbrains.kotlin.cli.jvm.compiler.EnvironmentConfigFiles
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment

--- a/build-logic/kdoc-annotator/src/main/kotlin/CompilerUtils.kt
+++ b/build-logic/kdoc-annotator/src/main/kotlin/CompilerUtils.kt
@@ -13,23 +13,41 @@ import org.jetbrains.kotlin.com.intellij.psi.impl.PsiFileFactoryImpl
 import org.jetbrains.kotlin.config.CompilerConfiguration
 import org.jetbrains.kotlin.idea.KotlinLanguage
 import org.jetbrains.kotlin.psi.KtFile
+import java.nio.file.FileVisitResult
 import java.nio.file.Files
 import java.nio.file.Path
+import java.nio.file.SimpleFileVisitor
+import java.nio.file.attribute.BasicFileAttributes
 import kotlin.io.path.extension
 import kotlin.io.path.name
 import kotlin.io.path.readText
-import kotlin.streams.asSequence
 
-fun forEachKtFileInDirectory(directory: Path, action: (KtFile, Path) -> Unit) {
+fun forEachKtFileInDirectory(
+    directory: Path,
+    shouldVisit: (Path) -> Boolean = { true },
+    action: (KtFile, Path) -> Unit,
+) {
     val project = createProjectForParsing()
     try {
-        Files.walk(directory)
-            .asSequence()
-            .filter { it.extension == "kt" }
-            .forEach { file ->
-                val ktFile = file.parseAsKtFile(project)
-                action(ktFile, file)
+        Files.walkFileTree(directory, object : SimpleFileVisitor<Path>() {
+            override fun preVisitDirectory(directoryToVisit: Path, attributes: BasicFileAttributes): FileVisitResult {
+                val relativePath = directory.relativize(directoryToVisit)
+                return if (directoryToVisit == directory || shouldVisit(relativePath)) {
+                    FileVisitResult.CONTINUE
+                } else {
+                    FileVisitResult.SKIP_SUBTREE
+                }
             }
+
+            override fun visitFile(file: Path, attributes: BasicFileAttributes): FileVisitResult {
+                val relativePath = directory.relativize(file)
+                if (file.extension == "kt" && shouldVisit(relativePath)) {
+                    val ktFile = file.parseAsKtFile(project)
+                    action(ktFile, file)
+                }
+                return FileVisitResult.CONTINUE
+            }
+        })
     } finally {
         Disposer.dispose(project)
     }

--- a/build-logic/kdoc-annotator/src/main/kotlin/CompilerUtils.kt
+++ b/build-logic/kdoc-annotator/src/main/kotlin/CompilerUtils.kt
@@ -1,0 +1,43 @@
+import org.jetbrains.kotlin.K1Deprecation
+import org.jetbrains.kotlin.cli.jvm.compiler.EnvironmentConfigFiles
+import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
+import org.jetbrains.kotlin.com.intellij.openapi.project.Project
+import org.jetbrains.kotlin.com.intellij.openapi.util.Disposer
+import org.jetbrains.kotlin.com.intellij.psi.impl.PsiFileFactoryImpl
+import org.jetbrains.kotlin.config.CompilerConfiguration
+import org.jetbrains.kotlin.idea.KotlinLanguage
+import org.jetbrains.kotlin.psi.KtFile
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlin.io.path.extension
+import kotlin.io.path.name
+import kotlin.io.path.readText
+import kotlin.streams.asSequence
+
+fun forEachKtFileInDirectory(directory: Path, action: (KtFile, Path) -> Unit) {
+    val project = createProjectForParsing()
+    try {
+        Files.walk(directory)
+            .asSequence()
+            .filter { it.extension == "kt" }
+            .forEach { file ->
+                val ktFile = file.parseAsKtFile(project)
+                action(ktFile, file)
+            }
+    } finally {
+        Disposer.dispose(project)
+    }
+}
+
+private fun Path.parseAsKtFile(project: Project): KtFile {
+    return PsiFileFactoryImpl(project).createFileFromText(name, KotlinLanguage.INSTANCE, readText()) as KtFile
+}
+
+@OptIn(K1Deprecation::class)
+private fun createProjectForParsing(): Project {
+    return KotlinCoreEnvironment.createForProduction(
+        Disposer.newDisposable("KDoc Annotator"),
+        CompilerConfiguration(),
+        EnvironmentConfigFiles.JVM_CONFIG_FILES
+    ).project
+}

--- a/build-logic/kdoc-annotator/src/main/kotlin/KDocCollector.kt
+++ b/build-logic/kdoc-annotator/src/main/kotlin/KDocCollector.kt
@@ -1,0 +1,67 @@
+import org.jetbrains.kotlin.com.intellij.psi.PsiElement
+import org.jetbrains.kotlin.com.intellij.psi.util.PsiTreeUtil
+import org.jetbrains.kotlin.kdoc.psi.api.KDoc
+import org.jetbrains.kotlin.psi.KtDeclaration
+import org.jetbrains.kotlin.psi.KtDeclarationContainer
+import org.jetbrains.kotlin.psi.KtFile
+import org.jetbrains.kotlin.psi.psiUtil.endOffset
+import org.jetbrains.kotlin.psi.psiUtil.isPublic
+import org.jetbrains.kotlin.psi.psiUtil.startOffset
+import java.nio.file.Path
+
+
+fun annotatePublicApiKDocs(file: KtFile, filePath: Path, link: String) {
+    val updater = KDocUpdater()
+
+    traversePublicApi(file) { declaration, fqname: String ->
+        updater.updateKDoc(declaration, fqname)
+    }
+
+    updater.executeUpdate(filePath, link)
+}
+
+fun removeFeedbackLinksFromKDocs(file: KtFile, filePath: Path) {
+    val originalContent = filePath.toFile().readText()
+    var updatedContent = originalContent
+    val kdocs = PsiTreeUtil.collectElementsOfType(file, KDoc::class.java)
+
+    for (kdoc in kdocs.sortedByDescending { it.startOffset }) {
+        updatedContent = updatedContent.replaceRange(
+            kdoc.startOffset,
+            kdoc.endOffset,
+            removeFeedbackLinksFromKDoc(kdoc.text)
+        )
+    }
+
+    if (updatedContent != originalContent) {
+        filePath.toFile().writeText(updatedContent)
+    }
+}
+
+fun traversePublicApi(file: KtFile, block: (KtDeclaration, String) -> Unit) {
+    traversePublicApi(file.declarations, name = file.packageFqName.asString(), block = block)
+}
+
+fun traversePublicApi(declarations: List<KtDeclaration>, name: String, block: (KtDeclaration, String) -> Unit) {
+    if (name.isBlank()) return
+
+    for (declaration: KtDeclaration in declarations) {
+        if (!declaration.isPublic) continue
+        val fqname = "$name.${declaration.name}"
+        block(declaration, fqname)
+
+        if (declaration !is KtDeclarationContainer) continue
+
+        traversePublicApi(declaration.declarations, fqname, block)
+    }
+}
+
+data class KDocLocation(val startOffset: Int, val endOffset: Int, val fqname: String)
+
+fun KDocUpdater.updateKDoc(declaration: KtDeclaration, fqname: String) {
+    val kdoc: KDoc = declaration.docComment ?: return
+    collectForUpdate(kdoc.lineStartOffset, kdoc.endOffset, fqname)
+}
+
+val PsiElement.lineStartOffset: Int
+    get() = containingFile.text.lastIndexOf('\n', startOffset - 1) + 1

--- a/build-logic/kdoc-annotator/src/main/kotlin/KDocCollector.kt
+++ b/build-logic/kdoc-annotator/src/main/kotlin/KDocCollector.kt
@@ -1,3 +1,9 @@
+/*
+ * Copyright 2014-2026 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package ktorbuild.kdoc
+
 import org.jetbrains.kotlin.com.intellij.psi.PsiElement
 import org.jetbrains.kotlin.com.intellij.psi.util.PsiTreeUtil
 import org.jetbrains.kotlin.kdoc.psi.api.KDoc
@@ -8,7 +14,6 @@ import org.jetbrains.kotlin.psi.psiUtil.endOffset
 import org.jetbrains.kotlin.psi.psiUtil.isPublic
 import org.jetbrains.kotlin.psi.psiUtil.startOffset
 import java.nio.file.Path
-
 
 fun annotatePublicApiKDocs(file: KtFile, filePath: Path, link: String) {
     val updater = KDocUpdater()

--- a/build-logic/kdoc-annotator/src/main/kotlin/KDocUpdater.kt
+++ b/build-logic/kdoc-annotator/src/main/kotlin/KDocUpdater.kt
@@ -1,3 +1,9 @@
+/*
+ * Copyright 2014-2026 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package ktorbuild.kdoc
+
 import java.nio.file.Path
 
 class KDocUpdater {

--- a/build-logic/kdoc-annotator/src/main/kotlin/KDocUpdater.kt
+++ b/build-logic/kdoc-annotator/src/main/kotlin/KDocUpdater.kt
@@ -1,0 +1,158 @@
+import java.nio.file.Path
+
+class KDocUpdater {
+    private val kdocs = mutableListOf<KDocLocation>()
+
+    fun collectForUpdate(startOffset: Int, endOffset: Int, fqname: String) {
+        kdocs += KDocLocation(startOffset, endOffset, fqname)
+    }
+
+    fun executeUpdate(file: Path, link: String) {
+        val content = file.toFile().readText()
+        kdocs.sortBy { it.startOffset }
+
+        val newContent = StringBuilder()
+        var lastUsedIndex = 0
+        for ((start, end, fqname) in kdocs) {
+            newContent.append(content.substring(lastUsedIndex, start))
+            lastUsedIndex = end
+
+            val kdoc = content.substring(start, end)
+            val newKdoc = updateKDocWithLink(kdoc, link, fqname)
+            newContent.append(newKdoc)
+        }
+
+        newContent.append(content.substring(lastUsedIndex))
+        val updatedContent = newContent.toString()
+        if (updatedContent != content) {
+            file.toFile().writeText(updatedContent)
+        }
+    }
+}
+
+private val KDOC_TAGS = listOf(
+    "param",
+    "property",
+    "return",
+    "constructor",
+    "receiver",
+    "throws",
+    "exception",
+    "see",
+    "author",
+    "since",
+    "suppress",
+    "sample"
+)
+
+internal fun updateKDocWithLink(content: String, link: String, fqname: String): String {
+    val sanitizedContent = removeFeedbackLinksFromKDoc(content)
+    val lines = sanitizedContent.split("\n")
+    if (lines.any { isKDocTagLine(it, "suppress") }) return sanitizedContent
+    if (lines.size == 1) {
+        return buildSingleLineKDoc(lines.first(), link, fqname)
+    }
+
+    var insertionIndex = lines.indexOfFirst(::isKDocTagLine)
+    if (insertionIndex == -1) {
+        insertionIndex = lines.size - 1
+    }
+
+    val indent = lines[1].takeWhile { it == ' ' }
+    val blankLine = "$indent*"
+
+    val updatedContent = buildString {
+        var lastLine = ""
+        fun appendLineNoDuplicates(line: String) {
+            val trimmedLine = line.trimEnd()
+            if (trimmedLine == lastLine && trimmedLine == blankLine) return
+            appendLine(trimmedLine)
+            lastLine = trimmedLine
+        }
+
+        for (i in 0 until insertionIndex) {
+            appendLineNoDuplicates(lines[i])
+        }
+
+        appendLineNoDuplicates(blankLine)
+        appendLineNoDuplicates(indent + formatLink(link, fqname))
+
+        if (insertionIndex != lines.size - 1) {
+            appendLineNoDuplicates(blankLine)
+        }
+
+        for (i in insertionIndex until lines.size - 1) {
+            appendLineNoDuplicates(lines[i])
+        }
+
+        append(lines.last())
+    }
+    return removeBoundaryBlankLinesFromKDoc(updatedContent)
+}
+
+internal fun removeFeedbackLinksFromKDoc(content: String): String {
+    val lines = content.split("\n").toMutableList()
+    var linkIndex = lines.indexOfFirst(::isFormattedLink)
+    while (linkIndex != -1) {
+        val previousBlankLine = lines.getOrNull(linkIndex - 1)?.takeIf { it.isBlankKDocLine() }
+        val nextBlankLine = lines.getOrNull(linkIndex + 1)?.takeIf { it.isBlankKDocLine() }
+        val nextContentIndex = linkIndex + 1 + if (nextBlankLine == null) 0 else 1
+        val keepBlankLine = lines.getOrNull(nextContentIndex)?.let(::isKDocTagLine) == true
+        val removalIndex = if (previousBlankLine == null) linkIndex else linkIndex - 1
+        val removalCount = 1 + listOfNotNull(previousBlankLine, nextBlankLine).size
+
+        repeat(removalCount) { lines.removeAt(removalIndex) }
+        if (keepBlankLine) {
+            lines.add(removalIndex, previousBlankLine ?: nextBlankLine!!)
+        }
+
+        linkIndex = lines.indexOfFirst(::isFormattedLink)
+    }
+
+    return removeBoundaryBlankLinesFromKDoc(lines.joinToString("\n"))
+}
+
+private fun removeBoundaryBlankLinesFromKDoc(content: String): String {
+    val lines = content.split("\n").toMutableList()
+    while (lines.getOrNull(1)?.isBlankKDocLine() == true) {
+        lines.removeAt(1)
+    }
+    while (lines.getOrNull(lines.lastIndex - 1)?.isBlankKDocLine() == true) {
+        lines.removeAt(lines.lastIndex - 1)
+    }
+    return lines.joinToString("\n")
+}
+
+private fun isKDocTagLine(line: String): Boolean {
+    return KDOC_TAGS.any { tag -> isKDocTagLine(line, tag) }
+}
+
+private fun isKDocTagLine(line: String, tag: String): Boolean {
+    val content = line.trimStart().removePrefix("*").trimStart()
+    return content == "@$tag" || content.startsWith("@$tag ") || content.startsWith("@$tag\t")
+}
+
+private fun String.isBlankKDocLine(): Boolean = trim().let { it.isEmpty() || it == "*" }
+
+private const val LINK_TITLE = "Report a problem"
+
+private fun isFormattedLink(line: String): Boolean {
+    return line.trimStart().startsWith("* [$LINK_TITLE]")
+}
+
+private fun formatLink(link: String, fqname: String): String {
+    return "* [$LINK_TITLE]($link?fqname=$fqname)"
+}
+
+private fun buildSingleLineKDoc(line: String, link: String, fqname: String): String {
+    val indent = line.takeWhile { it.isWhitespace() }
+    val rawKDoc = line.substringAfter("/**").substringBeforeLast("*/").trim()
+
+    return buildString {
+        appendLine("$indent/**")
+        appendLine("$indent * $rawKDoc")
+        appendLine("$indent *")
+        appendLine("$indent ${formatLink(link, fqname)}")
+        append("$indent */")
+    }
+}

--- a/build-logic/kdoc-annotator/src/main/kotlin/Main.kt
+++ b/build-logic/kdoc-annotator/src/main/kotlin/Main.kt
@@ -7,20 +7,28 @@ package ktorbuild.kdoc
 import java.nio.file.Path
 import kotlin.io.path.Path as createPath
 
+private const val EXCLUDE_ARGUMENT_PREFIX = "--exclude="
+
 fun main(args: Array<String>) {
-    if (args.size != 2) {
+    val excludeArguments = args.drop(2)
+    if (args.size < 2 || excludeArguments.any { !it.startsWith(EXCLUDE_ARGUMENT_PREFIX) }) {
         printHelp()
         return
     }
 
     val projectSources = args[0]
     val link = args[1]
+    val excludedPathPatterns = excludeArguments.map { it.removePrefix(EXCLUDE_ARGUMENT_PREFIX) }
 
-    updateKDocsInDirectory(createPath(projectSources), link)
+    updateKDocsInDirectory(createPath(projectSources), link, excludedPathPatterns)
 }
 
-private fun updateKDocsInDirectory(directory: Path, link: String) {
-    forEachKtFileInDirectory(directory) { ktFile, path ->
+private fun updateKDocsInDirectory(directory: Path, link: String, excludedPathPatterns: List<String>) {
+    val pathExclusions = PathExclusions(excludedPathPatterns)
+    forEachKtFileInDirectory(
+        directory,
+        shouldVisit = { it !in pathExclusions },
+    ) { ktFile, path ->
         if (path.isInTestSourceSet()) {
             removeFeedbackLinksFromKDocs(ktFile, path)
         } else {
@@ -43,5 +51,5 @@ internal fun Path.isInTestSourceSet(): Boolean {
 private fun printHelp() {
     println("KDoc annotator is a tool to add a feedback link for the KDoc documentation if this link is not present yet.")
     println("Usage:")
-    println("kdoc-annotator <path-to-project sources> <link>")
+    println("kdoc-annotator <path-to-project sources> <link> [${EXCLUDE_ARGUMENT_PREFIX}<path-pattern>]...")
 }

--- a/build-logic/kdoc-annotator/src/main/kotlin/Main.kt
+++ b/build-logic/kdoc-annotator/src/main/kotlin/Main.kt
@@ -1,0 +1,41 @@
+import java.nio.file.Path
+import kotlin.io.path.Path as createPath
+
+fun main(args: Array<String>) {
+    if (args.size != 2) {
+        printHelp()
+        return
+    }
+
+    val projectSources = args[0]
+    val link = args[1]
+
+    updateKDocsInDirectory(createPath(projectSources), link)
+}
+
+fun updateKDocsInDirectory(directory: Path, link: String) {
+    forEachKtFileInDirectory(directory) { ktFile, path ->
+        if (path.isInTestSourceSet()) {
+            removeFeedbackLinksFromKDocs(ktFile, path)
+        } else {
+            annotatePublicApiKDocs(ktFile, path, link)
+        }
+    }
+}
+
+internal fun Path.isInTestSourceSet(): Boolean {
+    val parent = parent ?: return false
+    return parent.iterator().asSequence()
+        .map { it.toString() }
+        .any { sourceSet ->
+            sourceSet == "test" ||
+                sourceSet.endsWith("Test") ||
+                sourceSet.startsWith("test") && sourceSet.getOrNull("test".length)?.isUpperCase() == true
+        }
+}
+
+fun printHelp() {
+    println("KDoc annotator is a tool to add a feedback link for the KDoc documentation if this link is not present yet.")
+    println("Usage:")
+    println("kdoc-annotator <path-to-project sources> <link>")
+}

--- a/build-logic/kdoc-annotator/src/main/kotlin/Main.kt
+++ b/build-logic/kdoc-annotator/src/main/kotlin/Main.kt
@@ -1,3 +1,9 @@
+/*
+ * Copyright 2014-2026 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package ktorbuild.kdoc
+
 import java.nio.file.Path
 import kotlin.io.path.Path as createPath
 
@@ -13,7 +19,7 @@ fun main(args: Array<String>) {
     updateKDocsInDirectory(createPath(projectSources), link)
 }
 
-fun updateKDocsInDirectory(directory: Path, link: String) {
+private fun updateKDocsInDirectory(directory: Path, link: String) {
     forEachKtFileInDirectory(directory) { ktFile, path ->
         if (path.isInTestSourceSet()) {
             removeFeedbackLinksFromKDocs(ktFile, path)
@@ -34,7 +40,7 @@ internal fun Path.isInTestSourceSet(): Boolean {
         }
 }
 
-fun printHelp() {
+private fun printHelp() {
     println("KDoc annotator is a tool to add a feedback link for the KDoc documentation if this link is not present yet.")
     println("Usage:")
     println("kdoc-annotator <path-to-project sources> <link>")

--- a/build-logic/kdoc-annotator/src/main/kotlin/PathExclusions.kt
+++ b/build-logic/kdoc-annotator/src/main/kotlin/PathExclusions.kt
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2014-2026 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package ktorbuild.kdoc
+
+import java.nio.file.Path
+
+internal class PathExclusions(patterns: List<String>) {
+    private val excludedPatternSegments = patterns.map { it.split('/') }
+
+    operator fun contains(path: Path): Boolean {
+        val pathSegments = path.iterator().asSequence().map(Path::toString).toList()
+        return excludedPatternSegments.any { matchesPattern(pathSegments, it) }
+    }
+}
+
+private fun matchesPattern(
+    pathSegments: List<String>,
+    patternSegments: List<String>,
+    pathIndex: Int = 0,
+    patternIndex: Int = 0,
+): Boolean {
+    if (patternIndex == patternSegments.size) return pathIndex == pathSegments.size
+    if (patternSegments[patternIndex] == "**") {
+        var nextPatternIndex = patternIndex + 1
+        while (nextPatternIndex < patternSegments.size && patternSegments[nextPatternIndex] == "**") {
+            nextPatternIndex++
+        }
+        if (nextPatternIndex == patternSegments.size) return true
+
+        for (candidatePathIndex in pathIndex until pathSegments.size) {
+            if (pathSegments[candidatePathIndex] == patternSegments[nextPatternIndex] &&
+                matchesPattern(pathSegments, patternSegments, candidatePathIndex + 1, nextPatternIndex + 1)
+            ) {
+                return true
+            }
+        }
+        return false
+    }
+    return pathIndex < pathSegments.size &&
+        pathSegments[pathIndex] == patternSegments[patternIndex] &&
+        matchesPattern(pathSegments, patternSegments, pathIndex + 1, patternIndex + 1)
+}

--- a/build-logic/kdoc-annotator/src/test/kotlin/IntegrationTest.kt
+++ b/build-logic/kdoc-annotator/src/test/kotlin/IntegrationTest.kt
@@ -1,0 +1,32 @@
+import org.junit.jupiter.api.Test
+import kotlin.io.path.Path
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class IntegrationTest {
+    @Test
+    fun testLockFreeLinkedList() {
+
+        val projectSources = "./src/test/test-data"
+        val link = "https://ktor.io/feedback"
+
+
+        val path = Path("../")
+
+        forEachKtFileInDirectory(Path(projectSources)) { ktFile, path ->
+            annotatePublicApiKDocs(ktFile, path, link)
+        }
+        
+    }
+
+    @Test
+    fun `detect test source sets`() {
+        assertTrue(Path("project/src/test/kotlin/Example.kt").isInTestSourceSet())
+        assertTrue(Path("project/src/commonTest/kotlin/Example.kt").isInTestSourceSet())
+        assertTrue(Path("project/src/integrationTest/kotlin/Example.kt").isInTestSourceSet())
+        assertTrue(Path("project/jvm/test/io/ktor/RequestHeadersTest.kt").isInTestSourceSet())
+        assertFalse(Path("project/src/main/kotlin/RequestHeadersTest.kt").isInTestSourceSet())
+        assertFalse(Path("project/src/commonMain/kotlin/Example.kt").isInTestSourceSet())
+        assertFalse(Path("project/ktor-client-tests/jvm/main/Example.kt").isInTestSourceSet())
+    }
+}

--- a/build-logic/kdoc-annotator/src/test/kotlin/IntegrationTest.kt
+++ b/build-logic/kdoc-annotator/src/test/kotlin/IntegrationTest.kt
@@ -9,7 +9,9 @@ import org.junit.jupiter.api.io.TempDir
 import java.nio.file.Path
 import kotlin.io.path.Path
 import kotlin.io.path.copyTo
+import kotlin.io.path.createDirectories
 import kotlin.io.path.readText
+import kotlin.io.path.writeText
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
@@ -26,6 +28,50 @@ class IntegrationTest {
         }
 
         assertEquals(expected, source.readText())
+    }
+
+    @Test
+    fun `exclude configured paths from scan`(@TempDir temporaryDirectory: Path) {
+        val excludedPathPatterns = listOf(
+            "**/.gradle/**",
+            "**/build/**",
+            "build-logic/**",
+            "build-settings-logic/**",
+        )
+        val includedSource = Path("ktor-client/ktor-client-core/common/src/Client.kt")
+        val excludedSources = listOf(
+            Path(".gradle/caches/Generated.kt"),
+            Path("ktor-client/.gradle/caches/Generated.kt"),
+            Path("build/generated/Generated.kt"),
+            Path("ktor-client/build/generated/Generated.kt"),
+            Path("build-logic/src/main/kotlin/KtorBuild.kt"),
+            Path("build-settings-logic/src/main/kotlin/KtorSettings.kt"),
+        )
+
+        for (source in excludedSources + listOf(includedSource)) {
+            temporaryDirectory.resolve(source).apply {
+                parent.createDirectories()
+                writeText("package example")
+            }
+        }
+
+        val scannedSources = mutableSetOf<Path>()
+        val pathExclusions = PathExclusions(excludedPathPatterns)
+        forEachKtFileInDirectory(
+            temporaryDirectory,
+            shouldVisit = { it !in pathExclusions },
+        ) { _, path ->
+            scannedSources.add(temporaryDirectory.relativize(path))
+        }
+
+        assertEquals(setOf(includedSource), scannedSources)
+    }
+
+    @Test
+    fun `continue searching after partial path pattern match`() {
+        val pathExclusions = PathExclusions(listOf("**/generated/src/**"))
+
+        assertTrue(Path("generated/cache/generated/src/Generated.kt") in pathExclusions)
     }
 
     @Test

--- a/build-logic/kdoc-annotator/src/test/kotlin/IntegrationTest.kt
+++ b/build-logic/kdoc-annotator/src/test/kotlin/IntegrationTest.kt
@@ -1,3 +1,9 @@
+/*
+ * Copyright 2014-2026 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package ktorbuild.kdoc
+
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
 import java.nio.file.Path

--- a/build-logic/kdoc-annotator/src/test/kotlin/IntegrationTest.kt
+++ b/build-logic/kdoc-annotator/src/test/kotlin/IntegrationTest.kt
@@ -1,22 +1,25 @@
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.nio.file.Path
 import kotlin.io.path.Path
+import kotlin.io.path.copyTo
+import kotlin.io.path.readText
+import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 class IntegrationTest {
     @Test
-    fun testLockFreeLinkedList() {
+    fun `annotate KDocs in LockFreeLinkedList`(@TempDir temporaryDirectory: Path) {
+        val raw = Path("./src/test/test-data/LockFreeLinkedList.raw.kt")
+        val expected = Path("./src/test/test-data/LockFreeLinkedList.expected.txt").readText()
+        val source = raw.copyTo(temporaryDirectory.resolve(raw.fileName))
 
-        val projectSources = "./src/test/test-data"
-        val link = "https://ktor.io/feedback"
-
-
-        val path = Path("../")
-
-        forEachKtFileInDirectory(Path(projectSources)) { ktFile, path ->
-            annotatePublicApiKDocs(ktFile, path, link)
+        forEachKtFileInDirectory(temporaryDirectory) { ktFile, path ->
+            annotatePublicApiKDocs(ktFile, path, "https://ktor.io/feedback/")
         }
-        
+
+        assertEquals(expected, source.readText())
     }
 
     @Test

--- a/build-logic/kdoc-annotator/src/test/kotlin/KdocUpdaterTest.kt
+++ b/build-logic/kdoc-annotator/src/test/kotlin/KdocUpdaterTest.kt
@@ -1,0 +1,290 @@
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class KdocUpdaterTest {
+
+    @Test
+    fun `update single line KDoc`() {
+
+        val kdoc = """/** Hello world */ """
+        val result = updateKDocWithLink(kdoc, "https://example.com", "a.b.c")
+
+        assertEquals("""
+            /**
+             * Hello world
+             *
+             * [Report a problem](https://example.com?fqname=a.b.c)
+             */
+        """.trimIndent(), result)
+    }
+
+    @Test
+    fun `update multi line KDoc`() {
+        val kdoc = """
+            /**
+             * Hello world
+             */
+        """.trimIndent()
+        val result = updateKDocWithLink(kdoc, "https://example.com", "a.b.c")
+        assertEquals("""
+            /**
+             * Hello world
+             *
+             * [Report a problem](https://example.com?fqname=a.b.c)
+             */
+        """.trimIndent(), result)
+    }
+
+    @Test
+    fun `update KDoc with param section`() {
+        val kdoc = """
+            /**
+             * Hello world
+             * @param a The first param
+             */
+        """.trimIndent()
+        val result = updateKDocWithLink(kdoc, "https://example.com", "a.b.c")
+        assertEquals("""
+            /**
+             * Hello world
+             *
+             * [Report a problem](https://example.com?fqname=a.b.c)
+             *
+             * @param a The first param
+             */
+        """.trimIndent(), result)
+    }
+
+    @Test
+    fun `update KDoc with param section separated with a blank line`() {
+        val kdoc = """
+            /**
+             * Hello world
+             *
+             * @param a The first param
+             */
+        """.trimIndent()
+        val result = updateKDocWithLink(kdoc, "https://example.com", "a.b.c")
+        assertEquals("""
+            /**
+             * Hello world
+             *
+             * [Report a problem](https://example.com?fqname=a.b.c)
+             *
+             * @param a The first param
+             */
+        """.trimIndent(), result)
+    }
+
+    @Test
+    fun `remove feedback link from suppressed KDoc`() {
+        val kdoc = """
+            /**
+             * @suppress **This is unstable API and it is subject to change.**
+             *
+             * [Report a problem](https://example.com?fqname=a.b.c)
+             */
+        """.trimIndent()
+
+        val result = updateKDocWithLink(kdoc, "https://example.com", "a.b.c")
+
+        assertEquals("""
+            /**
+             * @suppress **This is unstable API and it is subject to change.**
+             */
+        """.trimIndent(), result)
+    }
+
+    @Test
+    fun `do not add leading blank line when KDoc starts with tag`() {
+        val kdoc = """
+            /**
+             * @param value parameter description.
+             */
+        """.trimIndent()
+
+        val result = updateKDocWithLink(kdoc, "https://example.com", "a.b.c")
+
+        assertEquals("""
+            /**
+             * [Report a problem](https://example.com?fqname=a.b.c)
+             *
+             * @param value parameter description.
+             */
+        """.trimIndent(), result)
+    }
+
+    @Test
+    fun `move existing feedback link before KDoc tags without trailing blank line`() {
+        val kdoc = """
+            /**
+             * Generates an EC key pair for OIDC tests.
+             *
+             * @param keyId key ID written to token headers.
+             * @return generated test keys.
+             *
+             * [Report a problem](https://example.com?fqname=a.b.c)
+             */
+        """.trimIndent()
+
+        val result = updateKDocWithLink(kdoc, "https://example.com", "a.b.c")
+
+        assertEquals("""
+            /**
+             * Generates an EC key pair for OIDC tests.
+             *
+             * [Report a problem](https://example.com?fqname=a.b.c)
+             *
+             * @param keyId key ID written to token headers.
+             * @return generated test keys.
+             */
+        """.trimIndent(), result)
+    }
+
+    @Test
+    fun `do not treat inline annotation as KDoc tag`() {
+        val kdoc = """
+            /**
+             * Apple's delegate is
+             * declared `@property(nonatomic, weak)`.
+             */
+        """.trimIndent()
+
+        val result = updateKDocWithLink(kdoc, "https://example.com", "a.b.c")
+
+        assertEquals("""
+            /**
+             * Apple's delegate is
+             * declared `@property(nonatomic, weak)`.
+             *
+             * [Report a problem](https://example.com?fqname=a.b.c)
+             */
+        """.trimIndent(), result)
+    }
+
+    @Test
+    fun `remove feedback link inserted before inline annotation`() {
+        val kdoc = """
+            /**
+             * Apple's delegate is
+             *
+             * [Report a problem](https://example.com?fqname=a.b.c)
+             *
+             * declared `@property(nonatomic, weak)`.
+             */
+        """.trimIndent()
+
+        val result = removeFeedbackLinksFromKDoc(kdoc)
+
+        assertEquals("""
+            /**
+             * Apple's delegate is
+             * declared `@property(nonatomic, weak)`.
+             */
+        """.trimIndent(), result)
+    }
+
+    @Test
+    fun `remove feedback link from KDoc`() {
+        val kdoc = """
+            /**
+             * Hello world
+             *
+             * [Report a problem](https://example.com?fqname=a.b.c)
+             *
+             * @param a The first param
+             */
+        """.trimIndent()
+
+        val result = removeFeedbackLinksFromKDoc(kdoc)
+
+        assertEquals("""
+            /**
+             * Hello world
+             *
+             * @param a The first param
+             */
+        """.trimIndent(), result)
+    }
+
+    @Test
+    fun `remove leading blank lines without feedback link`() {
+        val kdoc = """
+            /**
+             *
+             *
+             * Hello world
+             */
+        """.trimIndent()
+
+        val result = removeFeedbackLinksFromKDoc(kdoc)
+
+        assertEquals("""
+            /**
+             * Hello world
+             */
+        """.trimIndent(), result)
+    }
+
+    @Test
+    fun `remove trailing blank lines without feedback link`() {
+        val kdoc = """
+            /**
+             * Hello world
+             *
+             *
+             */
+        """.trimIndent()
+
+        val result = removeFeedbackLinksFromKDoc(kdoc)
+
+        assertEquals("""
+            /**
+             * Hello world
+             */
+        """.trimIndent(), result)
+    }
+
+    @Test
+    fun `remove trailing feedback link from KDoc`() {
+        val kdoc = """
+            /**
+             * Hello world
+             *
+             * [Report a problem](https://example.com?fqname=a.b.c)
+             */
+        """.trimIndent()
+
+        val result = removeFeedbackLinksFromKDoc(kdoc)
+
+        assertEquals("""
+            /**
+             * Hello world
+             */
+        """.trimIndent(), result)
+    }
+
+    @Test
+    fun `update KDoc existing link`() {
+        val kdoc = """
+            /**
+             * Hello world
+             *
+             * [Report a problem](https://example.com?fqname=a.b.foo)
+             *
+             * @param a The first param
+             */
+        """.trimIndent()
+        val result = updateKDocWithLink(kdoc, "https://example.com", "a.b.bar")
+        assertEquals("""
+            /**
+             * Hello world
+             *
+             * [Report a problem](https://example.com?fqname=a.b.bar)
+             *
+             * @param a The first param
+             */
+        """.trimIndent(), result)
+    }
+}
+

--- a/build-logic/kdoc-annotator/src/test/kotlin/KdocUpdaterTest.kt
+++ b/build-logic/kdoc-annotator/src/test/kotlin/KdocUpdaterTest.kt
@@ -1,3 +1,9 @@
+/*
+ * Copyright 2014-2026 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package ktorbuild.kdoc
+
 import kotlin.test.Test
 import kotlin.test.assertEquals
 

--- a/build-logic/kdoc-annotator/src/test/kotlin/KdocUpdaterTest.kt
+++ b/build-logic/kdoc-annotator/src/test/kotlin/KdocUpdaterTest.kt
@@ -2,49 +2,40 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 
 class KdocUpdaterTest {
-
     @Test
     fun `update single line KDoc`() {
-
-        val kdoc = """/** Hello world */ """
-        val result = updateKDocWithLink(kdoc, "https://example.com", "a.b.c")
-
-        assertEquals("""
+        "/** Hello world */" shouldBeUpdatedTo """
             /**
              * Hello world
              *
              * [Report a problem](https://example.com?fqname=a.b.c)
              */
-        """.trimIndent(), result)
+        """
     }
 
     @Test
     fun `update multi line KDoc`() {
-        val kdoc = """
+        """
             /**
              * Hello world
              */
-        """.trimIndent()
-        val result = updateKDocWithLink(kdoc, "https://example.com", "a.b.c")
-        assertEquals("""
+        """ shouldBeUpdatedTo """
             /**
              * Hello world
              *
              * [Report a problem](https://example.com?fqname=a.b.c)
              */
-        """.trimIndent(), result)
+        """
     }
 
     @Test
     fun `update KDoc with param section`() {
-        val kdoc = """
+        """
             /**
              * Hello world
              * @param a The first param
              */
-        """.trimIndent()
-        val result = updateKDocWithLink(kdoc, "https://example.com", "a.b.c")
-        assertEquals("""
+        """ shouldBeUpdatedTo """
             /**
              * Hello world
              *
@@ -52,20 +43,18 @@ class KdocUpdaterTest {
              *
              * @param a The first param
              */
-        """.trimIndent(), result)
+        """
     }
 
     @Test
     fun `update KDoc with param section separated with a blank line`() {
-        val kdoc = """
+        """
             /**
              * Hello world
              *
              * @param a The first param
              */
-        """.trimIndent()
-        val result = updateKDocWithLink(kdoc, "https://example.com", "a.b.c")
-        assertEquals("""
+        """ shouldBeUpdatedTo """
             /**
              * Hello world
              *
@@ -73,50 +62,42 @@ class KdocUpdaterTest {
              *
              * @param a The first param
              */
-        """.trimIndent(), result)
+        """
     }
 
     @Test
     fun `remove feedback link from suppressed KDoc`() {
-        val kdoc = """
+        """
             /**
              * @suppress **This is unstable API and it is subject to change.**
              *
              * [Report a problem](https://example.com?fqname=a.b.c)
              */
-        """.trimIndent()
-
-        val result = updateKDocWithLink(kdoc, "https://example.com", "a.b.c")
-
-        assertEquals("""
+        """ shouldBeUpdatedTo """
             /**
              * @suppress **This is unstable API and it is subject to change.**
              */
-        """.trimIndent(), result)
+        """
     }
 
     @Test
     fun `do not add leading blank line when KDoc starts with tag`() {
-        val kdoc = """
+        """
             /**
              * @param value parameter description.
              */
-        """.trimIndent()
-
-        val result = updateKDocWithLink(kdoc, "https://example.com", "a.b.c")
-
-        assertEquals("""
+        """ shouldBeUpdatedTo """
             /**
              * [Report a problem](https://example.com?fqname=a.b.c)
              *
              * @param value parameter description.
              */
-        """.trimIndent(), result)
+        """
     }
 
     @Test
     fun `move existing feedback link before KDoc tags without trailing blank line`() {
-        val kdoc = """
+        """
             /**
              * Generates an EC key pair for OIDC tests.
              *
@@ -125,11 +106,7 @@ class KdocUpdaterTest {
              *
              * [Report a problem](https://example.com?fqname=a.b.c)
              */
-        """.trimIndent()
-
-        val result = updateKDocWithLink(kdoc, "https://example.com", "a.b.c")
-
-        assertEquals("""
+        """ shouldBeUpdatedTo """
             /**
              * Generates an EC key pair for OIDC tests.
              *
@@ -138,135 +115,29 @@ class KdocUpdaterTest {
              * @param keyId key ID written to token headers.
              * @return generated test keys.
              */
-        """.trimIndent(), result)
+        """
     }
 
     @Test
     fun `do not treat inline annotation as KDoc tag`() {
-        val kdoc = """
+        """
             /**
              * Apple's delegate is
              * declared `@property(nonatomic, weak)`.
              */
-        """.trimIndent()
-
-        val result = updateKDocWithLink(kdoc, "https://example.com", "a.b.c")
-
-        assertEquals("""
+        """ shouldBeUpdatedTo """
             /**
              * Apple's delegate is
              * declared `@property(nonatomic, weak)`.
              *
              * [Report a problem](https://example.com?fqname=a.b.c)
              */
-        """.trimIndent(), result)
-    }
-
-    @Test
-    fun `remove feedback link inserted before inline annotation`() {
-        val kdoc = """
-            /**
-             * Apple's delegate is
-             *
-             * [Report a problem](https://example.com?fqname=a.b.c)
-             *
-             * declared `@property(nonatomic, weak)`.
-             */
-        """.trimIndent()
-
-        val result = removeFeedbackLinksFromKDoc(kdoc)
-
-        assertEquals("""
-            /**
-             * Apple's delegate is
-             * declared `@property(nonatomic, weak)`.
-             */
-        """.trimIndent(), result)
-    }
-
-    @Test
-    fun `remove feedback link from KDoc`() {
-        val kdoc = """
-            /**
-             * Hello world
-             *
-             * [Report a problem](https://example.com?fqname=a.b.c)
-             *
-             * @param a The first param
-             */
-        """.trimIndent()
-
-        val result = removeFeedbackLinksFromKDoc(kdoc)
-
-        assertEquals("""
-            /**
-             * Hello world
-             *
-             * @param a The first param
-             */
-        """.trimIndent(), result)
-    }
-
-    @Test
-    fun `remove leading blank lines without feedback link`() {
-        val kdoc = """
-            /**
-             *
-             *
-             * Hello world
-             */
-        """.trimIndent()
-
-        val result = removeFeedbackLinksFromKDoc(kdoc)
-
-        assertEquals("""
-            /**
-             * Hello world
-             */
-        """.trimIndent(), result)
-    }
-
-    @Test
-    fun `remove trailing blank lines without feedback link`() {
-        val kdoc = """
-            /**
-             * Hello world
-             *
-             *
-             */
-        """.trimIndent()
-
-        val result = removeFeedbackLinksFromKDoc(kdoc)
-
-        assertEquals("""
-            /**
-             * Hello world
-             */
-        """.trimIndent(), result)
-    }
-
-    @Test
-    fun `remove trailing feedback link from KDoc`() {
-        val kdoc = """
-            /**
-             * Hello world
-             *
-             * [Report a problem](https://example.com?fqname=a.b.c)
-             */
-        """.trimIndent()
-
-        val result = removeFeedbackLinksFromKDoc(kdoc)
-
-        assertEquals("""
-            /**
-             * Hello world
-             */
-        """.trimIndent(), result)
+        """
     }
 
     @Test
     fun `update KDoc existing link`() {
-        val kdoc = """
+        """
             /**
              * Hello world
              *
@@ -274,17 +145,91 @@ class KdocUpdaterTest {
              *
              * @param a The first param
              */
-        """.trimIndent()
-        val result = updateKDocWithLink(kdoc, "https://example.com", "a.b.bar")
-        assertEquals("""
+        """ shouldBeUpdatedTo """
             /**
              * Hello world
              *
-             * [Report a problem](https://example.com?fqname=a.b.bar)
+             * [Report a problem](https://example.com?fqname=a.b.c)
              *
              * @param a The first param
              */
-        """.trimIndent(), result)
+        """
+    }
+
+    @Test
+    fun `remove feedback link from KDoc`() {
+        """
+            /**
+             * Hello world
+             *
+             * [Report a problem](https://example.com?fqname=a.b.c)
+             *
+             * @param a The first param
+             */
+        """ shouldBeSanitizedTo """
+            /**
+             * Hello world
+             *
+             * @param a The first param
+             */
+        """
+    }
+
+    @Test
+    fun `remove leading blank lines without feedback link`() {
+        """
+            /**
+             *
+             *
+             * Hello world
+             */
+        """ shouldBeSanitizedTo """
+            /**
+             * Hello world
+             */
+        """
+    }
+
+    @Test
+    fun `remove trailing blank lines without feedback link`() {
+        """
+            /**
+             * Hello world
+             *
+             *
+             */
+        """ shouldBeSanitizedTo """
+            /**
+             * Hello world
+             */
+        """
+    }
+
+    @Test
+    fun `remove trailing feedback link from KDoc`() {
+        """
+            /**
+             * Hello world
+             *
+             * [Report a problem](https://example.com?fqname=a.b.c)
+             */
+        """ shouldBeSanitizedTo """
+            /**
+             * Hello world
+             */
+        """
+    }
+
+    private infix fun String.shouldBeUpdatedTo(expected: String) {
+        val result = updateKDocWithLink(trimIndent(), TEST_FEEDBACK_LINK, TEST_FULLY_QUALIFIED_NAME)
+        assertEquals(expected.trimIndent(), result)
+    }
+
+    private infix fun String.shouldBeSanitizedTo(expected: String) {
+        val result = removeFeedbackLinksFromKDoc(trimIndent())
+        assertEquals(expected.trimIndent(), result)
     }
 }
 
+private const val TEST_FEEDBACK_LINK = "https://example.com"
+private const val TEST_FULLY_QUALIFIED_NAME = "a.b.c"

--- a/build-logic/kdoc-annotator/src/test/test-data/LockFreeLinkedList.expected.txt
+++ b/build-logic/kdoc-annotator/src/test/test-data/LockFreeLinkedList.expected.txt
@@ -40,11 +40,15 @@ public typealias RemoveFirstDesc<T> = LockFreeLinkedListNode.RemoveFirstDesc<T>
 
 /**
  * @suppress **This is unstable API and it is subject to change.**
+ *
+ * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.util.internal.AddLastDesc)
  */
 public typealias AddLastDesc<T> = LockFreeLinkedListNode.AddLastDesc<T>
 
 /**
  * @suppress **This is unstable API and it is subject to change.**
+ *
+ * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.util.internal.AbstractAtomicDesc)
  */
 public typealias AbstractAtomicDesc = LockFreeLinkedListNode.AbstractAtomicDesc
 
@@ -63,7 +67,7 @@ public abstract class OpDescriptor {
      * Returns `null` is operation was performed successfully or some other
      * object that indicates the failure reason.
      *
-     * [Report a problem](https://ktor.io/feedback?fqname=io.ktor.util.internal.OpDescriptor.perform)
+     * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.util.internal.OpDescriptor.perform)
      */
     public abstract fun perform(affected: Any?): Any?
 }
@@ -227,7 +231,7 @@ public open class LockFreeLinkedListNode {
     /**
      * Adds last item to this list.
      *
-     * [Report a problem](https://ktor.io/feedback?fqname=io.ktor.util.internal.LockFreeLinkedListNode.addLast)
+     * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.util.internal.LockFreeLinkedListNode.addLast)
      */
     public fun addLast(node: Node) {
         while (true) { // lock-free loop on prev.next
@@ -241,7 +245,7 @@ public open class LockFreeLinkedListNode {
     /**
      * Adds last item to this list atomically if the [condition] is true.
      *
-     * [Report a problem](https://ktor.io/feedback?fqname=io.ktor.util.internal.LockFreeLinkedListNode.addLastIf)
+     * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.util.internal.LockFreeLinkedListNode.addLastIf)
      */
     public inline fun addLastIf(node: Node, crossinline condition: () -> Boolean): Boolean {
         val condAdd = makeCondAddOp(node, condition)
@@ -334,7 +338,7 @@ public open class LockFreeLinkedListNode {
      * In particular, invoking [nextNode].[prevNode] might still return this node even though it is "already removed".
      * Invoke [helpRemove] to make sure that remove was completed.
      *
-     * [Report a problem](https://ktor.io/feedback?fqname=io.ktor.util.internal.LockFreeLinkedListNode.remove)
+     * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.util.internal.LockFreeLinkedListNode.remove)
      */
     public open fun remove(): Boolean {
         while (true) { // lock-free loop on next
@@ -792,7 +796,7 @@ public open class LockFreeLinkedListHead : LockFreeLinkedListNode() {
     /**
      * Iterates over all elements in this list of a specified type.
      *
-     * [Report a problem](https://ktor.io/feedback?fqname=io.ktor.util.internal.LockFreeLinkedListHead.forEach)
+     * [Report a problem](https://ktor.io/feedback/?fqname=io.ktor.util.internal.LockFreeLinkedListHead.forEach)
      */
     public inline fun <reified T : Node> forEach(block: (T) -> Unit) {
         var cur: Node = next as Node

--- a/build-logic/kdoc-annotator/src/test/test-data/LockFreeLinkedList.kt
+++ b/build-logic/kdoc-annotator/src/test/test-data/LockFreeLinkedList.kt
@@ -1,0 +1,821 @@
+/*
+ * Copyright 2014-2024 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.util.internal
+
+import kotlinx.atomicfu.*
+import kotlin.jvm.*
+
+/*
+ * Copied from kotlinx.coroutines
+ */
+
+private typealias Node = LockFreeLinkedListNode
+
+@PublishedApi
+internal const val UNDECIDED: Int = 0
+
+@PublishedApi
+internal const val SUCCESS: Int = 1
+
+@PublishedApi
+internal const val FAILURE: Int = 2
+
+@PublishedApi
+internal val CONDITION_FALSE: Any = Symbol("CONDITION_FALSE")
+
+@PublishedApi
+internal val ALREADY_REMOVED: Any = Symbol("ALREADY_REMOVED")
+
+@PublishedApi
+internal val LIST_EMPTY: Any = Symbol("LIST_EMPTY")
+
+private val REMOVE_PREPARED: Any = Symbol("REMOVE_PREPARED")
+
+/**
+ * @suppress **This is unstable API and it is subject to change.**
+ */
+public typealias RemoveFirstDesc<T> = LockFreeLinkedListNode.RemoveFirstDesc<T>
+
+/**
+ * @suppress **This is unstable API and it is subject to change.**
+ */
+public typealias AddLastDesc<T> = LockFreeLinkedListNode.AddLastDesc<T>
+
+/**
+ * @suppress **This is unstable API and it is subject to change.**
+ */
+public typealias AbstractAtomicDesc = LockFreeLinkedListNode.AbstractAtomicDesc
+
+private class Symbol(val symbol: String) {
+    override fun toString(): String = symbol
+}
+
+/**
+ * The most abstract operation that can be in process. Other threads observing an instance of this
+ * class in the fields of their object shall invoke [perform] to help.
+ *
+ * @suppress **This is unstable API and it is subject to change.**
+ */
+public abstract class OpDescriptor {
+    /**
+     * Returns `null` is operation was performed successfully or some other
+     * object that indicates the failure reason.
+     *
+     * [Report a problem](https://ktor.io/feedback?fqname=io.ktor.util.internal.OpDescriptor.perform)
+     */
+    public abstract fun perform(affected: Any?): Any?
+}
+
+private val NO_DECISION: Any = Symbol("NO_DECISION")
+
+/**
+ * Descriptor for multi-word atomic operation.
+ * Based on paper
+ * ["A Practical Multi-Word Compare-and-Swap Operation"](http://www.cl.cam.ac.uk/research/srgnetos/papers/2002-casn.pdf)
+ * by Timothy L. Harris, Keir Fraser and Ian A. Pratt.
+ *
+ * Note: parts of atomic operation must be globally ordered. Otherwise, this implementation will produce
+ * `StackOverflowError`.
+ *
+ * @suppress **This is unstable API and it is subject to change.**
+ */
+public abstract class AtomicOp<in T> : OpDescriptor() {
+    private val _consensus = atomic<Any?>(NO_DECISION)
+
+    public val isDecided: Boolean get() = _consensus.value !== NO_DECISION
+
+    public fun tryDecide(decision: Any?): Boolean {
+        check(decision !== NO_DECISION)
+        return _consensus.compareAndSet(NO_DECISION, decision)
+    }
+
+    private fun decide(decision: Any?): Any? = if (tryDecide(decision)) decision else _consensus.value
+
+    public abstract fun prepare(affected: T): Any? // `null` if Ok, or failure reason
+
+    public abstract fun complete(affected: T, failure: Any?) // failure != null if failed to prepare op
+
+    // returns `null` on success
+    @Suppress("UNCHECKED_CAST")
+    public final override fun perform(affected: Any?): Any? {
+        // make decision on status
+        var decision = this._consensus.value
+        if (decision === NO_DECISION) {
+            decision = decide(prepare(affected as T))
+        }
+
+        complete(affected as T, decision)
+        return decision
+    }
+}
+
+/**
+ * A part of multi-step atomic operation [AtomicOp].
+ *
+ * @suppress **This is unstable API and it is subject to change.**
+ */
+public abstract class AtomicDesc {
+
+    // returns `null` if prepared successfully
+    public abstract fun prepare(op: AtomicOp<*>): Any?
+
+    // decision == null if success
+    public abstract fun complete(op: AtomicOp<*>, failure: Any?)
+}
+
+/**
+ * Doubly-linked concurrent list node with remove support.
+ * Based on paper
+ * ["Lock-Free and Practical Doubly Linked List-Based Deques Using Single-Word Compare-and-Swap"](http://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.140.4693&rep=rep1&type=pdf)
+ * by Sundell and Tsigas.
+ *
+ * Important notes:
+ * * The instance of this class serves both as list head/tail sentinel and as the list item.
+ *   Sentinel node should be never removed.
+ * * There are no operations to add items to left side of the list, only to the end (right side), because we cannot
+ *   efficiently linearize them with atomic multi-step head-removal operations. In short,
+ *   support for [describeRemoveFirst] operation precludes ability to add items at the beginning.
+ *
+ * @suppress **This is unstable API and it is subject to change.**
+ */
+@Suppress("LeakingThis")
+public open class LockFreeLinkedListNode {
+
+    // Node | Removed | OpDescriptor
+    private val _next = atomic<Any>(this)
+
+    // Node | Removed
+    private val _prev = atomic<Any>(this)
+
+    // lazily cached removed ref to this
+    private val _removedRef = atomic<Removed?>(null)
+
+    private fun removed(): Removed =
+        _removedRef.value ?: Removed(this).also { _removedRef.lazySet(it) }
+
+    @PublishedApi
+    internal abstract class CondAddOp(
+        @JvmField val newNode: Node
+    ) : AtomicOp<Node>() {
+        @JvmField
+        var oldNext: Node? = null
+
+        override fun complete(affected: Node, failure: Any?) {
+            val success = failure == null
+            val update = if (success) newNode else oldNext
+            if (update != null && affected._next.compareAndSet(this, update)) {
+                // only the thread the makes this update actually finishes add operation
+                if (success) newNode.finishAdd(oldNext!!)
+            }
+        }
+    }
+
+    @PublishedApi
+    internal inline fun makeCondAddOp(node: Node, crossinline condition: () -> Boolean): CondAddOp =
+        object : CondAddOp(node) {
+            override fun prepare(affected: Node): Any? = if (condition()) null else CONDITION_FALSE
+        }
+
+    public val isRemoved: Boolean get() = next is Removed
+
+    // LINEARIZABLE. Returns Node | Removed
+    public val next: Any
+        get() {
+            _next.loop { next ->
+                if (next !is OpDescriptor) return next
+                next.perform(this)
+            }
+        }
+
+    // LINEARIZABLE. Returns next non-removed Node
+    public val nextNode: Node get() = next.unwrap()
+
+    // LINEARIZABLE. Returns Node | Removed
+    public val prev: Any
+        get() {
+            _prev.loop { prev ->
+                if (prev is Removed) return prev
+                prev as Node // otherwise, it can be only node
+                if (prev.next === this) return prev
+                correctPrev(prev, null)
+            }
+        }
+
+    // LINEARIZABLE. Returns prev non-removed Node
+    public val prevNode: Node get() = prev.unwrap()
+
+    // ------ addOneIfEmpty ------
+
+    public fun addOneIfEmpty(node: Node): Boolean {
+        node._prev.lazySet(this)
+        node._next.lazySet(this)
+        while (true) {
+            val next = next
+            if (next !== this) return false // this is not an empty list!
+            if (_next.compareAndSet(this, node)) {
+                // added successfully (linearized add) -- fixup the list
+                node.finishAdd(this)
+                return true
+            }
+        }
+    }
+
+    // ------ addLastXXX ------
+
+    /**
+     * Adds last item to this list.
+     *
+     * [Report a problem](https://ktor.io/feedback?fqname=io.ktor.util.internal.LockFreeLinkedListNode.addLast)
+     */
+    public fun addLast(node: Node) {
+        while (true) { // lock-free loop on prev.next
+            val prev = prev as Node // sentinel node is never removed, so prev is always defined
+            if (prev.addNext(node, this)) return
+        }
+    }
+
+    public fun <T : Node> describeAddLast(node: T): AddLastDesc<T> = AddLastDesc(this, node)
+
+    /**
+     * Adds last item to this list atomically if the [condition] is true.
+     *
+     * [Report a problem](https://ktor.io/feedback?fqname=io.ktor.util.internal.LockFreeLinkedListNode.addLastIf)
+     */
+    public inline fun addLastIf(node: Node, crossinline condition: () -> Boolean): Boolean {
+        val condAdd = makeCondAddOp(node, condition)
+        while (true) { // lock-free loop on prev.next
+            val prev = prev as Node // sentinel node is never removed, so prev is always defined
+            when (prev.tryCondAddNext(node, this, condAdd)) {
+                SUCCESS -> return true
+                FAILURE -> return false
+            }
+        }
+    }
+
+    public inline fun addLastIfPrev(node: Node, predicate: (Node) -> Boolean): Boolean {
+        while (true) { // lock-free loop on prev.next
+            val prev = prev as Node // sentinel node is never removed, so prev is always defined
+            if (!predicate(prev)) return false
+            if (prev.addNext(node, this)) return true
+        }
+    }
+
+    public inline fun addLastIfPrevAndIf(
+        node: Node,
+        predicate: (Node) -> Boolean, // prev node predicate
+        crossinline condition: () -> Boolean // atomically checked condition
+    ): Boolean {
+        val condAdd = makeCondAddOp(node, condition)
+        while (true) { // lock-free loop on prev.next
+            val prev = prev as Node // sentinel node is never removed, so prev is always defined
+            if (!predicate(prev)) return false
+            when (prev.tryCondAddNext(node, this, condAdd)) {
+                SUCCESS -> return true
+                FAILURE -> return false
+            }
+        }
+    }
+
+    // ------ addXXX util ------
+
+    /**
+     * Given:
+     * ```
+     *                +-----------------------+
+     *          this  |         node          V  next
+     *          +---+---+     +---+---+     +---+---+
+     *  ... <-- | P | N |     | P | N |     | P | N | --> ....
+     *          +---+---+     +---+---+     +---+---+
+     *                ^                       |
+     *                +-----------------------+
+     * ```
+     * Produces:
+     * ```
+     *          this            node             next
+     *          +---+---+     +---+---+     +---+---+
+     *  ... <-- | P | N | ==> | P | N | --> | P | N | --> ....
+     *          +---+---+     +---+---+     +---+---+
+     *                ^         |   ^         |
+     *                +---------+   +---------+
+     * ```
+     *  Where `==>` denotes linearization point.
+     *  Returns `false` if `next` was not following `this` node.
+     */
+    @PublishedApi
+    internal fun addNext(node: Node, next: Node): Boolean {
+        node._prev.lazySet(this)
+        node._next.lazySet(next)
+        if (!_next.compareAndSet(next, node)) return false
+        // added successfully (linearized add) -- fixup the list
+        node.finishAdd(next)
+        return true
+    }
+
+    // returns UNDECIDED, SUCCESS or FAILURE
+    @PublishedApi
+    internal fun tryCondAddNext(node: Node, next: Node, condAdd: CondAddOp): Int {
+        node._prev.lazySet(this)
+        node._next.lazySet(next)
+        condAdd.oldNext = next
+        if (!_next.compareAndSet(next, condAdd)) return UNDECIDED
+        // added operation successfully (linearized) -- complete it & fixup the list
+        return if (condAdd.perform(this) == null) SUCCESS else FAILURE
+    }
+
+    // ------ removeXXX ------
+
+    /**
+     * Removes this node from the list. Returns `true` when removed successfully, or `false` if the node was already
+     * removed or if it was not added to any list in the first place.
+     *
+     * **Note**: Invocation of this operation does not guarantee that remove was actually complete if result was `false`.
+     * In particular, invoking [nextNode].[prevNode] might still return this node even though it is "already removed".
+     * Invoke [helpRemove] to make sure that remove was completed.
+     *
+     * [Report a problem](https://ktor.io/feedback?fqname=io.ktor.util.internal.LockFreeLinkedListNode.remove)
+     */
+    public open fun remove(): Boolean {
+        while (true) { // lock-free loop on next
+            val next = this.next
+            // was already removed -- don't try to help (original thread will take care)
+            if (next is Removed) {
+                return false
+            }
+            if (next === this) return false // was not even added
+            val removed = (next as Node).removed()
+            if (_next.compareAndSet(next, removed)) {
+                // was removed successfully (linearized remove) -- fixup the list
+                finishRemove(next)
+                return true
+            }
+        }
+    }
+
+    public fun helpRemove() {
+        val removed = this.next as? Removed ?: error("Must be invoked on a removed node")
+        finishRemove(removed.ref)
+    }
+
+    public open fun describeRemove(): AtomicDesc? {
+        if (isRemoved) return null // fast path if was already removed
+        return object : AbstractAtomicDesc() {
+            private val _originalNext = atomic<Node?>(null)
+            override val affectedNode: Node get() = this@LockFreeLinkedListNode
+            override val originalNext get() = _originalNext.value
+            override fun failure(affected: Node, next: Any): Any? =
+                if (next is Removed) ALREADY_REMOVED else null
+
+            override fun onPrepare(affected: Node, next: Node): Any? {
+                // Note: onPrepare must use CAS to make sure the stale invocation is not
+                // going to overwrite the previous decision on successful preparation.
+                // Result of CAS is irrelevant, but we must ensure that it is set when invoker completes
+                _originalNext.compareAndSet(null, next)
+                return null // always success
+            }
+
+            override fun updatedNext(affected: Node, next: Node) = next.removed()
+            override fun finishOnSuccess(affected: Node, next: Node) = finishRemove(next)
+        }
+    }
+
+    public fun removeFirstOrNull(): Node? {
+        while (true) { // try to linearize
+            val first = next as Node
+            if (first === this) return null
+            if (first.remove()) return first
+            first.helpDelete() // must help delete, or loose lock-freedom
+        }
+    }
+
+    public fun describeRemoveFirst(): RemoveFirstDesc<Node> = RemoveFirstDesc(this)
+
+    public inline fun <reified T> removeFirstIfIsInstanceOf(): T? {
+        while (true) { // try to linearize
+            val first = next as Node
+            if (first === this) return null
+            if (first !is T) return null
+            if (first.remove()) return first
+            first.helpDelete() // must help delete, or loose lock-freedom
+        }
+    }
+
+    // just peek at item when predicate is true
+    public inline fun <reified T> removeFirstIfIsInstanceOfOrPeekIf(predicate: (T) -> Boolean): T? {
+        while (true) { // try to linearize
+            val first = next as Node
+            if (first === this) return null
+            if (first !is T) return null
+            if (predicate(first)) return first // just peek when predicate is true
+            if (first.remove()) return first
+            first.helpDelete() // must help delete, or loose lock-freedom
+        }
+    }
+
+    // ------ multi-word atomic operations helpers ------
+
+    public open class AddLastDesc<T : Node>(
+        @JvmField public val queue: Node,
+        @JvmField public val node: T
+    ) : AbstractAtomicDesc() {
+        init {
+            // require freshly allocated node here
+            check(node._next.value === node && node._prev.value === node)
+        }
+
+        final override fun takeAffectedNode(op: OpDescriptor): Node {
+            while (true) {
+                val prev = queue._prev.value as Node // this sentinel node is never removed
+                val next = prev._next.value
+                if (next === queue) return prev // all is good -> linked properly
+                if (next === op) return prev // all is good -> our operation descriptor is already there
+                if (next is OpDescriptor) { // some other operation descriptor -> help & retry
+                    next.perform(prev)
+                    continue
+                }
+                // linked improperly -- help insert
+                val affected = queue.correctPrev(prev, op)
+                // we can find node which this operation is already affecting while trying to correct prev
+                if (affected != null) return affected
+            }
+        }
+
+        private val _affectedNode = atomic<Node?>(null)
+        final override val affectedNode: Node? get() = _affectedNode.value
+        final override val originalNext: Node get() = queue
+
+        override fun retry(affected: Node, next: Any): Boolean = next !== queue
+
+        protected override fun onPrepare(affected: Node, next: Node): Any? {
+            // Note: onPrepare must use CAS to make sure the stale invocation is not
+            // going to overwrite the previous decision on successful preparation.
+            // Result of CAS is irrelevant, but we must ensure that it is set when invoker completes
+            _affectedNode.compareAndSet(null, affected)
+            return null // always success
+        }
+
+        override fun updatedNext(affected: Node, next: Node): Any {
+            // it is invoked only on successfully completion of operation, but this invocation can be stale,
+            // so we must use CAS to set both prev & next pointers
+            node._prev.compareAndSet(node, affected)
+            node._next.compareAndSet(node, queue)
+            return node
+        }
+
+        override fun finishOnSuccess(affected: Node, next: Node) {
+            node.finishAdd(queue)
+        }
+    }
+
+    public open class RemoveFirstDesc<T>(
+        @JvmField public val queue: Node
+    ) : AbstractAtomicDesc() {
+        private val _affectedNode = atomic<Node?>(null)
+        private val _originalNext = atomic<Node?>(null)
+
+        @Suppress("UNCHECKED_CAST")
+        public val result: T
+            get() = affectedNode!! as T
+
+        final override fun takeAffectedNode(op: OpDescriptor): Node = queue.next as Node
+        final override val affectedNode: Node? get() = _affectedNode.value
+        final override val originalNext: Node? get() = _originalNext.value
+
+        // check node predicates here, must signal failure if affect is not of type T
+        protected override fun failure(affected: Node, next: Any): Any? =
+            if (affected === queue) LIST_EMPTY else null
+
+        // validate the resulting node (return false if it should be deleted)
+        protected open fun validatePrepared(node: T): Boolean = true // false means remove node & retry
+
+        final override fun retry(affected: Node, next: Any): Boolean {
+            if (next !is Removed) return false
+            affected.helpDelete() // must help delete, or loose lock-freedom
+            return true
+        }
+
+        @Suppress("UNCHECKED_CAST")
+        final override fun onPrepare(affected: Node, next: Node): Any? {
+            check(affected !is LockFreeLinkedListHead)
+            if (!validatePrepared(affected as T)) return REMOVE_PREPARED
+
+            // Note: onPrepare must use CAS to make sure the stale invocation is not
+            // going to overwrite the previous decision on successful preparation.
+            // Result of CAS is irrelevant, but we must ensure that it is set when invoker completes
+            _affectedNode.compareAndSet(null, affected)
+            _originalNext.compareAndSet(null, next)
+
+            // ok
+            return null
+        }
+
+        final override fun updatedNext(affected: Node, next: Node): Any = next.removed()
+        final override fun finishOnSuccess(affected: Node, next: Node): Unit = affected.finishRemove(next)
+    }
+
+    public abstract class AbstractAtomicDesc : AtomicDesc() {
+        protected abstract val affectedNode: Node?
+        protected abstract val originalNext: Node?
+        protected open fun takeAffectedNode(op: OpDescriptor): Node = affectedNode!!
+
+        // next: Node | Removed
+
+        protected open fun failure(affected: Node, next: Any): Any? = null
+
+        // next: Node | Removed
+        protected open fun retry(affected: Node, next: Any): Boolean = false
+
+        // non-null on failure
+        protected abstract fun onPrepare(affected: Node, next: Node): Any?
+        protected abstract fun updatedNext(affected: Node, next: Node): Any
+        protected abstract fun finishOnSuccess(affected: Node, next: Node)
+
+        // This is Harris's RDCSS (Restricted Double-Compare Single Swap) operation
+        // It inserts "op" descriptor of when "op" status is still undecided (rolls back otherwise)
+        private class PrepareOp(
+            @JvmField val next: Node,
+            @JvmField val op: AtomicOp<Node>,
+            @JvmField val desc: AbstractAtomicDesc
+        ) : OpDescriptor() {
+            override fun perform(affected: Any?): Any? {
+                affected as Node // type assertion
+                val decision = desc.onPrepare(affected, next)
+                if (decision != null) {
+                    if (decision === REMOVE_PREPARED) {
+                        // remove element on failure
+                        val removed = next.removed()
+                        if (affected._next.compareAndSet(this, removed)) {
+                            affected.helpDelete()
+                        }
+                    } else {
+                        // some other failure -- mark as decided
+                        op.tryDecide(decision)
+                        // undo preparations
+                        affected._next.compareAndSet(this, next)
+                    }
+                    return decision
+                }
+                val update: Any = if (op.isDecided) next else op // restore if decision was already reached
+                affected._next.compareAndSet(this, update)
+                return null // ok
+            }
+        }
+
+        @Suppress("UNCHECKED_CAST")
+        final override fun prepare(op: AtomicOp<*>): Any? {
+            while (true) { // lock free loop on next
+                val affected = takeAffectedNode(op)
+                // read its original next pointer first
+                val next = affected._next.value
+                // then see if already reached consensus on overall operation
+                if (next === op) return null // already in process of operation -- all is good
+                if (op.isDecided) return null // already decided this operation -- go to next desc
+                if (next is OpDescriptor) {
+                    // some other operation is in process -- help it
+                    next.perform(affected)
+                    continue // and retry
+                }
+                // next: Node | Removed
+                val failure = failure(affected, next)
+                if (failure != null) return failure // signal failure
+                if (retry(affected, next)) continue // retry operation
+                val prepareOp = PrepareOp(next as Node, op as AtomicOp<Node>, this)
+                if (affected._next.compareAndSet(next, prepareOp)) {
+                    // prepared -- complete preparations
+                    val prepFail = prepareOp.perform(affected)
+                    if (prepFail === REMOVE_PREPARED) continue // retry
+                    return prepFail
+                }
+            }
+        }
+
+        final override fun complete(op: AtomicOp<*>, failure: Any?) {
+            val success = failure == null
+            val affectedNode = affectedNode ?: run { check(!success); return }
+            val originalNext = originalNext ?: run { check(!success); return }
+            val update = if (success) updatedNext(affectedNode, originalNext) else originalNext
+            if (affectedNode._next.compareAndSet(op, update)) {
+                if (success) finishOnSuccess(affectedNode, originalNext)
+            }
+        }
+    }
+
+    // ------ other helpers ------
+
+    /**
+     * Given:
+     * ```
+     *
+     *          prev            this             next
+     *          +---+---+     +---+---+     +---+---+
+     *  ... <-- | P | N | --> | P | N | --> | P | N | --> ....
+     *          +---+---+     +---+---+     +---+---+
+     *              ^ ^         |             |
+     *              | +---------+             |
+     *              +-------------------------+
+     * ```
+     * Produces:
+     * ```
+     *          prev            this             next
+     *          +---+---+     +---+---+     +---+---+
+     *  ... <-- | P | N | --> | P | N | --> | P | N | --> ....
+     *          +---+---+     +---+---+     +---+---+
+     *                ^         |   ^         |
+     *                +---------+   +---------+
+     * ```
+     */
+    private fun finishAdd(next: Node) {
+        next._prev.loop { nextPrev ->
+            if (nextPrev is Removed || this.next !== next) return // next was removed, remover fixes up links
+            if (next._prev.compareAndSet(nextPrev, this)) {
+                if (this.next is Removed) {
+                    // already removed
+                    next.correctPrev(nextPrev as Node, null)
+                }
+                return
+            }
+        }
+    }
+
+    private fun finishRemove(next: Node) {
+        helpDelete()
+        next.correctPrev(_prev.value.unwrap(), null)
+    }
+
+    private fun markPrev(): Node {
+        _prev.loop { prev ->
+            if (prev is Removed) return prev.ref
+            // See detailed comment in findHead on why `prev === this` is a special case for which we know that
+            // the prev should have being pointing to the head of list but finishAdd that was supposed
+            // to do that is not complete yet.
+            val removedPrev = (if (prev === this) findHead() else (prev as Node)).removed()
+            if (_prev.compareAndSet(prev, removedPrev)) return prev
+        }
+    }
+
+    /**
+     * Finds the head of the list (implementing [LockFreeLinkedListHead]) by following [next] pointers.
+     *
+     * The code in [kotlinx.coroutines.JobSupport] performs upgrade of a single node to a list.
+     * It uses [addOneIfEmpty] to add the list head to "empty list of a single node" once.
+     * During upgrade a transient state of the list looks like this:
+     *
+     * ```
+     *                +-----------------+
+     *                |                 |
+     *          node  V       head      |
+     *          +---+---+     +---+---+ |
+     *      +-> | P | N | --> | P | N |-+
+     *      |   +---+---+     +---+---+
+     *      |     |   ^         |
+     *      +---- +   +---------+
+     * ```
+     *
+     * The [prev] pointer in `node` still points to itself when [finishAdd] (invoked inside [addOneIfEmpty])
+     * has not completed yet. If this state is observed, then we know that [prev] should have been pointing
+     * to the list head. This function is looking up the head by following consistent chain of [next] pointers.
+     */
+    private fun findHead(): Node {
+        var cur = this
+        while (true) {
+            if (cur is LockFreeLinkedListHead) return cur
+            cur = cur.nextNode
+            check(cur !== this) { "Cannot loop to this while looking for list head" }
+        }
+    }
+
+    // fixes next links to the left of this node
+    @PublishedApi
+    internal fun helpDelete() {
+        var last: Node? = null // will set to the node left of prev when found
+        var prev: Node = markPrev()
+        var next: Node = (this._next.value as Removed).ref
+        while (true) {
+            // move to the right until first non-removed node
+            val nextNext = next.next
+            if (nextNext is Removed) {
+                next.markPrev()
+                next = nextNext.ref
+                continue
+            }
+            // move the left until first non-removed node
+            val prevNext = prev.next
+            if (prevNext is Removed) {
+                if (last != null) {
+                    prev.markPrev()
+                    last._next.compareAndSet(prev, prevNext.ref)
+                    prev = last
+                    last = null
+                } else {
+                    prev = prev._prev.value.unwrap()
+                }
+                continue
+            }
+            if (prevNext !== this) {
+                // skipped over some removed nodes to the left -- setup to fixup the next links
+                last = prev
+                prev = prevNext as Node
+                if (prev === next) return // already done!!!
+                continue
+            }
+            // Now prev & next are Ok
+            if (prev._next.compareAndSet(this, next)) return // success!
+        }
+    }
+
+    // fixes prev links from this node
+    // returns affected node by this operation when this op is in progress (and nothing can be corrected)
+    // returns null otherwise (prev was corrected)
+    private fun correctPrev(_prev: Node, op: OpDescriptor?): Node? {
+        var prev: Node = _prev
+
+        var last: Node? = null // will be set so that last.next === prev
+        while (true) {
+            // move the left until first non-removed node
+            val prevNext = prev._next.value
+            if (prevNext === op) return prev // part of the same op -- don't recurse, didn't correct prev
+            if (prevNext is OpDescriptor) { // help & retry
+                prevNext.perform(prev)
+                continue
+            }
+            if (prevNext is Removed) {
+                if (last !== null) {
+                    prev.markPrev()
+                    last._next.compareAndSet(prev, prevNext.ref)
+                    prev = last
+                    last = null
+                } else {
+                    prev = prev._prev.value.unwrap()
+                }
+                continue
+            }
+            val oldPrev = this._prev.value
+            if (oldPrev is Removed) return null // this node was removed, too -- its remover will take care
+            if (prevNext !== this) {
+                // need to fixup next
+                last = prev
+                prev = prevNext as Node
+                continue
+            }
+            if (oldPrev === prev) return null // it is already linked as needed
+            if (this._prev.compareAndSet(oldPrev, prev)) {
+                if (prev._prev.value !is Removed) return null // finish only if prev was not concurrently removed
+            }
+        }
+    }
+
+    internal fun validateNode(prev: Node, next: Node) {
+        check(prev === this._prev.value)
+        check(next === this._next.value)
+    }
+
+    override fun toString(): String =
+        "${this::class.simpleName}@${hashCode()}"
+}
+
+private class Removed(@JvmField val ref: Node) {
+    override fun toString(): String = "Removed[$ref]"
+}
+
+@PublishedApi
+internal fun Any.unwrap(): Node = (this as? Removed)?.ref ?: this as Node
+
+/**
+ * Head (sentinel) item of the linked list that is never removed.
+ *
+ * @suppress **This is unstable API and it is subject to change.**
+ */
+public open class LockFreeLinkedListHead : LockFreeLinkedListNode() {
+    public val isEmpty: Boolean get() = next === this
+
+    /**
+     * Iterates over all elements in this list of a specified type.
+     *
+     * [Report a problem](https://ktor.io/feedback?fqname=io.ktor.util.internal.LockFreeLinkedListHead.forEach)
+     */
+    public inline fun <reified T : Node> forEach(block: (T) -> Unit) {
+        var cur: Node = next as Node
+        while (cur != this) {
+            if (cur is T) block(cur)
+            cur = cur.nextNode
+        }
+    }
+
+    // just a defensive programming -- makes sure that list head sentinel is never removed
+    public final override fun remove(): Boolean = throw UnsupportedOperationException()
+
+    public final override fun describeRemove(): Nothing = throw UnsupportedOperationException()
+
+    internal fun validate() {
+        var prev: Node = this
+        var cur: Node = next as Node
+        while (cur != this) {
+            val next = cur.nextNode
+            cur.validateNode(prev, next)
+            prev = cur
+            cur = next
+        }
+        validateNode(prev, next as Node)
+    }
+}

--- a/build-logic/kdoc-annotator/src/test/test-data/LockFreeLinkedList.raw.kt
+++ b/build-logic/kdoc-annotator/src/test/test-data/LockFreeLinkedList.raw.kt
@@ -1,0 +1,807 @@
+/*
+ * Copyright 2014-2024 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.util.internal
+
+import kotlinx.atomicfu.*
+import kotlin.jvm.*
+
+/*
+ * Copied from kotlinx.coroutines
+ */
+
+private typealias Node = LockFreeLinkedListNode
+
+@PublishedApi
+internal const val UNDECIDED: Int = 0
+
+@PublishedApi
+internal const val SUCCESS: Int = 1
+
+@PublishedApi
+internal const val FAILURE: Int = 2
+
+@PublishedApi
+internal val CONDITION_FALSE: Any = Symbol("CONDITION_FALSE")
+
+@PublishedApi
+internal val ALREADY_REMOVED: Any = Symbol("ALREADY_REMOVED")
+
+@PublishedApi
+internal val LIST_EMPTY: Any = Symbol("LIST_EMPTY")
+
+private val REMOVE_PREPARED: Any = Symbol("REMOVE_PREPARED")
+
+/**
+ * @suppress **This is unstable API and it is subject to change.**
+ *
+ * [Report a problem](https://ktor.io/feedback?fqname=io.ktor.util.internal.RemoveFirstDesc)
+ */
+public typealias RemoveFirstDesc<T> = LockFreeLinkedListNode.RemoveFirstDesc<T>
+
+/** @suppress **This is unstable API and it is subject to change.** */
+public typealias AddLastDesc<T> = LockFreeLinkedListNode.AddLastDesc<T>
+
+/** @suppress **This is unstable API and it is subject to change.** */
+public typealias AbstractAtomicDesc = LockFreeLinkedListNode.AbstractAtomicDesc
+
+private class Symbol(val symbol: String) {
+    override fun toString(): String = symbol
+}
+
+/**
+ * The most abstract operation that can be in process. Other threads observing an instance of this
+ * class in the fields of their object shall invoke [perform] to help.
+ *
+ * @suppress **This is unstable API and it is subject to change.**
+ */
+public abstract class OpDescriptor {
+    /**
+     * Returns `null` is operation was performed successfully or some other
+     * object that indicates the failure reason.
+     */
+    public abstract fun perform(affected: Any?): Any?
+}
+
+private val NO_DECISION: Any = Symbol("NO_DECISION")
+
+/**
+ * Descriptor for multi-word atomic operation.
+ * Based on paper
+ * ["A Practical Multi-Word Compare-and-Swap Operation"](http://www.cl.cam.ac.uk/research/srgnetos/papers/2002-casn.pdf)
+ * by Timothy L. Harris, Keir Fraser and Ian A. Pratt.
+ *
+ * Note: parts of atomic operation must be globally ordered. Otherwise, this implementation will produce
+ * `StackOverflowError`.
+ *
+ * @suppress **This is unstable API and it is subject to change.**
+ */
+public abstract class AtomicOp<in T> : OpDescriptor() {
+    private val _consensus = atomic<Any?>(NO_DECISION)
+
+    public val isDecided: Boolean get() = _consensus.value !== NO_DECISION
+
+    public fun tryDecide(decision: Any?): Boolean {
+        check(decision !== NO_DECISION)
+        return _consensus.compareAndSet(NO_DECISION, decision)
+    }
+
+    private fun decide(decision: Any?): Any? = if (tryDecide(decision)) decision else _consensus.value
+
+    public abstract fun prepare(affected: T): Any? // `null` if Ok, or failure reason
+
+    public abstract fun complete(affected: T, failure: Any?) // failure != null if failed to prepare op
+
+    // returns `null` on success
+    @Suppress("UNCHECKED_CAST")
+    public final override fun perform(affected: Any?): Any? {
+        // make decision on status
+        var decision = this._consensus.value
+        if (decision === NO_DECISION) {
+            decision = decide(prepare(affected as T))
+        }
+
+        complete(affected as T, decision)
+        return decision
+    }
+}
+
+/**
+ * A part of multi-step atomic operation [AtomicOp].
+ *
+ * @suppress **This is unstable API and it is subject to change.**
+ */
+public abstract class AtomicDesc {
+
+    // returns `null` if prepared successfully
+    public abstract fun prepare(op: AtomicOp<*>): Any?
+
+    // decision == null if success
+    public abstract fun complete(op: AtomicOp<*>, failure: Any?)
+}
+
+/**
+ * Doubly-linked concurrent list node with remove support.
+ * Based on paper
+ * ["Lock-Free and Practical Doubly Linked List-Based Deques Using Single-Word Compare-and-Swap"](http://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.140.4693&rep=rep1&type=pdf)
+ * by Sundell and Tsigas.
+ *
+ * Important notes:
+ * * The instance of this class serves both as list head/tail sentinel and as the list item.
+ *   Sentinel node should be never removed.
+ * * There are no operations to add items to left side of the list, only to the end (right side), because we cannot
+ *   efficiently linearize them with atomic multi-step head-removal operations. In short,
+ *   support for [describeRemoveFirst] operation precludes ability to add items at the beginning.
+ *
+ * @suppress **This is unstable API and it is subject to change.**
+ */
+@Suppress("LeakingThis")
+public open class LockFreeLinkedListNode {
+
+    // Node | Removed | OpDescriptor
+    private val _next = atomic<Any>(this)
+
+    // Node | Removed
+    private val _prev = atomic<Any>(this)
+
+    // lazily cached removed ref to this
+    private val _removedRef = atomic<Removed?>(null)
+
+    private fun removed(): Removed =
+        _removedRef.value ?: Removed(this).also { _removedRef.lazySet(it) }
+
+    @PublishedApi
+    internal abstract class CondAddOp(
+        @JvmField val newNode: Node
+    ) : AtomicOp<Node>() {
+        @JvmField
+        var oldNext: Node? = null
+
+        override fun complete(affected: Node, failure: Any?) {
+            val success = failure == null
+            val update = if (success) newNode else oldNext
+            if (update != null && affected._next.compareAndSet(this, update)) {
+                // only the thread the makes this update actually finishes add operation
+                if (success) newNode.finishAdd(oldNext!!)
+            }
+        }
+    }
+
+    @PublishedApi
+    internal inline fun makeCondAddOp(node: Node, crossinline condition: () -> Boolean): CondAddOp =
+        object : CondAddOp(node) {
+            override fun prepare(affected: Node): Any? = if (condition()) null else CONDITION_FALSE
+        }
+
+    public val isRemoved: Boolean get() = next is Removed
+
+    // LINEARIZABLE. Returns Node | Removed
+    public val next: Any
+        get() {
+            _next.loop { next ->
+                if (next !is OpDescriptor) return next
+                next.perform(this)
+            }
+        }
+
+    // LINEARIZABLE. Returns next non-removed Node
+    public val nextNode: Node get() = next.unwrap()
+
+    // LINEARIZABLE. Returns Node | Removed
+    public val prev: Any
+        get() {
+            _prev.loop { prev ->
+                if (prev is Removed) return prev
+                prev as Node // otherwise, it can be only node
+                if (prev.next === this) return prev
+                correctPrev(prev, null)
+            }
+        }
+
+    // LINEARIZABLE. Returns prev non-removed Node
+    public val prevNode: Node get() = prev.unwrap()
+
+    // ------ addOneIfEmpty ------
+
+    public fun addOneIfEmpty(node: Node): Boolean {
+        node._prev.lazySet(this)
+        node._next.lazySet(this)
+        while (true) {
+            val next = next
+            if (next !== this) return false // this is not an empty list!
+            if (_next.compareAndSet(this, node)) {
+                // added successfully (linearized add) -- fixup the list
+                node.finishAdd(this)
+                return true
+            }
+        }
+    }
+
+    // ------ addLastXXX ------
+
+    /** Adds last item to this list. */
+    public fun addLast(node: Node) {
+        while (true) { // lock-free loop on prev.next
+            val prev = prev as Node // sentinel node is never removed, so prev is always defined
+            if (prev.addNext(node, this)) return
+        }
+    }
+
+    public fun <T : Node> describeAddLast(node: T): AddLastDesc<T> = AddLastDesc(this, node)
+
+    /**
+     * Adds last item to this list atomically if the [condition] is true.
+     */
+    public inline fun addLastIf(node: Node, crossinline condition: () -> Boolean): Boolean {
+        val condAdd = makeCondAddOp(node, condition)
+        while (true) { // lock-free loop on prev.next
+            val prev = prev as Node // sentinel node is never removed, so prev is always defined
+            when (prev.tryCondAddNext(node, this, condAdd)) {
+                SUCCESS -> return true
+                FAILURE -> return false
+            }
+        }
+    }
+
+    public inline fun addLastIfPrev(node: Node, predicate: (Node) -> Boolean): Boolean {
+        while (true) { // lock-free loop on prev.next
+            val prev = prev as Node // sentinel node is never removed, so prev is always defined
+            if (!predicate(prev)) return false
+            if (prev.addNext(node, this)) return true
+        }
+    }
+
+    public inline fun addLastIfPrevAndIf(
+        node: Node,
+        predicate: (Node) -> Boolean, // prev node predicate
+        crossinline condition: () -> Boolean // atomically checked condition
+    ): Boolean {
+        val condAdd = makeCondAddOp(node, condition)
+        while (true) { // lock-free loop on prev.next
+            val prev = prev as Node // sentinel node is never removed, so prev is always defined
+            if (!predicate(prev)) return false
+            when (prev.tryCondAddNext(node, this, condAdd)) {
+                SUCCESS -> return true
+                FAILURE -> return false
+            }
+        }
+    }
+
+    // ------ addXXX util ------
+
+    /**
+     * Given:
+     * ```
+     *                +-----------------------+
+     *          this  |         node          V  next
+     *          +---+---+     +---+---+     +---+---+
+     *  ... <-- | P | N |     | P | N |     | P | N | --> ....
+     *          +---+---+     +---+---+     +---+---+
+     *                ^                       |
+     *                +-----------------------+
+     * ```
+     * Produces:
+     * ```
+     *          this            node             next
+     *          +---+---+     +---+---+     +---+---+
+     *  ... <-- | P | N | ==> | P | N | --> | P | N | --> ....
+     *          +---+---+     +---+---+     +---+---+
+     *                ^         |   ^         |
+     *                +---------+   +---------+
+     * ```
+     *  Where `==>` denotes linearization point.
+     *  Returns `false` if `next` was not following `this` node.
+     */
+    @PublishedApi
+    internal fun addNext(node: Node, next: Node): Boolean {
+        node._prev.lazySet(this)
+        node._next.lazySet(next)
+        if (!_next.compareAndSet(next, node)) return false
+        // added successfully (linearized add) -- fixup the list
+        node.finishAdd(next)
+        return true
+    }
+
+    // returns UNDECIDED, SUCCESS or FAILURE
+    @PublishedApi
+    internal fun tryCondAddNext(node: Node, next: Node, condAdd: CondAddOp): Int {
+        node._prev.lazySet(this)
+        node._next.lazySet(next)
+        condAdd.oldNext = next
+        if (!_next.compareAndSet(next, condAdd)) return UNDECIDED
+        // added operation successfully (linearized) -- complete it & fixup the list
+        return if (condAdd.perform(this) == null) SUCCESS else FAILURE
+    }
+
+    // ------ removeXXX ------
+
+    /**
+     * Removes this node from the list. Returns `true` when removed successfully, or `false` if the node was already
+     * removed or if it was not added to any list in the first place.
+     *
+     * **Note**: Invocation of this operation does not guarantee that remove was actually complete if result was `false`.
+     * In particular, invoking [nextNode].[prevNode] might still return this node even though it is "already removed".
+     * Invoke [helpRemove] to make sure that remove was completed.
+     */
+    public open fun remove(): Boolean {
+        while (true) { // lock-free loop on next
+            val next = this.next
+            // was already removed -- don't try to help (original thread will take care)
+            if (next is Removed) {
+                return false
+            }
+            if (next === this) return false // was not even added
+            val removed = (next as Node).removed()
+            if (_next.compareAndSet(next, removed)) {
+                // was removed successfully (linearized remove) -- fixup the list
+                finishRemove(next)
+                return true
+            }
+        }
+    }
+
+    public fun helpRemove() {
+        val removed = this.next as? Removed ?: error("Must be invoked on a removed node")
+        finishRemove(removed.ref)
+    }
+
+    public open fun describeRemove(): AtomicDesc? {
+        if (isRemoved) return null // fast path if was already removed
+        return object : AbstractAtomicDesc() {
+            private val _originalNext = atomic<Node?>(null)
+            override val affectedNode: Node get() = this@LockFreeLinkedListNode
+            override val originalNext get() = _originalNext.value
+            override fun failure(affected: Node, next: Any): Any? =
+                if (next is Removed) ALREADY_REMOVED else null
+
+            override fun onPrepare(affected: Node, next: Node): Any? {
+                // Note: onPrepare must use CAS to make sure the stale invocation is not
+                // going to overwrite the previous decision on successful preparation.
+                // Result of CAS is irrelevant, but we must ensure that it is set when invoker completes
+                _originalNext.compareAndSet(null, next)
+                return null // always success
+            }
+
+            override fun updatedNext(affected: Node, next: Node) = next.removed()
+            override fun finishOnSuccess(affected: Node, next: Node) = finishRemove(next)
+        }
+    }
+
+    public fun removeFirstOrNull(): Node? {
+        while (true) { // try to linearize
+            val first = next as Node
+            if (first === this) return null
+            if (first.remove()) return first
+            first.helpDelete() // must help delete, or loose lock-freedom
+        }
+    }
+
+    public fun describeRemoveFirst(): RemoveFirstDesc<Node> = RemoveFirstDesc(this)
+
+    public inline fun <reified T> removeFirstIfIsInstanceOf(): T? {
+        while (true) { // try to linearize
+            val first = next as Node
+            if (first === this) return null
+            if (first !is T) return null
+            if (first.remove()) return first
+            first.helpDelete() // must help delete, or loose lock-freedom
+        }
+    }
+
+    // just peek at item when predicate is true
+    public inline fun <reified T> removeFirstIfIsInstanceOfOrPeekIf(predicate: (T) -> Boolean): T? {
+        while (true) { // try to linearize
+            val first = next as Node
+            if (first === this) return null
+            if (first !is T) return null
+            if (predicate(first)) return first // just peek when predicate is true
+            if (first.remove()) return first
+            first.helpDelete() // must help delete, or loose lock-freedom
+        }
+    }
+
+    // ------ multi-word atomic operations helpers ------
+
+    public open class AddLastDesc<T : Node>(
+        @JvmField public val queue: Node,
+        @JvmField public val node: T
+    ) : AbstractAtomicDesc() {
+        init {
+            // require freshly allocated node here
+            check(node._next.value === node && node._prev.value === node)
+        }
+
+        final override fun takeAffectedNode(op: OpDescriptor): Node {
+            while (true) {
+                val prev = queue._prev.value as Node // this sentinel node is never removed
+                val next = prev._next.value
+                if (next === queue) return prev // all is good -> linked properly
+                if (next === op) return prev // all is good -> our operation descriptor is already there
+                if (next is OpDescriptor) { // some other operation descriptor -> help & retry
+                    next.perform(prev)
+                    continue
+                }
+                // linked improperly -- help insert
+                val affected = queue.correctPrev(prev, op)
+                // we can find node which this operation is already affecting while trying to correct prev
+                if (affected != null) return affected
+            }
+        }
+
+        private val _affectedNode = atomic<Node?>(null)
+        final override val affectedNode: Node? get() = _affectedNode.value
+        final override val originalNext: Node get() = queue
+
+        override fun retry(affected: Node, next: Any): Boolean = next !== queue
+
+        protected override fun onPrepare(affected: Node, next: Node): Any? {
+            // Note: onPrepare must use CAS to make sure the stale invocation is not
+            // going to overwrite the previous decision on successful preparation.
+            // Result of CAS is irrelevant, but we must ensure that it is set when invoker completes
+            _affectedNode.compareAndSet(null, affected)
+            return null // always success
+        }
+
+        override fun updatedNext(affected: Node, next: Node): Any {
+            // it is invoked only on successfully completion of operation, but this invocation can be stale,
+            // so we must use CAS to set both prev & next pointers
+            node._prev.compareAndSet(node, affected)
+            node._next.compareAndSet(node, queue)
+            return node
+        }
+
+        override fun finishOnSuccess(affected: Node, next: Node) {
+            node.finishAdd(queue)
+        }
+    }
+
+    public open class RemoveFirstDesc<T>(
+        @JvmField public val queue: Node
+    ) : AbstractAtomicDesc() {
+        private val _affectedNode = atomic<Node?>(null)
+        private val _originalNext = atomic<Node?>(null)
+
+        @Suppress("UNCHECKED_CAST")
+        public val result: T
+            get() = affectedNode!! as T
+
+        final override fun takeAffectedNode(op: OpDescriptor): Node = queue.next as Node
+        final override val affectedNode: Node? get() = _affectedNode.value
+        final override val originalNext: Node? get() = _originalNext.value
+
+        // check node predicates here, must signal failure if affect is not of type T
+        protected override fun failure(affected: Node, next: Any): Any? =
+            if (affected === queue) LIST_EMPTY else null
+
+        // validate the resulting node (return false if it should be deleted)
+        protected open fun validatePrepared(node: T): Boolean = true // false means remove node & retry
+
+        final override fun retry(affected: Node, next: Any): Boolean {
+            if (next !is Removed) return false
+            affected.helpDelete() // must help delete, or loose lock-freedom
+            return true
+        }
+
+        @Suppress("UNCHECKED_CAST")
+        final override fun onPrepare(affected: Node, next: Node): Any? {
+            check(affected !is LockFreeLinkedListHead)
+            if (!validatePrepared(affected as T)) return REMOVE_PREPARED
+
+            // Note: onPrepare must use CAS to make sure the stale invocation is not
+            // going to overwrite the previous decision on successful preparation.
+            // Result of CAS is irrelevant, but we must ensure that it is set when invoker completes
+            _affectedNode.compareAndSet(null, affected)
+            _originalNext.compareAndSet(null, next)
+
+            // ok
+            return null
+        }
+
+        final override fun updatedNext(affected: Node, next: Node): Any = next.removed()
+        final override fun finishOnSuccess(affected: Node, next: Node): Unit = affected.finishRemove(next)
+    }
+
+    public abstract class AbstractAtomicDesc : AtomicDesc() {
+        protected abstract val affectedNode: Node?
+        protected abstract val originalNext: Node?
+        protected open fun takeAffectedNode(op: OpDescriptor): Node = affectedNode!!
+
+        // next: Node | Removed
+
+        protected open fun failure(affected: Node, next: Any): Any? = null
+
+        // next: Node | Removed
+        protected open fun retry(affected: Node, next: Any): Boolean = false
+
+        // non-null on failure
+        protected abstract fun onPrepare(affected: Node, next: Node): Any?
+        protected abstract fun updatedNext(affected: Node, next: Node): Any
+        protected abstract fun finishOnSuccess(affected: Node, next: Node)
+
+        // This is Harris's RDCSS (Restricted Double-Compare Single Swap) operation
+        // It inserts "op" descriptor of when "op" status is still undecided (rolls back otherwise)
+        private class PrepareOp(
+            @JvmField val next: Node,
+            @JvmField val op: AtomicOp<Node>,
+            @JvmField val desc: AbstractAtomicDesc
+        ) : OpDescriptor() {
+            override fun perform(affected: Any?): Any? {
+                affected as Node // type assertion
+                val decision = desc.onPrepare(affected, next)
+                if (decision != null) {
+                    if (decision === REMOVE_PREPARED) {
+                        // remove element on failure
+                        val removed = next.removed()
+                        if (affected._next.compareAndSet(this, removed)) {
+                            affected.helpDelete()
+                        }
+                    } else {
+                        // some other failure -- mark as decided
+                        op.tryDecide(decision)
+                        // undo preparations
+                        affected._next.compareAndSet(this, next)
+                    }
+                    return decision
+                }
+                val update: Any = if (op.isDecided) next else op // restore if decision was already reached
+                affected._next.compareAndSet(this, update)
+                return null // ok
+            }
+        }
+
+        @Suppress("UNCHECKED_CAST")
+        final override fun prepare(op: AtomicOp<*>): Any? {
+            while (true) { // lock free loop on next
+                val affected = takeAffectedNode(op)
+                // read its original next pointer first
+                val next = affected._next.value
+                // then see if already reached consensus on overall operation
+                if (next === op) return null // already in process of operation -- all is good
+                if (op.isDecided) return null // already decided this operation -- go to next desc
+                if (next is OpDescriptor) {
+                    // some other operation is in process -- help it
+                    next.perform(affected)
+                    continue // and retry
+                }
+                // next: Node | Removed
+                val failure = failure(affected, next)
+                if (failure != null) return failure // signal failure
+                if (retry(affected, next)) continue // retry operation
+                val prepareOp = PrepareOp(next as Node, op as AtomicOp<Node>, this)
+                if (affected._next.compareAndSet(next, prepareOp)) {
+                    // prepared -- complete preparations
+                    val prepFail = prepareOp.perform(affected)
+                    if (prepFail === REMOVE_PREPARED) continue // retry
+                    return prepFail
+                }
+            }
+        }
+
+        final override fun complete(op: AtomicOp<*>, failure: Any?) {
+            val success = failure == null
+            val affectedNode = affectedNode ?: run { check(!success); return }
+            val originalNext = originalNext ?: run { check(!success); return }
+            val update = if (success) updatedNext(affectedNode, originalNext) else originalNext
+            if (affectedNode._next.compareAndSet(op, update)) {
+                if (success) finishOnSuccess(affectedNode, originalNext)
+            }
+        }
+    }
+
+    // ------ other helpers ------
+
+    /**
+     * Given:
+     * ```
+     *
+     *          prev            this             next
+     *          +---+---+     +---+---+     +---+---+
+     *  ... <-- | P | N | --> | P | N | --> | P | N | --> ....
+     *          +---+---+     +---+---+     +---+---+
+     *              ^ ^         |             |
+     *              | +---------+             |
+     *              +-------------------------+
+     * ```
+     * Produces:
+     * ```
+     *          prev            this             next
+     *          +---+---+     +---+---+     +---+---+
+     *  ... <-- | P | N | --> | P | N | --> | P | N | --> ....
+     *          +---+---+     +---+---+     +---+---+
+     *                ^         |   ^         |
+     *                +---------+   +---------+
+     * ```
+     */
+    private fun finishAdd(next: Node) {
+        next._prev.loop { nextPrev ->
+            if (nextPrev is Removed || this.next !== next) return // next was removed, remover fixes up links
+            if (next._prev.compareAndSet(nextPrev, this)) {
+                if (this.next is Removed) {
+                    // already removed
+                    next.correctPrev(nextPrev as Node, null)
+                }
+                return
+            }
+        }
+    }
+
+    private fun finishRemove(next: Node) {
+        helpDelete()
+        next.correctPrev(_prev.value.unwrap(), null)
+    }
+
+    private fun markPrev(): Node {
+        _prev.loop { prev ->
+            if (prev is Removed) return prev.ref
+            // See detailed comment in findHead on why `prev === this` is a special case for which we know that
+            // the prev should have being pointing to the head of list but finishAdd that was supposed
+            // to do that is not complete yet.
+            val removedPrev = (if (prev === this) findHead() else (prev as Node)).removed()
+            if (_prev.compareAndSet(prev, removedPrev)) return prev
+        }
+    }
+
+    /**
+     * Finds the head of the list (implementing [LockFreeLinkedListHead]) by following [next] pointers.
+     *
+     * The code in [kotlinx.coroutines.JobSupport] performs upgrade of a single node to a list.
+     * It uses [addOneIfEmpty] to add the list head to "empty list of a single node" once.
+     * During upgrade a transient state of the list looks like this:
+     *
+     * ```
+     *                +-----------------+
+     *                |                 |
+     *          node  V       head      |
+     *          +---+---+     +---+---+ |
+     *      +-> | P | N | --> | P | N |-+
+     *      |   +---+---+     +---+---+
+     *      |     |   ^         |
+     *      +---- +   +---------+
+     * ```
+     *
+     * The [prev] pointer in `node` still points to itself when [finishAdd] (invoked inside [addOneIfEmpty])
+     * has not completed yet. If this state is observed, then we know that [prev] should have been pointing
+     * to the list head. This function is looking up the head by following consistent chain of [next] pointers.
+     */
+    private fun findHead(): Node {
+        var cur = this
+        while (true) {
+            if (cur is LockFreeLinkedListHead) return cur
+            cur = cur.nextNode
+            check(cur !== this) { "Cannot loop to this while looking for list head" }
+        }
+    }
+
+    // fixes next links to the left of this node
+    @PublishedApi
+    internal fun helpDelete() {
+        var last: Node? = null // will set to the node left of prev when found
+        var prev: Node = markPrev()
+        var next: Node = (this._next.value as Removed).ref
+        while (true) {
+            // move to the right until first non-removed node
+            val nextNext = next.next
+            if (nextNext is Removed) {
+                next.markPrev()
+                next = nextNext.ref
+                continue
+            }
+            // move the left until first non-removed node
+            val prevNext = prev.next
+            if (prevNext is Removed) {
+                if (last != null) {
+                    prev.markPrev()
+                    last._next.compareAndSet(prev, prevNext.ref)
+                    prev = last
+                    last = null
+                } else {
+                    prev = prev._prev.value.unwrap()
+                }
+                continue
+            }
+            if (prevNext !== this) {
+                // skipped over some removed nodes to the left -- setup to fixup the next links
+                last = prev
+                prev = prevNext as Node
+                if (prev === next) return // already done!!!
+                continue
+            }
+            // Now prev & next are Ok
+            if (prev._next.compareAndSet(this, next)) return // success!
+        }
+    }
+
+    // fixes prev links from this node
+    // returns affected node by this operation when this op is in progress (and nothing can be corrected)
+    // returns null otherwise (prev was corrected)
+    private fun correctPrev(_prev: Node, op: OpDescriptor?): Node? {
+        var prev: Node = _prev
+
+        var last: Node? = null // will be set so that last.next === prev
+        while (true) {
+            // move the left until first non-removed node
+            val prevNext = prev._next.value
+            if (prevNext === op) return prev // part of the same op -- don't recurse, didn't correct prev
+            if (prevNext is OpDescriptor) { // help & retry
+                prevNext.perform(prev)
+                continue
+            }
+            if (prevNext is Removed) {
+                if (last !== null) {
+                    prev.markPrev()
+                    last._next.compareAndSet(prev, prevNext.ref)
+                    prev = last
+                    last = null
+                } else {
+                    prev = prev._prev.value.unwrap()
+                }
+                continue
+            }
+            val oldPrev = this._prev.value
+            if (oldPrev is Removed) return null // this node was removed, too -- its remover will take care
+            if (prevNext !== this) {
+                // need to fixup next
+                last = prev
+                prev = prevNext as Node
+                continue
+            }
+            if (oldPrev === prev) return null // it is already linked as needed
+            if (this._prev.compareAndSet(oldPrev, prev)) {
+                if (prev._prev.value !is Removed) return null // finish only if prev was not concurrently removed
+            }
+        }
+    }
+
+    internal fun validateNode(prev: Node, next: Node) {
+        check(prev === this._prev.value)
+        check(next === this._next.value)
+    }
+
+    override fun toString(): String =
+        "${this::class.simpleName}@${hashCode()}"
+}
+
+private class Removed(@JvmField val ref: Node) {
+    override fun toString(): String = "Removed[$ref]"
+}
+
+@PublishedApi
+internal fun Any.unwrap(): Node = (this as? Removed)?.ref ?: this as Node
+
+/**
+ * Head (sentinel) item of the linked list that is never removed.
+ *
+ * @suppress **This is unstable API and it is subject to change.**
+ */
+public open class LockFreeLinkedListHead : LockFreeLinkedListNode() {
+    public val isEmpty: Boolean get() = next === this
+
+    /**
+     * Iterates over all elements in this list of a specified type.
+     */
+    public inline fun <reified T : Node> forEach(block: (T) -> Unit) {
+        var cur: Node = next as Node
+        while (cur != this) {
+            if (cur is T) block(cur)
+            cur = cur.nextNode
+        }
+    }
+
+    // just a defensive programming -- makes sure that list head sentinel is never removed
+    public final override fun remove(): Boolean = throw UnsupportedOperationException()
+
+    public final override fun describeRemove(): Nothing = throw UnsupportedOperationException()
+
+    internal fun validate() {
+        var prev: Node = this
+        var cur: Node = next as Node
+        while (cur != this) {
+            val next = cur.nextNode
+            cur.validateNode(prev, next)
+            prev = cur
+            cur = next
+        }
+        validateNode(prev, next as Node)
+    }
+}

--- a/build-logic/settings.gradle.kts
+++ b/build-logic/settings.gradle.kts
@@ -28,3 +28,5 @@ dependencyResolutionManagement {
 }
 
 rootProject.name = "build-logic"
+
+include("kdoc-annotator")

--- a/build-logic/src/main/kotlin/ktorbuild.root.gradle.kts
+++ b/build-logic/src/main/kotlin/ktorbuild.root.gradle.kts
@@ -15,5 +15,11 @@ printSyncModeNotice()
 
 wirePackageJsonAggregationTasks()
 
+tasks.register("annotateKDocs") {
+    group = "documentation"
+    description = "Adds feedback links to public API KDocs."
+    dependsOn(gradle.includedBuild("build-logic").task(":kdoc-annotator:run"))
+}
+
 configureYarn()
 configureNodeJs()

--- a/build-settings-logic/src/main/kotlin/ktorsettings.cache-redirector.settings.gradle.kts
+++ b/build-settings-logic/src/main/kotlin/ktorsettings.cache-redirector.settings.gradle.kts
@@ -69,7 +69,7 @@ fun RepositoryHandler.redirect() = configureEach {
 
 fun Project.overrideGradleDistributionUrl() {
     gradle.taskGraph.whenReady {
-        tasks.named<Wrapper>("wrapper") {
+        tasks.withType<Wrapper>().configureEach {
             distributionUrl = distributionUrl.maybeRedirect()
         }
     }


### PR DESCRIPTION
**Subsystem**
Build logic, KDoc tooling

**Motivation**
Keep the KDoc feedback-link annotator in the Ktor repository and make it available through the root build without scanning generated files or build infrastructure sources.

**Solution**
Move the annotator from [e5l/kdoc-annotator](https://github.com/e5l/kdoc-annotator) into `build-logic:kdoc-annotator`, align it with the repository Kotlin version, and expose the root `annotateKDocs` task. Add configurable path exclusions passed by Gradle, prune excluded directories during traversal, and cover annotation and exclusion behavior with integration and golden-file tests.

Validated with `:build-logic:kdoc-annotator:test --rerun` (17 tests) and `:build-logic:kdoc-annotator:assemble`.
