### PR TITLE
KTOR-9886 Fix skippedRead reset on runningLimit check

### DIFF
--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyHttpHandlerState.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyHttpHandlerState.kt
@@ -20,7 +20,7 @@ internal class NettyHttpHandlerState(
     internal fun onLastResponseMessage(context: ChannelHandlerContext) {
         activeRequests.decrementAndGet()
 
-        if (skippedRead.compareAndSet(expect = false, update = true) && activeRequests.value < runningLimit) {
+        if (activeRequests.value < runningLimit && skippedRead.compareAndSet(expect = true, update = false)) {
             context.read()
         }
         onCapacityAvailable(context)

--- a/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyHttpHandlerState.kt
+++ b/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyHttpHandlerState.kt
@@ -20,9 +20,11 @@ internal class NettyHttpHandlerState(
     internal fun onLastResponseMessage(context: ChannelHandlerContext) {
         activeRequests.decrementAndGet()
 
+        // Drain any already-decoded backlog first, then request another physical socket read if needed
+        onCapacityAvailable(context)
+
         if (activeRequests.value < runningLimit && skippedRead.compareAndSet(expect = true, update = false)) {
             context.read()
         }
-        onCapacityAvailable(context)
     }
 }

--- a/ktor-server/ktor-server-netty/jvm/test/io/ktor/tests/server/netty/NettyPipeliningTest.kt
+++ b/ktor-server/ktor-server-netty/jvm/test/io/ktor/tests/server/netty/NettyPipeliningTest.kt
@@ -154,6 +154,51 @@ class NettyPipeliningTest :
         }
     }
 
+    @Test
+    fun `keep-alive connection with runningLimit 1 serves a second sequential request`() = runTest {
+        val server = embeddedServer(
+            Netty,
+            module = {
+                routing {
+                    get("/") {
+                        call.respondText("response")
+                    }
+                }
+            },
+            configure = {
+                runningLimit = 1
+                connector {
+                    port = this@NettyPipeliningTest.port
+                    host = TEST_SERVER_HOST
+                }
+            }
+        )
+        server.start(wait = false)
+
+        try {
+            SelectorManager().use { selector ->
+                aSocket(selector).tcp().connect(TEST_SERVER_HOST, port).use { socket ->
+                    val writeChannel = socket.openWriteChannel()
+                    val readChannel = socket.openReadChannel()
+
+                    // First request must complete normally to increment activeRequests
+                    writeChannel.writeStringUtf8(pipelinedRequest("/"))
+                    writeChannel.flush()
+                    val firstResponse = withTimeout(5.seconds) { readChannel.readHttpResponse() }
+                    assertTrue(firstResponse.contains("response"), "Expected response, got:\n$firstResponse")
+
+                    // The second request must wait for first to finish
+                    writeChannel.writeStringUtf8(pipelinedRequest("/"))
+                    writeChannel.flush()
+                    val secondResponse = withTimeout(5.seconds) { readChannel.readHttpResponse() }
+                    assertTrue(secondResponse.contains("response"), "Expected response, got:\n$secondResponse")
+                }
+            }
+        } finally {
+            server.stop()
+        }
+    }
+
     private fun pipelinedRequest(path: String): String =
         "GET $path HTTP/1.1\r\nHost: $TEST_SERVER_HOST\r\nConnection: keep-alive\r\n\r\n"
 


### PR DESCRIPTION
**Subsystem**
Server, Netty

**Motivation**
[KTOR-9886](https://youtrack.jetbrains.com/issue/KTOR-9886) Netty: inverted skippedRead CAS leaves runningLimit read-resumption broken; runningLimit = 1 deadlocks keep-alive connections

This was supposed to have been fixed in "[KTOR-9875](https://youtrack.jetbrains.com/issue/KTOR-9875) Netty performance issues" but it would appear that I missed this commit when cleaning up the branch.

**Solution**
The check in `onLastResponseMessage` was inverted, which would cause pipelined requests to get stuck after hitting the running limit earlier in the pipeline, which would cause clients to hang.  The default value of 32 is pretty high so it doesn't happen so often in the wild.  Added a test to verify this behaviour after hitting an artificially low limit.

